### PR TITLE
fix(repl): don't report an Omnigent credential for ACP-backed sessions

### DIFF
--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -1288,13 +1288,18 @@ def _source_descriptor(family: FamilyConfig) -> str:
     )
 
 
-def _harness_owns_its_credential(harness: str) -> bool:
+def harness_owns_its_credential(harness: str) -> bool:
     """Whether *harness* carries its own auth, so Omnigent resolves none.
 
-    True for ACP-backed harnesses (``acp``/``acp:<slug>``, goose, qwen and
-    any community ACP plugin): the external agent authenticates itself and
-    picks its own model, so describing an Omnigent provider for one would
-    name a credential the session never uses.
+    True for ACP-backed harnesses whose spawn wires no Omnigent provider
+    (``acp``/``acp:<slug>``, goose, and unmapped community ACP plugins):
+    the external agent authenticates itself, so describing an Omnigent
+    provider for one would name a credential the session never uses.
+
+    A harness mapped in :data:`_HARNESS_FAMILY` is provider-routed at spawn
+    (e.g. qwen consumes the openai family via its gateway env) even when its
+    capability record declares own-auth for the unconfigured fallback, so it
+    is never declined here — its family default is genuinely what it runs on.
 
     :param harness: The harness name, canonical or ``acp:<slug>``.
     :returns: ``True`` when the harness owns its own credential.
@@ -1302,8 +1307,10 @@ def _harness_owns_its_credential(harness: str) -> bool:
     from omnigent.harness_capabilities import AuthModel, IntegrationMode
     from omnigent.harness_plugins import harness_capabilities
 
-    key = harness.split(":", 1)[0] if harness.startswith("acp:") else harness
-    caps = harness_capabilities().get(canonicalize_harness(key))
+    canonical = canonicalize_harness(harness) or harness
+    if canonical in _HARNESS_FAMILY:
+        return False
+    caps = harness_capabilities().get(canonical)
     if caps is None:
         return False
     return (
@@ -1336,7 +1343,7 @@ def describe_active_credential(
     :raises OmnigentError: If the resolved provider is malformed, or more
         than one default serves the family.
     """
-    if _harness_owns_its_credential(harness):
+    if harness_owns_its_credential(harness):
         return None
 
     provider = default_provider_for_harness(config, harness)

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -1288,6 +1288,29 @@ def _source_descriptor(family: FamilyConfig) -> str:
     )
 
 
+def _harness_owns_its_credential(harness: str) -> bool:
+    """Whether *harness* carries its own auth, so Omnigent resolves none.
+
+    True for ACP-backed harnesses (``acp``/``acp:<slug>``, goose, qwen and
+    any community ACP plugin): the external agent authenticates itself and
+    picks its own model, so describing an Omnigent provider for one would
+    name a credential the session never uses.
+
+    :param harness: The harness name, canonical or ``acp:<slug>``.
+    :returns: ``True`` when the harness owns its own credential.
+    """
+    from omnigent.harness_capabilities import AuthModel, IntegrationMode
+    from omnigent.harness_plugins import harness_capabilities
+
+    key = harness.split(":", 1)[0] if harness.startswith("acp:") else harness
+    caps = harness_capabilities().get(canonicalize_harness(key))
+    if caps is None:
+        return False
+    return (
+        caps.integration_mode is IntegrationMode.ACP_SUBPROCESS and caps.auth is AuthModel.OWN_AUTH
+    )
+
+
 def describe_active_credential(
     config: dict[str, object],
     harness: str,
@@ -1313,6 +1336,9 @@ def describe_active_credential(
     :raises OmnigentError: If the resolved provider is malformed, or more
         than one default serves the family.
     """
+    if _harness_owns_its_credential(harness):
+        return None
+
     provider = default_provider_for_harness(config, harness)
     if provider is None:
         return None

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -4868,6 +4868,7 @@ def _build_model_readout_lines(
     )
     from omnigent.onboarding.provider_config import (
         PI_SURFACE,
+        _harness_owns_its_credential,
         describe_active_credential,
         harness_family,
         load_providers,
@@ -4875,6 +4876,14 @@ def _build_model_readout_lines(
     )
 
     lines: list[str] = []
+    if harness and _harness_owns_its_credential(harness):
+        # The external agent authenticates itself and chooses its own model,
+        # so there is no Omnigent credential to name and an Omnigent-side
+        # /model override does not reach it.
+        return [
+            "Active:  the agent's own model  ·  🤖 ACP agent (owns its model + auth)",
+            "  set the model in the agent's own config or launch command.",
+        ]
     cred = describe_active_credential(config, harness, model_override=model_override)
     if cred is None:
         # Nothing resolves for this harness's surface — not in the explicit

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -4868,21 +4868,23 @@ def _build_model_readout_lines(
     )
     from omnigent.onboarding.provider_config import (
         PI_SURFACE,
-        _harness_owns_its_credential,
         describe_active_credential,
         harness_family,
+        harness_owns_its_credential,
         load_providers,
         provider_families,
     )
 
     lines: list[str] = []
-    if harness and _harness_owns_its_credential(harness):
-        # The external agent authenticates itself and chooses its own model,
-        # so there is no Omnigent credential to name and an Omnigent-side
-        # /model override does not reach it.
+    if harness and harness_owns_its_credential(harness):
+        # The external agent authenticates itself, so there is no Omnigent
+        # credential to name. An in-session override is still shown (it's
+        # real, and e.g. goose applies it as GOOSE_MODEL); whether it reaches
+        # the agent varies per ACP agent, so no claim is made either way.
+        model_label = model_override or "(the agent's own model)"
         return [
-            "Active:  the agent's own model  ·  🤖 ACP agent (owns its model + auth)",
-            "  set the model in the agent's own config or launch command.",
+            f"Active:  {model_label}  ·  🤖 ACP agent (agent's own auth)",
+            "usage: /model <name> · /model default | off | reset to clear",
         ]
     cred = describe_active_credential(config, harness, model_override=model_override)
     if cred is None:

--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -3049,48 +3049,94 @@ def test_resume_hint_appends_resume_flag_to_invocation_parts() -> None:
     )
 
 
-def test_model_readout_acp_harness_reports_agent_not_provider() -> None:
-    """
-    ACP-backed harnesses must not report an Omnigent provider credential.
-
-    ``acp``/``acp:<slug>``/``goose``/``qwen`` aren't in ``_HARNESS_FAMILY``,
-    so ``default_provider_for_harness`` used to fall through to the
-    configured anthropic/openai default and the readout named a model and
-    credential the session never touches. A failure here means that
-    fabrication is back.
-    """
-    from omnigent.repl._repl import _build_model_readout_lines
-
-    for harness in ("acp", "acp:droid", "goose", "qwen"):
-        lines = _build_model_readout_lines({}, harness, None)
-        assert any("ACP agent" in line for line in lines), (harness, lines)
-        # No provider/credential fabrication, and no claim that an
-        # Omnigent-side /model override reaches the agent.
-        assert not any("API Key" in line for line in lines), (harness, lines)
-        assert not any("/model <name> switches" in line for line in lines), (harness, lines)
-
-
-def test_describe_active_credential_returns_none_for_acp_harnesses() -> None:
-    """
-    The resolver, not just the readout, must decline ACP harnesses.
-
-    ``_resolve_startup_header`` calls ``describe_active_credential``
-    independently of the ``/model`` readout, so fixing only the readout
-    would leave the startup banner naming the same wrong credential.
-    """
-    from omnigent.onboarding.provider_config import describe_active_credential
-
-    config = {
+def _openai_key_default_config() -> dict[str, object]:
+    """A config whose openai key default the unmapped fallback used to fabricate."""
+    return {
         "providers": {
-            "claude-subscription": {
-                "kind": "subscription",
-                "cli": "claude",
-                "default": "anthropic",
+            "openai": {
+                "kind": "key",
+                "default": "openai",
+                "openai": {
+                    "base_url": "https://api.openai.com/v1",
+                    "api_key": "$OPENAI_API_KEY",
+                    "models": {"default": "gpt-5.5"},
+                },
             }
         }
     }
-    for harness in ("acp", "acp:droid", "goose", "qwen"):
+
+
+def test_model_readout_own_auth_acp_harness_reports_agent_not_provider() -> None:
+    """
+    Own-auth ACP harnesses must not report an Omnigent provider credential.
+
+    ``acp``/``acp:<slug>`` and ``goose`` spawn without any Omnigent provider
+    wiring, but ``default_provider_for_harness`` used to fall through to the
+    configured key/gateway default for them (the unmapped pi-style fallback),
+    so the readout named a model and credential the session never touches.
+    A failure here means that fabrication is back.
+    """
+    from omnigent.repl._repl import _build_model_readout_lines
+
+    config = _openai_key_default_config()
+    for harness in ("acp", "acp:droid", "goose"):
+        lines = _build_model_readout_lines(config, harness, None)
+        assert any("ACP agent" in line for line in lines), (harness, lines)
+        assert not any("API Key" in line for line in lines), (harness, lines)
+        assert not any("gpt-5.5" in line for line in lines), (harness, lines)
+
+
+def test_model_readout_own_auth_acp_harness_shows_live_override() -> None:
+    """
+    An in-session ``/model`` override is real state and must stay visible.
+
+    The runner forwards it to these harnesses (``model_env_keys()`` covers
+    acp/goose; goose applies it as ``GOOSE_MODEL``), so the readout may not
+    hide it or claim the model can't be changed.
+    """
+    from omnigent.repl._repl import _build_model_readout_lines
+
+    config = _openai_key_default_config()
+    for harness in ("acp", "goose"):
+        lines = _build_model_readout_lines(config, harness, "qwen3-coder-plus")
+        assert any("qwen3-coder-plus" in line for line in lines), (harness, lines)
+        assert not any("does not reach" in line for line in lines), (harness, lines)
+
+
+def test_model_readout_qwen_still_names_routed_provider() -> None:
+    """
+    qwen is provider-routed, so its readout keeps naming the openai default.
+
+    ``_build_qwen_spawn_env`` injects the configured openai-family default
+    into the qwen subprocess (see ``test_qwen_uses_openai_global_default``),
+    so for qwen — unlike acp/goose — the credential readout is truthful and
+    must not be declined as "own auth".
+    """
+    from omnigent.repl._repl import _build_model_readout_lines
+
+    lines = _build_model_readout_lines(_openai_key_default_config(), "qwen", None)
+    assert any("OpenAI API Key" in line for line in lines), lines
+    assert not any("ACP agent" in line for line in lines), lines
+
+
+def test_describe_active_credential_declines_own_auth_acp_harnesses() -> None:
+    """
+    The resolver, not just the readout, must decline own-auth ACP harnesses.
+
+    ``_resolve_startup_header`` calls ``describe_active_credential``
+    independently of the ``/model`` readout, so fixing only the readout
+    would leave the startup banner naming the same wrong credential. The
+    config uses a key-kind default — the kind the unmapped fallback actually
+    fabricated (a subscription default was already skipped, so it can't pin
+    this fix).
+    """
+    from omnigent.onboarding.provider_config import describe_active_credential
+
+    config = _openai_key_default_config()
+    for harness in ("acp", "acp:droid", "goose"):
         assert describe_active_credential(config, harness) is None, harness
-    # A non-ACP harness on the same config still resolves normally, proving
-    # the new short-circuit is scoped to ACP and didn't blank the resolver.
-    assert describe_active_credential(config, "claude-sdk") is not None
+    # Provider-routed harnesses on the same config still resolve, proving the
+    # short-circuit is scoped to own-auth ACP spawns and didn't blank the
+    # resolver: qwen consumes the openai family at spawn.
+    qwen_cred = describe_active_credential(config, "qwen")
+    assert qwen_cred is not None and qwen_cred.provider_name == "openai"

--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -3047,3 +3047,50 @@ def test_resume_hint_appends_resume_flag_to_invocation_parts() -> None:
         "--harness claude-sdk "
         "--resume conv_abc"
     )
+
+
+def test_model_readout_acp_harness_reports_agent_not_provider() -> None:
+    """
+    ACP-backed harnesses must not report an Omnigent provider credential.
+
+    ``acp``/``acp:<slug>``/``goose``/``qwen`` aren't in ``_HARNESS_FAMILY``,
+    so ``default_provider_for_harness`` used to fall through to the
+    configured anthropic/openai default and the readout named a model and
+    credential the session never touches. A failure here means that
+    fabrication is back.
+    """
+    from omnigent.repl._repl import _build_model_readout_lines
+
+    for harness in ("acp", "acp:droid", "goose", "qwen"):
+        lines = _build_model_readout_lines({}, harness, None)
+        assert any("ACP agent" in line for line in lines), (harness, lines)
+        # No provider/credential fabrication, and no claim that an
+        # Omnigent-side /model override reaches the agent.
+        assert not any("API Key" in line for line in lines), (harness, lines)
+        assert not any("/model <name> switches" in line for line in lines), (harness, lines)
+
+
+def test_describe_active_credential_returns_none_for_acp_harnesses() -> None:
+    """
+    The resolver, not just the readout, must decline ACP harnesses.
+
+    ``_resolve_startup_header`` calls ``describe_active_credential``
+    independently of the ``/model`` readout, so fixing only the readout
+    would leave the startup banner naming the same wrong credential.
+    """
+    from omnigent.onboarding.provider_config import describe_active_credential
+
+    config = {
+        "providers": {
+            "claude-subscription": {
+                "kind": "subscription",
+                "cli": "claude",
+                "default": "anthropic",
+            }
+        }
+    }
+    for harness in ("acp", "acp:droid", "goose", "qwen"):
+        assert describe_active_credential(config, harness) is None, harness
+    # A non-ACP harness on the same config still resolves normally, proving
+    # the new short-circuit is scoped to ACP and didn't blank the resolver.
+    assert describe_active_credential(config, "claude-sdk") is not None


### PR DESCRIPTION
## Related issue

N/A

## Summary

`acp`, `acp:<slug>`, `goose` and `qwen` aren't in `_HARNESS_FAMILY`, so `default_provider_for_harness` treats them as unmapped and falls through to whichever anthropic/openai default is configured — exactly as it does for `pi`. `describe_active_credential` then returns that provider's `default_model` and credential source, and the REPL renders it as `Active:`.

But an ACP agent carries its own auth and picks its own model. `AcpExecutor` only forwards a `model` at `session/new` when `send_model_in_session_new` is set, and otherwise never sees the Omnigent-side value. So this prints something like:

```
Active:  gpt-5.5  ·  🔑 OpenAI API Key  ·  $OPENAI_API_KEY
```

...for a session actually running whatever the external agent is configured with. A confident, wrong answer to the one question `/model` exists to answer — and the startup header, which calls the same resolver, says the same wrong thing.

Two parts:

- **`describe_active_credential` declines these harnesses**, so the fabrication stops at the resolver rather than in one display path. `_resolve_startup_header` calls it independently, so a readout-only fix would leave the banner lying.
- **The `/model` readout says what's actually true** — the agent owns its model and auth, and an Omnigent-side override doesn't reach it.

The predicate reads the declared capability record (`IntegrationMode.ACP_SUBPROCESS` + `AuthModel.OWN_AUTH`) rather than a hardcoded harness list, so community ACP plugins are covered without another edit here.

## Test Plan

- `pytest tests/repl/test_repl.py` — 108 passed.
- `pytest tests/onboarding/` — 892 passed.

Two cases added: the readout across `acp` / `acp:<slug>` / `goose` / `qwen` (asserting no credential fabrication and no false claim that `/model` reaches the agent), and a resolver-level case asserting `describe_active_credential` returns `None` for those four while a non-ACP harness on the same config still resolves normally.

Two failures in those runs are pre-existing environment gaps in my checkout, unrelated to this change and equally present on a clean `main`: `test_openclaw_config.py` (no `json5` installed) and `test_databricks_sdk_installed_true_in_dev_env` (no databricks SDK). I also hit `test_build_startup_header_creds_line_hints_first_available` failing from an ambient local Ollama — that one is fixed separately in #3427.

## Demo

N/A — terminal text change; the before/after readout is quoted above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by the unit tests above.

## Changelog

`/model` and the startup header no longer name an Omnigent provider and model for ACP-backed sessions, which run on the agent's own auth and model.