### PR TITLE
test(repl): pin detect_providers in the startup-header creds test

### DIFF
--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -1847,6 +1847,10 @@ def test_build_startup_header_creds_line_hints_first_available(tmp_path, monkeyp
         "    kind: databricks\n"
         "    profile: gtm-ws\n"
     )
+    # Hermetic: ignore a dev machine's ambient providers. A running local Ollama
+    # (TCP-probed at localhost:11434) serves openai and would outrank the
+    # Databricks fallback under test, so pin detection to none.
+    monkeypatch.setattr("omnigent.onboarding.detected.detect_providers", list)
     header = _build_startup_header(
         "claude-sdk", "Two-headed brainstorming partner.", ["anthropic", "openai"]
     )


### PR DESCRIPTION
## Related issue

N/A

## Summary

`test_build_startup_header_creds_line_hints_first_available` fails on any dev
machine with Ollama running, and passes in CI.

The test configures a Databricks profile as the fallback credential and asserts
the startup header names it. But `_build_startup_header` reaches
`detect_providers`, which TCP-probes `localhost:11434`. With Ollama up, that
probe succeeds, Ollama serves `openai`, and it outranks the Databricks fallback
the assertion is about — so the test fails locally for a reason that has nothing
to do with the ordering it exists to check. CI has no Ollama, so it stays green
and the flake is invisible there.

Pin provider detection to empty for this one test. Test-only; no source change.

## Test Plan

- `pytest tests/repl/test_repl.py -k startup_header_creds` — 2 passed, verified
  both with and without a local Ollama listening on `:11434`. Before the change
  the same command fails with Ollama running.
- `pre-commit run --files tests/repl/test_repl.py`.

## Demo

N/A — test-only change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The change *is* the coverage fix: it removes an ambient dependency from an
existing assertion rather than adding a new one. Verified by running the test
both with and without Ollama on `:11434` — the failure reproduces before the
change and not after, in both environments.
