### PR TITLE
[models] Discover ad-hoc CLI defaults

### DIFF
--- a/dev/lint/hardcoded_model_allowlist.txt
+++ b/dev/lint/hardcoded_model_allowlist.txt
@@ -18,7 +18,6 @@
 .github/workflows/security-triage.yml databricks-claude-sonnet-4-6 1
 .github/workflows/vscode-release-pr.yml databricks-claude-sonnet-4-6 1
 examples/kimi_hello.yaml kimi-k2-turbo 1
-omnigent/chat.py databricks-gpt-5-4 1
 omnigent/cli_config.py claude-opus-4-5-20251101-v1:0 1
 omnigent/cursor_native.py claude-opus-4-5 1
 omnigent/cursor_native.py claude-opus-4-6 1

--- a/docs/model-hardcoding-plan.md
+++ b/docs/model-hardcoding-plan.md
@@ -152,3 +152,11 @@ bound runner and forwards the CLI's model ids, default, descriptions, context
 windows, and credit rates. The server caches the runner response through the
 same asynchronous picker path as Codex, so provider changes no longer require an
 Omnigent source update and snapshots do not block on the CLI process.
+
+## Ad-hoc CLI Defaults
+
+Minimal agent YAMLs that declare neither a harness nor a model now resolve the
+Databricks OpenAI-family default from the provider catalog during bundle
+materialization. `--model` and `OMNIGENT_MODEL` remain higher-precedence explicit
+choices. If discovery is unavailable, the CLI asks for one of those explicit
+values instead of silently baking a release-specific model into the bundle.

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -57,6 +57,8 @@ from omnigent.errors import OmnigentError
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.inner import _proc
 from omnigent.inner.databricks_executor import _DatabricksBearerAuth, _read_databrickscfg
+from omnigent.model_catalog import resolve_catalog_model
+from omnigent.model_resolver import ModelResolutionError
 from omnigent.native_coding_agents import native_coding_agent_for_wrapper_label
 from omnigent.native_dispatch import resolve_hook_for_key
 from omnigent.process_logging import (
@@ -103,15 +105,6 @@ _SERVER_READY_FAST_POLL_WINDOW_SECONDS = 1.0
 # leaving zombie codex/claude processes.
 _REMOTE_RUNNER_STOP_GRACE_SECONDS = 8.0
 
-# Fallback model when the YAML declares neither ``executor.model``
-# nor ``executor.harness`` AND no ``--model`` / ``--harness``
-# override is supplied. Mirrors the legacy argparse CLI's
-# ``_DEFAULT_AD_HOC_MODEL`` so ``omnigent run examples/hello_world.yaml``
-# (a spec with no executor block) launches cleanly instead of
-# failing the strict omnigent validator with a cryptic
-# "executor.config.harness: required" error.
-_DEFAULT_AD_HOC_MODEL = "databricks-gpt-5-4"
-
 # How many of the NEWEST transcript items ``_persisted_turn_text``
 # fetches when reconciling a headless ``-p`` turn against the durable
 # store. The current turn's items are always the newest, and no single
@@ -146,20 +139,23 @@ def _default_cli_model() -> str:
     """
     Return the model used when neither YAML nor CLI flag picks one.
 
-    Reads ``OMNIGENT_MODEL`` from the environment with
-    :data:`_DEFAULT_AD_HOC_MODEL` as the final fallback. The read
-    happens at YAML-materialization time so the resolved model
-    gets baked into the bundle's executor block — the materialized
-    spec is self-contained and independent of any later env state.
+    Reads ``OMNIGENT_MODEL`` first, then resolves the Databricks OpenAI-family
+    default from the provider catalog. Resolution happens during materialization
+    so the bundle remains self-contained on its eventual runner.
 
-    Mirrors :func:`omnigent.inner.cli._default_cli_model` so
-    legacy and Omnigent paths agree on the env-var contract.
-
-    :returns: The default model identifier, e.g.
-        ``"databricks-gpt-5-4"`` or whatever the user pinned in
-        ``OMNIGENT_MODEL``.
+    :returns: The explicit environment model or discovered catalog default.
+    :raises click.ClickException: If no explicit or catalog model is available.
     """
-    return os.environ.get(_OMNIGENT_MODEL_ENV_VAR, _DEFAULT_AD_HOC_MODEL)
+    configured = os.environ.get(_OMNIGENT_MODEL_ENV_VAR)
+    if configured is not None:
+        return configured
+    try:
+        return resolve_catalog_model("databricks", family="openai").model_id
+    except ModelResolutionError as exc:
+        raise click.ClickException(
+            "No default model is available for this ad-hoc agent. Pass --model, "
+            "set OMNIGENT_MODEL, or retry when Databricks catalog discovery is available."
+        ) from exc
 
 
 @dataclass(frozen=True)
@@ -2671,8 +2667,8 @@ def _materialize_override_bundle(source: Path, overrides: ChatOverrides) -> Path
     Also materializes when the spec is a single-file YAML with no
     ``executor.harness`` AND no ``executor.model`` — the strict
     omnigent validator rejects that shape, and the legacy
-    argparse CLI used to paper over it by injecting
-    :data:`_DEFAULT_AD_HOC_MODEL`. This preserves that behavior so
+    argparse CLI used to paper over it by injecting a model. This preserves
+    that behavior through catalog resolution so
     ``omnigent run examples/hello_world.yaml`` (minimal spec) still
     launches cleanly.
 
@@ -2801,9 +2797,8 @@ def _spec_declares_harness_or_model(raw: _YamlMapping) -> bool:
     Recognizes the harness in either shape: a flat ``executor.harness``
     or the bundle-style nested ``executor.config.harness`` (e.g.
     ``examples/polly``). Without the nested check, an unpinned bundle
-    that declares its harness only under ``config`` would look
-    harness-less and get force-fed :data:`_DEFAULT_AD_HOC_MODEL` — a
-    GPT endpoint the claude-sdk harness can't speak.
+    that declares its harness only under ``config`` would look harness-less
+    and get paired with an unrelated model family.
 
     :param raw: Parsed top-level YAML mapping.
     :returns: True if ``executor.harness``, ``executor.model``, or
@@ -3020,12 +3015,7 @@ def _apply_overrides_to_raw(raw: _YamlMapping, overrides: ChatOverrides) -> None
     # the Databricks FM API rejects for Claude-typed entities.
     # Uses ``_spec_declares_harness_or_model`` — must agree with the
     # ``needs_fallback`` gate in :func:`_materialize_override_bundle`.
-    # Uses ``_default_cli_model`` (env-var-aware) instead of
-    # ``_DEFAULT_AD_HOC_MODEL`` directly so ``OMNIGENT_MODEL=foo``
-    # is honored on the ``omnigent/cli.py`` → ``run_chat`` direct
-    # path. Without this, that env var was silently dropped on the
-    # Omnigent path invoked through the ``omnigent`` console
-    # script (see ``designs/RUN_OMNIGENT_REPL_PARITY.md``).
+    # Resolve once before bundling so the runner receives a self-contained spec.
     if not _spec_declares_harness_or_model(raw):
         executor_block["model"] = _default_cli_model()
     _inject_openai_env_auth_if_needed(raw)

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -15,7 +15,6 @@ from omnigent_client import QueryResult
 
 import omnigent.chat as chat_module
 from omnigent.chat import (
-    _DEFAULT_AD_HOC_MODEL,
     _SERVER_READY_BACKOFF_POLL_SECONDS,
     _SERVER_READY_FAST_POLL_WINDOW_SECONDS,
     _SERVER_READY_INITIAL_POLL_SECONDS,
@@ -42,6 +41,7 @@ from omnigent.chat import (
 )
 from omnigent.cli import _build_resume_parts
 from omnigent.inner.databricks_executor import DatabricksCredentials
+from omnigent.model_resolver import ModelResolutionError
 from omnigent.spec import load as load_spec
 from omnigent.spec import validate as validate_spec
 
@@ -1182,7 +1182,9 @@ def test_chat_via_daemon_hands_daemon_runner_to_chat_with_server(
     ``runner_recover=None`` (no CLI-side restart).
     """
     agent_yaml = tmp_path / "hello.yaml"
-    agent_yaml.write_text("name: hello\nprompt: Say hi.\n")
+    agent_yaml.write_text(
+        "name: hello\nprompt: Say hi.\nexecutor:\n  model: databricks-gpt-test-model\n"
+    )
     captured: dict[str, object] = {}
 
     async def _fake_prepare(**kwargs: object) -> _DaemonChatSession:
@@ -1444,31 +1446,40 @@ def test_prepare_chat_session_via_daemon_fork_wins_over_resume(
 
 # ── OMNIGENT_MODEL env-var fallback ───────────────────
 #
-# These tests pin the env-var contract on the
-# ``omnigent/cli.py`` → ``run_chat`` direct path. Without
-# them, ``OMNIGENT_MODEL=foo`` was silently dropped on the
-# ``omnigent`` console-script default Omnigent path because
-# ``_apply_overrides_to_raw`` used the hardcoded
-# ``_DEFAULT_AD_HOC_MODEL`` instead of the env-var-aware
-# helper. See ``designs/RUN_OMNIGENT_REPL_PARITY.md``.
+# These tests pin explicit-environment and discovered-default precedence on
+# the ``omnigent/cli.py`` → ``run_chat`` path.
 
 
-def test_default_cli_model_returns_hardcoded_default_when_env_unset(
+def test_default_cli_model_resolves_catalog_when_env_unset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """
-    With ``OMNIGENT_MODEL`` unset, the helper returns the
-    hardcoded ``_DEFAULT_AD_HOC_MODEL``.
-
-    What this proves: the existing default behavior (the model
-    that ships in the README example) is preserved when no env
-    var is set. If this fails, users running
-    ``omnigent run hello.yaml`` without setting the env var
-    would suddenly land on a different model than they did
-    before — silently breaking their workflows.
-    """
+    """An unconfigured ad-hoc run resolves its Databricks catalog default."""
     monkeypatch.delenv("OMNIGENT_MODEL", raising=False)
-    assert _default_cli_model() == _DEFAULT_AD_HOC_MODEL
+    calls: list[tuple[str, str | None]] = []
+
+    def _resolve(provider: str, *, family: str | None = None) -> SimpleNamespace:
+        calls.append((provider, family))
+        return SimpleNamespace(model_id="catalog-default")
+
+    monkeypatch.setattr(chat_module, "resolve_catalog_model", _resolve)
+
+    assert _default_cli_model() == "catalog-default"
+    assert calls == [("databricks", "openai")]
+
+
+def test_default_cli_model_fails_clearly_without_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unavailable catalog directs users to explicit configuration."""
+    monkeypatch.delenv("OMNIGENT_MODEL", raising=False)
+
+    def _fail(*args: object, **kwargs: object) -> None:
+        raise ModelResolutionError("catalog unavailable")
+
+    monkeypatch.setattr(chat_module, "resolve_catalog_model", _fail)
+
+    with pytest.raises(click.ClickException, match="Pass --model, set OMNIGENT_MODEL"):
+        _default_cli_model()
 
 
 def test_default_cli_model_honors_omnigent_model_env_var(
@@ -1478,9 +1489,7 @@ def test_default_cli_model_honors_omnigent_model_env_var(
     With ``OMNIGENT_MODEL=foo`` set, the helper returns
     ``"foo"``.
 
-    What this proves: the env-var override fires. If the helper
-    returns ``_DEFAULT_AD_HOC_MODEL`` here, the env var was
-    silently dropped — exactly the regression this gap closed.
+    What this proves: the env-var override fires without consulting discovery.
     """
     monkeypatch.setenv("OMNIGENT_MODEL", "databricks-claude-sonnet-4-6")
     assert _default_cli_model() == "databricks-claude-sonnet-4-6"
@@ -1489,19 +1498,7 @@ def test_default_cli_model_honors_omnigent_model_env_var(
 def test_apply_overrides_uses_env_var_when_yaml_has_no_model_or_harness(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """
-    A YAML that declares neither ``executor.model`` nor
-    ``executor.harness``, processed with empty overrides and
-    ``OMNIGENT_MODEL=foo`` set, lands with ``executor.model =
-    "foo"``.
-
-    What this proves: the env var traverses
-    ``_apply_overrides_to_raw`` to the executor block. If this
-    fails with the assertion showing ``databricks-gpt-5-4``
-    (the hardcoded default), the helper isn't being called —
-    line 756 of ``omnigent/chat.py`` reverted to the literal
-    ``_DEFAULT_AD_HOC_MODEL`` and the env var is dropped again.
-    """
+    """A harness-less YAML receives the explicit environment model."""
     monkeypatch.setenv("OMNIGENT_MODEL", "databricks-claude-sonnet-4-6")
     raw: dict[str, object] = {"name": "ad_hoc", "prompt": "hi"}
 
@@ -1515,11 +1512,7 @@ def test_apply_overrides_uses_env_var_when_yaml_has_no_model_or_harness(
     )
     assert executor.get("model") == "databricks-claude-sonnet-4-6", (
         f"Expected env-var override 'databricks-claude-sonnet-4-6' to "
-        f"land in executor.model; got {executor.get('model')!r}. If "
-        f"this is 'databricks-gpt-5-4' (the hardcoded default), line "
-        f"756 of omnigent/chat.py is back to the literal "
-        f"_DEFAULT_AD_HOC_MODEL and OMNIGENT_MODEL is silently dropped "
-        f"on the omnigent/cli.py → run_chat path."
+        f"land in executor.model; got {executor.get('model')!r}."
     )
 
 
@@ -1530,10 +1523,7 @@ def test_apply_overrides_explicit_model_wins_over_env_var(
     A ``--model`` override takes precedence over
     ``OMNIGENT_MODEL``.
 
-    What this proves: the precedence chain is
-    ``--model`` > ``executor.model`` in YAML > ``OMNIGENT_MODEL``
-    > ``_DEFAULT_AD_HOC_MODEL``. If this fails, the env var is
-    overriding an explicit CLI flag — surprising and broken.
+    What this proves: explicit CLI arguments remain the highest precedence.
     """
     monkeypatch.setenv("OMNIGENT_MODEL", "from-env")
     raw: dict[str, object] = {"name": "ad_hoc", "prompt": "hi"}
@@ -1851,8 +1841,8 @@ def test_nested_config_harness_skips_ad_hoc_model_fallback(
     """
     A single-file spec that declares its harness under the bundle-style
     ``executor.config.harness`` (no flat ``harness:``, no ``model:``) must
-    NOT trigger the ``_DEFAULT_AD_HOC_MODEL`` fallback — this is the polly
-    shape (``examples/polly/config.yaml`` run as a file).
+    not trigger ad-hoc model resolution — this is the polly shape
+    (``examples/polly/config.yaml`` run as a file).
 
     Regression guard for the ``databricks-gpt-5-4`` injection: before
     ``_spec_declares_harness_or_model`` looked under ``config``, an unpinned

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -1516,6 +1516,31 @@ def test_apply_overrides_uses_env_var_when_yaml_has_no_model_or_harness(
     )
 
 
+def test_apply_overrides_yaml_model_wins_over_env_and_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A YAML model remains authoritative over fallback sources."""
+    monkeypatch.setenv("OMNIGENT_MODEL", "from-env")
+    monkeypatch.setattr(
+        chat_module,
+        "resolve_catalog_model",
+        lambda *args, **kwargs: pytest.fail(
+            f"catalog fallback called for explicit YAML model: {args=}, {kwargs=}"
+        ),
+    )
+    raw: dict[str, object] = {
+        "name": "configured",
+        "prompt": "hi",
+        "executor": {"model": "from-yaml"},
+    }
+
+    _apply_overrides_to_raw(raw, ChatOverrides())
+
+    executor = raw["executor"]
+    assert isinstance(executor, dict)
+    assert executor["model"] == "from-yaml"
+
+
 def test_apply_overrides_explicit_model_wins_over_env_var(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/e2e/test_repl_sessions_approval_e2e.py
+++ b/tests/e2e/test_repl_sessions_approval_e2e.py
@@ -388,10 +388,12 @@ def test_sessions_tool_call_approval_allows_tool(
 
 
 def _write_simple_agent_yaml(directory: Path) -> Path:
-    """Write a minimal agent YAML with no policies (no approval)."""
+    """Write a simple agent YAML with no policies (no approval)."""
     yaml_path = directory / "simple_hello.yaml"
     yaml_path.write_text(
         "name: simple_hello\n"
+        "executor:\n"
+        "  model: gpt-4o\n"
         "prompt: >-\n"
         "  You are a friendly assistant. Respond in exactly one short sentence.\n",
     )


### PR DESCRIPTION
## Related issue

Part of #3426

## Summary

Minimal agent YAMLs currently need the CLI to inject a model before validation, but the injected endpoint was release-specific and would become stale. Resolve that default from the Databricks OpenAI-family catalog during bundle materialization instead.

- Preserve explicit precedence: `--model`, then `OMNIGENT_MODEL`, then catalog discovery.
- Fail with actionable configuration guidance when discovery is unavailable rather than silently selecting an old endpoint.
- Remove the retired pin from the hardcoded-model lint baseline and document the migration boundary.

**ELI5:** the CLI now asks the catalog which default model is current instead of memorizing one model name forever.

```text
--model ───────────────┐
OMNIGENT_MODEL ────────┼─> materialized executor.model
Databricks catalog ────┘
```

## Test Plan

- [x] Ran `OMNIGENT_SKIP_WEB_UI=true uv run --frozen pytest -q tests/cli/test_chat.py`: 114 passed.
- [x] Ran pre-commit against `origin/main...HEAD`, including the hardcoded-model lint.

## Demo

N/A — non-visual CLI behavior.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Catalog success, explicit environment precedence, unavailable-catalog errors, materialization, and daemon CLI paths are covered with discovery disabled.

## Changelog

Minimal `omnigent run` agents now discover their default model instead of using a release-specific built-in endpoint.