### PR TITLE
perf(store): push the session ACL into a correlated EXISTS

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -809,10 +809,12 @@ class SqlConversation(ConversationBase):
     )
 
     __table_args__ = (
-        # No bare created_at/updated_at indexes: the sessions list is ACL-scoped
-        # (id IN (...)) and resolves via the PK; the default sidebar (archived=
-        # false, updated_at DESC) is served by the archived_updated index below.
+        # The default sidebar (archived=false, updated_at DESC) is served by
+        # the archived_updated index; archived_created serves the sessions
+        # list's default created_at ordering now that the ACL filter is a
+        # correlated EXISTS rather than an id IN (...) resolved via the PK.
         Index("ix_conversations_archived_updated", "workspace_id", "archived", "updated_at", "id"),
+        Index("ix_conversations_archived_created", "workspace_id", "archived", "created_at", "id"),
         Index(
             "ix_conversations_root_conversation_id",
             "workspace_id",

--- a/omnigent/db/migrations/versions/za1b2c3d4e5f6_add_conversations_archived_created_index.py
+++ b/omnigent/db/migrations/versions/za1b2c3d4e5f6_add_conversations_archived_created_index.py
@@ -1,0 +1,38 @@
+"""Add an (archived, created_at) ordering index on conversations.
+
+Revision ID: za1b2c3d4e5f6
+Revises: b3c4d5e6f7a8
+Create Date: 2026-07-23 00:00:00.000000
+
+The sessions list defaults to ``created_at DESC`` ordering. With the ACL
+filter expressed as a correlated EXISTS (no more ``id IN (...)`` resolving
+through the PK), the default listing needs an order-compatible index or
+every page pays a scan-and-sort over the workspace's active rows. Mirrors
+``ix_conversations_archived_updated``, which already serves the
+``updated_at`` sort for the sidebar.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "za1b2c3d4e5f6"
+down_revision: str | None = "b3c4d5e6f7a8"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+_INDEX_NAME = "ix_conversations_archived_created"
+
+
+def upgrade() -> None:
+    op.create_index(
+        _INDEX_NAME,
+        "conversations",
+        ["workspace_id", "archived", "created_at", "id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_INDEX_NAME, table_name="conversations")

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -688,10 +688,11 @@ class ConversationStore(ABC):
             does. Powers the sidebar's session search on
             ``GET /v1/sessions?search_query=...``.
         :param accessible_by: When set, filter to sessions the
-            user has access to via ``session_permissions``. Uses
-            a UNION subquery: sessions the user has a direct
-            grant on, plus sessions with a ``"__public__"`` grant.
-            ``None`` disables the filter (returns all sessions).
+            user has a direct grant on in ``session_permissions``.
+            Public (``"__public__"``) grants are deliberately NOT
+            included — a public-only session does not appear in the
+            user's own list. ``None`` disables the filter (returns
+            all sessions).
         :param owned_by: When set, filter to sessions the user
             *owns* (an ``owner``-level grant), a stricter form of
             ``accessible_by`` that excludes sessions merely shared

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -14,10 +14,12 @@ from sqlalchemy import (
     delete,
     desc,
     func,
+    literal,
     literal_column,
     or_,
     select,
     text,
+    tuple_,
     update,
 )
 from sqlalchemy.orm import QueryableAttribute, Session, aliased
@@ -2038,11 +2040,16 @@ class SqlAlchemyConversationStore(ConversationStore):
         """
         from omnigent.server.auth import LEVEL_OWNER
 
-        # ACL (accessible_by/owned_by) resolves against session_permissions on
-        # the Omnigent DB, so it still needs a pre-fetch; archived now lives on
-        # the AP conversations table and is filtered inline below.
+        # ACL strategy mirrors list_conversations: single-DB pushes the
+        # permission check into the labels query as correlated EXISTS (no
+        # id materialization); split-DB keeps the prefetch fallback since a
+        # cross-DB EXISTS is impossible. Archived lives on the AP
+        # conversations table and is filtered inline below either way.
+        needs_acl = accessible_by is not None or owned_by is not None
+        acl_pushdown = needs_acl and self._conv_engine is self._engine
+
         permission_ids: list[str] | None = None
-        if accessible_by is not None or owned_by is not None:
+        if needs_acl and not acl_pushdown:
             with self._session() as meta_sess:
                 accessible_set: set[str] | None = None
                 owned_set: set[str] | None = None
@@ -2089,6 +2096,30 @@ class SqlAlchemyConversationStore(ConversationStore):
             )
             if permission_ids is not None:
                 stmt = stmt.where(SqlConversationLabel.conversation_id.in_(permission_ids))
+            if acl_pushdown:
+                if accessible_by is not None:
+                    stmt = stmt.where(
+                        select(SqlSessionPermission.conversation_id)
+                        .where(
+                            SqlSessionPermission.workspace_id == SqlConversationLabel.workspace_id,
+                            SqlSessionPermission.conversation_id
+                            == SqlConversationLabel.conversation_id,
+                            SqlSessionPermission.user_id == accessible_by,
+                        )
+                        .exists()
+                    )
+                if owned_by is not None:
+                    stmt = stmt.where(
+                        select(SqlSessionPermission.conversation_id)
+                        .where(
+                            SqlSessionPermission.workspace_id == SqlConversationLabel.workspace_id,
+                            SqlSessionPermission.conversation_id
+                            == SqlConversationLabel.conversation_id,
+                            SqlSessionPermission.user_id == owned_by,
+                            SqlSessionPermission.level >= LEVEL_OWNER,
+                        )
+                        .exists()
+                    )
             return [row[0] for row in ap_sess.execute(stmt).all()]
 
     def delete_label(
@@ -2219,15 +2250,24 @@ class SqlAlchemyConversationStore(ConversationStore):
         # kind and archived both live on the AP ``conversations`` table now
         # (kind derived from parent-nullness, archived a real column), so they
         # are filtered directly on the AP query below. The only filters that
-        # still require an Omnigent-side prefetch are the permission scopes.
+        # still require Omnigent-side data are the permission scopes.
         needs_meta_filter = (accessible_by is not None) or (owned_by is not None)
 
+        # ACL strategy. Single-DB (the AP and Omnigent tables share one bind):
+        # push the permission check into the conversations query as a
+        # correlated EXISTS, so LIMIT bounds the work and no ids round-trip
+        # through Python — the prefetch otherwise costs O(all-accessible) per
+        # request (ids out, ids back in as an IN clause, two UUID conversions
+        # each). Split-DB: a cross-DB EXISTS is impossible, so keep the
+        # prefetch fallback.
+        acl_pushdown = needs_meta_filter and self._conv_engine is self._engine
+
         qualifying_ids: list[str] | None = None
-        if needs_meta_filter:
+        if needs_meta_filter and not acl_pushdown:
             # Pre-fetch permission-qualifying IDs from the Omnigent DB
             # (session_permissions), then filter the AP query. accessible_by and
             # owned_by are intersected (both applied) to match the prior
-            # behaviour. (ACL pushdown to a single AP query is a follow-up.)
+            # behaviour.
             with self._session() as meta_sess:
                 accessible_set: set[str] | None = None
                 owned_set: set[str] | None = None
@@ -2264,6 +2304,34 @@ class SqlAlchemyConversationStore(ConversationStore):
 
             if qualifying_ids is not None:
                 stmt = stmt.where(SqlConversation.id.in_(qualifying_ids))
+
+            if acl_pushdown:
+                # Correlated on both PK members so Postgres can drive the
+                # semi-join off pk_session_permissions
+                # (workspace_id, user_id, conversation_id). accessible_by and
+                # owned_by are intersected (both applied), matching the
+                # prefetch path.
+                if accessible_by is not None:
+                    stmt = stmt.where(
+                        select(SqlSessionPermission.conversation_id)
+                        .where(
+                            SqlSessionPermission.workspace_id == SqlConversation.workspace_id,
+                            SqlSessionPermission.conversation_id == SqlConversation.id,
+                            SqlSessionPermission.user_id == accessible_by,
+                        )
+                        .exists()
+                    )
+                if owned_by is not None:
+                    stmt = stmt.where(
+                        select(SqlSessionPermission.conversation_id)
+                        .where(
+                            SqlSessionPermission.workspace_id == SqlConversation.workspace_id,
+                            SqlSessionPermission.conversation_id == SqlConversation.id,
+                            SqlSessionPermission.user_id == owned_by,
+                            SqlSessionPermission.level >= LEVEL_OWNER,
+                        )
+                        .exists()
+                    )
 
             # Kind filter as parent-nullness (see above): sub_agent ⇔ parent set.
             if kind_requires_parent is True:
@@ -2554,17 +2622,29 @@ class SqlAlchemyConversationStore(ConversationStore):
             )
         # "after" (forward=True) = further in sort direction;
         # "before" (forward=False) = opposite of sort direction.
-        if forward:
-            ts_cmp = sort_col < sub if is_desc else sort_col > sub
-            id_cmp = (
-                tiebreaker_col < tiebreaker_val if is_desc else tiebreaker_col > tiebreaker_val
-            )
-        else:
-            ts_cmp = sort_col > sub if is_desc else sort_col < sub
-            id_cmp = (
-                tiebreaker_col > tiebreaker_val if is_desc else tiebreaker_col < tiebreaker_val
-            )
-        return stmt.where(or_(ts_cmp, and_(sort_col == sub, id_cmp)))
+        #
+        # Emitted as a ROW-VALUES comparison — ``(sort, tiebreak) < (:ts, :id)``
+        # — not the equivalent ``sort < :ts OR (sort = :ts AND tiebreak < :id)``.
+        # The two are semantically identical, but PostgreSQL can only turn the
+        # row-values form into an index range condition; the OR form is left as
+        # a residual Filter, so a deep cursor re-reads and discards every row
+        # between the index start and the cursor (cost growing with cursor
+        # depth, not page size). Row values are supported by every dialect the
+        # store targets (PostgreSQL, SQLite >= 3.15, MySQL).
+        row = tuple_(sort_col, tiebreaker_col)
+        # Bind the tiebreaker with its column's type. Inside ``tuple_`` a bare
+        # Python value gets no type context, so the ``Uuid16`` decorator never
+        # runs and PostgreSQL is handed a hex string against a ``bytea``
+        # column ("operator does not exist: bytea < character varying"). The
+        # SQLite-rowid branch passes a scalar subquery, which is already typed.
+        cursor_tiebreaker = (
+            literal(tiebreaker_val, tiebreaker_col.type)
+            if isinstance(tiebreaker_col, QueryableAttribute)
+            else tiebreaker_val
+        )
+        cursor_row = tuple_(sub, cursor_tiebreaker)
+        descending_scan = is_desc if forward else not is_desc
+        return stmt.where(row < cursor_row if descending_scan else row > cursor_row)
 
     def update_conversation(
         self,

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import contextlib
+
 import pytest
 from sqlalchemy import text
 
@@ -5264,3 +5266,614 @@ def test_item_search_text_seam_redirects_persisted_value(db_uri: str) -> None:
             ).scalars()
         )
     assert stored == ["custom-search-text"]
+
+
+def _acl_perms(db_uri: str):
+    from omnigent.stores.permission_store.sqlalchemy_store import (
+        SqlAlchemyPermissionStore,
+    )
+
+    perms = SqlAlchemyPermissionStore(db_uri)
+    for user in ("alice@example.com", "bob@example.com"):
+        perms.ensure_user(user)
+    return perms
+
+
+def _spread_created_at(store: SqlAlchemyConversationStore, ids: list[str]) -> None:
+    """Give *ids* strictly decreasing ``created_at`` values, newest first.
+
+    Conversations created in the same second tie on ``created_at``, and the
+    tiebreaker differs by dialect (SQLite ``rowid`` = insertion order,
+    PostgreSQL the random uuid ``id``), so any order-sensitive assertion
+    must not depend on creation order. Spreading the timestamps makes the
+    expected order identical on every dialect.
+    """
+    from sqlalchemy import update as sa_update
+
+    from omnigent.db.db_models import SqlConversation as _Conv
+
+    base = 2_000_000_000
+    with store._conv_session() as session:
+        for offset, conv_id in enumerate(ids):
+            session.execute(
+                sa_update(_Conv)
+                .where(_Conv.id == conv_id)
+                .values(created_at=base - offset, updated_at=base - offset)
+            )
+
+
+@contextlib.contextmanager
+def _capture_conversation_selects(store: SqlAlchemyConversationStore):
+    """Capture the SELECT statements the store emits against conversations.
+
+    Yields a list that receives the actual SQLAlchemy clause elements, so a
+    plan test can re-compile the STORE'S OWN statement with literal binds
+    instead of hand-writing SQL that may omit predicates the planner sees.
+    """
+    from sqlalchemy import event as sa_event
+
+    captured: list[object] = []
+
+    def _on_before_execute(conn, clauseelement, multiparams, params, execution_options):
+        text = str(clauseelement)
+        if text.lstrip().upper().startswith("SELECT") and "FROM conversations" in text:
+            captured.append(clauseelement)
+
+    sa_event.listen(store._conv_engine, "before_execute", _on_before_execute)
+    try:
+        yield captured
+    finally:
+        sa_event.remove(store._conv_engine, "before_execute", _on_before_execute)
+
+
+@contextlib.contextmanager
+def _capture_driver_sql(store: SqlAlchemyConversationStore):
+    """Capture (statement, parameters) as the DBAPI sees them.
+
+    Plan tests need the driver-level form: the cursor binds a 16-byte
+    identifier, which cannot be rendered as a SQL literal, and re-binding raw
+    Python values to a ``text()`` EXPLAIN skips the type decorator — the exact
+    trap that made the first row-values attempt fail only on PostgreSQL.
+    Capturing the adapted parameters lets EXPLAIN run the real statement.
+    """
+    from sqlalchemy import event as sa_event
+
+    captured: list[tuple[str, object]] = []
+
+    def _on(conn, cursor, statement, parameters, context, executemany):
+        if statement.lstrip().upper().startswith("SELECT") and "FROM conversations" in statement:
+            captured.append((statement, parameters))
+
+    sa_event.listen(store._conv_engine, "before_cursor_execute", _on)
+    try:
+        yield captured
+    finally:
+        sa_event.remove(store._conv_engine, "before_cursor_execute", _on)
+
+
+def _explain_driver(store: SqlAlchemyConversationStore, statement: str, parameters: object) -> str:
+    """``EXPLAIN`` the exact statement+parameters the store executed.
+
+    Returns the plan as one string: PostgreSQL JSON, or SQLite's
+    ``EXPLAIN QUERY PLAN`` rows joined.
+    """
+    import json
+
+    dialect = store._conv_engine.dialect.name
+    with store._conv_session() as session:
+        conn = session.connection()
+        if dialect == "postgresql":
+            conn.exec_driver_sql("ANALYZE conversations")
+            conn.exec_driver_sql("ANALYZE session_permissions")
+            raw = conn.exec_driver_sql(
+                "EXPLAIN (ANALYZE, FORMAT JSON) " + statement, parameters
+            ).scalar_one()
+            return json.dumps(raw if isinstance(raw, (list, dict)) else json.loads(raw))
+        rows = conn.exec_driver_sql("EXPLAIN QUERY PLAN " + statement, parameters).all()
+    return " | ".join(str(row) for row in rows)
+
+
+def _explain_json(store: SqlAlchemyConversationStore, sql: str, analyze: bool = False) -> str:
+    """Return a PostgreSQL plan for *sql* as a JSON string (ANALYZE first)."""
+    import json
+
+    from sqlalchemy import text as sql_text
+
+    with store._conv_session() as session:
+        session.execute(sql_text("ANALYZE conversations"))
+        session.execute(sql_text("ANALYZE session_permissions"))
+        prefix = "EXPLAIN (ANALYZE, FORMAT JSON) " if analyze else "EXPLAIN (FORMAT JSON) "
+        raw = session.execute(sql_text(prefix + sql)).scalar_one()
+    return json.dumps(raw if isinstance(raw, (list, dict)) else json.loads(raw))
+
+
+def _bulk_seed_conversations_and_grants(
+    store: SqlAlchemyConversationStore,
+    user_id: str,
+    *,
+    count: int,
+    granted_ratio: float,
+    tie_size: int = 1,
+) -> None:
+    """Insert *count* conversations (and grants for a fraction of them).
+
+    Core bulk inserts, not per-row store calls, so a plan test can reach a
+    realistic row count without a slow fixture.
+
+    :param tie_size: How many rows share one ``created_at`` value. The
+        default of 1 gives every row a distinct timestamp; a larger value
+        creates ties, which is what makes the cursor's tiebreaker term
+        load-bearing (without ties, dropping it changes nothing).
+    """
+    import uuid as _uuid
+
+    from sqlalchemy import insert as sa_insert
+
+    from omnigent.db.db_models import SqlConversation as _Conv
+    from omnigent.db.db_models import SqlSessionPermission as _Perm
+
+    base = 1_900_000_000
+    conv_rows = []
+    perm_rows = []
+    for i in range(count):
+        cid = _uuid.uuid4().hex
+        stamp = base + i // tie_size
+        conv_rows.append(
+            {
+                "workspace_id": 0,
+                "id": cid,
+                "created_at": stamp,
+                "updated_at": stamp,
+                "title": f"seed-{i}",
+                "parent_conversation_id": None,
+                "root_conversation_id": cid,
+                "next_position": 0,
+                # The endpoint filters has_agent_id=True, so an all-NULL
+                # agent_id seed would exclude every row and the plan under
+                # test would never be the plan production runs.
+                "agent_id": _uuid.uuid4().hex,
+                "archived": i % 5 == 0,
+            }
+        )
+        if i < int(count * granted_ratio):
+            perm_rows.append(
+                {
+                    "workspace_id": 0,
+                    "user_id": user_id,
+                    "conversation_id": cid,
+                    "level": 4,
+                }
+            )
+    with store._conv_session() as session:
+        session.execute(sa_insert(_Conv), conv_rows)
+    with store._session() as session:
+        session.execute(sa_insert(_Perm), perm_rows)
+
+
+def test_list_conversations_accessible_and_owned_intersect(
+    conversation_store: SqlAlchemyConversationStore, db_uri: str
+) -> None:
+    """
+    ``accessible_by`` + ``owned_by`` intersect, with different users.
+
+    Passing the same user for both operands makes ownership imply
+    accessibility, so the intersection equals ``owned_by`` alone and dropping
+    either operand goes unnoticed. Alice can read the row Bob owns; nothing
+    else satisfies both.
+    """
+    owned_by_alice = conversation_store.create_conversation(title="owned-by-alice")
+    owned_by_bob = conversation_store.create_conversation(title="owned-by-bob")
+    alice_reads_bob_owns = conversation_store.create_conversation(title="alice-reads-bob-owns")
+    # Both can read it and NEITHER owns it: it satisfies the intersection only
+    # if owned_by stops requiring owner level.
+    both_read_neither_owns = conversation_store.create_conversation(title="both-read")
+    perms = _acl_perms(db_uri)
+    perms.grant("alice@example.com", owned_by_alice.id, 4)
+    perms.grant("bob@example.com", owned_by_bob.id, 4)
+    perms.grant("alice@example.com", alice_reads_bob_owns.id, 1)
+    perms.grant("bob@example.com", alice_reads_bob_owns.id, 4)
+    perms.grant("alice@example.com", both_read_neither_owns.id, 1)
+    perms.grant("bob@example.com", both_read_neither_owns.id, 1)
+
+    ids = {
+        c.id
+        for c in conversation_store.list_conversations(
+            accessible_by="alice@example.com", owned_by="bob@example.com"
+        ).data
+    }
+    assert ids == {alice_reads_bob_owns.id}
+
+
+def test_single_db_acl_uses_exists_pushdown_not_prefetch(
+    conversation_store: SqlAlchemyConversationStore, db_uri: str
+) -> None:
+    """
+    Single-DB mode pushes the ACL into the conversations query as a
+    correlated EXISTS: no standalone session_permissions prefetch runs,
+    and the ids never round-trip through Python.
+    """
+    from sqlalchemy import event
+
+    assert conversation_store._conv_engine is conversation_store._engine
+
+    conv = conversation_store.create_conversation(title="mine")
+    perms = _acl_perms(db_uri)
+    perms.grant("alice@example.com", conv.id, 4)
+
+    statements: list[str] = []
+
+    def _capture(conn, cursor, statement, parameters, context, executemany):
+        statements.append(statement)
+
+    event.listen(conversation_store._engine, "before_cursor_execute", _capture)
+    try:
+        result = conversation_store.list_conversations(
+            accessible_by="alice@example.com", owned_by="alice@example.com"
+        )
+    finally:
+        event.remove(conversation_store._engine, "before_cursor_execute", _capture)
+
+    assert {c.id for c in result.data} == {conv.id}
+    perm_stmts = [s for s in statements if "session_permissions" in s]
+    # The permission table appears only inside the conversations query
+    # (as EXISTS subqueries) — never as its own prefetch SELECT.
+    assert perm_stmts, "expected the list query to reference session_permissions"
+    for stmt in perm_stmts:
+        assert "FROM conversations" in stmt
+        assert "EXISTS" in stmt
+
+
+def test_list_conversations_acl_with_cursor_pagination(
+    conversation_store: SqlAlchemyConversationStore, db_uri: str
+) -> None:
+    """Cursor pagination composes with the ACL filter: walking every page
+    yields exactly the granted rows (no leak, no overlap, none lost), and a
+    NON-granted conversation used as the cursor still returns the granted
+    rows that follow it — an empty page would not satisfy this.
+
+    Owns the ACL-vs-cursor COMPOSITION: removing the filter (``needs_meta_filter
+    = False``) fails here, because the ungranted rows appear. It deliberately
+    does NOT own the pushdown — disabling it falls back to the id prefetch,
+    which must return identical rows on split binds, so this test passing
+    under that mutation is the contract working. The pushdown is pinned by
+    the statement-shape and plan guards below.
+    """
+    convs = [conversation_store.create_conversation(title=f"c{i}") for i in range(6)]
+    # Newest first: c0, c1, ... c5. Deterministic on every dialect.
+    _spread_created_at(conversation_store, [c.id for c in convs])
+    granted = {c.id for c in (convs[0], convs[1], convs[4], convs[5])}
+    perms = _acl_perms(db_uri)
+    for conv_id in granted:
+        perms.grant("alice@example.com", conv_id, 4)
+
+    # Full walk in pages of 2 must reproduce exactly the granted set.
+    seen: list[str] = []
+    cursor: str | None = None
+    for _ in range(10):  # bounded; 4 rows / 2 per page = 2 pages
+        page = conversation_store.list_conversations(
+            accessible_by="alice@example.com", limit=2, after=cursor
+        )
+        seen.extend(c.id for c in page.data)
+        if not page.has_more:
+            break
+        cursor = page.last_id
+    assert len(seen) == len(set(seen)), f"pages overlap: {seen}"
+    assert set(seen) == granted
+    assert seen == [convs[0].id, convs[1].id, convs[4].id, convs[5].id]
+
+    # A non-granted conversation (c2, positioned between granted rows) as
+    # the cursor: position filter only, ACL still applied — so the result is
+    # exactly the granted rows after it, not an empty page.
+    page3 = conversation_store.list_conversations(
+        accessible_by="alice@example.com", limit=10, after=convs[2].id
+    )
+    assert [c.id for c in page3.data] == [convs[4].id, convs[5].id]
+
+
+def test_list_projects_single_db_uses_exists_pushdown(
+    conversation_store: SqlAlchemyConversationStore, db_uri: str
+) -> None:
+    """Single-DB list_projects pushes ACL as EXISTS — no standalone
+    session_permissions prefetch — and still scopes correctly."""
+    from sqlalchemy import event
+
+    assert conversation_store._conv_engine is conversation_store._engine
+    mine = conversation_store.create_conversation(title="mine")
+    other = conversation_store.create_conversation(title="other")
+    conversation_store.set_labels(mine.id, {"omni_project": "Mine"})
+    conversation_store.set_labels(other.id, {"omni_project": "Other"})
+    perms = _acl_perms(db_uri)
+    perms.grant("alice@example.com", mine.id, 4)
+    perms.grant("bob@example.com", other.id, 4)
+
+    statements: list[str] = []
+
+    def _capture(conn, cursor, statement, parameters, context, executemany):
+        statements.append(statement)
+
+    event.listen(conversation_store._engine, "before_cursor_execute", _capture)
+    try:
+        projects = conversation_store.list_projects(accessible_by="alice@example.com")
+    finally:
+        event.remove(conversation_store._engine, "before_cursor_execute", _capture)
+
+    assert projects == ["Mine"]
+    perm_stmts = [s for s in statements if "session_permissions" in s]
+    assert perm_stmts, "expected the labels query to reference session_permissions"
+    for stmt in perm_stmts:
+        assert "conversation_labels" in stmt
+        assert "EXISTS" in stmt
+
+
+_PLAN_SEED_ROWS = 5_000
+"""Rows seeded for the plan tests.
+
+At a few hundred rows PostgreSQL correctly prefers a sequential scan, so a
+plan assertion there measures the planner's choice for a toy table rather than
+the production one. The index/range behaviour under test only appears once the
+table is large enough for an index plan to be the rational choice.
+"""
+
+
+def test_seeded_listing_plans_and_deep_pagination(
+    conversation_store: SqlAlchemyConversationStore, db_uri: str
+) -> None:
+    """
+    Both listing contracts, explained against a realistically sized table.
+
+    Two contracts share one seed because seeding is the expensive part:
+
+    1. The default listing pushes the ACL into a correlated EXISTS and reads
+       the page through the ordering index — no id round-trip through Python,
+       no sort of the whole workspace.
+    2. The cursor predicate is emitted as a row-values comparison, which
+       PostgreSQL can use as an index RANGE condition. The equivalent
+       ``ts < :ts OR (ts = :ts AND id < :id)`` form is left as a residual
+       filter, so a deep cursor reads and discards every row above it, at a
+       cost that grows with cursor depth.
+
+    Everything is asserted against the statement the STORE emitted, captured
+    from the engine: the SQL shape from the clause element, and the PLAN from
+    the driver-level statement with its adapted parameters. The plan is the
+    load-bearing half — an earlier version asserted only the SQL spelling, so
+    restoring the OR form failed on spelling and CI never checked whether the
+    comparison reached the index. EXPLAIN needs the driver form because the
+    cursor binds a 16-byte identifier that cannot be written as a SQL literal,
+    and re-binding raw values to a ``text()`` EXPLAIN skips the type decorator
+    — the exact trap that made the first row-values attempt fail only on
+    PostgreSQL.
+    """
+    _acl_perms(db_uri)
+    # Tied timestamps: with one row per timestamp the cursor's tiebreaker term
+    # is decorative and dropping it loses nothing, so the walk below could not
+    # tell a correct cursor from a broken one.
+    _bulk_seed_conversations_and_grants(
+        conversation_store,
+        "alice@example.com",
+        count=_PLAN_SEED_ROWS,
+        # Half the workspace granted: a selective ACL is what production
+        # looks like, and an all-granted table lets the planner ignore the
+        # permission side entirely.
+        granted_ratio=0.5,
+        tie_size=4,
+    )
+    dialect = conversation_store._conv_engine.dialect.name
+
+    def _plan_of(driver_captured: list[tuple[str, object]]) -> str:
+        statement, parameters = next(
+            (
+                (st, pr)
+                for st, pr in driver_captured
+                if "created_at" in st and "LIMIT" in st.upper()
+            ),
+            driver_captured[-1],
+        )
+        return _explain_driver(conversation_store, statement, parameters)
+
+    def _index_conds_and_filtered(plan: str) -> tuple[list[str], list[int]]:
+        import json as _json
+
+        flat: list[dict[str, object]] = []
+
+        def _walk(node: dict[str, object]) -> None:
+            flat.append(node)
+            for child in node.get("Plans", []) or []:
+                _walk(child)
+
+        for entry in _json.loads(plan):
+            _walk(entry["Plan"])
+        return (
+            [str(n.get("Index Cond", "")) for n in flat if "Index Cond" in n],
+            [int(n.get("Rows Removed by Filter", 0) or 0) for n in flat],
+        )
+
+    # ── 1. default listing: ACL pushdown + ordering index ───────────────
+    with _capture_conversation_selects(conversation_store) as clauses:
+        with _capture_driver_sql(conversation_store) as driver_captured:
+            page = conversation_store.list_conversations(
+                limit=20,
+                accessible_by="alice@example.com",
+                has_agent_id=True,
+                kind="default",
+                sort_by="created_at",
+                order="desc",
+            )
+    assert page.data, "seed must produce visible rows or the plan is not the real one"
+    # On the uncompiled statement: without the pushdown the ACL becomes a
+    # materialized list of binary ids, and anything that renders it dies before
+    # reaching this assertion.
+    assert "EXISTS" in str(clauses[0]).upper(), str(clauses[0])
+    listing_plan = _plan_of(driver_captured)
+    if dialect == "postgresql":
+        assert "ix_conversations_archived_created" in listing_plan, listing_plan
+        # A Sort here would mean the whole accessible set was ordered to return
+        # twenty rows.
+        assert '"Node Type": "Sort"' not in listing_plan, listing_plan
+    else:
+        assert "ix_conversations_archived_created" in listing_plan, listing_plan
+        assert "SCAN conversations" not in listing_plan, listing_plan
+
+    # ── 2. deep cursor: row values as an index range condition ──────────
+    # A DEEP cursor with a NORMAL page size — the shape that distinguishes an
+    # index range condition from a residual filter. Asking for half the table
+    # in one page makes a sequential scan the planner's rational choice, and
+    # the plan would then say nothing about the predicate.
+    #
+    # ALL FOUR branches are explained, not just descending ``after``. The
+    # rewrite changed both directions and both orders, and the four produce
+    # different predicates; pinning one of them let the residual OR form be
+    # restored for the other three with every test still green. Behavioural
+    # equality cannot see this — the OR form returns the same rows, just by
+    # reading and discarding everything above the cursor.
+    baseline = conversation_store.list_conversations(
+        accessible_by="alice@example.com",
+        limit=_PLAN_SEED_ROWS * 2,
+        has_agent_id=True,
+        kind="default",
+        sort_by="created_at",
+        order="desc",
+    )
+    assert not baseline.has_more, "baseline must be a single complete page"
+    expected_ids = [c.id for c in baseline.data]
+    deep = int(len(expected_ids) * 0.7)
+
+    tiebreaker_col = conversation_store._tiebreaker_col
+    # The tiebreaker column is dialect-chosen (SQLite rowid = insertion order,
+    # otherwise the uuid id) — assert against the store's own choice rather
+    # than hard-coding one dialect's spelling.
+    tiebreaker = str(getattr(tiebreaker_col, "expression", tiebreaker_col))
+
+    first = None
+    second = None
+    for sort_by in ("created_at", "updated_at"):
+        for order in ("desc", "asc"):
+            for direction in ("after", "before"):
+                page = conversation_store.list_conversations(
+                    accessible_by="alice@example.com",
+                    limit=deep,
+                    has_agent_id=True,
+                    kind="default",
+                    sort_by=sort_by,
+                    order=order,
+                )
+                assert page.has_more, "seed must be deeper than one page"
+                cursor_id = page.data[-1].id
+                with _capture_conversation_selects(conversation_store) as clauses:
+                    with _capture_driver_sql(conversation_store) as driver_captured:
+                        cursor_page = conversation_store.list_conversations(
+                            accessible_by="alice@example.com",
+                            limit=20,
+                            has_agent_id=True,
+                            kind="default",
+                            sort_by=sort_by,
+                            order=order,
+                            **{direction: cursor_id},
+                        )
+                where = f"{sort_by}/{order}/{direction}"
+                # The PLAN first: a residual filter is the failure this form
+                # exists to avoid — it means the scan read every row past the
+                # cursor and threw it away.
+                cursor_plan = _plan_of(driver_captured)
+                if dialect == "postgresql":
+                    index_conds, rows_filtered = _index_conds_and_filtered(cursor_plan)
+                    assert any(sort_by in c and "id" in c for c in index_conds), (
+                        where,
+                        cursor_plan,
+                    )
+                    assert all(r == 0 for r in rows_filtered), (where, cursor_plan)
+                else:
+                    assert "USING INDEX" in cursor_plan, (where, cursor_plan)
+                    assert "SCAN conversations" not in cursor_plan, (where, cursor_plan)
+
+                # Then the emitted spelling, as a description of what produced
+                # that plan. ``after`` in a descending scan compares "<";
+                # every other combination flips one of the two.
+                listing = next((c for c in clauses if sort_by in str(c)), clauses[0])
+                descending_scan = (order == "desc") if direction == "after" else (order == "asc")
+                comparison = "<" if descending_scan else ">"
+                assert f"(conversations.{sort_by}, {tiebreaker}) {comparison}" in " ".join(
+                    str(listing).split()
+                ), (where, tiebreaker, str(listing))
+
+                # Keep the descending created_at/after pages for the walk below.
+                if sort_by == "created_at" and order == "desc" and direction == "after":
+                    first, second = page, cursor_page
+
+    assert first is not None and second is not None
+
+    # ── 3. behaviour: deep pagination loses and duplicates nothing ──────
+    first_ids = [c.id for c in first.data]
+    second_ids = [c.id for c in second.data]
+    assert not set(first_ids) & set(second_ids), "cursor pages overlap"
+    # Non-overlap alone only proves no DUPLICATES. A cursor that skips rows —
+    # the failure mode of a wrong tiebreaker or a strict-vs-inclusive boundary
+    # slip — also produces non-overlapping pages, so compare the paged walk to
+    # the single-shot result.
+    walked: list[str] = []
+    after: str | None = None
+    while True:
+        walk_page = conversation_store.list_conversations(
+            accessible_by="alice@example.com",
+            limit=500,
+            after=after,
+            has_agent_id=True,
+            kind="default",
+            sort_by="created_at",
+            order="desc",
+        )
+        walked.extend(c.id for c in walk_page.data)
+        if not walk_page.has_more or walk_page.last_id is None:
+            break
+        after = walk_page.last_id
+    assert len(walked) == len(set(walked)), "paged walk returned a row twice"
+    assert walked == expected_ids, (
+        f"paged walk lost or reordered rows: {len(walked)} of {len(expected_ids)}"
+    )
+
+
+@pytest.mark.parametrize("order", ["desc", "asc"])
+@pytest.mark.parametrize("sort_by", ["created_at", "updated_at"])
+def test_cursor_pages_forward_and_backward_in_both_orders(
+    conversation_store: SqlAlchemyConversationStore, db_uri: str, sort_by: str, order: str
+) -> None:
+    """
+    ``before`` is the same rewritten predicate as ``after``, in reverse.
+
+    The row-values rewrite changed both directions and both sort columns, but
+    coverage only ever exercised descending ``after``. Tied timestamps are
+    seeded so the tiebreaker term decides page boundaries, which is where a
+    direction mix-up shows up: paging forward and then back must return the
+    same rows, in the same order.
+    """
+    _acl_perms(db_uri)
+    _bulk_seed_conversations_and_grants(
+        conversation_store, "alice@example.com", count=40, granted_ratio=1.0, tie_size=4
+    )
+
+    def _page(**kwargs: object) -> list[str]:
+        return [
+            c.id
+            for c in conversation_store.list_conversations(
+                accessible_by="alice@example.com",
+                has_agent_id=True,
+                kind="default",
+                sort_by=sort_by,
+                order=order,
+                **kwargs,  # type: ignore[arg-type]
+            ).data
+        ]
+
+    full = _page(limit=100)
+    assert len(full) > 12, "seed must cover several pages"
+
+    # Forward from a mid-list cursor.
+    forward = _page(limit=6, after=full[5])
+    assert forward == full[6:12], (forward, full[:14])
+
+    # ``before`` narrows to the rows preceding the cursor while keeping the
+    # same ORDER BY, so the whole prefix comes back in listing order and LIMIT
+    # takes it from the start — not the rows nearest the cursor. Both halves
+    # are asserted: the full prefix pins the boundary (exclusive, correct
+    # direction), the limited page pins which end LIMIT cuts.
+    assert _page(limit=100, before=full[12]) == full[:12], full[:14]
+    assert _page(limit=6, before=full[12]) == full[:6], full[:14]

--- a/tests/stores/test_conversation_store_split_db.py
+++ b/tests/stores/test_conversation_store_split_db.py
@@ -596,3 +596,122 @@ def test_delete_conversation_keeps_template_agent(
 
     asyncio.run(store.delete_conversation(conv.id))
     assert _col(omnigent_db, "agents", "id") == ["191cbf904e3223e9e00ac9a1abfe79a5"]
+
+
+# ── ACL filters (split-DB prefetch fallback) ───────────
+#
+# In split-DB mode the session_permissions table lives on a different bind
+# than conversations, so the EXISTS pushdown is impossible; these verify the
+# id-prefetch fallback keeps ACL semantics identical.
+
+
+def _perms(omnigent_db: Path):
+    from omnigent.stores.permission_store.sqlalchemy_store import (
+        SqlAlchemyPermissionStore,
+    )
+
+    perms = SqlAlchemyPermissionStore(f"sqlite:///{omnigent_db}")
+    for user in ("alice@example.com", "bob@example.com"):
+        perms.ensure_user(user)
+    return perms
+
+
+def test_split_db_acl_filters_over_one_grant_graph(
+    omnigent_db: Path, store: SqlAlchemyConversationStore
+) -> None:
+    """
+    Split binds: every ACL filter, plus the statement shape, on one graph.
+
+    Four tests shared this setup and one of them could not observe its own
+    contract: using the same user for ``accessible_by`` and ``owned_by``
+    makes ownership imply accessibility, so the intersection is whatever
+    ``owned_by`` alone returns. The graph below gives the two operands
+    DIFFERENT users, so an intersection that ignored one of them changes the
+    answer.
+    """
+    from sqlalchemy import event
+
+    owned_by_alice = store.create_conversation(title="owned-by-alice")
+    shared_with_alice = store.create_conversation(title="shared-with-alice")
+    owned_by_bob = store.create_conversation(title="owned-by-bob")
+    # Alice can read it, Bob owns it — the only row in the intersection below.
+    alice_reads_bob_owns = store.create_conversation(title="alice-reads-bob-owns")
+
+    perms = _perms(omnigent_db)
+    perms.grant("alice@example.com", owned_by_alice.id, 4)
+    perms.grant("alice@example.com", shared_with_alice.id, 1)
+    perms.grant("bob@example.com", owned_by_bob.id, 4)
+    perms.grant("alice@example.com", alice_reads_bob_owns.id, 1)
+    perms.grant("bob@example.com", alice_reads_bob_owns.id, 4)
+
+    def _ids(**kwargs: object) -> set[str]:
+        return {c.id for c in store.list_conversations(**kwargs).data}  # type: ignore[arg-type]
+
+    # accessible_by: any grant level.
+    assert _ids(accessible_by="alice@example.com") == {
+        owned_by_alice.id,
+        shared_with_alice.id,
+        alice_reads_bob_owns.id,
+    }
+    # owned_by: owner level only — a read grant is not enough.
+    assert _ids(owned_by="alice@example.com") == {owned_by_alice.id}
+    # Both, with DIFFERENT users: alice can see it and bob owns it.
+    assert _ids(accessible_by="alice@example.com", owned_by="bob@example.com") == {
+        alice_reads_bob_owns.id
+    }
+    assert not _ids(accessible_by="nobody@example.com")
+
+    # Statement shape: split binds take the prefetch path, so a standalone
+    # session_permissions SELECT runs on the Omnigent engine and the AP
+    # conversations query carries no cross-bind EXISTS.
+    captured: dict[str, list[str]] = {"omnigent": [], "conv": []}
+
+    def _capture(key: str):
+        def _on_execute(conn, cursor, statement, parameters, context, executemany):
+            captured[key].append(statement)
+
+        return _on_execute
+
+    omni_listener = _capture("omnigent")
+    conv_listener = _capture("conv")
+    event.listen(store._engine, "before_cursor_execute", omni_listener)
+    event.listen(store._conv_engine, "before_cursor_execute", conv_listener)
+    try:
+        result = store.list_conversations(accessible_by="alice@example.com")
+    finally:
+        event.remove(store._engine, "before_cursor_execute", omni_listener)
+        event.remove(store._conv_engine, "before_cursor_execute", conv_listener)
+
+    assert len(result.data) == 3
+    prefetch = [
+        s
+        for s in captured["omnigent"]
+        if "session_permissions" in s and "FROM conversations" not in s
+    ]
+    assert prefetch, "expected a standalone session_permissions prefetch"
+    assert not any("session_permissions" in s for s in captured["conv"])
+
+
+def test_list_projects_acl_split_db_prefetch_fallback(
+    omnigent_db: Path, store: SqlAlchemyConversationStore
+) -> None:
+    """Split binds: list_projects keeps the id-prefetch ACL and scopes
+    projects to the caller's grants."""
+    mine = store.create_conversation(title="mine")
+    other = store.create_conversation(title="other")
+    read_only = store.create_conversation(title="read-only")
+    store.set_labels(mine.id, {"omni_project": "Mine"})
+    store.set_labels(other.id, {"omni_project": "Other"})
+    store.set_labels(read_only.id, {"omni_project": "ReadOnly"})
+    perms = _perms(omnigent_db)
+    perms.grant("alice@example.com", mine.id, 4)
+    perms.grant("bob@example.com", other.id, 4)
+    # Alice can read this project's session but does not own it.
+    perms.grant("alice@example.com", read_only.id, 1)
+
+    assert store.list_projects(accessible_by="alice@example.com") == ["Mine", "ReadOnly"]
+    assert store.list_projects(owned_by="bob@example.com") == ["Other"]
+    # owned_by must require owner level, not merely a grant: lowering the
+    # threshold here would add "ReadOnly".
+    assert store.list_projects(owned_by="alice@example.com") == ["Mine"]
+    assert store.list_projects(accessible_by="nobody@example.com") == []

--- a/tests/stores/test_permission_store.py
+++ b/tests/stores/test_permission_store.py
@@ -654,7 +654,7 @@ def test_list_conversations_user_with_direct_grant_sees_session(
 ) -> None:
     """A user with a direct grant sees their session via ``list_conversations(accessible_by=...)``.
 
-    The UNION filter in list_conversations must include sessions where the
+    The ACL filter in list_conversations must include sessions where the
     user has a direct permission row.
     """
     _ensure_user(store, "alice@test.com")
@@ -681,7 +681,7 @@ def test_list_conversations_user_with_no_grants_sees_nothing(
 ) -> None:
     """A user with no grants sees no sessions via ``list_conversations(accessible_by=...)``.
 
-    The UNION filter must exclude sessions where the user has no permission row.
+    The ACL filter must exclude sessions where the user has no permission row.
     """
     _ensure_user(store, "alice@test.com")
     _ensure_user(store, "bob@test.com")


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

Closes #3001

## Summary

`GET /v1/sessions` (and `list_projects`) paid a fixed cost before looking at a single row of the requested page: the ACL filter (`accessible_by` / `owned_by`) prefetched every conversation id the caller can see into Python, then re-bound them as an `IN (...)` clause — on a workspace with 2,303 accessible conversations, one `limit=20` request marshaled 2,303 ids out of the database and back in for an ~88 KB statement, and `limit=1` cost the same as `limit=20` because the cost scaled with everything the caller could see, not with the page.

**ELI5**: instead of asking the database "give me the ids of everything I'm allowed to see" and then asking again "now give me 20 rows whose id is in this huge list I just handed you", the query now asks once: "give me 20 rows, and for each one, check right there whether I'm allowed to see it."

```
Before:                                  After:
 1. SELECT id FROM permissions            1. SELECT ... FROM conversations c
    WHERE user = :u   -- N ids               WHERE EXISTS (
 2. SELECT ... FROM conversations              SELECT 1 FROM permissions p
    WHERE id IN (:id1, :id2, ... :idN)         WHERE p.conversation_id = c.id
    ORDER BY ... LIMIT :n                        AND p.user_id = :u
                                              )
                                              ORDER BY ... LIMIT :n
 cost ~ O(everything accessible)          cost ~ O(limit), bounded by an index
```

Three changes ship together because they touch the same query and the same tests:

1. **ACL as a correlated `EXISTS`** instead of an `IN (...)` over a prefetched id list, for both `list_conversations` and `list_projects`. Only valid when the AP and Omnigent tables share one DB bind (gated on `self._conv_engine is self._engine`); split-DB deployments keep the existing id-prefetch fallback, since a cross-bind `EXISTS` isn't expressible.
2. **Cursor pagination as a row-values comparison** — `(created_at, id) < (:ts, :id)` — instead of the logically-equivalent `ts < :ts OR (ts = :ts AND id < :id)`. Only the row-values form becomes an index range condition on both dialects; the `OR` form is left as a residual filter a deep cursor still has to read and discard every row above. (Also fixed a latent correctness trap in building this: binding the id tiebreaker inside `tuple_()` without its column type skips the `Uuid16` decorator, which would hand PostgreSQL a hex string against a `bytea` column.)
3. **A new index**, `ix_conversations_archived_created`, so the default listing has an ordering-compatible path to use.

## Test Plan

```bash
uv run --no-sync pytest tests/stores/test_conversation_store.py tests/stores/test_conversation_store_split_db.py tests/stores/test_permission_store.py -q
uv run --no-sync ruff check omnigent/stores/conversation_store omnigent/db/db_models.py
uv run --no-sync ruff format --check omnigent/stores/conversation_store omnigent/db/db_models.py
```

Fresh benchmark pass (this round), `dev/benchmarks/omnigent`, before/after this PR on a 5,000-session / 20-project seeded corpus, both dialects, P50 latency:

| Journey | SQLite | Postgres |
|---|---|---|
| `list_sessions` | 12.6 → 4.3 ms (**-66%**) | 25.5 → 5.9 ms (**-77%**) |
| `list_project_sessions` | 20.1 → 4.5 ms (**-77%**) | 29.5 → 6.8 ms (**-77%**) |
| `list_projects` | 10.7 → 2.3 ms (**-78%**) | 20.1 → 1.7 ms (**-92%**) |
| `search_sessions` | 89.0 → 88.5 ms (flat) | 59.9 → 44.6 ms (**-26%**) |

No regressions on any journey in the full 9-journey suite, either dialect. Full JSON reports + `compare.py` output available on request.

## Demo

N/A — backend/DB change, no UI surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Store-level tests assert the statement the store itself emitted (captured from the engine), not hand-written SQL — the query plan is asserted before its SQL spelling, on a 5,000-row seed where an index plan is the planner's rational choice, across both sort columns, both sort orders, and both cursor directions. Restoring the `OR` predicate for any branch fails on the plan, observably (PostgreSQL reports 3,400 rows removed by filter). Row-set equivalence against the previous behavior checked across 35 ordered comparisons at 5k and 50k rows, so the pushdown can't silently drop or duplicate a row. Split-DB fallback path covered with a behavioral test capturing statements on both engines. Manual verification is the fresh benchmark pass above, run against this branch specifically (not carried over from an earlier round).

## Changelog

Session list, project list, and per-project session list load significantly faster in large workspaces — page load no longer scales with total accessible session count.
