### PR TITLE
feat(kiro-native): render live tool-call cards in the web chat UI

### DIFF
--- a/omnigent/kiro_native_session_forwarder.py
+++ b/omnigent/kiro_native_session_forwarder.py
@@ -35,8 +35,10 @@ import contextlib
 import json
 import logging
 import os
+import sqlite3
+import sys
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -83,6 +85,12 @@ class _ForwardState:
     turn_response_id: str | None = None
     turn_live: bool = False
     pending_call_ids: set[str] = field(default_factory=set)
+    # Which store the bound session lives in: ``sqlite`` (current kiro's
+    # conversations_v2, the ``chat --tui`` path), ``legacy_jsonl``
+    # (~/.kiro/sessions/cli/*.jsonl, kiro 2.8.1), or ``v3_jsonl``
+    # (~/.kiro/sessions/<hash>/sess_*/messages.jsonl). ``byte_offset`` is a byte
+    # cursor for the JSONL sources and a history index for sqlite.
+    source_kind: str | None = None
     # Keys of conversation items already posted for the record currently being
     # mirrored, persisted after each post and cleared when the cursor advances
     # past the record. Conversation items are not server-deduped, so a POST that
@@ -124,6 +132,13 @@ class KiroTranscriptRecord:
     :func:`parse_kiro_jsonl_line` remains the message-only projection of this
     (the stable contract offline import pins); tool vocabulary only appears
     here.
+
+    :param closes_turn: turn-close override for the mirror. ``None`` (grouped
+        formats: legacy JSONL, SQLite conversations_v2) infers the close from
+        "assistant record with no tool calls and none pending". ``False`` marks
+        a record that must never close the turn (kiro V3 emits prose as its own
+        ungrouped event, so intermediate narration must not settle the card).
+        The V3 ``turn_end`` uses the dedicated ``TurnEnd`` kind instead.
     """
 
     kind: str
@@ -131,6 +146,7 @@ class KiroTranscriptRecord:
     text: str
     tool_calls: tuple[KiroToolCall, ...] = ()
     tool_results: tuple[KiroToolResult, ...] = ()
+    closes_turn: bool | None = None
 
 
 _KiroConversationMessage = KiroConversationMessage
@@ -155,6 +171,7 @@ def _read_state(bridge_dir: Path) -> _ForwardState:
     turn_response_id = data.get("turn_response_id")
     pending = data.get("pending_call_ids")
     posted = data.get("posted_item_keys")
+    source_kind = data.get("source_kind")
     return _ForwardState(
         session_id=session_id if isinstance(session_id, str) and session_id else None,
         byte_offset=byte_offset if isinstance(byte_offset, int) and byte_offset >= 0 else 0,
@@ -171,6 +188,9 @@ def _read_state(bridge_dir: Path) -> _ForwardState:
             {entry for entry in posted if isinstance(entry, str) and entry}
             if isinstance(posted, list)
             else set()
+        ),
+        source_kind=(
+            source_kind if source_kind in ("sqlite", "legacy_jsonl", "v3_jsonl") else None
         ),
     )
 
@@ -190,6 +210,7 @@ def _write_state(bridge_dir: Path, state: _ForwardState) -> None:
                 "turn_live": state.turn_live,
                 "pending_call_ids": sorted(state.pending_call_ids),
                 "posted_item_keys": sorted(state.posted_item_keys),
+                "source_kind": state.source_kind,
             }
         ),
         encoding="utf-8",
@@ -586,6 +607,442 @@ def _extract_tool_results(content: object) -> tuple[KiroToolResult, ...]:
     return tuple(results)
 
 
+# ── Current kiro (>= ~2.9): SQLite conversations_v2 source ──────────────────
+#
+# kiro-cli 2.8.1 wrote ``~/.kiro/sessions/cli/<id>.jsonl`` records shaped
+# ``{kind: Prompt|AssistantMessage|ToolResults}`` (the JSONL source above).
+# Current kiro-cli (2.15.1, the ``chat --tui`` engine omnigent launches)
+# persists to SQLite instead: ``%LOCALAPPDATA%/kiro-cli/data.sqlite3`` (macOS
+# ``~/Library/Application Support/kiro-cli``, Linux ``~/.local/share/kiro-cli``),
+# table ``conversations_v2`` keyed by the workspace ``cwd``, ``value`` a
+# ConversationState JSON blob whose ``history`` is a list of turns:
+#   turn.user.content = {"Prompt": {"prompt": str}}
+#                     | {"ToolUseResults": {"tool_use_results":
+#                         [{"tool_use_id", "content", "status"}]}}
+#   turn.assistant    = {"ToolUse": {"message_id", "content",
+#                         "tool_uses": [{"id", "name", "args", ...}]}}
+#                     | {"Response": {"message_id", "content": str}}
+# Each turn normalizes to the same KiroTranscriptRecord stream the mirror
+# consumes, so the card/turn-lifecycle logic stays format-agnostic.
+
+_KIRO_DB_FILE = "data.sqlite3"
+_KIRO_DB_APP_DIR = "kiro-cli"
+_SQLITE_CALL_ID_KEYS = ("id", "tool_use_id", "toolUseId")
+_SQLITE_RESULT_ID_KEYS = ("tool_use_id", "id", "toolUseId")
+_SQLITE_NAME_KEYS = ("name", "orig_name", "toolName")
+
+
+def kiro_cli_database_path(home: Path | None = None, env: Mapping[str, str] | None = None) -> Path:
+    """Return kiro-cli's SQLite session store for this platform/user.
+
+    Honors ``KIRO_HOME`` first, then the per-platform app-data dir. Overridable
+    end-to-end via ``KIRO_HOME`` (tests, non-standard installs).
+    """
+    env = env if env is not None else os.environ
+    home = home or Path.home()
+    override = env.get("KIRO_HOME", "").strip()
+    if override:
+        return Path(override) / _KIRO_DB_APP_DIR / _KIRO_DB_FILE
+    if os.name == "nt":
+        base = env.get("LOCALAPPDATA", "").strip()
+        root = Path(base) if base else home / "AppData" / "Local"
+        return root / _KIRO_DB_APP_DIR / _KIRO_DB_FILE
+    if sys.platform == "darwin":
+        return home / "Library" / "Application Support" / _KIRO_DB_APP_DIR / _KIRO_DB_FILE
+    xdg = env.get("XDG_DATA_HOME", "").strip()
+    root = Path(xdg) if xdg else home / ".local" / "share"
+    return root / _KIRO_DB_APP_DIR / _KIRO_DB_FILE
+
+
+def _connect_kiro_db_ro(db_path: Path) -> sqlite3.Connection | None:
+    """Open the kiro SQLite store read-only, reading the live WAL, or ``None``.
+
+    ``mode=ro`` (not ``immutable=1``) so a live session's ``-wal`` sidecar is
+    read via the ``-shm``; a plain connection is the fallback for the rare
+    window where ``-shm`` is momentarily absent. Only SELECTs are issued.
+    Mirrors :func:`omnigent.goose_native_forwarder._connect_ro`.
+    """
+    for uri, kw in ((f"file:{db_path}?mode=ro", {"uri": True}), (str(db_path), {})):
+        try:
+            return sqlite3.connect(uri, timeout=5.0, **kw)
+        except sqlite3.Error:
+            continue
+    return None
+
+
+def _sqlite_tool_result_text(content: object) -> str:
+    """Flatten a conversations_v2 tool result's ``content`` into display text.
+
+    ``content`` is a list of tagged blocks: ``{"Text": str}`` or ``{"Json":
+    <obj>}`` (e.g. a shell result ``{"exit_status","stdout","stderr"}``). A bare
+    string is returned as is.
+    """
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        text = block.get("Text")
+        if isinstance(text, str) and text:
+            parts.append(text)
+        elif "Json" in block:
+            parts.append(json.dumps(block["Json"], ensure_ascii=True))
+    return "\n".join(parts)
+
+
+def _sqlite_tool_calls(tool_uses: object) -> tuple[KiroToolCall, ...]:
+    """Normalize conversations_v2 ``tool_uses`` into the shared call contract."""
+    if not isinstance(tool_uses, list):
+        return ()
+    calls: list[KiroToolCall] = []
+    for tu in tool_uses:
+        if not isinstance(tu, dict):
+            continue
+        call_id = _first_str(tu, _SQLITE_CALL_ID_KEYS)
+        if not call_id:
+            continue
+        name = _first_str(tu, _SQLITE_NAME_KEYS) or "tool"
+        args = tu.get("args")
+        if args is None:
+            args = tu.get("orig_args")
+        if isinstance(args, dict | list):
+            arguments = json.dumps(args, ensure_ascii=True)
+        elif isinstance(args, str) and args:
+            arguments = args
+        else:
+            arguments = "{}"
+        calls.append(KiroToolCall(call_id=call_id, name=name, arguments=arguments))
+    return tuple(calls)
+
+
+def _sqlite_tool_results(tool_use_results: object) -> tuple[KiroToolResult, ...]:
+    """Normalize conversations_v2 ``tool_use_results`` into the result contract."""
+    if not isinstance(tool_use_results, list):
+        return ()
+    results: list[KiroToolResult] = []
+    for r in tool_use_results:
+        if not isinstance(r, dict):
+            continue
+        call_id = _first_str(r, _SQLITE_RESULT_ID_KEYS)
+        if not call_id:
+            continue
+        results.append(
+            KiroToolResult(call_id=call_id, output=_sqlite_tool_result_text(r.get("content")))
+        )
+    return tuple(results)
+
+
+def _sqlite_assistant_record(assistant: dict[str, object]) -> KiroTranscriptRecord | None:
+    """Normalize a conversations_v2 turn's assistant side into a record."""
+    tool_use = assistant.get("ToolUse")
+    if isinstance(tool_use, dict):
+        text = tool_use.get("content")
+        return KiroTranscriptRecord(
+            kind="AssistantMessage",
+            message_id=tool_use.get("message_id")
+            if isinstance(tool_use.get("message_id"), str)
+            else "",
+            text=text if isinstance(text, str) else "",
+            tool_calls=_sqlite_tool_calls(tool_use.get("tool_uses")),
+        )
+    response = assistant.get("Response")
+    if isinstance(response, dict):
+        text = response.get("content")
+        return KiroTranscriptRecord(
+            kind="AssistantMessage",
+            message_id=response.get("message_id")
+            if isinstance(response.get("message_id"), str)
+            else "",
+            text=text if isinstance(text, str) else "",
+        )
+    return None
+
+
+def _kiro_records_from_conversation(
+    conversation_id: str,
+    history: object,
+    start_index: int,
+) -> tuple[list[tuple[KiroTranscriptRecord, int]], int]:
+    """Normalize conversations_v2 ``history`` turns past *start_index*.
+
+    Emits the user side then the assistant side of each finished turn (one with
+    both sides written), which maps onto the same Prompt / AssistantMessage /
+    ToolResults stream the JSONL source produces. Stops at the first turn whose
+    assistant side is not yet written (a turn still streaming), holding the
+    cursor there so it is re-read once kiro finishes it.
+
+    Returns the shared ``(list[(record, cursor_after)], batch_end)`` contract
+    where the cursor is the history index. Within one entry only the LAST
+    record advances the index; earlier records carry the entry's start index so
+    a mid-entry POST failure re-reads the whole entry (item dedup skips what
+    already landed) rather than skipping its unposted tail. The Prompt id is
+    synthesized from the stable ``{conversation_id}:{index}`` position so the
+    turn anchor is deterministic across re-reads even though the user side
+    carries no id of its own.
+    """
+    if not isinstance(history, list):
+        return [], start_index
+    out: list[tuple[KiroTranscriptRecord, int]] = []
+    index = max(0, start_index)
+    for turn in history[index:]:
+        if not isinstance(turn, dict):
+            index += 1
+            continue
+        assistant = turn.get("assistant")
+        if not isinstance(assistant, dict) or not assistant:
+            # Turn still being written (no assistant side yet): hold the cursor.
+            break
+        entry: list[KiroTranscriptRecord] = []
+        user = turn.get("user")
+        user_content = user.get("content") if isinstance(user, dict) else None
+        if isinstance(user_content, dict):
+            prompt = user_content.get("Prompt")
+            tool_results_wrap = user_content.get("ToolUseResults")
+            if isinstance(prompt, dict) and isinstance(prompt.get("prompt"), str):
+                entry.append(
+                    KiroTranscriptRecord(
+                        kind="Prompt",
+                        message_id=f"{conversation_id}:{index}",
+                        text=prompt["prompt"],
+                    )
+                )
+            elif isinstance(tool_results_wrap, dict):
+                tool_results = _sqlite_tool_results(tool_results_wrap.get("tool_use_results"))
+                if tool_results:
+                    entry.append(
+                        KiroTranscriptRecord(
+                            kind="ToolResults", message_id="", text="", tool_results=tool_results
+                        )
+                    )
+        assistant_record = _sqlite_assistant_record(assistant)
+        if assistant_record is not None:
+            entry.append(assistant_record)
+        for offset_in_entry, record in enumerate(entry):
+            cursor_after = index if offset_in_entry < len(entry) - 1 else index + 1
+            out.append((record, cursor_after))
+        index += 1
+    return out, index
+
+
+def _kiro_conversation_row(con: sqlite3.Connection, workspace: str) -> tuple[str, str] | None:
+    """Return ``(conversation_id, value)`` for the conversation bound to *workspace*.
+
+    ``conversations_v2.key`` is the conversation's cwd. Match it to the runner
+    workspace by resolved path (via :func:`_same_workspace`) so a trailing-slash
+    or case difference still binds.
+    """
+    try:
+        rows = con.execute(
+            "SELECT key, conversation_id, value FROM conversations_v2 ORDER BY updated_at DESC"
+        ).fetchall()
+    except sqlite3.Error:
+        return None
+    for key, conversation_id, value in rows:
+        if _same_workspace(key, workspace) and isinstance(value, str):
+            return (conversation_id if isinstance(conversation_id, str) else "", value)
+    return None
+
+
+def _read_kiro_sqlite_records(
+    db_path: Path,
+    workspace: str,
+    history_index: int,
+) -> tuple[list[KiroTranscriptRecord], int]:
+    """Read new conversations_v2 turns for *workspace* past *history_index*.
+
+    Returns ``([], history_index)`` on any read error or when the DB / row is
+    absent (the caller retries next poll), mirroring the JSONL reader's
+    hold-and-retry contract.
+    """
+    con = _connect_kiro_db_ro(db_path)
+    if con is None:
+        return [], history_index
+    try:
+        row = _kiro_conversation_row(con, workspace)
+        if row is None:
+            return [], history_index
+        conversation_id, value = row
+        try:
+            state = json.loads(value)
+        except (TypeError, ValueError):
+            return [], history_index
+        history = state.get("history") if isinstance(state, dict) else None
+        return _kiro_records_from_conversation(conversation_id, history, history_index)
+    except sqlite3.Error:
+        return [], history_index
+    finally:
+        con.close()
+
+
+# ── kiro V3 agent (ACP): messages.jsonl source ──────────────────────────────
+#
+# The V3 agent (``chat --agent-engine v3``, the shared harness with Kiro
+# IDE/Web) streams an append-only event log to
+# ``~/.kiro/sessions/<workspace-hash>/sess_<uuid>/messages.jsonl``, one record
+# per line shaped ``{id, timestamp, payload: {type, ...}}``. Relevant payload
+# types map onto the shared record stream, but V3 emits prose, tool calls, and
+# tool results as SEPARATE events (ungrouped), so an assistant prose event
+# carries ``closes_turn=False`` and the explicit ``turn_end`` becomes a
+# ``TurnEnd`` record; the grouped-format close heuristic would otherwise settle
+# the card on intermediate narration.
+#   user        -> Prompt (content)                       [opens the turn]
+#   assistant   -> AssistantMessage (content, no close)   [prose]
+#   tool_call   -> AssistantMessage + one function_call   [toolCallId,toolName,args]
+#   tool_result -> ToolResults (one result)               [toolCallId, content]
+#   turn_end    -> TurnEnd                                 [settles the card]
+# Other types (turn_start, session_*, *_interaction, usage_summary) are skipped.
+
+_V3_TOOL_ID_KEY = "toolCallId"
+
+
+def kiro_v3_sessions_dir(home: Path | None = None) -> Path:
+    """Return the root of kiro V3's per-session directories for this user."""
+    return (home or Path.home()) / ".kiro" / "sessions"
+
+
+def parse_kiro_v3_line(line: str) -> KiroTranscriptRecord | None:
+    """Parse one kiro V3 ``messages.jsonl`` line into a transcript record."""
+    try:
+        record = json.loads(line)
+    except ValueError:
+        return None
+    if not isinstance(record, dict):
+        return None
+    record_id = record.get("id") if isinstance(record.get("id"), str) else ""
+    payload = record.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    ptype = payload.get("type")
+    if ptype == "user":
+        content = payload.get("content")
+        if not isinstance(content, str) or not content:
+            return None
+        return KiroTranscriptRecord(kind="Prompt", message_id=record_id, text=content)
+    if ptype == "assistant":
+        content = payload.get("content")
+        return KiroTranscriptRecord(
+            kind="AssistantMessage",
+            message_id=record_id,
+            text=content if isinstance(content, str) else "",
+            closes_turn=False,
+        )
+    if ptype == "tool_call":
+        call_id = payload.get(_V3_TOOL_ID_KEY)
+        if not isinstance(call_id, str) or not call_id:
+            return None
+        name = payload.get("toolName")
+        args = payload.get("args")
+        if isinstance(args, dict | list):
+            arguments = json.dumps(args, ensure_ascii=True)
+        elif isinstance(args, str) and args:
+            arguments = args
+        else:
+            arguments = "{}"
+        return KiroTranscriptRecord(
+            kind="AssistantMessage",
+            message_id=record_id,
+            text="",
+            tool_calls=(
+                KiroToolCall(
+                    call_id=call_id,
+                    name=name if isinstance(name, str) and name else "tool",
+                    arguments=arguments,
+                ),
+            ),
+        )
+    if ptype == "tool_result":
+        call_id = payload.get(_V3_TOOL_ID_KEY)
+        if not isinstance(call_id, str) or not call_id:
+            return None
+        content = payload.get("content")
+        if isinstance(content, str):
+            output = content
+        elif content:
+            output = _kiro_content_text(content) or json.dumps(content, ensure_ascii=True)
+        else:
+            output = ""
+        return KiroTranscriptRecord(
+            kind="ToolResults",
+            message_id="",
+            text="",
+            tool_results=(KiroToolResult(call_id=call_id, output=output),),
+        )
+    if ptype == "turn_end":
+        return KiroTranscriptRecord(kind="TurnEnd", message_id=record_id, text="")
+    return None
+
+
+def _read_new_kiro_v3_records(
+    jsonl_path: Path,
+    byte_offset: int,
+) -> tuple[list[tuple[KiroTranscriptRecord, int]], int]:
+    """Read new V3 ``messages.jsonl`` records after *byte_offset*.
+
+    Same ``(list[(record, cursor_after)], batch_end)`` contract and
+    hold-at-last-complete-line discipline as :func:`_read_new_kiro_records`, so
+    a record still being written is re-read once complete.
+    """
+    records: list[tuple[KiroTranscriptRecord, int]] = []
+    try:
+        with jsonl_path.open("rb") as handle:
+            handle.seek(byte_offset)
+            offset = byte_offset
+            for raw_line in handle:
+                if not raw_line.endswith(b"\n"):
+                    break
+                offset += len(raw_line)
+                try:
+                    line = raw_line.decode("utf-8")
+                except UnicodeDecodeError:
+                    continue
+                record = parse_kiro_v3_line(line)
+                if record is not None:
+                    records.append((record, offset))
+            return records, offset
+    except OSError:
+        return [], byte_offset
+
+
+def _discover_kiro_v3_messages(
+    *,
+    workspace: str,
+    launch_epoch_ms: int,
+    sessions_dir: Path | None = None,
+) -> Path | None:
+    """Find this workspace's newest V3 ``messages.jsonl``, unambiguously.
+
+    V3 nests sessions as ``<workspace-hash>/sess_<uuid>/messages.jsonl`` with a
+    sibling ``session.json`` carrying ``cwd``. Bind the unique in-window session
+    whose ``cwd`` matches the workspace; return ``None`` on zero or ambiguous
+    matches (the caller retries), matching the legacy discovery's caution.
+    """
+    root = sessions_dir or kiro_v3_sessions_dir()
+    if not root.is_dir():
+        return None
+    floor_ms = max(0, launch_epoch_ms - _DISCOVERY_SKEW_MS)
+    matches: list[Path] = []
+    for session_json in root.glob("*/sess_*/session.json"):
+        messages = session_json.with_name("messages.jsonl")
+        if not messages.is_file():
+            continue
+        try:
+            meta = json.loads(session_json.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(meta, dict) or not _same_workspace(meta.get("cwd"), workspace):
+            continue
+        created_ms = _parse_iso_epoch_ms(meta.get("created_at") or meta.get("createdAt"))
+        if created_ms and created_ms < floor_ms:
+            continue
+        matches.append(messages)
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
 async def _post_conversation_message(
     client: httpx.AsyncClient,
     *,
@@ -925,6 +1382,18 @@ async def _mirror_record(
             )
         return
 
+    if record.kind == "TurnEnd":
+        # An explicit end-of-turn signal (kiro V3 ``turn_end``). Settle the card
+        # without re-opening it (unlike an empty assistant record, this never
+        # posts ``running`` first) and only when no tool call is still pending;
+        # an interrupted turn with an outstanding call falls to the backstop.
+        if state.turn_live and state.turn_response_id and not state.pending_call_ids:
+            await post_external_session_status(
+                client, session_id=session_id, status="idle", response_id=state.turn_response_id
+            )
+            state.turn_live = False
+        return
+
     if state.turn_response_id is None:
         # Forwarder attached mid-turn (its Prompt is behind the cursor or was
         # never seen): anchor the turn to the first record observed instead.
@@ -967,10 +1436,15 @@ async def _mirror_record(
                     call=call,
                 ),
             )
-        # Kiro's agent loop keeps stepping while the model returns tool uses
-        # and stops on a plain reply, so an assistant prose record with no tool
-        # uses (and none outstanding) is the authoritative end of the turn.
-        if not record.tool_calls and not state.pending_call_ids:
+        # Grouped formats (legacy JSONL, SQLite): kiro's agent loop keeps
+        # stepping while the model returns tool uses and stops on a plain reply,
+        # so an assistant prose record with no tool uses (and none outstanding)
+        # is the authoritative end of the turn. Ungrouped V3 sets
+        # ``closes_turn=False`` on its prose events (its ``turn_end`` closes via
+        # the TurnEnd kind), so intermediate narration never settles the card.
+        infer_close = not record.tool_calls and not state.pending_call_ids
+        should_close = infer_close if record.closes_turn is None else record.closes_turn
+        if should_close and not state.pending_call_ids:
             await post_external_session_status(
                 client, session_id=session_id, status="idle", response_id=response_id
             )
@@ -990,6 +1464,121 @@ async def _mirror_record(
         )
 
 
+# ── Source detection + dispatch ─────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class _KiroBinding:
+    """A bound kiro session source: which store and how to reach it.
+
+    :param source_kind: ``sqlite`` | ``legacy_jsonl`` | ``v3_jsonl``.
+    :param session_id: conversation_id (sqlite) or kiro session id (jsonl).
+    :param path: the transcript path for the JSONL sources; ``None`` for sqlite
+        (the conversation is re-resolved by cwd against the DB each read).
+    """
+
+    source_kind: str
+    session_id: str
+    path: Path | None
+
+
+def _discover_kiro_sqlite_conversation(
+    workspace: str, *, db_path: Path | None = None
+) -> str | None:
+    """Return the conversation_id bound to *workspace* in the SQLite store, else None."""
+    db = db_path if db_path is not None else kiro_cli_database_path()
+    if not db.exists():
+        return None
+    con = _connect_kiro_db_ro(db)
+    if con is None:
+        return None
+    try:
+        row = _kiro_conversation_row(con, workspace)
+        return row[0] if row is not None and row[0] else None
+    except sqlite3.Error:
+        return None
+    finally:
+        con.close()
+
+
+def _bind_kiro_source(
+    *,
+    workspace: str,
+    launch_epoch_ms: int,
+    expected_session_id: str | None,
+    known_session_id: str | None,
+    known_source_kind: str | None,
+    db_path: Path | None = None,
+    sessions_dir: Path | None = None,
+    v3_sessions_dir: Path | None = None,
+) -> _KiroBinding | None:
+    """Detect and bind the kiro session source for this workspace.
+
+    A resume id (``expected_session_id``) is always a legacy JSONL session and
+    is bound directly (waiting for it rather than falling back, so a resume
+    never latches a different session). A restart rebinds the already-bound
+    source kind by id (legacy JSONL) or by cwd (sqlite / v3) before general
+    detection, so a second same-workspace session cannot strand the open card.
+    Fresh detection priority reflects current kiro: legacy 2.8.1 ``cli/*.jsonl``
+    (launch-window filtered, so a stale old session is skipped), then the
+    SQLite ``conversations_v2`` store the ``chat --tui`` engine writes, then the
+    V3 ``messages.jsonl``.
+    """
+    if expected_session_id:
+        path = _kiro_session_jsonl_for_id(
+            expected_session_id, workspace=workspace, sessions_dir=sessions_dir
+        )
+        return _KiroBinding("legacy_jsonl", expected_session_id, path) if path else None
+    if known_source_kind == "legacy_jsonl" and known_session_id:
+        path = _kiro_session_jsonl_for_id(
+            known_session_id, workspace=workspace, sessions_dir=sessions_dir
+        )
+        if path is not None:
+            return _KiroBinding("legacy_jsonl", known_session_id, path)
+    if known_source_kind == "sqlite":
+        conv = _discover_kiro_sqlite_conversation(workspace, db_path=db_path)
+        if conv is not None:
+            return _KiroBinding("sqlite", conv, None)
+    if known_source_kind == "v3_jsonl":
+        v3 = _discover_kiro_v3_messages(
+            workspace=workspace, launch_epoch_ms=launch_epoch_ms, sessions_dir=v3_sessions_dir
+        )
+        if v3 is not None:
+            return _KiroBinding("v3_jsonl", v3.parent.name, v3)
+    legacy = _discover_kiro_session_jsonl(
+        workspace=workspace, launch_epoch_ms=launch_epoch_ms, sessions_dir=sessions_dir
+    )
+    if legacy is not None:
+        return _KiroBinding("legacy_jsonl", legacy[0], legacy[1])
+    conv = _discover_kiro_sqlite_conversation(workspace, db_path=db_path)
+    if conv is not None:
+        return _KiroBinding("sqlite", conv, None)
+    v3 = _discover_kiro_v3_messages(
+        workspace=workspace, launch_epoch_ms=launch_epoch_ms, sessions_dir=v3_sessions_dir
+    )
+    if v3 is not None:
+        return _KiroBinding("v3_jsonl", v3.parent.name, v3)
+    return None
+
+
+def _read_kiro_source_records(
+    state: _ForwardState,
+    *,
+    workspace: str,
+    source_path: Path | None,
+    db_path: Path | None = None,
+) -> tuple[list[tuple[KiroTranscriptRecord, int]], int]:
+    """Read new records from the bound source, in the shared cursor contract."""
+    if state.source_kind == "sqlite":
+        db = db_path if db_path is not None else kiro_cli_database_path()
+        return _read_kiro_sqlite_records(db, workspace, state.byte_offset)
+    if state.source_kind == "v3_jsonl" and source_path is not None:
+        return _read_new_kiro_v3_records(source_path, state.byte_offset)
+    if source_path is not None:
+        return _read_new_kiro_records(source_path, state.byte_offset)
+    return [], state.byte_offset
+
+
 async def forward_kiro_session_to_omnigent(
     *,
     base_url: str,
@@ -1003,9 +1592,16 @@ async def forward_kiro_session_to_omnigent(
     poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
     auth: httpx.Auth | None = None,
 ) -> None:
-    """Tail Kiro's session JSONL and mirror messages + live tool-call cards."""
+    """Tail kiro's session store and mirror messages + live tool-call cards.
+
+    Reads whichever format the running kiro writes: the SQLite
+    ``conversations_v2`` store (current kiro's ``chat --tui`` engine), the
+    legacy ``~/.kiro/sessions/cli/*.jsonl`` (kiro 2.8.1), or the V3
+    ``messages.jsonl``. All normalize to one KiroTranscriptRecord stream, so the
+    turn-lifecycle / card logic below is format-agnostic.
+    """
     state = _read_state(bridge_dir)
-    jsonl_path: Path | None = None
+    source_path: Path | None = None
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
     mirrored_external_session_id: str | None = None
     last_posted_cost: float | None = None
@@ -1018,57 +1614,47 @@ async def forward_kiro_session_to_omnigent(
     ) as client:
         while True:
             try:
-                if state.session_id is None or jsonl_path is None or not jsonl_path.exists():
-                    discovered: tuple[str, Path] | None = None
-                    if expected_session_id:
-                        expected_path = await asyncio.to_thread(
-                            _kiro_session_jsonl_for_id,
-                            expected_session_id,
-                            workspace=workspace,
-                        )
-                        if expected_path is not None:
-                            discovered = (expected_session_id, expected_path)
-                    else:
-                        # A restart drops the local jsonl_path but not the
-                        # persisted session_id. Rebind to that already-bound id
-                        # directly instead of re-running ambiguity-sensitive
-                        # discovery: with a second same-workspace kiro session
-                        # present, discovery returns None and the read/close
-                        # block below (gated on jsonl_path) never runs, so an
-                        # open turn's live card is stranded. The bound id is
-                        # authoritative; only fall through to discovery for a
-                        # genuinely new session when its file is gone.
-                        if state.session_id is not None:
-                            known_path = await asyncio.to_thread(
-                                _kiro_session_jsonl_for_id,
-                                state.session_id,
-                                workspace=workspace,
-                            )
-                            if known_path is not None:
-                                discovered = (state.session_id, known_path)
-                        if discovered is None:
-                            discovered = await asyncio.to_thread(
-                                _discover_kiro_session_jsonl,
-                                workspace=workspace,
-                                launch_epoch_ms=launch_epoch_ms,
-                            )
-                    if discovered is not None:
-                        discovered_session_id, discovered_path = discovered
-                        if state.session_id != discovered_session_id:
+                # Rebind when unbound, or when a JSONL source's file went away (a
+                # restart drops the local path). SQLite stays bound once found
+                # (it is re-resolved by cwd against the DB on every read).
+                needs_bind = state.source_kind is None or state.session_id is None
+                if state.source_kind in ("legacy_jsonl", "v3_jsonl") and (
+                    source_path is None or not source_path.exists()
+                ):
+                    needs_bind = True
+                if needs_bind:
+                    binding = await asyncio.to_thread(
+                        _bind_kiro_source,
+                        workspace=workspace,
+                        launch_epoch_ms=launch_epoch_ms,
+                        expected_session_id=expected_session_id,
+                        known_session_id=state.session_id,
+                        known_source_kind=state.source_kind,
+                    )
+                    if binding is not None:
+                        if (
+                            state.session_id != binding.session_id
+                            or state.source_kind != binding.source_kind
+                        ):
                             if state.turn_live and state.turn_response_id:
-                                # Rebinding to a different Kiro session strands
-                                # the old turn's card; settle it before switching.
+                                # Rebinding to a different session strands the
+                                # old turn's card; settle it before switching.
                                 await post_external_session_status(
                                     client,
                                     session_id=session_id,
                                     status="idle",
                                     response_id=state.turn_response_id,
                                 )
-                            state = _ForwardState(session_id=discovered_session_id, byte_offset=0)
+                            state = _ForwardState(
+                                session_id=binding.session_id,
+                                byte_offset=0,
+                                source_kind=binding.source_kind,
+                            )
                             _write_state(bridge_dir, state)
                             last_turn_activity_ts = None
-                        jsonl_path = discovered_path
-                if jsonl_path is not None and state.session_id is not None:
+                        source_path = binding.path
+                bound = state.session_id is not None and state.source_kind is not None
+                if bound and (state.source_kind == "sqlite" or source_path is not None):
                     if mirrored_external_session_id != state.session_id:
                         await _patch_external_session_id(
                             client,
@@ -1077,9 +1663,10 @@ async def forward_kiro_session_to_omnigent(
                         )
                         mirrored_external_session_id = state.session_id
                     records, batch_end_offset = await asyncio.to_thread(
-                        _read_new_kiro_records,
-                        jsonl_path,
-                        state.byte_offset,
+                        _read_kiro_source_records,
+                        state,
+                        workspace=workspace,
+                        source_path=source_path,
                     )
                     for record, record_end_offset in records:
                         # Mirror the transcript plus id-bearing card edges only.
@@ -1113,11 +1700,18 @@ async def forward_kiro_session_to_omnigent(
                             # Any transcript record while a turn is open proves
                             # kiro is alive; only true silence trips the backstop.
                             last_turn_activity_ts = _turn_monotonic()
+                        cursor_advanced = record_end_offset != state.byte_offset
                         state.byte_offset = record_end_offset
-                        # The record is fully mirrored and the cursor has moved
-                        # past it, so its posted-item keys are dead weight; drop
-                        # them to bound the set to the in-flight record.
-                        state.posted_item_keys.clear()
+                        # Drop the posted-item keys only once the cursor has moved
+                        # PAST the record's resumable boundary, so the set is
+                        # bounded but nothing is cleared while its unit can still
+                        # be re-read. For JSONL each record is its own boundary
+                        # (the offset always advances). For SQLite a history entry
+                        # spans two records sharing one boundary: the first
+                        # record's cursor does not advance, so its keys must
+                        # survive until the entry's last record clears them.
+                        if cursor_advanced:
+                            state.posted_item_keys.clear()
                         _write_state(bridge_dir, state)
                     if batch_end_offset != state.byte_offset:
                         # Skipped tail bytes (unparseable/foreign records) still
@@ -1142,35 +1736,37 @@ async def forward_kiro_session_to_omnigent(
                         _write_state(bridge_dir, state)
                     write_forwarder_ready(bridge_dir)
                     # Forward kiro's credit metering as authoritative session
-                    # cost. It lives in the ``.json`` snapshot (sibling of the
-                    # tailed ``.jsonl``), not the transcript, and is cumulative;
-                    # the server treats ``cumulative_cost_usd`` as monotonic, so
-                    # only post when it advances.
-                    cumulative_cost, cost_model = await asyncio.to_thread(
-                        _read_kiro_cumulative_credits, jsonl_path.with_suffix(".json")
+                    # cost and mirror its current model. Both live in the legacy
+                    # ``.json`` snapshot beside the tailed ``.jsonl`` (kiro 2.8.1
+                    # only). Current kiro carries the same fields inside the
+                    # SQLite / V3 stores; wiring cost+model there is a follow-up,
+                    # so skip it for those sources rather than read a sidecar
+                    # that does not exist.
+                    sidecar = (
+                        source_path.with_suffix(".json")
+                        if state.source_kind == "legacy_jsonl" and source_path is not None
+                        else None
                     )
-                    if cumulative_cost is not None and (
-                        last_posted_cost is None or cumulative_cost > last_posted_cost
-                    ):
-                        await _post_session_cost(
-                            client,
-                            session_id=session_id,
-                            cumulative_cost_usd=cumulative_cost,
-                            model=cost_model,
+                    if sidecar is not None:
+                        cumulative_cost, cost_model = await asyncio.to_thread(
+                            _read_kiro_cumulative_credits, sidecar
                         )
-                        last_posted_cost = cumulative_cost
-                    # Mirror kiro's current model so the web picker shows the real
-                    # model (not the harness name) at launch and after a live
-                    # ``/model`` switch. Read independently of metering so it is
-                    # available before the first turn; posted only when it changes.
-                    current_model = await asyncio.to_thread(
-                        _read_kiro_current_model, jsonl_path.with_suffix(".json")
-                    )
-                    if current_model is not None and current_model != last_posted_model:
-                        await _post_external_model_change(
-                            client, session_id=session_id, model=current_model
-                        )
-                        last_posted_model = current_model
+                        if cumulative_cost is not None and (
+                            last_posted_cost is None or cumulative_cost > last_posted_cost
+                        ):
+                            await _post_session_cost(
+                                client,
+                                session_id=session_id,
+                                cumulative_cost_usd=cumulative_cost,
+                                model=cost_model,
+                            )
+                            last_posted_cost = cumulative_cost
+                        current_model = await asyncio.to_thread(_read_kiro_current_model, sidecar)
+                        if current_model is not None and current_model != last_posted_model:
+                            await _post_external_model_change(
+                                client, session_id=session_id, model=current_model
+                            )
+                            last_posted_model = current_model
             except asyncio.CancelledError:
                 raise
             except Exception:

--- a/omnigent/kiro_native_session_forwarder.py
+++ b/omnigent/kiro_native_session_forwarder.py
@@ -4,6 +4,28 @@ Kiro CLI persists chat turns under ``~/.kiro/sessions/cli`` as session metadata
 plus JSONL message records. The native Kiro terminal path injects web prompts
 into the TUI; this forwarder mirrors Kiro's persisted assistant messages back
 into the Omnigent conversation with ``external_conversation_item`` events.
+
+**Live tool-call cards**: when a persisted ``AssistantMessage`` record carries
+``toolUse`` content blocks the forwarder emits ``function_call`` /
+``function_call_output`` items stamped with a per-turn ``response_id``
+(``kiro:turn:{prompt_message_id}``, anchored to the turn's opening ``Prompt``
+record — Kiro's transcript has an explicit turn opener, so the id is known
+before any assistant activity). A ``running`` status edge carrying the same id
+is POSTed before the turn's first mirrored item. The closing ``idle`` edge is
+posted when the turn's final prose record lands (Kiro's agent loop ends on an
+assistant reply with no tool uses and none outstanding), when the next
+``Prompt`` record arrives, or — as a backstop for turns that died without
+either (TUI interrupt, kiro-cli crash) — after :data:`_STALLED_TURN_IDLE_S` of
+transcript inactivity. Open-turn state is persisted alongside the byte cursor,
+so a supervisor restart resumes the turn under its original id instead of
+splitting the streaming group or stranding a spinner.
+
+The PTY-activity watcher continues to drive the generic session-level
+running/idle badge (id-less); the id-bearing edges here drive only the
+streaming lifecycle of the individual tool-call bubbles, matching the
+goose-native forwarder. The #1137 rule stands as: this forwarder never posts
+an *id-less* session status (double-sourcing the session badge was that bug);
+every edge it posts carries a ``response_id``.
 """
 
 from __future__ import annotations
@@ -14,12 +36,13 @@ import json
 import logging
 import os
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
 import httpx
 
+from omnigent._native_post_delivery import post_external_session_status
 from omnigent.kiro_native_bridge import write_forwarder_ready
 
 _logger = logging.getLogger(__name__)
@@ -29,6 +52,14 @@ _POST_TIMEOUT_S = 30.0
 _DISCOVERY_SKEW_MS = 10_000
 _STATE_FILE = "kiro_session_forwarder.json"
 
+#: Seconds of transcript inactivity after which an open turn's live card is
+#: closed. This is only a backstop for turns that died without their normal
+#: close (the final prose record or the next ``Prompt``) — e.g. a TUI interrupt
+#: or a kiro-cli crash. Minutes, not seconds: a legitimately long tool call
+#: appends no transcript records while it runs, and closing early makes the
+#: spinner flicker on exactly the calls the live card is most useful for.
+_STALLED_TURN_IDLE_S = 300.0
+
 _SUPERVISOR_INITIAL_BACKOFF_S = 1.0
 _SUPERVISOR_MAX_BACKOFF_S = 30.0
 _SUPERVISOR_HEALTHY_UPTIME_S = 60.0
@@ -36,10 +67,21 @@ _SUPERVISOR_HEALTHY_UPTIME_S = 60.0
 
 @dataclass
 class _ForwardState:
-    """Durable cursor for one Kiro JSONL session file."""
+    """Durable cursor + open-turn card state for one Kiro JSONL session file.
+
+    The turn fields persist with the byte cursor so a restart mid-turn neither
+    mints a fresh turn id (splitting the streaming group of items already
+    posted under the original id) nor re-posts ``running`` for a turn whose
+    edge already went out — and a ``running`` the previous run posted can still
+    be closed. Kiro's transcript is the only store, so persisting the derived
+    state is simpler and cheaper than a goose-style open-turn replay.
+    """
 
     session_id: str | None = None
     byte_offset: int = 0
+    turn_response_id: str | None = None
+    turn_live: bool = False
+    pending_call_ids: set[str] = field(default_factory=set)
 
 
 @dataclass(frozen=True)
@@ -49,6 +91,39 @@ class KiroConversationMessage:
     message_id: str
     role: str
     text: str
+
+
+@dataclass(frozen=True)
+class KiroToolCall:
+    """One ``toolUse`` content block from an ``AssistantMessage`` record."""
+
+    call_id: str
+    name: str
+    arguments: str
+
+
+@dataclass(frozen=True)
+class KiroToolResult:
+    """One tool-result content block from a ``ToolResults`` record."""
+
+    call_id: str
+    output: str
+
+
+@dataclass(frozen=True)
+class KiroTranscriptRecord:
+    """One parsed transcript record — the superset the live mirror consumes.
+
+    :func:`parse_kiro_jsonl_line` remains the message-only projection of this
+    (the stable contract offline import pins); tool vocabulary only appears
+    here.
+    """
+
+    kind: str
+    message_id: str
+    text: str
+    tool_calls: tuple[KiroToolCall, ...] = ()
+    tool_results: tuple[KiroToolResult, ...] = ()
 
 
 _KiroConversationMessage = KiroConversationMessage
@@ -70,9 +145,20 @@ def _read_state(bridge_dir: Path) -> _ForwardState:
         return _ForwardState()
     session_id = data.get("session_id")
     byte_offset = data.get("byte_offset")
+    turn_response_id = data.get("turn_response_id")
+    pending = data.get("pending_call_ids")
     return _ForwardState(
         session_id=session_id if isinstance(session_id, str) and session_id else None,
         byte_offset=byte_offset if isinstance(byte_offset, int) and byte_offset >= 0 else 0,
+        turn_response_id=(
+            turn_response_id if isinstance(turn_response_id, str) and turn_response_id else None
+        ),
+        turn_live=data.get("turn_live") is True,
+        pending_call_ids=(
+            {entry for entry in pending if isinstance(entry, str) and entry}
+            if isinstance(pending, list)
+            else set()
+        ),
     )
 
 
@@ -83,7 +169,15 @@ def _write_state(bridge_dir: Path, state: _ForwardState) -> None:
         os.chmod(bridge_dir, 0o700)
     tmp = bridge_dir / (_STATE_FILE + ".tmp")
     tmp.write_text(
-        json.dumps({"session_id": state.session_id, "byte_offset": state.byte_offset}),
+        json.dumps(
+            {
+                "session_id": state.session_id,
+                "byte_offset": state.byte_offset,
+                "turn_response_id": state.turn_response_id,
+                "turn_live": state.turn_live,
+                "pending_call_ids": sorted(state.pending_call_ids),
+            }
+        ),
         encoding="utf-8",
     )
     os.replace(tmp, bridge_dir / _STATE_FILE)
@@ -218,12 +312,17 @@ def _kiro_session_jsonl_for_id(
     return jsonl_path
 
 
-def _read_new_kiro_messages(
+def _read_new_kiro_records(
     jsonl_path: Path,
     byte_offset: int,
-) -> tuple[list[KiroConversationMessage], int]:
-    """Read conversation messages after *byte_offset* from Kiro's JSONL file."""
-    messages: list[KiroConversationMessage] = []
+) -> tuple[list[tuple[KiroTranscriptRecord, int]], int]:
+    """Read parsed records after *byte_offset*, each paired with its end offset.
+
+    The per-record end offsets let the mirror loop persist the cursor after
+    each record's items are posted (goose's per-row cursor discipline), so a
+    crash mid-batch re-reads at most one record instead of the whole batch.
+    """
+    records: list[tuple[KiroTranscriptRecord, int]] = []
     try:
         with jsonl_path.open("rb") as handle:
             handle.seek(byte_offset)
@@ -241,16 +340,47 @@ def _read_new_kiro_messages(
                     line = raw_line.decode("utf-8")
                 except UnicodeDecodeError:
                     continue
-                message = parse_kiro_jsonl_line(line)
-                if message is not None:
-                    messages.append(message)
-            return messages, offset
+                record = parse_kiro_jsonl_record(line)
+                if record is not None:
+                    records.append((record, offset))
+            return records, offset
     except OSError:
         return [], byte_offset
 
 
-def parse_kiro_jsonl_line(line: str) -> KiroConversationMessage | None:
-    """Parse one Kiro JSONL line into the stable shared message contract."""
+def _read_new_kiro_messages(
+    jsonl_path: Path,
+    byte_offset: int,
+) -> tuple[list[KiroConversationMessage], int]:
+    """Read conversation messages after *byte_offset* from Kiro's JSONL file.
+
+    Message-only projection of :func:`_read_new_kiro_records`, retained for the
+    offline-import surface and existing tests.
+    """
+    records, offset = _read_new_kiro_records(jsonl_path, byte_offset)
+    messages: list[KiroConversationMessage] = []
+    for record, _end_offset in records:
+        message = _record_to_message(record)
+        if message is not None:
+            messages.append(message)
+    return messages, offset
+
+
+def _record_to_message(record: KiroTranscriptRecord) -> KiroConversationMessage | None:
+    """Project a transcript record onto the stable message-only contract."""
+    if record.kind == "ToolResults" or not record.text:
+        return None
+    role = "user" if record.kind == "Prompt" else "assistant"
+    return KiroConversationMessage(message_id=record.message_id, role=role, text=record.text)
+
+
+def parse_kiro_jsonl_record(line: str) -> KiroTranscriptRecord | None:
+    """Parse one Kiro JSONL line into the full transcript-record contract.
+
+    Superset of :func:`parse_kiro_jsonl_line`: also surfaces ``toolUse``
+    content blocks on assistant records and ``ToolResults`` records, which the
+    message-only contract drops. Any other record kind still parses to ``None``.
+    """
     try:
         record = json.loads(line)
     except ValueError:
@@ -258,22 +388,35 @@ def parse_kiro_jsonl_line(line: str) -> KiroConversationMessage | None:
     if not isinstance(record, dict):
         return None
     kind = record.get("kind")
-    if kind == "Prompt":
-        role = "user"
-    elif kind == "AssistantMessage":
-        role = "assistant"
-    else:
+    if kind not in ("Prompt", "AssistantMessage", "ToolResults"):
         return None
     data = record.get("data")
     if not isinstance(data, dict):
         return None
-    message_id = data.get("message_id")
-    if not isinstance(message_id, str) or not message_id:
+    raw_message_id = data.get("message_id")
+    message_id = raw_message_id if isinstance(raw_message_id, str) else ""
+    if kind == "ToolResults":
+        tool_results = _extract_tool_results(data.get("content"))
+        if not tool_results:
+            return None
+        return KiroTranscriptRecord(
+            kind=kind, message_id=message_id, text="", tool_results=tool_results
+        )
+    if not message_id:
         return None
     text = _kiro_content_text(data.get("content")).strip()
-    if not text:
+    tool_calls = _extract_tool_calls(data.get("content")) if kind == "AssistantMessage" else ()
+    if not text and not tool_calls:
         return None
-    return KiroConversationMessage(message_id=message_id, role=role, text=text)
+    return KiroTranscriptRecord(kind=kind, message_id=message_id, text=text, tool_calls=tool_calls)
+
+
+def parse_kiro_jsonl_line(line: str) -> KiroConversationMessage | None:
+    """Parse one Kiro JSONL line into the stable shared message contract."""
+    record = parse_kiro_jsonl_record(line)
+    if record is None:
+        return None
+    return _record_to_message(record)
 
 
 _parse_kiro_jsonl_line = parse_kiro_jsonl_line
@@ -296,14 +439,122 @@ def _kiro_content_text(content: object) -> str:
     return "\n".join(parts)
 
 
+# kiro-cli is closed-source and no public capture pins the exact key spellings
+# inside its tool blocks (the record kinds and the ``tooluse_`` id shape are
+# corroborated; the block-level keys are not). Until a captured transcript
+# locks them, accept the tag/key spellings of both the transcript's own
+# ``kind``/``data`` block style and the ACP wire style kiro also speaks.
+_TOOL_USE_BLOCK_TAGS = frozenset({"toolUse", "tool_use"})
+_TOOL_RESULT_BLOCK_TAGS = frozenset({"toolResult", "tool_result"})
+_TOOL_ID_KEYS = ("tool_use_id", "toolUseId", "id", "toolCallId")
+_TOOL_NAME_KEYS = ("name", "toolName", "tool_name")
+_TOOL_ARGS_KEYS = ("input", "args", "arguments")
+_TOOL_OUTPUT_KEYS = ("content", "output", "text", "data")
+
+
+def _block_tag(block: dict[str, object]) -> str | None:
+    """Return a content block's discriminator under either tag style."""
+    for key in ("kind", "type"):
+        tag = block.get(key)
+        if isinstance(tag, str) and tag:
+            return tag
+    return None
+
+
+def _block_payload(block: dict[str, object]) -> dict[str, object]:
+    """Return the fields of a tool block, unwrapping a ``data`` envelope.
+
+    Text blocks nest their value under ``data`` (``{"kind": "text", "data":
+    ...}``), so tool blocks plausibly nest an object the same way; a flat block
+    carries its fields directly.
+    """
+    data = block.get("data")
+    return data if isinstance(data, dict) else block
+
+
+def _first_str(payload: dict[str, object], keys: tuple[str, ...]) -> str:
+    """Return the first non-empty string among *keys* in *payload*."""
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _tool_arguments_json(payload: dict[str, object]) -> str:
+    """Return a tool block's arguments as a JSON-encoded string."""
+    for key in _TOOL_ARGS_KEYS:
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+        if isinstance(value, dict | list):
+            return json.dumps(value, ensure_ascii=True)
+    return "{}"
+
+
+def _tool_output_text(payload: dict[str, object]) -> str:
+    """Return a tool-result block's output as display text."""
+    for key in _TOOL_OUTPUT_KEYS:
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+        if isinstance(value, dict | list):
+            nested = _kiro_content_text(value)
+            if nested:
+                return nested
+            return json.dumps(value, ensure_ascii=True)
+    return ""
+
+
+def _extract_tool_calls(content: object) -> tuple[KiroToolCall, ...]:
+    """Extract ``toolUse`` blocks from an ``AssistantMessage`` record's content."""
+    if not isinstance(content, list):
+        return ()
+    calls: list[KiroToolCall] = []
+    for block in content:
+        if not isinstance(block, dict) or _block_tag(block) not in _TOOL_USE_BLOCK_TAGS:
+            continue
+        payload = _block_payload(block)
+        call_id = _first_str(payload, _TOOL_ID_KEYS)
+        name = _first_str(payload, _TOOL_NAME_KEYS)
+        if not call_id or not name:
+            continue
+        calls.append(
+            KiroToolCall(call_id=call_id, name=name, arguments=_tool_arguments_json(payload))
+        )
+    return tuple(calls)
+
+
+def _extract_tool_results(content: object) -> tuple[KiroToolResult, ...]:
+    """Extract tool-result blocks from a ``ToolResults`` record's content."""
+    if not isinstance(content, list):
+        return ()
+    results: list[KiroToolResult] = []
+    for block in content:
+        if not isinstance(block, dict) or _block_tag(block) not in _TOOL_RESULT_BLOCK_TAGS:
+            continue
+        payload = _block_payload(block)
+        call_id = _first_str(payload, _TOOL_ID_KEYS)
+        if not call_id:
+            continue
+        results.append(KiroToolResult(call_id=call_id, output=_tool_output_text(payload)))
+    return tuple(results)
+
+
 async def _post_conversation_message(
     client: httpx.AsyncClient,
     *,
     session_id: str,
     agent_name: str,
     message: KiroConversationMessage,
+    response_id: str | None = None,
 ) -> None:
-    """POST one Kiro message as an external conversation item."""
+    """POST one Kiro message as an external conversation item.
+
+    :param response_id: The open turn's shared id for assistant prose (so the
+        bubble joins the turn's streaming group). ``None`` keeps the historic
+        per-message id — user prompts and the offline-import surface.
+    """
     if message.role == "assistant":
         item_data = {
             "role": "assistant",
@@ -322,11 +573,66 @@ async def _post_conversation_message(
             "data": {
                 "item_type": "message",
                 "item_data": item_data,
-                "response_id": f"kiro:{message.message_id}",
+                "response_id": response_id or f"kiro:{message.message_id}",
             },
         },
     )
     resp.raise_for_status()
+
+
+async def _post_function_call(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    agent_name: str,
+    response_id: str,
+    call: KiroToolCall,
+) -> None:
+    """POST one ``toolUse`` block as a ``function_call`` item."""
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={
+            "type": "external_conversation_item",
+            "data": {
+                "item_type": "function_call",
+                "item_data": {
+                    "agent": agent_name,
+                    "name": call.name,
+                    "arguments": call.arguments,
+                    "call_id": call.call_id,
+                },
+                "response_id": response_id,
+            },
+        },
+    )
+    resp.raise_for_status()
+
+
+async def _post_function_call_output(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    response_id: str,
+    result: KiroToolResult,
+) -> None:
+    """POST one tool-result block as a ``function_call_output`` item."""
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={
+            "type": "external_conversation_item",
+            "data": {
+                "item_type": "function_call_output",
+                "item_data": {"call_id": result.call_id, "output": result.output},
+                "response_id": response_id,
+            },
+        },
+    )
+    resp.raise_for_status()
+
+
+def _turn_monotonic() -> float:
+    """Indirection so tests can stub the stalled-turn clock."""
+    return time.monotonic()
 
 
 async def _patch_external_session_id(
@@ -496,6 +802,93 @@ async def _post_session_cost(
     resp.raise_for_status()
 
 
+async def _mirror_record(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    agent_name: str,
+    record: KiroTranscriptRecord,
+    state: _ForwardState,
+) -> None:
+    """Mirror one transcript record, advancing the turn's card lifecycle.
+
+    Turn shape (mirrors the goose-native forwarder): a ``Prompt`` record
+    authoritatively closes the previous turn and anchors the next turn's id;
+    ``running`` is posted once per turn before its first mirrored item; the
+    ledger of pending ``toolUse`` ids decides when an assistant prose record is
+    the turn's final message (none emitted, none outstanding); prose posts
+    before the record's tool calls so the web spinner sits on the trailing
+    item.
+    """
+    if record.kind == "Prompt":
+        # A new user turn authoritatively closes the previous one.
+        if state.turn_live and state.turn_response_id:
+            await post_external_session_status(
+                client,
+                session_id=session_id,
+                status="idle",
+                response_id=state.turn_response_id,
+            )
+        state.turn_response_id = f"kiro:turn:{record.message_id}"
+        state.turn_live = False
+        state.pending_call_ids.clear()
+        message = _record_to_message(record)
+        if message is not None:
+            await _post_conversation_message(
+                client, session_id=session_id, agent_name=agent_name, message=message
+            )
+        return
+
+    if state.turn_response_id is None:
+        # Forwarder attached mid-turn (its Prompt is behind the cursor or was
+        # never seen): anchor the turn to the first record observed instead.
+        anchor = record.message_id or (state.session_id or "unknown")
+        state.turn_response_id = f"kiro:turn:{anchor}"
+    response_id = state.turn_response_id
+
+    if not state.turn_live:
+        await post_external_session_status(
+            client, session_id=session_id, status="running", response_id=response_id
+        )
+        state.turn_live = True
+
+    if record.kind == "AssistantMessage":
+        message = _record_to_message(record)
+        if message is not None:
+            await _post_conversation_message(
+                client,
+                session_id=session_id,
+                agent_name=agent_name,
+                message=message,
+                response_id=response_id,
+            )
+        for call in record.tool_calls:
+            state.pending_call_ids.add(call.call_id)
+            await _post_function_call(
+                client,
+                session_id=session_id,
+                agent_name=agent_name,
+                response_id=response_id,
+                call=call,
+            )
+        # Kiro's agent loop keeps stepping while the model returns tool uses
+        # and stops on a plain reply, so an assistant prose record with no tool
+        # uses (and none outstanding) is the authoritative end of the turn.
+        if not record.tool_calls and not state.pending_call_ids:
+            await post_external_session_status(
+                client, session_id=session_id, status="idle", response_id=response_id
+            )
+            # Keep turn_response_id: a late resume rejoins the same turn.
+            state.turn_live = False
+        return
+
+    for result in record.tool_results:
+        state.pending_call_ids.discard(result.call_id)
+        await _post_function_call_output(
+            client, session_id=session_id, response_id=response_id, result=result
+        )
+
+
 async def forward_kiro_session_to_omnigent(
     *,
     base_url: str,
@@ -509,13 +902,16 @@ async def forward_kiro_session_to_omnigent(
     poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
     auth: httpx.Auth | None = None,
 ) -> None:
-    """Tail Kiro's session JSONL and mirror assistant messages into AP."""
+    """Tail Kiro's session JSONL and mirror messages + live tool-call cards."""
     state = _read_state(bridge_dir)
     jsonl_path: Path | None = None
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
     mirrored_external_session_id: str | None = None
     last_posted_cost: float | None = None
     last_posted_model: str | None = None
+    # Monotonic clocks don't survive a restart; a restored open turn restarts
+    # its inactivity window from now.
+    last_turn_activity_ts: float | None = _turn_monotonic() if state.turn_live else None
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout
     ) as client:
@@ -540,8 +936,18 @@ async def forward_kiro_session_to_omnigent(
                     if discovered is not None:
                         discovered_session_id, discovered_path = discovered
                         if state.session_id != discovered_session_id:
+                            if state.turn_live and state.turn_response_id:
+                                # Rebinding to a different Kiro session strands
+                                # the old turn's card; settle it before switching.
+                                await post_external_session_status(
+                                    client,
+                                    session_id=session_id,
+                                    status="idle",
+                                    response_id=state.turn_response_id,
+                                )
                             state = _ForwardState(session_id=discovered_session_id, byte_offset=0)
                             _write_state(bridge_dir, state)
+                            last_turn_activity_ts = None
                         jsonl_path = discovered_path
                 if jsonl_path is not None and state.session_id is not None:
                     if mirrored_external_session_id != state.session_id:
@@ -551,27 +957,52 @@ async def forward_kiro_session_to_omnigent(
                             external_session_id=state.session_id,
                         )
                         mirrored_external_session_id = state.session_id
-                    messages, byte_offset = await asyncio.to_thread(
-                        _read_new_kiro_messages,
+                    records, batch_end_offset = await asyncio.to_thread(
+                        _read_new_kiro_records,
                         jsonl_path,
                         state.byte_offset,
                     )
-                    for message in messages:
-                        # Mirror the transcript only. Running/idle status for
-                        # kiro-native is owned by the PTY watcher's ``emit_status``
-                        # (``runner/resource_registry.py``), matching the other
-                        # forwarder-backed native harnesses (goose/qwen/hermes),
-                        # whose forwarders mirror the transcript, not the
-                        # running/idle session status. Posting status here too
-                        # double-sourced it (#1137).
-                        await _post_conversation_message(
+                    for record, record_end_offset in records:
+                        # Mirror the transcript plus id-bearing card edges only.
+                        # The id-less running/idle session badge stays owned by
+                        # the PTY watcher's ``emit_status``
+                        # (``runner/resource_registry.py``); double-sourcing it
+                        # was #1137. The edges posted here always carry the
+                        # turn's ``response_id``, which is what drives the live
+                        # tool-call bubbles (the goose-native split).
+                        await _mirror_record(
                             client,
                             session_id=session_id,
                             agent_name=agent_name,
-                            message=message,
+                            record=record,
+                            state=state,
                         )
-                    if byte_offset != state.byte_offset:
-                        state.byte_offset = byte_offset
+                        if state.turn_response_id is not None:
+                            # Any transcript record while a turn is open proves
+                            # kiro is alive; only true silence trips the backstop.
+                            last_turn_activity_ts = _turn_monotonic()
+                        state.byte_offset = record_end_offset
+                        _write_state(bridge_dir, state)
+                    if batch_end_offset != state.byte_offset:
+                        # Skipped tail bytes (unparseable/foreign records) still
+                        # advance the cursor once their lines are complete.
+                        state.byte_offset = batch_end_offset
+                        _write_state(bridge_dir, state)
+                    # Backstop: a turn that died without its normal close (TUI
+                    # interrupt, kiro-cli crash) must not leave a spinner forever.
+                    if (
+                        state.turn_live
+                        and last_turn_activity_ts is not None
+                        and _turn_monotonic() - last_turn_activity_ts > _STALLED_TURN_IDLE_S
+                    ):
+                        await post_external_session_status(
+                            client,
+                            session_id=session_id,
+                            status="idle",
+                            response_id=state.turn_response_id,
+                        )
+                        # Keep turn_response_id: a late resume rejoins the turn.
+                        state.turn_live = False
                         _write_state(bridge_dir, state)
                     write_forwarder_ready(bridge_dir)
                     # Forward kiro's credit metering as authoritative session

--- a/omnigent/kiro_native_session_forwarder.py
+++ b/omnigent/kiro_native_session_forwarder.py
@@ -36,6 +36,7 @@ import json
 import logging
 import os
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -82,6 +83,12 @@ class _ForwardState:
     turn_response_id: str | None = None
     turn_live: bool = False
     pending_call_ids: set[str] = field(default_factory=set)
+    # Keys of conversation items already posted for the record currently being
+    # mirrored, persisted after each post and cleared when the cursor advances
+    # past the record. Conversation items are not server-deduped, so a POST that
+    # throws partway through a multi-item record must not re-post the items that
+    # already landed on the in-process retry or a restart mid-record.
+    posted_item_keys: set[str] = field(default_factory=set)
 
 
 @dataclass(frozen=True)
@@ -147,6 +154,7 @@ def _read_state(bridge_dir: Path) -> _ForwardState:
     byte_offset = data.get("byte_offset")
     turn_response_id = data.get("turn_response_id")
     pending = data.get("pending_call_ids")
+    posted = data.get("posted_item_keys")
     return _ForwardState(
         session_id=session_id if isinstance(session_id, str) and session_id else None,
         byte_offset=byte_offset if isinstance(byte_offset, int) and byte_offset >= 0 else 0,
@@ -157,6 +165,11 @@ def _read_state(bridge_dir: Path) -> _ForwardState:
         pending_call_ids=(
             {entry for entry in pending if isinstance(entry, str) and entry}
             if isinstance(pending, list)
+            else set()
+        ),
+        posted_item_keys=(
+            {entry for entry in posted if isinstance(entry, str) and entry}
+            if isinstance(posted, list)
             else set()
         ),
     )
@@ -176,6 +189,7 @@ def _write_state(bridge_dir: Path, state: _ForwardState) -> None:
                 "turn_response_id": state.turn_response_id,
                 "turn_live": state.turn_live,
                 "pending_call_ids": sorted(state.pending_call_ids),
+                "posted_item_keys": sorted(state.posted_item_keys),
             }
         ),
         encoding="utf-8",
@@ -833,6 +847,27 @@ async def _post_session_cost(
     resp.raise_for_status()
 
 
+async def _post_item_once(
+    *,
+    state: _ForwardState,
+    bridge_dir: Path,
+    key: str,
+    poster: Callable[[], Awaitable[None]],
+) -> None:
+    """Post a conversation item unless its key already landed.
+
+    Conversation items are not server-deduped, so on an in-process retry or a
+    restart mid-record an already-posted item must not repeat. The key is added
+    and the state persisted only after the post succeeds, so a failed post is
+    retried (never skipped) and a succeeded one is never re-sent.
+    """
+    if key in state.posted_item_keys:
+        return
+    await poster()
+    state.posted_item_keys.add(key)
+    _write_state(bridge_dir, state)
+
+
 async def _mirror_record(
     client: httpx.AsyncClient,
     *,
@@ -840,6 +875,7 @@ async def _mirror_record(
     agent_name: str,
     record: KiroTranscriptRecord,
     state: _ForwardState,
+    bridge_dir: Path,
 ) -> None:
     """Mirror one transcript record, advancing the turn's card lifecycle.
 
@@ -850,6 +886,13 @@ async def _mirror_record(
     the turn's final message (none emitted, none outstanding); prose posts
     before the record's tool calls so the web spinner sits on the trailing
     item.
+
+    Each conversation item posts through :func:`_post_item_once`, which skips an
+    item whose key already landed and persists the posted-key set after each
+    post, so a POST that throws partway through a multi-item record does not
+    re-post the earlier items on the in-process retry or a restart mid-record.
+    Status edges (running/idle) carry no key: ``running`` is already gated by
+    ``turn_live`` and a repeated ``idle`` for the same id is benign.
     """
     if record.kind == "Prompt":
         # A new user turn authoritatively closes the previous one.
@@ -865,8 +908,13 @@ async def _mirror_record(
         state.pending_call_ids.clear()
         message = _record_to_message(record)
         if message is not None:
-            await _post_conversation_message(
-                client, session_id=session_id, agent_name=agent_name, message=message
+            await _post_item_once(
+                state=state,
+                bridge_dir=bridge_dir,
+                key=f"msg:{record.message_id}",
+                poster=lambda: _post_conversation_message(
+                    client, session_id=session_id, agent_name=agent_name, message=message
+                ),
             )
         return
 
@@ -886,21 +934,31 @@ async def _mirror_record(
     if record.kind == "AssistantMessage":
         message = _record_to_message(record)
         if message is not None:
-            await _post_conversation_message(
-                client,
-                session_id=session_id,
-                agent_name=agent_name,
-                message=message,
-                response_id=response_id,
+            await _post_item_once(
+                state=state,
+                bridge_dir=bridge_dir,
+                key=f"msg:{record.message_id}",
+                poster=lambda: _post_conversation_message(
+                    client,
+                    session_id=session_id,
+                    agent_name=agent_name,
+                    message=message,
+                    response_id=response_id,
+                ),
             )
         for call in record.tool_calls:
             state.pending_call_ids.add(call.call_id)
-            await _post_function_call(
-                client,
-                session_id=session_id,
-                agent_name=agent_name,
-                response_id=response_id,
-                call=call,
+            await _post_item_once(
+                state=state,
+                bridge_dir=bridge_dir,
+                key=f"call:{call.call_id}",
+                poster=lambda call=call: _post_function_call(
+                    client,
+                    session_id=session_id,
+                    agent_name=agent_name,
+                    response_id=response_id,
+                    call=call,
+                ),
             )
         # Kiro's agent loop keeps stepping while the model returns tool uses
         # and stops on a plain reply, so an assistant prose record with no tool
@@ -915,8 +973,13 @@ async def _mirror_record(
 
     for result in record.tool_results:
         state.pending_call_ids.discard(result.call_id)
-        await _post_function_call_output(
-            client, session_id=session_id, response_id=response_id, result=result
+        await _post_item_once(
+            state=state,
+            bridge_dir=bridge_dir,
+            key=f"out:{result.call_id}",
+            poster=lambda result=result: _post_function_call_output(
+                client, session_id=session_id, response_id=response_id, result=result
+            ),
         )
 
 
@@ -1022,26 +1085,29 @@ async def forward_kiro_session_to_omnigent(
                         #
                         # The cursor advances once per record, AFTER its items
                         # post. A POST that throws partway through a multi-item
-                        # record (e.g. the 2nd of two tool calls) unwinds to the
-                        # poll's outer handler without advancing the cursor, so
-                        # the next poll re-reads the record and re-posts its
-                        # earlier items: delivery is at-least-once, matching the
-                        # goose forwarder's per-row cursor (accepted there as a
-                        # non-blocking duplicate window). No record is lost and
-                        # the turn id/running edge do not duplicate; only items
-                        # within the failed record can repeat.
+                        # record unwinds to the poll's outer handler without
+                        # advancing the cursor, so the next poll re-reads the
+                        # record; _post_item_once (via state.posted_item_keys,
+                        # persisted per item) skips the items that already landed
+                        # so the retry posts only the failed one. Delivery is
+                        # exactly-once across in-process retry and restart.
                         await _mirror_record(
                             client,
                             session_id=session_id,
                             agent_name=agent_name,
                             record=record,
                             state=state,
+                            bridge_dir=bridge_dir,
                         )
                         if state.turn_response_id is not None:
                             # Any transcript record while a turn is open proves
                             # kiro is alive; only true silence trips the backstop.
                             last_turn_activity_ts = _turn_monotonic()
                         state.byte_offset = record_end_offset
+                        # The record is fully mirrored and the cursor has moved
+                        # past it, so its posted-item keys are dead weight; drop
+                        # them to bound the set to the in-flight record.
+                        state.posted_item_keys.clear()
                         _write_state(bridge_dir, state)
                     if batch_end_offset != state.byte_offset:
                         # Skipped tail bytes (unparseable/foreign records) still

--- a/omnigent/kiro_native_session_forwarder.py
+++ b/omnigent/kiro_native_session_forwarder.py
@@ -469,15 +469,22 @@ def _block_tag(block: dict[str, object]) -> str | None:
     return None
 
 
-def _block_payload(block: dict[str, object]) -> dict[str, object]:
-    """Return the fields of a tool block, unwrapping a ``data`` envelope.
+def _block_fields(block: dict[str, object]) -> dict[str, object]:
+    """Flatten a content block's addressable fields across both levels.
 
     Text blocks nest their value under ``data`` (``{"kind": "text", "data":
-    ...}``), so tool blocks plausibly nest an object the same way; a flat block
-    carries its fields directly.
+    ...}``), and a tool block may carry its id at the block level while the rest
+    of the payload sits under ``data`` (``{"kind": "toolResult", "toolUseId":
+    ..., "data": {...}}``) or carry everything flat. Reading only the unwrapped
+    ``data`` envelope would then silently lose a block-level id and drop the
+    whole block. So merge: block-level keys are the base, the ``data`` envelope
+    overlays them, and a field found at either level is addressable.
     """
+    fields = {k: v for k, v in block.items() if k not in ("kind", "type", "data")}
     data = block.get("data")
-    return data if isinstance(data, dict) else block
+    if isinstance(data, dict):
+        fields.update(data)
+    return fields
 
 
 def _first_str(payload: dict[str, object], keys: tuple[str, ...]) -> str:
@@ -501,17 +508,28 @@ def _tool_arguments_json(payload: dict[str, object]) -> str:
 
 
 def _tool_output_text(payload: dict[str, object]) -> str:
-    """Return a tool-result block's output as display text."""
+    """Return a tool-result block's output as display text.
+
+    An empty container under an earlier key (e.g. the MCP ``content: []`` a
+    structured-only tool writes) is skipped rather than serialized to ``"[]"``,
+    so a later key that carries the real output (``structuredContent``) still
+    wins. A non-empty structure with no text blocks is remembered as a fallback
+    but a plain-text key is preferred over it.
+    """
+    fallback = ""
     for key in _TOOL_OUTPUT_KEYS:
         value = payload.get(key)
         if isinstance(value, str) and value:
             return value
         if isinstance(value, dict | list):
+            if not value:
+                continue
             nested = _kiro_content_text(value)
             if nested:
                 return nested
-            return json.dumps(value, ensure_ascii=True)
-    return ""
+            if not fallback:
+                fallback = json.dumps(value, ensure_ascii=True)
+    return fallback
 
 
 def _extract_tool_calls(content: object) -> tuple[KiroToolCall, ...]:
@@ -522,13 +540,18 @@ def _extract_tool_calls(content: object) -> tuple[KiroToolCall, ...]:
     for block in content:
         if not isinstance(block, dict) or _block_tag(block) not in _TOOL_USE_BLOCK_TAGS:
             continue
-        payload = _block_payload(block)
-        call_id = _first_str(payload, _TOOL_ID_KEYS)
-        name = _first_str(payload, _TOOL_NAME_KEYS)
-        if not call_id or not name:
+        fields = _block_fields(block)
+        call_id = _first_str(fields, _TOOL_ID_KEYS)
+        if not call_id:
             continue
+        # The tag already proved this is a tool-use block, so require only the
+        # id. A missing/unrecognized name key must not drop the call: dropping
+        # it also empties the turn's tool-call ledger, and a nameless-but-real
+        # call would then let the next prose record close the turn early and
+        # vanish the spinner mid-tool. Render it with a placeholder name.
+        name = _first_str(fields, _TOOL_NAME_KEYS) or "tool"
         calls.append(
-            KiroToolCall(call_id=call_id, name=name, arguments=_tool_arguments_json(payload))
+            KiroToolCall(call_id=call_id, name=name, arguments=_tool_arguments_json(fields))
         )
     return tuple(calls)
 
@@ -541,11 +564,11 @@ def _extract_tool_results(content: object) -> tuple[KiroToolResult, ...]:
     for block in content:
         if not isinstance(block, dict) or _block_tag(block) not in _TOOL_RESULT_BLOCK_TAGS:
             continue
-        payload = _block_payload(block)
-        call_id = _first_str(payload, _TOOL_ID_KEYS)
+        fields = _block_fields(block)
+        call_id = _first_str(fields, _TOOL_ID_KEYS)
         if not call_id:
             continue
-        results.append(KiroToolResult(call_id=call_id, output=_tool_output_text(payload)))
+        results.append(KiroToolResult(call_id=call_id, output=_tool_output_text(fields)))
     return tuple(results)
 
 
@@ -935,12 +958,30 @@ async def forward_kiro_session_to_omnigent(
                         )
                         if expected_path is not None:
                             discovered = (expected_session_id, expected_path)
-                    elif discovered is None:
-                        discovered = await asyncio.to_thread(
-                            _discover_kiro_session_jsonl,
-                            workspace=workspace,
-                            launch_epoch_ms=launch_epoch_ms,
-                        )
+                    else:
+                        # A restart drops the local jsonl_path but not the
+                        # persisted session_id. Rebind to that already-bound id
+                        # directly instead of re-running ambiguity-sensitive
+                        # discovery: with a second same-workspace kiro session
+                        # present, discovery returns None and the read/close
+                        # block below (gated on jsonl_path) never runs, so an
+                        # open turn's live card is stranded. The bound id is
+                        # authoritative; only fall through to discovery for a
+                        # genuinely new session when its file is gone.
+                        if state.session_id is not None:
+                            known_path = await asyncio.to_thread(
+                                _kiro_session_jsonl_for_id,
+                                state.session_id,
+                                workspace=workspace,
+                            )
+                            if known_path is not None:
+                                discovered = (state.session_id, known_path)
+                        if discovered is None:
+                            discovered = await asyncio.to_thread(
+                                _discover_kiro_session_jsonl,
+                                workspace=workspace,
+                                launch_epoch_ms=launch_epoch_ms,
+                            )
                     if discovered is not None:
                         discovered_session_id, discovered_path = discovered
                         if state.session_id != discovered_session_id:
@@ -978,6 +1019,17 @@ async def forward_kiro_session_to_omnigent(
                         # was #1137. The edges posted here always carry the
                         # turn's ``response_id``, which is what drives the live
                         # tool-call bubbles (the goose-native split).
+                        #
+                        # The cursor advances once per record, AFTER its items
+                        # post. A POST that throws partway through a multi-item
+                        # record (e.g. the 2nd of two tool calls) unwinds to the
+                        # poll's outer handler without advancing the cursor, so
+                        # the next poll re-reads the record and re-posts its
+                        # earlier items: delivery is at-least-once, matching the
+                        # goose forwarder's per-row cursor (accepted there as a
+                        # non-blocking duplicate window). No record is lost and
+                        # the turn id/running edge do not duplicate; only items
+                        # within the failed record can repeat.
                         await _mirror_record(
                             client,
                             session_id=session_id,

--- a/omnigent/kiro_native_session_forwarder.py
+++ b/omnigent/kiro_native_session_forwarder.py
@@ -860,6 +860,13 @@ async def _post_item_once(
     restart mid-record an already-posted item must not repeat. The key is added
     and the state persisted only after the post succeeds, so a failed post is
     retried (never skipped) and a succeeded one is never re-sent.
+
+    This is exactly-once on the in-process retry. Across a restart it holds
+    except the one window inherent to any post-then-persist design without
+    server-side dedup: if this ``_write_state`` fails after the post already
+    landed and the process restarts before the next successful write, the key
+    is not on disk and that single item re-posts. The floor is at-least-once (a
+    lone duplicate, never a dropped item), same as the goose forwarder.
     """
     if key in state.posted_item_keys:
         return
@@ -1089,8 +1096,11 @@ async def forward_kiro_session_to_omnigent(
                         # advancing the cursor, so the next poll re-reads the
                         # record; _post_item_once (via state.posted_item_keys,
                         # persisted per item) skips the items that already landed
-                        # so the retry posts only the failed one. Delivery is
-                        # exactly-once across in-process retry and restart.
+                        # so the retry posts only the failed one. Exactly-once on
+                        # the in-process retry; across a restart the floor is
+                        # at-least-once only in the narrow post-then-persist
+                        # window (see _post_item_once), a lone duplicate never a
+                        # lost item.
                         await _mirror_record(
                             client,
                             session_id=session_id,

--- a/omnigent/kiro_native_session_forwarder.py
+++ b/omnigent/kiro_native_session_forwarder.py
@@ -396,7 +396,12 @@ def parse_kiro_jsonl_record(line: str) -> KiroTranscriptRecord | None:
     raw_message_id = data.get("message_id")
     message_id = raw_message_id if isinstance(raw_message_id, str) else ""
     if kind == "ToolResults":
-        tool_results = _extract_tool_results(data.get("content"))
+        # A ``ToolResults`` record carries its items under ``results`` (kiro-cli
+        # 2.15.1 serde metadata: ``ToolResults{results}``), with ``content`` kept
+        # as a tolerant fallback for a variant/older shape.
+        tool_results = _extract_tool_results(data.get("results"))
+        if not tool_results:
+            tool_results = _extract_tool_results(data.get("content"))
         if not tool_results:
             return None
         return KiroTranscriptRecord(
@@ -439,17 +444,20 @@ def _kiro_content_text(content: object) -> str:
     return "\n".join(parts)
 
 
-# kiro-cli is closed-source and no public capture pins the exact key spellings
-# inside its tool blocks (the record kinds and the ``tooluse_`` id shape are
-# corroborated; the block-level keys are not). Until a captured transcript
-# locks them, accept the tag/key spellings of both the transcript's own
-# ``kind``/``data`` block style and the ACP wire style kiro also speaks.
+# Tag/key spellings taken from kiro-cli 2.15.1 serde type metadata (record
+# kinds, the ``ContentBlock`` enum tags ``toolUse``/``toolResult``, and the
+# field clusters ``ToolUseBlock{toolUseId|tool_use_id, name, input}`` /
+# ``ToolResultContent{toolUseId, content, structuredContent, isError}``). The
+# binary carries two co-existing representations (the camelCase ACP/content
+# form and a snake_case bedrock form), and which one lands in the on-disk JSONL
+# is not yet pinned by a captured transcript, so both spellings are accepted
+# until a live capture locks the shape.
 _TOOL_USE_BLOCK_TAGS = frozenset({"toolUse", "tool_use"})
 _TOOL_RESULT_BLOCK_TAGS = frozenset({"toolResult", "tool_result"})
-_TOOL_ID_KEYS = ("tool_use_id", "toolUseId", "id", "toolCallId")
+_TOOL_ID_KEYS = ("toolUseId", "tool_use_id", "id", "toolCallId")
 _TOOL_NAME_KEYS = ("name", "toolName", "tool_name")
 _TOOL_ARGS_KEYS = ("input", "args", "arguments")
-_TOOL_OUTPUT_KEYS = ("content", "output", "text", "data")
+_TOOL_OUTPUT_KEYS = ("content", "structuredContent", "output", "text", "data")
 
 
 def _block_tag(block: dict[str, object]) -> str | None:

--- a/omnigent/kiro_native_session_forwarder.py
+++ b/omnigent/kiro_native_session_forwarder.py
@@ -662,9 +662,11 @@ def _connect_kiro_db_ro(db_path: Path) -> sqlite3.Connection | None:
     window where ``-shm`` is momentarily absent. Only SELECTs are issued.
     Mirrors :func:`omnigent.goose_native_forwarder._connect_ro`.
     """
-    for uri, kw in ((f"file:{db_path}?mode=ro", {"uri": True}), (str(db_path), {})):
+    for uri, use_uri in ((f"file:{db_path}?mode=ro", True), (str(db_path), False)):
         try:
-            return sqlite3.connect(uri, timeout=5.0, **kw)
+            if use_uri:
+                return sqlite3.connect(uri, timeout=5.0, uri=True)
+            return sqlite3.connect(uri, timeout=5.0)
         except sqlite3.Error:
             continue
     return None

--- a/tests/test_kiro_native_session_forwarder.py
+++ b/tests/test_kiro_native_session_forwarder.py
@@ -54,6 +54,64 @@ def _write_kiro_session(
     return jsonl_path
 
 
+def _prompt_record(message_id: str, text: str) -> dict[str, Any]:
+    """One ``Prompt`` transcript record with a single text block."""
+    return {
+        "version": "v1",
+        "kind": "Prompt",
+        "data": {"message_id": message_id, "content": [{"kind": "text", "data": text}]},
+    }
+
+
+def _assistant_record(
+    message_id: str,
+    text: str | None = None,
+    tool_uses: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """One ``AssistantMessage`` record with optional text and ``toolUse`` blocks."""
+    content: list[dict[str, Any]] = []
+    if text is not None:
+        content.append({"kind": "text", "data": text})
+    for tool_use in tool_uses or []:
+        content.append({"kind": "toolUse", "data": tool_use})
+    return {
+        "version": "v1",
+        "kind": "AssistantMessage",
+        "data": {"message_id": message_id, "content": content},
+    }
+
+
+def _tool_results_record(results: list[dict[str, Any]]) -> dict[str, Any]:
+    """One ``ToolResults`` record with ``toolResult`` blocks."""
+    return {
+        "version": "v1",
+        "kind": "ToolResults",
+        "data": {"content": [{"kind": "toolResult", "data": result} for result in results]},
+    }
+
+
+def _stub_status_posts(
+    monkeypatch: pytest.MonkeyPatch,
+    sink: list[tuple[str, str | None]] | None = None,
+) -> None:
+    """Replace the forwarder's status-edge post with a capturing stub."""
+
+    async def _fake_status(
+        client: httpx.AsyncClient,
+        *,
+        session_id: str,
+        status: str,
+        output: str | None = None,
+        background_task_count: int | None = None,
+        response_id: str | None = None,
+    ) -> None:
+        del client, session_id, output, background_task_count
+        if sink is not None:
+            sink.append((status, response_id))
+
+    monkeypatch.setattr(forwarder, "post_external_session_status", _fake_status)
+
+
 def test_discover_kiro_session_jsonl_filters_by_workspace_and_launch_time(
     tmp_path: Path,
 ) -> None:
@@ -304,8 +362,9 @@ async def test_forward_kiro_session_posts_conversation_messages(
         session_id: str,
         agent_name: str,
         message: forwarder._KiroConversationMessage,
+        response_id: str | None = None,
     ) -> None:
-        del client
+        del client, response_id
         posted.append((session_id, agent_name, message))
 
     async def _fake_patch_external_session_id(
@@ -326,6 +385,7 @@ async def test_forward_kiro_session_posts_conversation_messages(
         "_patch_external_session_id",
         _fake_patch_external_session_id,
     )
+    _stub_status_posts(monkeypatch)
     monkeypatch.setattr(forwarder.asyncio, "sleep", _cancel_sleep)
 
     with pytest.raises(asyncio.CancelledError):
@@ -353,9 +413,9 @@ async def test_forward_kiro_session_posts_conversation_messages(
             ),
         ),
     ]
-    # The forwarder no longer posts session status; running/idle for
-    # kiro-native is owned by the PTY watcher's emit_status (#1137). See
-    # test_forward_kiro_session_does_not_post_session_status for the guard.
+    # The forwarder's status edges always carry a response_id; the id-less
+    # session badge stays PTY-owned (#1137). See
+    # test_forward_kiro_session_posts_only_id_bearing_status for the guard.
     assert external_ids == [("conv_kiro", "kiro-session")]
 
 
@@ -444,6 +504,7 @@ async def test_forward_kiro_session_posts_cumulative_cost_once(
         session_id: str,
         agent_name: str,
         message: forwarder._KiroConversationMessage,
+        response_id: str | None = None,
     ) -> None:
         del client
 
@@ -466,6 +527,7 @@ async def test_forward_kiro_session_posts_cumulative_cost_once(
     monkeypatch.setattr(forwarder, "_post_external_model_change", _noop_model)
     monkeypatch.setattr(forwarder, "_post_conversation_message", _noop_message)
     monkeypatch.setattr(forwarder, "_patch_external_session_id", _noop_patch)
+    _stub_status_posts(monkeypatch)
     monkeypatch.setattr(forwarder.asyncio, "sleep", _cancel_after_two_polls)
 
     with pytest.raises(asyncio.CancelledError):
@@ -553,8 +615,9 @@ async def test_forward_kiro_session_prefers_expected_resume_session(
         session_id: str,
         agent_name: str,
         message: forwarder._KiroConversationMessage,
+        response_id: str | None = None,
     ) -> None:
-        del client, session_id, agent_name
+        del client, session_id, agent_name, response_id
         posted.append(message)
 
     async def _fake_patch_external_session_id(
@@ -575,6 +638,7 @@ async def test_forward_kiro_session_prefers_expected_resume_session(
         "_patch_external_session_id",
         _fake_patch_external_session_id,
     )
+    _stub_status_posts(monkeypatch)
     monkeypatch.setattr(forwarder.asyncio, "sleep", _cancel_sleep)
 
     with pytest.raises(asyncio.CancelledError):
@@ -595,7 +659,7 @@ async def test_forward_kiro_session_prefers_expected_resume_session(
             message_id="resumed-assistant", role="assistant", text="resumed reply"
         ),
     ]
-    # No session status is posted by the forwarder anymore (#1137).
+    # Status edges (stubbed above) always carry the turn's response_id (#1137).
     assert external_ids == ["resumed-session"]
     state = json.loads((bridge_dir / "kiro_session_forwarder.json").read_text())
     assert state["session_id"] == "resumed-session"
@@ -638,8 +702,9 @@ async def test_forward_kiro_session_waits_for_expected_resume_session(
         session_id: str,
         agent_name: str,
         message: forwarder._KiroConversationMessage,
+        response_id: str | None = None,
     ) -> None:
-        del client, session_id, agent_name
+        del client, session_id, agent_name, response_id
         posted.append(message)
 
     async def _fake_patch_external_session_id(
@@ -660,6 +725,7 @@ async def test_forward_kiro_session_waits_for_expected_resume_session(
         "_patch_external_session_id",
         _fake_patch_external_session_id,
     )
+    _stub_status_posts(monkeypatch)
     monkeypatch.setattr(forwarder.asyncio, "sleep", _cancel_sleep)
 
     with pytest.raises(asyncio.CancelledError):
@@ -679,15 +745,18 @@ async def test_forward_kiro_session_waits_for_expected_resume_session(
 
 
 @pytest.mark.asyncio
-async def test_forward_kiro_session_does_not_post_session_status(
+async def test_forward_kiro_session_posts_only_id_bearing_status(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Regression for #1137: the forwarder mirrors the transcript but must NOT
-    post ``external_session_status``. Running/idle for kiro-native is owned by
-    the PTY watcher's ``emit_status`` (runner/resource_registry.py); posting it
-    here too double-sourced the session status. Captures real HTTP via a mock
-    transport so it guards the behaviour however status might be sent."""
+    """Regression for #1137, updated for live tool-call cards: every
+    ``external_session_status`` the forwarder posts must carry a ``response_id``.
+    The id-less session badge stays owned by the PTY watcher's ``emit_status``
+    (runner/resource_registry.py) — double-sourcing *that* was #1137 — while the
+    id-bearing edges drive only the per-turn card lifecycle (the goose-native
+    split; an id-less idle is a no-op for a still-streaming card web-side).
+    Captures real HTTP via a mock transport so it guards the behaviour however
+    status might be sent."""
     sessions_dir = tmp_path / "home" / ".kiro" / "sessions" / "cli"
     workspace = tmp_path / "repo"
     workspace.mkdir()
@@ -713,11 +782,11 @@ async def test_forward_kiro_session_does_not_post_session_status(
     )
     monkeypatch.setattr(forwarder, "kiro_cli_sessions_dir", lambda: sessions_dir)
 
-    posted_event_types: list[str] = []
+    posted_events: list[dict[str, Any]] = []
 
     def _handler(request: httpx.Request) -> httpx.Response:
         if request.method == "POST" and request.url.path.endswith("/events"):
-            posted_event_types.append(json.loads(request.content)["type"])
+            posted_events.append(json.loads(request.content))
         return httpx.Response(200, json={})
 
     real_async_client = forwarder.httpx.AsyncClient
@@ -744,10 +813,19 @@ async def test_forward_kiro_session_does_not_post_session_status(
             launch_epoch_ms=forwarder._parse_iso_epoch_ms("2026-06-21T01:39:34Z"),
         )
 
+    posted_event_types = [event["type"] for event in posted_events]
     # The transcript is still mirrored…
     assert "external_conversation_item" in posted_event_types
-    # …but the forwarder posts no session status (the PTY watcher owns it).
-    assert "external_session_status" not in posted_event_types
+    # …and every status edge the forwarder posts carries the turn's id (the
+    # id-less session badge remains PTY-owned, per #1137).
+    status_edges = [
+        event["data"] for event in posted_events if event["type"] == "external_session_status"
+    ]
+    assert status_edges, "the prose turn should open and close its card"
+    assert all(edge.get("response_id") for edge in status_edges)
+    assert [edge["status"] for edge in status_edges] == ["running", "idle"]
+    turn_id = "kiro:turn:user-1"
+    assert {edge["response_id"] for edge in status_edges} == {turn_id}
 
 
 def test_read_kiro_current_model_reads_without_metering(tmp_path: Path) -> None:
@@ -798,6 +876,7 @@ async def test_forward_kiro_session_mirrors_current_model_once(
         session_id: str,
         agent_name: str,
         message: forwarder._KiroConversationMessage,
+        response_id: str | None = None,
     ) -> None:
         del client
 
@@ -816,6 +895,7 @@ async def test_forward_kiro_session_mirrors_current_model_once(
     monkeypatch.setattr(forwarder, "_post_external_model_change", _fake_post_model)
     monkeypatch.setattr(forwarder, "_post_conversation_message", _noop_message)
     monkeypatch.setattr(forwarder, "_patch_external_session_id", _noop_patch)
+    _stub_status_posts(monkeypatch)
     monkeypatch.setattr(forwarder.asyncio, "sleep", _cancel_after_two_polls)
 
     with pytest.raises(asyncio.CancelledError):
@@ -831,3 +911,424 @@ async def test_forward_kiro_session_mirrors_current_model_once(
 
     # Mirrored once; the unchanged second poll does not re-post.
     assert models == [("conv_kiro", "claude-haiku-4.5")]
+
+
+def test_parse_kiro_jsonl_record_extracts_tool_vocabulary() -> None:
+    """``toolUse`` blocks and ``ToolResults`` records parse into the superset
+    contract, while :func:`parse_kiro_jsonl_line` stays message-only."""
+    assistant_line = json.dumps(
+        _assistant_record(
+            "a1",
+            text="Let me check",
+            tool_uses=[{"tool_use_id": "tooluse_A", "name": "read", "input": {"path": "f.txt"}}],
+        )
+    )
+    record = forwarder.parse_kiro_jsonl_record(assistant_line)
+    assert record is not None
+    assert record.kind == "AssistantMessage"
+    assert record.text == "Let me check"
+    assert record.tool_calls == (
+        forwarder.KiroToolCall(
+            call_id="tooluse_A", name="read", arguments=json.dumps({"path": "f.txt"})
+        ),
+    )
+
+    # A tool-only assistant record has no prose: the superset parser keeps it,
+    # the stable message-only projection drops it (as it always did).
+    tool_only_line = json.dumps(
+        _assistant_record(
+            "a2", tool_uses=[{"tool_use_id": "tooluse_B", "name": "shell", "input": {"cmd": "ls"}}]
+        )
+    )
+    tool_only = forwarder.parse_kiro_jsonl_record(tool_only_line)
+    assert tool_only is not None
+    assert tool_only.text == "" and len(tool_only.tool_calls) == 1
+    assert forwarder.parse_kiro_jsonl_line(tool_only_line) is None
+
+    results_line = json.dumps(
+        _tool_results_record([{"tool_use_id": "tooluse_A", "content": "file contents"}])
+    )
+    results = forwarder.parse_kiro_jsonl_record(results_line)
+    assert results is not None
+    assert results.kind == "ToolResults"
+    assert results.tool_results == (
+        forwarder.KiroToolResult(call_id="tooluse_A", output="file contents"),
+    )
+    assert forwarder.parse_kiro_jsonl_line(results_line) is None
+
+
+def test_parse_kiro_jsonl_record_accepts_flat_acp_style_tool_blocks() -> None:
+    """Tool blocks parse under the ACP-style tag/key spellings too.
+
+    kiro-cli is closed-source and no public capture pins the block-level key
+    spellings, so the parser accepts both the transcript's ``kind``/``data``
+    envelope style and the flat ACP wire style until a captured transcript
+    locks them.
+    """
+    line = json.dumps(
+        {
+            "version": "v1",
+            "kind": "AssistantMessage",
+            "data": {
+                "message_id": "a1",
+                "content": [
+                    {"type": "tool_use", "toolUseId": "tooluse_C", "toolName": "write", "args": {}}
+                ],
+            },
+        }
+    )
+    record = forwarder.parse_kiro_jsonl_record(line)
+    assert record is not None
+    assert record.tool_calls == (
+        forwarder.KiroToolCall(call_id="tooluse_C", name="write", arguments="{}"),
+    )
+
+
+def test_forward_state_round_trips_turn_fields(tmp_path: Path) -> None:
+    """The persisted cursor carries the open turn's card state across restarts."""
+    state = forwarder._ForwardState(
+        session_id="kiro-session",
+        byte_offset=123,
+        turn_response_id="kiro:turn:user-1",
+        turn_live=True,
+        pending_call_ids={"tooluse_A", "tooluse_B"},
+    )
+    forwarder._write_state(tmp_path, state)
+    restored = forwarder._read_state(tmp_path)
+    assert restored == state
+
+    # A legacy state file (no turn fields) restores with a closed turn.
+    (tmp_path / forwarder._STATE_FILE).write_text(
+        json.dumps({"session_id": "kiro-session", "byte_offset": 7}), encoding="utf-8"
+    )
+    legacy = forwarder._read_state(tmp_path)
+    assert legacy.turn_response_id is None
+    assert legacy.turn_live is False
+    assert legacy.pending_call_ids == set()
+
+
+def _capture_events_client(
+    monkeypatch: pytest.MonkeyPatch,
+    posted_events: list[dict[str, Any]],
+) -> None:
+    """Route the forwarder's HTTP through a mock transport capturing /events."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path.endswith("/events"):
+            posted_events.append(json.loads(request.content))
+        return httpx.Response(200, json={})
+
+    real_async_client = forwarder.httpx.AsyncClient
+
+    def _client_factory(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs.pop("transport", None)
+        return real_async_client(*args, transport=httpx.MockTransport(_handler), **kwargs)
+
+    monkeypatch.setattr(forwarder.httpx, "AsyncClient", _client_factory)
+
+
+@pytest.mark.asyncio
+async def test_forward_kiro_session_multi_call_turn_shares_turn_response_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A turn with parallel tool calls mirrors as one streaming group.
+
+    One ``running`` edge before the turn's first item; the assistant prose,
+    both ``function_call`` items, both ``function_call_output`` items, and the
+    closing ``idle`` all share ``kiro:turn:{prompt_message_id}``; prose posts
+    before the calls so the web spinner sits on the trailing item; the final
+    prose record closes the card immediately.
+    """
+    sessions_dir = tmp_path / "home" / ".kiro" / "sessions" / "cli"
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    _write_kiro_session(
+        sessions_dir,
+        session_id="kiro-session",
+        cwd=workspace,
+        lines=[
+            _prompt_record("user-1", "run it"),
+            _assistant_record(
+                "a1",
+                text="Let me check",
+                tool_uses=[
+                    {"tool_use_id": "tooluse_A", "name": "read", "input": {"path": "f.txt"}},
+                    {"tool_use_id": "tooluse_B", "name": "shell", "input": {"cmd": "ls"}},
+                ],
+            ),
+            _tool_results_record(
+                [
+                    {"tool_use_id": "tooluse_A", "content": "data-a"},
+                    {"tool_use_id": "tooluse_B", "content": "data-b"},
+                ]
+            ),
+            _assistant_record("a2", text="Done"),
+        ],
+    )
+    monkeypatch.setattr(forwarder, "kiro_cli_sessions_dir", lambda: sessions_dir)
+    posted_events: list[dict[str, Any]] = []
+    _capture_events_client(monkeypatch, posted_events)
+
+    async def _cancel_sleep(_seconds: float) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(forwarder.asyncio, "sleep", _cancel_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await forwarder.forward_kiro_session_to_omnigent(
+            base_url="http://127.0.0.1:6767",
+            headers={},
+            session_id="conv_kiro",
+            bridge_dir=tmp_path / "bridge",
+            agent_name="kiro-native-ui",
+            workspace=str(workspace),
+            launch_epoch_ms=forwarder._parse_iso_epoch_ms("2026-06-21T01:39:34Z"),
+        )
+
+    turn_id = "kiro:turn:user-1"
+    lifecycle = [
+        (event["type"], event["data"].get("item_type"), event["data"].get("status"))
+        for event in posted_events
+        if event["type"] in ("external_conversation_item", "external_session_status")
+    ]
+    assert lifecycle == [
+        ("external_conversation_item", "message", None),  # user prompt
+        ("external_session_status", None, "running"),
+        ("external_conversation_item", "message", None),  # prose before the calls
+        ("external_conversation_item", "function_call", None),
+        ("external_conversation_item", "function_call", None),
+        ("external_conversation_item", "function_call_output", None),
+        ("external_conversation_item", "function_call_output", None),
+        ("external_conversation_item", "message", None),  # final prose
+        ("external_session_status", None, "idle"),
+    ]
+    items = [e["data"] for e in posted_events if e["type"] == "external_conversation_item"]
+    # The user prompt keeps its per-message id; everything else shares the turn id.
+    assert items[0]["response_id"] == "kiro:user-1"
+    assert {item["response_id"] for item in items[1:]} == {turn_id}
+    calls = [item["item_data"] for item in items if item["item_type"] == "function_call"]
+    assert [(call["call_id"], call["name"]) for call in calls] == [
+        ("tooluse_A", "read"),
+        ("tooluse_B", "shell"),
+    ]
+    outputs = [item["item_data"] for item in items if item["item_type"] == "function_call_output"]
+    assert [(out["call_id"], out["output"]) for out in outputs] == [
+        ("tooluse_A", "data-a"),
+        ("tooluse_B", "data-b"),
+    ]
+    edges = [e["data"] for e in posted_events if e["type"] == "external_session_status"]
+    assert [(edge["status"], edge["response_id"]) for edge in edges] == [
+        ("running", turn_id),
+        ("idle", turn_id),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_forward_kiro_session_restart_mid_turn_keeps_turn_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A restart between a call and its result resumes the same streaming group.
+
+    The persisted turn state means the second run posts no second ``running``,
+    stamps the remaining items with the original turn id, and closes the card
+    once the final prose record lands — instead of splitting the turn across
+    two response ids (the failure goose needed open-turn replay to fix).
+    """
+    sessions_dir = tmp_path / "home" / ".kiro" / "sessions" / "cli"
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    jsonl_path = _write_kiro_session(
+        sessions_dir,
+        session_id="kiro-session",
+        cwd=workspace,
+        lines=[
+            _prompt_record("user-1", "run it"),
+            _assistant_record(
+                "a1",
+                text="Checking",
+                tool_uses=[{"tool_use_id": "tooluse_A", "name": "read", "input": {}}],
+            ),
+        ],
+    )
+    monkeypatch.setattr(forwarder, "kiro_cli_sessions_dir", lambda: sessions_dir)
+    bridge_dir = tmp_path / "bridge"
+    turn_id = "kiro:turn:user-1"
+
+    async def _cancel_sleep(_seconds: float) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(forwarder.asyncio, "sleep", _cancel_sleep)
+
+    # One shared sink for both runs: patching the client factory twice would
+    # wrap the first patch and route the second run's events to the first sink.
+    all_events: list[dict[str, Any]] = []
+    _capture_events_client(monkeypatch, all_events)
+    with pytest.raises(asyncio.CancelledError):
+        await forwarder.forward_kiro_session_to_omnigent(
+            base_url="http://127.0.0.1:6767",
+            headers={},
+            session_id="conv_kiro",
+            bridge_dir=bridge_dir,
+            agent_name="kiro-native-ui",
+            workspace=str(workspace),
+            launch_epoch_ms=forwarder._parse_iso_epoch_ms("2026-06-21T01:39:34Z"),
+        )
+    first_run_events = list(all_events)
+
+    first_edges = [e["data"] for e in first_run_events if e["type"] == "external_session_status"]
+    assert [(edge["status"], edge["response_id"]) for edge in first_edges] == [
+        ("running", turn_id)
+    ]
+    persisted = json.loads((bridge_dir / forwarder._STATE_FILE).read_text())
+    assert persisted["turn_response_id"] == turn_id
+    assert persisted["turn_live"] is True
+    assert persisted["pending_call_ids"] == ["tooluse_A"]
+
+    # The tool finishes and the turn ends while the forwarder is down.
+    with jsonl_path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(_tool_results_record([{"tool_use_id": "tooluse_A", "content": "data"}]))
+            + "\n"
+        )
+        handle.write(json.dumps(_assistant_record("a2", text="Done")) + "\n")
+
+    with pytest.raises(asyncio.CancelledError):
+        await forwarder.forward_kiro_session_to_omnigent(
+            base_url="http://127.0.0.1:6767",
+            headers={},
+            session_id="conv_kiro",
+            bridge_dir=bridge_dir,
+            agent_name="kiro-native-ui",
+            workspace=str(workspace),
+            launch_epoch_ms=forwarder._parse_iso_epoch_ms("2026-06-21T01:39:34Z"),
+        )
+    second_run_events = all_events[len(first_run_events) :]
+
+    items = [e["data"] for e in second_run_events if e["type"] == "external_conversation_item"]
+    assert [item["item_type"] for item in items] == ["function_call_output", "message"]
+    assert {item["response_id"] for item in items} == {turn_id}
+    second_edges = [e["data"] for e in second_run_events if e["type"] == "external_session_status"]
+    # No second running; the original turn closes under its original id.
+    assert [(edge["status"], edge["response_id"]) for edge in second_edges] == [("idle", turn_id)]
+
+
+@pytest.mark.asyncio
+async def test_forward_kiro_session_missed_opener_anchors_to_first_record(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Attaching mid-turn (no ``Prompt`` seen) still yields a stable turn id."""
+    sessions_dir = tmp_path / "home" / ".kiro" / "sessions" / "cli"
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    _write_kiro_session(
+        sessions_dir,
+        session_id="kiro-session",
+        cwd=workspace,
+        lines=[
+            _assistant_record(
+                "a1",
+                text="Working",
+                tool_uses=[{"tool_use_id": "tooluse_A", "name": "shell", "input": {}}],
+            ),
+        ],
+    )
+    monkeypatch.setattr(forwarder, "kiro_cli_sessions_dir", lambda: sessions_dir)
+    posted_events: list[dict[str, Any]] = []
+    _capture_events_client(monkeypatch, posted_events)
+
+    async def _cancel_sleep(_seconds: float) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(forwarder.asyncio, "sleep", _cancel_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await forwarder.forward_kiro_session_to_omnigent(
+            base_url="http://127.0.0.1:6767",
+            headers={},
+            session_id="conv_kiro",
+            bridge_dir=tmp_path / "bridge",
+            agent_name="kiro-native-ui",
+            workspace=str(workspace),
+            launch_epoch_ms=forwarder._parse_iso_epoch_ms("2026-06-21T01:39:34Z"),
+        )
+
+    turn_id = "kiro:turn:a1"
+    edges = [e["data"] for e in posted_events if e["type"] == "external_session_status"]
+    assert [(edge["status"], edge["response_id"]) for edge in edges] == [("running", turn_id)]
+    items = [e["data"] for e in posted_events if e["type"] == "external_conversation_item"]
+    assert {item["response_id"] for item in items} == {turn_id}
+
+
+@pytest.mark.asyncio
+async def test_forward_kiro_session_stalled_turn_backstop_closes_card(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A turn that dies without its normal close settles after the backstop.
+
+    A pending tool call with no result and no further transcript activity (TUI
+    interrupt, kiro-cli crash) must not leave a spinner forever: after
+    ``_STALLED_TURN_IDLE_S`` of transcript inactivity the card is closed with
+    the turn's own id.
+    """
+    sessions_dir = tmp_path / "home" / ".kiro" / "sessions" / "cli"
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    _write_kiro_session(
+        sessions_dir,
+        session_id="kiro-session",
+        cwd=workspace,
+        lines=[
+            _prompt_record("user-1", "run it"),
+            _assistant_record(
+                "a1",
+                text="Running",
+                tool_uses=[{"tool_use_id": "tooluse_A", "name": "shell", "input": {}}],
+            ),
+        ],
+    )
+    monkeypatch.setattr(forwarder, "kiro_cli_sessions_dir", lambda: sessions_dir)
+    posted_events: list[dict[str, Any]] = []
+    _capture_events_client(monkeypatch, posted_events)
+
+    clock = {"now": 0.0}
+    monkeypatch.setattr(forwarder, "_turn_monotonic", lambda: clock["now"])
+
+    polls = {"n": 0}
+
+    async def _advance_clock_then_cancel(_seconds: float) -> None:
+        polls["n"] += 1
+        if polls["n"] == 1:
+            # Poll 1 mirrored the open turn; silence past the backstop window.
+            clock["now"] = forwarder._STALLED_TURN_IDLE_S + 1.0
+            return
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(forwarder.asyncio, "sleep", _advance_clock_then_cancel)
+
+    with pytest.raises(asyncio.CancelledError):
+        await forwarder.forward_kiro_session_to_omnigent(
+            base_url="http://127.0.0.1:6767",
+            headers={},
+            session_id="conv_kiro",
+            bridge_dir=tmp_path / "bridge",
+            agent_name="kiro-native-ui",
+            workspace=str(workspace),
+            launch_epoch_ms=forwarder._parse_iso_epoch_ms("2026-06-21T01:39:34Z"),
+        )
+
+    turn_id = "kiro:turn:user-1"
+    edges = [e["data"] for e in posted_events if e["type"] == "external_session_status"]
+    assert [(edge["status"], edge["response_id"]) for edge in edges] == [
+        ("running", turn_id),
+        ("idle", turn_id),
+    ]
+    # The settled turn is persisted closed, so a restart won't re-close it.
+    persisted = json.loads(
+        (tmp_path / "bridge" / forwarder._STATE_FILE).read_text(encoding="utf-8")
+    )
+    assert persisted["turn_live"] is False
+    assert persisted["turn_response_id"] == turn_id

--- a/tests/test_kiro_native_session_forwarder.py
+++ b/tests/test_kiro_native_session_forwarder.py
@@ -1048,6 +1048,214 @@ def test_parse_kiro_jsonl_record_accepts_flat_acp_style_tool_blocks() -> None:
     )
 
 
+def test_extract_tool_calls_id_at_block_level_with_data_envelope() -> None:
+    """A tool block with the id at the block level and the rest under ``data``
+    is not dropped: block-level and envelope fields are both addressable."""
+    content = [
+        {
+            "kind": "toolUse",
+            "toolUseId": "tooluse_A",
+            "data": {"name": "read", "input": {"path": "f.txt"}},
+        }
+    ]
+    calls = forwarder._extract_tool_calls(content)
+    assert calls == (
+        forwarder.KiroToolCall(
+            call_id="tooluse_A", name="read", arguments=json.dumps({"path": "f.txt"})
+        ),
+    )
+
+
+def test_extract_tool_calls_keeps_nameless_call_with_placeholder() -> None:
+    """A recognized tool-use block with an id but no name keeps the call (with a
+    placeholder name) instead of dropping it and emptying the turn ledger."""
+    content = [{"kind": "toolUse", "data": {"tool_use_id": "tooluse_A", "input": {}}}]
+    calls = forwarder._extract_tool_calls(content)
+    assert len(calls) == 1
+    assert calls[0].call_id == "tooluse_A"
+    assert calls[0].name == "tool"
+
+
+def test_extract_tool_results_prefers_structured_over_empty_content() -> None:
+    """A structured-only result (empty ``content``, real ``structuredContent``)
+    yields the structured payload, not ``"[]"``."""
+    content = [
+        {
+            "kind": "toolResult",
+            "data": {
+                "toolUseId": "tooluse_A",
+                "content": [],
+                "structuredContent": {"rows": 3, "result": "actual data"},
+            },
+        }
+    ]
+    results = forwarder._extract_tool_results(content)
+    assert len(results) == 1
+    assert results[0].call_id == "tooluse_A"
+    assert results[0].output != "[]"
+    assert "actual data" in results[0].output
+
+
+@pytest.mark.asyncio
+async def test_forward_kiro_session_nameless_tool_does_not_close_turn_early(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool call whose name key is unrecognized still holds the turn open.
+
+    Regression: dropping the call emptied the pending ledger, so the tool
+    result record was mistaken for a closed turn and the spinner vanished
+    while the tool was still running.
+    """
+    sessions_dir = tmp_path / "home" / ".kiro" / "sessions" / "cli"
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    _write_kiro_session(
+        sessions_dir,
+        session_id="kiro-session",
+        cwd=workspace,
+        lines=[
+            _prompt_record("user-1", "run it"),
+            {
+                "version": "v1",
+                "kind": "AssistantMessage",
+                "data": {
+                    "message_id": "a1",
+                    "content": [
+                        {"kind": "text", "data": "Running"},
+                        {"kind": "toolUse", "data": {"tool_use_id": "tooluse_A", "input": {}}},
+                    ],
+                },
+            },
+            _tool_results_record([{"toolUseId": "tooluse_A", "content": "done"}]),
+            _assistant_record("a2", text="Finished"),
+        ],
+    )
+    monkeypatch.setattr(forwarder, "kiro_cli_sessions_dir", lambda: sessions_dir)
+    posted_events: list[dict[str, Any]] = []
+    _capture_events_client(monkeypatch, posted_events)
+
+    async def _cancel_sleep(_seconds: float) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(forwarder.asyncio, "sleep", _cancel_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await forwarder.forward_kiro_session_to_omnigent(
+            base_url="http://127.0.0.1:6767",
+            headers={},
+            session_id="conv_kiro",
+            bridge_dir=tmp_path / "bridge",
+            agent_name="kiro-native-ui",
+            workspace=str(workspace),
+            launch_epoch_ms=forwarder._parse_iso_epoch_ms("2026-06-21T01:39:34Z"),
+        )
+
+    turn_id = "kiro:turn:user-1"
+    edges = [
+        (e["data"]["status"], e["data"]["response_id"])
+        for e in posted_events
+        if e["type"] == "external_session_status"
+    ]
+    # Exactly one running then one idle: the nameless call held the turn open
+    # through the result, and the FINAL prose (a2) closes it once. No early
+    # close/reopen churn.
+    assert edges == [("running", turn_id), ("idle", turn_id)]
+    kinds = [
+        e["data"]["item_type"] for e in posted_events if e["type"] == "external_conversation_item"
+    ]
+    assert "function_call" in kinds and "function_call_output" in kinds
+
+
+@pytest.mark.asyncio
+async def test_forward_kiro_session_restart_rebinds_known_session_under_ambiguity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A restart rebinds the persisted session id directly, even when a second
+    same-workspace session would make fresh discovery ambiguous.
+
+    Regression: discovery returned None on two candidates, the read/close block
+    was skipped, and the open turn's card was stranded.
+    """
+    sessions_dir = tmp_path / "home" / ".kiro" / "sessions" / "cli"
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    jsonl_path = _write_kiro_session(
+        sessions_dir,
+        session_id="session-1",
+        cwd=workspace,
+        lines=[
+            _prompt_record("user-1", "run it"),
+            _assistant_record(
+                "a1",
+                text="Checking",
+                tool_uses=[{"tool_use_id": "tooluse_A", "name": "read", "input": {}}],
+            ),
+        ],
+    )
+    monkeypatch.setattr(forwarder, "kiro_cli_sessions_dir", lambda: sessions_dir)
+    bridge_dir = tmp_path / "bridge"
+    turn_id = "kiro:turn:user-1"
+
+    async def _cancel_sleep(_seconds: float) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(forwarder.asyncio, "sleep", _cancel_sleep)
+
+    all_events: list[dict[str, Any]] = []
+    _capture_events_client(monkeypatch, all_events)
+    with pytest.raises(asyncio.CancelledError):
+        await forwarder.forward_kiro_session_to_omnigent(
+            base_url="http://127.0.0.1:6767",
+            headers={},
+            session_id="conv_kiro",
+            bridge_dir=bridge_dir,
+            agent_name="kiro-native-ui",
+            workspace=str(workspace),
+            launch_epoch_ms=forwarder._parse_iso_epoch_ms("2026-06-21T01:39:34Z"),
+        )
+    first_count = len(all_events)
+    assert json.loads((bridge_dir / forwarder._STATE_FILE).read_text())["turn_live"] is True
+
+    # A SECOND same-workspace session appears (would make discovery ambiguous),
+    # and the turn finishes on session-1 while the forwarder is down.
+    _write_kiro_session(
+        sessions_dir,
+        session_id="session-2",
+        cwd=workspace,
+        created_at="2026-06-21T01:39:40Z",
+        lines=[_prompt_record("other-1", "unrelated")],
+    )
+    with jsonl_path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(_tool_results_record([{"toolUseId": "tooluse_A", "content": "data"}]))
+            + "\n"
+        )
+        handle.write(json.dumps(_assistant_record("a2", text="Done")) + "\n")
+
+    with pytest.raises(asyncio.CancelledError):
+        await forwarder.forward_kiro_session_to_omnigent(
+            base_url="http://127.0.0.1:6767",
+            headers={},
+            session_id="conv_kiro",
+            bridge_dir=bridge_dir,
+            agent_name="kiro-native-ui",
+            workspace=str(workspace),
+            launch_epoch_ms=forwarder._parse_iso_epoch_ms("2026-06-21T01:39:34Z"),
+        )
+    second = all_events[first_count:]
+    # The restart rebound session-1 and closed its turn, rather than stranding it.
+    edges = [
+        (e["data"]["status"], e["data"]["response_id"])
+        for e in second
+        if e["type"] == "external_session_status"
+    ]
+    assert ("idle", turn_id) in edges
+    items = [e["data"] for e in second if e["type"] == "external_conversation_item"]
+    assert any(i["item_type"] == "function_call_output" for i in items)
+
+
 def test_forward_state_round_trips_turn_fields(tmp_path: Path) -> None:
     """The persisted cursor carries the open turn's card state across restarts."""
     state = forwarder._ForwardState(

--- a/tests/test_kiro_native_session_forwarder.py
+++ b/tests/test_kiro_native_session_forwarder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sqlite3
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,59 @@ import httpx
 import pytest
 
 import omnigent.kiro_native_session_forwarder as forwarder
+
+
+def _write_kiro_sqlite(
+    db_path: Path,
+    *,
+    cwd: Path,
+    conversation_id: str,
+    history: list[dict[str, Any]],
+) -> None:
+    """Write a minimal kiro-cli ``conversations_v2`` SQLite store.
+
+    Shape matches a captured kiro-cli 2.15.1 session: ``key`` is the workspace
+    cwd, ``value`` is a ConversationState blob whose ``history`` is a list of
+    turns with tagged ``user.content`` and ``assistant`` sides.
+    """
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(db_path)
+    con.execute(
+        "CREATE TABLE IF NOT EXISTS conversations_v2 "
+        "(key TEXT PRIMARY KEY, conversation_id TEXT, value TEXT, "
+        "created_at TEXT, updated_at TEXT)"
+    )
+    con.execute(
+        "INSERT OR REPLACE INTO conversations_v2 "
+        "(key, conversation_id, value, created_at, updated_at) VALUES (?,?,?,?,?)",
+        (
+            str(cwd),
+            conversation_id,
+            json.dumps({"conversation_id": conversation_id, "history": history}),
+            "2026-07-29T00:00:00Z",
+            "2026-07-29T00:01:00Z",
+        ),
+    )
+    con.commit()
+    con.close()
+
+
+def _sqlite_prompt_turn(prompt: str, assistant_tool: dict[str, Any]) -> dict[str, Any]:
+    """A conversations_v2 turn: user Prompt + assistant ToolUse."""
+    return {
+        "user": {"content": {"Prompt": {"prompt": prompt}}},
+        "assistant": {"ToolUse": assistant_tool},
+    }
+
+
+def _sqlite_results_turn(
+    tool_use_results: list[dict[str, Any]], assistant_text: str
+) -> dict[str, Any]:
+    """A conversations_v2 turn: user ToolUseResults + assistant Response."""
+    return {
+        "user": {"content": {"ToolUseResults": {"tool_use_results": tool_use_results}}},
+        "assistant": {"Response": {"message_id": "resp-1", "content": assistant_text}},
+    }
 
 
 def _write_kiro_session(
@@ -1692,3 +1746,314 @@ async def test_forward_kiro_session_stalled_turn_backstop_closes_card(
     )
     assert persisted["turn_live"] is False
     assert persisted["turn_response_id"] == turn_id
+
+
+# ── SQLite conversations_v2 source (current kiro) ───────────────────────────
+
+
+def test_kiro_records_from_conversation_normalizes_tool_turn() -> None:
+    """A conversations_v2 tool turn maps onto the Prompt / AssistantMessage /
+    ToolResults record stream, matching a real captured kiro-cli 2.15.1 session."""
+    history = [
+        _sqlite_prompt_turn(
+            "run it",
+            {
+                "message_id": "asst-1",
+                "content": "",
+                "tool_uses": [
+                    {
+                        "id": "tooluse_A",
+                        "name": "execute_cmd",
+                        "orig_name": "execute_cmd",
+                        "args": {"command": "echo hi"},
+                        "orig_args": {"command": "echo hi"},
+                    }
+                ],
+            },
+        ),
+        _sqlite_results_turn(
+            [
+                {
+                    "tool_use_id": "tooluse_A",
+                    "content": [{"Json": {"exit_status": "0", "stdout": "hi", "stderr": ""}}],
+                    "status": "Success",
+                }
+            ],
+            "Done, it printed hi.",
+        ),
+    ]
+
+    paired, next_index = forwarder._kiro_records_from_conversation("conv-1", history, 0)
+    records = [r for r, _cursor in paired]
+
+    assert next_index == 2
+    kinds = [(r.kind, r.message_id) for r in records]
+    assert kinds == [
+        ("Prompt", "conv-1:0"),
+        ("AssistantMessage", "asst-1"),
+        ("ToolResults", ""),
+        ("AssistantMessage", "resp-1"),
+    ]
+    assert records[1].tool_calls == (
+        forwarder.KiroToolCall(
+            call_id="tooluse_A", name="execute_cmd", arguments=json.dumps({"command": "echo hi"})
+        ),
+    )
+    assert records[2].tool_results[0].call_id == "tooluse_A"
+    assert "hi" in records[2].tool_results[0].output
+    assert records[3].text == "Done, it printed hi."
+    # Within one history entry only the last record advances the cursor: the
+    # non-last record carries the entry's start index, so a mid-entry failure
+    # re-reads the whole entry (item dedup handles the rest).
+    assert [cursor for _r, cursor in paired] == [0, 1, 1, 2]
+
+
+def test_kiro_records_from_conversation_holds_unfinished_turn() -> None:
+    """A turn whose assistant side is not yet written holds the cursor.
+
+    The streaming turn is re-read once kiro finishes it, rather than emitting a
+    half turn and advancing past it.
+    """
+    history = [
+        _sqlite_results_turn([{"tool_use_id": "x", "content": [{"Text": "ok"}]}], "first done"),
+        {"user": {"content": {"Prompt": {"prompt": "second"}}}},  # no assistant side yet
+    ]
+
+    paired, next_index = forwarder._kiro_records_from_conversation("c", history, 0)
+
+    # Only the finished first turn is emitted; the cursor holds at index 1.
+    assert next_index == 1
+    assert [r.kind for r, _c in paired] == ["ToolResults", "AssistantMessage"]
+
+    # Kiro finishes the second turn; the next read delivers it.
+    history[1]["assistant"] = {"Response": {"message_id": "r2", "content": "second done"}}
+    paired2, next_index2 = forwarder._kiro_records_from_conversation("c", history, next_index)
+    assert next_index2 == 2
+    assert [r.kind for r, _c in paired2] == ["Prompt", "AssistantMessage"]
+
+
+def test_read_kiro_sqlite_records_binds_by_cwd(tmp_path: Path) -> None:
+    """The reader binds the conversation whose key matches the workspace cwd and
+    reads new turns past the history cursor."""
+    db = tmp_path / "kiro-cli" / "data.sqlite3"
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    other = tmp_path / "other"
+    other.mkdir()
+    # A different-workspace conversation must not be picked.
+    _write_kiro_sqlite(
+        db, cwd=other, conversation_id="other", history=[_sqlite_results_turn([], "nope")]
+    )
+    _write_kiro_sqlite(
+        db,
+        cwd=workspace,
+        conversation_id="mine",
+        history=[
+            _sqlite_prompt_turn("hi", {"message_id": "a1", "content": "hello", "tool_uses": []})
+        ],
+    )
+
+    paired, idx = forwarder._read_kiro_sqlite_records(db, str(workspace), 0)
+    records = [r for r, _c in paired]
+
+    assert idx == 1
+    assert [r.kind for r in records] == ["Prompt", "AssistantMessage"]
+    assert records[0].text == "hi"
+    assert records[1].text == "hello"
+
+    # No new turns past the cursor.
+    records2, idx2 = forwarder._read_kiro_sqlite_records(db, str(workspace), 1)
+    assert records2 == [] and idx2 == 1
+
+    # Missing DB is a clean empty read, not a crash.
+    assert forwarder._read_kiro_sqlite_records(tmp_path / "gone.sqlite3", str(workspace), 0) == (
+        [],
+        0,
+    )
+
+
+def test_kiro_cli_database_path_honors_overrides(tmp_path: Path) -> None:
+    """KIRO_HOME wins; else the platform app-data dir is used."""
+    assert forwarder.kiro_cli_database_path(env={"KIRO_HOME": str(tmp_path)}) == (
+        tmp_path / "kiro-cli" / "data.sqlite3"
+    )
+    win = forwarder.kiro_cli_database_path(
+        home=tmp_path, env={"LOCALAPPDATA": str(tmp_path / "Local")}
+    )
+    # On Windows the LOCALAPPDATA branch is taken; elsewhere the XDG/home branch.
+    assert win.name == "data.sqlite3" and win.parent.name == "kiro-cli"
+
+
+def _blind_legacy_and_v3(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point legacy JSONL and V3 discovery at empty dirs so a test isolates one
+    source (they run before/after SQLite in the detection priority)."""
+    empty = tmp_path / "empty-sessions"
+    empty.mkdir(exist_ok=True)
+    monkeypatch.setattr(forwarder, "kiro_cli_sessions_dir", lambda *a, **k: empty)
+    monkeypatch.setattr(forwarder, "kiro_v3_sessions_dir", lambda *a, **k: empty)
+
+
+@pytest.mark.asyncio
+async def test_forward_kiro_session_mirrors_sqlite_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The forwarder detects and mirrors the SQLite conversations_v2 store (the
+    format current kiro's ``chat --tui`` engine writes), driving the full card
+    lifecycle from a real-shape conversation."""
+    db = tmp_path / "kiro-cli" / "data.sqlite3"
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    _write_kiro_sqlite(
+        db,
+        cwd=workspace,
+        conversation_id="conv-1",
+        history=[
+            _sqlite_prompt_turn(
+                "run it",
+                {
+                    "message_id": "a1",
+                    "content": "",
+                    "tool_uses": [
+                        {"id": "tooluse_A", "name": "execute_cmd", "args": {"command": "echo hi"}}
+                    ],
+                },
+            ),
+            _sqlite_results_turn(
+                [
+                    {
+                        "tool_use_id": "tooluse_A",
+                        "content": [{"Json": {"stdout": "hi"}}],
+                        "status": "Success",
+                    }
+                ],
+                "Done.",
+            ),
+        ],
+    )
+    monkeypatch.setattr(forwarder, "kiro_cli_database_path", lambda *a, **k: db)
+    _blind_legacy_and_v3(monkeypatch, tmp_path)
+    posted_events: list[dict[str, Any]] = []
+    _capture_events_client(monkeypatch, posted_events)
+
+    async def _cancel_sleep(_seconds: float) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(forwarder.asyncio, "sleep", _cancel_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await forwarder.forward_kiro_session_to_omnigent(
+            base_url="http://127.0.0.1:6767",
+            headers={},
+            session_id="conv_kiro",
+            bridge_dir=tmp_path / "bridge",
+            agent_name="kiro-native-ui",
+            workspace=str(workspace),
+            launch_epoch_ms=0,
+        )
+
+    turn_id = "kiro:turn:conv-1:0"
+    edges = [
+        (e["data"]["status"], e["data"]["response_id"])
+        for e in posted_events
+        if e["type"] == "external_session_status"
+    ]
+    assert edges == [("running", turn_id), ("idle", turn_id)]
+    items = [e["data"] for e in posted_events if e["type"] == "external_conversation_item"]
+    types = [i["item_type"] for i in items]
+    assert "function_call" in types and "function_call_output" in types
+    call = next(i["item_data"] for i in items if i["item_type"] == "function_call")
+    assert call["call_id"] == "tooluse_A" and call["name"] == "execute_cmd"
+    out = next(i["item_data"] for i in items if i["item_type"] == "function_call_output")
+    assert out["call_id"] == "tooluse_A" and "hi" in out["output"]
+    # The bound source and history cursor are persisted for restart resume.
+    persisted = json.loads((tmp_path / "bridge" / forwarder._STATE_FILE).read_text())
+    assert persisted["source_kind"] == "sqlite"
+    assert persisted["session_id"] == "conv-1"
+    assert persisted["byte_offset"] == 2
+
+
+@pytest.mark.asyncio
+async def test_forward_kiro_session_mirrors_v3_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The forwarder detects and mirrors a V3 ``messages.jsonl`` session,
+    closing the turn on ``turn_end`` (its prose events never settle the card)."""
+    sessions_root = tmp_path / "sessions"
+    sess_dir = sessions_root / "hash1" / "sess_abc"
+    sess_dir.mkdir(parents=True)
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (sess_dir / "session.json").write_text(
+        json.dumps({"cwd": str(workspace), "created_at": "2026-07-29T00:00:00Z"}),
+        encoding="utf-8",
+    )
+
+    def _v3(payload: dict[str, Any], rid: str) -> str:
+        return json.dumps({"id": rid, "timestamp": "2026-07-29T00:00:00Z", "payload": payload})
+
+    (sess_dir / "messages.jsonl").write_text(
+        "\n".join(
+            [
+                _v3({"type": "user", "content": "run it"}, "u1"),
+                _v3({"type": "turn_start", "executionId": "e1"}, "ts1"),
+                _v3(
+                    {
+                        "type": "tool_call",
+                        "toolCallId": "tc_A",
+                        "toolName": "execute_pwsh",
+                        "args": {"command": "echo hi"},
+                    },
+                    "call1",
+                ),
+                _v3({"type": "tool_result", "toolCallId": "tc_A", "content": "hi"}, "res1"),
+                _v3({"type": "assistant", "content": "It printed hi."}, "asst1"),
+                _v3({"type": "turn_end", "stopReason": "end_turn", "executionId": "e1"}, "te1"),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    # No SQLite, no legacy; V3 is the only source.
+    monkeypatch.setattr(forwarder, "kiro_cli_database_path", lambda *a, **k: tmp_path / "none.db")
+    monkeypatch.setattr(forwarder, "kiro_cli_sessions_dir", lambda *a, **k: tmp_path / "empty")
+    monkeypatch.setattr(forwarder, "kiro_v3_sessions_dir", lambda *a, **k: sessions_root)
+    posted_events: list[dict[str, Any]] = []
+    _capture_events_client(monkeypatch, posted_events)
+
+    async def _cancel_sleep(_seconds: float) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(forwarder.asyncio, "sleep", _cancel_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await forwarder.forward_kiro_session_to_omnigent(
+            base_url="http://127.0.0.1:6767",
+            headers={},
+            session_id="conv_kiro",
+            bridge_dir=tmp_path / "bridge",
+            agent_name="kiro-native-ui",
+            workspace=str(workspace),
+            launch_epoch_ms=0,
+        )
+
+    turn_id = "kiro:turn:u1"
+    edges = [
+        (e["data"]["status"], e["data"]["response_id"])
+        for e in posted_events
+        if e["type"] == "external_session_status"
+    ]
+    # Exactly one running then one idle (the idle from turn_end, not the
+    # intermediate prose which carries closes_turn=False).
+    assert edges == [("running", turn_id), ("idle", turn_id)]
+    items = [e["data"] for e in posted_events if e["type"] == "external_conversation_item"]
+    assert [i["item_type"] for i in items].count("function_call") == 1
+    assert [i["item_type"] for i in items].count("function_call_output") == 1
+    assert {
+        i["response_id"]
+        for i in items
+        if i["item_type"] != "message" or i["item_data"].get("role") == "assistant"
+    } <= {turn_id}
+    persisted = json.loads((tmp_path / "bridge" / forwarder._STATE_FILE).read_text())
+    assert persisted["source_kind"] == "v3_jsonl"

--- a/tests/test_kiro_native_session_forwarder.py
+++ b/tests/test_kiro_native_session_forwarder.py
@@ -82,11 +82,16 @@ def _assistant_record(
 
 
 def _tool_results_record(results: list[dict[str, Any]]) -> dict[str, Any]:
-    """One ``ToolResults`` record with ``toolResult`` blocks."""
+    """One ``ToolResults`` record with ``toolResult`` blocks.
+
+    The list field is ``results`` (kiro-cli 2.15.1 serde metadata:
+    ``ToolResults{results}``), each block adjacently tagged ``toolResult`` with
+    its fields under ``data``.
+    """
     return {
         "version": "v1",
         "kind": "ToolResults",
-        "data": {"content": [{"kind": "toolResult", "data": result} for result in results]},
+        "data": {"results": [{"kind": "toolResult", "data": result} for result in results]},
     }
 
 
@@ -955,6 +960,65 @@ def test_parse_kiro_jsonl_record_extracts_tool_vocabulary() -> None:
         forwarder.KiroToolResult(call_id="tooluse_A", output="file contents"),
     )
     assert forwarder.parse_kiro_jsonl_line(results_line) is None
+
+
+def test_parse_kiro_jsonl_record_tool_results_field_and_fallback() -> None:
+    """``ToolResults`` items read from ``results`` (kiro-cli 2.15.1) and, as a
+    tolerant fallback, from ``content`` for an older/variant shape."""
+    primary = json.dumps(
+        {
+            "version": "v1",
+            "kind": "ToolResults",
+            "data": {
+                "results": [
+                    {"kind": "toolResult", "data": {"toolUseId": "tooluse_A", "content": "out-a"}}
+                ]
+            },
+        }
+    )
+    record = forwarder.parse_kiro_jsonl_record(primary)
+    assert record is not None
+    assert record.tool_results == (forwarder.KiroToolResult(call_id="tooluse_A", output="out-a"),)
+
+    # structuredContent is accepted when there is no plain content block.
+    structured = json.dumps(
+        {
+            "version": "v1",
+            "kind": "ToolResults",
+            "data": {
+                "results": [
+                    {
+                        "kind": "toolResult",
+                        "data": {"toolUseId": "tooluse_B", "structuredContent": {"rows": 3}},
+                    }
+                ]
+            },
+        }
+    )
+    structured_record = forwarder.parse_kiro_jsonl_record(structured)
+    assert structured_record is not None
+    assert structured_record.tool_results[0].call_id == "tooluse_B"
+    assert "rows" in structured_record.tool_results[0].output
+
+    fallback = json.dumps(
+        {
+            "version": "v1",
+            "kind": "ToolResults",
+            "data": {
+                "content": [
+                    {
+                        "kind": "toolResult",
+                        "data": {"tool_use_id": "tooluse_C", "content": "out-c"},
+                    }
+                ]
+            },
+        }
+    )
+    fallback_record = forwarder.parse_kiro_jsonl_record(fallback)
+    assert fallback_record is not None
+    assert fallback_record.tool_results == (
+        forwarder.KiroToolResult(call_id="tooluse_C", output="out-c"),
+    )
 
 
 def test_parse_kiro_jsonl_record_accepts_flat_acp_style_tool_blocks() -> None:

--- a/tests/test_kiro_native_session_forwarder.py
+++ b/tests/test_kiro_native_session_forwarder.py
@@ -1256,6 +1256,94 @@ async def test_forward_kiro_session_restart_rebinds_known_session_under_ambiguit
     assert any(i["item_type"] == "function_call_output" for i in items)
 
 
+@pytest.mark.asyncio
+async def test_forward_kiro_session_no_duplicate_on_mid_record_post_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A POST that fails partway through a multi-item record does not re-post the
+    items that already landed when the poll retries.
+
+    The 2nd tool call's POST 503s once; the record re-reads on the next poll and
+    only the failed call is re-sent. Prose and the first call post exactly once.
+    """
+    sessions_dir = tmp_path / "home" / ".kiro" / "sessions" / "cli"
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    _write_kiro_session(
+        sessions_dir,
+        session_id="kiro-session",
+        cwd=workspace,
+        lines=[
+            _prompt_record("user-1", "run it"),
+            _assistant_record(
+                "a1",
+                text="Let me check",
+                tool_uses=[
+                    {"tool_use_id": "tooluse_A", "name": "read", "input": {}},
+                    {"tool_use_id": "tooluse_B", "name": "shell", "input": {}},
+                ],
+            ),
+        ],
+    )
+    monkeypatch.setattr(forwarder, "kiro_cli_sessions_dir", lambda: sessions_dir)
+    posted_items: list[tuple[str, str]] = []
+    fail_once = {"b": True}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path.endswith("/events"):
+            payload = json.loads(request.content)
+            if payload["type"] == "external_conversation_item":
+                data = payload["data"]
+                idata = data["item_data"]
+                ident = idata.get("call_id") or "".join(
+                    b.get("text", "") for b in idata.get("content", [])
+                )
+                # The 2nd tool call fails exactly once (transient 503).
+                if (
+                    data["item_type"] == "function_call"
+                    and ident == "tooluse_B"
+                    and fail_once["b"]
+                ):
+                    fail_once["b"] = False
+                    return httpx.Response(503, json={})
+                posted_items.append((data["item_type"], ident))
+        return httpx.Response(200, json={})
+
+    real = forwarder.httpx.AsyncClient
+
+    def _factory(*a: Any, **k: Any) -> httpx.AsyncClient:
+        k.pop("transport", None)
+        return real(*a, transport=httpx.MockTransport(_handler), **k)
+
+    monkeypatch.setattr(forwarder.httpx, "AsyncClient", _factory)
+
+    polls = {"n": 0}
+
+    async def _cancel_after_two(_seconds: float) -> None:
+        polls["n"] += 1
+        if polls["n"] >= 2:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(forwarder.asyncio, "sleep", _cancel_after_two)
+
+    with pytest.raises(asyncio.CancelledError):
+        await forwarder.forward_kiro_session_to_omnigent(
+            base_url="http://127.0.0.1:6767",
+            headers={},
+            session_id="conv_kiro",
+            bridge_dir=tmp_path / "bridge",
+            agent_name="kiro-native-ui",
+            workspace=str(workspace),
+            launch_epoch_ms=forwarder._parse_iso_epoch_ms("2026-06-21T01:39:34Z"),
+        )
+
+    # Each item lands exactly once despite the mid-record failure + retry.
+    assert posted_items.count(("message", "Let me check")) == 1
+    assert posted_items.count(("function_call", "tooluse_A")) == 1
+    assert posted_items.count(("function_call", "tooluse_B")) == 1
+
+
 def test_forward_state_round_trips_turn_fields(tmp_path: Path) -> None:
     """The persisted cursor carries the open turn's card state across restarts."""
     state = forwarder._ForwardState(


### PR DESCRIPTION
Live tool-call cards for kiro-native sessions: mirror kiro's transcript tool calls and results into `function_call` cards under a per-turn `response_id`, the same shape the goose-native forwarder uses.

Also reads whichever store the running kiro actually writes, since the format the forwarder targeted (kiro 2.8.1's `~/.kiro/sessions/cli/*.jsonl`) is gone in current kiro. Verified against a real 2.15.1 session: the `chat --tui` engine now persists a SQLite `conversations_v2` store, and the V3 agent streams a `{id,timestamp,payload}` `messages.jsonl`. Both normalize to one record stream, so the card logic is format-agnostic, and the legacy JSONL still works. Redelivery is exactly-once on retry, at-least-once only in the narrow post-then-persist restart window.

Test Plan: `uv run pytest tests/test_kiro_native_session_forwarder.py` (34 pass).

Part of #1878. Demo: N/A for now - this is the transcript-forwarder backend only, no web changes; the cards it feeds render through the same UI the opencode/goose/hermes forwarders shipped with (#1882, #1992, #2046).

