### PR TITLE
feat[pi]: Add initial model selection

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1839,13 +1839,25 @@ class HostProcess:
         resolves its own catalog at launch, and the in-session picker
         re-reads that authoritative snapshot after bind.
         """
-        if canonicalize_harness(frame.harness) != "claude-native":
+        harness = canonicalize_harness(frame.harness)
+        if harness not in {"claude-native", "pi-native"}:
             return HostModelOptionsResultFrame(
                 request_id=frame.request_id,
                 status="failed",
                 error=f"model options are unsupported for harness {frame.harness!r}",
             )
         try:
+            if harness == "pi-native":
+                from omnigent.pi_native import pi_native_model_options
+
+                return HostModelOptionsResultFrame(
+                    request_id=frame.request_id,
+                    status="ok",
+                    models=await asyncio.to_thread(
+                        pi_native_model_options,
+                        cwd=frame.workspace,
+                    ),
+                )
             from omnigent.claude_native import (
                 claude_native_model_options,
                 resolve_native_claude_config,

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -795,6 +795,7 @@ class HostModelOptionsFrame:
 
     request_id: str
     harness: str
+    workspace: str | None = None
 
 
 @dataclass
@@ -1166,6 +1167,7 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "kind": HostFrameKind.MODEL_OPTIONS.value,
                 "request_id": frame.request_id,
                 "harness": frame.harness,
+                "workspace": frame.workspace,
             }
         )
     if isinstance(frame, HostModelOptionsResultFrame):
@@ -1788,6 +1790,7 @@ def _decode_model_options(msg: dict[str, Any]) -> HostModelOptionsFrame:
     return HostModelOptionsFrame(
         request_id=_required_str(msg, "request_id"),
         harness=_required_str(msg, "harness"),
+        workspace=_optional_nullable_str(msg, "workspace"),
     )
 
 

--- a/omnigent/pi_native.py
+++ b/omnigent/pi_native.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import shutil
+import subprocess
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -56,6 +57,115 @@ _SESSION_LABELS = {
     "omnigent.ui": "terminal",
     _WRAPPER_LABEL_KEY: _WRAPPER_LABEL_VALUE,
 }
+
+
+def _pi_default_model_selection(
+    agent_dir: Path | None = None,
+    cwd: str | Path | None = None,
+) -> tuple[str, str] | None:
+    """Return Pi's configured ``(provider, model)`` default, if present."""
+    root = agent_dir or Path.home() / ".pi" / "agent"
+
+    def load_settings(path: Path) -> dict[str, Any]:
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        return raw if isinstance(raw, dict) else {}
+
+    settings = load_settings(root / "settings.json")
+    if cwd is not None:
+        settings.update(load_settings(Path(cwd) / ".pi" / "settings.json"))
+    provider = settings.get("defaultProvider")
+    model = settings.get("defaultModel")
+    if not isinstance(provider, str) or not provider.strip():
+        return None
+    if not isinstance(model, str) or not model.strip():
+        return None
+    return provider.strip(), model.strip()
+
+
+def pi_native_model_options(
+    *,
+    env: Mapping[str, str] | None = None,
+    cwd: str | Path | None = None,
+    run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> list[dict[str, Any]]:
+    """Return the models Pi itself reports as available on this machine."""
+    try:
+        executable = resolve_pi_executable(env=env)
+    except click.ClickException:
+        return []
+    args = [executable]
+    if cwd is not None and pi_supports_approve(executable):
+        args.append("--approve")
+    args.append("--list-models")
+    try:
+        result = run(
+            args,
+            env=dict(env) if env is not None else None,
+            cwd=os.fspath(cwd) if cwd is not None else None,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if result.returncode != 0:
+        return []
+
+    configured_agent_dir = env.get("PI_CODING_AGENT_DIR", "").strip() if env else ""
+    home = Path(env.get("HOME", str(Path.home()))) if env else Path.home()
+    default = _pi_default_model_selection(
+        Path(configured_agent_dir) if configured_agent_dir else home / ".pi" / "agent",
+        cwd=cwd,
+    )
+    options: list[dict[str, Any]] = []
+    option_index_by_model: dict[str, int] = {}
+    for line in result.stdout.splitlines()[1:]:
+        columns = line.split()
+        if len(columns) < 2:
+            continue
+        provider, model = columns[0], columns[1]
+        option: dict[str, Any] = {
+            "id": model,
+            "model": model,
+            "displayName": model,
+            "provider": provider,
+        }
+        if default == (provider, model):
+            option["isDefault"] = True
+        existing_index = option_index_by_model.get(model)
+        if existing_index is not None:
+            if option.get("isDefault") is True:
+                options[existing_index] = option
+            continue
+        option_index_by_model[model] = len(options)
+        options.append(option)
+    return options
+
+
+def resolve_pi_native_local_model_selection(
+    model: str,
+    *,
+    env: Mapping[str, str] | None = None,
+    cwd: str | Path | None = None,
+) -> tuple[str, str] | None:
+    """Resolve a model override against Pi's own available provider catalog."""
+    stripped = model.strip()
+    if not stripped:
+        return None
+    options = pi_native_model_options(env=env, cwd=cwd)
+    matches = [option for option in options if option.get("id") == stripped]
+    if not matches:
+        return None
+    selected = next((option for option in matches if option.get("isDefault") is True), matches[0])
+    provider = selected.get("provider")
+    resolved_model = selected.get("model")
+    if not isinstance(provider, str) or not isinstance(resolved_model, str):
+        return None
+    return provider, resolved_model
 
 
 @dataclass(frozen=True)

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -974,15 +974,20 @@ def write_pi_models_config(agent_dir: Path, provider: PiProviderConfig) -> Path:
 
 
 def pi_native_provider_launch(
-    agent_dir: Path, provider: PiProviderConfig
+    agent_dir: Path,
+    provider: PiProviderConfig,
+    *,
+    pin_model: bool = True,
 ) -> tuple[dict[str, str], list[str]]:
     """Write the managed config and return the launch env + CLI args for Pi.
 
     :param agent_dir: The managed Pi config dir for this session.
     :param provider: The resolved provider config.
+    :param pin_model: Whether to append an explicit ``--provider`` / ``--model``
+        selection. ``False`` leaves startup selection to Pi's native resolver.
     :returns: ``(env, args)`` — the env vars to merge into the terminal spec
         (relocating Pi's config dir) and the ``--provider``/``--model`` args to
-        append to the Pi command.
+        append to the Pi command when *pin_model* is true.
     """
     write_pi_models_config(agent_dir, provider)
     # Copy the user's global Pi settings but suppress defaultThinkingLevel.
@@ -997,6 +1002,8 @@ def pi_native_provider_launch(
 
     prepare_managed_pi_agent_dir(agent_dir, overlay={"defaultThinkingLevel": None})
     env = {PI_CODING_AGENT_DIR_ENV_VAR: str(agent_dir)}
+    if not pin_model:
+        return env, []
     # Resolve which provider the selected model lives in. Non-Claude models
     # (GLM, GPT, Llama…) are in additional_providers (omnigent-openai);
     # Claude models are in the primary provider (omnigent). Pass the correct

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -1850,6 +1850,7 @@ async def _auto_create_pi_terminal(
     # never touching the user's global ``~/.pi/agent``.
     credential_warning: str | None = None
     if not _pi_args_have_provider(launch_config.terminal_launch_args or []):
+        from omnigent.pi_native import resolve_pi_native_local_model_selection
         from omnigent.pi_native_credentials import (
             pi_native_provider_launch,
             resolve_pi_native_provider,
@@ -1862,13 +1863,30 @@ async def _auto_create_pi_terminal(
         # (no model declared) keeps the provider's default model.
         # model_override (set by /model or sys_session_create's model arg)
         # takes precedence over the spec's pinned executor.model.
-        spec_model = launch_config.model_override or _pi_native_model_from_spec(agent_spec)
-        provider = resolve_pi_native_provider(model=spec_model)
-        if provider is not None:
-            cred_env, cred_args = pi_native_provider_launch(bridge_dir / "pi-agent", provider)
-            pi_env.update(cred_env)
-            pi_args.extend(cred_args)
-            credential_warning = provider.credential_warning
+        spec_model = _pi_native_model_from_spec(agent_spec)
+        requested_model = launch_config.model_override or spec_model
+        local_selection = (
+            resolve_pi_native_local_model_selection(
+                launch_config.model_override,
+                cwd=launch_config.workspace,
+            )
+            if resume_session_id is None and launch_config.model_override
+            else None
+        )
+        if local_selection is not None:
+            local_provider, local_model = local_selection
+            pi_args.extend(["--provider", local_provider, "--model", local_model])
+        else:
+            provider = resolve_pi_native_provider(model=requested_model)
+            if provider is not None:
+                cred_env, cred_args = pi_native_provider_launch(
+                    bridge_dir / "pi-agent",
+                    provider,
+                    pin_model=resume_session_id is None and requested_model is not None,
+                )
+                pi_env.update(cred_env)
+                pi_args.extend(cred_args)
+                credential_warning = provider.credential_warning
     # Inherit the agent's os_env so its sandbox (e.g. ``type: none``),
     # egress_rules and env_passthrough are honoured. Without ``sandbox`` here
     # and ``parent_os_env`` below, launch_required_terminal falls back to

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -91,6 +91,7 @@ async def _proxy_model_options(
     host_registry: HostRegistry,
     host_conn: HostConnection,
     harness: str,
+    workspace: str | None = None,
 ) -> dict[str, Any]:
     """Ask a host for the model catalog it would use for a new session."""
     request_id = secrets.token_hex(8)
@@ -98,7 +99,7 @@ async def _proxy_model_options(
     future: asyncio.Future[dict[str, Any]] = loop.create_future()
     host_conn.pending_model_options[request_id] = future
     frame = encode_host_frame(
-        HostModelOptionsFrame(request_id=request_id, harness=harness),
+        HostModelOptionsFrame(request_id=request_id, harness=harness, workspace=workspace),
     )
     try:
         try:
@@ -647,6 +648,7 @@ def create_hosts_router(
         request: Request,
         host_id: str,
         harness: str,
+        workspace: str | None = None,
     ) -> dict[str, list[dict[str, Any]]]:
         """Return pre-launch model choices resolved by the selected host.
 
@@ -668,6 +670,7 @@ def create_hosts_router(
             host_registry=host_registry,
             host_conn=conn,
             harness=canonicalize_harness(harness) or harness,
+            workspace=workspace,
         )
         if result.get("status") != "ok":
             raise HTTPException(

--- a/openapi.json
+++ b/openapi.json
@@ -7548,6 +7548,22 @@
               "title": "Harness",
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Workspace"
+            }
           }
         ],
         "responses": {

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -99,6 +99,43 @@ async def test_handle_model_options_uses_host_claude_configuration(
     )
 
 
+async def test_handle_model_options_uses_host_pi_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The launch picker asks Pi for the models available on this host."""
+    from omnigent import pi_native
+
+    captured: dict[str, object] = {}
+
+    def model_options(**kwargs: object) -> list[dict[str, object]]:
+        captured.update(kwargs)
+        return [
+            {
+                "id": "system.ai.gpt-5-6-sol",
+                "model": "system.ai.gpt-5-6-sol",
+                "displayName": "system.ai.gpt-5-6-sol",
+                "provider": "databricks-mlflow",
+                "isDefault": True,
+            }
+        ]
+
+    monkeypatch.setattr(pi_native, "pi_native_model_options", model_options)
+    host = _make_host_process()
+
+    result = await host._handle_model_options(
+        HostModelOptionsFrame(
+            request_id="req_pi_models",
+            harness="pi-native",
+            workspace="/workspace/project",
+        ),
+    )
+
+    assert result.status == "ok"
+    assert result.models[0]["id"] == "system.ai.gpt-5-6-sol"
+    assert result.models[0]["isDefault"] is True
+    assert captured == {"cwd": "/workspace/project"}
+
+
 def _make_host_process() -> HostProcess:
     """Create a HostProcess with a test identity.
 

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -55,6 +55,22 @@ def test_model_options_frames_round_trip() -> None:
     assert request == HostModelOptionsFrame(
         request_id="req_models",
         harness="claude-native",
+        workspace=None,
+    )
+
+    workspace_request = decode_host_frame(
+        encode_host_frame(
+            HostModelOptionsFrame(
+                request_id="req_pi_models",
+                harness="pi-native",
+                workspace="/workspace/project",
+            ),
+        )
+    )
+    assert workspace_request == HostModelOptionsFrame(
+        request_id="req_pi_models",
+        harness="pi-native",
+        workspace="/workspace/project",
     )
 
     result = decode_host_frame(

--- a/tests/runner/test_app_pi_native_model.py
+++ b/tests/runner/test_app_pi_native_model.py
@@ -82,20 +82,35 @@ def _key_provider_config() -> dict[str, Any]:
     }
 
 
+@pytest.mark.parametrize(
+    (
+        "resume_session_id",
+        "model_override",
+        "spec_model",
+        "expected_model",
+        "expect_model_pin",
+    ),
+    [
+        (None, None, "claude-opus-4-7", "claude-opus-4-7", True),
+        (None, "claude-haiku-4-5", "claude-opus-4-7", "claude-haiku-4-5", True),
+        ("pi-session-resume", None, "claude-opus-4-7", "claude-opus-4-7", False),
+    ],
+)
 @pytest.mark.asyncio
-async def test_auto_create_pi_terminal_threads_spec_model_into_models_json(
+async def test_auto_create_pi_terminal_pins_explicit_model_only_for_fresh_session(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    resume_session_id: str | None,
+    model_override: str | None,
+    spec_model: str,
+    expected_model: str,
+    expect_model_pin: bool,
 ) -> None:
-    """End-to-end: the spec's ``executor.model`` reaches the generated models.json.
+    """An explicit model configures the catalog but only pins a fresh session.
 
-    Drives ``_auto_create_pi_terminal`` with a spec pinning
-    ``claude-opus-4-7`` and a key-kind provider whose family default is
-    ``claude-sonnet-4-6``. The threaded override must win: the generated
-    ``models.json`` selects ``claude-opus-4-7`` and the appended Pi
-    ``--model`` arg reflects it. This is the runner-side seam the feature
-    adds — without threading the spec model, the models.json would carry
-    the family default instead.
+    Covers both a session ``model_override`` and a spec ``executor.model``.
+    A fresh session receives explicit model args; a resumed session omits them
+    so Pi can restore its recorded model.
 
     :param tmp_path: Temp dir backing the pi-native bridge root.
     :param monkeypatch: Pytest monkeypatch fixture.
@@ -104,7 +119,7 @@ async def test_auto_create_pi_terminal_threads_spec_model_into_models_json(
     import omnigent.pi_native_bridge as pi_bridge
     import omnigent.pi_native_credentials as creds
 
-    session_id = "conv_pi_model_e2e"
+    session_id = f"conv_pi_model_{'resume' if resume_session_id else 'fresh'}"
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     # Redirect the bridge tree into tmp so the generated managed Pi config dir
@@ -114,7 +129,17 @@ async def test_auto_create_pi_terminal_threads_spec_model_into_models_json(
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
     monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
     # Resolve a Pi executable without requiring the real binary on PATH.
-    monkeypatch.setattr("omnigent.pi_native.resolve_pi_executable", lambda: "/usr/bin/pi")
+    monkeypatch.setattr(
+        "omnigent.pi_native.resolve_pi_executable", lambda **_kwargs: "/usr/bin/pi"
+    )
+
+    async def _resolve_resume_session(**_kwargs: Any) -> str | None:
+        return resume_session_id
+
+    monkeypatch.setattr(
+        "omnigent.runner.native.orchestration._resolve_pi_resume_session",
+        _resolve_resume_session,
+    )
 
     # ``resolve_pi_native_provider``'s default config_loader is bound at def
     # time, so inject the test config by patching the module symbol the runner
@@ -139,6 +164,7 @@ async def test_auto_create_pi_terminal_threads_spec_model_into_models_json(
                     "workspace": str(workspace),
                     "terminal_launch_args": None,
                     "external_session_id": None,
+                    "model_override": model_override,
                 },
                 request=httpx.Request("GET", f"/v1/sessions/{session_id}"),
             )
@@ -176,7 +202,7 @@ async def test_auto_create_pi_terminal_threads_spec_model_into_models_json(
         executor=ExecutorSpec(
             type="omnigent",
             config={"harness": "pi-native"},
-            model="claude-opus-4-7",
+            model=spec_model,
         ),
     )
 
@@ -189,30 +215,120 @@ async def test_auto_create_pi_terminal_threads_spec_model_into_models_json(
     )
 
     # The runner threaded the spec model into resolve_pi_native_provider.
-    assert captured["model"] == "claude-opus-4-7"
+    assert captured["model"] == expected_model
 
-    # The appended Pi args select the override, not the family default.
     args = launched["args"]
-    assert "--model" in args
-    assert args[args.index("--model") + 1] == "claude-opus-4-7"
-    assert "--provider" in args
+    if expect_model_pin:
+        assert "--model" in args
+        assert args[args.index("--model") + 1] == expected_model
+        assert "--provider" in args
+    else:
+        assert "--model" not in args
+        assert "--provider" not in args
 
     # The managed config dir env was set and its models.json selects the override.
     agent_dir = Path(launched["env"]["PI_CODING_AGENT_DIR"])
     models = json.loads((agent_dir / "models.json").read_text(encoding="utf-8"))
-    assert models["providers"]["omnigent"]["models"] == [{"id": "claude-opus-4-7"}]
+    assert models["providers"]["omnigent"]["models"] == [{"id": expected_model}]
 
 
 @pytest.mark.asyncio
-async def test_auto_create_pi_terminal_no_spec_model_uses_provider_default(
+async def test_auto_create_pi_terminal_resolves_local_model_in_workspace(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """With no spec model, the provider's family default is used (unchanged).
+    """A selected Pi model keeps the provider resolved in its workspace."""
+    import omnigent.pi_native as pi_native
+    import omnigent.pi_native_bridge as pi_bridge
 
-    Guards the ``None`` case: a spec without ``executor.model`` must leave
-    Pi on the provider default (``claude-sonnet-4-6`` here), not break the
-    launch.
+    session_id = "conv_pi_workspace_model"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(pi_bridge, "_BRIDGE_ROOT", tmp_path / "pi-native")
+    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(workspace))
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
+    monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
+    monkeypatch.setattr(pi_native, "resolve_pi_executable", lambda **_kwargs: "/usr/bin/pi")
+
+    captured: dict[str, Any] = {}
+
+    def _resolve_local(model: str, *, env: Any = None, cwd: Any = None):
+        captured.update(model=model, env=env, cwd=cwd)
+        return "project-provider", model
+
+    monkeypatch.setattr(pi_native, "resolve_pi_native_local_model_selection", _resolve_local)
+
+    class _SnapshotClient:
+        async def get(self, url: str, *, timeout: float) -> httpx.Response:
+            del url, timeout
+            return httpx.Response(
+                200,
+                json={
+                    "workspace": str(workspace),
+                    "terminal_launch_args": None,
+                    "external_session_id": None,
+                    "model_override": "project-model",
+                },
+                request=httpx.Request("GET", f"/v1/sessions/{session_id}"),
+            )
+
+    launched: dict[str, Any] = {}
+
+    class _FakeResourceRegistry:
+        terminal_registry = None
+
+        async def launch_required_terminal(
+            self,
+            session_id: str,
+            terminal_name: str,
+            session_key: str,
+            spec: Any,
+            *,
+            resource_role: str | None = None,
+            parent_os_env: Any = None,
+        ) -> SessionResourceView:
+            del terminal_name, session_key, resource_role, parent_os_env
+            launched["args"] = list(spec.args)
+            return SessionResourceView(
+                id="terminal_pi_main",
+                type="terminal",
+                session_id=session_id,
+                name="pi",
+            )
+
+    spec = AgentSpec(
+        spec_version=1,
+        name="pi-workspace-model",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "pi-native"}),
+    )
+
+    await _auto_create_pi_terminal(
+        session_id,
+        _FakeResourceRegistry(),  # type: ignore[arg-type]
+        lambda _sid, _event: None,
+        server_client=_SnapshotClient(),  # type: ignore[arg-type]
+        agent_spec=spec,
+    )
+
+    assert captured == {"model": "project-model", "env": None, "cwd": workspace}
+    assert launched["args"][-4:] == [
+        "--provider",
+        "project-provider",
+        "--model",
+        "project-model",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_auto_create_pi_terminal_no_spec_model_defers_to_pi_startup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no explicit model, configure the provider without pinning Pi.
+
+    The generated catalog still includes the provider fallback, but Pi receives
+    no ``--provider`` / ``--model`` arguments and applies its native startup
+    precedence instead.
 
     :param tmp_path: Temp dir backing the pi-native bridge root.
     :param monkeypatch: Pytest monkeypatch fixture.
@@ -228,7 +344,9 @@ async def test_auto_create_pi_terminal_no_spec_model_uses_provider_default(
     monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(workspace))
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
     monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
-    monkeypatch.setattr("omnigent.pi_native.resolve_pi_executable", lambda: "/usr/bin/pi")
+    monkeypatch.setattr(
+        "omnigent.pi_native.resolve_pi_executable", lambda **_kwargs: "/usr/bin/pi"
+    )
 
     real_resolve = creds.resolve_pi_native_provider
     captured: dict[str, Any] = {}
@@ -292,6 +410,8 @@ async def test_auto_create_pi_terminal_no_spec_model_uses_provider_default(
     )
 
     assert captured["model"] is None
+    assert "--provider" not in launched["args"]
+    assert "--model" not in launched["args"]
     agent_dir = Path(launched["env"]["PI_CODING_AGENT_DIR"])
     models = json.loads((agent_dir / "models.json").read_text(encoding="utf-8"))
     assert models["providers"]["omnigent"]["models"] == [{"id": "claude-sonnet-4-6"}]

--- a/tests/runner/test_app_pi_native_model.py
+++ b/tests/runner/test_app_pi_native_model.py
@@ -89,11 +89,20 @@ def _key_provider_config() -> dict[str, Any]:
         "spec_model",
         "expected_model",
         "expect_model_pin",
+        "local_selection",
     ),
     [
-        (None, None, "claude-opus-4-7", "claude-opus-4-7", True),
-        (None, "claude-haiku-4-5", "claude-opus-4-7", "claude-haiku-4-5", True),
-        ("pi-session-resume", None, "claude-opus-4-7", "claude-opus-4-7", False),
+        (None, None, "claude-opus-4-7", "claude-opus-4-7", True, None),
+        (None, "claude-haiku-4-5", "claude-opus-4-7", "claude-haiku-4-5", True, None),
+        (
+            None,
+            "project-model",
+            None,
+            "project-model",
+            True,
+            ("project-provider", "project-model"),
+        ),
+        ("pi-session-resume", None, "claude-opus-4-7", "claude-opus-4-7", False, None),
     ],
 )
 @pytest.mark.asyncio
@@ -105,6 +114,7 @@ async def test_auto_create_pi_terminal_pins_explicit_model_only_for_fresh_sessio
     spec_model: str,
     expected_model: str,
     expect_model_pin: bool,
+    local_selection: tuple[str, str] | None,
 ) -> None:
     """An explicit model configures the catalog but only pins a fresh session.
 
@@ -116,6 +126,7 @@ async def test_auto_create_pi_terminal_pins_explicit_model_only_for_fresh_sessio
     :param monkeypatch: Pytest monkeypatch fixture.
     :returns: None.
     """
+    import omnigent.pi_native as pi_native
     import omnigent.pi_native_bridge as pi_bridge
     import omnigent.pi_native_credentials as creds
 
@@ -152,6 +163,12 @@ async def test_auto_create_pi_terminal_pins_explicit_model_only_for_fresh_sessio
         return real_resolve(model=model, config_loader=_key_provider_config)
 
     monkeypatch.setattr(creds, "resolve_pi_native_provider", _resolve_with_test_config)
+
+    def _resolve_local(model: str, *, env: Any = None, cwd: Any = None):
+        captured.update(local_model=model, local_env=env, local_cwd=cwd)
+        return local_selection
+
+    monkeypatch.setattr(pi_native, "resolve_pi_native_local_model_selection", _resolve_local)
 
     class _SnapshotClient:
         """Fresh pi-native session snapshot (no launch args / external id)."""
@@ -214,9 +231,6 @@ async def test_auto_create_pi_terminal_pins_explicit_model_only_for_fresh_sessio
         agent_spec=spec,
     )
 
-    # The runner threaded the spec model into resolve_pi_native_provider.
-    assert captured["model"] == expected_model
-
     args = launched["args"]
     if expect_model_pin:
         assert "--model" in args
@@ -226,97 +240,14 @@ async def test_auto_create_pi_terminal_pins_explicit_model_only_for_fresh_sessio
         assert "--model" not in args
         assert "--provider" not in args
 
-    # The managed config dir env was set and its models.json selects the override.
-    agent_dir = Path(launched["env"]["PI_CODING_AGENT_DIR"])
-    models = json.loads((agent_dir / "models.json").read_text(encoding="utf-8"))
-    assert models["providers"]["omnigent"]["models"] == [{"id": expected_model}]
-
-
-@pytest.mark.asyncio
-async def test_auto_create_pi_terminal_resolves_local_model_in_workspace(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A selected Pi model keeps the provider resolved in its workspace."""
-    import omnigent.pi_native as pi_native
-    import omnigent.pi_native_bridge as pi_bridge
-
-    session_id = "conv_pi_workspace_model"
-    workspace = tmp_path / "workspace"
-    workspace.mkdir()
-    monkeypatch.setattr(pi_bridge, "_BRIDGE_ROOT", tmp_path / "pi-native")
-    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(workspace))
-    monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
-    monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
-    monkeypatch.setattr(pi_native, "resolve_pi_executable", lambda **_kwargs: "/usr/bin/pi")
-
-    captured: dict[str, Any] = {}
-
-    def _resolve_local(model: str, *, env: Any = None, cwd: Any = None):
-        captured.update(model=model, env=env, cwd=cwd)
-        return "project-provider", model
-
-    monkeypatch.setattr(pi_native, "resolve_pi_native_local_model_selection", _resolve_local)
-
-    class _SnapshotClient:
-        async def get(self, url: str, *, timeout: float) -> httpx.Response:
-            del url, timeout
-            return httpx.Response(
-                200,
-                json={
-                    "workspace": str(workspace),
-                    "terminal_launch_args": None,
-                    "external_session_id": None,
-                    "model_override": "project-model",
-                },
-                request=httpx.Request("GET", f"/v1/sessions/{session_id}"),
-            )
-
-    launched: dict[str, Any] = {}
-
-    class _FakeResourceRegistry:
-        terminal_registry = None
-
-        async def launch_required_terminal(
-            self,
-            session_id: str,
-            terminal_name: str,
-            session_key: str,
-            spec: Any,
-            *,
-            resource_role: str | None = None,
-            parent_os_env: Any = None,
-        ) -> SessionResourceView:
-            del terminal_name, session_key, resource_role, parent_os_env
-            launched["args"] = list(spec.args)
-            return SessionResourceView(
-                id="terminal_pi_main",
-                type="terminal",
-                session_id=session_id,
-                name="pi",
-            )
-
-    spec = AgentSpec(
-        spec_version=1,
-        name="pi-workspace-model",
-        executor=ExecutorSpec(type="omnigent", config={"harness": "pi-native"}),
-    )
-
-    await _auto_create_pi_terminal(
-        session_id,
-        _FakeResourceRegistry(),  # type: ignore[arg-type]
-        lambda _sid, _event: None,
-        server_client=_SnapshotClient(),  # type: ignore[arg-type]
-        agent_spec=spec,
-    )
-
-    assert captured == {"model": "project-model", "env": None, "cwd": workspace}
-    assert launched["args"][-4:] == [
-        "--provider",
-        "project-provider",
-        "--model",
-        "project-model",
-    ]
+    if local_selection is not None:
+        assert captured["local_cwd"] == workspace
+        assert args[args.index("--provider") + 1] == local_selection[0]
+    else:
+        assert captured["model"] == expected_model
+        agent_dir = Path(launched["env"]["PI_CODING_AGENT_DIR"])
+        models = json.loads((agent_dir / "models.json").read_text(encoding="utf-8"))
+        assert models["providers"]["omnigent"]["models"] == [{"id": expected_model}]
 
 
 @pytest.mark.asyncio

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -246,6 +246,24 @@ def test_provider_launch_returns_env_and_args(tmp_path: Path) -> None:
     assert (agent_dir / "models.json").exists()
 
 
+def test_provider_launch_can_defer_model_selection_to_pi(tmp_path: Path) -> None:
+    """Provider setup can omit model args so Pi applies its startup precedence."""
+    provider = creds.PiProviderConfig(
+        provider_id="omnigent",
+        base_url="https://api.anthropic.com",
+        api="anthropic-messages",
+        model="claude-sonnet-4-6",
+        api_key="sk-secret",
+        auth_header=False,
+    )
+    agent_dir = tmp_path / "pi-agent"
+    env, args = creds.pi_native_provider_launch(agent_dir, provider, pin_model=False)
+
+    assert env == {creds.PI_CODING_AGENT_DIR_ENV_VAR: str(agent_dir)}
+    assert args == []
+    assert (agent_dir / "models.json").exists()
+
+
 def test_openai_chat_wire_api_resolves_to_completions(monkeypatch: pytest.MonkeyPatch) -> None:
     """An OpenAI family with wire_api: chat → openai-completions API.
 

--- a/tests/test_pi_native_models.py
+++ b/tests/test_pi_native_models.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from omnigent import pi_native
+from omnigent.pi_native import pi_native_model_options
+
+
+def test_pi_native_model_options_uses_workspace_catalog_and_marks_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_dir = tmp_path / "pi-agent"
+    agent_dir.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / ".pi").mkdir()
+    (workspace / ".pi" / "settings.json").write_text(
+        json.dumps(
+            {
+                "defaultProvider": "databricks-mlflow",
+                "defaultModel": "system.ai.gpt-5-6-luna",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (agent_dir / "settings.json").write_text(
+        json.dumps(
+            {
+                "defaultProvider": "databricks-mlflow",
+                "defaultModel": "system.ai.gpt-5-6-sol",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    captured: dict[str, object] = {}
+
+    def run(args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured["args"] = args
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(
+            args=["pi", "--list-models"],
+            returncode=0,
+            stdout=(
+                "provider model context max-out thinking images\n"
+                "databricks-mlflow system.ai.gpt-5-6-sol 1.1M 128K yes yes\n"
+                "other-provider system.ai.gpt-5-6-luna 1.1M 128K yes yes\n"
+                "databricks-mlflow system.ai.gpt-5-6-luna 1.1M 128K yes yes\n"
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(pi_native, "pi_supports_approve", lambda _executable: True)
+
+    options = pi_native_model_options(
+        env={
+            "PATH": "/bin",
+            "OMNIGENT_PI_PATH": "/bin/echo",
+            "PI_CODING_AGENT_DIR": str(agent_dir),
+        },
+        cwd=workspace,
+        run=run,
+    )
+
+    assert [option["id"] for option in options] == [
+        "system.ai.gpt-5-6-sol",
+        "system.ai.gpt-5-6-luna",
+    ]
+    assert options[0]["provider"] == "databricks-mlflow"
+    assert "isDefault" not in options[0]
+    assert options[1]["provider"] == "databricks-mlflow"
+    assert options[1]["isDefault"] is True
+    assert captured["args"] == ["/bin/echo", "--approve", "--list-models"]
+    assert captured["cwd"] == str(workspace)
+
+
+def test_resolve_pi_native_local_model_selection_keeps_its_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        pi_native,
+        "pi_native_model_options",
+        lambda **_kwargs: [
+            {
+                "id": "system.ai.gpt-5-6-sol",
+                "model": "system.ai.gpt-5-6-sol",
+                "provider": "databricks-mlflow",
+                "isDefault": True,
+            }
+        ],
+    )
+
+    assert pi_native.resolve_pi_native_local_model_selection("system.ai.gpt-5-6-sol") == (
+        "databricks-mlflow",
+        "system.ai.gpt-5-6-sol",
+    )

--- a/tests/test_pi_native_models.py
+++ b/tests/test_pi_native_models.py
@@ -9,54 +9,39 @@ import pytest
 from omnigent import pi_native
 from omnigent.pi_native import pi_native_model_options
 
+_PROVIDER = "databricks-mlflow"
+_DEFAULT_MODEL = "system.ai.gpt-5-6-luna"
+_OTHER_MODEL = "system.ai.gpt-5-6-sol"
+_CATALOG = f"""provider model context max-out thinking images
+{_PROVIDER} {_OTHER_MODEL} 1.1M 128K yes yes
+other-provider {_DEFAULT_MODEL} 1.1M 128K yes yes
+{_PROVIDER} {_DEFAULT_MODEL} 1.1M 128K yes yes
+"""
+
+
+def _write_settings(path: Path, model: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"defaultProvider": _PROVIDER, "defaultModel": model}),
+        encoding="utf-8",
+    )
+
 
 def test_pi_native_model_options_uses_workspace_catalog_and_marks_default(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     agent_dir = tmp_path / "pi-agent"
-    agent_dir.mkdir()
     workspace = tmp_path / "workspace"
-    workspace.mkdir()
-    (workspace / ".pi").mkdir()
-    (workspace / ".pi" / "settings.json").write_text(
-        json.dumps(
-            {
-                "defaultProvider": "databricks-mlflow",
-                "defaultModel": "system.ai.gpt-5-6-luna",
-            }
-        ),
-        encoding="utf-8",
-    )
-    (agent_dir / "settings.json").write_text(
-        json.dumps(
-            {
-                "defaultProvider": "databricks-mlflow",
-                "defaultModel": "system.ai.gpt-5-6-sol",
-            }
-        ),
-        encoding="utf-8",
-    )
-
+    _write_settings(agent_dir / "settings.json", _OTHER_MODEL)
+    _write_settings(workspace / ".pi" / "settings.json", _DEFAULT_MODEL)
     captured: dict[str, object] = {}
 
     def run(args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-        captured["args"] = args
-        captured.update(kwargs)
-        return subprocess.CompletedProcess(
-            args=["pi", "--list-models"],
-            returncode=0,
-            stdout=(
-                "provider model context max-out thinking images\n"
-                "databricks-mlflow system.ai.gpt-5-6-sol 1.1M 128K yes yes\n"
-                "other-provider system.ai.gpt-5-6-luna 1.1M 128K yes yes\n"
-                "databricks-mlflow system.ai.gpt-5-6-luna 1.1M 128K yes yes\n"
-            ),
-            stderr="",
-        )
+        captured.update(args=args, **kwargs)
+        return subprocess.CompletedProcess(args, 0, _CATALOG, "")
 
     monkeypatch.setattr(pi_native, "pi_supports_approve", lambda _executable: True)
-
     options = pi_native_model_options(
         env={
             "PATH": "/bin",
@@ -67,13 +52,10 @@ def test_pi_native_model_options_uses_workspace_catalog_and_marks_default(
         run=run,
     )
 
-    assert [option["id"] for option in options] == [
-        "system.ai.gpt-5-6-sol",
-        "system.ai.gpt-5-6-luna",
-    ]
-    assert options[0]["provider"] == "databricks-mlflow"
+    assert [option["id"] for option in options] == [_OTHER_MODEL, _DEFAULT_MODEL]
+    assert options[0]["provider"] == _PROVIDER
     assert "isDefault" not in options[0]
-    assert options[1]["provider"] == "databricks-mlflow"
+    assert options[1]["provider"] == _PROVIDER
     assert options[1]["isDefault"] is True
     assert captured["args"] == ["/bin/echo", "--approve", "--list-models"]
     assert captured["cwd"] == str(workspace)
@@ -87,15 +69,15 @@ def test_resolve_pi_native_local_model_selection_keeps_its_provider(
         "pi_native_model_options",
         lambda **_kwargs: [
             {
-                "id": "system.ai.gpt-5-6-sol",
-                "model": "system.ai.gpt-5-6-sol",
-                "provider": "databricks-mlflow",
+                "id": _OTHER_MODEL,
+                "model": _OTHER_MODEL,
+                "provider": _PROVIDER,
                 "isDefault": True,
             }
         ],
     )
 
-    assert pi_native.resolve_pi_native_local_model_selection("system.ai.gpt-5-6-sol") == (
-        "databricks-mlflow",
-        "system.ai.gpt-5-6-sol",
+    assert pi_native.resolve_pi_native_local_model_selection(_OTHER_MODEL) == (
+        _PROVIDER,
+        _OTHER_MODEL,
     )

--- a/web/src/hooks/useHosts.test.tsx
+++ b/web/src/hooks/useHosts.test.tsx
@@ -386,6 +386,21 @@ describe("useHostModelOptions", () => {
     expect(result.current.data?.map((model) => model.displayName)).toEqual(["Sonnet 4.6"]);
   });
 
+  it("includes the selected workspace in the model-options request", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ models: [] }));
+
+    const { result } = renderHook(
+      () => useHostModelOptions("host_1", "pi-native", true, "/workspace/with spaces"),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/v1/hosts/host_1/harnesses/pi-native/model-options?workspace=%2Fworkspace%2Fwith+spaces",
+      expect.any(Object),
+    );
+  });
+
   it("does not fetch without a selected host", async () => {
     renderHook(() => useHostModelOptions(null, "claude-native"), { wrapper });
     await Promise.resolve();

--- a/web/src/hooks/useHosts.ts
+++ b/web/src/hooks/useHosts.ts
@@ -80,9 +80,13 @@ export function useHosts(options: UseHostsOptions = {}) {
 async function fetchHostModelOptions(
   hostId: string,
   harness: string,
+  workspace: string | null,
 ): Promise<NativeModelOption[]> {
+  const params = new URLSearchParams();
+  if (workspace) params.set("workspace", workspace);
+  const query = params.size > 0 ? `?${params.toString()}` : "";
   const res = await authenticatedFetch(
-    `/v1/hosts/${encodeURIComponent(hostId)}/harnesses/${encodeURIComponent(harness)}/model-options`,
+    `/v1/hosts/${encodeURIComponent(hostId)}/harnesses/${encodeURIComponent(harness)}/model-options${query}`,
   );
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   const body = (await res.json()) as { models?: NativeModelOption[] };
@@ -90,10 +94,15 @@ async function fetchHostModelOptions(
 }
 
 /** Model choices available before launch, resolved on the selected host. */
-export function useHostModelOptions(hostId: string | null, harness: string, enabled = true) {
+export function useHostModelOptions(
+  hostId: string | null,
+  harness: string,
+  enabled = true,
+  workspace: string | null = null,
+) {
   return useQuery({
-    queryKey: ["host-model-options", hostId, harness],
-    queryFn: () => fetchHostModelOptions(hostId as string, harness),
+    queryKey: ["host-model-options", hostId, harness, workspace],
+    queryFn: () => fetchHostModelOptions(hostId as string, harness, workspace),
     enabled: enabled && hostId !== null,
     staleTime: 30_000,
     retry: false,

--- a/web/src/lib/nativeCodingAgents.ts
+++ b/web/src/lib/nativeCodingAgents.ts
@@ -16,7 +16,8 @@ export type NativeCodingAgentIconKind =
   | "antigravity"
   | "kimi"
   | "hermes";
-export type NativeCodingAgentCapability = "permissionMode" | "approvalMode" | "cursorMode";
+export type NativeCodingAgentCapability =
+  "modelSelection" | "permissionMode" | "approvalMode" | "cursorMode";
 
 export interface NativeCodingAgentSpec {
   key: NativeCodingAgentIconKind;
@@ -38,7 +39,7 @@ export const NATIVE_CODING_AGENTS = [
     displayName: "Claude Code",
     iconKind: "claude",
     sortRank: 10,
-    capabilities: ["permissionMode"],
+    capabilities: ["modelSelection", "permissionMode"],
   },
   {
     key: "codex",
@@ -87,6 +88,7 @@ export const NATIVE_CODING_AGENTS = [
     displayName: "Pi",
     iconKind: "pi",
     sortRank: 40,
+    capabilities: ["modelSelection"],
   },
   {
     key: "kiro",

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { authenticatedFetch } from "@/lib/identity";
 import type { Host } from "@/hooks/useHosts";
-import { useHosts } from "@/hooks/useHosts";
+import { useHostModelOptions, useHosts } from "@/hooks/useHosts";
 import type { AvailableAgent } from "@/hooks/useAvailableAgents";
 import { useAvailableAgents } from "@/hooks/useAvailableAgents";
 import { NewChatLandingScreen, resetLandingDraft, sanitizeInitialPrompt } from "./NewChatDialog";
@@ -211,6 +211,15 @@ beforeEach(() => {
   navigateMock.mockReset();
   setPendingInitialPromptMock.mockReset();
   vi.mocked(authenticatedFetch).mockReset();
+  vi.mocked(useHostModelOptions).mockClear();
+  vi.mocked(useHostModelOptions).mockReturnValue({
+    data: [
+      { id: "opus", displayName: "Opus" },
+      { id: "sonnet", displayName: "Sonnet" },
+      { id: "haiku", displayName: "Haiku" },
+    ],
+    isLoading: false,
+  } as ReturnType<typeof useHostModelOptions>);
   // Clear the module-level landing draft so a base branch (or other field)
   // left behind by an unmounting test doesn't seed the next one.
   resetLandingDraft();
@@ -826,6 +835,126 @@ describe("NewChatLandingScreen create flow", () => {
     const body = JSON.parse(init.body as string);
     expect(body.model_override).toBe("opus");
     expect(body.reasoning_effort).toBe("high");
+  });
+
+  it("offers Pi models before launch and seeds Pi's direct default", async () => {
+    vi.mocked(useHostModelOptions).mockReturnValue({
+      data: [
+        {
+          id: "system.ai.gpt-5-6-sol",
+          displayName: "system.ai.gpt-5-6-sol",
+          isDefault: true,
+        },
+        {
+          id: "system.ai.gpt-5-6-luna",
+          displayName: "system.ai.gpt-5-6-luna",
+        },
+      ],
+      isLoading: false,
+    } as ReturnType<typeof useHostModelOptions>);
+    setAgents([agent({ id: "ag_pi", name: "pi-native-ui", display_name: "Pi" })]);
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_pi" }),
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    await waitFor(() =>
+      expect(useHostModelOptions).toHaveBeenLastCalledWith(
+        "host_1",
+        "pi-native",
+        true,
+        SEEDED_WORKSPACE,
+      ),
+    );
+    openAgentConfig("ag_pi");
+    expect(screen.getByTestId("new-chat-landing-config-model").textContent).toContain(
+      "system.ai.gpt-5-6-sol",
+    );
+    pickSelectOption("new-chat-landing-config-model", "system.ai.gpt-5-6-luna");
+    saveConfig();
+    typeMessage("go");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
+    const [, init] = vi.mocked(authenticatedFetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.model_override).toBe("system.ai.gpt-5-6-luna");
+    expect(body.reasoning_effort).toBeUndefined();
+  });
+
+  it("shows Pi's default when its catalog resolves after the config opens", async () => {
+    vi.mocked(useHostModelOptions).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as ReturnType<typeof useHostModelOptions>);
+    setAgents([agent({ id: "ag_pi", name: "pi-native-ui", display_name: "Pi" })]);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    openAgentConfig("ag_pi");
+    expect(screen.getByTestId("new-chat-landing-config-model").textContent).toContain(
+      "Loading models…",
+    );
+
+    vi.mocked(useHostModelOptions).mockReturnValue({
+      data: [
+        {
+          id: "system.ai.gpt-5-6-sol",
+          displayName: "system.ai.gpt-5-6-sol",
+          isDefault: true,
+        },
+        {
+          id: "system.ai.gpt-5-6-luna",
+          displayName: "system.ai.gpt-5-6-luna",
+        },
+      ],
+      isLoading: false,
+    } as ReturnType<typeof useHostModelOptions>);
+    typeMessage("trigger rerender");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-config-model").textContent).toContain(
+        "system.ai.gpt-5-6-sol (Default)",
+      ),
+    );
+  });
+
+  it("prefers the last valid Pi selection over Pi's configured default", async () => {
+    localStorage.setItem(
+      "omnigent:last-mode-by-harness",
+      JSON.stringify({ "pi-native": { model: "system.ai.gpt-5-6-luna" } }),
+    );
+    vi.mocked(useHostModelOptions).mockReturnValue({
+      data: [
+        {
+          id: "system.ai.gpt-5-6-sol",
+          displayName: "system.ai.gpt-5-6-sol",
+          isDefault: true,
+        },
+        {
+          id: "system.ai.gpt-5-6-luna",
+          displayName: "system.ai.gpt-5-6-luna",
+        },
+      ],
+      isLoading: false,
+    } as ReturnType<typeof useHostModelOptions>);
+    setAgents([agent({ id: "ag_pi", name: "pi-native-ui", display_name: "Pi" })]);
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_pi" }),
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    typeMessage("go");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
+    const [, init] = vi.mocked(authenticatedFetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.model_override).toBe("system.ai.gpt-5-6-luna");
   });
 
   it("seeds the model + effort from the last pick for claude-native on a new session", async () => {

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -31,6 +31,12 @@ const PROMPT_HISTORY_KEY = "omnigent:prompt-history:conv_new";
 // The seeded working directory (from the host's persisted recent) that the
 // create body must carry through.
 const SEEDED_WORKSPACE = "/Users/corey/universe/src/foo";
+const PI_DEFAULT_MODEL = "system.ai.gpt-5-6-sol";
+const PI_ALTERNATE_MODEL = "system.ai.gpt-5-6-luna";
+const PI_MODEL_OPTIONS = [
+  { id: PI_DEFAULT_MODEL, displayName: PI_DEFAULT_MODEL, isDefault: true },
+  { id: PI_ALTERNATE_MODEL, displayName: PI_ALTERNATE_MODEL },
+];
 
 // The landing screen navigates via the embed-aware routing abstraction
 // (`@/lib/routing`), not react-router directly — mock that so the create
@@ -138,6 +144,19 @@ function setHosts(hosts: Host[]): void {
 function setAgents(agents: AvailableAgent[]): void {
   vi.mocked(useAvailableAgents).mockReturnValue({ data: agents } as ReturnType<
     typeof useAvailableAgents
+  >);
+}
+
+function setPiAgent(): void {
+  setAgents([agent({ id: "ag_pi", name: "pi-native-ui", display_name: "Pi" })]);
+}
+
+function mockPiModelOptions(
+  isLoading = false,
+  data: ReturnType<typeof useHostModelOptions>["data"] = isLoading ? undefined : PI_MODEL_OPTIONS,
+): void {
+  vi.mocked(useHostModelOptions).mockReturnValue({ data, isLoading } as ReturnType<
+    typeof useHostModelOptions
   >);
 }
 
@@ -838,21 +857,8 @@ describe("NewChatLandingScreen create flow", () => {
   });
 
   it("offers Pi models before launch and seeds Pi's direct default", async () => {
-    vi.mocked(useHostModelOptions).mockReturnValue({
-      data: [
-        {
-          id: "system.ai.gpt-5-6-sol",
-          displayName: "system.ai.gpt-5-6-sol",
-          isDefault: true,
-        },
-        {
-          id: "system.ai.gpt-5-6-luna",
-          displayName: "system.ai.gpt-5-6-luna",
-        },
-      ],
-      isLoading: false,
-    } as ReturnType<typeof useHostModelOptions>);
-    setAgents([agent({ id: "ag_pi", name: "pi-native-ui", display_name: "Pi" })]);
+    mockPiModelOptions();
+    setPiAgent();
     vi.mocked(authenticatedFetch).mockResolvedValueOnce({
       ok: true,
       json: async () => ({ id: "conv_pi" }),
@@ -870,9 +876,9 @@ describe("NewChatLandingScreen create flow", () => {
     );
     openAgentConfig("ag_pi");
     expect(screen.getByTestId("new-chat-landing-config-model").textContent).toContain(
-      "system.ai.gpt-5-6-sol",
+      PI_DEFAULT_MODEL,
     );
-    pickSelectOption("new-chat-landing-config-model", "system.ai.gpt-5-6-luna");
+    pickSelectOption("new-chat-landing-config-model", PI_ALTERNATE_MODEL);
     saveConfig();
     typeMessage("go");
     fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
@@ -880,16 +886,13 @@ describe("NewChatLandingScreen create flow", () => {
     await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
     const [, init] = vi.mocked(authenticatedFetch).mock.calls[0] as [string, RequestInit];
     const body = JSON.parse(init.body as string);
-    expect(body.model_override).toBe("system.ai.gpt-5-6-luna");
+    expect(body.model_override).toBe(PI_ALTERNATE_MODEL);
     expect(body.reasoning_effort).toBeUndefined();
   });
 
   it("shows Pi's default when its catalog resolves after the config opens", async () => {
-    vi.mocked(useHostModelOptions).mockReturnValue({
-      data: undefined,
-      isLoading: true,
-    } as ReturnType<typeof useHostModelOptions>);
-    setAgents([agent({ id: "ag_pi", name: "pi-native-ui", display_name: "Pi" })]);
+    mockPiModelOptions(true);
+    setPiAgent();
 
     renderLanding();
     await waitForWorkspaceSeed();
@@ -898,25 +901,12 @@ describe("NewChatLandingScreen create flow", () => {
       "Loading models…",
     );
 
-    vi.mocked(useHostModelOptions).mockReturnValue({
-      data: [
-        {
-          id: "system.ai.gpt-5-6-sol",
-          displayName: "system.ai.gpt-5-6-sol",
-          isDefault: true,
-        },
-        {
-          id: "system.ai.gpt-5-6-luna",
-          displayName: "system.ai.gpt-5-6-luna",
-        },
-      ],
-      isLoading: false,
-    } as ReturnType<typeof useHostModelOptions>);
+    mockPiModelOptions();
     typeMessage("trigger rerender");
 
     await waitFor(() =>
       expect(screen.getByTestId("new-chat-landing-config-model").textContent).toContain(
-        "system.ai.gpt-5-6-sol (Default)",
+        `${PI_DEFAULT_MODEL} (Default)`,
       ),
     );
   });
@@ -924,23 +914,10 @@ describe("NewChatLandingScreen create flow", () => {
   it("prefers the last valid Pi selection over Pi's configured default", async () => {
     localStorage.setItem(
       "omnigent:last-mode-by-harness",
-      JSON.stringify({ "pi-native": { model: "system.ai.gpt-5-6-luna" } }),
+      JSON.stringify({ "pi-native": { model: PI_ALTERNATE_MODEL } }),
     );
-    vi.mocked(useHostModelOptions).mockReturnValue({
-      data: [
-        {
-          id: "system.ai.gpt-5-6-sol",
-          displayName: "system.ai.gpt-5-6-sol",
-          isDefault: true,
-        },
-        {
-          id: "system.ai.gpt-5-6-luna",
-          displayName: "system.ai.gpt-5-6-luna",
-        },
-      ],
-      isLoading: false,
-    } as ReturnType<typeof useHostModelOptions>);
-    setAgents([agent({ id: "ag_pi", name: "pi-native-ui", display_name: "Pi" })]);
+    mockPiModelOptions();
+    setPiAgent();
     vi.mocked(authenticatedFetch).mockResolvedValueOnce({
       ok: true,
       json: async () => ({ id: "conv_pi" }),
@@ -954,7 +931,7 @@ describe("NewChatLandingScreen create flow", () => {
     await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
     const [, init] = vi.mocked(authenticatedFetch).mock.calls[0] as [string, RequestInit];
     const body = JSON.parse(init.body as string);
-    expect(body.model_override).toBe("system.ai.gpt-5-6-luna");
+    expect(body.model_override).toBe(PI_ALTERNATE_MODEL);
   });
 
   it("seeds the model + effort from the last pick for claude-native on a new session", async () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1222,8 +1222,8 @@ function HarnessConfigModal({
   cursorExecMode,
   bypassSandbox,
   pickedModel,
-  claudeModelOptions,
-  claudeModelsLoading,
+  modelOptions,
+  modelsLoading,
   pickedEffort,
   pickedHarness,
   costControlMode,
@@ -1248,8 +1248,8 @@ function HarnessConfigModal({
   cursorExecMode: string;
   bypassSandbox: boolean;
   pickedModel: string;
-  claudeModelOptions: readonly { id: string; displayName: string }[];
-  claudeModelsLoading: boolean;
+  modelOptions: readonly { id: string; displayName: string; isDefault?: boolean }[];
+  modelsLoading: boolean;
   pickedEffort: string;
   pickedHarness: string | null;
   costControlMode: CostControlMode;
@@ -1266,6 +1266,8 @@ function HarnessConfigModal({
   // Feature ON → single "needs setup" badge; OFF → per-reason original text.
   const collapsedBadge = info !== "loading" && info.harness_install_enabled;
   const entryHarness = nativeCodingAgentForAvailableAgent(agent)?.harness ?? null;
+  const isPi = entryHarness === "pi-native";
+  const hasModelSelection = nativeAgentHasCapability(agent, "modelSelection");
   const hasPermission = nativeAgentHasCapability(agent, "permissionMode");
   const hasApproval = nativeAgentHasCapability(agent, "approvalMode");
   const hasCursor = nativeAgentHasCapability(agent, "cursorMode");
@@ -1276,6 +1278,7 @@ function HarnessConfigModal({
   // Local draft — seeded from the live state each time the modal opens so
   // Cancel can discard and re-opening always reflects the committed state.
   const [draftModel, setDraftModel] = useState(pickedModel);
+  const [draftModelTouched, setDraftModelTouched] = useState(false);
   const [draftEffort, setDraftEffort] = useState(pickedEffort);
   const [draftPermission, setDraftPermission] = useState(permissionMode);
   const [draftApproval, setDraftApproval] = useState(approvalMode);
@@ -1287,6 +1290,7 @@ function HarnessConfigModal({
   useEffect(() => {
     if (!open) return;
     setDraftModel(pickedModel);
+    setDraftModelTouched(false);
     setDraftEffort(pickedEffort);
     setDraftPermission(permissionMode);
     setDraftApproval(approvalMode);
@@ -1298,12 +1302,20 @@ function HarnessConfigModal({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
+  useEffect(() => {
+    if (!open || draftModelTouched) return;
+    setDraftModel(pickedModel);
+  }, [draftModelTouched, open, pickedModel]);
+
   // Only treat routing as "on" when it's actually offered for this agent —
   // otherwise a stale costControlMode="on" (e.g. server later disabled the
   // flag) would select the __smart__ sentinel with no matching Select item.
   const smartRoutingOn = smartRoutingEligible && draftRouting === "on";
-  const modelValue = smartRoutingOn ? MODEL_SELECT_SMART : draftModel || MODEL_SELECT_DEFAULT;
+  const modelValue = smartRoutingOn
+    ? MODEL_SELECT_SMART
+    : draftModel || (isPi ? undefined : MODEL_SELECT_DEFAULT);
   const onModelChange = (value: string) => {
+    setDraftModelTouched(true);
     if (value === MODEL_SELECT_SMART) {
       setDraftRouting("on");
       setDraftModel("");
@@ -1323,19 +1335,20 @@ function HarnessConfigModal({
   };
 
   const save = () => {
-    if (hasPermission) {
+    if (hasModelSelection) {
       // Order matters: commit model first (its setter clears routing when a
       // model is set), then routing (its setter clears the model when "on") —
       // the two setters enforce the mutual exclusion between them.
       setPickedModel(draftModel);
-      setPickedEffort(draftEffort);
-      setPermissionMode(draftPermission);
       if (entryHarness)
         writeHarnessOption(entryHarness, {
           model: draftModel,
-          effort: draftEffort,
-          mode: draftPermission,
+          ...(hasPermission ? { effort: draftEffort, mode: draftPermission } : {}),
         });
+      if (hasPermission) {
+        setPickedEffort(draftEffort);
+        setPermissionMode(draftPermission);
+      }
     } else if (hasApproval) {
       setApprovalMode(draftApproval);
       setBypassSandbox(draftBypass);
@@ -1390,7 +1403,7 @@ function HarnessConfigModal({
               </div>
             </ConfigRow>
           )}
-          {hasPermission && (
+          {hasModelSelection && (
             <>
               <ConfigRow label="Model" description="Underlying LLM">
                 <Select value={modelValue} onValueChange={onModelChange}>
@@ -1399,7 +1412,7 @@ function HarnessConfigModal({
                     data-testid="new-chat-landing-config-model"
                     aria-label="Model"
                   >
-                    <SelectValue />
+                    <SelectValue placeholder={modelsLoading ? "Loading models…" : "Select model"} />
                   </SelectTrigger>
                   <SelectContent
                     position="popper"
@@ -1409,18 +1422,18 @@ function HarnessConfigModal({
                     {smartRoutingEligible && (
                       <SelectItem value={MODEL_SELECT_SMART}>Smart Routing</SelectItem>
                     )}
-                    <SelectItem value={MODEL_SELECT_DEFAULT}>Default</SelectItem>
-                    {claudeModelOptions.map((m) => (
+                    {!isPi && <SelectItem value={MODEL_SELECT_DEFAULT}>Default</SelectItem>}
+                    {modelOptions.map((m) => (
                       <SelectItem key={m.id} value={m.id}>
                         {m.displayName}
                       </SelectItem>
                     ))}
-                    {claudeModelsLoading && (
+                    {modelsLoading && (
                       <div className="px-2.5 py-1 text-xs text-muted-foreground">
                         Loading models…
                       </div>
                     )}
-                    {!claudeModelsLoading && claudeModelOptions.length === 0 && (
+                    {!modelsLoading && modelOptions.length === 0 && (
                       <div className="px-2.5 py-1 text-xs text-muted-foreground">
                         Models unavailable
                       </div>
@@ -1429,45 +1442,49 @@ function HarnessConfigModal({
                 </Select>
               </ConfigRow>
 
-              <ConfigRow label="Effort" description="Reasoning depth vs. speed">
-                <Select
-                  value={draftEffort || EFFORT_SELECT_NONE}
-                  onValueChange={(v) => setDraftEffort(v === EFFORT_SELECT_NONE ? "" : v)}
-                  // Smart Routing picks the model + effort per turn, so an
-                  // explicit effort can't apply — freeze it to Default.
-                  disabled={smartRoutingOn}
-                >
-                  <SelectTrigger
-                    className="w-full"
-                    data-testid="new-chat-landing-config-effort"
-                    aria-label="Reasoning effort"
+              {hasPermission && (
+                <ConfigRow label="Effort" description="Reasoning depth vs. speed">
+                  <Select
+                    value={draftEffort || EFFORT_SELECT_NONE}
+                    onValueChange={(v) => setDraftEffort(v === EFFORT_SELECT_NONE ? "" : v)}
+                    // Smart Routing picks the model + effort per turn, so an
+                    // explicit effort can't apply — freeze it to Default.
+                    disabled={smartRoutingOn}
                   >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent
-                    position="popper"
-                    align="start"
-                    className="[&_[data-slot=select-item]]:pl-2.5"
-                  >
-                    <SelectItem value={EFFORT_SELECT_NONE}>Default</SelectItem>
-                    {CLAUDE_NATIVE_EFFORTS.map((e) => (
-                      <SelectItem key={e.value} value={e.value}>
-                        {e.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </ConfigRow>
+                    <SelectTrigger
+                      className="w-full"
+                      data-testid="new-chat-landing-config-effort"
+                      aria-label="Reasoning effort"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent
+                      position="popper"
+                      align="start"
+                      className="[&_[data-slot=select-item]]:pl-2.5"
+                    >
+                      <SelectItem value={EFFORT_SELECT_NONE}>Default</SelectItem>
+                      {CLAUDE_NATIVE_EFFORTS.map((e) => (
+                        <SelectItem key={e.value} value={e.value}>
+                          {e.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </ConfigRow>
+              )}
 
-              <ConfigRow label="Permissions" description="What the agent can do without asking">
-                <DescribedSelect
-                  value={draftPermission}
-                  onValueChange={setDraftPermission}
-                  options={CLAUDE_NATIVE_PERMISSION_MODES}
-                  testId="new-chat-landing-config-permission"
-                  ariaLabel="Permissions"
-                />
-              </ConfigRow>
+              {hasPermission && (
+                <ConfigRow label="Permissions" description="What the agent can do without asking">
+                  <DescribedSelect
+                    value={draftPermission}
+                    onValueChange={setDraftPermission}
+                    options={CLAUDE_NATIVE_PERMISSION_MODES}
+                    testId="new-chat-landing-config-permission"
+                    ariaLabel="Permissions"
+                  />
+                </ConfigRow>
+              )}
             </>
           )}
 
@@ -1760,24 +1777,6 @@ export function NewChatLandingScreen() {
   const [sandboxSelected, setSandboxSelected] = useState(
     () => landingDraft?.sandboxSelected ?? false,
   );
-  const { data: hostClaudeModelOptions, isLoading: hostClaudeModelsLoading } = useHostModelOptions(
-    selectedHostId,
-    "claude-native",
-    !sandboxSelected,
-  );
-  const claudeModelOptions = useMemo(
-    () =>
-      sandboxSelected
-        ? CLAUDE_NATIVE_MODELS.map((model) => ({
-            id: model.id,
-            displayName: model.label,
-          }))
-        : (hostClaudeModelOptions ?? []).map((option) => ({
-            id: option.id,
-            displayName: option.displayName ?? option.id,
-          })),
-    [hostClaudeModelOptions, sandboxSelected],
-  );
   // Desktop-shell host status for THIS machine (null outside Electron), so the
   // picker can tag the current machine and offer to auto-connect it.
   const [desktopHost, setDesktopHost] = useState<HostIdentity | null>(null);
@@ -1796,6 +1795,17 @@ export function NewChatLandingScreen() {
     () => landingDraft?.sandboxRepoBranch ?? "",
   );
   const [workspace, setWorkspace] = useState<string>(() => landingDraft?.workspace ?? "");
+  const [modelOptionsWorkspace, setModelOptionsWorkspace] = useState<string | null>(() => {
+    const initial = landingDraft?.workspace?.trim();
+    return initial ? initial : null;
+  });
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      const trimmed = workspace.trim();
+      setModelOptionsWorkspace(trimmed || null);
+    }, 250);
+    return () => window.clearTimeout(timer);
+  }, [workspace, selectedHostId, sandboxSelected]);
   const [branchName, setBranchName] = useState<string>(() => landingDraft?.branchName ?? "");
   // The base branch auto-fills from the configured default (Settings › Git)
   // when the user names a worktree branch, and is left alone once the user
@@ -2156,6 +2166,35 @@ export function NewChatLandingScreen() {
         : agentList.find((a) => a.id === effectiveAgentId),
     [agentList, effectiveAgentId, pendingAgent],
   );
+  const selectedNativeHarness = nativeCodingAgentForAvailableAgent(selectedAgent)?.harness ?? null;
+  const supportsModelSelection = nativeAgentHasCapability(selectedAgent, "modelSelection");
+  const modelOptionsHarness = selectedNativeHarness === "pi-native" ? "pi-native" : "claude-native";
+  const { data: hostModelOptions, isLoading: hostModelsLoading } = useHostModelOptions(
+    selectedHostId,
+    modelOptionsHarness,
+    !sandboxSelected &&
+      supportsModelSelection &&
+      (modelOptionsHarness !== "pi-native" || modelOptionsWorkspace !== null),
+    modelOptionsHarness === "pi-native" ? modelOptionsWorkspace : null,
+  );
+  const modelOptions = useMemo(
+    () =>
+      sandboxSelected && modelOptionsHarness === "claude-native"
+        ? CLAUDE_NATIVE_MODELS.map((model) => ({
+            id: model.id,
+            displayName: model.label,
+            isDefault: undefined,
+          }))
+        : (hostModelOptions ?? []).map((option) => ({
+            id: option.id,
+            displayName:
+              modelOptionsHarness === "pi-native" && option.isDefault
+                ? `${option.displayName ?? option.id} (Default)`
+                : (option.displayName ?? option.id),
+            isDefault: option.isDefault,
+          })),
+    [hostModelOptions, modelOptionsHarness, sandboxSelected],
+  );
   const supportsPermissionMode = nativeAgentHasCapability(selectedAgent, "permissionMode");
   const supportsApprovalMode = nativeAgentHasCapability(selectedAgent, "approvalMode");
   const supportsCursorMode = nativeAgentHasCapability(selectedAgent, "cursorMode");
@@ -2169,6 +2208,7 @@ export function NewChatLandingScreen() {
   // lives only in the modal now, so an agent with just that (e.g. Pi) still
   // needs the gear.
   const selectedAgentHasKnobs =
+    supportsModelSelection ||
     supportsPermissionMode ||
     supportsApprovalMode ||
     supportsCursorMode ||
@@ -2182,10 +2222,10 @@ export function NewChatLandingScreen() {
   // agent) never shows misleading Smart Routing rows in the tooltip.
   const routingOn = smartRoutingEligible && costControlMode === "on";
   const configSummary = useMemo((): { label: string; value: string }[] => {
+    const selectedModelLabel =
+      modelOptions.find((model) => model.id === pickedModel)?.displayName ?? "Default";
     if (supportsPermissionMode) {
-      const modelValue = routingOn
-        ? "Smart Routing"
-        : (claudeModelOptions.find((m) => m.id === pickedModel)?.displayName ?? "Default");
+      const modelValue = routingOn ? "Smart Routing" : selectedModelLabel;
       // Smart Routing freezes effort to the default (the router picks per turn),
       // so mirror the modal: show "Default" whenever routing is on or effort is
       // unset, else the picked level.
@@ -2202,6 +2242,7 @@ export function NewChatLandingScreen() {
         { label: "Permissions", value: permissionValue },
       ];
     }
+    if (supportsModelSelection) return [{ label: "Model", value: selectedModelLabel }];
     // Non-Claude routable agents surface Smart Routing as a standalone toggle,
     // so reflect it here when on (Claude folds it into Model above).
     const routingRow: { label: string; value: string }[] =
@@ -2234,6 +2275,7 @@ export function NewChatLandingScreen() {
     return routingRow;
   }, [
     supportsPermissionMode,
+    supportsModelSelection,
     supportsApprovalMode,
     supportsCursorMode,
     smartRoutingEligible,
@@ -2241,7 +2283,7 @@ export function NewChatLandingScreen() {
     brainHarnessLabels,
     routingOn,
     pickedModel,
-    claudeModelOptions,
+    modelOptions,
     pickedEffort,
     permissionMode,
     approvalMode,
@@ -2267,10 +2309,6 @@ export function NewChatLandingScreen() {
     setBypassSandbox(false);
     setCostControlMode(null);
   }, [effectiveAgentId, setCostControlMode]);
-  // The selected native harness, used to persist/seed its option knobs (mode /
-  // model / effort), which are harness-specific. null for non-native agents,
-  // which have no knobs to remember.
-  const selectedNativeHarness = nativeCodingAgentForAvailableAgent(selectedAgent)?.harness ?? null;
   // Seed the harness's knobs from the user's last picks when the selected
   // harness changes (including the first mount), so a returning user starts a
   // new session on the options they used last for that harness instead of the
@@ -2288,18 +2326,20 @@ export function NewChatLandingScreen() {
     // the current list resolves to the default for the same reason.
     const resolve = (modes: readonly { value: string }[], dflt: string) =>
       stored.mode != null && modes.some((m) => m.value === stored.mode) ? stored.mode : dflt;
+    if (supportsModelSelection) {
+      const fallbackModel =
+        selectedNativeHarness === "pi-native"
+          ? (modelOptions.find((model) => model.isDefault)?.id ?? modelOptions[0]?.id ?? "")
+          : "";
+      setPickedModel(
+        stored.model != null && modelOptions.some((model) => model.id === stored.model)
+          ? stored.model
+          : fallbackModel,
+      );
+    }
     if (supportsPermissionMode) {
       setPermissionMode(
         resolve(CLAUDE_NATIVE_PERMISSION_MODES, CLAUDE_NATIVE_DEFAULT_PERMISSION_MODE),
-      );
-      // The model + effort picker remembers its own last pick (same per-harness
-      // snapshot the mode knob uses), validated against the current vocab. With
-      // nothing stored (or a retired id) it resolves to "" — unselected, so the
-      // create omits the override and Claude Code uses its own configured model.
-      setPickedModel(
-        stored.model != null && claudeModelOptions.some((m) => m.id === stored.model)
-          ? stored.model
-          : "",
       );
       setPickedEffort(
         stored.effort != null && CLAUDE_NATIVE_EFFORTS.some((e) => e.value === stored.effort)
@@ -2314,7 +2354,7 @@ export function NewChatLandingScreen() {
     // Reseed on harness changes and when the selected host's catalog resolves;
     // capability flags are derived from the same harness and stay omitted.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedNativeHarness, claudeModelOptions]);
+  }, [selectedNativeHarness, modelOptions]);
   // Native-terminal agents interpret slash commands inside their own CLI
   // (the runner injects the text verbatim), so the landing composer must
   // not intercept them — no skills menu, no slash_command routing.
@@ -2805,6 +2845,7 @@ export function NewChatLandingScreen() {
       // exists" guard.
       const agent = agentList.find((a) => a.id === effectiveAgentId);
       const nativeLabels = nativeWrapperLabelsForAgent(agent);
+      const agentSupportsModelSelection = nativeAgentHasCapability(agent, "modelSelection");
       const agentSupportsPermissionMode = nativeAgentHasCapability(agent, "permissionMode");
       const agentSupportsApprovalMode = nativeAgentHasCapability(agent, "approvalMode");
       const agentSupportsCursorMode = nativeAgentHasCapability(agent, "cursorMode");
@@ -2887,12 +2928,11 @@ export function NewChatLandingScreen() {
                   : agentSupportsCursorMode && cursorExecMode !== CURSOR_NATIVE_DEFAULT_EXEC_MODE
                     ? (CURSOR_NATIVE_EXEC_MODES.find((m) => m.value === cursorExecMode)?.args ?? [])
                     : undefined,
-            // Model + reasoning effort, persisted on the session row before
-            // the runner launches. Only claude-native surfaces the picker, so
-            // only its agents carry the choice; the runner reads them as
-            // `--model` / `--effort` at terminal launch. An unselected ("")
-            // knob is omitted so Claude Code keeps its own configured model.
-            model_override: agentSupportsPermissionMode && pickedModel ? pickedModel : undefined,
+            // Model + reasoning effort, persisted before the runner launches.
+            // Claude and Pi both accept a launch model; only Claude accepts the
+            // separate effort override. An unselected model is omitted so the
+            // native CLI keeps its own configured default.
+            model_override: agentSupportsModelSelection && pickedModel ? pickedModel : undefined,
             reasoning_effort:
               agentSupportsPermissionMode && pickedEffort ? pickedEffort : undefined,
             // Smart routing toggle — server-side. The "Auto" harness always
@@ -3367,10 +3407,8 @@ export function NewChatLandingScreen() {
                     cursorExecMode={cursorExecMode}
                     bypassSandbox={bypassSandbox}
                     pickedModel={pickedModel}
-                    claudeModelOptions={claudeModelOptions}
-                    claudeModelsLoading={
-                      !sandboxSelected && selectedHostId !== null && hostClaudeModelsLoading
-                    }
+                    modelOptions={modelOptions}
+                    modelsLoading={!sandboxSelected && selectedHostId !== null && hostModelsLoading}
                     pickedEffort={pickedEffort}
                     pickedHarness={pickedHarness}
                     costControlMode={costControlMode}


### PR DESCRIPTION
## Related issue

N/A

## Summary

Pi currently starts without an Omnigent-native way to inspect the host's available models or choose an initial model, while fixed launch configuration can unintentionally override Pi's own default and resumed-session behavior. This adds pre-launch Pi model selection while keeping Pi authoritative when the user has not explicitly chosen an override.

- Discover the Pi model catalog on the selected host with `pi --approve --list-models`, including global and workspace settings used to identify Pi's configured default.
- Add the shared `modelSelection` capability for Pi and Claude, then surface Pi's default and available models in the New Chat configuration flow.
- Preserve Pi-native startup semantics: omit model arguments for implicit defaults and resumed sessions, but pass provider-safe model arguments for explicit UI or agent-spec selections.
- Persist valid Pi choices and fall back in order to the configured default, then the first available model.

**ELI5:** Omnigent now asks Pi which models it can use and shows Pi's preferred model in New Chat. If the user does nothing, Pi remains in control; if the user picks a model, Omnigent starts Pi with that explicit choice.

```text
Selected host + workspace
          |
          v
  pi --list-models
          |
          v
New Chat model selector ---- user chooses model ----> provider-safe Pi launch args
          |
          +---- no explicit choice / resume ----------> Pi chooses or restores model
```

## Test Plan

- `uv run pytest tests/test_pi_native_models.py tests/test_pi_native_credentials.py tests/host/test_connect.py tests/host/test_frames.py tests/runner/test_app_pi_native_model.py` (`231 passed`)
- `cd web && node_modules/.bin/vitest run src/hooks/useHosts.test.tsx src/shell/NewChatDialog.flow.test.tsx` (`74 passed`)
- `.venv/bin/pre-commit run --all-files` (passed)
- Verify New Chat with Pi displays `Loading models…` while resolving, then selects the model marked `(Default)` without reopening the configuration dialog.
- Verify choosing another Pi model sends it as `model_override`, while a resumed session does not force default model CLI arguments.

## Demo

<img width="1424" height="646" alt="Screenshot 2026-07-28 at 19 50 36" src="https://github.com/user-attachments/assets/5b77bcf3-d6f6-4b22-b144-56305ee63441" />
<img width="887" height="736" alt="Screenshot 2026-07-28 at 19 50 31" src="https://github.com/user-attachments/assets/dc40df8c-cf5e-44e3-9c73-af4ccabef81c" />
<img width="790" height="1042" alt="Screenshot 2026-07-28 at 19 51 19" src="https://github.com/user-attachments/assets/729ccae0-c3b3-45cf-bd9d-d7e4ebc98425" />


## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage includes Pi catalog parsing and defaults, host transport, provider-aware launch resolution, resume behavior, hook requests, selector persistence, and asynchronous default-model loading in the open New Chat modal.

## Changelog

Choose an initial Pi model from New Chat while preserving Pi's configured default and resumed-session model.
