### PR TITLE
fix(cli): resolve conversation ids pasted with stray punctuation in `omni resume`

### DIFF
--- a/omnigent/resume_dispatch.py
+++ b/omnigent/resume_dispatch.py
@@ -35,6 +35,11 @@ from omnigent.native_coding_agents import native_coding_agent_for_wrapper_label
 
 _logger = logging.getLogger(__name__)
 
+# Characters a copy-paste commonly drags along around an id (sentence
+# punctuation, quoting, brackets). Never valid in any id spelling, so
+# stripping them from the ends cannot change which conversation resolves.
+_PASTE_PUNCTUATION = " \t`'\"()[]{}<>.,;:"
+
 
 def run_resume(
     *,
@@ -164,10 +169,24 @@ def _dispatch_by_runtime(
     :param server: Optional remote Omnigent server URL. ``None`` when
         the lookup should hit a freshly-started local server (the
         claude-native wrapper owns its own local server lifecycle).
-    :raises click.ClickException: When the conversation can't be
-        resolved, can't be classified, or is not a terminal-native
-        session.
+    :raises click.ClickException: When *target* is not a valid
+        conversation id, the conversation can't be resolved, can't be
+        classified, or is not a terminal-native session.
     """
+    from omnigent.db.db_models import InvalidUuidError, uuid_to_bytes
+
+    # Resolve the id the argument contains, then canonicalize to bare hex
+    # before any lookup: a paste drags punctuation along (trailing period,
+    # wrapping quotes or backticks), and none of it can ever be part of a
+    # valid id — so strip it and resume rather than erroring. A malformed
+    # id would otherwise surface as a raw StatementError traceback from
+    # the local store's Uuid16 bind, and downstream consumers key
+    # sessions on the bare spelling.
+    try:
+        target = uuid_to_bytes(target.strip(_PASTE_PUNCTUATION)).hex()
+    except InvalidUuidError as exc:
+        raise click.ClickException("Invalid session id.") from exc
+
     if server is not None:
         wrapper = _read_wrapper_label_remote(server=server, conv_id=target)
         if _dispatch_wrapper(

--- a/tests/test_resume_dispatch.py
+++ b/tests/test_resume_dispatch.py
@@ -339,6 +339,108 @@ def test_dispatch_by_runtime_claude_native_local_still_routes_to_wrapper(
     assert captured["claude_args"] == ()
 
 
+@pytest.mark.parametrize(
+    "pasted",
+    [
+        "7e52264a6dc51b019fc572f221c81e72.",  # sentence-final period
+        "`7e52264a6dc51b019fc572f221c81e72`",  # markdown backticks
+        "'7e52264a6dc51b019fc572f221c81e72',",  # quoted list element
+        "(7e52264a6dc51b019fc572f221c81e72)",  # parenthesized
+    ],
+)
+def test_dispatch_by_runtime_accepts_id_with_paste_punctuation(
+    monkeypatch: pytest.MonkeyPatch,
+    pasted: str,
+) -> None:
+    """
+    An id pasted with surrounding punctuation resolves — the lookup and
+    the wrapper both receive the bare id it contains. Rejecting it (or
+    worse, the raw ``StatementError`` traceback the ``Uuid16`` bind used
+    to raise) would fail a command the user copied in good faith.
+    """
+    seen: dict[str, str] = {}
+
+    def _label(*, conv_id: str) -> str:
+        """Record the id the store lookup receives."""
+        seen["conv_id"] = conv_id
+        return "codex-native-ui"
+
+    monkeypatch.setattr(resume_dispatch, "_read_wrapper_label_local", _label)
+    captured: dict[str, Any] = {}
+
+    def _capture(**kwargs: Any) -> None:
+        """Record the kwargs ``run_codex_native`` was called with."""
+        captured.update(kwargs)
+
+    monkeypatch.setattr("omnigent.codex_native.run_codex_native", _capture)
+
+    resume_dispatch._dispatch_by_runtime(target=pasted, server=None)
+
+    assert seen["conv_id"] == "7e52264a6dc51b019fc572f221c81e72"
+    assert captured["session_id"] == "7e52264a6dc51b019fc572f221c81e72"
+
+
+def test_dispatch_by_runtime_malformed_id_raises_before_any_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    An argument containing no valid conv id (here: truncated) surfaces
+    a short ``ClickException`` — and never reaches a store or server
+    lookup, where the ``Uuid16`` bind would raise a raw
+    ``StatementError`` traceback at the user.
+    """
+
+    def _fail_if_called(**kwargs: Any) -> None:
+        """Marker — fails the test if any lookup is reached."""
+        del kwargs
+        raise AssertionError("lookup reached with a malformed conv id")
+
+    monkeypatch.setattr(resume_dispatch, "_read_wrapper_label_local", _fail_if_called)
+    monkeypatch.setattr(resume_dispatch, "_read_wrapper_label_remote", _fail_if_called)
+
+    with pytest.raises(click.ClickException) as excinfo:
+        resume_dispatch._dispatch_by_runtime(
+            target="7e52264a",
+            server=None,
+        )
+
+    assert excinfo.value.message == "Invalid session id."
+
+
+def test_dispatch_by_runtime_legacy_prefixed_id_canonicalized_to_bare_hex(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A legacy ``conv_<hex>`` spelling still resolves — and is
+    canonicalized to bare hex before lookup and wrapper dispatch, so
+    downstream consumers that key sessions on the bare spelling never
+    see the prefixed form.
+    """
+    seen: dict[str, str] = {}
+
+    def _label(*, conv_id: str) -> str:
+        """Record the id the store lookup receives."""
+        seen["conv_id"] = conv_id
+        return "codex-native-ui"
+
+    monkeypatch.setattr(resume_dispatch, "_read_wrapper_label_local", _label)
+    captured: dict[str, Any] = {}
+
+    def _capture(**kwargs: Any) -> None:
+        """Record the kwargs ``run_codex_native`` was called with."""
+        captured.update(kwargs)
+
+    monkeypatch.setattr("omnigent.codex_native.run_codex_native", _capture)
+
+    resume_dispatch._dispatch_by_runtime(
+        target="conv_415c9954e2fe4b9276083a4d2c66f689",
+        server=None,
+    )
+
+    assert seen["conv_id"] == "415c9954e2fe4b9276083a4d2c66f689"
+    assert captured["session_id"] == "415c9954e2fe4b9276083a4d2c66f689"
+
+
 def test_dispatch_by_runtime_non_wrapper_local_raises_with_hint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #3464

## Summary

- `omni resume <id>` crashed with a raw `StatementError` traceback when the id carried stray punctuation from a paste (e.g. a trailing period): the raw CLI argument flowed into the local store, where the `Uuid16` bind's `uuid_to_bytes` fails loud on anything that isn't a 32-char hex uuid. The binary-uuid migration guarded the server boundary (malformed id → 404) but the CLI's direct local-store path never got an equivalent guard.
- Fix: resolve the id the argument contains. At the top of `_dispatch_by_runtime` — the choke point both the direct-id and picker forms route through, before any local or remote lookup — strip the punctuation a paste drags along (sentence punctuation, quotes, backticks, brackets; none of it can ever be part of a valid id) and resume normally. A pasted `omni resume <id>.` now behaves identically to `omni resume <id>`.
- Only when no valid id remains (truncated, non-hex) does the command fail, with a short `Invalid session id.` error instead of the traceback.
- The same call canonicalizes valid legacy spellings (`conv_<hex>`, dashed) to bare hex before lookup and wrapper dispatch, so downstream consumers that key sessions on the bare spelling never see the prefixed form (the failure pattern behind #3458 / #3440).

## Test Plan

- `pytest tests/test_resume_dispatch.py` — 21 passed (new: 4-case parametrized acceptance of pasted punctuation — trailing period, backticks, quotes+comma, parens — asserting the store lookup and the wrapper both receive the bare id; truncated id raises before any lookup; legacy `conv_`-prefixed id canonicalized to bare hex).
- Manual: `omnigent resume '7e52264a6dc51b019fc572f221c81e72.'` now proceeds exactly like the bare id (on a machine without that conversation: the normal `Conversation ... not found` message, with the cleaned id); a truncated id prints the one-line error below.
- `pre-commit run` on the changed files — clean.

## Demo

Before (id pasted with a trailing period):

```
⚠️  Omnigent ran into an issue.
─── technical details ─────────────────────────────
Traceback (most recent call last):
  ...
sqlalchemy.exc.StatementError: (omnigent.db.db_models.InvalidUuidError) expected a 32-char hex uuid, got '7e52264a6dc51b019fc572f221c81e72.'
```

After: `omni resume 7e52264a6dc51b019fc572f221c81e72.` resumes the session, identically to the bare id. An argument containing no valid id fails as:

```
Error: Invalid session id.
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually ran `omnigent resume` from the venv with the pasted id from the report (trailing period) and confirmed it proceeds with the bare id; unit tests cover acceptance across punctuation shapes, the guard firing before any store/server lookup for unrecoverable input, and legacy-spelling canonicalization.

## Changelog

`omni resume` now accepts a conversation id pasted with stray punctuation (trailing period, quotes, backticks) instead of crashing

This pull request and its description were written by Isaac.
