### PR TITLE
refactor(harness): registry-driven native launch — special arms + turn-path (PR 1.5b-ii)

### DIFF
--- a/designs/harness-modular-registry-proposal.md
+++ b/designs/harness-modular-registry-proposal.md
@@ -437,7 +437,8 @@ Phase 2: 2.1–2.4).
 | 1.2 Signature normalization | landed | #3244 |
 | 1.3 Resume hubs | landed | #3314 |
 | 1.5a Runner spawn-env | landed | #3495 |
-| 1.5b-i Runner launch (scaffolding + 8 uniform arms) | in review | (this PR) |
+| 1.5b-i Runner launch (scaffolding + 8 uniform arms) | in review | #3500 |
+| 1.5b-ii Runner launch (3 special arms + turn-path opencode) | in review | (this PR) |
 
 ## Risks and open questions
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -54,6 +54,7 @@ from omnigent.llms.summarize import (
     build_summarization_prompt,
     extract_summary_text,
 )
+from omnigent.native_coding_agents import native_coding_agent_for_harness
 from omnigent.policies.types import FAIL_CLOSED_PHASES
 from omnigent.runner import native as _native
 from omnigent.runner import pending_approvals
@@ -73,6 +74,7 @@ from omnigent.runner.native import (
     _REPL_TERMINAL_NAME,
     _REPL_TERMINAL_SESSION_KEY,
     NativeLaunchContext,
+    PreLaunchResult,
     ResolvedSpec,
     _antigravity_native_terminal_arrives_via_transfer,
     _auto_create_antigravity_terminal,
@@ -105,7 +107,6 @@ from omnigent.runner.native import (
     _launch_native_terminal,
     _log_terminal_lookup_miss,
     _native_terminal_start_error_response,
-    _publish_native_terminal_start_error,
     _publish_terminal_pending,
     _publish_tmux_target_for_bridge,
     _required_runner_env,
@@ -143,7 +144,7 @@ from omnigent.server.schemas import (
     BackgroundSessionTitleResponse,
 )
 from omnigent.spec.skill_sources import SkillSourceContext, resolve_harness_skills
-from omnigent.spec.types import LocalToolInfo, SkillSpec
+from omnigent.spec.types import AgentSpec, LocalToolInfo, SkillSpec
 from omnigent.terminals.control_bridge import bridge_tmux_control_to_websocket
 from omnigent.terminals.ws_bridge import (
     WS_CLOSE_TERMINAL_NOT_FOUND,
@@ -2615,354 +2616,214 @@ def create_runner_app(
 
         terminal_ready: bool | None = None
 
-        if harness_name == "claude-native":
-            terminal_ready = False
-            _ensure_lock = _claude_terminal_ensure_locks.setdefault(session_id, asyncio.Lock())
-            async with _ensure_lock:
-                _tr = resource_registry.terminal_registry
-                _has_terminal = (
-                    _tr is not None and _tr.get(session_id, "claude", "main") is not None
-                )
-                if _has_terminal and await _claude_native_session_wants_rebuild(
-                    server_client,
-                    session_id,
-                    init_context.envelope,
-                ):
-                    _logger.info(
-                        "Claude terminal stale after agent switch; tearing it down to "
-                        "rebuild from current items: session=%s",
-                        session_id,
+        _native_agent = native_coding_agent_for_harness(harness_name)
+        if _native_agent is not None:
+            # Each native harness contributes only its launch parameters here;
+            # a single _launch_native_terminal call at the end runs them. The
+            # 8 uniform harnesses differ only in their lock dict and whether
+            # they pass an agent-spec resolver; the 3 special harnesses
+            # (claude/codex/antigravity) add a pre_launch check and, for
+            # claude/codex, a build_context enrichment. All wire the comment
+            # relay (pi/opencode route their policy hook through it).
+            _launch_locks = {
+                "claude": _claude_terminal_ensure_locks,
+                "codex": _codex_terminal_ensure_locks,
+                "pi": _pi_terminal_ensure_locks,
+                "cursor": _cursor_terminal_ensure_locks,
+                "kiro": _kiro_terminal_ensure_locks,
+                "antigravity": _antigravity_terminal_ensure_locks,
+                "opencode": _opencode_terminal_ensure_locks,
+                "goose": _goose_terminal_ensure_locks,
+                "hermes": _hermes_terminal_ensure_locks,
+                "qwen": _qwen_terminal_ensure_locks,
+                "kimi": _kimi_terminal_ensure_locks,
+            }[_native_agent.key]
+            _launch_ctx = NativeLaunchContext(
+                session_id=session_id,
+                resource_registry=resource_registry,
+                publish_event=_publish_event,
+                server_client=server_client,
+                ensure_comment_relay=_ensure_comment_relay_started,
+            )
+            _launch_pre: Callable[[bool], Awaitable[PreLaunchResult]] | None = None
+            _launch_build: (
+                Callable[[NativeLaunchContext], Awaitable[NativeLaunchContext]] | None
+            ) = None
+            _launch_resolve_spec: (
+                Callable[[], Awaitable[AgentSpec | ResolvedSpec | None]] | None
+            ) = None
+
+            if harness_name == "claude-native":
+
+                async def _claude_pre_launch(has_terminal: bool) -> PreLaunchResult:
+                    # Mirror the inline arm exactly: a rebuild (agent switch) tears
+                    # the stale terminal down, but the transfer-inbound check still
+                    # runs on the resulting terminal-absent state and, if a sibling
+                    # session's terminal is rotating in, wins over create. So the
+                    # combined rebuild+inbound case is teardown + wait-for-transfer,
+                    # NOT teardown + fresh create (which would race the rotation).
+                    wants_rebuild = has_terminal and await _claude_native_session_wants_rebuild(
+                        server_client, session_id, init_context.envelope
                     )
-                    if _tr is not None:
-                        await _tr.cleanup_conversation(session_id)
-                    _has_terminal = False
-                _logger.info(
-                    "Claude terminal auto-create decision: session=%s terminal_registry=%s "
-                    "has_existing_terminal=%s",
-                    session_id,
-                    _tr is not None,
-                    _has_terminal,
-                )
-                _terminal_inbound = False
-                if not _has_terminal:
-                    _terminal_inbound = await _claude_native_terminal_arrives_via_transfer(
-                        server_client=server_client,
-                        session_id=session_id,
-                        resource_registry=resource_registry,
-                        session_labels=init_context.labels,
-                    )
-                    _logger.info(
-                        "Claude terminal transfer-inbound check: session=%s terminal_inbound=%s",
-                        session_id,
-                        _terminal_inbound,
-                    )
-                if not _has_terminal and not _terminal_inbound:
-                    _native_bundle_dir: Path | None = None
-                    _native_agent_name: str | None = None
-                    _native_skills_filter: str | list[str] = "all"
+                    if wants_rebuild:
+                        _logger.info(
+                            "Claude terminal stale after agent switch; tearing it down to "
+                            "rebuild from current items: session=%s",
+                            session_id,
+                        )
+                    # The inline arm ran the transfer check whenever the terminal was
+                    # (or just became, via rebuild) absent. Return force_recreate and
+                    # skip together: the shell tears down first (rebuild), then honors
+                    # skip (inbound) — so rebuild+inbound is teardown + wait-for-transfer.
+                    inbound = False
+                    if not has_terminal or wants_rebuild:
+                        inbound = await _claude_native_terminal_arrives_via_transfer(
+                            server_client=server_client,
+                            session_id=session_id,
+                            resource_registry=resource_registry,
+                            session_labels=init_context.labels,
+                        )
+                        _logger.info(
+                            "Claude terminal transfer-inbound check: session=%s "
+                            "terminal_inbound=%s",
+                            session_id,
+                            inbound,
+                        )
+                    return PreLaunchResult(force_recreate=wants_rebuild, skip=inbound)
+
+                async def _claude_build_context(ctx: NativeLaunchContext) -> NativeLaunchContext:
+                    bundle_dir: Path | None = None
+                    agent_name: str | None = None
+                    skills_filter: str | list[str] = "all"
                     try:
-                        _native_spec = await _resolve_session_agent_spec(session_id)
+                        spec = await _resolve_session_agent_spec(session_id)
                     except OmnigentError:
-                        _native_spec = None
+                        spec = None
                         _logger.info(
                             "Claude terminal spec resolution failed; continuing without "
                             "bundle skills: session=%s",
                             session_id,
                         )
-                    if _native_spec is not None:
-                        _native_entry = _session_spec_cache.get(session_id)
-                        _native_bundle_dir = (
-                            _resolved_spec_workdir(_native_entry)
-                            if _native_entry is not None
-                            else None
-                        )
-                        _native_agent_name = getattr(_native_spec, "name", None)
-                        _native_skills_filter = getattr(_native_spec, "skills_filter", "all")
-                    if _native_bundle_dir is None:
-                        _native_bundle_dir = Path(
-                            tempfile.mkdtemp(prefix="omnigent-skill-bundle-")
-                        )
+                    if spec is not None:
+                        entry = _session_spec_cache.get(session_id)
+                        bundle_dir = _resolved_spec_workdir(entry) if entry is not None else None
+                        agent_name = getattr(spec, "name", None)
+                        skills_filter = getattr(spec, "skills_filter", "all")
+                    if bundle_dir is None:
+                        bundle_dir = Path(tempfile.mkdtemp(prefix="omnigent-skill-bundle-"))
                     _logger.info(
                         "Claude terminal auto-create inputs resolved: session=%s "
                         "bundle_dir=%s agent_name=%s skills_filter=%s",
                         session_id,
-                        _native_bundle_dir,
-                        _native_agent_name,
-                        _native_skills_filter,
+                        bundle_dir,
+                        agent_name,
+                        skills_filter,
                     )
-                    _ensure_orchestrator_skills_in_bundle(_native_bundle_dir, _native_spec)
-                    _publish_terminal_pending(_publish_event, session_id, True)
-                    try:
-                        await _auto_create_claude_terminal(
-                            session_id,
-                            resource_registry,
-                            _publish_event,
-                            server_client=server_client,
-                            bundle_dir=_native_bundle_dir,
-                            agent_name=_native_agent_name,
-                            agent_spec=_native_spec,
-                            skills_filter=_native_skills_filter,
-                            session_init=init_context.envelope,
-                            auth_token_factory=auth_token_factory,
-                            resolve_launch_config=lambda: _resolve_session_claude_launch_config(
-                                session_id
-                            ),
-                            record_launch_config=_session_claude_launch_configs.__setitem__,
-                        )
-                        terminal_ready = True
-                    except Exception as exc:
-                        _logger.exception(
-                            "Failed to auto-create claude terminal for %s",
-                            session_id,
-                        )
-                        _publish_native_terminal_start_error(
-                            _publish_event,
-                            session_id,
-                            "Claude",
-                            exc,
-                        )
-                    finally:
-                        _publish_terminal_pending(_publish_event, session_id, False)
-                elif _has_terminal:
-                    terminal_ready = True
-                elif _terminal_inbound:
-                    _logger.info(
-                        "Skipping claude terminal auto-create for %s; a sibling "
-                        "session's terminal will transfer in (rotation target).",
-                        session_id,
+                    _ensure_orchestrator_skills_in_bundle(bundle_dir, spec)
+                    return dataclasses.replace(
+                        ctx,
+                        bundle_dir=bundle_dir,
+                        agent_name=agent_name,
+                        agent_spec=spec,
+                        skills_filter=skills_filter,
+                        session_init=init_context.envelope,
+                        auth_token_factory=auth_token_factory,
+                        resolve_launch_config=lambda: _resolve_session_claude_launch_config(
+                            session_id
+                        ),
+                        record_launch_config=_session_claude_launch_configs.__setitem__,
                     )
 
-        if harness_name == "codex-native":
-            _codex_ensure_lock = _codex_terminal_ensure_locks.setdefault(
-                session_id, asyncio.Lock()
-            )
-            async with _codex_ensure_lock:
-                _tr = resource_registry.terminal_registry
-                _has_codex_terminal = (
-                    _tr is not None and _tr.get(session_id, "codex", "main") is not None
-                )
-                _needs_terminal = await _codex_session_needs_runner_terminal(
-                    server_client, session_id
-                )
-                if not _has_codex_terminal and _needs_terminal:
-                    _codex_bundle_dir: Path | None = None
-                    _codex_skills_filter: str | list[str] = "all"
+                _launch_pre = _claude_pre_launch
+                _launch_build = _claude_build_context
+
+            elif harness_name == "codex-native":
+
+                async def _codex_pre_launch(has_terminal: bool) -> PreLaunchResult:
+                    needs = await _codex_session_needs_runner_terminal(server_client, session_id)
+                    if not needs and not has_terminal:
+                        _logger.info(
+                            "Skipping codex terminal auto-create for %s; session "
+                            "snapshot was not available.",
+                            session_id,
+                        )
+                    return PreLaunchResult(needs_terminal=needs)
+
+                async def _codex_build_context(ctx: NativeLaunchContext) -> NativeLaunchContext:
+                    bundle_dir: Path | None = None
+                    skills_filter: str | list[str] = "all"
                     try:
-                        _codex_spec = await _resolve_session_agent_spec(session_id)
+                        spec = await _resolve_session_agent_spec(session_id)
                     except OmnigentError:
-                        _codex_spec = None
-                    if _codex_spec is not None:
-                        _codex_entry = _session_spec_cache.get(session_id)
-                        _codex_bundle_dir = (
-                            _resolved_spec_workdir(_codex_entry)
-                            if _codex_entry is not None
-                            else None
-                        )
-                        _codex_skills_filter = getattr(_codex_spec, "skills_filter", "all")
-                    if _codex_bundle_dir is not None and _codex_spec is not None:
-                        _ensure_orchestrator_skills_in_bundle(_codex_bundle_dir, _codex_spec)
-                    _publish_terminal_pending(_publish_event, session_id, True)
-                    try:
-                        await _auto_create_codex_terminal(
-                            session_id,
-                            resource_registry,
-                            _publish_event,
-                            bundle_dir=_codex_bundle_dir,
-                            skills_filter=_codex_skills_filter,
-                            agent_spec=spec_entry,
-                            server_client=server_client,
-                            ensure_comment_relay=_ensure_comment_relay_started,
-                        )
-                    except Exception as exc:
-                        _logger.exception(
-                            "Failed to auto-create codex terminal for %s",
-                            session_id,
-                        )
-                        _publish_native_terminal_start_error(
-                            _publish_event,
-                            session_id,
-                            "Codex",
-                            exc,
-                        )
-                    finally:
-                        _publish_terminal_pending(_publish_event, session_id, False)
-                elif not _needs_terminal:
-                    _logger.info(
-                        "Skipping codex terminal auto-create for %s; session "
-                        "snapshot was not available.",
-                        session_id,
+                        spec = None
+                    if spec is not None:
+                        entry = _session_spec_cache.get(session_id)
+                        bundle_dir = _resolved_spec_workdir(entry) if entry is not None else None
+                        skills_filter = getattr(spec, "skills_filter", "all")
+                    if bundle_dir is not None and spec is not None:
+                        _ensure_orchestrator_skills_in_bundle(bundle_dir, spec)
+                    # Preserve the inline arm's use of the outer spec_entry (not the
+                    # locally-resolved spec) as agent_spec.
+                    return dataclasses.replace(
+                        ctx,
+                        bundle_dir=bundle_dir,
+                        skills_filter=skills_filter,
+                        agent_spec=spec_entry,
                     )
 
-        if harness_name == "pi-native":
-            # pi resolves its spec unwrapped — a resolution error surfaces as a
-            # terminal-start error (preserved by not swallowing in the resolver).
-            await _launch_native_terminal(
-                harness_name,
-                NativeLaunchContext(
-                    session_id=session_id,
-                    resource_registry=resource_registry,
-                    publish_event=_publish_event,
-                    server_client=server_client,
-                    ensure_comment_relay=_ensure_comment_relay_started,
-                ),
-                ensure_locks=_pi_terminal_ensure_locks,
-                resolve_agent_spec=lambda: _resolve_session_agent_spec(session_id),
-            )
+                _launch_pre = _codex_pre_launch
+                _launch_build = _codex_build_context
 
-        if harness_name == "cursor-native":
-            await _launch_native_terminal(
-                harness_name,
-                NativeLaunchContext(
-                    session_id=session_id,
-                    resource_registry=resource_registry,
-                    publish_event=_publish_event,
-                    server_client=server_client,
-                    ensure_comment_relay=_ensure_comment_relay_started,
-                ),
-                ensure_locks=_cursor_terminal_ensure_locks,
-                resolve_agent_spec=lambda: _resolve_session_agent_spec_or_none(session_id),
-            )
+            elif harness_name == "antigravity-native":
 
-        if harness_name == "kiro-native":
-            await _launch_native_terminal(
-                harness_name,
-                NativeLaunchContext(
-                    session_id=session_id,
-                    resource_registry=resource_registry,
-                    publish_event=_publish_event,
-                    server_client=server_client,
-                    ensure_comment_relay=_ensure_comment_relay_started,
-                ),
-                ensure_locks=_kiro_terminal_ensure_locks,
-            )
+                async def _antigravity_pre_launch(has_terminal: bool) -> PreLaunchResult:
+                    needs = (
+                        await _session_payload_for_host_spawn_check(server_client, session_id)
+                    ) is not None
+                    if not has_terminal:
+                        inbound = await _antigravity_native_terminal_arrives_via_transfer(
+                            server_client=server_client,
+                            session_id=session_id,
+                            resource_registry=resource_registry,
+                        )
+                        _logger.info(
+                            "Antigravity terminal transfer-inbound check: session=%s "
+                            "terminal_inbound=%s",
+                            session_id,
+                            inbound,
+                        )
+                        if inbound:
+                            return PreLaunchResult(skip=True)
+                    if not needs:
+                        _logger.info(
+                            "Skipping antigravity terminal auto-create for %s; session "
+                            "snapshot was not available.",
+                            session_id,
+                        )
+                    return PreLaunchResult(needs_terminal=needs)
 
-        if harness_name == "antigravity-native":
-            _antigravity_ensure_lock = _antigravity_terminal_ensure_locks.setdefault(
-                session_id, asyncio.Lock()
-            )
-            async with _antigravity_ensure_lock:
-                _tr = resource_registry.terminal_registry
-                _has_antigravity_terminal = (
-                    _tr is not None and _tr.get(session_id, "antigravity", "main") is not None
+                _launch_pre = _antigravity_pre_launch
+
+            elif harness_name == "pi-native":
+                # pi resolves its spec unwrapped — a resolution error surfaces as
+                # a terminal-start error (the resolver does not swallow it).
+                _launch_resolve_spec = lambda: _resolve_session_agent_spec(session_id)  # noqa: E731
+            elif harness_name in ("cursor-native", "opencode-native", "kimi-native"):
+                _launch_resolve_spec = lambda: _resolve_session_agent_spec_or_none(  # noqa: E731
+                    session_id
                 )
-                _needs_terminal = (
-                    await _session_payload_for_host_spawn_check(server_client, session_id)
-                ) is not None
-                _antigravity_inbound = False
-                if not _has_antigravity_terminal:
-                    _antigravity_inbound = await _antigravity_native_terminal_arrives_via_transfer(
-                        server_client=server_client,
-                        session_id=session_id,
-                        resource_registry=resource_registry,
-                    )
-                    _logger.info(
-                        "Antigravity terminal transfer-inbound check: session=%s "
-                        "terminal_inbound=%s",
-                        session_id,
-                        _antigravity_inbound,
-                    )
-                if not _has_antigravity_terminal and _needs_terminal and not _antigravity_inbound:
-                    _publish_terminal_pending(_publish_event, session_id, True)
-                    try:
-                        await _auto_create_antigravity_terminal(
-                            session_id,
-                            resource_registry,
-                            _publish_event,
-                            server_client=server_client,
-                            ensure_comment_relay=_ensure_comment_relay_started,
-                        )
-                    except Exception as exc:
-                        _logger.exception(
-                            "Failed to auto-create antigravity terminal for %s",
-                            session_id,
-                        )
-                        _publish_native_terminal_start_error(
-                            _publish_event,
-                            session_id,
-                            "Antigravity",
-                            exc,
-                        )
-                    finally:
-                        _publish_terminal_pending(_publish_event, session_id, False)
-                elif _antigravity_inbound:
-                    _logger.info(
-                        "Skipping antigravity terminal auto-create for %s; a sibling "
-                        "session's terminal will transfer in (rotation target).",
-                        session_id,
-                    )
-                elif not _needs_terminal:
-                    _logger.info(
-                        "Skipping antigravity terminal auto-create for %s; session "
-                        "snapshot was not available.",
-                        session_id,
-                    )
 
-        if harness_name == "opencode-native":
-            await _launch_native_terminal(
+            _launch_result = await _launch_native_terminal(
                 harness_name,
-                NativeLaunchContext(
-                    session_id=session_id,
-                    resource_registry=resource_registry,
-                    publish_event=_publish_event,
-                    server_client=server_client,
-                    ensure_comment_relay=_ensure_comment_relay_started,
-                ),
-                ensure_locks=_opencode_terminal_ensure_locks,
-                resolve_agent_spec=lambda: _resolve_session_agent_spec_or_none(session_id),
+                _launch_ctx,
+                ensure_locks=_launch_locks,
+                pre_launch=_launch_pre,
+                build_context=_launch_build,
+                resolve_agent_spec=_launch_resolve_spec,
             )
-
-        if harness_name == "goose-native":
-            await _launch_native_terminal(
-                harness_name,
-                NativeLaunchContext(
-                    session_id=session_id,
-                    resource_registry=resource_registry,
-                    publish_event=_publish_event,
-                    server_client=server_client,
-                    ensure_comment_relay=_ensure_comment_relay_started,
-                ),
-                ensure_locks=_goose_terminal_ensure_locks,
-            )
-
-        if harness_name == "hermes-native":
-            await _launch_native_terminal(
-                harness_name,
-                NativeLaunchContext(
-                    session_id=session_id,
-                    resource_registry=resource_registry,
-                    publish_event=_publish_event,
-                    server_client=server_client,
-                    ensure_comment_relay=_ensure_comment_relay_started,
-                ),
-                ensure_locks=_hermes_terminal_ensure_locks,
-            )
-
-        if harness_name == "qwen-native":
-            await _launch_native_terminal(
-                harness_name,
-                NativeLaunchContext(
-                    session_id=session_id,
-                    resource_registry=resource_registry,
-                    publish_event=_publish_event,
-                    server_client=server_client,
-                    ensure_comment_relay=_ensure_comment_relay_started,
-                ),
-                ensure_locks=_qwen_terminal_ensure_locks,
-            )
-
-        if harness_name == "kimi-native":
-            await _launch_native_terminal(
-                harness_name,
-                NativeLaunchContext(
-                    session_id=session_id,
-                    resource_registry=resource_registry,
-                    publish_event=_publish_event,
-                    server_client=server_client,
-                    ensure_comment_relay=_ensure_comment_relay_started,
-                ),
-                ensure_locks=_kimi_terminal_ensure_locks,
-                resolve_agent_spec=lambda: _resolve_session_agent_spec_or_none(session_id),
-            )
+            # Only claude reported terminal_ready in the create-session response.
+            if harness_name == "claude-native":
+                terminal_ready = _launch_result
 
         if (
             spec is not None
@@ -5934,42 +5795,32 @@ def create_runner_app(
             _version_cache[conv_id] = agent_version
 
         if harness_name == "opencode-native":
-            _oc_lock = _opencode_terminal_ensure_locks.setdefault(conv_id, asyncio.Lock())
-            async with _oc_lock:
-                _oc_tr = resource_registry.terminal_registry
-                _oc_ready = (
-                    _oc_tr is not None and _oc_tr.get(conv_id, "opencode", "main") is not None
+            # Turn-path cold-boot: ensure the terminal exists before the turn.
+            # A launch failure here aborts the turn with a 503 (reraise=True),
+            # unlike the create-session arms that publish a start-error event.
+            try:
+                await _launch_native_terminal(
+                    harness_name,
+                    NativeLaunchContext(
+                        session_id=conv_id,
+                        resource_registry=resource_registry,
+                        publish_event=_publish_event,
+                        server_client=server_client,
+                        ensure_comment_relay=_ensure_comment_relay_started,
+                    ),
+                    ensure_locks=_opencode_terminal_ensure_locks,
+                    resolve_agent_spec=lambda: _resolve_session_agent_spec_or_none(conv_id),
+                    reraise=True,
                 )
-                if not _oc_ready:
-                    _publish_terminal_pending(_publish_event, conv_id, True)
-                    try:
-                        try:
-                            _oc_spec = await _resolve_session_agent_spec(conv_id)
-                        except OmnigentError:
-                            _oc_spec = None
-                        await _auto_create_opencode_terminal(
-                            conv_id,
-                            resource_registry,
-                            _publish_event,
-                            agent_spec=_oc_spec,
-                            server_client=server_client,
-                            ensure_comment_relay=_ensure_comment_relay_started,
-                        )
-                    except Exception as exc:
-                        _logger.exception(
-                            "opencode-native cold-boot ensure failed for %s", conv_id
-                        )
-                        return JSONResponse(
-                            status_code=503,
-                            content={
-                                "error": "opencode_native_boot_failed",
-                                "detail": _client_safe_error_detail(
-                                    exc, context="opencode-native boot"
-                                ),
-                            },
-                        )
-                    finally:
-                        _publish_terminal_pending(_publish_event, conv_id, False)
+            except Exception as exc:
+                _logger.exception("opencode-native cold-boot ensure failed for %s", conv_id)
+                return JSONResponse(
+                    status_code=503,
+                    content={
+                        "error": "opencode_native_boot_failed",
+                        "detail": _client_safe_error_detail(exc, context="opencode-native boot"),
+                    },
+                )
 
         try:
             client = await process_manager.get_client(conv_id, harness_name, env=spawn_env)

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -6416,8 +6416,10 @@ class PreLaunchResult:
 
     :param skip: When ``True``, do not auto-create (e.g. a sibling session's
         terminal is transferring in).
-    :param force_recreate: When ``True``, tear down an existing terminal and
-        recreate (e.g. claude rebuild after an in-place agent switch).
+    :param force_recreate: When ``True``, tear down the session's terminals
+        (``cleanup_conversation``, which is session-wide, not just this harness's
+        terminal) and recreate — e.g. claude rebuild after an in-place agent
+        switch. Mirrors the original claude arm's teardown scope.
     :param needs_terminal: When ``False``, skip auto-create because the session
         snapshot said a runner terminal is not needed (codex/antigravity).
     """
@@ -6547,10 +6549,12 @@ async def _launch_antigravity(ctx: NativeLaunchContext) -> SessionResourceView:
 async def _launch_claude(ctx: NativeLaunchContext) -> SessionResourceView:
     """Adapter: build the claude-native terminal from a launch context.
 
-    ``server_client`` is required by the builder; the launch dispatch only
-    reaches this adapter with a bound client.
+    ``server_client`` is required by the builder; the claude launch arm always
+    binds one. Raise explicitly (rather than ``assert``, which ``-O`` strips) so
+    a future caller that forgets gets a clear error instead of a ``None`` deref.
     """
-    assert ctx.server_client is not None  # guaranteed by the claude launch arm
+    if ctx.server_client is None:
+        raise ValueError("claude-native launch requires a bound server_client")
     return await _auto_create_claude_terminal(
         ctx.session_id,
         ctx.resource_registry,
@@ -6572,35 +6576,44 @@ async def _launch_native_terminal(
     ctx: NativeLaunchContext,
     *,
     ensure_locks: MutableMapping[str, asyncio.Lock],
-    pre_launch: PreLaunchResult | None = None,
+    pre_launch: Callable[[bool], Awaitable[PreLaunchResult]] | None = None,
     resolve_agent_spec: (Callable[[], Awaitable[AgentSpec | ResolvedSpec | None]] | None) = None,
+    build_context: Callable[[NativeLaunchContext], Awaitable[NativeLaunchContext]] | None = None,
+    reraise: bool = False,
 ) -> bool | None:
     """Auto-create a native harness terminal through the provider seam.
 
     Replaces the per-harness ``if harness_name == "<x>-native"`` launch arms:
     resolves ``provider.auto_create_terminal`` from the registry and runs the
     shared lock / existence-check / pending-event / error-event mechanics every
-    arm shared. Harness-specific pre-call logic (claude rebuild+transfer,
-    codex/antigravity needs-checks) is computed by the caller and passed as
-    *pre_launch*.
+    arm shared.
 
-    ``agent_spec`` is resolved lazily via *resolve_agent_spec*, called inside the
-    create block only when a terminal is actually being created — matching the
-    original arms, which resolved the spec only on creation and with per-harness
-    error semantics (pi lets a resolution error surface as a terminal-start
-    error; cursor/opencode/kimi swallow ``OmnigentError`` in their resolver;
-    kiro/goose/hermes/qwen pass no resolver at all). The resolved spec replaces
-    ``ctx.agent_spec`` before the adapter runs.
+    The special arms' ``has_terminal``-dependent pre-call checks (claude rebuild
+    + transfer-inbound, codex/antigravity needs-terminal) run in *pre_launch*,
+    invoked inside the lock with the computed ``has_terminal`` so it sees the
+    same state the inline arms did. Context enrichment that must happen only on
+    create (claude's bundle_dir / agent_name / skills, codex's bundle_dir) runs
+    in *build_context*; the simpler uniform arms use *resolve_agent_spec* to fill
+    just ``agent_spec``. Both run inside the create block, so their work (and
+    error semantics) is skipped when a terminal already exists.
 
     :param harness_name: Harness id, e.g. ``"pi-native"``.
     :param ctx: Launch inputs; the resolved adapter reads the subset it needs.
     :param ensure_locks: Per-harness ``{session_id: Lock}`` map owned by the
         runner (kept there so session cleanup can pop the lock by name).
-    :param pre_launch: Optional pre-launch decision from a special arm.
+    :param pre_launch: Optional async callback ``(has_terminal) -> PreLaunchResult``
+        run inside the lock to decide skip / force_recreate / needs_terminal.
     :param resolve_agent_spec: Optional async callback that resolves the session
-        agent spec, invoked once inside the create block. Its exceptions are
-        surfaced as terminal-start errors (a resolver that wants to tolerate
-        ``OmnigentError`` must swallow it itself and return ``None``).
+        agent spec, invoked once inside the create block; the result replaces
+        ``ctx.agent_spec``. Its exceptions surface as terminal-start errors (a
+        resolver that tolerates ``OmnigentError`` must swallow it and return
+        ``None``). Mutually exclusive with *build_context*.
+    :param build_context: Optional async callback that returns the fully enriched
+        context, invoked once inside the create block (for arms that resolve more
+        than ``agent_spec``). Mutually exclusive with *resolve_agent_spec*.
+    :param reraise: When ``True``, a builder failure re-raises after publishing
+        the pending-off event instead of publishing a start-error event — used by
+        the turn-path opencode cold-boot, which converts failure to an HTTP 503.
     :returns: ``True`` when a terminal exists or was created, ``False`` when
         creation failed or was skipped, or ``None`` when *harness_name* is not a
         native harness with a launch adapter (caller handles it another way).
@@ -6611,7 +6624,6 @@ async def _launch_native_terminal(
     provider = native_provider_for_key(agent.key)
     if provider is None:
         return None
-    decision = pre_launch or PreLaunchResult()
 
     lock = ensure_locks.setdefault(ctx.session_id, asyncio.Lock())
     async with lock:
@@ -6620,6 +6632,7 @@ async def _launch_native_terminal(
             registry is not None
             and registry.get(ctx.session_id, agent.terminal_name, "main") is not None
         )
+        decision = await pre_launch(has_terminal) if pre_launch is not None else PreLaunchResult()
         if has_terminal and decision.force_recreate:
             if registry is not None:
                 await registry.cleanup_conversation(ctx.session_id)
@@ -6632,7 +6645,9 @@ async def _launch_native_terminal(
         adapter = resolve_hook(provider, "auto_create_terminal")
         _publish_terminal_pending(ctx.publish_event, ctx.session_id, True)
         try:
-            if resolve_agent_spec is not None:
+            if build_context is not None:
+                ctx = await build_context(ctx)
+            elif resolve_agent_spec is not None:
                 ctx = dataclasses.replace(ctx, agent_spec=await resolve_agent_spec())
             await adapter(ctx)
             return True
@@ -6642,6 +6657,8 @@ async def _launch_native_terminal(
                 agent.terminal_name,
                 ctx.session_id,
             )
+            if reraise:
+                raise
             _publish_native_terminal_start_error(
                 ctx.publish_event,
                 ctx.session_id,

--- a/tests/runner/test_app_sessions_native_events_lifecycle.py
+++ b/tests/runner/test_app_sessions_native_events_lifecycle.py
@@ -679,7 +679,9 @@ async def test_claude_native_model_options_use_session_launch_catalog(
             metadata={"terminal_name": "claude", "session_key": "main", "running": True},
         )
 
-    monkeypatch.setattr("omnigent.runner.app._auto_create_claude_terminal", _fake_auto_create)
+    monkeypatch.setattr(
+        "omnigent.runner.native.orchestration._auto_create_claude_terminal", _fake_auto_create
+    )
     app = create_runner_app(
         process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
         spec_resolver=_resolver,
@@ -764,7 +766,9 @@ async def test_claude_native_model_options_config_error_is_not_retryable(
             metadata={"terminal_name": "claude", "session_key": "main", "running": True},
         )
 
-    monkeypatch.setattr("omnigent.runner.app._auto_create_claude_terminal", _fake_auto_create)
+    monkeypatch.setattr(
+        "omnigent.runner.native.orchestration._auto_create_claude_terminal", _fake_auto_create
+    )
     app = create_runner_app(
         process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
         spec_resolver=_resolver,

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -2241,7 +2241,9 @@ async def test_create_session_auto_create_guard_skips_rotation_targets(
         del resource_registry, publish_event
         created.append(session_id)
 
-    monkeypatch.setattr("omnigent.runner.app._auto_create_claude_terminal", _recording_auto_create)
+    monkeypatch.setattr(
+        "omnigent.runner.native.orchestration._auto_create_claude_terminal", _recording_auto_create
+    )
 
     native_spec = AgentSpec(
         spec_version=1,
@@ -2515,7 +2517,8 @@ async def test_create_session_antigravity_auto_create_guard_skips_rotation_targe
         created.append(session_id)
 
     monkeypatch.setattr(
-        "omnigent.runner.app._auto_create_antigravity_terminal", _recording_auto_create
+        "omnigent.runner.native.orchestration._auto_create_antigravity_terminal",
+        _recording_auto_create,
     )
 
     native_spec = AgentSpec(

--- a/tests/runner/test_app_sessions_native_workflow_init.py
+++ b/tests/runner/test_app_sessions_native_workflow_init.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import dataclasses
 import json
 import logging
 import uuid
@@ -416,16 +417,53 @@ async def test_launch_native_terminal_force_recreate_tears_down_existing(
 
     monkeypatch.setattr("omnigent.runner.native._launch_pi", _fake_launch_pi)
     registry = _FakeTerminalRegistry(existing=True)
+
+    async def _pre_launch(_has_terminal: bool) -> PreLaunchResult:
+        return PreLaunchResult(force_recreate=True)
+
     result = await _launch_native_terminal(
         "pi-native",
         _launch_ctx(resource_registry=_FakeResourceRegistry(registry)),
         ensure_locks={},
-        pre_launch=PreLaunchResult(force_recreate=True),
+        pre_launch=_pre_launch,
     )
 
     assert result is True
     assert registry.cleaned == ["conv_x"]
     assert created == ["conv_x"]
+
+
+@pytest.mark.asyncio
+async def test_launch_native_terminal_force_recreate_and_skip_tears_down_without_create(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """force_recreate + skip together = teardown but NO create.
+
+    Preserves the claude rebuild+transfer-inbound case: the stale terminal is
+    torn down, but because a sibling session's terminal is rotating in (skip),
+    creation is left to the transfer instead of racing it with a fresh launch.
+    """
+    from omnigent.runner.native import PreLaunchResult, _launch_native_terminal
+
+    async def _must_not_call(ctx: NativeLaunchContext) -> object:
+        raise AssertionError("adapter must not run when the transfer will deliver")
+
+    monkeypatch.setattr("omnigent.runner.native._launch_pi", _must_not_call)
+    registry = _FakeTerminalRegistry(existing=True)
+
+    async def _pre_launch(_has_terminal: bool) -> PreLaunchResult:
+        return PreLaunchResult(force_recreate=True, skip=True)
+
+    result = await _launch_native_terminal(
+        "pi-native",
+        _launch_ctx(resource_registry=_FakeResourceRegistry(registry)),
+        ensure_locks={},
+        pre_launch=_pre_launch,
+    )
+
+    assert result is False
+    # Torn down (rebuild) but not recreated (skip → the transfer delivers).
+    assert registry.cleaned == ["conv_x"]
 
 
 @pytest.mark.asyncio
@@ -441,8 +479,14 @@ async def test_launch_native_terminal_skip_and_needs_terminal_return_false(
     monkeypatch.setattr("omnigent.runner.native._launch_pi", _must_not_call)
 
     for decision in (PreLaunchResult(skip=True), PreLaunchResult(needs_terminal=False)):
+
+        async def _pre_launch(
+            _has_terminal: bool, _d: PreLaunchResult = decision
+        ) -> PreLaunchResult:
+            return _d
+
         result = await _launch_native_terminal(
-            "pi-native", _launch_ctx(), ensure_locks={}, pre_launch=decision
+            "pi-native", _launch_ctx(), ensure_locks={}, pre_launch=_pre_launch
         )
         assert result is False
 
@@ -514,6 +558,68 @@ async def test_launch_native_terminal_non_native_returns_none() -> None:
 
     result = await _launch_native_terminal("claude-sdk", _launch_ctx(), ensure_locks={})
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_launch_native_terminal_build_context_enriches_only_on_create(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """build_context runs inside the create block and feeds the adapter's ctx."""
+    from omnigent.runner.native import _launch_native_terminal
+
+    seen: dict[str, Any] = {}
+    build_calls = {"n": 0}
+
+    async def _fake_launch_pi(ctx: NativeLaunchContext) -> object:
+        seen["bundle_dir"] = ctx.bundle_dir
+        return object()
+
+    async def _build(ctx: NativeLaunchContext) -> NativeLaunchContext:
+        build_calls["n"] += 1
+        return dataclasses.replace(ctx, bundle_dir=Path("/tmp/enriched"))
+
+    monkeypatch.setattr("omnigent.runner.native._launch_pi", _fake_launch_pi)
+
+    await _launch_native_terminal(
+        "pi-native", _launch_ctx(), ensure_locks={}, build_context=_build
+    )
+    assert build_calls["n"] == 1
+    assert seen["bundle_dir"] == Path("/tmp/enriched")
+
+    # Existing terminal: build_context must NOT run.
+    await _launch_native_terminal(
+        "pi-native",
+        _launch_ctx(resource_registry=_FakeResourceRegistry(_FakeTerminalRegistry(existing=True))),
+        ensure_locks={},
+        build_context=_build,
+    )
+    assert build_calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_launch_native_terminal_reraise_propagates_without_error_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """reraise=True re-raises the builder failure instead of publishing an event."""
+    from omnigent.runner.native import _launch_native_terminal
+
+    async def _boom(ctx: NativeLaunchContext) -> object:
+        raise RuntimeError("cold-boot blew up")
+
+    monkeypatch.setattr("omnigent.runner.native._launch_pi", _boom)
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    with pytest.raises(RuntimeError, match="cold-boot blew up"):
+        await _launch_native_terminal(
+            "pi-native",
+            _launch_ctx(publish_event=lambda name, event: events.append((name, event))),
+            ensure_locks={},
+            reraise=True,
+        )
+
+    # No start-error event was published (the caller converts the raise to a 503);
+    # only the pending on/off bracket events, none of which carry an error.
+    assert not any("error" in name.lower() or "error" in event for name, event in events)
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_session_resources.py
+++ b/tests/runner/test_session_resources.py
@@ -2195,7 +2195,9 @@ async def test_claude_terminal_ensure_concurrent_calls_create_once(
         terminal_ready = True
         return fake_view
 
-    monkeypatch.setattr("omnigent.runner.app._auto_create_claude_terminal", fake_auto_create)
+    monkeypatch.setattr(
+        "omnigent.runner.native.orchestration._auto_create_claude_terminal", fake_auto_create
+    )
 
     async def fake_get_terminal_resource(
         self: Any,


### PR DESCRIPTION
> **Stacked on #3500 (PR 1.5b-i).** Base branch is `harness-seam-1-5b-i-pr`, so this diff shows only 1.5b-ii's changes. Merge #3500 first; GitHub retargets this to `main` automatically.

## Workstream progress

Modular native-harness registry (`designs/harness-modular-registry-proposal.md`). **~14 PRs total** — Phase 1: 1.1–1.4, 1.5a/b/c, 1.6, 1.7, 1.8; Phase 2: 2.1–2.4.

- ✅ Phase 0 + 1.1 (#3239), 1.2 (#3244), 1.3 (#3314), 1.5a (#3495) — landed. 1.4 descoped.
- 🔄 1.5b-i scaffolding + 8 uniform arms — #3500 (in review).
- 🔄 **1.5b-ii — 3 special arms + turn-path opencode + consolidated dispatch — this PR.** Completes the launch epicenter.
- ⏳ 1.5c terminal-route → 1.6 interrupt/stop → 1.7 seeding → 1.8 enumerations, then Phase 2.

## Related issue

N/A — Phase 1, PR 1.5b-ii of the modular native-harness registry.

## Summary

Completes the runner launch seam. Routes the **3 special arms** (claude/codex/antigravity) and the **turn-path opencode cold-boot** through the seam, and **consolidates all 11 create-session legs into one dispatch**. Behavior-preserving.

- **`orchestration.py`** — extend the shell `_launch_native_terminal` with:
  - `pre_launch`: async `(has_terminal) -> PreLaunchResult`, run **inside the lock** so the `has_terminal`-dependent checks (claude rebuild + transfer-inbound, codex/antigravity needs-terminal) see the same state the inline arms did.
  - `build_context`: lazy full-context enrichment (claude's `bundle_dir`/`agent_name`/`skills` + the 3 closures; codex's bundle), run **only on create**.
  - `reraise`: turn-path opencode converts a launch failure to an HTTP 503 instead of publishing a start-error event.
- **`app.py`** — replace the 11 per-harness create-session legs with a **collect-then-dispatch** block: each leg only assigns its lock dict, context, and optional `pre_launch`/`build_context`/`resolve_agent_spec`; a single `_launch_native_terminal` call runs them. (Per review feedback on 1.5b-i — one call, not 11.)
- **`terminal_ready`** — only claude populated it in the create-session response, so only claude's dispatch result is captured back. (The consolidation fixes a regression where the first cut of the claude conversion dropped `terminal_ready`, which would have flipped claude sessions' response field from `true` to `null`.)

## Test Plan

```
python -m pytest tests/test_harness_plugins.py tests/test_native_dispatch.py \
  tests/runner/test_app_sessions_native_workflow_init.py -q   # 75 passed
python -m pytest tests/runner/test_app_sessions_native_terminals_autocreate.py -q   # 48 passed
python -m pytest tests/runner/test_app_sessions_native_events_lifecycle.py -q -k "not codex"  # 23 passed
python -m pytest tests/runner/test_session_resources.py -q -k claude   # 2 passed
python -m ruff check omnigent/ tests/ -q   # clean
```

**Monkeypatch repoints (the behavior-preservation-critical bit):** arms that now route through the seam resolve `omnigent.runner.native:_launch_<x>` → the adapter calls `orchestration._auto_create_<x>_terminal`, **bypassing app-level patches**. Repointed the affected create-session patches to the orchestration symbol:
- claude create-session: `events_lifecycle` (603/688), `session_resources` (2198).
- create-session auto-create **guard** tests (claude + antigravity rotation-target skips): `terminals_autocreate` (2252/2526).

The terminal-**attach/route** patches (`terminal_routing`, `attach_ws`) are **1.5c scope** and still exercise the app-level builders — left untouched (verified green).

New shell unit coverage: `build_context` enriches only on create; `reraise` propagates without a start-error event.

Pre-existing codex `events_lifecycle` failures (app-server/gateway-env artifacts) are unchanged — codex's arm behavior is preserved.

## Demo

N/A — backend refactor, behavior-preserving. Launch path covered by the unchanged `workflow_init` / `terminals_autocreate` HTTP suites.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The special arms' pre-call logic and the turn-path 503 contract are covered by the existing `terminals_autocreate` guard tests (repointed) and `events_lifecycle` / `workflow_init` HTTP suites, all green. New shell unit tests cover the two new shell hooks (`build_context`, `reraise`).

This pull request and its description were written by Isaac.
