### PR TITLE
fix(app): Respect configured font in start page chat composer

### DIFF
--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -774,6 +774,26 @@ describe("NewChatLandingScreen", () => {
     expect(screen.getByTestId("new-chat-landing-input")).toBeTruthy();
   });
 
+  it("inherits the configured UI font in the landing composer", () => {
+    mockAgents([
+      {
+        id: "ag_debby",
+        name: "debby",
+        display_name: "Debby",
+        description: "Multi-agent debate",
+        harness: "claude-sdk",
+        skills: [{ name: "debate", description: "Have both heads argue it out" }],
+      },
+    ]);
+    renderLanding();
+
+    const input = screen.getByTestId("new-chat-landing-input");
+    const prompt = screen.getByText("Describe a task, or try a skill");
+
+    expect(input.className).not.toMatch(/\bfont-\[/);
+    expect(prompt.className).not.toMatch(/\bfont-\[/);
+  });
+
   it("preserves the typed message and attachments when the landing screen unmounts and remounts", () => {
     // Navigating into an existing session and back unmounts the landing
     // screen; the draft is stashed at module scope so the half-composed

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -3174,21 +3174,21 @@ export function NewChatLandingScreen() {
               rows={1}
               autoFocus
               data-testid="new-chat-landing-input"
-              // Compose-pill text spec: SF Pro Text system stack at
-              // 14px/20px. (Note: sub-16px inputs make mobile Safari
+              // Compose-pill text spec: configured UI family at 14px/20px.
+              // (Note: sub-16px inputs make mobile Safari
               // auto-zoom on focus — accepted tradeoff per the design.)
               // Heights are border-box (16px top + 4px bottom padding lives
               // inside them): min 60px = one 20px line + a spare line of
               // breathing room; max 200px = the spec's 180px of content.
               // useAutoGrowTextarea drives the height between the two.
-              className="max-h-[200px] min-h-[60px] w-full resize-none overflow-y-auto bg-transparent px-4 pt-4 pb-1 font-['SF_Pro_Text',-apple-system,BlinkMacSystemFont,system-ui,sans-serif] text-sm leading-5 text-foreground outline-none placeholder:text-muted-foreground md:select-text"
+              className="max-h-[200px] min-h-[60px] w-full resize-none overflow-y-auto bg-transparent px-4 pt-4 pb-1 text-sm leading-5 text-foreground outline-none placeholder:text-muted-foreground md:select-text"
             />
             {/* Gated on an empty draft so it reads as the placeholder.
                 pointer-events-none lets clicks fall through to focus the
                 textarea; the pills themselves opt back in. */}
             {pillSkills.length > 0 && message.length === 0 && (
               <div className="pointer-events-none absolute inset-x-4 top-4 flex flex-wrap items-center gap-2">
-                <span className="font-['SF_Pro_Text',-apple-system,BlinkMacSystemFont,system-ui,sans-serif] text-sm leading-5 text-muted-foreground">
+                <span className="text-sm leading-5 text-muted-foreground">
                   Describe a task, or try a skill
                 </span>
                 <SkillPills skills={pillSkills} onPick={applySkillPill} />


### PR DESCRIPTION
## Related issue

N/A

## Summary

The new-session landing composer pinned its text to an SF Pro system stack, so it ignored the UI font family selected under Appearance. This removes the local font overrides from the composer input and its skill prompt so the pre-session view inherits the same configured UI font as established chats.

A focused regression test ensures the landing composer does not reintroduce a local arbitrary font-family override.

## Test Plan

- `pnpm --dir web exec vitest run src/shell/NewChatDialog.test.tsx -t "inherits the configured UI font"`
- `uv run --frozen --extra dev pre-commit run --all-files`
- Manually set a distinctive font under Settings → Appearance, return to the new-session landing screen, and confirm the composer and skill prompt use it before creating a session.

## Demo

### Before (DOES NOT follow custom font family defined for the host)
<img width="1246" height="628" alt="Screenshot 2026-07-29 at 14 30 26" src="https://github.com/user-attachments/assets/e92c1f01-ed1c-4a78-a402-3bfbd50d3fd0" />

### After (follows custom font family defined for the host)
<img width="947" height="448" alt="Screenshot 2026-07-29 at 14 30 00" src="https://github.com/user-attachments/assets/87ba744e-c6c2-465e-8b5e-da17b469af4d" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test covers both font-overridden elements in the pre-session composer: the textarea and the skill prompt overlay. Manual visual verification remains pending with the before/after screenshots.

## Changelog

The new-session composer now uses your configured UI font.
