### PR TITLE
fix(sessions): validate policy-evaluate payloads per phase instead of failing open

### DIFF
--- a/omnigent/server/routes/sessions/routes_hooks.py
+++ b/omnigent/server/routes/sessions/routes_hooks.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, NamedTuple
 
 from fastapi import (
     APIRouter,
@@ -405,16 +405,74 @@ def register_hooks_routes(
             media_type="application/json",
         )
 
-    # ── Proto event-type → internal Phase mapping ────────────────────
-    _PROTO_EVENT_TYPE_TO_PHASE: dict[str, Phase] = {
-        "PHASE_TOOL_CALL": Phase.TOOL_CALL,
-        "PHASE_TOOL_RESULT": Phase.TOOL_RESULT,
-        "PHASE_LLM_REQUEST": Phase.LLM_REQUEST,
-        "PHASE_LLM_RESPONSE": Phase.LLM_RESPONSE,
+    # ── Proto event-type → validation schema, as ONE total mapping ────
+    #
+    # This used to be three independent structures: which wire types are
+    # accepted, which phases require an object payload, and which phases
+    # need a tool name and where it may come from. The docstring on each
+    # said "one schema per phase" while the code let you add a wire type to
+    # the first table alone — the new phase was then accepted, validated as
+    # permissively as possible (``dict | str``), and got no tool-name rule
+    # at all, because the other two tables simply had no entry for it and
+    # every lookup against them used a permissive default (``in a
+    # frozenset`` / ``.get(phase, ())``).
+    #
+    # A NamedTuple with no defaults on either field makes that impossible:
+    # you cannot add a wire type without also deciding, right there, both
+    # whether its payload must be an object and where its tool name (if any)
+    # comes from. There is deliberately no fallback path for a phase this
+    # dict doesn't recognize — the "Unknown event type" branch below is the
+    # only way to reach past it, and it 400s rather than silently allowing.
+    #
+    # ``data`` shape: tool and LLM phases carry a structured payload, so a
+    # string there is a malformed call. REQUEST carries prompt text and is
+    # the only phase where a bare string is a legitimate wire form.
+    #
+    # Tool name containers are listed in precedence order because two
+    # first-party producers spell it differently: claude-native and the
+    # in-process tool dispatch send ``request_data.name``, while the OpenCode
+    # plugin sends the tool in ``event.target``. Both are established wire
+    # shapes; requiring one spelling 400s the other, and that producer treats
+    # any non-2xx as ALLOW — so a stricter guard silently disabled its
+    # policies instead of tightening them.
+    class _PhaseSchema(NamedTuple):
+        phase: Phase
+        data_must_be_object: bool
+        tool_name_sources: tuple[tuple[str, str], ...]
+
+    _PHASE_SCHEMA_BY_WIRE_TYPE: dict[str, _PhaseSchema] = {
+        "PHASE_TOOL_CALL": _PhaseSchema(
+            phase=Phase.TOOL_CALL,
+            data_must_be_object=True,
+            tool_name_sources=(("data", "event.data.name"),),
+        ),
+        "PHASE_TOOL_RESULT": _PhaseSchema(
+            phase=Phase.TOOL_RESULT,
+            data_must_be_object=True,
+            tool_name_sources=(
+                ("request_data", "event.request_data.name"),
+                ("target", "event.target"),
+            ),
+        ),
+        "PHASE_LLM_REQUEST": _PhaseSchema(
+            phase=Phase.LLM_REQUEST,
+            data_must_be_object=True,
+            tool_name_sources=(),
+        ),
+        "PHASE_LLM_RESPONSE": _PhaseSchema(
+            phase=Phase.LLM_RESPONSE,
+            data_must_be_object=True,
+            tool_name_sources=(),
+        ),
         # A native session's UserPromptSubmit hook posts the request phase
         # here (the server-level _evaluate_input_policy skips native message
-        # events). The prompt text rides in ``event.data.text``.
-        "PHASE_REQUEST": Phase.REQUEST,
+        # events). The prompt text rides in ``event.data.text``, and this is
+        # the only phase where ``data`` as a bare string is legitimate.
+        "PHASE_REQUEST": _PhaseSchema(
+            phase=Phase.REQUEST,
+            data_must_be_object=False,
+            tool_name_sources=(),
+        ),
     }
     _PHASE_TO_PROTO_ACTION: dict[PolicyAction, str] = {
         PolicyAction.ALLOW: "POLICY_ACTION_ALLOW",
@@ -487,13 +545,21 @@ def register_hooks_routes(
                 code=ErrorCode.INVALID_INPUT,
             )
         event_type = event.get("type")
-        phase = _PROTO_EVENT_TYPE_TO_PHASE.get(event_type or "")
-        if phase is None:
+        if event_type is not None and not isinstance(event_type, str):
+            # An unhashable type (list / dict) would raise inside the phase
+            # lookup below and surface as a 500 instead of a client error.
             raise OmnigentError(
-                f"Unknown event type: {event_type!r}. "
-                f"Expected one of {list(_PROTO_EVENT_TYPE_TO_PHASE)}.",
+                f"Policy evaluate 'event.type' must be a string; got {type(event_type).__name__}.",
                 code=ErrorCode.INVALID_INPUT,
             )
+        schema = _PHASE_SCHEMA_BY_WIRE_TYPE.get(event_type or "")
+        if schema is None:
+            raise OmnigentError(
+                f"Unknown event type: {event_type!r}. "
+                f"Expected one of {list(_PHASE_SCHEMA_BY_WIRE_TYPE)}.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        phase = schema.phase
         # Optional stable re-attach id for hook retries. Validated but not
         # required — absent on non-retrying callers (old hooks, direct API use).
         raw_elicitation_id = payload.get("_omnigent_elicitation_id")
@@ -508,7 +574,80 @@ def register_hooks_routes(
                     code=ErrorCode.INVALID_INPUT,
                 )
             hook_elicitation_id = raw_elicitation_id
-        data = event.get("data") or {}
+        # Validation is driven from the per-phase schema above rather than
+        # from a chain of conditionals: rules that live in branches get
+        # applied to whichever phase happens to reach that branch. The three
+        # rules below are independent and all of them run for every phase.
+        #
+        # Everything is checked BEFORE normalizing. ``or {}`` turns null,
+        # false, 0, "" and [] into an empty object, and a tool phase
+        # evaluating with no name gates with ``tool_name=None``, which skips
+        # every tool-scoped policy — on a hook that blocks, that fails open.
+        raw_data = event.get("data")
+        if schema.data_must_be_object:
+            # An absent payload is as malformed as a wrongly typed one here:
+            # ``None`` normalized to ``{}`` and evaluated as an empty call,
+            # which was the original defect's headline vector.
+            if not isinstance(raw_data, dict):
+                raise OmnigentError(
+                    f"Policy evaluate 'event.data' must be an object for "
+                    f"{event_type!r}; got {type(raw_data).__name__}.",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+        elif not isinstance(raw_data, (dict, str)):
+            # Absent is malformed here too: every first-party producer of this
+            # phase sends the prompt text, and ``None`` normalized to ``{}``
+            # gates on an empty prompt.
+            raise OmnigentError(
+                f"Policy evaluate 'event.data' must be an object or string for "
+                f"{event_type!r}; got {type(raw_data).__name__}.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        # A tool-scoped gate cannot run without a tool name, and allowing by
+        # default is the wrong direction on a blocking hook. Producers spell
+        # the name in different places, so any declared source satisfies the
+        # rule; the resolved name is written back to the container the engine
+        # reads, so the guard and the gate agree on it.
+        name_sources = schema.tool_name_sources
+        if name_sources:
+            resolved_name: str | None = None
+            for container_key, _field_path in name_sources:
+                if container_key == "data":
+                    candidate = raw_data.get("name") if isinstance(raw_data, dict) else None
+                elif container_key == "target":
+                    candidate = event.get("target")
+                else:
+                    container = event.get(container_key)
+                    candidate = container.get("name") if isinstance(container, dict) else None
+                if isinstance(candidate, str) and candidate:
+                    resolved_name = candidate
+                    break
+            if resolved_name is None:
+                paths = " or ".join(repr(path) for _key, path in name_sources)
+                raise OmnigentError(
+                    f"Policy evaluate requires a non-empty tool name in {paths} "
+                    f"for {event_type!r}.",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+            primary_key = name_sources[0][0]
+            if primary_key != "data":
+                # Normalize onto the container the engine reads, so a producer
+                # that names the tool elsewhere gets tool-scoped policies too
+                # instead of merely passing validation.
+                primary = event.get(primary_key)
+                event[primary_key] = (
+                    {**primary, "name": resolved_name}
+                    if isinstance(primary, dict)
+                    else {"name": resolved_name}
+                )
+        data = raw_data or {}
+        raw_event_context = event.get("context")
+        if raw_event_context is not None and not isinstance(raw_event_context, dict):
+            raise OmnigentError(
+                f"Policy evaluate 'event.context' must be an object; got "
+                f"{type(raw_event_context).__name__}.",
+                code=ErrorCode.INVALID_INPUT,
+            )
 
         conv = conversation_store.get_conversation(session_id)
         if conv is None:

--- a/tests/server/integration/test_sessions_policy_evaluate.py
+++ b/tests/server/integration/test_sessions_policy_evaluate.py
@@ -63,6 +63,25 @@ def _deny_bash_tool(event: dict[str, Any]) -> dict[str, Any]:
     return {"result": "ALLOW"}
 
 
+def _deny_bash_tool_result(event: dict[str, Any]) -> dict[str, Any]:
+    """
+    Policy that denies tool RESULTS from Bash, scoped by tool name.
+
+    Reads the name from the container the engine populates, so it fires only
+    when the route resolved a tool name for this phase — which is what makes
+    the normalization of alternative wire spellings observable.
+
+    :param event: V0 event dict.
+    :returns: DENY for Bash tool results, ALLOW otherwise.
+    """
+    if event.get("type") != "tool_result":
+        return {"result": "ALLOW"}
+    # ``target`` is the resolved tool name in the V0 event dict.
+    if event.get("target") == "Bash":
+        return {"result": "DENY", "reason": "Bash results are blocked."}
+    return {"result": "ALLOW"}
+
+
 def _deny_sensitive_output(event: dict[str, Any]) -> dict[str, Any]:
     """
     Policy that denies tool results containing ``SECRET``.
@@ -1162,3 +1181,181 @@ async def test_llm_response_allow_when_no_matching_policy(
     assert body["result"] in ("POLICY_ACTION_ALLOW", "POLICY_ACTION_UNSPECIFIED"), (
         f"Expected ALLOW or UNSPECIFIED for no-policy session, got {body['result']}."
     )
+
+
+# The wire phases the evaluate route accepts, and whether ``event.data`` may
+# be a bare string on that phase. Both the guard and this table are derived
+# from the same rule, so a phase cannot be validated in production and left
+# out of the oracle — which is how null and empty-string survived a round.
+_EVALUATE_PHASES: tuple[tuple[str, bool], ...] = (
+    ("PHASE_TOOL_CALL", False),
+    ("PHASE_TOOL_RESULT", False),
+    ("PHASE_LLM_REQUEST", False),
+    ("PHASE_LLM_RESPONSE", False),
+    ("PHASE_REQUEST", True),
+)
+
+# Everything that is not an object, including the two that normalize to an
+# empty object rather than erroring. A non-empty list is included alongside
+# the empty one deliberately: both are non-dict and must be rejected the
+# same way, but a mutation that special-cased "falsy" values (None, False,
+# 0, "", []) while accepting any truthy non-dict would have passed with only
+# the empty list present — [] is falsy, [1] is not.
+_NON_OBJECT_DATA: tuple[tuple[object, str], ...] = (
+    (None, "null"),
+    (False, "false"),
+    (0, "zero"),
+    ("", "empty-string"),
+    ("a string", "raw-string"),
+    ([], "empty-list"),
+    ([1], "non-empty-list"),
+    (7, "int"),
+)
+
+
+def _valid_name_fields(phase: str) -> dict[str, object]:
+    """Fields that satisfy the tool-name rule for *phase*, if it has one."""
+    if phase == "PHASE_TOOL_RESULT":
+        return {"request_data": {"name": "Bash"}}
+    return {}
+
+
+def _malformed_evaluate_events() -> list[tuple[dict[str, object], str]]:
+    """Build the malformed-payload table from the rules being enforced.
+
+    Generated rather than hand-listed so neither rule can be covered for one
+    phase and missed for another — the defect this guard was written for, and
+    then repeated twice: once by validating raw ``data`` only on phases that
+    keep their tool name there, and once by accepting every falsy value that
+    normalizes to an empty object.
+    """
+    cases: list[tuple[dict[str, object], str]] = [
+        ({"type": ["not", "hashable"]}, "unhashable event.type"),
+    ]
+    for phase, allows_string in _EVALUATE_PHASES:
+        for bad, why in _NON_OBJECT_DATA:
+            if allows_string and isinstance(bad, str):
+                continue  # a legitimate wire form on this phase
+            event: dict[str, object] = {"type": phase, **_valid_name_fields(phase)}
+            if bad is not None:
+                event["data"] = bad
+            cases.append((event, f"{why} data on {phase}"))
+    cases += [
+        ({"type": "PHASE_TOOL_CALL", "data": {}}, "no name key in TOOL_CALL data"),
+        ({"type": "PHASE_TOOL_CALL", "data": {"name": ""}}, "empty TOOL_CALL name"),
+        ({"type": "PHASE_TOOL_CALL", "data": {"name": 7}}, "non-string TOOL_CALL name"),
+        ({"type": "PHASE_TOOL_RESULT", "data": {"result": "ok"}}, "no name source at all"),
+        (
+            {"type": "PHASE_TOOL_RESULT", "data": {"result": "ok"}, "request_data": {"name": ""}},
+            "empty request_data.name and no target",
+        ),
+        (
+            {"type": "PHASE_TOOL_RESULT", "data": {"result": "ok"}, "target": ""},
+            "empty target and no request_data",
+        ),
+        (
+            {"type": "PHASE_TOOL_RESULT", "data": {"result": "ok"}, "request_data": "a string"},
+            "non-object request_data with no target",
+        ),
+        (
+            {"type": "PHASE_TOOL_CALL", "data": {"name": "Bash"}, "context": 7},
+            "non-object context",
+        ),
+    ]
+    return cases
+
+
+@pytest.mark.asyncio
+async def test_policy_evaluate_rejects_malformed_event_shapes(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    Malformed hook payloads must be rejected with a structured 400.
+
+    Every falsy ``data`` here used to normalize to ``{}`` before validation
+    and return 200/ALLOW — on a tool phase that means tool-name-scoped
+    policies were skipped entirely on a BLOCKING hook, which is worse than
+    the 500s the earliest guards were added for. The phase strings are the
+    wire values (``PHASE_*``); using the internal names short-circuits at the
+    unknown-type check and never reaches these guards, so the suite once
+    stayed green with the validation deleted.
+
+    One session for the whole table: each case is an independent request, so a
+    fresh session per case bought nothing but setup time. Every acceptance is
+    collected before asserting, so one run reports every case that regressed,
+    and the structured error code is checked rather than the status alone.
+    """
+    from tests.server.helpers import create_test_session
+
+    snap = await create_test_session(client, title="malformed-events")
+    accepted: list[str] = []
+    for event, why in _malformed_evaluate_events():
+        resp = await client.post(
+            f"/v1/sessions/{snap['id']}/policies/evaluate",
+            json={"event": event},
+        )
+        if resp.status_code != 400:
+            accepted.append(f"{why}: {resp.status_code} {resp.text[:120]}")
+            continue
+        body = resp.json()
+        code = (body.get("error") or {}).get("code") if isinstance(body, dict) else None
+        if code != "invalid_input":
+            accepted.append(f"{why}: 400 but code={code!r}")
+    assert not accepted, "malformed payloads accepted:\n" + "\n".join(accepted)
+
+
+@pytest.mark.asyncio
+async def test_policy_evaluate_gates_every_first_party_tool_result_shape(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Both established spellings of the tool name are accepted AND gated.
+
+    Requiring ``request_data.name`` rejected the OpenCode plugin's shape,
+    which sends the tool in ``event.target`` — and that producer converts any
+    non-2xx into ALLOW, so a stricter guard silently disabled its policies
+    instead of tightening them.
+
+    Asserting a 200 would not be enough: the guard could accept the shape
+    while the engine still saw no tool name, leaving tool-scoped policies
+    skipped exactly as before. A tool-scoped DENY is asserted instead, so the
+    resolved name has to reach the container the engine reads.
+    """
+    deny_policy = FunctionPolicySpec(
+        name="admin__deny_bash_result",
+        on=None,
+        function=FunctionRef(path=f"{__name__}._deny_bash_tool_result"),
+    )
+    original_caps = get_caps()
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.get_caps",
+        lambda: RuntimeCaps(
+            execution_timeout=original_caps.execution_timeout,
+            default_policies=[deny_policy],
+        ),
+    )
+
+    agent = await create_test_agent(client)
+    session_id = await _create_session(client, agent["id"])
+    shapes = {
+        "request_data.name (claude-native, tool dispatch)": {
+            "type": "PHASE_TOOL_RESULT",
+            "data": {"result": "ok"},
+            "request_data": {"name": "Bash"},
+        },
+        "target (opencode plugin)": {
+            "type": "PHASE_TOOL_RESULT",
+            "data": {"result": "ok"},
+            "target": "Bash",
+        },
+    }
+    for why, event in shapes.items():
+        resp = await client.post(
+            f"/v1/sessions/{session_id}/policies/evaluate",
+            json={"event": event},
+        )
+        assert resp.status_code == 200, f"{why}: {resp.status_code} {resp.text[:160]}"
+        assert resp.json()["result"] == "POLICY_ACTION_DENY", (
+            f"{why}: the tool-scoped policy did not see a tool name — {resp.text[:160]}"
+        )

--- a/tests/server/routes/test_sessions_policy.py
+++ b/tests/server/routes/test_sessions_policy.py
@@ -959,8 +959,10 @@ async def test_output_deny_replaces_text():
 def test_build_evaluation_context_request_accepts_string_data() -> None:
     """REQUEST-phase ``data`` may be a bare string and must NOT raise.
 
-    opencode's policy plugin sends the prompt text directly as ``data`` for
-    PHASE_REQUEST (``{"event": {"type": "PHASE_REQUEST", "data": "<prompt>"}}``).
+    A bare string is accepted for compatibility with older or third-party
+    callers that send the prompt text directly rather than wrapped in an
+    object — OpenCode's own plugin used to be one of these, but now sends
+    ``{"text": ...}`` like the native hooks (see the dict-data test below).
     The old code did ``data.get("text")`` unconditionally and ``AttributeError``ed
     on a string, 500ing the evaluate endpoint — which silently failed the
     request-phase gate OPEN (cost-over-budget terminal prompts sailed through).


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

N/A — found review of DB-perf work (#3001, #3402, #3003, #3004, #3403), not a pre-filed report. Small and contained enough (3 files, no API/ABI change) that it didn't seem to warrant opening one first per CONTRIBUTING.md's "larger changes" bar.

## Summary

`/hooks/policy-evaluate` is a **blocking** hook — a harness waits on its allow/deny verdict before running a tool. Its payload validation rules were applied from a chain of conditionals, so a rule in one branch only ever ran for whichever phase happened to land in that branch. Three rules now come from one per-phase schema, and all three run for every phase, every time.

**ELI5**: the old code was three separate lookup tables (which wire types exist, which need an object payload, where the tool name lives), each with its own permissive fallback if a phase was missing. A phase added to the first table alone was silently accepted and validated as loosely as possible. Now there's one table, and every entry must answer all three questions at once — you can't add a phase without deciding what it validates against.

What was actually getting through, on production traffic, before this fix:

- **`event.data` was accepted as an object, a string, or absent, then normalized with `or {}`.** For a tool phase that meant a malformed or missing payload evaluated as though the caller had sent nothing — every tool-name-scoped policy silently skipped, and the hook answered allow on a call it should have gated.
- **Only one spelling of the tool name was accepted.** `claude-native` and the in-process tool dispatch send `request_data.name`; the OpenCode plugin sends it in `event.target`. Requiring the first rejected the second with a 400 — and that plugin treats any non-2xx as ALLOW, so every OpenCode `TOOL_RESULT` policy was silently disabled rather than tightened. Any declared source now satisfies the rule, and the resolved name is written onto the container the engine reads, so those policies actually gate instead of merely passing validation.
- **`event.context` wasn't validated as an object at all.**
- **`event.type` was used as a dict key before being checked.** An unhashable value raised inside the lookup and surfaced as a 500 instead of a 400.

## Test Plan

```bash
uv run --no-sync pytest tests/server/integration/test_sessions_policy_evaluate.py tests/server/routes/test_sessions_policy.py -q
uv run --no-sync ruff check omnigent/server/routes/sessions/routes_hooks.py
uv run --no-sync ruff format --check omnigent/server/routes/sessions/routes_hooks.py
```

## Demo

N/A — backend validation change, no UI surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The test table enumerates each phase and non-object-data vector and cross-multiplies them, rather than hand-listing every case, since the production schema lives inside a route-registration closure and isn't importable from a test module to check for drift directly. It asserts the structured error code, not just the HTTP status, and includes a non-empty list alongside the empty one — both are simply non-dict, but hand-listing only the empty list is coincidentally falsy in a way a narrower, wrong fix (special-casing falsy values) would still have passed. Five mutations kill it: accepting object-or-string-or-absent everywhere, requiring a single tool-name spelling, dropping the context rule, validating the alternative tool-name spelling without normalizing it onto the container the engine reads (caught because the oracle asserts a tool-scoped DENY, not just a 200), and giving one phase's schema entry a wrongly permissive object requirement. A pre-existing test's docstring claiming OpenCode sends `REQUEST` data as a bare string was also corrected — it now sends a structured payload like every other first-party producer; the bare-string acceptance is kept for older/third-party compatibility, worded accordingly.

## Changelog

Fixed a bug where a malformed or unrecognized tool-call payload on certain harnesses (notably OpenCode) could silently bypass a configured tool-call policy instead of being blocked or asked.
