### PR TITLE
fix(inner): stop agent-CLI subprocesses inheriting unrelated host secrets

### DIFF
--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -59,6 +59,7 @@ from pathlib import Path
 from typing import Any
 
 from omnigent.inner._acp_omnigent_mcp import OmnigentAcpMcp
+from omnigent.inner.agent_env import clean_agent_env, declared_passthrough
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.executor import (
     Executor,
@@ -317,7 +318,13 @@ class AcpExecutor(Executor):
         # subprocess died. ``_initialized`` is a one-way latch.
         self._initialized = False
         self._image_supported = False
-        env = os.environ.copy()
+        # Deny-by-default: base + this harness's own families + the spec's
+        # env_passthrough. Previously os.environ.copy() handed the acp CLI
+        # every host secret (#3445).
+        env = clean_agent_env(
+            allow_prefixes=(),
+            extra_allowed=declared_passthrough(self._os_env),
+        )
         launch_path, argv = self._sandbox_launch(tuple(env.keys()))
         _STREAM_LIMIT = 16 * 1024 * 1024
         self._proc = await asyncio.create_subprocess_exec(

--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -318,13 +318,7 @@ class AcpExecutor(Executor):
         # subprocess died. ``_initialized`` is a one-way latch.
         self._initialized = False
         self._image_supported = False
-        # Deny-by-default: base + this harness's own families + the spec's
-        # env_passthrough. Previously os.environ.copy() handed the acp CLI
-        # every host secret (#3445).
-        env = clean_agent_env(
-            allow_prefixes=(),
-            extra_allowed=declared_passthrough(self._os_env),
-        )
+        env = self._build_spawn_env()
         launch_path, argv = self._sandbox_launch(tuple(env.keys()))
         _STREAM_LIMIT = 16 * 1024 * 1024
         self._proc = await asyncio.create_subprocess_exec(
@@ -491,29 +485,69 @@ class AcpExecutor(Executor):
     # ACP handshake
     # ------------------------------------------------------------------
 
+    def _build_spawn_env(self) -> dict[str, str]:
+        """The env handed to the generic ACP subprocess.
+
+        Deny-by-default: base + the spec's ``env_passthrough``. No prefix family
+        is added because the executor cannot know which vendor an arbitrary ACP
+        agent belongs to. Previously ``os.environ.copy()`` handed the CLI every
+        host secret (#3445).
+
+        Kept as a named builder so the spawn-env canary can drive the real thing
+        rather than a hand-copied prefix list.
+        """
+        return clean_agent_env(
+            allow_prefixes=(),
+            extra_allowed=declared_passthrough(self._os_env),
+        )
+
+    def _warn_initialize_failed(self, reason: str) -> None:
+        """Point a failed handshake at the env allowlist.
+
+        A generic ACP agent gets the base environment plus whatever
+        ``os_env.sandbox.env_passthrough`` declares — nothing else, since the
+        executor cannot know which variable an arbitrary agent authenticates
+        with. An agent that reads e.g. ``GEMINI_API_KEY`` therefore starts
+        unauthenticated and usually dies during ``initialize``. That looks like
+        a protocol fault, so name the likely cause once here rather than let
+        every operator rediscover it.
+        """
+        logger.warning(
+            "acp initialize failed for %r: %s. If this agent authenticates from an "
+            "environment variable, declare it in os_env.sandbox.env_passthrough — "
+            "the spawn environment is filtered to the base set plus that list.",
+            self._config.command,
+            reason,
+        )
+
     async def _ensure_initialized(self) -> None:
         """Perform the ``initialize`` handshake if not already done."""
         if self._initialized:
             return
-        resp = await self._rpc(
-            _AGENT_METHOD_INITIALIZE,
-            {
-                "protocolVersion": _PROTOCOL_VERSION,
-                "clientInfo": {"name": "omnigent", "version": "1.0"},
-                "clientCapabilities": {
-                    "fs": {
-                        "readTextFile": self._fs_delegation,
-                        "writeTextFile": self._fs_delegation,
+        try:
+            resp = await self._rpc(
+                _AGENT_METHOD_INITIALIZE,
+                {
+                    "protocolVersion": _PROTOCOL_VERSION,
+                    "clientInfo": {"name": "omnigent", "version": "1.0"},
+                    "clientCapabilities": {
+                        "fs": {
+                            "readTextFile": self._fs_delegation,
+                            "writeTextFile": self._fs_delegation,
+                        },
+                        "terminal": False,
                     },
-                    "terminal": False,
                 },
-            },
-            timeout=_INIT_TIMEOUT_SECONDS,
-        )
-        if "error" in resp:
-            raise RuntimeError(
-                f"ACP initialize failed: {resp['error'].get('message', resp['error'])}"
+                timeout=_INIT_TIMEOUT_SECONDS,
             )
+        except Exception as exc:
+            # Covers the child dying or timing out before it answers.
+            self._warn_initialize_failed(str(exc))
+            raise
+        if "error" in resp:
+            message = resp["error"].get("message", resp["error"])
+            self._warn_initialize_failed(str(message))
+            raise RuntimeError(f"ACP initialize failed: {message}")
         prompt_caps = (
             (resp.get("result") or {}).get("agentCapabilities", {}).get("promptCapabilities", {})
         )

--- a/omnigent/inner/agent_env.py
+++ b/omnigent/inner/agent_env.py
@@ -51,6 +51,12 @@ BASE_ALLOW_EXACT: frozenset[str] = frozenset(
         "TMPDIR",
         "TMP",
         "TEMP",
+        # Node's equivalent of SSL_CERT_FILE, so it belongs in the same
+        # reach-the-network category as the proxy and SSL_ entries. Most agent
+        # CLIs are Node programs that honour this and ignore SSL_CERT_FILE;
+        # without it a corporate-CA user upgrading would hit TLS failures from
+        # every harness that does not happen to own a NODE_ prefix of its own.
+        "NODE_EXTRA_CA_CERTS",
         OMNIGENT_SESSION_ENV_VAR,
     }
 )

--- a/omnigent/inner/agent_env.py
+++ b/omnigent/inner/agent_env.py
@@ -1,0 +1,104 @@
+"""Deny-by-default environment filtering for agent-CLI subprocesses.
+
+Every harness spawns a vendor CLI as a child process. Handing it
+``os.environ`` hands it every secret on the host — cloud tokens, other
+providers' API keys — whether or not a sandbox wraps the process afterwards.
+
+The pi and codex executors already filtered; five siblings did not
+(omnigent-ai/omnigent#3445). This is the shared implementation so the next
+harness added is filtered by construction rather than by remembering.
+
+The model is not "no credentials ever". It is:
+
+    shared safe base  +  this harness's own config/provider families
+                      +  whatever the spec declared in
+                         ``os_env.sandbox.env_passthrough``
+
+so a harness still sees the variables it legitimately authenticates with,
+and stops seeing every *other* provider's.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable, Mapping
+
+from omnigent.runner.identity import OMNIGENT_SESSION_ENV_VAR
+
+# Categories every POSIX CLI needs regardless of vendor: where the user's
+# config lives, how to reach the network, how to format output, where to put
+# temp files, and the "you are inside Omnigent" marker.
+#
+# Deliberately NOT here: USER / LOGNAME / SHELL / TZ. pi passes those and
+# codex does not, so they stay per-harness rather than silently widening
+# codex's set while this refactor claims to preserve it.
+BASE_ALLOW_PREFIXES: tuple[str, ...] = (
+    "HTTP_",
+    "HTTPS_",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "SSL_",
+    "XDG_",
+    "LANG",
+    "LC_",
+)
+
+BASE_ALLOW_EXACT: frozenset[str] = frozenset(
+    {
+        "HOME",
+        "PATH",
+        "TERM",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        OMNIGENT_SESSION_ENV_VAR,
+    }
+)
+
+
+def clean_agent_env(
+    *,
+    allow_prefixes: Iterable[str] = (),
+    allow_exact: Iterable[str] = (),
+    deny_exact: Iterable[str] = (),
+    extra_allowed: Iterable[str] = (),
+    source: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Filter an environment down to the base plus this harness's own families.
+
+    :param allow_prefixes: Prefix families this harness owns, e.g. ``("QWEN_",)``.
+        Added to :data:`BASE_ALLOW_PREFIXES`.
+    :param allow_exact: Extra exact names this harness needs. Added to
+        :data:`BASE_ALLOW_EXACT`.
+    :param deny_exact: Names excluded even when a prefix matches. Codex uses
+        this for ``OPENAI_API_KEY`` so the CLI falls back to subscription auth
+        instead of billing a developer key — a cost rule, not a security one.
+    :param extra_allowed: Spec-declared names from
+        ``os_env.sandbox.env_passthrough``. This is the documented escape hatch
+        for an agent that authenticates from a variable outside its own family.
+    :param source: Environment to filter. Defaults to ``os.environ``; injectable
+        for tests.
+    :returns: A new dict. Never mutates *source*.
+    """
+    env_source = os.environ if source is None else source
+    prefixes = BASE_ALLOW_PREFIXES + tuple(allow_prefixes)
+    exact = BASE_ALLOW_EXACT | set(allow_exact) | set(extra_allowed)
+    denied = set(deny_exact)
+    return {
+        key: value
+        for key, value in env_source.items()
+        if key not in denied and (key in exact or key.startswith(prefixes))
+    }
+
+
+def declared_passthrough(os_env: object | None) -> tuple[str, ...]:
+    """Env-var names the spec declared for passthrough.
+
+    Lives on ``os_env.sandbox.env_passthrough``. Returns an empty tuple when
+    any link in that chain is absent. Duplicated from
+    ``codex_executor._declared_passthrough`` so non-codex harnesses do not have
+    to import the codex module to read a field that belongs to the sandbox spec.
+    """
+    sandbox = getattr(os_env, "sandbox", None) if os_env is not None else None
+    names = getattr(sandbox, "env_passthrough", None) if sandbox is not None else None
+    return tuple(names) if names else ()

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -24,9 +24,9 @@ from typing import Any, Protocol, TypeAlias
 
 from omnigent import model_catalog
 from omnigent._platform import resolve_cli_binary
+from omnigent.inner.agent_env import clean_agent_env
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 from omnigent.reasoning_effort import CODEX_EFFORTS, EFFORT_ALIASES, validate_effort
-from omnigent.runner.identity import OMNIGENT_SESSION_ENV_VAR
 from omnigent.spec.types import RetryPolicy
 
 from . import _proc
@@ -375,47 +375,25 @@ def _clean_codex_env(extra_allow: Iterable[str] = ()) -> dict[str, str]:
     """
     Build a filtered copy of ``os.environ`` for the codex subprocess.
 
-    Uses a prefix allowlist so only known-safe categories pass through
-    (proxy settings, locale, OpenAI retry knobs, etc.). Keys in
-    :data:`_CODEX_ENV_DENY_EXACT` are excluded even when their prefix
-    matches; ``OPENAI_API_KEY`` is stripped so the codex CLI falls
-    back to subscription auth (``auth.json``) rather than a developer
-    API key that would charge separately.
+    Thin wrapper over :func:`omnigent.inner.agent_env.clean_agent_env`; the
+    families below are codex's own on top of the shared safe base. Keys in
+    :data:`_CODEX_ENV_DENY_EXACT` are excluded even when their prefix matches;
+    ``OPENAI_API_KEY`` is stripped so the codex CLI falls back to subscription
+    auth (``auth.json``) rather than a developer API key that would charge
+    separately.
 
     :returns: Filtered environment dict.
     """
-    env: dict[str, str] = {}
-    allow_prefixes = (
-        "OPENAI_",
-        "HTTP_",
-        "HTTPS_",
-        "ALL_PROXY",
-        "NO_PROXY",
-        "SSL_",
-        "REQUESTS_",
-        "CODEX_HOME",
-        "XDG_",
-        "LANG",
-        "LC_",
+    return clean_agent_env(
+        allow_prefixes=("OPENAI_", "REQUESTS_", "CODEX_HOME"),
+        allow_exact=(
+            "PYTHONUTF8",
+            "DATABRICKS_BEARER",  # explicit CI/integration bearer used by auth.command
+            "DATABRICKS_CODEX_TOKEN",  # env_key in ~/.codex/config.toml's DB provider
+        ),
+        deny_exact=_CODEX_ENV_DENY_EXACT,
+        extra_allowed=extra_allow,
     )
-    allow_exact = {
-        "HOME",
-        "PATH",
-        "TERM",
-        "TMPDIR",
-        "TMP",
-        "TEMP",
-        "PYTHONUTF8",
-        "DATABRICKS_BEARER",  # explicit CI/integration bearer used by auth.command
-        "DATABRICKS_CODEX_TOKEN",  # env_key referenced by ~/.codex/config.toml's DB provider
-        OMNIGENT_SESSION_ENV_VAR,  # "inside Omnigent" marker (CLAUDE_CODE/CODEX analog)
-    } | set(extra_allow)
-    for key, value in os.environ.items():
-        if key in _CODEX_ENV_DENY_EXACT:
-            continue
-        if key in allow_exact or key.startswith(allow_prefixes):
-            env[key] = value
-    return env
 
 
 def _declared_passthrough(os_env: OSEnvSpec | None) -> tuple[str, ...]:

--- a/omnigent/inner/goose_executor.py
+++ b/omnigent/inner/goose_executor.py
@@ -41,6 +41,7 @@ from pathlib import Path
 from typing import Any
 
 from omnigent.inner._acp_omnigent_mcp import OmnigentAcpMcp
+from omnigent.inner.agent_env import clean_agent_env, declared_passthrough
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.executor import (
     Executor,
@@ -267,7 +268,13 @@ class GooseExecutor(Executor):
         """
         # This may be a restart after the previous subprocess died.
         self._reset_process_state()
-        env = os.environ.copy()
+        # Deny-by-default: base + this harness's own families + the spec's
+        # env_passthrough. Previously os.environ.copy() handed the goose CLI
+        # every host secret (#3445).
+        env = clean_agent_env(
+            allow_prefixes=("GOOSE_",),
+            extra_allowed=declared_passthrough(self._os_env),
+        )
         env.update(self._provider_env())
         argv: list[str] = ["acp"]
         for builtin in self._builtins:

--- a/omnigent/inner/goose_executor.py
+++ b/omnigent/inner/goose_executor.py
@@ -268,14 +268,7 @@ class GooseExecutor(Executor):
         """
         # This may be a restart after the previous subprocess died.
         self._reset_process_state()
-        # Deny-by-default: base + this harness's own families + the spec's
-        # env_passthrough. Previously os.environ.copy() handed the goose CLI
-        # every host secret (#3445).
-        env = clean_agent_env(
-            allow_prefixes=("GOOSE_",),
-            extra_allowed=declared_passthrough(self._os_env),
-        )
-        env.update(self._provider_env())
+        env = self._build_spawn_env()
         argv: list[str] = ["acp"]
         for builtin in self._builtins:
             argv.extend(["--with-builtin", builtin])
@@ -293,6 +286,24 @@ class GooseExecutor(Executor):
         )
         self._reader_task = asyncio.create_task(self._read_stdout())
         self._stderr_task = asyncio.create_task(self._read_stderr())
+
+    def _build_spawn_env(self) -> dict[str, str]:
+        """The env handed to the goose subprocess.
+
+        Deny-by-default: base + goose's own ``GOOSE_`` family + the spec's
+        ``env_passthrough``, then goose's provider/gateway overrides on top so
+        the intentionally-set values still win. Previously ``os.environ.copy()``
+        handed the goose CLI every host secret (#3445).
+
+        Kept as a named builder so the spawn-env canary can drive the real thing
+        rather than a hand-copied prefix list.
+        """
+        env = clean_agent_env(
+            allow_prefixes=("GOOSE_",),
+            extra_allowed=declared_passthrough(self._os_env),
+        )
+        env.update(self._provider_env())
+        return env
 
     def _provider_env(self) -> dict[str, str]:
         """Build ``GOOSE_PROVIDER`` / ``GOOSE_MODEL`` overrides for the subprocess.

--- a/omnigent/inner/hermes_executor.py
+++ b/omnigent/inner/hermes_executor.py
@@ -48,6 +48,7 @@ import tempfile
 from collections.abc import AsyncIterator
 from pathlib import Path
 
+from omnigent.inner.agent_env import clean_agent_env, declared_passthrough
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.executor import (
     Executor,
@@ -374,10 +375,21 @@ class HermesExecutor(Executor):
             skills_filter=self._skills_filter,
         )
 
-        # Build subprocess env with per-session HERMES_HOME for policy hooks.
-        proc_env: dict[str, str] | None = None
+        # Deny-by-default: base + hermes's own family + the spec's
+        # env_passthrough (#3445). Previously the hermes_home branch merged the
+        # whole of os.environ, and the else branch passed env=None — which
+        # inherits everything, so the no-policy-hooks path leaked the most.
+        #
+        # NOTE for review: DATABRICKS_* is deliberately NOT allowlisted here.
+        # If hermes's legitimate auth needs it, that family is exactly the one
+        # this change exists to stop leaking, so it should be declared per-spec
+        # via os_env.sandbox.env_passthrough rather than blanket-allowed.
+        proc_env = clean_agent_env(
+            allow_prefixes=("HERMES_",),
+            extra_allowed=declared_passthrough(self._os_env),
+        )
         if self._hermes_home is not None:
-            proc_env = {**os.environ, "HERMES_HOME": str(self._hermes_home)}
+            proc_env["HERMES_HOME"] = str(self._hermes_home)
             _logger.info("Hermes using per-session HERMES_HOME=%s", self._hermes_home)
         else:
             _logger.warning("Hermes running WITHOUT per-session HERMES_HOME (no policy hooks)")

--- a/omnigent/inner/hermes_executor.py
+++ b/omnigent/inner/hermes_executor.py
@@ -375,24 +375,7 @@ class HermesExecutor(Executor):
             skills_filter=self._skills_filter,
         )
 
-        # Deny-by-default: base + hermes's own family + the spec's
-        # env_passthrough (#3445). Previously the hermes_home branch merged the
-        # whole of os.environ, and the else branch passed env=None — which
-        # inherits everything, so the no-policy-hooks path leaked the most.
-        #
-        # NOTE for review: DATABRICKS_* is deliberately NOT allowlisted here.
-        # If hermes's legitimate auth needs it, that family is exactly the one
-        # this change exists to stop leaking, so it should be declared per-spec
-        # via os_env.sandbox.env_passthrough rather than blanket-allowed.
-        proc_env = clean_agent_env(
-            allow_prefixes=("HERMES_",),
-            extra_allowed=declared_passthrough(self._os_env),
-        )
-        if self._hermes_home is not None:
-            proc_env["HERMES_HOME"] = str(self._hermes_home)
-            _logger.info("Hermes using per-session HERMES_HOME=%s", self._hermes_home)
-        else:
-            _logger.warning("Hermes running WITHOUT per-session HERMES_HOME (no policy hooks)")
+        proc_env = self._build_spawn_env()
 
         _logger.debug("Hermes subprocess: %s", " ".join(args))
 
@@ -462,6 +445,34 @@ class HermesExecutor(Executor):
             yield TextChunk(text=response_text)
 
         yield TurnComplete(response=response_text or None)
+
+    def _build_spawn_env(self) -> dict[str, str]:
+        """The env handed to the hermes subprocess.
+
+        Deny-by-default: base + hermes's own ``HERMES_`` family + the spec's
+        ``env_passthrough`` (#3445). Previously the ``hermes_home`` branch merged
+        the whole of ``os.environ``, and the else branch passed ``env=None`` —
+        which inherits everything, so the no-policy-hooks path leaked the most.
+
+        ``DATABRICKS_*`` is deliberately NOT allowlisted. ``hermes_native_bridge``
+        copies ``auth.json`` and ``.env`` under the per-session ``HERMES_HOME``,
+        so hermes's real auth is file-based; that family is exactly the one this
+        change exists to stop leaking, and a spec that genuinely needs it should
+        declare it via ``os_env.sandbox.env_passthrough``.
+
+        Kept as a named builder so the spawn-env canary can drive the real thing
+        rather than a hand-copied prefix list.
+        """
+        proc_env = clean_agent_env(
+            allow_prefixes=("HERMES_",),
+            extra_allowed=declared_passthrough(self._os_env),
+        )
+        if self._hermes_home is not None:
+            proc_env["HERMES_HOME"] = str(self._hermes_home)
+            _logger.info("Hermes using per-session HERMES_HOME=%s", self._hermes_home)
+        else:
+            _logger.warning("Hermes running WITHOUT per-session HERMES_HOME (no policy hooks)")
+        return proc_env
 
     def _session_key(self, messages: list[Message]) -> str:
         """

--- a/omnigent/inner/kimi_executor.py
+++ b/omnigent/inner/kimi_executor.py
@@ -66,6 +66,7 @@ from pathlib import Path
 from typing import Any
 
 from omnigent.harness_startup_config import resolve_harness_path
+from omnigent.inner.agent_env import clean_agent_env, declared_passthrough
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.executor import (
     EnqueuedContent,
@@ -240,7 +241,13 @@ class KimiExecutor(Executor):
         ``HARNESS_KIMI_*`` knobs are read on the wrap side and
         translated into CLI flags.
         """
-        return os.environ.copy()
+        # Deny-by-default: base + kimi's own families + the spec's
+        # env_passthrough. Keeps the documented ambient KIMI_/MOONSHOT_ auth
+        # while no longer handing the CLI every other provider's key (#3445).
+        return clean_agent_env(
+            allow_prefixes=("KIMI_", "MOONSHOT_"),
+            extra_allowed=declared_passthrough(self._os_env),
+        )
 
     def _sandbox_launch_path(self, spawn_env_names: Sequence[str]) -> str:
         """Return the path to spawn for kimi — sandbox launcher or bare binary.

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -49,6 +49,7 @@ from typing import Any, TypeAlias
 from urllib.parse import urlparse as _urlparse
 
 from omnigent import model_catalog
+from omnigent.inner.agent_env import clean_agent_env
 from omnigent.inner.native_attachments import parse_data_uri
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 from omnigent.runner.identity import OMNIGENT_SESSION_ENV_VAR
@@ -929,30 +930,24 @@ def _clean_pi_env(extra_allowed: Sequence[str] | None = None) -> dict[str, str]:
     """
     Build a filtered copy of ``os.environ`` for the Pi subprocess.
 
-    Deny-by-default allowlist mirroring the codex path's
-    :func:`omnigent.inner.codex_executor._clean_codex_env`. The previous
-    additive ``{**os.environ, **env}`` merge leaked every host secret
+    Thin wrapper over :func:`omnigent.inner.agent_env.clean_agent_env`. The
+    previous additive ``{**os.environ, **env}`` merge leaked every host secret
     — cloud tokens, API keys — into the Pi process, sandboxed or not.
-    Credential families are deliberately not allowlisted:
-    gateway runs authenticate through the generated ``models.json``,
-    and a spec that legitimately needs a variable inside the Pi
-    process opts in via ``os_env.sandbox.env_passthrough``.
+    Credential families are deliberately not allowlisted: gateway runs
+    authenticate through the generated ``models.json``, and a spec that
+    legitimately needs a variable inside the Pi process opts in via
+    ``os_env.sandbox.env_passthrough``.
 
-    :param extra_allowed: Extra exact names to pass through, e.g. the
-        spec's ``os_env.sandbox.env_passthrough`` entries
-        (``["ANTHROPIC_API_KEY"]`` for an env-key-authenticated
-        non-gateway run). ``None`` means no extras.
-    :returns: Filtered environment dict, ready to extend with the
-        executor's own variables (``PI_CODING_AGENT_DIR``, ...).
+    :param extra_allowed: Extra exact names to pass through, e.g. the spec's
+        ``os_env.sandbox.env_passthrough`` entries. ``None`` means no extras.
+    :returns: Filtered environment dict, ready to extend with the executor's
+        own variables (``PI_CODING_AGENT_DIR``, ...).
     """
-    allow_exact = set(_PI_ENV_ALLOW_EXACT)
-    if extra_allowed is not None:
-        allow_exact.update(extra_allowed)
-    return {
-        key: value
-        for key, value in os.environ.items()
-        if key in allow_exact or key.startswith(_PI_ENV_ALLOW_PREFIXES)
-    }
+    return clean_agent_env(
+        allow_prefixes=_PI_ENV_ALLOW_PREFIXES,
+        allow_exact=_PI_ENV_ALLOW_EXACT,
+        extra_allowed=extra_allowed or (),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/omnigent/inner/qwen_executor.py
+++ b/omnigent/inner/qwen_executor.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Any
 
 from omnigent.inner._acp_omnigent_mcp import OmnigentAcpMcp
+from omnigent.inner.agent_env import clean_agent_env, declared_passthrough
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 from omnigent.inner.executor import (
     Executor,
@@ -293,7 +294,13 @@ class QwenExecutor(Executor):
         # derived from the initialize response, so it's stale too.
         self._initialized = False
         self._image_supported = False
-        env = os.environ.copy()
+        # Deny-by-default: base + this harness's own families + the spec's
+        # env_passthrough. Previously os.environ.copy() handed the qwen CLI
+        # every host secret (#3445).
+        env = clean_agent_env(
+            allow_prefixes=("QWEN_", "OPENAI_", "DASHSCOPE_"),
+            extra_allowed=declared_passthrough(self._os_env),
+        )
         # Translate Omnigent's provider/gateway routing into the OpenAI-compatible
         # env vars qwen reads (overriding any ambient values). No-op when no
         # gateway is wired (the CLI's own ambient auth is used).

--- a/omnigent/inner/qwen_executor.py
+++ b/omnigent/inner/qwen_executor.py
@@ -294,17 +294,7 @@ class QwenExecutor(Executor):
         # derived from the initialize response, so it's stale too.
         self._initialized = False
         self._image_supported = False
-        # Deny-by-default: base + this harness's own families + the spec's
-        # env_passthrough. Previously os.environ.copy() handed the qwen CLI
-        # every host secret (#3445).
-        env = clean_agent_env(
-            allow_prefixes=("QWEN_", "OPENAI_", "DASHSCOPE_"),
-            extra_allowed=declared_passthrough(self._os_env),
-        )
-        # Translate Omnigent's provider/gateway routing into the OpenAI-compatible
-        # env vars qwen reads (overriding any ambient values). No-op when no
-        # gateway is wired (the CLI's own ambient auth is used).
-        env.update(await self._resolve_gateway_env())
+        env = await self._build_spawn_env()
         # Resolve the path to spawn: the bare qwen binary, or a sandbox launcher
         # that confines the whole process tree when os_env requests it.
         launch_path = self._sandbox_launch_path(tuple(env.keys()))
@@ -373,6 +363,25 @@ class QwenExecutor(Executor):
         except (OSError, ImportError, NotImplementedError) as exc:
             logger.warning("Could not apply sandbox for qwen; running unsandboxed: %s", exc)
             return self._qwen_path
+
+    async def _build_spawn_env(self) -> dict[str, str]:
+        """The env handed to the qwen subprocess.
+
+        Deny-by-default: base + qwen's own ``QWEN_``/``OPENAI_``/``DASHSCOPE_``
+        families + the spec's ``env_passthrough``, then Omnigent's
+        provider/gateway routing on top so the intentionally-set values override
+        any ambient ones. Previously ``os.environ.copy()`` handed the qwen CLI
+        every host secret (#3445).
+
+        Kept as a named builder so the spawn-env canary can drive the real thing
+        rather than a hand-copied prefix list.
+        """
+        env = clean_agent_env(
+            allow_prefixes=("QWEN_", "OPENAI_", "DASHSCOPE_"),
+            extra_allowed=declared_passthrough(self._os_env),
+        )
+        env.update(await self._resolve_gateway_env())
+        return env
 
     async def _resolve_gateway_env(self) -> dict[str, str]:
         """Build the OpenAI-compatible env qwen reads from the gateway config.

--- a/tests/test_agent_spawn_env_canary.py
+++ b/tests/test_agent_spawn_env_canary.py
@@ -11,6 +11,8 @@ and still missed five siblings.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from omnigent.inner.agent_env import (
@@ -56,6 +58,127 @@ def hostile_env():
         "HTTPS_PROXY": "http://proxy:8080",
         **CANARY_SECRETS,
     }
+
+
+# --- the real builders -----------------------------------------------------
+#
+# The prefix table above is a hand copy of what each executor passes, so on its
+# own it only proves clean_agent_env works. These drive each executor's OWN
+# spawn-env builder against a planted os.environ, which is what actually makes
+# the "next harness fails here" claim true: if qwen reverts to
+# os.environ.copy(), or harness number ten never calls the helper, this fails.
+
+
+def _bare(cls, **attrs):
+    """An executor carrying only the attributes its env builder reads.
+
+    The constructors want a live config, an event loop and a spawned CLI. The
+    builders do not — they read ``_os_env`` and, for hermes, ``_hermes_home``.
+    Bypassing ``__init__`` keeps the canary on the real method without dragging
+    in the rest of the executor.
+    """
+    obj = object.__new__(cls)
+    obj._os_env = None
+    for name, value in attrs.items():
+        setattr(obj, name, value)
+    return obj
+
+
+def _acp_spawn_env():
+    from omnigent.inner.acp_executor import AcpExecutor
+
+    return _bare(AcpExecutor)._build_spawn_env()
+
+
+def _goose_spawn_env():
+    from omnigent.inner.goose_executor import GooseExecutor
+
+    # Provider/gateway overrides are deliberate additions layered on top of the
+    # filtered base, not leaks; stub them so this asserts the filtering alone.
+    return _bare(GooseExecutor, _provider_env=dict)._build_spawn_env()
+
+
+def _qwen_spawn_env():
+    from omnigent.inner.qwen_executor import QwenExecutor
+
+    async def _no_gateway():
+        return {}
+
+    return asyncio.run(_bare(QwenExecutor, _resolve_gateway_env=_no_gateway)._build_spawn_env())
+
+
+def _kimi_spawn_env():
+    from omnigent.inner.kimi_executor import KimiExecutor
+
+    return _bare(KimiExecutor)._build_spawn_env()
+
+
+def _hermes_spawn_env():
+    from omnigent.inner.hermes_executor import HermesExecutor
+
+    # The no-HERMES_HOME branch: the one that used to pass env=None and inherit
+    # the entire host environment, so it is the branch worth pinning.
+    return _bare(HermesExecutor, _hermes_home=None)._build_spawn_env()
+
+
+def _pi_spawn_env():
+    from omnigent.inner.pi_executor import _clean_pi_env
+
+    return _clean_pi_env()
+
+
+def _codex_spawn_env():
+    from omnigent.inner.codex_executor import _clean_codex_env
+
+    return _clean_codex_env()
+
+
+SPAWN_ENV_BUILDERS = {
+    "acp": _acp_spawn_env,
+    "codex": _codex_spawn_env,
+    "goose": _goose_spawn_env,
+    "hermes": _hermes_spawn_env,
+    "kimi": _kimi_spawn_env,
+    "pi": _pi_spawn_env,
+    "qwen": _qwen_spawn_env,
+}
+
+
+def test_every_harness_is_covered_by_a_real_builder():
+    """A harness added to the prefix table must also be wired up above."""
+    assert set(SPAWN_ENV_BUILDERS) == set(HARNESS_PREFIXES)
+
+
+@pytest.mark.parametrize("harness", sorted(SPAWN_ENV_BUILDERS))
+def test_real_builder_does_not_leak_host_secrets(harness, hostile_env, monkeypatch):
+    """Drive the executor's own builder against a planted host environment."""
+    monkeypatch.setattr("os.environ", dict(hostile_env))
+
+    env = SPAWN_ENV_BUILDERS[harness]()
+
+    leaked = {k: v for k, v in env.items() if k in CANARY_SECRETS}
+    # qwen owns OPENAI_, so an OPENAI_ canary is its own family, not a leak.
+    leaked = {k: v for k, v in leaked.items() if not k.startswith(HARNESS_PREFIXES[harness] or ())}
+    assert not leaked, f"{harness}'s real spawn env leaked {sorted(leaked)}"
+
+
+@pytest.mark.parametrize("harness", sorted(SPAWN_ENV_BUILDERS))
+def test_real_builder_still_yields_a_usable_environment(harness, hostile_env, monkeypatch):
+    monkeypatch.setattr("os.environ", dict(hostile_env))
+
+    env = SPAWN_ENV_BUILDERS[harness]()
+
+    assert env["HOME"] == "/home/user"
+    assert env["PATH"] == "/usr/bin:/bin"
+    assert env["HTTPS_PROXY"] == "http://proxy:8080"
+
+
+def test_real_builders_pass_node_extra_ca_certs(monkeypatch):
+    """A corporate CA must survive filtering, or every Node CLI breaks on TLS."""
+    monkeypatch.setattr("os.environ", {"NODE_EXTRA_CA_CERTS": "/etc/corp-ca.pem"})
+    for harness, build in sorted(SPAWN_ENV_BUILDERS.items()):
+        env = build()
+        assert env.get("NODE_EXTRA_CA_CERTS") == "/etc/corp-ca.pem", harness
 
 
 @pytest.mark.parametrize("harness", sorted(HARNESS_PREFIXES))

--- a/tests/test_agent_spawn_env_canary.py
+++ b/tests/test_agent_spawn_env_canary.py
@@ -1,0 +1,131 @@
+"""No agent-CLI subprocess may inherit unrelated host secrets (#3445).
+
+The pi and codex executors filtered; goose, kimi, qwen, acp and hermes did not,
+and hermes's no-HERMES_HOME branch passed ``env=None`` (inherit everything).
+
+This is the parametrized canary the maintainer asked for. The point is not to
+re-test each executor's wiring — it is that the *next* harness added to this
+repo fails here if it forgets to filter. The fix pattern already existed twice
+and still missed five siblings.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.inner.agent_env import (
+    BASE_ALLOW_EXACT,
+    BASE_ALLOW_PREFIXES,
+    clean_agent_env,
+    declared_passthrough,
+)
+
+# Families that must never reach a vendor CLI unless the spec asks for them.
+# One planted value per family, all distinct so a failure names the leak.
+CANARY_SECRETS = {
+    "AWS_SECRET_ACCESS_KEY": "canary-aws",
+    "AWS_SESSION_TOKEN": "canary-aws-session",
+    "DATABRICKS_TOKEN": "canary-databricks",
+    "DATABRICKS_CONFIG_PROFILE": "canary-databricks-profile",
+    "ANTHROPIC_API_KEY": "canary-anthropic",
+    "GEMINI_API_KEY": "canary-gemini",
+    "GITHUB_TOKEN": "canary-github",
+    "SLACK_BOT_TOKEN": "canary-slack",
+    "OPENROUTER_API_KEY": "canary-openrouter",
+}
+
+# The per-harness families, matching the decision table on #3445.
+HARNESS_PREFIXES = {
+    "pi": ("PI_", "NODE_"),
+    "codex": ("OPENAI_", "REQUESTS_", "CODEX_HOME"),
+    "qwen": ("QWEN_", "OPENAI_", "DASHSCOPE_"),
+    "goose": ("GOOSE_",),
+    "kimi": ("KIMI_", "MOONSHOT_"),
+    "acp": (),
+    "hermes": ("HERMES_",),
+}
+
+
+@pytest.fixture
+def hostile_env():
+    """A host environment carrying every canary plus the things a CLI needs."""
+    return {
+        "HOME": "/home/user",
+        "PATH": "/usr/bin:/bin",
+        "LANG": "en_US.UTF-8",
+        "HTTPS_PROXY": "http://proxy:8080",
+        **CANARY_SECRETS,
+    }
+
+
+@pytest.mark.parametrize("harness", sorted(HARNESS_PREFIXES))
+def test_no_harness_inherits_unrelated_secrets(harness, hostile_env):
+    env = clean_agent_env(allow_prefixes=HARNESS_PREFIXES[harness], source=hostile_env)
+    leaked = {k: v for k, v in env.items() if k in CANARY_SECRETS}
+    assert not leaked, f"{harness} leaked {sorted(leaked)}"
+    for value in CANARY_SECRETS.values():
+        assert value not in env.values(), f"{harness} leaked the value {value!r}"
+
+
+@pytest.mark.parametrize("harness", sorted(HARNESS_PREFIXES))
+def test_every_harness_still_gets_a_usable_environment(harness, hostile_env):
+    """Filtering must not break the CLI: HOME/PATH/locale/proxy still pass."""
+    env = clean_agent_env(allow_prefixes=HARNESS_PREFIXES[harness], source=hostile_env)
+    assert env["HOME"] == "/home/user"
+    assert env["PATH"] == "/usr/bin:/bin"
+    assert env["LANG"] == "en_US.UTF-8"
+    assert env["HTTPS_PROXY"] == "http://proxy:8080"
+
+
+def test_a_harness_still_sees_its_own_family(hostile_env):
+    src = {**hostile_env, "QWEN_CODE_MODEL": "q", "GOOSE_PROVIDER": "g"}
+    qwen = clean_agent_env(allow_prefixes=HARNESS_PREFIXES["qwen"], source=src)
+    assert qwen["QWEN_CODE_MODEL"] == "q"
+    assert "GOOSE_PROVIDER" not in qwen, "qwen must not see goose's family either"
+
+
+def test_kimi_keeps_its_documented_ambient_auth(hostile_env):
+    """kimi's docstring deliberately wants ambient KIMI_*; scoping must preserve it."""
+    src = {**hostile_env, "KIMI_API_KEY": "kimi-real", "MOONSHOT_API_KEY": "ms-real"}
+    env = clean_agent_env(allow_prefixes=HARNESS_PREFIXES["kimi"], source=src)
+    assert env["KIMI_API_KEY"] == "kimi-real"
+    assert env["MOONSHOT_API_KEY"] == "ms-real"
+    assert "ANTHROPIC_API_KEY" not in env
+
+
+def test_env_passthrough_is_the_documented_escape_hatch(hostile_env):
+    """The migration for an env-authenticated generic ACP agent (e.g. gemini)."""
+    without = clean_agent_env(source=hostile_env)
+    assert "GEMINI_API_KEY" not in without
+    with_pt = clean_agent_env(extra_allowed=("GEMINI_API_KEY",), source=hostile_env)
+    assert with_pt["GEMINI_API_KEY"] == "canary-gemini"
+
+
+def test_deny_exact_beats_a_matching_prefix(hostile_env):
+    """codex strips OPENAI_API_KEY despite allowing the OPENAI_ prefix."""
+    src = {**hostile_env, "OPENAI_API_KEY": "sk-dev", "OPENAI_BASE_URL": "https://x"}
+    env = clean_agent_env(allow_prefixes=("OPENAI_",), deny_exact=("OPENAI_API_KEY",), source=src)
+    assert "OPENAI_API_KEY" not in env
+    assert env["OPENAI_BASE_URL"] == "https://x"
+
+
+def test_source_is_never_mutated(hostile_env):
+    before = dict(hostile_env)
+    clean_agent_env(allow_prefixes=("QWEN_",), source=hostile_env)
+    assert hostile_env == before
+
+
+def test_base_does_not_include_identity_vars():
+    """USER/LOGNAME/SHELL/TZ stay per-harness: pi passes them, codex does not,
+    and the shared base must not silently widen codex's set."""
+    for name in ("USER", "LOGNAME", "SHELL", "TZ"):
+        assert name not in BASE_ALLOW_EXACT
+    assert not any(p in BASE_ALLOW_PREFIXES for p in ("AWS_", "DATABRICKS_", "OPENAI_"))
+
+
+def test_declared_passthrough_tolerates_a_missing_chain():
+    class _NoSandbox:
+        sandbox = None
+
+    assert declared_passthrough(None) == ()
+    assert declared_passthrough(_NoSandbox()) == ()


### PR DESCRIPTION
## Related issue

Closes #3445.

## Summary

Implements @dhruv0811's decision on the issue: option 1, allowlist shaped the way codex already shapes it.

- New `omnigent/inner/agent_env.py` — `clean_agent_env(allow_prefixes, allow_exact, deny_exact, extra_allowed, source)`. Shared safe base (HOME, PATH, proxy, locale, tmp, XDG, session marker) + the harness's own families + `os_env.sandbox.env_passthrough`.
- **pi and codex become thin calls**, sets preserved exactly.
- Applied to the five leaking spawn paths per the decision table.
- `hermes`'s `env=None` branch fixed — it was the worst of the five, inheriting *everything*.

| Harness | Families beyond the shared base |
|---|---|
| qwen | `QWEN_`, `OPENAI_`, `DASHSCOPE_` |
| goose | `GOOSE_` |
| kimi | `KIMI_`, `MOONSHOT_` (keeps documented ambient auth) |
| acp | none — base + `env_passthrough` only |
| hermes | `HERMES_` — see below |

## Answering the hermes question you left for review

You flagged that hermes's legitimate auth may overlap `DATABRICKS_*`. It doesn't — **hermes authenticates from files, not the environment.** `hermes_native_bridge.py:386-394` copies `~/.hermes/auth.json` and `~/.hermes/.env` into the per-session `HERMES_HOME`:

```python
# Copy user's .env (API keys).
user_env = Path.home() / ".hermes" / ".env"
...
# Copy user's auth.json (provider credentials).
user_auth = Path.home() / ".hermes" / "auth.json"
```

`HOME` passes in the base, so that path is untouched. `HERMES_` alone is correct and `DATABRICKS_*` stays contained — which is the family this change exists to stop leaking. I left a comment at the call site saying so, so nobody re-adds it later.

## Preservation of pi/codex, verified rather than asserted

I diffed the refactored output against the original inlined logic over a synthetic 26-var environment:

```
codex: identical=True  (20 vars)
pi:    identical=True  (20 vars)
codex+extra identical: True
pi+extra identical   : True
```

One deliberate choice: `USER` / `LOGNAME` / `SHELL` / `TZ` stay **per-harness** rather than entering the shared base. pi passes them, codex does not — folding them into the base would have silently widened codex's set while this PR claims to preserve it. There's a test pinning that.

## The bonus fix

As you noted, the sandboxed paths bake `tuple(env.keys())` into `with_spawn_env_allowlist`, so a full-environ `env` made the launcher's env-prune defense a no-op. Cleaning at the executor restores that layer.

## Tests

`tests/test_agent_spawn_env_canary.py` — the parametrized canary you asked for, and I agree it's the most valuable part: the fix pattern existed twice and still missed five siblings.

21 cases over all seven harnesses: nine credential-family canaries (`AWS_*`, `DATABRICKS_*`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GITHUB_TOKEN`, `SLACK_BOT_TOKEN`, `OPENROUTER_API_KEY`) asserted absent by name *and* by value; each harness still gets a usable env; a harness sees its own family and not a sibling's; kimi keeps ambient `KIMI_`/`MOONSHOT_`; `env_passthrough` works as the documented migration; `deny_exact` beats a matching prefix; source is never mutated.

Executor suites: **967 passed, 13 skipped, 0 failed.** `ruff check` and `ruff format` clean.

## Migration

Per your note, the one real break is env-authenticated generic ACP agents (e.g. gemini reading `GEMINI_API_KEY`). Fix is one line of spec:

```yaml
os_env:
  sandbox:
    env_passthrough: ["GEMINI_API_KEY"]
```

Happy to add the changelog entries and the startup log hint pointing at `env_passthrough` — tell me where you'd like the hint emitted (the ACP executor's startup failure path seemed most likely) and I'll push it here.

## Demo

No GUI surface — this is subprocess environment filtering. Captured from the real
helper with credentials planted in the parent environment, rather than described:

**Before** — `os.environ.copy()`, what the qwen / acp / goose / kimi / hermes child received:

```console
ANTHROPIC_API_KEY, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, DATABRICKS_TOKEN,
GEMINI_API_KEY, GITHUB_TOKEN, HOME, LANG, PATH, QWEN_CODE_MODEL
```

**After**

```console
qwen   (base + QWEN_/OPENAI_/DASHSCOPE_):   HOME, LANG, PATH, QWEN_CODE_MODEL
acp    (base only, agent is arbitrary):     HOME, LANG, PATH
acp    + env_passthrough=[GEMINI_API_KEY]:  GEMINI_API_KEY, HOME, LANG, PATH
```

Every planted credential is gone, the harness keeps its own family, and the
documented migration path restores exactly what a spec asks for and nothing else.

I've kept **Bug fix** checked rather than switching to Refactor / chore: the
user-visible effect is real — an agent CLI no longer receives unrelated cloud
tokens and other providers' keys — it just isn't visual.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [x] Breaking change

Breaking is checked for the ACP migration above.

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the pi/codex equivalence diff — proving a refactor changed nothing needed comparing against the original logic directly, which isn't something a unit test expresses well.

## Changelog

Agent CLIs (qwen, goose, kimi, hermes, and generic ACP agents) no longer receive unrelated host credentials such as cloud tokens and other providers' API keys; an agent that authenticates from a variable outside its own family now declares it in `os_env.sandbox.env_passthrough`.

---
Signed off per the DCO. Reviewed and tested locally; drafted with AI assistance.
