### PR TITLE
refactor(sandboxes): remove legacy registry fallback and add provider docs

### DIFF
--- a/docs/extending/sandbox_providers.md
+++ b/docs/extending/sandbox_providers.md
@@ -1,0 +1,153 @@
+# Sandbox providers
+
+Omnigent supports running agent hosts in remote sandboxes. Built-in providers
+(Modal, Daytona, CoreWeave Sandbox, E2B, Islo, OpenShell, Boxlite, Kubernetes)
+ship with the core package. Third-party packages can add new providers through
+the `omnigent.sandbox_providers` entrypoint group.
+
+## How it works
+
+Each sandbox provider implements the
+[`SandboxLifecycle`](../../omnigent/onboarding/sandboxes/base.py) interface.
+Providers that exec into a running sandbox (Modal, Daytona, …) inherit
+`ExecModelHostLauncher`, which provides a default `start_host` that probes
+`$HOME`, creates a workspace, clones a repo, and backgrounds `omnigent host`.
+Providers whose sandbox boots running the host directly (Kubernetes) inherit
+`SandboxHostLauncher` and override `start_host` to build the infrastructure
+manifest instead.
+
+## Creating a community sandbox provider
+
+### 1. Implement the launcher
+
+```python
+# omnigent_community_sandbox_acme/launcher.py
+from omnigent.onboarding.sandboxes.base import ExecModelHostLauncher
+from omnigent.onboarding.sandboxes.types import SandboxCapabilities
+
+
+class AcmeSandboxLauncher(ExecModelHostLauncher):
+    provider = "acme"
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        return SandboxCapabilities(
+            cli_bootstrap=True,
+            managed_launch=True,
+            local_port_forward=False,
+            resume_stopped=False,
+            programmatic_terminate=True,
+            file_copy=True,
+            streaming_exec=False,
+            foreground_exec=True,
+        )
+
+    def prepare(self) -> None:
+        # Verify credentials / tooling
+        ...
+
+    def provision(self, name: str) -> str:
+        # Create the sandbox, return its id
+        ...
+
+    def run(self, sandbox_id: str, command: str, *, check: bool = True):
+        # Execute a command in the sandbox
+        ...
+
+    def put(self, sandbox_id: str, local_path, remote_path: str) -> None:
+        # Copy a file into the sandbox
+        ...
+
+    def terminate(self, sandbox_id: str) -> None:
+        # Delete the sandbox
+        ...
+```
+
+### 2. Register the contribution
+
+```python
+# omnigent_community_sandbox_acme/plugin.py
+from omnigent.onboarding.sandboxes.registry import (
+    SandboxProviderContribution,
+    SandboxProviderMetadata,
+)
+
+def get_contribution() -> SandboxProviderContribution:
+    return SandboxProviderContribution(
+        name="omnigent-acme",
+        providers={
+            "acme": SandboxProviderMetadata(
+                name="acme",
+                launcher_class="omnigent.community.sandbox.acme:AcmeSandboxLauncher",
+            )
+        },
+    )
+```
+
+### 3. Declare the entrypoint in `pyproject.toml`
+
+```toml
+[project.entry-points."omnigent.sandbox_providers"]
+acme = "omnigent_community_sandbox_acme.plugin:get_contribution"
+```
+
+### 4. Install and use
+
+```bash
+pip install omnigent-community-sandbox-acme
+omnigent sandbox create --provider acme --server https://your-host
+```
+
+## Namespace requirement
+
+Community provider code **must** live under the `omnigent.community.sandbox`
+namespace package. This is enforced by the registry's validation — a
+contribution whose `launcher_class` points outside this namespace is rejected
+with a clear error.
+
+To use the namespace, create a package under `omnigent/community/sandbox/` in
+your distribution:
+
+```
+omnigent/
+  community/
+    sandbox/
+      acme/
+        __init__.py
+        launcher.py
+```
+
+The `omnigent.community.sandbox` namespace package is already set up by core
+Omnigent using `pkgutil.extend_path`, so your package's files are discovered
+automatically when installed.
+
+## Server-managed sandboxes
+
+To use a community provider for server-managed sessions, add it to the
+server's `sandbox:` config:
+
+```yaml
+sandbox:
+  provider: acme
+  server_url: https://your-host
+```
+
+The server resolves the provider through the registry and calls
+`prepare()` → `provision()` → `start_host()` → wait for online registration.
+Each managed sandbox authenticates back with a server-minted per-launch token.
+
+## Provider capabilities
+
+Providers declare their feature set via a `capabilities` property returning
+`SandboxCapabilities`:
+
+| Capability | Description |
+|---|---|
+| `cli_bootstrap` | Supports `omnigent sandbox create` / `connect` |
+| `managed_launch` | Supports server-managed `host_type="managed"` sessions |
+| `local_port_forward` | Can bridge a local port into the sandbox |
+| `resume_stopped` | Can resume a stopped sandbox in place |
+| `programmatic_terminate` | Can terminate a sandbox programmatically |
+| `file_copy` | Supports copying files into the sandbox |
+| `streaming_exec` | Supports streaming process execution |
+| `foreground_exec` | Supports a foreground exec with inherited stdio |

--- a/omnigent/onboarding/sandboxes/__init__.py
+++ b/omnigent/onboarding/sandboxes/__init__.py
@@ -8,10 +8,6 @@ the ``omnigent.sandbox_providers`` entry point group.
 
 from __future__ import annotations
 
-import importlib
-import importlib.util
-import warnings
-
 import click
 
 from omnigent.onboarding.sandboxes.base import (
@@ -86,27 +82,6 @@ __all__ = [
     "ship_wheels",
 ]
 
-# Legacy registration surface. It is no longer used by the registry, but is kept
-# as a fallback path so any provider not yet loaded through the entrypoint
-# mechanism still resolves for one release cycle.
-_LAUNCHERS: dict[str, str] = {
-    "lakebox": "omnigent.onboarding.sandboxes.lakebox:LakeboxLauncher",
-    "modal": "omnigent.onboarding.sandboxes.modal:ModalSandboxLauncher",
-    "daytona": "omnigent.onboarding.sandboxes.daytona:DaytonaSandboxLauncher",
-    "boxlite": "omnigent.onboarding.sandboxes.boxlite:BoxliteSandboxLauncher",
-    # CoreWeave Sandbox via the official cwsandbox SDK (the
-    # `omnigent[cwsandbox]` extra), imported lazily like modal/daytona.
-    "cwsandbox": "omnigent.onboarding.sandboxes.cwsandbox:CWSandboxLauncher",
-    "islo": "omnigent.onboarding.sandboxes.islo:IsloSandboxLauncher",
-    # E2B (https://e2b.dev) via the official `e2b` SDK (the
-    # `omnigent[e2b]` extra), imported lazily like modal/daytona.
-    "e2b": "omnigent.onboarding.sandboxes.e2b:E2BSandboxLauncher",
-    "openshell": "omnigent.onboarding.sandboxes.openshell:OpenShellSandboxLauncher",
-    # On-demand Kubernetes runner Pod via the official kubernetes client (the
-    # `omnigent[kubernetes]` extra), imported lazily like modal/daytona.
-    "kubernetes": "omnigent.onboarding.sandboxes.kubernetes:KubernetesSandboxLauncher",
-}
-
 
 def get_launcher(provider: str, *, workspace_host: str | None = None) -> SandboxLauncher:
     """
@@ -127,40 +102,12 @@ def get_launcher(provider: str, *, workspace_host: str | None = None) -> Sandbox
     :raises click.ClickException: If the provider is unknown or its
         launcher module is not present in this build.
     """
-    if provider in plugin_state():
-        try:
-            return instantiate(provider, workspace_host=workspace_host)
-        except SandboxRegistryError as exc:
-            raise click.ClickException(str(exc)) from exc
-
-    # Legacy fallback for any provider not yet loaded by the registry.
-    warnings.warn(
-        f"Sandbox provider '{provider}' was resolved through the legacy "
-        f"_LAUNCHERS registry. Use the SandboxProviderContribution or "
-        f"omnigent.sandbox_providers entrypoints instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    target = _LAUNCHERS.get(provider)
-    if target is None:
+    if provider not in plugin_state():
         offered = ", ".join(available_providers()) or "(none in this build)"
         raise click.ClickException(
             f"Unknown or unavailable sandbox provider '{provider}'. Available: {offered}."
         )
-    module_name = target.partition(":")[0]
-    if importlib.util.find_spec(module_name) is None:
-        offered = ", ".join(available_providers()) or "(none in this build)"
-        raise click.ClickException(
-            f"Unknown or unavailable sandbox provider '{provider}'. Available: {offered}."
-        )
-    if provider == "lakebox" and workspace_host is not None:
-        # Imported here (not at module top) because the lakebox module
-        # may be absent from a distribution; the availability check above
-        # guarantees it exists in this one.
-        import omnigent.onboarding.sandboxes.lakebox as lakebox  # type: ignore[import-not-found]
-
-        return lakebox.LakeboxLauncher(workspace_host=workspace_host)
-    module_name, _, class_name = target.partition(":")
-    module = importlib.import_module(module_name)
-    launcher_cls: type[SandboxLauncher] = getattr(module, class_name)
-    return launcher_cls()
+    try:
+        return instantiate(provider, workspace_host=workspace_host)
+    except SandboxRegistryError as exc:
+        raise click.ClickException(str(exc)) from exc

--- a/tests/onboarding/sandboxes/test_registry.py
+++ b/tests/onboarding/sandboxes/test_registry.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 from dataclasses import dataclass
 from typing import Any
 
@@ -274,12 +273,11 @@ def test_get_launcher_uses_registry() -> None:
 def test_get_launcher_unknown_raises_click_exception() -> None:
     """An unknown provider still surfaces as a click.ClickException."""
     reset_plugin_state_for_tests()
-    with contextlib.suppress(DeprecationWarning):
-        with pytest.raises(
-            click.ClickException,
-            match="Unknown or unavailable sandbox provider",
-        ):
-            get_launcher("definitely-not-real")
+    with pytest.raises(
+        click.ClickException,
+        match="Unknown or unavailable sandbox provider",
+    ):
+        get_launcher("definitely-not-real")
 
 
 def test_instantiate_rejects_non_launcher_class(


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Remove the legacy `_LAUNCHERS` fallback from `__init__.py` — all providers
  are now resolved exclusively through the `SandboxProviderRegistry`
  contribution-based registry.
- Simplify `get_launcher()` to a single code path (no more
  `DeprecationWarning` / legacy import fallback).
- Remove unused `warnings` / `importlib` / `importlib.util` imports from
  `__init__.py`.
- Add `docs/extending/sandbox_providers.md` documenting how to implement and
  register a third-party sandbox provider, including a minimal example
  package with `pyproject.toml` entrypoint, the namespace requirement, and
  the capability reference table.

## Test Plan

```bash
uv run pytest tests/onboarding/sandboxes tests/sandbox tests/cli/test_cli.py tests/server -k managed -q
pre-commit run --files <changed files>
```

All 782 selected tests pass and pre-commit is clean.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing tests pass unchanged. The test that expected a `DeprecationWarning`
from the legacy path was updated to no longer suppress it. New docs are
prose-only and need no test coverage.