### PR TITLE
docs(policies): document static YAML registration for cel_policy

### DIFF
--- a/omnigent/policies/builtins/cel.py
+++ b/omnigent/policies/builtins/cel.py
@@ -10,7 +10,36 @@ The expression receives the full ``PolicyEvent`` dict as an
 (``"DENY"``, ``"ASK"``, or ``"ALLOW"``) and an optional
 ``"reason"`` key. Non-map returns abstain.
 
-Register via the session policy API::
+Register statically in an agent's YAML, or dynamically on a running
+session via the policy API.
+
+Static, in an agent ``config.yaml`` (``policies:`` block, parsed by
+:mod:`omnigent.inner.loader` — ``handler`` + ``factory_params``)::
+
+    policies:
+      block_shell:
+        type: function
+        handler: omnigent.policies.builtins.cel.cel_policy
+        factory_params:
+          expression: 'event.type == "tool_call" && event.data.name == "sys_os_shell"'
+          reason: Shell access is blocked.
+
+Static, in a bundled agent spec (``guardrails.policies``, parsed by
+:mod:`omnigent.spec.parser` — note the different spelling: a
+``function`` mapping with ``path`` + ``arguments``; this parser does
+NOT read ``factory_params``)::
+
+    guardrails:
+      policies:
+        block_shell:
+          type: function
+          function:
+            path: omnigent.policies.builtins.cel.cel_policy
+            arguments:
+              expression: 'event.type == "tool_call" && event.data.name == "sys_os_shell"'
+              reason: Shell access is blocked.
+
+Dynamic, via the session policy API::
 
     POST /v1/sessions/{session_id}/policies
     {


### PR DESCRIPTION
The cel_policy module docstring only showed the session policy REST API, which reads as if dynamic registration were the only route — it misled at least one integration into building per-session REST registration for a policy that never varies. Both static YAML forms work and are now documented, including the spelling difference between the two parsers (config.yaml: handler + factory_params via omnigent.inner.loader; bundled agent specs: guardrails.policies with a function {path, arguments} mapping via omnigent.spec.parser, which ignores factory_params). Docs-only; both examples verified against their parsers.