### PR TITLE
test: make sandbox-cwd assertions portable across macOS firmlinks

### DIFF
--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -2842,25 +2842,26 @@ def test_resolve_sandbox_cwd_roots_relative_at_runner_workspace(monkeypatch) -> 
     """A relative ``os_env.cwd`` (notably the default ``"."``) resolves
     against ``OMNIGENT_RUNNER_WORKSPACE`` — not the daemon's process cwd
     — so the sandbox root matches the tmux terminal and never falls back
-    to ``$HOME``. Absolute paths are honored verbatim."""
+    to ``$HOME``. Absolute paths keep their root and are resolved by
+    ``Path.resolve(strict=False)``."""
     from omnigent.inner.claude_sdk_executor import _resolve_sandbox_cwd
 
     monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", "/home/bobby/code/agents")
     monkeypatch.chdir("/tmp")
 
-    # ``_resolve_sandbox_cwd`` ends in ``Path.resolve()``, and macOS routes
-    # these literal paths through firmlinks (``/home`` -> the automounter,
+    # ``_resolve_sandbox_cwd`` ends in ``Path.resolve(strict=False)``. On macOS,
+    # these literal paths route through firmlinks (``/home`` -> the automounter,
     # ``/tmp`` -> ``/private/tmp``), so compare against the same resolution
     # instead of literal strings. On Linux both sides are identical.
-    workspace = str(Path("/home/bobby/code/agents").resolve())
-    assert str(_resolve_sandbox_cwd(".")) == workspace
-    assert str(_resolve_sandbox_cwd(None)) == workspace
-    assert str(_resolve_sandbox_cwd("src")) == str(Path("/home/bobby/code/agents/src").resolve())
-    assert str(_resolve_sandbox_cwd("/etc/foo")) == str(Path("/etc/foo").resolve())
+    workspace = Path("/home/bobby/code/agents").resolve(strict=False)
+    assert _resolve_sandbox_cwd(".") == workspace
+    assert _resolve_sandbox_cwd(None) == workspace
+    assert _resolve_sandbox_cwd("src") == (workspace / "src").resolve(strict=False)
+    assert _resolve_sandbox_cwd("/etc/foo") == Path("/etc/foo").resolve(strict=False)
 
     # No workspace set → falls back to the process cwd (prior behavior).
     monkeypatch.delenv("OMNIGENT_RUNNER_WORKSPACE", raising=False)
-    assert str(_resolve_sandbox_cwd(".")) == str(Path("/tmp").resolve())
+    assert _resolve_sandbox_cwd(".") == Path("/tmp").resolve(strict=False)
 
 
 @pytest.mark.parametrize("env_value", ["1", "true", "yes"])

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -2848,14 +2848,19 @@ def test_resolve_sandbox_cwd_roots_relative_at_runner_workspace(monkeypatch) -> 
     monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", "/home/bobby/code/agents")
     monkeypatch.chdir("/tmp")
 
-    assert str(_resolve_sandbox_cwd(".")) == "/home/bobby/code/agents"
-    assert str(_resolve_sandbox_cwd(None)) == "/home/bobby/code/agents"
-    assert str(_resolve_sandbox_cwd("src")) == "/home/bobby/code/agents/src"
-    assert str(_resolve_sandbox_cwd("/etc/foo")) == "/etc/foo"
+    # ``_resolve_sandbox_cwd`` ends in ``Path.resolve()``, and macOS routes
+    # these literal paths through firmlinks (``/home`` -> the automounter,
+    # ``/tmp`` -> ``/private/tmp``), so compare against the same resolution
+    # instead of literal strings. On Linux both sides are identical.
+    workspace = str(Path("/home/bobby/code/agents").resolve())
+    assert str(_resolve_sandbox_cwd(".")) == workspace
+    assert str(_resolve_sandbox_cwd(None)) == workspace
+    assert str(_resolve_sandbox_cwd("src")) == str(Path("/home/bobby/code/agents/src").resolve())
+    assert str(_resolve_sandbox_cwd("/etc/foo")) == str(Path("/etc/foo").resolve())
 
     # No workspace set → falls back to the process cwd (prior behavior).
     monkeypatch.delenv("OMNIGENT_RUNNER_WORKSPACE", raising=False)
-    assert str(_resolve_sandbox_cwd(".")) == "/tmp"
+    assert str(_resolve_sandbox_cwd(".")) == str(Path("/tmp").resolve())
 
 
 @pytest.mark.parametrize("env_value", ["1", "true", "yes"])


### PR DESCRIPTION
`test_resolve_sandbox_cwd_roots_relative_at_runner_workspace` fails on every macOS dev box (green on Linux CI): `_resolve_sandbox_cwd` ends in `Path.resolve(strict=False)`, and macOS routes the test's literal paths through firmlinks — `/home` via the automounter to `/System/Volumes/Data/...`, `/tmp` → `/private/tmp`, `/etc` → `/private/etc` — so all five literal-string assertions mismatch locally.

Fix: compare against the same `Path(...).resolve()` on the expectation side. On Linux both sides are identical strings, so CI behavior is unchanged; on macOS the test now passes.

Verified fail-before/pass-after on an M-series Mac (pre-fix: fails with the `/System/Volumes/Data` prefix; post-fix: passes). ruff format/check clean; DCO signed.