### PR TITLE
fix(config): fall back to the harness default when a stored command override is stale

### DIFF
--- a/omnigent/harness_startup_config.py
+++ b/omnigent/harness_startup_config.py
@@ -34,9 +34,15 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 from typing import Any
 
 _logger = logging.getLogger(__name__)
+
+# Executable-resolution seam for the stale-override fallback. Module-level so
+# tests can pin it and precedence assertions don't depend on what happens to
+# be installed on the machine running them.
+_which = shutil.which
 
 # The release in which the legacy ``HARNESS_<NAME>_PATH`` read is removed.
 # Deprecated in v0.6.0; two versions of back-compat, then removal.
@@ -277,6 +283,11 @@ def resolve_harness_command(
     3. config ``harness.<canonical>.command`` (when *cfg* is provided).
     4. *default* — the harness's built-in executable name.
 
+    An env- or config-layer override that no longer resolves to an
+    executable is skipped with a warning when *default* does resolve
+    (see :func:`_fallback_if_stale`); the explicit flag is never
+    second-guessed.
+
     :param harness: A harness id (canonical or alias), e.g.
         ``"claude-native"`` or ``"codex"``.
     :param default: Built-in fallback executable, e.g. ``"claude"``.
@@ -296,14 +307,51 @@ def resolve_harness_command(
     # be shadowed by a config ``harness.<id>.command``.
     env_value = resolve_harness_path(canonical)
     if env_value:
-        return env_value
+        return _fallback_if_stale(env_value, default, "env", canonical)
     if cfg is not None:
         _, overrides = resolve_harness_config(cfg)
         entry = overrides.get(canonical)
         if entry is not None:
             command = entry.get(_OVERRIDE_KEY_COMMAND)
             if isinstance(command, str) and command.strip():
-                return command.strip()
+                return _fallback_if_stale(command.strip(), default, "config", canonical)
+    return default
+
+
+def _fallback_if_stale(command: str, default: str, source: str, canonical: str) -> str:
+    """Return *command*, or *default* when *command* is a stale override.
+
+    A stored override can outlive the binary it names — e.g. a
+    ``harness.claude-native.command`` pinned to a versioned install path
+    (``…/claude/versions/2.1.216``) that the next reinstall deleted.
+    Launching would then die in preflight even though the built-in
+    default still works, so in keeping with this module's warn+skip
+    philosophy the stale override is skipped with a warning instead of
+    taking the launch down with it.
+
+    The fallback fires only when *command* does not resolve to an
+    executable while *default* does. When neither resolves, *command*
+    is kept so the launch error names the operator's configured value,
+    and the explicit ``--command`` flag never reaches this path — a
+    per-invocation choice should fail loudly, not be second-guessed.
+
+    :param command: The override value from the env or config layer.
+    :param default: The harness's built-in executable name.
+    :param source: Layer that supplied the override, for the log line.
+    :param canonical: Canonical harness id, for the log line.
+    :returns: *command*, or *default* when the override is stale.
+    """
+    if _which(command) is not None or _which(default) is None:
+        return command
+    _logger.warning(
+        "Ignoring stale %s command override %r for harness %r: it does not "
+        "resolve to an executable, but the default %r does. Update or remove "
+        "the override.",
+        source,
+        command,
+        canonical,
+        default,
+    )
     return default
 
 

--- a/tests/test_harness_startup_config.py
+++ b/tests/test_harness_startup_config.py
@@ -4,12 +4,22 @@ from __future__ import annotations
 
 import pytest
 
+from omnigent import harness_startup_config
 from omnigent.harness_startup_config import (
     resolve_harness_args,
     resolve_harness_command,
     resolve_harness_config,
     resolve_harness_path,
 )
+
+
+@pytest.fixture(autouse=True)
+def _every_command_resolves(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin executable resolution so precedence assertions don't depend on
+    what happens to be installed on the machine running the tests. The
+    stale-override tests re-pin ``_which`` per case."""
+    monkeypatch.setattr(harness_startup_config, "_which", lambda cmd: f"/resolved/{cmd}")
+
 
 # ── resolve_harness_config ───────────────────────────────────────────
 
@@ -198,6 +208,73 @@ def test_command_empty_explicit_falls_through(
     # An empty --command flag should not shadow the env var.
     assert (
         resolve_harness_command("codex", default="codex", explicit="   ", cfg={}) == "/env/codex"
+    )
+
+
+# ── stale-override fallback ─────────────────────────────────────────
+
+
+def _only_default_resolves(default: str):
+    """A ``_which`` where nothing but *default* is an executable."""
+    return lambda cmd: f"/resolved/{cmd}" if cmd == default else None
+
+
+def test_command_stale_config_override_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A config pin to a deleted binary is skipped for a working default.
+
+    The motivating incident: ``harness.claude-native.command`` pinned to
+    a versioned Claude install path that a reinstall deleted, killing
+    every launch in preflight.
+    """
+    monkeypatch.delenv("OMNIGENT_CODEX_PATH", raising=False)
+    monkeypatch.delenv("HARNESS_CODEX_PATH", raising=False)
+    monkeypatch.setattr(harness_startup_config, "_which", _only_default_resolves("codex"))
+    cfg = {"harness": {"codex": {"command": "/gone/versions/1.2.3/codex"}}}
+    with caplog.at_level("WARNING"):
+        assert resolve_harness_command("codex", default="codex", explicit=None, cfg=cfg) == "codex"
+    assert "stale config command override" in caplog.text
+
+
+def test_command_stale_env_override_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("OMNIGENT_CODEX_PATH", "/gone/codex")
+    monkeypatch.setattr(harness_startup_config, "_which", _only_default_resolves("codex"))
+    with caplog.at_level("WARNING"):
+        assert resolve_harness_command("codex", default="codex", explicit=None, cfg={}) == "codex"
+    assert "stale env command override" in caplog.text
+
+
+def test_command_stale_override_kept_when_default_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When neither resolves, keep the override so the launch error names
+    the operator's configured value rather than a default they never chose."""
+    monkeypatch.delenv("OMNIGENT_CODEX_PATH", raising=False)
+    monkeypatch.delenv("HARNESS_CODEX_PATH", raising=False)
+    monkeypatch.setattr(harness_startup_config, "_which", lambda cmd: None)
+    cfg = {"harness": {"codex": {"command": "/gone/codex"}}}
+    with caplog.at_level("WARNING"):
+        assert (
+            resolve_harness_command("codex", default="codex", explicit=None, cfg=cfg)
+            == "/gone/codex"
+        )
+    assert "stale" not in caplog.text
+
+
+def test_command_stale_explicit_flag_never_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A per-invocation ``--command`` should fail loudly, not be second-guessed."""
+    monkeypatch.setattr(harness_startup_config, "_which", _only_default_resolves("codex"))
+    assert (
+        resolve_harness_command("codex", default="codex", explicit="/gone/codex", cfg={})
+        == "/gone/codex"
     )
 
 


### PR DESCRIPTION
## Problem

A `harness.<id>.command` config override (or `OMNIGENT_<NAME>_PATH` env var) can outlive the binary it names. Real incident: `harness.claude-native.command` was pinned to a versioned Claude Code install path (`~/.local/share/claude/versions/2.1.216`); a later reinstall left only the new version on disk, and from then on **every** `omni claude` launch died in preflight —

```
Error: Claude Code CLI command '/home/ubuntu/.local/share/claude/versions/2.1.216' was not found on local PATH. --server selects the Omnigent server only; Claude still runs locally.
```

— even though a perfectly good `claude` was on PATH the whole time. On an unattended host (a Slack-triggered dispatcher queueing runs) this is a hard outage with a misleading symptom ("session exited before it bound").

## Fix

`resolve_harness_command` now skips an env- or config-layer override that no longer resolves to an executable **when the built-in default does resolve**, logging a warning that names the stale value. This matches the module's documented warn+skip philosophy ("a bad config never crashes").

Deliberate edges:
- **Neither resolves** → keep the override, so the launch error names the operator's configured value rather than a default they never chose.
- **Explicit `--command` flag** → never second-guessed; a per-invocation choice should fail loudly.

Resolution goes through a module-level `_which` seam. The test file pins it with an autouse fixture, which also makes the existing precedence assertions deterministic — previously an override like `/env/claude` was asserted verbatim, which this change would (correctly) reroute on any machine that has `claude` installed.

## Testing

- 4 new tests: config-layer fallback + warning, env-layer fallback + warning, override kept when the default is also missing, explicit flag untouched.
- `uv run pytest tests/test_harness_startup_config.py` → 31 passed.
- `pyrefly check omnigent/harness_startup_config.py` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)