### PR TITLE
fix(web): open workspace Markdown links in file viewer

### DIFF
--- a/tests/e2e_ui/chat/test_chat_file_path_links.py
+++ b/tests/e2e_ui/chat/test_chat_file_path_links.py
@@ -15,6 +15,11 @@ mentions three paths in backticks:
   - ``/etc/hosts`` — absolute and OUTSIDE the workspace → stays inert code
     (must never linkify).
 
+The message also includes a standard Markdown anchor whose destination is the
+absolute workspace path with a ``:line`` suffix. It must open the same
+session-scoped FileViewer instead of navigating the browser to a host-local
+URL.
+
 ``~`` expansion can only land inside the workspace when the root is itself
 under the runner's home. The default e2e workspace lives under ``$TMPDIR``
 (not home), so this test pins the agent's ``os_env.cwd`` to a fresh directory
@@ -148,7 +153,13 @@ def linkify_session(
         tilde_path = f"~/{rel_from_home}/{_ROOT_FILE}" if rel_from_home else f"~/{_ROOT_FILE}"
         abs_path = f"{root}/{_ROOT_FILE}"
 
-        message_text = f"Files I referenced:\n\n- `{tilde_path}`\n- `{abs_path}`\n- `/etc/hosts`\n"
+        message_text = (
+            f"Files I referenced:\n\n"
+            f"- `{tilde_path}`\n"
+            f"- `{abs_path}`\n"
+            f"- [README link]({abs_path}:2)\n"
+            f"- `/etc/hosts`\n"
+        )
         event_resp = httpx.post(
             f"{live_server}/v1/sessions/{session_id}/events",
             json={
@@ -184,6 +195,15 @@ def test_chat_linkifies_workspace_paths_including_home_relative(
     # before the fix because it starts with "/").
     expect(page.get_by_role("button", name=abs_path)).to_be_visible()
 
+    # A Markdown anchor to the same absolute path carries an optional line
+    # suffix. Its href must be a session-scoped file deep link, not the raw
+    # host path that the browser would resolve against the Omnigent origin.
+    markdown_link = page.get_by_role("link", name="README link")
+    expect(markdown_link).to_be_visible()
+    expect(markdown_link).to_have_attribute("href", re.compile(r"[?&]file=README\.md(?:&|$)"))
+    markdown_link.click()
+    page.wait_for_url(re.compile(r"[?&]file=README\.md(?:&|$)"), timeout=15_000)
+
     # The negative: an absolute path outside the workspace must NOT be a link and
     # must remain an inert <code> span. A button here would mean we linkified a
     # path the FileViewer can't open.
@@ -194,6 +214,12 @@ def test_chat_linkifies_workspace_paths_including_home_relative(
         "/etc/hosts should stay an inert <code> span, not a link — a different "
         "tag means an outside-workspace path was wrongly linkified."
     )
+
+    # Reset before exercising the existing inline-code link below; both links
+    # target README.md, so leaving ?file set would make its URL assertion vacuous.
+    page.goto(f"{base_url}/c/{session_id}")
+    tilde_link = page.get_by_role("button", name=tilde_path)
+    expect(tilde_link).to_be_visible(timeout=30_000)
 
     # Clicking the tilde link opens the FileViewer on the RESOLVED relative path
     # (README.md), not the literal "~/..." text. The clinching assertion is the

--- a/web/src/components/blocks/BlockRenderer.test.tsx
+++ b/web/src/components/blocks/BlockRenderer.test.tsx
@@ -493,7 +493,7 @@ function renderMessage(
   );
 }
 
-describe("BlockRenderer inline file-path linkification", () => {
+describe("BlockRenderer file-path linkification", () => {
   const fetchMock = vi.fn();
 
   beforeEach(() => {
@@ -627,6 +627,22 @@ describe("BlockRenderer inline file-path linkification", () => {
     link.click();
     expect(openFile).toHaveBeenCalledWith("src/app.ts");
     expect(fetchMock.mock.calls[0][0]).toContain("/filesystem/src?");
+  });
+
+  it("routes a Markdown workspace link through the file viewer", () => {
+    const openFile = vi.fn();
+    renderMessage("See [notes.ts](/home/u/ws/src/Design%20Notes.ts%3A351) for details.", {
+      openFile,
+      isChangedPath: () => false,
+      conversationId: "conv_1",
+      workspaceRoot: "/home/u/ws",
+      workspaceHome: "/home/u",
+    });
+
+    const link = screen.getByRole("link", { name: "notes.ts" });
+    expect(link.getAttribute("href")).toContain("file=src%2FDesign+Notes.ts");
+    link.click();
+    expect(openFile).toHaveBeenCalledWith("src/Design Notes.ts");
   });
 
   it("leaves an absolute path OUTSIDE the workspace root as plain code (no fetch)", async () => {

--- a/web/src/components/blocks/BlockRenderer.test.tsx
+++ b/web/src/components/blocks/BlockRenderer.test.tsx
@@ -645,6 +645,20 @@ describe("BlockRenderer file-path linkification", () => {
     expect(openFile).toHaveBeenCalledWith("src/Design Notes.ts");
   });
 
+  it("preserves Streamdown attributes on external Markdown links", () => {
+    renderMessage("See [GitHub](https://github.com/omnigent-ai/omnigent).", {
+      openFile: vi.fn(),
+      isChangedPath: () => false,
+      conversationId: "conv_1",
+    });
+
+    const link = screen.getByRole("link", { name: "GitHub" });
+    expect(link.getAttribute("data-streamdown")).toBe("link");
+    expect(link.className).toContain("wrap-anywhere");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")?.split(/\s+/)).toContain("noreferrer");
+  });
+
   it("leaves an absolute path OUTSIDE the workspace root as plain code (no fetch)", async () => {
     // `/etc/hosts` is absolute but not under the root → unresolvable → must
     // never linkify, and must not trigger an existence listing.

--- a/web/src/components/blocks/BlockRenderer.tsx
+++ b/web/src/components/blocks/BlockRenderer.tsx
@@ -135,6 +135,71 @@ function WorkspacePathInlineCode({
   );
 }
 
+const FILE_LOCATION_SUFFIX = /:\d+(?::\d+)?$/;
+
+function decodeWorkspacePathReference(href: string): string | null {
+  try {
+    return decodeURIComponent(href).replace(FILE_LOCATION_SUFFIX, "");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Markdown-link renderer that routes absolute workspace paths through the
+ * FileViewer instead of treating them as browser-local URLs.
+ */
+function WorkspacePathMarkdownLink({
+  children,
+  href,
+  onClick,
+  ...linkProps
+}: React.ComponentPropsWithoutRef<"a">) {
+  const openFile = useFileViewer();
+  const { root, home } = useWorkspacePaths();
+  const explicitWorkspacePath =
+    typeof href === "string" && (href.startsWith("/") || href.startsWith("~/"));
+  const rawPath = explicitWorkspacePath ? decodeWorkspacePathReference(href) : null;
+  const linkPath = rawPath ? toWorkspaceRelativePath(rawPath, root, home) : null;
+
+  if (!openFile || !linkPath) {
+    return (
+      <a href={href} onClick={onClick} {...linkProps}>
+        {children}
+      </a>
+    );
+  }
+
+  const fileUrl = new URL(window.location.href);
+  fileUrl.searchParams.set("file", linkPath);
+  fileUrl.searchParams.delete("comment");
+  const fileHref = `${fileUrl.pathname}${fileUrl.search}${fileUrl.hash}`;
+
+  return (
+    <a
+      href={fileHref}
+      onClick={(event) => {
+        onClick?.(event);
+        if (
+          event.defaultPrevented ||
+          event.button !== 0 ||
+          event.metaKey ||
+          event.ctrlKey ||
+          event.shiftKey ||
+          event.altKey
+        ) {
+          return;
+        }
+        event.preventDefault();
+        openFile(linkPath);
+      }}
+      {...linkProps}
+    >
+      {children}
+    </a>
+  );
+}
+
 // Markdown images open in the shared lightbox on click, matching uploaded and
 // generated images. (Remote `src`s are still gated by Streamdown's image
 // security; this only adds the zoom affordance to whatever does render.)
@@ -146,6 +211,7 @@ function ZoomableMarkdownImage({ src, alt, ...props }: React.ComponentProps<"img
 // Stable module-level override map so MessageResponse's memo (which ignores
 // `components` changes) never sees a new identity.
 const FILE_PATH_AWARE_COMPONENTS = {
+  a: WorkspacePathMarkdownLink,
   inlineCode: WorkspacePathInlineCode,
   img: ZoomableMarkdownImage,
 };

--- a/web/src/components/blocks/BlockRenderer.tsx
+++ b/web/src/components/blocks/BlockRenderer.tsx
@@ -151,12 +151,18 @@ function decodeWorkspacePathReference(href: string): string | null {
  */
 function WorkspacePathMarkdownLink({
   children,
+  className,
   href,
   onClick,
   ...linkProps
 }: React.ComponentPropsWithoutRef<"a">) {
+  // Streamdown passes its mdast node to custom renderers; never forward that
+  // internal object to the DOM anchor.
+  Reflect.deleteProperty(linkProps, "node");
   const openFile = useFileViewer();
   const { root, home } = useWorkspacePaths();
+  const incomplete = href === "streamdown:incomplete-link";
+  const linkClassName = cn("wrap-anywhere font-medium text-primary underline", className);
   const explicitWorkspacePath =
     typeof href === "string" && (href.startsWith("/") || href.startsWith("~/"));
   const rawPath = explicitWorkspacePath ? decodeWorkspacePathReference(href) : null;
@@ -164,7 +170,16 @@ function WorkspacePathMarkdownLink({
 
   if (!openFile || !linkPath) {
     return (
-      <a href={href} onClick={onClick} {...linkProps}>
+      <a
+        className={linkClassName}
+        data-incomplete={incomplete}
+        data-streamdown="link"
+        href={href}
+        onClick={onClick}
+        rel="noreferrer"
+        target="_blank"
+        {...linkProps}
+      >
         {children}
       </a>
     );
@@ -177,6 +192,9 @@ function WorkspacePathMarkdownLink({
 
   return (
     <a
+      className={linkClassName}
+      data-incomplete={incomplete}
+      data-streamdown="link"
       href={fileHref}
       onClick={(event) => {
         onClick?.(event);
@@ -193,6 +211,8 @@ function WorkspacePathMarkdownLink({
         event.preventDefault();
         openFile(linkPath);
       }}
+      rel="noreferrer"
+      target="_blank"
       {...linkProps}
     >
       {children}


### PR DESCRIPTION
## Related issue

Closes #3064

## Summary

- Route absolute and home-relative workspace Markdown links through the existing FileViewer instead of opening host-local browser URLs.
- Strip optional `:line` / `:line:column` suffixes, decode encoded destinations, and preserve external or outside-workspace links.

## Test Plan

- `cd web && npm test` — 4,704 passed, 3 expected failures, 1 skipped.
- `cd web && npm run type-check`
- `cd web && npm run build`
- `/tmp/omnigent-pr-venv/bin/pytest tests/e2e_ui/chat/test_chat_file_path_links.py::test_chat_linkifies_workspace_paths_including_home_relative -v --browser-channel=chrome`
- `/tmp/omnigent-pr-venv/bin/pre-commit run --all-files`

## Demo

![A workspace Markdown link opening README.md in Omnigent's FileViewer](https://raw.githubusercontent.com/pr-gupta/omnigent/pr-assets/pr-demo/workspace-markdown-link.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The colocated Vitest regression covers destination decoding, location-suffix stripping, safe deep-link generation, and FileViewer routing. The Playwright regression verifies the complete remote-session UI flow.

## Changelog

Workspace file links in agent responses now open in the in-app file viewer.
