### PR TITLE
fix(terminals): make web-terminal scrolling work for mouse-tracking TUIs (mode replay + trackpad wheel)

### DIFF
--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -185,6 +185,11 @@ async def _run_tmux_capture(socket_path: str, tmux_target: str) -> bytes | None:
       lines that were never part of the app's UI — corrupting the seed. tmux's
       ``#{alternate_on}`` distinguishes the two.
 
+    **Screen/input modes** (alt screen, mouse tracking, DECCKM) are replayed
+    around the content via :func:`_mode_restore_escapes` — capture-pane records
+    cells only, and a TUI that enabled these before this client attached would
+    otherwise be unscrollable in the browser (see that function's docstring).
+
     :param socket_path: tmux server socket path.
     :param tmux_target: The ``-t`` target, e.g. ``"main"``.
     :returns: The captured bytes to write into xterm, or ``None`` on failure
@@ -225,24 +230,88 @@ async def _run_tmux_capture(socket_path: str, tmux_target: str) -> bytes | None:
     # staircase.
     normalized = _CAPTURE_ROW_SEP_RE.sub(b"\r\n", body)
     cursor = _cursor_restore_escape(meta)
-    return b"\x1b[H\x1b[2J" + normalized + cursor
+    prelude, postlude = _mode_restore_escapes(meta)
+    return prelude + b"\x1b[H\x1b[2J" + normalized + cursor + postlude
 
 
 @dataclass(frozen=True)
 class _PaneMetadata:
-    """Pane state needed to reconstruct the seed: cursor + screen mode.
+    """Pane state needed to reconstruct the seed: cursor + screen/input modes.
 
     :param cursor_x: 0-based cursor column from ``#{cursor_x}``.
     :param cursor_y: 0-based cursor row from ``#{cursor_y}``.
     :param cursor_visible: Whether ``#{cursor_flag}`` reported the cursor shown.
     :param alternate_on: Whether the pane is on the alternate screen
         (``#{alternate_on}`` == 1).
+    :param mouse_standard: DECSET 1000 (button press/release) from
+        ``#{mouse_standard_flag}``.
+    :param mouse_button: DECSET 1002 (press/release + drag) from
+        ``#{mouse_button_flag}``.
+    :param mouse_all: DECSET 1003 (any motion) from ``#{mouse_all_flag}``.
+    :param mouse_sgr: DECSET 1006 (SGR report encoding) from
+        ``#{mouse_sgr_flag}``.
+    :param mouse_utf8: DECSET 1005 (UTF-8 report encoding) from
+        ``#{mouse_utf8_flag}``.
+    :param app_cursor_keys: DECCKM (application cursor keys) from
+        ``#{keypad_cursor_flag}``.
     """
 
     cursor_x: int
     cursor_y: int
     cursor_visible: bool
     alternate_on: bool
+    mouse_standard: bool = False
+    mouse_button: bool = False
+    mouse_all: bool = False
+    mouse_sgr: bool = False
+    mouse_utf8: bool = False
+    app_cursor_keys: bool = False
+
+
+def _mode_restore_escapes(meta: _PaneMetadata | None) -> tuple[bytes, bytes]:
+    """Build the DECSET escapes that restore the pane program's screen modes.
+
+    ``capture-pane`` replays cell contents only — the mode-set sequences the
+    program emitted at startup (enter alternate screen, enable mouse tracking)
+    happened before this client attached and are never in the ``%output``
+    stream. Without replaying them the browser xterm believes no mouse
+    tracking is active, so a wheel over a TUI that scrolls via mouse reports
+    (OpenCode, claude, vim) sends nothing at all and the view cannot scroll
+    until the program happens to re-toggle its modes.
+
+    tmux tracks each mode as a pane flag, so the seed can reconstruct them:
+
+    - Prelude (before the clear + content): ``?1049h`` when the pane is on the
+      alternate screen, so the seed paints into xterm's alt buffer and never
+      pollutes primary-screen scrollback.
+    - Postlude (after the cursor restore): the mouse tracking mode
+      (``?1000h``/``?1002h``/``?1003h``), its report encoding
+      (``?1005h``/``?1006h``), and DECCKM (``?1h``) so wheel-to-arrow
+      fallback picks the encoding the program expects.
+
+    Only enables are emitted: every attach starts a fresh xterm whose modes
+    default off, so disables would be no-ops.
+
+    :param meta: Pane metadata, or ``None`` (no modes restored).
+    :returns: ``(prelude, postlude)`` byte strings, either possibly empty.
+    """
+    if meta is None:
+        return b"", b""
+    prelude = b"\x1b[?1049h" if meta.alternate_on else b""
+    postlude = b""
+    if meta.mouse_standard:
+        postlude += b"\x1b[?1000h"
+    if meta.mouse_button:
+        postlude += b"\x1b[?1002h"
+    if meta.mouse_all:
+        postlude += b"\x1b[?1003h"
+    if meta.mouse_utf8:
+        postlude += b"\x1b[?1005h"
+    if meta.mouse_sgr:
+        postlude += b"\x1b[?1006h"
+    if meta.app_cursor_keys:
+        postlude += b"\x1b[?1h"
+    return prelude, postlude
 
 
 async def _capture_pane_metadata(
@@ -268,7 +337,9 @@ async def _capture_pane_metadata(
             "-p",
             "-t",
             tmux_target,
-            "#{cursor_x},#{cursor_y},#{cursor_flag},#{alternate_on}",
+            "#{cursor_x},#{cursor_y},#{cursor_flag},#{alternate_on},"
+            "#{mouse_standard_flag},#{mouse_button_flag},#{mouse_all_flag},"
+            "#{mouse_sgr_flag},#{mouse_utf8_flag},#{keypad_cursor_flag}",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.DEVNULL,
         )
@@ -278,12 +349,19 @@ async def _capture_pane_metadata(
     if proc.returncode != 0:
         return None
     try:
-        x_str, y_str, flag_str, alt_str = stdout.decode().strip().split(",")
+        fields = [f.strip() for f in stdout.decode().strip().split(",")]
+        x_str, y_str, flag_str, alt_str, std, btn, allm, sgr, utf8, ckm = fields
         return _PaneMetadata(
             cursor_x=int(x_str),
             cursor_y=int(y_str),
-            cursor_visible=flag_str.strip() == "1",
-            alternate_on=alt_str.strip() == "1",
+            cursor_visible=flag_str == "1",
+            alternate_on=alt_str == "1",
+            mouse_standard=std == "1",
+            mouse_button=btn == "1",
+            mouse_all=allm == "1",
+            mouse_sgr=sgr == "1",
+            mouse_utf8=utf8 == "1",
+            app_cursor_keys=ckm == "1",
         )
     except (ValueError, UnicodeDecodeError):
         return None

--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -350,7 +350,14 @@ async def _capture_pane_metadata(
         return None
     try:
         fields = [f.strip() for f in stdout.decode().strip().split(",")]
-        x_str, y_str, flag_str, alt_str, std, btn, allm, sgr, utf8, ckm = fields
+        if len(fields) < 4:
+            return None
+        # A tmux without some mouse/DECCKM formats expands them to "" (the
+        # field count holds), but pad regardless: a flags anomaly must cost
+        # only the optional mode replay, never the mandatory cursor and
+        # alt-screen state the rest of the seed depends on.
+        fields += ["0"] * (10 - len(fields))
+        x_str, y_str, flag_str, alt_str, std, btn, allm, sgr, utf8, ckm = fields[:10]
         return _PaneMetadata(
             cursor_x=int(x_str),
             cursor_y=int(y_str),

--- a/tests/e2e_ui/shells/test_new_shell.py
+++ b/tests/e2e_ui/shells/test_new_shell.py
@@ -173,7 +173,7 @@ def test_shell_wheel_scroll_reaches_mouse_tracking_program(
     # (the mode set Claude Code and OpenCode use), stdin appended to a file.
     textarea = terminal_view.locator("textarea.xterm-helper-textarea")
     textarea.focus()
-    page.keyboard.type(f"stty raw -echo; printf '\\e[?1003h\\e[?1006h'; cat > {log}")
+    page.keyboard.type(f"stty raw -echo; printf '\\e[?1003h\\e[?1006h'; cat > '{log}'")
     page.keyboard.press("Enter")
     # Let the mode enables round-trip so the browser xterm starts forwarding.
     page.wait_for_timeout(1_500)

--- a/tests/e2e_ui/shells/test_new_shell.py
+++ b/tests/e2e_ui/shells/test_new_shell.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import re
 import time
+from pathlib import Path
 
 from playwright.sync_api import Page, expect
 
@@ -142,7 +143,7 @@ def test_new_shell_accepts_typed_command(page: Page, terminal_session: tuple[str
 
 
 def test_shell_wheel_scroll_reaches_mouse_tracking_program(
-    page: Page, terminal_session: tuple[str, str], tmp_path
+    page: Page, terminal_session: tuple[str, str], tmp_path: Path
 ) -> None:
     """Trackpad-sized wheel deltas reach a mouse-tracking TUI as SGR reports.
 

--- a/tests/e2e_ui/shells/test_new_shell.py
+++ b/tests/e2e_ui/shells/test_new_shell.py
@@ -39,6 +39,7 @@ independent session.
 from __future__ import annotations
 
 import re
+import time
 
 from playwright.sync_api import Page, expect
 
@@ -138,6 +139,71 @@ def test_new_shell_accepts_typed_command(page: Page, terminal_session: tuple[str
     # "terminal session ended". A regression that drops user input or kills
     # the PTY on first keystroke would flip this out of ``connected``.
     expect(terminal_view).to_have_attribute("data-state", "connected")
+
+
+def test_shell_wheel_scroll_reaches_mouse_tracking_program(
+    page: Page, terminal_session: tuple[str, str], tmp_path
+) -> None:
+    """Trackpad-sized wheel deltas reach a mouse-tracking TUI as SGR reports.
+
+    TUIs like Claude Code and OpenCode scroll their transcript via mouse
+    reports, so the browser terminal must translate wheel gestures into SGR
+    sequences. xterm's built-in conversion damps small pixel deltas to at
+    most ~1 report per gesture, which reads as "scrolling doesn't work" on
+    macOS trackpads; the custom wheel handler accumulates deltas and emits
+    one report per whole line. Pin that end-to-end: a program in the shell
+    enables mouse tracking and records its stdin to a file (absolute
+    ``tmp_path`` — the shell and this test share a host, sidestepping the
+    cwd/filesystem-API mismatch that made cwd-relative side-effects
+    fragile), then a ~80px gesture of 4px ticks must land >=3 wheel-up
+    reports. The damped path yields <=1, so this fails on a regression.
+    """
+    base_url, session_id = terminal_session
+    log = tmp_path / "wheel.log"
+
+    page.goto(f"{base_url}/c/{session_id}")
+    _open_new_shell(page)
+
+    terminal_view = page.get_by_test_id("terminal-view").last
+    expect(terminal_view).to_be_visible(timeout=60_000)
+    expect(terminal_view).to_have_attribute("data-state", "connected", timeout=20_000)
+
+    # Become a minimal mouse-tracking "TUI": raw tty (so mouse bytes flow
+    # byte-by-byte, not line-buffered), any-motion tracking + SGR encoding
+    # (the mode set Claude Code and OpenCode use), stdin appended to a file.
+    textarea = terminal_view.locator("textarea.xterm-helper-textarea")
+    textarea.focus()
+    page.keyboard.type(f"stty raw -echo; printf '\\e[?1003h\\e[?1006h'; cat > {log}")
+    page.keyboard.press("Enter")
+    # Let the mode enables round-trip so the browser xterm starts forwarding.
+    page.wait_for_timeout(1_500)
+
+    # Slow two-finger scroll: 20 ticks of 4px over the terminal screen. With
+    # a ~17px cell this is ~4.7 lines -> >=3 SGR wheel-up reports from the
+    # accumulating handler; xterm's damped built-in emits at most 1.
+    screen = terminal_view.locator(".xterm-screen").first
+    box = screen.bounding_box()
+    assert box is not None, "xterm screen should have a bounding box"
+    page.mouse.move(box["x"] + box["width"] / 2, box["y"] + box["height"] / 2)
+    for _ in range(20):
+        page.mouse.wheel(0, -4)
+        page.wait_for_timeout(25)
+
+    # The reports traverse browser -> WS -> tmux -> program asynchronously;
+    # poll the log rather than sleeping a fixed amount.
+    deadline = time.monotonic() + 15
+    reports = 0
+    while time.monotonic() < deadline:
+        reports = log.read_bytes().count(b"\x1b[<64") if log.exists() else 0
+        if reports >= 3:
+            break
+        page.wait_for_timeout(500)
+    assert reports >= 3, (
+        f"expected >=3 SGR wheel-up reports to reach the shell program, got {reports} "
+        f"(log: {log.read_bytes()[:200]!r})"
+        if log.exists()
+        else "wheel log never created"
+    )
 
 
 def test_workspace_rail_preserves_outer_top_inset(

--- a/tests/terminals/test_control_bridge.py
+++ b/tests/terminals/test_control_bridge.py
@@ -488,6 +488,62 @@ async def test_seed_alternate_screen_does_not_leak_primary_history() -> None:
 
 @pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
 @pytest.mark.asyncio
+async def test_seed_replays_alt_screen_and_mouse_modes() -> None:
+    """The seed replays the pane program's screen/input modes.
+
+    capture-pane records cells only; a TUI that entered the alternate screen
+    and enabled mouse tracking BEFORE this client attached (OpenCode, vim)
+    would otherwise leave the browser xterm believing no tracking is active —
+    wheel events then send nothing and the view cannot scroll.
+    """
+    from omnigent.terminals.control_bridge import _run_tmux_capture
+
+    # The OpenCode/bubbletea shape: alt screen + any-motion mouse + SGR.
+    sock, target = await _new_private_tmux(
+        "python3 -c 'import sys,time; "
+        'sys.stdout.write("\\x1b[?1049h\\x1b[?1003h\\x1b[?1006h\\x1b[1;1HTUI"); '
+        "sys.stdout.flush(); time.sleep(30)'"
+    )
+    await asyncio.sleep(0.5)
+    try:
+        seed = await _run_tmux_capture(str(sock), target)
+        assert seed is not None
+        # Alt screen entered BEFORE the clear+content so the seed paints into
+        # the alt buffer, never into primary-screen scrollback.
+        assert seed.startswith(b"\x1b[?1049h"), f"seed prelude missing 1049h: {seed[:16]!r}"
+        assert b"\x1b[?1003h" in seed, "mouse any-motion mode not replayed"
+        assert b"\x1b[?1006h" in seed, "SGR mouse encoding not replayed"
+        # Modes the program never set stay unset.
+        assert b"\x1b[?1002h" not in seed
+        assert b"\x1b[?1000h" not in seed
+    finally:
+        await _kill_tmux(sock)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_seed_plain_shell_replays_no_modes() -> None:
+    """A primary-screen pane with no mouse tracking gets no mode escapes.
+
+    Spurious enables would put the browser xterm on the alt buffer (killing
+    native scrollback) or swallow wheel events into mouse reports the shell
+    can't use.
+    """
+    from omnigent.terminals.control_bridge import _run_tmux_capture
+
+    sock, target = await _new_private_tmux("bash")
+    await asyncio.sleep(0.5)
+    try:
+        seed = await _run_tmux_capture(str(sock), target)
+        assert seed is not None
+        for mode in (b"?1049h", b"?1000h", b"?1002h", b"?1003h", b"?1005h", b"?1006h", b"?1h"):
+            assert b"\x1b[" + mode not in seed, f"spurious mode enable {mode!r} in seed"
+    finally:
+        await _kill_tmux(sock)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
 async def test_control_bridge_read_only_drops_input() -> None:
     """read_only=True must not inject typed bytes into the pane."""
     sock, target = await _new_private_tmux("cat")

--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -14,13 +14,18 @@ import {
   SYNC_ECHO_MAX_BYTES,
   SYNC_ECHO_WINDOW_MS,
   TerminalSession,
+  WHEEL_REPORTS_MAX_PER_EVENT,
   applyTerminalCopy,
   isUnexpectedTerminalClose,
   loadWebglRenderer,
   openTerminalLink,
+  sgrWheelReports,
   shouldEchoSynchronously,
   terminalTheme,
   terminalKeyEventPayload,
+  wheelReportPayload,
+  type WheelMouseState,
+  type WheelScreenMetrics,
 } from "./TerminalSession";
 
 describe("openTerminalLink", () => {
@@ -240,6 +245,157 @@ describe("isUnexpectedTerminalClose", () => {
     expect(isUnexpectedTerminalClose(4404)).toBe(false);
     expect(isUnexpectedTerminalClose(4405)).toBe(false);
     expect(isUnexpectedTerminalClose(4500)).toBe(false);
+  });
+});
+
+describe("sgrWheelReports", () => {
+  it("encodes wheel-up as button 64 and wheel-down as 65, one report per line", () => {
+    expect(sgrWheelReports(-2, 5, 7)).toBe("\x1b[<64;5;7M\x1b[<64;5;7M");
+    expect(sgrWheelReports(1, 1, 1)).toBe("\x1b[<65;1;1M");
+  });
+
+  it("emits nothing for zero lines", () => {
+    expect(sgrWheelReports(0, 5, 7)).toBe("");
+  });
+});
+
+describe("wheelReportPayload", () => {
+  const sgrModes: WheelMouseState = { mouseTrackingMode: "vt200", sgrEncoding: true };
+  const screen: WheelScreenMetrics = {
+    left: 0,
+    top: 0,
+    cellWidth: 8,
+    cellHeight: 16,
+    cols: 80,
+    rows: 24,
+  };
+
+  /** Count occurrences of an SGR report prefix without a control-char regex. */
+  function countReports(data: string, prefix: string): number {
+    return data.split(prefix).length - 1;
+  }
+
+  function wheelEvent(
+    deltaY: number,
+    over: Partial<Pick<WheelEvent, "deltaMode" | "shiftKey" | "clientX" | "clientY">> = {},
+  ) {
+    return {
+      deltaY,
+      deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+      shiftKey: false,
+      clientX: 100,
+      clientY: 100,
+      ...over,
+    };
+  }
+
+  it("defers to xterm and resets the carry when mouse tracking is off", () => {
+    // WHY: with no app tracking (a plain shell on the control transport) the
+    // wheel must scroll xterm's native scrollback, and a stale fraction from a
+    // previous tracking-on scroll must not leak into the next one.
+    const result = wheelReportPayload(
+      wheelEvent(-40),
+      { mouseTrackingMode: "none", sgrEncoding: true },
+      screen,
+      0.9,
+    );
+    expect(result).toEqual({ consume: false, data: "", partial: 0 });
+  });
+
+  it("defers to xterm when the program did not request SGR encoding", () => {
+    // WHY: synthesized reports are SGR-formatted; a program tracking the
+    // mouse with the legacy default encoding could not parse them.
+    const result = wheelReportPayload(
+      wheelEvent(-40),
+      { mouseTrackingMode: "vt200", sgrEncoding: false },
+      screen,
+      0,
+    );
+    expect(result.consume).toBe(false);
+  });
+
+  it("defers on shift-wheel, zero delta, and unmeasurable layout, keeping the carry", () => {
+    // WHY: shift-wheel mirrors xterm's built-in escape hatch; deltaY 0 is a
+    // horizontal-only tick; null screen means layout isn't measurable yet. None
+    // of these should destroy accumulated fractional scroll.
+    for (const [ev, scr] of [
+      [wheelEvent(-40, { shiftKey: true }), screen],
+      [wheelEvent(0), screen],
+      [wheelEvent(-40), null],
+    ] as const) {
+      expect(wheelReportPayload(ev, sgrModes, scr, 0.4)).toEqual({
+        consume: false,
+        data: "",
+        partial: 0.4,
+      });
+    }
+  });
+
+  it("accumulates small trackpad deltas across events into whole-line reports", () => {
+    // WHY: this is the macOS-trackpad regression this helper exists for —
+    // xterm's own conversion damps sub-50px deltas to nearly nothing. Ten 4px
+    // ticks over a 16px cell are 2.5 lines and must yield exactly 2 reports,
+    // with the remaining half line carried, and every event consumed so
+    // xterm's damped path never double-fires.
+    let partial = 0;
+    let reports = "";
+    for (let i = 0; i < 10; i++) {
+      const result = wheelReportPayload(wheelEvent(4), sgrModes, screen, partial);
+      expect(result.consume).toBe(true);
+      partial = result.partial;
+      reports += result.data;
+    }
+    expect(countReports(reports, "\x1b[<65")).toBe(2);
+    expect(partial).toBeCloseTo(0.5);
+  });
+
+  it("converts a discrete wheel notch to one report per whole line, carrying the rest", () => {
+    const result = wheelReportPayload(wheelEvent(-120), sgrModes, screen, 0);
+    expect(countReports(result.data, "\x1b[<64")).toBe(7); // 120/16 = 7.5
+    expect(result.partial).toBeCloseTo(-0.5);
+  });
+
+  it("honors line and page delta modes", () => {
+    const line = wheelReportPayload(
+      wheelEvent(3, { deltaMode: WheelEvent.DOM_DELTA_LINE }),
+      sgrModes,
+      screen,
+      0,
+    );
+    expect(countReports(line.data, "\x1b[<65")).toBe(3);
+
+    const page = wheelReportPayload(
+      wheelEvent(1, { deltaMode: WheelEvent.DOM_DELTA_PAGE }),
+      sgrModes,
+      screen,
+      0,
+    );
+    expect(countReports(page.data, "\x1b[<65")).toBe(screen.rows);
+  });
+
+  it("caps the reports for one event and discards the excess", () => {
+    // WHY: the cap bounds the input burst; discarding (not banking) the excess
+    // keeps a pathological delta from continuing to scroll long after the
+    // gesture ended.
+    const result = wheelReportPayload(wheelEvent(16 * 1000), sgrModes, screen, 0);
+    expect(countReports(result.data, "\x1b[<65")).toBe(WHEEL_REPORTS_MAX_PER_EVENT);
+    expect(result.partial).toBe(0);
+  });
+
+  it("places the report at the pointer's cell, clamped to the grid", () => {
+    // clientX 100 / 8px = col 13 (1-based); clientY 100 / 16px = row 7.
+    const at = wheelReportPayload(wheelEvent(16), sgrModes, screen, 0);
+    expect(at.data).toBe("\x1b[<65;13;7M");
+
+    // Pointer outside the grid clamps to the edges instead of emitting
+    // coordinates tmux/the app would reject.
+    const clamped = wheelReportPayload(
+      wheelEvent(16, { clientX: -50, clientY: 99999 }),
+      sgrModes,
+      screen,
+      0,
+    );
+    expect(clamped.data).toBe("\x1b[<65;1;24M");
   });
 });
 

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -223,7 +223,10 @@ export function shouldEchoSynchronously(byteLength: number, msSinceLastInput: nu
  */
 // eslint-disable-next-line no-underscore-dangle
 type TerminalCore = {
-  _core?: { writeSync?: (data: Uint8Array, maxSubsequentCalls?: number) => void };
+  _core?: {
+    writeSync?: (data: Uint8Array, maxSubsequentCalls?: number) => void;
+    coreMouseService?: { activeEncoding?: string };
+  };
 };
 
 /**
@@ -297,6 +300,124 @@ export function applyTerminalCopy(
 }
 
 /**
+ * Ceiling on synthesized wheel reports for a single DOM wheel event, so a
+ * page-mode or pathological delta can't flood the input channel.
+ */
+export const WHEEL_REPORTS_MAX_PER_EVENT = 50;
+
+/**
+ * Mouse state consulted by {@link wheelReportPayload}. ``mouseTrackingMode``
+ * comes from the public ``term.modes``; ``sgrEncoding`` is whether the pane
+ * program requested SGR mouse encoding (``?1006h``) — the public ``IModes``
+ * does not expose the encoding, so the session feature-detects it from
+ * xterm's core mouse service (see ``TerminalSession.sgrMouseEncodingActive``).
+ */
+export type WheelMouseState = {
+  mouseTrackingMode: "none" | "x10" | "vt200" | "drag" | "any";
+  sgrEncoding: boolean;
+};
+
+/** Screen geometry needed to place and scale a wheel report. */
+export type WheelScreenMetrics = {
+  /** Viewport coordinates of the character grid's top-left corner. */
+  left: number;
+  top: number;
+  /** Size of one character cell in CSS pixels. */
+  cellWidth: number;
+  cellHeight: number;
+  cols: number;
+  rows: number;
+};
+
+/**
+ * Build SGR mouse-wheel reports for *lines* scroll steps at cell
+ * (*col*, *row*), 1-based. Negative lines scroll up (button 64),
+ * positive down (button 65); 0 yields "".
+ */
+export function sgrWheelReports(lines: number, col: number, row: number): string {
+  if (lines === 0) return "";
+  const button = lines < 0 ? 64 : 65;
+  return `\x1b[<${button};${col};${row}M`.repeat(Math.abs(lines));
+}
+
+/**
+ * Decide how one DOM wheel event over the terminal becomes SGR mouse-wheel
+ * reports, carrying fractional scroll across events.
+ *
+ * xterm's built-in wheel→report conversion is unusable with macOS
+ * trackpads: it damps sub-50px pixel deltas by ×0.3 and emits at most one
+ * report per DOM event regardless of magnitude, so two-finger scrolling
+ * over a mouse-tracking TUI (Claude Code, tmux with ``mouse on``) barely
+ * moves. This helper replaces that path: deltas convert to lines at face
+ * value, the fractional remainder accumulates in *partial* so a run of
+ * small trackpad deltas still adds up, and one report is emitted per whole
+ * line (capped at {@link WHEEL_REPORTS_MAX_PER_EVENT}; the excess is
+ * discarded rather than banked so a giant delta can't keep scrolling long
+ * after the gesture).
+ *
+ * The event is only consumed when the pane program is tracking the mouse
+ * with SGR encoding — both tmux ``mouse on`` (PTY transport) and Claude
+ * Code's own tracking (control transport) request SGR. Otherwise the
+ * caller must let xterm handle the wheel natively so, e.g., a plain shell
+ * on the control transport scrolls xterm's own scrollback. Shift-wheel is
+ * also left to xterm, mirroring its built-in escape hatch.
+ *
+ * Pure helper — exported for direct unit testing; production code calls it
+ * from the session's custom wheel handler.
+ *
+ * :param event: The DOM wheel event fields consulted.
+ * :param mouse: Current mouse tracking mode + SGR-encoding flag.
+ * :param screen: Character-grid geometry, or ``null`` when layout isn't
+ *     measurable yet (event is left to xterm).
+ * :param partial: Fractional lines carried over from previous events.
+ * :returns: ``consume`` — whether the caller owns the event (prevent
+ *     default, return ``false`` to xterm); ``data`` — SGR reports to feed
+ *     to the terminal ("" when the accumulator hasn't reached a whole
+ *     line); ``partial`` — the new carry.
+ */
+export function wheelReportPayload(
+  event: Pick<WheelEvent, "deltaY" | "deltaMode" | "shiftKey" | "clientX" | "clientY">,
+  mouse: WheelMouseState,
+  screen: WheelScreenMetrics | null,
+  partial: number,
+): { consume: boolean; data: string; partial: number } {
+  if (mouse.mouseTrackingMode === "none" || !mouse.sgrEncoding) {
+    // Tracking off (or an encoding we don't synthesize): xterm's native
+    // handling is correct. Drop the carry so a stale fraction can't leak
+    // into the next tracking-on scroll.
+    return { consume: false, data: "", partial: 0 };
+  }
+  if (event.shiftKey || event.deltaY === 0 || screen === null) {
+    return { consume: false, data: "", partial };
+  }
+  let lines: number;
+  switch (event.deltaMode) {
+    case WheelEvent.DOM_DELTA_LINE:
+      lines = event.deltaY;
+      break;
+    case WheelEvent.DOM_DELTA_PAGE:
+      lines = event.deltaY * screen.rows;
+      break;
+    default:
+      lines = event.deltaY / screen.cellHeight;
+  }
+  const total = partial + lines;
+  const whole = Math.trunc(total);
+  const capped = Math.max(
+    -WHEEL_REPORTS_MAX_PER_EVENT,
+    Math.min(WHEEL_REPORTS_MAX_PER_EVENT, whole),
+  );
+  const clamp = (v: number, max: number) => Math.min(Math.max(v, 1), max);
+  const col = clamp(Math.floor((event.clientX - screen.left) / screen.cellWidth) + 1, screen.cols);
+  const row = clamp(Math.floor((event.clientY - screen.top) / screen.cellHeight) + 1, screen.rows);
+  return {
+    consume: true,
+    data: sgrWheelReports(capped, col, row),
+    partial: capped === whole ? total - whole : 0,
+  };
+}
+
+/**
  * One xterm ↔ tmux WebSocket bridge tied to a single DOM container.
  *
  * The constructor performs all the setup synchronously — open the
@@ -328,6 +449,8 @@ export class TerminalSession {
    * control transport, would otherwise be an avoidable ``refresh-client -C``.
    */
   private lastSentSize: { cols: number; rows: number } | null = null;
+  /** Fractional wheel lines carried across events (see {@link wheelReportPayload}). */
+  private wheelPartialLines = 0;
 
   /**
    * Construct, attach to the DOM, and open the WebSocket.
@@ -506,6 +629,29 @@ export class TerminalSession {
       return false;
     });
 
+    // Replace xterm's lossy wheel→mouse-report conversion (trackpad deltas
+    // are damped and capped to one report per event, which reads as
+    // "scrolling doesn't work" on macOS trackpads) with the accumulating
+    // synthesis in wheelReportPayload. term.input routes the reports
+    // through the normal onData path above, so they hit the WS send and
+    // the input-activity bookkeeping like any keystroke.
+    this.term.attachCustomWheelEventHandler((e) => {
+      const result = wheelReportPayload(
+        e,
+        {
+          mouseTrackingMode: this.term.modes.mouseTrackingMode,
+          sgrEncoding: this.sgrMouseEncodingActive(),
+        },
+        this.screenMetrics(),
+        this.wheelPartialLines,
+      );
+      this.wheelPartialLines = result.partial;
+      if (!result.consume) return true;
+      if (result.data) this.term.input(result.data, true);
+      e.preventDefault();
+      return false;
+    });
+
     // ResizeObserver fires on any layout-affecting change (window
     // resize, font load, CSS class change). tmux deduplicates same-
     // size events server-side, so no throttle needed here.
@@ -587,6 +733,43 @@ export class TerminalSession {
       }
     }
     this.term.write(bytes);
+  }
+
+  /**
+   * Whether the pane program requested SGR mouse encoding (``?1006h``).
+   *
+   * The public ``IModes`` exposes the tracking mode but not the encoding,
+   * so this feature-detects xterm's core mouse service — same pattern as
+   * the ``writeSync`` fast path. Both tmux with ``mouse on`` (PTY
+   * transport) and Claude Code (control transport) request SGR; when the
+   * private shape is missing or the encoding is anything else, the wheel
+   * handler defers to xterm rather than synthesizing reports the program
+   * could not parse.
+   */
+  private sgrMouseEncodingActive(): boolean {
+    // eslint-disable-next-line no-underscore-dangle
+    const core = (this.term as unknown as TerminalCore)._core;
+    return core?.coreMouseService?.activeEncoding === "SGR";
+  }
+
+  /**
+   * Measure the character grid for wheel-report placement, or ``null``
+   * when layout isn't available (pre-mount, jsdom). Reads the
+   * ``.xterm-screen`` element because the outer container includes
+   * padding that would skew the per-cell math.
+   */
+  private screenMetrics(): WheelScreenMetrics | null {
+    const { cols, rows } = this.term;
+    const rect = this.term.element?.querySelector(".xterm-screen")?.getBoundingClientRect();
+    if (!rect || rect.width <= 0 || rect.height <= 0 || cols <= 0 || rows <= 0) return null;
+    return {
+      left: rect.left,
+      top: rect.top,
+      cellWidth: rect.width / cols,
+      cellHeight: rect.height / rows,
+      cols,
+      rows,
+    };
   }
 
   private sendResize(): void {


### PR DESCRIPTION
## Related issue

N/A — reported in Slack: "using terminal view of OpenCode on Omnigent somehow prevents me to scroll the window … if I go back to Chat view and then back to Terminal, the scroll bar disappears again."

## Summary

Web-terminal scrolling over mouse-tracking TUIs (OpenCode, Claude Code, vim) is broken in two independent ways; this PR fixes both.

- **Control-bridge seed loses terminal modes** (`omnigent/terminals/control_bridge.py`): the attach seed replays `capture-pane` cell contents but not the mode-set sequences the TUI emitted at startup (alt screen `?1049h`, mouse tracking `?1000h/?1002h/?1003h`, SGR `?1006h`, DECCKM). The browser xterm therefore believes no mouse tracking is active — a wheel gesture sends **zero bytes** and the view cannot scroll. Apps that set modes once at startup (bubbletea: OpenCode) are permanently dead; Claude Code recovers only because the attach-time resize makes ink repaint and re-assert its modes. Every Chat→Terminal flip re-attaches and re-loses the state, matching the report. Fix: reconstruct the modes from tmux's pane flags (`mouse_*_flag`, `alternate_on`, `keypad_cursor_flag`) and replay them around the seed — alt screen before the content so it never pollutes primary scrollback, mouse/DECCKM enables after the cursor restore.
- **xterm's wheel→mouse-report conversion swallows trackpads** (`web/src/components/blocks/TerminalSession.ts`): xterm 6.0 damps sub-50px pixel deltas by ×0.3 and emits at most one report per DOM wheel event, so a full macOS two-finger gesture scrolls the TUI ~1–2 lines — "scrolling flat doesn't work". Fix: a custom `attachCustomWheelEventHandler` that accumulates deltas at face value (carrying the fraction across events) and emits one SGR report per whole line, capped per event. It only engages when the pane program is tracking the mouse with SGR encoding (feature-detected from xterm's core, since the public `IModes` doesn't expose the encoding); otherwise it defers to xterm so a plain shell on the control transport keeps native scrollback.

**ELI5**: the web terminal joins the party after the TUI already said "send me mouse events" — and nobody relays that message, so the browser never sends any. And even when the browser does know, its wheel math rounds a trackpad swipe down to almost nothing. Now the bridge repeats the TUI's request on every attach, and the browser converts finger-distance to scroll-lines 1:1.

```
   TUI startup: ESC[?1049h ?1003h ?1006h ──> tmux pane flags (recorded)
                                                  │
   web attach: capture-pane cells  ────────────┐  │  before: modes lost → wheel sends 0 bytes
               + mode replay (this PR)  <──────┴──┘  after:  browser xterm mode-correct
                                                  │
   wheel: 30 × 6px ──[xterm builtin: ×0.3, 1 report/event → 1–2 lines]── before
          30 × 6px ──[custom handler: Σpx / cellHeight → N reports  ]── after (~14 lines)
```

## Test Plan

- `pytest tests/terminals/test_control_bridge.py` — 13 pass (11 existing + 2 new: mode replay for an alt-screen + `1003`/SGR pane; no spurious enables for a plain shell). Real-tmux tests, no mocks.
- `vitest run src/components/blocks/TerminalSession.test.ts` — 35 pass (9 new: delta accumulation across events, line/page delta modes, per-event cap, pointer-cell clamping, and every defer branch). `tsc --noEmit`, `oxlint`, `prettier` clean.
- End-to-end A/B on two live servers (same machine, same gesture driven via CDP; ground truth = server-side `tmux capture-pane` of the TUI, wire truth = CDP WebSocket frame sniffing):

| harness | metric | pre-fix | post-fix |
|---|---|---|---|
| OpenCode (idle attach) | modes in attach stream | none | `1049h`+`1003h`+`1006h` |
| OpenCode | wheel bytes sent / TUI scrolled | **0 / no** | 5+ SGR reports / **yes** |
| OpenCode | after Chat→Terminal flip | still dead | still works |
| Claude Code | lines scrolled per ~250px gesture | **~2** | **~14** |

- Regression guard: with a plain shell (no mouse tracking) the custom handler defers and xterm-native scrollback still works; seed adds no escapes for a shell pane (covered by the new pytest).

## Demo

Quantitative demo is the A/B table above (screen recordings don't capture the "wheel sends zero bytes" wire-level difference well). Reviewer repro in ~2 min:

1. `omnigent opencode` on a build of main, open the conversation URL, switch the pill to Terminal, run a prompt that prints 200 lines, two-finger scroll → nothing moves.
2. Same on this branch → the transcript tracks the gesture, and keeps working after flipping Chat→Terminal.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification = the scripted browser A/B in the Test Plan (Playwright + CDP against two live servers, pane-capture ground truth), plus human trackpad testing on both builds. The wheel handler's DOM-event → SGR-report math and the bridge's mode replay are both pinned by automated tests; the full browser→WS→tmux→TUI loop is exercised by the scripted A/B rather than `tests/e2e_ui` because the mock-LLM e2e harness has no mouse-wheel driver today.

## Changelog

Terminal view scrolling now works with macOS trackpads and with TUIs that enable mouse tracking at startup (OpenCode, Claude Code)
