### PR TITLE
feat[web]: Queue browser element prompts while agents run

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -104,6 +104,7 @@ import {
   type PendingInitialPrompt,
   type PendingUserMessage,
   type QueuedMessage,
+  shouldQueueMessage,
   useChatStore,
 } from "@/store/chatStore";
 import { isNativeTerminalSession, nativeCodingAgentForHarness } from "@/lib/nativeCodingAgents";
@@ -500,10 +501,7 @@ export function shouldQueueSend(
   sessionStatus: SessionStatus,
   queuedMessages: QueuedMessage[],
 ): boolean {
-  if (conversationId === null) return false;
-  const isBusy = status === "streaming" || sessionStatus === "running";
-  const hasQueued = queuedMessages.some((m) => m.conversationId === conversationId);
-  return isBusy || hasQueued;
+  return shouldQueueMessage(conversationId, status, sessionStatus, queuedMessages);
 }
 
 // Author labels render only in a shared session; ChatPage provides the

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import {
   MemoryRouter,
   Route,
@@ -531,6 +531,106 @@ describe("AppShell header", () => {
     renderShell("/c/conv_terminal");
 
     expect(screen.getByTestId("view-probe")).toHaveAttribute("data-terminal-starting-up", "false");
+  });
+});
+
+describe("AppShell browser design-mode submit", () => {
+  it("queues a browser element request while the conversation is running", () => {
+    mockConversations([{ id: "conv_browser", permission_level: 4 }]);
+    useSessionAgentMock.mockReturnValue({
+      data: { id: "agent_browser", name: "browser-agent", description: "" } as Agent,
+    } as ReturnType<typeof useSessionAgent>);
+
+    let submit:
+      | ((payload: {
+          conversationId?: string;
+          id?: number;
+          element?: { tag?: string; text?: string };
+          prompt?: string;
+        }) => void)
+      | undefined;
+    let select:
+      | ((payload: { conversationId?: string; screenshot?: string | null }) => void)
+      | undefined;
+    const signalResult = vi.fn().mockResolvedValue({ ok: true });
+    const desktop = {
+      kind: "electron",
+      browserOpenOrNavigate: vi.fn(),
+      onBrowserElementSelected: vi.fn((callback) => {
+        select = callback;
+        return vi.fn();
+      }),
+      onBrowserElementPromptSubmit: vi.fn((callback) => {
+        submit = callback;
+        return vi.fn();
+      }),
+      onBrowserElementPromptDismiss: vi.fn(() => vi.fn()),
+      browserSignalDesignResult: signalResult,
+    };
+    Object.defineProperty(window, "omnigentDesktop", {
+      configurable: true,
+      value: desktop,
+    });
+
+    const originalSend = useChatStore.getState().send;
+    const send = vi.fn().mockResolvedValue(undefined);
+    useChatStore.setState({
+      conversationId: "conv_browser",
+      boundAgentId: "agent_browser",
+      status: "idle",
+      sessionStatus: "running",
+      queuedMessages: [],
+      send,
+    });
+
+    try {
+      renderShell("/c/conv_browser");
+      expect(submit).toBeTypeOf("function");
+
+      act(() => {
+        select?.({
+          conversationId: "conv_browser",
+          screenshot: "data:image/png;base64,cG5n",
+        });
+        submit?.({
+          conversationId: "conv_browser",
+          id: 7,
+          element: { tag: "button", text: "Save" },
+          prompt: "Make this button larger",
+        });
+      });
+
+      const queued = useChatStore.getState().queuedMessages;
+      expect(queued).toHaveLength(1);
+      expect(queued[0]).toEqual(
+        expect.objectContaining({
+          conversationId: "conv_browser",
+          agentId: "agent_browser",
+        }),
+      );
+      expect(queued[0]!.text).toContain("Make this button larger");
+      expect(queued[0]!.text).toContain("Element: <button>");
+      expect(queued[0]!.files).toHaveLength(1);
+      expect(queued[0]!.files?.[0]).toEqual(
+        expect.objectContaining({ name: "design-element-7.png", type: "image/png" }),
+      );
+      expect(send).not.toHaveBeenCalled();
+      expect(signalResult).toHaveBeenCalledWith("conv_browser", {
+        id: 7,
+        ok: true,
+        message: "Queued. Use Steer now to send it immediately.",
+      });
+    } finally {
+      useChatStore.setState({
+        conversationId: null,
+        boundAgentId: null,
+        status: "idle",
+        sessionStatus: "idle",
+        send: originalSend,
+        queuedMessages: [],
+      });
+      Reflect.deleteProperty(window, "omnigentDesktop");
+    }
   });
 });
 

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -62,7 +62,7 @@ import { isCodexNativeSession } from "@/lib/codexPlanMode";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { isSingleUserMode } from "@/lib/capabilities";
 import { isCurrentServerLocal } from "@/lib/serverOrigin";
-import { useChatStore } from "@/store/chatStore";
+import { shouldQueueMessage, useChatStore } from "@/store/chatStore";
 import { livenessRowFromSession, useSessionLiveness } from "@/hooks/useSessionLiveness";
 import { useResizableInlinePanel } from "@/hooks/useResizableInlinePanel";
 import { ChatHeader } from "./ChatHeader";
@@ -569,8 +569,8 @@ export function AppShell() {
   // Design-mode submit routing. Lives here (with the hoisted relay) because the
   // in-page popup posts back via preload IPC delivered to the always-mounted
   // shell, not BrowserPane. On submit: build the `[Design Mode — …]` message,
-  // attach the cropped screenshot, send via the NORMAL chat path (no backend
-  // route), then signal the result back for green/red. Dismiss is a no-op.
+  // attach the cropped screenshot, then use the same queue-or-send policy as
+  // the composer. Dismiss is a no-op.
   // Routes to the conversation's own bound agent (the picked element belongs to
   // the page it drives). The screenshot arrives on the earlier element-selected
   // event, so we stash the latest per conversation and pair it at submit time.
@@ -631,14 +631,24 @@ export function AppShell() {
         const text = buildDesignModePrompt(payload.element, payload.prompt);
         const shot = designShotRef.current.get(cid);
         const file = dataUrlToFile(shot, `design-element-${submitId}.png`);
-        void useChatStore
-          .getState()
-          .send(text, boundAgentId, file ? [file] : undefined)
-          .then(() => signal(true, "Sent to agent."))
-          .catch((err: unknown) => signal(false, `Send failed: ${String(err)}`));
-        // Clear the stashed screenshot so a later submit without a fresh pick
-        // doesn't reuse a stale crop.
+        const files = file ? [file] : undefined;
+        // The File now owns the screenshot bytes; don't let a later submit
+        // reuse this crop even if the owning session changed meanwhile.
         designShotRef.current.delete(cid);
+        const chat = useChatStore.getState();
+        if (chat.conversationId !== cid) {
+          signal(false, "This browser session is no longer active.");
+          return;
+        }
+        if (shouldQueueMessage(cid, chat.status, chat.sessionStatus, chat.queuedMessages)) {
+          chat.enqueueMessageForConversation(cid, text, boundAgentId, files);
+          signal(true, "Queued. Use Steer now to send it immediately.");
+        } else {
+          void chat
+            .send(text, boundAgentId, files)
+            .then(() => signal(true, "Sent to agent."))
+            .catch((err: unknown) => signal(false, `Send failed: ${String(err)}`));
+        }
       } catch (err) {
         signal(false, `Error: ${String(err)}`);
       }

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -8504,6 +8504,30 @@ describe("chatStore — client-side message queue", () => {
     expect(useChatStore.getState().queuedMessages).toEqual([]);
   });
 
+  it("enqueueMessageForConversation preserves the supplied conversation and agent", () => {
+    const screenshot = new File(["png"], "element.png", { type: "image/png" });
+    useChatStore.setState({
+      conversationId: "conv_active",
+      boundAgentId: "agent_active",
+      status: "streaming",
+      sessionStatus: "running",
+      queuedMessages: [],
+    });
+
+    useChatStore
+      .getState()
+      .enqueueMessageForConversation("conv_browser", "change this", "agent_browser", [screenshot]);
+
+    expect(useChatStore.getState().queuedMessages).toEqual([
+      expect.objectContaining({
+        text: "change this",
+        conversationId: "conv_browser",
+        agentId: "agent_browser",
+        files: [screenshot],
+      }),
+    ]);
+  });
+
   it("dequeueMessage removes the message with the given id, keeping order", () => {
     useChatStore.setState({
       conversationId: "conv_abc",

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -181,6 +181,29 @@ export interface QueuedMessage {
 }
 
 /**
+ * Whether a submitted message should be queued rather than POSTed now.
+ *
+ * Queue when busy, or when this conversation already has a queued message even
+ * if it reads idle: the direct-send and queue-drain paths aren't ordered, so a
+ * later direct send could overtake a still-queued earlier one when status
+ * flickers idle mid-queue. A new chat always sends.
+ *
+ * ``waiting`` is not busy for queueing: the turn already ended and only
+ * background work remains, so the server can accept a new turn immediately.
+ */
+export function shouldQueueMessage(
+  conversationId: string | null,
+  status: "idle" | "streaming",
+  sessionStatus: SessionStatus,
+  queuedMessages: QueuedMessage[],
+): boolean {
+  if (conversationId === null) return false;
+  const isBusy = status === "streaming" || sessionStatus === "running";
+  const hasQueued = queuedMessages.some((message) => message.conversationId === conversationId);
+  return isBusy || hasQueued;
+}
+
+/**
  * A conversation's in-flight optimistic bubbles, stashed so they survive
  * in-app navigation. See {@link ChatState.pendingByConversation}.
  */
@@ -548,6 +571,16 @@ export interface ChatState {
    * turn) when the session next goes idle — see the `session_status` handler.
    */
   enqueueMessage: (text: string, files?: File[]) => void;
+  /**
+   * Queue a message for an explicit conversation and agent. Used by shell-level
+   * interaction surfaces whose event already carries its owning conversation.
+   */
+  enqueueMessageForConversation: (
+    conversationId: string,
+    text: string,
+    agentId: string | null,
+    files?: File[],
+  ) => void;
   /** Remove a queued message by id (the strip's per-row delete). */
   dequeueMessage: (queueId: string) => void;
   /**
@@ -940,6 +973,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
   enqueueMessage: (text, files) => {
     const { conversationId, boundAgentId } = get();
     if (conversationId === null) return;
+    get().enqueueMessageForConversation(conversationId, text, boundAgentId, files);
+  },
+
+  enqueueMessageForConversation: (conversationId, text, agentId, files) => {
     queueSeq += 1;
     const queueId = `q_${queueSeq}`;
     set((s) => ({
@@ -949,7 +986,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
           queueId,
           text,
           conversationId,
-          ...(boundAgentId !== null ? { agentId: boundAgentId } : {}),
+          ...(agentId !== null ? { agentId } : {}),
           ...(files && files.length > 0 ? { files } : {}),
         },
       ],


### PR DESCRIPTION
## Related issue

N/A

## Summary

Browser design-mode prompts previously bypassed the client-side message queue and posted immediately, so users could not review, reorder, or steer an element-specific follow-up while an agent was already working. This change routes those prompts through the same queue policy as regular composer messages while preserving the selected element context and cropped screenshot.

- Share one queue decision between the composer and browser design mode.
- Queue browser prompts while the session is busy or already has queued work; continue sending immediately while idle.
- Preserve the originating conversation and bound agent, and reject stale browser submissions after a session switch.
- Reuse the existing edit, delete, reorder, auto-flush, and **Steer now** behavior without changing harness or backend capabilities.

**ELI5:** selecting a page element while the agent is busy now adds the request to the same waiting line as a typed follow-up. The user can leave it there or press **Steer now** to send it immediately.

```text
Browser element + prompt
          |
          v
   shared queue policy
      /          \
 busy/queued     idle
    |              |
 queue strip    send now
    |
 edit / delete / reorder / steer
```

## Test Plan

- `npm test -- --run src/store/chatStore.test.ts src/pages/ChatPage.composer.test.tsx src/shell/AppShell.test.tsx`
  - 3 test files passed
  - 479 tests passed
- `npm run type-check`
- `uv run --frozen pre-commit run --all-files`

## Demo

<img width="1370" height="1554" alt="Screenshot 2026-07-28 at 18 49 17" src="https://github.com/user-attachments/assets/6532007a-68b8-499d-904c-ce79d8b2ff84" />

<img width="1508" height="1785" alt="Screenshot 2026-07-28 at 18 53 00" src="https://github.com/user-attachments/assets/a906f6bf-bf3b-4b1f-9c51-70710eee7ea6" />

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added regression coverage for conversation-scoped queue entries and browser design-mode submissions, including screenshot preservation, agent binding, and avoiding a direct send while the session is running.

## Changelog

Browser element prompts now join the message queue while an agent is working, so they can be reviewed or steered immediately.
