### PR TITLE
feat(acp): support OpenClaw Gateway ACP registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,9 @@ omnigent hermes                      # Hermes Agent (Nous Research)
 omnigent pi                          # Pi
 ```
 
+Using OpenClaw? See the [OpenClaw integration guide](docs/openclaw.md) to import
+its coding agents or drive a live OpenClaw Gateway session over ACP.
+
 #### 🐙 Polly and 🟠🔵 Debby
 
 Two example agents ship with the repo, and they make good first sessions:

--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -169,6 +169,28 @@ executor:
 CLI flags such as `--harness qwen` and `--model <id>` can override or supply
 missing executor values.
 
+## Custom ACP agents
+
+`harness: acp:<slug>` runs any configured Agent Client Protocol server command.
+Register commands in `~/.omnigent/config.yaml` under `acp.agents`; the slug is
+derived from the agent name.
+
+OpenClaw's Gateway ACP bridge is one such server. It rejects per-session
+`mcpServers`, so disable Omnigent's MCP relay for that entry and let OpenClaw
+use its own tools, routing, memory, and channels:
+
+```yaml
+acp:
+  agents:
+    - name: OpenClaw
+      command: openclaw acp --url <gateway-url> --token <token>
+      omnigent_mcp: false
+```
+
+Then run it with `omni run --harness acp:openclaw` or select `OpenClaw` in the
+app. See the [OpenClaw integration guide](openclaw.md) for registry import,
+Gateway setup, and compatibility details.
+
 ## Local OS access
 
 Declare `os_env` only for agents that need local file/shell tools.

--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -183,7 +183,7 @@ use its own tools, routing, memory, and channels:
 acp:
   agents:
     - name: OpenClaw
-      command: openclaw acp --url <gateway-url> --token <token>
+      command: openclaw acp --url <gateway-url> --token-file <token-file>
       omnigent_mcp: false
 ```
 

--- a/docs/openclaw.md
+++ b/docs/openclaw.md
@@ -1,0 +1,96 @@
+# OpenClaw integration
+
+Omnigent can work with OpenClaw in two different ways:
+
+| Goal | What Omnigent drives | Setup |
+|---|---|---|
+| Use coding agents registered in OpenClaw/acpx | Each agent's ACP command directly | Import the registry or use `--from-openclaw` |
+| Use OpenClaw's routing, memory, and channels | The live OpenClaw Gateway through `openclaw acp` | Register the Gateway bridge as an `acp:` agent |
+
+Choose the first option when you want a coding agent such as Codex or Gemini
+inside Omnigent. Choose the second when OpenClaw itself is the assistant you
+want to reach from Omnigent.
+
+## Import coding agents
+
+Omnigent can read agent commands from either of OpenClaw's supported ACP
+registry locations:
+
+- `~/.acpx/config.json`
+- `~/.openclaw/openclaw.json`
+
+To import the discovered agents into `~/.omnigent/config.yaml`, run:
+
+```bash
+omni setup
+```
+
+Open **Configure harnesses**, select **Import from OpenClaw**, choose the
+detected registry, and confirm the agents to import. Each imported agent appears
+as `acp:<slug>` in Omnigent's harness picker and keeps its own authentication.
+Omnigent stores the launch command, not the agent's credentials.
+
+For a one-off run without changing Omnigent's config, address an agent by its
+OpenClaw/acpx registry name:
+
+```bash
+omni run --from-openclaw "Gemini CLI"
+```
+
+This path drives the selected coding agent directly. It does not bring
+OpenClaw's Gateway session, memory, routing, or channels into the conversation.
+
+## Drive the OpenClaw Gateway
+
+The `openclaw acp` command exposes a live OpenClaw Gateway session as an ACP
+server over stdio. Register that command in `~/.omnigent/config.yaml`:
+
+```yaml
+acp:
+  agents:
+    - name: OpenClaw
+      command: openclaw acp --url <gateway-url> --token <token>
+      omnigent_mcp: false
+```
+
+> [!CAUTION]
+> The Gateway token is stored as part of the launch command in
+> `~/.omnigent/config.yaml`. Do not commit or share that file, and use a token
+> with the narrowest permissions OpenClaw supports.
+
+Replace `<gateway-url>` and `<token>` with the connection details for your
+running Gateway, then launch it with:
+
+```bash
+omni run --harness acp:openclaw
+```
+
+The connection is a hub over a hub:
+
+```text
+Omnigent --ACP over stdio--> openclaw acp --WebSocket--> OpenClaw Gateway
+                                                        |-- routing
+                                                        |-- memory
+                                                        `-- channels and agents
+```
+
+### Why `omnigent_mcp` must be false
+
+Omnigent normally lends its builtin tools to ACP agents by including
+`mcpServers` in `session/new`. OpenClaw's Gateway bridge rejects per-session MCP
+servers, so the OpenClaw entry must set `omnigent_mcp: false`. OpenClaw keeps
+using its own tools; the setting only disables Omnigent's additional MCP relay
+for this agent.
+
+### Compatibility status
+
+The protocol-level path matches for initialization, session creation, prompts,
+cancellation, streaming updates, and permission requests. A full turn against a
+live OpenClaw Gateway still needs validation on an unmanaged machine to confirm
+that final assistant text streams back cleanly. OpenClaw cannot be installed or
+run in the project's managed development and CI environments.
+
+If session creation reports that `mcpServers` is unsupported, confirm that the
+entry contains `omnigent_mcp: false` and restart the Omnigent session. If the
+turn reaches OpenClaw but no final reply appears, capture both Omnigent and
+OpenClaw logs and report the behavior before relying on the integration.

--- a/docs/openclaw.md
+++ b/docs/openclaw.md
@@ -49,16 +49,16 @@ server over stdio. Register that command in `~/.omnigent/config.yaml`:
 acp:
   agents:
     - name: OpenClaw
-      command: openclaw acp --url <gateway-url> --token <token>
+      command: openclaw acp --url <gateway-url> --token-file <token-file>
       omnigent_mcp: false
 ```
 
 > [!CAUTION]
-> The Gateway token is stored as part of the launch command in
-> `~/.omnigent/config.yaml`. Do not commit or share that file, and use a token
+> Prefer `--token-file` so the Gateway token is not stored in the launch
+> command. Do not commit or share `~/.omnigent/config.yaml`, and use a token
 > with the narrowest permissions OpenClaw supports.
 
-Replace `<gateway-url>` and `<token>` with the connection details for your
+Replace `<gateway-url>` and `<token-file>` with the connection details for your
 running Gateway, then launch it with:
 
 ```bash
@@ -82,13 +82,30 @@ servers, so the OpenClaw entry must set `omnigent_mcp: false`. OpenClaw keeps
 using its own tools; the setting only disables Omnigent's additional MCP relay
 for this agent.
 
+### Session and tool boundaries
+
+Omni owns the outer conversation and transcript; OpenClaw owns the
+Gateway-backed ACP session. OpenClaw's Control UI is a separate Gateway client,
+not a second view that Omni continuously mirrors. Messages entered in the
+Control UI while Omni is offline are therefore not imported into the Omni
+conversation. Use Omni as the canonical conversation when you need its
+transcript and resume behavior.
+
+With `omnigent_mcp: false`, OpenClaw still has its own native tools (for
+example, shell and filesystem tools), but it does not receive Omnigent's
+additional MCP relay. Enabling the setting is currently incompatible with
+OpenClaw's Gateway ACP bridge because that bridge rejects per-session MCP
+servers.
+
 ### Compatibility status
 
 The protocol-level path matches for initialization, session creation, prompts,
-cancellation, streaming updates, and permission requests. A full turn against a
-live OpenClaw Gateway still needs validation on an unmanaged machine to confirm
-that final assistant text streams back cleanly. OpenClaw cannot be installed or
-run in the project's managed development and CI environments.
+cancellation, and streaming updates. Manual validation against a live Gateway
+has also confirmed the configured worktree, native shell/filesystem tools, and
+Omni conversation resume. Bidirectional synchronization with the OpenClaw
+Control UI and per-session Omnigent MCP are not supported by this integration.
+OpenClaw cannot be installed or run in the project's managed development and CI
+environments.
 
 If session creation reports that `mcpServers` is unsupported, confirm that the
 entry contains `omnigent_mcp: false` and restart the Omnigent session. If the

--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -3778,7 +3778,10 @@ def _run_configure_harnesses_interactive() -> None:
             openclaw_agents_to_acp_entries,
         )
 
-        acp_summary = acp_config_summary()
+        try:
+            acp_summary = acp_config_summary()
+        except ValueError as exc:
+            raise click.ClickException(f"Invalid acp.agents configuration: {exc}") from exc
         for agent in acp_summary.agents:
             rows.append(
                 (

--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -579,7 +579,12 @@ class AcpExecutor(Executor):
         if self._session_id is not None:
             return self._session_id
 
-        params: _AcpJsonObject = {"cwd": self._cwd}
+        params: _AcpJsonObject = {
+            "cwd": self._cwd,
+            # ACP requires this field even when no per-session MCP servers are
+            # configured. Keep it empty when Omnigent MCP is disabled.
+            "mcpServers": [],
+        }
         if self._config.omnigent_mcp:
             params["mcpServers"] = self._mcp.session_new_servers(
                 tools=self._omnigent_tools,

--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -579,13 +579,14 @@ class AcpExecutor(Executor):
         if self._session_id is not None:
             return self._session_id
 
-        mcp_servers = self._mcp.session_new_servers(
-            tools=self._omnigent_tools,
-            tool_executor=getattr(self, "_tool_executor", None),
-            loop=asyncio.get_event_loop(),
-            enabled=self._config.omnigent_mcp,
-        )
-        params: _AcpJsonObject = {"cwd": self._cwd, "mcpServers": mcp_servers}
+        params: _AcpJsonObject = {"cwd": self._cwd}
+        if self._config.omnigent_mcp:
+            params["mcpServers"] = self._mcp.session_new_servers(
+                tools=self._omnigent_tools,
+                tool_executor=getattr(self, "_tool_executor", None),
+                loop=asyncio.get_event_loop(),
+                enabled=True,
+            )
         client_id: str | None = None
         if self._config.session_id_mode == "client":
             client_id = secrets.token_urlsafe(16)

--- a/omnigent/inner/acp_harness.py
+++ b/omnigent/inner/acp_harness.py
@@ -24,6 +24,8 @@ Env vars read at startup:
   configured to accept one in ``session/new``).
 - ``HARNESS_ACP_SESSION_ID_MODE``: ``server`` (default) or ``client``.
 - ``HARNESS_ACP_SEND_MODEL``: ``"1"`` to send the model in ``session/new``.
+- ``HARNESS_ACP_OMNIGENT_MCP``: ``"0"`` to omit Omnigent's MCP relay from
+  ``session/new``.
 - ``HARNESS_ACP_OS_ENV``: JSON-encoded :class:`OSEnvSpec`. When unset, falls
   back to ``caller_process`` + ``sandbox=none``.
 - ``HARNESS_ACP_PROMPT_TIMEOUT_S``: optional idle (time-without-progress) deadline in
@@ -50,8 +52,16 @@ _ENV_NAME = "HARNESS_ACP_NAME"
 _ENV_MODEL = "HARNESS_ACP_MODEL"
 _ENV_SESSION_ID_MODE = "HARNESS_ACP_SESSION_ID_MODE"
 _ENV_SEND_MODEL = "HARNESS_ACP_SEND_MODEL"
+_ENV_OMNIGENT_MCP = "HARNESS_ACP_OMNIGENT_MCP"
 _ENV_CWD = "HARNESS_ACP_CWD"
 _ENV_OS_ENV = "HARNESS_ACP_OS_ENV"
+
+
+def _env_enabled(name: str, *, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
 
 
 def _resolve_os_env() -> OSEnvSpec:
@@ -99,7 +109,8 @@ def _build_acp_executor() -> Executor:
     name = os.environ.get(_ENV_NAME, "").strip() or "ACP agent"
     model = os.environ.get(_ENV_MODEL, "").strip() or None
     session_id_mode = os.environ.get(_ENV_SESSION_ID_MODE, "").strip() or "server"
-    send_model = os.environ.get(_ENV_SEND_MODEL, "").strip() in ("1", "true", "yes")
+    send_model = _env_enabled(_ENV_SEND_MODEL, default=False)
+    omnigent_mcp = _env_enabled(_ENV_OMNIGENT_MCP, default=True)
     cwd = os.environ.get(_ENV_CWD) or os.environ.get("OMNIGENT_RUNNER_WORKSPACE") or None
 
     config = AcpAgentConfig(
@@ -108,6 +119,7 @@ def _build_acp_executor() -> Executor:
         model=model,
         session_id_mode=session_id_mode,
         send_model_in_session_new=send_model,
+        omnigent_mcp=omnigent_mcp,
     )
     return AcpExecutor(config=config, cwd=cwd, os_env=_resolve_os_env())
 

--- a/omnigent/inner/acp_harness.py
+++ b/omnigent/inner/acp_harness.py
@@ -24,8 +24,8 @@ Env vars read at startup:
   configured to accept one in ``session/new``).
 - ``HARNESS_ACP_SESSION_ID_MODE``: ``server`` (default) or ``client``.
 - ``HARNESS_ACP_SEND_MODEL``: ``"1"`` to send the model in ``session/new``.
-- ``HARNESS_ACP_OMNIGENT_MCP``: ``"0"`` to omit Omnigent's MCP relay from
-  ``session/new``.
+- ``HARNESS_ACP_OMNIGENT_MCP``: ``"0"`` to disable Omnigent's MCP relay;
+  ``session/new`` still receives an empty ``mcpServers`` array.
 - ``HARNESS_ACP_OS_ENV``: JSON-encoded :class:`OSEnvSpec`. When unset, falls
   back to ``caller_process`` + ``sandbox=none``.
 - ``HARNESS_ACP_PROMPT_TIMEOUT_S``: optional idle (time-without-progress) deadline in

--- a/omnigent/onboarding/acp_auth.py
+++ b/omnigent/onboarding/acp_auth.py
@@ -48,6 +48,7 @@ class AcpAgentEntry:
         in ``session/new``; see :class:`omnigent.inner.acp_executor.AcpAgentConfig`).
     :param session_id_mode: ``"server"`` (default) or ``"client"``.
     :param send_model: Send the model in ``session/new`` (Qwen-shaped agents).
+    :param omnigent_mcp: Lend Omnigent's builtin MCP relay in ``session/new``.
     """
 
     slug: str
@@ -56,6 +57,7 @@ class AcpAgentEntry:
     model: str | None = None
     session_id_mode: str = "server"
     send_model: bool = False
+    omnigent_mcp: bool = True
 
 
 def slugify(name: str) -> str:
@@ -117,6 +119,7 @@ def acp_agents(config: dict[str, object] | None = None) -> list[AcpAgentEntry]:
                 model=model.strip() if isinstance(model, str) and model.strip() else None,
                 session_id_mode=mode if mode in ("server", "client") else "server",
                 send_model=bool(raw.get("send_model", False)),
+                omnigent_mcp=bool(raw.get("omnigent_mcp", True)),
             )
         )
     return entries
@@ -154,6 +157,8 @@ def acp_agents_settings(entries: list[AcpAgentEntry]) -> dict[str, object]:
             item["session_id_mode"] = e.session_id_mode
         if e.send_model:
             item["send_model"] = True
+        if not e.omnigent_mcp:
+            item["omnigent_mcp"] = False
         agents.append(item)
     return {ACP_CONFIG_KEY: {_AGENTS_FIELD: agents}}
 

--- a/omnigent/onboarding/acp_auth.py
+++ b/omnigent/onboarding/acp_auth.py
@@ -78,9 +78,10 @@ def acp_agents(config: dict[str, object] | None = None) -> list[AcpAgentEntry]:
     """Return the configured ACP agents, each with a unique derived slug.
 
     Reads the ``acp:`` block's ``agents`` list. Malformed entries (not a dict,
-    or missing ``name`` / ``command``) are skipped. Slugs are assigned in list
-    order; a collision (two names slugifying the same) gets a ``-2`` / ``-3`` …
-    suffix so every returned entry is uniquely addressable.
+    or missing ``name`` / ``command``) are skipped. Invalid ``omnigent_mcp``
+    values raise ``ValueError`` instead of being silently coerced. Slugs are
+    assigned in list order; a collision (two names slugifying the same) gets a
+    ``-2`` / ``-3`` … suffix so every returned entry is uniquely addressable.
 
     :param config: A pre-loaded config mapping; ``None`` loads
         ``~/.omnigent/config.yaml`` via :func:`load_config`.
@@ -111,6 +112,9 @@ def acp_agents(config: dict[str, object] | None = None) -> list[AcpAgentEntry]:
         slug = base if count == 1 else f"{base}-{count}"
         model = raw.get("model")
         mode = raw.get("session_id_mode")
+        omnigent_mcp = raw.get("omnigent_mcp", True)
+        if not isinstance(omnigent_mcp, bool):
+            raise ValueError("acp agent omnigent_mcp must be a boolean")
         entries.append(
             AcpAgentEntry(
                 slug=slug,
@@ -119,7 +123,7 @@ def acp_agents(config: dict[str, object] | None = None) -> list[AcpAgentEntry]:
                 model=model.strip() if isinstance(model, str) and model.strip() else None,
                 session_id_mode=mode if mode in ("server", "client") else "server",
                 send_model=bool(raw.get("send_model", False)),
-                omnigent_mcp=bool(raw.get("omnigent_mcp", True)),
+                omnigent_mcp=omnigent_mcp,
             )
         )
     return entries

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1565,6 +1565,7 @@ def _build_acp_spawn_env(
         env["HARNESS_ACP_SESSION_ID_MODE"] = agent.session_id_mode
         if agent.send_model:
             env["HARNESS_ACP_SEND_MODEL"] = "1"
+        env["HARNESS_ACP_OMNIGENT_MCP"] = "1" if agent.omnigent_mcp else "0"
 
         model = _resolve_spec_model(spec)
         if model is not None and not model.startswith(("databricks-", "databricks/")):

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1548,10 +1548,14 @@ def _build_acp_spawn_env(
             isinstance(name, str) and name.strip() and isinstance(command, str) and command.strip()
         ):
             raise ValueError("executor acp_agent requires non-empty string name and command")
+        omnigent_mcp = embedded.get("omnigent_mcp", True)
+        if not isinstance(omnigent_mcp, bool):
+            raise ValueError("executor acp_agent omnigent_mcp must be a boolean")
         agent = AcpAgentEntry(
             slug=slug or "agent",
             name=name.strip(),
             command=command.strip(),
+            omnigent_mcp=omnigent_mcp,
         )
     else:
         agent = resolve_acp_agent(slug) if slug else None

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -1755,6 +1755,33 @@ def test_overview_lists_configured_acp_agents_as_rows(isolated_config, monkeypat
     assert "Custom ACP agent" not in names
 
 
+def test_setup_reports_invalid_acp_omnigent_mcp(isolated_config) -> None:
+    config_path = os.path.join(isolated_config, "config.yaml")
+    with open(config_path, "w") as f:
+        yaml.safe_dump(
+            {
+                "acp": {
+                    "agents": [
+                        {
+                            "name": "OpenClaw",
+                            "command": "openclaw acp",
+                            "omnigent_mcp": "false",
+                        }
+                    ]
+                }
+            },
+            f,
+        )
+
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input="q\n")
+
+    assert result.exit_code != 0
+    assert (
+        "Invalid acp.agents configuration: acp agent omnigent_mcp must be a boolean"
+        in result.output
+    )
+
+
 def test_overview_always_lists_openclaw_import_row(isolated_config, monkeypatch) -> None:
     """OpenClaw import remains available even when discovery finds nothing."""
     options, selectable, _descriptions, _compact, _max_visible = _capture_setup_overview(

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -83,6 +83,20 @@ async def test_session_new_server_mode_adopts_returned_id() -> None:
 
 
 @pytest.mark.asyncio
+async def test_session_new_omits_mcp_servers_when_omnigent_mcp_disabled() -> None:
+    ex = AcpExecutor(AcpAgentConfig(command="x", omnigent_mcp=False))
+    captured: dict = {}
+
+    async def fake_rpc(method, params, timeout=30.0):
+        captured["params"] = params
+        return {"result": {"sessionId": "srv-42"}}
+
+    ex._rpc = fake_rpc  # type: ignore[assignment]
+    await ex._ensure_session()
+    assert "mcpServers" not in captured["params"]
+
+
+@pytest.mark.asyncio
 async def test_session_new_client_mode_generates_and_sends_id() -> None:
     ex = AcpExecutor(
         AcpAgentConfig(
@@ -307,6 +321,7 @@ def test_harness_wrap_builds_executor(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HARNESS_ACP_NAME", "Goose")
     monkeypatch.setenv("HARNESS_ACP_SESSION_ID_MODE", "client")
     monkeypatch.setenv("HARNESS_ACP_SEND_MODEL", "1")
+    monkeypatch.setenv("HARNESS_ACP_OMNIGENT_MCP", "0")
     monkeypatch.setenv("HARNESS_ACP_MODEL", "gpt-5.3")
     ex = acp_harness._build_acp_executor()
     assert isinstance(ex, AcpExecutor)
@@ -314,6 +329,7 @@ def test_harness_wrap_builds_executor(monkeypatch: pytest.MonkeyPatch) -> None:
     assert ex._config.name == "Goose"
     assert ex._config.session_id_mode == "client"
     assert ex._config.send_model_in_session_new is True
+    assert ex._config.omnigent_mcp is False
     assert ex._config.model == "gpt-5.3"
 
 
@@ -527,7 +543,7 @@ async def test_acp_session_new_omnigent_mcp_disabled_per_agent() -> None:
 
     ex._rpc = fake_rpc  # type: ignore[assignment]
     await ex._ensure_session()
-    assert captured["params"]["mcpServers"] == []
+    assert "mcpServers" not in captured["params"]
 
 
 @pytest.mark.asyncio

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -83,7 +83,7 @@ async def test_session_new_server_mode_adopts_returned_id() -> None:
 
 
 @pytest.mark.asyncio
-async def test_session_new_omits_mcp_servers_when_omnigent_mcp_disabled() -> None:
+async def test_session_new_sends_empty_mcp_servers_when_omnigent_mcp_disabled() -> None:
     ex = AcpExecutor(AcpAgentConfig(command="x", omnigent_mcp=False))
     captured: dict = {}
 
@@ -93,7 +93,7 @@ async def test_session_new_omits_mcp_servers_when_omnigent_mcp_disabled() -> Non
 
     ex._rpc = fake_rpc  # type: ignore[assignment]
     await ex._ensure_session()
-    assert "mcpServers" not in captured["params"]
+    assert captured["params"]["mcpServers"] == []
 
 
 @pytest.mark.asyncio
@@ -531,7 +531,7 @@ async def test_acp_session_new_carries_mcp_servers() -> None:
 
 @pytest.mark.asyncio
 async def test_acp_session_new_omnigent_mcp_disabled_per_agent() -> None:
-    """`omnigent_mcp=False` on the agent config → no mcpServers in session/new."""
+    """`omnigent_mcp=False` disables relay setup but preserves ACP's field."""
     ex = AcpExecutor(AcpAgentConfig(command="x", omnigent_mcp=False))
     ex._tool_executor = lambda n, a: None  # type: ignore[assignment]
     ex._omnigent_tools = [{"name": "sys_agent_list"}]
@@ -543,7 +543,7 @@ async def test_acp_session_new_omnigent_mcp_disabled_per_agent() -> None:
 
     ex._rpc = fake_rpc  # type: ignore[assignment]
     await ex._ensure_session()
-    assert "mcpServers" not in captured["params"]
+    assert captured["params"]["mcpServers"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/onboarding/test_acp_auth.py
+++ b/tests/onboarding/test_acp_auth.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from omnigent.onboarding.acp_auth import acp_agents, acp_agents_settings
+
+
+def test_omnigent_mcp_round_trips_only_when_disabled() -> None:
+    entries = acp_agents(
+        {
+            "acp": {
+                "agents": [
+                    {
+                        "name": "OpenClaw",
+                        "command": "openclaw acp --url https://gateway --token token",
+                        "omnigent_mcp": False,
+                    },
+                    {
+                        "name": "Goose",
+                        "command": "goose acp",
+                        "model": "gpt-5.3",
+                        "session_id_mode": "client",
+                    },
+                ]
+            }
+        }
+    )
+
+    assert [entry.omnigent_mcp for entry in entries] == [False, True]
+    assert acp_agents_settings(entries) == {
+        "acp": {
+            "agents": [
+                {
+                    "name": "OpenClaw",
+                    "command": "openclaw acp --url https://gateway --token token",
+                    "omnigent_mcp": False,
+                },
+                {
+                    "name": "Goose",
+                    "command": "goose acp",
+                    "model": "gpt-5.3",
+                    "session_id_mode": "client",
+                },
+            ]
+        }
+    }

--- a/tests/onboarding/test_acp_auth.py
+++ b/tests/onboarding/test_acp_auth.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from omnigent.onboarding.acp_auth import acp_agents, acp_agents_settings
 
 
@@ -42,3 +44,21 @@ def test_omnigent_mcp_round_trips_only_when_disabled() -> None:
             ]
         }
     }
+
+
+@pytest.mark.parametrize("value", ["false", None, 0, 1])
+def test_omnigent_mcp_requires_boolean(value: object) -> None:
+    with pytest.raises(ValueError, match="omnigent_mcp must be a boolean"):
+        acp_agents(
+            {
+                "acp": {
+                    "agents": [
+                        {
+                            "name": "OpenClaw",
+                            "command": "openclaw acp",
+                            "omnigent_mcp": value,
+                        }
+                    ]
+                }
+            }
+        )

--- a/tests/runtime/test_acp_spawn_env.py
+++ b/tests/runtime/test_acp_spawn_env.py
@@ -23,6 +23,11 @@ from omnigent.spec.types import AgentSpec, ExecutorSpec, LLMConfig
 _AGENTS = [
     {"name": "Gemini CLI", "command": "gemini --experimental-acp"},
     {"name": "Goose", "command": "goose acp", "model": "gpt-5.3", "session_id_mode": "client"},
+    {
+        "name": "OpenClaw",
+        "command": "openclaw acp --url https://gateway --token token",
+        "omnigent_mcp": False,
+    },
 ]
 _MISSING = object()
 
@@ -66,6 +71,7 @@ def test_slug_resolves_to_command(_isolate_config: Path) -> None:
     assert env["HARNESS_ACP_COMMAND"] == "goose acp"
     assert env["HARNESS_ACP_NAME"] == "Goose"
     assert env["HARNESS_ACP_SESSION_ID_MODE"] == "client"
+    assert env["HARNESS_ACP_OMNIGENT_MCP"] == "1"
     # Per-agent model applies when the spec pins none.
     assert env["HARNESS_ACP_MODEL"] == "gpt-5.3"
 
@@ -118,6 +124,13 @@ def test_send_model_flag_forwarded(_isolate_config: Path) -> None:
     )
     env = _build_acp_spawn_env(_make_spec(harness="acp:qwen"))
     assert env["HARNESS_ACP_SEND_MODEL"] == "1"
+
+
+def test_omnigent_mcp_flag_forwarded(_isolate_config: Path) -> None:
+    _write_acp_config(_isolate_config)
+    env = _build_acp_spawn_env(_make_spec(harness="acp:openclaw"))
+    assert env["HARNESS_ACP_COMMAND"] == "openclaw acp --url https://gateway --token token"
+    assert env["HARNESS_ACP_OMNIGENT_MCP"] == "0"
 
 
 @pytest.mark.parametrize(

--- a/tests/runtime/test_acp_spawn_env.py
+++ b/tests/runtime/test_acp_spawn_env.py
@@ -133,9 +133,30 @@ def test_omnigent_mcp_flag_forwarded(_isolate_config: Path) -> None:
     assert env["HARNESS_ACP_OMNIGENT_MCP"] == "0"
 
 
+def test_embedded_omnigent_mcp_flag_forwarded() -> None:
+    env = _build_acp_spawn_env(
+        _make_spec(
+            harness="acp:openclaw",
+            acp_agent={
+                "name": "OpenClaw",
+                "command": "openclaw acp",
+                "omnigent_mcp": False,
+            },
+        )
+    )
+    assert env["HARNESS_ACP_OMNIGENT_MCP"] == "0"
+
+
 @pytest.mark.parametrize(
     "acp_agent",
-    [None, "not-a-mapping", {}, {"name": "Helper"}, {"name": "Helper", "command": " "}],
+    [
+        None,
+        "not-a-mapping",
+        {},
+        {"name": "Helper"},
+        {"name": "Helper", "command": " "},
+        {"name": "Helper", "command": "helper", "omnigent_mcp": "false"},
+    ],
 )
 def test_malformed_embedded_agent_fails_loudly(acp_agent: object) -> None:
     with pytest.raises(ValueError, match="executor acp_agent"):


### PR DESCRIPTION
## Related issue

Closes #3388

## Summary

- Adds a per-agent `omnigent_mcp` ACP config knob so ACP servers that reject per-session MCP can opt out without disabling MCP globally.
- Wires the knob through `AcpAgentEntry` → `_build_acp_spawn_env` → `acp_harness` → `AcpAgentConfig`, including embedded one-shot ACP agents.
- Validates `omnigent_mcp` as a real YAML boolean in both global and embedded config paths, so quoted values such as `"false"` fail clearly instead of silently re-enabling the relay.
- Sends `mcpServers: []` when the relay is disabled, preserving the required ACP field for strict servers such as OpenClaw.
- Documents OpenClaw Gateway setup, token-file authentication, the separate Omni/OpenClaw session boundaries, and the current lack of Control UI back-sync.

ELI5: OpenClaw already has its own tool hub. This lets Omnigent talk to OpenClaw over ACP without trying to hand OpenClaw an extra Omnigent tool list that its Gateway bridge rejects.

```text
~/.omnigent/config.yaml
  acp.agents[].omnigent_mcp
          │
          ▼
HARNESS_ACP_OMNIGENT_MCP
          │
          ▼
AcpAgentConfig.omnigent_mcp
          │
          ▼
session/new: relay servers, or mcpServers: [] when disabled
```

## Test Plan

- `uv run --no-sync pytest tests/runtime/test_acp_spawn_env.py tests/inner/test_acp_executor.py tests/onboarding/test_acp_auth.py -q` — 56 passed.
- `pre-commit run --files omnigent/onboarding/acp_auth.py tests/onboarding/test_acp_auth.py` — passed.
- `pre-commit run --files docs/AGENT_YAML_SPEC.md omnigent/runtime/workflow.py tests/runtime/test_acp_spawn_env.py` — passed.
- Manual OpenClaw Gateway verification with `uv run omni --harness acp:openclaw`:
  - confirmed `pwd` and `git branch --show-current` use the `pr-3420` worktree;
  - read and summarized `README.md` without modifying the repository;
  - created and read `/tmp/omnigent-acp-smoke.txt`;
  - created `acp-smoke.txt` in the worktree and confirmed native tool execution;
  - closed and resumed Omni, then confirmed the conversation context returned.
- `pre-commit run --all-files` passed all applicable hooks; the two Swift hooks could not parse the existing iOS files in the local environment.

## Demo

N/A — config/runtime/docs change only. Manual OpenClaw verification was completed on an unmanaged macOS machine; no UI behavior changed.

<img width="1719" height="1187" alt="image" src="https://github.com/user-attachments/assets/032e7691-c0e6-472e-8b5c-1323c08c286f" />

<img width="1050" height="1187" alt="image" src="https://github.com/user-attachments/assets/270266f1-6fd5-4e04-a8e3-27fc4163850f" />


## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage verifies config parse/serialize, strict boolean validation for global and embedded config, global and embedded spawn-env emission, harness env parsing, and the strict ACP `session/new` shape when `omnigent_mcp` is false. Manual verification covered the live OpenClaw ACP bridge, workspace propagation, native shell/filesystem tools, and Omni resume. Per-session Omnigent MCP and bidirectional synchronization with OpenClaw’s Control UI remain unsupported by the current OpenClaw bridge.

## Changelog

ACP agents can opt out of Omnigent’s MCP relay with `omnigent_mcp: false`, enabling compatible OpenClaw Gateway ACP registrations.
