### PR TITLE
docs(polly): explain Claude auto permission mode

### DIFF
--- a/examples/polly/agents/claude_code/config.yaml
+++ b/examples/polly/agents/claude_code/config.yaml
@@ -6,9 +6,13 @@ executor:
   type: omnigent
   config:
     harness: claude-native
-    # Headless workers can't answer ApprovalCards, and managed Claude
-    # settings disable ``bypassPermissions``. ``auto`` auto-approves without
-    # prompting and is allowed under managed settings (-> ``--permission-mode auto``).
+    # ``permission_mode: auto`` becomes Claude Code's ``--permission-mode auto``,
+    # auto-approving tool use without prompts. This worker runs headless under
+    # polly, so no human can answer an ApprovalCard and a prompting mode would
+    # deadlock the run. Managed Claude settings disable ``bypassPermissions``,
+    # while permitting ``auto``. Auto-approval remains bounded by the
+    # ``guardrails.policies.blast_radius`` policy below, which denies force-push,
+    # ``rm -rf /``, and hard-reset to a remote ref.
     permission_mode: auto
 
 prompt: |


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Explain how the Polly Claude Code worker's auto permission mode maps to its runtime flag and prevents headless approval deadlocks.
- Clarify why managed settings require auto instead of bypass permissions and how the blast-radius policy still blocks catastrophic commands.

## Test Plan

- `python -c "import yaml,sys;yaml.safe_load(open('examples/polly/agents/claude_code/config.yaml'))"`
- `uv run pytest tests/e2e/omnigent/test_example_polly.py -q` (14 passed)
- `uv run pre-commit run --files examples/polly/agents/claude_code/config.yaml`
- Compared the file against HEAD after removing comment lines; all non-comment lines were byte-identical.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified the YAML parses, every non-comment line remains byte-identical, and the existing Polly example-config loader suite passes all 14 tests.

## Changelog

Clarify the safety and headless-runtime behavior of Polly's Claude Code permission mode.
