### PR TITLE
[models] Route from discovered model catalogs

### DIFF
--- a/dev/lint/hardcoded_model_allowlist.txt
+++ b/dev/lint/hardcoded_model_allowlist.txt
@@ -61,13 +61,8 @@ omnigent/onboarding/wizard.py databricks-gpt-5-4 1
 omnigent/onboarding/wizard.py gpt-4o 1
 omnigent/policies/builtins/routing.py databricks-claude-opus-4-6 1
 omnigent/policies/builtins/routing.py o3 1
-omnigent/server/smart_routing.py databricks-claude-haiku-4-5 3
-omnigent/server/smart_routing.py databricks-claude-opus-4-8 2
-omnigent/server/smart_routing.py databricks-claude-sonnet-4-6 2
-omnigent/server/smart_routing.py databricks-gpt-5-4 2
-omnigent/server/smart_routing.py databricks-gpt-5-4-mini 2
-omnigent/server/smart_routing.py databricks-gpt-5-4-nano 2
-omnigent/server/smart_routing.py databricks-gpt-5-5 3
+omnigent/server/smart_routing.py databricks-claude-haiku-4-5 1
+omnigent/server/smart_routing.py databricks-gpt-5-5 1
 omnigent/server/smart_routing.py databricks-gpt-5-5-pro 1
 omnigent/server/smart_routing.py databricks-gpt-5-6-luna 1
 omnigent/server/smart_routing.py databricks-gpt-5-6-sol 1

--- a/docs/model-hardcoding-plan.md
+++ b/docs/model-hardcoding-plan.md
@@ -16,9 +16,8 @@ The remaining pins fall into a few buckets:
   `omnigent/inner/*_executor.py`, and `omnigent/codex_native_app_server.py`
   still carry fallback model ids.
 - **Static pickers/catalogs:** `omnigent/model_catalog.py`,
-  `omnigent/cursor_native.py`, `omnigent/kiro_native.py`, and
-  `omnigent/server/smart_routing.py` encode static model choices for CLIs or
-  routing tiers that do not always expose a live listing API.
+  `omnigent/cursor_native.py`, and `omnigent/kiro_native.py` encode static
+  model choices for CLIs that do not always expose a live listing API.
 - **Policy and sizing logic:** `omnigent/llms/context_window.py`,
   `omnigent/policies/builtins/routing.py`, and `omnigent/tools/builtins/spawn.py`
   mention concrete models when mapping windows, routing examples, or dispatch
@@ -133,3 +132,15 @@ boundary:
 Static picker rows, smart-routing tiers, context/wire heuristics, and CI model
 inputs remain separate migration slices because they require different discovery
 or configuration sources.
+
+## Smart Routing Migration
+
+Smart routing now treats the runner's live worker catalog as its only candidate
+source. Provider-relative cost metadata orders candidates for the stable `fast`,
+`balanced`, and `powerful` intents; catalog order remains the tie-breaker when
+cost is unknown. If discovery is unavailable, routing skips the override and the
+harness keeps the provider-resolved default instead of consulting a stale table.
+
+The remaining exact compatibility exclusions in smart routing are temporary
+wire-API workarounds. They stay isolated until catalog wire metadata can express
+the affected harness constraints without model-name checks.

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -7977,13 +7977,12 @@ async def _handle_advise_models_mcp(
         return _mcp_tool_result(rpc_id, json.dumps({"router_on": False, "recommendations": []}))
 
     from omnigent.model_catalog import spec_harness
-    from omnigent.server.smart_routing import fetch_runner_models, infer_models
+    from omnigent.server.smart_routing import fetch_runner_models
 
     # Fetch live model catalog from the runner once; used below to populate
     # per-agent model lists when the caller omits explicit models.
     # Keys are worker names ("self", "claude_code", etc.) as returned by
-    # catalog_for_spec.  None when runner is unreachable — falls back to
-    # infer_models static table.
+    # catalog_for_spec. None when runner discovery is unavailable.
     _runner_catalog: dict[str, list[str]] | None = None
     if session_id is not None and runner_router is not None:
         _runner_client = await _get_runner_client(session_id, runner_router)
@@ -8058,12 +8057,10 @@ async def _handle_advise_models_mcp(
                 candidates = explicit_models
             else:
                 harness_key = _resolve_harness_for_worker(agent) or agent
-                # Prefer live runner catalog (worker name or harness key);
-                # fall back to static infer_models table.
+                # Prefer the worker name, then its normalized harness key.
                 candidates = (
                     (_runner_catalog or {}).get(agent)
                     or (_runner_catalog or {}).get(harness_key)
-                    or infer_models(harness_key)
                     or []
                 )
             if candidates:

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -16,6 +16,8 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
+from omnigent.model_metadata import ModelCostTier, ModelIntent
+
 if TYPE_CHECKING:
     import httpx  # used in type annotations only; runtime import is lazy in fetch_runner_models
 
@@ -24,57 +26,6 @@ _logger = logging.getLogger(__name__)
 # Custom-method path (Google API convention) appended to the external
 # router's base URL, e.g. ``<base_url>/routes:select``.
 ROUTES_SELECT_PATH = "routes:select"
-
-# ── Model lists per harness family ──────────────────────────────────────────
-#
-# Ordered cheapest → most powerful within each family.
-
-MODEL_LISTS: dict[str, list[str]] = {
-    "claude": [
-        "databricks-claude-haiku-4-5",
-        "databricks-claude-sonnet-4-6",
-        "databricks-claude-opus-4-8",
-    ],
-    "gpt": [
-        "databricks-gpt-5-4-nano",
-        "databricks-gpt-5-4-mini",
-        "databricks-gpt-5-4",
-        "databricks-gpt-5-5",
-    ],
-    # pi is multi-model: Claude and GPT both available.
-    "pi": [
-        "databricks-gpt-5-4-nano",
-        "databricks-claude-haiku-4-5",
-        "databricks-gpt-5-4-mini",
-        "databricks-claude-sonnet-4-6",
-        "databricks-gpt-5-4",
-        "databricks-claude-opus-4-8",
-        "databricks-gpt-5-5",
-    ],
-}
-
-_HARNESS_FAMILY: dict[str, str] = {
-    "claude-sdk": "claude",
-    "claude_sdk": "claude",
-    "claude-native": "claude",
-    "pi": "pi",
-    "codex": "gpt",
-    "codex-native": "gpt",
-    "openai-agents": "gpt",
-    "openai-agents-sdk": "gpt",
-    "agents_sdk": "gpt",
-}
-
-
-def infer_models(harness: str | None) -> list[str] | None:
-    """Return available models for *harness*, or ``None`` if unroutable."""
-    if harness is None:
-        return None
-    family = _HARNESS_FAMILY.get(harness)
-    if family is None:
-        return None
-    return MODEL_LISTS.get(family)
-
 
 # ── RoutingClient protocol ──────────────────────────────────────────────────
 
@@ -126,9 +77,9 @@ async def fetch_runner_models(
     """Fetch live model availability from the runner's ``/v1/sessions/{id}/models`` endpoint.
 
     Converts the ``sys_list_models``-shaped catalog into the harness →
-    model-id-list format expected by :class:`RoutingClient`.  Falls back
-    to ``None`` on any HTTP/parse failure so callers can use the static
-    :func:`infer_models` table instead.
+    model-id-list format expected by :class:`RoutingClient`. Models with
+    provider-relative cost metadata are ordered economy → standard → premium;
+    catalog order remains the deterministic tie-breaker.
 
     :param session_id: Session/conversation identifier.
     :param runner_client: Async HTTP client pointed at the runner.
@@ -159,7 +110,24 @@ async def fetch_runner_models(
         models_raw = row.get("models", [])
         if not isinstance(models_raw, list):
             continue
-        ids = [m["id"] for m in models_raw if isinstance(m, dict) and isinstance(m.get("id"), str)]
+        cost_order = {
+            ModelCostTier.ECONOMY.value: 0,
+            ModelCostTier.STANDARD.value: 1,
+            ModelCostTier.PREMIUM.value: 2,
+        }
+        indexed_models = [
+            (index, model)
+            for index, model in enumerate(models_raw)
+            if isinstance(model, dict) and isinstance(model.get("id"), str)
+        ]
+        ordered_models = sorted(
+            indexed_models,
+            key=lambda item: (
+                cost_order.get(item[1].get("cost_tier"), len(cost_order)),
+                item[0],
+            ),
+        )
+        ids = [model["id"] for _, model in ordered_models]
         if ids:
             result[worker_name] = ids
     return result or None
@@ -200,19 +168,17 @@ Harness descriptions:
 - pi: Multi-model headless harness; can run both Claude and GPT models;
   best for read-only exploration, review, and cross-vendor verification.
 
-Model tiers (cheapest → most capable within each family):
-- Claude: haiku < sonnet < opus
-- GPT: *-nano < *-mini < base (e.g. gpt-5-4-nano < gpt-5-4-mini < gpt-5-4 < gpt-5-5)
+Each harness list is ordered by provider-relative cost when the catalog reports
+it, with provider catalog order as the tie-breaker. Classify the task using
+stable model intents and choose the corresponding relative position:
 
-Trade-off guidance — classify the task and pick the corresponding model:
-
-  SIMPLE   → cheapest available model (haiku for Claude; nano for GPT)
+  SIMPLE   → {fast_intent}: first available model
              Examples: greetings, quick lookups, one-line fixes, trivial Q&A.
 
-  MODERATE → mid-range model (sonnet for Claude; mini for GPT)
+  MODERATE → {balanced_intent}: middle available model
              Examples: single-file edits, debugging a known issue, brief explanations.
 
-  COMPLEX  → most capable model (opus for Claude; newest base GPT)
+  COMPLEX  → {powerful_intent}: last available model
              Examples: multi-file refactors, architecture decisions, security analysis,
              long reasoning chains, tasks requiring high accuracy or broad context.
 
@@ -232,7 +198,12 @@ def _build_rubric(available_models: dict[str, list[str]]) -> str:
     for harness, models in available_models.items():
         model_lines = "\n".join(f"    - {m}" for m in models)
         sections.append(f"  harness: {harness}\n{model_lines}")
-    return _JUDGE_SYSTEM_TEMPLATE.format(harness_menu="\n".join(sections))
+    return _JUDGE_SYSTEM_TEMPLATE.format(
+        harness_menu="\n".join(sections),
+        fast_intent=ModelIntent.FAST.value,
+        balanced_intent=ModelIntent.BALANCED.value,
+        powerful_intent=ModelIntent.POWERFUL.value,
+    )
 
 
 _VERDICT_SCHEMA: dict[str, object] = {
@@ -606,8 +577,7 @@ _AUTO_ROUTING_HARNESSES: tuple[str, ...] = ("claude-sdk", "codex", "pi")
 # sub-agent names declared in the parent spec (e.g. "claude_code") plus "self"
 # for the session's own harness — NOT by harness id. Map the common worker
 # names back to their harness id so a child session's catalog still yields
-# routable candidates. Unknown worker names are ignored (the static
-# infer_models fallback covers them).
+# routable candidates. Unknown worker names are ignored.
 _WORKER_NAME_TO_HARNESS: dict[str, str] = {
     "claude_code": "claude-sdk",
     "claude-sdk": "claude-sdk",
@@ -685,10 +655,8 @@ async def route_session_harness(
     """Pick the best harness + model for a new session via the routing client.
 
     Builds a candidate set from the live runner catalog when *catalog_session_id*
-    (defaulting to *session_id*) and *runner_client* are provided, falling back
-    to the static ``infer_models`` table for any harness not represented in the
-    live data.  Only harnesses in :data:`_AUTO_ROUTING_HARNESSES` are offered as
-    candidates.
+    (defaulting to *session_id*) and *runner_client* are provided. Only harnesses
+    in :data:`_AUTO_ROUTING_HARNESSES` are offered as candidates.
 
     :param user_message: The user's first message text, used to size the task.
     :param session_id: Session being routed (optional).
@@ -739,17 +707,8 @@ async def route_session_harness(
                 # First worker wins for a given harness id (dedupe).
                 harness_models.setdefault(harness, worker_models)
 
-    # Fall back to the static table when the live catalog produced no
-    # routable candidates (e.g. a child session whose catalog only lists
-    # "self" under an unrecognized worker name, or the runner was unreachable).
     if not harness_models:
-        for h in _AUTO_ROUTING_HARNESSES:
-            models = infer_models(h)
-            if models:
-                harness_models[h] = models
-
-    if not harness_models:
-        return None, None, None, "No routable harnesses are available on this runner."
+        return None, None, None, "No discovered routable harnesses are available on this runner."
 
     try:
         result = await _caps.routing_client.route(user_message, harness_models)
@@ -821,7 +780,7 @@ async def route_session_harness(
 
 
 async def route_turn(
-    harness: str | None,
+    _harness: str | None,
     user_message: str,
     *,
     session_id: str | None = None,
@@ -829,10 +788,9 @@ async def route_turn(
 ) -> tuple[str | None, dict[str, Any] | None]:
     """Pick the best model for a turn via :attr:`RuntimeCaps.routing_client`.
 
-    When *session_id* and *runner_client* are provided, fetches live model
-    availability from the runner's ``/v1/sessions/{id}/models`` endpoint.
-    Falls back to the static :func:`infer_models` lookup table if the runner
-    is unreachable or returns no data.
+    Fetches live model availability from the runner's
+    ``/v1/sessions/{id}/models`` endpoint. Routing is skipped when discovery
+    is unavailable so the harness can use its provider-resolved default.
     """
     try:
         from omnigent.runtime._globals import _caps
@@ -852,10 +810,7 @@ async def route_turn(
         if catalog and "self" in catalog:
             available = {"self": catalog["self"]}
     if not available:
-        models = infer_models(harness)
-        if models is None:
-            return None, None
-        available = {harness or "": models}
+        return None, None
 
     result = await _caps.routing_client.route(user_message, available)
     if result is None:

--- a/tests/server/test_smart_routing.py
+++ b/tests/server/test_smart_routing.py
@@ -19,7 +19,6 @@ from omnigent.server.smart_routing import (
     RoutingResult,
     _build_rubric,
     fetch_runner_models,
-    infer_models,
     route_session_harness,
     route_turn,
 )
@@ -72,12 +71,60 @@ class _FakeRoutingClient:
         return self._result
 
 
-# ── infer_models ────────────────────────────────────────────────────
+_TEST_MODELS = {
+    "claude-sdk": [
+        "databricks-claude-haiku-4-5",
+        "databricks-claude-sonnet-4-6",
+        "databricks-claude-opus-4-8",
+    ],
+    "claude-native": ["databricks-claude-haiku-4-5"],
+    "codex": ["databricks-gpt-5-4-nano", "databricks-gpt-5-5"],
+    "codex-native": ["databricks-gpt-5-4-nano"],
+    "openai-agents": ["databricks-gpt-5-4-nano"],
+    "pi": [
+        "databricks-claude-haiku-4-5",
+        "databricks-gpt-5-4-nano",
+        "databricks-gpt-5-5",
+    ],
+}
 
 
-def test_infer_models_claude_sdk() -> None:
+def _models_for(harness: str | None) -> list[str] | None:
+    models = _TEST_MODELS.get(harness or "")
+    return list(models) if models is not None else None
+
+
+def _catalog_client() -> MagicMock:
+    workers = {
+        "claude_code": _TEST_MODELS["claude-sdk"],
+        "codex": _TEST_MODELS["codex"],
+        "pi": _TEST_MODELS["pi"],
+        "self": _TEST_MODELS["claude-sdk"],
+    }
+    response = MagicMock()
+    response.json.return_value = {
+        "workers": {
+            worker: {
+                "source": "catalog",
+                "verified": True,
+                "models": [{"id": model} for model in models],
+                "note": "",
+            }
+            for worker, models in workers.items()
+        }
+    }
+    response.raise_for_status = MagicMock()
+    client = MagicMock()
+    client.get = AsyncMock(return_value=response)
+    return client
+
+
+# ── test catalog fixtures ───────────────────────────────────────────
+
+
+def test_models_fixture_claude_sdk() -> None:
     """claude-sdk returns the claude model list."""
-    models = infer_models("claude-sdk")
+    models = _models_for("claude-sdk")
     assert models is not None
     assert any("haiku" in m for m in models)
     assert any("opus" in m for m in models)
@@ -87,33 +134,33 @@ def test_infer_models_claude_sdk() -> None:
     assert haiku_idx < opus_idx
 
 
-def test_infer_models_native_harnesses() -> None:
-    assert infer_models("claude-native") is not None
-    assert infer_models("codex-native") is not None
+def test_models_fixture_native_harnesses() -> None:
+    assert _models_for("claude-native") is not None
+    assert _models_for("codex-native") is not None
 
 
-def test_infer_models_codex() -> None:
-    models = infer_models("codex")
+def test_models_fixture_codex() -> None:
+    models = _models_for("codex")
     assert models is not None
     assert any("gpt" in m for m in models)
 
 
-def test_infer_models_openai_agents() -> None:
-    assert infer_models("openai-agents") is not None
+def test_models_fixture_openai_agents() -> None:
+    assert _models_for("openai-agents") is not None
 
 
-def test_infer_models_pi() -> None:
+def test_models_fixture_pi() -> None:
     """pi is multi-model — both Claude and GPT."""
-    models = infer_models("pi")
+    models = _models_for("pi")
     assert models is not None
     assert any("haiku" in m for m in models)
     assert any("gpt" in m for m in models)
 
 
-def test_infer_models_unknown_harness() -> None:
-    assert infer_models("cursor") is None
-    assert infer_models("antigravity") is None
-    assert infer_models(None) is None
+def test_models_fixture_unknown_harness() -> None:
+    assert _models_for("cursor") is None
+    assert _models_for("antigravity") is None
+    assert _models_for(None) is None
 
 
 # ── _build_rubric ───────────────────────────────────────────────────
@@ -153,7 +200,7 @@ async def test_llm_routing_client_returns_result() -> None:
         "rationale": "hard refactor",
     }
     client = LLMRoutingClient(_FakeLLMClient(verdict))
-    models = infer_models("claude-sdk")
+    models = _models_for("claude-sdk")
     assert models is not None
     result = await client.route("refactor auth", {"claude-sdk": models})
     assert result is not None
@@ -165,7 +212,7 @@ async def test_llm_routing_client_returns_result() -> None:
 @pytest.mark.asyncio
 async def test_llm_routing_client_harness_mismatch_re_resolves() -> None:
     """If the judge picks a harness that doesn't own the model, fall back."""
-    claude_models = infer_models("claude-sdk")
+    claude_models = _models_for("claude-sdk")
     assert claude_models is not None
     verdict = {
         "harness": "codex",  # codex doesn't have claude models
@@ -185,7 +232,7 @@ async def test_llm_routing_client_harness_mismatch_re_resolves() -> None:
 @pytest.mark.asyncio
 async def test_llm_routing_client_unknown_harness_re_resolves() -> None:
     """If the judge returns an unrecognised harness, fall back to model ownership."""
-    models = infer_models("claude-sdk")
+    models = _models_for("claude-sdk")
     assert models is not None
     verdict = {
         "harness": "hallucinated-harness",
@@ -203,7 +250,7 @@ async def test_llm_routing_client_unknown_harness_re_resolves() -> None:
 async def test_llm_routing_client_clamps_hallucinated_model() -> None:
     verdict = {"harness": "claude-sdk", "model": "hallucinated-model", "rationale": "hard"}
     client = LLMRoutingClient(_FakeLLMClient(verdict))
-    models = infer_models("claude-sdk")
+    models = _models_for("claude-sdk")
     assert models is not None
     result = await client.route("hard task", {"claude-sdk": models})
     assert result is not None
@@ -214,7 +261,7 @@ async def test_llm_routing_client_clamps_hallucinated_model() -> None:
 async def test_llm_routing_client_rejects_empty_model() -> None:
     verdict = {"harness": "claude-sdk", "model": "", "rationale": "x"}
     client = LLMRoutingClient(_FakeLLMClient(verdict))
-    models = infer_models("claude-sdk")
+    models = _models_for("claude-sdk")
     assert models is not None
     result = await client.route("hello", {"claude-sdk": models})
     assert result is None
@@ -227,7 +274,7 @@ async def test_llm_routing_client_returns_none_on_error() -> None:
             raise TypeError("boom")
 
     client = LLMRoutingClient(_BrokenLLM())
-    models = infer_models("claude-sdk")
+    models = _models_for("claude-sdk")
     assert models is not None
     result = await client.route("hello", {"claude-sdk": models})
     assert result is None
@@ -275,6 +322,32 @@ async def test_fetch_runner_models_parses_catalog() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fetch_runner_models_orders_reported_cost_tiers() -> None:
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "workers": {
+            "self": {
+                "models": [
+                    {"id": "premium-model", "cost_tier": "premium"},
+                    {"id": "unknown-model"},
+                    {"id": "economy-model", "cost_tier": "economy"},
+                    {"id": "standard-model", "cost_tier": "standard"},
+                ]
+            }
+        }
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    result = await fetch_runner_models("conv_123", mock_client)
+
+    assert result == {
+        "self": ["economy-model", "standard-model", "premium-model", "unknown-model"]
+    }
+
+
+@pytest.mark.asyncio
 async def test_fetch_runner_models_returns_none_on_http_error() -> None:
     import httpx
 
@@ -318,7 +391,12 @@ async def test_route_turn_uses_caps_routing_client() -> None:
         "omnigent.runtime._globals._caps",
         new=caps,
     ):
-        model, v = await route_turn("claude-sdk", "hello")
+        model, v = await route_turn(
+            "claude-sdk",
+            "hello",
+            session_id="conv_123",
+            runner_client=_catalog_client(),
+        )
     assert model == "databricks-claude-haiku-4-5"
     assert v is not None
     assert "tier" not in v
@@ -385,19 +463,15 @@ async def test_route_turn_uses_runner_catalog_when_available() -> None:
 
 
 @pytest.mark.asyncio
-async def test_route_turn_falls_back_to_static_when_runner_unavailable() -> None:
-    """Falls back to infer_models when runner catalog fetch fails."""
+async def test_route_turn_skips_routing_when_runner_unavailable() -> None:
+    """A discovery failure leaves the provider-resolved default untouched."""
     import httpx
 
     mock_client = MagicMock()
     mock_client.get = AsyncMock(side_effect=httpx.HTTPError("runner down"))
 
-    expected = RoutingResult(
-        model="databricks-claude-haiku-4-5",
-        rationale="simple",
-        harness="claude-sdk",
-    )
-    caps = _FakeCaps(routing_client=_FakeRoutingClient(expected))
+    routing_client = AsyncMock()
+    caps = _FakeCaps(routing_client=routing_client)
     with patch("omnigent.runtime._globals._caps", new=caps):
         model, _v = await route_turn(
             "claude-sdk",
@@ -405,8 +479,8 @@ async def test_route_turn_falls_back_to_static_when_runner_unavailable() -> None
             session_id="conv_123",
             runner_client=mock_client,
         )
-    # Still routes — fell back to static infer_models
-    assert model == "databricks-claude-haiku-4-5"
+    assert model is None
+    routing_client.route.assert_not_awaited()
 
 
 # ── ExternalRoutingClient ─────────────────────────────────────────────
@@ -806,7 +880,9 @@ async def test_route_session_harness_surfaces_router_error_detail() -> None:
 
     caps = _FakeCaps(routing_client=_FailingClient())
     with patch("omnigent.runtime._globals._caps", new=caps):
-        harness, model, _verdict, error = await route_session_harness("hi")
+        harness, model, _verdict, error = await route_session_harness(
+            "hi", session_id="conv_123", runner_client=_catalog_client()
+        )
     assert harness is None
     assert model is None
     assert error is not None
@@ -827,7 +903,11 @@ async def test_route_session_harness_picks_harness_and_model() -> None:
     )
     caps = _FakeCaps(routing_client=_FakeRoutingClient(expected))
     with patch("omnigent.runtime._globals._caps", new=caps):
-        harness, model, verdict, error = await route_session_harness("refactor the auth module")
+        harness, model, verdict, error = await route_session_harness(
+            "refactor the auth module",
+            session_id="conv_123",
+            runner_client=_catalog_client(),
+        )
     assert harness == "claude-sdk"
     assert model == "databricks-claude-opus-4-8"
     assert verdict is not None
@@ -836,8 +916,8 @@ async def test_route_session_harness_picks_harness_and_model() -> None:
 
 
 @pytest.mark.asyncio
-async def test_route_session_harness_passes_all_sdk_harnesses_static() -> None:
-    """Without a runner_client, all _AUTO_ROUTING_HARNESSES appear as candidates."""
+async def test_route_session_harness_passes_discovered_sdk_harnesses() -> None:
+    """The live worker catalog supplies every routable harness candidate."""
     received_harnesses: list[str] = []
 
     class _CapturingClient:
@@ -849,7 +929,9 @@ async def test_route_session_harness_passes_all_sdk_harnesses_static() -> None:
 
     caps = _FakeCaps(routing_client=_CapturingClient())
     with patch("omnigent.runtime._globals._caps", new=caps):
-        await route_session_harness("quick task")
+        await route_session_harness(
+            "quick task", session_id="conv_123", runner_client=_catalog_client()
+        )
     for h in _AUTO_ROUTING_HARNESSES:
         assert h in received_harnesses, f"harness {h!r} missing from candidate set"
 
@@ -1012,15 +1094,15 @@ async def test_route_session_harness_maps_worker_names_to_harnesses() -> None:
 
 
 @pytest.mark.asyncio
-async def test_route_session_harness_falls_back_when_catalog_has_only_self() -> None:
-    """A catalog with only an unrecognized 'self' worker falls back to the static table."""
+async def test_route_session_harness_reports_when_catalog_has_only_self() -> None:
+    """An unrecognized self-only catalog cannot invent auto-harness candidates."""
     from unittest.mock import AsyncMock, MagicMock
 
     mock_response = MagicMock()
     mock_response.json.return_value = {
         "workers": {
             # "self" is not in _WORKER_NAME_TO_HARNESS, so live matching yields
-            # nothing and the static infer_models fallback kicks in.
+            # no auto-harness candidates.
             "self": {
                 "source": "catalog",
                 "verified": True,
@@ -1033,16 +1115,11 @@ async def test_route_session_harness_falls_back_when_catalog_has_only_self() -> 
     mock_client = MagicMock()
     mock_client.get = AsyncMock(return_value=mock_response)
 
-    received: list[str] = []
-
     class _CapturingClient:
         async def route(
             self, _message: str, available_models: dict[str, list[str]]
         ) -> RoutingResult | None:
-            received.extend(available_models.keys())
-            return RoutingResult(
-                model="databricks-claude-opus-4-8", rationale="x", harness="claude-sdk"
-            )
+            raise AssertionError(f"router should not receive {available_models!r}")
 
     caps = _FakeCaps(routing_client=_CapturingClient())
     with patch("omnigent.runtime._globals._caps", new=caps):
@@ -1051,11 +1128,8 @@ async def test_route_session_harness_falls_back_when_catalog_has_only_self() -> 
             session_id="conv_child",
             runner_client=mock_client,
         )
-    # Static fallback offers all _AUTO_ROUTING_HARNESSES.
-    for h in _AUTO_ROUTING_HARNESSES:
-        assert h in received, f"static fallback should offer {h!r}"
-    assert harness == "claude-sdk"
-    assert error is None
+    assert harness is None
+    assert error == "No discovered routable harnesses are available on this runner."
 
 
 @pytest.mark.asyncio
@@ -1100,7 +1174,9 @@ async def test_route_session_harness_sends_full_candidate_set_unfiltered() -> No
 
     caps = _FakeCaps(routing_client=_CapturingClient())
     with patch("omnigent.runtime._globals._caps", new=caps):
-        await route_session_harness("hello")
+        await route_session_harness(
+            "hello", session_id="conv_123", runner_client=_catalog_client()
+        )
     # The excluded-on-pi models are still SENT (router requires the full set);
     # incompatibility is handled post-verdict by the redirect.
     assert "databricks-claude-haiku-4-5" in pi_models
@@ -1120,7 +1196,9 @@ async def test_route_session_harness_redirects_incompatible_router_pick() -> Non
     )
     caps = _FakeCaps(routing_client=_FakeRoutingClient(expected))
     with patch("omnigent.runtime._globals._caps", new=caps):
-        harness, model, _verdict, error = await route_session_harness("do something")
+        harness, model, _verdict, error = await route_session_harness(
+            "do something", session_id="conv_123", runner_client=_catalog_client()
+        )
     assert harness == "codex", f"gpt-5.5 on pi should redirect to codex, got {harness!r}"
     assert model == "databricks-gpt-5-5"
     assert error is None
@@ -1132,7 +1210,9 @@ async def test_route_session_harness_redirects_claude_on_pi_to_claude_sdk() -> N
     expected = RoutingResult(model="databricks-claude-haiku-4-5", rationale="cheap", harness="pi")
     caps = _FakeCaps(routing_client=_FakeRoutingClient(expected))
     with patch("omnigent.runtime._globals._caps", new=caps):
-        harness, model, _verdict, error = await route_session_harness("quick q")
+        harness, model, _verdict, error = await route_session_harness(
+            "quick q", session_id="conv_123", runner_client=_catalog_client()
+        )
     assert harness == "claude-sdk", f"claude on pi should redirect to claude-sdk, got {harness!r}"
     assert model == "databricks-claude-haiku-4-5"
     assert error is None
@@ -1148,7 +1228,11 @@ async def test_route_session_harness_falls_back_by_model_when_harness_absent() -
     )
     caps = _FakeCaps(routing_client=_FakeRoutingClient(expected))
     with patch("omnigent.runtime._globals._caps", new=caps):
-        harness, model, _verdict, _error = await route_session_harness("what time is it?")
+        harness, model, _verdict, _error = await route_session_harness(
+            "what time is it?",
+            session_id="conv_123",
+            runner_client=_catalog_client(),
+        )
     # codex precedes pi in _AUTO_ROUTING_HARNESSES, so a GPT model owned by both
     # deterministically resolves to codex.
     assert harness == "codex"


### PR DESCRIPTION
## Related issue

Part of #3426

## Summary

Smart routing still carried a release-specific model table and vendor-name tier rules, so an unavailable runner catalog could silently reintroduce stale defaults after the runtime migration. This stacked PR makes the runner's live worker catalog the only routing candidate source and leaves the provider-resolved harness default untouched when discovery is unavailable.

Stacked on #3448; review the runtime-default migration first.

ELI5: the router now chooses only from models the runner says are available; if it cannot ask the runner, it does not guess.

```mermaid
flowchart LR
    A[Runner worker catalog] --> B[Order by relative cost]
    B --> C[fast / balanced / powerful rubric]
    C --> D[Routing client]
    D --> E[Validated harness + model]
    F[Discovery unavailable] --> G[Keep provider-resolved default]
```

- Removes the static smart-routing model table and its fallback from session routing, turn routing, and `sys_advise_models`.
- Orders candidates by normalized economy, standard, and premium metadata while preserving provider catalog order as the deterministic tie-breaker.
- Replaces vendor-specific name tiers in the judge prompt with stable `fast`, `balanced`, and `powerful` intents.
- Ratchets eight hardcode allowances; the remaining exact entries are isolated wire-compatibility workarounds for a follow-up slice.

**How to review:** start with candidate discovery and fallback removal in `omnigent/server/smart_routing.py`, then check the advisor call site and test fixture changes.

**Risk / scope:** routing now skips model selection during runner catalog outages instead of using a static table. The request still proceeds on the provider-resolved default from #3448. Exact Pi wire-API exclusions remain unchanged.

## Test Plan

- [x] Ran `uv run --no-sync pytest -q tests/server/test_smart_routing.py tests/server/integration/test_sessions_model_override.py` (`67 passed`).
- [x] Ran focused Ruff checks on routing, advisor, and test files.
- [x] Ran the hardcoded-model lint against the full tracked scan surface.
- [x] Ran staged `pre-commit run`; all applicable hooks passed.
- [x] Ran `pre-commit run --all-files`; relevant hooks passed, while unrelated web Prettier and routing protobuf hooks remain unavailable locally because of missing frontend/`grpc_tools` prerequisites.

## Demo

N/A — non-visual routing behavior.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — automated routing and session integration coverage exercises discovery, ordering, outage fallback, harness ownership, and external-router behavior.

## Changelog

Smart routing now chooses only from models discovered on the active runner instead of falling back to release-specific model names.
