### PR TITLE
fix(ci): exclude dev/pre tags from the backcompat version matrix

### DIFF
--- a/.github/scripts/ci/backcompat-pairwise-matrix.sh
+++ b/.github/scripts/ci/backcompat-pairwise-matrix.sh
@@ -3,7 +3,7 @@
 # `e2e_matrix` and `integration_matrix`.
 #
 # We test `main` (the checked-out code = client + tests, always) against each
-# non-rc release tag AT OR ABOVE the backcompat floor (MIN_VERSION, default
+# final (non-prerelease) release tag AT OR ABOVE the backcompat floor (MIN_VERSION, default
 # 0.2.0 — the first release with the mock-LLM e2e infra; see below), on BOTH
 # axes — and ONLY those cells:
 #   (server=main,      runner=<release>)  — new server vs a previously-shipped runner
@@ -17,8 +17,9 @@
 #
 # Env in:
 #   VERSIONS    optional comma-separated override of the version set used for
-#               BOTH axes (e.g. "main,v0.2.0"). Empty = main + all non-rc tags.
-#               Blank entries are dropped and surrounding whitespace trimmed.
+#               BOTH axes (e.g. "main,v0.2.0"). Empty = main + all final
+#               (non-prerelease) tags. Blank entries are dropped and
+#               surrounding whitespace trimmed.
 #   NUM_SHARDS  e2e shard count per cell (default 4).
 # Out (GITHUB_OUTPUT):
 #   e2e_matrix={"include":[{"server":..,"runner":..,"shard_id":..,"num_shards":..}, ...]}
@@ -61,9 +62,12 @@ if [ -n "${VERSIONS:-}" ]; then
   IFS=',' read -ra raw <<<"$VERSIONS"
 else
   raw=("main")
-  # `[^a-z]rc[0-9]` so we drop vX.Y.ZrcN without over-excluding tags that merely
-  # contain the substring "rc" (e.g. a hypothetical "...march").
-  while IFS= read -r tag; do raw+=("$tag"); done < <(git tag --sort=-v:refname | grep -viE '(^|[^a-z])rc[0-9]')
+  # Drop pre-release tags (vX.Y.ZrcN / .devN / preN — same trio github-release.yml
+  # skips): they are snapshots of main, so main-vs-them is not a compat signal, and
+  # under the 256-job cap they would evict the oldest FINAL releases from coverage.
+  # `[^a-z]` guards against over-excluding tags that merely contain the substring
+  # (e.g. a hypothetical "...march"). An explicit VERSIONS override still accepts them.
+  while IFS= read -r tag; do raw+=("$tag"); done < <(git tag --sort=-v:refname | grep -viE '(^|[^a-z])(rc|dev|pre)[0-9]')
 fi
 
 # Trim whitespace, drop blanks, reject invalid tokens, drop below-floor releases.

--- a/.github/workflows/server-compat.yml
+++ b/.github/workflows/server-compat.yml
@@ -4,7 +4,7 @@ name: Backwards-Compat
 # suites, over the FULL pairwise (server, runner) version matrix.
 #
 # The version universe is `main` (the checked-out code = client + tests, always)
-# plus every non-rc release tag; we cross every server version with every runner
+# plus every final (non-prerelease) release tag; we cross every server version with every runner
 # version. Each cell pins the server and/or runner subprocess to that build
 # (a "main" axis value leaves that component on the checked-out code) while the
 # client and tests stay on main. The (main, main) cell is omitted — it pins
@@ -18,13 +18,13 @@ name: Backwards-Compat
 #
 # Triggers:
 #   workflow_dispatch   manual; optional `versions` CSV overrides the set.
-#   schedule            every 12h; full pairwise over main + all non-rc tags.
+#   schedule            every 12h; full pairwise over main + all final tags.
 
 on:
   workflow_dispatch:
     inputs:
       versions:
-        description: "Comma-separated version set for BOTH axes (e.g. 'main,v0.2.0'). Empty = main + all non-rc tags."
+        description: "Comma-separated version set for BOTH axes (e.g. 'main,v0.2.0'). Empty = main + all final (non-prerelease) tags."
         required: false
         default: ""
   schedule:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The 12-hourly `server-compat.yml` matrix builds its default version set from **all** tags, filtering out only `rcN` — `devN` / `preN` tags slip through into the main↔release compat cells.
- This is live waste today: a stray `v0.4.0.dev0` tag (pointing at a July 2 `main` commit) has been in the matrix for a month, burning ~10 meaningless jobs per scheduled run (main-vs-a-main-snapshot is not a compat signal). With nightly prerelease builds planned (~25 tags/month), the 256-job cap would start evicting the **oldest final releases** — exactly the coverage this workflow exists to provide.
- Fix: extend the tag filter to the same `rc/dev/pre` trio that `github-release.yml` already skips, and update the stale "non-rc" comments. An explicit `versions` dispatch override still accepts prerelease tags, so a prerelease can still be compat-tested deliberately.

ELI5: the nightly compatibility test decides which old versions to test against by listing release tags. It knew to ignore `rc` candidates but not `dev`/`pre` snapshots, so it was testing "today's code vs a copy of recent code" — which proves nothing — and, as snapshots pile up, it would crowd out the real old versions.

## Test Plan

- Synthetic tag repo (`v0.2.0 v0.5.1 v0.7.0 v0.9.0 v0.7.0rc1 v0.7.0rc2 v0.8.0.dev20260730 v0.8.0.dev20260731 v0.3.0pre1`):
  - old grep kept both dev tags + the pre tag in the default set;
  - patched script: `versions: main v0.9.0 v0.7.0 v0.5.1 v0.2.0` (8 pairs / 32 e2e jobs) — prerelease tags excluded;
  - `VERSIONS='main,v0.8.0.dev20260730' bash backcompat-pairwise-matrix.sh` still yields `versions: main v0.8.0.dev20260730` — the explicit override path is unaffected.
- Real repo: `diff <(git tag | grep -viE '(^|[^a-z])rc[0-9]') <(git tag | grep -viE '(^|[^a-z])(rc|dev|pre)[0-9]')` → the only delta is `v0.4.0.dev0`, i.e. the fix removes exactly the stray snapshot and changes nothing else.
- `pre-commit run` on both files: clean.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

There is no test infrastructure for the `.github/scripts/ci/*.sh` matrix scripts; verified by running the script against a synthetic tag corpus (before/after, plus the `VERSIONS` override path) and by diffing old-vs-new filter output over the real repo's tags (only `v0.4.0.dev0` drops out).

This pull request and its description were written by Isaac.
