### PR TITLE
fix(desktop): share dialog no longer hides behind the active Browser tab

### DIFF
--- a/justfile
+++ b/justfile
@@ -76,11 +76,11 @@ _ensure-electron:
 
 [group('electron')]
 electron-dev: _ensure-web _ensure-electron
-    pnpm --filter web/electron run dev
+    pnpm --filter ./web/electron run dev
 
 [group('electron')]
 electron-build: _ensure-web _ensure-electron
-    pnpm --filter web/electron run build
+    pnpm --filter ./web/electron run build
 
 # --- Lint ---
 

--- a/web/electron/src/browserIpc.js
+++ b/web/electron/src/browserIpc.js
@@ -315,6 +315,16 @@ function registerBrowserIpc({ ipcMain, isPinnedOriginSender, getRegistryForEvent
     return { ok: r.ok, error: r.error };
   });
 
+  // Hide/restore the active view while a DOM overlay (share dialog, etc.) is
+  // open in the renderer. The native view paints above ALL renderer DOM, so
+  // overlays must suppress it to appear on top; hidden (not detached) so the
+  // page keeps running and reappears instantly on overlay close.
+  ipcMain.handle("omnigent:browser-set-overlay-suppressed", (event, args) => {
+    const g = gateRegistry(event);
+    if (g.error) return { ok: false, error: g.error };
+    return g.registry.setOverlaySuppressed(!!args?.suppressed);
+  });
+
   // Reposition the active conversation's view to freshly-measured bounds.
   ipcMain.handle("omnigent:browser-resize", (event, args) => {
     const g = gateRegistry(event);

--- a/web/electron/src/browserViewRegistry.js
+++ b/web/electron/src/browserViewRegistry.js
@@ -33,6 +33,22 @@ function createBrowserViewRegistry({
 } = {}) {
   const entries = new Map(); // conversationId -> BrowserViewEntry
   let activeConversationId = null;
+  // While true, the active view stays hidden (not detached): the native view
+  // paints ABOVE every DOM element, so an open renderer overlay (share dialog,
+  // etc.) would otherwise render underneath the page. Applied to whichever
+  // entry is (or becomes) active until cleared.
+  let overlaySuppressed = false;
+
+  /** Hide/show a view in place — never throws, no-op on stubs without setVisible. */
+  function setViewVisible(entry, visible) {
+    const view = entry && entry.view;
+    if (!view || typeof view.setVisible !== "function") return;
+    try {
+      view.setVisible(visible);
+    } catch {
+      /* destroyed */
+    }
+  }
 
   function makeEntry(conversationId, view) {
     const entry = {
@@ -176,6 +192,7 @@ function createBrowserViewRegistry({
       } catch {
         /* host gone */
       }
+      setViewVisible(entry, !overlaySuppressed);
     }
     // Signal the renderer a view now exists. On a fresh conversation the view is
     // created detached (no host-active-changed fires), so without this the pane
@@ -252,8 +269,26 @@ function createBrowserViewRegistry({
     } catch {
       /* host gone */
     }
+    // Re-apply visibility on every attach: setVisible(false) persists on the
+    // view across detach/attach, so a swap while an overlay is open must stay
+    // hidden, and a normal swap must undo any earlier suppression.
+    setViewVisible(next, !overlaySuppressed);
     next.boundsController.resync();
     sendToRenderer("browser-host-active-changed", { conversationId });
+    return { ok: true };
+  }
+
+  // Hide (suppressed=true) or restore (false) the active view while a DOM
+  // overlay is open in the renderer. Hidden, not detached: the page keeps
+  // running and the pane's bounds loop stays wired, so closing the overlay
+  // restores it instantly. The flag outlives the current active entry — a view
+  // activated while suppressed attaches hidden.
+  function setOverlaySuppressed(suppressed) {
+    overlaySuppressed = !!suppressed;
+    if (activeConversationId !== null) {
+      const entry = entries.get(activeConversationId);
+      if (entry) setViewVisible(entry, !overlaySuppressed);
+    }
     return { ok: true };
   }
 
@@ -310,10 +345,12 @@ function createBrowserViewRegistry({
     getOrCreate,
     openOrNavigate,
     setActive,
+    setOverlaySuppressed,
     close,
     closeAll,
     // Introspection
     activeConversationId: () => activeConversationId,
+    overlaySuppressed: () => overlaySuppressed,
     size: () => entries.size,
     has: (conversationId) => entries.has(conversationId),
     forEach: (fn) => entries.forEach(fn),

--- a/web/electron/src/preload.js
+++ b/web/electron/src/preload.js
@@ -196,6 +196,13 @@ contextBridge.exposeInMainWorld("omnigentDesktop", {
   browserSetActive: (conversationId) =>
     ipcRenderer.invoke("omnigent:browser-set-active", { conversationId }),
   /**
+   * Hide (true) / restore (false) the active view while a DOM overlay
+   * (dialog/modal) is open — the native view otherwise paints above it.
+   * @param {boolean} suppressed
+   */
+  browserSetOverlaySuppressed: (suppressed) =>
+    ipcRenderer.invoke("omnigent:browser-set-overlay-suppressed", { suppressed }),
+  /**
    * Reposition the conversation's view to freshly-measured placeholder bounds.
    * @param {string} conversationId
    * @param {{x:number,y:number,width:number,height:number,devicePixelRatio?:number}} bounds

--- a/web/electron/test/browserViewRegistry.test.js
+++ b/web/electron/test/browserViewRegistry.test.js
@@ -333,3 +333,105 @@ describe("browserViewRegistry — child window.open is denied (S3)", () => {
     assert.deepEqual(windowOpen("https://example.com/ok"), { action: "deny" });
   });
 });
+
+describe("browserViewRegistry — overlay suppression (modal above the native view)", () => {
+  // The native WebContentsView paints above ALL renderer DOM, so an open
+  // modal (e.g. the share dialog) must hide the view for its lifetime. These
+  // tests drive setOverlaySuppressed with setVisible-recording stub views.
+  function makeVisibilityRegistry() {
+    const attached = [];
+    const makeStubView = () => {
+      const view = {
+        visibleCalls: [],
+        setVisible(v) {
+          view.visibleCalls.push(v);
+        },
+        setBounds() {},
+        webContents: {
+          loadURL() {},
+          close() {},
+          removeListener() {},
+          on() {},
+          setWindowOpenHandler() {},
+        },
+      };
+      return view;
+    };
+    const registry = createBrowserViewRegistry({
+      WebContentsViewCtor: () => makeStubView(),
+      createBoundsController: createBrowserViewBoundsController,
+      attachToHost: (view) => attached.push(view),
+      detachFromHost: () => {},
+      sendToRenderer: () => {},
+      getHostZoomFactor: () => 1,
+    });
+    return { registry, attached };
+  }
+
+  it("hides the active view when suppressed and restores it when cleared", () => {
+    const { registry, attached } = makeVisibilityRegistry();
+    registry.openOrNavigate("conv_1", "https://example.com");
+    registry.setActive("conv_1");
+    const view = attached[0];
+    view.visibleCalls.length = 0;
+
+    assert.deepEqual(registry.setOverlaySuppressed(true), { ok: true });
+    assert.equal(registry.overlaySuppressed(), true);
+    assert.deepEqual(view.visibleCalls, [false], "overlay open → view hidden");
+
+    assert.deepEqual(registry.setOverlaySuppressed(false), { ok: true });
+    assert.equal(registry.overlaySuppressed(), false);
+    assert.deepEqual(view.visibleCalls, [false, true], "overlay closed → view restored");
+  });
+
+  it("attaches a view HIDDEN when it becomes active while suppressed", () => {
+    const { registry, attached } = makeVisibilityRegistry();
+    registry.openOrNavigate("conv_1", "https://example.com");
+    registry.setOverlaySuppressed(true);
+    registry.setActive("conv_1");
+    const view = attached[0];
+    assert.equal(
+      view.visibleCalls.at(-1),
+      false,
+      "a view activated under an open overlay must not paint over it",
+    );
+  });
+
+  it("keeps the replacement view hidden when the active view swaps while suppressed", () => {
+    const { registry, attached } = makeVisibilityRegistry();
+    registry.openOrNavigate("conv_1", "https://example.com");
+    registry.openOrNavigate("conv_2", "https://example.org");
+    registry.setActive("conv_1");
+    registry.setOverlaySuppressed(true);
+    registry.setActive("conv_2");
+    const second = attached[1];
+    assert.equal(second.visibleCalls.at(-1), false, "swapped-in view stays hidden");
+  });
+
+  it("re-shows on attach after suppression cleared while detached (setVisible(false) persists)", () => {
+    const { registry, attached } = makeVisibilityRegistry();
+    registry.openOrNavigate("conv_1", "https://example.com");
+    registry.setActive("conv_1");
+    registry.setOverlaySuppressed(true); // hidden
+    registry.setActive(null); // detached while hidden
+    registry.setOverlaySuppressed(false); // overlay closed with nothing active
+    registry.setActive("conv_1"); // re-attach must undo the stale hidden state
+    const view = attached[0];
+    assert.equal(view.visibleCalls.at(-1), true, "re-attach restores visibility");
+  });
+
+  it("suppression with no active view is a safe no-op", () => {
+    const { registry } = makeVisibilityRegistry();
+    assert.deepEqual(registry.setOverlaySuppressed(true), { ok: true });
+    assert.deepEqual(registry.setOverlaySuppressed(false), { ok: true });
+  });
+
+  it("tolerates stub views without setVisible (older Electron)", () => {
+    // The shared makeRegistry views have no setVisible — must not throw.
+    const ctx = makeRegistry();
+    ctx.registry.openOrNavigate("conv_1", "https://example.com");
+    ctx.registry.setActive("conv_1");
+    assert.deepEqual(ctx.registry.setOverlaySuppressed(true), { ok: true });
+    assert.deepEqual(ctx.registry.setOverlaySuppressed(false), { ok: true });
+  });
+});

--- a/web/src/hooks/useSuppressBrowserView.test.tsx
+++ b/web/src/hooks/useSuppressBrowserView.test.tsx
@@ -1,0 +1,83 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// supportsBrowser gates the hook; force it true so it reaches the bridge.
+vi.mock("@/lib/nativeBridge", () => ({
+  supportsBrowser: () => true,
+}));
+
+import { useSuppressBrowserView } from "./useSuppressBrowserView";
+
+/** Install a `window.omnigentDesktop` bridge; returns the suppression mock. */
+function installBridge() {
+  const browserSetOverlaySuppressed = vi.fn().mockResolvedValue({ ok: true });
+  (window as unknown as { omnigentDesktop?: unknown }).omnigentDesktop = {
+    browserSetOverlaySuppressed,
+  };
+  return browserSetOverlaySuppressed;
+}
+
+afterEach(() => {
+  delete (window as unknown as { omnigentDesktop?: unknown }).omnigentDesktop;
+});
+
+describe("useSuppressBrowserView", () => {
+  it("hides the native view while active and restores it on close", () => {
+    const suppress = installBridge();
+    const { rerender } = renderHook(({ open }) => useSuppressBrowserView(open), {
+      initialProps: { open: false },
+    });
+    expect(suppress).not.toHaveBeenCalled();
+
+    // Overlay opens (e.g. the share dialog) → the view must hide, or the
+    // native page paints over the modal.
+    rerender({ open: true });
+    expect(suppress).toHaveBeenCalledTimes(1);
+    expect(suppress).toHaveBeenLastCalledWith(true);
+
+    // Overlay closes → the view comes back.
+    rerender({ open: false });
+    expect(suppress).toHaveBeenCalledTimes(2);
+    expect(suppress).toHaveBeenLastCalledWith(false);
+  });
+
+  it("restores the view on unmount while still active", () => {
+    const suppress = installBridge();
+    const { unmount } = renderHook(() => useSuppressBrowserView(true));
+    expect(suppress).toHaveBeenLastCalledWith(true);
+    unmount();
+    expect(suppress).toHaveBeenLastCalledWith(false);
+  });
+
+  it("never calls the bridge while inactive", () => {
+    const suppress = installBridge();
+    const { unmount } = renderHook(() => useSuppressBrowserView(false));
+    unmount();
+    expect(suppress).not.toHaveBeenCalled();
+  });
+
+  it("keeps the view hidden until the LAST overlapping overlay closes", () => {
+    const suppress = installBridge();
+    const first = renderHook(() => useSuppressBrowserView(true));
+    const second = renderHook(() => useSuppressBrowserView(true));
+    // Only the first open crosses the 0→1 boundary.
+    expect(suppress).toHaveBeenCalledTimes(1);
+    expect(suppress).toHaveBeenLastCalledWith(true);
+
+    first.unmount();
+    // One overlay still open — the view must stay hidden.
+    expect(suppress).toHaveBeenCalledTimes(1);
+
+    second.unmount();
+    expect(suppress).toHaveBeenCalledTimes(2);
+    expect(suppress).toHaveBeenLastCalledWith(false);
+  });
+
+  it("no-ops on shells that predate browserSetOverlaySuppressed", () => {
+    (window as unknown as { omnigentDesktop?: unknown }).omnigentDesktop = {};
+    expect(() => {
+      const { unmount } = renderHook(() => useSuppressBrowserView(true));
+      unmount();
+    }).not.toThrow();
+  });
+});

--- a/web/src/hooks/useSuppressBrowserView.ts
+++ b/web/src/hooks/useSuppressBrowserView.ts
@@ -1,0 +1,39 @@
+/** Hide the embedded browser's native WebContentsView while a DOM overlay
+ *  (dialog/modal) is open. The native view paints ABOVE every DOM element —
+ *  no z-index can put a modal over it — so overlays that must appear on top
+ *  suppress it for their open lifetime. Ref-counted across instances so
+ *  overlapping overlays don't unhide the view early; no-op outside Electron
+ *  and on desktop shells that predate the browser bridge. */
+import { useEffect } from "react";
+import { supportsBrowser } from "@/lib/nativeBridge";
+
+/** Slice of `window.omnigentDesktop` this hook calls. Typed locally (like
+ *  BrowserPane) so the hook doesn't depend on the full nativeBridge type;
+ *  optional because an older shell may predate the method. */
+interface OverlayBridge {
+  browserSetOverlaySuppressed?: (suppressed: boolean) => Promise<{ ok: boolean; error?: string }>;
+}
+
+function getBridge(): OverlayBridge | null {
+  if (!supportsBrowser()) return null;
+  const w = window as unknown as { omnigentDesktop?: OverlayBridge };
+  return w.omnigentDesktop ?? null;
+}
+
+// Count of currently-open overlays across all hook instances. The view is
+// hidden while the count is > 0 and restored only when it returns to 0.
+let openOverlays = 0;
+
+export function useSuppressBrowserView(active: boolean) {
+  useEffect(() => {
+    if (!active) return;
+    const bridge = getBridge();
+    if (!bridge?.browserSetOverlaySuppressed) return;
+    openOverlays += 1;
+    if (openOverlays === 1) void bridge.browserSetOverlaySuppressed(true);
+    return () => {
+      openOverlays -= 1;
+      if (openOverlays === 0) void getBridge()?.browserSetOverlaySuppressed?.(false);
+    };
+  }, [active]);
+}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -44,6 +44,7 @@ import {
 } from "@/hooks/useChildSessions";
 import { useDebugMode } from "@/hooks/useDebugMode";
 import { useBrowserAgentRelay } from "@/hooks/useBrowserAgentRelay";
+import { useSuppressBrowserView } from "@/hooks/useSuppressBrowserView";
 import {
   AGENT_TERMINAL_IDS,
   inventoryTerminals,
@@ -254,6 +255,10 @@ export function AppShell() {
       : false,
   );
   const [shareOpen, setShareOpen] = useState(false);
+  // While the share dialog is open, hide the embedded browser's native view —
+  // it paints above all DOM, so the dialog would otherwise sit underneath the
+  // page when the Browser tab is active.
+  useSuppressBrowserView(shareOpen);
   const [forkOpen, setForkOpen] = useState(false);
   // Truncation point for a "fork from here" opened from a message's
   // actions (ChatPage, via ForkDialogContext). `null` = full clone —


### PR DESCRIPTION
## Related issue

N/A

## Summary

With the Workspace rail's **Browser** tab active, opening the **Share** dialog rendered it *underneath* the page. The embedded browser is a native Electron `WebContentsView` painted over the renderer DOM, so no CSS z-index can put a modal above it.

- The browser-view registry gains a `setOverlaySuppressed(suppressed)` flag that hides the active view **in place** (`setVisible`, not detach — the page keeps running and reappears instantly when the overlay closes). It's re-applied on every attach, so a view activated or swapped in while an overlay is open attaches hidden.
- Exposed over IPC (`omnigent:browser-set-overlay-suppressed`) and the preload bridge (`browserSetOverlaySuppressed`).
- A new ref-counted `useSuppressBrowserView(open)` hook wires the share dialog's open state to the bridge in `AppShell`; overlapping overlays can share it without unhiding early. No-op on the web build and on desktop shells that predate the browser bridge.

**ELI5:** the browser tab is a real second browser window glued on top of the app, so the share popup was opening *behind* it. Now the glued-on window ducks out of sight while the popup is open and pops back when it closes.

```
share dialog opens
  AppShell: useSuppressBrowserView(shareOpen)
    └─ preload: browserSetOverlaySuppressed(true)
         └─ IPC: omnigent:browser-set-overlay-suppressed
              └─ registry.setOverlaySuppressed(true) → activeView.setVisible(false)
share dialog closes → same path with false → activeView.setVisible(true)
```

## Test Plan

- `node --test` in `web/electron` — 226 pass, including 6 new registry tests: hide/restore on suppress toggle, attach-hidden while suppressed, hidden across active-view swaps, re-show after suppression cleared while detached, no-throw with no active view / on views without `setVisible`.
- `vitest run src/hooks/useSuppressBrowserView.test.tsx` — 5 new tests: suppress on open, restore on close/unmount, no bridge calls while closed, ref-counted overlapping overlays, no-op on older shells.
- Live-Electron harness (real `BrowserWindow` + `WebContentsView`s on the repo's Electron 42, driving the actual `browserViewRegistry` module): all 7 runtime checks pass, including `getVisible()` flipping with suppression and attach-while-suppressed staying hidden.
- Pre-existing note: `pnpm --filter web run type-check` / some jest-dom-matcher suites fail identically on a clean `origin/main` checkout in my environment (jest-dom matcher registration), unrelated to this change.

## Demo

Composited captures from the live-Electron harness (a DOM "share modal" plus a real `WebContentsView` page, rendered exactly as the compositor layers them):

*Before — Browser tab page paints over the open share modal; After — with suppression the modal is visible while the dialog is open.*

<!-- drag in: 1-browser-tab-covers-modal.png / 2-modal-visible-while-suppressed.png -->

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification = the live-Electron harness described in the Test Plan: real `WebContentsView`s attached to a `BrowserWindow`, asserting `getVisible()` across suppress → restore → swap-while-suppressed, plus before/after screenshots. The compositing behavior itself (native view above DOM) can't be exercised from jsdom/node unit tests.

## Changelog

The share dialog now appears above the embedded Browser tab in the desktop app instead of being hidden behind the page.

This pull request and its description were written by Isaac.
