### PR TITLE
ci: bump @anthropic-ai/claude-code 2.1.170→2.1.212

### DIFF
--- a/.github/actions/run-omnigent-agent/action.yml
+++ b/.github/actions/run-omnigent-agent/action.yml
@@ -36,7 +36,7 @@ inputs:
   claude-code-version:
     description: "@anthropic-ai/claude-code npm version to install."
     required: false
-    default: 2.1.170
+    default: 2.1.212
 
 runs:
   using: composite

--- a/.github/ci-deps/package.json
+++ b/.github/ci-deps/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Pinned npm CLIs the e2e workflow installs (claude-code, codex, pi).",
   "dependencies": {
-    "@anthropic-ai/claude-code": "2.1.163",
+    "@anthropic-ai/claude-code": "2.1.212",
     "@earendil-works/pi-coding-agent": "0.79.0",
     "@openai/codex": "0.139.0"
   }

--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -255,7 +255,7 @@ jobs:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/.cc-cli" && cd "${GITHUB_WORKSPACE}/.cc-cli"
-          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.170
+          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.212
           node node_modules/@anthropic-ai/claude-code/install.cjs
           echo "${GITHUB_WORKSPACE}/.cc-cli/node_modules/.bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -247,7 +247,7 @@ jobs:
         run: |
           CC_CLI_DIR="${RUNNER_TEMP}/omnigent-cc-cli"
           mkdir -p "$CC_CLI_DIR" && cd "$CC_CLI_DIR"
-          npm install --no-audit --no-fund @anthropic-ai/claude-code@2.1.170
+          npm install --no-audit --no-fund @anthropic-ai/claude-code@2.1.212
           echo "$CC_CLI_DIR/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Install Codex CLI

--- a/.github/workflows/flake-stress-ui.yml
+++ b/.github/workflows/flake-stress-ui.yml
@@ -234,7 +234,7 @@ jobs:
         run: |
           CC_CLI_DIR="${RUNNER_TEMP}/omnigent-cc-cli"
           mkdir -p "$CC_CLI_DIR" && cd "$CC_CLI_DIR"
-          npm install --no-audit --no-fund @anthropic-ai/claude-code@2.1.170
+          npm install --no-audit --no-fund @anthropic-ai/claude-code@2.1.212
           echo "$CC_CLI_DIR/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Install Codex CLI

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -180,7 +180,7 @@ jobs:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/.cc-cli" && cd "${GITHUB_WORKSPACE}/.cc-cli"
-          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.170
+          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.212
           node node_modules/@anthropic-ai/claude-code/install.cjs
           echo "${GITHUB_WORKSPACE}/.cc-cli/node_modules/.bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -172,7 +172,7 @@ jobs:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/.cc-cli" && cd "${GITHUB_WORKSPACE}/.cc-cli"
-          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.170
+          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.212
           node node_modules/@anthropic-ai/claude-code/install.cjs
           echo "${GITHUB_WORKSPACE}/.cc-cli/node_modules/.bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/security-triage.yml
+++ b/.github/workflows/security-triage.yml
@@ -196,7 +196,7 @@ jobs:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/.cc-cli" && cd "${GITHUB_WORKSPACE}/.cc-cli"
-          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.170
+          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.212
           node node_modules/@anthropic-ai/claude-code/install.cjs
           echo "${GITHUB_WORKSPACE}/.cc-cli/node_modules/.bin" >> "$GITHUB_PATH"
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ importers:
   .github/ci-deps:
     dependencies:
       '@anthropic-ai/claude-code':
-        specifier: 2.1.163
-        version: 2.1.163
+        specifier: 2.1.212
+        version: 2.1.212
       '@earendil-works/pi-coding-agent':
         specifier: 0.79.0
         version: 0.79.0(@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
@@ -441,52 +441,52 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@anthropic-ai/claude-code-darwin-arm64@2.1.163':
-    resolution: {integrity: sha512-SZPoYNIjj8Osgde5m2UtJcUlKPqnqajc1uwzBk87qU+cqpMKg2KNBMN5rGUoHCX81fNs6jdWJuKuJgCB6Eqazw==}
+  '@anthropic-ai/claude-code-darwin-arm64@2.1.212':
+    resolution: {integrity: sha512-QjQwqJU5XzAl1mdlnY+hQxK/pGx6/0q59BfHWiKsSeLyMBpK9avgwu+kap8kzSigSEdbo1rIABO8t2EKqzvvaA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-code-darwin-x64@2.1.163':
-    resolution: {integrity: sha512-MTy4TO8LUqnRxGXoIE3Jk5bYgiRqvJlXSIZxAO2m69Is9HK+mLevzU9Rr1ZKy+49ExJCNp8392G6+LEUP5+hdQ==}
+  '@anthropic-ai/claude-code-darwin-x64@2.1.212':
+    resolution: {integrity: sha512-dHnDk1jQHP1xG5hMEHHvgYqXHcgBapH/s1whqDw4KlAOxycgZKd4s2YQbRuygb7HNEpTLBnnLue5+Zv+RCfLzw==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-code-linux-arm64-musl@2.1.163':
-    resolution: {integrity: sha512-Quu85w7PxNYxxikc0tMQvT5EQH4debsci8EuTx97AYiuptmHmKgi5EkwQxwNo8YXS5IttwUU9QLc41FA6JEa8A==}
+  '@anthropic-ai/claude-code-linux-arm64-musl@2.1.212':
+    resolution: {integrity: sha512-OmNXhGKaf1F3XrqYL5GnMIAFMv4Og3H4ehEREX6JLiZU2AC3ckyPawqvvhqyhoJx+a6KN59+6rEC97DyQMgo5Q==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-code-linux-arm64@2.1.163':
-    resolution: {integrity: sha512-DLKiXFVTIuUfTnmeGoOEvOTwv5z0xi0yY1wSigubX3Q0jP12RgL3IBYOAtb4ytM3voAi4n/NhixvTwOWly2EEw==}
+  '@anthropic-ai/claude-code-linux-arm64@2.1.212':
+    resolution: {integrity: sha512-PcQptwO1t9q6tkL41yjmf5jxLU7Kzce4apW6KzuDvffN8ueKzGfR+9PecyQt2W1/dD2x1fAhWjAaQA6XiP2SyQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-code-linux-x64-musl@2.1.163':
-    resolution: {integrity: sha512-DAEhRqBlUkURnOiVGQWIu3Mje466l9dOSQn8TVZx3HdZwUtb0JiRul4rIGWuV10APnVpKteUHdw3WvBASkKluQ==}
+  '@anthropic-ai/claude-code-linux-x64-musl@2.1.212':
+    resolution: {integrity: sha512-AXkXlvUd/SWydG8XSEIKgq0fUHh/5+zdVj43mv+Fv0+p3Yv3vc528+tQo0NPGH3fU0weVYHarII69TgRQasP1w==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-code-linux-x64@2.1.163':
-    resolution: {integrity: sha512-K0CAuLxVqLhenPzi56Ysx157GHDXvcSyegyEFlr3jKdmjIClBynQZlRdZdePeQWBdmz5KrnzJ/lT5zzSH5GKUQ==}
+  '@anthropic-ai/claude-code-linux-x64@2.1.212':
+    resolution: {integrity: sha512-NCJ/EHcC1QfAm7EUH/F5m+cE6QQO5fhceCxtnySpFu0T4+eq6tORcJcbUY/bHGsKKa8MiAmjyv3nXFWnV5h/oA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-code-win32-arm64@2.1.163':
-    resolution: {integrity: sha512-wqFdygVVhpl3SZ9OlWx41+sU9G45FeSxHqXS9vKoHGk+h7n8SdNLipiXcqslhTBIilcKslQpq9WxlU8o8gyjeQ==}
+  '@anthropic-ai/claude-code-win32-arm64@2.1.212':
+    resolution: {integrity: sha512-SYh28kyBjPj5HYnRJ6FSK7tAGxXip2qemGo15N1V31KBQVqPgt67vvCI4E8k1+7yeCV31j3mpq6pBJi+1LDFHw==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-code-win32-x64@2.1.163':
-    resolution: {integrity: sha512-uTd+gFmqTQ9lVsA9dsVBYKeIKj6lB5zVNWWKUqV9RdDavDFXTgbbPw7LffEfQcbkiAU4UK+CQFuRRqXjJqsCDQ==}
+  '@anthropic-ai/claude-code-win32-x64@2.1.212':
+    resolution: {integrity: sha512-Fz/A6+V1ezafl/Zk9DMLTpoc9yVSdUf5UT0ZNBp6m0y1PwRyq7EMXlGh9V8O+Cb5/qPJF5K01onArNkYczSjbg==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-code@2.1.163':
-    resolution: {integrity: sha512-aK+hmLIaxp6v2M/fifhrCdYJ+kuQuGOl4Iok+AwRijeZl/HMn55rkwF6lEIq1Ny0xNCp2UKiZcmCegyoMumoWg==}
+  '@anthropic-ai/claude-code@2.1.212':
+    resolution: {integrity: sha512-MEasj1oaoARRKEWU7eHJ6DWC2TC8ogml9QUDihbmxYI2Ij5Ol1leW90DIj8/a0xX3lfHZOwT3gJr0JxVKa8Sxw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -7757,40 +7757,40 @@ snapshots:
       package-manager-detector: 1.7.0
       tinyexec: 1.2.4
 
-  '@anthropic-ai/claude-code-darwin-arm64@2.1.163':
+  '@anthropic-ai/claude-code-darwin-arm64@2.1.212':
     optional: true
 
-  '@anthropic-ai/claude-code-darwin-x64@2.1.163':
+  '@anthropic-ai/claude-code-darwin-x64@2.1.212':
     optional: true
 
-  '@anthropic-ai/claude-code-linux-arm64-musl@2.1.163':
+  '@anthropic-ai/claude-code-linux-arm64-musl@2.1.212':
     optional: true
 
-  '@anthropic-ai/claude-code-linux-arm64@2.1.163':
+  '@anthropic-ai/claude-code-linux-arm64@2.1.212':
     optional: true
 
-  '@anthropic-ai/claude-code-linux-x64-musl@2.1.163':
+  '@anthropic-ai/claude-code-linux-x64-musl@2.1.212':
     optional: true
 
-  '@anthropic-ai/claude-code-linux-x64@2.1.163':
+  '@anthropic-ai/claude-code-linux-x64@2.1.212':
     optional: true
 
-  '@anthropic-ai/claude-code-win32-arm64@2.1.163':
+  '@anthropic-ai/claude-code-win32-arm64@2.1.212':
     optional: true
 
-  '@anthropic-ai/claude-code-win32-x64@2.1.163':
+  '@anthropic-ai/claude-code-win32-x64@2.1.212':
     optional: true
 
-  '@anthropic-ai/claude-code@2.1.163':
+  '@anthropic-ai/claude-code@2.1.212':
     optionalDependencies:
-      '@anthropic-ai/claude-code-darwin-arm64': 2.1.163
-      '@anthropic-ai/claude-code-darwin-x64': 2.1.163
-      '@anthropic-ai/claude-code-linux-arm64': 2.1.163
-      '@anthropic-ai/claude-code-linux-arm64-musl': 2.1.163
-      '@anthropic-ai/claude-code-linux-x64': 2.1.163
-      '@anthropic-ai/claude-code-linux-x64-musl': 2.1.163
-      '@anthropic-ai/claude-code-win32-arm64': 2.1.163
-      '@anthropic-ai/claude-code-win32-x64': 2.1.163
+      '@anthropic-ai/claude-code-darwin-arm64': 2.1.212
+      '@anthropic-ai/claude-code-darwin-x64': 2.1.212
+      '@anthropic-ai/claude-code-linux-arm64': 2.1.212
+      '@anthropic-ai/claude-code-linux-arm64-musl': 2.1.212
+      '@anthropic-ai/claude-code-linux-x64': 2.1.212
+      '@anthropic-ai/claude-code-linux-x64-musl': 2.1.212
+      '@anthropic-ai/claude-code-win32-arm64': 2.1.212
+      '@anthropic-ai/claude-code-win32-x64': 2.1.212
 
   '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
     dependencies:


### PR DESCRIPTION
## Summary
- v2.1.170 has a corrupted/missing npm cache entry on GitHub Actions runners — `install.cjs` is not found after `npm install`, causing the Polly AI Review and other CI steps to fail with `MODULE_NOT_FOUND`
- Bumps all hardcoded `2.1.170` pins to `2.1.212` (current `stable` tag) across workflows and actions, forcing runners to fetch a fresh copy
- Also bumps `.github/ci-deps/package.json` (was pinned at `2.1.163`) for consistency

The failure was pre-existing across multiple PRs (fix/codex-native-prune-stale-bridge-dirs, fix/codex-native-share-plugins-cache, etc.) and is not caused by any specific PR's code changes.

## Test Plan
- CI on this PR should show the "Install Claude Code CLI" step passing in polly-review, issue-triage, security-triage, doc-sync, and e2e-ui workflows

## Demo
N/A — CI infrastructure fix

## Type of change
- [x] Bug fix

## Test coverage
- [x] Not applicable

## Coverage notes
CI-only change; no production code modified.