### PR TITLE
fix(files): pass session_id to FileStore.get when resolving attachments

### DIFF
--- a/omnigent/runtime/content_resolver.py
+++ b/omnigent/runtime/content_resolver.py
@@ -15,7 +15,7 @@ import copy
 import logging
 from typing import Any
 
-from omnigent.entities import ConversationItem, MessageData
+from omnigent.entities import ConversationItem, MessageData, StoredFile
 from omnigent.stores import ArtifactStore, FileStore
 
 _logger = logging.getLogger(__name__)
@@ -287,6 +287,31 @@ def _is_text_like_attachment(content_type: str, filename: str | None) -> bool:
     return attachment_text_type_for_extension(filename) is not None
 
 
+def get_file_for_session(
+    file_store: FileStore,
+    file_id: str,
+    session_id: str | None,
+) -> StoredFile | None:
+    """Look up file metadata, always passing the owning session id.
+
+    ``FileStore.get`` declares ``session_id`` as optional, but some
+    deployments back it with a store whose ``get`` requires the session
+    id to route the lookup — omitting the argument raises ``TypeError``
+    there. Always pass it explicitly. A scoped lookup hides legacy
+    unscoped rows (``session_id IS NULL``), so fall back to an unscoped
+    read on a miss; callers still enforce ownership on the returned row.
+
+    :param file_store: Store for file metadata lookups.
+    :param file_id: Unique file identifier, e.g. ``"file_abc123"``.
+    :param session_id: Owning session id, or ``None`` when unknown.
+    :returns: The :class:`StoredFile` if found, otherwise ``None``.
+    """
+    file_meta = file_store.get(file_id, session_id=session_id)
+    if file_meta is None and session_id is not None:
+        file_meta = file_store.get(file_id, session_id=None)
+    return file_meta
+
+
 def extract_text_attachments(
     content: list[dict[str, Any]],
     file_store: FileStore,
@@ -322,7 +347,7 @@ def extract_text_attachments(
         if not isinstance(file_id, str):
             continue
         try:
-            file_meta = file_store.get(file_id)
+            file_meta = get_file_for_session(file_store, file_id, session_id)
         except Exception:  # best-effort scan; never break message delivery
             continue
         if file_meta is None:
@@ -511,7 +536,7 @@ def _resolve_file_id_block(
     """
     file_id = block["file_id"]
     owner_session_id = session_id or _session_id_from_block(block)
-    file_meta = file_store.get(file_id)
+    file_meta = get_file_for_session(file_store, file_id, owner_session_id)
     if file_meta is None or (
         file_meta.session_id is not None and file_meta.session_id != owner_session_id
     ):

--- a/omnigent/tools/builtins/download_file.py
+++ b/omnigent/tools/builtins/download_file.py
@@ -91,7 +91,9 @@ class DownloadFileTool(Tool):
         if file_store is None or artifact_store is None:
             return json.dumps({"error": "File store not configured."})
 
-        record = file_store.get(file_id)
+        from omnigent.runtime.content_resolver import get_file_for_session
+
+        record = get_file_for_session(file_store, file_id, ctx.conversation_id)
         if record is None:
             return json.dumps({"error": f"File {file_id!r} not found."})
 

--- a/tests/runtime/test_compaction.py
+++ b/tests/runtime/test_compaction.py
@@ -514,7 +514,7 @@ def test_resolver_parameterized_image_is_cleared_before_token_counting() -> None
     )
 
     class _FileStore:
-        def get(self, file_id: str) -> StoredFile | None:
+        def get(self, file_id: str, session_id: str | None = None) -> StoredFile | None:
             return stored if file_id == stored.id else None
 
     class _ArtifactStore:

--- a/tests/runtime/test_content_resolver.py
+++ b/tests/runtime/test_content_resolver.py
@@ -15,6 +15,7 @@ from omnigent.entities.conversation import (
 )
 from omnigent.runtime.content_resolver import (
     extract_text_attachments,
+    get_file_for_session,
     resolve_content_references,
 )
 
@@ -32,14 +33,20 @@ class FakeFileStore:
 
     files: dict[str, StoredFile]
 
-    def get(self, file_id: str) -> StoredFile | None:
+    def get(self, file_id: str, session_id: str | None = None) -> StoredFile | None:
         """
         Return the StoredFile for *file_id*, or ``None``.
 
         :param file_id: The file identifier to look up.
+        :param session_id: If set, only return a file owned by this session.
         :returns: The matching StoredFile or None.
         """
-        return self.files.get(file_id)
+        row = self.files.get(file_id)
+        if row is None:
+            return None
+        if session_id is not None and row.session_id != session_id:
+            return None
+        return row
 
 
 @dataclass
@@ -387,6 +394,90 @@ def test_missing_file_id_raises_value_error(
             file_store,
             artifact_store,  # type: ignore[arg-type]
         )
+
+
+class SessionRequiredFileStore:
+    """
+    FileStore whose ``get`` requires ``session_id`` — no default.
+
+    Mirrors dual-store deployments that use the session id to route
+    the lookup; calling ``get(file_id)`` there raises ``TypeError``.
+
+    :param files: Mapping of file_id to StoredFile.
+    """
+
+    def __init__(self, files: dict[str, StoredFile]) -> None:
+        self.files = files
+
+    def get(self, file_id: str, session_id: str | None) -> StoredFile | None:
+        """
+        Return the StoredFile for *file_id*, enforcing scope.
+
+        :param file_id: The file identifier to look up.
+        :param session_id: Required owning-session filter.
+        :returns: The matching StoredFile or None.
+        """
+        row = self.files.get(file_id)
+        if row is None:
+            return None
+        if session_id is not None and row.session_id != session_id:
+            return None
+        return row
+
+
+def test_store_requiring_session_id_resolves_file_id(
+    artifact_store: FakeArtifactStore,
+) -> None:
+    """
+    Resolution must pass ``session_id`` to ``FileStore.get`` — a store
+    whose ``get`` requires it (dual-store deployments) previously got
+    ``TypeError`` and the message-carrying request 500'd.
+    """
+    store = SessionRequiredFileStore(
+        files={
+            "file_img": StoredFile(
+                id="file_img",
+                created_at=1000,
+                filename="photo.png",
+                bytes=len(PNG_BYTES),
+                content_type="image/png",
+                session_id="conv_1",
+            ),
+        }
+    )
+    item = _make_conversation_item([{"type": "input_image", "file_id": "file_img"}])
+
+    result = resolve_content_references(
+        [item],
+        store,  # type: ignore[arg-type]
+        artifact_store,  # type: ignore[arg-type]
+        session_id="conv_1",
+    )
+
+    assert isinstance(result[0].data, MessageData)
+    block = result[0].data.content[0]
+    assert block["image_url"].startswith("data:image/png;base64,")
+
+
+def test_scoped_lookup_falls_back_to_unscoped_legacy_file(
+    artifact_store: FakeArtifactStore,
+) -> None:
+    """
+    A legacy unscoped file (``session_id`` is None) is invisible to a
+    session-scoped ``get``; get_file_for_session must fall back to an
+    unscoped read so the reference still resolves.
+    """
+    unscoped = StoredFile(
+        id="file_img",
+        created_at=1000,
+        filename="photo.png",
+        bytes=len(PNG_BYTES),
+        content_type="image/png",
+    )
+    store = SessionRequiredFileStore(files={"file_img": unscoped})
+
+    assert get_file_for_session(store, "file_img", "conv_1") is unscoped  # type: ignore[arg-type]
+    assert get_file_for_session(store, "file_missing", "conv_1") is None  # type: ignore[arg-type]
 
 
 def test_original_item_not_mutated(

--- a/tests/tools/builtins/test_file_tools.py
+++ b/tests/tools/builtins/test_file_tools.py
@@ -97,14 +97,20 @@ class _FakeFileStore:
             data = list(self._files.values())
         return _FakePage(data=data[:limit])
 
-    def get(self, file_id: str) -> _FakeFile | None:
+    def get(self, file_id: str, session_id: str | None = None) -> _FakeFile | None:
         """
         Look up a file by ID.
 
         :param file_id: The file ID.
+        :param session_id: If set, only return a file owned by this session.
         :returns: The file record, or None.
         """
-        return self._files.get(file_id)
+        row = self._files.get(file_id)
+        if row is None:
+            return None
+        if session_id is not None and row.session_id != session_id:
+            return None
+        return row
 
 
 class _FakeArtifactStore:


### PR DESCRIPTION
## Related issue

N/A — root-caused from a hung staging session; no tracking issue filed.

## Summary

Sending a chat message with a pasted image (or any attachment) 500'd on deployments whose `FileStore.get` implementation requires the owning session id (dual-store setups): attachment resolution called `file_store.get(file_id)` with no `session_id`, raising `TypeError: get() missing 1 required positional argument: 'session_id'` before the message was persisted or forwarded. On native-terminal sessions the message isn't persisted server-side at all (the terminal echoes it back), so the session hung silently — the upload succeeded, but no message ever existed and no turn started.

- Add `get_file_for_session()` in `content_resolver.py`: always pass `session_id` to `FileStore.get`, with an unscoped fallback read on a miss so legacy rows (`session_id IS NULL`) stay resolvable. Callers keep enforcing ownership on the returned row, so behavior with the built-in SQLAlchemy store is unchanged.
- Route the three call sites that omitted `session_id` through it: `_resolve_file_id_block` (the 500), `extract_text_attachments` (the request-phase PII scan was silently skipping every attachment on such deployments), and the `download_file` builtin tool.
- Update test fakes to match the `FileStore.get(file_id, session_id=None)` ABC signature.

ELI5: the file cabinet at some sites refuses to look anything up unless you also say whose drawer it's in. Our code sometimes asked for a file without naming the drawer, so the whole request blew up. Now we always name the drawer, and if the file predates drawers, we check the shared shelf.

```
web UI ── upload image ──► /resources/files ── 201 ✅
web UI ── send message ──► /events
                             └─ resolve input_image file_id
                                  └─ file_store.get(file_id)   ← TypeError → 500 ❌
                                     (now: get(file_id, session_id=...))
```

## Test Plan

- Repro'd against a live deployment: `POST /sessions/{id}/events` with an `input_image` block returned 500 with the `DualFileStore.get() missing 1 required positional argument: 'session_id'` traceback in server logs; this change makes resolution pass the session id that store needs.
- New regression tests: a fake store whose `get` *requires* `session_id` (mirrors dual-store deployments) resolves an `input_image` block end-to-end, and the unscoped-legacy-row fallback is covered.
- `uv run pytest tests/runtime/test_content_resolver.py tests/runtime/test_compaction.py tests/tools/builtins/test_file_tools.py` — 153 passed.
- `pre-commit run` on the changed files — all hooks pass.

## Demo

N/A — non-visual server-side fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually reproduced the failing `POST /events` (image attachment → 500 with `DualFileStore.get` TypeError) against a live deployment and confirmed the failing call site; the store contract itself is exercised by the new unit tests with a session-id-requiring fake.

## Changelog

Messages with pasted images or file attachments no longer fail (and silently hang the session) on deployments whose file store requires session-scoped lookups.

This pull request and its description were written by Isaac.
