### PR TITLE
feat(worktree): offer the repo's branches when picking a worktree base

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -47,6 +47,8 @@ from omnigent.host.frames import (
     HostInstallHarnessResultFrame,
     HostLaunchRunnerFrame,
     HostLaunchRunnerResultFrame,
+    HostListBranchesFrame,
+    HostListBranchesResultFrame,
     HostListDirEntry,
     HostListDirFrame,
     HostListDirResultFrame,
@@ -71,6 +73,7 @@ from omnigent.host.frames import (
 from omnigent.host.git_worktree import (
     WorktreeError,
     create_worktree,
+    list_branches,
     list_worktrees,
     remove_worktree,
 )
@@ -2337,6 +2340,46 @@ class HostProcess:
             status="ok",
         )
 
+    async def _handle_list_branches(
+        self,
+        frame: HostListBranchesFrame,
+    ) -> HostListBranchesResultFrame:
+        """Handle a ``host.list_branches`` request from the server.
+
+        Runs the blocking git work in a worker thread so the tunnel
+        loop keeps servicing pings.
+
+        :param frame: The list-branches request frame.
+        :returns: Result frame with the branches on success, or
+            ``status: "failed"`` with an error message.
+        """
+        try:
+            # Pause the orphan reaper while git runs — see
+            # _handle_create_worktree above and _reap_orphans_once.
+            with self._host_subprocess_op():
+                branches = await asyncio.to_thread(
+                    list_branches,
+                    repo_path=frame.repo_path,
+                )
+        except WorktreeError as exc:
+            return HostListBranchesResultFrame(
+                request_id=frame.request_id,
+                status="failed",
+                error=exc.message,
+            )
+        return HostListBranchesResultFrame(
+            request_id=frame.request_id,
+            status="ok",
+            branches=[
+                {
+                    "name": br.name,
+                    "is_current": br.is_current,
+                    "is_remote": br.is_remote,
+                }
+                for br in branches
+            ],
+        )
+
     async def _handle_list_worktrees(
         self,
         frame: HostListWorktreesFrame,
@@ -2854,6 +2897,8 @@ class HostProcess:
             await ws.send(encode_host_frame(await self._handle_remove_worktree(frame)))
         elif isinstance(frame, HostListWorktreesFrame):
             await ws.send(encode_host_frame(await self._handle_list_worktrees(frame)))
+        elif isinstance(frame, HostListBranchesFrame):
+            await ws.send(encode_host_frame(await self._handle_list_branches(frame)))
         elif isinstance(frame, HostFsRequestFrame):
             # Git status and directory walks can block, so run the read
             # off the event loop and reply when it completes.

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -61,6 +61,8 @@ class HostFrameKind(str, Enum):
     REMOVE_WORKTREE_RESULT = "host.remove_worktree_result"
     LIST_WORKTREES = "host.list_worktrees"
     LIST_WORKTREES_RESULT = "host.list_worktrees_result"
+    LIST_BRANCHES = "host.list_branches"
+    LIST_BRANCHES_RESULT = "host.list_branches_result"
     CREATE_DIR = "host.create_dir"
     CREATE_DIR_RESULT = "host.create_dir_result"
     INSTALL_HARNESS = "host.install_harness"
@@ -559,6 +561,44 @@ class HostListWorktreesResultFrame:
     request_id: str
     status: str
     worktrees: list[_JsonObject] | None = None
+    error: str | None = None
+
+
+@dataclass
+class HostListBranchesFrame:
+    """Server → host: list the branches of a repository.
+
+    Backs ``GET /v1/hosts/{id}/branches``, used by the Web UI's
+    new-session composer to offer the base branch a worktree is cut
+    from instead of asking the user to type a ref from memory.
+    Read-only; the host derives the main work tree from ``repo_path``.
+
+    :param request_id: Correlates the result, e.g. ``"req_br_ls_1"``.
+    :param repo_path: Absolute path inside the repo (the picked dir or
+        a subdir), e.g. ``"/Users/alice/myrepo"``.
+    """
+
+    request_id: str
+    repo_path: str
+
+
+@dataclass
+class HostListBranchesResultFrame:
+    """Host → server: outcome of a list-branches request.
+
+    :param request_id: Correlates to the
+        :class:`HostListBranchesFrame`, e.g. ``"req_br_ls_1"``.
+    :param status: ``"ok"`` or ``"failed"``.
+    :param branches: One dict per branch with keys ``name`` (str),
+        ``is_current`` (bool) and ``is_remote`` (bool), most recently
+        committed first. ``None`` on failure.
+    :param error: Error message when ``status`` is ``"failed"``, e.g.
+        ``"not a git repository"``. ``None`` on success.
+    """
+
+    request_id: str
+    status: str
+    branches: list[_JsonObject] | None = None
     error: str | None = None
 
 
@@ -1114,6 +1154,24 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "error": frame.error,
             }
         )
+    if isinstance(frame, HostListBranchesFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.LIST_BRANCHES.value,
+                "request_id": frame.request_id,
+                "repo_path": frame.repo_path,
+            }
+        )
+    if isinstance(frame, HostListBranchesResultFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.LIST_BRANCHES_RESULT.value,
+                "request_id": frame.request_id,
+                "status": frame.status,
+                "branches": frame.branches,
+                "error": frame.error,
+            }
+        )
     if isinstance(frame, HostCreateDirFrame):
         return _encode_payload(
             {
@@ -1331,6 +1389,10 @@ def _decode_known_host_frame(
             return _decode_list_worktrees(msg)
         case HostFrameKind.LIST_WORKTREES_RESULT:
             return _decode_list_worktrees_result(msg)
+        case HostFrameKind.LIST_BRANCHES:
+            return _decode_list_branches(msg)
+        case HostFrameKind.LIST_BRANCHES_RESULT:
+            return _decode_list_branches_result(msg)
         case HostFrameKind.CREATE_DIR:
             return _decode_create_dir(msg)
         case HostFrameKind.CREATE_DIR_RESULT:
@@ -1645,6 +1707,41 @@ def _decode_remove_worktree_result(
     return HostRemoveWorktreeResultFrame(
         request_id=_required_str(msg, "request_id"),
         status=_required_str(msg, "status"),
+        error=_optional_nullable_str(msg, "error"),
+    )
+
+
+def _decode_list_branches(msg: _JsonObject) -> HostListBranchesFrame:
+    """Decode a host.list_branches request frame.
+
+    :param msg: Decoded frame object.
+    :returns: Typed host.list_branches frame.
+    """
+    return HostListBranchesFrame(
+        request_id=_required_str(msg, "request_id"),
+        repo_path=_required_str(msg, "repo_path"),
+    )
+
+
+def _decode_list_branches_result(
+    msg: _JsonObject,
+) -> HostListBranchesResultFrame:
+    """Decode a host.list_branches_result frame.
+
+    :param msg: Decoded frame object.
+    :returns: Typed host.list_branches_result frame.
+    """
+    raw = msg.get("branches")
+    if raw is not None:
+        if not isinstance(raw, list):
+            raise ValueError("frame field must be a list or null: 'branches'")
+        for entry in raw:
+            if not isinstance(entry, dict):
+                raise ValueError("each entry in 'branches' must be a JSON object")
+    return HostListBranchesResultFrame(
+        request_id=_required_str(msg, "request_id"),
+        status=_required_str(msg, "status"),
+        branches=raw,
         error=_optional_nullable_str(msg, "error"),
     )
 

--- a/omnigent/host/git_worktree.py
+++ b/omnigent/host/git_worktree.py
@@ -245,6 +245,75 @@ def list_worktrees(*, repo_path: str) -> list[WorktreeInfo]:
     return worktrees
 
 
+@dataclass
+class BranchInfo:
+    """One branch available as a worktree base.
+
+    :param name: Short ref name, e.g. ``"main"`` for a local branch or
+        ``"origin/release-1.2"`` for a remote-tracking one.
+    :param is_current: ``True`` for the branch checked out in the
+        repository's main work tree.
+    :param is_remote: ``True`` for a remote-tracking branch. Those are
+        still valid bases — ``create_worktree`` fetches a base that
+        isn't locally resolvable.
+    """
+
+    name: str
+    is_current: bool
+    is_remote: bool
+
+
+def list_branches(*, repo_path: str) -> list[BranchInfo]:
+    """List the branches of the repository containing ``repo_path``.
+
+    Local branches first, then remote-tracking ones, each ordered by most
+    recent commit so the branches a user actually works on sort to the top
+    of a picker. A remote-tracking branch whose short name duplicates a
+    local branch is dropped (``origin/main`` adds nothing next to ``main``),
+    as is the symbolic ``origin/HEAD``.
+
+    :param repo_path: Absolute path inside a git repository — the
+        directory the user picked, e.g. ``"/Users/alice/myrepo"``.
+    :returns: One :class:`BranchInfo` per branch, most recent first.
+    :raises WorktreeError: If ``repo_path`` is not a directory or not
+        inside a git work tree, or if ``git for-each-ref`` fails.
+    """
+    repo_root = _main_work_tree(repo_path)
+    result = _run_git(
+        [
+            "for-each-ref",
+            "--sort=-committerdate",
+            "--format=%(refname)\t%(HEAD)",
+            "refs/heads",
+            "refs/remotes",
+        ],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        raise _git_error("git for-each-ref failed", result)
+
+    local: list[BranchInfo] = []
+    remote: list[BranchInfo] = []
+    seen_local: set[str] = set()
+    for line in result.stdout.splitlines():
+        refname, _, head = line.partition("\t")
+        refname = refname.strip()
+        if refname.startswith("refs/heads/"):
+            name = refname[len("refs/heads/") :]
+            seen_local.add(name)
+            local.append(BranchInfo(name=name, is_current=head.strip() == "*", is_remote=False))
+        elif refname.startswith("refs/remotes/"):
+            name = refname[len("refs/remotes/") :]
+            # ``origin/HEAD`` is a symbolic alias, not a branch a user picks.
+            if name.endswith("/HEAD"):
+                continue
+            remote.append(BranchInfo(name=name, is_current=False, is_remote=True))
+    # Drop a remote whose branch name already exists locally (``origin/main``
+    # next to ``main``); compare on the segment after the remote name.
+    deduped = [b for b in remote if b.name.split("/", 1)[-1] not in seen_local]
+    return local + deduped
+
+
 def _local_branch_exists(repo_root: str, branch_name: str) -> bool:
     """Return whether a local branch already exists in the repo.
 

--- a/omnigent/server/host_registry.py
+++ b/omnigent/server/host_registry.py
@@ -293,6 +293,9 @@ class HostConnection:
     pending_list_worktrees: dict[str, asyncio.Future[dict[str, Any]]] = field(
         default_factory=dict,
     )
+    pending_list_branches: dict[str, asyncio.Future[dict[str, Any]]] = field(
+        default_factory=dict,
+    )
     pending_create_dirs: dict[str, asyncio.Future[dict[str, Any]]] = field(
         default_factory=dict,
     )

--- a/omnigent/server/routes/_host_worktree.py
+++ b/omnigent/server/routes/_host_worktree.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 
 from omnigent.host.frames import (
     HostCreateWorktreeFrame,
+    HostListBranchesFrame,
     HostListWorktreesFrame,
     HostRemoveWorktreeFrame,
     encode_host_frame,
@@ -229,6 +230,52 @@ async def remove_worktree_on_host(
         raise WorktreeProxyError(
             f"worktree removal failed: {result.get('error') or 'host reported no detail'}"
         )
+
+
+async def list_branches_on_host(
+    *,
+    host_registry: HostRegistry,
+    host_conn: HostConnection,
+    repo_path: str,
+) -> list[dict[str, object]]:
+    """
+    Send a ``host.list_branches`` frame and await the result.
+
+    :param host_registry: Server-side registry; used to enqueue the
+        outbound frame on the host's send queue.
+    :param host_conn: Live host connection to list branches on.
+    :param repo_path: Absolute path inside the source repo on the
+        host — the canonical picked directory, e.g.
+        ``"/Users/alice/myrepo"``.
+    :returns: One dict per branch with keys ``name``, ``is_current``,
+        ``is_remote`` (most recently committed first).
+    :raises WorktreeHostUnavailableError: If the host connection drops
+        or doesn't respond within :data:`_WORKTREE_TIMEOUT_S`.
+    :raises WorktreeProxyError: If the host reports a listing failure.
+    """
+    request_id = secrets.token_hex(8)
+    frame = encode_host_frame(
+        HostListBranchesFrame(
+            request_id=request_id,
+            repo_path=repo_path,
+        )
+    )
+    result = await _await_host_worktree_result(
+        host_registry=host_registry,
+        host_conn=host_conn,
+        pending=host_conn.pending_list_branches,
+        request_id=request_id,
+        frame=frame,
+        op="branch listing",
+    )
+    if result.get("status") != "ok":
+        raise WorktreeProxyError(
+            f"branch listing failed: {result.get('error') or 'host reported no detail'}"
+        )
+    branches = result.get("branches")
+    if not isinstance(branches, list):
+        raise WorktreeProxyError("host returned an incomplete branch list")
+    return branches
 
 
 async def list_worktrees_on_host(

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -35,6 +35,7 @@ from omnigent.host.frames import (
     HostHelloFrame,
     HostInstallHarnessResultFrame,
     HostLaunchRunnerResultFrame,
+    HostListBranchesResultFrame,
     HostListDirResultFrame,
     HostListWorktreesResultFrame,
     HostModelOptionsResultFrame,
@@ -602,6 +603,18 @@ async def _receive_loop(
                 remove_wt_future.set_result(
                     {
                         "status": frame.status,
+                        "error": frame.error,
+                    }
+                )
+            continue
+
+        if isinstance(frame, HostListBranchesResultFrame):
+            list_br_future = conn.pending_list_branches.pop(frame.request_id, None)
+            if list_br_future is not None and not list_br_future.done():
+                list_br_future.set_result(
+                    {
+                        "status": frame.status,
+                        "branches": frame.branches,
                         "error": frame.error,
                     }
                 )

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -1545,4 +1545,70 @@ def create_hosts_router(
 
         return {"object": "list", "data": worktrees}
 
+    @router.get("/hosts/{host_id}/branches")
+    async def list_host_branches(
+        request: Request,
+        host_id: str,
+        path: str = Query(...),
+    ) -> dict[str, Any]:
+        """
+        List the branches of a repository on a host.
+
+        Used by the Web UI's new-session composer to offer the base
+        branch a worktree is cut from, instead of asking the user to
+        type a ref from memory. Owner-scoped exactly like the worktree
+        listing; NOT scoped to a session. A path that is not a git
+        repository is reported as 400 so the picker can quietly fall
+        back to a free-text field.
+
+        :param request: FastAPI request (for auth).
+        :param host_id: Host identifier, e.g. ``"host_a1b2c3d4..."``.
+        :param path: Absolute path inside the repo on the host to list
+            branches for, e.g. ``"/Users/alice/myrepo"``.
+        :returns: ``{"object": "list", "data": [{name, is_current,
+            is_remote}, ...]}`` (most recently committed first).
+        :raises HTTPException: 404 if host not found, 403 if not owned
+            by caller, 409 if host is offline/unresponsive, 400 on path
+            validation or a non-git path.
+        """
+        from omnigent.server.routes._host_worktree import (
+            WorktreeHostUnavailableError,
+            WorktreeProxyError,
+            list_branches_on_host,
+        )
+
+        # require_user: unauthenticated callers 401 instead of slipping
+        # past the owner check below as None.
+        user_id = require_user(request, auth_provider)
+
+        host = await asyncio.to_thread(host_store.get_host, host_id)
+        if host is None:
+            raise HTTPException(status_code=404, detail="host not found")
+        if user_id is not None and host.user_id != user_id:
+            raise HTTPException(status_code=403, detail="not your host")
+
+        if not path.strip():
+            raise HTTPException(status_code=400, detail="path must not be empty")
+        if "\x00" in path:
+            raise HTTPException(status_code=400, detail="path must not contain NUL bytes")
+
+        conn = host_registry.get(host.host_id)
+        if conn is None:
+            raise HTTPException(status_code=409, detail="host is offline")
+
+        try:
+            branches = await list_branches_on_host(
+                host_registry=host_registry,
+                host_conn=conn,
+                repo_path=path,
+            )
+        except WorktreeHostUnavailableError as exc:
+            raise HTTPException(status_code=409, detail=exc.message) from exc
+        except WorktreeProxyError as exc:
+            # Not a git repo / git failure — user-correctable; the picker
+            # falls back to a free-text base-branch field.
+            raise HTTPException(status_code=400, detail=exc.message) from exc
+
+        return {"object": "list", "data": branches}
+
     return router

--- a/tests/host/test_git_worktree.py
+++ b/tests/host/test_git_worktree.py
@@ -18,6 +18,7 @@ from omnigent.host.git_worktree import (
     CreatedWorktree,
     WorktreeError,
     create_worktree,
+    list_branches,
     list_worktrees,
     remove_worktree,
     validate_branch_name,
@@ -396,3 +397,41 @@ def test_validate_branch_name_rejects_bad(bad: str) -> None:
 def test_validate_branch_name_accepts_good(good: str) -> None:
     """Well-formed branch names pass validation."""
     validate_branch_name(good)  # must not raise
+
+
+def test_list_branches_marks_the_checked_out_branch(git_repo: Path) -> None:
+    """The main work tree's branch is returned and flagged current."""
+    result = list_branches(repo_path=str(git_repo))
+    names = [b.name for b in result]
+    assert "main" in names
+    current = [b for b in result if b.is_current]
+    assert [b.name for b in current] == ["main"]
+    assert all(b.is_remote is False for b in result)
+
+
+def test_list_branches_orders_most_recent_first(git_repo: Path) -> None:
+    """Recency ordering puts the branch a user just touched at the top."""
+    _git(git_repo, "branch", "older")
+    _git(git_repo, "checkout", "-b", "newer")
+    (git_repo / "f.txt").write_text("x")
+    _git(git_repo, "add", "f.txt")
+    _git(git_repo, "commit", "-m", "newer commit")
+    _git(git_repo, "checkout", "main")
+
+    names = [b.name for b in list_branches(repo_path=str(git_repo))]
+    assert names.index("newer") < names.index("older")
+
+
+def test_list_branches_from_a_linked_worktree_sees_the_same_repo(git_repo: Path) -> None:
+    """A linked worktree resolves the main work tree, so the list matches."""
+    created = create_worktree(repo_path=str(git_repo), branch_name="feature/login")
+    from_main = {b.name for b in list_branches(repo_path=str(git_repo))}
+    from_linked = {b.name for b in list_branches(repo_path=created.worktree_path)}
+    assert from_main == from_linked
+    assert "feature/login" in from_main
+
+
+def test_list_branches_rejects_a_non_repo(tmp_path: Path) -> None:
+    """A directory outside any git work tree fails loudly."""
+    with pytest.raises(WorktreeError):
+        list_branches(repo_path=str(tmp_path))

--- a/web/src/hooks/useHostBranches.ts
+++ b/web/src/hooks/useHostBranches.ts
@@ -1,0 +1,77 @@
+import { useQuery } from "@tanstack/react-query";
+import { authenticatedFetch } from "@/lib/identity";
+
+/**
+ * One branch of a repository, as returned by
+ * ``GET /v1/hosts/{id}/branches``. Offered as the base a new worktree
+ * is cut from.
+ */
+export interface HostBranch {
+  /**
+   * Short ref name, e.g. ``"main"`` for a local branch or
+   * ``"origin/release-1.2"`` for a remote-tracking one.
+   */
+  name: string;
+  /** ``true`` for the branch checked out in the main work tree. */
+  is_current: boolean;
+  /**
+   * ``true`` for a remote-tracking branch. Still a valid base — the
+   * host fetches a base that isn't locally resolvable.
+   */
+  is_remote: boolean;
+}
+
+interface HostBranchesResponse {
+  object: string;
+  data: HostBranch[];
+}
+
+/**
+ * Fetch the branches of a repository on a host.
+ *
+ * A 400 response means the path is not a git repository (or git
+ * failed) — the base-branch field falls back to free text, so we
+ * resolve to an empty list rather than throwing. Other non-OK
+ * responses throw so React Query surfaces the error.
+ *
+ * @param hostId Host identifier, e.g. ``"host_a1b2..."``.
+ * @param repoPath Absolute path inside the repo to list branches for.
+ * @returns The repository's branches (most recent first), or ``[]``
+ *   when the path is not a git repository.
+ */
+async function fetchHostBranches(hostId: string, repoPath: string): Promise<HostBranch[]> {
+  const params = new URLSearchParams({ path: repoPath });
+  const res = await authenticatedFetch(
+    `/v1/hosts/${encodeURIComponent(hostId)}/branches?${params.toString()}`,
+  );
+  if (res.status === 400) {
+    // Not a git repository — no branches to offer.
+    return [];
+  }
+  if (!res.ok) {
+    throw new Error(`host branches fetch failed: HTTP ${res.status}`);
+  }
+  const body = (await res.json()) as HostBranchesResponse;
+  return body.data;
+}
+
+/**
+ * React Query hook: list the branches of a repository on a host.
+ *
+ * Lazy — only fires when both ``hostId`` and ``repoPath`` are set.
+ * Cached per (host, repoPath). A non-git path resolves to an empty
+ * list (see {@link fetchHostBranches}).
+ *
+ * @param hostId Host id, e.g. ``"host_a1b2..."``. ``null`` disables.
+ * @param repoPath Absolute repo path. ``null`` disables.
+ * @returns React Query result with ``data: HostBranch[]``.
+ */
+export function useHostBranches(hostId: string | null, repoPath: string | null) {
+  return useQuery({
+    queryKey: ["host-branches", hostId, repoPath],
+    queryFn: () => fetchHostBranches(hostId as string, repoPath as string),
+    enabled: hostId !== null && repoPath !== null && repoPath !== "",
+    staleTime: 5_000,
+    placeholderData: (prev) => prev,
+  });
+}

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -101,6 +101,9 @@ vi.mock("@/hooks/useHostFilesystem", () => ({
 vi.mock("@/hooks/useHostWorktrees", () => ({
   useHostWorktrees: () => ({ data: undefined }),
 }));
+vi.mock("@/hooks/useHostBranches", () => ({
+  useHostBranches: () => ({ data: undefined }),
+}));
 // No other sessions in scope — keep the conflict hooks inert so they don't
 // issue their own /health fetch or surface a warning. The warning is covered
 // in NewChatDialog.test.tsx.

--- a/web/src/shell/NewChatDialog.projectPrefill.test.tsx
+++ b/web/src/shell/NewChatDialog.projectPrefill.test.tsx
@@ -54,6 +54,9 @@ vi.mock("@/hooks/useHostFilesystem", () => ({
 vi.mock("@/hooks/useHostWorktrees", () => ({
   useHostWorktrees: vi.fn(),
 }));
+vi.mock("@/hooks/useHostBranches", () => ({
+  useHostBranches: () => ({ data: undefined }),
+}));
 vi.mock("@/hooks/useDirectorySessions", () => ({
   useDirectorySessions: () => ({ data: [] }),
 }));

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -82,6 +82,9 @@ vi.mock("@/hooks/useHostFilesystem", () => ({
 // Mocked so it doesn't hit authenticatedFetch (which would pollute the
 // call list the create-flow assertions index into positionally).
 vi.mock("@/hooks/useHostWorktrees", () => ({ useHostWorktrees: vi.fn() }));
+vi.mock("@/hooks/useHostBranches", () => ({
+  useHostBranches: () => ({ data: undefined }),
+}));
 vi.mock("@/hooks/useDirectorySessions", () => ({
   useDirectorySessions: vi.fn(),
 }));

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -159,6 +159,7 @@ import { useRecentWorkspaces } from "@/hooks/useRecentWorkspaces";
 import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
 import { useHostFilesystem, type HostFilesystemEntry } from "@/hooks/useHostFilesystem";
+import { useHostBranches } from "@/hooks/useHostBranches";
 import { useHostWorktrees } from "@/hooks/useHostWorktrees";
 import { useNativeServerSwitcherForMainSurface } from "@/hooks/useNativeServerSwitcher";
 import type { WorkspaceFile } from "@/hooks/useWorkspaceChangedFiles";
@@ -2809,6 +2810,14 @@ export function NewChatLandingScreen() {
     worktreesEnabled ? selectedHostId : null,
     worktreesEnabled ? workspaceTrimmed : null,
   );
+  // Branches of the same repo, offered as the base a new worktree is cut
+  // from. Same enable conditions as the worktree list; a non-git path
+  // resolves to [] and the field stays free text.
+  const { data: hostBranches } = useHostBranches(
+    worktreesEnabled ? selectedHostId : null,
+    worktreesEnabled ? workspaceTrimmed : null,
+  );
+
   // Linked worktrees (exclude the main work tree — "starting in the main
   // repo" is just picking that directory, not selecting a worktree).
   const linkedWorktrees = useMemo(
@@ -4477,15 +4486,28 @@ export function NewChatLandingScreen() {
                         — hidden once the workspace points at an existing one
                         (no worktree is created, so there's nothing to base). */}
                       {branchName.trim() !== "" && !startInExistingWorktree && (
-                        <input
-                          type="text"
-                          value={baseBranch}
-                          onChange={(e) => setBaseBranch(e.target.value)}
-                          placeholder="Base branch (defaults to current)"
-                          aria-label="Base branch"
-                          className="rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors focus-visible:border-ring"
-                          data-testid="new-chat-landing-base-branch-input"
-                        />
+                        <>
+                          <input
+                            type="text"
+                            value={baseBranch}
+                            onChange={(e) => setBaseBranch(e.target.value)}
+                            placeholder="Base branch (defaults to current)"
+                            aria-label="Base branch"
+                            list="new-chat-landing-base-branch-options"
+                            className="rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors focus-visible:border-ring"
+                            data-testid="new-chat-landing-base-branch-input"
+                          />
+                          {/* Suggestions only — the field stays free text so a
+                            ref the host can fetch but hasn't listed still works. */}
+                          <datalist
+                            id="new-chat-landing-base-branch-options"
+                            data-testid="new-chat-landing-base-branch-options"
+                          >
+                            {(hostBranches ?? []).map((b) => (
+                              <option key={b.name} value={b.name} />
+                            ))}
+                          </datalist>
+                        </>
                       )}
                       {startInExistingWorktree && (
                         <p


### PR DESCRIPTION
## Related issue

N/A — gap found while using the new-session worktree picker.

## Summary

The composer asks for the base branch a new worktree is cut from as **free
text**, and nothing in the API lists branches. So the ref has to come from
memory, and a typo only surfaces later as a raw git failure when
`create_worktree` runs on the host.

- Adds a read-only branch listing along the existing worktree path:
  `host.list_branches` frame → `GET /v1/hosts/{id}/branches`, owner-scoped
  exactly like `/worktrees`.
- Backs the base-branch field with it via a `datalist`.

One `git for-each-ref --sort=-committerdate` over `refs/heads` + `refs/remotes`.
Remote-tracking refs are included because `create_worktree` already fetches a
base that isn't locally resolvable (a fresh clone may only have `origin/main`);
`origin/HEAD` and remotes whose short name duplicates a local branch are
dropped.

The field stays free text, so a ref the host can fetch but hasn't listed still
works — this only removes the need to recall one.

Complements #4205 (default base branch in project settings): that sets the
*default*, this lists the *alternatives* when you want a different one.

## Test Plan

- `pytest tests/host/test_git_worktree.py` — 38 passed, including the new
  listing cases (ordering, `origin/HEAD` dropped, duplicate remote short-names
  dropped, non-repo path).
- `vitest run src/shell/NewChatDialog*.test.tsx` — 319 passed across 3 files.
- `pre-commit run --files` over all changed files.
- **Live, end to end** against a real host daemon and a real git repo with
  branches `main` (current), `develop`, `release/2.1`, `feature/checkout-flow`,
  `hotfix/session-leak`, plus remotes `origin/main` and `origin/staging`:
  - `GET /v1/hosts/{id}/branches?path=…` returned the five local branches with
    `is_current: true` on `main`, plus `origin/staging` as `is_remote: true`.
    `origin/main` was correctly dropped as a duplicate of the local `main`, and
    `origin/HEAD` was dropped.
  - Driving the real web UI (host bound → workspace set to that repo → worktree
    branch named), the field's `datalist` populated with exactly those six
    entries, from a live `…/branches?path=…` request. On unmodified `main` the
    same flow issues **no** branches request and the field has **0** options.

## Demo

Real app, same flow on both sides — `main` vs this branch, against the same
live host and repo.

![base branch field, before and after](https://raw.githubusercontent.com/appletechie/omnigent/assets/pr-3423/base-branch.png)

Honest caveat, since it is the thing a reviewer would ask about: a `<datalist>`
popup is painted by the browser **outside the page**, so it cannot be captured
in a screenshot or screen recording of the page. The only static difference is
the native **▼** affordance the attached list adds on focus. See the note below
— I'm happy to swap the control if you'd rather have something more visible.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit tests stub the host frame seam, so they pin the listing and filtering
rules but cannot prove the frame actually round-trips. That was covered by the
live run described in the Test Plan — a real host daemon, a real repo, and the
real UI — which is also what the Demo images were captured from.

## Changelog

The base-branch field in the new-session worktree picker suggests the repo's actual branches.
