### PR TITLE
[models] Discover Kiro picker models from CLI

### DIFF
--- a/dev/lint/hardcoded_model_allowlist.txt
+++ b/dev/lint/hardcoded_model_allowlist.txt
@@ -38,10 +38,6 @@ omnigent/inner/pi_executor.py databricks-gpt-5-4 1
 omnigent/inner/pi_executor.py databricks-gpt-5-4-mini 1
 omnigent/inner/pi_executor.py databricks-gpt-5-5 1
 omnigent/inner/pi_executor.py databricks-gpt-5-5-pro 1
-omnigent/kiro_native.py claude-haiku-4.5 1
-omnigent/kiro_native.py claude-sonnet-4 1
-omnigent/kiro_native.py claude-sonnet-4.5 1
-omnigent/kiro_native.py deepseek-3.2 1
 omnigent/llms/context_window.py o1 1
 omnigent/llms/context_window.py o3 1
 omnigent/llms/context_window.py o4 1

--- a/docs/model-hardcoding-plan.md
+++ b/docs/model-hardcoding-plan.md
@@ -15,9 +15,9 @@ The remaining pins fall into a few buckets:
   `omnigent/pi_native_credentials.py`, `omnigent/opencode_native_provider.py`,
   `omnigent/inner/*_executor.py`, and `omnigent/codex_native_app_server.py`
   still carry fallback model ids.
-- **Static pickers/catalogs:** `omnigent/model_catalog.py`,
-  `omnigent/cursor_native.py`, and `omnigent/kiro_native.py` encode static
-  model choices for CLIs that do not always expose a live listing API.
+- **Static pickers/catalogs:** `omnigent/model_catalog.py` and
+  `omnigent/cursor_native.py` encode static model choices for CLIs that do not
+  expose a directly reusable live listing API.
 - **Policy and sizing logic:** `omnigent/llms/context_window.py`,
   `omnigent/policies/builtins/routing.py`, and `omnigent/tools/builtins/spawn.py`
   mention concrete models when mapping windows, routing examples, or dispatch
@@ -144,3 +144,11 @@ harness keeps the provider-resolved default instead of consulting a stale table.
 The remaining exact compatibility exclusions in smart routing are temporary
 wire-API workarounds. They stay isolated until catalog wire metadata can express
 the affected harness constraints without model-name checks.
+
+## Kiro Picker Migration
+
+The Kiro Web picker now runs `kiro-cli chat --list-models --format json` on the
+bound runner and forwards the CLI's model ids, default, descriptions, context
+windows, and credit rates. The server caches the runner response through the
+same asynchronous picker path as Codex, so provider changes no longer require an
+Omnigent source update and snapshots do not block on the CLI process.

--- a/omnigent/kiro_native.py
+++ b/omnigent/kiro_native.py
@@ -161,7 +161,6 @@ def list_kiro_cli_model_options(
             "id": model_id,
             "displayName": display_name,
             "isDefault": model_id == default_id,
-            "isCurrent": False,
         }
         description = raw_model.get("description")
         if isinstance(description, str) and description.strip():
@@ -179,11 +178,6 @@ def list_kiro_cli_model_options(
     if not options:
         raise ValueError("Kiro model list did not contain any valid models")
     return options
-
-
-def kiro_base_model_options() -> list[dict[str, Any]]:
-    """Backward-compatible alias for live Kiro model discovery."""
-    return list_kiro_cli_model_options()
 
 
 def build_kiro_launch(

--- a/omnigent/kiro_native.py
+++ b/omnigent/kiro_native.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import shutil
+import subprocess
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -47,46 +48,6 @@ from omnigent.native_terminal import url_component
 _DEFAULT_KIRO_COMMAND = "kiro-cli"
 _KIRO_PATH_ENV = "OMNIGENT_KIRO_PATH"
 _AGENT_NAME = "kiro-native-ui"
-
-# Curated kiro-cli base models for the Web UI picker. Static (like cursor-native,
-# the other launch-only-model vendor) rather than runner-discovered: the list is
-# global and fixed, not account-scoped. ids match what ``kiro-cli --model`` accepts
-# (and ``--list-models`` reports); ``auto`` is kiro's default and a real literal id.
-# Refresh by hand from ``kiro-cli chat --list-models --format json`` if Kiro
-# ships/renames a model.
-_KIRO_BASE_MODELS: list[dict[str, Any]] = [
-    {"id": "auto", "displayName": "Auto", "isDefault": True},
-    {"id": "claude-sonnet-4.5", "displayName": "Claude Sonnet 4.5"},
-    {"id": "claude-sonnet-4", "displayName": "Claude Sonnet 4"},
-    {"id": "claude-haiku-4.5", "displayName": "Claude Haiku 4.5"},
-    {"id": "deepseek-3.2", "displayName": "DeepSeek V3.2"},
-    {"id": "minimax-m2.5", "displayName": "MiniMax M2.5"},
-    {"id": "minimax-m2.1", "displayName": "MiniMax M2.1"},
-    {"id": "glm-5", "displayName": "GLM-5"},
-    {"id": "qwen3-coder-next", "displayName": "Qwen3 Coder Next"},
-]
-
-
-def kiro_base_model_options() -> list[dict[str, Any]]:
-    """Return the curated kiro base-model options for the Web UI picker.
-
-    Mirrors :func:`omnigent.cursor_native.cursor_base_model_options`: each option
-    carries ``id`` (the value ``kiro-cli --model`` accepts), ``displayName``, and
-    ``isDefault``/``isCurrent`` flags. kiro applies the model only at launch, so
-    the picked id is persisted as ``model_override`` and consumed by the runner.
-
-    :returns: Fresh option dicts (callers may mutate); base order preserved.
-    """
-    return [
-        {
-            "id": m["id"],
-            "displayName": m["displayName"],
-            "isDefault": bool(m.get("isDefault", False)),
-            "isCurrent": False,
-        }
-        for m in _KIRO_BASE_MODELS
-    ]
-
 
 _TERMINAL_NAME = "kiro"
 _TERMINAL_SESSION_KEY = "main"
@@ -161,6 +122,68 @@ def resolve_kiro_executable(
             f"Kiro, or set {_KIRO_PATH_ENV}=/path/to/kiro-cli."
         )
     return resolved
+
+
+def list_kiro_cli_model_options(
+    *,
+    env: Mapping[str, str] | None = None,
+    timeout_s: float = 10.0,
+) -> list[dict[str, Any]]:
+    """Discover Kiro picker options from the installed CLI."""
+    executable = resolve_kiro_executable(env=env)
+    completed = subprocess.run(
+        [executable, "chat", "--list-models", "--format", "json"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=timeout_s,
+        env=dict(env) if env is not None else None,
+    )
+    payload = json.loads(completed.stdout)
+    raw_models = payload.get("models") if isinstance(payload, dict) else None
+    if not isinstance(raw_models, list):
+        raise ValueError("Kiro model list must contain a models array")
+    default_model = payload.get("default_model")
+    default_id = default_model.strip() if isinstance(default_model, str) else None
+    options: list[dict[str, Any]] = []
+    for raw_model in raw_models:
+        if not isinstance(raw_model, dict):
+            continue
+        raw_id = raw_model.get("model_id")
+        if not isinstance(raw_id, str) or not raw_id.strip():
+            continue
+        model_id = raw_id.strip()
+        raw_name = raw_model.get("model_name")
+        display_name = (
+            raw_name.strip() if isinstance(raw_name, str) and raw_name.strip() else model_id
+        )
+        option: dict[str, Any] = {
+            "id": model_id,
+            "displayName": display_name,
+            "isDefault": model_id == default_id,
+            "isCurrent": False,
+        }
+        description = raw_model.get("description")
+        if isinstance(description, str) and description.strip():
+            option["description"] = description.strip()
+        context_window = raw_model.get("context_window_tokens")
+        if isinstance(context_window, int) and context_window > 0:
+            option["contextWindow"] = context_window
+        rate_multiplier = raw_model.get("rate_multiplier")
+        if isinstance(rate_multiplier, (int, float)):
+            option["rateMultiplier"] = rate_multiplier
+        rate_unit = raw_model.get("rate_unit")
+        if isinstance(rate_unit, str) and rate_unit.strip():
+            option["rateUnit"] = rate_unit.strip()
+        options.append(option)
+    if not options:
+        raise ValueError("Kiro model list did not contain any valid models")
+    return options
+
+
+def kiro_base_model_options() -> list[dict[str, Any]]:
+    """Backward-compatible alias for live Kiro model discovery."""
+    return list_kiro_cli_model_options()
 
 
 def build_kiro_launch(

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -8580,6 +8580,29 @@ def create_runner_app(
                 },
             )
 
+    @app.get("/v1/sessions/{session_id}/kiro-model-options")
+    async def get_session_kiro_model_options(session_id: str) -> JSONResponse:
+        if _session_harness_name(session_id) != "kiro-native":
+            return JSONResponse(status_code=200, content={"models": []})
+        from omnigent.kiro_native import list_kiro_cli_model_options
+
+        try:
+            models = await asyncio.to_thread(list_kiro_cli_model_options)
+        except Exception as exc:  # noqa: BLE001 - picker failures are retryable.
+            _logger.warning(
+                "Kiro-native model discovery failed for session=%s",
+                session_id,
+                exc_info=True,
+            )
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "kiro_native_model_options_failed",
+                    "detail": _client_safe_error_detail(exc, context="kiro-native model options"),
+                },
+            )
+        return JSONResponse(status_code=200, content={"models": models})
+
     @app.get("/v1/sessions/{session_id}/claude-model-options")
     async def get_session_claude_model_options(session_id: str) -> JSONResponse:
         if _session_harness_name(session_id) != "claude-native":

--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -628,6 +628,7 @@ _UPLOAD_READ_CHUNK_BYTES: int = 1024 * 1024
 _MODEL_OPTIONS_ENDPOINT_BY_WRAPPER: dict[str, str] = {
     _CLAUDE_NATIVE_WRAPPER_LABEL_VALUE: "claude-model-options",
     _CODEX_NATIVE_WRAPPER_LABEL_VALUE: "codex-model-options",
+    _KIRO_NATIVE_WRAPPER_LABEL_VALUE: "kiro-model-options",
     _OPENCODE_NATIVE_WRAPPER_LABEL_VALUE: "codex-model-options",
     # pi-native is deliberately NOT here: its catalog is PUSHED by the resident
     # extension (``external_model_options`` → ``_pushed_model_options_cache``),

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -6286,7 +6286,7 @@ async def _fetch_model_options(
       cache below: the catalog never changes per session, and routing it
       through that cache would let a ``refresh_state`` snapshot (which pops the
       cache) blank the picker on an effort/model change.
-    * **codex-native** — a *live*, account-scoped catalog only the bound runner
+    * **codex-native / kiro-native** — a *live* catalog only the bound runner
       can read (its app-server ``model/list``). Like skills, this stays off the
       snapshot hot path: the first snapshot kicks a background fetch and returns
       ``[]``; subsequent snapshots serve the cache.
@@ -6306,10 +6306,6 @@ async def _fetch_model_options(
         from omnigent.cursor_native import cursor_base_model_options
 
         return cursor_base_model_options()
-    if wrapper == _KIRO_NATIVE_WRAPPER_LABEL_VALUE:
-        from omnigent.kiro_native import kiro_base_model_options
-
-        return kiro_base_model_options()
     if wrapper == _PI_NATIVE_WRAPPER_LABEL_VALUE:
         # pi-native's catalog is PUSHED by its extension (its live
         # ``ctx.modelRegistry``), not fetched: that reflects the models pi

--- a/tests/e2e_ui/chat/test_kiro_model_metadata.py
+++ b/tests/e2e_ui/chat/test_kiro_model_metadata.py
@@ -14,8 +14,7 @@ def _patch_session_as_kiro_native(page: Page, session_id: str) -> list[dict]:
     The server fixture seeds a normal session so the page boots against the real
     app/server. This route patch rewrites only ``GET``/``PATCH
     /v1/sessions/{session_id}`` as seen by the browser into a kiro-native
-    snapshot carrying the curated kiro ``model_options`` (the shape
-    :func:`omnigent.kiro_native.kiro_base_model_options` serves) and a persisted
+    snapshot carrying discovered Kiro ``model_options`` and a persisted
     ``model_override``.
 
     :param page: Playwright page before navigation.
@@ -54,14 +53,13 @@ def _patch_session_as_kiro_native(page: Page, session_id: str) -> list[dict]:
         }
         payload["harness"] = "kiro-native"
         payload["model_options"] = [
-            {"id": "auto", "displayName": "Auto", "isDefault": True, "isCurrent": False},
+            {"id": "auto", "displayName": "Auto", "isDefault": True},
             {
                 "id": "claude-haiku-4.5",
                 "displayName": "Claude Haiku 4.5",
                 "isDefault": False,
-                "isCurrent": False,
             },
-            {"id": "glm-5", "displayName": "GLM-5", "isDefault": False, "isCurrent": False},
+            {"id": "glm-5", "displayName": "GLM-5", "isDefault": False},
         ]
         payload.setdefault("model_override", "claude-haiku-4.5")
         latest_payload = dict(payload)
@@ -75,7 +73,7 @@ def test_kiro_native_picker_lists_models_and_persists_pick(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """The kiro-native picker renders the curated catalog and persists a pick.
+    """The kiro-native picker renders the discovered catalog and persists a pick.
 
     kiro applies the chosen model as ``--model`` at launch, so the picker writes
     the selection to ``model_override`` (no in-session mirror). This covers the
@@ -97,7 +95,7 @@ def test_kiro_native_picker_lists_models_and_persists_pick(
     gear.click()
     page.get_by_test_id("composer-config-model").click()
 
-    # The curated kiro catalog renders with its display names.
+    # The discovered Kiro catalog renders with its display names.
     haiku_row = page.locator('[role="option"][data-model-id="claude-haiku-4.5"]')
     expect(haiku_row).to_be_visible()
     expect(haiku_row).to_contain_text("Claude Haiku 4.5")

--- a/tests/runner/test_app_sessions_native_events_lifecycle.py
+++ b/tests/runner/test_app_sessions_native_events_lifecycle.py
@@ -13,6 +13,7 @@ import pytest
 from omnigent import (
     claude_native_bridge,
     codex_native_bridge,
+    kiro_native,
     kiro_native_bridge,
 )
 from omnigent.claude_native_bridge import (
@@ -244,6 +245,46 @@ async def test_events_codex_native_settings_change_uses_thread_settings_update(
         f"codex-native {event_payload['type']} must call thread/settings/update "
         f"with next-turn settings; got {fake_client.requests!r}."
     )
+
+
+@pytest.mark.asyncio
+async def test_kiro_native_model_options_use_cli_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conv_id = "a7e721bf0e124d2fb5bc1bc36772864e"
+    expected = [
+        {
+            "id": "provider-latest",
+            "displayName": "Provider Latest",
+            "isDefault": True,
+        }
+    ]
+    monkeypatch.setattr(kiro_native, "list_kiro_cli_model_options", lambda: expected)
+    spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "kiro-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        response = await client.get(f"/v1/sessions/{conv_id}/kiro-model-options")
+
+    assert response.status_code == 200
+    assert response.json() == {"models": expected}
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_app_sessions_native_events_lifecycle.py
+++ b/tests/runner/test_app_sessions_native_events_lifecycle.py
@@ -288,6 +288,44 @@ async def test_kiro_native_model_options_use_cli_catalog(
 
 
 @pytest.mark.asyncio
+async def test_kiro_native_model_options_failure_is_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Discovery failures return 503 so the server leaves its cache cold."""
+    conv_id = "b29b45fd569245b2bc0dd79694e73886"
+
+    def _fail_discovery() -> list[dict[str, object]]:
+        raise RuntimeError("catalog unavailable")
+
+    monkeypatch.setattr(kiro_native, "list_kiro_cli_model_options", _fail_discovery)
+    spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "kiro-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "ag_1"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        response = await client.get(f"/v1/sessions/{conv_id}/kiro-model-options")
+
+    assert response.status_code == 503, response.text
+    assert response.json()["error"] == "kiro_native_model_options_failed"
+
+
+@pytest.mark.asyncio
 async def test_opencode_native_model_options_uses_cli_catalog(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -820,8 +820,10 @@ async def test_kiro_session_snapshot_loads_runner_model_catalog(
                                 "id": "provider-latest",
                                 "displayName": "Provider Latest",
                                 "isDefault": True,
+                                "description": "Provider supplied description",
                                 "contextWindow": 256_000,
                                 "rateMultiplier": 0.5,
+                                "rateUnit": "Credit",
                             }
                         ]
                     }
@@ -854,8 +856,12 @@ async def test_kiro_session_snapshot_loads_runner_model_catalog(
 
     assert f"/v1/sessions/{session_id}/kiro-model-options" in fake_client.get_calls
     assert [model.id for model in snapshot.model_options] == ["provider-latest"]
+    assert snapshot.model_options[0].model_dump()["description"] == (
+        "Provider supplied description"
+    )
     assert snapshot.model_options[0].model_dump()["contextWindow"] == 256_000
     assert snapshot.model_options[0].model_dump()["rateMultiplier"] == 0.5
+    assert snapshot.model_options[0].model_dump()["rateUnit"] == "Credit"
 
 
 @pytest.mark.asyncio

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -34,9 +34,9 @@ async def _drain_runner_skills(session_id: str) -> None:
 
 
 async def _drain_model_options(session_id: str) -> None:
-    """Pump the loop until the background Codex model-options fetch lands.
+    """Pump the loop until the background native model-options fetch lands.
 
-    Codex model options are eventual-consistent like skills: the first
+    Runner model options are eventual-consistent like skills: the first
     snapshot returns ``[]`` and starts the runner query; a later snapshot
     serves the cache.
     """
@@ -781,6 +781,81 @@ async def test_session_snapshot_includes_model_options_from_runner(
         {"reasoningEffort": "high", "description": "High"},
         {"reasoningEffort": "xhigh", "description": "Extra high"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_kiro_session_snapshot_loads_runner_model_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from omnigent.server.routes import sessions as _mod
+
+    _mod._runner_skills_cache.clear()
+    _mod._runner_skills_inflight.clear()
+    _mod._model_options_cache.clear()
+    _mod._model_options_inflight.clear()
+
+    class _FakeResponse:
+        status_code = 200
+
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def json(self) -> dict[str, object]:
+            return self._payload
+
+    class _FakeRunnerClient:
+        def __init__(self) -> None:
+            self.get_calls: list[str] = []
+
+        async def get(self, url: str, timeout: float = 5.0) -> _FakeResponse:
+            del timeout
+            self.get_calls.append(url)
+            if url.endswith("/skills"):
+                return _FakeResponse({"skills": []})
+            if url.endswith("/kiro-model-options"):
+                return _FakeResponse(
+                    {
+                        "models": [
+                            {
+                                "id": "provider-latest",
+                                "displayName": "Provider Latest",
+                                "isDefault": True,
+                                "contextWindow": 256_000,
+                                "rateMultiplier": 0.5,
+                            }
+                        ]
+                    }
+                )
+            return _FakeResponse({"status": "idle"})
+
+    session_id = "5c782829093f4ebcbf18684eed8a9155"
+    fake_client = _FakeRunnerClient()
+    monkeypatch.setattr("omnigent.runtime.get_runner_client", lambda: fake_client)
+    monkeypatch.setattr("omnigent.runtime.get_runner_router", lambda: None)
+    conv = Conversation(
+        id=session_id,
+        created_at=1,
+        updated_at=1,
+        root_conversation_id=session_id,
+        agent_id="ag_test",
+        labels={
+            _mod._CLAUDE_NATIVE_WRAPPER_LABEL_KEY: _mod._KIRO_NATIVE_WRAPPER_LABEL_VALUE,
+        },
+    )
+    conv_store = _ConversationStore(
+        [_message_item("item_1", "hi")],
+        conversations={session_id: conv},
+    )
+
+    first = await _get_session_snapshot(conv_store, session_id)  # type: ignore[arg-type]
+    assert first.model_options == []
+    await _drain_model_options(session_id)
+    snapshot = await _get_session_snapshot(conv_store, session_id)  # type: ignore[arg-type]
+
+    assert f"/v1/sessions/{session_id}/kiro-model-options" in fake_client.get_calls
+    assert [model.id for model in snapshot.model_options] == ["provider-latest"]
+    assert snapshot.model_options[0].model_dump()["contextWindow"] == 256_000
+    assert snapshot.model_options[0].model_dump()["rateMultiplier"] == 0.5
 
 
 @pytest.mark.asyncio

--- a/tests/test_kiro_native.py
+++ b/tests/test_kiro_native.py
@@ -32,6 +32,7 @@ from omnigent.kiro_native import (
     build_kiro_launch,
     kiro_base_model_options,
     kiro_terminal_resource_id,
+    list_kiro_cli_model_options,
     resolve_kiro_executable,
     run_kiro_native,
 )
@@ -546,16 +547,65 @@ async def test_wait_for_kiro_terminal_ready_times_out() -> None:
         await _wait_for_kiro_terminal_ready(client, "conv", timeout_s=0.05)
 
 
-def test_kiro_base_model_options_shape_and_default() -> None:
-    """The curated kiro catalog exposes picker option dicts with one default."""
-    options = kiro_base_model_options()
-    ids = [o["id"] for o in options]
+def test_list_kiro_cli_model_options_maps_live_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "models": [
+            {
+                "model_name": "Automatic",
+                "model_id": "auto",
+                "description": "Choose by task",
+                "context_window_tokens": 1_000_000,
+                "rate_multiplier": 1.0,
+                "rate_unit": "Credit",
+            },
+            {"model_name": "Latest", "model_id": "provider-latest"},
+        ],
+        "default_model": "auto",
+    }
+    captured: list[list[str]] = []
 
-    # Canonical ids confirmed against ``kiro-cli --list-models`` (2.10.0).
-    assert ids[0] == "auto"
-    assert "claude-haiku-4.5" in ids and "glm-5" in ids
-    # Exactly one default, and every option carries the picker fields.
-    assert [o["id"] for o in options if o["isDefault"]] == ["auto"]
-    for option in options:
-        assert set(option) == {"id", "displayName", "isDefault", "isCurrent"}
-        assert option["isCurrent"] is False
+    def _run(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        captured.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout=json.dumps(payload), stderr="")
+
+    monkeypatch.setattr(shutil, "which", lambda _command: "/opt/kiro-cli")
+    monkeypatch.setattr(subprocess, "run", _run)
+
+    options = list_kiro_cli_model_options()
+
+    assert captured == [["/opt/kiro-cli", "chat", "--list-models", "--format", "json"]]
+    assert options == [
+        {
+            "id": "auto",
+            "displayName": "Automatic",
+            "isDefault": True,
+            "isCurrent": False,
+            "description": "Choose by task",
+            "contextWindow": 1_000_000,
+            "rateMultiplier": 1.0,
+            "rateUnit": "Credit",
+        },
+        {
+            "id": "provider-latest",
+            "displayName": "Latest",
+            "isDefault": False,
+            "isCurrent": False,
+        },
+    ]
+    assert kiro_base_model_options() == options
+
+
+def test_list_kiro_cli_model_options_rejects_empty_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(shutil, "which", lambda _command: "/opt/kiro-cli")
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda argv, **_: subprocess.CompletedProcess(
+            argv, 0, stdout=json.dumps({"models": []}), stderr=""
+        ),
+    )
+
+    with pytest.raises(ValueError, match="valid models"):
+        list_kiro_cli_model_options()

--- a/tests/test_kiro_native.py
+++ b/tests/test_kiro_native.py
@@ -30,7 +30,6 @@ from omnigent.kiro_native import (
     _update_startup_progress,
     _wait_for_kiro_terminal_ready,
     build_kiro_launch,
-    kiro_base_model_options,
     kiro_terminal_resource_id,
     list_kiro_cli_model_options,
     resolve_kiro_executable,
@@ -579,7 +578,6 @@ def test_list_kiro_cli_model_options_maps_live_metadata(monkeypatch: pytest.Monk
             "id": "auto",
             "displayName": "Automatic",
             "isDefault": True,
-            "isCurrent": False,
             "description": "Choose by task",
             "contextWindow": 1_000_000,
             "rateMultiplier": 1.0,
@@ -589,10 +587,38 @@ def test_list_kiro_cli_model_options_maps_live_metadata(monkeypatch: pytest.Monk
             "id": "provider-latest",
             "displayName": "Latest",
             "isDefault": False,
-            "isCurrent": False,
         },
     ]
-    assert kiro_base_model_options() == options
+
+
+@pytest.mark.parametrize("default_model", [None, "missing-model"])
+def test_list_kiro_cli_model_options_allows_no_matching_default(
+    monkeypatch: pytest.MonkeyPatch,
+    default_model: str | None,
+) -> None:
+    payload: dict[str, object] = {
+        "models": [{"model_name": "Latest", "model_id": "provider-latest"}],
+    }
+    if default_model is not None:
+        payload["default_model"] = default_model
+    monkeypatch.setattr(shutil, "which", lambda _command: "/opt/kiro-cli")
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda argv, **_: subprocess.CompletedProcess(
+            argv, 0, stdout=json.dumps(payload), stderr=""
+        ),
+    )
+
+    options = list_kiro_cli_model_options()
+
+    assert options == [
+        {
+            "id": "provider-latest",
+            "displayName": "Latest",
+            "isDefault": False,
+        }
+    ]
 
 
 def test_list_kiro_cli_model_options_rejects_empty_catalog(

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -1673,6 +1673,27 @@ describe("Composer config gear", () => {
     expect(screen.getByTestId("composer-config-effort")).toBeTruthy();
   });
 
+  it("uses the Default sentinel when Kiro marks no catalog row as default", async () => {
+    const options = [
+      { id: "auto", displayName: "Automatic", isDefault: false },
+      { id: "provider-latest", displayName: "Latest", isDefault: false },
+    ];
+    renderWithTooltips(
+      <Composer
+        {...composerProps({
+          showEffort: false,
+          showModels: true,
+          modelPickerKind: "kiro",
+          codexModelOptions: options,
+        })}
+      />,
+    );
+
+    fireEvent.click(gear()!);
+    await screen.findByTestId("composer-config-modal");
+    expect(screen.getByTestId("composer-config-model")).toHaveTextContent("Default");
+  });
+
   it("does not open the modal via bare /model when the gear is disabled (not live)", async () => {
     // Bare /model bumps the open nonce; on a non-live session the gear is
     // inert, so the nonce must NOT open a modal that can't apply a change.


### PR DESCRIPTION
## Related issue

Part of #3426

## Summary

The Kiro Web picker duplicated the model list already exposed by `kiro-cli`, so every Kiro release could leave Omnigent showing stale or retired choices. This stacked PR discovers the catalog on the bound runner and sends the CLI-owned metadata through the existing asynchronous picker cache.

Stacked on #3450; review the discovery-only smart-routing change first.

ELI5: Omnigent now asks the installed Kiro CLI what models it supports instead of keeping a second handwritten list.

```mermaid
flowchart LR
    A[kiro-cli JSON model list] --> B[Runner endpoint]
    B --> C[Server single-flight cache]
    C --> D[Session snapshot]
    D --> E[Web model picker]
```

- Replaces the curated Kiro table with `kiro-cli chat --list-models --format json`.
- Preserves CLI-provided ids, default selection, descriptions, context windows, and credit-rate metadata.
- Removes the obsolete synchronous `kiro_base_model_options()` alias and omits unsupported current-state metadata.
- Runs discovery on the bound runner and keeps CLI process latency off the session snapshot hot path.
- Removes four Kiro hardcode allowances and documents the live picker boundary.

**How to review:** start with the parser in `omnigent/kiro_native.py`, then follow the runner endpoint into the server picker cache.

**Risk / scope:** a missing, logged-out, or malformed Kiro CLI now leaves the picker temporarily unavailable and retryable instead of serving a stale list. Cursor remains curated because its public list uses a compound namespace that does not round-trip through the interactive picker.

## Test Plan

- [x] Ran `OMNIGENT_SKIP_WEB_UI=true uv run --frozen pytest -q tests/test_kiro_native.py tests/runner/test_app_sessions_native_events_lifecycle.py tests/server/routes/test_sessions_snapshot.py` (`118 passed`).
- [x] Ran the Web test suite (`4,705 passed`, `3 expected fail`, `1 skipped`).
- [x] Ran the hardcoded-model lint against the full tracked scan surface.
- [x] Ran targeted `pre-commit run --files ...`; all applicable hooks passed.
- [x] Manually ran `kiro-cli chat --list-models --format json` with Kiro CLI 2.15.1 and verified the parser contract against its output.

## Demo

N/A — the picker contents remain the same shape; their source changes from a curated table to live CLI discovery.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification checked the installed CLI's real JSON field names and value types. Automated tests cover parsing, absent or mismatched defaults, the Web picker Default fallback, malformed catalogs, runner transport, asynchronous snapshot caching, and metadata preservation.

## Changelog

The Kiro model picker now follows the models and metadata reported by the installed Kiro CLI.