### PR TITLE
feat(web): render Mermaid in markdown previews

### DIFF
--- a/tests/e2e_ui/files/test_markdown_mermaid_preview.py
+++ b/tests/e2e_ui/files/test_markdown_mermaid_preview.py
@@ -1,0 +1,88 @@
+"""E2E: Mermaid code fences render as diagrams in Markdown Preview mode.
+
+Markdown files default to the rich-text editor, but the read-only Preview pane
+uses ``CodeViewer``'s ``react-markdown`` pipeline. This test pins that path: a
+``mermaid`` fence becomes an SVG diagram while ordinary fences remain code, and
+Source mode keeps the Mermaid text editable.
+
+Seeded via the filesystem PUT endpoint (no agent run).
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_MARKDOWN_FILE_PATH = "mermaid_preview.md"
+
+_MARKDOWN_CONTENT = """\
+# Mermaid Preview
+
+```mermaid
+flowchart LR
+  A[Markdown] --> B[Preview]
+```
+
+```js
+const stillCode = true;
+```
+"""
+
+
+@pytest.fixture
+def seeded_mermaid_markdown_session(
+    seeded_session: tuple[str, str],
+) -> Iterator[tuple[str, str]]:
+    base_url, session_id = seeded_session
+    resp = httpx.put(
+        f"{base_url}/v1/sessions/{session_id}"
+        f"/resources/environments/default/filesystem/{_MARKDOWN_FILE_PATH}",
+        json={"content": _MARKDOWN_CONTENT, "encoding": "utf-8"},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    try:
+        yield (base_url, session_id)
+    finally:
+        shutil.rmtree(_REPO_ROOT / session_id, ignore_errors=True)
+
+
+def test_mermaid_fence_renders_as_preview_diagram(
+    page: Page,
+    seeded_mermaid_markdown_session: tuple[str, str],
+) -> None:
+    """Preview turns Mermaid fences into SVGs and preserves other code fences."""
+    base_url, session_id = seeded_mermaid_markdown_session
+    page.add_init_script(
+        """
+        window.localStorage.setItem(
+          "omnigent:file-view-preferences",
+          JSON.stringify({
+            diffActive: false,
+            diffLayout: "unified",
+            previewableViewMode: "preview",
+            hideWhitespace: false,
+            wrapLines: false,
+          }),
+        );
+        """
+    )
+    page.goto(f"{base_url}/c/{session_id}?file={_MARKDOWN_FILE_PATH}")
+
+    file_viewer = page.locator('[data-testid="file-viewer"]:visible')
+    expect(file_viewer).to_be_visible()
+
+    mermaid_preview = file_viewer.get_by_test_id("mermaid-preview")
+    expect(mermaid_preview).to_be_visible(timeout=10_000)
+    expect(mermaid_preview.locator("svg")).to_be_visible(timeout=10_000)
+    expect(file_viewer.locator("pre > code.language-mermaid")).to_have_count(0)
+
+    js_code = file_viewer.locator("pre > code.language-js")
+    expect(js_code).to_contain_text("const stillCode = true;")

--- a/web/src/shell/CodeViewer.test.tsx
+++ b/web/src/shell/CodeViewer.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { useFileContent } from "@/hooks/useFileContent";
 import { CodeViewer } from "./CodeViewer";
@@ -296,6 +296,15 @@ describe("CodeViewer markdown preview rendering (issue #970)", () => {
   it("renders fenced code blocks", () => {
     const { container } = renderMd("```js\nconst x = 1;\n```");
     expect(container.querySelector("pre code")?.textContent).toContain("const x = 1;");
+  });
+
+  it("renders Mermaid fences as diagrams instead of plain code", async () => {
+    const { container } = renderMd("```mermaid\nflowchart LR\n  A --> B\n```");
+    expect(screen.getByTestId("mermaid-preview")).toBeDefined();
+    expect(container.querySelector("pre > code.language-mermaid")).toBeNull();
+    await waitFor(() =>
+      expect(container.querySelector("[data-testid='mermaid-preview'] svg")).not.toBeNull(),
+    );
   });
 
   it("renders blockquotes", () => {

--- a/web/src/shell/CodeViewer.test.tsx
+++ b/web/src/shell/CodeViewer.test.tsx
@@ -298,6 +298,12 @@ describe("CodeViewer markdown preview rendering (issue #970)", () => {
     expect(container.querySelector("pre code")?.textContent).toContain("const x = 1;");
   });
 
+  it("renders raw HTML pre blocks without treating them as Mermaid fences", () => {
+    const { container } = renderMd("<pre>literal raw pre</pre>");
+    expect(container.querySelector("pre")?.textContent).toBe("literal raw pre");
+    expect(screen.queryByTestId("mermaid-preview")).toBeNull();
+  });
+
   it("renders Mermaid fences as diagrams instead of plain code", async () => {
     const { container } = renderMd("```mermaid\nflowchart LR\n  A --> B\n```");
     expect(screen.getByTestId("mermaid-preview")).toBeDefined();

--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -157,7 +157,7 @@ function MermaidPreview({ source }: { source: string }) {
 // adds no attack surface. Only literal integer pixel values are forwarded.
 const MARKDOWN_COMPONENTS: Components = {
   pre({ children, ...props }) {
-    const child = Children.count(children) === 1 ? Children.only(children) : null;
+    const child = Children.count(children) === 1 && isValidElement(children) ? children : null;
     if (
       isValidElement<{ className?: string; children?: ReactNode }>(child) &&
       child.props.className?.split(/\s+/).includes("language-mermaid")

--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -12,6 +12,8 @@
 
 import { createPortal } from "react-dom";
 import {
+  Children,
+  isValidElement,
   lazy,
   Suspense,
   useCallback,
@@ -19,6 +21,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type ReactNode,
   type RefObject,
 } from "react";
 import {
@@ -39,6 +42,8 @@ import remarkEmoji from "remark-emoji";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import { rehypeGithubAlerts } from "rehype-github-alerts";
+import { mermaid } from "@streamdown/mermaid";
+import { Streamdown } from "streamdown";
 import { type Comment } from "@/hooks/useComments";
 import {
   type FileContentResponse,
@@ -132,6 +137,18 @@ const MARKDOWN_REHYPE_PLUGINS: Options["rehypePlugins"] = [
   [rehypeSanitize, MARKDOWN_SANITIZE_SCHEMA],
 ];
 
+const MERMAID_STREAMDOWN_PLUGINS = { mermaid };
+
+function MermaidPreview({ source }: { source: string }) {
+  return (
+    <div data-testid="mermaid-preview" className="not-prose my-4 overflow-auto">
+      <Streamdown plugins={MERMAID_STREAMDOWN_PLUGINS}>
+        {`\`\`\`mermaid\n${source.replace(/\n$/, "")}\n\`\`\``}
+      </Streamdown>
+    </div>
+  );
+}
+
 // Tailwind Preflight applies `img { height: auto }`, which overrides the HTML
 // `width`/`height` *attributes* (presentational hints lose to any author CSS).
 // GitHub honors explicit dimensions, so mirror them onto an inline style —
@@ -139,6 +156,16 @@ const MARKDOWN_REHYPE_PLUGINS: Options["rehypePlugins"] = [
 // after sanitize (React components render the already-sanitized tree), so it
 // adds no attack surface. Only literal integer pixel values are forwarded.
 const MARKDOWN_COMPONENTS: Components = {
+  pre({ children, ...props }) {
+    const child = Children.count(children) === 1 ? Children.only(children) : null;
+    if (
+      isValidElement<{ className?: string; children?: ReactNode }>(child) &&
+      child.props.className?.split(/\s+/).includes("language-mermaid")
+    ) {
+      return <MermaidPreview source={String(child.props.children ?? "")} />;
+    }
+    return <pre {...props}>{children}</pre>;
+  },
   img({ node: _node, width, height, style, ...props }) {
     const px = (v: string | number | undefined) =>
       typeof v === "number" || (typeof v === "string" && /^\d+$/.test(v)) ? `${v}px` : undefined;


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Render fenced `mermaid` blocks as SVG diagrams in the Markdown file viewer's Preview mode instead of showing them as plain code.
- Reuse Omnigent's existing `@streamdown/mermaid` integration, so this adds no new frontend dependency.
- Preserve normal fenced code rendering and keep Mermaid source editable in Edit and Source modes.

**ELI5:** when the Markdown preview encounters a `mermaid` code fence, it sends that block through the existing Mermaid renderer; all other code fences continue through the normal Markdown renderer.

```mermaid
flowchart LR
  A[Markdown preview] --> B{Mermaid fence?}
  B -- Yes --> C[Streamdown Mermaid plugin]
  C --> D[SVG diagram]
  B -- No --> E[Normal code block]
```

## Test Plan

- `pnpm --filter web exec vitest run src/shell/CodeViewer.test.tsx`
- `pnpm --filter web exec oxlint src/shell/CodeViewer.tsx src/shell/CodeViewer.test.tsx`
- `pnpm --filter web exec prettier --check src/shell/CodeViewer.tsx src/shell/CodeViewer.test.tsx`
- `uv run ruff check tests/e2e_ui/files/test_markdown_mermaid_preview.py`
- `uv run ruff format --check tests/e2e_ui/files/test_markdown_mermaid_preview.py`
- `uv run pytest tests/e2e_ui/files/test_markdown_mermaid_preview.py -q --ui-skip-build`
- `pnpm --filter web build`
- `.venv/bin/pre-commit run --all-files`

## Demo

### Before 
<img width="1300" height="1853" alt="Screenshot 2026-07-29 at 16 53 22" src="https://github.com/user-attachments/assets/2699e2b9-0ca6-4503-aad3-831051f21805" />

### After
<img width="889" height="1504" alt="Screenshot 2026-07-29 at 16 52 22" src="https://github.com/user-attachments/assets/88897128-1c12-4846-8e56-a36e58b35494" />


## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused unit test exercises the real Streamdown Mermaid plugin and waits for an SVG to be produced, while also asserting that the original Mermaid code block is no longer rendered as plain code. The focused UI E2E seeds a Markdown file, opens it in Preview mode, and verifies the Mermaid fence renders as an SVG while a normal JavaScript fence remains code.

## Changelog

Markdown file previews render fenced Mermaid diagrams.

