### PR TITLE
fix(web): show startup spinner when a send relaunches a disconnected runner

### DIFF
--- a/web/src/components/SessionStateBadge.test.tsx
+++ b/web/src/components/SessionStateBadge.test.tsx
@@ -47,6 +47,16 @@ describe("SessionStateBadge — per-state rendering", () => {
     expect(container.querySelector(".bg-success")).toBeNull();
   });
 
+  it("renders starting with the same spinner as running and its own label", () => {
+    const { container } = renderBadge({ kind: "starting" });
+    const badge = screen.getByTestId("session-state-badge");
+    expect(badge).toHaveAttribute("data-state", "starting");
+    expect(badge).toHaveAttribute("aria-label", "Session starting up");
+    const spinner = container.querySelector('[data-testid="running-dot"]');
+    expect(spinner).not.toBeNull();
+    expect(spinner?.getAttribute("class")).toContain("animate-spin");
+  });
+
   it("renders unseen messages as a solid (non-pulsing) brand-pink dot", () => {
     const { container } = renderBadge({ kind: "unseen" });
     const badge = screen.getByTestId("session-state-badge");

--- a/web/src/components/SessionStateBadge.tsx
+++ b/web/src/components/SessionStateBadge.tsx
@@ -41,6 +41,14 @@ function describe(state: SessionState): Visual {
         tooltip: "Session running",
         render: () => <RunningDot className="size-2.5" />,
       };
+    case "starting":
+      // Same spinner as running — the session is coming up, not yet working.
+      return {
+        kind: state.kind,
+        ariaLabel: "Session starting up",
+        tooltip: "Session starting up",
+        render: () => <RunningDot className="size-2.5" />,
+      };
     case "unseen":
       // Solid brand-pink dot — distinguished from the running indicator,
       // which is a grey spinner.

--- a/web/src/hooks/useSessionState.ts
+++ b/web/src/hooks/useSessionState.ts
@@ -14,7 +14,14 @@
 import type { Conversation } from "@/hooks/useConversations";
 
 export type SessionState =
-  { kind: "awaiting"; count: number } | { kind: "running" } | { kind: "unseen" };
+  | { kind: "awaiting"; count: number }
+  | { kind: "running" }
+  | { kind: "unseen" }
+  // The open session's launch/relaunch window — a send in flight or the PTY
+  // being created before the server confirms `running`. Not derivable from a
+  // conversation row (it reads the chat store), so `getSessionState` never
+  // returns it; the sidebar row folds it in for the bound session only.
+  | { kind: "starting" };
 
 export function getSessionState(
   conversation: Pick<Conversation, "status" | "pending_elicitations_count"> | undefined | null,

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -459,7 +459,12 @@ beforeEach(() => {
   // todo list from one test doesn't leak into the next.
   // Reset terminal-first startup signals so one test's terminalPending /
   // failed status can't leak into another's terminalStartingUp.
-  useChatStore.setState({ todos: [], terminalPending: false, sessionStatus: "idle" });
+  useChatStore.setState({
+    todos: [],
+    terminalPending: false,
+    sessionStatus: "idle",
+    status: "idle",
+  });
 });
 
 afterEach(cleanup);
@@ -531,6 +536,22 @@ describe("AppShell header", () => {
     renderShell("/c/conv_terminal");
 
     expect(screen.getByTestId("view-probe")).toHaveAttribute("data-terminal-starting-up", "false");
+  });
+
+  it("keeps the terminal-startup spinner when a send is relaunching a failed session", () => {
+    // A runner disconnect marks the session failed, and that status lingers
+    // until the relaunched runner pushes a fresh edge. A send in flight
+    // (local status "streaming") means the host is relaunching the runner
+    // right now, so the spinner must show through the relaunch window
+    // instead of leaving a silent gap until the runner is fully booted.
+    mockConversations([
+      { id: "conv_terminal", permission_level: null, labels: { "omnigent.ui": "terminal" } },
+    ]);
+    useChatStore.setState({ terminalPending: true, sessionStatus: "failed", status: "streaming" });
+
+    renderShell("/c/conv_terminal");
+
+    expect(screen.getByTestId("view-probe")).toHaveAttribute("data-terminal-starting-up", "true");
   });
 });
 

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1164,15 +1164,22 @@ export function AppShell() {
   // either the runner is launching/relaunching (liveness `starting`, known the
   // instant a message is sent) or it's up and auto-creating the PTY
   // (`terminalPending`). Idle stopped sessions are neither → greyed, not spinning.
-  // Suppressed once the session has failed: a runner that crashed before
-  // connecting (`runner_failed_to_start`), or a host that refused the launch
-  // (`harness_not_configured`), sits in the `starting` grace window but can
-  // never come up — so drop the spinner the instant the failed status lands
-  // and let the error banner stand alone. `sessionStatus` (declared above) is
-  // set by both the live `session.status:failed` push and the snapshot reload.
+  // Suppressed once the session has failed AND no send is in flight: a runner
+  // that crashed before connecting (`runner_failed_to_start`), or a host that
+  // refused the launch (`harness_not_configured`), sits in the `starting` grace
+  // window but can never come up — so drop the spinner and let the error banner
+  // stand alone. A runner *disconnect* also marks the session failed, though,
+  // and that status lingers until the relaunched runner pushes a fresh edge —
+  // so an in-flight send (`chatStatus === "streaming"`, which is what upgrades
+  // liveness to `starting`) overrides the suppression: the host is relaunching
+  // the runner right now and the user must see the spinner, not a silent gap.
+  // If the relaunch fails, the fresh `session.status: failed` edge settles the
+  // local send lifecycle back to `idle` and the suppression re-engages.
+  // `sessionStatus` (declared above) is set by both the live
+  // `session.status:failed` push and the snapshot reload.
   const terminalStartingUp =
     !terminalsAvailable &&
-    sessionStatus !== "failed" &&
+    (sessionStatus !== "failed" || chatStatus === "streaming") &&
     (liveness.kind === "starting" || terminalPending);
   // A rail-opened shell (any open terminal key other than the agent's
   // own terminal) takes over the main view chrome-free:

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -153,6 +153,7 @@ vi.mock("@/lib/serverOrigin", () => ({
 }));
 
 import { useConversations } from "@/hooks/useConversations";
+import { useChatStore } from "@/store/chatStore";
 import { Sidebar } from "./Sidebar";
 
 const useConvMock = vi.mocked(useConversations);
@@ -240,6 +241,9 @@ beforeEach(() => {
   pinnedIdsRef.current = [];
   // Default to a multi-user server so the tab-based tests see the tabs.
   isServerLocalMock.mockReturnValue(false);
+  // The bound session's startup signal (send in flight / PTY pending) feeds
+  // the row's "starting" badge; reset so one test's state can't leak.
+  useChatStore.setState({ conversationId: null, status: "idle", terminalPending: false });
 });
 
 /** Seed the server-authoritative pinned set (replaces the old localStorage seed). */
@@ -514,6 +518,30 @@ describe("Sidebar session list", () => {
     const idleRow = screen.getByRole("link", { name: /conv_idle/ }).closest("li")!;
     expect(within(idleRow).queryByTestId("session-state-badge")).toBeNull();
     expect(within(idleRow).queryByText("now")).toBeNull();
+  });
+
+  it("shows a starting spinner on the bound session while a send is waking it", () => {
+    // The launch/relaunch window: the user sent a message (local status
+    // "streaming") but the server hasn't confirmed `running` — a cold boot or
+    // a send waking a disconnected runner. The row's server status is stale
+    // ("failed" after a runner disconnect), yet the sidebar must show the
+    // session is coming up, matching the chat's "Starting up…" indicator.
+    mockConversations([
+      conv("conv_waking", "Claude Code", { status: "failed" }),
+      conv("conv_other", "Claude Code"),
+    ]);
+    useChatStore.setState({ conversationId: "conv_waking", status: "streaming" });
+
+    renderSidebar();
+
+    const wakingRow = screen.getByRole("link", { name: /conv_waking/ }).closest("li")!;
+    expect(within(wakingRow).getByTestId("session-state-badge")).toHaveAttribute(
+      "data-state",
+      "starting",
+    );
+    // Only the bound session reads the store signal — other rows stay bare.
+    const otherRow = screen.getByRole("link", { name: /conv_other/ }).closest("li")!;
+    expect(within(otherRow).queryByTestId("session-state-badge")).toBeNull();
   });
 
   it("shows the full session title in a styled tooltip on hover", async () => {

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -136,6 +136,7 @@ import { isSessionStoppable } from "@/lib/sessionStop";
 import { getCurrentUserId, resolveIdentity } from "@/lib/identity";
 import { isImeCompositionKeyEvent } from "@/lib/ime";
 import { getSessionState, type SessionState } from "@/hooks/useSessionState";
+import { useChatStore } from "@/store/chatStore";
 import {
   isConversationUnseen,
   isExplicitlyUnread,
@@ -2741,12 +2742,22 @@ function ConversationRow({
   // surface the actionable approval tag. The row still renders bold (the
   // unread signal) via `hasUnseenMessages` below.
   const derivedState = getSessionState(conversation);
+  // The bound session's launch/relaunch window: a send is in flight (local
+  // status "streaming") or the runner is auto-creating the PTY
+  // (`terminalPending`), but the server hasn't confirmed `running` yet — a
+  // cold boot, or a send waking a disconnected runner. Without this the row
+  // shows nothing while the session is visibly "Starting up…" in the chat.
+  // Only the bound (open) conversation has this store state; other rows read
+  // false, and the server-derived states above win once they land.
+  const isStartingUp = useChatStore(
+    (s) => s.conversationId === conversation.id && (s.status === "streaming" || s.terminalPending),
+  );
   const sessionState =
     derivedState?.kind === "awaiting"
       ? derivedState
       : hasUnseenMessages
         ? { kind: "unseen" as const }
-        : derivedState;
+        : (derivedState ?? (isStartingUp ? { kind: "starting" as const } : null));
 
   // Drag-and-drop: a row is grabbable when the viewer owns it (re-filing is
   // owner-only, like the Move-to-project kebab item), outside selection /


### PR DESCRIPTION
## Related issue

N/A

## Summary

Sending a message to a session whose runner had disconnected relaunches the runner on its host — but the chat UI showed **no spinner or indicator for the entire relaunch window**, unlike a brand-new session's "Starting up…" state. The message just sat there until the runner fully booted.

Root cause: when a runner tunnel drops, the server publishes `session.status: failed` for its sessions (`_on_runner_disconnect`), and that status lingers client-side until the relaunched runner pushes a fresh edge. AppShell's `terminalStartingUp` gate (`sessionStatus !== "failed"`) — added so a dead-on-arrival launch (`runner_failed_to_start` / `harness_not_configured`) doesn't spin forever next to its error banner — can't tell that case apart from "disconnected but actively relaunching", so it suppressed the pill spinner and the in-thread `RunnerStartingIndicator` through the whole wake. Terminal-first (native) sessions surface *all* launch states through `terminalStartingUp`, so nothing showed.

The fix: the failed-status suppression now yields while a send is in flight (`chatStatus === "streaming"` — the same signal that upgrades liveness to `starting`). If the relaunch genuinely fails, the fresh `failed` edge settles the local send lifecycle back to `idle` and the suppression re-engages, so permanently dead sessions still show only the error banner.

ELI5: the app remembers "this session crashed" and hides the loading spinner so a hopeless session doesn't spin forever. But sending a message un-crashes the session (the host restarts the runner) — and the app kept hiding the spinner while that restart was actually happening. Now, while your message is in flight, the spinner shows.

```
runner dies ──► session.status: failed (lingers until runner reboots)
user sends ──► status "streaming" ──► liveness "starting"
                                        │
before: sessionStatus==="failed" ───────┤ spinner suppressed ⇒ silent gap
after:  failed && !streaming  ──────────┘ spinner shows through relaunch
```

**Follow-up in this PR:** the left sidebar showed no indicator at all while a session was starting up (cold boot or send-to-wake) — the row's spinner is driven by the server-side `running` status, which doesn't land until the runner is fully booted. The bound session's row now shows the same grey spinner (a new `starting` badge state, tooltip "Session starting up") whenever a send is in flight or the PTY is being created and the server hasn't confirmed `running` yet; the server-derived states (awaiting / unseen / running) still take precedence the moment they land.

## Test Plan

- Live end-to-end repro (dev server + vite + real `omnigent claude` host-bound session, driven by Playwright): SIGKILL the runner, wait for the health poll to observe it, send a message, and sample the DOM + chat-store state at 200 ms.
  - Before: no indicator of any kind from send until the relaunched runner pushed `running` (`sessionStatus` stayed `failed`, `terminalStartingUp` stayed `false`).
  - After: "Starting up…" row + Terminal-pill spinner visible from the instant of send through the relaunch window, then normal "Working…" takeover.
- `pnpm exec vitest run src/shell/AppShell.test.tsx src/pages/RunnerStartingIndicator.test.tsx` — 98/98 pass, including a new case (failed session + send in flight ⇒ spinner shows) beside the existing suppression test (failed + idle ⇒ spinner hidden).
- Live check for the sidebar spinner (same stack): with the runner asleep, sending a message flips the row badge to `starting` at the instant of send, and it hands off to `running` when the server confirms — previously the row was bare for that whole window.
- `pnpm exec vitest run src/shell/Sidebar.test.tsx src/components/SessionStateBadge.test.tsx` — 64/64 pass, including new cases for the `starting` badge and the bound-session-only store read.

## Demo

After the fix — message sent to a disconnected runner; "Starting up…" row and pill spinner during the relaunch (previously blank):

![starting-up spinner during runner relaunch](https://raw.githubusercontent.com/dbczumar/omnigent/assets/starting-up-indicator/starting-up-spinner-after.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit test covers the gate (`terminalStartingUp` true when `sessionStatus === "failed"` with a send in flight, false when idle). The full wake path (runner kill → send → host relaunch → spinner) was verified manually with a scripted Playwright run against a real host-bound claude-native session, timeline-sampling the store and DOM; there is currently no host-bound session fixture in `tests/e2e_ui` to automate that flow.

## Changelog

The chat view shows the "Starting up…" spinner while a message is waking a disconnected runner, instead of nothing until the runner boots; the sidebar row shows a spinner while a session is starting up

