### PR TITLE
fix(ci): install agent CLIs under RUNNER_TEMP so a repo-root package.json can't hoist them

### DIFF
--- a/.github/actions/run-omnigent-agent/action.yml
+++ b/.github/actions/run-omnigent-agent/action.yml
@@ -64,11 +64,15 @@ runs:
         CLAUDE_CODE_VERSION: ${{ inputs.claude-code-version }}
       run: |
         set -euo pipefail
-        mkdir -p "${GITHUB_WORKSPACE}/.cc-cli"
-        cd "${GITHUB_WORKSPACE}/.cc-cli"
+        # Install outside the checked-out tree: a repo-root package.json would
+        # otherwise capture this bare `npm install` and hoist it there, leaving
+        # this dir's node_modules empty.
+        CC_CLI_DIR="${RUNNER_TEMP}/omnigent-cc-cli"
+        mkdir -p "$CC_CLI_DIR"
+        cd "$CC_CLI_DIR"
         npm install --ignore-scripts --no-audit --no-fund "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
         node node_modules/@anthropic-ai/claude-code/install.cjs
-        echo "${GITHUB_WORKSPACE}/.cc-cli/node_modules/.bin" >> "$GITHUB_PATH"
+        echo "$CC_CLI_DIR/node_modules/.bin" >> "$GITHUB_PATH"
 
     - name: Write Omnigent provider config
       shell: bash

--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -254,10 +254,14 @@ jobs:
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
-          mkdir -p "${GITHUB_WORKSPACE}/.cc-cli" && cd "${GITHUB_WORKSPACE}/.cc-cli"
+          # Install outside the checked-out tree: a repo-root package.json would
+          # otherwise capture this bare `npm install` and hoist it there, leaving
+          # this dir's node_modules empty.
+          CC_CLI_DIR="${RUNNER_TEMP}/omnigent-cc-cli"
+          mkdir -p "$CC_CLI_DIR" && cd "$CC_CLI_DIR"
           npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.212
           node node_modules/@anthropic-ai/claude-code/install.cjs
-          echo "${GITHUB_WORKSPACE}/.cc-cli/node_modules/.bin" >> "$GITHUB_PATH"
+          echo "$CC_CLI_DIR/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Write Omnigent provider config
         if: steps.plan.outputs.proceed == 'true' && steps.creds.outputs.available == 'true'

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -179,10 +179,14 @@ jobs:
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
-          mkdir -p "${GITHUB_WORKSPACE}/.cc-cli" && cd "${GITHUB_WORKSPACE}/.cc-cli"
+          # Install outside the checked-out tree: a repo-root package.json would
+          # otherwise capture this bare `npm install` and hoist it there, leaving
+          # this dir's node_modules empty.
+          CC_CLI_DIR="${RUNNER_TEMP}/omnigent-cc-cli"
+          mkdir -p "$CC_CLI_DIR" && cd "$CC_CLI_DIR"
           npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.212
           node node_modules/@anthropic-ai/claude-code/install.cjs
-          echo "${GITHUB_WORKSPACE}/.cc-cli/node_modules/.bin" >> "$GITHUB_PATH"
+          echo "$CC_CLI_DIR/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Set LLM credentials
         if: steps.creds.outputs.available == 'true'

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -171,19 +171,26 @@ jobs:
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
-          mkdir -p "${GITHUB_WORKSPACE}/.cc-cli" && cd "${GITHUB_WORKSPACE}/.cc-cli"
+          # Install outside the checked-out tree: a repo-root package.json would
+          # otherwise capture this bare `npm install` and hoist it there, leaving
+          # this dir's node_modules empty.
+          CC_CLI_DIR="${RUNNER_TEMP}/omnigent-cc-cli"
+          mkdir -p "$CC_CLI_DIR" && cd "$CC_CLI_DIR"
           npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.212
           node node_modules/@anthropic-ai/claude-code/install.cjs
-          echo "${GITHUB_WORKSPACE}/.cc-cli/node_modules/.bin" >> "$GITHUB_PATH"
+          echo "$CC_CLI_DIR/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Install Codex CLI
         if: steps.trigger.outputs.skip != 'true' && steps.creds.outputs.available == 'true'
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
-          mkdir -p "${GITHUB_WORKSPACE}/.codex-cli" && cd "${GITHUB_WORKSPACE}/.codex-cli"
+          # Install outside the checked-out tree so a repo-root package.json
+          # can't capture this bare `npm install` and hoist it away from here.
+          CODEX_CLI_DIR="${RUNNER_TEMP}/omnigent-codex-cli"
+          mkdir -p "$CODEX_CLI_DIR" && cd "$CODEX_CLI_DIR"
           npm install --ignore-scripts --no-audit --no-fund @openai/codex@0.139.0
-          echo "${GITHUB_WORKSPACE}/.codex-cli/node_modules/.bin" >> "$GITHUB_PATH"
+          echo "$CODEX_CLI_DIR/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Set LLM credentials
         if: steps.trigger.outputs.skip != 'true' && steps.creds.outputs.available == 'true'

--- a/.github/workflows/security-triage.yml
+++ b/.github/workflows/security-triage.yml
@@ -195,10 +195,14 @@ jobs:
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
-          mkdir -p "${GITHUB_WORKSPACE}/.cc-cli" && cd "${GITHUB_WORKSPACE}/.cc-cli"
+          # Install outside the checked-out tree: a repo-root package.json would
+          # otherwise capture this bare `npm install` and hoist it there, leaving
+          # this dir's node_modules empty.
+          CC_CLI_DIR="${RUNNER_TEMP}/omnigent-cc-cli"
+          mkdir -p "$CC_CLI_DIR" && cd "$CC_CLI_DIR"
           npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.212
           node node_modules/@anthropic-ai/claude-code/install.cjs
-          echo "${GITHUB_WORKSPACE}/.cc-cli/node_modules/.bin" >> "$GITHUB_PATH"
+          echo "$CC_CLI_DIR/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Write gateway profile (~/.databrickscfg)
         if: steps.creds.outputs.available == 'true'


### PR DESCRIPTION
## Related issue

N/A

## Summary

The AI-agent CI workflows install the Claude Code / Codex CLIs with a bare `npm install` after `cd`-ing into a workspace subdir (`.cc-cli` / `.codex-cli`) that has no `package.json` of its own. npm walks **up** to the nearest ancestor `package.json` to find the project root.

- #3379 added a **repo-root `package.json`** (pnpm migration). That became the ancestor npm resolves, so the install landed in `${GITHUB_WORKSPACE}/node_modules` instead of the subdir. The follow-up `node node_modules/@anthropic-ai/claude-code/install.cjs` (run from the now-empty subdir) failed with `MODULE_NOT_FOUND`, reddening **Polly review**, **issue/security triage**, **doc-sync**, and the **run-omnigent-agent** action.
- The `added 2 packages` line in the logs was the tell — `claude-code` has zero deps, so an isolated install would report 1; "2" meant npm reconciled the whole root tree.
- A version bump (2.1.170 → 2.1.212, #3404) did **not** help because the failure is orthogonal to the package version — 2.1.212 ships `install.cjs` fine.

Fix: install into `${RUNNER_TEMP}/omnigent-{cc,codex}-cli` — **outside** the checked-out tree, so no ancestor `package.json` can ever capture the install. This matches the pattern `e2e-ui.yml` and `flake-stress-ui.yml` already use (those two were never affected precisely because they already install under `RUNNER_TEMP`).

## Test Plan

- Reproduced the hoisting offline: with a repo-root `package.json` present and none in the install subdir, `npm install <pkg>` mutates the **root** `package.json` and drops `node_modules` at the root, leaving the subdir empty → `MODULE_NOT_FOUND`. Installing under a sibling temp dir keeps `node_modules` local and leaves the root untouched.
- Confirmed `@anthropic-ai/claude-code@2.1.212` ships `install.cjs` and declares `postinstall: node install.cjs`, so the `--ignore-scripts` + explicit `node install.cjs` flow is still valid.
- `pre-commit run --files <changed>` passes (yaml syntax, whitespace, EOF).
- Real validation is CI itself: this PR's Polly review job exercises the patched `polly-review.yml` install step.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

CI-only change with no unit-testable surface. Verified by reproducing the npm parent-`package.json` hoisting behavior offline (both the failure and the fix) and by confirming the target package ships `install.cjs`. The patched Polly-review workflow validates itself on this PR.

This pull request and its description were written by Isaac.
