### PR TITLE
fix(sessions): restrict shared-session approvals to owners

### DIFF
--- a/omnigent/server/routes/sessions/routes_elicitations.py
+++ b/omnigent/server/routes/sessions/routes_elicitations.py
@@ -25,6 +25,7 @@ from omnigent.server._elicitation_registry import (
 )
 from omnigent.server.auth import (
     LEVEL_EDIT,
+    LEVEL_OWNER,
     AuthProvider,
 )
 from omnigent.server.routes._auth_helpers import (
@@ -91,7 +92,7 @@ def register_elicitations_routes(
         The ``elicitation_id`` is taken from the URL rather than the
         body, so the unguessable id (``secrets.token_hex(16)``) is
         the capability scoping the resolution — combined with the
-        session-owner ``LEVEL_EDIT`` gate below and the server-side
+        session-owner ``LEVEL_OWNER`` gate below and the server-side
         ownership check inside :func:`_resolve_elicitation`.
 
         :param request: The inbound request, used for identity
@@ -110,7 +111,7 @@ def register_elicitations_routes(
         """
         user_id = _get_user_id(request, auth_provider)
         access = await _require_access_and_level(
-            user_id, session_id, LEVEL_EDIT, permission_store, conversation_store
+            user_id, session_id, LEVEL_OWNER, permission_store, conversation_store
         )
         conv = access.conversation
         if conv is None:

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -534,6 +534,11 @@ def register_events_routes(
                 pass
             return {"queued": False}
         if body.type == _APPROVAL_TYPE:
+            # Approval authorizes a tool to run with the session owner's
+            # execution identity, so shared editors may not resolve it.
+            await _require_access(
+                user_id, session_id, LEVEL_OWNER, permission_store, conversation_store
+            )
             # Deliver the verdict through the shared resolver: it
             # sets any server-side harness Future (owner-checked),
             # clears the sidebar badge, and forwards

--- a/tests/server/integration/test_sessions_elicitation_resolve_url.py
+++ b/tests/server/integration/test_sessions_elicitation_resolve_url.py
@@ -45,6 +45,7 @@ from omnigent.runtime import get_caps, session_stream
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.runtime.caps import RuntimeCaps
 from omnigent.server.app import create_app
+from omnigent.server.auth import LEVEL_EDIT
 from omnigent.spec.types import FunctionPolicySpec, FunctionRef
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 from omnigent.stores.artifact_store.local import LocalArtifactStore
@@ -1337,26 +1338,31 @@ async def test_resolve_url_cross_user_forbidden(
     auth_client: httpx.AsyncClient,
 ) -> None:
     """
-    A non-owner cannot reach the resolve endpoint when auth is
+    A shared editor cannot reach the resolve endpoint when auth is
     active.
 
-    Alice owns the session; Bob's POST to its resolve URL is rejected
-    by the ``LEVEL_EDIT`` access gate before any resolution runs. The
+    Alice owns the session and grants Bob edit access. Bob's POST to
+    its resolve URL is rejected by the ``LEVEL_OWNER`` access gate
+    before any resolution runs. The
     unguessable elicitation id is a capability, but session-owner
-    access control is the outer fence — Bob must not get past it even
-    with a valid-looking id.
+    access control is the outer fence — edit access must not authorize
+    tools that execute with Alice's credentials.
     """
     agent = await create_test_agent(auth_client, user="alice@example.com")
     session_id = await _create_session(auth_client, agent["id"], user="alice@example.com")
+    grant = await auth_client.put(
+        f"/v1/sessions/{session_id}/permissions",
+        json={"user_id": "bob@example.com", "level": LEVEL_EDIT},
+        headers={"X-Forwarded-Email": "alice@example.com"},
+    )
+    assert grant.status_code == 200, grant.text
 
     resp = await auth_client.post(
         f"/v1/sessions/{session_id}/elicitations/elicit_whatever/resolve",
         json={"action": "accept"},
         headers={"X-Forwarded-Email": "bob@example.com"},
     )
-    # Non-owner is denied (403 forbidden, or 404 to avoid leaking
-    # existence — both are acceptable refusals).
-    assert resp.status_code in (403, 404), resp.text
+    assert resp.status_code == 403, resp.text
 
 
 # ── GET /sessions/{id}/elicitations/{eid} (approval page) ────

--- a/tests/server/integration/test_sessions_permissions.py
+++ b/tests/server/integration/test_sessions_permissions.py
@@ -734,6 +734,41 @@ async def test_edit_grant_allows_post_but_blocks_permission_management(
     )
 
 
+async def test_edit_grant_cannot_resolve_approval_event(
+    auth_client: httpx.AsyncClient,
+) -> None:
+    """Only the owner may approve tools that run with owner credentials."""
+    agent = await create_test_agent(auth_client, user="bryan")
+    session = await _create_session_as(auth_client, agent["id"], "user-a")
+    session_id = session["id"]
+    grant = await _grant_permission(
+        auth_client,
+        session_id,
+        granter="user-a",
+        target_user="user-b",
+        level=LEVEL_EDIT,
+    )
+    assert grant.status_code == 200
+
+    approval = {
+        "type": "approval",
+        "data": {"elicitation_id": "elicit_test", "action": "accept"},
+    }
+    editor_response = await auth_client.post(
+        f"/v1/sessions/{session_id}/events",
+        json=approval,
+        headers={"X-Forwarded-Email": "user-b"},
+    )
+    assert editor_response.status_code == 403, editor_response.text
+
+    owner_response = await auth_client.post(
+        f"/v1/sessions/{session_id}/events",
+        json=approval,
+        headers={"X-Forwarded-Email": "user-a"},
+    )
+    assert owner_response.status_code == 202, owner_response.text
+
+
 async def test_archive_requires_owner_access(
     auth_client: httpx.AsyncClient,
 ) -> None:


### PR DESCRIPTION
## Related issue

Part of #2150

## Summary

Shared-session tools execute with the session owners runner identity and ambient credentials, so an edit grant must not also grant authority to approve those tools.

- Require owner access for both generic approval events and URL-based elicitation resolution.
- Keep shared editors able to steer sessions while preventing them from authorizing owner-credentialed tool calls.
- Add integration coverage for both approval entry points.

### ELI5

Alice owns the runner and shares a session with Bob. Bob may send messages, but only Alice may click Approve when the agent wants to run a protected tool using Alice credentials.

```text
Bob (editor) ── message ──> Alice session        allowed
Bob (editor) ── approve ──> Alice credentials    denied
Alice (owner) ─ approve ──> Alice credentials    allowed
```

## Test Plan

- [x] `OMNIGENT_SKIP_WEB_UI=true uv run pytest tests/server/integration/test_sessions_elicitation_resolve_url.py tests/server/integration/test_sessions_permissions.py -k "approval or elicitation or edit_grant or stop_session" -q` (24 passed)
- [x] `pre-commit run --files omnigent/server/routes/sessions/routes_events.py omnigent/server/routes/sessions/routes_elicitations.py tests/server/integration/test_sessions_permissions.py tests/server/integration/test_sessions_elicitation_resolve_url.py`
- [x] `uv run ruff check` and `uv run ruff format --check` on changed files

## Demo

N/A — server authorization change with no visual UI changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The integration tests exercise authenticated owner and editor requests through both approval route boundaries.

## Changelog

Only session owners can approve tools that run with owner credentials in shared sessions.