### PR TITLE
feat(web): semantic tool-run fold labels in chat view

### DIFF
--- a/tests/e2e_ui/chat/test_two_agent_chat.py
+++ b/tests/e2e_ui/chat/test_two_agent_chat.py
@@ -117,8 +117,9 @@ def _expect_dispatch_tool_call_rendered(page: Page) -> None:
     """Assert the `sys_session_send` dispatch shows as a transcript tool call.
 
     A lone call can render directly; completed multi-step turns fold calls
-    into a collapsed "See N steps" group. Expand groups when present. The
-    trigger renders toolTitle.ts's raw-name fallback
+    into a collapsed summary group labeled by formatToolRunLabel (generic
+    "Called N tools" for unrecognized sys_* names). Expand groups when
+    present. The trigger renders toolTitle.ts's raw-name fallback
     ("sys_session_send(...)"), not the friendly "Start child session:"
     verb: sessionTitle() reads `tool`/`session` args while the named
     spawn schema (omnigent/tools/builtins/spawn.py) sends `agent`/`title`,
@@ -133,7 +134,7 @@ def _expect_dispatch_tool_call_rendered(page: Page) -> None:
         expect(direct_call.first).to_be_visible()
         return
 
-    step_groups = page.get_by_text(re.compile(r"^See \d+ steps?$"))
+    step_groups = page.get_by_text(re.compile(r"^Called \d+ tools?$"))
     expect(step_groups.first).to_be_visible()
     for group in step_groups.all():
         group.click()

--- a/tests/e2e_ui/chat/test_working_indicator_reload.py
+++ b/tests/e2e_ui/chat/test_working_indicator_reload.py
@@ -218,7 +218,9 @@ def test_live_tool_output_updates_running_card(
             arguments='{"command": "pytest -q"}',
         )
 
-        trigger = page.locator('button[title^="shell"]').first
+        # toolTitle.ts formats `shell` calls as the bare command, so the
+        # trigger's tooltip is the command string, not "shell(...)".
+        trigger = page.locator('button[title="pytest -q"]').first
         expect(trigger).to_be_visible(timeout=10_000)
         expect(trigger.locator(".animate-spin")).to_be_visible(timeout=10_000)
 

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -1871,6 +1871,101 @@ def approval_session(
                 respawned_runner.wait(timeout=5)
 
 
+# ---------------------------------------------------------------------------
+# Tool-run fold probe: an ``os_env`` agent whose mock LLM queue emits a
+# deterministic sys_os_shell("ls") → sys_os_read("README.md") tool sequence,
+# then a short text reply. Used to assert the chat view's collapsed tool-run
+# summary carries the semantic action label ("Listed 1 directory, read 1
+# file") rather than a generic step count. Same registration/bind contract
+# as :func:`approval_session`, minus the guardrails block (nothing gated).
+# ---------------------------------------------------------------------------
+
+_TOOL_FOLD_AGENT_NAME = "tool_fold_probe"
+_TOOL_FOLD_AGENT_YAML = """\
+spec_version: 1
+name: {name}
+prompt: |
+  You are a deterministic tool-run assistant. When the user asks you to
+  inspect the workspace, you MUST do exactly this and nothing else:
+
+  1. Call sys_os_shell with command set to exactly: ls
+  2. Call sys_os_read with path set to exactly: README.md
+  3. Reply with one short sentence.
+
+executor:
+  model: {model}
+  config:
+    harness: openai-agents
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+"""
+
+
+@pytest.fixture
+def tool_fold_session(
+    live_server: str,
+    mock_llm_server_url: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[tuple[str, str]]:
+    """A runner-bound session whose turn runs a shell + read tool pair.
+
+    The mock queue is keyed by a per-fixture unique model name (same
+    isolation rationale as :func:`approval_session`): two tool-call
+    responses, then a text fallback for the wrap-up LLM call.
+
+    :param live_server: Spawned server fixture.
+    :param mock_llm_server_url: Session-scoped mock LLM server URL.
+    :param tmp_path_factory: Pytest temp path factory (for a respawn log).
+    :returns: ``(base_url, session_id)``. Send any turn to run the
+        deterministic ls → read → reply sequence.
+    """
+    import json as _json
+    import uuid as _uuid
+
+    model = f"tool-fold-probe-{_uuid.uuid4().hex[:8]}"
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "call_ls",
+                        "name": "sys_os_shell",
+                        "arguments": _json.dumps({"command": "ls"}),
+                    }
+                ]
+            },
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "call_read",
+                        "name": "sys_os_read",
+                        "arguments": _json.dumps({"path": "README.md"}),
+                    }
+                ]
+            },
+        ],
+        key=model,
+    )
+    set_fallback_mock_llm(mock_llm_server_url, model, "Workspace inspected.")
+
+    respawned = _ensure_runner_online(live_server, tmp_path_factory)
+    runner_id = str(_server_state["runner_id"])
+    yaml_text = _TOOL_FOLD_AGENT_YAML.format(name=_TOOL_FOLD_AGENT_NAME, model=model)
+    session_id = _create_bundled_session(live_server, runner_id, yaml_text)
+    try:
+        yield (live_server, session_id)
+    finally:
+        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+        if respawned is not None:
+            respawned.terminate()
+            respawned.wait(timeout=5)
+
+
 @pytest.fixture(autouse=True)
 def _ui_defaults() -> None:
     """

--- a/tests/e2e_ui/messages/test_message_render_parity.py
+++ b/tests/e2e_ui/messages/test_message_render_parity.py
@@ -326,3 +326,37 @@ def test_custom_agent_message_render_parity(
 # is owned by the native-harness CI enablement work; until that lands, this
 # suite covers the render-parity / no-duplicate logic via the custom
 # openai-agents agent above.
+
+
+@pytest.mark.timeout(300)
+def test_tool_run_fold_semantic_label(
+    page: Page,
+    tool_fold_session: tuple[str, str],
+) -> None:
+    """A completed tool run folds into a semantic action summary, like the TUI.
+
+    The ``tool_fold_probe`` agent deterministically runs
+    ``sys_os_shell("ls")`` then ``sys_os_read("README.md")`` before
+    replying. Once the turn settles, the chat view must collapse that run
+    into a single summary row labeled with the actions taken — "Listed 1
+    directory, read 1 file" (``formatToolRunLabel`` in
+    ``web/src/lib/toolTitle.ts``) — matching the native CLIs' step
+    one-liners, not a generic "See N steps" count. Expanding the row must
+    reveal the individual tool cards.
+    """
+    base_url, session_id = tool_fold_session
+    page.goto(f"{base_url}/c/{session_id}")
+    _ensure_chat_view(page)
+    _send(page, "Inspect the workspace.")
+
+    # The fold only forms once the wrap-up text lands (a live run keeps its
+    # streaming tail visible), so waiting for the label covers the turn.
+    fold = page.get_by_text("Listed 1 directory, read 1 file", exact=True)
+    expect(fold).to_be_visible(timeout=_CUSTOM_TURN_TIMEOUT_MS)
+    expect(page.locator(_WORKING)).to_have_count(0, timeout=30_000)
+
+    # Expanding reveals the individual per-tool rows (toolTitle.ts titles:
+    # the raw command for shell, "Read <path>" for reads).
+    fold.click()
+    expect(page.get_by_text("ls", exact=True).first).to_be_visible()
+    expect(page.get_by_text("README.md").first).to_be_visible()

--- a/web/src/components/blocks/BlockRenderer.test.tsx
+++ b/web/src/components/blocks/BlockRenderer.test.tsx
@@ -221,11 +221,10 @@ describe("BlockRenderer dispatch", () => {
     expect(sections[1]!).not.toHaveClass("mt-2");
   });
 
-  it("'See N steps' counts the whole tool run, including the streaming tail", () => {
-    // While streaming, the most-recent tools render as a visible tail
-    // OUTSIDE the fold. The "See N steps" label must count the whole run
-    // (5), not just the folded part — else it reads "See 2 steps" with 3
-    // more tool cards visible below (the reported miscount).
+  it("labels the fold with only the hidden count while the tail streams", () => {
+    // The most-recent tools render as a visible tail OUTSIDE the fold, so
+    // the fold line describes only what's hidden ("Called 2 tools") — a
+    // whole-run count would double-count the tool cards visible below.
     const tool = (n: number): RenderItem => ({
       kind: "tool",
       itemId: `fc_${n}`,
@@ -252,15 +251,50 @@ describe("BlockRenderer dispatch", () => {
       tool(5),
     ];
     render(<BlockRenderer items={items} sessionStatus="running" />);
-    expect(screen.getByText("See 5 steps")).toBeDefined();
-    expect(screen.queryByText("See 2 steps")).toBeNull();
-    // The label counts the WHOLE run, but the recent tools must still be
-    // visible as a tail OUTSIDE the collapsed group — the most-recent tool
-    // renders (the collapsed group's content is unmounted), while an older
-    // one stays folded. Guards against a regression that folds everything
-    // (the count would still read 5, but the live tail would vanish).
+    expect(screen.getByText("Called 2 tools")).toBeDefined();
+    expect(screen.queryByText("Called 5 tools")).toBeNull();
+    // The recent tools must be visible as a tail OUTSIDE the collapsed
+    // group — the most-recent tool renders (the collapsed group's content
+    // is unmounted), while an older one stays folded. Guards against a
+    // regression that folds everything.
     expect(screen.getByText(/tool_5/)).toBeDefined();
     expect(screen.queryByText(/tool_1/)).toBeNull();
+  });
+
+  it("folds the whole run into one labeled row once the session is idle", () => {
+    // Mirrors the terminal's collapsed past turns: after a run
+    // completes, every step folds into a single expandable summary
+    // line labeled with the run's actions.
+    const tool = (n: number, name = `tool_${n}`): RenderItem => ({
+      kind: "tool",
+      itemId: `fc_${n}`,
+      execution: {
+        name,
+        arguments: {},
+        argsSummary: "",
+        callId: `c_${n}`,
+        agentName: "nessie",
+        executedBy: "server",
+        output: "ok",
+      },
+      output: "ok",
+      state: "output-available",
+      startedAt: null,
+      duration: undefined,
+    });
+    const items: RenderItem[] = [
+      tool(1, "Bash"),
+      tool(2, "Bash"),
+      tool(3),
+      tool(4),
+      tool(5),
+      { kind: "text", itemId: "m1", text: "Done.", final: true },
+    ];
+    render(<BlockRenderer items={items} sessionStatus="idle" />);
+    // The whole run folds; the label describes all five steps.
+    expect(screen.getByText("Ran 2 shell commands, called 3 other tools")).toBeDefined();
+    expect(screen.queryByText(/tool_5/)).toBeNull();
+    expect(screen.queryByText(/Bash/)).toBeNull();
   });
 
   // Proves the markdown throttle is actually wired into the render path (not

--- a/web/src/components/blocks/BlockRenderer.tsx
+++ b/web/src/components/blocks/BlockRenderer.tsx
@@ -3,15 +3,15 @@
 // `ChatPage`, not as an inline render item — no case for it here.
 //
 // Tool-call collapsing: within a contiguous run of tool / native_tool
-// items, older tools fold into a single "See N steps" line (rendered
-// by `ToolGroupSummary`). The trailing `STREAMING_TAIL` tools (any
-// state) stay outside the group ONLY when (a) the session is still
-// running and (b) the very last item in the transcript is a tool —
-// meaning the agent hasn't produced any text/reasoning after this
-// run yet, so these tools are the live activity. Once the agent
-// emits anything else after a tool run (or once the session is
-// idle), the run collapses except for still-in-progress spinners and
-// durable routing/fan-out cards.
+// items, tools fold into a single summary line describing what's
+// hidden ("Read 2 files", rendered by `ToolGroupSummary`). While the
+// run is the live activity — the session is running and the run is
+// the last thing in the transcript — the trailing `STREAMING_TAIL`
+// tools stay visible as individual rows so the user can watch recent
+// steps; once the agent emits anything after the run (or the session
+// goes idle), the whole run folds into the one expandable line, like
+// the terminal's collapsed past turns. Still-in-progress spinners and
+// durable routing/fan-out cards never fold regardless of position.
 
 import type { ReactNode } from "react";
 import { useMemo } from "react";
@@ -298,7 +298,6 @@ type ToolRunFragment =
   | {
       kind: "group";
       tools: RenderItem[];
-      count?: number;
     }
   | {
       kind: "standalone";
@@ -329,28 +328,24 @@ export function BlockRenderer({ items, sessionStatus }: BlockRendererProps) {
       const run = items.slice(runStart, i);
       i -= 1; // outer loop will i += 1
 
-      // Only the run at `streamingRunStart` (when set) is treated as
-      // "currently streaming". Earlier runs, and any run followed by
-      // assistant text/reasoning, collapse the same way they would
-      // when idle.
+      // Only the run at `streamingRunStart` (when set) keeps a visible
+      // tail. Earlier runs, and any run followed by assistant
+      // text/reasoning, fold entirely the same way they would when idle.
       const isStreamingRun = runStart === streamingRunStart;
       const fragments = partitionToolRun(run, isStreamingRun);
 
       if (isStreamingRun && fragments[0]?.kind === "group") {
         const [group, ...tail] = fragments;
-        // Wrap (group + trailing tail) in a single MessageContent child
-        // so the message column's `gap-2` only applies AROUND this
-        // pair, not BETWEEN them — the tail's `peer-data-[state=open]:mt-0`
-        // can then truly bring the two bordered blocks flush when the
-        // group is expanded.
+        // Wrap (fold line + trailing tail) in a single MessageContent
+        // child so the message column's `gap-2` only applies AROUND the
+        // run, not BETWEEN its rows. The tail rows sit at the same
+        // indent as the fold line — they're peers in one flat run, like
+        // the terminal's step list; only the fold's expanded contents
+        // are nested (inside `ToolGroupSummary`).
         rendered.push(
-          <div key={`tool-group-with-tail:${runStart}`}>
-            <ToolGroupSummary tools={group.tools} count={group.count} />
-            {tail.length > 0 && (
-              <div className="mt-1 ml-2 space-y-1 border-l pl-3 py-1 peer-data-[state=open]:mt-0">
-                {tail.map((fragment, idx) => renderToolRunFragment(fragment, runStart, idx))}
-              </div>
-            )}
+          <div key={`tool-group-with-tail:${runStart}`} className="space-y-1">
+            <ToolGroupSummary tools={group.tools} />
+            {tail.map((fragment, idx) => renderToolRunFragment(fragment, runStart, idx))}
           </div>,
         );
       } else {
@@ -372,44 +367,17 @@ export function BlockRenderer({ items, sessionStatus }: BlockRendererProps) {
 
 /**
  * Split a contiguous tool run into the part that folds into the
- * "See N steps" group versus the part rendered individually.
+ * collapsed summary group versus the part rendered individually.
  *
  * For the live-streaming run, the trailing `STREAMING_TAIL` tools
  * (regardless of state) stay outside the group so the user can watch
- * the most recent activity. For any other run — older runs in the
- * transcript, or any run once the loop is idle — only still-in-progress
- * tools and persistent routing plan cards stay outside; everything else
- * folds.
+ * the most recent activity; any other run folds entirely. In-progress
+ * spinners and persistent routing plan cards never fold, so a routing
+ * judgement isn't swallowed mid-fan-out when later spawns push it past
+ * the tail window.
  */
 function partitionToolRun(run: RenderItem[], isStreamingRun: boolean): ToolRunFragment[] {
-  if (isStreamingRun) {
-    const tailStart = Math.max(0, run.length - STREAMING_TAIL);
-    const fragments: ToolRunFragment[] = [];
-    let group: RenderItem[] = [];
-    // The "See N steps" count reflects the WHOLE run (folded head + visible
-    // tail), so a folded head doesn't read "See 2 steps" with more visible.
-    const flushGroup = () => {
-      if (group.length === 0) return;
-      fragments.push({ kind: "group", tools: group, count: run.length });
-      group = [];
-    };
-    for (let index = 0; index < run.length; index += 1) {
-      const item = run[index]!;
-      // The trailing tail is the live edge; in-progress spinners and durable
-      // routing/fan-out cards never fold (mirrors the idle branch below), so a
-      // routing judgement isn't swallowed mid-fan-out when later spawns push
-      // it past the tail window.
-      if (index >= tailStart || isInProgressTool(item) || isPersistentToolCard(item)) {
-        flushGroup();
-        fragments.push({ kind: "standalone", tool: item, index });
-      } else {
-        group.push(item);
-      }
-    }
-    flushGroup();
-    return fragments;
-  }
-
+  const tailStart = isStreamingRun ? Math.max(0, run.length - STREAMING_TAIL) : run.length;
   const fragments: ToolRunFragment[] = [];
   let group: RenderItem[] = [];
   const flushGroup = () => {
@@ -417,10 +385,9 @@ function partitionToolRun(run: RenderItem[], isStreamingRun: boolean): ToolRunFr
     fragments.push({ kind: "group", tools: group });
     group = [];
   };
-
   for (let index = 0; index < run.length; index += 1) {
     const item = run[index]!;
-    if (isInProgressTool(item) || isPersistentToolCard(item)) {
+    if (index >= tailStart || isInProgressTool(item) || isPersistentToolCard(item)) {
       flushGroup();
       fragments.push({ kind: "standalone", tool: item, index });
     } else {
@@ -438,11 +405,7 @@ function renderToolRunFragment(
 ): ReactNode {
   if (fragment.kind === "group") {
     return (
-      <ToolGroupSummary
-        key={`tool-group:${runStart}:${fragmentIndex}`}
-        tools={fragment.tools}
-        count={fragment.count}
-      />
+      <ToolGroupSummary key={`tool-group:${runStart}:${fragmentIndex}`} tools={fragment.tools} />
     );
   }
   return renderItem(fragment.tool, runStart + fragment.index, false);

--- a/web/src/components/blocks/ToolCard.test.ts
+++ b/web/src/components/blocks/ToolCard.test.ts
@@ -202,9 +202,9 @@ describe("ToolGroupSummary", () => {
     } as unknown as RenderItem;
   }
 
-  it("labels the run with a pluralized step count and renders children when expanded", () => {
-    // WHY: the summary line counts the full contiguous run; ">1" pluralizes
-    // "steps", and expanding mounts each tool card.
+  it("labels unrecognized hidden tools generically and renders children when expanded", () => {
+    // WHY: several unrecognized tools get the generic "Called N tools",
+    // and expanding mounts each tool card.
     const { container } = render(
       createElement(
         TooltipProvider,
@@ -214,31 +214,46 @@ describe("ToolGroupSummary", () => {
         }),
       ),
     );
-    expect(screen.getByText("See 2 steps")).toBeInTheDocument();
+    expect(screen.getByText("Called 2 tools")).toBeInTheDocument();
     fireEvent.click(container.querySelector<HTMLElement>('[data-slot="collapsible-trigger"]')!);
     expect(screen.getByText("alpha_tool")).toBeInTheDocument();
     expect(screen.getByText("beta_tool")).toBeInTheDocument();
   });
 
-  it("uses the singular 'step' for one tool and honors an explicit count override", () => {
-    // WHY: n===1 drops the plural; `count` overrides tools.length so a
-    // streaming tail isn't undercounted.
-    const { rerender } = render(
+  it("uses the singular 'tool' for one hidden unrecognized tool", () => {
+    render(
       createElement(
         TooltipProvider,
         null,
         createElement(ToolGroupSummary, { tools: [toolItem("t1", "solo_tool")] }),
       ),
     );
-    expect(screen.getByText("See 1 step")).toBeInTheDocument();
+    expect(screen.getByText("Called 1 tool")).toBeInTheDocument();
+  });
+
+  it("labels recognized hidden tools with the semantic CLI-style phrase", () => {
+    // WHY: recognized tool names (Claude Code's Bash/Read) replace the
+    // bare count with the action summary the native CLI prints.
+    const { rerender } = render(
+      createElement(
+        TooltipProvider,
+        null,
+        createElement(ToolGroupSummary, {
+          tools: [toolItem("t1", "Read"), toolItem("t2", "Read")],
+        }),
+      ),
+    );
+    expect(screen.getByText("Read 2 files")).toBeInTheDocument();
 
     rerender(
       createElement(
         TooltipProvider,
         null,
-        createElement(ToolGroupSummary, { tools: [toolItem("t1", "solo_tool")], count: 5 }),
+        createElement(ToolGroupSummary, {
+          tools: [toolItem("t1", "Bash"), toolItem("t2", "Read"), toolItem("t3", "Read")],
+        }),
       ),
     );
-    expect(screen.getByText("See 5 steps")).toBeInTheDocument();
+    expect(screen.getByText("Ran 1 shell command, read 2 files")).toBeInTheDocument();
   });
 });

--- a/web/src/components/blocks/ToolCard.tsx
+++ b/web/src/components/blocks/ToolCard.tsx
@@ -29,7 +29,12 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { cn } from "@/lib/utils";
 import type { RenderItem, ToolState } from "@/lib/renderItems";
 import { iconForTool } from "@/lib/toolIcon";
-import { type ToolTitle, formatToolTitle } from "@/lib/toolTitle";
+import {
+  type ToolRunCall,
+  type ToolTitle,
+  formatToolRunLabel,
+  formatToolTitle,
+} from "@/lib/toolTitle";
 import { useFileViewer } from "@/shell/FileViewerContext";
 
 const OUTPUT_PREVIEW_LINE_LIMIT = 80;
@@ -224,29 +229,21 @@ export function ToolCard({
 }
 
 /**
- * Render a contiguous run of tool calls as one muted "See N steps" line.
- * Clicking expands to show each tool as its own (also-collapsible)
- * trigger. `BlockRenderer` decides which tools fold here (older tools
- * once a streaming-tail of the most recent ones has been peeled off,
- * or all completed tools once streaming finishes).
+ * Render the folded (older) part of a contiguous tool run as one muted
+ * summary line ("Read 2 files"). Clicking expands to show each tool as
+ * its own (also-collapsible) trigger. `BlockRenderer` decides which
+ * tools fold here: older tools once the visible tail of the most
+ * recent ones has been peeled off.
  */
-export function ToolGroupSummary({ tools, count }: { tools: RenderItem[]; count?: number }) {
-  // Label the FULL contiguous run, not just the folded tools — during
-  // streaming the most-recent tools render as a visible tail outside this
-  // group, so counting only `tools` would undercount ("See 2 steps" when
-  // there are more visible). `count` defaults to the folded length for
-  // fully-collapsed runs (reload / idle), where they're equal.
-  const n = count ?? tools.length;
-  const label = `See ${n} step${n === 1 ? "" : "s"}`;
+export function ToolGroupSummary({ tools }: { tools: RenderItem[] }) {
+  const label = formatToolRunLabel(tools.map(toolRunCall));
   return (
     // Named `group/tool-summary` so this collapsible only rotates its
     // OWN chevron (line 296 in `ToolTriggerRow` uses an unnamed
     // `group-data-[state=open]:rotate-90` that would otherwise match
     // any ancestor `.group[data-state=open]` and incorrectly rotate
     // chevrons of inner tool cards when this outer group is open).
-    // `peer` lets `BlockRenderer`'s trailing tail react to this
-    // collapsible's open/closed state for the border-join effect.
-    <Collapsible defaultOpen={false} className="group/tool-summary peer not-prose w-full">
+    <Collapsible defaultOpen={false} className="group/tool-summary not-prose w-full">
       <CollapsibleTrigger className="flex cursor-pointer items-center gap-1.5 py-0.5 text-left text-muted-foreground text-xs transition-colors hover:text-foreground">
         <ChevronRightIcon className="size-3.5 shrink-0 transition-transform group-data-[state=open]/tool-summary:rotate-90" />
         <span>{label}</span>
@@ -284,6 +281,15 @@ export function ToolGroupSummary({ tools, count }: { tools: RenderItem[]; count?
       </CollapsibleContent>
     </Collapsible>
   );
+}
+
+/** Tool name + args used to categorize a run item for the summary label. */
+function toolRunCall(item: RenderItem): ToolRunCall {
+  if (item.kind === "tool") {
+    return { name: item.execution.name, args: item.execution.arguments };
+  }
+  if (item.kind === "native_tool") return { name: item.toolType, args: item.data };
+  return { name: "" };
 }
 
 /**

--- a/web/src/lib/toolTitle.test.ts
+++ b/web/src/lib/toolTitle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatToolTitle } from "./toolTitle";
+import { formatToolRunLabel, formatToolTitle } from "./toolTitle";
 
 describe("formatToolTitle", () => {
   it("strips sys_os_shell down to the command string with no bold verb", () => {
@@ -134,6 +134,70 @@ describe("formatToolTitle", () => {
     });
   });
 
+  it("formats Claude Code native tools like the CLI's step lines", () => {
+    // Bash prefers the model-written description (what the TUI prints)
+    // over the raw command; without one, the command shows.
+    expect(
+      formatToolTitle("Bash", { command: "ls docs", description: "List docs directory" }),
+    ).toEqual({ verb: null, body: "List docs directory" });
+    expect(formatToolTitle("Bash", { command: "ls docs" })).toEqual({
+      verb: null,
+      body: "ls docs",
+    });
+    expect(formatToolTitle("Read", { file_path: "/repo/README.md" })).toEqual({
+      verb: "Read",
+      body: "/repo/README.md",
+    });
+    expect(formatToolTitle("Edit", { file_path: "a.py" })).toEqual({ verb: "Edit", body: "a.py" });
+    expect(formatToolTitle("Grep", { pattern: "TODO" })).toEqual({
+      verb: "Search:",
+      body: "TODO",
+    });
+    expect(formatToolTitle("TodoWrite", { todos: [] })).toEqual({
+      verb: "Update todos",
+      body: "",
+    });
+    expect(formatToolTitle("Task", { description: "Explore auth module" })).toEqual({
+      verb: "Sub-agent:",
+      body: "Explore auth module",
+    });
+  });
+
+  it("formats codex native tools like its TUI", () => {
+    expect(formatToolTitle("shell", { command: "/bin/bash -lc 'cat notes.txt'" })).toEqual({
+      verb: null,
+      body: "cat notes.txt",
+    });
+    expect(
+      formatToolTitle("apply_patch", {
+        changes: [{ path: "/repo/notes.txt", kind: { type: "update" } }],
+      }),
+    ).toEqual({ verb: "Edit", body: "/repo/notes.txt" });
+    expect(formatToolTitle("apply_patch", { changes: [{ path: "a" }, { path: "b" }] })).toEqual({
+      verb: "Edit",
+      body: "2 files",
+    });
+  });
+
+  it("formats pi / opencode lowercase tools, honoring filePath and path args", () => {
+    expect(formatToolTitle("bash", { command: "cat notes.txt" })).toEqual({
+      verb: null,
+      body: "cat notes.txt",
+    });
+    expect(formatToolTitle("read", { filePath: "/repo/notes.txt" })).toEqual({
+      verb: "Read",
+      body: "/repo/notes.txt",
+    });
+    expect(formatToolTitle("edit", { path: "notes.txt", edits: [] })).toEqual({
+      verb: "Edit",
+      body: "notes.txt",
+    });
+    expect(formatToolTitle("write", { filePath: "out.txt" })).toEqual({
+      verb: "Write",
+      body: "out.txt",
+    });
+  });
+
   it("falls back when a known tool's required arg is missing or wrong-typed", () => {
     expect(formatToolTitle("sys_os_shell", {}, "fallback")).toEqual({
       verb: null,
@@ -147,5 +211,82 @@ describe("formatToolTitle", () => {
       verb: null,
       body: "sys_os_shell({command:42})",
     });
+  });
+});
+
+describe("formatToolRunLabel", () => {
+  const call = (name: string, args?: Record<string, unknown>) => ({ name, args });
+
+  it("labels single-category folds with the CLI-style phrase, pluralized", () => {
+    expect(formatToolRunLabel([call("Bash")])).toBe("Ran 1 shell command");
+    expect(formatToolRunLabel([call("Bash"), call("sys_os_shell")])).toBe("Ran 2 shell commands");
+    expect(formatToolRunLabel([call("Read"), call("Read")])).toBe("Read 2 files");
+    expect(formatToolRunLabel([call("Edit"), call("Write"), call("MultiEdit")])).toBe(
+      "Edited 3 files",
+    );
+    expect(formatToolRunLabel([call("Grep")])).toBe("Ran 1 search");
+    expect(formatToolRunLabel([call("Grep"), call("Glob")])).toBe("Ran 2 searches");
+  });
+
+  it("recategorizes ls / cat shell commands like the native TUIs", () => {
+    expect(formatToolRunLabel([call("Bash", { command: "ls docs" })])).toBe("Listed 1 directory");
+    expect(
+      formatToolRunLabel([
+        call("Bash", { command: "ls" }),
+        call("sys_os_shell", { command: "ls -la /tmp" }),
+      ]),
+    ).toBe("Listed 2 directories");
+    expect(formatToolRunLabel([call("Bash", { command: "cat notes.txt" })])).toBe("Read 1 file");
+    // `ls` embedded in a larger command is still a shell command.
+    expect(formatToolRunLabel([call("Bash", { command: "echo hi && ls" })])).toBe(
+      "Ran 1 shell command",
+    );
+  });
+
+  it("categorizes pi / opencode lowercase tool names", () => {
+    expect(
+      formatToolRunLabel([
+        call("bash", { command: "ls" }),
+        call("bash", { command: "cat notes.txt" }),
+        call("edit", { path: "notes.txt" }),
+      ]),
+    ).toBe("Listed 1 directory, read 1 file, edited 1 file");
+    expect(formatToolRunLabel([call("read", { filePath: "a.txt" }), call("write")])).toBe(
+      "Read 1 file, edited 1 file",
+    );
+  });
+
+  it("unwraps codex's login-shell wrapper before categorizing", () => {
+    expect(formatToolRunLabel([call("shell", { command: "/bin/bash -lc ls" })])).toBe(
+      "Listed 1 directory",
+    );
+    expect(formatToolRunLabel([call("shell", { command: "/bin/zsh -lc 'cat notes.txt'" })])).toBe(
+      "Read 1 file",
+    );
+    expect(formatToolRunLabel([call("shell", { command: "/bin/bash -lc 'git status'" })])).toBe(
+      "Ran 1 shell command",
+    );
+  });
+
+  it("joins mixed categories in fixed order, appending unrecognized tools", () => {
+    expect(formatToolRunLabel([call("Read"), call("Bash"), call("Read"), call("TodoWrite")])).toBe(
+      "Ran 1 shell command, read 2 files, called 1 other tool",
+    );
+    expect(
+      formatToolRunLabel([
+        call("Bash", { command: "git status" }),
+        call("Bash", { command: "ls" }),
+      ]),
+    ).toBe("Ran 1 shell command, listed 1 directory");
+  });
+
+  it("strips the mcp__omnigent__ prefix before categorizing", () => {
+    expect(formatToolRunLabel([call("mcp__omnigent__sys_os_read")])).toBe("Read 1 file");
+  });
+
+  it("falls back to a generic 'Called N tools' when no tool is recognized", () => {
+    expect(formatToolRunLabel([call("turn_diff")])).toBe("Called 1 tool");
+    expect(formatToolRunLabel([call("TodoWrite")])).toBe("Called 1 tool");
+    expect(formatToolRunLabel([call("alpha_tool"), call("beta_tool")])).toBe("Called 2 tools");
   });
 });

--- a/web/src/lib/toolTitle.ts
+++ b/web/src/lib/toolTitle.ts
@@ -127,6 +127,70 @@ const FORMATTERS: Record<string, ArgFormatter> = {
       : { verb: `Send to '${id}':`, body: payload };
   },
 
+  // Claude Code native harness tools — mirror the step lines its TUI
+  // prints. Shell steps carry a model-written description ("List docs
+  // directory") which the CLI surfaces; prefer it over the raw command.
+  Bash: (args) => {
+    const desc = asString(args.description);
+    if (desc !== null) return { verb: null, body: desc };
+    const cmd = asString(args.command);
+    return cmd === null ? null : { verb: null, body: cmd };
+  },
+  Read: (args) => withPath("Read", args.file_path),
+  Write: (args) => withPath("Write", args.file_path),
+  Edit: (args) => withPath("Edit", args.file_path),
+  MultiEdit: (args) => withPath("Edit", args.file_path),
+  NotebookEdit: (args) => withPath("Edit", args.notebook_path),
+  Grep: (args) => {
+    const pattern = asString(args.pattern);
+    return pattern === null ? null : { verb: "Search:", body: pattern };
+  },
+  Glob: (args) => {
+    const pattern = asString(args.pattern);
+    return pattern === null ? null : { verb: "Find files:", body: pattern };
+  },
+  WebSearch: (args) => {
+    const q = asString(args.query);
+    return q === null ? null : { verb: "Web search:", body: `"${q}"` };
+  },
+  WebFetch: (args) => {
+    const url = asString(args.url);
+    return url === null ? null : { verb: "Web fetch:", body: url };
+  },
+  TodoWrite: () => verbOnly("Update todos"),
+  Task: (args) => {
+    const desc = asString(args.description);
+    return desc === null ? verbOnly("Run sub-agent") : { verb: "Sub-agent:", body: desc };
+  },
+
+  // Codex native harness tools. Codex wraps every command in a login
+  // shell (`/bin/bash -lc '...'`); show the inner command like its TUI.
+  shell: (args) => {
+    const cmd = asString(args.command);
+    return cmd === null ? null : { verb: null, body: unwrapShellCommand(cmd) };
+  },
+  apply_patch: (args) => {
+    const changes = Array.isArray(args.changes) ? args.changes : null;
+    if (changes === null || changes.length === 0) return null;
+    if (changes.length === 1) {
+      const only = changes[0];
+      const path = only !== null && typeof only === "object" ? Reflect.get(only, "path") : null;
+      const p = asString(path);
+      if (p !== null) return { verb: "Edit", body: p };
+    }
+    return { verb: "Edit", body: `${changes.length} files` };
+  },
+
+  // Pi / OpenCode native harness tools (lowercase names). OpenCode
+  // passes `filePath`, Pi passes `path`.
+  bash: (args) => {
+    const cmd = asString(args.command);
+    return cmd === null ? null : { verb: null, body: cmd };
+  },
+  read: (args) => withPath("Read", args.filePath ?? args.path),
+  edit: (args) => withPath("Edit", args.filePath ?? args.path),
+  write: (args) => withPath("Write", args.filePath ?? args.path),
+
   // Web tools.
   web_search: (args) => {
     const q = asString(args.query);
@@ -161,6 +225,127 @@ export function formatToolTitle(
   const fallback =
     argsSummary !== undefined && argsSummary.length > 0 ? `${name}(${argsSummary})` : name;
   return { verb: null, body: fallback };
+}
+
+/**
+ * Action categories for the collapsed tool-run summary line. Names cover
+ * the omnigent sys_* tools plus the native harness CLIs (Claude Code's
+ * Bash/Read/Edit..., Codex's shell/apply_patch). Shell calls whose
+ * command is a bare `ls` re-categorize as directory listings, matching
+ * the Claude Code TUI's step summaries.
+ */
+type RunCategory = "shell" | "list" | "read" | "edit" | "search";
+
+/** One tool call in a folded run: its name plus (optional) arguments. */
+export interface ToolRunCall {
+  name: string;
+  args?: Record<string, unknown>;
+}
+
+const RUN_CATEGORIES: Record<string, RunCategory> = {
+  Bash: "shell",
+  sys_os_shell: "shell",
+  shell: "shell",
+  local_shell: "shell",
+  bash: "shell",
+  Read: "read",
+  sys_os_read: "read",
+  read: "read",
+  Edit: "edit",
+  Write: "edit",
+  MultiEdit: "edit",
+  NotebookEdit: "edit",
+  apply_patch: "edit",
+  sys_os_edit: "edit",
+  sys_os_write: "edit",
+  edit: "edit",
+  write: "edit",
+  patch: "edit",
+  Grep: "search",
+  Glob: "search",
+  WebSearch: "search",
+  web_search: "search",
+  grep: "search",
+  glob: "search",
+  list: "list",
+};
+
+const RUN_CATEGORY_ORDER: readonly RunCategory[] = ["shell", "list", "read", "edit", "search"];
+
+function runPhrase(category: RunCategory, n: number): string {
+  const s = n === 1 ? "" : "s";
+  switch (category) {
+    case "shell":
+      return `ran ${n} shell command${s}`;
+    case "list":
+      return `listed ${n} director${n === 1 ? "y" : "ies"}`;
+    case "read":
+      return `read ${n} file${s}`;
+    case "edit":
+      return `edited ${n} file${s}`;
+    case "search":
+      return `ran ${n} search${n === 1 ? "" : "es"}`;
+  }
+}
+
+function stripOmnigentPrefix(name: string): string {
+  return name.startsWith("mcp__omnigent__") ? name.slice("mcp__omnigent__".length) : name;
+}
+
+// Login-shell wrapper Codex puts around every command, e.g.
+// `/bin/bash -lc 'cat notes.txt'` or `/bin/zsh -lc ls`.
+const SHELL_WRAPPER_RE = /^(?:\S+\/)?(?:bash|zsh|sh|dash|fish)\s+-l?c\s+([\s\S]+)$/;
+
+/** Peel a login-shell wrapper (and its quotes) off a command string. */
+function unwrapShellCommand(command: string): string {
+  const match = SHELL_WRAPPER_RE.exec(command.trim());
+  if (match === null) return command.trim();
+  const inner = match[1]!.trim();
+  const quote = inner[0];
+  if ((quote === "'" || quote === '"') && inner.length >= 2 && inner.endsWith(quote)) {
+    return inner.slice(1, -1).trim();
+  }
+  return inner;
+}
+
+function categorizeCall(call: ToolRunCall): RunCategory | "other" {
+  const name = stripOmnigentPrefix(call.name);
+  const category = RUN_CATEGORIES[name] ?? "other";
+  if (category === "shell") {
+    const raw = typeof call.args?.command === "string" ? call.args.command : "";
+    const command = unwrapShellCommand(raw);
+    if (command === "ls" || command.startsWith("ls ")) return "list";
+    if (command === "cat" || command.startsWith("cat ")) return "read";
+  }
+  return category;
+}
+
+/**
+ * Label for the folded (hidden) part of a tool run, mirroring the
+ * semantic one-liners the native CLIs print: "Read 2 files", "Ran 1
+ * shell command, read 2 files". Runs made up entirely of unrecognized
+ * tools fall back to a generic "Called N tools".
+ */
+export function formatToolRunLabel(calls: ToolRunCall[]): string {
+  const counts = new Map<RunCategory | "other", number>();
+  for (const call of calls) {
+    const category = categorizeCall(call);
+    counts.set(category, (counts.get(category) ?? 0) + 1);
+  }
+
+  const known = RUN_CATEGORY_ORDER.filter((c) => counts.has(c));
+  const other = counts.get("other") ?? 0;
+
+  if (known.length === 0) {
+    return `Called ${calls.length} tool${calls.length === 1 ? "" : "s"}`;
+  }
+
+  const phrases = known.map((c) => runPhrase(c, counts.get(c)!));
+  if (other > 0) {
+    phrases.push(`called ${other} other tool${other === 1 ? "" : "s"}`);
+  }
+  const label = phrases.join(", ");
+  return label.charAt(0).toUpperCase() + label.slice(1);
 }
 
 function asString(v: unknown): string | null {


### PR DESCRIPTION
## Related issue

N/A

## Summary

The chat view and the terminal view of the same native session read very differently: the terminal shows the CLI's own step summaries ("Ran 1 shell command", "Read 3 files") while the chat view collapsed every completed tool run into a generic **"See N steps"** line. This PR derives the same semantic labels the native CLIs print from the folded calls' tool names and arguments, closing the readability gap.

- `formatToolRunLabel` (new, in `web/src/lib/toolTitle.ts`) buckets a folded run into shell / list / read / edit / search actions and renders CLI-style phrasing: "Ran 1 shell command, read 2 files", "Listed 1 directory", "Edited 3 files". Runs made up entirely of unrecognized tools fall back to "Called N tools", so no harness loses the collapse affordance.
- Coverage across harnesses: omnigent `sys_*` tools, Claude Code (`Bash`/`Read`/`Edit`/…), Codex (`shell`/`apply_patch`, with its `/bin/bash -lc '…'` login-shell wrapper unwrapped before classification), and pi / OpenCode lowercase names (`bash`/`read`/`edit`/…, honoring both `filePath` and `path` args).
- Command-level classification mirrors the vendor TUIs: a shell call that is a bare `ls` labels as "Listed 1 directory", a bare `cat` as a file read; compound commands stay "shell command".
- Per-step titles (visible when a fold is expanded) added for the native harness tools: Claude Code `Bash` prefers the model-written `description` like the TUI does, Codex `shell` shows the unwrapped command, `apply_patch` shows "Edit &lt;path&gt;".
- The fold line now describes only its own (hidden) contents, so the whole-run `count` plumbing through `BlockRenderer` → `ToolGroupSummary` is deleted — the label can no longer double-count the visible streaming tail.

ELI5: the chat transcript's "See 3 steps" link now says what those steps actually were — "Ran 1 shell command, read 2 files" — the same way the Claude Code / Codex terminals narrate their work.

```
Before (idle run of Bash + Read + Read):        After:
  > See 3 steps                                   > Ran 1 shell command, read 2 files
```

## Test Plan

- Unit tests in the existing suites (`toolTitle.test.ts`, `ToolCard.test.ts`, `BlockRenderer.test.tsx`) cover pluralization, category ordering, the `ls`/`cat` reclassification, codex wrapper unwrapping, the `mcp__omnigent__` prefix strip, the unknown-tool fallback, and the streaming-tail label. Full web suite: 3534 passed.
- New e2e_ui test `test_tool_run_fold_semantic_label` (in `tests/e2e_ui/messages/test_message_render_parity.py`, fixture in `conftest.py`) drives a deterministic mock-LLM agent through `sys_os_shell("ls")` → `sys_os_read("README.md")` and asserts the fold reads "Listed 1 directory, read 1 file" and expands to the per-tool rows. Verified locally up to the known repo-wide mock-LLM infra failure (the pre-existing `test_custom_agent_message_render_parity` control fails identically on an untouched tree).
- Manually verified end-to-end against a dev server built from this branch, with real sessions on four native harnesses (claude-native, codex-native, pi-native, opencode-native) plus claude-sdk, scraping the rendered labels with headless Playwright.

## Demo

Labels rendered from real native-harness sessions on a dev server running this branch:

| Harness | Fold label |
|---|---|
| Claude Code | "Ran 1 shell command, listed 1 directory, read 4 files" |
| Codex | "Listed 1 directory, read 1 file" / "Edited 1 file" / "Called 1 tool" |
| Pi | "Listed 1 directory, read 1 file" / "Edited 1 file" |
| OpenCode | "Listed 1 directory" / "Read 1 file" / "Edited 1 file" |

(Screenshots to be attached in a follow-up comment.)

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: built the SPA from this branch, served it from a dedicated local server, and drove real claude-native, codex-native, pi-native, and opencode-native TUI sessions against it; asserted the rendered fold labels and expanded step titles by scraping the live pages with headless Playwright. The new e2e_ui test exercises the same assertion path but cannot run green locally due to the pre-existing repo-wide mock-LLM infra failure (control test fails identically).

## Changelog

Collapsed tool runs in the chat view are labeled by what they did ("Ran 1 shell command, read 2 files") instead of "See N steps"
