### PR TITLE
fix(hosts): don't let a stale tunnel teardown flip a reconnected host offline

### DIFF
--- a/omnigent/server/host_registry.py
+++ b/omnigent/server/host_registry.py
@@ -382,7 +382,12 @@ class HostRegistry:
             self._hosts[key] = conn
         return conn
 
-    def deregister(self, host_id: str, workspace_id: int | None = None) -> None:
+    def deregister(
+        self,
+        host_id: str,
+        workspace_id: int | None = None,
+        conn: HostConnection | None = None,
+    ) -> HostConnection | None:
         """Remove a host connection.
 
         No-op if ``(workspace_id, host_id)`` is not registered.
@@ -391,10 +396,20 @@ class HostRegistry:
             spelling (see :func:`_canonical_host_id`).
         :param workspace_id: Tenant partition; defaults to
             :func:`current_workspace_id`.
+        :param conn: Optional generation guard. When provided, the entry
+            is removed only if it is this exact connection object, so a
+            reconnecting host's teardown can't evict the newer tunnel
+            that already replaced it (see :meth:`register`).
+        :returns: The removed connection, or ``None`` when the host was
+            already offline or the guard did not match.
         """
         ws_id = current_workspace_id() if workspace_id is None else workspace_id
+        key = (ws_id, _canonical_host_id(host_id))
         with self._lock:
-            self._hosts.pop((ws_id, _canonical_host_id(host_id)), None)
+            current = self._hosts.get(key)
+            if current is None or (conn is not None and current is not conn):
+                return None
+            return self._hosts.pop(key)
 
     def get(self, host_id: str, workspace_id: int | None = None) -> HostConnection | None:
         """Look up a live host connection.

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -325,16 +325,21 @@ def create_host_tunnel_router(
                     receive_task,
                     return_exceptions=True,
                 )
-                host_registry.deregister(host_id)
-                await asyncio.to_thread(host_store.set_offline, host_id)
-                if on_host_disconnect is not None:
-                    try:
-                        await on_host_disconnect(host_id, tunnel_owner)
-                    except Exception:
-                        _logger.exception(
-                            "on_host_disconnect callback failed for %s",
-                            host_id,
-                        )
+                # Pass ``conn`` so a teardown that lost the race to a
+                # reconnect leaves the newer tunnel — and the row it just
+                # marked online — alone. Without the guard the old
+                # connection's cleanup flips a live host offline, and the
+                # ping loop's heartbeat never restores the flag.
+                if host_registry.deregister(host_id, conn=conn) is not None:
+                    await asyncio.to_thread(host_store.set_offline, host_id)
+                    if on_host_disconnect is not None:
+                        try:
+                            await on_host_disconnect(host_id, tunnel_owner)
+                        except Exception:
+                            _logger.exception(
+                                "on_host_disconnect callback failed for %s",
+                                host_id,
+                            )
 
         except WebSocketDisconnect:
             _logger.warning("Host %s disconnected", host_id)
@@ -343,8 +348,7 @@ def create_host_tunnel_router(
             # register — e.g. the upsert IntegrityError when a peer
             # connects with another owner's host_id — must not deregister
             # or flip that owner's host offline (cross-user DoS).
-            if conn is not None:
-                host_registry.deregister(host_id)
+            if conn is not None and host_registry.deregister(host_id, conn=conn) is not None:
                 await asyncio.to_thread(host_store.set_offline, host_id)
                 if on_host_disconnect is not None:
                     try:
@@ -356,9 +360,9 @@ def create_host_tunnel_router(
                         )
         except Exception:
             _logger.exception("Host tunnel error for %s", host_id)
-            # Same guard as above: don't touch a host we never registered.
-            if conn is not None:
-                host_registry.deregister(host_id)
+            # Same guard as above: don't touch a host we never registered,
+            # nor one a newer connection has since taken over.
+            if conn is not None and host_registry.deregister(host_id, conn=conn) is not None:
                 await asyncio.to_thread(host_store.set_offline, host_id)
 
     return router

--- a/tests/server/test_host_registry.py
+++ b/tests/server/test_host_registry.py
@@ -95,7 +95,30 @@ def test_deregister_noop_for_unknown() -> None:
     registration; it must not raise.
     """
     registry = HostRegistry()
-    registry.deregister("host_nonexistent")
+    assert registry.deregister("host_nonexistent") is None
+
+
+def test_deregister_guard_keeps_reconnected_connection() -> None:
+    """
+    Verify a stale teardown can't evict the connection that replaced it.
+
+    A host that reconnects before its old tunnel finishes tearing down
+    registers a new connection; the old handler's deregister must not
+    remove it. Without the guard the caller also flips the live host's
+    row offline, and the ping loop's heartbeat never restores it.
+    """
+    registry = HostRegistry()
+    old = registry.register("host_ccc", FakeWebSocket(), _make_hello(), owner="carol")
+    new = registry.register("host_ccc", FakeWebSocket(), _make_hello(), owner="carol")
+
+    # Stale handler tears down after the reconnect: no removal, so its
+    # caller skips set_offline.
+    assert registry.deregister("host_ccc", conn=old) is None
+    assert registry.get("host_ccc") is new
+
+    # The current connection's own teardown still removes it.
+    assert registry.deregister("host_ccc", conn=new) is new
+    assert registry.get("host_ccc") is None
 
 
 def test_online_host_ids() -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

When a host's tunnel recycles, the host reconnects and `HostRegistry.register` replaces the entry — newest wins, by design. But the *old* connection's teardown then runs and unconditionally calls `host_registry.deregister` + `host_store.set_offline` (three paths in `routes/host_tunnel.py`).

The result is a live, heartbeating host pinned at `status=offline` and hidden from the UI — permanently, because `HostStore.heartbeat` is a bare `update(...).values(updated_at=now_epoch())` whose own docstring notes it "Does not change ``status``". Nothing restores the row until a later reconnect happens to win the race. Any WS recycle reproduces it (idle proxy timeout, a close frame that never arrives).

The fix gives `HostRegistry.deregister` a connection-generation guard: remove the entry only if it *is* that exact connection, and return what was removed. The three teardown paths then call `set_offline` only when they actually removed their own connection.

This isn't a new pattern — `RunnerRegistry.deregister` in `runner/transports/ws_tunnel/registry.py` already does exactly this, down to the same optional-object parameter and the same docstring note about stale handlers deleting a newer tunnel. This brings the host registry in line with its sibling.

**Why not just have the heartbeat restore `status='online'`?** That papers over the race: the row still flaps offline→online for up to `PING_INTERVAL_S`, and every consumer reading `status` in that window sees a live host as down. The guard removes the wrong write at its source.

**Suppressing the stale `on_host_disconnect` is intentional.** In `server/app.py` that callback is only `announce_hosts_changed`, and the reconnect's `on_host_connect` has already fired it.

## Test Plan

- `pytest tests/server/test_host_registry.py` — 17 passed (new cases cover deregister-with-stale-connection and the returned-connection contract).
- `pytest tests/server/ -k host` — 430 passed, 2307 deselected.

Observed on a real fleet before the fix: a host visible as `offline` in the UI while its tunnel was actively heartbeating, recovering only on the next reconnect.

## Demo

N/A — no visual surface of its own; the effect is a host no longer showing offline while connected.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: reproduced the stale-teardown ordering against a running server by recycling a host tunnel, confirming the row stayed `offline` while heartbeats continued before the change, and stayed `online` after.

## Changelog

Hosts no longer get stuck showing offline after their tunnel reconnects.