### PR TITLE
fix(pi): match the codex gateway by path segment, not substring

### DIFF
--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -703,6 +703,19 @@ def _redact_argv_for_log(args: Sequence[str]) -> list[str]:
     return redacted
 
 
+def _gateway_path_segments(base_url: str) -> list[str]:
+    """Return *base_url*'s path split into segments, for whole-segment matching.
+
+    Matching an AI Gateway surface by substring lets a query string carrying
+    the text, or a merely prefixed segment (``/ai-gateway/codex-shim/v1``),
+    misclassify a generic OpenAI-compatible gateway.
+
+    :param base_url: A configured provider base URL.
+    :returns: The URL path's ``/``-separated segments.
+    """
+    return _urlparse(base_url).path.split("/")
+
+
 def _build_models_json(
     host: str,
     token: str,
@@ -745,13 +758,18 @@ def _build_models_json(
     # (``.../ai-gateway/codex/v1``), which 404s pi's openai-completions
     # ``/chat/completions`` POST. Re-route only that case to serving-endpoints;
     # generic providers (no ``/ai-gateway/codex``) pass through.
-    if raw_openai_base_url and "/ai-gateway/codex" in raw_openai_base_url:
+    _segments = _gateway_path_segments(raw_openai_base_url) if raw_openai_base_url else []
+    is_codex_gateway = any(
+        first == "ai-gateway" and second == "codex"
+        for first, second in zip(_segments, _segments[1:], strict=False)
+    )
+    if is_codex_gateway:
         openai_base_url = serving_endpoints_url
     else:
         openai_base_url = raw_openai_base_url or serving_endpoints_url
     # For non-Databricks providers (e.g. OpenAI API key, LiteLLM) the
     # /ai-gateway/* paths don't exist — use the generic base URL for all paths.
-    is_generic_provider = bool(raw_openai_base_url and "/ai-gateway/" not in raw_openai_base_url)
+    is_generic_provider = bool(raw_openai_base_url) and "ai-gateway" not in _segments
     if is_generic_provider:
         codex_gateway_url = openai_base_url
         mlflow_gateway_url = openai_base_url

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -34,6 +34,7 @@ import asyncio
 import base64
 import contextlib
 import hmac
+import itertools
 import json
 import logging
 import os
@@ -761,7 +762,7 @@ def _build_models_json(
     _segments = _gateway_path_segments(raw_openai_base_url) if raw_openai_base_url else []
     is_codex_gateway = any(
         first == "ai-gateway" and second == "codex"
-        for first, second in zip(_segments, _segments[1:], strict=False)
+        for first, second in itertools.pairwise(_segments)
     )
     if is_codex_gateway:
         openai_base_url = serving_endpoints_url

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -435,6 +435,42 @@ class TestBuildModelsJson(unittest.TestCase):
         self.assertIn("databricks-anthropic", providers)
         self.assertIn("databricks-completions", providers)
 
+    def test_codex_prefixed_segment_is_not_the_codex_gateway(self):
+        # The codex-gateway guard matches whole path segments, not a substring.
+        # ``/ai-gateway/codex-shim/v1`` merely starts with "codex"; treating it
+        # as the Codex Responses gateway would re-route the completions
+        # providers to serving-endpoints and 404 every turn against it.
+        url = "https://ws.example.com/ai-gateway/codex-shim/v1"
+        providers = _build_models_json("https://ws.example.com", "tok", base_urls={"openai": url})[
+            "providers"
+        ]
+        self.assertEqual(providers["databricks"]["baseUrl"], url)
+        self.assertEqual(providers["databricks-completions"]["baseUrl"], url)
+
+    def test_query_string_mentioning_gateway_stays_generic(self):
+        # Only the URL *path* decides. A generic gateway whose query string
+        # happens to carry the text must keep passing through — a substring
+        # test would classify it as a Databricks gateway and rewrite every
+        # provider URL out from under it.
+        url = "https://gateway.example.com/v1?upstream=/ai-gateway/codex/v1"
+        providers = _build_models_json("https://ws.example.com", "tok", base_urls={"openai": url})[
+            "providers"
+        ]
+        self.assertEqual(providers["databricks-openai"]["baseUrl"], url)
+        self.assertEqual(providers["databricks"]["baseUrl"], url)
+
+    def test_real_codex_gateway_still_reroutes_completions(self):
+        # The guard must still fire for the genuine article, or the ucode
+        # Codex Responses gateway 404s pi's /chat/completions POST.
+        url = "https://ws.example.com/ai-gateway/codex/v1"
+        providers = _build_models_json("https://ws.example.com", "tok", base_urls={"openai": url})[
+            "providers"
+        ]
+        self.assertEqual(providers["databricks-openai"]["baseUrl"], url)
+        self.assertEqual(
+            providers["databricks"]["baseUrl"], "https://ws.example.com/serving-endpoints"
+        )
+
     def test_dynamic_model_declared_image_capable(self):
         # #515: a dynamically-registered model must advertise image input, or
         # Pi's transformMessages strips every image block ("model does not


### PR DESCRIPTION
## Related issue

N/A

## Summary

`_build_models_json` classifies a configured `openai` base URL with two substring tests over the whole URL:

```python
if raw_openai_base_url and "/ai-gateway/codex" in raw_openai_base_url: ...
is_generic_provider = bool(raw_openai_base_url and "/ai-gateway/" not in raw_openai_base_url)
```

Substrings are the wrong granularity here, and two real shapes misclassify:

- **`.../ai-gateway/codex-shim/v1`** — merely *prefixed* with `codex`, but matched as the Codex Responses gateway. The completions providers then get re-routed to `serving-endpoints`, where every turn 404s.
- **A generic gateway whose query string carries the text** (`https://gw.example.com/v1?upstream=/ai-gateway/codex/v1`) — stops being "generic", so its base URL is rewritten out from under it.

Matches `ai-gateway` and `codex` as whole, consecutive segments of the URL **path** instead. The genuine `/ai-gateway/codex/v1` gateway keeps its current behaviour exactly.

Reuses the already-imported `_urlparse`; `zip(segments, segments[1:])` avoids pulling in `itertools` for one call site.

## Test Plan

`pytest tests/inner/test_pi_executor.py` — **140 passed** (3 added).

The three cases pin the boundary from both directions: `codex-shim` is not the codex gateway, a query-string mention stays generic, and the real codex gateway still re-routes the completions providers to `serving-endpoints`. That last one is the regression guard — a fix that over-corrected would break the ucode path this branch exists to protect.

Verified the classifier directly across seven URL shapes (real gateway, `codex-shim`, `mlflow`, CLIProxyAPI, OpenRouter, query-string mention, `None`); only the two described above change verdict.

`pre-commit run --files omnigent/inner/pi_executor.py tests/inner/test_pi_executor.py` clean.

## Demo

N/A — no visual surface; this changes provider base-URL selection only.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by the unit tests above.

## Changelog

Pi no longer misroutes providers for gateway URLs that merely contain `ai-gateway/codex` outside their path.