### PR TITLE
fix(native): key bridge dirs on the bare, post-migration session id

### DIFF
--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from omnigent.native_bridge_ids import normalize_bridge_id
+
 _logger = logging.getLogger(__name__)
 
 ANTIGRAVITY_NATIVE_BRIDGE_ID_LABEL_KEY = "omnigent.antigravity_native.bridge_id"
@@ -201,11 +203,13 @@ def bridge_dir_for_bridge_id(bridge_id: str) -> Path:
     """
     Return the bridge directory for a native Antigravity bridge id.
 
-    :param bridge_id: Opaque bridge id, e.g. ``"bridge_abc123"``.
+    :param bridge_id: Opaque bridge id, e.g. ``"bridge_abc123"``. A legacy
+        ``conv_``-prefixed id is normalised, so both spellings of a session
+        share one directory.
     :returns: Absolute bridge directory under
         ``~/.omnigent/antigravity-native``.
     """
-    digest = hashlib.sha256(bridge_id.encode("utf-8")).hexdigest()[:32]
+    digest = hashlib.sha256(normalize_bridge_id(bridge_id).encode("utf-8")).hexdigest()[:32]
     return _BRIDGE_ROOT / digest
 
 

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -54,6 +54,7 @@ from urllib import error, request
 from omnigent._platform import stable_user_id
 from omnigent.claude_native_message_display_hook import MESSAGE_DELTAS_FILE
 from omnigent.kiro_native_bridge import bridge_root as kiro_bridge_root
+from omnigent.native_bridge_ids import normalize_bridge_id
 
 if TYPE_CHECKING:
     from omnigent.llms.context_window import ModelPricing
@@ -763,11 +764,13 @@ def bridge_dir_for_bridge_id(bridge_id: str) -> Path:
     """
     Return the deterministic bridge directory for a Claude-native bridge.
 
-    :param bridge_id: Opaque bridge id, e.g. ``"bridge_abc123"``.
+    :param bridge_id: Opaque bridge id, e.g. ``"bridge_abc123"``. A legacy
+        ``conv_``-prefixed id is normalised, so both spellings of a session
+        share one directory.
     :returns: Absolute bridge directory under
         ``/tmp/omnigent-<UID>/claude-native``.
     """
-    digest = hashlib.sha256(bridge_id.encode("utf-8")).hexdigest()[:32]
+    digest = hashlib.sha256(normalize_bridge_id(bridge_id).encode("utf-8")).hexdigest()[:32]
     return _BRIDGE_ROOT / digest
 
 
@@ -799,7 +802,7 @@ def build_claude_native_spawn_env(
     :returns: Environment variables needed by
         :class:`ClaudeNativeExecutor`.
     """
-    resolved_bridge_id = bridge_id or conversation_id
+    resolved_bridge_id = normalize_bridge_id(bridge_id or conversation_id)
     return {
         BRIDGE_DIR_ENV_VAR: str(bridge_dir_for_bridge_id(resolved_bridge_id)),
         REQUEST_SESSION_ID_ENV_VAR: conversation_id,
@@ -828,7 +831,7 @@ def prepare_bridge_dir(
         no ucode profile is active.
     :returns: Bridge directory path.
     """
-    resolved_bridge_id = bridge_id or conversation_id
+    resolved_bridge_id = normalize_bridge_id(bridge_id or conversation_id)
     bridge_dir = bridge_dir_for_bridge_id(resolved_bridge_id)
     _ensure_secure_dir(bridge_dir)
     config = _read_json_file(bridge_dir / _CONFIG_FILE)

--- a/omnigent/codex_native_bridge.py
+++ b/omnigent/codex_native_bridge.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 import tomllib
 
+from omnigent.native_bridge_ids import normalize_bridge_id
+
 CODEX_NATIVE_BRIDGE_ID_LABEL_KEY = "omnigent.codex_native.bridge_id"
 CODEX_NATIVE_BRIDGE_DIR_ENV_VAR = "HARNESS_CODEX_NATIVE_BRIDGE_DIR"
 CODEX_NATIVE_REQUEST_SESSION_ID_ENV_VAR = "HARNESS_CODEX_NATIVE_REQUEST_SESSION_ID"
@@ -87,11 +89,13 @@ def bridge_dir_for_bridge_id(bridge_id: str) -> Path:
     """
     Return the bridge directory for a native Codex bridge id.
 
-    :param bridge_id: Opaque bridge id, e.g. ``"bridge_abc123"``.
+    :param bridge_id: Opaque bridge id, e.g. ``"bridge_abc123"``. A legacy
+        ``conv_``-prefixed id is normalised, so both spellings of a session
+        share one directory.
     :returns: Absolute bridge directory under
         ``~/.omnigent/codex-native``.
     """
-    digest = hashlib.sha256(bridge_id.encode("utf-8")).hexdigest()[:32]
+    digest = hashlib.sha256(normalize_bridge_id(bridge_id).encode("utf-8")).hexdigest()[:32]
     return _BRIDGE_ROOT / digest
 
 

--- a/omnigent/db/migrations/versions/c4d5e6f7a8b9_strip_conv_prefix_from_bridge_id_labels.py
+++ b/omnigent/db/migrations/versions/c4d5e6f7a8b9_strip_conv_prefix_from_bridge_id_labels.py
@@ -1,0 +1,63 @@
+"""strip the legacy conv_ prefix from native bridge-id label values
+
+Revision ID: c4d5e6f7a8b9
+Revises: b3c4d5e6f7a8
+Create Date: 2026-07-28 00:00:00.000000
+
+Revision ``z7a2b3c4d5e6`` converted ids to bare 32-char hex, but it rewrote id
+*columns* (plus the ``session_id`` echoed inside ``resource_event`` items). The
+native harnesses also store a session id as a label *value* — ``value`` of the
+``omnigent.<harness>_native.bridge_id`` labels — and those kept their old
+``conv_<hex>`` spelling.
+
+That splits a session in two: the terminal that launches the agent keys its
+bridge directory on the (bare) session id, while the harness executor keys its
+own on the (prefixed) label. The two then rendezvous in different directories,
+the executor finds a foreign ``active_session_id`` in the bridge config, and
+every turn fails the stale-session guard with "no longer active after /clear"
+— no message ever reaches the terminal.
+
+Rewrites the affected values in place. Idempotent: only rows still carrying the
+prefix are touched, so a re-run is a no-op. ``-cleared`` suffixed values keep
+their suffix (only the prefix is removed).
+
+No downgrade: the prefix is a pre-migration spelling of the very same id, and
+restoring it would re-break the sessions this fixes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c4d5e6f7a8b9"
+down_revision: str | None = "b3c4d5e6f7a8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Every harness names its label ``omnigent.<harness>_native.bridge_id``, so one
+# suffix match covers claude, codex, opencode and antigravity at once.
+_LABEL_KEY_PATTERN = "%.bridge_id"
+_LEGACY_PREFIX = "conv_"
+
+
+def upgrade() -> None:
+    """Drop the ``conv_`` prefix from every native bridge-id label value."""
+    op.execute(
+        sa.text(
+            "UPDATE conversation_labels"
+            " SET value = SUBSTR(value, :cut)"
+            " WHERE key LIKE :key_pattern AND value LIKE :value_pattern"
+        ).bindparams(
+            # SUBSTR is 1-based in every dialect we target.
+            cut=len(_LEGACY_PREFIX) + 1,
+            key_pattern=_LABEL_KEY_PATTERN,
+            value_pattern=f"{_LEGACY_PREFIX}%",
+        )
+    )
+
+
+def downgrade() -> None:
+    """No-op: the stripped prefix was a legacy spelling of the same id."""

--- a/omnigent/inner/claude_native_executor.py
+++ b/omnigent/inner/claude_native_executor.py
@@ -132,10 +132,7 @@ class ClaudeNativeExecutor(Executor):
         del tools, system_prompt
         if not _session_is_active(self._bridge_dir, self._request_session_id):
             yield ExecutorError(
-                message=(
-                    "Claude native session is no longer active after /clear; "
-                    "open the latest conversation and retry."
-                )
+                message=_stale_session_message(self._bridge_dir, self._request_session_id)
             )
             return
         text = _latest_user_text(messages, self._bridge_dir)
@@ -234,6 +231,26 @@ def _request_session_id_from_env() -> str | None:
     """
     raw = os.environ.get(REQUEST_SESSION_ID_ENV_VAR, "").strip()
     return raw or None
+
+
+def _stale_session_message(bridge_dir: Path, request_session_id: str | None) -> str:
+    """
+    Build the turn-rejected message for a bridge bound to another session.
+
+    Names both sides of the mismatch: a bridge whose owner is an unrelated id
+    (rather than the expected post-``/clear`` successor) points at an id-shape
+    disagreement between the terminal and this executor, not at a real ``/clear``.
+
+    :param bridge_dir: Native bridge directory.
+    :param request_session_id: Omnigent session id this turn belongs to.
+    :returns: Error message for the rejected turn.
+    """
+    return (
+        "Claude native session is no longer active after /clear; "
+        "open the latest conversation and retry. "
+        f"(bridge {bridge_dir} is bound to session "
+        f"{read_active_session_id(bridge_dir)!r}, this turn is {request_session_id!r})"
+    )
 
 
 def _session_is_active(bridge_dir: Path, request_session_id: str | None) -> bool:

--- a/omnigent/native_bridge_ids.py
+++ b/omnigent/native_bridge_ids.py
@@ -1,0 +1,26 @@
+"""Identifier normalisation shared by the native-harness bridges."""
+
+from __future__ import annotations
+
+# Conversation ids carried this prefix before they became bare 32-char hex
+# (see ``omnigent.db.db_models._LEGACY_ID_PREFIXES``). A bridge-id label stores
+# a session id as its *value*, and the binary-uuid migration rewrote id columns
+# only -- so a session created before it still names itself ``conv_<hex>``
+# there, while every other code path now says ``<hex>``.
+_LEGACY_CONVERSATION_PREFIX = "conv_"
+
+
+def normalize_bridge_id(bridge_id: str) -> str:
+    """
+    Return a native-harness bridge id in its bare, post-migration form.
+
+    Bridge dirs are keyed on a digest of this id, so a legacy-prefixed and a
+    bare spelling of the same session must not resolve to different dirs --
+    the harness executor and the terminal that launched the agent would then
+    rendezvous in two places and no message would ever reach the pane.
+
+    :param bridge_id: Bridge id from a label or a session id, e.g.
+        ``"conv_abc123"``, ``"abc123"`` or ``"abc123-cleared"``.
+    :returns: The same id without the legacy ``conv_`` prefix.
+    """
+    return bridge_id.removeprefix(_LEGACY_CONVERSATION_PREFIX)

--- a/omnigent/opencode_native_bridge.py
+++ b/omnigent/opencode_native_bridge.py
@@ -33,6 +33,8 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
+from omnigent.native_bridge_ids import normalize_bridge_id
+
 # Env var the runner stamps on the harness process so the executor can
 # locate its bridge directory. Mirrors ``HARNESS_CODEX_NATIVE_BRIDGE_DIR``.
 OPENCODE_NATIVE_BRIDGE_DIR_ENV_VAR = "HARNESS_OPENCODE_NATIVE_BRIDGE_DIR"
@@ -274,11 +276,14 @@ def bridge_dir_for_bridge_id(bridge_id: str) -> Path:
     """
     Return the bridge directory for an OpenCode-native bridge id.
 
-    :param bridge_id: Opaque bridge id, e.g. ``"conv_abc123"``.
+    :param bridge_id: Opaque bridge id, e.g. ``"abc123"``. A legacy
+        ``conv_``-prefixed id is normalised, so both spellings of a session
+        share one directory.
     :returns: Absolute bridge directory under
         ``~/.omnigent/opencode-native``.
     """
-    digest = hashlib.sha256(bridge_id.encode("utf-8")).hexdigest()[:_ID_HASH_CHARS]
+    normalized = normalize_bridge_id(bridge_id)
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:_ID_HASH_CHARS]
     return _BRIDGE_ROOT / digest
 
 

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -6278,9 +6278,12 @@ async def _claude_native_bridge_id_for_session(
         ``None`` selects the legacy labels callback.
     :returns: Opaque bridge id from
         ``omnigent.claude_native.bridge_id`` when present, otherwise
-        *session_id* for legacy single-session bridges.
+        *session_id* for legacy single-session bridges. A label written
+        before ids dropped their ``conv_`` prefix is normalised, so it still
+        compares equal to the ids every other path now spells bare.
     """
     from omnigent.claude_native_bridge import BRIDGE_ID_LABEL_KEY
+    from omnigent.native_bridge_ids import normalize_bridge_id
 
     labels = (
         session_labels
@@ -6292,7 +6295,7 @@ async def _claude_native_bridge_id_for_session(
     )
     bridge_id = labels.get(BRIDGE_ID_LABEL_KEY)
     if isinstance(bridge_id, str) and bridge_id:
-        return bridge_id
+        return normalize_bridge_id(bridge_id)
     return session_id
 
 

--- a/tests/db/test_migration_bridge_id_label_prefix.py
+++ b/tests/db/test_migration_bridge_id_label_prefix.py
@@ -1,0 +1,102 @@
+"""Tests for the bridge-id label prefix migration (c4d5e6f7a8b9)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic import command
+
+from omnigent.db.utils import _build_alembic_config
+
+_PREVIOUS_REVISION = "b3c4d5e6f7a8"
+_REVISION = "c4d5e6f7a8b9"
+_SESSION_ID = "3066bdff8fbc4e9eafbd0978c4a61537"
+_OTHER_ID = "348df11325544a27a380459299f2800f"
+
+
+def _upgrade(uri: str, engine: sa.Engine, revision: str) -> None:
+    config = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.upgrade(config, revision)
+
+
+def _downgrade(uri: str, engine: sa.Engine, revision: str) -> None:
+    config = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.downgrade(config, revision)
+
+
+def _insert_labels(engine: sa.Engine, rows: list[tuple[str, str, str]]) -> None:
+    with engine.begin() as conn:
+        for conversation_id, key, value in rows:
+            conn.execute(
+                sa.text(
+                    "INSERT INTO conversation_labels"
+                    " (workspace_id, conversation_id, key, value, updated_at)"
+                    " VALUES (0, :cid, :key, :value, 1)"
+                ),
+                {"cid": conversation_id, "key": key, "value": value},
+            )
+
+
+def _label_values(engine: sa.Engine) -> dict[str, str]:
+    with engine.begin() as conn:
+        return {
+            row[0]: row[1]
+            for row in conn.execute(sa.text("SELECT key, value FROM conversation_labels"))
+        }
+
+
+def test_upgrade_strips_conv_prefix_from_bridge_id_labels(tmp_path: Path) -> None:
+    """
+    Bridge-id labels must end up spelling their session id the bare way.
+
+    A label left at ``conv_<hex>`` while the session id is ``<hex>`` sends the
+    harness executor and the terminal to two different bridge directories, so
+    every turn fails the stale-session guard. Only the prefix goes: a
+    ``-cleared`` marker and non-bridge-id labels survive verbatim.
+    """
+    uri = f"sqlite:///{tmp_path / 'bridge_labels.db'}"
+    engine = sa.create_engine(uri)
+    _upgrade(uri, engine, _PREVIOUS_REVISION)
+    _insert_labels(
+        engine,
+        [
+            (_SESSION_ID, "omnigent.claude_native.bridge_id", f"conv_{_SESSION_ID}"),
+            (_SESSION_ID, "omnigent.codex_native.bridge_id", f"conv_{_SESSION_ID}-cleared"),
+            (_OTHER_ID, "omnigent.opencode_native.bridge_id", _OTHER_ID),
+            (_OTHER_ID, "omnigent.fork.source_id", f"conv_{_SESSION_ID}"),
+        ],
+    )
+
+    _upgrade(uri, engine, _REVISION)
+
+    assert _label_values(engine) == {
+        "omnigent.claude_native.bridge_id": _SESSION_ID,
+        "omnigent.codex_native.bridge_id": f"{_SESSION_ID}-cleared",
+        "omnigent.opencode_native.bridge_id": _OTHER_ID,
+        # Not a bridge id: resolved through a uuid column bind, which already
+        # strips the legacy prefix, so the stored value stays as it is.
+        "omnigent.fork.source_id": f"conv_{_SESSION_ID}",
+    }
+
+
+def test_upgrade_is_idempotent(tmp_path: Path) -> None:
+    """A second run over already-stripped values must be a no-op."""
+    uri = f"sqlite:///{tmp_path / 'bridge_labels_rerun.db'}"
+    engine = sa.create_engine(uri)
+    _upgrade(uri, engine, _PREVIOUS_REVISION)
+    _insert_labels(
+        engine,
+        [(_SESSION_ID, "omnigent.claude_native.bridge_id", f"conv_{_SESSION_ID}")],
+    )
+
+    _upgrade(uri, engine, _REVISION)
+    # downgrade() leaves the data alone, so re-upgrading replays upgrade().
+    _downgrade(uri, engine, _PREVIOUS_REVISION)
+    _upgrade(uri, engine, _REVISION)
+
+    assert _label_values(engine) == {"omnigent.claude_native.bridge_id": _SESSION_ID}

--- a/tests/test_native_bridge_ids.py
+++ b/tests/test_native_bridge_ids.py
@@ -1,0 +1,67 @@
+"""Tests for legacy bridge-id normalisation across the native harnesses."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.antigravity_native_bridge import (
+    bridge_dir_for_bridge_id as antigravity_bridge_dir,
+)
+from omnigent.claude_native_bridge import (
+    BRIDGE_DIR_ENV_VAR,
+    REQUEST_SESSION_ID_ENV_VAR,
+    build_claude_native_spawn_env,
+)
+from omnigent.claude_native_bridge import (
+    bridge_dir_for_bridge_id as claude_bridge_dir,
+)
+from omnigent.codex_native_bridge import (
+    bridge_dir_for_bridge_id as codex_bridge_dir,
+)
+from omnigent.native_bridge_ids import normalize_bridge_id
+from omnigent.opencode_native_bridge import (
+    bridge_dir_for_bridge_id as opencode_bridge_dir,
+)
+
+_SESSION_ID = "3066bdff8fbc4e9eafbd0978c4a61537"
+
+
+@pytest.mark.parametrize(
+    ("bridge_id", "expected"),
+    [
+        (f"conv_{_SESSION_ID}", _SESSION_ID),
+        (_SESSION_ID, _SESSION_ID),
+        (f"conv_{_SESSION_ID}-cleared", f"{_SESSION_ID}-cleared"),
+        (f"{_SESSION_ID}-cleared", f"{_SESSION_ID}-cleared"),
+    ],
+)
+def test_normalize_bridge_id_strips_only_the_legacy_prefix(
+    bridge_id: str,
+    expected: str,
+) -> None:
+    """The ``conv_`` prefix goes; the ``-cleared`` suffix and bare ids stay."""
+    assert normalize_bridge_id(bridge_id) == expected
+
+
+@pytest.mark.parametrize(
+    "bridge_dir_for_bridge_id",
+    [claude_bridge_dir, codex_bridge_dir, opencode_bridge_dir, antigravity_bridge_dir],
+)
+def test_legacy_and_bare_bridge_ids_share_one_dir(bridge_dir_for_bridge_id) -> None:  # type: ignore[no-untyped-def]
+    """Both spellings of a session id must key the same rendezvous directory."""
+    assert bridge_dir_for_bridge_id(f"conv_{_SESSION_ID}") == bridge_dir_for_bridge_id(_SESSION_ID)
+
+
+def test_spawn_env_from_legacy_label_targets_the_terminals_bridge_dir() -> None:
+    """
+    A pre-migration ``conv_``-prefixed bridge-id label must not split the session.
+
+    The terminal keys its bridge dir on the bare session id. When the executor's
+    spawn env resolved the label verbatim it landed in the pre-migration dir,
+    read a foreign ``active_session_id`` there, and rejected every turn as a
+    stale post-``/clear`` session — the message never reached the pane.
+    """
+    spawn_env = build_claude_native_spawn_env(_SESSION_ID, bridge_id=f"conv_{_SESSION_ID}")
+
+    assert spawn_env[BRIDGE_DIR_ENV_VAR] == str(claude_bridge_dir(_SESSION_ID))
+    assert spawn_env[REQUEST_SESSION_ID_ENV_VAR] == _SESSION_ID

--- a/tests/test_native_bridge_ids.py
+++ b/tests/test_native_bridge_ids.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from pathlib import Path
+
 import pytest
 
 from omnigent.antigravity_native_bridge import (
@@ -47,7 +50,9 @@ def test_normalize_bridge_id_strips_only_the_legacy_prefix(
     "bridge_dir_for_bridge_id",
     [claude_bridge_dir, codex_bridge_dir, opencode_bridge_dir, antigravity_bridge_dir],
 )
-def test_legacy_and_bare_bridge_ids_share_one_dir(bridge_dir_for_bridge_id) -> None:  # type: ignore[no-untyped-def]
+def test_legacy_and_bare_bridge_ids_share_one_dir(
+    bridge_dir_for_bridge_id: Callable[[str], Path],
+) -> None:
     """Both spellings of a session id must key the same rendezvous directory."""
     assert bridge_dir_for_bridge_id(f"conv_{_SESSION_ID}") == bridge_dir_for_bridge_id(_SESSION_ID)
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

Resuming a claude-native session created before the binary-uuid migration silently breaks: the web UI shows no answer, only `RuntimeError: inner executor error: Claude native session is no longer active after /clear; open the latest conversation and retry.` — on a session that was never `/clear`ed.

- Migration `z7a2b3c4d5e6` dropped the `conv_` prefix from id **columns**, but the native harnesses also store a session id as a label **value** (`omnigent.<harness>_native.bridge_id`). Those values kept the old `conv_<hex>` spelling, and nothing normalizes them — unlike a fork-source label, a bridge id is hashed into a directory name, never bound to a uuid column, so the existing bind-time prefix stripping never sees it.
- The bridge dir is `sha256(bridge_id)[:32]`, so the two spellings key **different** directories. The terminal auto-create normalizes to the bare session id and prepares its bridge there; the harness spawn env resolves the prefixed label and points the executor at the pre-migration dir. The executor reads that stale `bridge.json`, finds an `active_session_id` that isn't its own, and rejects every turn — the message never reaches the tmux pane.
- Fix: normalize the legacy prefix where bridge ids become directories (claude, codex, opencode, antigravity) and where the claude-native label is read, plus a migration that rewrites the stored values so databases stop diverging in the first place. The `-cleared` marker is preserved.
- The guard's error message now names both sides of the mismatch. It unconditionally blamed `/clear`, which points the diagnosis at the wrong thing entirely.

### ELI5

Two halves of a session have to meet in the same folder. The folder name is a hash of the session's id. After the migration one half says `conv_3066…` and the other says `3066…` — same session, two different folders, so they never meet and your message is dropped on the floor.

```
                     before                              after
  terminal ──► sha256("3066…")   = 2959b9…     terminal ──► 2959b9…
  executor ──► sha256("conv_3066…") = d3de07…  executor ──► 2959b9…   (same dir)
                    ✗ never meet                        ✓ rendezvous
```

## Test Plan

- New `tests/test_native_bridge_ids.py`: prefix normalization (incl. the `-cleared` suffix), all four harnesses resolve both spellings to one dir, and the regression case — a spawn env built from a `conv_`-prefixed label must point at the terminal's own bridge dir.
- New `tests/db/test_migration_bridge_id_label_prefix.py`: the migration strips the prefix on `*.bridge_id` labels only, keeps `-cleared`, leaves non-bridge-id labels alone, and is idempotent on re-run.
- `pytest tests/inner/test_claude_native_executor.py tests/test_claude_native_bridge.py tests/test_codex_native_bridge.py tests/test_opencode_native_bridge.py tests/test_antigravity_native_bridge.py` — 321 passed.
- `pytest tests/db` — 354 passed; the 3 failures in `tests/db/test_utils.py` are `ModuleNotFoundError: No module named 'psycopg'` in the local env and are unrelated to this change.
- Reproduced against a live server: a resumed session's harness process carried `HARNESS_CLAUDE_NATIVE_BRIDGE_DIR=…/d3de07c4…` (= `sha256("conv_<id>")`) while the runner log showed `bridge prepared: …/2959b951…` (= `sha256("<id>")`), and every turn failed the guard. After stripping the prefix from the stored labels the two agree and turns land in the pane again.

## Demo

N/A — no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the live repro described in the Test Plan: a pre-migration claude-native session on a running server, confirmed by comparing the harness process env against the runner's prepared bridge dir before and after the label fix. The automated tests cover the id normalization and the migration; the split itself only manifests across a real runner/harness spawn, which has no unit-level harness.

## Changelog

Resuming a native session created before the id migration no longer fails every turn with a spurious "session is no longer active after /clear".
