### PR TITLE
fix(sessions): raise seed-title cap to 150, keep LLM titles short

### DIFF
--- a/omnigent/entities/__init__.py
+++ b/omnigent/entities/__init__.py
@@ -4,6 +4,8 @@ from omnigent.entities.account import Account, AccountToken
 from omnigent.entities.agent import Agent, LoadedAgent
 from omnigent.entities.comment import Comment, CommentsFingerprint
 from omnigent.entities.conversation import (
+    MAX_CONVERSATION_TITLE_CHARS,
+    MAX_LLM_TITLE_CHARS,
     NON_CONTENT_ITEM_TYPES,
     CompactionData,
     Conversation,
@@ -40,6 +42,8 @@ from omnigent.entities.session_resources import (
 
 __all__ = [
     "DEFAULT_ENVIRONMENT_ID",
+    "MAX_CONVERSATION_TITLE_CHARS",
+    "MAX_LLM_TITLE_CHARS",
     "NON_CONTENT_ITEM_TYPES",
     "Account",
     "AccountToken",

--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -278,10 +278,20 @@ class MessageData(BaseModel):
         return self
 
 
+#: Max characters for a mechanically-synthesized seed title (the collapsed
+#: first user message). Well under the ``VARCHAR(768)`` column.
+MAX_CONVERSATION_TITLE_CHARS = 150
+
+#: Tighter cap for LLM-generated titles (background inference and the
+#: current-agent auto-rename API). Rejecting long model output nudges the
+#: model toward the short, 2-5 word titles the inference prompt asks for.
+MAX_LLM_TITLE_CHARS = 60
+
+
 def synthesize_conversation_title(
     content: list[dict[str, Any]],
     *,
-    limit: int = 60,
+    limit: int = MAX_CONVERSATION_TITLE_CHARS,
 ) -> str | None:
     """
     Derive a one-line conversation title from message content blocks.

--- a/omnigent/server/background_session_titles.py
+++ b/omnigent/server/background_session_titles.py
@@ -10,7 +10,10 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from omnigent.entities.conversation import synthesize_conversation_title
+from omnigent.entities.conversation import (
+    MAX_LLM_TITLE_CHARS,
+    synthesize_conversation_title,
+)
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.harness_plugins import background_title_generators
 from omnigent.stores.conversation_store import ConversationStore
@@ -56,7 +59,7 @@ def normalize_background_title(value: str | None) -> str | None:
     first_line = next((line.strip() for line in value.splitlines() if line.strip()), "")
     title = " ".join(first_line.strip(_TITLE_WRAPPERS).split())
     title = _TRAILING_PUNCTUATION.sub("", title).strip()
-    if len(title) < 2 or len(title) > 60:
+    if len(title) < 2 or len(title) > MAX_LLM_TITLE_CHARS:
         return None
     return title
 

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -16,7 +16,7 @@ from typing import Annotated, Any, Literal, get_args
 
 from pydantic import BaseModel, ConfigDict, Field, Strict, field_validator, model_validator
 
-from omnigent.entities import ConversationItem
+from omnigent.entities import MAX_LLM_TITLE_CHARS, ConversationItem
 
 # ── Shared ──────────────────────────────────────────────────────
 
@@ -1970,7 +1970,7 @@ class UpdateSessionRequest(BaseModel):
 class AutomaticSessionRenameRequest(BaseModel):
     """Request body for the current-agent automatic rename endpoint."""
 
-    title: str = Field(min_length=2, max_length=60)
+    title: str = Field(min_length=2, max_length=MAX_LLM_TITLE_CHARS)
 
     model_config = ConfigDict(extra="forbid")
 

--- a/tests/entities/test_conversation.py
+++ b/tests/entities/test_conversation.py
@@ -84,7 +84,10 @@ def test_to_api_dict_exposes_interrupted_assistant_marker() -> None:
         ([], None),
         ([{"type": "input_file", "file_id": "file_123"}], None),
         ([{"type": "input_text", "text": "   \n  "}], None),
-        ([{"type": "input_text", "text": "a" * 100}], "a" * 59 + "…"),
+        # Under the 150-char default cap: kept in full, no ellipsis.
+        ([{"type": "input_text", "text": "a" * 100}], "a" * 100),
+        # Over the cap: truncated to 149 chars + ellipsis.
+        ([{"type": "input_text", "text": "a" * 200}], "a" * 149 + "…"),
         # claude-native attachment marker (claude_native_executor
         # prepends "[Attached: <path>]\n\n<text>") — the marker line is
         # dropped so the title is the user's text, not a temp-file path.

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -6764,7 +6764,7 @@ async def test_external_user_message_seeds_title_on_claude_native_session(
     untitled session. The transcript forwarder's first
     ``external_conversation_item`` user-message POST must trigger
     the generic ``_seed_missing_title_from_user_message`` path and
-    populate the title with the standard first-60-char synthesis.
+    populate the title with the standard first-message synthesis.
     This pins the integration of that helper with the external-
     conversation-item route for the claude-native label combination,
     so a future refactor of either side can't silently break the
@@ -6807,7 +6807,7 @@ async def test_external_user_message_seeds_title_on_claude_native_session(
     snap = await client.get(f"/v1/sessions/{session['id']}")
     assert snap.status_code == 200
     # The synthesized title equals the first message when it already fits
-    # the first-60-char budget. If this is empty or unchanged from None,
+    # the synthesis char budget. If this is empty or unchanged from None,
     # the generic seed path didn't fire on the external_conversation_item
     # route for claude-native labels.
     assert snap.json()["title"] == first_message, (


### PR DESCRIPTION
## Related issue

N/A

## Summary

Session titles were being truncated more aggressively than expected. There are two independent title paths and both were hardcoded to **60 chars**:

- **Mechanical seed titles** — the collapsed first user message. A long first message lost its tail permanently (cut to 59 chars + `…`, baked into the stored string) *before* the sidebar's width-based CSS ellipsis ever applied.
- **LLM-generated titles** — background inference + the current-agent auto-rename endpoint.

This raises the **seed-title** cap to **150** (well under the `VARCHAR(768)` column), so seed titles keep more of the user's own text and rely on the sidebar CSS ellipsis for display clipping. **LLM titles keep the 60-char cap** on purpose — rejecting long model output nudges the model toward the short 2-5 word titles the inference prompt asks for.

Both caps are now named constants (`MAX_CONVERSATION_TITLE_CHARS = 150`, `MAX_LLM_TITLE_CHARS = 60`) in `omnigent/entities/conversation.py` so the seed / background-inference / auto-rename paths can't silently drift.

Note: this only affects **newly created** sessions — existing titles already truncated at 59 chars stay as-is (the dropped characters are gone).

## Test Plan

- `python -m pytest tests/entities/test_conversation.py tests/server/test_background_session_titles.py tests/server/routes/test_session_title_seeding.py` — all pass.
- Updated `test_synthesize_conversation_title`: the `"a"*100` case now expects the full 100 chars (under the 150 cap); added an `"a"*200` → `"a"*149 + "…"` case to still exercise truncation at the new default.
- Verified the LLM cap is unchanged: `normalize_background_title("x"*61) is None` and `AutomaticSessionRenameRequest(title="x"*61)` raises `ValidationError`, while 60 chars is accepted.

## Demo

N/A — server-side title-length logic; no visual component beyond the existing sidebar ellipsis.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by updated unit/integration tests above.

## Changelog

Longer session titles: auto-generated titles keep up to 150 characters of the first message instead of cutting off at 60

This pull request and its description were written by Isaac.