### PR TITLE
feat(sessions): add delegated approval authority

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -561,6 +561,8 @@ class SqlSessionPermission(OmnigentBase):
     :param level: Numeric permission level: ``1`` = read,
         ``2`` = edit, ``3`` = manage. Each level subsumes the
         ones below it (comparison is ``>=``).
+    :param can_approve: Owner-controlled authority to resolve privileged
+        action approvals for this session.
     """
 
     __tablename__ = "session_permissions"
@@ -582,6 +584,12 @@ class SqlSessionPermission(OmnigentBase):
         primary_key=True,
     )
     level: Mapped[int] = mapped_column(Integer, nullable=False)
+    can_approve: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=false(),
+        default=False,
+    )
 
     __table_args__ = (
         CheckConstraint("level IN (1, 2, 3, 4)", name="ck_session_permissions_level"),

--- a/omnigent/db/migrations/versions/c4d5e6f7a8b9_add_session_approval_delegation.py
+++ b/omnigent/db/migrations/versions/c4d5e6f7a8b9_add_session_approval_delegation.py
@@ -1,0 +1,37 @@
+"""Add delegated approval authority to session permissions.
+
+Revision ID: c4d5e6f7a8b9
+Revises: b3c4d5e6f7a8
+Create Date: 2026-07-28
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c4d5e6f7a8b9"
+down_revision: str | None = "b3c4d5e6f7a8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the owner-controlled approval capability."""
+    with op.batch_alter_table("session_permissions") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "can_approve",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+
+
+def downgrade() -> None:
+    """Remove delegated approval authority."""
+    with op.batch_alter_table("session_permissions") as batch_op:
+        batch_op.drop_column("can_approve")

--- a/omnigent/entities/permission.py
+++ b/omnigent/entities/permission.py
@@ -15,11 +15,14 @@ class SessionPermission:
         e.g. ``"conv_abc123"``.
     :param level: Numeric permission level: ``1`` = read,
         ``2`` = edit, ``3`` = manage. Comparison is ``>=``.
+    :param can_approve: Whether the owner delegated privileged-action
+        approval authority to this user.
     """
 
     user_id: str
     conversation_id: str
     level: int
+    can_approve: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
@@ -36,6 +39,8 @@ class ResolvedAccess:
     :param user_grant_level: The user's own grant level on the
         conversation (``1`` = read, ``2`` = edit, ``3`` = manage,
         ``4`` = owner), or ``None`` if they have no direct grant.
+    :param user_can_approve: Whether the user's direct grant carries
+        delegated approval authority.
     :param public_grant_level: The ``"__public__"`` sentinel grant level
         on the conversation (same ``1``–``4`` scale), or ``None`` if the
         session is not public.
@@ -44,3 +49,4 @@ class ResolvedAccess:
     is_admin: bool
     user_grant_level: int | None
     public_grant_level: int | None
+    user_can_approve: bool = False

--- a/omnigent/server/permissions.py
+++ b/omnigent/server/permissions.py
@@ -105,6 +105,14 @@ def resolved_level(access: ResolvedAccess) -> int | None:
     return access.public_grant_level
 
 
+def resolved_can_approve(access: ResolvedAccess) -> bool:
+    """Whether a resolved top-level access snapshot may approve actions."""
+    return access.is_admin or (
+        access.user_grant_level is not None
+        and (access.user_grant_level >= LEVEL_OWNER or access.user_can_approve)
+    )
+
+
 def check_is_manager(
     user_id: str | None,
     conversation_id: str,
@@ -127,3 +135,28 @@ def check_is_manager(
         permission_store,
         conversation_store,
     )
+
+
+def check_session_approval_access(
+    user_id: str | None,
+    conversation_id: str,
+    permission_store: PermissionStore,
+    conversation_store: ConversationStore,
+) -> bool:
+    """Return whether a user may approve privileged session actions."""
+    if user_id is not None and permission_store.is_admin(user_id):
+        return True
+    conv = conversation_store.get_conversation(conversation_id)
+    if conv is None:
+        return False
+    if conv.parent_conversation_id is not None:
+        return check_session_approval_access(
+            user_id,
+            conv.parent_conversation_id,
+            permission_store,
+            conversation_store,
+        )
+    if user_id is None:
+        return False
+    grant = permission_store.get(user_id, conversation_id)
+    return grant is not None and (grant.level >= LEVEL_OWNER or grant.can_approve)

--- a/omnigent/server/routes/_auth_helpers.py
+++ b/omnigent/server/routes/_auth_helpers.py
@@ -32,7 +32,9 @@ from omnigent.server.auth import (
 )
 from omnigent.server.permissions import (
     check_session_access,
+    check_session_approval_access,
     resolved_allows,
+    resolved_can_approve,
     resolved_level,
 )
 from omnigent.stores import ConversationStore
@@ -180,6 +182,78 @@ async def require_access(
     )
 
 
+def _require_approval_access_sync(
+    user_id: str | None,
+    conversation_id: str,
+    permission_store: PermissionStore | None,
+    conversation_store: ConversationStore,
+) -> None:
+    """Synchronous core of :func:`require_approval_access`."""
+    if permission_store is None:
+        return
+    if user_id is None:
+        raise OmnigentError("Authentication required", code=ErrorCode.UNAUTHORIZED)
+    if check_session_approval_access(
+        user_id, conversation_id, permission_store, conversation_store
+    ):
+        return
+    if check_session_access(user_id, conversation_id, 1, permission_store, conversation_store):
+        raise OmnigentError(
+            f"{user_id!r} needs delegated approval permission on session {conversation_id!r}",
+            code=ErrorCode.FORBIDDEN,
+        )
+    raise OmnigentError("Conversation not found", code=ErrorCode.NOT_FOUND)
+
+
+async def require_approval_access(
+    user_id: str | None,
+    conversation_id: str,
+    permission_store: PermissionStore | None,
+    conversation_store: ConversationStore,
+) -> None:
+    """Require owner or explicitly delegated approval authority."""
+    await asyncio.to_thread(
+        _require_approval_access_sync,
+        user_id,
+        conversation_id,
+        permission_store,
+        conversation_store,
+    )
+
+
+def _get_approval_access_sync(
+    user_id: str | None,
+    conversation_id: str,
+    permission_store: PermissionStore | None,
+    conversation_store: ConversationStore,
+) -> bool | None:
+    """Return effective approval authority without raising."""
+    if permission_store is None or user_id is None:
+        return None
+    return check_session_approval_access(
+        user_id,
+        conversation_id,
+        permission_store,
+        conversation_store,
+    )
+
+
+async def get_approval_access(
+    user_id: str | None,
+    conversation_id: str,
+    permission_store: PermissionStore | None,
+    conversation_store: ConversationStore,
+) -> bool | None:
+    """Return whether the user may accept privileged session actions."""
+    return await asyncio.to_thread(
+        _get_approval_access_sync,
+        user_id,
+        conversation_id,
+        permission_store,
+        conversation_store,
+    )
+
+
 def _get_permission_level_sync(
     user_id: str | None,
     conversation_id: str,
@@ -244,10 +318,13 @@ class SessionAccess:
         when permissions are disabled (no lookup happened) or for admins
         (who bypass the conversation lookup) — callers fall back to their
         own fetch in those cases.
+    :param can_approve: Whether the caller may accept privileged actions,
+        or ``None`` when permissions are disabled.
     """
 
     level: int | None
     conversation: Conversation | None
+    can_approve: bool | None
 
 
 def _require_access_and_level_sync(
@@ -283,7 +360,7 @@ def _require_access_and_level_sync(
         404 no access at all / conversation not found.
     """
     if permission_store is None:
-        return SessionAccess(level=None, conversation=None)
+        return SessionAccess(level=None, conversation=None, can_approve=None)
     if user_id is None:
         raise OmnigentError(
             "Authentication required",
@@ -301,7 +378,7 @@ def _require_access_and_level_sync(
     # conversation). A missing conversation is left for the snapshot builder
     # to 404 on, exactly as today.
     if access.is_admin:
-        return SessionAccess(level=level, conversation=None)
+        return SessionAccess(level=level, conversation=None, can_approve=True)
 
     conv = conversation_store.get_conversation(conversation_id)
     if conv is None:
@@ -326,7 +403,17 @@ def _require_access_and_level_sync(
             conversation_store,
         )
     if allowed:
-        return SessionAccess(level=level, conversation=conv)
+        can_approve = (
+            resolved_can_approve(access)
+            if conv.parent_conversation_id is None
+            else check_session_approval_access(
+                user_id,
+                conv.parent_conversation_id,
+                permission_store,
+                conversation_store,
+            )
+        )
+        return SessionAccess(level=level, conversation=conv, can_approve=can_approve)
 
     # Denied — distinguish "has some access but not enough" (403) from
     # "no access at all" (404, to avoid leaking session existence).

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -1000,6 +1000,20 @@ def _permission_level_from_grants(
     return None
 
 
+def _approval_access_from_grants(
+    user_id: str | None,
+    grants: list[SessionPermission],
+    is_admin: bool,
+) -> bool | None:
+    """Derive effective approval authority from pre-fetched grants."""
+    if user_id is None:
+        return None
+    if is_admin:
+        return True
+    user_grant = next((grant for grant in grants if grant.user_id == user_id), None)
+    return user_grant is not None and (user_grant.level >= LEVEL_OWNER or user_grant.can_approve)
+
+
 def _owner_from_grants(grants: list[SessionPermission]) -> str | None:
     """
     Find the session owner from a pre-fetched list of grants.
@@ -8484,6 +8498,7 @@ __all__ = [
     "_announce_session_added",
     "_apply_liveness_to_items",
     "_apply_pending_policy_ask_writes",
+    "_approval_access_from_grants",
     "_attachment_disposition",
     "_authorize_bundled_parent_and_inherit_runner",
     "_await_settled_managed_launch",

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -539,6 +539,11 @@ def _build_session_list_item(
     # only); assert for the type checker without a runtime branch.
     assert conv.agent_id is not None
     level = _permission_level_from_grants(user_id, grants, user_is_admin)
+    can_approve = (
+        _approval_access_from_grants(user_id, grants, user_is_admin)
+        if permissions_enabled
+        else None
+    )
     owner = _owner_from_grants(grants) if permissions_enabled else None
     # Per-viewer read tracking, embedded so the client hydrates the unread
     # dots straight from the list (no separate fetch). Built per-user here —
@@ -559,6 +564,7 @@ def _build_session_list_item(
         host_id=conv.host_id,
         reasoning_effort=conv.reasoning_effort,
         permission_level=level,
+        can_approve=can_approve,
         owner=owner,
         external_session_id=conv.external_session_id,
         # The persisted row count is a CROSS-REPLICA mirror: the replica
@@ -644,6 +650,7 @@ def _build_session_response(
     items: list[ConversationItem],
     status: Literal["idle", "running", "waiting", "failed"],
     permission_level: int | None = None,
+    can_approve: bool | None = None,
     background_task_count: int | None = None,
     llm_model: str | None = None,
     context_window: int | None = None,
@@ -678,6 +685,8 @@ def _build_session_response(
     :param permission_level: The requesting user's numeric level
         on this session (1=read, 2=edit, 3=manage), or ``None``
         when permissions are disabled.
+    :param can_approve: Whether the requesting user may accept
+        privileged actions, or ``None`` when permissions are disabled.
     :param runner_online: Session-scoped liveness for the bound
         runner/host, e.g. ``False`` for a dead tunneled runner.
         ``None`` when no lookup is wired.
@@ -765,6 +774,7 @@ def _build_session_response(
         reasoning_effort=conv.reasoning_effort,
         items=items,
         permission_level=permission_level,
+        can_approve=can_approve,
         sub_agent_name=conv.sub_agent_name,
         kind=conv.kind,
         parent_session_id=conv.parent_conversation_id,
@@ -6364,6 +6374,7 @@ async def _get_session_snapshot(
     conv_store: ConversationStore,
     session_id: str,
     permission_level: int | None = None,
+    can_approve: bool | None = None,
     agent_store: AgentStore | None = None,
     agent_cache: AgentCache | None = None,
     conversation: Conversation | None = None,
@@ -6388,6 +6399,8 @@ async def _get_session_snapshot(
         e.g. ``"conv_abc123"``.
     :param permission_level: The requesting user's numeric level
         on this session, or ``None`` when permissions are disabled.
+    :param can_approve: Whether the requesting user may accept
+        privileged actions, or ``None`` when permissions are disabled.
     :param agent_store: Optional agent store used to look up the
         bound agent's bundle location. ``None`` in legacy call sites
         that don't yet pass it.
@@ -6619,6 +6632,7 @@ async def _get_session_snapshot(
         items,
         status,
         permission_level,
+        can_approve,
         background_task_count=_session_background_task_count_cache.get(session_id),
         llm_model=llm_model,
         context_window=context_window,

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -74,6 +74,9 @@ from omnigent.server.background_session_titles import (
 from omnigent.server.host_registry import HostRegistry, RunnerExitReports
 from omnigent.server.permissions import check_session_access
 from omnigent.server.routes._auth_helpers import (
+    get_approval_access as _get_approval_access,
+)
+from omnigent.server.routes._auth_helpers import (
     get_permission_level as _get_permission_level,
 )
 from omnigent.server.routes._auth_helpers import (
@@ -294,6 +297,7 @@ def register_core_routes(
             await asyncio.to_thread(permission_store.ensure_user, user_id)
             await asyncio.to_thread(permission_store.grant, user_id, resp.id, LEVEL_OWNER)
             resp.permission_level = await _get_permission_level(user_id, resp.id, permission_store)
+            resp.can_approve = True
         # Push the new session to this user's other open tabs (see the
         # multipart path above for the rationale).
         _announce_session_added(user_id, resp.id)
@@ -683,6 +687,7 @@ def register_core_routes(
             conversation_store,
             session_id,
             access.level,
+            access.can_approve,
             agent_store,
             agent_cache,
             conversation=access.conversation,
@@ -1832,11 +1837,20 @@ def register_core_routes(
                 )
                 if not filed:
                     raise _session_not_found()
-        level = await _get_permission_level(user_id, session_id, permission_store)
+        level, can_approve = await asyncio.gather(
+            _get_permission_level(user_id, session_id, permission_store),
+            _get_approval_access(
+                user_id,
+                session_id,
+                permission_store,
+                conversation_store,
+            ),
+        )
         return await _get_session_snapshot(
             conversation_store,
             session_id,
             level,
+            can_approve,
             agent_store,
             agent_cache,
             liveness_lookup=liveness_lookup,
@@ -2049,6 +2063,7 @@ def register_core_routes(
             fork_items.data,
             "idle",
             permission_level=level,
+            can_approve=True if permission_store is not None else None,
             last_task_error=None,
             agent_name=base_agent.name,
         )
@@ -2266,12 +2281,21 @@ def register_core_routes(
         background_tasks.add_task(_reset_runner_resources_after_switch, session_id)
 
         items = await asyncio.to_thread(conversation_store.list_items, session_id, limit=10000)
-        level = await _get_permission_level(user_id, session_id, permission_store)
+        level, can_approve = await asyncio.gather(
+            _get_permission_level(user_id, session_id, permission_store),
+            _get_approval_access(
+                user_id,
+                session_id,
+                permission_store,
+                conversation_store,
+            ),
+        )
         return _build_session_response(
             updated,
             items.data,
             "idle",
             permission_level=level,
+            can_approve=can_approve,
             last_task_error=None,
             agent_name=target_agent.name,
         )

--- a/omnigent/server/routes/sessions/routes_elicitations.py
+++ b/omnigent/server/routes/sessions/routes_elicitations.py
@@ -25,7 +25,6 @@ from omnigent.server._elicitation_registry import (
 )
 from omnigent.server.auth import (
     LEVEL_EDIT,
-    LEVEL_OWNER,
     AuthProvider,
 )
 from omnigent.server.routes._auth_helpers import (
@@ -33,6 +32,9 @@ from omnigent.server.routes._auth_helpers import (
 )
 from omnigent.server.routes._auth_helpers import (
     require_access_and_level as _require_access_and_level,
+)
+from omnigent.server.routes._auth_helpers import (
+    require_approval_access as _require_approval_access,
 )
 from omnigent.server.routes._errors import session_not_found as _session_not_found
 from omnigent.server.routes._sessions.common import *
@@ -92,7 +94,7 @@ def register_elicitations_routes(
         The ``elicitation_id`` is taken from the URL rather than the
         body, so the unguessable id (``secrets.token_hex(16)``) is
         the capability scoping the resolution — combined with the
-        session-owner ``LEVEL_OWNER`` gate below and the server-side
+        delegated approval gate below and the server-side
         ownership check inside :func:`_resolve_elicitation`.
 
         :param request: The inbound request, used for identity
@@ -110,14 +112,27 @@ def register_elicitations_routes(
         :raises OmnigentError: 404 if no session exists.
         """
         user_id = _get_user_id(request, auth_provider)
-        access = await _require_access_and_level(
-            user_id, session_id, LEVEL_OWNER, permission_store, conversation_store
+        if body.action == "accept":
+            await _require_approval_access(
+                user_id, session_id, permission_store, conversation_store
+            )
+        else:
+            await _require_access_and_level(
+                user_id,
+                session_id,
+                LEVEL_EDIT,
+                permission_store,
+                conversation_store,
+            )
+        _logger.info(
+            "approval verdict submitted: session=%s actor=%s action=%s",
+            session_id,
+            user_id,
+            body.action,
         )
-        conv = access.conversation
+        conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
         if conv is None:
-            conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
-            if conv is None:
-                raise _session_not_found()
+            raise _session_not_found()
         _resolve_data = {"elicitation_id": elicitation_id, **body.model_dump(exclude_none=True)}
         await _resolve_elicitation(session_id, _resolve_data, runner_router, conversation_store)
         # Apply any policy writes deferred by the relay tool-call ASK gate
@@ -176,6 +191,7 @@ def register_elicitations_routes(
         params = event.get("params") if isinstance(event.get("params"), dict) else {}
         return {
             "status": "pending",
+            "can_approve": access.can_approve,
             "message": params.get("message", "Approval required"),
             "phase": params.get("phase", ""),
             "policy_name": params.get("policy_name", ""),

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -65,6 +65,9 @@ from omnigent.server.routes._auth_helpers import (
     require_access_and_level as _require_access_and_level,
 )
 from omnigent.server.routes._auth_helpers import (
+    require_approval_access as _require_approval_access,
+)
+from omnigent.server.routes._auth_helpers import (
     require_user as _require_user,
 )
 from omnigent.server.routes._errors import session_not_found as _session_not_found
@@ -568,10 +571,19 @@ def register_events_routes(
                 pass
             return {"queued": False}
         if body.type == _APPROVAL_TYPE:
-            # Approval authorizes a tool to run with the session owner's
-            # execution identity, so shared editors may not resolve it.
-            await _require_access(
-                user_id, session_id, LEVEL_OWNER, permission_store, conversation_store
+            # Accepting authorizes a tool to run with the session owner's
+            # execution identity, so authority must be explicitly delegated.
+            # Editors may still decline/cancel to stop an unsafe or unwanted
+            # action; the route-level edit gate above already authorizes that.
+            if body.data.get("action") not in {"decline", "cancel"}:
+                await _require_approval_access(
+                    user_id, session_id, permission_store, conversation_store
+                )
+            _logger.info(
+                "approval verdict submitted: session=%s actor=%s action=%s",
+                session_id,
+                user_id,
+                body.data.get("action"),
             )
             # Deliver the verdict through the shared resolver: it
             # sets any server-side harness Future (owner-checked),

--- a/omnigent/server/routes/sessions/routes_permissions.py
+++ b/omnigent/server/routes/sessions/routes_permissions.py
@@ -26,6 +26,7 @@ from omnigent.server._elicitation_registry import (
     _PreResolvedHarnessElicitation,
 )
 from omnigent.server.auth import (
+    LEVEL_EDIT,
     LEVEL_MANAGE,
     LEVEL_OWNER,
     LEVEL_READ,
@@ -127,9 +128,8 @@ def register_permissions_routes(
                     "cannot be shared on this Omnigent server.",
                     code=ErrorCode.FORBIDDEN,
                 )
-        if (
-            _sharing_mode in (SharingMode.READ_ONLY, SharingMode.RESTRICTED_READ_ONLY)
-            and body.level > LEVEL_READ
+        if _sharing_mode in (SharingMode.READ_ONLY, SharingMode.RESTRICTED_READ_ONLY) and (
+            body.level > LEVEL_READ or body.can_approve is True
         ):
             raise OmnigentError(
                 "Sharing is limited to read-only access on this Omnigent server.",
@@ -166,9 +166,35 @@ def register_permissions_routes(
                 "Cannot modify owner permissions",
                 code=ErrorCode.FORBIDDEN,
             )
+        can_approve = (
+            existing.can_approve
+            if body.can_approve is None and existing is not None
+            else bool(body.can_approve)
+        )
+        if can_approve and body.level < LEVEL_EDIT:
+            raise OmnigentError(
+                "Approval delegation requires edit access",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        if body.user_id == RESERVED_USER_PUBLIC and can_approve:
+            raise OmnigentError(
+                "Public access cannot approve privileged actions",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        approval_capability_changed = (
+            existing.can_approve if existing is not None else False
+        ) != can_approve
+        if approval_capability_changed:
+            await _require_access(
+                user_id, session_id, LEVEL_OWNER, permission_store, conversation_store
+            )
         await asyncio.to_thread(permission_store.ensure_user, body.user_id)
         perm = await asyncio.to_thread(
-            permission_store.grant, body.user_id, session_id, body.level
+            permission_store.grant,
+            body.user_id,
+            session_id,
+            body.level,
+            can_approve=can_approve,
         )
         # Push the now-shared session to the GRANTEE's open tabs so it
         # appears in their sidebar without a list poll.
@@ -177,6 +203,7 @@ def register_permissions_routes(
             user_id=perm.user_id,
             conversation_id=perm.conversation_id,
             level=perm.level,
+            can_approve=perm.can_approve,
         )
 
     @router.delete(
@@ -291,6 +318,7 @@ def register_permissions_routes(
                     user_id=g.user_id,
                     conversation_id=g.conversation_id,
                     level=g.level,
+                    can_approve=g.can_approve,
                 )
                 for g in grants
             ],

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1666,6 +1666,9 @@ class SessionResponse(BaseModel):
         permission level on this session: ``1`` = read, ``2`` =
         edit, ``3`` = manage. ``None`` when permissions are
         disabled (single-user mode without a permission store).
+    :param can_approve: Whether the requesting user may accept
+        privileged actions for this session. ``None`` when permissions
+        are disabled.
     :param llm_model: The LLM model identifier from the bound
         agent's spec, e.g. ``"anthropic/claude-sonnet-4-6"``.
         ``None`` when the agent has no explicit ``llm:`` block or
@@ -1828,6 +1831,7 @@ class SessionResponse(BaseModel):
     reasoning_effort: str | None = None
     items: list[ConversationItem] = Field(default_factory=list)
     permission_level: int | None = None
+    can_approve: bool | None = None
     sub_agent_name: str | None = None
     kind: str = "default"
     parent_session_id: str | None = None
@@ -2208,6 +2212,9 @@ class SessionListItem(BaseModel):
         permission level on this session: ``1`` = read, ``2`` =
         edit, ``3`` = manage. ``None`` when permissions are
         disabled.
+    :param can_approve: Whether the requesting user may accept
+        privileged actions for this session. ``None`` when permissions
+        are disabled.
     :param owner: The user_id of the session owner, or ``None``
         when permissions are disabled. Included so the sidebar
         can display the owner without a separate API call.
@@ -2287,6 +2294,7 @@ class SessionListItem(BaseModel):
     host_online: bool | None = None
     reasoning_effort: str | None = None
     permission_level: int | None = None
+    can_approve: bool | None = None
     owner: str | None = None
     external_session_id: str | None = None
     pending_elicitations_count: int = 0
@@ -2408,10 +2416,13 @@ class GrantPermissionRequest(BaseModel):
         read access.
     :param level: Numeric permission level: ``1`` = read,
         ``2`` = edit, ``3`` = manage.
+    :param can_approve: Whether the owner delegates privileged-action
+        approval authority to this user.
     """
 
     user_id: str
     level: int = Field(ge=1, le=3)
+    can_approve: bool | None = None
 
 
 class PermissionObject(BaseModel):
@@ -2423,11 +2434,13 @@ class PermissionObject(BaseModel):
         ``"conv_abc123"``.
     :param level: Numeric permission level (1=read, 2=edit,
         3=manage).
+    :param can_approve: Whether this grantee may approve privileged actions.
     """
 
     user_id: str
     conversation_id: str
     level: int
+    can_approve: bool = False
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/omnigent/stores/permission_store/__init__.py
+++ b/omnigent/stores/permission_store/__init__.py
@@ -1,8 +1,8 @@
 """Permission store — manages session-level access grants.
 
-Each grant is a ``(user_id, conversation_id, level)`` triple where
-level is an integer: 1=read, 2=edit, 3=manage. The ``"__public__"``
-sentinel user ID represents public read access.
+Each grant carries a numeric access level plus an independent, owner-controlled
+approval capability. The ``"__public__"`` sentinel user ID represents public
+read access and can never approve privileged actions.
 """
 
 from abc import ABC, abstractmethod
@@ -32,6 +32,8 @@ class PermissionStore(ABC):
         user_id: str,
         conversation_id: str,
         level: int,
+        *,
+        can_approve: bool = False,
     ) -> SessionPermission:
         """Upsert a permission grant.
 
@@ -46,6 +48,8 @@ class PermissionStore(ABC):
             e.g. ``"conv_abc123"``.
         :param level: Numeric permission level (1=read, 2=edit,
             3=manage).
+        :param can_approve: Whether the session owner delegated approval
+            authority to the grantee.
         :returns: The resulting :class:`SessionPermission`.
         """
         ...

--- a/omnigent/stores/permission_store/sqlalchemy_store.py
+++ b/omnigent/stores/permission_store/sqlalchemy_store.py
@@ -50,6 +50,7 @@ def _to_entity(row: SqlSessionPermission) -> SessionPermission:
         user_id=row.user_id,
         conversation_id=row.conversation_id,
         level=row.level,
+        can_approve=row.can_approve,
     )
 
 
@@ -77,6 +78,8 @@ class SqlAlchemyPermissionStore(PermissionStore):
         user_id: str,
         conversation_id: str,
         level: int,
+        *,
+        can_approve: bool = False,
     ) -> SessionPermission:
         """Upsert a permission grant. See base class for contract."""
         with self._session() as session:
@@ -85,6 +88,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
                 "user_id": user_id,
                 "conversation_id": conversation_id,
                 "level": level,
+                "can_approve": can_approve,
             }
             if dialect == "sqlite":
                 stmt = (
@@ -92,14 +96,14 @@ class SqlAlchemyPermissionStore(PermissionStore):
                     .values(**values)
                     .on_conflict_do_update(
                         index_elements=["workspace_id", "user_id", "conversation_id"],
-                        set_={"level": level},
+                        set_={"level": level, "can_approve": can_approve},
                     )
                 )
             elif dialect == "mysql":
                 stmt = (
                     mysql_insert(SqlSessionPermission)
                     .values(**values)
-                    .on_duplicate_key_update(level=level)
+                    .on_duplicate_key_update(level=level, can_approve=can_approve)
                 )
             else:
                 stmt = (
@@ -107,7 +111,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
                     .values(**values)
                     .on_conflict_do_update(
                         index_elements=["workspace_id", "user_id", "conversation_id"],
-                        set_={"level": level},
+                        set_={"level": level, "can_approve": can_approve},
                     )
                 )
             session.execute(stmt)
@@ -116,6 +120,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
                 user_id=user_id,
                 conversation_id=conversation_id,
                 level=level,
+                can_approve=can_approve,
             )
 
     def revoke(self, user_id: str, conversation_id: str) -> bool:
@@ -390,6 +395,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
                 is_admin=False,
                 user_grant_level=None,
                 public_grant_level=None,
+                user_can_approve=False,
             )
         # One session = one connection checkout + transaction. Against a
         # remote DB (Lakebase) this is the round-trip that matters; the three
@@ -410,6 +416,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
                 is_admin=user_row is not None and user_row.is_admin,
                 user_grant_level=user_grant.level if user_grant is not None else None,
                 public_grant_level=public_grant.level if public_grant is not None else None,
+                user_can_approve=(user_grant.can_approve if user_grant is not None else False),
             )
 
     def has_any_grants(self, conversation_id: str) -> bool:

--- a/openapi.json
+++ b/openapi.json
@@ -1646,6 +1646,18 @@
       "GrantPermissionRequest": {
         "description": "Request body for `PUT /v1/sessions/{id}/permissions`.",
         "properties": {
+          "can_approve": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Whether the owner delegates privileged-action approval authority to this user.",
+            "title": "Can Approve"
+          },
           "level": {
             "description": "Numeric permission level: `1` = read, `2` = edit, `3` = manage.",
             "maximum": 3.0,
@@ -2515,6 +2527,12 @@
       "PermissionObject": {
         "description": "API representation of a session permission grant.",
         "properties": {
+          "can_approve": {
+            "default": false,
+            "description": "Whether this grantee may approve privileged actions.",
+            "title": "Can Approve",
+            "type": "boolean"
+          },
           "conversation_id": {
             "description": "The session, e.g. `\"conv_abc123\"`.",
             "title": "Conversation Id",
@@ -4094,6 +4112,18 @@
             "title": "Archived",
             "type": "boolean"
           },
+          "can_approve": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Whether the requesting user may accept privileged actions for this session. `None` when permissions are disabled.",
+            "title": "Can Approve"
+          },
           "comments_count": {
             "default": 0,
             "description": "Total number of review comments (any status) on this session. Together with `comments_updated_at` it forms a change fingerprint: an add or edit bumps the timestamp, a delete changes the count, so the web client can invalidate its cached comment list when either field changes in a `WS /v1/sessions/updates` frame. `0` when the session has no comments or the server has no comment store wired.",
@@ -4822,6 +4852,18 @@
             ],
             "description": "Background shells (claude-native) still running as of the last status edge, so a reload re-shows \"N shells still running\" even though the session has settled to `\"idle\"`. `None` (the default / omitted) when no shells are tracked.",
             "title": "Background Task Count"
+          },
+          "can_approve": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Whether the requesting user may accept privileged actions for this session. `None` when permissions are disabled.",
+            "title": "Can Approve"
           },
           "context_window": {
             "anyOf": [

--- a/tests/e2e_ui/collaboration/test_permissions_modal.py
+++ b/tests/e2e_ui/collaboration/test_permissions_modal.py
@@ -9,16 +9,18 @@ button, the add-user grant form, the per-row level select, and revoke —
 and pins each one against the server's ``/permissions`` state so a
 silently-broken control can't pass.
 
-Single owner identity (the headerless ``local`` user, same as every other
-e2e_ui context), so no second browser is needed: every assertion is on the
-owner's own modal plus a REST read-back. No agent run — the modal only
-needs a session to exist.
+The modal-control test uses one owner identity and REST read-backs. The
+approval-control test opens the same session as a shared editor and parks a
+real permission hook, proving the editor can reject but cannot approve until
+the owner delegates that capability. No agent run is needed.
 """
 
 from __future__ import annotations
 
 import re
+import threading
 import time
+import uuid
 from collections.abc import Callable, Iterator
 
 import httpx
@@ -36,6 +38,7 @@ from tests.e2e_ui.collaboration._multi_user_server import (
 _PUBLIC_USER = "__public__"
 _LEVEL_READ = 1
 _LEVEL_EDIT = 2
+_APPROVAL_CARD = '[data-testid="approval-card"]'
 
 
 @pytest.fixture(scope="module")
@@ -55,8 +58,8 @@ def _admin_page(browser: Browser) -> Page:
     return context.new_page()
 
 
-def _permissions(base_url: str, session_id: str) -> dict[str, int]:
-    """Read the session's grants as a ``{user_id: level}`` map (admin view).
+def _permission(base_url: str, session_id: str, user_id: str) -> tuple[int, bool] | None:
+    """Read one session grant as ``(level, can_approve)`` (admin view).
 
     The multi-user server 401s headerless reads, so this authenticates as the
     admin identity the browser also uses.
@@ -67,7 +70,106 @@ def _permissions(base_url: str, session_id: str) -> dict[str, int]:
         timeout=10.0,
     )
     resp.raise_for_status()
-    return {p["user_id"]: p["level"] for p in resp.json()["permissions"]}
+    for permission in resp.json()["permissions"]:
+        if permission["user_id"] == user_id:
+            return permission["level"], permission["can_approve"]
+    return None
+
+
+def _grant_editor(
+    server: MultiUserServer,
+    user_id: str,
+    *,
+    can_approve: bool,
+) -> None:
+    """Grant edit access, optionally with delegated approval authority."""
+    resp = httpx.put(
+        f"{server.base_url}/v1/sessions/{server.session_id}/permissions",
+        json={"user_id": user_id, "level": _LEVEL_EDIT, "can_approve": can_approve},
+        headers={"X-Forwarded-Email": ADMIN_EMAIL},
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+
+
+def _pending_elicitation_ids(server: MultiUserServer) -> set[str]:
+    """Return pending elicitation ids from the admin-visible snapshot."""
+    resp = httpx.get(
+        f"{server.base_url}/v1/sessions/{server.session_id}",
+        headers={"X-Forwarded-Email": ADMIN_EMAIL},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    return {
+        item["elicitation_id"]
+        for item in resp.json().get("pending_elicitations") or []
+        if isinstance(item.get("elicitation_id"), str)
+    }
+
+
+def _park_permission_hook(
+    server: MultiUserServer,
+    elicitation_id: str,
+    sink: dict,
+) -> None:
+    """Park a real Claude permission hook and record its eventual verdict."""
+    try:
+        sink["response"] = httpx.post(
+            f"{server.base_url}/v1/sessions/{server.session_id}/hooks/permission-request",
+            json={
+                "session_id": "claude_e2e_shared",
+                "transcript_path": "/tmp/transcript.jsonl",
+                "cwd": "/tmp",
+                "permission_mode": "default",
+                "hook_event_name": "PermissionRequest",
+                "tool_name": "Bash",
+                "tool_input": {"command": "git push origin main"},
+                "tool_use_id": "tool_use_shared_e2e",
+                "_omnigent_elicitation_id": elicitation_id,
+            },
+            headers={"X-Forwarded-Email": ADMIN_EMAIL},
+            timeout=120.0,
+        )
+    except Exception as exc:
+        sink["error"] = exc
+
+
+def _start_permission_hook(
+    server: MultiUserServer,
+    elicitation_id: str,
+) -> dict:
+    """Start a hook worker and wait until its approval card is parked."""
+    sink: dict = {}
+    worker = threading.Thread(
+        target=_park_permission_hook,
+        args=(server, elicitation_id, sink),
+        daemon=True,
+    )
+    sink["worker"] = worker
+    worker.start()
+    _wait_for(lambda: elicitation_id in _pending_elicitation_ids(server))
+    return sink
+
+
+def _assert_hook_verdict(sink: dict, expected: str) -> None:
+    """Wait for a parked hook and assert its Claude allow/deny verdict."""
+    sink["worker"].join(timeout=30.0)
+    assert not sink["worker"].is_alive(), "permission hook did not receive the UI verdict"
+    assert "error" not in sink, f"permission hook failed: {sink.get('error')!r}"
+    response = sink["response"]
+    assert response.status_code == 200, response.text
+    decision = response.json()["hookSpecificOutput"]["decision"]
+    assert decision["behavior"] == expected
+
+
+def _resolve_for_cleanup(server: MultiUserServer, elicitation_id: str) -> None:
+    """Best-effort decline so a failed assertion cannot strand a hook worker."""
+    httpx.post(
+        f"{server.base_url}/v1/sessions/{server.session_id}/elicitations/{elicitation_id}/resolve",
+        json={"action": "decline"},
+        headers={"X-Forwarded-Email": ADMIN_EMAIL},
+        timeout=10.0,
+    )
 
 
 def _wait_for(
@@ -161,7 +263,7 @@ def test_permissions_modal_controls_drive_server_state(
     browser: Browser,
     multi_user_server: MultiUserServer,
 ) -> None:
-    """Public toggle, copy-link, grant, level-change and revoke all work.
+    """Public toggle, copy-link, grant, approval delegation and revoke all work.
 
     Walks the whole modal surface in one session so each control is
     pinned against the ``/permissions`` REST state it mutates. Runs on a
@@ -182,12 +284,12 @@ def test_permissions_modal_controls_drive_server_state(
     # ── Public access switch: off → on creates a __public__ grant ────
     public_switch = dialog.get_by_role("switch")
     expect(public_switch).not_to_be_checked()
-    assert _PUBLIC_USER not in _permissions(base_url, session_id)
+    assert _permission(base_url, session_id, _PUBLIC_USER) is None
     public_switch.click()
     expect(public_switch).to_be_checked()
     # The grant lands server-side (poll briefly: the toggle fires an async
     # mutation, so the REST read can race the optimistic UI flip).
-    _wait_for(lambda: _permissions(base_url, session_id).get(_PUBLIC_USER) == _LEVEL_READ)
+    _wait_for(lambda: _permission(base_url, session_id, _PUBLIC_USER) == (_LEVEL_READ, False))
 
     # ── Copy link: writes a shareable, session-scoped URL ────────────
     dialog.get_by_role("button", name="Copy link").click()
@@ -203,18 +305,84 @@ def test_permissions_modal_controls_drive_server_state(
     dialog.get_by_role("button", name="Grant").click()
     # The new row renders the grantee and the REST state agrees at Read.
     expect(dialog.get_by_title(grantee)).to_be_visible()
-    _wait_for(lambda: _permissions(base_url, session_id).get(grantee) == _LEVEL_READ)
+    _wait_for(lambda: _permission(base_url, session_id, grantee) == (_LEVEL_READ, False))
 
-    # ── Change that user's level Read → Edit via the row select ──────
+    # ── Delegate approval: Read → Edit + approve ─────────────────────
+    expect(
+        dialog.get_by_text("Approvers can authorize actions that use your session credentials.")
+    ).to_be_visible()
     level_select = dialog.get_by_role("combobox", name=f"Permission level for {grantee}")
     level_select.click()
-    page.get_by_role("option", name="Edit").click()
-    _wait_for(lambda: _permissions(base_url, session_id).get(grantee) == _LEVEL_EDIT)
+    page.get_by_role("option", name="Edit + approve", exact=True).click()
+    expect(level_select).to_contain_text("Edit + approve")
+    _wait_for(lambda: _permission(base_url, session_id, grantee) == (_LEVEL_EDIT, True))
+
+    # ── Remove approval authority while retaining Edit access ────────
+    level_select.click()
+    page.get_by_role("option", name="Edit", exact=True).click()
+    expect(level_select).to_contain_text("Edit")
+    _wait_for(lambda: _permission(base_url, session_id, grantee) == (_LEVEL_EDIT, False))
 
     # ── Revoke the user: row disappears, grant is gone server-side ───
     dialog.get_by_role("button", name="Revoke").click()
     expect(dialog.get_by_title(grantee)).to_have_count(0)
-    _wait_for(lambda: grantee not in _permissions(base_url, session_id))
+    _wait_for(lambda: _permission(base_url, session_id, grantee) is None)
+
+
+def test_shared_editor_can_reject_but_needs_delegation_to_approve(
+    browser: Browser,
+    multi_user_server: MultiUserServer,
+) -> None:
+    """Approval controls follow the viewer's effective delegated capability."""
+    server = multi_user_server
+    editor = f"editor-{uuid.uuid4().hex[:8]}@ui.test"
+    _grant_editor(server, editor, can_approve=False)
+
+    context = browser.new_context(extra_http_headers={"X-Forwarded-Email": editor})
+    page = context.new_page()
+    elicitation_ids: list[str] = []
+    sinks: list[dict] = []
+    try:
+        # A plain editor may stop the owner's pending action, but cannot
+        # authorize it to run with the owner's session credentials.
+        editor_elicitation = f"elicit_claude_{uuid.uuid4().hex}"
+        elicitation_ids.append(editor_elicitation)
+        sinks.append(_start_permission_hook(server, editor_elicitation))
+        page.goto(f"{server.public_url}/c/{server.session_id}")
+
+        card = page.locator(f'{_APPROVAL_CARD}[data-state="pending"]').first
+        expect(card).to_be_visible(timeout=30_000)
+        expect(card.get_by_role("note")).to_contain_text("delegated approver")
+        expect(card.get_by_role("button", name="Approve", exact=True)).to_be_disabled()
+        reject = card.get_by_role("button", name="Reject", exact=True)
+        expect(reject).to_be_enabled()
+        reject.click()
+        _assert_hook_verdict(sinks[-1], "deny")
+        _wait_for(lambda: editor_elicitation not in _pending_elicitation_ids(server))
+
+        # Once the owner delegates approval authority, a fresh snapshot makes
+        # the same editor's Approve control actionable for the next prompt.
+        _grant_editor(server, editor, can_approve=True)
+        delegated_elicitation = f"elicit_claude_{uuid.uuid4().hex}"
+        elicitation_ids.append(delegated_elicitation)
+        sinks.append(_start_permission_hook(server, delegated_elicitation))
+        page.reload()
+
+        delegated_card = page.locator(f'{_APPROVAL_CARD}[data-state="pending"]').first
+        expect(delegated_card).to_be_visible(timeout=30_000)
+        expect(delegated_card.get_by_role("note")).to_have_count(0)
+        approve = delegated_card.get_by_role("button", name="Approve", exact=True)
+        expect(approve).to_be_enabled()
+        expect(delegated_card.get_by_role("button", name="Reject", exact=True)).to_be_enabled()
+        approve.click()
+        _assert_hook_verdict(sinks[-1], "allow")
+        _wait_for(lambda: delegated_elicitation not in _pending_elicitation_ids(server))
+    finally:
+        for elicitation_id in elicitation_ids:
+            _resolve_for_cleanup(server, elicitation_id)
+        for sink in sinks:
+            sink["worker"].join(timeout=10.0)
+        context.close()
 
 
 def test_share_modal_qr_code_opens_mobile_deep_link(

--- a/tests/server/integration/test_sessions_elicitation_resolve_url.py
+++ b/tests/server/integration/test_sessions_elicitation_resolve_url.py
@@ -1338,15 +1338,14 @@ async def test_resolve_url_cross_user_forbidden(
     auth_client: httpx.AsyncClient,
 ) -> None:
     """
-    A shared editor cannot reach the resolve endpoint when auth is
-    active.
+    A shared editor needs explicit approval delegation.
 
     Alice owns the session and grants Bob edit access. Bob's POST to
-    its resolve URL is rejected by the ``LEVEL_OWNER`` access gate
-    before any resolution runs. The
+    its resolve URL is initially rejected before any resolution runs. The
     unguessable elicitation id is a capability, but session-owner
-    access control is the outer fence — edit access must not authorize
-    tools that execute with Alice's credentials.
+    delegation is the outer fence — edit access alone must not authorize
+    tools that execute with Alice's credentials. Alice can then delegate
+    that authority explicitly.
     """
     agent = await create_test_agent(auth_client, user="alice@example.com")
     session_id = await _create_session(auth_client, agent["id"], user="alice@example.com")
@@ -1363,6 +1362,27 @@ async def test_resolve_url_cross_user_forbidden(
         headers={"X-Forwarded-Email": "bob@example.com"},
     )
     assert resp.status_code == 403, resp.text
+
+    decline = await auth_client.post(
+        f"/v1/sessions/{session_id}/elicitations/elicit_decline/resolve",
+        json={"action": "decline"},
+        headers={"X-Forwarded-Email": "bob@example.com"},
+    )
+    assert decline.status_code == 202, decline.text
+
+    delegated = await auth_client.put(
+        f"/v1/sessions/{session_id}/permissions",
+        json={"user_id": "bob@example.com", "level": LEVEL_EDIT, "can_approve": True},
+        headers={"X-Forwarded-Email": "alice@example.com"},
+    )
+    assert delegated.status_code == 200, delegated.text
+
+    resp = await auth_client.post(
+        f"/v1/sessions/{session_id}/elicitations/elicit_whatever/resolve",
+        json={"action": "accept"},
+        headers={"X-Forwarded-Email": "bob@example.com"},
+    )
+    assert resp.status_code == 202, resp.text
 
 
 # ── GET /sessions/{id}/elicitations/{eid} (approval page) ────

--- a/tests/server/integration/test_sessions_permissions.py
+++ b/tests/server/integration/test_sessions_permissions.py
@@ -317,6 +317,7 @@ async def _grant_permission(
     granter: str,
     target_user: str,
     level: int,
+    can_approve: bool | None = None,
 ) -> httpx.Response:
     """Grant a permission on a session.
 
@@ -325,11 +326,15 @@ async def _grant_permission(
     :param granter: User identity of the granter.
     :param target_user: User to receive the grant.
     :param level: Numeric permission level (1/2/3).
+    :param can_approve: Optional delegated approval capability.
     :returns: The raw httpx response.
     """
+    body: dict[str, Any] = {"user_id": target_user, "level": level}
+    if can_approve is not None:
+        body["can_approve"] = can_approve
     return await client.put(
         f"/v1/sessions/{session_id}/permissions",
-        json={"user_id": target_user, "level": level},
+        json=body,
         headers={"X-Forwarded-Email": granter},
     )
 
@@ -734,10 +739,10 @@ async def test_edit_grant_allows_post_but_blocks_permission_management(
     )
 
 
-async def test_edit_grant_cannot_resolve_approval_event(
+async def test_owner_can_delegate_approval_event_authority(
     auth_client: httpx.AsyncClient,
 ) -> None:
-    """Only the owner may approve tools that run with owner credentials."""
+    """Editors need an explicit owner grant before approving owner-run tools."""
     agent = await create_test_agent(auth_client, user="bryan")
     session = await _create_session_as(auth_client, agent["id"], "user-a")
     session_id = session["id"]
@@ -761,12 +766,104 @@ async def test_edit_grant_cannot_resolve_approval_event(
     )
     assert editor_response.status_code == 403, editor_response.text
 
+    editor_snapshot = await auth_client.get(
+        f"/v1/sessions/{session_id}",
+        headers={"X-Forwarded-Email": "user-b"},
+    )
+    assert editor_snapshot.status_code == 200, editor_snapshot.text
+    assert editor_snapshot.json()["can_approve"] is False
+    editor_rows = await _list_sessions_as(auth_client, "user-b")
+    assert next(row for row in editor_rows if row["id"] == session_id)["can_approve"] is False
+
+    decline_response = await auth_client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={
+            "type": "approval",
+            "data": {"elicitation_id": "elicit_decline", "action": "decline"},
+        },
+        headers={"X-Forwarded-Email": "user-b"},
+    )
+    assert decline_response.status_code == 202, decline_response.text
+
+    delegated_grant = await _grant_permission(
+        auth_client,
+        session_id,
+        granter="user-a",
+        target_user="user-b",
+        level=LEVEL_EDIT,
+        can_approve=True,
+    )
+    assert delegated_grant.status_code == 200, delegated_grant.text
+    assert delegated_grant.json()["can_approve"] is True
+
+    delegated_snapshot = await auth_client.get(
+        f"/v1/sessions/{session_id}",
+        headers={"X-Forwarded-Email": "user-b"},
+    )
+    assert delegated_snapshot.status_code == 200, delegated_snapshot.text
+    assert delegated_snapshot.json()["can_approve"] is True
+    delegated_rows = await _list_sessions_as(auth_client, "user-b")
+    assert next(row for row in delegated_rows if row["id"] == session_id)["can_approve"] is True
+
+    delegated_response = await auth_client.post(
+        f"/v1/sessions/{session_id}/events",
+        json=approval,
+        headers={"X-Forwarded-Email": "user-b"},
+    )
+    assert delegated_response.status_code == 202, delegated_response.text
+
+    revoked_grant = await _grant_permission(
+        auth_client,
+        session_id,
+        granter="user-a",
+        target_user="user-b",
+        level=LEVEL_EDIT,
+        can_approve=False,
+    )
+    assert revoked_grant.status_code == 200, revoked_grant.text
+    assert revoked_grant.json()["can_approve"] is False
+
+    revoked_response = await auth_client.post(
+        f"/v1/sessions/{session_id}/events",
+        json=approval,
+        headers={"X-Forwarded-Email": "user-b"},
+    )
+    assert revoked_response.status_code == 403, revoked_response.text
+
     owner_response = await auth_client.post(
         f"/v1/sessions/{session_id}/events",
         json=approval,
         headers={"X-Forwarded-Email": "user-a"},
     )
     assert owner_response.status_code == 202, owner_response.text
+
+
+async def test_manager_cannot_delegate_approval_authority(
+    auth_client: httpx.AsyncClient,
+) -> None:
+    """Sharing managers cannot grant authority over owner credentials."""
+    agent = await create_test_agent(auth_client, user="bryan")
+    session = await _create_session_as(auth_client, agent["id"], "user-a")
+    session_id = session["id"]
+    manager_grant = await _grant_permission(
+        auth_client,
+        session_id,
+        granter="user-a",
+        target_user="user-b",
+        level=LEVEL_MANAGE,
+    )
+    assert manager_grant.status_code == 200
+
+    response = await _grant_permission(
+        auth_client,
+        session_id,
+        granter="user-b",
+        target_user="user-c",
+        level=LEVEL_EDIT,
+        can_approve=True,
+    )
+
+    assert response.status_code == 403, response.text
 
 
 async def test_archive_requires_owner_access(

--- a/tests/server/routes/test_auth_helpers.py
+++ b/tests/server/routes/test_auth_helpers.py
@@ -73,6 +73,7 @@ async def test_owner_gets_level_and_conversation(
         "the conversation must be returned so the snapshot can reuse it"
     )
     assert access.conversation.id == conv.id
+    assert access.can_approve is True
 
 
 @pytest.mark.asyncio
@@ -129,6 +130,7 @@ async def test_admin_allowed_and_bypasses_conversation_fetch(
     )
 
     assert access.level == LEVEL_OWNER
+    assert access.can_approve is True
     assert access.conversation is None, (
         "admin path must not fetch the conversation (it bypasses the lookup)"
     )
@@ -160,6 +162,22 @@ async def test_public_grant_allows_but_level_reports_user_grant(
     assert access.level == LEVEL_READ, (
         f"displayed level must be the user's own read grant, got {access.level}"
     )
+    assert access.can_approve is False, "public OWNER access must not confer approval authority"
+
+
+@pytest.mark.asyncio
+async def test_delegated_editor_gets_approval_authority(
+    perm_store: SqlAlchemyPermissionStore, conv_store: SqlAlchemyConversationStore
+) -> None:
+    """An editor's direct approval capability is returned to snapshot callers."""
+    conv = conv_store.create_conversation()
+    perm_store.ensure_user(ALICE)
+    perm_store.grant(ALICE, conv.id, LEVEL_EDIT, can_approve=True)
+
+    access = await require_access_and_level(ALICE, conv.id, LEVEL_EDIT, perm_store, conv_store)
+
+    assert access.level == LEVEL_EDIT
+    assert access.can_approve is True
 
 
 @pytest.mark.asyncio
@@ -187,6 +205,7 @@ async def test_sub_agent_delegates_access_to_parent(
     assert access.conversation.id == child.id, "snapshot reuses the sub-agent row"
     # Displayed level is the direct grant on the sub-agent (none granted).
     assert access.level is None, "displayed level is the sub-agent's own grant, which is None here"
+    assert access.can_approve is True, "sub-agents inherit approval authority from their parent"
 
 
 @pytest.mark.asyncio
@@ -200,6 +219,7 @@ async def test_permissions_disabled_returns_empty_access(
 
     assert access.level is None
     assert access.conversation is None
+    assert access.can_approve is None
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_permissions.py
+++ b/tests/server/test_permissions.py
@@ -38,6 +38,7 @@ from omnigent.server.permissions import (
     check_is_manager,
     check_session_access,
     resolved_allows,
+    resolved_can_approve,
     resolved_level,
 )
 
@@ -919,3 +920,56 @@ def test_resolved_level_none_when_no_access() -> None:
     access = ResolvedAccess(is_admin=False, user_grant_level=None, public_grant_level=None)
     assert resolved_level(access) is None
     assert resolved_allows(access, LEVEL_READ) is False
+
+
+@pytest.mark.parametrize(
+    ("access", "expected"),
+    [
+        (
+            ResolvedAccess(
+                is_admin=True,
+                user_grant_level=None,
+                public_grant_level=None,
+            ),
+            True,
+        ),
+        (
+            ResolvedAccess(
+                is_admin=False,
+                user_grant_level=LEVEL_OWNER,
+                public_grant_level=None,
+            ),
+            True,
+        ),
+        (
+            ResolvedAccess(
+                is_admin=False,
+                user_grant_level=LEVEL_EDIT,
+                public_grant_level=None,
+                user_can_approve=True,
+            ),
+            True,
+        ),
+        (
+            ResolvedAccess(
+                is_admin=False,
+                user_grant_level=LEVEL_EDIT,
+                public_grant_level=None,
+            ),
+            False,
+        ),
+        (
+            ResolvedAccess(
+                is_admin=False,
+                user_grant_level=None,
+                public_grant_level=LEVEL_OWNER,
+            ),
+            False,
+        ),
+    ],
+)
+def test_resolved_can_approve_uses_direct_authority(
+    access: ResolvedAccess, expected: bool
+) -> None:
+    """Only admins, owners, and explicitly delegated users may approve."""
+    assert resolved_can_approve(access) is expected

--- a/tests/stores/test_permission_store.py
+++ b/tests/stores/test_permission_store.py
@@ -113,6 +113,21 @@ def test_grant_is_persisted_and_retrievable(store: SqlAlchemyPermissionStore, db
     )
 
 
+def test_grant_persists_delegated_approval_authority(
+    store: SqlAlchemyPermissionStore,
+    db_uri: str,
+) -> None:
+    """Approval delegation survives the permission-store round trip."""
+    _ensure_user(store, "approver@test.com")
+    conv_id = _create_conversation(db_uri)
+
+    store.grant("approver@test.com", conv_id, level=2, can_approve=True)
+
+    fetched = store.get("approver@test.com", conv_id)
+    assert fetched is not None
+    assert fetched.can_approve is True
+
+
 def test_grant_upsert_upgrades_level(store: SqlAlchemyPermissionStore, db_uri: str) -> None:
     """Granting to the same (user, session) pair overwrites the level upward.
 
@@ -825,7 +840,7 @@ def test_resolve_access_direct_grant_only(store: SqlAlchemyPermissionStore, db_u
     """
     _ensure_user(store, "alice@test.com")
     conv_id = _create_conversation(db_uri)
-    store.grant("alice@test.com", conv_id, level=2)
+    store.grant("alice@test.com", conv_id, level=2, can_approve=True)
 
     resolved = store.resolve_access("alice@test.com", conv_id)
 
@@ -837,6 +852,7 @@ def test_resolve_access_direct_grant_only(store: SqlAlchemyPermissionStore, db_u
     assert resolved.public_grant_level is None, (
         f"expected no public grant, got {resolved.public_grant_level}"
     )
+    assert resolved.user_can_approve is True
 
 
 def test_resolve_access_separates_user_and_public_grants(

--- a/web/src/components/PermissionsModal.test.tsx
+++ b/web/src/components/PermissionsModal.test.tsx
@@ -141,7 +141,7 @@ describe("PermissionsModal", () => {
     fireEvent.click(grantBtn);
 
     await waitFor(() => {
-      expect(grantMock).toHaveBeenCalledWith("conv_abc", "carol@example.com", 1);
+      expect(grantMock).toHaveBeenCalledWith("conv_abc", "carol@example.com", 1, false);
     });
   });
 
@@ -190,7 +190,7 @@ describe("PermissionsModal", () => {
     fireEvent.click(await screen.findByRole("option", { name: "Edit" }));
 
     await waitFor(() => {
-      expect(grantMock).toHaveBeenCalledWith("conv_abc", "bob@example.com", 2);
+      expect(grantMock).toHaveBeenCalledWith("conv_abc", "bob@example.com", 2, false);
     });
     // Editing the level must never delete the existing grant.
     expect(revokeMock).not.toHaveBeenCalled();
@@ -232,6 +232,43 @@ describe("PermissionsModal", () => {
     await waitFor(() => {
       expect(grantMock).toHaveBeenCalledWith("conv_abc", "__public__", 1);
     });
+  });
+
+  it("lets owners grant edit plus approval authority", async () => {
+    listMock.mockResolvedValue([]);
+    grantMock.mockResolvedValue({
+      user_id: "bob@example.com",
+      conversation_id: "conv_abc",
+      level: 2,
+      can_approve: true,
+    });
+
+    render(
+      <PermissionsModal
+        sessionId="conv_abc"
+        open={true}
+        onOpenChange={() => {}}
+        canDelegateApprovals
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(listMock).toHaveBeenCalled());
+    fireEvent.change(screen.getByPlaceholderText("alice@example.com"), {
+      target: { value: "bob@example.com" },
+    });
+    const formSelect = screen.getByRole("combobox");
+    formSelect.focus();
+    fireEvent.keyDown(formSelect, { key: "Enter" });
+    fireEvent.click(await screen.findByRole("option", { name: "Edit + approve" }));
+    fireEvent.click(screen.getByRole("button", { name: /grant/i }));
+
+    await waitFor(() => {
+      expect(grantMock).toHaveBeenCalledWith("conv_abc", "bob@example.com", 2, true);
+    });
+    expect(
+      screen.getByText("Approvers can authorize actions that use your session credentials."),
+    ).toBeInTheDocument();
   });
 
   it("displays server error messages from failed grant", async () => {

--- a/web/src/components/PermissionsModal.tsx
+++ b/web/src/components/PermissionsModal.tsx
@@ -61,9 +61,15 @@ interface PermissionsModalProps {
   sessionId: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  canDelegateApprovals?: boolean;
 }
 
-export function PermissionsModal({ sessionId, open, onOpenChange }: PermissionsModalProps) {
+export function PermissionsModal({
+  sessionId,
+  open,
+  onOpenChange,
+  canDelegateApprovals = false,
+}: PermissionsModalProps) {
   // Server sharing policy. While the boot probe is in flight we treat the
   // server as "on" (fail open) so the modal renders its full controls; the
   // server-side gate is the real enforcement point regardless.
@@ -99,8 +105,9 @@ export function PermissionsModal({ sessionId, open, onOpenChange }: PermissionsM
     const trimmed = newUserId.trim();
     if (!trimmed) return;
     setError(null);
+    const canApprove = newLevel === "2-approve";
     grant.mutate(
-      { userId: trimmed, level: parseInt(newLevel, 10) },
+      { userId: trimmed, level: canApprove ? 2 : parseInt(newLevel, 10), canApprove },
       {
         onSuccess: () => {
           setNewUserId("");
@@ -118,9 +125,9 @@ export function PermissionsModal({ sessionId, open, onOpenChange }: PermissionsM
     });
   }
 
-  function handleChangeLevel(userId: string, level: number) {
+  function handleChangeLevel(userId: string, level: number, canApprove: boolean) {
     setError(null);
-    grant.mutate({ userId, level }, { onError: (err) => setError(err.message) });
+    grant.mutate({ userId, level, canApprove }, { onError: (err) => setError(err.message) });
   }
 
   function handlePublicToggle(checked: boolean) {
@@ -212,6 +219,7 @@ export function PermissionsModal({ sessionId, open, onOpenChange }: PermissionsM
                     onChangeLevel={handleChangeLevel}
                     busy={grant.isPending || revoke.isPending}
                     readOnly={sharingReadOnly}
+                    canDelegateApprovals={canDelegateApprovals}
                   />
                 ))}
               </div>
@@ -239,6 +247,9 @@ export function PermissionsModal({ sessionId, open, onOpenChange }: PermissionsM
                 <SelectItem value="1">Read</SelectItem>
                 {/* Read-only sharing caps new grants at view; hide Edit. */}
                 {!sharingReadOnly && <SelectItem value="2">Edit</SelectItem>}
+                {!sharingReadOnly && canDelegateApprovals && (
+                  <SelectItem value="2-approve">Edit + approve</SelectItem>
+                )}
               </SelectContent>
             </Select>
           </div>
@@ -247,6 +258,12 @@ export function PermissionsModal({ sessionId, open, onOpenChange }: PermissionsM
             Grant
           </Button>
         </form>
+
+        {canDelegateApprovals && !sharingReadOnly && (
+          <p className="text-xs text-muted-foreground">
+            Approvers can authorize actions that use your session credentials.
+          </p>
+        )}
 
         {error && <p className="text-xs text-destructive">{error}</p>}
 
@@ -568,12 +585,14 @@ function GrantRow({
   onChangeLevel,
   busy,
   readOnly,
+  canDelegateApprovals,
 }: {
   permission: Permission;
   onRevoke: (userId: string) => void;
-  onChangeLevel: (userId: string, level: number) => void;
+  onChangeLevel: (userId: string, level: number, canApprove: boolean) => void;
   busy: boolean;
   readOnly: boolean;
+  canDelegateApprovals: boolean;
 }) {
   const isOwner = permission.level === 4;
   // Manage is not grantable from the UI, so a pre-existing manage grant
@@ -582,7 +601,10 @@ function GrantRow({
   const isManage = permission.level === 3;
   // Read-only sharing mode: existing grants can't be re-leveled, so the level
   // shows as a fixed label (like owner/manage) — but the row stays revocable.
-  const fixedLevel = isOwner || isManage || readOnly;
+  const fixedLevel =
+    isOwner || isManage || readOnly || (permission.can_approve && !canDelegateApprovals);
+  const baseLevelLabel = LEVEL_LABELS[permission.level] ?? "Read";
+  const levelLabel = permission.can_approve ? `${baseLevelLabel} + approve` : baseLevelLabel;
 
   return (
     <div className="flex items-center gap-2 rounded-md px-2 py-0.5 hover:bg-muted/50">
@@ -594,12 +616,15 @@ function GrantRow({
       </span>
       {fixedLevel ? (
         <span className="flex h-8 w-28 items-center px-3 text-sm text-muted-foreground">
-          {LEVEL_LABELS[permission.level] ?? "Read"}
+          {levelLabel}
         </span>
       ) : (
         <Select
-          value={String(permission.level)}
-          onValueChange={(v) => onChangeLevel(permission.user_id, parseInt(v, 10))}
+          value={permission.can_approve ? "2-approve" : String(permission.level)}
+          onValueChange={(value) => {
+            const canApprove = value === "2-approve";
+            onChangeLevel(permission.user_id, canApprove ? 2 : parseInt(value, 10), canApprove);
+          }}
           disabled={busy}
         >
           <SelectTrigger
@@ -611,6 +636,7 @@ function GrantRow({
           <SelectContent>
             <SelectItem value="1">Read</SelectItem>
             <SelectItem value="2">Edit</SelectItem>
+            {canDelegateApprovals && <SelectItem value="2-approve">Edit + approve</SelectItem>}
           </SelectContent>
         </Select>
       )}

--- a/web/src/components/blocks/ApprovalCard.test.tsx
+++ b/web/src/components/blocks/ApprovalCard.test.tsx
@@ -30,6 +30,68 @@ describe("ApprovalCard — binary approve/reject", () => {
     expect(screen.queryByTestId("approval-card-options")).toBeNull();
   });
 
+  it("disables approval but leaves rejection available without authority", () => {
+    const submitSpy = vi.fn();
+    render(
+      <ApprovalCard
+        elicitationId="elic_shared"
+        message="Run a privileged command?"
+        phase="tool_call"
+        policyName="approve_shell_commands"
+        contentPreview="sudo command"
+        requestedSchema={{}}
+        status="pending"
+        response={null}
+        canApprove={false}
+        allowAllEdits={true}
+        rememberScope={{ tool: "Bash" }}
+        onSubmit={submitSpy}
+      />,
+    );
+
+    for (const name of ["Approve", "Accept & allow all edits", /don't ask again for Bash/i]) {
+      expect((screen.getByRole("button", { name }) as HTMLButtonElement).disabled).toBe(true);
+    }
+    const reject = screen.getByRole("button", { name: "Reject" }) as HTMLButtonElement;
+    expect(reject.disabled).toBe(false);
+    expect(screen.getByRole("note").textContent).toContain("delegated approver");
+
+    fireEvent.click(reject);
+    expect(submitSpy).toHaveBeenCalledWith("elic_shared", "decline");
+  });
+
+  it("disables Codex approval variants but leaves rejection available", () => {
+    render(
+      <ApprovalCard
+        elicitationId="elic_codex_shared"
+        message="Run tests?"
+        phase="codex_command_approval"
+        policyName="codex_native_command_approval"
+        contentPreview=""
+        requestedSchema={{}}
+        status="pending"
+        response={null}
+        canApprove={false}
+        codexCommand={{
+          command: "pytest",
+          cwd: "/workspace",
+          reason: null,
+          execPolicyAmendment: ["pytest"],
+        }}
+      />,
+    );
+
+    expect((screen.getByRole("button", { name: "Approve" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect(
+      (screen.getByRole("button", { name: "Approve and remember" }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect((screen.getByRole("button", { name: "Reject" }) as HTMLButtonElement).disabled).toBe(
+      false,
+    );
+  });
+
   it("renders Codex command approvals from structured extras instead of raw JSON", () => {
     // Codex command approval frames carry internal correlation ids in
     // content_preview. The card should show only user-relevant command
@@ -406,6 +468,30 @@ describe("ApprovalCard — multi-choice options", () => {
     expect(submitSpy).toHaveBeenCalledWith("elic_pick", "accept", { answer: "Beta" });
   });
 
+  it("disables every multi-choice answer without approval authority", () => {
+    render(
+      <ApprovalCard
+        elicitationId="elic_shared_pick"
+        message="Pick one"
+        phase="ask_user_question"
+        policyName="claude_native_ask_user_question"
+        contentPreview="Pick one"
+        requestedSchema={{
+          type: "object",
+          properties: { answer: { type: "string", enum: ["Alpha", "Beta"] } },
+        }}
+        status="pending"
+        response={null}
+        canApprove={false}
+      />,
+    );
+
+    expect((screen.getByRole("button", { name: "Alpha" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect((screen.getByRole("button", { name: "Beta" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
   it("renders 'Selected: <label>' on the responded card when content carries an answer", () => {
     // The store stamps `response.content.answer` after a successful
     // submit so the responded pill can show the actual choice
@@ -515,6 +601,30 @@ describe("ApprovalCard — AskUserQuestion form (parsed from content_preview)", 
 
     fireEvent.click(screen.getByLabelText("React"));
     expect(submit.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("keeps question submission disabled but cancellation enabled without authority", () => {
+    render(
+      <ApprovalCard
+        elicitationId="elic_shared_question"
+        message="Claude wants to call AskUserQuestion"
+        phase="pre_tool_use"
+        policyName="claude_native_permission"
+        contentPreview={sampleSinglePreview}
+        requestedSchema={{}}
+        status="pending"
+        response={null}
+        canApprove={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("React"));
+    expect((screen.getByRole("button", { name: /submit/i }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect((screen.getByRole("button", { name: /cancel/i }) as HTMLButtonElement).disabled).toBe(
+      false,
+    );
   });
 
   it("submits gathered answers via submitApproval on click", () => {
@@ -1075,6 +1185,30 @@ describe("ApprovalCard — ExitPlanMode plan review", () => {
     expect(submitSpy).toHaveBeenCalledWith("elic_plan_auto", "accept", {
       allow_all_edits: true,
     });
+  });
+
+  it("disables plan approval but leaves rejection available without authority", () => {
+    render(
+      <ApprovalCard
+        elicitationId="elic_shared_plan"
+        status="pending"
+        response={null}
+        canApprove={false}
+        {...planProps}
+      />,
+    );
+
+    expect(
+      (screen.getByRole("button", { name: /yes, and use auto mode/i }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByRole("button", { name: /yes, manually approve edits/i }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByRole("button", { name: /reject with feedback/i }) as HTMLButtonElement).disabled,
+    ).toBe(false);
   });
 
   it("submits a plain accept for 'Yes, manually approve edits'", () => {

--- a/web/src/components/blocks/ApprovalCard.tsx
+++ b/web/src/components/blocks/ApprovalCard.tsx
@@ -149,6 +149,8 @@ interface ApprovalCardProps {
    * elicitation (edit tools take the ``allowAllEdits`` path instead).
    */
   rememberScope?: RememberScope | null;
+  /** Whether this viewer may accept the pending action. Rejection stays available. */
+  canApprove?: boolean;
   /**
    * Verdict submitter override. Defaults to `chatStore.submitApproval`
    * (the in-chat path: optimistic block flip + resolve POST + rollback).
@@ -173,6 +175,7 @@ export function ApprovalCard({
   codexCommand,
   allowAllEdits,
   rememberScope,
+  canApprove = true,
   onSubmit,
 }: ApprovalCardProps) {
   const submit: SubmitApprovalFn =
@@ -286,12 +289,12 @@ export function ApprovalCard({
     : undefined;
   const binaryButtons = (
     <div className="flex flex-wrap gap-2 pt-1">
-      <Button size="sm" onClick={() => submitBinary("accept")}>
+      <Button size="sm" onClick={() => submitBinary("accept")} disabled={!canApprove}>
         <CheckIcon className="mr-1 size-3.5" />
         Approve
       </Button>
       {allowAllEdits && (
-        <Button size="sm" variant="outline" onClick={submitAllowAllEdits}>
+        <Button size="sm" variant="outline" onClick={submitAllowAllEdits} disabled={!canApprove}>
           <CheckIcon className="mr-1 size-3.5" />
           Accept & allow all edits
         </Button>
@@ -301,6 +304,7 @@ export function ApprovalCard({
           size="sm"
           variant="outline"
           onClick={submitRemember}
+          disabled={!canApprove}
           title={rememberTitle}
           data-testid="approval-card-remember"
         >
@@ -316,7 +320,7 @@ export function ApprovalCard({
   );
   const codexCommandButtons = (
     <div className="flex flex-wrap items-center gap-2 pt-1" data-testid="codex-command-actions">
-      <Button size="sm" onClick={() => submitBinary("accept")}>
+      <Button size="sm" onClick={() => submitBinary("accept")} disabled={!canApprove}>
         <CheckIcon className="mr-1 size-3.5" />
         Approve
       </Button>
@@ -325,6 +329,7 @@ export function ApprovalCard({
           size="sm"
           variant="outline"
           onClick={() => submitExecPolicyAmendment(execPolicyAmendment)}
+          disabled={!canApprove}
         >
           <CheckIcon className="mr-1 size-3.5" />
           Approve and remember
@@ -483,6 +488,11 @@ export function ApprovalCard({
         )}
       </AlertTitle>
       <AlertDescription className="flex flex-col gap-2">
+        {!canApprove && (
+          <span className="text-xs text-muted-foreground" role="note">
+            Only the session owner or a delegated approver can approve. You can still reject.
+          </span>
+        )}
         {isExitPlanMode ? (
           <>
             <span>Claude finished planning and wants to proceed.</span>
@@ -491,6 +501,7 @@ export function ApprovalCard({
               onAcceptAuto={submitAllowAllEdits}
               onAccept={() => submitBinary("accept")}
               onReject={submitPlanRejection}
+              canApprove={canApprove}
             />
           </>
         ) : isAskUserQuestion ? (
@@ -498,6 +509,7 @@ export function ApprovalCard({
             questions={askPayload.questions}
             onSubmit={submitAnswers}
             onReject={() => submitBinary("decline")}
+            canSubmit={canApprove}
           />
         ) : isCodexCommandApproval ? (
           <>
@@ -539,6 +551,7 @@ export function ApprovalCard({
                     size="sm"
                     variant="outline"
                     onClick={() => submitOption(optLabel)}
+                    disabled={!canApprove}
                   >
                     {optLabel}
                   </Button>
@@ -564,9 +577,11 @@ export function ApprovalCard({
 export function ElicitationCard({
   item,
   onSubmit,
+  canApprove,
 }: {
   item: Extract<RenderItem, { kind: "elicitation" }>;
   onSubmit?: SubmitApprovalFn;
+  canApprove?: boolean;
 }) {
   return (
     <ApprovalCard
@@ -584,6 +599,7 @@ export function ElicitationCard({
       codexCommand={item.codexCommand}
       allowAllEdits={item.allowAllEdits}
       rememberScope={item.rememberScope}
+      canApprove={canApprove}
       onSubmit={onSubmit}
     />
   );

--- a/web/src/components/blocks/AskUserQuestionForm.tsx
+++ b/web/src/components/blocks/AskUserQuestionForm.tsx
@@ -44,6 +44,7 @@ interface AskUserQuestionFormProps {
   questions: ClaudeQuestion[];
   onSubmit: (answers: AskUserQuestionAnswers) => void;
   onReject: () => void;
+  canSubmit?: boolean;
 }
 
 /**
@@ -82,7 +83,12 @@ function questionKey(question: ClaudeQuestion): string {
   return question.id && question.id.length > 0 ? question.id : question.question;
 }
 
-export function AskUserQuestionForm({ questions, onSubmit, onReject }: AskUserQuestionFormProps) {
+export function AskUserQuestionForm({
+  questions,
+  onSubmit,
+  onReject,
+  canSubmit = true,
+}: AskUserQuestionFormProps) {
   // Currently-visible question (carousel index).
   const [currentIndex, setCurrentIndex] = useState(0);
 
@@ -367,7 +373,7 @@ export function AskUserQuestionForm({ questions, onSubmit, onReject }: AskUserQu
           <Button
             size="sm"
             onClick={handleSubmit}
-            disabled={!allAnswered}
+            disabled={!allAnswered || !canSubmit}
             data-testid="ask-user-question-submit"
           >
             <CheckIcon className="mr-1 size-3.5" />

--- a/web/src/components/blocks/BlockRenderer.tsx
+++ b/web/src/components/blocks/BlockRenderer.tsx
@@ -292,6 +292,7 @@ const STREAMING_TAIL = 3;
 interface BlockRendererProps {
   items: RenderItem[];
   sessionStatus: SessionStatus;
+  canApprove?: boolean;
 }
 
 type ToolRunFragment =
@@ -306,7 +307,7 @@ type ToolRunFragment =
       index: number;
     };
 
-export function BlockRenderer({ items, sessionStatus }: BlockRendererProps) {
+export function BlockRenderer({ items, sessionStatus, canApprove = true }: BlockRendererProps) {
   const rendered: ReactNode[] = [];
   let previousRenderedItemWasText = false;
   const isAgentActive = sessionStatus === "running" || sessionStatus === "waiting";
@@ -363,7 +364,7 @@ export function BlockRenderer({ items, sessionStatus }: BlockRendererProps) {
     }
 
     const followsText = item.kind === "text" && previousRenderedItemWasText;
-    rendered.push(renderItem(item, i, i === reasoningStreamingIdx, followsText));
+    rendered.push(renderItem(item, i, i === reasoningStreamingIdx, followsText, canApprove));
     previousRenderedItemWasText = item.kind === "text";
   }
 
@@ -491,6 +492,7 @@ function renderItem(
   index: number,
   isReasoningStreaming: boolean,
   followsText = false,
+  canApprove = true,
 ): ReactNode {
   const key = keyFor(item, index);
   switch (item.kind) {
@@ -587,7 +589,7 @@ function renderItem(
         />
       );
     case "elicitation":
-      return <ElicitationCard key={key} item={item} />;
+      return <ElicitationCard key={key} item={item} canApprove={canApprove} />;
   }
 }
 

--- a/web/src/components/blocks/ExitPlanModeReview.tsx
+++ b/web/src/components/blocks/ExitPlanModeReview.tsx
@@ -33,6 +33,8 @@ interface ExitPlanModeReviewProps {
   onAccept: () => void;
   /** Reject; `feedback` is the user's typed revision guidance (`""` when none). */
   onReject: (feedback: string) => void;
+  /** Whether this viewer may approve the plan. */
+  canApprove?: boolean;
 }
 
 export function ExitPlanModeReview({
@@ -40,6 +42,7 @@ export function ExitPlanModeReview({
   onAcceptAuto,
   onAccept,
   onReject,
+  canApprove = true,
 }: ExitPlanModeReviewProps) {
   const [rejecting, setRejecting] = useState(false);
   const [feedback, setFeedback] = useState("");
@@ -75,11 +78,11 @@ export function ExitPlanModeReview({
         </div>
       ) : (
         <div className="flex flex-wrap gap-2 pt-1">
-          <Button size="sm" onClick={onAcceptAuto}>
+          <Button size="sm" onClick={onAcceptAuto} disabled={!canApprove}>
             <ZapIcon className="mr-1 size-3.5" />
             Yes, and use auto mode
           </Button>
-          <Button size="sm" variant="outline" onClick={onAccept}>
+          <Button size="sm" variant="outline" onClick={onAccept} disabled={!canApprove}>
             <CheckIcon className="mr-1 size-3.5" />
             Yes, manually approve edits
           </Button>

--- a/web/src/hooks/useApproveHotkey.test.tsx
+++ b/web/src/hooks/useApproveHotkey.test.tsx
@@ -50,6 +50,13 @@ describe("useApproveHotkey", () => {
     expect(submitApproval).toHaveBeenCalledWith("e1", "accept");
   });
 
+  it("does not accept when the viewer lacks approval authority", () => {
+    blocks = [pending];
+    renderHook(() => useApproveHotkey(false));
+    press();
+    expect(submitApproval).not.toHaveBeenCalled();
+  });
+
   it("accepts the most recent pending approval", () => {
     blocks = [
       { type: "elicitation", elicitationId: "old", status: "pending" },

--- a/web/src/hooks/useApproveHotkey.ts
+++ b/web/src/hooks/useApproveHotkey.ts
@@ -18,12 +18,13 @@ import { useEffect } from "react";
 import type { ElicitationBlock } from "@/lib/blocks";
 import { useChatStore } from "@/store/chatStore";
 
-export function useApproveHotkey(): void {
+export function useApproveHotkey(canApprove = true): void {
   useEffect(() => {
     const handler = (e: globalThis.KeyboardEvent): void => {
       // Cmd/Ctrl, not Alt/Shift (mirrors the session-switch hotkey's guard).
       if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
       if (e.key !== "Enter") return;
+      if (!canApprove) return;
 
       const { blocks, submitApproval } = useChatStore.getState();
       // Newest-first: accept the most recent still-pending prompt that takes a
@@ -44,5 +45,5 @@ export function useApproveHotkey(): void {
 
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, []);
+  }, [canApprove]);
 }

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -72,6 +72,8 @@ export interface Conversation {
   updated_at: number;
   labels: Record<string, string>;
   permission_level: number | null;
+  /** Whether this viewer may accept privileged actions for the session. */
+  can_approve?: boolean | null;
   owner?: string | null;
   runner_id?: string | null;
   /** Host that launched the runner for this session, e.g. ``"host_a1b2"``. */
@@ -200,6 +202,7 @@ export async function fetchConversationById(id: string): Promise<Conversation | 
     updated_at: wire.updated_at ?? wire.created_at,
     labels: wire.labels ?? {},
     permission_level: wire.permission_level ?? null,
+    can_approve: wire.can_approve ?? null,
     owner: wire.owner ?? null,
     runner_id: wire.runner_id ?? null,
     host_id: wire.host_id ?? null,

--- a/web/src/hooks/usePermissions.ts
+++ b/web/src/hooks/usePermissions.ts
@@ -54,12 +54,20 @@ export function useSessionOwner(sessionId: string | null) {
 export function useGrantPermission(sessionId: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ userId, level }: { userId: string; level: number }) =>
-      grantPermission(sessionId, userId, level),
+    mutationFn: ({ userId, level, canApprove }: GrantPermissionInput) =>
+      canApprove === undefined
+        ? grantPermission(sessionId, userId, level)
+        : grantPermission(sessionId, userId, level, canApprove),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: permissionsKey(sessionId) });
     },
   });
+}
+
+interface GrantPermissionInput {
+  userId: string;
+  level: number;
+  canApprove?: boolean;
 }
 
 /** Revoke a permission. Invalidates the permissions list on success. */

--- a/web/src/lib/inbox.test.ts
+++ b/web/src/lib/inbox.test.ts
@@ -53,9 +53,23 @@ describe("collectInboxItems", () => {
     // display-label helpers (wrapper label → "Claude Code", etc.).
     expect(items[0].row).toBe(row);
     expect(items[0].resolveSessionId).toBe("conv_a");
+    expect(items[0].canApprove).toBe(true);
     // Content must survive the parse, not just the structure.
     expect(items[0].elicitation.message).toBe("approve elicit_1?");
     expect(items[0].elicitation.policyName).toBe("ask_everything");
+  });
+
+  it("carries the snapshot viewer's approval capability", () => {
+    const row = makeRow({ id: "conv_shared" });
+    const items = collectInboxItems([
+      {
+        row,
+        pendingElicitations: [makeRawElicitation("elicit_shared")],
+        canApprove: false,
+      },
+    ]);
+
+    expect(items[0].canApprove).toBe(false);
   });
 
   it("routes mirrored child prompts to the child via target_session_id", () => {

--- a/web/src/lib/inbox.ts
+++ b/web/src/lib/inbox.ts
@@ -24,6 +24,8 @@ export interface InboxItem {
    * (sub-agent) prompt into its parent's snapshot.
    */
   resolveSessionId: string;
+  /** Whether the viewer may accept this session's privileged actions. */
+  canApprove: boolean;
   elicitation: ElicitationRequest;
 }
 
@@ -32,6 +34,8 @@ export interface InboxSource {
   row: Conversation;
   /** Raw `response.elicitation_request` event dicts from `Session.pendingElicitations`. */
   pendingElicitations: Array<Record<string, unknown>>;
+  /** Whether the snapshot viewer may accept privileged actions. */
+  canApprove?: boolean;
 }
 
 /**
@@ -47,7 +51,7 @@ export function collectInboxItems(sources: InboxSource[]): InboxItem[] {
   const items: InboxItem[] = [];
   const seen = new Set<string>();
   const newestFirst = [...sources].sort((a, b) => b.row.updated_at - a.row.updated_at);
-  for (const { row, pendingElicitations } of newestFirst) {
+  for (const { row, pendingElicitations, canApprove } of newestFirst) {
     for (const raw of pendingElicitations) {
       const evt = parseEvent("response.elicitation_request", raw);
       if (evt === null || evt.type !== "elicitation_request") continue;
@@ -56,6 +60,7 @@ export function collectInboxItems(sources: InboxSource[]): InboxItem[] {
       items.push({
         row,
         resolveSessionId: evt.targetSessionId ?? row.id,
+        canApprove: canApprove ?? true,
         elicitation: evt,
       });
     }

--- a/web/src/lib/permissionsApi.test.ts
+++ b/web/src/lib/permissionsApi.test.ts
@@ -96,6 +96,17 @@ describe("grantPermission", () => {
     });
   });
 
+  it("forwards delegated approval authority explicitly", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ user_id: "bob", conversation_id: "conv_abc", level: 2, can_approve: true }),
+    );
+
+    await grantPermission("conv_abc", "bob", 2, true);
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(JSON.parse(init.body as string).can_approve).toBe(true);
+  });
+
   it.each([
     [1, "read"],
     [2, "edit"],

--- a/web/src/lib/permissionsApi.ts
+++ b/web/src/lib/permissionsApi.ts
@@ -95,6 +95,7 @@ export interface Permission {
   user_id: string;
   conversation_id: string;
   level: number;
+  can_approve?: boolean;
 }
 
 export async function listPermissions(sessionId: string): Promise<Permission[]> {
@@ -129,13 +130,19 @@ export async function grantPermission(
   sessionId: string,
   userId: string,
   level: number,
+  canApprove?: boolean,
 ): Promise<Permission> {
+  const body = {
+    user_id: userId,
+    level,
+    ...(canApprove === undefined ? {} : { can_approve: canApprove }),
+  };
   const res = await authenticatedFetch(
     `/v1/sessions/${encodeURIComponent(sessionId)}/permissions`,
     {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ user_id: userId, level }),
+      body: JSON.stringify(body),
     },
   );
   if (!res.ok) {

--- a/web/src/lib/sessionsApi.test.ts
+++ b/web/src/lib/sessionsApi.test.ts
@@ -94,6 +94,7 @@ describe("createSession", () => {
       pendingElicitations: [],
       pendingInputs: [],
       permissionLevel: null,
+      canApprove: null,
       parentSessionId: null,
       subAgentName: null,
       kind: "default",
@@ -639,6 +640,20 @@ describe("getSession", () => {
     );
     const session = await getSession("conv_abc");
     expect(session.permissionLevel).toBe(4);
+  });
+
+  it("maps can_approve from the wire to canApprove", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({
+        id: "conv_abc",
+        agent_id: "ag",
+        status: "idle",
+        created_at: 0,
+        can_approve: false,
+      }),
+    );
+    const session = await getSession("conv_abc");
+    expect(session.canApprove).toBe(false);
   });
 
   it("treats a missing permission_level as null", async () => {

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -185,6 +185,8 @@ interface SessionResponseWire {
    * entirely, and absent on older recorded fixtures.
    */
   permission_level?: number | null;
+  /** Whether this viewer may accept privileged actions for the session. */
+  can_approve?: boolean | null;
   /**
    * Parent conversation id when this session is a sub-agent (child),
    * e.g. ``"conv_parent987"``. ``null`` (or absent on older fixtures)
@@ -310,6 +312,7 @@ function sessionFromWire(wire: SessionResponseWire): Session {
       ...(p.created_by !== undefined ? { createdBy: p.created_by } : {}),
     })),
     permissionLevel: wire.permission_level ?? null,
+    canApprove: wire.can_approve ?? null,
     parentSessionId: wire.parent_session_id ?? null,
     subAgentName: wire.sub_agent_name ?? null,
     kind: wire.kind === "sub_agent" ? "sub_agent" : "default",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -372,6 +372,8 @@ export interface Session {
    * permissively, so that's fine for unblocking interaction.
    */
   permissionLevel: number | null;
+  /** Whether this viewer may accept privileged actions for the session. */
+  canApprove?: boolean | null;
   /**
    * Parent conversation id when this session is a sub-agent (child),
    * e.g. ``"conv_parent987"``. ``null`` for top-level sessions.

--- a/web/src/pages/ApprovePage.test.tsx
+++ b/web/src/pages/ApprovePage.test.tsx
@@ -76,6 +76,23 @@ describe("ApprovePage states", () => {
     expect(screen.getByRole("button", { name: /Reject/ })).toBeInTheDocument();
   });
 
+  it("disables approve but keeps reject enabled for a plain editor", async () => {
+    vi.mocked(identity.authenticatedFetch).mockResolvedValue(
+      jsonResponse({
+        status: "pending",
+        message: "Run the migration?",
+        can_approve: false,
+      }),
+    );
+    renderPage();
+
+    expect(
+      (await screen.findByRole("button", { name: /Approve/ })) as HTMLButtonElement,
+    ).toHaveProperty("disabled", true);
+    expect(screen.getByRole("button", { name: /Reject/ })).toHaveProperty("disabled", false);
+    expect(screen.getByRole("note").textContent).toContain("delegated approver");
+  });
+
   it("shows the resolved state when the elicitation is no longer pending", async () => {
     // WHY: a `status: "resolved"` payload means the prompt was already
     // resolved/timed-out/cancelled — no buttons, just an informational alert.

--- a/web/src/pages/ApprovePage.tsx
+++ b/web/src/pages/ApprovePage.tsx
@@ -29,6 +29,7 @@ interface ElicitationData {
   phase?: string;
   policy_name?: string;
   content_preview?: string;
+  can_approve?: boolean | null;
 }
 
 type PageState =
@@ -158,6 +159,11 @@ export function ApprovePage() {
             )}
           </AlertTitle>
           <AlertDescription className="flex flex-col gap-2">
+            {state.data.can_approve === false && (
+              <span className="text-xs text-muted-foreground" role="note">
+                Only the session owner or a delegated approver can approve. You can still reject.
+              </span>
+            )}
             <span>{state.data.message}</span>
             {state.data.content_preview && (
               <pre className="max-h-64 overflow-y-auto rounded bg-muted px-2 py-1 font-mono text-xs whitespace-pre-wrap break-words">
@@ -165,7 +171,11 @@ export function ApprovePage() {
               </pre>
             )}
             <div className="flex flex-wrap gap-2 pt-1">
-              <Button size="sm" onClick={() => void submit("accept")}>
+              <Button
+                size="sm"
+                onClick={() => void submit("accept")}
+                disabled={state.data.can_approve === false}
+              >
                 <CheckIcon className="mr-1 size-3.5" />
                 Approve
               </Button>

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1076,6 +1076,7 @@ export function ChatPage() {
     urlConvId,
     conversationsData !== undefined,
   );
+  const canApprove = activeSession?.canApprove ?? activeConv?.can_approve ?? true;
   const readOnlyReason = readOnlyReasonForSessionLabels(activeSession, activeConv);
   // Once present, the live session snapshot is authoritative.
   const capabilitySource = {
@@ -1130,6 +1131,7 @@ export function ChatPage() {
       hasMoreHistory={hasMoreHistory}
       loadingMoreHistory={loadingMoreHistory}
       permissionLevel={permissionLevel}
+      canApprove={canApprove}
       readOnlyReason={readOnlyReason}
       effortLevels={effortLevels}
       showEffort={showEffort}
@@ -1354,6 +1356,8 @@ interface MainAgentSurfaceProps {
   /** Whether a load-more fetch is currently in flight. */
   loadingMoreHistory: boolean;
   permissionLevel: number | null;
+  /** Whether this viewer may accept privileged actions. */
+  canApprove: boolean;
   /** Forces composer read-only with the given placeholder when non-null. See ``ComposerProps.readOnlyReason``. */
   readOnlyReason: string | null;
   effortLevels: readonly string[];
@@ -1435,6 +1439,7 @@ function MainAgentSurface({
   hasMoreHistory,
   loadingMoreHistory,
   permissionLevel,
+  canApprove,
   readOnlyReason,
   effortLevels,
   showEffort,
@@ -1744,7 +1749,7 @@ function MainAgentSurface({
             ) : (
               <>
                 {streamBubbles.map((bubble) => (
-                  <BubbleView key={bubbleKey(bubble)} bubble={bubble} />
+                  <BubbleView key={bubbleKey(bubble)} bubble={bubble} canApprove={canApprove} />
                 ))}
                 {/* Pending elicitation cards, floated to the bottom of the
                     chat so an outstanding question stays in view (stick-to-
@@ -1763,7 +1768,7 @@ function MainAgentSurface({
                     data-testid="bottom-elicitation"
                   >
                     <MessageContent className="w-full">
-                      <ElicitationCard item={item} />
+                      <ElicitationCard item={item} canApprove={canApprove} />
                     </MessageContent>
                   </Message>
                 ))}
@@ -3020,7 +3025,7 @@ function CompactionLoadingIndicator() {
 // markdown/syntax-highlighting subtree. See `bubblesEqual`. Exported for
 // the user-bubble markdown render tests.
 export const BubbleView = memo(
-  function BubbleView({ bubble }: { bubble: Bubble }) {
+  function BubbleView({ bubble, canApprove = true }: { bubble: Bubble; canApprove?: boolean }) {
     if (bubble.kind === "user") return <UserBubble bubble={bubble} />;
     if (bubble.kind === "compaction_loading") {
       return <CompactionLoadingIndicator />;
@@ -3036,9 +3041,9 @@ export const BubbleView = memo(
         />
       );
     }
-    return <AssistantBubble bubble={bubble} />;
+    return <AssistantBubble bubble={bubble} canApprove={canApprove} />;
   },
-  (prev, next) => bubblesEqual(prev.bubble, next.bubble),
+  (prev, next) => prev.canApprove === next.canApprove && bubblesEqual(prev.bubble, next.bubble),
 );
 
 /**
@@ -3254,7 +3259,13 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
   );
 }
 
-function AssistantBubble({ bubble }: { bubble: Extract<Bubble, { kind: "assistant" }> }) {
+function AssistantBubble({
+  bubble,
+  canApprove,
+}: {
+  bubble: Extract<Bubble, { kind: "assistant" }>;
+  canApprove: boolean;
+}) {
   // The walker only emits an assistant bubble when at least one
   // assistant-side block exists, so `items` is non-empty here in the
   // common case. The "Working…" shimmer for the empty-items / streaming
@@ -3285,7 +3296,11 @@ function AssistantBubble({ bubble }: { bubble: Extract<Bubble, { kind: "assistan
         className={isWide ? "max-w-full" : "max-w-3xl"}
       >
         <MessageContent className={isWide ? "w-full" : undefined}>
-          <BlockRenderer items={bubble.items} sessionStatus={sessionStatus} />
+          <BlockRenderer
+            items={bubble.items}
+            sessionStatus={sessionStatus}
+            canApprove={canApprove}
+          />
         </MessageContent>
         {bubble.lifecycle === "cancelled" && (
           <p

--- a/web/src/pages/InboxPage.tsx
+++ b/web/src/pages/InboxPage.tsx
@@ -108,7 +108,13 @@ export function InboxPage() {
   const sources: InboxSource[] = [];
   rows.forEach((row, i) => {
     const snapshot = snapshotQueries[i]?.data;
-    if (snapshot) sources.push({ row, pendingElicitations: snapshot.pendingElicitations ?? [] });
+    if (snapshot) {
+      sources.push({
+        row,
+        pendingElicitations: snapshot.pendingElicitations ?? [],
+        canApprove: snapshot.canApprove ?? true,
+      });
+    }
   });
   const items = collectInboxItems(sources);
 
@@ -327,6 +333,7 @@ export function InboxPage() {
                   codexCommand={item.elicitation.codexCommand}
                   allowAllEdits={item.elicitation.allowAllEdits}
                   rememberScope={item.elicitation.rememberScope}
+                  canApprove={item.canApprove}
                   onSubmit={makeSubmit(item)}
                 />
               )}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -130,10 +130,6 @@ import type { RightRailTab } from "./railTabs";
  * more than one agent (the root has at least one child).
  */
 export function AppShell() {
-  // Cmd/Ctrl+Enter accepts the pending harness approval prompt. Bound once
-  // here so it works on every chat route, regardless of where focus sits.
-  useApproveHotkey();
-
   // Lock the iOS shell to the visual viewport so the soft keyboard can't pan
   // the whole document (which would hide the header and break the layout).
   // No-op off the iOS shell. Scoped here so auth pages keep normal scrolling.
@@ -334,6 +330,10 @@ export function AppShell() {
     conversationId,
     conversationsData !== undefined,
   );
+  const canApprove = activeSession?.canApprove ?? activeConv?.can_approve ?? true;
+  // Cmd/Ctrl+Enter accepts the pending prompt only when this viewer has
+  // owner or delegated approval authority.
+  useApproveHotkey(canApprove);
   // Labels can come from the sidebar row (``activeConv``) for top-level
   // sessions OR the per-session snapshot (``activeSession``) for ALL
   // sessions including children. The sidebar list omits child (sub-agent)
@@ -1480,6 +1480,7 @@ export function AppShell() {
               sessionId={conversationId}
               open={shareOpen}
               onOpenChange={setShareOpen}
+              canDelegateApprovals={isOwnerLevel(permissionLevel)}
             />
           )}
           {conversationId && (

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -3160,7 +3160,12 @@ function ConversationRow({
           </DropdownMenu>
         </div>
       )}
-      <PermissionsModal sessionId={conversation.id} open={shareOpen} onOpenChange={setShareOpen} />
+      <PermissionsModal
+        sessionId={conversation.id}
+        open={shareOpen}
+        onOpenChange={setShareOpen}
+        canDelegateApprovals={isOwner}
+      />
       <Dialog
         open={deleteOpen}
         onOpenChange={(open) => {


### PR DESCRIPTION
## Related issue

Closes #2150

## Summary

Builds on the landed #3422 and #3416 changes for model-visible authorship and deny-by-default owner approval authority. This final stack layer lets an owner explicitly delegate approval authority without granting ownership or permission-management access.

**ELI5:** The owner can give a trusted collaborator a one-purpose “yes” stamp. Editors can still say “no” to stop an action, but only the owner or someone holding that stamp can authorize it. The robot still belongs to the owner and still uses the owner's keys.

```mermaid
flowchart LR
    Owner[Session owner] -->|grants Edit + approve| Approver[Delegated approver]
    Approver -->|accept| Approval[Privileged action]
    Editor[Ordinary editor] -->|decline or cancel| Approval
    Approval -->|accepted actions execute as owner| Runner[Owner runner and credentials]
```

- Adds an independent `can_approve` permission capability with an additive, default-off database migration.
- Allows owners and explicit delegates through both generic approval-event and URL-elicitation accept paths; ordinary editors remain denied for accept but may decline or cancel.
- Restricts capability changes to owners, requires at least edit access, excludes public/read-only sharing, inherits through sub-agent sessions, and logs the acting user and verdict.
- Exposes the viewer's effective approval capability in session/list/elicitation payloads.
- Disables every accept affordance for unauthorized viewers—binary, Codex, remember, allow-edits, plan, question, option, and keyboard shortcut—while keeping Reject/Cancel available.
- Adds an owner-only `Edit + approve` choice in the sharing dialog with a warning that actions use session credentials.

## Test Plan

- `uv run --frozen pytest tests/entities/test_permission.py tests/stores/test_permission_store.py tests/server/test_permissions.py tests/server/routes/test_auth_helpers.py tests/server/integration/test_sessions_permissions.py tests/server/integration/test_sessions_elicitation_resolve_url.py -q` (204 passed)
- `uv run --frozen pytest tests/server/test_openapi_drift.py -q` (1 passed)
- `pnpm exec vitest run src/components/PermissionsModal.test.tsx src/components/blocks/ApprovalCard.test.tsx src/pages/ApprovePage.test.tsx src/hooks/useApproveHotkey.test.tsx src/lib/permissionsApi.test.ts src/lib/sessionsApi.test.ts src/lib/inbox.test.ts` from `web/` (175 passed)
- `uv run --frozen pytest tests/e2e_ui/collaboration/test_permissions_modal.py::test_shared_editor_can_reject_but_needs_delegation_to_approve -q` (1 passed)
- `uv run --frozen pre-commit run --all-files`

## Demo

https://github.com/user-attachments/assets/8919cf45-cdcc-4b04-a439-93a920a5f073


The sharing dialog adds an owner-only **Edit + approve** option. For a shared editor without that capability, approval buttons are disabled with an explanation while Reject/Cancel remains enabled. The flow is illustrated in the diagram above.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage exercises capability persistence, owner-only delegation and revocation, manager/public/read-only denial, parent/child approval resolution, viewer capability payloads, disabled approval controls, enabled rejection controls, migrations, and existing permission behavior.

## Changelog

Session owners can grant trusted collaborators permission to approve privileged actions without transferring ownership; ordinary editors can reject but cannot approve.