### PR TITLE
Implement runtime-native deferred tool call approvals (#3368)(DEFER primitive)

### DIFF
--- a/omnigent/runner/policy.py
+++ b/omnigent/runner/policy.py
@@ -94,7 +94,7 @@ class PolicyVerdict:
         when the policy did not return a replacement.
     """
 
-    action: Literal["allow", "deny", "ask"]
+    action: Literal["allow", "deny", "ask", "defer"]
     deny_text: str | None = None
     policy_name: str | None = None
     reason: str | None = None
@@ -316,6 +316,13 @@ class RunnerToolPolicyGate:
                     deny_text=format_deny_text(gated.name, result.reason),
                     policy_name=gated.name,
                     reason=result.reason,
+                )
+            if result.action == PolicyAction.DEFER:
+                return PolicyVerdict(
+                    action="defer",
+                    policy_name=gated.name,
+                    reason=result.reason,
+                    data=result.data,
                 )
             if result.data is not None:
                 composed_data = result.data

--- a/omnigent/runtime/deferred/__init__.py
+++ b/omnigent/runtime/deferred/__init__.py
@@ -1,0 +1,30 @@
+"""
+Runtime-native deferred action approval system.
+
+Surfaces deferred tool-call execution manifests for asynchronous
+human approval.
+"""
+
+from omnigent.runtime.deferred.hashing import compute_manifest_hash
+from omnigent.runtime.deferred.models import (
+    DeferredAction,
+    DeferredActionStatus,
+    DeferredAuditEvent,
+    DeferredManifest,
+)
+from omnigent.runtime.deferred.store import (
+    DeferredActionStore,
+    MemoryDeferredActionStore,
+    get_deferred_store,
+)
+
+__all__ = [
+    "DeferredAction",
+    "DeferredActionStatus",
+    "DeferredAuditEvent",
+    "DeferredManifest",
+    "DeferredActionStore",
+    "MemoryDeferredActionStore",
+    "compute_manifest_hash",
+    "get_deferred_store",
+]

--- a/omnigent/runtime/deferred/events.py
+++ b/omnigent/runtime/deferred/events.py
@@ -1,0 +1,60 @@
+"""
+Session stream event publishers for deferred action state transitions.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from omnigent.runtime import session_stream
+from omnigent.runtime.deferred.models import DeferredAction
+
+_logger = logging.getLogger(__name__)
+
+
+def _publish_deferred_event(event_type: str, session_id: str, action: DeferredAction) -> None:
+    """Helper to publish deferred action state change event to session stream."""
+    event_payload: dict[str, Any] = {
+        "type": event_type,
+        "action": action.to_dict(),
+    }
+    try:
+        session_stream.publish(session_id, event_payload)
+    except Exception as exc:
+        _logger.warning("Failed to publish deferred action event %s: %s", event_type, exc)
+
+
+def emit_deferred_created(session_id: str, action: DeferredAction) -> None:
+    """Emit response.deferred.created SSE stream event."""
+    _publish_deferred_event("response.deferred.created", session_id, action)
+
+
+def emit_deferred_approved(session_id: str, action: DeferredAction) -> None:
+    """Emit response.deferred.approved SSE stream event."""
+    _publish_deferred_event("response.deferred.approved", session_id, action)
+
+
+def emit_deferred_rejected(session_id: str, action: DeferredAction) -> None:
+    """Emit response.deferred.rejected SSE stream event."""
+    _publish_deferred_event("response.deferred.rejected", session_id, action)
+
+
+def emit_deferred_executed(session_id: str, action: DeferredAction) -> None:
+    """Emit response.deferred.executed SSE stream event."""
+    _publish_deferred_event("response.deferred.executed", session_id, action)
+
+
+def emit_deferred_expired(session_id: str, action: DeferredAction) -> None:
+    """Emit response.deferred.expired SSE stream event."""
+    _publish_deferred_event("response.deferred.expired", session_id, action)
+
+
+def emit_deferred_failed(session_id: str, action: DeferredAction) -> None:
+    """Emit response.deferred.failed SSE stream event."""
+    _publish_deferred_event("response.deferred.failed", session_id, action)
+
+
+def emit_deferred_hash_drift(session_id: str, action: DeferredAction) -> None:
+    """Emit response.deferred.hash_drift SSE stream event."""
+    _publish_deferred_event("response.deferred.hash_drift", session_id, action)

--- a/omnigent/runtime/deferred/hashing.py
+++ b/omnigent/runtime/deferred/hashing.py
@@ -1,0 +1,42 @@
+"""
+Manifest hashing functions for tamper detection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from omnigent.runtime.deferred.models import DeferredManifest
+
+
+def _canonicalize(obj: Any) -> Any:
+    """Recursively sort dict keys for deterministic JSON serialization."""
+    if isinstance(obj, dict):
+        return {k: _canonicalize(v) for k, v in sorted(obj.items())}
+    if isinstance(obj, list):
+        return [_canonicalize(x) for x in obj]
+    return obj
+
+
+def compute_manifest_hash(manifest: DeferredManifest) -> str:
+    """
+    Compute deterministic SHA-256 hash of a deferred manifest.
+
+    Canonicalizes dictionary keys to ensure identical payloads produce
+    identical hash output across platforms.
+    """
+    canonical_payload = {
+        "tool": manifest.tool,
+        "arguments": _canonicalize(manifest.arguments),
+        "base_hash": manifest.base_hash,
+        "session_id": manifest.session_id,
+        "target": manifest.target,
+    }
+    raw_bytes = json.dumps(
+        canonical_payload,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(raw_bytes).hexdigest()

--- a/omnigent/runtime/deferred/manager.py
+++ b/omnigent/runtime/deferred/manager.py
@@ -1,0 +1,311 @@
+"""
+Lifecycle manager for freezing, approving, rejecting, and executing deferred actions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import secrets
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from omnigent.runtime.deferred import events
+from omnigent.runtime.deferred.hashing import compute_manifest_hash
+from omnigent.runtime.deferred.models import (
+    DeferredAction,
+    DeferredActionStatus,
+    DeferredAuditEvent,
+    DeferredManifest,
+)
+from omnigent.runtime.deferred.store import DeferredActionStore, get_deferred_store
+
+_logger = logging.getLogger(__name__)
+
+# Default expiration budget for a deferred action (1 hour).
+DEFAULT_DEFERRED_EXPIRATION_SECONDS = 3600
+
+
+class DeferredActionError(Exception):
+    """Base exception for deferred action processing errors."""
+
+
+class DeferredExpiredError(DeferredActionError):
+    """Raised when an operation is requested on an expired deferred action."""
+
+
+class HashDriftError(DeferredActionError):
+    """Raised when base state or manifest hash has drifted before approval."""
+
+
+class DeferredStateError(DeferredActionError):
+    """Raised when an invalid state transition is requested."""
+
+
+class DeferredActionManager:
+    """
+    Manages deferred action freezing, verification, approval, rejection, and execution.
+    """
+
+    def __init__(self, store: DeferredActionStore | None = None) -> None:
+        self._store = store or get_deferred_store()
+        self._lock = asyncio.Lock()
+
+    async def freeze(
+        self,
+        *,
+        tool: str,
+        arguments: dict[str, Any],
+        base_hash: str,
+        session_id: str,
+        target: str | None = None,
+        task_id: str | None = None,
+        deciding_policy: str | None = None,
+        reason: str | None = None,
+        expiration_seconds: int = DEFAULT_DEFERRED_EXPIRATION_SECONDS,
+        actor: str = "agent",
+    ) -> DeferredAction:
+        """
+        Freeze a proposed tool call manifest into a deferred action.
+        """
+        manifest = DeferredManifest(
+            tool=tool,
+            arguments=arguments,
+            base_hash=base_hash,
+            session_id=session_id,
+            target=target,
+        )
+        manifest_hash = compute_manifest_hash(manifest)
+        action_id = f"def_{secrets.token_hex(16)}"
+
+        now_dt = datetime.now(timezone.utc)
+        expires_dt = now_dt + timedelta(seconds=expiration_seconds)
+
+        now_str = now_dt.isoformat()
+        expires_str = expires_dt.isoformat()
+
+        action = DeferredAction(
+            id=action_id,
+            manifest=manifest,
+            manifest_hash=manifest_hash,
+            status="PENDING",
+            created_at=now_str,
+            expires_at=expires_str,
+            session_id=session_id,
+            task_id=task_id,
+            deciding_policy=deciding_policy,
+            reason=reason,
+        )
+
+        audit_event = DeferredAuditEvent(
+            id=f"evt_{secrets.token_hex(12)}",
+            action_id=action_id,
+            event_type="CREATE",
+            timestamp=now_str,
+            actor=actor,
+            details={
+                "tool": tool,
+                "manifest_hash": manifest_hash,
+                "reason": reason,
+            },
+        )
+
+        await self._store.save_action(action)
+        await self._store.add_audit_event(audit_event)
+        events.emit_deferred_created(session_id, action)
+
+        return action
+
+    async def approve(
+        self,
+        action_id: str,
+        *,
+        actor: str,
+        current_base_hash: str,
+    ) -> DeferredAction:
+        """
+        Mark a deferred action as APPROVED after verifying expiration and hash matching.
+
+        Requires mandatory current_base_hash to verify against stored state.
+        """
+        async with self._lock:
+            action = await self._store.get_action(action_id)
+            if action is None:
+                raise DeferredActionError(f"Deferred action {action_id!r} not found")
+
+            # Idempotent return if already approved or executed
+            if action.status in ("APPROVED", "EXECUTED"):
+                return action
+
+            if action.status != "PENDING":
+                raise DeferredStateError(
+                    f"Cannot approve action {action_id!r} with status {action.status!r}",
+                )
+
+            now_dt = datetime.now(timezone.utc)
+            now_str = now_dt.isoformat()
+
+            # 1. Check expiration
+            expires_dt = datetime.fromisoformat(action.expires_at)
+            if now_dt > expires_dt:
+                action.status = "EXPIRED"
+                await self._store.save_action(action)
+                await self._store.add_audit_event(
+                    DeferredAuditEvent(
+                        id=f"evt_{secrets.token_hex(12)}",
+                        action_id=action_id,
+                        event_type="EXPIRE",
+                        timestamp=now_str,
+                        actor="system",
+                        details={"reason": "Approval attempt after expiration"},
+                    ),
+                )
+                events.emit_deferred_expired(action.session_id, action)
+                raise DeferredExpiredError(f"Deferred action {action_id!r} has expired")
+
+            # 2. Check hash drift
+            current_manifest = DeferredManifest(
+                tool=action.manifest.tool,
+                arguments=action.manifest.arguments,
+                base_hash=current_base_hash,
+                session_id=action.manifest.session_id,
+                target=action.manifest.target,
+            )
+            current_hash = compute_manifest_hash(current_manifest)
+
+            if current_hash != action.manifest_hash:
+                action.status = "HASH_DRIFT"
+                await self._store.save_action(action)
+                await self._store.add_audit_event(
+                    DeferredAuditEvent(
+                        id=f"evt_{secrets.token_hex(12)}",
+                        action_id=action_id,
+                        event_type="HASH_DRIFT",
+                        timestamp=now_str,
+                        actor=actor,
+                        details={
+                            "expected_hash": action.manifest_hash,
+                            "current_hash": current_hash,
+                            "expected_base_hash": action.manifest.base_hash,
+                            "current_base_hash": current_base_hash,
+                        },
+                    ),
+                )
+                events.emit_deferred_hash_drift(action.session_id, action)
+                raise HashDriftError(
+                    f"State drift detected for action {action_id!r}: base state changed",
+                )
+
+            # 3. Valid approval
+            action.status = "APPROVED"
+            await self._store.save_action(action)
+            await self._store.add_audit_event(
+                DeferredAuditEvent(
+                    id=f"evt_{secrets.token_hex(12)}",
+                    action_id=action_id,
+                    event_type="APPROVE",
+                    timestamp=now_str,
+                    actor=actor,
+                ),
+            )
+            events.emit_deferred_approved(action.session_id, action)
+            return action
+
+    async def execute(
+        self,
+        action_id: str,
+        executor_func: Callable[[], Awaitable[Any]],
+    ) -> DeferredAction:
+        """
+        Execute an APPROVED deferred action callback.
+
+        Transitions to EXECUTED on success, or FAILED if an exception occurs.
+        """
+        async with self._lock:
+            action = await self._store.get_action(action_id)
+            if action is None:
+                raise DeferredActionError(f"Deferred action {action_id!r} not found")
+
+            if action.status == "EXECUTED":
+                return action
+
+            if action.status != "APPROVED":
+                raise DeferredStateError(
+                    f"Cannot execute action {action_id!r} in status {action.status!r}",
+                )
+
+            now_str = datetime.now(timezone.utc).isoformat()
+
+            try:
+                await executor_func()
+                action.status = "EXECUTED"
+                await self._store.save_action(action)
+                await self._store.add_audit_event(
+                    DeferredAuditEvent(
+                        id=f"evt_{secrets.token_hex(12)}",
+                        action_id=action_id,
+                        event_type="EXECUTE",
+                        timestamp=now_str,
+                        actor="system",
+                    ),
+                )
+                events.emit_deferred_executed(action.session_id, action)
+                return action
+            except Exception as exc:
+                action.status = "FAILED"
+                action.error_message = str(exc)
+                await self._store.save_action(action)
+                await self._store.add_audit_event(
+                    DeferredAuditEvent(
+                        id=f"evt_{secrets.token_hex(12)}",
+                        action_id=action_id,
+                        event_type="FAIL",
+                        timestamp=now_str,
+                        actor="system",
+                        details={"error": str(exc)},
+                    ),
+                )
+                events.emit_deferred_failed(action.session_id, action)
+                raise
+
+    async def reject(
+        self,
+        action_id: str,
+        *,
+        actor: str,
+        reason: str | None = None,
+    ) -> DeferredAction:
+        """
+        Reject a pending deferred action.
+        """
+        async with self._lock:
+            action = await self._store.get_action(action_id)
+            if action is None:
+                raise DeferredActionError(f"Deferred action {action_id!r} not found")
+
+            if action.status == "REJECTED":
+                return action
+
+            if action.status not in ("PENDING", "APPROVED"):
+                raise DeferredStateError(
+                    f"Cannot reject action {action_id!r} with status {action.status!r}",
+                )
+
+            now_str = datetime.now(timezone.utc).isoformat()
+            action.status = "REJECTED"
+            action.reason = reason or action.reason
+            await self._store.save_action(action)
+            await self._store.add_audit_event(
+                DeferredAuditEvent(
+                    id=f"evt_{secrets.token_hex(12)}",
+                    action_id=action_id,
+                    event_type="REJECT",
+                    timestamp=now_str,
+                    actor=actor,
+                    details={"reason": reason},
+                ),
+            )
+            events.emit_deferred_rejected(action.session_id, action)
+            return action

--- a/omnigent/runtime/deferred/models.py
+++ b/omnigent/runtime/deferred/models.py
@@ -1,0 +1,99 @@
+"""
+Data models for runtime deferred actions and audit trails.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+DeferredActionStatus = Literal[
+    "PENDING",
+    "APPROVED",
+    "REJECTED",
+    "EXPIRED",
+    "EXECUTED",
+    "FAILED",
+    "HASH_DRIFT",
+]
+
+
+@dataclass(frozen=True)
+class DeferredManifest:
+    """
+    Captured manifest representing a deferred tool call effect.
+    """
+
+    tool: str
+    arguments: dict[str, Any]
+    base_hash: str
+    session_id: str
+    target: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert manifest to a standard JSON serializable dict."""
+        return {
+            "tool": self.tool,
+            "arguments": self.arguments,
+            "base_hash": self.base_hash,
+            "session_id": self.session_id,
+            "target": self.target,
+        }
+
+
+@dataclass
+class DeferredAuditEvent:
+    """
+    Append-only record of a state transition or action taken on a deferred action.
+    """
+
+    id: str
+    action_id: str
+    event_type: Literal[
+        "CREATE",
+        "APPROVE",
+        "REJECT",
+        "EXECUTE",
+        "EXPIRE",
+        "FAIL",
+        "HASH_DRIFT",
+    ]
+    timestamp: str
+    actor: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class DeferredAction:
+    """
+    Runtime record representing a frozen deferred tool execution gate.
+    """
+
+    id: str
+    manifest: DeferredManifest
+    manifest_hash: str
+    status: DeferredActionStatus
+    created_at: str
+    expires_at: str
+    session_id: str
+    task_id: str | None = None
+    deciding_policy: str | None = None
+    reason: str | None = None
+    error_message: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert action object to a dictionary payload."""
+        return {
+            "id": self.id,
+            "manifest": self.manifest.to_dict(),
+            "manifest_hash": self.manifest_hash,
+            "status": self.status,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+            "session_id": self.session_id,
+            "task_id": self.task_id,
+            "deciding_policy": self.deciding_policy,
+            "reason": self.reason,
+            "error_message": self.error_message,
+        }

--- a/omnigent/runtime/deferred/store.py
+++ b/omnigent/runtime/deferred/store.py
@@ -1,0 +1,96 @@
+"""
+Storage interface and memory implementation for deferred actions and audit events.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from abc import ABC, abstractmethod
+from typing import Sequence
+
+from omnigent.runtime.deferred.models import DeferredAction, DeferredAuditEvent
+
+
+class DeferredActionStore(ABC):
+    """
+    Abstract storage interface for deferred actions and audit logs.
+    """
+
+    @abstractmethod
+    async def save_action(self, action: DeferredAction) -> None:
+        """Save or update a deferred action in storage."""
+
+    @abstractmethod
+    async def get_action(self, action_id: str) -> DeferredAction | None:
+        """Fetch a deferred action by ID."""
+
+    @abstractmethod
+    async def list_actions_for_session(self, session_id: str) -> list[DeferredAction]:
+        """List all deferred actions associated with a session."""
+
+    @abstractmethod
+    async def add_audit_event(self, event: DeferredAuditEvent) -> None:
+        """Append an audit event to the action's log."""
+
+    @abstractmethod
+    async def list_audit_events(self, action_id: str) -> list[DeferredAuditEvent]:
+        """List all audit log events for an action."""
+
+
+class MemoryDeferredActionStore(DeferredActionStore):
+    """
+    Thread-safe in-memory store for deferred actions and audit trails.
+    """
+
+    def __init__(self) -> None:
+        self._actions: dict[str, DeferredAction] = {}
+        self._audit_events: dict[str, list[DeferredAuditEvent]] = {}
+        self._lock = asyncio.Lock()
+
+    async def save_action(self, action: DeferredAction) -> None:
+        """Store or overwrite a deferred action."""
+        async with self._lock:
+            self._actions[action.id] = action
+
+    async def get_action(self, action_id: str) -> DeferredAction | None:
+        """Retrieve action by ID."""
+        async with self._lock:
+            return self._actions.get(action_id)
+
+    async def list_actions_for_session(self, session_id: str) -> list[DeferredAction]:
+        """Return all actions registered for a session ID."""
+        async with self._lock:
+            return [
+                action
+                for action in self._actions.values()
+                if action.session_id == session_id
+            ]
+
+    async def add_audit_event(self, event: DeferredAuditEvent) -> None:
+        """Append audit event row."""
+        async with self._lock:
+            if event.action_id not in self._audit_events:
+                self._audit_events[event.action_id] = []
+            self._audit_events[event.action_id].append(event)
+
+    async def list_audit_events(self, action_id: str) -> list[DeferredAuditEvent]:
+        """Fetch chronological audit events for action_id."""
+        async with self._lock:
+            return list(self._audit_events.get(action_id, []))
+
+
+_global_store: DeferredActionStore | None = None
+
+
+def get_deferred_store() -> DeferredActionStore:
+    """Get or initialize the global memory store instance."""
+    global _global_store
+    if _global_store is None:
+        _global_store = MemoryDeferredActionStore()
+    return _global_store
+
+
+def set_deferred_store(store: DeferredActionStore | None) -> None:
+    """Set global store instance (primarily for testing)."""
+    global _global_store
+    _global_store = store

--- a/omnigent/runtime/policies/engine.py
+++ b/omnigent/runtime/policies/engine.py
@@ -333,6 +333,8 @@ class PolicyEngine:
         accumulated_state: list[StateUpdate] = []
         ask_reasons: list[str] = []
         deciding_ask_policies: list[str] = []
+        defer_reasons: list[str] = []
+        deciding_defer_policies: list[str] = []
         # Sequentially accumulated data: each policy that returns data
         # has its output fed back into ctx.content so the next policy
         # in the chain transforms the already-transformed payload rather
@@ -378,6 +380,11 @@ class PolicyEngine:
                     f"{policy.spec.name}: {result.reason or 'approval required'}",
                 )
                 deciding_ask_policies.append(policy.spec.name)
+            elif result.action == PolicyAction.DEFER:
+                defer_reasons.append(
+                    f"{policy.spec.name}: {result.reason or 'deferred approval required'}",
+                )
+                deciding_defer_policies.append(policy.spec.name)
 
         if ask_reasons:
             # DO NOT apply label writes or state updates here — the ASK
@@ -391,6 +398,15 @@ class PolicyEngine:
                 set_labels=dict(accumulated) if accumulated else None,
                 state_updates=list(accumulated_state) if accumulated_state else None,
                 deciding_policies=deciding_ask_policies,
+                data=composed_data,
+            )
+        if defer_reasons:
+            return PolicyResult(
+                action=PolicyAction.DEFER,
+                reason="; ".join(defer_reasons),
+                set_labels=dict(accumulated) if accumulated else None,
+                state_updates=list(accumulated_state) if accumulated_state else None,
+                deciding_policies=deciding_defer_policies,
                 data=composed_data,
             )
         if not read_only:

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -85,6 +85,9 @@ from omnigent.server.routes.sessions import (
     create_sessions_router,
     set_server_runner_router,
 )
+from omnigent.server.routes.deferred_actions import (
+    router as deferred_actions_router,
+)
 from omnigent.server.routes.sharing import create_sharing_router
 from omnigent.server.routes.terminal_attach import create_terminal_attach_router
 from omnigent.server.routes.usage import create_usage_router
@@ -2418,6 +2421,8 @@ def create_app(
         prefix="/v1",
         tags=["sharing"],
     )
+
+    app.include_router(deferred_actions_router)
 
     # First-class projects (owner-private session containers). Mounted only
     # when a project store is wired; the endpoints self-scope to the caller.

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -61,6 +61,7 @@ from omnigent.runtime import (
     pending_elicitations,
     pending_inputs,
 )
+from omnigent.runtime.deferred.manager import DeferredActionManager
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.runtime.policies.approval import (
     build_elicitation_request_event,
@@ -6034,6 +6035,38 @@ async def _handle_mcp_tools_call(
                 rpc_id,
                 -32000,
                 f"Denied by policy: {call_result.reason or 'no reason given'}",
+            )
+
+        if call_result.action == PolicyAction.DEFER:
+            manager = DeferredActionManager()
+            deferred_action = await manager.freeze(
+                tool=namespaced_name,
+                arguments=arguments,
+                base_hash=session_id,
+                session_id=session_id,
+                deciding_policy=call_result.deciding_policy,
+                reason=call_result.reason,
+            )
+            return JSONResponse(
+                content={
+                    "jsonrpc": "2.0",
+                    "id": rpc_id,
+                    "result": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": json.dumps(
+                                    {
+                                        "status": "deferred",
+                                        "deferred_id": deferred_action.id,
+                                        "message": f"Action deferred for out-of-band approval: {call_result.reason or 'approval required'}",
+                                    }
+                                ),
+                            }
+                        ],
+                        "isError": False,
+                    },
+                }
             )
 
         if call_result.action == PolicyAction.ASK:

--- a/omnigent/server/routes/deferred_actions.py
+++ b/omnigent/server/routes/deferred_actions.py
@@ -1,0 +1,130 @@
+"""
+REST API routes for listing, viewing, approving, and rejecting deferred actions.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel
+
+from omnigent.runtime.deferred.manager import (
+    DeferredActionError,
+    DeferredActionManager,
+    DeferredExpiredError,
+    DeferredStateError,
+    HashDriftError,
+)
+from omnigent.runtime.deferred.store import get_deferred_store
+
+_logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["deferred_actions"])
+
+
+class ApproveRequest(BaseModel):
+    """Payload for approving a deferred action."""
+
+    actor: str = "user"
+    current_base_hash: str
+
+
+class RejectRequest(BaseModel):
+    """Payload for rejecting a deferred action."""
+
+    actor: str = "user"
+    reason: str | None = None
+
+
+@router.get("/v1/sessions/{session_id}/deferred_actions")
+async def list_deferred_actions(session_id: str) -> dict[str, Any]:
+    """List all deferred actions for a given session."""
+    store = get_deferred_store()
+    actions = await store.list_actions_for_session(session_id)
+    return {"deferred_actions": [action.to_dict() for action in actions]}
+
+
+@router.get("/v1/deferred_actions/{action_id}")
+async def get_deferred_action(action_id: str) -> dict[str, Any]:
+    """Retrieve details and audit trail events for a deferred action."""
+    store = get_deferred_store()
+    action = await store.get_action(action_id)
+    if action is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Deferred action {action_id!r} not found",
+        )
+    events = await store.list_audit_events(action_id)
+    return {
+        "action": action.to_dict(),
+        "audit_events": [
+            {
+                "id": evt.id,
+                "action_id": evt.action_id,
+                "event_type": evt.event_type,
+                "timestamp": evt.timestamp,
+                "actor": evt.actor,
+                "details": evt.details,
+            }
+            for evt in events
+        ],
+    }
+
+
+@router.post("/v1/deferred_actions/{action_id}/approve")
+async def approve_deferred_action(
+    action_id: str,
+    payload: ApproveRequest,
+) -> dict[str, Any]:
+    """
+    Approve a deferred action.
+
+    Verifies expiration and base hash equality, transitioning status to APPROVED.
+    Returns immediately without blocking on tool execution.
+    """
+    manager = DeferredActionManager()
+    try:
+        action = await manager.approve(
+            action_id,
+            actor=payload.actor,
+            current_base_hash=payload.current_base_hash,
+        )
+        return {"status": "success", "action": action.to_dict()}
+    except DeferredExpiredError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail=str(exc),
+        ) from exc
+    except HashDriftError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+    except (DeferredStateError, DeferredActionError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+@router.post("/v1/deferred_actions/{action_id}/reject")
+async def reject_deferred_action(
+    action_id: str,
+    payload: RejectRequest,
+) -> dict[str, Any]:
+    """Reject a pending deferred action."""
+    manager = DeferredActionManager()
+    try:
+        action = await manager.reject(
+            action_id,
+            actor=payload.actor,
+            reason=payload.reason,
+        )
+        return {"status": "success", "action": action.to_dict()}
+    except (DeferredStateError, DeferredActionError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -1138,17 +1138,19 @@ class Phase(str, Enum):
 
 class PolicyAction(str, Enum):
     """
-    The three decisions a policy can emit.
+    The decisions a policy can emit.
 
     - ``ALLOW``: the phase proceeds normally.
-    - ``ASK``: park for user approval; on approve → ALLOW, on
+    - ``ASK``: park for synchronous user approval; on approve → ALLOW, on
       refuse/timeout → DENY.
+    - ``DEFER``: freeze manifest for out-of-band asynchronous approval.
     - ``DENY``: short-circuit the phase; replace content with a
       sentinel so downstream steps cannot act on it.
     """
 
     ALLOW = "allow"
     ASK = "ask"
+    DEFER = "defer"
     DENY = "deny"
 
 

--- a/tests/runtime/deferred/test_manager.py
+++ b/tests/runtime/deferred/test_manager.py
@@ -1,0 +1,187 @@
+"""
+Unit and lifecycle tests for DeferredActionManager and MemoryDeferredActionStore.
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from omnigent.runtime.deferred.manager import (
+    DeferredActionError,
+    DeferredActionManager,
+    DeferredExpiredError,
+    DeferredStateError,
+    HashDriftError,
+)
+from omnigent.runtime.deferred.store import MemoryDeferredActionStore
+
+
+@pytest.mark.asyncio
+async def test_freeze_and_approve_lifecycle():
+    """Verify freeze -> approve -> execute happy path lifecycle."""
+    store = MemoryDeferredActionStore()
+    manager = DeferredActionManager(store=store)
+
+    action = await manager.freeze(
+        tool="sys_os_edit",
+        arguments={"file": "test.txt", "text": "hello"},
+        base_hash="hash_base_1",
+        session_id="session_100",
+        actor="test_user",
+    )
+
+    assert action.status == "PENDING"
+    assert action.id.startswith("def_")
+
+    # Approve with matching base_hash
+    approved_action = await manager.approve(
+        action.id,
+        actor="admin",
+        current_base_hash="hash_base_1",
+    )
+
+    assert approved_action.status == "APPROVED"
+
+    # Execute callback
+    executed = False
+
+    async def _dummy_exec():
+        nonlocal executed
+        executed = True
+
+    final_action = await manager.execute(action.id, _dummy_exec)
+
+    assert final_action.status == "EXECUTED"
+    assert executed is True
+
+    # Audit events check
+    audit_events = await store.list_audit_events(action.id)
+    event_types = [evt.event_type for evt in audit_events]
+    assert event_types == ["CREATE", "APPROVE", "EXECUTE"]
+
+
+@pytest.mark.asyncio
+async def test_executor_crash_transitions_to_failed():
+    """Verify exception inside executor transitions action status to FAILED."""
+    store = MemoryDeferredActionStore()
+    manager = DeferredActionManager(store=store)
+
+    action = await manager.freeze(
+        tool="sys_os_shell",
+        arguments={"command": "exit 1"},
+        base_hash="hash_base_1",
+        session_id="session_101",
+    )
+
+    await manager.approve(
+        action.id,
+        actor="admin",
+        current_base_hash="hash_base_1",
+    )
+
+    async def _crashing_exec():
+        raise RuntimeError("Command execution failed")
+
+    with pytest.raises(RuntimeError, match="Command execution failed"):
+        await manager.execute(action.id, _crashing_exec)
+
+    failed_action = await store.get_action(action.id)
+    assert failed_action.status == "FAILED"
+    assert "Command execution failed" in (failed_action.error_message or "")
+
+
+@pytest.mark.asyncio
+async def test_hash_drift_detection_fail_closed():
+    """Verify modifying base hash before approval raises HashDriftError and sets HASH_DRIFT."""
+    store = MemoryDeferredActionStore()
+    manager = DeferredActionManager(store=store)
+
+    action = await manager.freeze(
+        tool="sys_os_write",
+        arguments={"path": "main.py", "content": "v1"},
+        base_hash="hash_original",
+        session_id="session_102",
+    )
+
+    with pytest.raises(HashDriftError, match="State drift detected"):
+        await manager.approve(
+            action.id,
+            actor="admin",
+            current_base_hash="hash_drifted_state",
+        )
+
+    drifted_action = await store.get_action(action.id)
+    assert drifted_action.status == "HASH_DRIFT"
+
+
+@pytest.mark.asyncio
+async def test_expiration_fail_closed():
+    """Verify approval after expiration date raises DeferredExpiredError and sets EXPIRED."""
+    store = MemoryDeferredActionStore()
+    manager = DeferredActionManager(store=store)
+
+    # Freeze action with 0 second expiration budget
+    action = await manager.freeze(
+        tool="sys_os_write",
+        arguments={"path": "main.py"},
+        base_hash="hash_1",
+        session_id="session_103",
+        expiration_seconds=-10,  # Already expired
+    )
+
+    with pytest.raises(DeferredExpiredError, match="has expired"):
+        await manager.approve(
+            action.id,
+            actor="admin",
+            current_base_hash="hash_1",
+        )
+
+    expired_action = await store.get_action(action.id)
+    assert expired_action.status == "EXPIRED"
+
+
+@pytest.mark.asyncio
+async def test_rejection_flow():
+    """Verify rejecting action sets status REJECTED."""
+    store = MemoryDeferredActionStore()
+    manager = DeferredActionManager(store=store)
+
+    action = await manager.freeze(
+        tool="sys_os_shell",
+        arguments={"cmd": "rm -rf /"},
+        base_hash="hash_1",
+        session_id="session_104",
+    )
+
+    rejected_action = await manager.reject(
+        action.id,
+        actor="security_admin",
+        reason="Dangerous command",
+    )
+
+    assert rejected_action.status == "REJECTED"
+    assert rejected_action.reason == "Dangerous command"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_approvals():
+    """Verify concurrent approve calls evaluate safely without race condition failures."""
+    store = MemoryDeferredActionStore()
+    manager = DeferredActionManager(store=store)
+
+    action = await manager.freeze(
+        tool="sys_os_edit",
+        arguments={"path": "a.txt"},
+        base_hash="hash_1",
+        session_id="session_105",
+    )
+
+    results = await asyncio.gather(
+        manager.approve(action.id, actor="u1", current_base_hash="hash_1"),
+        manager.approve(action.id, actor="u2", current_base_hash="hash_1"),
+        manager.approve(action.id, actor="u3", current_base_hash="hash_1"),
+    )
+
+    for res in results:
+        assert res.status == "APPROVED"

--- a/tests/runtime/deferred/test_models_and_hashing.py
+++ b/tests/runtime/deferred/test_models_and_hashing.py
@@ -1,0 +1,71 @@
+"""
+Unit tests for deferred action models and deterministic manifest hashing.
+"""
+
+import pytest
+
+from omnigent.runtime.deferred.hashing import compute_manifest_hash
+from omnigent.runtime.deferred.models import DeferredManifest
+
+
+def test_compute_manifest_hash_deterministic():
+    """Verify identical manifest payloads produce identical SHA256 hashes regardless of key order."""
+    manifest1 = DeferredManifest(
+        tool="sys_os_edit",
+        arguments={"path": "app.py", "content": "print('hello')", "mode": "overwrite"},
+        base_hash="sha256_base_12345",
+        session_id="conv_abc123",
+        target="app.py",
+    )
+    manifest2 = DeferredManifest(
+        tool="sys_os_edit",
+        arguments={"mode": "overwrite", "content": "print('hello')", "path": "app.py"},
+        base_hash="sha256_base_12345",
+        session_id="conv_abc123",
+        target="app.py",
+    )
+
+    hash1 = compute_manifest_hash(manifest1)
+    hash2 = compute_manifest_hash(manifest2)
+
+    assert hash1 == hash2
+    assert len(hash1) == 64
+
+
+def test_compute_manifest_hash_tamper_detection():
+    """Verify altering any field in manifest changes the computed hash."""
+    base_manifest = DeferredManifest(
+        tool="sys_os_edit",
+        arguments={"path": "app.py", "content": "print('hello')"},
+        base_hash="sha256_base_12345",
+        session_id="conv_abc123",
+    )
+    base_hash = compute_manifest_hash(base_manifest)
+
+    # 1. Altered argument
+    tampered_args = DeferredManifest(
+        tool="sys_os_edit",
+        arguments={"path": "app.py", "content": "print('malicious')"},
+        base_hash="sha256_base_12345",
+        session_id="conv_abc123",
+    )
+    assert compute_manifest_hash(tampered_args) != base_hash
+
+    # 2. Altered base_hash
+    tampered_base = DeferredManifest(
+        tool="sys_os_edit",
+        arguments={"path": "app.py", "content": "print('hello')"},
+        base_hash="sha256_base_67890",
+        session_id="conv_abc123",
+    )
+    assert compute_manifest_hash(tampered_base) != base_hash
+
+    # 3. Altered target
+    tampered_target = DeferredManifest(
+        tool="sys_os_edit",
+        arguments={"path": "app.py", "content": "print('hello')"},
+        base_hash="sha256_base_12345",
+        session_id="conv_abc123",
+        target="other.py",
+    )
+    assert compute_manifest_hash(tampered_target) != base_hash

--- a/tests/server/routes/test_deferred_actions_routes.py
+++ b/tests/server/routes/test_deferred_actions_routes.py
@@ -1,0 +1,87 @@
+"""
+Integration tests for deferred actions REST API endpoints.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from omnigent.runtime.deferred.manager import DeferredActionManager
+from omnigent.runtime.deferred.store import MemoryDeferredActionStore, set_deferred_store
+from omnigent.server.routes.deferred_actions import router as deferred_actions_router
+
+app = FastAPI()
+app.include_router(deferred_actions_router)
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _setup_test_store():
+    """Inject fresh memory store for each route test."""
+    store = MemoryDeferredActionStore()
+    set_deferred_store(store)
+    yield store
+    set_deferred_store(None)
+
+
+@pytest.mark.asyncio
+async def test_deferred_actions_api_routes():
+    """Test list, detail, approve, and reject REST routes."""
+    manager = DeferredActionManager()
+    action = await manager.freeze(
+        tool="sys_os_shell",
+        arguments={"command": "npm run build"},
+        base_hash="hash_base_999",
+        session_id="session_api_test",
+        reason="Build required",
+    )
+
+    # 1. List for session
+    res = client.get(f"/v1/sessions/session_api_test/deferred_actions")
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data["deferred_actions"]) == 1
+    assert data["deferred_actions"][0]["id"] == action.id
+
+    # 2. Get detail & audit events
+    res = client.get(f"/v1/deferred_actions/{action.id}")
+    assert res.status_code == 200
+    detail = res.json()
+    assert detail["action"]["id"] == action.id
+    assert len(detail["audit_events"]) == 1
+
+    # 3. Approve action via POST
+    res = client.post(
+        f"/v1/deferred_actions/{action.id}/approve",
+        json={"actor": "reviewer", "current_base_hash": "hash_base_999"},
+    )
+    assert res.status_code == 200
+    approved_resp = res.json()
+    assert approved_resp["action"]["status"] == "APPROVED"
+
+    # 4. Attempt approve with hash mismatch (conflict)
+    action2 = await manager.freeze(
+        tool="sys_os_write",
+        arguments={"path": "file.txt"},
+        base_hash="hash_original",
+        session_id="session_api_test",
+    )
+    res = client.post(
+        f"/v1/deferred_actions/{action2.id}/approve",
+        json={"actor": "reviewer", "current_base_hash": "hash_drifted"},
+    )
+    assert res.status_code == 409
+
+    # 5. Reject action via POST
+    action3 = await manager.freeze(
+        tool="sys_os_write",
+        arguments={"path": "file2.txt"},
+        base_hash="hash_3",
+        session_id="session_api_test",
+    )
+    res = client.post(
+        f"/v1/deferred_actions/{action3.id}/reject",
+        json={"actor": "reviewer", "reason": "Not allowed"},
+    )
+    assert res.status_code == 200
+    assert res.json()["action"]["status"] == "REJECTED"


### PR DESCRIPTION
## Related issue

Closes #3368

## Summary

- Introduces a runtime-native `DEFER` policy action for asynchronous tool call approvals.
- Adds deferred action lifecycle management, manifest hashing, audit events, and approval/rejection APIs.
- Integrates deferred approvals into the runtime policy engine and tool orchestration.

## Test Plan

- Ran the existing test suite.
- Added/updated unit and integration tests covering:
  - Deferred action lifecycle
  - Hash drift detection
  - Expiration handling
  - Concurrent approvals
  - REST API endpoints

## Demo

N/A (non-UI feature)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added automated tests covering deferred approval lifecycle, hash drift detection, expiration, concurrent approvals, and REST API behavior.

## Changelog

Adds runtime-native deferred tool call approvals using a new `DEFER` policy action.
