### PR TITLE
fix(web): sidebar rename targets the wrong session when the list reorders mid-interaction

### DIFF
--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -798,6 +798,57 @@ describe("right-click context menu", () => {
     expect(mocks.rename.mutate).toHaveBeenCalledWith({ id: "conv_a", title: "Renamed A" });
   });
 
+  it("keeps the order held while a rename edit is open even after the pointer leaves", () => {
+    // The pointer naturally drifts out of the sidebar while typing a new
+    // title. If that released the freeze, background updated_at churn would
+    // shuffle rows around the open input — and moving the input's DOM node
+    // blurs it, committing a half-typed title. An open rename edit must hold
+    // the order on its own; the snap-back happens once the edit ends.
+    const convA: Conversation = {
+      ...CONV,
+      id: "conv_a",
+      title: "Session A",
+      updated_at: 1_700_000_200,
+    };
+    const convB: Conversation = {
+      ...CONV,
+      id: "conv_b",
+      title: "Session B",
+      updated_at: 1_700_000_100,
+    };
+    mockConversations([convA, convB]);
+    const view = renderSidebar();
+
+    // Open the rename input on session A via right-click → Rename.
+    fireEvent.mouseOver(screen.getByTestId("sidebar-conversation-list"));
+    fireEvent.contextMenu(screen.getByRole("link", { name: /Session A/ }));
+    fireEvent.click(screen.getByTestId("rename-conversation"));
+    const input = screen.getByTestId("rename-conversation-input") as HTMLInputElement;
+
+    // The pointer leaves the list mid-edit; then session B's updated_at bumps.
+    fireEvent.mouseOut(screen.getByTestId("sidebar-conversation-list"), {
+      relatedTarget: document.body,
+    });
+    mockConversations([{ ...convB, updated_at: 1_700_000_300 }, convA]);
+    view.rerenderSidebar();
+
+    // The edit row still holds the top slot (the edit input replaces A's link,
+    // so B — below it — must still be the only link, not the first row).
+    expect(screen.getByTestId("rename-conversation-input")).toBe(input);
+    const listEl = screen.getByTestId("sidebar-conversation-list");
+    const rowB = screen.getByRole("link", { name: /Session B/ });
+    expect(input.compareDocumentPosition(rowB) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(listEl).toContainElement(rowB);
+
+    // Committing the rename targets session A and releases the hold: the
+    // order snaps to reality (B first).
+    fireEvent.change(input, { target: { value: "Renamed A" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(mocks.rename.mutate).toHaveBeenCalledWith({ id: "conv_a", title: "Renamed A" });
+    const after = screen.getAllByRole("link", { name: /^Session/ });
+    expect(after[0]).toHaveAccessibleName(/Session B/);
+  });
+
   it("snaps the order back to reality when the pointer leaves the list", () => {
     const convA: Conversation = {
       ...CONV,

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -218,7 +218,11 @@ function renderSidebar(activeId?: string, info?: ServerInfo) {
   );
   // No explicit info → CapabilitiesContext default ("loading"), matching every
   // pre-existing test (sharing treated as on).
-  return render(info ? <CapabilitiesProvider info={info}>{tree}</CapabilitiesProvider> : tree);
+  const ui = info ? <CapabilitiesProvider info={info}>{tree}</CapabilitiesProvider> : tree;
+  const view = render(ui);
+  // Re-render the same tree so a test can apply a new `mockConversations`
+  // list mid-flight (e.g. simulating a reorder pushed between user clicks).
+  return Object.assign(view, { rerenderSidebar: () => view.rerender(ui) });
 }
 
 beforeEach(() => {
@@ -453,6 +457,54 @@ describe("double-click to rename", () => {
     fireEvent.keyDown(input, { key: "Enter" });
     expect(mocks.rename.mutate).toHaveBeenCalledTimes(1);
     expect(mocks.rename.mutate).toHaveBeenCalledWith({ id: "conv_1", title: "Renamed" });
+  });
+
+  it("ignores a double-click whose first click landed on a different row", () => {
+    // A native double-click delivers click, click, dblclick to one element.
+    // If the list reorders between the two clicks (a session's updated_at
+    // bump pushes rows around under the cursor), the second click and the
+    // dblclick land on whichever row slid into place — which must NOT enter
+    // rename, or the user renames a session they never aimed at.
+    const convA: Conversation = {
+      ...CONV,
+      id: "conv_a",
+      title: "Session A",
+      updated_at: 1_700_000_200,
+    };
+    const convB: Conversation = {
+      ...CONV,
+      id: "conv_b",
+      title: "Session B",
+      updated_at: 1_700_000_100,
+    };
+    mockConversations([convA, convB]);
+    const view = renderSidebar();
+
+    // Click #1 of the user's double-click lands on session A (the top row).
+    fireEvent.click(screen.getByRole("link", { name: /Session A/ }));
+
+    // Before click #2, session B's updated_at bumps and the list reorders —
+    // B now occupies the screen position where A was.
+    mockConversations([{ ...convB, updated_at: 1_700_000_300 }, convA]);
+    view.rerenderSidebar();
+
+    // Click #2 and the dblclick land on B, the row now under the cursor.
+    const rowB = screen.getByRole("link", { name: /Session B/ });
+    fireEvent.click(rowB);
+    fireEvent.dblClick(rowB);
+
+    // B saw only the second click, so it must not enter rename.
+    expect(screen.queryByTestId("rename-conversation-input")).toBeNull();
+    expect(mocks.rename.mutate).not.toHaveBeenCalled();
+
+    // A clean double-click on B — both clicks on the row — still renames it.
+    fireEvent.click(rowB);
+    fireEvent.click(rowB);
+    fireEvent.dblClick(rowB);
+    const input = screen.getByTestId("rename-conversation-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Renamed B" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(mocks.rename.mutate).toHaveBeenCalledWith({ id: "conv_b", title: "Renamed B" });
   });
 
   it("does not enter rename on double-click for a viewer-only row", () => {

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -200,29 +200,34 @@ function serverInfo(overrides: Partial<ServerInfo> = {}): ServerInfo {
 // server sharing policy via CapabilitiesProvider (default "loading" → on).
 function renderSidebar(activeId?: string, info?: ServerInfo) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  const sidebar = <Sidebar open={true} onClose={vi.fn()} />;
-  const tree = (
-    <QueryClientProvider client={qc}>
-      <TooltipProvider>
-        <MemoryRouter initialEntries={[activeId ? `/c/${activeId}` : "/"]}>
-          {activeId ? (
-            <Routes>
-              <Route path="/c/:conversationId" element={sidebar} />
-            </Routes>
-          ) : (
-            sidebar
-          )}
-        </MemoryRouter>
-      </TooltipProvider>
-    </QueryClientProvider>
-  );
-  // No explicit info → CapabilitiesContext default ("loading"), matching every
-  // pre-existing test (sharing treated as on).
-  const ui = info ? <CapabilitiesProvider info={info}>{tree}</CapabilitiesProvider> : tree;
-  const view = render(ui);
-  // Re-render the same tree so a test can apply a new `mockConversations`
-  // list mid-flight (e.g. simulating a reorder pushed between user clicks).
-  return Object.assign(view, { rerenderSidebar: () => view.rerender(ui) });
+  // Build a FRESH element tree per render: re-rendering the identical element
+  // reference lets React bail out without re-invoking the sidebar, which
+  // would swallow a `mockConversations` swap applied mid-test.
+  const makeUi = () => {
+    const sidebar = <Sidebar open={true} onClose={vi.fn()} />;
+    const tree = (
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={[activeId ? `/c/${activeId}` : "/"]}>
+            {activeId ? (
+              <Routes>
+                <Route path="/c/:conversationId" element={sidebar} />
+              </Routes>
+            ) : (
+              sidebar
+            )}
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    );
+    // No explicit info → CapabilitiesContext default ("loading"), matching
+    // every pre-existing test (sharing treated as on).
+    return info ? <CapabilitiesProvider info={info}>{tree}</CapabilitiesProvider> : tree;
+  };
+  const view = render(makeUi());
+  // Re-render so a test can apply a new `mockConversations` list mid-flight
+  // (e.g. simulating a reorder pushed between user clicks).
+  return Object.assign(view, { rerenderSidebar: () => view.rerender(makeUi()) });
 }
 
 beforeEach(() => {
@@ -749,6 +754,75 @@ describe("right-click context menu", () => {
     // inline rename input appears.
     fireEvent.click(screen.getByTestId("rename-conversation"));
     expect(screen.getByTestId("rename-conversation-input")).toBeInTheDocument();
+  });
+
+  it("holds the list order under the pointer so a right-click rename hits the aimed row", () => {
+    // A right-click is a single event, so nothing can cross-check it like the
+    // double-click guard does — if the list reorders in the instant before
+    // the click lands, the row that slid under the cursor opens its (visually
+    // identical) menu and gets renamed. The fix is upstream: while the
+    // pointer is inside the list, every row's sort key is frozen so rows
+    // can't move under the cursor at all.
+    const convA: Conversation = {
+      ...CONV,
+      id: "conv_a",
+      title: "Session A",
+      updated_at: 1_700_000_200,
+    };
+    const convB: Conversation = {
+      ...CONV,
+      id: "conv_b",
+      title: "Session B",
+      updated_at: 1_700_000_100,
+    };
+    mockConversations([convA, convB]);
+    const view = renderSidebar();
+
+    // The pointer moves over the list, aiming at session A (the top row).
+    fireEvent.mouseOver(screen.getByTestId("sidebar-conversation-list"));
+
+    // Session B's updated_at bumps past A before the right-click lands.
+    mockConversations([{ ...convB, updated_at: 1_700_000_300 }, convA]);
+    view.rerenderSidebar();
+
+    // The order holds: A is still the top row, exactly where the user aims.
+    const links = screen.getAllByRole("link", { name: /^Session/ });
+    expect(links[0]).toHaveAccessibleName(/Session A/);
+
+    // Right-click the top row and rename it — the PATCH targets session A.
+    fireEvent.contextMenu(links[0]);
+    fireEvent.click(screen.getByTestId("rename-conversation"));
+    const input = screen.getByTestId("rename-conversation-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Renamed A" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(mocks.rename.mutate).toHaveBeenCalledWith({ id: "conv_a", title: "Renamed A" });
+  });
+
+  it("snaps the order back to reality when the pointer leaves the list", () => {
+    const convA: Conversation = {
+      ...CONV,
+      id: "conv_a",
+      title: "Session A",
+      updated_at: 1_700_000_200,
+    };
+    const convB: Conversation = {
+      ...CONV,
+      id: "conv_b",
+      title: "Session B",
+      updated_at: 1_700_000_100,
+    };
+    mockConversations([convA, convB]);
+    const view = renderSidebar();
+
+    fireEvent.mouseOver(screen.getByTestId("sidebar-conversation-list"));
+    mockConversations([{ ...convB, updated_at: 1_700_000_300 }, convA]);
+    view.rerenderSidebar();
+    expect(screen.getAllByRole("link", { name: /^Session/ })[0]).toHaveAccessibleName(/Session A/);
+
+    fireEvent.mouseOut(screen.getByTestId("sidebar-conversation-list"), {
+      relatedTarget: document.body,
+    });
+    expect(screen.getAllByRole("link", { name: /^Session/ })[0]).toHaveAccessibleName(/Session B/);
   });
 });
 

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -2592,6 +2592,10 @@ function SessionTooltipContent({
   );
 }
 
+// Max gap between the first click and the dblclick of one double-click.
+// Browsers pair clicks within ~500ms; the margin absorbs event-loop delay.
+const DOUBLE_CLICK_PAIR_WINDOW_MS = 750;
+
 function ConversationRow({
   conversation,
   isPinned,
@@ -2788,6 +2792,11 @@ function ConversationRow({
     },
     [setDragNodeRef],
   );
+  // Timestamps of the last two clicks this row received, for the dblclick
+  // rename guard: the list can reorder between the two clicks of a
+  // double-click (an updated_at bump slides another row under the cursor),
+  // and only a row that saw both clicks may enter rename.
+  const recentClickTimesRef = useRef<number[]>([]);
 
   if (isEditing) {
     return (
@@ -2943,6 +2952,7 @@ function ConversationRow({
         selectionMode && isSelected && SIDEBAR_ACTIVE_HIGHLIGHT,
       )}
       onClick={(e) => {
+        recentClickTimesRef.current = [...recentClickTimesRef.current.slice(-1), performance.now()];
         // Swallow the click that trails a drag so it doesn't navigate.
         if (justDraggedRef.current) {
           e.preventDefault();
@@ -2960,6 +2970,16 @@ function ConversationRow({
         if (selectionMode) return;
         if (!isOwner) return;
         e.preventDefault();
+        // The dblclick's own second click was already recorded above, so
+        // exactly ONE recent click means the first click landed on a different
+        // row — the list reordered mid-double-click and renaming here would
+        // hit the wrong session. Zero recent clicks (synthetic dblclick with
+        // no click events, e.g. in tests) stays allowed.
+        const now = performance.now();
+        const recent = recentClickTimesRef.current.filter(
+          (t) => now - t <= DOUBLE_CLICK_PAIR_WINDOW_MS,
+        );
+        if (recent.length === 1) return;
         setIsEditing(true);
       }}
       title={isMobile ? (conversation.title ?? conversation.id) : undefined}

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -191,6 +191,12 @@ const DROP_TARGET_HIGHLIGHT = SIDEBAR_ACTIVE_HIGHLIGHT;
 // a query observer per row (which would also re-run on every project mutation).
 const ProjectNamesContext = createContext<Map<string, string>>(new Map());
 const HostsByIdContext = createContext<ReadonlyMap<string, Host>>(new Map());
+// Rows report an in-progress inline-rename edit here so ConversationList can
+// hold the sort order for the edit's whole duration — the pointer often
+// leaves the list while typing, and a reorder then would shuffle rows around
+// the open input (and can even blur it mid-edit, committing a half-typed
+// title). See the order-freeze block in ConversationList.
+const RowEditHoldContext = createContext<(id: string, editing: boolean) => void>(() => {});
 
 function SidebarRowDataProvider({
   projectNamesById,
@@ -1208,16 +1214,32 @@ function ConversationList({
     setActiveOverride((prev) => computeNextActiveOverride(activeId, allConversations, prev));
   }, [activeId, allConversations]);
 
-  // While the pointer is inside the list, pin every row's sort key so
-  // background updated_at bumps can't reorder rows under the cursor — a row
-  // sliding into place mid-interaction receives the click / right-click and
-  // the rename it triggers, hitting a session the user never aimed at. The
+  // While the pointer is inside the list OR a rename edit is open, pin every
+  // row's sort key so background updated_at bumps can't reorder rows under
+  // the cursor / around the edit input — a row sliding into place
+  // mid-interaction receives the click / right-click and the rename it
+  // triggers, hitting a session the user never aimed at; a reorder during an
+  // edit can move (and blur) the input, committing a half-typed title. The
   // map accumulates keys lazily inside sortByUpdatedAtDesc (a render-time ref
-  // write, like projectRenderedIdsRef) and is cleared on pointer-leave, when
-  // the order snaps back to reality.
+  // write, like projectRenderedIdsRef) and is cleared once neither hold is
+  // active, when the order snaps back to reality.
   const frozenKeysRef = useRef<Map<string, number>>(new Map());
-  const [orderFrozen, setOrderFrozen] = useState(false);
+  const [pointerInside, setPointerInside] = useState(false);
+  const [editingIds, setEditingIds] = useState<ReadonlySet<string>>(() => new Set());
+  const reportRowEditing = useCallback((id: string, editing: boolean) => {
+    setEditingIds((prev) => {
+      if (prev.has(id) === editing) return prev;
+      const next = new Set(prev);
+      if (editing) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  }, []);
+  const orderFrozen = pointerInside || editingIds.size > 0;
   const frozenKeys = orderFrozen ? frozenKeysRef.current : null;
+  useEffect(() => {
+    if (!orderFrozen) frozenKeysRef.current.clear();
+  }, [orderFrozen]);
 
   // Build sections: Pinned and Archived are peeled off; the rest splits into
   // the viewer's own sessions (Chats) and ones shared with them. Archived
@@ -1625,232 +1647,234 @@ function ConversationList({
         onDragEnd={handleDragEnd}
         onDragCancel={() => setActiveDrag(null)}
       >
-        <div
-          className="flex flex-col gap-4 pr-1"
-          data-testid="sidebar-conversation-list"
-          // Freeze the sort order while the pointer is over the list (and
-          // snap it back on leave) so rows never move under the cursor.
-          onMouseEnter={() => setOrderFrozen(true)}
-          onMouseLeave={() => {
-            frozenKeysRef.current.clear();
-            setOrderFrozen(false);
-          }}
-        >
-          {/* Removing a filed session from its project means dropping it back
+        <RowEditHoldContext.Provider value={reportRowEditing}>
+          <div
+            className="flex flex-col gap-4 pr-1"
+            data-testid="sidebar-conversation-list"
+            // Freeze the sort order while the pointer is over the list so rows
+            // never move under the cursor. The frozen-keys map is cleared by the
+            // effect above once no hold (pointer or open rename edit) remains.
+            onMouseEnter={() => setPointerInside(true)}
+            onMouseLeave={() => setPointerInside(false)}
+          >
+            {/* Removing a filed session from its project means dropping it back
             onto the flat "Chats" list — so the Chats section itself is the
             ungroup target (wrapped below). This top strip is only a FALLBACK
             for when there are no ungrouped chats yet, so the Chats section
             isn't rendered and there'd otherwise be nowhere to drop. */}
-          {!showShared && activeDrag?.project != null && sections.sessions.length === 0 && (
-            <UngroupDropZone />
-          )}
-          {totalVisible === 0 ? (
-            <>
-              <p className="px-2 py-1 text-muted-foreground text-xs">{emptyMessage}</p>
-              {/* The list is one paginated stream ordered by updated_at across
+            {!showShared && activeDrag?.project != null && sections.sessions.length === 0 && (
+              <UngroupDropZone />
+            )}
+            {totalVisible === 0 ? (
+              <>
+                <p className="px-2 py-1 text-muted-foreground text-xs">{emptyMessage}</p>
+                {/* The list is one paginated stream ordered by updated_at across
               owned + shared sessions, so the current tab can be empty on the
               loaded window while its sessions live on a later page. Keep the
               sentinel mounted so pagination continues instead of stranding the
               user on a false "empty" state. */}
-              {hasMorePages && (
-                <InfiniteScrollSentinel
-                  hasMore={hasMorePages}
-                  isFetching={isFetchingNextPage}
-                  fetchMore={fetchNextPage}
-                  scrollRoot={scrollContainerRef}
-                />
-              )}
-            </>
-          ) : (
-            <>
-              {sections.pinned.length > 0 && (
-                // Drop a session here to pin it — pin-precedence then floats it
-                // out of any project into this section. Active only while dragging
-                // an unpinned session; outline-only highlight.
-                <PinDropZone active={activeDrag != null && !activeDrag.isPinned}>
-                  <ConversationSection
-                    title="Pinned"
-                    conversations={sections.pinned}
-                    pinnedConversationIds={pinnedConversationIds}
-                    collapsed={effectiveCollapsedSections.includes("Pinned")}
-                    onToggleCollapsed={() => effectiveToggleSectionCollapsed("Pinned")}
-                    onRowClick={onRowClick}
-                    onTogglePinned={onTogglePinned}
-                    selectionMode={selectionMode}
-                    selectedIds={selectedIds}
-                    onToggleSelected={onToggleSelected}
-                    onProjectAssigned={expandProject}
+                {hasMorePages && (
+                  <InfiniteScrollSentinel
+                    hasMore={hasMorePages}
+                    isFetching={isFetchingNextPage}
+                    fetchMore={fetchNextPage}
+                    scrollRoot={scrollContainerRef}
                   />
-                </PinDropZone>
-              )}
-              {/* Projects: a "Projects" group header, with each project rendered as
-              a collapsible folder row nested beneath it. Folders default
-              collapsed; an empty folder shows "No sessions". The folder icon marks
-              a project row; the group/section headers carry no icon or count.
-              Shown on the "mine" tab even with zero projects, so "New project"
-              (create-empty) is discoverable — projects are a My-sessions tool. */}
-              {activeTab !== "shared" && (
-                <SectionGroup
-                  title="Projects"
-                  collapsed={effectiveCollapsedSections.includes("Projects")}
-                  onToggleCollapsed={() => effectiveToggleSectionCollapsed("Projects")}
-                  headerAction={(() => {
-                    const allNames = sections.projectGroups.map((g) => g.name);
-                    // "New project" is always available (even when collapsed) so
-                    // the create-empty flow is reachable; the expand/revert control
-                    // is only meaningful when there are folders and the group is open.
-                    const showExpandControls =
-                      !effectiveCollapsedSections.includes("Projects") && allNames.length > 0;
-                    // Once every folder is open the only useful move is to undo it,
-                    // so the control flips to "revert" — which restores the set open
-                    // before "Expand all", or collapses everything when there's no
-                    // real last state (folders opened by hand). Otherwise it expands.
-                    const allExpanded =
-                      allNames.length > 0 && allNames.every((n) => expandedProjects.includes(n));
-                    return (
-                      // gap-0.5 between the two controls mirrors the row/folder
-                      // icon spacing, so every right-gutter pair lines up.
-                      <div className="flex items-center gap-0.5">
-                        {showExpandControls &&
-                          (allExpanded ? (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  type="button"
-                                  variant="ghost"
-                                  size="icon-xs"
-                                  aria-label="Collapse to previous"
-                                  data-testid="revert-projects"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    revertProjects();
-                                  }}
-                                >
-                                  <Minimize2Icon className="size-3.5" />
-                                </Button>
-                              </TooltipTrigger>
-                              <TooltipContent side="bottom">Collapse to previous</TooltipContent>
-                            </Tooltip>
-                          ) : (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  type="button"
-                                  variant="ghost"
-                                  size="icon-xs"
-                                  aria-label="Expand all"
-                                  data-testid="expand-all-projects"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    expandAllProjects(allNames);
-                                  }}
-                                >
-                                  <Maximize2Icon className="size-3.5" />
-                                </Button>
-                              </TooltipTrigger>
-                              <TooltipContent side="bottom">Expand all</TooltipContent>
-                            </Tooltip>
-                          ))}
-                        <NewProjectButton onCreated={expandProject} />
-                      </div>
-                    );
-                  })()}
-                >
-                  {sections.projectGroups.map((group) => (
-                    <ProjectFolder
-                      key={group.name}
-                      name={group.name}
-                      projectId={group.id}
-                      expanded={expandedProjects.includes(group.name)}
-                      // Best-effort marker from the globally-loaded window: a
-                      // collapsed folder hasn't fetched its own sessions yet.
-                      marker={projectMarkerState(group.conversations)}
-                      onToggleCollapsed={() => toggleProjectExpanded(group.name)}
+                )}
+              </>
+            ) : (
+              <>
+                {sections.pinned.length > 0 && (
+                  // Drop a session here to pin it — pin-precedence then floats it
+                  // out of any project into this section. Active only while dragging
+                  // an unpinned session; outline-only highlight.
+                  <PinDropZone active={activeDrag != null && !activeDrag.isPinned}>
+                    <ConversationSection
+                      title="Pinned"
+                      conversations={sections.pinned}
                       pinnedConversationIds={pinnedConversationIds}
-                      activeOverride={activeOverride}
-                      frozenSortKeys={frozenKeys}
-                      scrollRoot={scrollContainerRef}
+                      collapsed={effectiveCollapsedSections.includes("Pinned")}
+                      onToggleCollapsed={() => effectiveToggleSectionCollapsed("Pinned")}
                       onRowClick={onRowClick}
                       onTogglePinned={onTogglePinned}
                       selectionMode={selectionMode}
                       selectedIds={selectedIds}
                       onToggleSelected={onToggleSelected}
                       onProjectAssigned={expandProject}
-                      projectRenderedIdsRef={projectRenderedIdsRef}
                     />
-                  ))}
-                  {sections.projectGroups.length === 0 &&
-                    !effectiveCollapsedSections.includes("Projects") && (
-                      <p className="px-3 py-1.5 text-xs text-muted-foreground">
-                        No projects yet. Create one to group your sessions.
-                      </p>
-                    )}
-                </SectionGroup>
-              )}
-              {sections.sessions.length > 0 && (
-                // Drop a session here to send it to the flat "Chats" list — where
-                // unfiled, unpinned sessions live. Active while dragging a filed
-                // session (removes it from its project) or a pinned one (unpins
-                // it), since both have somewhere to land here.
-                <ChatsDropZone
-                  active={activeDrag != null && (activeDrag.project != null || activeDrag.isPinned)}
-                >
-                  <ConversationSection
-                    title="Sessions"
-                    conversations={sections.sessions}
-                    pinnedConversationIds={pinnedConversationIds}
-                    collapsed={effectiveCollapsedSections.includes("Chats")}
-                    onToggleCollapsed={() => effectiveToggleSectionCollapsed("Chats")}
-                    onRowClick={onRowClick}
-                    onTogglePinned={onTogglePinned}
-                    selectionMode={selectionMode}
-                    selectedIds={selectedIds}
-                    onToggleSelected={onToggleSelected}
-                    onProjectAssigned={expandProject}
-                    headerAction={
-                      !selectionMode ? (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon-xs"
-                              aria-label="Select sessions"
-                              data-testid="toggle-selection-mode"
-                              onClick={(event) => {
-                                event.stopPropagation();
-                                onEnterSelectionMode();
-                              }}
-                            >
-                              <ListChecksIcon className="size-3.5" />
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom">Select sessions</TooltipContent>
-                        </Tooltip>
-                      ) : undefined
+                  </PinDropZone>
+                )}
+                {/* Projects: a "Projects" group header, with each project rendered as
+              a collapsible folder row nested beneath it. Folders default
+              collapsed; an empty folder shows "No sessions". The folder icon marks
+              a project row; the group/section headers carry no icon or count.
+              Shown on the "mine" tab even with zero projects, so "New project"
+              (create-empty) is discoverable — projects are a My-sessions tool. */}
+                {activeTab !== "shared" && (
+                  <SectionGroup
+                    title="Projects"
+                    collapsed={effectiveCollapsedSections.includes("Projects")}
+                    onToggleCollapsed={() => effectiveToggleSectionCollapsed("Projects")}
+                    headerAction={(() => {
+                      const allNames = sections.projectGroups.map((g) => g.name);
+                      // "New project" is always available (even when collapsed) so
+                      // the create-empty flow is reachable; the expand/revert control
+                      // is only meaningful when there are folders and the group is open.
+                      const showExpandControls =
+                        !effectiveCollapsedSections.includes("Projects") && allNames.length > 0;
+                      // Once every folder is open the only useful move is to undo it,
+                      // so the control flips to "revert" — which restores the set open
+                      // before "Expand all", or collapses everything when there's no
+                      // real last state (folders opened by hand). Otherwise it expands.
+                      const allExpanded =
+                        allNames.length > 0 && allNames.every((n) => expandedProjects.includes(n));
+                      return (
+                        // gap-0.5 between the two controls mirrors the row/folder
+                        // icon spacing, so every right-gutter pair lines up.
+                        <div className="flex items-center gap-0.5">
+                          {showExpandControls &&
+                            (allExpanded ? (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon-xs"
+                                    aria-label="Collapse to previous"
+                                    data-testid="revert-projects"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      revertProjects();
+                                    }}
+                                  >
+                                    <Minimize2Icon className="size-3.5" />
+                                  </Button>
+                                </TooltipTrigger>
+                                <TooltipContent side="bottom">Collapse to previous</TooltipContent>
+                              </Tooltip>
+                            ) : (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon-xs"
+                                    aria-label="Expand all"
+                                    data-testid="expand-all-projects"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      expandAllProjects(allNames);
+                                    }}
+                                  >
+                                    <Maximize2Icon className="size-3.5" />
+                                  </Button>
+                                </TooltipTrigger>
+                                <TooltipContent side="bottom">Expand all</TooltipContent>
+                              </Tooltip>
+                            ))}
+                          <NewProjectButton onCreated={expandProject} />
+                        </div>
+                      );
+                    })()}
+                  >
+                    {sections.projectGroups.map((group) => (
+                      <ProjectFolder
+                        key={group.name}
+                        name={group.name}
+                        projectId={group.id}
+                        expanded={expandedProjects.includes(group.name)}
+                        // Best-effort marker from the globally-loaded window: a
+                        // collapsed folder hasn't fetched its own sessions yet.
+                        marker={projectMarkerState(group.conversations)}
+                        onToggleCollapsed={() => toggleProjectExpanded(group.name)}
+                        pinnedConversationIds={pinnedConversationIds}
+                        activeOverride={activeOverride}
+                        frozenSortKeys={frozenKeys}
+                        scrollRoot={scrollContainerRef}
+                        onRowClick={onRowClick}
+                        onTogglePinned={onTogglePinned}
+                        selectionMode={selectionMode}
+                        selectedIds={selectedIds}
+                        onToggleSelected={onToggleSelected}
+                        onProjectAssigned={expandProject}
+                        projectRenderedIdsRef={projectRenderedIdsRef}
+                      />
+                    ))}
+                    {sections.projectGroups.length === 0 &&
+                      !effectiveCollapsedSections.includes("Projects") && (
+                        <p className="px-3 py-1.5 text-xs text-muted-foreground">
+                          No projects yet. Create one to group your sessions.
+                        </p>
+                      )}
+                  </SectionGroup>
+                )}
+                {sections.sessions.length > 0 && (
+                  // Drop a session here to send it to the flat "Chats" list — where
+                  // unfiled, unpinned sessions live. Active while dragging a filed
+                  // session (removes it from its project) or a pinned one (unpins
+                  // it), since both have somewhere to land here.
+                  <ChatsDropZone
+                    active={
+                      activeDrag != null && (activeDrag.project != null || activeDrag.isPinned)
                     }
-                  />
-                </ChatsDropZone>
-              )}
-              {/* Both tabs render this same Pinned / Projects / Sessions tree;
+                  >
+                    <ConversationSection
+                      title="Sessions"
+                      conversations={sections.sessions}
+                      pinnedConversationIds={pinnedConversationIds}
+                      collapsed={effectiveCollapsedSections.includes("Chats")}
+                      onToggleCollapsed={() => effectiveToggleSectionCollapsed("Chats")}
+                      onRowClick={onRowClick}
+                      onTogglePinned={onTogglePinned}
+                      selectionMode={selectionMode}
+                      selectedIds={selectedIds}
+                      onToggleSelected={onToggleSelected}
+                      onProjectAssigned={expandProject}
+                      headerAction={
+                        !selectionMode ? (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon-xs"
+                                aria-label="Select sessions"
+                                data-testid="toggle-selection-mode"
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  onEnterSelectionMode();
+                                }}
+                              >
+                                <ListChecksIcon className="size-3.5" />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent side="bottom">Select sessions</TooltipContent>
+                          </Tooltip>
+                        ) : undefined
+                      }
+                    />
+                  </ChatsDropZone>
+                )}
+                {/* Both tabs render this same Pinned / Projects / Sessions tree;
               `sections` is scoped to the active tab's conversations (owned vs.
               shared), and Projects is empty on the Shared tab. */}
-              {/* Archived sessions are no longer listed here — they live on the
+                {/* Archived sessions are no longer listed here — they live on the
               Settings page ("Archived chats"), reachable from the footer. */}
-              {/* Infinite-scroll sentinel for the global list. Pagination extends
+                {/* Infinite-scroll sentinel for the global list. Pagination extends
               the Chats list, so it hides with a collapsed Chats group — a loader
               under a collapsed group reads orphaned. */}
-              {!effectiveCollapsedSections.includes("Chats") && (
-                <InfiniteScrollSentinel
-                  hasMore={hasMorePages}
-                  isFetching={isFetchingNextPage}
-                  fetchMore={fetchNextPage}
-                  scrollRoot={scrollContainerRef}
-                />
-              )}
-            </>
-          )}
-        </div>
+                {!effectiveCollapsedSections.includes("Chats") && (
+                  <InfiniteScrollSentinel
+                    hasMore={hasMorePages}
+                    isFetching={isFetchingNextPage}
+                    fetchMore={fetchNextPage}
+                    scrollRoot={scrollContainerRef}
+                  />
+                )}
+              </>
+            )}
+          </div>
+        </RowEditHoldContext.Provider>
         {/* The dragged row's preview follows the pointer (rendered in a portal),
           a compact card showing the session's title. */}
         <DragOverlay dropAnimation={null}>
@@ -2700,6 +2724,16 @@ function ConversationRow({
   const stopSession = useStopSession();
   const isArchived = conversation.archived === true;
   const [isEditing, setIsEditing] = useState(false);
+  // Hold the list's sort order while this row's rename input is open — the
+  // pointer usually drifts out of the sidebar during typing, and a reorder
+  // then would shuffle rows around (or move + blur) the input. Cleanup covers
+  // commit, cancel, and unmount alike.
+  const reportRowEditing = useContext(RowEditHoldContext);
+  useEffect(() => {
+    if (!isEditing) return;
+    reportRowEditing(conversation.id, true);
+    return () => reportRowEditing(conversation.id, false);
+  }, [isEditing, conversation.id, reportRowEditing]);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [stopOpen, setStopOpen] = useState(false);
   // The kebab menu is controlled so the project submenu can close the whole

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -963,6 +963,7 @@ function ProjectFolder({
   onToggleCollapsed,
   pinnedConversationIds,
   activeOverride,
+  frozenSortKeys,
   scrollRoot,
   onRowClick,
   onTogglePinned,
@@ -980,6 +981,9 @@ function ProjectFolder({
   onToggleCollapsed: () => void;
   pinnedConversationIds: string[];
   activeOverride: ActiveChatOverride | null;
+  /** Pointer-inside sort-key freeze shared with the flat list (see
+      ConversationList); null while the pointer is outside the list. */
+  frozenSortKeys: Map<string, number> | null;
   scrollRoot: RefObject<HTMLElement | null>;
   onRowClick: (e: MouseEvent<HTMLAnchorElement>) => void;
   onTogglePinned: (conversationId: string) => void;
@@ -997,8 +1001,9 @@ function ProjectFolder({
     return sortByUpdatedAtDesc(
       loaded.filter((c) => !pinnedSet.has(c.id)),
       activeOverride,
+      frozenSortKeys,
     );
-  }, [query.data, pinnedSet, activeOverride]);
+  }, [query.data, pinnedSet, activeOverride, frozenSortKeys]);
 
   // Register this folder's rendered IDs synchronously during render so the
   // shift-select range uses the real per-project data, not the global list.
@@ -1203,6 +1208,17 @@ function ConversationList({
     setActiveOverride((prev) => computeNextActiveOverride(activeId, allConversations, prev));
   }, [activeId, allConversations]);
 
+  // While the pointer is inside the list, pin every row's sort key so
+  // background updated_at bumps can't reorder rows under the cursor — a row
+  // sliding into place mid-interaction receives the click / right-click and
+  // the rename it triggers, hitting a session the user never aimed at. The
+  // map accumulates keys lazily inside sortByUpdatedAtDesc (a render-time ref
+  // write, like projectRenderedIdsRef) and is cleared on pointer-leave, when
+  // the order snaps back to reality.
+  const frozenKeysRef = useRef<Map<string, number>>(new Map());
+  const [orderFrozen, setOrderFrozen] = useState(false);
+  const frozenKeys = orderFrozen ? frozenKeysRef.current : null;
+
   // Build sections: Pinned and Archived are peeled off; the rest splits into
   // the viewer's own sessions (Chats) and ones shared with them. Archived
   // sessions render in their own group at the bottom (below "Shared with
@@ -1251,7 +1267,11 @@ function ConversationList({
                 !pinnedIdSet.has(c.id),
             );
             inProject.forEach((c) => filedIds.add(c.id));
-            return { id, name, conversations: sortByUpdatedAtDesc(inProject, activeOverride) };
+            return {
+              id,
+              name,
+              conversations: sortByUpdatedAtDesc(inProject, activeOverride, frozenKeys),
+            };
           });
     // NOTE: empty projects are intentionally NOT filtered out. A project comes
     // from the server project list (useProjects), so it can have zero *loaded*
@@ -1263,10 +1283,12 @@ function ConversationList({
     const sessions = sortByUpdatedAtDesc(
       tabScoped.filter((c) => !pinnedIdSet.has(c.id) && !filedIds.has(c.id)),
       activeOverride,
+      frozenKeys,
     );
     const archived = sortByUpdatedAtDesc(
       allWithPinned.filter((c) => c.archived === true),
       activeOverride,
+      frozenKeys,
     );
     return { pinned, sessions, archived, projectGroups };
   }, [
@@ -1274,6 +1296,7 @@ function ConversationList({
     pinnedConversations,
     pinnedSet,
     activeOverride,
+    frozenKeys,
     projects,
     activeTab,
     viewerId,
@@ -1602,7 +1625,17 @@ function ConversationList({
         onDragEnd={handleDragEnd}
         onDragCancel={() => setActiveDrag(null)}
       >
-        <div className="flex flex-col gap-4 pr-1">
+        <div
+          className="flex flex-col gap-4 pr-1"
+          data-testid="sidebar-conversation-list"
+          // Freeze the sort order while the pointer is over the list (and
+          // snap it back on leave) so rows never move under the cursor.
+          onMouseEnter={() => setOrderFrozen(true)}
+          onMouseLeave={() => {
+            frozenKeysRef.current.clear();
+            setOrderFrozen(false);
+          }}
+        >
           {/* Removing a filed session from its project means dropping it back
             onto the flat "Chats" list — so the Chats section itself is the
             ungroup target (wrapped below). This top strip is only a FALLBACK
@@ -1735,6 +1768,7 @@ function ConversationList({
                       onToggleCollapsed={() => toggleProjectExpanded(group.name)}
                       pinnedConversationIds={pinnedConversationIds}
                       activeOverride={activeOverride}
+                      frozenSortKeys={frozenKeys}
                       scrollRoot={scrollContainerRef}
                       onRowClick={onRowClick}
                       onTogglePinned={onTogglePinned}

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -2727,9 +2728,12 @@ function ConversationRow({
   // Hold the list's sort order while this row's rename input is open — the
   // pointer usually drifts out of the sidebar during typing, and a reorder
   // then would shuffle rows around (or move + blur) the input. Cleanup covers
-  // commit, cancel, and unmount alike.
+  // commit, cancel, and unmount alike. Layout effect (not passive): rename
+  // can start with the pointer already outside the list (context menu is a
+  // portal), and a passive effect would leave a post-paint frame where churn
+  // could reorder — and blur — the just-mounted input before the hold lands.
   const reportRowEditing = useContext(RowEditHoldContext);
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!isEditing) return;
     reportRowEditing(conversation.id, true);
     return () => reportRowEditing(conversation.id, false);

--- a/web/src/shell/sidebarNav.ts
+++ b/web/src/shell/sidebarNav.ts
@@ -180,12 +180,33 @@ export function filterConversations(
 // pill. The active chat uses its frozen snapshot from
 // `activeOverride` instead of its live `updated_at`, so sending a message
 // in the chat you're already viewing doesn't move it.
+//
+// `frozenKeys` (when non-null) pins EVERY row's sort key at its
+// first-seen value: a row's key is read from the map, or captured into it
+// on first sight. The sidebar passes its map while the pointer is inside
+// the list, so background `updated_at` bumps can't slide rows under the
+// cursor — a mid-interaction reorder sends clicks, right-clicks, and the
+// renames they trigger to the wrong session. Rows first seen while frozen
+// (a folder expanding, a page loading) capture their key on entry, and
+// the caller clears the map when the pointer leaves so the order snaps
+// back to reality.
 export function sortByUpdatedAtDesc(
   conversations: Conversation[],
   activeOverride: ActiveChatOverride | null,
+  frozenKeys?: Map<string, number> | null,
 ): Conversation[] {
-  const effective = (c: Conversation): number =>
-    activeOverride?.id === c.id ? activeOverride.updatedAt : c.updated_at;
+  const effective = (c: Conversation): number => {
+    if (frozenKeys) {
+      const frozen = frozenKeys.get(c.id);
+      if (frozen !== undefined) return frozen;
+      // Capture the override value for the active row so dropping the
+      // override mid-hover (navigating to another chat) can't move it.
+      const live = activeOverride?.id === c.id ? activeOverride.updatedAt : c.updated_at;
+      frozenKeys.set(c.id, live);
+      return live;
+    }
+    return activeOverride?.id === c.id ? activeOverride.updatedAt : c.updated_at;
+  };
   return [...conversations].sort((a, b) => effective(b) - effective(a));
 }
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

Renaming a session from the sidebar could rename the **wrong session** whenever the list reordered mid-interaction (a background session's `updated_at` bump pushing rows around under the cursor). Three legs of the same hazard, fixed at the source:

- **Double-click rename**: browsers pair the two clicks of a double-click by pointer position/timing, not element identity — if the list reorders between them, the `dblclick` fires on whichever row slid under the cursor and opens rename there. Each row now tracks its last two clicks and only enters rename when it saw **both** clicks of the pair.
- **Right-click / kebab rename**: a single event can't be cross-checked, so the fix is upstream — while the pointer is inside the conversation list, every row's sort key is **frozen** (`sortByUpdatedAtDesc` gains a lazily-populated frozen-keys map), so rows can't move under the cursor at all. Order snaps back to reality when the pointer leaves.
- **Open rename edit**: the pointer naturally drifts out of the sidebar while typing, which released the hover freeze and let churn shuffle rows around (and potentially move + blur → commit) the open input. Rows now report an in-progress edit via `RowEditHoldContext`, and the freeze stays engaged while the pointer is inside the list **or** any rename edit is open.

ELI5: the sidebar used to be like a whack-a-mole board that kept shuffling moles while you were mid-swing — you'd bonk the wrong mole. Now the board holds still whenever your hand is over it or you're mid-bonk.

```
                         updated_at churn (WS push)
                                   │
                                   ▼
              ┌────────────────────────────────────────┐
              │ sortByUpdatedAtDesc(rows, activeOverride,│
              │                     frozenKeys?)        │
              └────────────────────────────────────────┘
                                   ▲
                 frozenKeys ≠ null while:
                   • pointer inside list  (mouseenter/leave)
                   • any rename edit open (RowEditHoldContext)
                 + per-row click-pair guard on dblclick rename
```

## Test Plan

- `pnpm vitest run src/shell/Sidebar.rowActions.test.tsx` — 31 tests, including 4 new regression tests. Each new test was verified to **fail** with the fix stashed and pass with it:
  - ignores a double-click whose first click landed on a different row
  - holds the list order under the pointer so a right-click rename hits the aimed row
  - keeps the order held while a rename edit is open even after the pointer leaves
  - snaps the order back to reality when the pointer leaves the list
- Full `src/shell/` suite: 84 files, 1648 tests green.
- Manual: dedicated local server with a background loop leapfrogging two sessions' `updated_at` every 6s; verified rows hold still under the pointer and during an open rename, rename always lands on the aimed session, and order snaps back on pointer-leave/commit.

Also fixes a latent test-harness bug: `rerenderSidebar` re-rendered the identical React element, letting React bail out and silently ignore mid-test data swaps.

## Demo

The reorder race needs live background churn to show; repro locally with two sessions whose `updated_at` alternates (any running agent session works):
1. Hover the sidebar — rows hold their positions (they reshuffle only when the pointer leaves).
2. Right-click → Rename mid-churn — the rename lands on the row you aimed at.
3. With the rename input open, move the pointer out of the sidebar — the list still holds until you commit/cancel.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the parts unit tests can't reach in jsdom: real browser click-pairing on double-click, live WS-driven reorders from a server with churning `updated_at`, and pointer enter/leave freeze behavior end-to-end in the served UI.

## Changelog

Renaming a session in the sidebar no longer hits the wrong row when the list reorders — row order holds while the pointer is over the list or a rename is in progress
