### PR TITLE
chore(pnpm): drop nodeLinker: hoisted for the default isolated layout

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,6 @@ settings:
   minimumReleaseAge: 10080
   autoInstallPeers: false
   strictPeerDependencies: false
-  nodeLinker: hoisted
 
 # jest-dom doesn't declare vitest as a (peer) dependency, so under pnpm's store
 # layout its `declare module "vitest"` matcher-type augmentation can't resolve


### PR DESCRIPTION
## Related issue

N/A

## Summary

- `nodeLinker: hoisted` was a compatibility shim from the npm→pnpm migration
  that forced an npm-style flat `node_modules`. Removing it returns pnpm to its
  default isolated/symlinked layout (packages under `node_modules/.pnpm/…`),
  restoring strict dependency isolation — dependencies must be declared, so
  phantom/undeclared deps stop resolving by accident.
- Validated that the blockers the shim was assumed to guard against don't
  actually block under the isolated layout (details in Test Plan). The Shiki
  cyclic-import crash is handled by the existing `manualChunks` guard in
  `web/vite.config.ts` (a chunking concern, independent of the node linker), and
  electron-builder v26 collects the production dependency tree correctly through
  pnpm's symlinks.

## Test Plan

Validated locally under the isolated layout:
- `pnpm install --frozen-lockfile` — clean and lockfile-consistent (the linker
  setting is not part of the lockfile, so no lockfile churn).
- `pnpm --filter web run build` — succeeds; Shiki resolves to a single acyclic
  chunk via the existing `manualChunks` guard.
- Electron packaging: `pnpm --filter web run build:overlay` then
  `electron-builder --dir` builds and signs the app; inspected the resulting
  `app.asar` — it bundles exactly the production dep tree (`electron-updater`,
  `js-yaml` + their 14 transitive deps) with zero dev-dependency bloat.
- Tailwind v4 `@source` scan follows the symlink: the emitted CSS is
  byte-identical between the hoisted and isolated builds.
- oxlint (schema) and prettier run; `node web/node_modules/vite/bin/vite.js
  --version` (Android Gradle entry) and `web/node_modules/.bin/tsc --version`
  (iOS Fastlane probe) resolve via pnpm's direct-dependency symlinks.

Not runnable locally — relying on CI to confirm: Docker image build,
`electron-build` full installers, and `android-bundle` / iOS app builds.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Node-linker layout has no unit-test surface; verified manually via a full
install + web build + electron `--dir` packaging (inspecting the packaged
`app.asar` dependency tree) + a Tailwind CSS byte-diff, and confirmed the
hardcoded node_modules paths (vite entry, tsc/prettier/oxlint) resolve through
pnpm's direct-dependency symlinks. Remaining platform builds are covered by CI.

Signed-off-by: Zeyi (Rice) Fan <zeyi.f@databricks.com>

