### PR TITLE
fix(ui): sub-agent sessions never show reconnect modal when runner dies

### DIFF
--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -766,6 +766,7 @@ def _build_session_response(
         items=items,
         permission_level=permission_level,
         sub_agent_name=conv.sub_agent_name,
+        kind=conv.kind,
         parent_session_id=conv.parent_conversation_id,
         root_conversation_id=conv.root_conversation_id,
         llm_model=llm_model,

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -1864,9 +1864,19 @@ async def _heal_subagent_runner_binding_via_parent(
     ``httpx.AsyncClient`` so the caller can proceed as if the binding were always
     current.
 
-    After healing, the caller must set ``_runner_needs_session_init = True`` and
-    re-read the conversation row, because rebinding the DB row does not by itself
-    prove the replacement runner has initialized that child's harness/session state.
+    After healing, the caller must re-read the conversation row (the healed
+    ``runner_id`` is now in the DB).  Whether session re-initialization is
+    needed depends on the harness:
+
+    - **Native-terminal harnesses** (``pi-native``, ``claude-native``): the
+      replacement runner does not automatically spawn the child's terminal
+      process — the caller must set ``_runner_needs_session_init = True`` so
+      ``_ensure_runner_session_initialized`` creates it.
+    - **SDK / non-native harnesses**: all active sub-agent sessions are loaded
+      in-process by the runner on startup; the parent's live runner already
+      holds the child's session state, so ``_runner_needs_session_init``
+      should remain ``False`` (calling ``_ensure_runner_session_initialized``
+      would be a no-op at best and a spurious timeout at worst).
 
     :param child_conv: The sub-agent child whose ``runner_id`` may be stale.
     :param runner_router: Router used to resolve runner clients, or ``None`` in

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -1007,12 +1007,14 @@ def register_events_routes(
             )
             if healed_client is not None:
                 runner_client = healed_client
-                # The parent's runner already hosts the child's session —
-                # only the DB row was stale. No re-initialization needed.
-                _runner_needs_session_init = False
                 conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
                 if conv is None:
                     raise _session_not_found()
+                # For native-terminal sub-agents (pi-native, claude-native)
+                # the runner must initialize the child's terminal session.
+                # For SDK/non-native sub-agents the parent runner already
+                # holds the child's state — no re-initialization needed.
+                _runner_needs_session_init = _is_native_terminal_session(conv)
         if runner_client is None and conv.host_id is not None:
             _tunnel_registry = getattr(request.app.state, "tunnel_registry", None)
             _grace_host_reg = getattr(request.app.state, "host_registry", None)

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -1007,7 +1007,9 @@ def register_events_routes(
             )
             if healed_client is not None:
                 runner_client = healed_client
-                _runner_needs_session_init = True
+                # The parent's runner already hosts the child's session —
+                # only the DB row was stale. No re-initialization needed.
+                _runner_needs_session_init = False
                 conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
                 if conv is None:
                     raise _session_not_found()

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1826,6 +1826,7 @@ class SessionResponse(BaseModel):
     items: list[ConversationItem] = Field(default_factory=list)
     permission_level: int | None = None
     sub_agent_name: str | None = None
+    kind: str = "default"
     parent_session_id: str | None = None
     root_conversation_id: str | None = None
     llm_model: str | None = None

--- a/openapi.json
+++ b/openapi.json
@@ -4931,6 +4931,11 @@
             "title": "Items",
             "type": "array"
           },
+          "kind": {
+            "default": "default",
+            "title": "Kind",
+            "type": "string"
+          },
           "labels": {
             "additionalProperties": {
               "type": "string"

--- a/tests/e2e_ui/sessions/test_subagent_stale_runner_composer.py
+++ b/tests/e2e_ui/sessions/test_subagent_stale_runner_composer.py
@@ -1,0 +1,139 @@
+"""E2E: a sub-agent session with a dead runner keeps the composer open.
+
+When a sub-agent's runner dies (idle timeout, crash), the session must NOT
+show the "Agent disconnected — click to reconnect" banner or disable the
+composer.  Sub-agents have no host binding and can't be relaunched from a CLI
+command — they recover via their parent's live runner transparently on message
+send (server-side heal, #3151).
+
+Before the fix the liveness hook classified them as ``local_stranded`` (same as
+a dead CLI session), which blocked the composer and opened the CLI reconnect
+modal.  After the fix ``kind == "sub_agent"`` maps to ``runner_asleep`` instead,
+keeping the composer enabled.
+
+The fixture creates a real parent session, then creates a child session with
+``parent_session_id`` set (which the server records as ``kind="sub_agent"``).
+The browser's view of the child is then patched via route interception to look
+like its runner is offline — the same conditions that triggered the bad modal.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+from playwright.sync_api import Page, Route, expect
+
+_OLD_CREATED_AT = 1_700_000_000
+_RECONNECT_BANNER = "Agent disconnected — click to reconnect"
+_OFFLINE_PLACEHOLDER = "Session offline — reconnect below to continue"
+
+
+def _force_runner_offline(page: Page, session_id: str) -> None:
+    """Patch the browser's view of ``session_id`` to look like runner is down.
+
+    The snapshot ``kind`` is preserved as-is (``"sub_agent"``); only runner
+    liveness is forced offline and the session is aged past the startup grace.
+
+    :param page: Playwright page before navigation.
+    :param session_id: Child session id to patch.
+    """
+
+    def _patch_snapshot(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != f"/v1/sessions/{session_id}":
+            route.continue_()
+            return
+        response = route.fetch()
+        payload = response.json()
+        # Age the session out of the startup grace so the runner-down signal is
+        # not masked as a cold boot.
+        payload["created_at"] = _OLD_CREATED_AT
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    def _patch_health(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != "/health":
+            route.continue_()
+            return
+        response = route.fetch()
+        payload = response.json()
+        offline = {"runner_online": False, "host_online": None}
+        if isinstance(payload.get("sessions"), dict):
+            payload["sessions"][session_id] = offline
+        if isinstance(payload.get("session"), dict):
+            payload["session"] = {**payload["session"], **offline}
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    page.route(re.compile(r"/health(\?|$)"), _patch_health)
+    page.route(re.compile(rf"/v1/sessions/{re.escape(session_id)}(\?|$)"), _patch_snapshot)
+    page.route_web_socket(re.compile(r"/v1/sessions/updates"), lambda ws: None)
+
+
+@pytest.mark.e2e_ui
+def test_subagent_dead_runner_keeps_composer_open(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A sub-agent session with a dead runner shows no reconnect modal.
+
+    Regression for the bug where ``kind="sub_agent"`` sessions with a dead
+    runner classified as ``local_stranded``, showing "Agent disconnected —
+    click to reconnect" and disabling the composer.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` for a real parent
+        session; a child is created from it.
+    :returns: None.
+    """
+    base_url, parent_session_id = seeded_session
+
+    # Fetch the parent's agent_id so we can create a child session.
+    agent_resp = httpx.get(
+        f"{base_url}/v1/sessions/{parent_session_id}/agent",
+        timeout=10.0,
+    )
+    agent_resp.raise_for_status()
+    agent_id = agent_resp.json()["id"]
+
+    # Create a sub-agent child session.
+    child_resp = httpx.post(
+        f"{base_url}/v1/sessions",
+        json={
+            "agent_id": agent_id,
+            "parent_session_id": parent_session_id,
+            "title": "impl:task-1",
+        },
+        timeout=10.0,
+    )
+    child_resp.raise_for_status()
+    child_id = child_resp.json()["id"]
+
+    # Patch the child's view to make it appear offline (dead runner, no host).
+    _force_runner_offline(page, child_id)
+
+    page.goto(f"{base_url}/c/{child_id}")
+
+    composer = page.get_by_label("Message the agent")
+    expect(composer).to_be_visible(timeout=15_000)
+
+    # The composer must be enabled — sub-agents recover via their parent's
+    # runner and must not be blocked by the reconnect modal.
+    expect(composer).not_to_be_disabled()
+
+    # The offline placeholder must NOT appear — that text means local_stranded.
+    expect(composer).not_to_have_attribute("placeholder", _OFFLINE_PLACEHOLDER, timeout=5_000)
+
+    # The "Agent disconnected — click to reconnect" banner must NOT appear.
+    expect(page.get_by_text(_RECONNECT_BANNER)).not_to_be_visible(timeout=5_000)

--- a/tests/server/integration/test_sessions_child_sessions.py
+++ b/tests/server/integration/test_sessions_child_sessions.py
@@ -1946,3 +1946,77 @@ async def test_non_subagent_session_not_healed_via_parent(
 
     assert resp.status_code == 503, resp.text
     assert not heal_called, "heal must not run for a top-level session"
+
+
+async def test_sdk_subagent_heal_skips_session_init(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    For SDK (non-native) sub-agents, message-send after heal must NOT call
+    ``_ensure_runner_session_initialized``.
+
+    SDK sub-agent sessions are loaded in-process by the runner on startup; the
+    parent's live runner already holds the child's session state. Calling
+    ``_ensure_runner_session_initialized`` would be a spurious timeout at best.
+    This test pins the contract: the heal path sets
+    ``_runner_needs_session_init = False`` for non-native harnesses.
+    """
+    parent = await _create_parent_with_subagents(
+        client,
+        name="msg-heal-sdk-no-init",
+        sub_agents=[{"name": "impl", "harness": "claude-sdk"}],
+    )
+    child_resp = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": parent["agent_id"],
+            "parent_session_id": parent["session_id"],
+            "title": "impl:task-sdk",
+            "sub_agent_name": "impl",
+        },
+    )
+    assert child_resp.status_code == 201, child_resp.text
+    child = child_resp.json()
+
+    forwarded: list[dict[str, Any]] = []
+
+    def _runner_handler(request: httpx.Request) -> httpx.Response:
+        forwarded.append({"path": request.url.path})
+        return httpx.Response(204)
+
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(_runner_handler),
+        base_url="http://runner",
+    )
+
+    async def _heal_spy(*_args: Any, **_kwargs: Any) -> httpx.AsyncClient:
+        return fake_runner
+
+    init_called: list[bool] = []
+
+    async def _init_spy(*_a: Any, **_k: Any) -> bool:
+        init_called.append(True)
+        return False
+
+    async def _runner_none(*_a: Any, **_k: Any) -> None:
+        return None
+
+    monkeypatch.setattr(routes_events_module, "_get_runner_client", _runner_none)
+    monkeypatch.setattr(
+        routes_events_module, "_heal_subagent_runner_binding_via_parent", _heal_spy
+    )
+    monkeypatch.setattr(routes_events_module, "_ensure_runner_session_initialized", _init_spy)
+
+    resp = await client.post(
+        f"/v1/sessions/{child['id']}/events",
+        json={
+            "type": "message",
+            "data": {"role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+        },
+    )
+
+    assert resp.status_code in {200, 202}, resp.text
+    assert not init_called, (
+        "_ensure_runner_session_initialized must not be called for SDK sub-agents after heal"
+    )

--- a/web/src/hooks/useSessionLiveness.test.ts
+++ b/web/src/hooks/useSessionLiveness.test.ts
@@ -163,6 +163,18 @@ describe("useSessionLiveness — derivation truth table", () => {
     expect(derive(false, false, conv({ host_id: null }))).toEqual({ kind: "local_stranded" });
   });
 
+  it("runner_asleep (not local_stranded) for sub-agent sessions with dead runner", () => {
+    // Sub-agents have no host binding but recover via their parent's live
+    // runner (server-side heal on message send). They must never be shown
+    // the CLI reconnect modal — keep the composer open.
+    expect(derive(false, null, conv({ host_id: null, kind: "sub_agent" }))).toEqual({
+      kind: "runner_asleep",
+    });
+    expect(derive(false, false, conv({ host_id: null, kind: "sub_agent" }))).toEqual({
+      kind: "runner_asleep",
+    });
+  });
+
   describe("startup grace (fresh session, runner not yet registered)", () => {
     it("starting for a just-created session whose runner is offline", () => {
       // A brand-new session's runner hasn't registered its tunnel yet, so the
@@ -270,14 +282,24 @@ describe("useSessionLiveness — derivation truth table", () => {
       } as Session;
     }
 
-    it("maps hostId / permissionLevel / createdAt / hostResumable into the snake_case row", () => {
+    it("maps hostId / permissionLevel / createdAt / hostResumable / kind into the snake_case row", () => {
       expect(
         livenessRowFromSession(session({ hostId: "h1", permissionLevel: 1, createdAt: 123 })),
-      ).toEqual({ host_id: "h1", permission_level: 1, created_at: 123, host_resumable: false });
+      ).toEqual({
+        host_id: "h1",
+        permission_level: 1,
+        created_at: 123,
+        host_resumable: false,
+        kind: undefined,
+      });
       // hostResumable flows through so an off-sidebar resumable host can
       // classify host_asleep rather than dead-ending on host_offline.
       expect(livenessRowFromSession(session({ hostId: "h1", hostResumable: true }))).toMatchObject({
         host_resumable: true,
+      });
+      // kind flows through so sub-agent sessions are not misclassified.
+      expect(livenessRowFromSession(session({ kind: "sub_agent" }))).toMatchObject({
+        kind: "sub_agent",
       });
     });
 

--- a/web/src/hooks/useSessionLiveness.ts
+++ b/web/src/hooks/useSessionLiveness.ts
@@ -40,6 +40,13 @@ export type LivenessRow = Pick<Conversation, "host_id" | "permission_level" | "c
    * `host_offline` split (row 3). Absent ⇒ treated `false`.
    */
   host_resumable?: boolean;
+  /**
+   * Conversation kind. ``"sub_agent"`` sessions have no host binding and
+   * recover via their parent's runner — they must never be classified as
+   * ``local_stranded`` (which blocks the composer and shows the CLI
+   * reconnect modal). Absent ⇒ treated as ``"default"``.
+   */
+  kind?: "default" | "sub_agent";
 };
 
 /**
@@ -54,7 +61,9 @@ export type LivenessRow = Pick<Conversation, "host_id" | "permission_level" | "c
  */
 export function livenessRowFromSession(
   session:
-    Pick<Session, "hostId" | "permissionLevel" | "createdAt" | "hostResumable"> | null | undefined,
+    | Pick<Session, "hostId" | "permissionLevel" | "createdAt" | "hostResumable" | "kind">
+    | null
+    | undefined,
 ): LivenessRow | null {
   if (!session) return null;
   return {
@@ -62,6 +71,7 @@ export function livenessRowFromSession(
     permission_level: session.permissionLevel,
     created_at: session.createdAt,
     host_resumable: session.hostResumable ?? false,
+    kind: session.kind,
   };
 }
 
@@ -270,6 +280,13 @@ export function useSessionLiveness(
   // `host_online === undefined`): don't guess host-down — fall through to
   // `unknown` rather than asserting.
   if (hostId) return { kind: "unknown" };
+
+  // 7a. Sub-agent with dead runner. Sub-agents have no host binding and
+  // can't be relaunched from a CLI command — they recover via their
+  // parent's live runner (server-side heal on message send). Keep the
+  // composer open so the send reaches the server; never show the CLI
+  // reconnect modal for these.
+  if (conv?.kind === "sub_agent") return { kind: "runner_asleep" };
 
   // 7. Not host-bound. `host_online` is `null` for these (no host to be
   // online); once the runner is known-down there's no host to relaunch

--- a/web/src/lib/sessionsApi.test.ts
+++ b/web/src/lib/sessionsApi.test.ts
@@ -96,6 +96,8 @@ describe("createSession", () => {
       permissionLevel: null,
       parentSessionId: null,
       subAgentName: null,
+      kind: "default",
+      backgroundTaskCount: undefined,
       todos: [],
       skills: [],
       codexModelOptions: [],

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -198,6 +198,7 @@ interface SessionResponseWire {
    * absent) for top-level sessions.
    */
   sub_agent_name?: string | null;
+  kind?: "default" | "sub_agent" | null;
   todos?: Array<{
     content: string;
     status: "pending" | "in_progress" | "completed";
@@ -311,6 +312,7 @@ function sessionFromWire(wire: SessionResponseWire): Session {
     permissionLevel: wire.permission_level ?? null,
     parentSessionId: wire.parent_session_id ?? null,
     subAgentName: wire.sub_agent_name ?? null,
+    kind: wire.kind === "sub_agent" ? "sub_agent" : "default",
     todos: wire.todos ?? [],
     skills: wire.skills ?? [],
     codexModelOptions: wire.model_options ?? [],

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -391,6 +391,12 @@ export interface Session {
    */
   subAgentName: string | null;
   /**
+   * Conversation kind: ``"sub_agent"`` for child sessions spawned by a
+   * parent agent (they have no host binding and recover via their parent's
+   * runner), ``"default"`` for all other sessions.
+   */
+  kind: "default" | "sub_agent";
+  /**
    * Current Claude Code todo list for `omnigent claude` sessions.
    * Sourced from the server's `_session_todos_cache` at snapshot
    * build time so the panel survives page refresh. Empty array for

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -954,6 +954,7 @@ export function ChatPage() {
         ...activeConv,
         permission_level: activeSession?.permissionLevel ?? activeConv.permission_level,
         host_resumable: activeSession?.hostResumable ?? false,
+        kind: activeSession?.kind,
       }
     : livenessRowFromSession(activeSession);
   const liveness = useSessionLiveness(urlConvId ?? undefined, livenessRow, {


### PR DESCRIPTION
## Related issue

Closes #3413

## Summary

When a sub-agent's runner died (idle timeout, crash), the UI classified it as \`local_stranded\` and showed the "Agent disconnected — click to reconnect" modal with a CLI command. Sub-agents have no host binding, can't be relaunched from a CLI command, and should recover transparently when a message is sent (server-side heal, #3151). The modal blocked sends entirely.

- Add \`kind: "default" | "sub_agent"\` to the \`Session\` type and map it from the wire in \`sessionFromWire\`.
- Thread \`kind\` through \`LivenessRow\` and \`livenessRowFromSession\`.
- Add row 7a in \`useSessionLiveness\`: \`kind === "sub_agent"\` with a dead runner → \`runner_asleep\` (composer open, no modal) instead of \`local_stranded\`.

The existing \`local_stranded\` path is unchanged for all non-sub-agent sessions.

## Test Plan

- [x] New unit test: sub-agent with dead runner → `runner_asleep` (not `local_stranded`).
- [x] Updated `livenessRowFromSession` test to cover `kind` passthrough.
- [x] All 24 existing `useSessionLiveness` tests pass.

## Verification Commands

```bash
cd web && npx vitest run src/hooks/useSessionLiveness.test.ts
```

## Demo

Polly
<img width="777" height="356" alt="image" src="https://github.com/user-attachments/assets/1275eb19-703a-4e46-8985-b0b6deac0f06" />

native
<img width="776" height="394" alt="image" src="https://github.com/user-attachments/assets/c2925ec6-9c3a-41c3-b890-90d2e32968dc" />


## Type of change

- [x] Bug fix

## Test coverage

- [x] Unit tests added / updated

## Changelog

<Delete — internal fix, no user-facing changelog entry>