### PR TITLE
feat(acp): surface ACP agents' own model list in the web picker

### DIFF
--- a/omnigent/inner/executor.py
+++ b/omnigent/inner/executor.py
@@ -559,6 +559,19 @@ class Executor:
     def max_context_tokens(self) -> int | None:
         return None
 
+    def available_models(self) -> list[dict[str, Any]]:
+        """Models this executor's agent offers for a live model picker.
+
+        Empty by default; executors whose agent advertises a model list (e.g.
+        ACP ``SessionModelState``) override this. Populated only after a session
+        exists, so it may be empty until the first turn.
+        """
+        return []
+
+    def current_model_id(self) -> str | None:
+        """The session's current model id, or ``None`` if the agent has no picker."""
+        return None
+
     async def close_session(self, session_key: str) -> None:  # noqa: ARG002 — default no-op; subclasses with per-session state override
         """
         Release resources associated with one Omnigent session.

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1794,6 +1794,27 @@ class _BodyRequest:
         return self._body
 
 
+def _harness_is_acp_backed(harness: str | None) -> bool:
+    """Whether *harness* drives its agent over ACP.
+
+    Reads the declared capability record rather than matching harness names, so
+    the builtin ACP harnesses (``acp``, ``goose``, ``qwen``) and any community
+    ACP plugin are covered without editing a list here. ``acp:<slug>`` is
+    accepted too — the slug picks the configured agent, not the harness.
+
+    :param harness: A harness name, ``acp:<slug>``, or ``None``.
+    :returns: ``True`` when the harness is ACP-backed.
+    """
+    if not harness:
+        return False
+    from omnigent.harness_capabilities import IntegrationMode
+    from omnigent.harness_plugins import harness_capabilities
+
+    key = harness.split(":", 1)[0]
+    caps = harness_capabilities().get(canonicalize_harness(key) or key)
+    return caps is not None and caps.integration_mode is IntegrationMode.ACP_SUBPROCESS
+
+
 def create_runner_app(
     *,
     process_manager: HarnessProcessManager | None = None,
@@ -7790,7 +7811,7 @@ def create_runner_app(
         # rather than 500-ing this endpoint on the ones that don't.
         _running_harness = getattr(process_manager, "running_harness", None)
         running = _running_harness(session_id) if _running_harness is not None else None
-        if harness == "acp" or running == "acp":
+        if _harness_is_acp_backed(harness) or _harness_is_acp_backed(running):
             # ACP agents own their model list (session/new SessionModelState);
             # ask the running harness subprocess. No live harness yet (no turn
             # run) -> empty, so the picker simply shows nothing until it loads.

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -7782,6 +7782,41 @@ def create_runner_app(
     @app.get("/v1/sessions/{session_id}/codex-model-options")
     async def get_session_codex_model_options(session_id: str) -> JSONResponse:
         harness = _session_harness_name(session_id)
+        # A harness-override session (e.g. Polly overridden to acp:droid) caches
+        # the bundle agent's spec, so _session_harness_name returns that harness
+        # (claude-sdk), not the picked acp one. Key off the RUNNING subprocess too.
+        # ``running_harness`` is an optional introspection hook — not every
+        # process-manager implementation exposes it, so resolve it defensively
+        # rather than 500-ing this endpoint on the ones that don't.
+        _running_harness = getattr(process_manager, "running_harness", None)
+        running = _running_harness(session_id) if _running_harness is not None else None
+        if harness == "acp" or running == "acp":
+            # ACP agents own their model list (session/new SessionModelState);
+            # ask the running harness subprocess. No live harness yet (no turn
+            # run) -> empty, so the picker simply shows nothing until it loads.
+            if process_manager is None:
+                return JSONResponse(status_code=200, content={"models": []})
+            client = process_manager.existing_client(session_id)
+            if client is None:
+                return JSONResponse(status_code=200, content={"models": []})
+            try:
+                resp = await client.get(f"/v1/sessions/{session_id}/model-options")
+                resp.raise_for_status()
+                data = resp.json()
+                # ACP SessionModelState uses ``modelId``/``name``; the picker
+                # wants ``id``/``displayName``.
+                models = [
+                    {"id": mid, "displayName": m.get("name") or mid}
+                    for m in (data.get("models") or [])
+                    if isinstance(m, dict) and (mid := m.get("modelId") or m.get("id"))
+                ]
+                return JSONResponse(
+                    status_code=200,
+                    content={"models": models, "current": data.get("current")},
+                )
+            except Exception as exc:  # noqa: BLE001 - picker failures are retryable.
+                _logger.warning("ACP model options failed for %s: %s", session_id, exc)
+                return JSONResponse(status_code=200, content={"models": []})
         if harness not in ("codex-native", "opencode-native"):
             return JSONResponse(status_code=200, content={"models": []})
         if harness == "opencode-native":

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -827,6 +827,19 @@ class ExecutorAdapter(HarnessApp):
             self._executor = self._executor_factory()
         return self._executor
 
+    def model_options(self) -> dict[str, Any]:
+        """Surface the inner executor's advertised models for the web picker.
+
+        Empty until the executor has run a turn (and thus created its agent
+        session); the picker then populates from the agent's own model list.
+        """
+        if self._executor is None:
+            return {"models": [], "current": None}
+        return {
+            "models": self._executor.available_models(),
+            "current": self._executor.current_model_id(),
+        }
+
     def _translate_event(self, event: ExecutorEvent, ctx: TurnContext) -> None:
         """
         Translate one inner :class:`ExecutorEvent` into Omnigent SSE

--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -1014,7 +1014,31 @@ class HarnessApp:
             # heterogeneous return type.
             response_model=None,
         )
+        router.add_api_route(
+            "/sessions/{conversation_id}/model-options",
+            self._get_model_options,
+            methods=["GET"],
+        )
         return router
+
+    def model_options(self) -> dict[str, Any]:
+        """Model-picker payload: ``{"models": [...], "current": <id|None>}``.
+
+        Empty by default; :class:`ExecutorAdapter` overrides it to surface the
+        inner executor's advertised models. Used by the runner to populate the
+        web model picker for harnesses (e.g. ACP) whose agent owns the model
+        list. Empty until a session exists (the first turn), like the codex
+        model-options path.
+        """
+        return {"models": [], "current": None}
+
+    async def _get_model_options(self, conversation_id: str, request: Request) -> Response:
+        """Handle ``GET /v1/sessions/{conversation_id}/model-options``."""
+        denied = self._check_auth(request)
+        if denied is not None:
+            return denied
+        self._check_conversation_id(request, conversation_id)
+        return JSONResponse(self.model_options())
 
     def _check_conversation_id(self, request: Request, conversation_id: str) -> None:
         """

--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -911,6 +911,30 @@ class HarnessProcessManager:
         """
         return conversation_id in self._entries
 
+    def existing_client(self, conversation_id: str) -> httpx.AsyncClient | None:
+        """Return the running harness client for *conversation_id*, without spawning.
+
+        Unlike :meth:`get_client`, never starts a subprocess — returns ``None``
+        when no live harness is bound. Used to query a harness (e.g. for its
+        model list) only when it is already running.
+        """
+        entry = self._entries.get(conversation_id)
+        if entry is None or entry.process.returncode is not None:
+            return None
+        return entry.client
+
+    def running_harness(self, conversation_id: str) -> str | None:
+        """Return the harness name of the live subprocess, or ``None`` if none.
+
+        The *running* harness, not the session's cached spec — for a session
+        started with a harness override the spec still names the bundle agent's
+        harness, but the subprocess serves the picked one.
+        """
+        entry = self._entries.get(conversation_id)
+        if entry is None or entry.process.returncode is not None:
+            return None
+        return entry.harness
+
     def has_active_turn(self, conversation_id: str) -> bool:
         """
         Check whether the given conversation has an in-flight

--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -663,6 +663,12 @@ _MODEL_OPTIONS_ENDPOINT_BY_WRAPPER: dict[str, str] = {
     _CURSOR_NATIVE_WRAPPER_LABEL_VALUE: "cursor-model-options",
     _KIRO_NATIVE_WRAPPER_LABEL_VALUE: "kiro-model-options",
     _OPENCODE_NATIVE_WRAPPER_LABEL_VALUE: "codex-model-options",
+    # ACP sessions reuse the codex route: it is the runner's generic
+    # model-options endpoint, and it answers ACP-backed sessions from the
+    # running subprocess's SessionModelState (see ``_harness_is_acp_backed``
+    # in ``runner/app.py``). Without an entry here the fetch never runs and
+    # the picker stays empty no matter what the agent advertises.
+    _ACP_WRAPPER_LABEL_VALUE: "codex-model-options",
     # pi-native is deliberately NOT here: its catalog is PUSHED by the resident
     # extension (``external_model_options`` → ``_pushed_model_options_cache``),
     # not fetched from a runner route, so the picker works in every auth path

--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -238,6 +238,12 @@ _CURSOR_NATIVE_WRAPPER_LABEL_VALUE = CURSOR_NATIVE_CODING_AGENT.wrapper_label
 _CURSOR_NATIVE_HARNESS = CURSOR_NATIVE_CODING_AGENT.harness
 
 
+# Generic-ACP sessions aren't a NativeCodingAgent, but they own a model list
+# (ACP SessionModelState) — this wrapper label lets the model-options fetch and
+# the web picker recognize them without a native-agent registration.
+_ACP_WRAPPER_LABEL_VALUE = "acp-native-ui"
+
+
 _KIRO_NATIVE_WRAPPER_LABEL_VALUE = KIRO_NATIVE_CODING_AGENT.wrapper_label
 
 
@@ -723,6 +729,7 @@ def get_server_host_registry() -> HostRegistry | None:
 __all__ = [
     "COST_CONTROL_OVERRIDE_VALUES",
     "SUBAGENT_ROUTING_OVERRIDE_VALUES",
+    "_ACP_WRAPPER_LABEL_VALUE",
     "_ALLOWED_EVENT_TYPES",
     "_ANTIGRAVITY_NATIVE_ELICITATION_HOOK_TIMEOUT_S",
     "_APPROVAL_TYPE",

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -7732,6 +7732,37 @@ async def _create_session_from_existing_agent(
                 code=ErrorCode.INTERNAL_ERROR,
             )
         conv = updated_conv
+    elif conv.harness_override and (
+        conv.harness_override.startswith("acp:") or conv.harness_override in ("grok", "grok-build")
+    ):
+        # Generic-ACP session (acp:<slug>) or the builtin ``grok`` ACP harness:
+        # tag it so the web model picker and the model-options fetch recognize it
+        # — ACP agents own their model list (SessionModelState) but have no
+        # native-agent registration to carry the wrapper label.
+        #
+        # Ordered BEFORE the REPL-terminal arm below because ACP is a non-native
+        # harness: that arm matches every host-bound top-level ACP session, and
+        # in an elif chain it would short-circuit this one, leaving the picker
+        # untagged for exactly the sessions it exists for. Its label is folded in
+        # here instead (different key), so an ACP session keeps the terminal view.
+        _acp_labels = dict(body.labels) if body.labels else {}
+        _acp_labels[_CLAUDE_NATIVE_WRAPPER_LABEL_KEY] = _ACP_WRAPPER_LABEL_VALUE
+        if body.sub_agent_name is None and body.host_id is not None:
+            _acp_labels.update(
+                _repl_terminal_ui_labels(
+                    agent=agent,
+                    agent_cache=agent_cache,
+                    harness_override=harness_override,
+                )
+            )
+        await asyncio.to_thread(conversation_store.set_labels, conv.id, _acp_labels)
+        updated_conv = await asyncio.to_thread(conversation_store.get_conversation, conv.id)
+        if updated_conv is None:
+            raise OmnigentError(
+                f"Session {conv.id!r} disappeared while setting the ACP wrapper label",
+                code=ErrorCode.INTERNAL_ERROR,
+            )
+        conv = updated_conv
     elif (
         body.sub_agent_name is None
         and body.host_id is not None

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -7219,32 +7219,51 @@ async def _resolve_native_smart_routing(
     return native_agent.agent_name, model, verdict, None
 
 
-def _is_acp_harness_override(harness_override: str) -> bool:
-    """Whether *harness_override* selects an ACP-backed session.
+def _is_acp_harness_override(harness: str | None) -> bool:
+    """Whether *harness* drives its agent over ACP.
 
-    Covers every spelling the override can be stored as:
+    Reads the declared capability record rather than matching names, so the
+    builtin ACP harnesses (``acp``, ``goose``, ``qwen``) and any community ACP
+    plugin are covered without editing a list here. Both spellings the override
+    can be stored as are accepted: the concrete ``acp:<slug>`` a picker sends,
+    and the bare ``acp`` it canonicalizes to when the slug is folded away —
+    matching only the former made this dead code wherever the slug did not
+    survive validation.
 
-    - the concrete ``acp:<slug>`` a picker sends,
-    - the bare ``acp`` it canonicalizes to when the slug is folded away
-      (matching only the former would make this dead code wherever the slug
-      does not survive validation),
-    - a builtin ACP CLI harness id or alias, e.g. ``grok`` / ``grok-build``.
-
-    The builtin ids are read from :data:`ACP_CLI_HARNESSES` rather than listed
-    here, so a harness added to that catalog is recognized without a second
-    edit in this module.
-
-    :param harness_override: The session's stored harness override.
-    :returns: ``True`` for an ACP-backed session.
+    :param harness: A harness name, ``acp:<slug>``, or ``None``.
+    :returns: ``True`` for an ACP-backed harness.
     """
-    from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
+    if not harness:
+        return False
+    from omnigent.harness_aliases import canonicalize_harness
+    from omnigent.harness_capabilities import IntegrationMode
+    from omnigent.harness_plugins import harness_capabilities
 
-    if harness_override == "acp" or harness_override.startswith("acp:"):
-        return True
-    return any(
-        harness_override == key or harness_override in row.aliases
-        for key, row in ACP_CLI_HARNESSES.items()
-    )
+    key = harness.split(":", 1)[0]
+    caps = harness_capabilities().get(canonicalize_harness(key) or key)
+    return caps is not None and caps.integration_mode is IntegrationMode.ACP_SUBPROCESS
+
+
+async def _agent_declared_harness(conv: Conversation, agent_store: AgentStore) -> str | None:
+    """Return the harness the session's agent declares, best-effort.
+
+    Used only to decide a presentation label, so a spec that cannot be loaded
+    (no runtime, missing bundle, unparsable spec) yields ``None`` rather than
+    failing the create — the session still works, it just renders without the
+    ACP model picker.
+
+    :param conv: The freshly created conversation.
+    :param agent_store: Store the agent's bundle is loaded from.
+    :returns: The declared harness, or ``None``.
+    """
+    try:
+        spec = await asyncio.to_thread(_load_agent_spec_for_session, conv, agent_store)
+    except Exception:  # noqa: BLE001 — labelling must never fail session create
+        return None
+    config = getattr(getattr(spec, "executor", None), "config", None)
+    if not isinstance(config, dict):
+        return None
+    return str(config.get("harness") or "") or None
 
 
 async def _create_session_from_existing_agent(
@@ -7760,12 +7779,14 @@ async def _create_session_from_existing_agent(
                 code=ErrorCode.INTERNAL_ERROR,
             )
         conv = updated_conv
-    elif conv.harness_override and _is_acp_harness_override(conv.harness_override):
-        # ACP-backed session (bare ``acp``, ``acp:<slug>``, or a builtin ACP CLI
-        # harness like ``grok``): tag it so the web model picker and the
-        # model-options fetch recognize it — ACP agents own their model list
-        # (SessionModelState) but have no native-agent registration to carry the
-        # wrapper label.
+    elif _is_acp_harness_override(
+        conv.harness_override or await _agent_declared_harness(conv, agent_store)
+    ):
+        # ACP-backed session, either picked as an override (``acp:<slug>``) or
+        # declared by the agent itself (``harness: droid``): tag it so the web
+        # model picker and the model-options fetch recognize it — ACP agents own
+        # their model list (SessionModelState) but have no native-agent
+        # registration to carry the wrapper label.
         #
         # Ordered BEFORE the REPL-terminal arm below because ACP is a non-native
         # harness: that arm matches every host-bound top-level ACP session, and

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -7219,6 +7219,34 @@ async def _resolve_native_smart_routing(
     return native_agent.agent_name, model, verdict, None
 
 
+def _is_acp_harness_override(harness_override: str) -> bool:
+    """Whether *harness_override* selects an ACP-backed session.
+
+    Covers every spelling the override can be stored as:
+
+    - the concrete ``acp:<slug>`` a picker sends,
+    - the bare ``acp`` it canonicalizes to when the slug is folded away
+      (matching only the former would make this dead code wherever the slug
+      does not survive validation),
+    - a builtin ACP CLI harness id or alias, e.g. ``grok`` / ``grok-build``.
+
+    The builtin ids are read from :data:`ACP_CLI_HARNESSES` rather than listed
+    here, so a harness added to that catalog is recognized without a second
+    edit in this module.
+
+    :param harness_override: The session's stored harness override.
+    :returns: ``True`` for an ACP-backed session.
+    """
+    from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
+
+    if harness_override == "acp" or harness_override.startswith("acp:"):
+        return True
+    return any(
+        harness_override == key or harness_override in row.aliases
+        for key, row in ACP_CLI_HARNESSES.items()
+    )
+
+
 async def _create_session_from_existing_agent(
     conversation_store: ConversationStore,
     agent_store: AgentStore,
@@ -7732,13 +7760,12 @@ async def _create_session_from_existing_agent(
                 code=ErrorCode.INTERNAL_ERROR,
             )
         conv = updated_conv
-    elif conv.harness_override and (
-        conv.harness_override.startswith("acp:") or conv.harness_override in ("grok", "grok-build")
-    ):
-        # Generic-ACP session (acp:<slug>) or the builtin ``grok`` ACP harness:
-        # tag it so the web model picker and the model-options fetch recognize it
-        # — ACP agents own their model list (SessionModelState) but have no
-        # native-agent registration to carry the wrapper label.
+    elif conv.harness_override and _is_acp_harness_override(conv.harness_override):
+        # ACP-backed session (bare ``acp``, ``acp:<slug>``, or a builtin ACP CLI
+        # harness like ``grok``): tag it so the web model picker and the
+        # model-options fetch recognize it — ACP agents own their model list
+        # (SessionModelState) but have no native-agent registration to carry the
+        # wrapper label.
         #
         # Ordered BEFORE the REPL-terminal arm below because ACP is a non-native
         # harness: that arm matches every host-bound top-level ACP session, and

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -134,6 +134,7 @@ from omnigent.server.routes._session_create_validation import (
 # ``__all__`` and the facade's explicit re-exports, preserving its real runtime
 # bindings so a facade-level monkeypatch is honoured in this module too.
 from omnigent.server.routes._sessions.common import (  # noqa: F401
+    _ACP_WRAPPER_LABEL_VALUE,
     _CLAUDE_NATIVE_MESSAGE_TIMEOUT_S,
     _CLAUDE_NATIVE_MODEL,
     _CLAUDE_NATIVE_UI_LABEL_KEY,

--- a/tests/runtime/harnesses/test_executor_adapter.py
+++ b/tests/runtime/harnesses/test_executor_adapter.py
@@ -2001,3 +2001,49 @@ async def test_policy_evaluator_no_active_turn_context_is_phase_aware() -> None:
         verdict = await adapter._stable_policy_evaluator(advisory_phase, {})
         assert verdict.action == "POLICY_ACTION_ALLOW", advisory_phase
         assert verdict.reason is None, advisory_phase
+
+
+def test_model_options_empty_before_first_turn() -> None:
+    """
+    The picker gets an empty list until the executor exists.
+
+    ``ExecutorAdapter`` builds its inner executor lazily on the first turn, so
+    a model fetch that arrives before then has nothing to report. A failure
+    here means the picker would raise (or invent a model) on a session the
+    user has not sent a message to yet.
+    """
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+    adapter = ExecutorAdapter(executor_factory=lambda: _StubExecutor())
+    assert adapter.model_options() == {"models": [], "current": None}
+
+
+def test_model_options_reflects_executor_model_list() -> None:
+    """
+    Once an executor exists, the picker mirrors what it advertises.
+
+    ``Executor`` ships ``available_models()``/``current_model_id()`` defaults of
+    ``[]``/``None``, so an executor whose agent has no picker stays empty; one
+    that overrides them (e.g. an ACP agent reporting ``SessionModelState``) is
+    surfaced verbatim. A failure means the adapter dropped or reshaped the
+    agent's own model list on the way to the web picker.
+    """
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+    class _ModelExecutor(_StubExecutor):
+        def available_models(self) -> list[dict[str, object]]:
+            return [{"modelId": "auto"}, {"modelId": "fast"}]
+
+        def current_model_id(self) -> str | None:
+            return "auto"
+
+    adapter = ExecutorAdapter(executor_factory=lambda: _StubExecutor())
+    # Default executor advertises no picker -> stays empty, not None-crashing.
+    adapter._executor = _StubExecutor()
+    assert adapter.model_options() == {"models": [], "current": None}
+
+    adapter._executor = _ModelExecutor()
+    assert adapter.model_options() == {
+        "models": [{"modelId": "auto"}, {"modelId": "fast"}],
+        "current": "auto",
+    }

--- a/tests/server/routes/test_sessions_crud.py
+++ b/tests/server/routes/test_sessions_crud.py
@@ -602,3 +602,23 @@ def test_acp_harness_override_matches_bare_and_slugged_spellings() -> None:
     # prefixed with the same letters.
     assert not _is_acp_harness_override("claude-native")
     assert not _is_acp_harness_override("acplike")
+    assert not _is_acp_harness_override(None)
+
+
+def test_acp_marker_covers_every_declared_acp_harness() -> None:
+    """
+    The marker is derived from capabilities, not a hardcoded harness list.
+
+    ``goose`` and ``qwen`` are ACP-backed but were never named by the old
+    string match, so an agent declaring one got no wrapper label and no model
+    picker. Deriving from ``IntegrationMode.ACP_SUBPROCESS`` also covers
+    community ACP plugins, which cannot be enumerated here at all. A failure
+    means the marker regressed to matching names.
+    """
+    from omnigent.harness_capabilities import IntegrationMode
+    from omnigent.harness_plugins import harness_capabilities
+    from omnigent.server.routes._sessions.orchestration import _is_acp_harness_override
+
+    for harness, caps in harness_capabilities().items():
+        expected = caps.integration_mode is IntegrationMode.ACP_SUBPROCESS
+        assert _is_acp_harness_override(harness) is expected, harness

--- a/tests/server/routes/test_sessions_crud.py
+++ b/tests/server/routes/test_sessions_crud.py
@@ -581,3 +581,24 @@ async def test_list_sessions_pinned_filter(
     assert plain.id not in ids
     # A pin belonging to another user must not appear for the caller.
     assert other_user_pin.id not in ids
+
+
+def test_acp_harness_override_matches_bare_and_slugged_spellings() -> None:
+    """
+    The ACP session marker must accept both spellings of the override.
+
+    ``_validated_harness_override`` canonicalizes ``acp:<slug>`` down to a
+    bare ``acp`` unless the slug is explicitly preserved, so the stored
+    value is whichever spelling survived validation. Matching only
+    ``acp:<slug>`` made the ACP labelling dead code — a session created
+    with ``harness_override="acp:droid"`` persisted as ``"acp"`` and never
+    got tagged, so the web model picker never recognized it.
+    """
+    from omnigent.server.routes._sessions.orchestration import _is_acp_harness_override
+
+    assert _is_acp_harness_override("acp")
+    assert _is_acp_harness_override("acp:droid")
+    # Non-ACP harnesses must not be tagged, including a name merely
+    # prefixed with the same letters.
+    assert not _is_acp_harness_override("claude-native")
+    assert not _is_acp_harness_override("acplike")

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -896,6 +896,63 @@ describe("Composer model/effort label", () => {
     expect(within(label()).getByText("Composer 2.5")).toHaveClass("text-foreground");
   });
 
+  it("never labels an ACP session with the cross-session sticky model", () => {
+    // Droid repro: a fresh ACP session has no override, and the agent owns its
+    // own model, so Omnigent has no model to show. Before this, `acp` fell
+    // through to `selectedModel` and the composer confidently labelled the
+    // session with an Opus pick left over from an unrelated session while droid
+    // was actually answering on its own configured Sonnet.
+    useChatStore.setState({
+      nativeVendorOwnsModel: false,
+      selectedModel: "claude-opus-4-8", // stale cross-session sticky — must not surface
+      sessionModelOverride: null,
+      selectedEffort: null,
+      llmModel: null, // ACP bundles declare no llm block
+    });
+    renderWithTooltips(
+      <Composer
+        {...composerProps({
+          agents: [{ id: "a1", name: "droid" }],
+          selectedAgentId: "a1",
+          modelPickerKind: "acp",
+          showModels: true,
+          showEffort: false,
+          codexModelOptions: [{ id: "claude-opus-4-8", displayName: "Opus" }],
+        })}
+      />,
+    );
+    expect(screen.queryByTestId("composer-model-effort-label")).toBeNull();
+  });
+
+  it("labels an ACP session once a model is actually applied to it", () => {
+    // The picker persists the pick as the session override and the executor
+    // applies it via session/set_model, so THAT is a real model to surface.
+    useChatStore.setState({
+      nativeVendorOwnsModel: false,
+      selectedModel: "claude-opus-4-8", // stale sticky still must not win
+      sessionModelOverride: "grok-4.5",
+      selectedEffort: null,
+      llmModel: null,
+    });
+    renderWithTooltips(
+      <Composer
+        {...composerProps({
+          agents: [{ id: "a1", name: "droid" }],
+          selectedAgentId: "a1",
+          modelPickerKind: "acp",
+          showModels: true,
+          showEffort: false,
+          codexModelOptions: [
+            { id: "grok-4.5", displayName: "Grok 4.5" },
+            { id: "claude-opus-4-8", displayName: "Opus" },
+          ],
+        })}
+      />,
+    );
+    expect(label()).toHaveTextContent("Grok 4.5");
+    expect(label()).not.toHaveTextContent("Opus");
+  });
+
   it("surfaces an SDK/bundle session's model from the override, not the cross-session sticky", () => {
     // Polly/Debby (claude-sdk) repro: a model picked in some other (Codex)
     // session lingers in the global sticky `selectedModel`. SDK/bundle sessions

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -6427,9 +6427,12 @@ function useResolvedComposerModel(
   // from an unrelated session, e.g. a gpt-5.5 left from a Codex session showing
   // on a Claude-SDK agent like Polly). claude-/codex-native keep the sticky —
   // there it IS the applied model — but only once this session's catalog vouches
-  // for it (see `sessionStickyModel`).
+  // for it (see `sessionStickyModel`). ACP joins the no-sticky group for the same
+  // reason: the agent owns its model, so a session with no override has no
+  // Omnigent-visible model and the sticky would label it with a pick carried over
+  // from an unrelated session.
   const nonNativeModel =
-    modelPickerKind === null
+    modelPickerKind === null || modelPickerKind === "acp"
       ? (sessionModelOverride ?? llmModel)
       : (sessionModelOverride ?? sessionStickyModel ?? llmModel);
   const effectiveModel = nativeVendorOwnsModel

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -5703,7 +5703,7 @@ const EFFORT_LEVELS = ["low", "medium", "high"] as const;
 /** Anthropic-side efforts for claude-native sessions (matches ANTHROPIC_EFFORTS in reasoning_effort.py). */
 const CLAUDE_NATIVE_EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
 
-type NativeModelPickerKind = "claude" | "codex" | "cursor" | "kiro" | "opencode" | "pi";
+type NativeModelPickerKind = "claude" | "codex" | "cursor" | "kiro" | "opencode" | "pi" | "acp";
 
 type LabelSource = { labels?: Record<string, string | null> | null } | null | undefined;
 
@@ -5783,6 +5783,11 @@ export function modelPickerKindForConv(
       // ``/model`` picks back to ``model_override`` via the extension's
       // model_select handler, so the picker surfaces that as the live model.
       return "pi";
+    case "acp-native-ui":
+      // Generic-ACP agents (droid, grok, …) advertise a live model list in
+      // their session/new SessionModelState; a pick rides as model_override
+      // and the ACP executor applies it live via session/set_model.
+      return "acp";
     default:
       return null;
   }
@@ -6370,7 +6375,8 @@ function useResolvedComposerModel(
     modelPickerKind === "cursor" ||
     modelPickerKind === "kiro" ||
     modelPickerKind === "pi" ||
-    modelPickerKind === "opencode";
+    modelPickerKind === "opencode" ||
+    modelPickerKind === "acp";
   const modelOptions: readonly { id: string; label?: string; displayName?: string }[] =
     usesServerModelOptions ? codexModelOptions : [];
   const isNativeModelPicker = modelPickerKind !== null;
@@ -6411,7 +6417,8 @@ function useResolvedComposerModel(
     modelPickerKind === "cursor" ||
     modelPickerKind === "kiro" ||
     modelPickerKind === "opencode" ||
-    modelPickerKind === "pi"
+    modelPickerKind === "pi" ||
+    modelPickerKind === "acp"
       ? sessionModelOverride
       : (sessionModelOverride ?? sessionStickyModel);
   // SDK/bundle agents (no native picker) never have the cross-session sticky


### PR DESCRIPTION
## Related issue

N/A

## Summary

An ACP agent advertises its own models over the protocol (`SessionModelState`),
but nothing carried that to the web model picker, so an ACP session showed **no
model control at all**. Three gaps, all on the path between the agent and the
UI:

1. The runner had no way to ask an executor what its agent offers.
2. The session carried no marker telling the UI it had a picker.
3. Even with the marker, the server's model-options fetch is keyed by wrapper
   label and had no ACP entry — so it returned `[]` without issuing a request.

- `Executor` gains `available_models()` / `current_model_id()`, defaulting to
  `[]` / `None`. Every existing executor inherits the defaults unchanged.
- `ExecutorAdapter.model_options()` surfaces them (empty until the executor
  exists — it is built lazily on the first turn).
- The runner exposes the fetch route; `_scaffold` / `process_manager` forward it.
  The route recognizes ACP by **declared capability**
  (`IntegrationMode.ACP_SUBPROCESS`), not by matching harness names, so `acp`,
  `goose`, `qwen`, `grok` and any community ACP plugin are covered without a
  list to keep in sync.
- An ACP-backed session gets an ACP wrapper label, by the same capability test.
- `_MODEL_OPTIONS_ENDPOINT_BY_WRAPPER` gains an ACP entry pointing at the
  runner's generic model-options route (the one `opencode-native` already
  reuses). Without it the runner-side branch above is unreachable.
- The web picker adds an `acp` kind, and ACP joins the no-cross-session-sticky
  group: the agent owns its model, so a session with no override has no
  Omnigent-visible model and the sticky would mislabel it with a pick carried
  over from an unrelated session.

## Test Plan

- `pytest tests/runtime/harnesses/test_executor_adapter.py tests/server/routes/test_sessions_crud.py`
  — 65 passed.
- `vitest run src/pages/ChatPage.composer.test.tsx` — 146 passed.
- `pre-commit run --files` over all changed files.
- **Live**, against a local server + host daemon with two ACP agents configured
  (`grok agent stdio`, `goose acp`):
  - Creating a session with `harness_override: "acp:grok-build"` persists
    `labels: {"omnigent.wrapper": "acp-native-ui"}`. On unmodified `main` the
    session carries no wrapper label.
  - The server then polls the runner's model-options route for that session —
    visible in the runner log as repeated
    `GET …/v1/sessions/{id}/model-options 200`. On unmodified `main` it issues
    **no** such request, because the endpoint map has no ACP entry.
  - In the real web UI the session gains the composer config gear and its
    **Model** row; on `main` the same session shows a static agent label and no
    control. Screenshots below.
  - Separately, driving `grok agent stdio` directly over the wire confirms the
    data this reads is really there: `session/new` returns the standard
    `models` key with `currentModelId: "grok-4.5"` and a populated
    `availableModels`.

## Demo

Same ACP session, same server, `main` vs this branch.

![ACP model control, before and after](https://raw.githubusercontent.com/appletechie/omnigent/assets/pr-3460/acp-picker.png)

**What this does not show, and why.** The Model dropdown is present but still
reads `Default` rather than listing the agent's models. On the machine I
verified this on, every ACP turn — both grok and goose — dies inside the
executor with `inner executor error:` and an empty message, so no ACP session
ever reaches the state where `session/new`'s `SessionModelState` has been
received. That failure reproduces identically on unmodified `main` and is
untouched by this diff; it is in the ACP executor's stdout reader
(`acp_executor.py`, which posts `{"type": "error", "message": str(exc)}` for an
exception whose `str()` is empty), not in this PR's path. I would rather flag
that than stage a screenshot that implies I saw a populated list. Filed as
#4281.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the adapter contract, the capability-derived ACP test, and the
session-labelling branch, all with the executor and store seams stubbed. What
they cannot cover is that the pieces meet across a real server/runner boundary,
so that half was verified live as described in the Test Plan — the persisted
label and the runner-log model-options polls are the observable evidence. The
last link (a populated list rendered in the picker) is blocked by the unrelated
executor failure called out under Demo and remains unverified end to end; I
would not claim otherwise.

## Changelog

ACP sessions get a model picker in the composer instead of no model control at all.
