### PR TITLE
[models] Add intent resolver contracts

### DIFF
--- a/docs/model-hardcoding-plan.md
+++ b/docs/model-hardcoding-plan.md
@@ -66,8 +66,9 @@ prepared with `just ensure`; CI is the enforcement backstop.
 ## Migration Plan
 
 1. **Introduce logical model intents.** Replace fallback ids with stable intents
-   such as `default`, `fast`, `balanced`, `large-context`, `coding`, `image`,
-   and `judge`.
+   currently required by callers: `default`, `fast`, `balanced`, and
+   `powerful`. Add purpose-specific intents only when a concrete caller needs
+   semantics that explicit capability or context requirements cannot express.
 2. **Resolve intents at runtime.** Add one resolver that maps intents to the
    active provider's live catalog, with provider-specific preference rules and
    clear errors when no compatible model exists.

--- a/docs/model-hardcoding-plan.md
+++ b/docs/model-hardcoding-plan.md
@@ -82,3 +82,25 @@ prepared with `just ensure`; CI is the enforcement backstop.
    increases and stale allowances.
 6. **Document escape hatches.** If a temporary pin is unavoidable, require a
    short rationale near the call site and the smallest allowlist count.
+
+## Resolver Contract
+
+The first migration building block lives in `omnigent/model_metadata.py` and
+`omnigent/model_resolver.py`:
+
+- Callers request a stable `ModelIntent` instead of a concrete model id.
+- `ModelMetadata` records known capabilities, context window, provider-relative
+  cost tier, and supported wire APIs. Capability support is tri-state so a
+  provider that reports only ids does not accidentally claim support.
+- Resolution follows explicit user/session choice, configured provider default,
+  live catalog, then documented static fallback precedence.
+- Capability, context, family, and wire requirements filter discovered models;
+  unknown metadata does not satisfy a requirement.
+- Provider catalog order is the default tie-breaker. Providers with richer
+  preference rules can supply a `ModelPreferencePolicy` without changing
+  callers or the precedence contract.
+
+This contract is intentionally pure and side-effect free. Follow-up migrations
+will adapt executor defaults and smart routing to it, then enrich catalog entries
+from provider and MLflow metadata. Until those callers move, their existing
+selection behavior remains unchanged.

--- a/docs/model-hardcoding-plan.md
+++ b/docs/model-hardcoding-plan.md
@@ -95,8 +95,16 @@ The first migration building block lives in `omnigent/model_metadata.py` and
   provider that reports only ids does not accidentally claim support.
 - Resolution follows explicit user/session choice, configured provider default,
   live catalog, then documented static fallback precedence.
+- Explicit user/session choices intentionally bypass compatibility requirements.
+  When an explicit model is absent from the catalog, its metadata and family
+  remain unknown rather than being inferred from its id.
 - Capability, context, family, and wire requirements filter discovered models;
   unknown metadata does not satisfy a requirement.
+- Intents provide best-effort ranking rather than hard tier guarantees. Callers
+  can inspect the selected metadata when they need to report the actual tier.
+- Wire metadata distinguishes Anthropic Messages, OpenAI Chat Completions,
+  OpenAI Responses, Gemini/Vertex `generateContent`, and Bedrock Converse. It
+  does not describe native CLI, ACP, or other harness transport protocols.
 - Provider catalog order is the default tie-breaker. Providers with richer
   preference rules can supply a `ModelPreferencePolicy` without changing
   callers or the precedence contract.

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -37,13 +37,14 @@ import logging
 import os
 import subprocess
 import threading
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 import httpx
 from cachetools import TTLCache
 
 from omnigent._platform import default_shell_argv
+from omnigent.model_metadata import ModelMetadata
 from omnigent.model_override import model_family_mismatch
 from omnigent.onboarding.provider_config import (
     ANTHROPIC_FAMILY,
@@ -154,13 +155,18 @@ class ModelEntry:
         ``"databricks-claude-sonnet-4-6"`` or ``"gpt-5.4-mini"``.
     :param family: Vendor family token — ``"claude"``, ``"openai"``, or
         ``"other"``.
-    :param context_window: Context window in tokens when the provider
-        reports one (e.g. OpenRouter ``context_length``), else ``None``.
+    :param metadata: Provider-neutral capabilities and limits. Metadata fields
+        remain unknown when the listing API reports only a model id.
     """
 
     id: str
     family: str
-    context_window: int | None = None
+    metadata: ModelMetadata = field(default_factory=ModelMetadata)
+
+    @property
+    def context_window(self) -> int | None:
+        """Return the normalized context window for compatibility callers."""
+        return self.metadata.context_window
 
 
 @dataclass(frozen=True)
@@ -715,8 +721,23 @@ def _listing_payload(listing: ModelListing) -> dict[str, Any]:  # type: ignore[e
     models: list[dict[str, Any]] = []  # type: ignore[explicit-any]  # JSON-shaped tool payload
     for entry in listing.models:
         row: dict[str, Any] = {"id": entry.id, "family": entry.family}  # type: ignore[explicit-any]
-        if entry.context_window is not None:
-            row["context_window"] = entry.context_window
+        metadata = entry.metadata
+        if metadata.context_window is not None:
+            row["context_window"] = metadata.context_window
+        capabilities = {
+            capability.value: supported
+            for supported, values in (
+                (True, metadata.supported_capabilities),
+                (False, metadata.unsupported_capabilities),
+            )
+            for capability in sorted(values, key=lambda value: value.value)
+        }
+        if capabilities:
+            row["capabilities"] = capabilities
+        if metadata.cost_tier is not None:
+            row["cost_tier"] = metadata.cost_tier.value
+        if metadata.wire_apis:
+            row["wire_apis"] = sorted(wire_api.value for wire_api in metadata.wire_apis)
         models.append(row)
     return {
         "source": listing.source,
@@ -1084,7 +1105,9 @@ def _fetch_openai_compatible_listing(
             ModelEntry(
                 id=model_id,
                 family=model_family_token(model_id),
-                context_window=context_length if isinstance(context_length, int) else None,
+                metadata=ModelMetadata(
+                    context_window=context_length if isinstance(context_length, int) else None
+                ),
             )
         )
     return ModelListing(

--- a/omnigent/model_metadata.py
+++ b/omnigent/model_metadata.py
@@ -13,10 +13,6 @@ class ModelIntent(str, Enum):
     FAST = "fast"
     BALANCED = "balanced"
     POWERFUL = "powerful"
-    LARGE_CONTEXT = "large-context"
-    CODING = "coding"
-    IMAGE = "image"
-    JUDGE = "judge"
 
 
 class ModelCapability(str, Enum):

--- a/omnigent/model_metadata.py
+++ b/omnigent/model_metadata.py
@@ -1,0 +1,80 @@
+"""Provider-neutral metadata used for model selection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ModelIntent(str, Enum):
+    """Stable purpose requested by a model-selection caller."""
+
+    DEFAULT = "default"
+    FAST = "fast"
+    BALANCED = "balanced"
+    POWERFUL = "powerful"
+    LARGE_CONTEXT = "large-context"
+    CODING = "coding"
+    IMAGE = "image"
+    JUDGE = "judge"
+
+
+class ModelCapability(str, Enum):
+    """A model feature that can be required without inspecting its id."""
+
+    TOOL_USE = "tool-use"
+    REASONING = "reasoning"
+    VISION = "vision"
+    IMAGE_GENERATION = "image-generation"
+    STRUCTURED_OUTPUT = "structured-output"
+
+
+class ModelCostTier(str, Enum):
+    """Provider-relative cost tier used to rank compatible models."""
+
+    ECONOMY = "economy"
+    STANDARD = "standard"
+    PREMIUM = "premium"
+
+
+class ModelWireAPI(str, Enum):
+    """Wire protocols a model endpoint is known to accept."""
+
+    ANTHROPIC_MESSAGES = "anthropic-messages"
+    OPENAI_CHAT = "openai-chat"
+    OPENAI_RESPONSES = "openai-responses"
+    GEMINI = "gemini"
+
+
+@dataclass(frozen=True)
+class ModelMetadata:
+    """Normalized, provider-neutral facts about one model.
+
+    Capability support is tri-state. A capability in
+    :attr:`supported_capabilities` is supported, one in
+    :attr:`unsupported_capabilities` is known not to be supported, and one in
+    neither set is unknown. Unknown is intentionally distinct from unsupported
+    because many provider listing APIs return ids without capability metadata.
+    """
+
+    supported_capabilities: frozenset[ModelCapability] = frozenset()
+    unsupported_capabilities: frozenset[ModelCapability] = frozenset()
+    context_window: int | None = None
+    cost_tier: ModelCostTier | None = None
+    wire_apis: frozenset[ModelWireAPI] = frozenset()
+
+    def __post_init__(self) -> None:
+        overlap = self.supported_capabilities & self.unsupported_capabilities
+        if overlap:
+            names = ", ".join(sorted(capability.value for capability in overlap))
+            raise ValueError(f"capabilities cannot be both supported and unsupported: {names}")
+        if self.context_window is not None and self.context_window <= 0:
+            raise ValueError("context_window must be positive")
+
+    def supports(self, capability: ModelCapability) -> bool | None:
+        """Return known support for *capability*, or ``None`` when unknown."""
+        if capability in self.supported_capabilities:
+            return True
+        if capability in self.unsupported_capabilities:
+            return False
+        return None

--- a/omnigent/model_metadata.py
+++ b/omnigent/model_metadata.py
@@ -39,7 +39,8 @@ class ModelWireAPI(str, Enum):
     ANTHROPIC_MESSAGES = "anthropic-messages"
     OPENAI_CHAT = "openai-chat"
     OPENAI_RESPONSES = "openai-responses"
-    GEMINI = "gemini"
+    GEMINI_GENERATE_CONTENT = "gemini-generate-content"
+    BEDROCK_CONVERSE = "bedrock-converse"
 
 
 @dataclass(frozen=True)

--- a/omnigent/model_resolver.py
+++ b/omnigent/model_resolver.py
@@ -58,7 +58,11 @@ class ModelResolutionRequest:
 
 @dataclass(frozen=True)
 class ModelResolution:
-    """Resolved model plus the metadata and precedence branch used."""
+    """Resolved model plus known metadata and the precedence branch used.
+
+    ``family`` is unavailable when an explicit or configured model is absent
+    from the supplied catalogs.
+    """
 
     model_id: str
     source: ModelResolutionSource
@@ -106,7 +110,9 @@ class MetadataPreferencePolicy:
 
     Provider catalog order remains the stable tie-breaker. Providers can pass
     their own :class:`ModelPreferencePolicy` when their preference rules are
-    richer than the normalized metadata.
+    richer than the normalized metadata. Intent is a best-effort ordering hint,
+    not a hard cost-tier requirement; the selected tier remains available on
+    the resolution metadata.
     """
 
     def rank(
@@ -143,11 +149,12 @@ def resolve_model(
 ) -> ModelResolution:
     """Resolve a model using explicit, configured, live, then static precedence.
 
-    An explicit user/session model always wins, even when it is absent from the
-    catalog. A configured default wins when its known metadata satisfies the
-    request; an unlisted configured default can satisfy requests with no
-    capability, context, family, or wire constraints. Catalog and fallback
-    candidates must have positive metadata for every requested constraint.
+    An explicit user/session model always wins and intentionally bypasses
+    capability, context, family, and wire constraints, even when it is absent
+    from the catalog. A configured default wins when its known metadata
+    satisfies the request; an unlisted configured default can satisfy requests
+    with no metadata constraints. Catalog and fallback candidates must have
+    positive metadata for every requested constraint.
     """
     all_models = (*live_models, *static_fallbacks)
     if request.explicit_model is not None:

--- a/omnigent/model_resolver.py
+++ b/omnigent/model_resolver.py
@@ -1,0 +1,282 @@
+"""Deterministic model-intent resolution over provider catalog entries."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol
+
+from omnigent.model_metadata import (
+    ModelCapability,
+    ModelCostTier,
+    ModelIntent,
+    ModelMetadata,
+    ModelWireAPI,
+)
+
+
+class ModelCandidate(Protocol):
+    """Catalog entry shape consumed by :func:`resolve_model`."""
+
+    id: str
+    family: str
+    metadata: ModelMetadata
+
+
+class ModelResolutionSource(str, Enum):
+    """Precedence branch that supplied a resolved model."""
+
+    EXPLICIT = "explicit"
+    CONFIGURED_DEFAULT = "configured-default"
+    LIVE_CATALOG = "live-catalog"
+    STATIC_FALLBACK = "static-fallback"
+
+
+@dataclass(frozen=True)
+class ModelResolutionRequest:
+    """One provider-neutral model selection request."""
+
+    intent: ModelIntent = ModelIntent.DEFAULT
+    explicit_model: str | None = None
+    configured_default: str | None = None
+    required_capabilities: frozenset[ModelCapability] = frozenset()
+    minimum_context_window: int | None = None
+    required_wire_api: ModelWireAPI | None = None
+    allowed_families: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        for field_name, value in (
+            ("explicit_model", self.explicit_model),
+            ("configured_default", self.configured_default),
+        ):
+            if value is not None and not value.strip():
+                raise ValueError(f"{field_name} must not be empty")
+        if self.minimum_context_window is not None and self.minimum_context_window <= 0:
+            raise ValueError("minimum_context_window must be positive")
+
+
+@dataclass(frozen=True)
+class ModelResolution:
+    """Resolved model plus the metadata and precedence branch used."""
+
+    model_id: str
+    source: ModelResolutionSource
+    metadata: ModelMetadata
+    family: str | None = None
+
+
+class ModelResolutionError(ValueError):
+    """Raised when no candidate can satisfy a model request."""
+
+
+class ModelPreferencePolicy(Protocol):
+    """Provider-specific ordering policy for compatible candidates."""
+
+    def rank(
+        self,
+        intent: ModelIntent,
+        candidates: Sequence[ModelCandidate],
+    ) -> Sequence[ModelCandidate]:
+        """Return *candidates* in preferred order for *intent*."""
+        ...
+
+
+_INTENT_CAPABILITIES: dict[ModelIntent, frozenset[ModelCapability]] = {
+    ModelIntent.CODING: frozenset({ModelCapability.TOOL_USE}),
+    ModelIntent.IMAGE: frozenset({ModelCapability.IMAGE_GENERATION}),
+    ModelIntent.JUDGE: frozenset({ModelCapability.STRUCTURED_OUTPUT}),
+}
+
+_COST_TIER_ORDER: dict[ModelIntent, tuple[ModelCostTier, ...]] = {
+    ModelIntent.FAST: (
+        ModelCostTier.ECONOMY,
+        ModelCostTier.STANDARD,
+        ModelCostTier.PREMIUM,
+    ),
+    ModelIntent.BALANCED: (
+        ModelCostTier.STANDARD,
+        ModelCostTier.ECONOMY,
+        ModelCostTier.PREMIUM,
+    ),
+    ModelIntent.POWERFUL: (
+        ModelCostTier.PREMIUM,
+        ModelCostTier.STANDARD,
+        ModelCostTier.ECONOMY,
+    ),
+}
+
+
+class MetadataPreferencePolicy:
+    """Default ranking policy using normalized cost and context metadata.
+
+    Provider catalog order remains the stable tie-breaker. Providers can pass
+    their own :class:`ModelPreferencePolicy` when their preference rules are
+    richer than the normalized metadata.
+    """
+
+    def rank(
+        self,
+        intent: ModelIntent,
+        candidates: Sequence[ModelCandidate],
+    ) -> Sequence[ModelCandidate]:
+        indexed = tuple(enumerate(candidates))
+        if intent == ModelIntent.LARGE_CONTEXT:
+            return tuple(
+                candidate
+                for _, candidate in sorted(
+                    indexed,
+                    key=lambda pair: (
+                        pair[1].metadata.context_window is None,
+                        -(pair[1].metadata.context_window or 0),
+                        pair[0],
+                    ),
+                )
+            )
+
+        tier_order = _COST_TIER_ORDER.get(intent)
+        if tier_order is None:
+            return tuple(candidates)
+        tier_rank = {tier: index for index, tier in enumerate(tier_order)}
+        unknown_rank = len(tier_order)
+        return tuple(
+            candidate
+            for _, candidate in sorted(
+                indexed,
+                key=lambda pair: (
+                    tier_rank[pair[1].metadata.cost_tier]
+                    if pair[1].metadata.cost_tier is not None
+                    else unknown_rank,
+                    pair[0],
+                ),
+            )
+        )
+
+
+def intent_capabilities(intent: ModelIntent) -> frozenset[ModelCapability]:
+    """Return capabilities implied by a stable model intent."""
+    return _INTENT_CAPABILITIES.get(intent, frozenset())
+
+
+def resolve_model(
+    request: ModelResolutionRequest,
+    live_models: Sequence[ModelCandidate],
+    *,
+    static_fallbacks: Sequence[ModelCandidate] = (),
+    preference_policy: ModelPreferencePolicy | None = None,
+) -> ModelResolution:
+    """Resolve a model using explicit, configured, live, then static precedence.
+
+    An explicit user/session model always wins, even when it is absent from the
+    catalog. A configured default wins when its known metadata satisfies the
+    request; an unlisted configured default can satisfy requests with no
+    capability, context, family, or wire constraints. Catalog and fallback
+    candidates must have positive metadata for every requested constraint.
+    """
+    all_models = (*live_models, *static_fallbacks)
+    if request.explicit_model is not None:
+        return _named_resolution(
+            request.explicit_model,
+            ModelResolutionSource.EXPLICIT,
+            all_models,
+        )
+
+    capabilities = request.required_capabilities | intent_capabilities(request.intent)
+    if request.configured_default is not None:
+        configured = _find_candidate(request.configured_default, all_models)
+        if configured is not None and _is_compatible(configured, request, capabilities):
+            return _candidate_resolution(configured, ModelResolutionSource.CONFIGURED_DEFAULT)
+        if configured is None and _request_has_no_metadata_constraints(request, capabilities):
+            return _named_resolution(
+                request.configured_default,
+                ModelResolutionSource.CONFIGURED_DEFAULT,
+                (),
+            )
+
+    policy = preference_policy or MetadataPreferencePolicy()
+    live_compatible = tuple(
+        model for model in live_models if _is_compatible(model, request, capabilities)
+    )
+    if live_compatible:
+        selected = policy.rank(request.intent, live_compatible)[0]
+        return _candidate_resolution(selected, ModelResolutionSource.LIVE_CATALOG)
+
+    fallback_compatible = tuple(
+        model for model in static_fallbacks if _is_compatible(model, request, capabilities)
+    )
+    if fallback_compatible:
+        selected = policy.rank(request.intent, fallback_compatible)[0]
+        return _candidate_resolution(selected, ModelResolutionSource.STATIC_FALLBACK)
+
+    constraints = sorted(capability.value for capability in capabilities)
+    if request.minimum_context_window is not None:
+        constraints.append(f"context>={request.minimum_context_window}")
+    if request.required_wire_api is not None:
+        constraints.append(f"wire={request.required_wire_api.value}")
+    if request.allowed_families:
+        constraints.append(f"family in {sorted(request.allowed_families)!r}")
+    detail = ", ".join(constraints) if constraints else "provider compatibility"
+    raise ModelResolutionError(f"no model satisfies intent {request.intent.value!r} ({detail})")
+
+
+def _request_has_no_metadata_constraints(
+    request: ModelResolutionRequest,
+    capabilities: frozenset[ModelCapability],
+) -> bool:
+    return not (
+        capabilities
+        or request.minimum_context_window is not None
+        or request.required_wire_api is not None
+        or request.allowed_families
+    )
+
+
+def _find_candidate(
+    model_id: str,
+    candidates: Sequence[ModelCandidate],
+) -> ModelCandidate | None:
+    return next((candidate for candidate in candidates if candidate.id == model_id), None)
+
+
+def _is_compatible(
+    candidate: ModelCandidate,
+    request: ModelResolutionRequest,
+    capabilities: frozenset[ModelCapability],
+) -> bool:
+    if request.allowed_families and candidate.family not in request.allowed_families:
+        return False
+    if any(candidate.metadata.supports(capability) is not True for capability in capabilities):
+        return False
+    if request.minimum_context_window is not None:
+        context_window = candidate.metadata.context_window
+        if context_window is None or context_window < request.minimum_context_window:
+            return False
+    if (
+        request.required_wire_api is not None
+        and request.required_wire_api not in candidate.metadata.wire_apis
+    ):
+        return False
+    return True
+
+
+def _candidate_resolution(
+    candidate: ModelCandidate,
+    source: ModelResolutionSource,
+) -> ModelResolution:
+    return ModelResolution(
+        model_id=candidate.id,
+        source=source,
+        metadata=candidate.metadata,
+        family=candidate.family,
+    )
+
+
+def _named_resolution(
+    model_id: str,
+    source: ModelResolutionSource,
+    candidates: Sequence[ModelCandidate],
+) -> ModelResolution:
+    candidate = _find_candidate(model_id, candidates)
+    if candidate is not None:
+        return _candidate_resolution(candidate, source)
+    return ModelResolution(model_id=model_id, source=source, metadata=ModelMetadata())

--- a/omnigent/model_resolver.py
+++ b/omnigent/model_resolver.py
@@ -82,12 +82,6 @@ class ModelPreferencePolicy(Protocol):
         ...
 
 
-_INTENT_CAPABILITIES: dict[ModelIntent, frozenset[ModelCapability]] = {
-    ModelIntent.CODING: frozenset({ModelCapability.TOOL_USE}),
-    ModelIntent.IMAGE: frozenset({ModelCapability.IMAGE_GENERATION}),
-    ModelIntent.JUDGE: frozenset({ModelCapability.STRUCTURED_OUTPUT}),
-}
-
 _COST_TIER_ORDER: dict[ModelIntent, tuple[ModelCostTier, ...]] = {
     ModelIntent.FAST: (
         ModelCostTier.ECONOMY,
@@ -121,19 +115,6 @@ class MetadataPreferencePolicy:
         candidates: Sequence[ModelCandidate],
     ) -> Sequence[ModelCandidate]:
         indexed = tuple(enumerate(candidates))
-        if intent == ModelIntent.LARGE_CONTEXT:
-            return tuple(
-                candidate
-                for _, candidate in sorted(
-                    indexed,
-                    key=lambda pair: (
-                        pair[1].metadata.context_window is None,
-                        -(pair[1].metadata.context_window or 0),
-                        pair[0],
-                    ),
-                )
-            )
-
         tier_order = _COST_TIER_ORDER.get(intent)
         if tier_order is None:
             return tuple(candidates)
@@ -151,11 +132,6 @@ class MetadataPreferencePolicy:
                 ),
             )
         )
-
-
-def intent_capabilities(intent: ModelIntent) -> frozenset[ModelCapability]:
-    """Return capabilities implied by a stable model intent."""
-    return _INTENT_CAPABILITIES.get(intent, frozenset())
 
 
 def resolve_model(
@@ -181,7 +157,7 @@ def resolve_model(
             all_models,
         )
 
-    capabilities = request.required_capabilities | intent_capabilities(request.intent)
+    capabilities = request.required_capabilities
     if request.configured_default is not None:
         configured = _find_candidate(request.configured_default, all_models)
         if configured is not None and _is_compatible(configured, request, capabilities):

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -22,10 +22,18 @@ from cachetools import TTLCache
 
 import omnigent.model_catalog as model_catalog
 from omnigent.model_catalog import (
+    ModelEntry,
+    ModelListing,
     catalog_for_spec,
     list_models_for_worker,
     resolve_model_provider,
     spec_harness,
+)
+from omnigent.model_metadata import (
+    ModelCapability,
+    ModelCostTier,
+    ModelMetadata,
+    ModelWireAPI,
 )
 from omnigent.runtime.credentials.databricks import WorkspaceCreds
 from omnigent.spec.types import AgentSpec, ApiKeyAuth, DatabricksAuth, ExecutorSpec
@@ -1118,6 +1126,41 @@ def test_catalog_payload_is_json_serializable_and_omits_unknown_context(
     payload = json.loads(json.dumps(catalog))
     assert payload["worker"]["source"] == "gateway"
     assert all("context_window" not in m for m in payload["worker"]["models"])
+
+
+def test_catalog_payload_serializes_normalized_model_metadata() -> None:
+    """Known metadata is exposed without inventing values for unknown fields."""
+    listing = ModelListing(
+        source="catalog",
+        verified=True,
+        models=(
+            ModelEntry(
+                id="provider/model-a",
+                family="provider-family",
+                metadata=ModelMetadata(
+                    supported_capabilities=frozenset({ModelCapability.TOOL_USE}),
+                    unsupported_capabilities=frozenset({ModelCapability.VISION}),
+                    context_window=200_000,
+                    cost_tier=ModelCostTier.STANDARD,
+                    wire_apis=frozenset({ModelWireAPI.OPENAI_RESPONSES}),
+                ),
+            ),
+        ),
+        note="test catalog",
+    )
+
+    payload = model_catalog._listing_payload(listing)
+
+    assert payload["models"] == [
+        {
+            "id": "provider/model-a",
+            "family": "provider-family",
+            "context_window": 200_000,
+            "capabilities": {"tool-use": True, "vision": False},
+            "cost_tier": "standard",
+            "wire_apis": ["openai-responses"],
+        }
+    ]
 
 
 def test_spec_harness_derivation() -> None:

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -47,10 +47,14 @@ def _candidate(
     )
 
 
-def test_explicit_model_wins_without_catalog_metadata() -> None:
+def test_explicit_model_bypasses_constraints_without_catalog_metadata() -> None:
     resolution = resolve_model(
         ModelResolutionRequest(
             explicit_model="user-choice",
+            required_capabilities=frozenset({ModelCapability.TOOL_USE}),
+            minimum_context_window=200_000,
+            required_wire_api=ModelWireAPI.BEDROCK_CONVERSE,
+            allowed_families=frozenset({"required-family"}),
         ),
         [_candidate("catalog-choice")],
     )
@@ -58,6 +62,7 @@ def test_explicit_model_wins_without_catalog_metadata() -> None:
     assert resolution.model_id == "user-choice"
     assert resolution.source == ModelResolutionSource.EXPLICIT
     assert resolution.metadata == ModelMetadata()
+    assert resolution.family is None
 
 
 def test_configured_default_wins_before_live_catalog() -> None:
@@ -123,6 +128,26 @@ def test_cost_intents_rank_by_normalized_tier(intent: ModelIntent, expected: str
     resolution = resolve_model(ModelResolutionRequest(intent=intent), models)
 
     assert resolution.model_id == expected
+
+
+def test_cost_intent_returns_best_available_tier() -> None:
+    resolution = resolve_model(
+        ModelResolutionRequest(intent=ModelIntent.FAST),
+        [_candidate("premium", cost_tier=ModelCostTier.PREMIUM)],
+    )
+
+    assert resolution.model_id == "premium"
+    assert resolution.metadata.cost_tier == ModelCostTier.PREMIUM
+
+
+def test_wire_api_vocabulary_covers_model_endpoint_adapters() -> None:
+    assert {wire_api.value for wire_api in ModelWireAPI} == {
+        "anthropic-messages",
+        "bedrock-converse",
+        "gemini-generate-content",
+        "openai-chat",
+        "openai-responses",
+    }
 
 
 def test_constraints_filter_family_context_capability_and_wire_api() -> None:

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -1,0 +1,224 @@
+"""Unit tests for provider-neutral model-intent resolution."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+
+from omnigent.model_catalog import ModelEntry
+from omnigent.model_metadata import (
+    ModelCapability,
+    ModelCostTier,
+    ModelIntent,
+    ModelMetadata,
+    ModelWireAPI,
+)
+from omnigent.model_resolver import (
+    ModelCandidate,
+    ModelPreferencePolicy,
+    ModelResolutionError,
+    ModelResolutionRequest,
+    ModelResolutionSource,
+    resolve_model,
+)
+
+
+def _candidate(
+    model_id: str,
+    *,
+    family: str = "provider-family",
+    supported: frozenset[ModelCapability] = frozenset(),
+    unsupported: frozenset[ModelCapability] = frozenset(),
+    context_window: int | None = None,
+    cost_tier: ModelCostTier | None = None,
+    wire_apis: frozenset[ModelWireAPI] = frozenset(),
+) -> ModelEntry:
+    return ModelEntry(
+        id=model_id,
+        family=family,
+        metadata=ModelMetadata(
+            supported_capabilities=supported,
+            unsupported_capabilities=unsupported,
+            context_window=context_window,
+            cost_tier=cost_tier,
+            wire_apis=wire_apis,
+        ),
+    )
+
+
+def test_explicit_model_wins_without_catalog_metadata() -> None:
+    resolution = resolve_model(
+        ModelResolutionRequest(
+            intent=ModelIntent.CODING,
+            explicit_model="user-choice",
+        ),
+        [_candidate("catalog-choice")],
+    )
+
+    assert resolution.model_id == "user-choice"
+    assert resolution.source == ModelResolutionSource.EXPLICIT
+    assert resolution.metadata == ModelMetadata()
+
+
+def test_configured_default_wins_before_live_catalog() -> None:
+    models = [_candidate("provider-default"), _candidate("catalog-choice")]
+
+    resolution = resolve_model(
+        ModelResolutionRequest(configured_default="provider-default"),
+        models,
+    )
+
+    assert resolution.model_id == "provider-default"
+    assert resolution.source == ModelResolutionSource.CONFIGURED_DEFAULT
+
+
+def test_capability_intent_skips_unverified_configured_default() -> None:
+    coding_model = _candidate(
+        "tool-capable",
+        supported=frozenset({ModelCapability.TOOL_USE}),
+    )
+
+    resolution = resolve_model(
+        ModelResolutionRequest(
+            intent=ModelIntent.CODING,
+            configured_default="unlisted-default",
+        ),
+        [coding_model],
+    )
+
+    assert resolution.model_id == "tool-capable"
+    assert resolution.source == ModelResolutionSource.LIVE_CATALOG
+
+
+def test_unknown_capability_does_not_satisfy_requirement() -> None:
+    unknown = _candidate("unknown-tools")
+    supported = _candidate(
+        "known-tools",
+        supported=frozenset({ModelCapability.TOOL_USE}),
+    )
+
+    resolution = resolve_model(
+        ModelResolutionRequest(intent=ModelIntent.CODING),
+        [unknown, supported],
+    )
+
+    assert resolution.model_id == "known-tools"
+
+
+@pytest.mark.parametrize(
+    ("intent", "expected"),
+    [
+        (ModelIntent.FAST, "economy"),
+        (ModelIntent.BALANCED, "standard"),
+        (ModelIntent.POWERFUL, "premium"),
+    ],
+)
+def test_cost_intents_rank_by_normalized_tier(intent: ModelIntent, expected: str) -> None:
+    models = [
+        _candidate("premium", cost_tier=ModelCostTier.PREMIUM),
+        _candidate("economy", cost_tier=ModelCostTier.ECONOMY),
+        _candidate("standard", cost_tier=ModelCostTier.STANDARD),
+    ]
+
+    resolution = resolve_model(ModelResolutionRequest(intent=intent), models)
+
+    assert resolution.model_id == expected
+
+
+def test_large_context_intent_prefers_largest_known_window() -> None:
+    models = [
+        _candidate("unknown-window"),
+        _candidate("large-window", context_window=500_000),
+        _candidate("small-window", context_window=100_000),
+    ]
+
+    resolution = resolve_model(
+        ModelResolutionRequest(intent=ModelIntent.LARGE_CONTEXT),
+        models,
+    )
+
+    assert resolution.model_id == "large-window"
+
+
+def test_constraints_filter_family_context_capability_and_wire_api() -> None:
+    required_capabilities = frozenset(
+        {ModelCapability.REASONING, ModelCapability.STRUCTURED_OUTPUT}
+    )
+    compatible = _candidate(
+        "compatible",
+        family="allowed",
+        supported=required_capabilities,
+        context_window=250_000,
+        wire_apis=frozenset({ModelWireAPI.OPENAI_RESPONSES}),
+    )
+    wrong_wire = _candidate(
+        "wrong-wire",
+        family="allowed",
+        supported=required_capabilities,
+        context_window=250_000,
+        wire_apis=frozenset({ModelWireAPI.OPENAI_CHAT}),
+    )
+
+    resolution = resolve_model(
+        ModelResolutionRequest(
+            required_capabilities=required_capabilities,
+            minimum_context_window=200_000,
+            required_wire_api=ModelWireAPI.OPENAI_RESPONSES,
+            allowed_families=frozenset({"allowed"}),
+        ),
+        [wrong_wire, compatible],
+    )
+
+    assert resolution.model_id == "compatible"
+
+
+def test_static_fallback_is_used_only_after_live_candidates_fail() -> None:
+    fallback = _candidate(
+        "fallback",
+        supported=frozenset({ModelCapability.IMAGE_GENERATION}),
+    )
+
+    resolution = resolve_model(
+        ModelResolutionRequest(intent=ModelIntent.IMAGE),
+        [_candidate("live-with-unknown-capabilities")],
+        static_fallbacks=[fallback],
+    )
+
+    assert resolution.model_id == "fallback"
+    assert resolution.source == ModelResolutionSource.STATIC_FALLBACK
+
+
+def test_provider_preference_policy_can_override_default_order() -> None:
+    class _ReversePolicy(ModelPreferencePolicy):
+        def rank(
+            self,
+            intent: ModelIntent,
+            candidates: Sequence[ModelCandidate],
+        ) -> Sequence[ModelCandidate]:
+            del intent
+            return tuple(reversed(candidates))
+
+    resolution = resolve_model(
+        ModelResolutionRequest(),
+        [_candidate("first"), _candidate("second")],
+        preference_policy=_ReversePolicy(),
+    )
+
+    assert resolution.model_id == "second"
+
+
+def test_no_compatible_model_raises_clear_error() -> None:
+    with pytest.raises(ModelResolutionError, match=r"coding.*tool-use"):
+        resolve_model(
+            ModelResolutionRequest(intent=ModelIntent.CODING),
+            [_candidate("unknown-tools")],
+        )
+
+
+def test_metadata_rejects_conflicting_capability_facts() -> None:
+    with pytest.raises(ValueError, match="both supported and unsupported"):
+        ModelMetadata(
+            supported_capabilities=frozenset({ModelCapability.VISION}),
+            unsupported_capabilities=frozenset({ModelCapability.VISION}),
+        )

--- a/tests/test_model_resolver.py
+++ b/tests/test_model_resolver.py
@@ -50,7 +50,6 @@ def _candidate(
 def test_explicit_model_wins_without_catalog_metadata() -> None:
     resolution = resolve_model(
         ModelResolutionRequest(
-            intent=ModelIntent.CODING,
             explicit_model="user-choice",
         ),
         [_candidate("catalog-choice")],
@@ -73,7 +72,7 @@ def test_configured_default_wins_before_live_catalog() -> None:
     assert resolution.source == ModelResolutionSource.CONFIGURED_DEFAULT
 
 
-def test_capability_intent_skips_unverified_configured_default() -> None:
+def test_capability_requirement_skips_unverified_configured_default() -> None:
     coding_model = _candidate(
         "tool-capable",
         supported=frozenset({ModelCapability.TOOL_USE}),
@@ -81,8 +80,8 @@ def test_capability_intent_skips_unverified_configured_default() -> None:
 
     resolution = resolve_model(
         ModelResolutionRequest(
-            intent=ModelIntent.CODING,
             configured_default="unlisted-default",
+            required_capabilities=frozenset({ModelCapability.TOOL_USE}),
         ),
         [coding_model],
     )
@@ -99,7 +98,7 @@ def test_unknown_capability_does_not_satisfy_requirement() -> None:
     )
 
     resolution = resolve_model(
-        ModelResolutionRequest(intent=ModelIntent.CODING),
+        ModelResolutionRequest(required_capabilities=frozenset({ModelCapability.TOOL_USE})),
         [unknown, supported],
     )
 
@@ -124,21 +123,6 @@ def test_cost_intents_rank_by_normalized_tier(intent: ModelIntent, expected: str
     resolution = resolve_model(ModelResolutionRequest(intent=intent), models)
 
     assert resolution.model_id == expected
-
-
-def test_large_context_intent_prefers_largest_known_window() -> None:
-    models = [
-        _candidate("unknown-window"),
-        _candidate("large-window", context_window=500_000),
-        _candidate("small-window", context_window=100_000),
-    ]
-
-    resolution = resolve_model(
-        ModelResolutionRequest(intent=ModelIntent.LARGE_CONTEXT),
-        models,
-    )
-
-    assert resolution.model_id == "large-window"
 
 
 def test_constraints_filter_family_context_capability_and_wire_api() -> None:
@@ -180,7 +164,9 @@ def test_static_fallback_is_used_only_after_live_candidates_fail() -> None:
     )
 
     resolution = resolve_model(
-        ModelResolutionRequest(intent=ModelIntent.IMAGE),
+        ModelResolutionRequest(
+            required_capabilities=frozenset({ModelCapability.IMAGE_GENERATION})
+        ),
         [_candidate("live-with-unknown-capabilities")],
         static_fallbacks=[fallback],
     )
@@ -209,9 +195,9 @@ def test_provider_preference_policy_can_override_default_order() -> None:
 
 
 def test_no_compatible_model_raises_clear_error() -> None:
-    with pytest.raises(ModelResolutionError, match=r"coding.*tool-use"):
+    with pytest.raises(ModelResolutionError, match=r"default.*tool-use"):
         resolve_model(
-            ModelResolutionRequest(intent=ModelIntent.CODING),
+            ModelResolutionRequest(required_capabilities=frozenset({ModelCapability.TOOL_USE})),
             [_candidate("unknown-tools")],
         )
 


### PR DESCRIPTION
## Related issue

Part of #3426

## Summary

The hardcoded-model migration needs one stable selection boundary before executor defaults and smart routing can move away from concrete ids. This PR defines that boundary without changing current runtime defaults: callers can express intent and compatibility requirements, catalogs can expose normalized metadata, and one resolver owns precedence.

ELI5: callers ask for “fast,” “balanced,” or “powerful” and separately require concrete features such as tool use or vision. The resolver chooses from models the provider says are compatible instead of callers memorizing model names.

```mermaid
flowchart LR
    A[Intent + requirements] --> B{Explicit choice?}
    B -- yes --> C[Honor explicit model]
    B -- no --> D{Compatible configured default?}
    D -- yes --> E[Use provider default]
    D -- no --> F[Rank compatible live catalog]
    F -- empty --> G[Rank documented static fallback]
    F -- match --> H[Resolved model + metadata]
    G -- match --> H
    G -- empty --> I[Clear resolution error]
```

- Defines only the caller-backed `default`, `fast`, `balanced`, and `powerful` intents, plus explicit tri-state capability, context-window, provider-relative cost-tier, and wire-API metadata; the wire vocabulary covers Anthropic Messages, OpenAI Chat/Responses, Gemini/Vertex generateContent, and Bedrock Converse.
- Adds deterministic explicit → configured default → live catalog → static fallback resolution, with provider catalog order as the tie-breaker and an extension point for provider-specific ranking.
- Extends catalog entries and serialized model payloads with normalized metadata while retaining the existing context-window accessor.
- Documents the contract and keeps executor/native defaults and smart-routing migration deliberately out of scope for follow-up PRs.

## Test Plan

- [x] Added resolver unit coverage for precedence, explicit override semantics, explicit capability requirements, unknown metadata, best-effort cost-tier ranking, complete wire-API vocabulary, provider policies, static fallback, and clear failures.
- [x] Added catalog payload coverage for normalized capability, context, cost-tier, and wire-API serialization.
- [x] Ran focused resolver, catalog, smart-routing, and OpenAI/Anthropic/Gemini/Vertex/Bedrock/Databricks adapter tests (`283 passed`).
- [x] Ran staged `pre-commit run`; all applicable hooks passed, including Ruff and the hardcoded-model lint.
- [x] Ran focused strict typing with `mypy --follow-imports=skip omnigent/model_metadata.py omnigent/model_resolver.py`.

## Demo

N/A — non-visual model-selection contract.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — automated unit and adjacent smart-routing coverage exercise the contract and catalog integration.

## Changelog

Model selection can now represent provider choices through stable intents and normalized capability metadata.
