### PR TITLE
[tests] Stabilize Codex model metadata E2E

### DIFF
--- a/tests/e2e_ui/chat/test_codex_model_metadata.py
+++ b/tests/e2e_ui/chat/test_codex_model_metadata.py
@@ -125,7 +125,10 @@ def test_codex_native_picker_uses_raw_model_metadata(
     expect(model_row).to_contain_text("Codex Pretty 5.5")
     # Close the model listbox, then open the Effort dropdown.
     page.keyboard.press("Escape")
-    page.get_by_test_id("composer-config-effort").click()
+    expect(model_row).to_be_hidden()
+    effort_trigger = page.get_by_test_id("composer-config-effort")
+    expect(effort_trigger).to_be_visible()
+    effort_trigger.click()
     effort_row = page.locator('[role="option"][data-effort-level="xhigh"]')
     expect(effort_row).to_be_visible()
     expect(effort_row).to_contain_text("xhigh")


### PR DESCRIPTION
## Related issue

N/A

## Summary

The Codex model metadata E2E could race Radix Select teardown: after closing the Model listbox with `Escape`, the test immediately clicked the Effort trigger while the previous select was still animating/unmounting. Playwright sometimes saw the effort trigger detach mid-click and timed out.

- Wait for the model option to be hidden after `Escape` before interacting with the Effort select
- Re-resolve the Effort trigger and assert it is visible before clicking
- Keep the production UI unchanged; this only stabilizes the test interaction sequence

## Test Plan

- `python -m py_compile tests/e2e_ui/chat/test_codex_model_metadata.py`
- Attempted focused E2E verification: `pytest tests/e2e_ui/chat/test_codex_model_metadata.py::test_codex_native_picker_uses_raw_model_metadata --browser chromium`
  - Blocked in local setup because Corepack could not download `pnpm` from `registry.npmjs.org` (`ECONNREFUSED`)

## Demo

N/A — test-only change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This updates the existing flaky E2E test to wait for the first dropdown to close before opening the second dropdown. Full local E2E execution was blocked by Corepack/npm registry connectivity during fixture setup.

## Changelog

N/A — test-only change.
