### PR TITLE
feat(kubernetes): configurable sandbox pod-ready timeout

### DIFF
--- a/deploy/kubernetes/overlays/sandbox-runners/sandbox-config.yaml
+++ b/deploy/kubernetes/overlays/sandbox-runners/sandbox-config.yaml
@@ -49,5 +49,6 @@ data:
         #   - claim_name: omnigent-datasets
         #     mount_path: /mnt/datasets
         #     read_only: true        # default true; set false only for claims meant as shared scratch
+        # pod_ready_timeout_s: 300   # Pod-start wait budget in seconds (default 90); raise when image pulls run long
         # in_cluster: true           # config source: true=in-cluster SA only, false=kubeconfig only, omit=try both
         # kubeconfig: /path/to/config  # out-of-cluster kubeconfig (env: OMNIGENT_KUBERNETES_KUBECONFIG)

--- a/omnigent/onboarding/sandboxes/kubernetes.py
+++ b/omnigent/onboarding/sandboxes/kubernetes.py
@@ -172,7 +172,9 @@ _INIT_CONTAINER_NAME: str = "workspace-prep"
 # Pod-start wait budget, consumed inside start_host BEFORE the
 # shared _wait_for_host_online poll, so a Pod that can't schedule / pull its
 # image / clone its repo fails fast with a clear reason instead of as a generic
-# online timeout. Kept tight; a cold image pull is the usual slow case.
+# online timeout. Kept tight; a cold image pull is the usual slow case —
+# deployments whose host image regularly takes longer to pull can raise the
+# budget via ``sandbox.kubernetes.pod_ready_timeout_s``.
 _POD_READY_TIMEOUT_S: int = 90
 _POD_READY_POLL_S: float = 2.0
 
@@ -1021,6 +1023,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
         resources: dict[str, object] | None = None,
         pvc_mounts: Sequence[Mapping[str, object]] | None = None,
         secret_mounts: Sequence[Mapping[str, object]] | None = None,
+        pod_ready_timeout_s: int | None = None,
     ) -> None:
         """
         Store provider config for lazy use by :meth:`start_host` / :meth:`terminate`.
@@ -1042,6 +1045,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
         self._resources = resources
         self._pvc_mounts = list(pvc_mounts) if pvc_mounts else None
         self._secret_mounts = list(secret_mounts) if secret_mounts else None
+        self._pod_ready_timeout_s = pod_ready_timeout_s
         self._core: k8s_client.CoreV1Api | None = None
         self._batch: k8s_client.BatchV1Api | None = None
         self._api_client: k8s_client.ApiClient | None = None
@@ -1373,7 +1377,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
         Filters out Pods with a ``deletionTimestamp`` (being torn down) and
         prefers a running Pod over a pending one when a replacement exists.
         Re-raises 401/403 so RBAC misconfigurations surface immediately
-        instead of masquerading as a 90s timeout.
+        instead of masquerading as a readiness timeout.
 
         :param namespace: Namespace the Job lives in.
         :param job_name: The Job whose child Pod to find.
@@ -1430,7 +1434,12 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
         from urllib3.exceptions import HTTPError
 
         core = self._load_core()
-        deadline = time.monotonic() + _POD_READY_TIMEOUT_S
+        timeout_s = (
+            self._pod_ready_timeout_s
+            if self._pod_ready_timeout_s is not None
+            else _POD_READY_TIMEOUT_S
+        )
+        deadline = time.monotonic() + timeout_s
         last_reason: str | None = None
         pod_name: str | None = None
         while True:
@@ -1441,7 +1450,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
                     if time.monotonic() >= deadline:
                         raise click.ClickException(
                             f"Kubernetes sandbox job '{job_name}' did not create a "
-                            f"child pod within {_POD_READY_TIMEOUT_S}s."
+                            f"child pod within {timeout_s}s."
                         )
                     time.sleep(_POD_READY_POLL_S)
                     continue
@@ -1458,7 +1467,17 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
                 if getattr(exc, "status", None) == 404:
                     # Under OnFailure the Job may replace the Pod (eviction,
                     # preemption, node drain) — re-discover instead of failing.
+                    replaced_pod_name = pod_name
                     pod_name = None
+                    if time.monotonic() >= deadline:
+                        raise click.ClickException(
+                            self._pod_failure_message(
+                                namespace,
+                                replaced_pod_name,
+                                "disappeared and could not be rediscovered before the "
+                                f"{timeout_s}s deadline",
+                            )
+                        ) from exc
                     time.sleep(_POD_READY_POLL_S)
                     continue
                 last_reason = _api_reason(exc)
@@ -1467,8 +1486,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
                         self._pod_failure_message(
                             namespace,
                             pod_name,
-                            "could not be read before the "
-                            f"{_POD_READY_TIMEOUT_S}s deadline ({last_reason})",
+                            f"could not be read before the {timeout_s}s deadline ({last_reason})",
                         )
                     ) from exc
                 time.sleep(_POD_READY_POLL_S)
@@ -1480,8 +1498,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
                         self._pod_failure_message(
                             namespace,
                             pod_name,
-                            "could not be read before the "
-                            f"{_POD_READY_TIMEOUT_S}s deadline ({last_reason})",
+                            f"could not be read before the {timeout_s}s deadline ({last_reason})",
                         )
                     ) from exc
                 time.sleep(_POD_READY_POLL_S)
@@ -1515,7 +1532,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
                     self._pod_failure_message(
                         namespace,
                         pod_name,
-                        f"did not start within {_POD_READY_TIMEOUT_S}s "
+                        f"did not start within {timeout_s}s "
                         f"(last phase '{phase or 'unknown'}'{detail})",
                     )
                 )

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -1164,6 +1164,7 @@ def _parse_single_provider_sandbox_config(raw: dict[str, object]) -> ManagedSand
                     "resources",
                     "pvc_mounts",
                     "secret_mounts",
+                    "pod_ready_timeout_s",
                 },
                 "sandbox.kubernetes",
             )
@@ -1182,6 +1183,9 @@ def _parse_single_provider_sandbox_config(raw: dict[str, object]) -> ManagedSand
             resources=_parse_kubernetes_resources(raw),
             pvc_mounts=pvc_mounts,
             secret_mounts=secret_mounts,
+            pod_ready_timeout_s=_parse_provider_positive_int(
+                raw, "kubernetes", "pod_ready_timeout_s"
+            ),
         )
         token_ttl_s = KUBERNETES_MANAGED_TOKEN_TTL_S
     else:
@@ -2431,6 +2435,7 @@ def _kubernetes_launcher_factory(
     resources: dict[str, object] | None,
     pvc_mounts: list[dict[str, object]] | None,
     secret_mounts: list[dict[str, object]] | None,
+    pod_ready_timeout_s: int | None,
 ) -> Callable[[], SandboxHostLauncher]:
     """
     Build the launcher factory for the YAML ``provider: kubernetes`` path.
@@ -2456,6 +2461,8 @@ def _kubernetes_launcher_factory(
         or ``None``.
     :param secret_mounts: Normalized Secret file-mount entries added to every
         runner Pod (rotation-friendly credential volumes), or ``None``.
+    :param pod_ready_timeout_s: Pod-start wait budget in seconds, or ``None``
+        for the launcher's built-in default.
     :returns: A factory producing parameterized Kubernetes launchers.
     :raises ValueError: When a name or node-selector label is malformed.
     """
@@ -2477,6 +2484,7 @@ def _kubernetes_launcher_factory(
             resources=resources,
             pvc_mounts=pvc_mounts,
             secret_mounts=secret_mounts,
+            pod_ready_timeout_s=pod_ready_timeout_s,
         )
 
     return _build

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -920,6 +920,47 @@ def test_launch_host_times_out_with_reason(
         )
 
 
+@pytest.mark.parametrize(
+    ("wait_state", "expected"),
+    [
+        ("undiscovered", "did not create a child pod within 1s"),
+        ("replaced", "could not be rediscovered before the 1s deadline"),
+        ("read-error", "could not be read before the 1s deadline"),
+        ("pending", "did not start within 1s"),
+    ],
+)
+def test_configured_pod_ready_timeout_bounds_entire_job_wait(
+    fake_clients: tuple[_FakeCore, _FakeBatch],
+    monkeypatch: pytest.MonkeyPatch,
+    wait_state: str,
+    expected: str,
+) -> None:
+    """The configured budget bounds discovery, replacement, reads, and Pending."""
+    core, _batch = fake_clients
+    pod = _pod(phase="Pending")
+    if wait_state != "undiscovered":
+        core.pod_list_items = [pod]
+    if wait_state == "replaced":
+        core.read_default = _FakeApiException(status=404, reason="Not Found")
+    elif wait_state == "read-error":
+        core.read_default = _FakeApiException(status=500, reason="Internal Server Error")
+    else:
+        core.read_default = pod
+
+    ticks = iter((0.0, 1.0))
+    monkeypatch.setattr(k8s.time, "monotonic", lambda: next(ticks))
+    launcher = KubernetesSandboxLauncher(
+        in_cluster=True,
+        namespace="omnigent-sandboxes",
+        secret_name="omnigent-creds",
+        env=(),
+        pod_ready_timeout_s=1,
+    )
+
+    with pytest.raises(click.ClickException, match=expected):
+        launcher._wait_for_pod_running("omnigent-sandboxes", "omnigent-job-timeout")
+
+
 def test_terminate_deletes_job_and_secret(
     fake_clients: tuple[_FakeCore, _FakeBatch],
 ) -> None:

--- a/tests/server/helpers.py
+++ b/tests/server/helpers.py
@@ -217,6 +217,7 @@ class FakeSandboxLauncher(SandboxLauncher):
         self.resources: dict[str, object] | None = None
         self.pvc_mounts: list[dict[str, object]] | None = None
         self.secret_mounts: list[dict[str, object]] | None = None
+        self.pod_ready_timeout_s: int | None = None
         self.prepared = False
         self.provisioned_names: list[str] = []
         self.commands: list[str] = []
@@ -553,9 +554,9 @@ def install_fake_kubernetes_launcher(
 
     The managed flow constructs ``KubernetesSandboxLauncher(image=…, env=…,
     namespace=…, secret_name=…, service_account=…, node_selector=…,
-    kubeconfig=…, in_cluster=…, resources=…, pvc_mounts=…)``; the shim records those
-    constructor args on the fake and hands it back, so production code runs
-    unmodified against it.
+    kubeconfig=…, in_cluster=…, resources=…, pvc_mounts=…, secret_mounts=…,
+    pod_ready_timeout_s=…)``; the shim records those constructor args on the
+    fake and hands it back, so production code runs unmodified against it.
 
     :param monkeypatch: The test's ``pytest.MonkeyPatch``.
     :param fake: The fake launcher to substitute.
@@ -575,6 +576,7 @@ def install_fake_kubernetes_launcher(
         resources: dict[str, object] | None = None,
         pvc_mounts: list[dict[str, object]] | None = None,
         secret_mounts: list[dict[str, object]] | None = None,
+        pod_ready_timeout_s: int | None = None,
     ) -> FakeSandboxLauncher:
         """Stand-in constructor recording the construction wiring."""
         fake.image = image
@@ -588,6 +590,7 @@ def install_fake_kubernetes_launcher(
         fake.resources = resources
         fake.pvc_mounts = pvc_mounts
         fake.secret_mounts = secret_mounts
+        fake.pod_ready_timeout_s = pod_ready_timeout_s
         return fake
 
     monkeypatch.setattr(kubernetes_mod, "KubernetesSandboxLauncher", _ctor)

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -657,7 +657,8 @@ def test_parse_valid_kubernetes_config_builds_parameterized_factory(
     """
     The documented kubernetes YAML shape parses into a config whose factory
     constructs Kubernetes launchers carrying namespace / Secret / SA / node
-    selector / in-cluster / resources, with the 7-day token TTL.
+    selector / in-cluster / resources / pod-ready timeout, with the 7-day
+    token TTL.
     """
     cfg = parse_sandbox_config(
         {
@@ -672,6 +673,7 @@ def test_parse_valid_kubernetes_config_builds_parameterized_factory(
                 "node_selector": {"omnigent.ai/runner-ready": "true"},
                 "in_cluster": True,
                 "resources": {"requests": {"cpu": "500m"}, "limits": {"memory": "8Gi"}},
+                "pod_ready_timeout_s": 300,
             },
         }
     )
@@ -692,6 +694,7 @@ def test_parse_valid_kubernetes_config_builds_parameterized_factory(
     assert fake.node_selector == {"omnigent.ai/runner-ready": "true"}
     assert fake.in_cluster is True
     assert fake.resources == {"requests": {"cpu": "500m"}, "limits": {"memory": "8Gi"}}
+    assert fake.pod_ready_timeout_s == 300
 
 
 def test_parse_kubernetes_without_section_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -712,6 +715,7 @@ def test_parse_kubernetes_without_section_defaults(monkeypatch: pytest.MonkeyPat
     assert fake.in_cluster is None
     assert fake.resources is None
     assert fake.pvc_mounts is None
+    assert fake.pod_ready_timeout_s is None
 
 
 def test_parse_host_config_threads_verbatim_without_resolving_secrets(
@@ -847,6 +851,11 @@ def test_parse_host_config_lossy_json_key_collision_fails_loud() -> None:
         # A misspelled section key would silently no-op (e.g. no PVCs mounted)
         # without the allowlist check.
         ({"pvc_mount": [{"claim_name": "c", "mount_path": "/mnt/x"}]}, "unknown key"),
+        # The wait budget must be a real positive integer — a coerced "90" or
+        # a YAML boolean would silently change how long launches may take.
+        ({"pod_ready_timeout_s": 0}, "positive integer"),
+        ({"pod_ready_timeout_s": "90"}, "positive integer"),
+        ({"pod_ready_timeout_s": True}, "positive integer"),
     ],
 )
 def test_parse_kubernetes_invalid_block_fails_loud(


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Makes the sandbox Pod-start wait budget configurable: new optional `sandbox.kubernetes.pod_ready_timeout_s` (positive integer; default unchanged at 90s).
- The constant's comment already notes "a cold image pull is the usual slow case" — on our cluster a cold pull of the host image takes longer than the whole budget (`Successfully pulled image ... in 1m28.145s`), so every first launch on a fresh node dies at the deadline while the pull is still in progress, and the relaunch only succeeds because the image is then cached.
- The configured budget drives both the wait deadline and the timeout error messages, so operator-facing failures report the effective value.

## Test Plan

- `pytest tests/onboarding/sandboxes/test_kubernetes.py tests/server/test_managed_hosts.py` — 217 passed: parse-level cases (`0`, `"90"`, `True` rejected as not a positive integer, reusing `_parse_provider_positive_int`), launcher wiring, and a launcher test proving a configured budget drives the deadline and its message.
- Production: with `pod_ready_timeout_s: 300`, cold-node launches survive the first image pull instead of timing out and relying on the retry.

## Demo

Terminal run of the change (config parse, fail-at-startup validation, and the timeout message carrying the configured budget):

```
>>> pod_ready_timeout_s: 300 parses at startup: True
>>> a quoted "90" fails server startup:
ValueError: server config 'sandbox.kubernetes.pod_ready_timeout_s' must be a positive integer
>>> timeout failure reports the configured budget (demo value 3s):
Kubernetes sandbox pod 'omnigent-pod-demo' did not start within 3s (last phase 'Pending'). Inspect with `kubectl describe pod omnigent-pod-demo -n omnigent-sandboxes`.
```
<img width="1208" height="137" alt="Screenshot 2026-07-28 at 15 12 33" src="https://github.com/user-attachments/assets/c420970c-12ba-4893-aea0-15cb6d6b73a9" />


## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: on a node with no cached host image, launches previously failed at the 90s deadline (`did not start within 90s`, last reason image pull); with a 300s budget the same launch completes on the first attempt.

## Changelog

`sandbox.kubernetes.pod_ready_timeout_s` raises the managed runner Pod start budget for clusters where image pulls run long
