### PR TITLE
[runner] Preserve sub-agent wake attribution

### DIFF
--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -979,6 +979,7 @@ def create_app(
         OMNIGENT_SESSION_ENV_VALUE,
         OMNIGENT_SESSION_ENV_VAR,
         RUNNER_ID_ENV_VAR,
+        RUNNER_TUNNEL_TOKEN_HEADER,
         get_stable_runner_id,
     )
     from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
@@ -1017,6 +1018,7 @@ def create_app(
     # token cache); otherwise build our own.
     if auth_token_factory is None:
         auth_token_factory = _make_auth_token_factory()
+    binding_token = _runner_tunnel_binding_token_from_env()
     server_client = httpx.AsyncClient(
         base_url=server_url,
         auth=_RunnerDatabricksAuth(auth_token_factory),
@@ -1029,7 +1031,11 @@ def create_app(
         #
         # The workspace-routing header (empty unless a ?o= selector was
         # recorded for this server) routes these callbacks to the workspace.
-        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN, **databricks_request_headers(server_url)},
+        headers={
+            "Origin": OMNIGENT_INTERNAL_WS_ORIGIN,
+            **({RUNNER_TUNNEL_TOKEN_HEADER: binding_token} if binding_token is not None else {}),
+            **databricks_request_headers(server_url),
+        },
         timeout=httpx.Timeout(5.0, read=None),
         # NOTE: ``follow_redirects`` deliberately stays False.
         # ``_RunnerDatabricksAuth.auth_flow`` needs to *see* the
@@ -1108,7 +1114,7 @@ def create_app(
     # Reuse the tunnel binding token for runner-side request auth.
     # The same secret is already shared between the
     # CLI launcher and this runner process via env var.
-    runner_auth_token = _runner_tunnel_binding_token_from_env()
+    runner_auth_token = binding_token
 
     app = create_runner_app(
         process_manager=pm,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -912,6 +912,8 @@ class _SubagentWorkEntry:
     :param wrapper_label: Optional terminal wrapper label from the
         child session, e.g. ``"codex-native-ui"`` for codex-native
         native sub-agents.
+    :param created_by: Human actor that dispatched this child turn, if
+        known from the parent turn context.
     :param status: Current work status, e.g. ``"launching"`` or
         ``"running"``.
     :param output: Terminal child output or error text. ``None``
@@ -929,6 +931,7 @@ class _SubagentWorkEntry:
     agent: str
     title: str
     wrapper_label: str | None = None
+    created_by: str | None = None
     status: str = "launching"
     output: str | None = None
     created_at: float = dataclasses.field(default_factory=time.time)
@@ -970,6 +973,7 @@ def register_subagent_work(
     agent: str,
     title: str,
     wrapper_label: str | None = None,
+    created_by: str | None = None,
 ) -> _SubagentWorkEntry:
     """
     Register one running sub-agent dispatch.
@@ -985,6 +989,8 @@ def register_subagent_work(
     :param title: Sub-agent instance title, e.g. ``"auth"``.
     :param wrapper_label: Optional child ``omnigent.wrapper``
         label, e.g. ``"claude-code-native-ui"``.
+    :param created_by: Human actor that dispatched this child turn, if
+        known from the parent turn context.
     :returns: The registered work entry.
     """
     prior = _subagent_work_by_child.get(child_session_id)
@@ -1002,6 +1008,7 @@ def register_subagent_work(
         agent=agent,
         title=title,
         wrapper_label=wrapper_label,
+        created_by=created_by,
     )
     _drained_delivered_subagent_children.discard(child_session_id)
     _subagent_work_by_child[child_session_id] = entry
@@ -1266,6 +1273,8 @@ async def _deliver_subagent_wake_post(
     server_client: httpx.AsyncClient,
     parent_id: str,
     notice: str,
+    *,
+    created_by: str | None = None,
 ) -> bool:
     """
     POST a sub-agent wake notice with a bounded retry on transient failure.
@@ -1281,6 +1290,8 @@ async def _deliver_subagent_wake_post(
     :param server_client: Omnigent HTTP client for the runner subprocess.
     :param parent_id: Parent session to wake, e.g. ``"conv_parent123"``.
     :param notice: The ``[System: ...]`` notice text to inject.
+    :param created_by: Human actor that dispatched the completed child
+        turn, if known.
     :returns: ``True`` if a 2xx was confirmed, ``False`` if every attempt
         failed (transport error, timeout, or non-2xx response).
     """
@@ -1294,6 +1305,7 @@ async def _deliver_subagent_wake_post(
                         "role": "user",
                         "content": [{"type": "input_text", "text": notice}],
                     },
+                    **({"created_by": created_by} if created_by is not None else {}),
                 },
                 # The server gates this injected wake at the parent's REQUEST
                 # phase, which can PARK on a human ASK (e.g. session_cost_budget)
@@ -5504,8 +5516,12 @@ def create_runner_app(
                 _ingest_now_serving[session_id] = _seq + 1
                 _cond.notify_all()
 
-    async def _post_subagent_wake_notice(parent_id: str, notice: str, child_id: str) -> None:
-        delivered = await _deliver_subagent_wake_post(server_client, parent_id, notice)
+    async def _post_subagent_wake_notice(
+        parent_id: str, notice: str, child_id: str, created_by: str | None
+    ) -> None:
+        delivered = await _deliver_subagent_wake_post(
+            server_client, parent_id, notice, created_by=created_by
+        )
         if not delivered:
             _subagent_wake_pending.discard(parent_id)
             _logger.warning(
@@ -5536,7 +5552,12 @@ def create_runner_app(
             pending=inbox.qsize(),
         )
         _wake_task = loop.create_task(
-            _post_subagent_wake_notice(entry.parent_session_id, notice, entry.child_session_id)
+            _post_subagent_wake_notice(
+                entry.parent_session_id,
+                notice,
+                entry.child_session_id,
+                entry.created_by,
+            )
         )
         _wake_task.add_done_callback(_background_tasks.discard)
         _background_tasks.add(_wake_task)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1295,6 +1295,7 @@ async def _deliver_subagent_wake_post(
     :returns: ``True`` if a 2xx was confirmed, ``False`` if every attempt
         failed (transport error, timeout, or non-2xx response).
     """
+    attribution_created_by = created_by
     for attempt in range(1, _WAKE_POST_MAX_ATTEMPTS + 1):
         try:
             resp = await server_client.post(
@@ -1305,7 +1306,11 @@ async def _deliver_subagent_wake_post(
                         "role": "user",
                         "content": [{"type": "input_text", "text": notice}],
                     },
-                    **({"created_by": created_by} if created_by is not None else {}),
+                    **(
+                        {"created_by": attribution_created_by}
+                        if attribution_created_by is not None
+                        else {}
+                    ),
                 },
                 # The server gates this injected wake at the parent's REQUEST
                 # phase, which can PARK on a human ASK (e.g. session_cost_budget)
@@ -1324,6 +1329,18 @@ async def _deliver_subagent_wake_post(
             resp.raise_for_status()
             return True
         except (httpx.HTTPError, asyncio.TimeoutError) as exc:
+            if (
+                attribution_created_by is not None
+                and isinstance(exc, httpx.HTTPStatusError)
+                and exc.response.status_code == 403
+            ):
+                _logger.debug(
+                    "Sub-agent wake POST attribution rejected for parent=%s; "
+                    "retrying without actor",
+                    parent_id,
+                )
+                attribution_created_by = None
+                continue
             last_attempt = attempt >= _WAKE_POST_MAX_ATTEMPTS
             retryable = isinstance(exc, asyncio.TimeoutError) or _wake_post_is_retryable(exc)
             _logger.debug(

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -1001,6 +1001,49 @@ async def _session_turn_actor(
     return actor if isinstance(actor, str) and actor else None
 
 
+async def _post_child_message_event(
+    server_client: httpx.AsyncClient,
+    session_id: str,
+    *,
+    content: list[dict[str, Any]],
+    created_by: str | None,
+) -> httpx.Response:
+    """Post a child message, retrying once without best-effort attribution."""
+
+    def _payload(actor: str | None) -> dict[str, Any]:
+        return {
+            "type": "message",
+            "data": {
+                "role": "user",
+                "content": content,
+            },
+            **({"created_by": actor} if actor is not None else {}),
+        }
+
+    resp = await server_client.post(
+        f"/v1/sessions/{session_id}/events",
+        json=_payload(created_by),
+        # This message is gated at the recipient's REQUEST phase, which can
+        # PARK on a human ASK (e.g. session_cost_budget) up to the policy's
+        # ``ask_timeout``. A 30s read budget severed that park → fail-closed
+        # /retry → duplicate cards. Wait for the real verdict (one-day read
+        # budget, fast connect); a non-parking eval still returns immediately.
+        timeout=_ASK_GATE_DELIVERY_TIMEOUT,
+    )
+    if created_by is None or resp.status_code != 403:
+        return resp
+
+    _logger.debug(
+        "Child message POST attribution rejected for session=%s; retrying without actor",
+        session_id,
+    )
+    return await server_client.post(
+        f"/v1/sessions/{session_id}/events",
+        json=_payload(None),
+        timeout=_ASK_GATE_DELIVERY_TIMEOUT,
+    )
+
+
 def _subagent_model_from_args(args: dict[str, Any]) -> str | None:
     """
     Extract and validate the per-dispatch model from ``sys_session_send`` args.
@@ -1880,22 +1923,11 @@ async def _execute_subagent_tool(
     # post_event forwards it to the runner and starts the child
     # turn.
     try:
-        msg_resp = await server_client.post(
-            f"/v1/sessions/{child_session_id}/events",
-            json={
-                "type": "message",
-                "data": {
-                    "role": "user",
-                    "content": message_content,
-                },
-                **({"created_by": dispatch_created_by} if dispatch_created_by is not None else {}),
-            },
-            # This message is gated at the recipient's REQUEST phase, which can
-            # PARK on a human ASK (e.g. session_cost_budget) up to the policy's
-            # ``ask_timeout``. A 30s read budget severed that park → fail-closed
-            # /retry → duplicate cards. Wait for the real verdict (one-day read
-            # budget, fast connect); a non-parking eval still returns immediately.
-            timeout=_ASK_GATE_DELIVERY_TIMEOUT,
+        msg_resp = await _post_child_message_event(
+            server_client,
+            child_session_id,
+            content=message_content,
+            created_by=dispatch_created_by,
         )
     except httpx.HTTPError as exc:
         teardown_warning = await _teardown_failed_child(
@@ -2042,21 +2074,11 @@ async def _send_to_existing_session(
     )
 
     try:
-        msg_resp = await server_client.post(
-            f"/v1/sessions/{target_session_id}/events",
-            json={
-                "type": "message",
-                "data": {
-                    "role": "user",
-                    "content": [{"type": "input_text", "text": message}],
-                },
-                **({"created_by": created_by} if created_by is not None else {}),
-            },
-            # Same as the other message-send: gated at the recipient's REQUEST
-            # phase, which can PARK on a human ASK up to the policy's
-            # ``ask_timeout``. Wait for the real verdict (one-day read budget,
-            # fast connect) instead of severing at 30s and retrying into duplicates.
-            timeout=_ASK_GATE_DELIVERY_TIMEOUT,
+        msg_resp = await _post_child_message_event(
+            server_client,
+            target_session_id,
+            content=[{"type": "input_text", "text": message}],
+            created_by=created_by,
         )
     except httpx.HTTPError as exc:
         _runner_app.unregister_child_session(target_session_id)

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -1526,10 +1526,6 @@ async def _execute_subagent_tool(
         _runner_app._session_inboxes_ref.setdefault(conversation_id, session_inbox)
     elif conversation_id not in _runner_app._session_inboxes_ref:
         return "Error: sys_session_send requires parent session inbox"
-    dispatch_created_by = await _session_turn_actor(
-        server_client=server_client,
-        conversation_id=conversation_id,
-    )
 
     try:
         model = _subagent_model_from_args(args)
@@ -1590,6 +1586,10 @@ async def _execute_subagent_tool(
                 "existing session. Re-send without 'cost_budget' to continue "
                 f"session {target_session_id!r}."
             )
+        dispatch_created_by = await _session_turn_actor(
+            server_client=server_client,
+            conversation_id=conversation_id,
+        )
         return await _send_to_existing_session(
             target_session_id,
             message,
@@ -1610,6 +1610,11 @@ async def _execute_subagent_tool(
     # Verify the sub-agent exists in the parent spec.
     if not _has_subagent(sub_agent_name, agent_spec):
         return f"Error: sub-agent {sub_agent_name!r} not found in agent spec"
+
+    dispatch_created_by = await _session_turn_actor(
+        server_client=server_client,
+        conversation_id=conversation_id,
+    )
 
     # Use the PARENT's agent_id — inline sub-agents are part of
     # the same bundle, not separately registered. The runner

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -212,6 +212,7 @@ _ASYNC_INBOX_TOOLS = frozenset(
 # continues child sessions. The read-only observability helpers
 # (peek/list/close) dispatch via ``_SESSION_QUERY_TOOLS`` below.
 _SUBAGENT_TOOLS = frozenset({"sys_session_send"})
+_TURN_ACTOR_LABEL = "omnigent.turn_actor"
 
 # Priority 5f.0a: Session-create write. ``sys_session_create`` spawns a
 # child session (parent forced to the caller) from an existing agent_id
@@ -981,6 +982,25 @@ def _subagent_message_from_args(args: dict[str, Any]) -> str | None:
     return None
 
 
+async def _session_turn_actor(
+    *,
+    server_client: httpx.AsyncClient,
+    conversation_id: str,
+) -> str | None:
+    """Return the parent turn actor label for runner-originated callbacks."""
+    try:
+        resp = await server_client.get(f"/v1/sessions/{conversation_id}", timeout=10.0)
+    except (httpx.HTTPError, RuntimeError):
+        return None
+    if resp.status_code != 200:
+        return None
+    labels = resp.json().get("labels")
+    if not isinstance(labels, dict):
+        return None
+    actor = labels.get(_TURN_ACTOR_LABEL)
+    return actor if isinstance(actor, str) and actor else None
+
+
 def _subagent_model_from_args(args: dict[str, Any]) -> str | None:
     """
     Extract and validate the per-dispatch model from ``sys_session_send`` args.
@@ -1463,6 +1483,10 @@ async def _execute_subagent_tool(
         _runner_app._session_inboxes_ref.setdefault(conversation_id, session_inbox)
     elif conversation_id not in _runner_app._session_inboxes_ref:
         return "Error: sys_session_send requires parent session inbox"
+    dispatch_created_by = await _session_turn_actor(
+        server_client=server_client,
+        conversation_id=conversation_id,
+    )
 
     try:
         model = _subagent_model_from_args(args)
@@ -1529,6 +1553,7 @@ async def _execute_subagent_tool(
             server_client=server_client,
             conversation_id=conversation_id,
             publish_event=publish_event,
+            created_by=dispatch_created_by,
         )
 
     # Named mode: (agent, title) spawn-or-continue.
@@ -1817,6 +1842,7 @@ async def _execute_subagent_tool(
         agent=str(sub_agent_name),
         title=session_name,
         wrapper_label=child_wrapper_label,
+        created_by=dispatch_created_by,
     )
     _publish_child_launching_update(
         parent_session_id=conversation_id,
@@ -1862,6 +1888,7 @@ async def _execute_subagent_tool(
                     "role": "user",
                     "content": message_content,
                 },
+                **({"created_by": dispatch_created_by} if dispatch_created_by is not None else {}),
             },
             # This message is gated at the recipient's REQUEST phase, which can
             # PARK on a human ASK (e.g. session_cost_budget) up to the policy's
@@ -1921,6 +1948,7 @@ async def _send_to_existing_session(
     server_client: httpx.AsyncClient,
     conversation_id: str,
     publish_event: Callable[[str, dict[str, Any]], None] | None = None,
+    created_by: str | None = None,
 ) -> str:
     """
     Post a message to an existing direct-child session, return a handle.
@@ -2002,6 +2030,7 @@ async def _send_to_existing_session(
         agent=agent_label,
         title=parsed.title or "",
         wrapper_label=_session_wrapper_label(snap_data),
+        created_by=created_by,
     )
     _publish_child_launching_update(
         parent_session_id=conversation_id,
@@ -2021,6 +2050,7 @@ async def _send_to_existing_session(
                     "role": "user",
                     "content": [{"type": "input_text", "text": message}],
                 },
+                **({"created_by": created_by} if created_by is not None else {}),
             },
             # Same as the other message-send: gated at the recipient's REQUEST
             # phase, which can PARK on a human ASK up to the policy's

--- a/omnigent/server/routes/sessions/__init__.py
+++ b/omnigent/server/routes/sessions/__init__.py
@@ -508,6 +508,7 @@ def create_sessions_router(
         runner_exit_reports=runner_exit_reports,
         host_registry=host_registry,
         background_title_coordinator=background_title_coordinator,
+        runner_tunnel_tokens=runner_tunnel_tokens,
     )
 
     register_permissions_routes(

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -218,6 +218,16 @@ def register_events_routes(
             conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
             if conv is None:
                 raise _session_not_found()
+        body_created_by = _attribution_user(body.created_by)
+        if body_created_by is not None:
+            await _require_access_and_level(
+                body_created_by,
+                session_id,
+                LEVEL_EDIT,
+                permission_store,
+                conversation_store,
+            )
+        created_by = body_created_by or _attribution_user(user_id)
         # Validate event type at the route boundary. Anything not in
         # ``_ALLOWED_EVENT_TYPES`` is a client mistake — failing here
         # is far better than silently persisting an item the agent
@@ -649,7 +659,7 @@ def register_events_routes(
                 conv,
                 body,
                 conversation_store,
-                created_by=_attribution_user(user_id),
+                created_by=created_by,
                 background_title_coordinator=background_title_coordinator,
             )
             return {"queued": False, "item_id": item_id}
@@ -1113,7 +1123,7 @@ def register_events_routes(
                             conversation_store,
                             launch_attempt.error,
                             runner_router,
-                            created_by=_attribution_user(user_id),
+                            created_by=created_by,
                         )
                         return {"queued": True, "item_id": item_id}
                     relaunched_runner_id = launch_attempt.runner_id
@@ -1197,7 +1207,7 @@ def register_events_routes(
                     conversation_store,
                     offline_error,
                     runner_router,
-                    created_by=_attribution_user(user_id),
+                    created_by=created_by,
                 )
                 return {"queued": True, "item_id": item_id}
             # Raise so the Omnigent server doesn't persist an item the
@@ -1275,7 +1285,7 @@ def register_events_routes(
                 runner_client,
                 agent=_agent,
                 has_mcp_servers=_has_mcp_servers,
-                created_by=_attribution_user(user_id),
+                created_by=created_by,
             )
             if pending_background_title is not None:
                 pending_background_title.schedule()
@@ -1290,7 +1300,7 @@ def register_events_routes(
             file_store=file_store,
             artifact_store=artifact_store,
             has_mcp_servers=_has_mcp_servers,
-            created_by=_attribution_user(user_id),
+            created_by=created_by,
             runner_router=runner_router,
             native_terminal_ready=native_terminal_ready,
         )

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -25,6 +25,7 @@ from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE as _HARNESS_NOT_CONFIGURED_ERROR_CODE,
 )
+from omnigent.runner.identity import RUNNER_TUNNEL_TOKEN_HEADER, token_bound_runner_id
 from omnigent.runner.routing import RunnerRouter
 from omnigent.runtime import (
     session_stream,
@@ -111,8 +112,18 @@ def register_events_routes(
     runner_exit_reports: RunnerExitReports | None = None,
     host_registry: HostRegistry | None = None,
     background_title_coordinator: BackgroundSessionTitleCoordinator | None = None,
+    runner_tunnel_tokens: frozenset[str] | None = None,
 ) -> None:
     """Register the events, stream, and delete routes on router."""
+
+    def _has_runner_created_by_authority(request: Request, conv: Any) -> bool:
+        token = (request.headers.get(RUNNER_TUNNEL_TOKEN_HEADER) or "").strip()
+        if not token:
+            return False
+        if runner_tunnel_tokens is not None and token in runner_tunnel_tokens:
+            return True
+        runner_id = getattr(conv, "runner_id", None)
+        return isinstance(runner_id, str) and token_bound_runner_id(token) == runner_id
 
     @router.post(
         "/sessions/{session_id}/events",
@@ -218,16 +229,26 @@ def register_events_routes(
             conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
             if conv is None:
                 raise _session_not_found()
+        created_by = _attribution_user(user_id)
         body_created_by = _attribution_user(body.created_by)
         if body_created_by is not None:
-            await _require_access_and_level(
-                body_created_by,
-                session_id,
-                LEVEL_EDIT,
-                permission_store,
-                conversation_store,
-            )
-        created_by = body_created_by or _attribution_user(user_id)
+            if not _has_runner_created_by_authority(request, conv):
+                raise OmnigentError(
+                    "created_by is reserved for runner-originated session events",
+                    code=ErrorCode.FORBIDDEN,
+                )
+            try:
+                await _require_access_and_level(
+                    body_created_by,
+                    session_id,
+                    LEVEL_EDIT,
+                    permission_store,
+                    conversation_store,
+                )
+            except OmnigentError:
+                pass
+            else:
+                created_by = body_created_by
         # Validate event type at the route boundary. Anything not in
         # ``_ALLOWED_EVENT_TYPES`` is a client mistake — failing here
         # is far better than silently persisting an item the agent

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1158,6 +1158,8 @@ class SessionEventInput(BaseModel):
         "description": "...", "parameters": {...}}}]``. Ignored
         when the event steers into an active task: that task's
         tools are fixed at start time.
+    :param created_by: Optional internal attribution actor for runner-
+        originated events that are triggered by a prior human turn.
     """
 
     type: str
@@ -1167,6 +1169,7 @@ class SessionEventInput(BaseModel):
     data: dict[str, Any] = Field(default_factory=dict)
     model_override: str | None = None
     tools: list[dict[str, Any]] | None = None
+    created_by: str | None = None
 
 
 class SessionGitOptions(BaseModel):

--- a/tests/e2e_ui/chat/test_codex_model_metadata.py
+++ b/tests/e2e_ui/chat/test_codex_model_metadata.py
@@ -123,8 +123,9 @@ def test_codex_native_picker_uses_raw_model_metadata(
     model_row = page.locator('[role="option"][data-model-id="gpt-5.5"]')
     expect(model_row).to_be_visible()
     expect(model_row).to_contain_text("Codex Pretty 5.5")
-    # Close the model listbox, then open the Effort dropdown.
-    page.keyboard.press("Escape")
+    # Re-select the current model to close the listbox without sending Escape
+    # to the surrounding dialog.
+    model_row.click()
     expect(model_row).to_be_hidden()
     effort_trigger = page.get_by_test_id("composer-config-effort")
     expect(effort_trigger).to_be_visible()

--- a/tests/runner/test_app_sessions_native_wake_forwarders.py
+++ b/tests/runner/test_app_sessions_native_wake_forwarders.py
@@ -28,10 +28,12 @@ class _WakePost:
     :param url: The path the wake notice was POSTed to, e.g.
         ``"/v1/sessions/0349c7f62dcaa06b868e9c088c39f062/events"``.
     :param notice: The injected notice text pulled out of the request body.
+    :param created_by: Optional attribution actor sent with the wake notice.
     """
 
     url: str
     notice: str
+    created_by: str | None = None
 
 
 class _QueuedResponseServerClient:
@@ -69,7 +71,14 @@ class _QueuedResponseServerClient:
         :raises AssertionError: If more POSTs are made than responses queued.
         """
         notice = json["data"]["content"][0]["text"]
-        self.calls.append(_WakePost(url=url, notice=notice))
+        created_by = json.get("created_by")
+        self.calls.append(
+            _WakePost(
+                url=url,
+                notice=notice,
+                created_by=created_by if isinstance(created_by, str) else None,
+            )
+        )
         assert self._responses, (
             f"Wake POST made {len(self.calls)} call(s) but only "
             f"{len(self.calls) - 1} response(s) were queued — the retry "
@@ -138,6 +147,23 @@ async def test_wake_post_retries_transient_503_then_succeeds(
     assert len(_no_wake_backoff) == 1, (
         f"Expected one backoff before the single retry, got {_no_wake_backoff}."
     )
+
+
+async def test_wake_post_carries_dispatch_actor() -> None:
+    """A wake notice preserves the collaborator that dispatched the child."""
+    parent_id = "5a81ef19fce549929c8f9925c2ee034f"
+    client = _QueuedResponseServerClient([_wake_response(200, parent_id)])
+
+    delivered = await runner_app_mod._deliver_subagent_wake_post(
+        client,  # type: ignore[arg-type]
+        parent_id,
+        "[System: worker completed]",
+        created_by="bob@example.com",
+    )
+
+    assert delivered is True
+    assert len(client.calls) == 1
+    assert client.calls[0].created_by == "bob@example.com"
 
 
 async def test_wake_post_persistent_503_returns_failure(

--- a/tests/runner/test_app_sessions_native_wake_forwarders.py
+++ b/tests/runner/test_app_sessions_native_wake_forwarders.py
@@ -166,6 +166,26 @@ async def test_wake_post_carries_dispatch_actor() -> None:
     assert client.calls[0].created_by == "bob@example.com"
 
 
+async def test_wake_post_retries_without_actor_when_attribution_is_rejected() -> None:
+    """A stale collaborator grant cannot permanently drop a parent wake."""
+    parent_id = "32561551610d43b39dc4e394b78ea89d"
+    client = _QueuedResponseServerClient(
+        [_wake_response(403, parent_id), _wake_response(200, parent_id)]
+    )
+
+    delivered = await runner_app_mod._deliver_subagent_wake_post(
+        client,  # type: ignore[arg-type]
+        parent_id,
+        "[System: worker completed]",
+        created_by="bob@example.com",
+    )
+
+    assert delivered is True
+    assert len(client.calls) == 2
+    assert client.calls[0].created_by == "bob@example.com"
+    assert client.calls[1].created_by is None
+
+
 async def test_wake_post_persistent_503_returns_failure(
     _no_wake_backoff: list[float],
 ) -> None:

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -2844,6 +2844,134 @@ async def test_sys_session_send_reuses_existing_child_session(
     assert published[-1]["child"]["busy"] is False
 
 
+@pytest.mark.asyncio
+async def test_sys_session_send_named_child_retries_without_rejected_actor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing runner token cannot make new-child dispatch teardown the child."""
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    event_posts: list[dict[str, Any]] = []
+    delete_posts = 0
+
+    monkeypatch.setattr(runner_app, "get_session_agent_id", lambda _sid: "ag_parent")
+    monkeypatch.setattr(runner_app, "register_child_session", lambda *a, **k: None)
+    session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        nonlocal delete_posts
+        if request.method == "GET" and request.url.path == "/v1/sessions/conv_parent_retry":
+            return httpx.Response(
+                200,
+                json={"labels": {"omnigent.turn_actor": "bob@example.com"}},
+            )
+        if (
+            request.method == "GET"
+            and request.url.path == "/v1/sessions/conv_parent_retry/child_sessions"
+        ):
+            return httpx.Response(200, json={"data": []})
+        if request.method == "POST" and request.url.path == "/v1/sessions":
+            return httpx.Response(201, json={"id": "conv_child_retry"})
+        if request.method == "POST" and request.url.path == "/v1/sessions/conv_child_retry/events":
+            event_posts.append(json.loads(request.content))
+            if len(event_posts) == 1:
+                return httpx.Response(403, json={"error": "created_by rejected"})
+            return httpx.Response(202, json={"queued": True})
+        if request.method == "DELETE" and request.url.path == "/v1/sessions/conv_child_retry":
+            delete_posts += 1
+            return httpx.Response(204)
+        return httpx.Response(404, json={"error": str(request.url)})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        try:
+            output = await execute_tool(
+                tool_name="sys_session_send",
+                arguments=json.dumps({"agent": "worker", "title": "retry", "args": "continue"}),
+                server_client=server_client,
+                conversation_id="conv_parent_retry",
+                agent_spec=SimpleNamespace(sub_agents=[SimpleNamespace(name="worker")]),
+                session_inbox=session_inbox,
+            )
+        finally:
+            runner_app.unregister_subagent_work("conv_child_retry")
+            runner_app._session_inboxes_ref.pop("conv_parent_retry", None)
+
+    payload = json.loads(output)
+    assert payload["conversation_id"] == "conv_child_retry"
+    assert payload["status"] == "launching"
+    assert len(event_posts) == 2
+    assert event_posts[0]["created_by"] == "bob@example.com"
+    assert "created_by" not in event_posts[1]
+    assert delete_posts == 0
+
+
+@pytest.mark.asyncio
+async def test_sys_session_send_existing_child_retries_without_rejected_actor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing runner token cannot make existing-child dispatch fail closed."""
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    event_posts: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(runner_app, "register_child_session", lambda *a, **k: None)
+    session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path == "/v1/sessions/conv_parent_existing":
+            return httpx.Response(
+                200,
+                json={"labels": {"omnigent.turn_actor": "bob@example.com"}},
+            )
+        if request.method == "GET" and request.url.path == "/v1/sessions/conv_existing_retry":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "conv_existing_retry",
+                    "parent_session_id": "conv_parent_existing",
+                    "title": "worker:retry",
+                },
+            )
+        if (
+            request.method == "POST"
+            and request.url.path == "/v1/sessions/conv_existing_retry/events"
+        ):
+            event_posts.append(json.loads(request.content))
+            if len(event_posts) == 1:
+                return httpx.Response(403, json={"error": "created_by rejected"})
+            return httpx.Response(202, json={"queued": True})
+        return httpx.Response(404, json={"error": str(request.url)})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        try:
+            output = await execute_tool(
+                tool_name="sys_session_send",
+                arguments=json.dumps({"session_id": "conv_existing_retry", "args": "continue"}),
+                server_client=server_client,
+                conversation_id="conv_parent_existing",
+                agent_spec=SimpleNamespace(sub_agents=[SimpleNamespace(name="worker")]),
+                session_inbox=session_inbox,
+            )
+        finally:
+            runner_app.unregister_subagent_work("conv_existing_retry")
+            runner_app._session_inboxes_ref.pop("conv_parent_existing", None)
+
+    payload = json.loads(output)
+    assert payload["conversation_id"] == "conv_existing_retry"
+    assert payload["status"] == "launching"
+    assert len(event_posts) == 2
+    assert event_posts[0]["created_by"] == "bob@example.com"
+    assert "created_by" not in event_posts[1]
+
+
 def _spec_with_subagent_harness(harness: str) -> SimpleNamespace:
     """
     Build a parent-spec stub declaring one ``worker`` sub-agent.

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -2778,6 +2778,11 @@ async def test_sys_session_send_reuses_existing_child_session(
 
     async def _server_handler(request: httpx.Request) -> httpx.Response:
         nonlocal create_posts
+        if request.method == "GET" and request.url.path == "/v1/sessions/conv_parent":
+            return httpx.Response(
+                200,
+                json={"labels": {"omnigent.turn_actor": "bob@example.com"}},
+            )
         if (
             request.method == "GET"
             and request.url.path == "/v1/sessions/conv_parent/child_sessions"
@@ -2832,6 +2837,7 @@ async def test_sys_session_send_reuses_existing_child_session(
     assert payload["conversation_id"] == "conv_existing"
     assert payload["status"] == "launching"
     assert "continued ok" not in payload["message"]
+    assert event_posts[0]["created_by"] == "bob@example.com"
     assert event_posts[0]["data"]["content"][0]["text"] == "continue"
     assert published[-1]["type"] == "session.child_session.updated"
     assert published[-1]["child"]["current_task_status"] == "launching"

--- a/tests/server/integration/test_sessions_attribution.py
+++ b/tests/server/integration/test_sessions_attribution.py
@@ -23,6 +23,7 @@ import pytest_asyncio
 from fastapi import FastAPI
 
 from omnigent.entities import MessageData, NewConversationItem
+from omnigent.runner.identity import RUNNER_TUNNEL_TOKEN_HEADER, token_bound_runner_id
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.server.app import create_app
 from omnigent.server.auth import LEVEL_EDIT
@@ -41,6 +42,16 @@ from omnigent.stores.permission_store.sqlalchemy_store import (
 )
 from tests.server.conftest import ControllableMockClient
 from tests.server.helpers import create_test_agent
+
+_RUNNER_BINDING_TOKEN = "runner-created-by-token"
+
+
+def _bind_runner(db_uri: str, session_id: str) -> dict[str, str]:
+    """Bind a test runner token to *session_id* and return request headers."""
+    runner_id = token_bound_runner_id(_RUNNER_BINDING_TOKEN)
+    assert SqlAlchemyConversationStore(db_uri).set_runner_id(session_id, runner_id) is True
+    return {RUNNER_TUNNEL_TOKEN_HEADER: _RUNNER_BINDING_TOKEN}
+
 
 # ── Route helper: actor is stamped onto the new item ─────────────────────────
 
@@ -246,6 +257,11 @@ class _CaptureRunnerClient:
         raise NotImplementedError
 
 
+async def _noop_relay_ready(*_: Any, **__: Any) -> None:
+    """Stand in for runner stream relay setup in attribution route tests."""
+    return
+
+
 @pytest.mark.asyncio
 async def test_post_event_records_authenticated_poster(
     auth_client: httpx.AsyncClient,
@@ -265,6 +281,7 @@ async def test_post_event_records_authenticated_poster(
         return _CaptureRunnerClient()
 
     monkeypatch.setattr(sessions_mod, "_get_runner_client", _stub)
+    monkeypatch.setattr(sessions_mod, "_ensure_runner_relay_ready", _noop_relay_ready)
 
     session_id = _seed_shared_session(
         db_uri,
@@ -294,6 +311,47 @@ async def test_post_event_uses_runner_supplied_created_by(
 ) -> None:
     """Runner-originated wake events preserve the triggering collaborator."""
     from omnigent.server.routes import sessions as sessions_mod
+    from omnigent.server.routes.sessions import routes_events as events_mod
+
+    async def _stub(*_: Any, **__: Any) -> _CaptureRunnerClient:
+        return _CaptureRunnerClient()
+
+    monkeypatch.setattr(sessions_mod, "_get_runner_client", _stub)
+    monkeypatch.setattr(events_mod, "_ensure_runner_relay_ready", _noop_relay_ready)
+
+    session_id = _seed_shared_session(
+        db_uri,
+        {"alice@example.com": LEVEL_EDIT, "bob@example.com": LEVEL_EDIT},
+    )
+    runner_headers = _bind_runner(db_uri, session_id)
+
+    resp = await auth_client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={
+            "type": "message",
+            "created_by": "bob@example.com",
+            "data": {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "[System: sub-agent done]"}],
+            },
+        },
+        headers={"X-Forwarded-Email": "alice@example.com", **runner_headers},
+    )
+    assert resp.status_code == 202, resp.text
+
+    items = await asyncio.to_thread(SqlAlchemyConversationStore(db_uri).list_items, session_id)
+    [persisted] = items.data
+    assert persisted.created_by == "bob@example.com"
+
+
+@pytest.mark.asyncio
+async def test_post_event_rejects_client_supplied_created_by(
+    auth_client: httpx.AsyncClient,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Co-editors cannot spoof another editor as the policy actor."""
+    from omnigent.server.routes import sessions as sessions_mod
 
     async def _stub(*_: Any, **__: Any) -> _CaptureRunnerClient:
         return _CaptureRunnerClient()
@@ -310,18 +368,50 @@ async def test_post_event_uses_runner_supplied_created_by(
         json={
             "type": "message",
             "created_by": "bob@example.com",
+            "data": {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        },
+        headers={"X-Forwarded-Email": "alice@example.com"},
+    )
+
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_post_event_stale_runner_created_by_falls_back_to_runner_user(
+    auth_client: httpx.AsyncClient,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A revoked collaborator cannot strand a trusted runner wake notice."""
+    from omnigent.server.routes import sessions as sessions_mod
+    from omnigent.server.routes.sessions import routes_events as events_mod
+
+    async def _stub(*_: Any, **__: Any) -> _CaptureRunnerClient:
+        return _CaptureRunnerClient()
+
+    monkeypatch.setattr(sessions_mod, "_get_runner_client", _stub)
+    monkeypatch.setattr(events_mod, "_ensure_runner_relay_ready", _noop_relay_ready)
+
+    session_id = _seed_shared_session(db_uri, {"alice@example.com": LEVEL_EDIT})
+    runner_headers = _bind_runner(db_uri, session_id)
+
+    resp = await auth_client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={
+            "type": "message",
+            "created_by": "bob@example.com",
             "data": {
                 "role": "user",
                 "content": [{"type": "input_text", "text": "[System: sub-agent done]"}],
             },
         },
-        headers={"X-Forwarded-Email": "alice@example.com"},
+        headers={"X-Forwarded-Email": "alice@example.com", **runner_headers},
     )
     assert resp.status_code == 202, resp.text
 
     items = await asyncio.to_thread(SqlAlchemyConversationStore(db_uri).list_items, session_id)
     [persisted] = items.data
-    assert persisted.created_by == "bob@example.com"
+    assert persisted.created_by == "alice@example.com"
 
 
 @pytest.mark.asyncio

--- a/tests/server/integration/test_sessions_attribution.py
+++ b/tests/server/integration/test_sessions_attribution.py
@@ -266,7 +266,10 @@ async def test_post_event_records_authenticated_poster(
 
     monkeypatch.setattr(sessions_mod, "_get_runner_client", _stub)
 
-    session_id = _seed_shared_session(db_uri, {"alice@example.com": LEVEL_EDIT})
+    session_id = _seed_shared_session(
+        db_uri,
+        {"alice@example.com": LEVEL_EDIT, "bob@example.com": LEVEL_EDIT},
+    )
 
     resp = await auth_client.post(
         f"/v1/sessions/{session_id}/events",
@@ -281,6 +284,44 @@ async def test_post_event_records_authenticated_poster(
     items = await asyncio.to_thread(SqlAlchemyConversationStore(db_uri).list_items, session_id)
     [persisted] = items.data
     assert persisted.created_by == "alice@example.com"
+
+
+@pytest.mark.asyncio
+async def test_post_event_uses_runner_supplied_created_by(
+    auth_client: httpx.AsyncClient,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runner-originated wake events preserve the triggering collaborator."""
+    from omnigent.server.routes import sessions as sessions_mod
+
+    async def _stub(*_: Any, **__: Any) -> _CaptureRunnerClient:
+        return _CaptureRunnerClient()
+
+    monkeypatch.setattr(sessions_mod, "_get_runner_client", _stub)
+
+    session_id = _seed_shared_session(
+        db_uri,
+        {"alice@example.com": LEVEL_EDIT, "bob@example.com": LEVEL_EDIT},
+    )
+
+    resp = await auth_client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={
+            "type": "message",
+            "created_by": "bob@example.com",
+            "data": {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "[System: sub-agent done]"}],
+            },
+        },
+        headers={"X-Forwarded-Email": "alice@example.com"},
+    )
+    assert resp.status_code == 202, resp.text
+
+    items = await asyncio.to_thread(SqlAlchemyConversationStore(db_uri).list_items, session_id)
+    [persisted] = items.data
+    assert persisted.created_by == "bob@example.com"
 
 
 @pytest.mark.asyncio

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -3560,6 +3560,7 @@ async def test_post_external_session_status_idle_forwards_persisted_assistant_ou
                 "data": {"status": "idle", "output": "AP_NATIVE_DONE"},
                 "model_override": None,
                 "tools": None,
+                "created_by": None,
             },
         }
     ]


### PR DESCRIPTION
## Related issue

Closes #2548

## Summary

Shared-session sub-agent completions currently wake the parent session through a runner-originated message that falls back to the session owner's auth token, so a collaborator's sub-agent result can appear authored by the wrong person. This threads the verified turn actor through the `sys_session_send` dispatch path and wake notice, while requiring any supplied attribution actor to still have edit access to the session.

- Records the parent turn actor on runner-local sub-agent work entries.
- Includes that actor on child message POSTs and parent wake-notice POSTs.
- Teaches session event ingestion to honor a supplied `created_by` actor after access validation.

ELI5: when Bob asks a helper agent to do work inside Alice's shared session, the “helper finished” note now says Bob caused it, not Alice.

```text
User B turn -> sys_session_send -> child session
     |              |                  |
     |              v                  v
     |       store created_by      child completes
     |                                 |
     v                                 v
parent wake notice <---------- created_by=User B
```

## Test Plan

- `env OMNIGENT_SKIP_WEB_UI=true uv run pytest tests/runner/test_app_sessions_native_wake_forwarders.py tests/server/integration/test_sessions_attribution.py tests/runner/test_runner_dispatch.py::test_sys_session_send_reuses_existing_child_session`
- `env OMNIGENT_SKIP_WEB_UI=true uv run pre-commit run`

## Demo

N/A — server/runner attribution fix with automated regression coverage.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Regression tests cover the wake POST payload, `sys_session_send` actor propagation, and session event persistence of a runner-supplied actor.

## Changelog

Shared-session sub-agent completion notices are attributed to the collaborator who dispatched the sub-agent.
