### PR TITLE
fix(sessions): honor ask_timeout on the MCP tool-call approval path

### DIFF
--- a/omnigent/runner/proxy_mcp_manager.py
+++ b/omnigent/runner/proxy_mcp_manager.py
@@ -278,10 +278,16 @@ class ProxyMcpManager:
                     if self._publish_event is not None
                     else (lambda _s, _e: None)
                 )
+                # The spec-resolved ask_timeout rides on the elicitation
+                # params; without it the park falls back to one day and a
+                # policy's own approval window never applies on this path.
+                _req: dict[str, Any] = input_requests[elicitation_id] or {}
+                _ask_timeout = (_req.get("params") or {}).get("timeoutSeconds")
                 approved = await pending_approvals.wait_for_user_approval(
                     elicitation_id=elicitation_id,
                     conversation_id=self._session_id,
                     publish_event=_pub,
+                    timeout_seconds=float(_ask_timeout) if _ask_timeout is not None else None,
                 )
 
                 payload = {

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -8157,6 +8157,7 @@ def _mcp_input_required_response(
     message: str,
     request_state: str,
     session_id: str | None = None,
+    ask_timeout: int | None = None,
 ) -> Response:
     """
     Return an MCP ``InputRequiredResult`` asking the runner to collect
@@ -8181,6 +8182,9 @@ def _mcp_input_required_response(
     :param session_id: Session/conversation id for constructing the
         approval page URL, e.g. ``"conv_abc123"``. ``None`` omits the
         URL (form mode).
+    :param ask_timeout: Spec-resolved approval window in seconds, e.g.
+        ``600``. Carried as ``timeoutSeconds`` so the runner's park honors
+        it instead of its own one-day fallback. ``None`` omits the field.
     :returns: A :class:`Response` carrying the JSON-RPC 2.0
         ``InputRequiredResult`` envelope.
     """
@@ -8193,6 +8197,8 @@ def _mcp_input_required_response(
             "required": ["approved"],
         },
     }
+    if ask_timeout is not None:
+        params["timeoutSeconds"] = ask_timeout
     if session_id is not None and _ELICITATION_MODE == "url":
         params["mode"] = "url"
         params["url"] = f"/approve/{session_id}/{elicitation_id}"

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -6049,6 +6049,7 @@ async def _handle_mcp_tools_call(
                 message=call_result.reason or "Approval required to run this tool",
                 request_state=request_state,
                 session_id=session_id,
+                ask_timeout=resolve_ask_timeout(engine, call_result),
             )
         # ALLOW — apply labels now that we know the action is not ASK.
         if call_result.set_labels:

--- a/tests/runner/test_proxy_mcp_manager.py
+++ b/tests/runner/test_proxy_mcp_manager.py
@@ -502,3 +502,92 @@ async def test_call_tool_uses_configured_read_timeout() -> None:
         "otherwise call_tool may regress to httpx's shorter default."
     )
     assert timeout["connect"] == 10.0, "Connect timeout stays short to fail fast on a dead server"
+
+
+# ── call_tool approval timeout ─────────────────────────────────────────────
+
+
+def _input_required_resp(params: dict[str, Any]) -> httpx.Response:
+    """Build an MRTR ``input_required`` response with one elicitation.
+
+    :param params: The elicitation ``params`` dict, e.g.
+        ``{"message": "Approve?", "timeoutSeconds": 600}``.
+    :returns: A scripted :class:`httpx.Response` for the stub transport.
+    """
+    return _json_resp(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "resultType": "input_required",
+                "requestState": "{}",
+                "inputRequests": {"elicit_1": {"method": "elicitation/create", "params": params}},
+            },
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_call_tool_passes_elicitation_timeout_to_approval_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``timeoutSeconds`` on the elicitation params must reach ``wait_for_user_approval``.
+
+    Failure means a policy's ``ask_timeout`` never applies on the MCP proxy
+    path, so the approval park falls back to the runner's one-day default.
+    """
+    done = _json_resp(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {"content": [{"type": "text", "text": "ok"}], "isError": False},
+        }
+    )
+    transport = _StubTransport(
+        [_input_required_resp({"message": "Approve?", "timeoutSeconds": 600}), done]
+    )
+    manager = _make_manager(transport)
+    captured: dict[str, Any] = {}
+
+    async def _fake_wait(**kwargs: Any) -> bool:
+        captured.update(kwargs)
+        return True
+
+    monkeypatch.setattr("omnigent.runner.pending_approvals.wait_for_user_approval", _fake_wait)
+
+    output = await manager.call_tool(_make_spec("github"), "github__search", {})
+
+    assert output == "ok"
+    assert captured["timeout_seconds"] == 600.0, (
+        "The elicitation's timeoutSeconds must be forwarded as the approval "
+        "wait budget; otherwise ask_timeout policies are unreachable here."
+    )
+    retry = transport.calls[1]
+    assert retry.body["params"]["inputResponses"] == {"elicit_1": {"action": "accept"}}
+
+
+@pytest.mark.asyncio
+async def test_call_tool_approval_wait_unbounded_without_timeout_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without ``timeoutSeconds`` the approval wait must pass ``None``.
+
+    Failure means the runner invents a budget the server never sent, changing
+    behavior for servers that intentionally leave the fallback in place.
+    """
+    done = _json_resp({"jsonrpc": "2.0", "id": 2, "result": {"content": []}})
+    transport = _StubTransport([_input_required_resp({"message": "Approve?"}), done])
+    manager = _make_manager(transport)
+    captured: dict[str, Any] = {}
+
+    async def _fake_wait(**kwargs: Any) -> bool:
+        captured.update(kwargs)
+        return True
+
+    monkeypatch.setattr("omnigent.runner.pending_approvals.wait_for_user_approval", _fake_wait)
+
+    await manager.call_tool(_make_spec("github"), "github__search", {})
+
+    assert captured["timeout_seconds"] is None, (
+        "No timeoutSeconds hint means the runner keeps its existing fallback"
+    )

--- a/tests/server/integration/test_sessions_elicitation_resolve_url.py
+++ b/tests/server/integration/test_sessions_elicitation_resolve_url.py
@@ -1515,3 +1515,43 @@ def test_mrtr_response_no_session_id_stays_form(monkeypatch: pytest.MonkeyPatch)
     params = body["result"]["inputRequests"]["elicit_abc"]["params"]
     assert params["mode"] == "form"
     assert "url" not in params
+
+
+def test_mrtr_response_carries_ask_timeout() -> None:
+    """
+    A spec-resolved ``ask_timeout`` must surface as ``timeoutSeconds``
+    in the MRTR elicitation params, so the runner's approval park can
+    honor the policy's window instead of its own fallback.
+    """
+
+    from omnigent.server.routes.sessions import _mcp_input_required_response
+
+    resp = _mcp_input_required_response(
+        rpc_id=1,
+        elicitation_id="elicit_abc",
+        message="Approve?",
+        request_state="{}",
+        ask_timeout=600,
+    )
+    body = json.loads(resp.body)
+    params = body["result"]["inputRequests"]["elicit_abc"]["params"]
+    assert params["timeoutSeconds"] == 600
+
+
+def test_mrtr_response_omits_timeout_when_unresolved() -> None:
+    """
+    Without ``ask_timeout`` the MRTR params must not carry
+    ``timeoutSeconds``, leaving the runner's existing fallback in place.
+    """
+
+    from omnigent.server.routes.sessions import _mcp_input_required_response
+
+    resp = _mcp_input_required_response(
+        rpc_id=1,
+        elicitation_id="elicit_abc",
+        message="Approve?",
+        request_state="{}",
+    )
+    body = json.loads(resp.body)
+    params = body["result"]["inputRequests"]["elicit_abc"]["params"]
+    assert "timeoutSeconds" not in params


### PR DESCRIPTION
## Related issue

N/A

## Summary

- An ASK raised through `POST /v1/sessions/{id}/mcp` returned an
-   `InputRequiredResult` with no timeout, so the runner parked on its own
-   one-day fallback. A policy declaring `ask_timeout: 600` therefore waited
-   up to 24 hours on this route — the policy's approval window was unreachable.
- - The server now carries the spec-resolved `ask_timeout` as `timeoutSeconds`
-   inside the elicitation params (the runner already reads that entry for the
-   elicitation id), and the runner passes it to `wait_for_user_approval`.
- - Omitted when unknown: a server that does not send `timeoutSeconds` leaves
-   the runner's existing fallback untouched, so mixed-version deployments are
-   unaffected in both directions.
ELI5: a policy can say "wait 10 minutes for a human to approve this tool
call" — but on the MCP proxy path that number never reached the code doing
the waiting, which always waited a day. Now the number rides along with the
approval request.

## Test Plan

- `uv run pytest tests/runner/test_proxy_mcp_manager.py tests/server/integration/test_sessions_elicitation_resolve_url.py tests/runner/test_pending_approvals.py` — all green.
- - New unit tests pin both halves and both directions:
-   - runner: `timeoutSeconds` on the elicitation params reaches
-     `wait_for_user_approval` as `timeout_seconds` (and `None` is passed when
-     the hint is absent);
-   - server: `_mcp_input_required_response(ask_timeout=600)` emits
-     `params.timeoutSeconds == 600`, and omits the field when unresolved.
- - Verified in a live deployment (k8s, managed sandboxes): with
-   `ask_timeout: 3600` resolved from the agent's guardrails, the MCP proxy
-   response now carries `"timeoutSeconds": 3600` in the elicitation params and
-   the patched runner reads it into the approval wait.
## Demo

Live session on a patched deployment. The agent's guardrails resolve
`ask_timeout: 3600`, with a `risk_score` ASK policy on `sys_os_shell`; the
approval is raised on the MCP tool-call path
(`POST /v1/sessions/{id}/mcp`). The approval card parks waiting for a
human, and the wait now honors the policy's `ask_timeout` (3600 s here)
instead of the runner's hard-coded one-day fallback:

<img width="1568" height="734" alt="3502-ask-card" src="https://github.com/user-attachments/assets/3f5037c0-b2c1-4343-9a90-dca43e037080" />

The timeout path itself is pinned on both sides by the unit tests above,
plus the live verification in the Test Plan.

## Type of change

- [x] Bug fix
- [ ] - [ ] Feature
- [ ] - [ ] UI / frontend change
- [ ] - [ ] Refactor / chore
- [ ] - [ ] Docs
- [ ] - [ ] Test / CI
- [ ] - [ ] Breaking change
## Test coverage

- [x] Unit tests added / updated
- [ ] - [ ] Integration tests added / updated
- [ ] - [ ] E2E tests added / updated
- [ ] - [x] Manual verification completed
- [ ] - [ ] Existing tests cover this change
- [ ] - [ ] Not applicable
## Coverage notes

Manual verification: live k8s deployment with `ask_timeout: 3600` in the
agent's guardrails — the elicitation params returned on the MCP proxy path
carry `"timeoutSeconds": 3600` and the runner forwards it to the approval
wait, replacing the previous one-day fallback. The unit tests above cover
the wire contract on both sides.

## Changelog

A policy's `ask_timeout` now applies to approval prompts raised through the
MCP tool-call path, instead of the runner's one-day fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)