### PR TITLE
fix(hermes-native): let the user config hand external MCP servers to Hermes

### DIFF
--- a/omnigent/hermes_native_bridge.py
+++ b/omnigent/hermes_native_bridge.py
@@ -264,13 +264,16 @@ def build_hermes_native_spawn_env(session_id: str) -> dict[str, str]:
 
 
 # Keys from the user's ``~/.hermes/config.yaml`` that the per-session
-# HERMES_HOME needs in order to authenticate with the inference provider.
+# HERMES_HOME needs: inference auth plus operator-provisioned MCP servers
+# (``mcp_servers`` merges under the bridge's own entry; the agent spec's
+# ``tools:`` never reaches this harness).
 _USER_CONFIG_KEYS = frozenset(
     {
         "model",
         "providers",
         "fallback_providers",
         "credential_pool_strategies",
+        "mcp_servers",
     }
 )
 

--- a/tests/test_hermes_native_bridge.py
+++ b/tests/test_hermes_native_bridge.py
@@ -359,6 +359,34 @@ def test_write_policy_hook_config_merges_user_model(tmp_path, monkeypatch) -> No
     assert config["hooks_auto_accept"] is True
 
 
+def test_write_policy_hook_config_merges_user_mcp_servers(tmp_path, monkeypatch) -> None:
+    """User-declared ``mcp_servers`` must survive into the per-session config.
+
+    The agent spec's ``tools:`` never reaches the hermes-native harness, so
+    the user's ``~/.hermes/config.yaml`` is the only way to hand a Hermes
+    session operator-provisioned MCP servers. Dropping the key here silently
+    strips those servers.
+    """
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    user_hermes = tmp_path / ".hermes"
+    user_hermes.mkdir()
+
+    import yaml
+
+    (user_hermes / "config.yaml").write_text(
+        yaml.dump({"mcp_servers": {"github": {"command": "gh-mcp", "args": ["serve"]}}})
+    )
+
+    monkeypatch.setattr(b.Path, "home", staticmethod(lambda: tmp_path))
+
+    hermes_home = b.write_policy_hook_config(bridge_dir, "http://localhost:6767", "s3")
+    config = json.loads((hermes_home / "config.yaml").read_text())
+    assert config["mcp_servers"]["github"] == {"command": "gh-mcp", "args": ["serve"]}
+    # The bridge's own stdio server must still be registered alongside.
+    assert "omnigent" in config["mcp_servers"]
+
+
 def test_read_hermes_home_returns_path_when_exists(tmp_path) -> None:
     (tmp_path / "hermes_home").mkdir()
     assert b.read_hermes_home(tmp_path) == tmp_path / "hermes_home"


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The hermes-native harness never receives the agent spec's `tools:`
  section, so the only way to hand a Hermes session operator-provisioned
  MCP servers is the user's `~/.hermes/config.yaml`.
- `_USER_CONFIG_KEYS` — the whitelist of keys copied from that file into
  the per-session `HERMES_HOME` — did not include `mcp_servers`, so those
  declarations were silently dropped.
- The merge site already exists: `write_policy_hook_config` layers the
  bridge's own `omnigent` stdio server on top of `config.get("mcp_servers", {})`.
  Adding the key to the whitelist is all that was missing; the bridge's own
  entry still wins on name collision.

ELI5: you can list extra MCP servers (GitHub, Jira, …) in your Hermes
config file, but the per-session copy of that config forgot to carry the
list over — so the servers never showed up in the session. Now the list
rides along, and the built-in Omnigent server is still added on top.

## Test Plan

- `uv run pytest tests/test_hermes_native_bridge.py` — all green.
- New unit test `test_write_policy_hook_config_merges_user_mcp_servers`
  pins both properties: a user-declared server survives into the
  per-session `config.yaml`, and the bridge's own `omnigent` entry is
  still registered alongside it.

## Demo

Live hermes-native session on a patched deployment. The user's
`~/.hermes/config.yaml` declares three operator-provisioned MCP servers
(`data-governance`, `linear`, `mail`). Comparing the `mcp_servers` keys of
the user config vs the per-session `HERMES_HOME/config.yaml` from inside
the session:

```
USER mcp_servers:        ['data-governance', 'linear', 'mail']
PER-SESSION mcp_servers: ['data-governance', 'linear', 'mail', 'omnigent']
  <- /tmp/omnigent-*/hermes-native/<hash>/hermes_home/config.yaml
```

All three user-declared servers survive into the per-session config
(before this patch the list was `['omnigent']` only), and the bridge's own
`omnigent` entry is still layered on top:

<img width="1742" height="815" alt="3503-config-merge" src="https://github.com/user-attachments/assets/979d453c-a1b9-4d5f-83bf-166fe8ed6b20" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test covers the whitelist + merge contract end-to-end through
`write_policy_hook_config` (user config on disk → per-session
`HERMES_HOME/config.yaml`). Manual verification: see Demo — a
user-declared server reaches a live session's per-session config and its
tools are callable.

## Changelog

`mcp_servers` declared in the user's `~/.hermes/config.yaml` now reach
hermes-native sessions instead of being dropped from the per-session
config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
