### PR TITLE
fix(release): stage the full lockstep stamp in the release commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -615,8 +615,10 @@ jobs:
           git config user.name "omnigent-ci[bot]"
           git config user.email "294685417+omnigent-ci[bot]@users.noreply.github.com"
 
-          git add pyproject.toml sdks/python-client/pyproject.toml sdks/ui/pyproject.toml \
-            omnigent/version.py uv.lock
+          # Stage everything the stamp touched: update_versions.py owns the
+          # file set, and a hand-kept path list here goes stale whenever a
+          # package joins the lockstep (bump-version.yml stages the same way).
+          git add -A
           if git diff --cached --quiet; then
             echo "No version changes to commit (already stamped)."
           else


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Since `omnigent-slack` joined the version lockstep, `scripts/update_versions.py` stamps **four** packages — but `release.yml`'s cut job still staged a hand-kept list of the original five paths, silently dropping `integrations/slack/pyproject.toml` from the release commit.
- This already shipped broken: at the `v0.7.0` tag, root `pyproject.toml` pins `omnigent-slack==0.7.0` and `uv.lock` is stamped `0.7.0`, but the in-tree slack package still says `0.7.0.dev0`. Consequences at that tag: `uv sync --locked` fails, and a source install with the `[slack]` extra cannot resolve. Lint failed on both `release/v0.7.0` pushes (21:51 and 21:58 UTC, Jul 27) but the tag push happens in the same operation, so nothing blocked. The three core PyPI wheels were unaffected (their files were in the list).
- Fix: stage with `git add -A` (the same way `bump-version.yml` stages the identical stamp + `uv lock` sequence), so the staged set tracks whatever `update_versions.py` stamps and can't drift when the next package joins the lockstep.

No tag rewrite is attempted for `v0.7.0` (tags are immutable by policy); the next cut on `release/v0.7.0` (e.g. a `0.7.1`) will stamp all four files correctly once this merges.

## Test Plan

- Verified the defect at the shipped tag: `git show v0.7.0:integrations/slack/pyproject.toml` → `version = "0.7.0.dev0"` while `git show v0.7.0:pyproject.toml` pins `omnigent-slack==0.7.0`, and the release commit's stat lists exactly 5 files.
- Verified `lint.yml` concluded `failure` on both `release/v0.7.0` push runs.
- Verified nothing else in the cut job writes to the worktree before the commit step (`uv run --no-project` uses ephemeral envs outside the workspace; `uv lock` touches only `uv.lock`), so `git add -A` stages exactly the stamp.
- `pre-commit run` on the workflow file: clean.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Manual verification completed
- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Release workflows have no test harness; verification is the tag-tree forensics above plus the next release cut (whose branch-push lint run gates the exact `uv sync --locked` consistency this fixes).

This pull request and its description were written by Isaac.
