### PR TITLE
feat(model-discovery): add max_results and parent params to UC model-services request

### DIFF
--- a/omnigent/databricks_model_discovery.py
+++ b/omnigent/databricks_model_discovery.py
@@ -16,6 +16,8 @@ _MODEL_SERVICES_PATH = "/api/2.1/unity-catalog/model-services"
 _ANTHROPIC_MODELS_PATH = "/ai-gateway/anthropic/v1/models"
 _MODEL_SERVICE_PREFIX = "model-services/"
 _SYSTEM_MODEL_PREFIX = "system.ai."
+_MODEL_SERVICES_MAX_RESULTS = 1000
+_MODEL_SERVICES_PARENT = "schemas/system.ai"
 _PAGE_SIZE = 100
 _MAX_PAGES = 100
 _HTTP_TIMEOUT_S = 10.0
@@ -54,7 +56,10 @@ def _list_model_service_ids(
     page_token: str | None = None
     seen_tokens: set[str] = set()
     for _ in range(_MAX_PAGES):
-        params = {"page_size": str(_PAGE_SIZE)}
+        params: dict[str, str] = {
+            "max_results": str(_MODEL_SERVICES_MAX_RESULTS),
+            "parent": _MODEL_SERVICES_PARENT,
+        }
         if page_token is not None:
             params["page_token"] = page_token
         response = client.get(

--- a/tests/test_databricks_model_discovery.py
+++ b/tests/test_databricks_model_discovery.py
@@ -53,7 +53,8 @@ def test_model_services_are_paginated_filtered_and_version_sorted() -> None:
         "haiku": "system.ai.claude-haiku-4-5",
     }
     assert len(requests) == 2
-    assert requests[0].url.params["page_size"] == "100"
+    assert requests[0].url.params["max_results"] == "1000"
+    assert requests[0].url.params["parent"] == "schemas/system.ai"
 
 
 def test_anthropic_gateway_is_the_legacy_fallback() -> None:


### PR DESCRIPTION
## Summary

- Adds `max_results=1000` and `parent=schemas/system.ai` query parameters to the Unity Catalog model-services API call in `_list_model_service_ids`
- Scopes the listing to `system.ai` models directly at the API level (previously filtered client-side), and raises the result cap to 1000
- Matches the recommended API call: `/ajax-api/2.1/unity-catalog/model-services?max_results=1000&parent=schemas%2Fsystem.ai`

## Test Plan

- Updated `test_model_services_are_paginated_filtered_and_version_sorted` to assert the new `max_results` and `parent` params are sent on requests
- All 10 existing `test_databricks_model_discovery.py` tests pass

## Demo

N/A — no UI change

## Type of change

- [x] Bug fix / improvement (non-breaking change)

## Test coverage

- [x] Existing tests updated

## Coverage notes

N/A

This pull request and its description were written by Isaac.