### PR TITLE
[models] Let Kimi own the example default

### DIFF
--- a/dev/lint/hardcoded_model_allowlist.txt
+++ b/dev/lint/hardcoded_model_allowlist.txt
@@ -17,7 +17,6 @@
 .github/workflows/polly-review.yml databricks-gpt-5-5 1
 .github/workflows/security-triage.yml databricks-claude-sonnet-4-6 1
 .github/workflows/vscode-release-pr.yml databricks-claude-sonnet-4-6 1
-examples/kimi_hello.yaml kimi-k2-turbo 1
 omnigent/cli_config.py claude-opus-4-5-20251101-v1:0 1
 omnigent/cursor_native.py claude-opus-4-5 1
 omnigent/cursor_native.py claude-opus-4-6 1

--- a/docs/model-hardcoding-plan.md
+++ b/docs/model-hardcoding-plan.md
@@ -171,3 +171,9 @@ prefilling a source-controlled model pin.
 The same policy supplies the final runtime fallback for key, gateway, and local
 providers. Explicit agent and provider defaults still win; without either,
 runtime discovery fails with configuration guidance when no catalog is available.
+
+## Kimi Example Default
+
+The Kimi launcher example declares only the harness. With no explicit
+`--model` or session override, Omnigent omits `HARNESS_KIMI_MODEL` and lets the
+Kimi CLI use the default from its own provider configuration.

--- a/examples/kimi_hello.yaml
+++ b/examples/kimi_hello.yaml
@@ -11,9 +11,8 @@ description: >-
 # under ``examples/polly/`` / ``examples/debby/``.
 executor:
   harness: kimi
-  # Override per-invocation via ``-m kimi-k2-turbo`` or ``/model`` in the REPL.
-  # With no model pinned, Kimi picks the default model set in its config.
-  model: kimi-k2-turbo
+  # Override per-invocation via ``-m <model-id>`` or ``/model`` in the REPL.
+  # Otherwise Kimi uses the default model from its own config.
 
 prompt: |
   You are Kimi Code, running headlessly inside Omnigent. Help the user with
@@ -42,7 +41,7 @@ prompt: |
 # Try it:
 #   omnigent run examples/kimi_hello.yaml
 #   omnigent run examples/kimi_hello.yaml -p "summarise the README"
-#   omnigent run examples/kimi_hello.yaml -m kimi-k2-turbo
+#   omnigent run examples/kimi_hello.yaml -m <model-id>
 #
 # Or as a shortcut for any kimi-harness run:
 #   omnigent kimi -p "list the files in the current directory"

--- a/tests/runtime/test_provider_spawn_env.py
+++ b/tests/runtime/test_provider_spawn_env.py
@@ -1273,6 +1273,7 @@ def test_kimi_no_provider_emits_no_gateway_vars(config_home: Path) -> None:
 
     env = _build_kimi_spawn_env(spec, cwd=None)
 
+    assert "HARNESS_KIMI_MODEL" not in env
     assert "HARNESS_KIMI_GATEWAY_BASE_URL" not in env
     assert "HARNESS_KIMI_GATEWAY_API_KEY" not in env
     assert "HARNESS_KIMI_GATEWAY_PROVIDER" not in env


### PR DESCRIPTION
## Related issue

Part of #3426

## Summary

The Kimi launcher example pins a specific Moonshot release even though the Kimi CLI already owns provider and default-model configuration. Remove the duplicate source-controlled default so the example follows the user's Kimi setup over time.

- Keep explicit `--model` and session overrides working as before.
- Omit `HARNESS_KIMI_MODEL` when the example has no override, allowing Kimi's configured default to win.
- Remove the example's hardcoded-model lint allowance and document the ownership boundary.

**ELI5:** the example now asks Kimi to use the model you configured instead of overriding it with an old sample value.

```text
explicit Omnigent override ──> HARNESS_KIMI_MODEL
no override ─────────────────> Kimi config default
```

## Test Plan

- [x] `uv run --no-sync pytest -q tests/runtime/test_provider_spawn_env.py -k kimi` — 12 passed.
- [x] Loaded `examples/kimi_hello.yaml` and verified its parsed model is `None` with harness `kimi`.
- [x] Ran staged pre-commit hooks, including YAML and hardcoded-model checks.

## Demo

N/A — non-visual example configuration.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Spawn-environment coverage verifies both explicit Kimi models and delegation when no model is declared.

## Changelog

The Kimi launcher example now respects the default model configured in Kimi Code.
