### PR TITLE
Cache session items with ETag and immutable scroll-back pages

### DIFF
--- a/omnigent/server/routes/sessions/routes_items.py
+++ b/omnigent/server/routes/sessions/routes_items.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 
 from fastapi import (
     APIRouter,
     Query,
     Request,
+    status,
 )
+from fastapi.responses import Response
 
 from omnigent.runtime.policies.approval import _ELICITATION_MODE
 from omnigent.server._elicitation_registry import (
@@ -44,6 +47,79 @@ from omnigent.server.schemas import (
 from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.permission_store import PermissionStore
 
+# Cache-Control for the immutable (scroll-back) vs. live-tail item pages.
+# Committed items never mutate, so a page fully below the tail is immutable
+# and served with no revalidation; the tail may grow, so it is revalidated
+# against the ETag. Both are ``private`` — item bodies are per-session data
+# that a shared cache must never store.
+_SESSION_ITEMS_IMMUTABLE_MAX_AGE_S = 86400
+_SESSION_ITEMS_CACHE_IMMUTABLE = (
+    f"private, max-age={_SESSION_ITEMS_IMMUTABLE_MAX_AGE_S}, immutable"
+)
+_SESSION_ITEMS_CACHE_TAIL = "private, no-cache"
+
+
+def _session_items_cache_control(is_historical: bool) -> str:
+    """
+    Return the ``Cache-Control`` value for a session-items page.
+
+    :param is_historical: ``True`` when the page is bounded strictly below
+        the live tail (a scroll-back page that can never change), ``False``
+        for the growing tail.
+    :returns: The immutable policy for a historical page, else the
+        revalidate-always tail policy.
+    """
+    return _SESSION_ITEMS_CACHE_IMMUTABLE if is_historical else _SESSION_ITEMS_CACHE_TAIL
+
+
+def _session_items_etag(
+    first_id: str | None,
+    last_id: str | None,
+    count: int,
+    has_more: bool,
+) -> str:
+    """
+    Build a validator ETag for a page of session items.
+
+    Items are append-only, so a page's content is fully determined by its
+    boundary ids, its length, and whether more rows follow — no field of an
+    existing item can change without a new id appearing. The tag is weak
+    (``W/``) because it validates semantic page equivalence, not a
+    byte-exact body (gzip vs identity encodings share the same page).
+
+    :param first_id: Id of the first item in the page, or ``None`` when empty.
+    :param last_id: Id of the last item in the page, or ``None`` when empty.
+    :param count: Number of items in the page.
+    :param has_more: Whether more items exist beyond the page.
+    :returns: A weak ETag string, e.g. ``'W/"a1b2c3d4"'``.
+    """
+    digest = hashlib.sha256(f"{first_id}:{last_id}:{count}:{has_more}".encode()).hexdigest()[:16]
+    return f'W/"{digest}"'
+
+
+def _if_none_match_matches(header_value: str | None, etag: str) -> bool:
+    """
+    Return whether an ``If-None-Match`` header matches *etag*.
+
+    Handles a comma-separated list of tags and normalizes the weak
+    prefix so a weak validator compares equal regardless of how the
+    client echoes it. ``*`` matches any current representation.
+
+    :param header_value: Raw ``If-None-Match`` request header, or ``None``.
+    :param etag: The ETag computed for the current page.
+    :returns: ``True`` when the client's cached copy is still current.
+    """
+    if not header_value:
+        return False
+
+    def _normalize(tag: str) -> str:
+        return tag.strip().removeprefix("W/")
+
+    if header_value.strip() == "*":
+        return True
+    wanted = _normalize(etag)
+    return any(_normalize(candidate) == wanted for candidate in header_value.split(","))
+
 
 def register_items_routes(
     router: APIRouter,
@@ -62,18 +138,30 @@ def register_items_routes(
     )
     async def list_session_items(
         request: Request,
+        response: Response,
         session_id: str,
         limit: int = Query(default=100, ge=1, le=1000),
         after: str | None = Query(default=None),
         before: str | None = Query(default=None),
         order: str = Query(default="asc", pattern="^(asc|desc)$"),
-    ) -> PaginatedList:
+    ) -> PaginatedList | Response:
         """
         List items in a session with cursor-based pagination.
 
         Delegates to the conversation items store — session_id is
         the conversation_id. Same pagination contract as
         ``GET /v1/conversations/{id}/items``.
+
+        Conversation items are append-only and never rewritten in place, so
+        this endpoint is HTTP-cacheable. A page bounded strictly below the
+        live tail (a scroll-back request — one carrying an ``after`` /
+        ``before`` cursor with no more rows beyond it) can never change, so
+        it is served ``Cache-Control: immutable`` — the browser re-serves it
+        with no network round-trip at all. The live tail (the cursorless
+        open fetch, or any page with ``has_more``) can grow when the agent
+        commits a turn, so it is served ``no-cache`` with a validator
+        ``ETag``: the browser revalidates via ``If-None-Match`` and gets an
+        empty ``304`` when nothing changed, saving the body transfer.
 
         :param session_id: Session/conversation identifier,
             e.g. ``"conv_abc123"``.
@@ -84,7 +172,9 @@ def register_items_routes(
         :param before: Cursor — return items before this item ID.
         :param order: Sort order, ``"asc"`` (chronological,
             default) or ``"desc"``.
-        :returns: A :class:`PaginatedList` of conversation items.
+        :returns: A :class:`PaginatedList` of conversation items, or a bare
+            ``304`` :class:`Response` when the client's ``If-None-Match``
+            matches the current page.
         :raises OmnigentError: 404 if no session exists.
         """
         user_id = _get_user_id(request, auth_provider)
@@ -103,6 +193,20 @@ def register_items_routes(
             before=before,
             order=order,
         )
+        # A cursor-bounded page with nothing older/newer beyond it sits
+        # entirely below the live tail — since items never mutate, it is
+        # immutable and safe to cache with no revalidation. Everything else
+        # is (or touches) the growing tail: revalidate against the ETag.
+        is_historical = (after is not None or before is not None) and not page.has_more
+        etag = _session_items_etag(page.first_id, page.last_id, len(page.data), page.has_more)
+        cache_control = _session_items_cache_control(is_historical)
+        if _if_none_match_matches(request.headers.get("if-none-match"), etag):
+            not_modified = Response(status_code=status.HTTP_304_NOT_MODIFIED)
+            not_modified.headers["ETag"] = etag
+            not_modified.headers["Cache-Control"] = cache_control
+            return not_modified
+        response.headers["ETag"] = etag
+        response.headers["Cache-Control"] = cache_control
         data = [m.to_api_dict() for m in page.data]
         return PaginatedList(
             data=data,

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -2685,6 +2685,104 @@ async def test_list_session_items_404_for_nonexistent(
     assert resp.status_code == 404
 
 
+async def test_list_session_items_tail_is_revalidatable(
+    client: httpx.AsyncClient,
+) -> None:
+    """The live-tail page (cursorless open fetch) carries a validator ETag
+    and a no-cache policy, and a matching If-None-Match yields an empty 304."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"], initial_message="etag tail")
+    await _wait_for_idle(client, session["id"])
+
+    resp = await client.get(f"/v1/sessions/{session['id']}/items")
+    assert resp.status_code == 200
+    etag = resp.headers.get("etag")
+    assert etag and etag.startswith('W/"')
+    # The tail can grow, so it must be revalidated, never cached blindly.
+    assert "no-cache" in resp.headers.get("cache-control", "")
+
+    # Re-request with the returned validator: unchanged → empty 304.
+    revalidated = await client.get(
+        f"/v1/sessions/{session['id']}/items",
+        headers={"If-None-Match": etag},
+    )
+    assert revalidated.status_code == 304
+    assert revalidated.headers.get("etag") == etag
+    assert revalidated.content == b""
+
+
+async def test_list_session_items_historical_page_is_immutable(
+    client: httpx.AsyncClient,
+) -> None:
+    """A cursor-bounded scroll-back page with nothing older beyond it is
+    immutable and served with a no-revalidation Cache-Control."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"], initial_message="etag history")
+    await _wait_for_idle(client, session["id"])
+
+    # Page backwards from the newest item: descending order past the tail.
+    newest = await client.get(
+        f"/v1/sessions/{session['id']}/items",
+        params={"limit": 1, "order": "desc"},
+    )
+    assert newest.status_code == 200
+    body = newest.json()
+    if not body["data"]:
+        pytest.skip("session has no items to page behind")
+    cursor = body["last_id"]
+
+    historical = await client.get(
+        f"/v1/sessions/{session['id']}/items",
+        params={"limit": 100, "order": "desc", "after": cursor},
+    )
+    assert historical.status_code == 200
+    # Bounded below the tail (no more rows) → immutable, cached without a
+    # revalidation round-trip.
+    assert historical.json()["has_more"] is False
+    cache_control = historical.headers.get("cache-control", "")
+    assert "immutable" in cache_control
+    assert "no-cache" not in cache_control
+
+
+async def test_list_session_items_etag_changes_when_tail_grows(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """A new committed item changes the tail ETag so a stale If-None-Match
+    no longer 304s — the client refetches the grown page."""
+    from omnigent.entities import MessageData, NewConversationItem
+
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"], initial_message="etag grow 1")
+    await _wait_for_idle(client, session["id"])
+
+    first = await client.get(f"/v1/sessions/{session['id']}/items")
+    etag_before = first.headers["etag"]
+
+    # Append another committed item directly through the store (no runner is
+    # bound in this harness), so the tail page grows by one row.
+    store = SqlAlchemyConversationStore(db_uri)
+    await asyncio.to_thread(
+        store.append,
+        session["id"],
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_grow",
+                data=MessageData(role="user", content=[{"type": "input_text", "text": "grow 2"}]),
+            )
+        ],
+    )
+
+    revalidated = await client.get(
+        f"/v1/sessions/{session['id']}/items",
+        headers={"If-None-Match": etag_before},
+    )
+    # Tail grew → validator no longer matches → full 200 with a new ETag.
+    assert revalidated.status_code == 200
+    assert revalidated.headers["etag"] != etag_before
+
+
 # ── GET /v1/sessions/{id} snapshot fields ────────────────
 
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Make `GET /v1/sessions/{id}/items` HTTP-cacheable. Committed conversation items are append-only and never rewritten, so re-opening a session currently re-downloads its whole history every time.
- A cursor-bounded scroll-back page (an `after`/`before` request with no more rows beyond it) can never change, so it is served `Cache-Control: private, max-age=1d, immutable` — the browser re-serves it with zero network round-trips.
- The live tail (the cursorless open fetch, or any page with `has_more`) can grow, so it is served `private, no-cache` with a weak validator `ETag`. The browser revalidates via `If-None-Match` and gets an empty `304` when nothing changed, saving the body transfer. All `private` — item bodies are per-session data a shared cache must not store.

## Test Plan

New integration tests in `tests/server/integration/test_sessions_endpoints.py`: the tail page is revalidatable (`ETag` + `no-cache`, and a matching `If-None-Match` yields an empty `304`); a bounded scroll-back page is `immutable`; and the tail `ETag` changes when a new item is appended so a stale validator refetches. Verified live: unchanged re-open returns `304` with an empty body; a bounded page returns `immutable`.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Confirmed against a live server: unchanged re-open of `/items` returns `304 Not Modified` with a 0-byte body; a cursor-bounded scroll-back page returns `Cache-Control: private, max-age=86400, immutable`.
