### PR TITLE
feat(kubernetes): configurable sandbox Pod tolerations

### DIFF
--- a/deploy/kubernetes/overlays/sandbox-runners/sandbox-config.yaml
+++ b/deploy/kubernetes/overlays/sandbox-runners/sandbox-config.yaml
@@ -42,6 +42,11 @@ data:
         # env: [PROXY_URL]           # SERVER env vars injected as literal Pod env (prefer secret_name for creds)
         # node_selector:             # extra node labels; default kubernetes.io/arch: amd64, override to arm64 to run there
         #   disktype: ssd
+        # tolerations:               # Pod tolerations, e.g. for a tainted dedicated agent node pool
+        #   - key: dedicated
+        #     operator: Equal
+        #     value: agents
+        #     effect: NoSchedule
         # resources:                 # runner Pod sizing (defaults: 0.5-2 cpu / 1-4Gi)
         #   requests: {cpu: "500m", memory: "1Gi"}
         #   limits: {cpu: "2", memory: "4Gi"}

--- a/omnigent/onboarding/sandboxes/kubernetes.py
+++ b/omnigent/onboarding/sandboxes/kubernetes.py
@@ -476,6 +476,7 @@ def build_pod_manifest(
     host_config: dict[str, object] | None = None,
     resources: dict[str, object] | None = None,
     pvc_mounts: Sequence[Mapping[str, object]] | None = None,
+    tolerations: Sequence[Mapping[str, object]] | None = None,
 ) -> dict[str, object]:
     """
     Build the sandbox Pod manifest as a plain dict.
@@ -506,6 +507,8 @@ def build_pod_manifest(
     - Operator *pvc_mounts* become ``persistentVolumeClaim`` volumes mounted on
       the **host container only** (read-only unless opted out); the init
       container sees only HOME, so nothing external is exposed at clone time.
+    - Operator *tolerations* are emitted verbatim on the Pod spec, letting
+      runner Pods schedule onto tainted nodes (e.g. a dedicated agent pool).
 
     :param pod_name: DNS-label-safe Pod name (see :func:`_new_pod_name`).
     :param namespace: Namespace the Pod is created in.
@@ -537,6 +540,8 @@ def build_pod_manifest(
     :param pvc_mounts: Normalized PVC mounts (``{claim_name, mount_path,
         read_only}``) added as ``persistentVolumeClaim`` volumes on the host
         container only, or ``None``.
+    :param tolerations: Manifest-shaped toleration entries emitted verbatim on
+        the Pod spec (validated at config-parse time), or ``None`` for none.
     :returns: The Pod manifest dict.
     """
     pod_resources = _resolve_pod_resources(resources)
@@ -652,6 +657,8 @@ def build_pod_manifest(
         "initContainers": [init_container],
         "containers": [host_container],
     }
+    if tolerations:
+        spec["tolerations"] = [dict(entry) for entry in tolerations]
     return {
         "apiVersion": "v1",
         "kind": "Pod",
@@ -839,6 +846,7 @@ class KubernetesSandboxLauncher(SandboxLauncher):
         in_cluster: bool | None = None,
         resources: dict[str, object] | None = None,
         pvc_mounts: Sequence[Mapping[str, object]] | None = None,
+        tolerations: Sequence[Mapping[str, object]] | None = None,
     ) -> None:
         """
         Initialize the launcher.
@@ -865,6 +873,8 @@ class KubernetesSandboxLauncher(SandboxLauncher):
             for the built-in defaults.
         :param pvc_mounts: Normalized ``sandbox.kubernetes.pvc_mounts`` entries
             (validated at parse time), or ``None`` for none.
+        :param tolerations: Manifest-shaped ``sandbox.kubernetes.tolerations``
+            entries (validated at parse time), or ``None`` for none.
         """
         self._image_ref = image
         self._namespace = namespace
@@ -876,6 +886,7 @@ class KubernetesSandboxLauncher(SandboxLauncher):
         self._in_cluster = in_cluster
         self._resources = resources
         self._pvc_mounts = list(pvc_mounts) if pvc_mounts else None
+        self._tolerations = [dict(entry) for entry in tolerations] if tolerations else None
         self._core: k8s_client.CoreV1Api | None = None
         self._api_client: k8s_client.ApiClient | None = None
 
@@ -1165,6 +1176,7 @@ class KubernetesSandboxLauncher(SandboxLauncher):
                     harness_secret=self._resolve_secret(),
                     env_literals=env_literals,
                     node_selector=self._node_selector,
+                    tolerations=self._tolerations,
                     workspace=workspace,
                     clone_dir=clone_dir,
                     repo_url=repo_url,

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -836,6 +836,7 @@ def parse_sandbox_config(raw: object) -> ManagedSandboxConfig | None:
                     "in_cluster",
                     "resources",
                     "pvc_mounts",
+                    "tolerations",
                 },
                 "sandbox.kubernetes",
             )
@@ -850,6 +851,7 @@ def parse_sandbox_config(raw: object) -> ManagedSandboxConfig | None:
             in_cluster=_parse_provider_bool(raw, "kubernetes", "in_cluster"),
             resources=_parse_kubernetes_resources(raw),
             pvc_mounts=_parse_kubernetes_pvc_mounts(raw),
+            tolerations=_parse_kubernetes_tolerations(raw),
         )
         token_ttl_s = KUBERNETES_MANAGED_TOKEN_TTL_S
     else:
@@ -1914,6 +1916,84 @@ def _parse_kubernetes_pvc_mounts(raw: dict[str, object]) -> list[dict[str, objec
     return normalized or None
 
 
+def _parse_kubernetes_tolerations(raw: dict[str, object]) -> list[dict[str, object]] | None:
+    """
+    Extract and validate the optional ``sandbox.kubernetes.tolerations`` list.
+
+    Each entry is a Pod toleration in the usual Kubernetes shape (the
+    config-side ``toleration_seconds`` maps to manifest ``tolerationSeconds``),
+    letting runner Pods schedule onto tainted nodes — the common case is a
+    dedicated agent node pool carrying a ``NoSchedule`` taint. Validated at
+    parse time so an operator typo fails server startup instead of the first
+    managed launch, and normalized to manifest shape so
+    :func:`~omnigent.onboarding.sandboxes.kubernetes.build_pod_manifest` can
+    emit entries verbatim.
+
+    :param raw: The raw ``sandbox`` mapping.
+    :returns: Manifest-shaped entries, or ``None`` when omitted or empty.
+    :raises ValueError: When the list or any entry has the wrong shape, or an
+        entry combines fields Kubernetes itself would reject at Pod creation.
+    """
+    section = _parse_provider_section(raw, "kubernetes")
+    if section is None:
+        return None
+    value = section.get("tolerations")
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        raise ValueError(
+            "server config 'sandbox.kubernetes.tolerations' must be a list of "
+            "{key?, operator?, value?, effect?, toleration_seconds?} entries"
+        )
+    normalized: list[dict[str, object]] = []
+    for i, entry in enumerate(value):
+        path_prefix = f"sandbox.kubernetes.tolerations[{i}]"
+        if not isinstance(entry, dict):
+            raise ValueError(f"server config '{path_prefix}' must be a mapping")
+        _reject_unknown_keys(
+            entry, {"key", "operator", "value", "effect", "toleration_seconds"}, path_prefix
+        )
+        toleration: dict[str, object] = {}
+        for field in ("key", "operator", "value", "effect"):
+            if field not in entry:
+                continue
+            field_value = entry[field]
+            if not isinstance(field_value, str) or not field_value.strip():
+                raise ValueError(
+                    f"server config '{path_prefix}.{field}' must be a non-empty string"
+                )
+            toleration[field] = field_value.strip()
+        if toleration.get("operator") not in (None, "Exists", "Equal"):
+            raise ValueError(f"server config '{path_prefix}.operator' must be 'Exists' or 'Equal'")
+        if toleration.get("operator") == "Exists" and "value" in toleration:
+            # Mirrors the API server's own toleration validation, surfaced at
+            # startup instead of at the first Pod create.
+            raise ValueError(
+                f"server config '{path_prefix}' cannot combine operator 'Exists' with 'value'"
+            )
+        if toleration.get("effect") not in (None, "NoSchedule", "PreferNoSchedule", "NoExecute"):
+            raise ValueError(
+                f"server config '{path_prefix}.effect' must be 'NoSchedule', "
+                "'PreferNoSchedule' or 'NoExecute'"
+            )
+        if "toleration_seconds" in entry:
+            seconds = entry["toleration_seconds"]
+            if isinstance(seconds, bool) or not isinstance(seconds, int) or seconds < 0:
+                raise ValueError(
+                    f"server config '{path_prefix}.toleration_seconds' must be a "
+                    "non-negative integer"
+                )
+            if toleration.get("effect") != "NoExecute":
+                raise ValueError(
+                    f"server config '{path_prefix}.toleration_seconds' requires effect 'NoExecute'"
+                )
+            toleration["tolerationSeconds"] = seconds
+        if not toleration:
+            raise ValueError(f"server config '{path_prefix}' must set at least one field")
+        normalized.append(toleration)
+    return normalized or None
+
+
 def _kubernetes_launcher_factory(
     *,
     image: str | None,
@@ -1926,6 +2006,7 @@ def _kubernetes_launcher_factory(
     in_cluster: bool | None,
     resources: dict[str, object] | None,
     pvc_mounts: list[dict[str, object]] | None,
+    tolerations: list[dict[str, object]] | None,
 ) -> Callable[[], SandboxLauncher]:
     """
     Build the launcher factory for the YAML ``provider: kubernetes`` path.
@@ -1949,6 +2030,8 @@ def _kubernetes_launcher_factory(
     :param resources: Validated ``resources`` block, or ``None`` for defaults.
     :param pvc_mounts: Normalized PVC mount entries added to every runner Pod,
         or ``None``.
+    :param tolerations: Manifest-shaped toleration entries added to every
+        runner Pod, or ``None``.
     :returns: A factory producing parameterized Kubernetes launchers.
     :raises ValueError: When a name or node-selector label is malformed.
     """
@@ -1969,6 +2052,7 @@ def _kubernetes_launcher_factory(
             in_cluster=in_cluster,
             resources=resources,
             pvc_mounts=pvc_mounts,
+            tolerations=tolerations,
         )
 
     return _build

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -236,6 +236,21 @@ def test_build_pod_manifest_omits_envfrom_without_harness_secret() -> None:
     assert "envFrom" not in manifest["spec"]["containers"][0]
 
 
+def test_build_pod_manifest_omits_tolerations_when_unconfigured() -> None:
+    """No tolerations config → no tolerations key; scheduling is unchanged."""
+    manifest = build_pod_manifest(**_MANIFEST_KW)
+    assert "tolerations" not in manifest["spec"]
+
+
+def test_build_pod_manifest_emits_configured_tolerations_verbatim() -> None:
+    """Parse-time-normalized tolerations land on the Pod spec as given."""
+    tolerations = [
+        {"key": "dedicated", "operator": "Equal", "value": "agents", "effect": "NoSchedule"}
+    ]
+    manifest = build_pod_manifest(**{**_MANIFEST_KW, "tolerations": tolerations})
+    assert manifest["spec"]["tolerations"] == tolerations
+
+
 def test_build_pod_manifest_defaults_to_amd64_node_selector() -> None:
     """No node_selector → Pods keep the amd64 default placement."""
     manifest = build_pod_manifest(**{**_MANIFEST_KW, "node_selector": None})

--- a/tests/server/helpers.py
+++ b/tests/server/helpers.py
@@ -519,7 +519,8 @@ def install_fake_kubernetes_launcher(
 
     The managed flow constructs ``KubernetesSandboxLauncher(image=…, env=…,
     namespace=…, secret_name=…, service_account=…, node_selector=…,
-    kubeconfig=…, in_cluster=…, resources=…, pvc_mounts=…)``; the shim records those
+    kubeconfig=…, in_cluster=…, resources=…, pvc_mounts=…, tolerations=…)``; the
+    shim records those
     constructor args on the fake and hands it back, so production code runs
     unmodified against it.
 
@@ -540,6 +541,7 @@ def install_fake_kubernetes_launcher(
         in_cluster: bool | None = None,
         resources: dict[str, object] | None = None,
         pvc_mounts: list[dict[str, object]] | None = None,
+        tolerations: list[dict[str, object]] | None = None,
     ) -> FakeSandboxLauncher:
         """Stand-in constructor recording the construction wiring."""
         fake.image = image
@@ -552,6 +554,7 @@ def install_fake_kubernetes_launcher(
         fake.in_cluster = in_cluster
         fake.resources = resources
         fake.pvc_mounts = pvc_mounts
+        fake.tolerations = tolerations
         return fake
 
     monkeypatch.setattr(kubernetes_mod, "KubernetesSandboxLauncher", _ctor)

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -504,7 +504,7 @@ def test_parse_valid_kubernetes_config_builds_parameterized_factory(
     """
     The documented kubernetes YAML shape parses into a config whose factory
     constructs Kubernetes launchers carrying namespace / Secret / SA / node
-    selector / in-cluster / resources, with the 7-day token TTL.
+    selector / in-cluster / resources / tolerations, with the 7-day token TTL.
     """
     cfg = parse_sandbox_config(
         {
@@ -519,6 +519,14 @@ def test_parse_valid_kubernetes_config_builds_parameterized_factory(
                 "node_selector": {"omnigent.ai/runner-ready": "true"},
                 "in_cluster": True,
                 "resources": {"requests": {"cpu": "500m"}, "limits": {"memory": "8Gi"}},
+                "tolerations": [
+                    {
+                        "key": "dedicated",
+                        "operator": "Equal",
+                        "value": "agents",
+                        "effect": "NoSchedule",
+                    }
+                ],
             },
         }
     )
@@ -538,6 +546,9 @@ def test_parse_valid_kubernetes_config_builds_parameterized_factory(
     assert fake.node_selector == {"omnigent.ai/runner-ready": "true"}
     assert fake.in_cluster is True
     assert fake.resources == {"requests": {"cpu": "500m"}, "limits": {"memory": "8Gi"}}
+    assert fake.tolerations == [
+        {"key": "dedicated", "operator": "Equal", "value": "agents", "effect": "NoSchedule"}
+    ]
 
 
 def test_parse_kubernetes_without_section_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -690,6 +701,13 @@ def test_parse_host_config_lossy_json_key_collision_fails_loud() -> None:
         # A misspelled section key would silently no-op (e.g. no PVCs mounted)
         # without the allowlist check.
         ({"pvc_mount": [{"claim_name": "c", "mount_path": "/mnt/x"}]}, "unknown key"),
+        ({"tolerations": {"key": "dedicated"}}, "must be a list"),
+        ({"tolerations": [{"key": "dedicated", "efect": "NoSchedule"}]}, "unknown key"),
+        ({"tolerations": [{"operator": "Exists", "value": "agents"}]}, "Exists"),
+        # tolerationSeconds without NoExecute is rejected by the API server;
+        # surface it at parse time like the other semantic checks.
+        ({"tolerations": [{"key": "burst", "toleration_seconds": 300}]}, "NoExecute"),
+        ({"tolerations": [{}]}, "at least one field"),
     ],
 )
 def test_parse_kubernetes_invalid_block_fails_loud(
@@ -824,6 +842,37 @@ def test_parse_kubernetes_pvc_mounts_invalid_fails_loud(
                 "kubernetes": {"pvc_mounts": pvc_mounts},
             }
         )
+
+
+def test_parse_kubernetes_tolerations_normalize_and_reach_launcher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """tolerations parse into manifest shape (tolerationSeconds) on the launcher."""
+    cfg = parse_sandbox_config(
+        {
+            "provider": "kubernetes",
+            "server_url": "http://s.svc.cluster.local",
+            "kubernetes": {
+                "tolerations": [
+                    {
+                        "key": "dedicated",
+                        "operator": "Equal",
+                        "value": "agents",
+                        "effect": "NoSchedule",
+                    },
+                    {"key": "burst", "effect": "NoExecute", "toleration_seconds": 300},
+                ]
+            },
+        }
+    )
+    assert cfg is not None
+    fake = FakeSandboxLauncher()
+    install_fake_kubernetes_launcher(monkeypatch, fake)
+    assert cfg.launcher_factory() is fake
+    assert fake.tolerations == [
+        {"key": "dedicated", "operator": "Equal", "value": "agents", "effect": "NoSchedule"},
+        {"key": "burst", "effect": "NoExecute", "tolerationSeconds": 300},
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Related issue

N/A

## Summary

- New optional `sandbox.kubernetes.tolerations` config list for managed sandbox runners: entries are validated at parse time (an operator typo fails server startup, like `pvc_mounts`), normalized to manifest shape (`toleration_seconds` → `tolerationSeconds`), and emitted verbatim on the runner Pod spec.
- Lets runner Pods schedule onto tainted nodes — the common case being a dedicated agent node pool carrying a `NoSchedule` taint, which managed sandboxes cannot target today.
- Semantic checks mirror the API server's own toleration validation (`Exists` + `value` rejected, `toleration_seconds` requires `NoExecute`) so misconfigurations surface at startup instead of at the first Pod create.

## Test Plan

- `pytest tests/onboarding/sandboxes/test_kubernetes.py tests/server/test_managed_hosts.py` — 221 passed: new parse-level valid/invalid cases, launcher wiring through the fake-launcher seam, and manifest emission tests (absent by default / emitted verbatim).
- Running in production on our OVH managed Kubernetes cluster whose sandbox node pool carries a `NoSchedule` taint: runner Pods schedule onto the pool with the config set and stay `Pending` without it.

## Demo

Terminal run of the change (config → parse → generated Pod spec, and the fail-at-startup path):

```
>>> config with sandbox.kubernetes.tolerations parses at startup: True
>>> resulting Pod spec.tolerations:
[
  {
    "key": "dedicated",
    "operator": "Equal",
    "value": "agents",
    "effect": "NoSchedule"
  }
]
>>> operator typo fails server startup, not the first launch:
ValueError: server config 'sandbox.kubernetes.tolerations[0].toleration_seconds' requires effect 'NoExecute'
```
<img width="870" height="238" alt="Screenshot 2026-07-28 at 15 10 58" src="https://github.com/user-attachments/assets/87dce14f-724b-4bf9-a8ff-82be1c170999" />


On our production cluster, runner Pods carrying these tolerations schedule onto the tainted dedicated pool; without them the same launch stays `Pending` with `FailedScheduling` (untolerated taint).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: on a production cluster with a tainted dedicated node pool, runner Pods schedule onto the pool once `sandbox.kubernetes.tolerations` is set, and scheduling fails without it (`FailedScheduling`, untolerated taint).

## Changelog

Managed Kubernetes sandboxes accept `sandbox.kubernetes.tolerations` so runner Pods can schedule onto tainted node pools
