### PR TITLE
feat(web): add "always steer" setting to steer follow-ups instead of queuing

### DIFF
--- a/tests/e2e_ui/chat/test_always_steer.py
+++ b/tests/e2e_ui/chat/test_always_steer.py
@@ -1,4 +1,4 @@
-"""E2E: Settings → Chat "Always steer" dispatches busy follow-ups now."""
+"""E2E: Settings → General "Always steer" dispatches busy follow-ups now."""
 
 from __future__ import annotations
 
@@ -29,15 +29,16 @@ def _wait_for(page: Page, predicate: Callable[[], bool], *, timeout_s: float = 3
     raise AssertionError(f"condition not met within {timeout_s:.0f}s")
 
 
-def _open_chat_settings(page: Page, base_url: str, *, from_chat: bool = False) -> Locator:
+def _open_general_settings(page: Page, base_url: str, *, from_chat: bool = False) -> Locator:
     if from_chat:
         page.get_by_test_id("settings-button").click()
     else:
         page.goto(f"{base_url}/settings/appearance")
-    chat_link = page.get_by_test_id("settings-nav-chat")
-    expect(chat_link).to_be_visible(timeout=30_000)
-    chat_link.click()
-    expect(page).to_have_url(re.compile(r"/settings/chat$"))
+    general_link = page.get_by_test_id("settings-nav-general")
+    expect(general_link).to_be_visible(timeout=30_000)
+    general_link.click()
+    expect(page).to_have_url(re.compile(r"/settings/general$"))
+    expect(page.get_by_role("heading", name="Composer", exact=True)).to_be_visible()
     toggle = page.get_by_test_id("always-steer-toggle")
     expect(toggle).to_be_visible()
     return toggle
@@ -99,7 +100,7 @@ def test_always_steer_persists_and_posts_a_busy_followup(
     """A reloaded opt-in sends through the real server while the turn is gated."""
     base_url, session_id, mock_url = paused_mid_turn_session
 
-    toggle = _open_chat_settings(page, base_url)
+    toggle = _open_general_settings(page, base_url)
     expect(toggle).to_have_attribute("aria-checked", "false")
     assert page.evaluate(f"localStorage.getItem('{_STORAGE_KEY}')") is None
 
@@ -131,7 +132,7 @@ def test_always_steer_persists_and_posts_a_busy_followup(
 
     page.reload()
     expect(page.get_by_text(_DIRECT_FOLLOWUP, exact=True)).to_be_visible(timeout=30_000)
-    toggle = _open_chat_settings(page, base_url, from_chat=True)
+    toggle = _open_general_settings(page, base_url, from_chat=True)
     expect(toggle).to_have_attribute("aria-checked", "true")
 
 
@@ -154,7 +155,7 @@ def test_existing_queue_still_drains_in_order_after_enabling_always_steer(
     expect(queue).to_contain_text(_EARLIER_QUEUED)
     assert posts == [_INITIAL_ORDERING]
 
-    toggle = _open_chat_settings(page, base_url, from_chat=True)
+    toggle = _open_general_settings(page, base_url, from_chat=True)
     expect(toggle).to_have_attribute("aria-checked", "false")
     toggle.click()
     expect(toggle).to_have_attribute("aria-checked", "true")

--- a/tests/e2e_ui/chat/test_always_steer.py
+++ b/tests/e2e_ui/chat/test_always_steer.py
@@ -1,0 +1,181 @@
+"""E2E: Settings → Chat "Always steer" dispatches busy follow-ups now."""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from collections.abc import Callable
+from urllib.parse import urlparse
+
+import httpx
+from playwright.sync_api import Locator, Page, Request, expect
+
+_STORAGE_KEY = "omnigent:always-steer"
+_COMPOSER_LABEL = "Message the agent"
+_INITIAL_DIRECT = "always-steer initial direct turn"
+_DIRECT_FOLLOWUP = "always-steer direct busy follow-up"
+_INITIAL_ORDERING = "always-steer initial ordering turn"
+_EARLIER_QUEUED = "always-steer earlier queued follow-up"
+_LATER_QUEUED = "always-steer later queued follow-up"
+
+
+def _wait_for(page: Page, predicate: Callable[[], bool], *, timeout_s: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        page.wait_for_timeout(100)
+    raise AssertionError(f"condition not met within {timeout_s:.0f}s")
+
+
+def _open_chat_settings(page: Page, base_url: str, *, from_chat: bool = False) -> Locator:
+    if from_chat:
+        page.get_by_test_id("settings-button").click()
+    else:
+        page.goto(f"{base_url}/settings/appearance")
+    chat_link = page.get_by_test_id("settings-nav-chat")
+    expect(chat_link).to_be_visible(timeout=30_000)
+    chat_link.click()
+    expect(page).to_have_url(re.compile(r"/settings/chat$"))
+    toggle = page.get_by_test_id("always-steer-toggle")
+    expect(toggle).to_be_visible()
+    return toggle
+
+
+def _send(page: Page, text: str) -> None:
+    page.get_by_label(_COMPOSER_LABEL).fill(text)
+    page.get_by_role("button", name="Send", exact=True).click()
+
+
+def _wait_for_gate(page: Page, mock_url: str) -> None:
+    def pending() -> bool:
+        return bool(httpx.get(f"{mock_url}/gate/pending", timeout=5.0).json()["pending"])
+
+    _wait_for(page, pending)
+
+
+def _release_gate(mock_url: str) -> None:
+    response = httpx.post(f"{mock_url}/gate/release", timeout=5.0)
+    response.raise_for_status()
+    assert response.json()["released"] is True
+
+
+def _record_message_posts(page: Page, session_id: str) -> list[str]:
+    posts: list[str] = []
+
+    def record(request: Request) -> None:
+        if request.method != "POST":
+            return
+        if urlparse(request.url).path != f"/v1/sessions/{session_id}/events":
+            return
+        body = request.post_data_json
+        if not isinstance(body, dict) or body.get("type") != "message":
+            return
+        content = body.get("data", {}).get("content", [])
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "input_text":
+                posts.append(str(block.get("text", "")))
+
+    page.on("request", record)
+    return posts
+
+
+def _items_contain(base_url: str, session_id: str, *texts: str) -> bool:
+    response = httpx.get(
+        f"{base_url}/v1/sessions/{session_id}/items",
+        params={"limit": 1000},
+        timeout=10.0,
+    )
+    response.raise_for_status()
+    payload = json.dumps(response.json())
+    return all(text in payload for text in texts)
+
+
+def test_always_steer_persists_and_posts_a_busy_followup(
+    page: Page,
+    paused_mid_turn_session: tuple[str, str, str],
+) -> None:
+    """A reloaded opt-in sends through the real server while the turn is gated."""
+    base_url, session_id, mock_url = paused_mid_turn_session
+
+    toggle = _open_chat_settings(page, base_url)
+    expect(toggle).to_have_attribute("aria-checked", "false")
+    assert page.evaluate(f"localStorage.getItem('{_STORAGE_KEY}')") is None
+
+    toggle.click()
+    expect(toggle).to_have_attribute("aria-checked", "true")
+    assert page.evaluate(f"localStorage.getItem('{_STORAGE_KEY}')") == "true"
+
+    page.reload()
+    toggle = page.get_by_test_id("always-steer-toggle")
+    expect(toggle).to_have_attribute("aria-checked", "true", timeout=30_000)
+
+    posts = _record_message_posts(page, session_id)
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.get_by_label(_COMPOSER_LABEL)).to_be_visible(timeout=30_000)
+    _send(page, _INITIAL_DIRECT)
+    _wait_for_gate(page, mock_url)
+    _wait_for(page, lambda: posts == [_INITIAL_DIRECT])
+
+    _send(page, _DIRECT_FOLLOWUP)
+    _wait_for(page, lambda: posts == [_INITIAL_DIRECT, _DIRECT_FOLLOWUP])
+    expect(page.get_by_test_id("composer-queued-strip")).to_have_count(0)
+
+    _release_gate(mock_url)
+    _wait_for(
+        page,
+        lambda: _items_contain(base_url, session_id, _INITIAL_DIRECT, _DIRECT_FOLLOWUP),
+        timeout_s=60.0,
+    )
+
+    page.reload()
+    expect(page.get_by_text(_DIRECT_FOLLOWUP, exact=True)).to_be_visible(timeout=30_000)
+    toggle = _open_chat_settings(page, base_url, from_chat=True)
+    expect(toggle).to_have_attribute("aria-checked", "true")
+
+
+def test_existing_queue_still_drains_in_order_after_enabling_always_steer(
+    page: Page,
+    paused_mid_turn_session: tuple[str, str, str],
+) -> None:
+    """A queued message keeps later sends behind it even after the opt-in."""
+    base_url, session_id, mock_url = paused_mid_turn_session
+    posts = _record_message_posts(page, session_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.get_by_label(_COMPOSER_LABEL)).to_be_visible(timeout=30_000)
+    _send(page, _INITIAL_ORDERING)
+    _wait_for_gate(page, mock_url)
+    _wait_for(page, lambda: posts == [_INITIAL_ORDERING])
+
+    _send(page, _EARLIER_QUEUED)
+    queue = page.get_by_test_id("composer-queued-strip")
+    expect(queue).to_contain_text(_EARLIER_QUEUED)
+    assert posts == [_INITIAL_ORDERING]
+
+    toggle = _open_chat_settings(page, base_url, from_chat=True)
+    expect(toggle).to_have_attribute("aria-checked", "false")
+    toggle.click()
+    expect(toggle).to_have_attribute("aria-checked", "true")
+    page.get_by_role("link", name="Back", exact=True).click()
+    expect(page).to_have_url(re.compile(rf"/c/{re.escape(session_id)}$"))
+    expect(queue).to_contain_text(_EARLIER_QUEUED)
+
+    _send(page, _LATER_QUEUED)
+    expect(queue).to_contain_text(_LATER_QUEUED)
+    page.wait_for_timeout(300)
+    assert posts == [_INITIAL_ORDERING]
+
+    _release_gate(mock_url)
+    _wait_for(
+        page,
+        lambda: posts == [_INITIAL_ORDERING, _EARLIER_QUEUED, _LATER_QUEUED],
+        timeout_s=90.0,
+    )
+    _wait_for(
+        page,
+        lambda: _items_contain(base_url, session_id, _EARLIER_QUEUED, _LATER_QUEUED),
+        timeout_s=60.0,
+    )
+    expect(queue).to_have_count(0)

--- a/web/src/lib/alwaysSteerPreferences.test.ts
+++ b/web/src/lib/alwaysSteerPreferences.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_ALWAYS_STEER, readAlwaysSteer, writeAlwaysSteer } from "./alwaysSteerPreferences";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("alwaysSteerPreferences", () => {
+  it("defaults to off (queue mid-turn follow-ups) when nothing is stored", () => {
+    // Opt-in: with no stored preference a busy-session follow-up still parks in
+    // the queue strip, so read must report the feature off.
+    expect(DEFAULT_ALWAYS_STEER).toBe(false);
+    expect(readAlwaysSteer()).toBe(false);
+  });
+
+  it("round-trips both boolean values", () => {
+    writeAlwaysSteer(true);
+    expect(readAlwaysSteer()).toBe(true);
+
+    writeAlwaysSteer(false);
+    expect(readAlwaysSteer()).toBe(false);
+  });
+
+  it('treats any non-"true" stored value as off (defensive against hand edits)', () => {
+    // Only the exact string "true" enables always-steer; garbage or a stale
+    // format reads as off rather than silently changing dispatch behavior.
+    localStorage.setItem("omnigent:always-steer", "1");
+    expect(readAlwaysSteer()).toBe(false);
+
+    localStorage.setItem("omnigent:always-steer", "yes");
+    expect(readAlwaysSteer()).toBe(false);
+
+    localStorage.setItem("omnigent:always-steer", "true");
+    expect(readAlwaysSteer()).toBe(true);
+  });
+
+  it("never throws when storage is inaccessible", () => {
+    // Private-mode / quota failures surface as throws from the Storage API.
+    // Both helpers must swallow them — a broken preference must not break the
+    // composer or settings.
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("access denied");
+    });
+    expect(() => writeAlwaysSteer(true)).not.toThrow();
+    expect(readAlwaysSteer()).toBe(false);
+  });
+});

--- a/web/src/lib/alwaysSteerPreferences.ts
+++ b/web/src/lib/alwaysSteerPreferences.ts
@@ -1,0 +1,43 @@
+// Persisted, per-device preference for how a message sent while the agent is
+// busy is dispatched.
+//
+// Normally a follow-up typed mid-turn is parked in the client-side queue strip
+// (editable / reorderable) and auto-flushed when the agent goes idle. When this
+// opt-in preference is on, a follow-up skips the queue and is POSTed
+// immediately — steered into the running turn where the harness supports live
+// injection, folded in at the next turn boundary otherwise. It's a device-local
+// dispatch preference — no account or session state changes — so it lives in
+// localStorage like the other `*Preferences` helpers.
+
+const STORAGE_KEY = "omnigent:always-steer";
+
+export const DEFAULT_ALWAYS_STEER = false;
+
+/**
+ * Read the persisted "always steer" preference. Returns the default (off) when
+ * nothing is stored, on a server render (no `window`), or when the stored value
+ * is malformed — never throws, so a corrupt entry can't break the app.
+ */
+export function readAlwaysSteer(): boolean {
+  if (typeof window === "undefined") return DEFAULT_ALWAYS_STEER;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return DEFAULT_ALWAYS_STEER;
+    return raw === "true";
+  } catch {
+    return DEFAULT_ALWAYS_STEER;
+  }
+}
+
+/**
+ * Persist the "always steer" preference. Swallows quota/access errors so a
+ * failed write can't break the app.
+ */
+export function writeAlwaysSteer(value: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, value ? "true" : "false");
+  } catch {
+    // localStorage quota or access errors shouldn't break the app.
+  }
+}

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -2785,4 +2785,17 @@ describe("shouldQueueSend", () => {
   it("ignores queued messages belonging to a different conversation", () => {
     expect(shouldQueueSend("conv_a", "idle", "idle", [q("conv_b")])).toBe(false);
   });
+
+  it("sends directly while busy when alwaysSteer is on", () => {
+    // The whole point of the preference: a mid-turn follow-up is POSTed now
+    // (steered) instead of parking in the queue strip.
+    expect(shouldQueueSend("conv_a", "streaming", "idle", [], true)).toBe(false);
+    expect(shouldQueueSend("conv_a", "idle", "running", [], true)).toBe(false);
+  });
+
+  it("still queues under alwaysSteer when this conversation has a queued message", () => {
+    // The ordering guard outranks always-steer: draining must stay in order, so
+    // a direct send can't overtake a still-queued earlier one.
+    expect(shouldQueueSend("conv_a", "streaming", "running", [q("conv_a")], true)).toBe(true);
+  });
 });

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -120,6 +120,7 @@ import {
   nativeCodingAgentForSubagentWrapper,
   WRAPPER_LABEL_KEY,
 } from "@/lib/nativeCodingAgents";
+import { readAlwaysSteer } from "@/lib/alwaysSteerPreferences";
 import {
   buildMentionPreamble,
   detectMentionAt,
@@ -643,16 +644,24 @@ export function shouldShowAuthorBadge(
  * turn immediately instead of stalling behind that background work. (The
  * "Working…" spinner and sidebar dot still treat ``waiting`` as active — those
  * reflect background activity, which is a separate concern from send gating.)
+ *
+ * ``alwaysSteer`` (a per-device preference) drops the busy gate entirely: a
+ * follow-up sent mid-turn is POSTed now — steered into the running turn —
+ * instead of parking in the queue strip. The ``hasQueued`` guard still holds:
+ * once this conversation has a queued message it must drain in order, or a
+ * direct send could overtake a still-queued earlier one on an idle flicker.
  */
 export function shouldQueueSend(
   conversationId: string | null,
   status: "idle" | "streaming",
   sessionStatus: SessionStatus,
   queuedMessages: QueuedMessage[],
+  alwaysSteer = false,
 ): boolean {
   if (conversationId === null) return false;
-  const isBusy = status === "streaming" || sessionStatus === "running";
   const hasQueued = queuedMessages.some((m) => m.conversationId === conversationId);
+  if (alwaysSteer) return hasQueued;
+  const isBusy = status === "streaming" || sessionStatus === "running";
   return isBusy || hasQueued;
 }
 
@@ -1238,10 +1247,18 @@ export function ChatPage() {
       return;
     }
     // Queue instead of POSTing now (see shouldQueueSend). enqueueMessage flushes
-    // FIFO immediately when genuinely idle, so nothing stalls.
+    // FIFO immediately when genuinely idle, so nothing stalls. With the
+    // always-steer preference on, a mid-turn follow-up skips the queue and is
+    // POSTed now instead.
     const chat = useChatStore.getState();
     if (
-      shouldQueueSend(chat.conversationId, chat.status, chat.sessionStatus, chat.queuedMessages)
+      shouldQueueSend(
+        chat.conversationId,
+        chat.status,
+        chat.sessionStatus,
+        chat.queuedMessages,
+        readAlwaysSteer(),
+      )
     ) {
       chat.enqueueMessage(text, files);
       return;

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -167,6 +167,7 @@ import {
   type TranscriptViewDefault,
 } from "@/lib/transcriptViewPreferences";
 import { readDefaultBaseBranch, writeDefaultBaseBranch } from "@/lib/baseBranchPreferences";
+import { readAlwaysSteer, writeAlwaysSteer } from "@/lib/alwaysSteerPreferences";
 import { readAlwaysUseWorktree, writeAlwaysUseWorktree } from "@/lib/worktreeDefaultPreferences";
 import {
   DEFAULT_HIDE_UNCONFIGURED_HARNESSES,
@@ -293,6 +294,7 @@ export function SettingsPage() {
   return (
     <PageScroll contentClassName="px-8" extraBottom="2.5rem">
       {section === "appearance" && <AppearanceSection />}
+      {section === "chat" && <ChatSection />}
       {section === "git" && <GitSection />}
       {section === "shortcuts" && <ShortcutsSection />}
       {section === "import" && <ImportSection />}
@@ -1047,6 +1049,50 @@ function AlwaysUseWorktreeControl() {
         componentId="settings.git.always_use_worktree"
       />
     </div>
+  );
+}
+
+/**
+ * Opt-in dispatch for messages sent while the agent is working.
+ */
+function AlwaysSteerControl() {
+  const [value, setValue] = useState(() => readAlwaysSteer());
+  const labelId = useId();
+  const toggle = useCallback((next: boolean) => {
+    setValue(next);
+    writeAlwaysSteer(next);
+  }, []);
+  return (
+    <div className="flex items-start justify-between gap-6">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span id={labelId} className="text-ui font-medium">
+          Always steer
+        </span>
+        <span className="text-ui text-muted-foreground">
+          Send follow-ups straight into the running turn instead of queuing them. The agent folds
+          each one into its current work where the harness supports it, otherwise at the next turn.
+        </span>
+      </div>
+      <Switch
+        aria-labelledby={labelId}
+        checked={value}
+        onCheckedChange={toggle}
+        data-testid="always-steer-toggle"
+        className="mt-0.5 shrink-0"
+        componentId="settings.chat.always_steer"
+      />
+    </div>
+  );
+}
+
+/** Chat behavior settings. */
+function ChatSection() {
+  return (
+    <Section title="Chat" description="Configure how Omnigent handles your messages.">
+      <div className="flex flex-col gap-8">
+        <AlwaysSteerControl />
+      </div>
+    </Section>
   );
 }
 

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -9,6 +9,7 @@
  *
  * Sections:
  *
+ * - **General** — app-wide behavior preferences.
  * - **Appearance** — theme mode (System / Light / Dark), terminal theme,
  *   default transcript view, Workspace panel default, and UI/code font controls.
  * - **Git** — Git behavior: the global "always use a random worktree" default
@@ -294,7 +295,7 @@ export function SettingsPage() {
   return (
     <PageScroll contentClassName="px-8" extraBottom="2.5rem">
       {section === "appearance" && <AppearanceSection />}
-      {section === "chat" && <ChatSection />}
+      {section === "general" && <GeneralSection />}
       {section === "git" && <GitSection />}
       {section === "shortcuts" && <ShortcutsSection />}
       {section === "import" && <ImportSection />}
@@ -1079,18 +1080,21 @@ function AlwaysSteerControl() {
         onCheckedChange={toggle}
         data-testid="always-steer-toggle"
         className="mt-0.5 shrink-0"
-        componentId="settings.chat.always_steer"
+        componentId="settings.general.always_steer"
       />
     </div>
   );
 }
 
-/** Chat behavior settings. */
-function ChatSection() {
+/** App-wide behavior settings. */
+function GeneralSection() {
   return (
-    <Section title="Chat" description="Configure how Omnigent handles your messages.">
-      <div className="flex flex-col gap-8">
-        <AlwaysSteerControl />
+    <Section title="General" description="Configure general Omnigent behavior.">
+      <div className="flex flex-col gap-3">
+        <h2 className="text-ui font-medium">Composer</h2>
+        <div className="rounded-xl border border-border bg-card px-4 py-3">
+          <AlwaysSteerControl />
+        </div>
       </div>
     </Section>
   );

--- a/web/src/shell/settingsNav.test.tsx
+++ b/web/src/shell/settingsNav.test.tsx
@@ -6,6 +6,7 @@
 // instead of the homepage. Section links still close it.
 
 import { cleanup, fireEvent, render, renderHook, screen } from "@testing-library/react";
+import { SettingsIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import { MemoryRouter, useNavigate } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -65,6 +66,15 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("settingsNavGroups", () => {
+  it("starts general preferences with a General gear entry", () => {
+    const general = settingsNavGroups(false, false).find((group) => group.title === "General");
+    expect(general?.items[0]).toMatchObject({
+      id: "general",
+      label: "General",
+      icon: SettingsIcon,
+    });
+  });
+
   it("flags Keyboard shortcuts as hidden on mobile, but not the other items", () => {
     const items = settingsNavGroups(false, false).flatMap((g) => g.items);
     const shortcuts = items.find((i) => i.id === "shortcuts");
@@ -151,6 +161,10 @@ describe("SettingsSidebarBody", () => {
     expect(screen.queryByRole("button", { name: "Close sidebar" })).not.toBeInTheDocument();
     expect(screen.getByTestId("settings-nav-appearance").querySelector("svg")).toHaveClass(
       "ui-icon",
+    );
+    expect(screen.getByTestId("settings-nav-general")).toHaveAttribute(
+      "href",
+      "/settings/general",
     );
   });
 

--- a/web/src/shell/settingsNav.test.tsx
+++ b/web/src/shell/settingsNav.test.tsx
@@ -162,10 +162,7 @@ describe("SettingsSidebarBody", () => {
     expect(screen.getByTestId("settings-nav-appearance").querySelector("svg")).toHaveClass(
       "ui-icon",
     );
-    expect(screen.getByTestId("settings-nav-general")).toHaveAttribute(
-      "href",
-      "/settings/general",
-    );
+    expect(screen.getByTestId("settings-nav-general")).toHaveAttribute("href", "/settings/general");
   });
 
   it("uses the shared row geometry with normal-weight labels", () => {

--- a/web/src/shell/settingsNav.tsx
+++ b/web/src/shell/settingsNav.tsx
@@ -13,8 +13,8 @@ import {
   DownloadIcon,
   GitBranchIcon,
   KeyboardIcon,
-  MessagesSquareIcon,
   PaletteIcon,
+  SettingsIcon,
   Share2Icon,
   ShieldCheckIcon,
   TerminalIcon,
@@ -32,7 +32,7 @@ import { SIDEBAR_ROW } from "./sidebarStyles";
 
 export type SettingsSectionId =
   | "appearance"
-  | "chat"
+  | "general"
   | "git"
   | "shortcuts"
   | "import"
@@ -46,7 +46,7 @@ export type SettingsSectionId =
 
 const SECTION_IDS: readonly SettingsSectionId[] = [
   "appearance",
-  "chat",
+  "general",
   "git",
   "shortcuts",
   "import",
@@ -88,8 +88,8 @@ export function settingsNavGroups(
   isSingleUser = false,
 ): SettingsNavGroup[] {
   const general: SettingsNavItem[] = [
+    { id: "general", label: "General", icon: SettingsIcon },
     { id: "appearance", label: "Appearance", icon: PaletteIcon },
-    { id: "chat", label: "Chat", icon: MessagesSquareIcon },
     { id: "git", label: "Git", icon: GitBranchIcon },
     { id: "shortcuts", label: "Keyboard shortcuts", icon: KeyboardIcon, hideOnMobile: true },
     { id: "import", label: "Import sessions", icon: DownloadIcon },

--- a/web/src/shell/settingsNav.tsx
+++ b/web/src/shell/settingsNav.tsx
@@ -13,6 +13,7 @@ import {
   DownloadIcon,
   GitBranchIcon,
   KeyboardIcon,
+  MessagesSquareIcon,
   PaletteIcon,
   Share2Icon,
   ShieldCheckIcon,
@@ -31,6 +32,7 @@ import { SIDEBAR_ROW } from "./sidebarStyles";
 
 export type SettingsSectionId =
   | "appearance"
+  | "chat"
   | "git"
   | "shortcuts"
   | "import"
@@ -44,6 +46,7 @@ export type SettingsSectionId =
 
 const SECTION_IDS: readonly SettingsSectionId[] = [
   "appearance",
+  "chat",
   "git",
   "shortcuts",
   "import",
@@ -86,6 +89,7 @@ export function settingsNavGroups(
 ): SettingsNavGroup[] {
   const general: SettingsNavItem[] = [
     { id: "appearance", label: "Appearance", icon: PaletteIcon },
+    { id: "chat", label: "Chat", icon: MessagesSquareIcon },
     { id: "git", label: "Git", icon: GitBranchIcon },
     { id: "shortcuts", label: "Keyboard shortcuts", icon: KeyboardIcon, hideOnMobile: true },
     { id: "import", label: "Import sessions", icon: DownloadIcon },


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Adds an opt-in, per-device **"Always steer"** setting. When on, a message sent while the agent is busy is POSTed immediately (steered into the running turn) instead of parking in the client-side queue strip to auto-flush on idle.
- Steer here means the same thing it already does for the per-message "Steer" button: POST now, and the harness folds it into the current turn where it supports live injection (claude/codex/pi-sdk, codex-native, claude-native), otherwise at the next turn boundary. It does **not** interrupt/cancel the turn.
- New **"Chat"** settings section holds the toggle, alongside Appearance / Git.

The ordering guard is preserved: if this conversation already has a queued message, a new send still queues even with always-steer on, so a direct send can't overtake a still-queued earlier one on an idle flicker.

## Test Plan

- `vitest run src/lib/alwaysSteerPreferences.test.ts` — 4/4 pass (default off, round-trip, defensive parse, never-throws).
- `vitest run src/pages/ChatPage.composer.test.tsx` — 106/106 pass, including 2 new `shouldQueueSend` cases: busy + alwaysSteer → send now; busy + alwaysSteer + already-queued → still queues (ordering guard).
- `vitest run src/pages/SettingsPage.test.tsx` — 46/46 pass (new Chat section doesn't regress existing settings).
- `vitest run src/shell/settingsNav.test.tsx` — pass (new "chat" nav item doesn't break nav grouping/gating).
- `oxlint` on all changed files — no errors.
- `tsc -b` — no errors in any changed file.

## Demo

N/A in this PR — I wasn't able to capture a recording in my environment. The change is a single labeled `Switch` under a new **Settings → Chat** section titled "Always steer" (description: "Send follow-ups straight into the running turn instead of queuing them…"), matching the existing toggle styling (e.g. "Hide unconfigured harnesses"). Happy to add a screen recording if a reviewer wants one before merge.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The behavior fork lives in the pure, unit-tested `shouldQueueSend()` and the preference helper, both covered by new unit tests. The toggle UI reuses the established `*Preferences` + `Switch` pattern and renders through the existing (passing) SettingsPage/settingsNav test suites. I did not exercise it in a running app locally — the environment couldn't install the web dependencies — so end-to-end steer delivery per harness is unverified by me here and worth a quick manual check on merge.

## Changelog

Add an "Always steer" setting that sends follow-ups straight into the running turn instead of queuing them

This pull request and its description were written by Isaac.
