### PR TITLE
[models] Resolve runtime defaults from catalogs

### DIFF
--- a/dev/lint/hardcoded_model_allowlist.txt
+++ b/dev/lint/hardcoded_model_allowlist.txt
@@ -20,7 +20,6 @@
 examples/kimi_hello.yaml kimi-k2-turbo 1
 omnigent/chat.py databricks-gpt-5-4 1
 omnigent/cli_config.py claude-opus-4-5-20251101-v1:0 1
-omnigent/codex_native_app_server.py databricks-gpt-5-5 1
 omnigent/cursor_native.py claude-opus-4-5 1
 omnigent/cursor_native.py claude-opus-4-6 1
 omnigent/cursor_native.py claude-opus-4-7 1
@@ -32,12 +31,6 @@ omnigent/cursor_native.py gpt-5.2-codex 1
 omnigent/cursor_native.py gpt-5.3-codex 1
 omnigent/cursor_native.py gpt-5.4 1
 omnigent/cursor_native.py gpt-5.5 1
-omnigent/inner/codex_executor.py databricks-gpt-5-5 1
-omnigent/inner/codex_executor.py gpt-5.4-mini 1
-omnigent/inner/databricks_executor.py databricks-claude-sonnet-4-6 1
-omnigent/inner/open_responses_sdk.py gpt-5.3-codex 1
-omnigent/inner/openai_agents_sdk_executor.py databricks-gpt-5-5 1
-omnigent/inner/openai_agents_sdk_executor.py gpt-5.3-codex 1
 omnigent/inner/pi_executor.py databricks-claude-opus-4-8 1
 omnigent/inner/pi_executor.py databricks-claude-sonnet-4-5 1
 omnigent/inner/pi_executor.py databricks-claude-sonnet-4-6 1
@@ -61,14 +54,11 @@ omnigent/model_catalog.py claude-sonnet-5 1
 omnigent/model_catalog.py gpt-5.4 1
 omnigent/model_catalog.py gpt-5.4-mini 1
 omnigent/model_catalog.py gpt-5.5 1
-omnigent/onboarding/databricks_config.py databricks-claude-opus-4-8 1
 omnigent/onboarding/providers/__init__.py claude-opus-4-8 1
 omnigent/onboarding/providers/__init__.py gpt-5.5 1
 omnigent/onboarding/providers/__init__.py kimi-k2.6 1
 omnigent/onboarding/wizard.py databricks-gpt-5-4 1
 omnigent/onboarding/wizard.py gpt-4o 1
-omnigent/opencode_native_provider.py databricks-claude-sonnet-4-6 1
-omnigent/pi_native_credentials.py databricks-claude-sonnet-4-6 1
 omnigent/policies/builtins/routing.py databricks-claude-opus-4-6 1
 omnigent/policies/builtins/routing.py o3 1
 omnigent/server/smart_routing.py databricks-claude-haiku-4-5 3

--- a/docs/model-hardcoding-plan.md
+++ b/docs/model-hardcoding-plan.md
@@ -109,7 +109,27 @@ The first migration building block lives in `omnigent/model_metadata.py` and
   preference rules can supply a `ModelPreferencePolicy` without changing
   callers or the precedence contract.
 
-This contract is intentionally pure and side-effect free. Follow-up migrations
-will adapt executor defaults and smart routing to it, then enrich catalog entries
-from provider and MLflow metadata. Until those callers move, their existing
-selection behavior remains unchanged.
+This contract is intentionally pure and side-effect free. Runtime callers adapt
+provider discovery into candidates at the boundary; later migrations can move
+smart routing and remaining policy decisions without coupling them to catalog I/O.
+
+## Runtime Default Migration
+
+The first runtime slice adapts the MLflow provider catalog into normalized
+resolver candidates and moves unresolved executor/native defaults behind that
+boundary:
+
+- Explicit request, spec, ucode, and provider-configured models still win and do
+  not depend on discovery.
+- Generic Anthropic/OpenAI providers and Databricks gateway paths resolve the
+  appropriate Claude/OpenAI catalog family with the `default` intent.
+- Catalog capability, context-window, and pricing data become normalized
+  metadata; missing capability facts remain unknown rather than supported.
+- A missing live catalog produces a clear configuration/discovery error instead
+  of silently selecting a stale release-specific fallback.
+- Executor and native-launch tests stub the catalog boundary, while catalog and
+  resolver tests exercise metadata normalization and selection independently.
+
+Static picker rows, smart-routing tiers, context/wire heuristics, and CI model
+inputs remain separate migration slices because they require different discovery
+or configuration sources.

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -3010,6 +3010,9 @@ def _apply_overrides_to_raw(raw: _YamlMapping, overrides: ChatOverrides) -> None
             llm_block = raw.get("llm")
             if isinstance(llm_block, dict):
                 llm_block.pop("model", None)
+            env_model = os.environ.get(_OMNIGENT_MODEL_ENV_VAR)
+            if env_model is not None:
+                executor_block["model"] = env_model
     # When neither harness nor model is declared — after overrides —
     # inject the ad-hoc default. Gated on harness absence so a YAML
     # like ``claude_code_agent.yaml`` (declares harness, no model)

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -47,6 +47,7 @@ import yaml
 from websockets.exceptions import ConnectionClosed, ConnectionClosedError, WebSocketException
 from websockets.frames import Close
 
+from omnigent import model_catalog
 from omnigent._native_resume_hint import echo_native_resume_hint
 from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
 from omnigent._startup_profile import StartupProfiler
@@ -1614,10 +1615,7 @@ def _ucode_config_for_profile(
     if not profile:
         return None
 
-    from omnigent.onboarding.databricks_config import (
-        DATABRICKS_CLAUDE_DEFAULT_MODEL,
-        get_workspace_url_for_profile,
-    )
+    from omnigent.onboarding.databricks_config import get_workspace_url_for_profile
     from omnigent.onboarding.ucode_state import read_ucode_state
 
     workspace_url = get_workspace_url_for_profile(profile)
@@ -1739,7 +1737,9 @@ def _ucode_config_for_profile(
     return ClaudeNativeUcodeConfig(
         env=env,
         api_key_helper=agent_state.auth_command,
-        model=default_model or configured_default or DATABRICKS_CLAUDE_DEFAULT_MODEL,
+        model=default_model
+        or configured_default
+        or model_catalog.resolve_catalog_model("databricks", family="claude").model_id,
     )
 
 

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -20,6 +20,8 @@ from typing import TYPE_CHECKING, Any
 import tomlkit
 import websockets
 
+from omnigent import model_catalog
+
 if TYPE_CHECKING:
     from omnigent.onboarding.provider_config import ProviderEntry
 
@@ -55,7 +57,6 @@ CodexParams = dict[str, Any]
 _CONNECT_RETRY_DELAY_SECONDS = 0.05
 _CONNECT_TIMEOUT_SECONDS = 10.0
 _STDERR_CHUNK_LIMIT = 65536
-_DATABRICKS_CODEX_DEFAULT_MODEL = "databricks-gpt-5-5"
 _UDS_WEBSOCKET_HANDSHAKE_URI = "ws://localhost/rpc"
 _MAX_WEBSOCKET_MESSAGE_SIZE_BYTES = 128 << 20
 # hooks.json filename written into the private CODEX_HOME registering the
@@ -1222,7 +1223,8 @@ def build_codex_native_server(
         host = host.rstrip("/")
         config_overrides.extend(
             _databricks_codex_config_overrides(
-                model=model or _DATABRICKS_CODEX_DEFAULT_MODEL,
+                model=model
+                or model_catalog.resolve_catalog_model("databricks", family="openai").model_id,
                 base_url=_databricks_codex_base_url(host),
                 auth_command=_databricks_codex_auth_command(host, profile),
             )

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -52,6 +52,7 @@ from omnigent.reasoning_effort import CLAUDE_EFFORTS, validate_effort
 from omnigent.spec.types import RetryPolicy
 
 from ._subprocess_lifecycle import close_anyio_subprocess_transport
+from .async_utils import run_sync_on_thread
 from .claude_gateway_shim import DATABRICKS_CLAUDE_ADAPTIVE_THINKING_PREFIXES, ClaudeGatewayShim
 from .datamodel import OSEnvSandboxSpec, OSEnvSpec
 from .executor import (
@@ -2181,7 +2182,12 @@ class ClaudeSDKExecutor(Executor):
         # spawning, so no ``databricks-*`` default is injected there.
         model = cfg.model or self._model_override
         if model is None and self._gateway_uses_databricks_profile:
-            model = model_catalog.resolve_catalog_model("databricks", family="claude").model_id
+            resolution = await run_sync_on_thread(
+                model_catalog.resolve_catalog_model,
+                "databricks",
+                family="claude",
+            )
+            model = resolution.model_id
 
         # Build env: Databricks gateway settings derived from profile-backed
         # creds. CLAUDECODE removal happens around the subprocess spawn in

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -42,12 +42,12 @@ from dataclasses import dataclass
 from types import ModuleType
 from typing import Any, Protocol, TypeAlias, cast
 
+from omnigent import model_catalog
 from omnigent._platform import resolve_cli_binary, stable_user_id
 from omnigent.inner import _proc
 from omnigent.inner.bundle_skills import ensure_bundle_plugin_manifest
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 from omnigent.llms.adapters._content import parse_data_uri as _parse_replay_data_uri
-from omnigent.onboarding.databricks_config import DATABRICKS_CLAUDE_DEFAULT_MODEL
 from omnigent.reasoning_effort import CLAUDE_EFFORTS, validate_effort
 from omnigent.spec.types import RetryPolicy
 
@@ -741,8 +741,6 @@ def _best_effort_close(resource: _Stream | _Process) -> None:
 # Default model for the Databricks-profile gateway path (no gateway base URL
 # supplied directly), used when no spec/cfg model is set. On the ucode-cached
 # path the Omnigent producer resolves the model instead (see workflow.py).
-_DATABRICKS_CLAUDE_DEFAULT_MODEL = DATABRICKS_CLAUDE_DEFAULT_MODEL
-
 _CLAUDE_API_KEY_HELPER_ENV_KEY = "OMNIGENT_CLAUDE_API_KEY_HELPER"
 
 
@@ -2183,7 +2181,7 @@ class ClaudeSDKExecutor(Executor):
         # spawning, so no ``databricks-*`` default is injected there.
         model = cfg.model or self._model_override
         if model is None and self._gateway_uses_databricks_profile:
-            model = _DATABRICKS_CLAUDE_DEFAULT_MODEL
+            model = model_catalog.resolve_catalog_model("databricks", family="claude").model_id
 
         # Build env: Databricks gateway settings derived from profile-backed
         # creds. CLAUDECODE removal happens around the subprocess spawn in

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol, TypeAlias
 
+from omnigent import model_catalog
 from omnigent._platform import resolve_cli_binary
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 from omnigent.reasoning_effort import CODEX_EFFORTS, EFFORT_ALIASES, validate_effort
@@ -98,14 +99,6 @@ _TURN_COMPLETED_DRAIN_SECONDS = 1.0
 _CODEX_VERSION_PROBE_TIMEOUT_SECONDS = 5.0
 _STDERR_CHUNK_LIMIT = 65536
 _STREAM_READ_CHUNK_SIZE = 65536
-_OPENAI_CODEX_DEFAULT_MODEL = "gpt-5.4-mini"
-# Databricks-specific default model for the Databricks-profile-derivation
-# gateway path (no gateway base URL supplied directly). The neutral
-# generic-provider gateway path never uses this — it requires the Omnigent producer
-# to resolve a concrete model. Used only when constructing the codex config
-# from ~/.databrickscfg credentials with no spec/override model.
-_DATABRICKS_CODEX_DEFAULT_MODEL = "databricks-gpt-5-5"
-
 # Files symlinked from the real CODEX_HOME into the per-session temp home.
 # Symlinks (not copies) so credential refreshes in the real home propagate
 # to running sessions without any action from Omnigent.
@@ -2551,9 +2544,13 @@ class CodexExecutor(Executor):
                     if gateway_auth_command is not None
                     else _databricks_codex_auth_command(host, databricks_profile)
                 )
-                # Databricks-profile path: a Databricks default is legitimate.
+                # Databricks-profile path: select a gateway endpoint from the
+                # catalog when no caller supplied one.
                 self._gateway_uses_databricks_profile = True
-                effective_model = model or _DATABRICKS_CODEX_DEFAULT_MODEL
+                effective_model = (
+                    model
+                    or model_catalog.resolve_catalog_model("databricks", family="openai").model_id
+                )
             else:
                 if base_url_override is None:
                     raise OSError(
@@ -2700,20 +2697,12 @@ class CodexExecutor(Executor):
         cfg = config or ExecutorConfig()
         session_key = _session_key(messages)
         state = self._session_states.setdefault(session_key, _CodexSessionState())
-        # cfg.model (per-request /model override) wins over the spec
-        # default (HARNESS_CODEX_MODEL → self._model_override). The final
-        # fallback is the Databricks default only on the Databricks-profile
-        # gateway path; the neutral gateway path (and the built-in path) never
-        # select a ``databricks-*`` model.
-        model = (
-            cfg.model
-            or self._model_override
-            or (
-                _DATABRICKS_CODEX_DEFAULT_MODEL
-                if self._gateway_uses_databricks_profile
-                else _OPENAI_CODEX_DEFAULT_MODEL
-            )
-        )
+        # cfg.model (per-request /model override) wins over the spec default.
+        # An unresolved default comes from the active provider catalog.
+        model = cfg.model or self._model_override
+        if model is None:
+            provider_name = "databricks" if self._gateway_uses_databricks_profile else "openai"
+            model = model_catalog.resolve_catalog_model(provider_name, family="openai").model_id
         effective_cwd = (
             self._cwd or (self._os_env_spec.cwd if self._os_env_spec else None) or os.getcwd()
         )

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -31,6 +31,7 @@ from omnigent.spec.types import RetryPolicy
 
 from . import _proc
 from ._subprocess_lifecycle import close_subprocess_transport
+from .async_utils import run_sync_on_thread
 from .codex_goal_command import goal_objective_from_content as _goal_objective_from_content
 from .databricks_executor import (
     _databricks_gateway_host,
@@ -2702,7 +2703,12 @@ class CodexExecutor(Executor):
         model = cfg.model or self._model_override
         if model is None:
             provider_name = "databricks" if self._gateway_uses_databricks_profile else "openai"
-            model = model_catalog.resolve_catalog_model(provider_name, family="openai").model_id
+            resolution = await run_sync_on_thread(
+                model_catalog.resolve_catalog_model,
+                provider_name,
+                family="openai",
+            )
+            model = resolution.model_id
         effective_cwd = (
             self._cwd or (self._os_env_spec.cwd if self._os_env_spec else None) or os.getcwd()
         )

--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -899,7 +899,12 @@ class DatabricksExecutor(Executor):
         cfg = config or ExecutorConfig()
         model = cfg.model
         if not model:
-            model = model_catalog.resolve_catalog_model("databricks", family="claude").model_id
+            resolution = await run_sync_on_thread(
+                model_catalog.resolve_catalog_model,
+                "databricks",
+                family="claude",
+            )
+            model = resolution.model_id
         session_key = self._session_key(messages)
         state = self._get_or_create_session_state(session_key)
         state.interrupt_requested = False

--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -24,6 +24,8 @@ from typing import TYPE_CHECKING, Any, TypeAlias
 
 import httpx
 
+from omnigent import model_catalog
+
 if TYPE_CHECKING:
     from openai import OpenAI, Stream
     from openai.types.chat import ChatCompletionChunk
@@ -897,7 +899,7 @@ class DatabricksExecutor(Executor):
         cfg = config or ExecutorConfig()
         model = cfg.model
         if not model:
-            model = "databricks-claude-sonnet-4-6"
+            model = model_catalog.resolve_catalog_model("databricks", family="claude").model_id
         session_key = self._session_key(messages)
         state = self._get_or_create_session_state(session_key)
         state.interrupt_requested = False

--- a/omnigent/inner/open_responses_sdk.py
+++ b/omnigent/inner/open_responses_sdk.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 import pydantic
 
+from omnigent import model_catalog
 from omnigent.llms.adapters._content import redact_inline_data_uris
 from omnigent.spec.types import RetryPolicy
 
@@ -534,7 +535,9 @@ class OpenResponsesExecutor(Executor):
         config: ExecutorConfig | None = None,
     ) -> AsyncIterator[ExecutorEvent]:
         cfg = config or ExecutorConfig()
-        model = cfg.model or "gpt-5.3-codex"
+        model = (
+            cfg.model or model_catalog.resolve_catalog_model("openai", family="openai").model_id
+        )
         session_key = self._session_key(messages)
         state = self._get_or_create_session_state(session_key)
         state.interrupt_requested = False

--- a/omnigent/inner/open_responses_sdk.py
+++ b/omnigent/inner/open_responses_sdk.py
@@ -535,9 +535,14 @@ class OpenResponsesExecutor(Executor):
         config: ExecutorConfig | None = None,
     ) -> AsyncIterator[ExecutorEvent]:
         cfg = config or ExecutorConfig()
-        model = (
-            cfg.model or model_catalog.resolve_catalog_model("openai", family="openai").model_id
-        )
+        model = cfg.model
+        if model is None:
+            resolution = await run_sync_on_thread(
+                model_catalog.resolve_catalog_model,
+                "openai",
+                family="openai",
+            )
+            model = resolution.model_id
         session_key = self._session_key(messages)
         state = self._get_or_create_session_state(session_key)
         state.interrupt_requested = False

--- a/omnigent/inner/openai_agents_sdk_executor.py
+++ b/omnigent/inner/openai_agents_sdk_executor.py
@@ -32,6 +32,7 @@ from omnigent.llms.errors import is_context_length_exceeded as _is_context_lengt
 from omnigent.reasoning_effort import OPENAI_AGENTS_EFFORTS, validate_effort
 from omnigent.spec.types import RetryPolicy
 
+from .async_utils import run_sync_on_thread
 from .executor import (
     Executor,
     ExecutorConfig,
@@ -1443,7 +1444,12 @@ class OpenAIAgentsSDKExecutor(Executor):
         model = cfg.model or self._model_override
         if model is None:
             provider_name = "databricks" if self._databricks else "openai"
-            model = model_catalog.resolve_catalog_model(provider_name, family="openai").model_id
+            resolution = await run_sync_on_thread(
+                model_catalog.resolve_catalog_model,
+                provider_name,
+                family="openai",
+            )
+            model = resolution.model_id
         agents_sdk = cast(_AgentsSDK, _ensure_agents_sdk())
         session_key = self._session_key(messages)
         try:

--- a/omnigent/inner/openai_agents_sdk_executor.py
+++ b/omnigent/inner/openai_agents_sdk_executor.py
@@ -26,6 +26,7 @@ from typing import Any, Literal, Protocol, TypeAlias, cast
 
 import httpx
 
+from omnigent import model_catalog
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 from omnigent.llms.errors import is_context_length_exceeded as _is_context_length_exceeded
 from omnigent.reasoning_effort import OPENAI_AGENTS_EFFORTS, validate_effort
@@ -53,9 +54,6 @@ from .open_responses_sdk import (
 )
 
 logger = logging.getLogger(__name__)
-
-_OPENAI_AGENTS_DEFAULT_MODEL = "gpt-5.3-codex"
-_DATABRICKS_OPENAI_AGENTS_DEFAULT_MODEL = "databricks-gpt-5-5"
 
 # Total run attempts per turn (1 initial + retries). The Databricks
 # gateway occasionally returns a completed-but-empty turn (status
@@ -1442,15 +1440,10 @@ class OpenAIAgentsSDKExecutor(Executor):
         # cfg.model (per-request /model override; agent name no longer
         # leaks here) wins over the spec default
         # (HARNESS_OPENAI_AGENTS_MODEL → self._model_override).
-        model = (
-            cfg.model
-            or self._model_override
-            or (
-                _DATABRICKS_OPENAI_AGENTS_DEFAULT_MODEL
-                if self._databricks
-                else _OPENAI_AGENTS_DEFAULT_MODEL
-            )
-        )
+        model = cfg.model or self._model_override
+        if model is None:
+            provider_name = "databricks" if self._databricks else "openai"
+            model = model_catalog.resolve_catalog_model(provider_name, family="openai").model_id
         agents_sdk = cast(_AgentsSDK, _ensure_agents_sdk())
         session_key = self._session_key(messages)
         try:

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -55,6 +55,7 @@ from omnigent.runner.identity import OMNIGENT_SESSION_ENV_VAR
 from omnigent.spec.types import RetryPolicy
 
 from ._subprocess_lifecycle import close_subprocess_transport
+from .async_utils import run_sync_on_thread
 from .databricks_executor import _read_databrickscfg
 from .datamodel import OSEnvSandboxSpec, OSEnvSpec
 from .executor import (
@@ -1861,7 +1862,7 @@ class PiExecutor(Executor):
                 return str(meta["session_id"])
         return "__default__"
 
-    def _resolve_model(self, config: ExecutorConfig | None) -> str | None:
+    async def _resolve_model(self, config: ExecutorConfig | None) -> str | None:
         """
         Determine the model name to pass to Pi.
 
@@ -1879,7 +1880,12 @@ class PiExecutor(Executor):
         cfg = config or ExecutorConfig()
         model = cfg.model or self._model_override
         if model is None and self._gateway_uses_databricks_profile:
-            return model_catalog.resolve_catalog_model("databricks", family="claude").model_id
+            resolution = await run_sync_on_thread(
+                model_catalog.resolve_catalog_model,
+                "databricks",
+                family="claude",
+            )
+            return resolution.model_id
         return model
 
     async def _ensure_tool_server(self, tools: list[ToolSpec]) -> int | None:
@@ -2115,7 +2121,7 @@ class PiExecutor(Executor):
                 if token:
                     self._databricks_token = token
         session_key = self._session_key(messages)
-        model = self._resolve_model(config)
+        model = await self._resolve_model(config)
 
         try:
             rpc = await self._ensure_rpc(session_key, system_prompt, model, tools)

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -48,9 +48,9 @@ from dataclasses import dataclass, field
 from typing import Any, TypeAlias
 from urllib.parse import urlparse as _urlparse
 
+from omnigent import model_catalog
 from omnigent.inner.native_attachments import parse_data_uri
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
-from omnigent.onboarding.databricks_config import DATABRICKS_CLAUDE_DEFAULT_MODEL
 from omnigent.runner.identity import OMNIGENT_SESSION_ENV_VAR
 from omnigent.spec.types import RetryPolicy
 
@@ -1867,10 +1867,9 @@ class PiExecutor(Executor):
 
         ``cfg.model`` (per-request /model override) wins over the spec
         default (``HARNESS_PI_MODEL`` → ``self._model_override``). On the
-        Databricks-profile gateway path a missing model falls back to
-        :data:`DATABRICKS_CLAUDE_DEFAULT_MODEL` — Pi's own default is an
-        Anthropic-direct id the gateway rejects. Elsewhere ``None`` falls
-        through to let Pi pick its own default.
+        Databricks-profile gateway path a missing model resolves from the
+        Databricks Claude catalog — Pi's own default may be a direct-provider
+        id the gateway rejects. Elsewhere ``None`` lets Pi pick its own default.
 
         :param config: Optional :class:`ExecutorConfig` whose ``model``
             takes precedence when set.
@@ -1880,7 +1879,7 @@ class PiExecutor(Executor):
         cfg = config or ExecutorConfig()
         model = cfg.model or self._model_override
         if model is None and self._gateway_uses_databricks_profile:
-            return DATABRICKS_CLAUDE_DEFAULT_MODEL
+            return model_catalog.resolve_catalog_model("databricks", family="claude").model_id
         return model
 
     async def _ensure_tool_server(self, tools: list[ToolSpec]) -> int | None:

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -46,7 +46,12 @@ from cachetools import TTLCache
 from omnigent._platform import default_shell_argv
 from omnigent.model_metadata import ModelCapability, ModelCostTier, ModelIntent, ModelMetadata
 from omnigent.model_override import model_family_mismatch
-from omnigent.model_resolver import ModelResolution, ModelResolutionRequest, resolve_model
+from omnigent.model_resolver import (
+    ModelResolution,
+    ModelResolutionError,
+    ModelResolutionRequest,
+    resolve_model,
+)
 from omnigent.onboarding.provider_config import (
     ANTHROPIC_FAMILY,
     CLI_CONFIG_KIND,
@@ -336,11 +341,6 @@ def catalog_model_entries(provider_name: str) -> tuple[ModelEntry, ...]:
                 supported.add(capability)
             elif value is False:
                 unsupported.add(capability)
-        context_window = (
-            model.max_input_tokens + (model.max_output_tokens or 0)
-            if model.max_input_tokens is not None
-            else None
-        )
         entries.append(
             ModelEntry(
                 id=model.name,
@@ -348,7 +348,7 @@ def catalog_model_entries(provider_name: str) -> tuple[ModelEntry, ...]:
                 metadata=ModelMetadata(
                     supported_capabilities=frozenset(supported),
                     unsupported_capabilities=frozenset(unsupported),
-                    context_window=context_window,
+                    context_window=model.max_input_tokens,
                     cost_tier=cost_tiers.get(index),
                 ),
             )
@@ -365,6 +365,10 @@ def resolve_catalog_model(
 ) -> ModelResolution:
     """Resolve a model from the live bundled provider catalog.
 
+    Default intent preserves the onboarding provider's general-purpose model
+    policy after family and gateway-routing constraints are applied. Other
+    intents continue to rank all compatible catalog candidates by metadata.
+
     :param provider_name: MLflow catalog provider name.
     :param intent: Stable selection intent.
     :param configured_default: Optional provider-configured model. It is
@@ -375,7 +379,23 @@ def resolve_catalog_model(
     :returns: The resolver result with source and normalized metadata.
     :raises ModelResolutionError: When no compatible catalog model exists.
     """
+    from omnigent.onboarding.providers import default_chat_model
+
     models = list(catalog_model_entries(provider_name))
+    if provider_name.lower() == "databricks":
+        models = [model for model in models if model.id.lower().startswith("databricks-")]
+
+    if configured_default is None and intent == ModelIntent.DEFAULT:
+        compatible_ids = {model.id for model in models if family is None or model.family == family}
+        preferred_default = default_chat_model(
+            provider_name,
+            allowed_models=compatible_ids,
+        )
+        if preferred_default is not None and (
+            family is None or model_family_token(preferred_default) == family
+        ):
+            configured_default = preferred_default
+
     if configured_default is not None and all(model.id != configured_default for model in models):
         models.insert(
             0,
@@ -384,14 +404,21 @@ def resolve_catalog_model(
                 family=family or model_family_token(configured_default),
             ),
         )
-    return resolve_model(
-        ModelResolutionRequest(
-            intent=intent,
-            configured_default=configured_default,
-            allowed_families=frozenset({family}) if family is not None else frozenset(),
-        ),
-        models,
-    )
+    try:
+        return resolve_model(
+            ModelResolutionRequest(
+                intent=intent,
+                configured_default=configured_default,
+                allowed_families=(frozenset({family}) if family is not None else frozenset()),
+            ),
+            models,
+        )
+    except ModelResolutionError as exc:
+        family_detail = f" for family {family!r}" if family is not None else ""
+        raise ModelResolutionError(
+            f"no compatible model resolved from provider {provider_name!r}{family_detail}; "
+            "configure an explicit model or retry when catalog discovery is available"
+        ) from exc
 
 
 def _catalog_cost_tiers(models: list[ModelInfo]) -> dict[int, ModelCostTier]:

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -38,14 +38,15 @@ import os
 import subprocess
 import threading
 from dataclasses import dataclass, field, replace
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
 from cachetools import TTLCache
 
 from omnigent._platform import default_shell_argv
-from omnigent.model_metadata import ModelMetadata
+from omnigent.model_metadata import ModelCapability, ModelCostTier, ModelIntent, ModelMetadata
 from omnigent.model_override import model_family_mismatch
+from omnigent.model_resolver import ModelResolution, ModelResolutionRequest, resolve_model
 from omnigent.onboarding.provider_config import (
     ANTHROPIC_FAMILY,
     CLI_CONFIG_KIND,
@@ -56,6 +57,9 @@ from omnigent.onboarding.provider_config import (
     ProviderEntry,
 )
 from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
+
+if TYPE_CHECKING:
+    from omnigent.onboarding.providers import ModelInfo
 
 _logger = logging.getLogger(__name__)
 
@@ -300,6 +304,120 @@ def model_family_token(model_id: str) -> str:
     if "gpt" in lower or "codex" in lower:
         return "openai"
     return "other"
+
+
+def catalog_model_entries(provider_name: str) -> tuple[ModelEntry, ...]:
+    """Load provider chat models as normalized resolver candidates.
+
+    The upstream MLflow catalog is fetched and cached by
+    :func:`omnigent.onboarding.providers.get_chat_models`. This adapter keeps
+    provider discovery separate from selection while preserving catalog order
+    as the resolver's deterministic tie-breaker.
+
+    :param provider_name: MLflow catalog provider, e.g. ``"openai"`` or
+        ``"databricks"``.
+    :returns: Normalized model entries, newest/preferred catalog entries first.
+    """
+    from omnigent.onboarding.providers import get_chat_models
+
+    models = get_chat_models(provider_name)
+    cost_tiers = _catalog_cost_tiers(models)
+    entries: list[ModelEntry] = []
+    for index, model in enumerate(models):
+        supported: set[ModelCapability] = set()
+        unsupported: set[ModelCapability] = set()
+        for capability, value in (
+            (ModelCapability.TOOL_USE, model.supports_function_calling),
+            (ModelCapability.REASONING, model.supports_reasoning),
+            (ModelCapability.VISION, model.supports_vision),
+            (ModelCapability.STRUCTURED_OUTPUT, model.supports_structured_output),
+        ):
+            if value is True:
+                supported.add(capability)
+            elif value is False:
+                unsupported.add(capability)
+        context_window = (
+            model.max_input_tokens + (model.max_output_tokens or 0)
+            if model.max_input_tokens is not None
+            else None
+        )
+        entries.append(
+            ModelEntry(
+                id=model.name,
+                family=model_family_token(model.name),
+                metadata=ModelMetadata(
+                    supported_capabilities=frozenset(supported),
+                    unsupported_capabilities=frozenset(unsupported),
+                    context_window=context_window,
+                    cost_tier=cost_tiers.get(index),
+                ),
+            )
+        )
+    return tuple(entries)
+
+
+def resolve_catalog_model(
+    provider_name: str,
+    *,
+    intent: ModelIntent = ModelIntent.DEFAULT,
+    configured_default: str | None = None,
+    family: str | None = None,
+) -> ModelResolution:
+    """Resolve a model from the live bundled provider catalog.
+
+    :param provider_name: MLflow catalog provider name.
+    :param intent: Stable selection intent.
+    :param configured_default: Optional provider-configured model. It is
+        represented as a candidate in *family* so provider configuration keeps
+        precedence even when the remote catalog has not learned the id yet.
+    :param family: Optional normalized catalog family (``"claude"`` /
+        ``"openai"`` / ``"other"``).
+    :returns: The resolver result with source and normalized metadata.
+    :raises ModelResolutionError: When no compatible catalog model exists.
+    """
+    models = list(catalog_model_entries(provider_name))
+    if configured_default is not None and all(model.id != configured_default for model in models):
+        models.insert(
+            0,
+            ModelEntry(
+                id=configured_default,
+                family=family or model_family_token(configured_default),
+            ),
+        )
+    return resolve_model(
+        ModelResolutionRequest(
+            intent=intent,
+            configured_default=configured_default,
+            allowed_families=frozenset({family}) if family is not None else frozenset(),
+        ),
+        models,
+    )
+
+
+def _catalog_cost_tiers(models: list[ModelInfo]) -> dict[int, ModelCostTier]:
+    """Assign provider-relative thirds from reported token prices."""
+    priced: list[tuple[int, float]] = []
+    for index, model in enumerate(models):
+        input_price = getattr(model, "input_price", None)
+        output_price = getattr(model, "output_price", None)
+        if isinstance(input_price, (int, float)) and isinstance(output_price, (int, float)):
+            priced.append((index, float(input_price) + float(output_price)))
+    distinct = sorted({price for _, price in priced})
+    if not distinct:
+        return {}
+    if len(distinct) == 1:
+        return {index: ModelCostTier.STANDARD for index, _ in priced}
+    tiers: dict[int, ModelCostTier] = {}
+    price_rank = {price: rank / (len(distinct) - 1) for rank, price in enumerate(distinct)}
+    for index, price in priced:
+        percentile = price_rank[price]
+        if percentile <= 1 / 3:
+            tiers[index] = ModelCostTier.ECONOMY
+        elif percentile >= 2 / 3:
+            tiers[index] = ModelCostTier.PREMIUM
+        else:
+            tiers[index] = ModelCostTier.STANDARD
+    return tiers
 
 
 def spec_harness(spec: Any) -> str | None:  # type: ignore[explicit-any]  # structural spec stubs in tests

--- a/omnigent/onboarding/databricks_config.py
+++ b/omnigent/onboarding/databricks_config.py
@@ -78,13 +78,6 @@ def databricks_sdk_installed() -> bool:
         return False
 
 
-# Fallback Claude model for the Databricks AI gateway when neither the spec
-# nor the workspace's ucode state names one. Must be a ``databricks-*``
-# endpoint name — the gateway rejects Anthropic-direct ids like the CLI's
-# own ``opus[1m]`` default.
-DATABRICKS_CLAUDE_DEFAULT_MODEL = "databricks-claude-opus-4-8"
-
-
 def list_databricks_profiles() -> list[str]:
     """Return the profile section names declared in ``~/.databrickscfg``.
 

--- a/omnigent/onboarding/providers/__init__.py
+++ b/omnigent/onboarding/providers/__init__.py
@@ -15,7 +15,7 @@ import json
 import re
 import threading
 import urllib.request
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from dataclasses import dataclass
 from typing import Any
 
@@ -450,7 +450,11 @@ _DEFAULT_MODEL_OVERRIDE: dict[str, str] = {
 }
 
 
-def default_chat_model(provider: str) -> str | None:
+def default_chat_model(
+    provider: str,
+    *,
+    allowed_models: Collection[str] | None = None,
+) -> str | None:
     """
     Return the catalog's canonical default chat model for a provider.
 
@@ -476,7 +480,12 @@ def default_chat_model(provider: str) -> str | None:
     ``gpt-5.5``) even when the bundled catalog lags. Other providers follow
     the dynamic rule above.
 
+    Explicit provider pins remain authoritative even when they are newer than
+    the catalog. ``allowed_models`` constrains only the dynamic catalog rule,
+    which lets callers apply family or routing compatibility before selection.
+
     :param provider: Provider name, e.g. ``"anthropic"`` or ``"openai"``.
+    :param allowed_models: Optional model ids eligible for dynamic selection.
     :returns: The default model id, e.g. ``"claude-opus-4-8"`` or
         ``"gpt-5.5"``, or ``None`` when the catalog has no chat model for
         that provider (genuinely unknown provider).
@@ -487,8 +496,11 @@ def default_chat_model(provider: str) -> str | None:
     if override is not None:
         return override
 
+    allowed = set(allowed_models) if allowed_models is not None else None
     general: list[str] = []
     for model in get_chat_models(provider):
+        if allowed is not None and model.name not in allowed:
+            continue
         lowered = model.name.lower()
         if any(token in lowered for token in _SPECIALTY_MODEL_TOKENS):
             continue

--- a/omnigent/onboarding/providers/__init__.py
+++ b/omnigent/onboarding/providers/__init__.py
@@ -30,17 +30,31 @@ class ModelInfo:
     :param name: The model identifier, e.g. ``"claude-sonnet-4-20250514"``.
     :param provider: The provider name, e.g. ``"anthropic"``.
     :param mode: The model mode, e.g. ``"chat"``, ``"embedding"``, or ``None``.
-    :param supports_function_calling: Whether the model supports tool use.
+    :param supports_function_calling: Whether the model supports tool use, or
+        ``None`` when the catalog does not report it.
+    :param supports_reasoning: Whether the model supports reasoning, or
+        ``None`` when unknown.
+    :param supports_vision: Whether the model supports image input, or
+        ``None`` when unknown.
+    :param supports_structured_output: Whether the model supports response
+        schemas, or ``None`` when unknown.
     :param max_input_tokens: Maximum input context window size, or ``None``.
     :param max_output_tokens: Maximum output tokens, or ``None``.
+    :param input_price: Input price per million tokens, or ``None``.
+    :param output_price: Output price per million tokens, or ``None``.
     """
 
     name: str
     provider: str
     mode: str | None = None
-    supports_function_calling: bool = False
+    supports_function_calling: bool | None = None
+    supports_reasoning: bool | None = None
+    supports_vision: bool | None = None
+    supports_structured_output: bool | None = None
     max_input_tokens: int | None = None
     max_output_tokens: int | None = None
+    input_price: float | None = None
+    output_price: float | None = None
 
 
 @dataclass
@@ -352,18 +366,21 @@ def get_models(provider: str) -> list[ModelInfo]:
 
             context = entry.get("context_window", {})
             capabilities = entry.get("capabilities", {})
+            pricing = entry.get("pricing", {})
 
             models.append(
                 ModelInfo(
                     name=model_name,
                     provider=provider,
                     mode=entry.get("mode"),
-                    supports_function_calling=capabilities.get(
-                        "function_calling",
-                        False,
-                    ),
+                    supports_function_calling=capabilities.get("function_calling"),
+                    supports_reasoning=capabilities.get("reasoning"),
+                    supports_vision=capabilities.get("vision"),
+                    supports_structured_output=capabilities.get("response_schema"),
                     max_input_tokens=context.get("max_input"),
                     max_output_tokens=context.get("max_output"),
+                    input_price=pricing.get("input_per_million_tokens"),
+                    output_price=pricing.get("output_per_million_tokens"),
                 )
             )
 
@@ -490,12 +507,11 @@ def default_chat_model(provider: str) -> str | None:
 # Model sorting — newest/best models first
 # ---------------------------------------------------------------------------
 
-# Matches version-like numbers in model names: gpt-4 → 4, claude-3.5 → 3.5,
-# o1 → 1, gpt-4.1 → 4.1, llama-4 → 4
-_VERSION_PATTERN = re.compile(
-    r"(?:^|[-/])"  # start of string or separator
-    r"(?:gpt-?|o|claude-?|llama-?|gemini-?|deepseek-?v?)?"
-    r"(\d+(?:\.\d+)?)"  # version number (e.g. 4, 3.5, 4.1)
+# Vendor marker used to isolate version tokens from provider prefixes, model
+# sizes, and dates. The previous optional marker treated any number as a model
+# version, so a size such as ``120b`` could outrank a newer vendor model.
+_VERSION_FAMILY_PATTERN = re.compile(
+    r"(?:^|[-/])(?:gpt|claude|llama|gemini|deepseek(?:-v)?|o)(?=[-/]?\d|[-/])"
 )
 
 # Matches dates: 2025-04-14, 20250414, 20241022
@@ -509,10 +525,19 @@ def _extract_model_version(name: str) -> float:
     :param name: Model name, e.g. ``"gpt-4.1-2025-04-14"``.
     :returns: Version as float, or ``0.0`` if none found.
     """
-    match = _VERSION_PATTERN.search(name)
-    if match:
-        return float(match.group(1))
-    return 0.0
+    family = _VERSION_FAMILY_PATTERN.search(name.lower())
+    if family is None:
+        return 0.0
+    suffix = _DATE_PATTERN.sub("", name[family.end() :])
+    tokens = [
+        token for token in re.split(r"[-/]", suffix) if re.fullmatch(r"\d+(?:\.\d+)?", token)
+    ]
+    if not tokens:
+        return 0.0
+    primary = float(tokens[0])
+    if "." not in tokens[0] and len(tokens) > 1 and len(tokens[1]) == 1:
+        return float(f"{tokens[0]}.{tokens[1]}")
+    return primary
 
 
 def _extract_model_date(name: str) -> int:

--- a/omnigent/opencode_native_provider.py
+++ b/omnigent/opencode_native_provider.py
@@ -28,6 +28,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from omnigent import model_catalog
+
 if TYPE_CHECKING:
     from omnigent.spec.types import MCPServerConfig
 
@@ -39,8 +41,6 @@ DATABRICKS_GATEWAY_PROVIDER_ID = "databricks-gateway"
 DATABRICKS_GATEWAY_PROVIDER_NAME = "Databricks AI Gateway"
 # Endpoint that exposes the workspace's OpenAI-compatible chat completions.
 _SERVING_ENDPOINTS_PATH = "serving-endpoints"
-# Fallback chat model when neither the spec nor config names one.
-DEFAULT_DATABRICKS_GATEWAY_MODEL = "databricks-claude-sonnet-4-6"
 
 
 @dataclass(frozen=True)
@@ -254,9 +254,8 @@ def resolve_databricks_gateway(
 
     :param profile: A ``~/.databrickscfg`` profile name, e.g. ``"oss"``;
         ``None`` short-circuits.
-    :param model_id: Endpoint/model id to pin; defaults to
-        :data:`DEFAULT_DATABRICKS_GATEWAY_MODEL` (a ``databricks-*`` chat
-        endpoint the gateway routes).
+    :param model_id: Endpoint/model id to pin. When omitted or incompatible,
+        the Databricks Claude catalog supplies the endpoint.
     :returns: A resolution, or ``None`` when the gateway can't be resolved.
     """
     if not profile:
@@ -277,7 +276,11 @@ def resolve_databricks_gateway(
         _logger.info("opencode Databricks gateway resolve failed for %r: %r", profile, exc)
         return None
 
-    resolved_model = _gateway_endpoint_for_model(model_id) or DEFAULT_DATABRICKS_GATEWAY_MODEL
+    resolved_model = _gateway_endpoint_for_model(model_id)
+    if resolved_model is None:
+        resolved_model = model_catalog.resolve_catalog_model(
+            "databricks", family="claude"
+        ).model_id
     return OpenCodeGatewayResolution(
         base_url=f"{host}/{_SERVING_ENDPOINTS_PATH}",
         api_key=token,

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
+from omnigent import model_catalog
 from omnigent.model_override import normalize_model_for_provider
 from omnigent.onboarding.provider_config import (
     CHAT_WIRE_API,
@@ -57,11 +58,6 @@ PI_CODING_AGENT_DIR_ENV_VAR = "PI_CODING_AGENT_DIR"
 # Provider id registered in the generated ``models.json``. Stable so
 # ``--provider`` can select it.
 _PI_PROVIDER_ID = "omnigent"
-
-# Default model for the Databricks AI Gateway's Anthropic surface — the same
-# default the in-process Databricks executor pins. Used when the session
-# carries no explicit model override.
-_DATABRICKS_PI_DEFAULT_MODEL = "databricks-claude-sonnet-4-6"
 
 # Provider id for the secondary OpenAI Responses provider (GPT models that only
 # support tools via the Responses API, e.g. gpt-5.5, gpt-5.6-*).
@@ -293,7 +289,7 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         provider_id=_PI_PROVIDER_ID,
         base_url=f"{host}{_DATABRICKS_ANTHROPIC_GATEWAY_PATH}",
         api="anthropic-messages",
-        model=model or _DATABRICKS_PI_DEFAULT_MODEL,
+        model=model or model_catalog.resolve_catalog_model("databricks", family="claude").model_id,
         # Pi resolves a "!command" apiKey at request time, so the gateway
         # bearer token is refreshed per request (the auth command itself
         # force-refreshes), matching codex-native's refresh semantics.
@@ -788,7 +784,7 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         provider_id=_PI_PROVIDER_ID,
         base_url=_gateway_anthropic_base_url(transport.base_url),
         api="anthropic-messages",
-        model=model or _DATABRICKS_PI_DEFAULT_MODEL,
+        model=model or model_catalog.resolve_catalog_model("databricks", family="claude").model_id,
         # Pi resolves a "!command" apiKey at request time, so the gateway
         # bearer token (the codex auth command prints it) is refreshed per
         # request — matching codex-native's refresh semantics.

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -9767,6 +9767,13 @@ def _build_spawn_env_from_spec(
     # dispatch, model-key lookup, and logging below all key off the base harness;
     # the concrete agent's slug is read from the spec by ``_build_acp_spawn_env``.
     harness = canonicalize_harness(harness) or harness
+    effective_spec = spec
+    if model_override is not None:
+        executor = getattr(spec, "executor", None)
+        if hasattr(spec, "model_copy") and hasattr(executor, "model_copy"):
+            effective_spec = spec.model_copy(
+                update={"executor": executor.model_copy(update={"model": model_override})}
+            )
     try:
         from omnigent.runtime.workflow import (
             _build_acp_spawn_env,
@@ -9783,32 +9790,32 @@ def _build_spawn_env_from_spec(
         )
 
         if harness == "claude-sdk":
-            env = _build_claude_sdk_spawn_env(spec, cwd=cwd, workdir=workdir)
+            env = _build_claude_sdk_spawn_env(effective_spec, cwd=cwd, workdir=workdir)
         elif harness == "codex":
-            env = _build_codex_spawn_env(spec, cwd=cwd, workdir=workdir)
+            env = _build_codex_spawn_env(effective_spec, cwd=cwd, workdir=workdir)
         elif harness == "pi":
-            env = _build_pi_spawn_env(spec, cwd=cwd, workdir=workdir)
+            env = _build_pi_spawn_env(effective_spec, cwd=cwd, workdir=workdir)
         elif harness == "openai-agents":
-            env = _build_openai_agents_sdk_spawn_env(spec)
+            env = _build_openai_agents_sdk_spawn_env(effective_spec)
         elif harness == "cursor":
-            env = _build_cursor_spawn_env(spec, cwd=cwd, workdir=workdir)
+            env = _build_cursor_spawn_env(effective_spec, cwd=cwd, workdir=workdir)
         elif harness == "antigravity":
-            env = _build_antigravity_spawn_env(spec)
+            env = _build_antigravity_spawn_env(effective_spec)
         elif harness == "kimi":
-            env = _build_kimi_spawn_env(spec, cwd=cwd)
+            env = _build_kimi_spawn_env(effective_spec, cwd=cwd)
         elif harness == "qwen":
-            env = _build_qwen_spawn_env(spec, cwd=cwd, workdir=workdir)
+            env = _build_qwen_spawn_env(effective_spec, cwd=cwd, workdir=workdir)
         elif harness == "goose":
-            env = _build_goose_spawn_env(spec, cwd=cwd, workdir=workdir)
+            env = _build_goose_spawn_env(effective_spec, cwd=cwd, workdir=workdir)
         elif harness == "acp":
-            env = _build_acp_spawn_env(spec, cwd=cwd, workdir=workdir)
+            env = _build_acp_spawn_env(effective_spec, cwd=cwd, workdir=workdir)
         elif harness == "copilot":
-            env = _build_copilot_spawn_env(spec, cwd=cwd, workdir=workdir)
+            env = _build_copilot_spawn_env(effective_spec, cwd=cwd, workdir=workdir)
         else:
             builder_path = spawn_env_builders().get(harness)
             if builder_path is not None:
                 builder = load_object(builder_path)
-                env = builder(spec, cwd=cwd, workdir=workdir)
+                env = builder(effective_spec, cwd=cwd, workdir=workdir)
             else:
                 # Native terminal harnesses and unknown harnesses build env elsewhere.
                 return None

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -34,8 +34,9 @@ from omnigent.entities import (
 from omnigent.env_credentials import expand_envvars_with_omnigent_prefix
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.llms import Client as LLMClient
+from omnigent.model_catalog import resolve_catalog_model
+from omnigent.model_resolver import ModelResolutionError
 from omnigent.onboarding.databricks_config import (
-    DATABRICKS_CLAUDE_DEFAULT_MODEL,
     get_workspace_url_for_profile,
 )
 from omnigent.onboarding.detected import (
@@ -162,13 +163,8 @@ class UcodeHarnessConfig:
     :param host_key: Harness gateway workspace host env var.
     :param auth_key: Optional harness gateway auth command env var.
     :param refresh_key: Optional harness gateway auth refresh interval env var.
-    :param databricks_default_model: Fallback model id to use on the
-        Databricks gateway path when neither the spec nor the ucode
-        state names a model, e.g. ``"databricks-claude-opus-4-8"``.
-        ``None`` for harnesses with no confirmed Databricks default.
-        Required because the Databricks AI gateway only routes
-        ``databricks-*`` endpoint names, so the CLI's own host-config
-        default (an Anthropic-direct id) is not a usable fallback there.
+    :param catalog_family: Normalized Databricks catalog family used when
+        neither the spec nor ucode state names a model.
     """
 
     agent_name: str
@@ -179,7 +175,7 @@ class UcodeHarnessConfig:
     host_key: str
     auth_key: str | None
     refresh_key: str | None
-    databricks_default_model: str | None = None
+    catalog_family: str
 
 
 _UCODE_HARNESS_CONFIGS: dict[AgentHarnessType, UcodeHarnessConfig] = {
@@ -192,9 +188,7 @@ _UCODE_HARNESS_CONFIGS: dict[AgentHarnessType, UcodeHarnessConfig] = {
         host_key="HARNESS_CLAUDE_SDK_GATEWAY_HOST",
         auth_key="HARNESS_CLAUDE_SDK_GATEWAY_AUTH_COMMAND",
         refresh_key="HARNESS_CLAUDE_SDK_GATEWAY_AUTH_REFRESH_INTERVAL_MS",
-        # The executor only applies this on the profile-derived gateway path,
-        # so the producer must supply it on the ucode-cached path.
-        databricks_default_model=DATABRICKS_CLAUDE_DEFAULT_MODEL,
+        catalog_family="claude",
     ),
     "codex": UcodeHarnessConfig(
         agent_name="codex",
@@ -205,6 +199,7 @@ _UCODE_HARNESS_CONFIGS: dict[AgentHarnessType, UcodeHarnessConfig] = {
         host_key="HARNESS_CODEX_GATEWAY_HOST",
         auth_key="HARNESS_CODEX_GATEWAY_AUTH_COMMAND",
         refresh_key="HARNESS_CODEX_GATEWAY_AUTH_REFRESH_INTERVAL_MS",
+        catalog_family="openai",
     ),
     "pi": UcodeHarnessConfig(
         agent_name="pi",
@@ -215,9 +210,7 @@ _UCODE_HARNESS_CONFIGS: dict[AgentHarnessType, UcodeHarnessConfig] = {
         host_key="HARNESS_PI_GATEWAY_HOST",
         auth_key="HARNESS_PI_GATEWAY_AUTH_COMMAND",
         refresh_key="HARNESS_PI_GATEWAY_AUTH_REFRESH_INTERVAL_MS",
-        # Same parity as claude-sdk: the executor only defaults on the
-        # profile-derived gateway path, so the producer must supply it here.
-        databricks_default_model=DATABRICKS_CLAUDE_DEFAULT_MODEL,
+        catalog_family="claude",
     ),
     "openai-agents-sdk": UcodeHarnessConfig(
         agent_name="codex",
@@ -228,6 +221,7 @@ _UCODE_HARNESS_CONFIGS: dict[AgentHarnessType, UcodeHarnessConfig] = {
         host_key="HARNESS_OPENAI_AGENTS_GATEWAY_HOST",
         auth_key="HARNESS_OPENAI_AGENTS_GATEWAY_AUTH_COMMAND",
         refresh_key=None,
+        catalog_family="openai",
     ),
     "qwen": UcodeHarnessConfig(
         agent_name="qwen",
@@ -238,6 +232,7 @@ _UCODE_HARNESS_CONFIGS: dict[AgentHarnessType, UcodeHarnessConfig] = {
         host_key="HARNESS_QWEN_GATEWAY_HOST",
         auth_key="HARNESS_QWEN_GATEWAY_AUTH_COMMAND",
         refresh_key=None,
+        catalog_family="openai",
     ),
     # NB: ``antigravity`` is intentionally absent. Unlike the gateway
     # harnesses above, the Antigravity SDK authenticates Gemini-natively
@@ -335,10 +330,14 @@ def configure_agent_harness_with_ucode(
         refresh_key=config.refresh_key,
         workspace_url=state.workspace_host,
     )
-    # When ucode caches no model, default it so the CLI doesn't fall back to
-    # its host-config model (an Anthropic-direct id the gateway rejects).
-    if config.model_key not in env and config.databricks_default_model:
-        env[config.model_key] = config.databricks_default_model
+    # When ucode caches no model, resolve a Databricks endpoint so the CLI
+    # cannot fall back to a direct-provider model the gateway rejects.
+    if config.model_key not in env:
+        env[config.model_key] = _resolve_catalog_default_model(
+            "databricks",
+            config.catalog_family,
+            context=f"ucode {harness_type!r} gateway",
+        )
 
 
 def _inject_ucode_agent_state(
@@ -667,13 +666,32 @@ def configure_agent_harness_with_provider(
 # ``openai`` catalog), but routing through this map keeps the family→catalog
 # coupling explicit and one place to change if a family ever fans out to a
 # differently-named catalog (e.g. an openai-compatible vendor).
-_FAMILY_CATALOG_PROVIDER: dict[str, str] = {
-    ANTHROPIC_FAMILY: "anthropic",
-    OPENAI_FAMILY: "openai",
+_FAMILY_CATALOG_TARGET: dict[str, tuple[str, str]] = {
+    ANTHROPIC_FAMILY: ("anthropic", "claude"),
+    OPENAI_FAMILY: ("openai", "openai"),
 }
 
 
-def _catalog_default_model(family_name: str) -> str | None:
+def _resolve_catalog_default_model(
+    provider_name: str,
+    family: str,
+    *,
+    context: str,
+) -> str:
+    """Resolve one live catalog default or raise an actionable input error."""
+    try:
+        return resolve_catalog_model(provider_name, family=family).model_id
+    except ModelResolutionError as exc:
+        raise OmnigentError(
+            f"No default model resolved for {context}: the {provider_name!r} model "
+            f"catalog has no compatible {family!r} entry. Set 'executor.model' in "
+            "the agent YAML or a provider 'models.default', or retry when catalog "
+            "discovery is available.",
+            code=ErrorCode.INVALID_INPUT,
+        ) from exc
+
+
+def _catalog_default_model(family_name: str) -> str:
     """Return the bundled catalog's default model for a provider family.
 
     Used as the model-resolution fallback for a ``key`` / ``gateway`` /
@@ -688,17 +706,22 @@ def _catalog_default_model(family_name: str) -> str | None:
 
     :param family_name: The omnigent family, ``"anthropic"`` or
         ``"openai"``.
-    :returns: The catalog default model id, e.g. ``"claude-opus-4-6-20260205"``
-        or ``"gpt-5.4-2026-03-05"``, or ``None`` when the family has no
-        catalog mapping or the catalog has no chat model for it (genuinely
-        unknown — the caller then fails loud).
+    :returns: The live catalog's preferred model id.
+    :raises OmnigentError: If the family is unknown or discovery has no
+        compatible model.
     """
-    from omnigent.onboarding.providers import default_chat_model
-
-    catalog_provider = _FAMILY_CATALOG_PROVIDER.get(family_name)
-    if catalog_provider is None:
-        return None
-    return default_chat_model(catalog_provider)
+    target = _FAMILY_CATALOG_TARGET.get(family_name)
+    if target is None:
+        raise OmnigentError(
+            f"No model catalog is configured for provider family {family_name!r}.",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    provider_name, catalog_family = target
+    return _resolve_catalog_default_model(
+        provider_name,
+        catalog_family,
+        context=f"provider family {family_name!r}",
+    )
 
 
 def _apply_provider_family(
@@ -730,26 +753,7 @@ def _apply_provider_family(
     if cfg.model_key not in env and family.default_model:
         env[cfg.model_key] = family.default_model
     if cfg.model_key not in env:
-        # Neither the spec nor the provider names a model. On a KNOWN family
-        # (anthropic / openai) fall back to the bundled catalog's default for
-        # that vendor — a real designed default — rather than failing loud.
-        # The neutral gateway path never selects a ``databricks-*`` model;
-        # the executor's old flag-triggered ``databricks-*`` fallback is gone.
-        catalog_default = _catalog_default_model(_PROVIDER_HARNESS_FAMILY[harness_type])
-        if catalog_default is not None:
-            env[cfg.model_key] = catalog_default
-    if cfg.model_key not in env:
-        # Fail loud only when the catalog also has nothing for this family
-        # (a genuinely unknown family — should not happen for the two known
-        # ones, but keeps the resolution total).
-        raise OmnigentError(
-            f"No model resolved for the {harness_type!r} harness on a generic provider: "
-            "the agent spec sets no model, the provider's family has no "
-            "'models.default', and the bundled catalog has no default for that family. "
-            "Set 'executor.model' in the agent YAML, or add a "
-            "'models: {default: ...}' to that provider family in ~/.omnigent/config.yaml.",
-            code=ErrorCode.INVALID_INPUT,
-        )
+        env[cfg.model_key] = _catalog_default_model(_PROVIDER_HARNESS_FAMILY[harness_type])
     if harness_type == "codex":
         # Codex defaults to the Responses wire API; OpenRouter-style
         # chat-only gateways set wire_api: chat. See codex_harness.py.
@@ -783,20 +787,7 @@ def _apply_provider_to_openai_agents(env: dict[str, str], family: FamilyConfig) 
     if "HARNESS_OPENAI_AGENTS_MODEL" not in env and family.default_model:
         env["HARNESS_OPENAI_AGENTS_MODEL"] = family.default_model
     if "HARNESS_OPENAI_AGENTS_MODEL" not in env:
-        catalog_default = _catalog_default_model(OPENAI_FAMILY)
-        if catalog_default is not None:
-            env["HARNESS_OPENAI_AGENTS_MODEL"] = catalog_default
-    if "HARNESS_OPENAI_AGENTS_MODEL" not in env:
-        # Fail loud only when the catalog has no default for the openai family
-        # (genuinely unknown — should not happen for a known family).
-        raise OmnigentError(
-            "No model resolved for the 'openai-agents-sdk' harness on a generic provider: "
-            "the agent spec sets no model, the provider's 'openai' family has no "
-            "'models.default', and the bundled catalog has no default for it. "
-            "Set 'executor.model' in the agent YAML, or add a "
-            "'models: {default: ...}' to that provider family in ~/.omnigent/config.yaml.",
-            code=ErrorCode.INVALID_INPUT,
-        )
+        env["HARNESS_OPENAI_AGENTS_MODEL"] = _catalog_default_model(OPENAI_FAMILY)
     if family.wire_api is not None:
         env["HARNESS_OPENAI_AGENTS_USE_RESPONSES"] = (
             "true" if family.wire_api == RESPONSES_WIRE_API else "false"
@@ -880,20 +871,7 @@ def _apply_provider_to_pi(env: dict[str, str], entry: ProviderEntry) -> None:
     if "HARNESS_PI_MODEL" not in env and auth_source.default_model:
         env["HARNESS_PI_MODEL"] = auth_source.default_model
     if "HARNESS_PI_MODEL" not in env:
-        catalog_default = _catalog_default_model(auth_family)
-        if catalog_default is not None:
-            env["HARNESS_PI_MODEL"] = catalog_default
-    if "HARNESS_PI_MODEL" not in env:
-        # Fail loud only when the catalog has no default for the chosen family
-        # (genuinely unknown — should not happen for a known family).
-        raise OmnigentError(
-            "No model resolved for the 'pi' harness on a generic provider: the agent "
-            "spec sets no model, the provider family has no 'models.default', and the "
-            "bundled catalog has no default for it. Set 'executor.model' in the agent "
-            "YAML, or add a 'models: {default: ...}' to that provider family in "
-            "~/.omnigent/config.yaml.",
-            code=ErrorCode.INVALID_INPUT,
-        )
+        env["HARNESS_PI_MODEL"] = _catalog_default_model(auth_family)
 
 
 def _apply_cli_config_databricks_to_pi(env: dict[str, str], entry: ProviderEntry) -> None:

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -1550,6 +1550,21 @@ def test_apply_overrides_explicit_model_wins_over_env_var(
     )
 
 
+def test_apply_overrides_harness_uses_explicit_env_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A CLI harness override keeps an explicit environment model pin."""
+    monkeypatch.setenv("OMNIGENT_MODEL", "from-env")
+    raw: dict[str, object] = {"name": "ad_hoc", "prompt": "hi"}
+
+    _apply_overrides_to_raw(raw, ChatOverrides(harness="openai-agents"))
+
+    executor = raw["executor"]
+    assert isinstance(executor, dict)
+    assert executor["harness"] == "openai-agents"
+    assert executor["model"] == "from-env"
+
+
 def test_apply_overrides_canonicalizes_claude_harness_alias() -> None:
     """AP override materialization normalizes ``--harness claude``."""
     raw: dict[str, object] = {"name": "claude_agent", "prompt": "hi"}

--- a/tests/e2e/omnigent/_example_helpers.py
+++ b/tests/e2e/omnigent/_example_helpers.py
@@ -159,8 +159,8 @@ def run_one_shot(
     :param harness: ``--harness`` value, or ``None`` to let the
         YAML's ``executor.type`` win (used when the YAML pins a
         specific harness like ``claude_sdk``).
-    :param model: ``--model`` override, only passed when *harness*
-        is non-None (co-selected).
+    :param model: Optional ``--model`` override, independent of whether
+        the YAML or the CLI selects the harness.
     :returns: The completed subprocess. Caller decides which
         fields to assert.
     """
@@ -218,8 +218,8 @@ def run_one_shot_at_path(
     ]
     if harness is not None:
         argv.extend(["--harness", harness])
-        if model is not None:
-            argv.extend(["--model", model])
+    if model is not None:
+        argv.extend(["--model", model])
     # run_with_group_timeout, not subprocess.run: grandchildren
     # (server / runner / harness) hold the pipes past timeout.
     return run_with_group_timeout(

--- a/tests/inner/conftest.py
+++ b/tests/inner/conftest.py
@@ -13,11 +13,23 @@ import os
 import pathlib
 import sys
 import time
+from types import SimpleNamespace
 
 import pytest
 import pytest_asyncio
 
 from tests import _model_pools
+
+
+@pytest.fixture(autouse=True)
+def _stub_executor_catalog_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep executor unit tests deterministic without catalog network access."""
+
+    def _resolve(provider_name: str, *, family: str, **kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(model_id=f"catalog-{provider_name}-{family}-default")
+
+    monkeypatch.setattr("omnigent.model_catalog.resolve_catalog_model", _resolve)
+
 
 # Diagnostic: dump every thread's stack every 90s. The dispatcher's
 # stderr lands in the workflow log directly, but xdist workers route

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -7,6 +7,7 @@ import logging
 import os
 import sys
 import tempfile
+import threading
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -561,15 +562,27 @@ class TestConstructor(unittest.TestCase):
                 executor = ClaudeSDKExecutor(gateway=True)
 
             captured: dict[str, str | None] = {}
+            event_loop_thread = threading.get_ident()
+
+            def _resolve_model(provider_name: str, *, family: str) -> SimpleNamespace:
+                self.assertNotEqual(threading.get_ident(), event_loop_thread)
+                self.assertEqual((provider_name, family), ("databricks", "claude"))
+                return SimpleNamespace(model_id="catalog-databricks-claude-default")
 
             async def fake_get_or_create_client(sdk, *, session_key, options, model):
                 captured["model"] = model
                 raise RuntimeError("stop after model resolution")
 
-            with patch.object(
-                executor,
-                "_get_or_create_client",
-                side_effect=fake_get_or_create_client,
+            with (
+                patch(
+                    "omnigent.model_catalog.resolve_catalog_model",
+                    side_effect=_resolve_model,
+                ),
+                patch.object(
+                    executor,
+                    "_get_or_create_client",
+                    side_effect=fake_get_or_create_client,
+                ),
             ):
                 with self.assertRaises(RuntimeError):
                     async for _ in executor.run_turn([{"role": "user", "content": "hi"}], [], ""):

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -547,10 +547,7 @@ class TestConstructor(unittest.TestCase):
         generic-provider gateway path never does this (see
         ``test_neutral_gateway_no_model_does_not_inject_databricks_default``).
         """
-        from omnigent.inner.claude_sdk_executor import (
-            _DATABRICKS_CLAUDE_DEFAULT_MODEL,
-            ClaudeSDKExecutor,
-        )
+        from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
         from omnigent.inner.databricks_executor import DatabricksCredentials
 
         async def _t():
@@ -578,7 +575,7 @@ class TestConstructor(unittest.TestCase):
                     async for _ in executor.run_turn([{"role": "user", "content": "hi"}], [], ""):
                         pass
 
-            self.assertEqual(captured["model"], _DATABRICKS_CLAUDE_DEFAULT_MODEL)
+            self.assertEqual(captured["model"], "catalog-databricks-claude-default")
 
         _run(_t())
 

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -413,7 +413,7 @@ class TestCodexExecutor(unittest.TestCase):
             self.assertIsInstance(events[2], ToolCallComplete)
             self.assertIsInstance(events[3], TurnComplete)
             self.assertEqual(fake_session.calls[0]["system_prompt"], "Be helpful.")
-            self.assertEqual(fake_session.calls[0]["model"], "gpt-5.4-mini")
+            self.assertEqual(fake_session.calls[0]["model"], "catalog-openai-openai-default")
             self.assertEqual(fake_session.calls[0]["tools"][0]["name"], "calculate")
 
         _run(_t())
@@ -441,7 +441,7 @@ class TestCodexExecutor(unittest.TestCase):
             ]
 
             self.assertEqual(events[-1].response, "done")
-            self.assertEqual(fake_session.calls[0]["model"], "databricks-gpt-5-5")
+            self.assertEqual(fake_session.calls[0]["model"], "catalog-databricks-openai-default")
 
         _run(_t())
 

--- a/tests/inner/test_databricks_executor.py
+++ b/tests/inner/test_databricks_executor.py
@@ -574,7 +574,7 @@ class TestDatabricksExecutorConfig(unittest.TestCase):
         _run(_t())
 
     def test_default_model(self):
-        """When no model is specified, falls back to databricks-claude-sonnet-4-6."""
+        """When no model is specified, resolves the Databricks Claude catalog."""
 
         async def _t():
             chunks = _make_text_stream("ok")
@@ -584,7 +584,7 @@ class TestDatabricksExecutorConfig(unittest.TestCase):
             [e async for e in executor.run_turn([], [], "", config=ExecutorConfig())]
             self.assertEqual(
                 client.chat.completions.last_kwargs["model"],
-                "databricks-claude-sonnet-4-6",
+                "catalog-databricks-claude-default",
             )
 
         _run(_t())

--- a/tests/inner/test_databricks_executor.py
+++ b/tests/inner/test_databricks_executor.py
@@ -3,10 +3,13 @@
 import asyncio
 import json
 import sys
+import threading
 import unittest
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import patch
 
 import databricks.sdk.config as _sdk_config_mod
 
@@ -574,14 +577,24 @@ class TestDatabricksExecutorConfig(unittest.TestCase):
         _run(_t())
 
     def test_default_model(self):
-        """When no model is specified, resolves the Databricks Claude catalog."""
+        """Catalog default resolution does not block the event-loop thread."""
 
         async def _t():
             chunks = _make_text_stream("ok")
             client = FakeClient(chunks)
             executor = DatabricksExecutor(client=client)
+            event_loop_thread = threading.get_ident()
 
-            [e async for e in executor.run_turn([], [], "", config=ExecutorConfig())]
+            def _resolve_model(provider_name: str, *, family: str) -> SimpleNamespace:
+                self.assertNotEqual(threading.get_ident(), event_loop_thread)
+                self.assertEqual((provider_name, family), ("databricks", "claude"))
+                return SimpleNamespace(model_id="catalog-databricks-claude-default")
+
+            with patch(
+                "omnigent.model_catalog.resolve_catalog_model",
+                side_effect=_resolve_model,
+            ):
+                [e async for e in executor.run_turn([], [], "", config=ExecutorConfig())]
             self.assertEqual(
                 client.chat.completions.last_kwargs["model"],
                 "catalog-databricks-claude-default",

--- a/tests/inner/test_openai_agents_sdk_executor.py
+++ b/tests/inner/test_openai_agents_sdk_executor.py
@@ -568,11 +568,11 @@ class TestOpenAIAgentsSDKExecutor(unittest.TestCase):
             self.assertEqual(events[-1].response, "done")
             self.assertEqual(
                 _FakeRunner.last_calls[0]["agent"].model,
-                "databricks-gpt-5-5",
+                "catalog-databricks-openai-default",
             )
             self.assertEqual(
                 _FakeRunner.last_calls[0]["run_config"].kwargs["model"],
-                "databricks-gpt-5-5",
+                "catalog-databricks-openai-default",
             )
 
         _run(_t())

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -1491,7 +1491,8 @@ class TestResolveModel(unittest.TestCase):
         with patch("omnigent.inner.pi_executor._find_pi_cli", return_value="/usr/bin/pi"):
             executor = PiExecutor(model="constructor-default")
         self.assertEqual(
-            executor._resolve_model(ExecutorConfig(model="cfg-override")), "cfg-override"
+            _run(executor._resolve_model(ExecutorConfig(model="cfg-override"))),
+            "cfg-override",
         )
 
     def test_constructor_default_used_when_no_cfg_override(self):
@@ -1501,7 +1502,8 @@ class TestResolveModel(unittest.TestCase):
         with patch("omnigent.inner.pi_executor._find_pi_cli", return_value="/usr/bin/pi"):
             executor = PiExecutor(model="constructor-default")
         self.assertEqual(
-            executor._resolve_model(ExecutorConfig(model=None)), "constructor-default"
+            _run(executor._resolve_model(ExecutorConfig(model=None))),
+            "constructor-default",
         )
 
     def test_cfg_model_used_when_no_constructor_default(self):
@@ -1512,7 +1514,8 @@ class TestResolveModel(unittest.TestCase):
         with patch("omnigent.inner.pi_executor._find_pi_cli", return_value="/usr/bin/pi"):
             executor = PiExecutor()
         self.assertEqual(
-            executor._resolve_model(ExecutorConfig(model="config-model")), "config-model"
+            _run(executor._resolve_model(ExecutorConfig(model="config-model"))),
+            "config-model",
         )
 
 
@@ -2875,7 +2878,7 @@ def test_profile_gateway_resolves_databricks_default_model() -> None:
         ),
     ):
         executor = PiExecutor(gateway=True)
-    assert executor._resolve_model(ExecutorConfig(model=None)) == (
+    assert _run(executor._resolve_model(ExecutorConfig(model=None))) == (
         "catalog-databricks-claude-default"
     )
 
@@ -2896,7 +2899,7 @@ def test_profile_gateway_default_does_not_clobber_explicit_model() -> None:
         ),
     ):
         executor = PiExecutor(gateway=True, model="databricks-gpt-5-4")
-    assert executor._resolve_model(ExecutorConfig(model=None)) == "databricks-gpt-5-4"
+    assert _run(executor._resolve_model(ExecutorConfig(model=None))) == "databricks-gpt-5-4"
 
 
 def test_ucode_gateway_host_path_does_not_inject_default_model() -> None:
@@ -2921,7 +2924,7 @@ def test_ucode_gateway_host_path_does_not_inject_default_model() -> None:
             gateway_host="https://example.databricks.com",
             gateway_auth_command="printf token",
         )
-    assert executor._resolve_model(ExecutorConfig(model=None)) is None
+    assert _run(executor._resolve_model(ExecutorConfig(model=None))) is None
 
 
 def test_non_gateway_path_does_not_inject_default_model() -> None:
@@ -2932,7 +2935,7 @@ def test_non_gateway_path_does_not_inject_default_model() -> None:
     """
     with patch("omnigent.inner.pi_executor._find_pi_cli", return_value="/usr/bin/pi"):
         executor = PiExecutor()
-    assert executor._resolve_model(ExecutorConfig(model=None)) is None
+    assert _run(executor._resolve_model(ExecutorConfig(model=None))) is None
 
 
 def test_models_json_lists_only_gateway_verified_models() -> None:

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -38,7 +38,6 @@ from omnigent.inner.pi_executor import (
     _split_pi_prompt,
     _ToolServer,
 )
-from omnigent.onboarding.databricks_config import DATABRICKS_CLAUDE_DEFAULT_MODEL
 from omnigent.runtime.harnesses._scaffold import PolicyVerdictPayload
 
 
@@ -2876,7 +2875,9 @@ def test_profile_gateway_resolves_databricks_default_model() -> None:
         ),
     ):
         executor = PiExecutor(gateway=True)
-    assert executor._resolve_model(ExecutorConfig(model=None)) == DATABRICKS_CLAUDE_DEFAULT_MODEL
+    assert executor._resolve_model(ExecutorConfig(model=None)) == (
+        "catalog-databricks-claude-default"
+    )
 
 
 def test_profile_gateway_default_does_not_clobber_explicit_model() -> None:
@@ -2932,22 +2933,6 @@ def test_non_gateway_path_does_not_inject_default_model() -> None:
     with patch("omnigent.inner.pi_executor._find_pi_cli", return_value="/usr/bin/pi"):
         executor = PiExecutor()
     assert executor._resolve_model(ExecutorConfig(model=None)) is None
-
-
-def test_databricks_default_model_is_resolvable_in_models_json() -> None:
-    """
-    The shared Databricks default must route to the anthropic provider AND
-    be listed in that provider's models — otherwise the default the
-    producer/executor inject can't be resolved by pi at spawn time.
-
-    Failure means the default-model constant and pi's models.json drifted
-    apart: every modelless gateway agent would fail its first turn with a
-    pi "unknown model" error.
-    """
-    assert _pi_provider_for_model(DATABRICKS_CLAUDE_DEFAULT_MODEL) == "databricks-anthropic"
-    models = _build_models_json("https://host.example.com", "tok")
-    anthropic_ids = [m["id"] for m in models["providers"]["databricks-anthropic"]["models"]]
-    assert DATABRICKS_CLAUDE_DEFAULT_MODEL in anthropic_ids
 
 
 def test_models_json_lists_only_gateway_verified_models() -> None:

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -11,6 +11,7 @@ import textwrap
 import unittest
 from datetime import datetime
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -2881,6 +2882,32 @@ def test_profile_gateway_resolves_databricks_default_model() -> None:
     assert _run(executor._resolve_model(ExecutorConfig(model=None))) == (
         "catalog-databricks-claude-default"
     )
+
+
+def test_catalog_default_is_registered_in_models_json() -> None:
+    """Pi registers a catalog-selected gateway default before launch."""
+    catalog_default = "databricks-claude-catalog-default"
+    with (
+        patch("omnigent.inner.pi_executor._find_pi_cli", return_value="/usr/bin/pi"),
+        patch(
+            "omnigent.inner.pi_executor._read_databrickscfg",
+            return_value=DatabricksCredentials(host="https://h.example.com", token="tok"),
+        ),
+        patch(
+            "omnigent.model_catalog.resolve_catalog_model",
+            return_value=SimpleNamespace(model_id=catalog_default),
+        ),
+    ):
+        executor = PiExecutor(gateway=True)
+        resolved = _run(executor._resolve_model(ExecutorConfig(model=None)))
+
+    models = _build_models_json("https://h.example.com", "tok", model=resolved)
+    anthropic_ids = {
+        entry["id"] for entry in models["providers"]["databricks-anthropic"]["models"]
+    }
+
+    assert resolved == catalog_default
+    assert catalog_default in anthropic_ids
 
 
 def test_profile_gateway_default_does_not_clobber_explicit_model() -> None:

--- a/tests/onboarding/test_providers.py
+++ b/tests/onboarding/test_providers.py
@@ -193,6 +193,27 @@ def test_get_chat_models_sorted_newest_first() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("provider-gpt-5-6", 5.6),
+        ("provider-claude-opus-4-8", 4.8),
+        ("provider/llama-3.1-instruct", 3.1),
+        ("o3", 3.0),
+        ("provider-gpt-audio-2025-12-15", 0.0),
+        ("provider-gpt-oss-120b", 0.0),
+        ("provider-qwen35-122b", 0.0),
+    ],
+)
+def test_extract_model_version_ignores_dates_sizes_and_unknown_families(
+    name: str, expected: float
+) -> None:
+    """Only vendor version tokens influence newest-first ordering."""
+    from omnigent.onboarding.providers import _extract_model_version
+
+    assert _extract_model_version(name) == expected
+
+
 # ── default_chat_model ─────────────────────────────────────
 
 

--- a/tests/onboarding/test_providers.py
+++ b/tests/onboarding/test_providers.py
@@ -274,6 +274,26 @@ def test_default_chat_model_dynamic_skips_specialty_variants() -> None:
     assert general[0].startswith("gpt-")
 
 
+def test_default_chat_model_limits_dynamic_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Callers can constrain dynamic defaults before policy selection."""
+    models = [
+        ModelInfo(name="gpt-audio-new", provider="vendor", mode="chat"),
+        ModelInfo(name="gpt-new", provider="vendor", mode="chat"),
+        ModelInfo(name="gpt-compatible", provider="vendor", mode="chat"),
+    ]
+    monkeypatch.setattr(_providers_mod, "get_chat_models", lambda _provider: models)
+
+    assert (
+        default_chat_model(
+            "vendor",
+            allowed_models={"gpt-audio-new", "gpt-compatible"},
+        )
+        == "gpt-compatible"
+    )
+
+
 def test_default_chat_model_unknown_provider_is_none() -> None:
     """An unknown provider yields None (the runtime then fails loud)."""
     assert default_chat_model("nonexistent_provider_xyz") is None

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -1389,6 +1389,8 @@ def test_build_spawn_env_applies_model_override(
         "    anthropic:\n"
         "      base_url: https://api.anthropic.com\n"
         "      api_key: $ANTHROPIC_API_KEY\n"
+        "      models:\n"
+        "        default: test-default\n"
     )
     spec = AgentSpec(
         spec_version=1,
@@ -1430,6 +1432,8 @@ async def test_resolve_harness_config_applies_harness_override(
         "    anthropic:\n"
         "      base_url: https://api.anthropic.com\n"
         "      api_key: $ANTHROPIC_API_KEY\n"
+        "      models:\n"
+        "        default: test-default\n"
     )
     spec = AgentSpec(
         spec_version=1,

--- a/tests/runtime/test_claude_sdk_spawn_env.py
+++ b/tests/runtime/test_claude_sdk_spawn_env.py
@@ -38,6 +38,10 @@ def _isolate_global_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> N
     :param tmp_path: Temporary directory for the isolated config.
     """
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow._resolve_catalog_default_model",
+        lambda provider_name, family, *, context: f"catalog-{provider_name}-{family}-default",
+    )
 
 
 def _make_spec(
@@ -225,7 +229,7 @@ def test_ucode_state_without_model_falls_back_to_databricks_default(
 
     assert env["HARNESS_CLAUDE_SDK_GATEWAY"] == "true"
     # The verified routable gateway endpoint name, not the CLI's own default.
-    assert env["HARNESS_CLAUDE_SDK_MODEL"] == "databricks-claude-opus-4-8"
+    assert env["HARNESS_CLAUDE_SDK_MODEL"] == "catalog-databricks-claude-default"
 
 
 def test_ucode_state_with_model_is_not_overridden_by_default(

--- a/tests/runtime/test_pi_spawn_env.py
+++ b/tests/runtime/test_pi_spawn_env.py
@@ -30,6 +30,10 @@ def _isolate_global_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> N
     :param tmp_path: Temporary directory for the isolated config.
     """
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow._resolve_catalog_default_model",
+        lambda provider_name, family, *, context: f"catalog-{provider_name}-{family}-default",
+    )
 
 
 def _make_spec(*, model: str | None = None, profile: str | None = None) -> AgentSpec:
@@ -141,7 +145,7 @@ def test_ucode_state_without_model_falls_back_to_databricks_default(
 
     assert env["HARNESS_PI_GATEWAY"] == "true"
     # The verified routable gateway endpoint name, not pi's own default.
-    assert env["HARNESS_PI_MODEL"] == "databricks-claude-opus-4-8"
+    assert env["HARNESS_PI_MODEL"] == "catalog-databricks-claude-default"
 
 
 def test_ucode_state_with_model_is_not_overridden_by_default(

--- a/tests/runtime/test_provider_spawn_env.py
+++ b/tests/runtime/test_provider_spawn_env.py
@@ -21,6 +21,7 @@ subprocess spawn, no real CLI.
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import yaml as _yaml
@@ -44,6 +45,13 @@ from omnigent.spec.types import (
     ProviderAuth,
 )
 
+_CATALOG_DEFAULTS = {
+    ("anthropic", "claude"): "catalog-anthropic-default",
+    ("openai", "openai"): "catalog-openai-default",
+    ("databricks", "claude"): "catalog-databricks-claude-default",
+    ("databricks", "openai"): "catalog-databricks-openai-default",
+}
+
 
 @pytest.fixture(autouse=True)
 def _clear_ambient_keys(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -59,6 +67,16 @@ def _clear_ambient_keys(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "DATABRICKS_TOKEN"):
         monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow._resolve_catalog_default_model",
+        lambda provider_name, family, *, context: _CATALOG_DEFAULTS[(provider_name, family)],
+    )
+    monkeypatch.setattr(
+        "omnigent.model_catalog.resolve_catalog_model",
+        lambda provider_name, *, family, **kwargs: SimpleNamespace(
+            model_id=_CATALOG_DEFAULTS[(provider_name, family)]
+        ),
+    )
 
 
 @pytest.fixture
@@ -625,8 +643,6 @@ def test_claude_sdk_falls_back_to_catalog_default_model(config_home: Path) -> No
     a real model. The base_url assertion proves the provider branch fired
     (not a vacuous pass).
     """
-    from omnigent.onboarding.providers import default_chat_model
-
     config: dict[str, object] = {
         "providers": {
             "anthropic": {
@@ -641,9 +657,7 @@ def test_claude_sdk_falls_back_to_catalog_default_model(config_home: Path) -> No
 
     env = _build_claude_sdk_spawn_env(spec, workdir=None)
 
-    catalog_default = default_chat_model("anthropic")
-    assert catalog_default is not None  # the catalog knows anthropic
-    assert catalog_default.startswith("claude-")  # a real anthropic model
+    catalog_default = _CATALOG_DEFAULTS[("anthropic", "claude")]
     # The provider branch fired (gateway base_url set) AND the model came
     # from the catalog, not from a provider/spec default and not a failure.
     assert env["HARNESS_CLAUDE_SDK_GATEWAY_BASE_URL"] == "https://api.anthropic.com"
@@ -668,8 +682,6 @@ def test_codex_falls_back_to_catalog_default_model(config_home: Path) -> None:
     ``HARNESS_CODEX_MODEL`` equal to the catalog's default openai model
     (a ``gpt-*`` flagship, not an audio/realtime specialty variant).
     """
-    from omnigent.onboarding.providers import default_chat_model
-
     config: dict[str, object] = {
         "providers": {
             "openai": {
@@ -684,9 +696,7 @@ def test_codex_falls_back_to_catalog_default_model(config_home: Path) -> None:
 
     env = _build_codex_spawn_env(spec, workdir=None)
 
-    catalog_default = default_chat_model("openai")
-    assert catalog_default is not None
-    assert catalog_default.startswith("gpt-")  # a real general-purpose openai model
+    catalog_default = _CATALOG_DEFAULTS[("openai", "openai")]
     assert env["HARNESS_CODEX_GATEWAY_BASE_URL"] == "https://api.openai.com/v1"
     assert env["HARNESS_CODEX_MODEL"] == catalog_default
 
@@ -698,8 +708,6 @@ def test_openai_agents_falls_back_to_catalog_default_model(config_home: Path) ->
 
     Proves the analogous fallback in :func:`_apply_provider_to_openai_agents`.
     """
-    from omnigent.onboarding.providers import default_chat_model
-
     config: dict[str, object] = {
         "providers": {
             "openai": {
@@ -714,8 +722,7 @@ def test_openai_agents_falls_back_to_catalog_default_model(config_home: Path) ->
 
     env = _build_openai_agents_sdk_spawn_env(spec)
 
-    catalog_default = default_chat_model("openai")
-    assert catalog_default is not None
+    catalog_default = _CATALOG_DEFAULTS[("openai", "openai")]
     assert env["HARNESS_OPENAI_AGENTS_GATEWAY_BASE_URL"] == "https://api.openai.com/v1"
     assert env["HARNESS_OPENAI_AGENTS_MODEL"] == catalog_default
 
@@ -783,8 +790,6 @@ def test_qwen_falls_back_to_catalog_default_model(config_home: Path) -> None:
 
     Proves the analogous fallback in :func:`_build_qwen_spawn_env`.
     """
-    from omnigent.onboarding.providers import default_chat_model
-
     config: dict[str, object] = {
         "providers": {
             "openai": {
@@ -799,8 +804,7 @@ def test_qwen_falls_back_to_catalog_default_model(config_home: Path) -> None:
 
     env = _build_qwen_spawn_env(spec, workdir=None)
 
-    catalog_default = default_chat_model("openai")
-    assert catalog_default is not None
+    catalog_default = _CATALOG_DEFAULTS[("openai", "openai")]
     # qwen uses the single gateway base URL (not JSON object like pi)
     assert env["HARNESS_QWEN_GATEWAY_BASE_URL"] == "https://api.openai.com/v1"
     assert env["HARNESS_QWEN_MODEL"] == catalog_default
@@ -814,8 +818,6 @@ def test_pi_falls_back_to_catalog_default_model(config_home: Path) -> None:
     pi prefers the anthropic family for auth, so the model fallback must
     come from the anthropic catalog default.
     """
-    from omnigent.onboarding.providers import default_chat_model
-
     config: dict[str, object] = {
         "providers": {
             "anthropic": {
@@ -830,8 +832,7 @@ def test_pi_falls_back_to_catalog_default_model(config_home: Path) -> None:
 
     env = _build_pi_spawn_env(spec, workdir=None)
 
-    catalog_default = default_chat_model("anthropic")
-    assert catalog_default is not None
+    catalog_default = _CATALOG_DEFAULTS[("anthropic", "claude")]
     assert env["HARNESS_PI_MODEL"] == catalog_default
 
 
@@ -844,8 +845,6 @@ def test_provider_default_beats_catalog_default(config_home: Path) -> None:
     catalog. Failure means the precedence (provider default > catalog
     default) regressed.
     """
-    from omnigent.onboarding.providers import default_chat_model
-
     _write_config(config_home, _anthropic_default_config())  # declares "claude-default-model"
     spec = _make_spec(harness="claude-sdk")
 
@@ -853,7 +852,7 @@ def test_provider_default_beats_catalog_default(config_home: Path) -> None:
 
     # The provider's explicit default is used, not the catalog's.
     assert env["HARNESS_CLAUDE_SDK_MODEL"] == "claude-default-model"
-    assert env["HARNESS_CLAUDE_SDK_MODEL"] != default_chat_model("anthropic")
+    assert env["HARNESS_CLAUDE_SDK_MODEL"] != _CATALOG_DEFAULTS[("anthropic", "claude")]
 
 
 def test_spec_model_beats_catalog_default(config_home: Path) -> None:
@@ -1135,8 +1134,8 @@ def test_pi_cli_config_databricks_default_routes_gateway(
     # table (the "!" Pi-models.json prefix is stripped for the transport var).
     # The fixture's [auth] declares command="jq" with no args, so it is "jq".
     assert env["HARNESS_PI_GATEWAY_AUTH_COMMAND"] == "jq"
-    # Default model is the Databricks gateway default (no spec/override model).
-    assert env["HARNESS_PI_MODEL"] == "databricks-claude-sonnet-4-6"
+    # No spec/override model: use the Databricks Claude catalog selection.
+    assert env["HARNESS_PI_MODEL"] == _CATALOG_DEFAULTS[("databricks", "claude")]
 
 
 _DISMISSIBLE_CODEX_CONFIG_TOML = """

--- a/tests/runtime/test_reasoning_effort_validation.py
+++ b/tests/runtime/test_reasoning_effort_validation.py
@@ -62,7 +62,7 @@ async def test_codex_coerces_max_to_xhigh() -> None:
             messages=[{"role": "user", "content": "hi"}],
             tools=[],
             system_prompt="",
-            config=ExecutorConfig(extra={"reasoning_effort": "max"}),
+            config=ExecutorConfig(model="test-model", extra={"reasoning_effort": "max"}),
         )
     ]
     assert not any(isinstance(e, ExecutorError) for e in events)
@@ -112,7 +112,7 @@ async def test_openai_agents_coerces_max_to_xhigh(monkeypatch: pytest.MonkeyPatc
             messages=[{"role": "user", "content": "hi"}],
             tools=[],
             system_prompt="",
-            config=ExecutorConfig(extra={"reasoning_effort": "max"}),
+            config=ExecutorConfig(model="test-model", extra={"reasoning_effort": "max"}),
         ):
             pass
 

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -33,6 +33,16 @@ from omnigent.terminals.ws_bridge import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _stub_catalog_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "omnigent.model_catalog.resolve_catalog_model",
+        lambda provider_name, *, family, **kwargs: SimpleNamespace(
+            model_id=f"catalog-{provider_name}-{family}-default"
+        ),
+    )
+
+
 def test_claude_terminal_request_pins_launch_cwd(tmp_path, monkeypatch) -> None:
     """
     The terminal launch body pins ``cwd`` to the user's launch dir.
@@ -506,7 +516,7 @@ def test_ucode_config_for_profile_defaults_model_when_ucode_omits_it(
 
     assert config is not None
     # The verified routable gateway endpoint name, not the CLI's own default.
-    assert config.model == "databricks-claude-opus-4-8"
+    assert config.model == "catalog-databricks-claude-default"
 
 
 def test_ucode_config_refreshes_live_models_and_builds_picker_options(

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -28,6 +28,16 @@ from omnigent.codex_native_elicitation import codex_elicitation_id
 from omnigent.spec import load
 
 
+@pytest.fixture(autouse=True)
+def _stub_catalog_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "omnigent.model_catalog.resolve_catalog_model",
+        lambda provider_name, *, family, **kwargs: SimpleNamespace(
+            model_id=f"catalog-{provider_name}-{family}-default"
+        ),
+    )
+
+
 def _write_codex_auth(path: Path, payload: object) -> None:
     """Write a test Codex auth.json payload."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -841,7 +851,7 @@ def test_build_codex_remote_args_passes_transport_verbatim(
             None,
             [
                 "-c",
-                'model="databricks-gpt-5-5"',
+                'model="catalog-databricks-openai-default"',
                 "-c",
                 'model_provider="omnigent_databricks"',
                 "--remote",
@@ -854,7 +864,7 @@ def test_build_codex_remote_args_passes_transport_verbatim(
             "thread_host",
             [
                 "-c",
-                'model="databricks-gpt-5-5"',
+                'model="catalog-databricks-openai-default"',
                 "-c",
                 'model_provider="omnigent_databricks"',
                 "resume",
@@ -890,7 +900,7 @@ def test_build_codex_remote_args_emits_config_overrides_before_subcommand(
             thread_id=thread_id,
             remote_url="ws://127.0.0.1:9876",
             config_overrides=(
-                'model="databricks-gpt-5-5"',
+                'model="catalog-databricks-openai-default"',
                 'model_provider="omnigent_databricks"',
             ),
         )

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -297,7 +297,7 @@ def test_build_codex_native_server_uses_profile_host_without_static_token(
         socket_path=tmp_path / "codex.sock",
         codex_home=tmp_path / "codex-home",
         cwd=tmp_path,
-        model=None,
+        model="test-model",
         profile="oss",
         bridge_dir=tmp_path / "bridge",
         ap_server_url=None,

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -25,16 +25,21 @@ from omnigent.model_catalog import (
     ModelEntry,
     ModelListing,
     catalog_for_spec,
+    catalog_model_entries,
     list_models_for_worker,
+    resolve_catalog_model,
     resolve_model_provider,
     spec_harness,
 )
 from omnigent.model_metadata import (
     ModelCapability,
     ModelCostTier,
+    ModelIntent,
     ModelMetadata,
     ModelWireAPI,
 )
+from omnigent.model_resolver import ModelResolutionError, ModelResolutionSource
+from omnigent.onboarding.providers import ModelInfo
 from omnigent.runtime.credentials.databricks import WorkspaceCreds
 from omnigent.spec.types import AgentSpec, ApiKeyAuth, DatabricksAuth, ExecutorSpec
 
@@ -1161,6 +1166,98 @@ def test_catalog_payload_serializes_normalized_model_metadata() -> None:
             "wire_apis": ["openai-responses"],
         }
     ]
+
+
+def test_bundled_catalog_entries_normalize_capabilities_context_and_cost(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MLflow model facts become provider-neutral resolver metadata."""
+    models = [
+        ModelInfo(
+            name="provider/model-premium",
+            provider="provider",
+            mode="chat",
+            supports_function_calling=True,
+            supports_reasoning=True,
+            supports_vision=False,
+            supports_structured_output=True,
+            max_input_tokens=100_000,
+            max_output_tokens=20_000,
+            input_price=10.0,
+            output_price=30.0,
+        ),
+        ModelInfo(
+            name="provider/model-economy",
+            provider="provider",
+            mode="chat",
+            input_price=0.1,
+            output_price=0.2,
+        ),
+        ModelInfo(
+            name="provider/model-standard",
+            provider="provider",
+            mode="chat",
+            input_price=2.0,
+            output_price=6.0,
+        ),
+    ]
+    monkeypatch.setattr("omnigent.onboarding.providers.get_chat_models", lambda provider: models)
+
+    entries = catalog_model_entries("provider")
+
+    premium = entries[0]
+    assert premium.metadata.context_window == 120_000
+    assert premium.metadata.cost_tier == ModelCostTier.PREMIUM
+    assert premium.metadata.supports(ModelCapability.TOOL_USE) is True
+    assert premium.metadata.supports(ModelCapability.REASONING) is True
+    assert premium.metadata.supports(ModelCapability.VISION) is False
+    assert premium.metadata.supports(ModelCapability.STRUCTURED_OUTPUT) is True
+    assert entries[1].metadata.cost_tier == ModelCostTier.ECONOMY
+    assert entries[2].metadata.cost_tier == ModelCostTier.STANDARD
+
+
+def test_resolve_catalog_model_uses_intent_and_configured_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    models = [
+        ModelInfo(
+            name="model-economy",
+            provider="provider",
+            mode="chat",
+            input_price=0.1,
+            output_price=0.2,
+        ),
+        ModelInfo(
+            name="model-premium",
+            provider="provider",
+            mode="chat",
+            input_price=10.0,
+            output_price=30.0,
+        ),
+    ]
+    monkeypatch.setattr("omnigent.onboarding.providers.get_chat_models", lambda provider: models)
+
+    powerful = resolve_catalog_model("provider", intent=ModelIntent.POWERFUL)
+    configured = resolve_catalog_model(
+        "provider",
+        intent=ModelIntent.POWERFUL,
+        configured_default="model-configured",
+        family="other",
+    )
+
+    assert powerful.model_id == "model-premium"
+    assert powerful.source == ModelResolutionSource.LIVE_CATALOG
+    assert configured.model_id == "model-configured"
+    assert configured.source == ModelResolutionSource.CONFIGURED_DEFAULT
+
+
+def test_resolve_catalog_model_fails_when_discovery_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("omnigent.onboarding.providers.get_chat_models", lambda provider: [])
+
+    with pytest.raises(ModelResolutionError, match="no model satisfies"):
+        resolve_catalog_model("provider")
 
 
 def test_spec_harness_derivation() -> None:

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -1201,12 +1201,12 @@ def test_bundled_catalog_entries_normalize_capabilities_context_and_cost(
             output_price=6.0,
         ),
     ]
-    monkeypatch.setattr("omnigent.onboarding.providers.get_chat_models", lambda provider: models)
+    monkeypatch.setattr("omnigent.onboarding.providers.get_chat_models", lambda _provider: models)
 
     entries = catalog_model_entries("provider")
 
     premium = entries[0]
-    assert premium.metadata.context_window == 120_000
+    assert premium.metadata.context_window == 100_000
     assert premium.metadata.cost_tier == ModelCostTier.PREMIUM
     assert premium.metadata.supports(ModelCapability.TOOL_USE) is True
     assert premium.metadata.supports(ModelCapability.REASONING) is True
@@ -1235,7 +1235,7 @@ def test_resolve_catalog_model_uses_intent_and_configured_precedence(
             output_price=30.0,
         ),
     ]
-    monkeypatch.setattr("omnigent.onboarding.providers.get_chat_models", lambda provider: models)
+    monkeypatch.setattr("omnigent.onboarding.providers.get_chat_models", lambda _provider: models)
 
     powerful = resolve_catalog_model("provider", intent=ModelIntent.POWERFUL)
     configured = resolve_catalog_model(
@@ -1251,12 +1251,87 @@ def test_resolve_catalog_model_uses_intent_and_configured_precedence(
     assert configured.source == ModelResolutionSource.CONFIGURED_DEFAULT
 
 
+def test_resolve_catalog_default_preserves_provider_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default resolution skips specialty models after family filtering."""
+    models = [
+        ModelInfo(name="gpt-audio-new", provider="gateway", mode="chat"),
+        ModelInfo(name="gpt-general", provider="gateway", mode="chat"),
+        ModelInfo(name="claude-general", provider="gateway", mode="chat"),
+    ]
+    monkeypatch.setattr("omnigent.onboarding.providers.get_chat_models", lambda provider: models)
+
+    resolution = resolve_catalog_model("gateway", family="openai")
+
+    assert resolution.model_id == "gpt-general"
+    assert resolution.source == ModelResolutionSource.CONFIGURED_DEFAULT
+
+
+@pytest.mark.parametrize(
+    ("provider", "family", "expected_model"),
+    [
+        ("anthropic", "claude", "claude-opus-4-8"),
+        ("openai", "openai", "gpt-5.5"),
+    ],
+)
+def test_resolve_catalog_default_preserves_provider_pin_when_catalog_lags(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+    family: str,
+    expected_model: str,
+) -> None:
+    """Provider pins remain valid before the remote catalog learns their ids."""
+    monkeypatch.setattr(
+        "omnigent.onboarding.providers.get_chat_models",
+        lambda _provider: [
+            ModelInfo(name=f"{family}-catalog-model", provider=provider, mode="chat")
+        ],
+    )
+
+    resolution = resolve_catalog_model(provider, family=family)
+
+    assert resolution.model_id == expected_model
+    assert resolution.source == ModelResolutionSource.CONFIGURED_DEFAULT
+
+
+@pytest.mark.parametrize(
+    ("family", "expected_model"),
+    [
+        ("claude", "databricks-claude-general"),
+        ("openai", "databricks-gpt-general"),
+    ],
+)
+def test_resolve_databricks_default_requires_gateway_routable_id(
+    monkeypatch: pytest.MonkeyPatch,
+    family: str,
+    expected_model: str,
+) -> None:
+    """Databricks defaults exclude bare vendor ids the gateway rejects."""
+    models = [
+        ModelInfo(name="claude-newer", provider="databricks", mode="chat"),
+        ModelInfo(name="gpt-newer", provider="databricks", mode="chat"),
+        ModelInfo(name="databricks-claude-general", provider="databricks", mode="chat"),
+        ModelInfo(name="databricks-gpt-general", provider="databricks", mode="chat"),
+    ]
+    monkeypatch.setattr("omnigent.onboarding.providers.get_chat_models", lambda _provider: models)
+
+    resolution = resolve_catalog_model("databricks", family=family)
+
+    assert resolution.model_id == expected_model
+    assert resolution.model_id.startswith("databricks-")
+    assert resolution.family == family
+
+
 def test_resolve_catalog_model_fails_when_discovery_is_empty(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("omnigent.onboarding.providers.get_chat_models", lambda provider: [])
 
-    with pytest.raises(ModelResolutionError, match="no model satisfies"):
+    with pytest.raises(
+        ModelResolutionError,
+        match="configure an explicit model or retry when catalog discovery is available",
+    ):
         resolve_catalog_model("provider")
 
 

--- a/tests/test_opencode_native_provider.py
+++ b/tests/test_opencode_native_provider.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import pytest
 
 from omnigent.opencode_native_provider import (
-    DEFAULT_DATABRICKS_GATEWAY_MODEL,
     OpenCodeGatewayResolution,
     _gateway_endpoint_for_model,
     _strip_jsonc_comments,
@@ -23,6 +22,16 @@ from omnigent.opencode_native_provider import (
     resolve_databricks_gateway,
     write_opencode_provider_config,
 )
+
+
+@pytest.fixture(autouse=True)
+def _stub_catalog_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "omnigent.model_catalog.resolve_catalog_model",
+        lambda provider_name, *, family, **kwargs: types.SimpleNamespace(
+            model_id=f"catalog-{provider_name}-{family}-default"
+        ),
+    )
 
 
 def test_build_omnigent_mcp_server_points_serve_mcp_at_bridge_dir() -> None:
@@ -154,7 +163,7 @@ def test_resolve_gateway_defaults_non_gateway_model(monkeypatch: pytest.MonkeyPa
     _install_fake_sdk(monkeypatch, host="https://ws.databricks.com", token="t")
     res = resolve_databricks_gateway("oss", model_id="claude-opus-4")
     assert res is not None
-    assert res.model_id == DEFAULT_DATABRICKS_GATEWAY_MODEL
+    assert res.model_id == "catalog-databricks-claude-default"
 
 
 def test_resolve_gateway_none_when_no_token(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -5,10 +5,21 @@ from __future__ import annotations
 import json
 import stat
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from omnigent import pi_native_credentials as creds
+
+
+@pytest.fixture(autouse=True)
+def _stub_catalog_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "omnigent.model_catalog.resolve_catalog_model",
+        lambda provider_name, *, family, **kwargs: SimpleNamespace(
+            model_id=f"catalog-{provider_name}-{family}-default"
+        ),
+    )
 
 
 def _databricks_config() -> dict[str, object]:
@@ -40,7 +51,7 @@ def test_resolves_databricks_default_to_anthropic_gateway(monkeypatch: pytest.Mo
     assert provider is not None
     assert provider.api == "anthropic-messages"
     assert provider.base_url == "https://wkspc.example.com/ai-gateway/anthropic"
-    assert provider.model == "databricks-claude-sonnet-4-6"
+    assert provider.model == "catalog-databricks-claude-default"
     assert provider.auth_header is True
     # apiKey is a "!command" so Pi refreshes the gateway token per request.
     assert provider.api_key.startswith("!")
@@ -398,7 +409,7 @@ def test_cli_config_databricks_resolves_to_anthropic_gateway(
     assert (
         provider.base_url == "https://1965859176160743.ai-gateway.cloud.databricks.com/anthropic"
     )
-    assert provider.model == "databricks-claude-sonnet-4-6"
+    assert provider.model == "catalog-databricks-claude-default"
     assert provider.auth_header is True
     # apiKey is a "!command" rebuilt from the table's [X.auth] command + args
     # so Pi refreshes the gateway token per request.


### PR DESCRIPTION
## Related issue

Part of #3426

## Summary

Runtime harnesses still choose release-specific model ids even after the resolver contract exists, so provider releases can make defaults stale across several independent call sites. This stacked PR moves those defaults to provider catalog discovery while preserving explicit user, spec, ucode, provider-configured, and existing provider-policy choices.

Builds on the resolver contract landed in #3443.

ELI5: when no model was chosen, Omnigent now asks the active provider for the best compatible model instead of guessing a model name baked into the code.

```mermaid
flowchart LR
    A[Explicit or configured model] --> B[Use as-is]
    C[Missing default] --> D[Load provider catalog]
    D --> E[Normalize metadata]
    E --> F[Filter compatible family and route]
    F --> G[Apply general-purpose default policy]
    G --> H[Executor or native harness]
```

- Normalizes MLflow catalog entries into resolver candidates with tri-state capabilities, input context capacity, provider-relative cost tiers, and deterministic family filtering.
- Preserves default-policy behavior for default intent: specialty models remain excluded and existing provider pins/tier preferences remain authoritative until their dedicated migration PR.
- Requires dynamically selected Databricks defaults to use gateway-routable `databricks-*` ids while retaining explicit configured endpoint overrides.
- Replaces concrete defaults across workflow routing, SDK executors, Databricks execution, and Claude/Codex/Pi/OpenCode native launch paths.
- Reports catalog misses with actionable model-configuration guidance instead of a low-context resolver error.\n- Offloads cold catalog discovery from async turn paths so network timeouts do not stall the shared event loop.
- Improves version ordering and removes ten obsolete hardcode allowances.

**How to review:** start with `omnigent/model_catalog.py`, then review one executor and one native path before treating the remaining call-site changes as the same migration pattern.

**Risk / scope:** catalog availability now matters only when callers omit every explicit/configured model and no existing provider pin applies. Databricks has no static provider pin, so cold-cache, egress-restricted deployments must set `executor.model` or a provider `models.default`; otherwise resolution fails with actionable guidance instead of using a stale baked-in id. Smart-routing intent selection, static pickers, and CI model inputs remain follow-up stack slices.

## Test Plan

- [x] Ran 405 affected executor tests after moving catalog discovery off async turn loops.\n- [x] Ran 251 Claude SDK and Pi tests after covering the final async path and restoring models.json parity; one documented macOS path-canonicalization test was deselected.\n- [x] Ran 85 focused catalog\/provider tests after the default-policy review fix.
- [x] Ran 150 broader catalog/provider/workflow tests: 149 passed; the documented ambient Claude-login test remains environment-sensitive.
- [x] Verified the live Databricks catalog has 14 Claude and 16 OpenAI entries and every matching id is `databricks-*` prefixed.
- [x] Ran repository-wide pre-commit: relevant hooks, including the hardcoded-model lint, passed; existing `web-prettier` and stale routing-protobuf baseline failures remain.
- [x] Ran targeted pre-commit on the restacked conflict resolution; all hooks passed.

Known unrelated local exclusions/failures:
- `tests/runtime/test_provider_spawn_env.py::test_claude_sdk_falls_back_to_first_available_anthropic_credential`: a locally installed Claude subscription outranks the configured non-default provider.
- Repository-wide `web-prettier` and `routing-pb2-fresh` failures reproduce independently of this diff.

## Demo

N/A — non-visual model-resolution change.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — focused automated catalog, workflow, executor, and native tests cover this migration.

## Changelog

Default model selection now follows the active provider catalog instead of release-specific model names baked into runtime harnesses, while retaining general-purpose selection policy and Databricks gateway routability. In cold-cache Databricks environments without GitHub egress, configure `executor.model` or a provider `models.default`.