### PR TITLE
feat(sandbox): make recursive dotfile hiding opt-in and add explicit mask_paths

### DIFF
--- a/omnigent/inner/_cwd_scan.py
+++ b/omnigent/inner/_cwd_scan.py
@@ -16,6 +16,19 @@ expressions for Seatbelt), but the *decision* of which paths to mask
 is identical. Centralising the walker here guarantees both backends
 hide exactly the same set of entries; only the emit shape differs.
 
+Recursion is controlled by the ``recursive`` flag, which defaults to
+``False`` (top-level-only) — the same default as the spec key
+``cwd_hidden_scan_recursive`` that every sandbox backend threads
+through, so the walker and the product agree on one default. Set it
+to ``True`` (spec: ``cwd_hidden_scan_recursive: true``) to walk the
+whole tree.
+
+Top-level-only is the scalable default for medium/large projects: it
+still masks the credential-shaped dotfiles that live at the root of
+``cwd`` / ``$HOME`` (``.git``, ``.env``, ``.aws``, ``.ssh``, ...)
+without paying to walk the whole tree. Deeply nested dotfiles are left
+visible in that mode; enable recursion for untrusted trees.
+
 The walker also implements the bounded-traversal contract:
 
 - ``cwd_hidden_scan_max_entries`` caps how many filesystem entries
@@ -133,6 +146,7 @@ def scan_cwd_mask_entries(
     safe_roots: Sequence[Path],
     max_entries: int,
     overflow: str,
+    recursive: bool = False,
     logger_name: str | None = None,
     scope_label: str = "cwd",
     deprioritize_names: Sequence[str] = _DEFAULT_DEPRIORITIZED_DIRS,
@@ -189,6 +203,16 @@ def scan_cwd_mask_entries(
         disable the cap.
     :param overflow: One of ``"error"``, ``"warn"``, ``"unlimited"``.
         See module docstring for per-mode semantics.
+    :param recursive: Whether to descend into subdirectories. Defaults
+        to ``False`` (top-level-only), matching the spec key
+        ``cwd_hidden_scan_recursive`` that every backend passes
+        through. When ``False`` the walker scans only the immediate
+        children of *cwd* — the top-level dotfile / escaping-symlink
+        checks still run, but a dotfile nested below the top level
+        (e.g. ``cwd/src/config/.env``) is NOT masked, and the entry
+        cap and deprioritization machinery are effectively no-ops
+        because no subtree is ever queued. Pass ``True`` to walk the
+        whole tree.
     :param logger_name: Logger name used for the warn-mode warning
         message. ``None`` falls back to this module's logger; backends
         pass their own logger name so the warning surfaces under the
@@ -291,7 +315,9 @@ def scan_cwd_mask_entries(
             # Not masked — recurse only into real directories so a
             # rogue symlink-to-dir can't cause a loop. Deprioritized
             # dirs go to the deferred tier so they're walked last.
-            if child.is_dir(follow_symlinks=False):
+            # When ``recursive`` is False we scan only the top level of
+            # each root, so we never descend past the immediate children.
+            if recursive and child.is_dir(follow_symlinks=False):
                 if child.name in deprioritize:
                     deferred.append(child_path)
                 else:

--- a/omnigent/inner/bwrap_sandbox.py
+++ b/omnigent/inner/bwrap_sandbox.py
@@ -1239,7 +1239,9 @@ def _dotfile_and_symlink_mask_args(
     # Explicit operator-declared masks: hide these regardless of name
     # or depth, on top of the dotfile walk. Kind is decided by a stat
     # so a directory tmpfs-masks and a file /dev/null-masks; a missing
-    # path is dropped by the re-stat below.
+    # path is dropped by the re-stat below. ``is_dir`` follows symlinks
+    # (unlike the walker's ``follow_symlinks=False``), so a symlink to a
+    # directory tmpfs-masks at the link location.
     for mask_path in policy.mask_paths or []:
         key = str(mask_path)
         if key in seen_mask_paths:

--- a/omnigent/inner/bwrap_sandbox.py
+++ b/omnigent/inner/bwrap_sandbox.py
@@ -69,7 +69,7 @@ import sys
 from collections.abc import Sequence
 from pathlib import Path
 
-from ._cwd_scan import scan_cwd_mask_entries
+from ._cwd_scan import MaskedEntry, MaskKind, scan_cwd_mask_entries
 from ._seccomp import (
     SCMP_CMP_EQ,
     SCMP_CMP_GE,
@@ -345,6 +345,12 @@ class BwrapSandboxBackend(SandboxBackend):
             else list(_DEFAULT_CWD_ALLOW_HIDDEN)
         )
 
+        mask_paths = (
+            [_resolve_root(cwd, path) for path in sandbox_spec.mask_paths]
+            if sandbox_spec.mask_paths
+            else None
+        )
+
         return SandboxPolicy(
             backend_type=self.type_name,
             active=True,
@@ -355,6 +361,8 @@ class BwrapSandboxBackend(SandboxBackend):
             cwd_allow_hidden=cwd_allow_hidden,
             cwd_hidden_scan_max_entries=sandbox_spec.cwd_hidden_scan_max_entries,
             cwd_hidden_scan_overflow=sandbox_spec.cwd_hidden_scan_overflow,
+            cwd_hidden_scan_recursive=sandbox_spec.cwd_hidden_scan_recursive,
+            mask_paths=mask_paths,
             env_passthrough=(
                 list(sandbox_spec.env_passthrough)
                 if sandbox_spec.env_passthrough is not None
@@ -1190,6 +1198,7 @@ def _dotfile_and_symlink_mask_args(
         safe_roots=safe_roots,
         max_entries=policy.cwd_hidden_scan_max_entries,
         overflow=policy.cwd_hidden_scan_overflow,
+        recursive=policy.cwd_hidden_scan_recursive,
         logger_name=__name__,
     )
     for entry in entries:
@@ -1207,6 +1216,7 @@ def _dotfile_and_symlink_mask_args(
                 safe_roots=safe_roots,
                 max_entries=policy.cwd_hidden_scan_max_entries,
                 overflow=policy.cwd_hidden_scan_overflow,
+                recursive=policy.cwd_hidden_scan_recursive,
                 logger_name=__name__,
                 scope_label="read_paths",
             )
@@ -1226,6 +1236,17 @@ def _dotfile_and_symlink_mask_args(
                 continue
             seen_mask_paths.add(key)
             entries.append(entry)
+    # Explicit operator-declared masks: hide these regardless of name
+    # or depth, on top of the dotfile walk. Kind is decided by a stat
+    # so a directory tmpfs-masks and a file /dev/null-masks; a missing
+    # path is dropped by the re-stat below.
+    for mask_path in policy.mask_paths or []:
+        key = str(mask_path)
+        if key in seen_mask_paths:
+            continue
+        seen_mask_paths.add(key)
+        kind: MaskKind = "dir" if mask_path.is_dir() else "file"
+        entries.append(MaskedEntry(path=mask_path, kind=kind))
     args: list[str] = []
     for entry in entries:
         # Re-stat just before emitting: a mask overlays onto an EXISTING

--- a/omnigent/inner/datamodel.py
+++ b/omnigent/inner/datamodel.py
@@ -636,6 +636,36 @@ class OSEnvSandboxSpec:
     # (untrusted source trees, supervisor-spawned forks) where an
     # unmasked dotfile past the cap would be an unacceptable leak.
     cwd_hidden_scan_overflow: str = "warn"
+    # Whether the dotfile / escaping-symlink masker recurses into
+    # subdirectories. ``False`` (default) scans only the immediate
+    # children of cwd and each ``read_paths`` root — the top-level
+    # dotfiles (``.git``, ``.env``, ``.aws``, ``.ssh``, ...) that
+    # carry the overwhelming majority of secrets are still masked,
+    # but the walker no longer pays to descend the whole tree. This
+    # is the scalable default: a recursive walk of a medium/large
+    # project (or ``read_paths: ["~/"]``) visits enormous numbers of
+    # entries and routinely trips :attr:`cwd_hidden_scan_max_entries`.
+    #
+    # L6 (security trade-off): with the top-level-only default, a
+    # dotfile nested below the first level (e.g.
+    # ``cwd/services/api/.env`` or ``~/projects/foo/.netrc``) is NOT
+    # masked and stays readable by the sandboxed helper. Set this to
+    # ``True`` for untrusted source trees where a deeply-nested
+    # credential file would be an unacceptable leak; the cap /
+    # overflow knobs then bound the cost of the full walk.
+    cwd_hidden_scan_recursive: bool = False
+    # Explicit files/directories to hide from the sandboxed helper,
+    # regardless of whether their basename starts with ``.``. Each
+    # entry is a path string resolved like ``read_paths`` (``~`` is
+    # expanded; relative paths are taken against cwd; ``$VAR`` is NOT
+    # expanded). Directories are masked as an empty view, files as an
+    # empty file — the same masking the dotfile walker emits. Use this
+    # to hide a specific secret the name-based masker wouldn't catch
+    # (e.g. ``config/production.key``) or a deeply-nested dotfile
+    # without turning on full recursion. Applied on top of the
+    # dotfile mask in every mode. ``None`` and ``[]`` both mean "no
+    # explicit masks".
+    mask_paths: list[str] | None = None
     # Environment-variable allowlist for the helper subprocess, beyond
     # the always-passed minimal default (PATH/HOME/USER/LANG/LC_*/etc.;
     # see :data:`omnigent.inner.os_env._DEFAULT_ENV_PASSTHROUGH`).

--- a/omnigent/inner/loader.py
+++ b/omnigent/inner/loader.py
@@ -822,6 +822,8 @@ def _parse_os_env_sandbox_spec(data: YamlData | str | bool | None) -> OSEnvSandb
     fields = OSEnvSandboxSpec.__dataclass_fields__
     max_entries_raw = data.get("cwd_hidden_scan_max_entries")
     overflow_raw = data.get("cwd_hidden_scan_overflow")
+    recursive_raw = data.get("cwd_hidden_scan_recursive")
+    mask_paths_raw = data.get("mask_paths")
     return OSEnvSandboxSpec(
         type=sandbox_type,
         read_paths=data.get("read_paths"),
@@ -847,6 +849,12 @@ def _parse_os_env_sandbox_spec(data: YamlData | str | bool | None) -> OSEnvSandb
             if overflow_raw is not None
             else fields["cwd_hidden_scan_overflow"].default
         ),
+        cwd_hidden_scan_recursive=(
+            bool(recursive_raw)
+            if recursive_raw is not None
+            else fields["cwd_hidden_scan_recursive"].default
+        ),
+        mask_paths=list(mask_paths_raw) if mask_paths_raw is not None else None,
         env_passthrough=data.get("env_passthrough"),
         egress_rules=egress_rules,
         egress_allow_private_destinations=allow_private,

--- a/omnigent/inner/sandbox.py
+++ b/omnigent/inner/sandbox.py
@@ -88,6 +88,15 @@ class SandboxPolicy:
     :param cwd_hidden_scan_overflow: One of ``"error"``, ``"warn"``,
         or ``"unlimited"``. See :class:`OSEnvSandboxSpec` for the
         per-mode semantics.
+    :param cwd_hidden_scan_recursive: When ``False`` (default) the
+        dotfile / escaping-symlink masker scans only the top level of
+        cwd and each read root; when ``True`` it recurses the full
+        tree. See :class:`OSEnvSandboxSpec` for the security
+        trade-off.
+    :param mask_paths: Explicit files/directories the helper must not
+        see, resolved to absolute paths by the backend. Masked with
+        the same emit shape as the dotfile walker's entries (empty
+        dir / empty file). ``None`` means no explicit masks.
     :param env_passthrough: User-declared environment-variable names
         the helper subprocess is allowed to inherit beyond the
         always-passed minimal default
@@ -151,6 +160,8 @@ class SandboxPolicy:
     cwd_allow_hidden: list[str] | None = None
     cwd_hidden_scan_max_entries: int = 50000
     cwd_hidden_scan_overflow: str = "warn"
+    cwd_hidden_scan_recursive: bool = False
+    mask_paths: list[Path] | None = None
     env_passthrough: list[str] | None = None
     spawn_env_allowlist: list[str] | None = None
     egress_relay_port: int | None = None
@@ -179,6 +190,10 @@ class SandboxPolicy:
             ),
             "cwd_hidden_scan_max_entries": self.cwd_hidden_scan_max_entries,
             "cwd_hidden_scan_overflow": self.cwd_hidden_scan_overflow,
+            "cwd_hidden_scan_recursive": self.cwd_hidden_scan_recursive,
+            "mask_paths": (
+                [str(path) for path in self.mask_paths] if self.mask_paths is not None else None
+            ),
             "env_passthrough": (
                 list(self.env_passthrough) if self.env_passthrough is not None else None
             ),
@@ -220,6 +235,12 @@ class SandboxPolicy:
         max_entries = max_entries_raw if isinstance(max_entries_raw, int) else 50000
         overflow_raw = data.get("cwd_hidden_scan_overflow", "warn")
         overflow = overflow_raw if isinstance(overflow_raw, str) else "warn"
+        recursive_raw = data.get("cwd_hidden_scan_recursive", False)
+        recursive = recursive_raw if isinstance(recursive_raw, bool) else False
+        mask_paths_data = data.get("mask_paths")
+        mask_paths: list[Path] | None = None
+        if isinstance(mask_paths_data, list):
+            mask_paths = [Path(str(path)) for path in mask_paths_data]
         env_passthrough_data = data.get("env_passthrough")
         env_passthrough: list[str] | None = None
         if isinstance(env_passthrough_data, list):
@@ -250,6 +271,8 @@ class SandboxPolicy:
             cwd_allow_hidden=cwd_allow_hidden,
             cwd_hidden_scan_max_entries=max_entries,
             cwd_hidden_scan_overflow=overflow,
+            cwd_hidden_scan_recursive=recursive,
+            mask_paths=mask_paths,
             env_passthrough=env_passthrough,
             spawn_env_allowlist=spawn_env_allowlist,
             egress_relay_port=egress_relay_port,
@@ -476,6 +499,8 @@ def _clone_policy_with(
         ),
         cwd_hidden_scan_max_entries=policy.cwd_hidden_scan_max_entries,
         cwd_hidden_scan_overflow=policy.cwd_hidden_scan_overflow,
+        cwd_hidden_scan_recursive=policy.cwd_hidden_scan_recursive,
+        mask_paths=(list(policy.mask_paths) if policy.mask_paths is not None else None),
         env_passthrough=(
             list(policy.env_passthrough) if policy.env_passthrough is not None else None
         ),

--- a/omnigent/inner/seatbelt_sandbox.py
+++ b/omnigent/inner/seatbelt_sandbox.py
@@ -1005,6 +1005,8 @@ def _build_profile(
     # Explicit operator-declared masks: deny these regardless of name
     # or depth, on top of the dotfile walk. A directory becomes a
     # ``(subpath ...)`` deny and a file/other a ``(literal ...)`` deny.
+    # ``is_dir`` follows symlinks (unlike the walker); a missing path
+    # still emits a harmless literal deny (no re-stat drop like bwrap).
     for mask_path in policy.mask_paths or []:
         key = str(mask_path)
         if key in seen_mask_paths:

--- a/omnigent/inner/seatbelt_sandbox.py
+++ b/omnigent/inner/seatbelt_sandbox.py
@@ -122,7 +122,7 @@ import tempfile
 from collections.abc import Sequence
 from pathlib import Path
 
-from ._cwd_scan import scan_cwd_mask_entries
+from ._cwd_scan import MaskedEntry, MaskKind, scan_cwd_mask_entries
 from .datamodel import OSEnvSandboxSpec, OSEnvSpec
 from .sandbox import (
     SandboxBackend,
@@ -423,6 +423,12 @@ class SeatbeltSandboxBackend(SandboxBackend):
                     name,
                 )
 
+        mask_paths = (
+            [_resolve_root(cwd, path) for path in sandbox_spec.mask_paths]
+            if sandbox_spec.mask_paths
+            else None
+        )
+
         return SandboxPolicy(
             backend_type=self.type_name,
             active=True,
@@ -433,6 +439,8 @@ class SeatbeltSandboxBackend(SandboxBackend):
             cwd_allow_hidden=cwd_allow_hidden,
             cwd_hidden_scan_max_entries=sandbox_spec.cwd_hidden_scan_max_entries,
             cwd_hidden_scan_overflow=sandbox_spec.cwd_hidden_scan_overflow,
+            cwd_hidden_scan_recursive=sandbox_spec.cwd_hidden_scan_recursive,
+            mask_paths=mask_paths,
             env_passthrough=(
                 list(sandbox_spec.env_passthrough)
                 if sandbox_spec.env_passthrough is not None
@@ -981,6 +989,7 @@ def _build_profile(
         safe_roots=safe_roots,
         max_entries=policy.cwd_hidden_scan_max_entries,
         overflow=policy.cwd_hidden_scan_overflow,
+        recursive=policy.cwd_hidden_scan_recursive,
         logger_name=__name__,
     )
     for entry in mask_entries:
@@ -993,6 +1002,16 @@ def _build_profile(
             already_seen=seen_mask_paths,
         )
     )
+    # Explicit operator-declared masks: deny these regardless of name
+    # or depth, on top of the dotfile walk. A directory becomes a
+    # ``(subpath ...)`` deny and a file/other a ``(literal ...)`` deny.
+    for mask_path in policy.mask_paths or []:
+        key = str(mask_path)
+        if key in seen_mask_paths:
+            continue
+        seen_mask_paths.add(key)
+        kind: MaskKind = "dir" if mask_path.is_dir() else "file"
+        mask_entries.append(MaskedEntry(path=mask_path, kind=kind))
     if mask_entries:
         lines.append("")
         lines.append(";; Dotfile / escaping-symlink mask (cwd + read_paths)")
@@ -1811,6 +1830,7 @@ def _scan_read_paths_mask_entries(
                 safe_roots=safe_roots,
                 max_entries=policy.cwd_hidden_scan_max_entries,
                 overflow=policy.cwd_hidden_scan_overflow,
+                recursive=policy.cwd_hidden_scan_recursive,
                 logger_name=__name__,
                 scope_label="read_paths",
             )

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -885,6 +885,8 @@ def _parse_os_env_sandbox(
         ["/home/me/.claude.json"], "cwd_allow_hidden": [".venv",
         ".git"], "cwd_hidden_scan_max_entries": 100000,
         "cwd_hidden_scan_overflow": "warn",
+        "cwd_hidden_scan_recursive": False,
+        "mask_paths": ["config/production.key"],
         "env_passthrough": ["AWS_PROFILE", "GITHUB_TOKEN"],
         "allow_network": False}``.
     :returns: A populated :class:`OSEnvSandboxSpec` when the
@@ -894,8 +896,10 @@ def _parse_os_env_sandbox(
         ``cwd_allow_hidden`` entry contains a path separator, or
         ``cwd_hidden_scan_max_entries`` is not a positive integer,
         or ``cwd_hidden_scan_overflow`` is not one of ``"error"``,
-        ``"warn"``, ``"unlimited"``, or ``env_passthrough`` is not
-        a list of POSIX environment variable names.
+        ``"warn"``, ``"unlimited"``, or ``cwd_hidden_scan_recursive``
+        is not a boolean, or ``mask_paths`` is not a list of non-empty
+        strings, or ``env_passthrough`` is not a list of POSIX
+        environment variable names.
     """
     if raw is None:
         return None
@@ -910,6 +914,8 @@ def _parse_os_env_sandbox(
     cwd_allow_hidden = _parse_cwd_allow_hidden(raw.get("cwd_allow_hidden"))
     max_entries = _parse_cwd_hidden_scan_max_entries(raw.get("cwd_hidden_scan_max_entries"))
     overflow = _parse_cwd_hidden_scan_overflow(raw.get("cwd_hidden_scan_overflow"))
+    recursive = _parse_cwd_hidden_scan_recursive(raw.get("cwd_hidden_scan_recursive"))
+    mask_paths = _parse_mask_paths(raw.get("mask_paths"))
     env_passthrough = _parse_env_passthrough(raw.get("env_passthrough"))
     egress_rules = _parse_egress_rules(raw.get("egress_rules"))
     raw_type = raw.get("type")
@@ -971,6 +977,8 @@ def _parse_os_env_sandbox(
         cwd_allow_hidden=cwd_allow_hidden,
         cwd_hidden_scan_max_entries=max_entries,
         cwd_hidden_scan_overflow=overflow,
+        cwd_hidden_scan_recursive=recursive,
+        mask_paths=mask_paths,
         env_passthrough=env_passthrough,
         egress_rules=egress_rules,
         egress_allow_private_destinations=allow_private,
@@ -1092,6 +1100,68 @@ def _parse_cwd_hidden_scan_overflow(raw: object) -> str:
             code=ErrorCode.INVALID_INPUT,
         )
     return raw
+
+
+def _parse_cwd_hidden_scan_recursive(raw: object) -> bool:
+    """
+    Parse ``os_env.sandbox.cwd_hidden_scan_recursive``.
+
+    Falls back to the dataclass default (``False`` — top-level-only
+    scan) when the field is absent. Rejects non-boolean values.
+
+    :param raw: Raw value from the YAML, e.g. ``True`` or ``None``.
+    :returns: ``True`` to recurse the full tree, ``False`` to scan
+        only the top level of each root.
+    :raises OmnigentError: If ``raw`` is not a boolean.
+    """
+    if raw is None:
+        return OSEnvSandboxSpec.__dataclass_fields__["cwd_hidden_scan_recursive"].default
+    if not isinstance(raw, bool):
+        raise OmnigentError(
+            "os_env.sandbox.cwd_hidden_scan_recursive must be a boolean, "
+            f"got {type(raw).__name__}: {raw!r}",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    return raw
+
+
+def _parse_mask_paths(raw: object) -> list[str] | None:
+    """
+    Parse and validate the ``mask_paths:`` field of ``os_env.sandbox``.
+
+    Each entry is a path string the backend resolves like
+    ``read_paths`` (``~`` expanded, relative-to-cwd, ``$VAR`` left
+    intact). We only validate shape here; path resolution happens in
+    the backend's ``resolve()``.
+
+    :param raw: Raw value from the YAML — ``None``, or a list of
+        non-empty path strings.
+    :returns: The list of path strings, or ``None`` when absent.
+    :raises OmnigentError: If ``raw`` is not a list, or any entry is
+        not a non-empty string.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, list):
+        raise OmnigentError(
+            f"os_env.sandbox.mask_paths must be a list, got {type(raw).__name__}",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    sanitized: list[str] = []
+    for entry in raw:
+        if not isinstance(entry, str):
+            raise OmnigentError(
+                "os_env.sandbox.mask_paths entries must be strings, "
+                f"got {type(entry).__name__}: {entry!r}",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        if not entry:
+            raise OmnigentError(
+                "os_env.sandbox.mask_paths entries must not be empty strings",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        sanitized.append(entry)
+    return sanitized
 
 
 # POSIX-portable environment variable name: starts with a letter or

--- a/tests/inner/test_bwrap_sandbox.py
+++ b/tests/inner/test_bwrap_sandbox.py
@@ -94,6 +94,8 @@ def _make_policy(
     read_roots: list[Path] | None = None,
     cwd_hidden_scan_max_entries: int | None = None,
     cwd_hidden_scan_overflow: str | None = None,
+    cwd_hidden_scan_recursive: bool | None = None,
+    mask_paths: list[Path] | None = None,
 ) -> SandboxPolicy:
     """
     Build a :class:`SandboxPolicy` directly without going through the
@@ -116,6 +118,11 @@ def _make_policy(
         cwd scan cap; ``None`` keeps the dataclass default (50000).
     :param cwd_hidden_scan_overflow: Override for the overflow mode;
         ``None`` keeps the dataclass default (``"error"``).
+    :param cwd_hidden_scan_recursive: Override for the recursive-walk
+        flag; ``None`` keeps the dataclass default (``False``,
+        top-level only).
+    :param mask_paths: Explicit absolute paths to mask; ``None`` keeps
+        the dataclass default (no explicit masks).
     :returns: A populated :class:`SandboxPolicy`.
     """
     kwargs: dict[str, object] = {
@@ -131,6 +138,10 @@ def _make_policy(
         kwargs["cwd_hidden_scan_max_entries"] = cwd_hidden_scan_max_entries
     if cwd_hidden_scan_overflow is not None:
         kwargs["cwd_hidden_scan_overflow"] = cwd_hidden_scan_overflow
+    if cwd_hidden_scan_recursive is not None:
+        kwargs["cwd_hidden_scan_recursive"] = cwd_hidden_scan_recursive
+    if mask_paths is not None:
+        kwargs["mask_paths"] = mask_paths
     return SandboxPolicy(**kwargs)  # type: ignore[arg-type]
 
 
@@ -1074,6 +1085,86 @@ def test_dotfile_masking_hides_disallowed_dotfiles(tmp_path: Path) -> None:
     # Non-dotfile is untouched.
     assert not _argv_mentions(argv, regular_path, after_token="--tmpfs")
     assert not _argv_mentions(argv, regular_path, after_token="--bind-try")
+
+
+def test_dotfile_masking_non_recursive_default_leaves_nested_dotfiles(
+    tmp_path: Path,
+) -> None:
+    """
+    With the production default (``cwd_hidden_scan_recursive=False``)
+    the bwrap masker hides top-level dotfiles but leaves a nested
+    dotfile visible — no mask triple is emitted for it.
+    """
+    (tmp_path / ".env").write_text("TOP=secret")
+    nested = tmp_path / "services" / "api"
+    nested.mkdir(parents=True)
+    (nested / ".env").write_text("DB=secret")
+
+    backend = _make_backend()
+    policy = _make_policy(tmp_path, allow_hidden=[".venv"])
+    argv = backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, tmp_path)
+
+    cwd = tmp_path.resolve(strict=False)
+    top_env = str(cwd / ".env")
+    nested_env = str(cwd / "services" / "api" / ".env")
+
+    assert _has_pair(argv, "--bind-try", "/dev/null", top_env), (
+        "Top-level .env should still be masked in non-recursive mode."
+    )
+    assert not _argv_mentions(argv, nested_env, after_token="--bind-try"), (
+        "Non-recursive default must NOT descend into subdirectories; "
+        "nested .env should stay visible."
+    )
+
+
+def test_dotfile_masking_recursive_opt_in_masks_nested_dotfiles(
+    tmp_path: Path,
+) -> None:
+    """
+    Opting into ``cwd_hidden_scan_recursive=True`` restores the deep
+    walk: a nested dotfile is masked with ``--bind-try /dev/null``.
+    """
+    nested = tmp_path / "services" / "api"
+    nested.mkdir(parents=True)
+    (nested / ".env").write_text("DB=secret")
+
+    backend = _make_backend()
+    policy = _make_policy(tmp_path, allow_hidden=[".venv"], cwd_hidden_scan_recursive=True)
+    argv = backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, tmp_path)
+
+    nested_env = str(tmp_path.resolve(strict=False) / "services" / "api" / ".env")
+    assert _has_pair(argv, "--bind-try", "/dev/null", nested_env), (
+        "Recursive opt-in should mask the nested .env."
+    )
+
+
+def test_mask_paths_hides_explicit_file_and_dir(tmp_path: Path) -> None:
+    """
+    Explicit ``mask_paths`` entries are masked regardless of name or
+    depth: a plain (non-dot) file becomes ``--bind-try /dev/null`` and
+    a directory becomes ``--tmpfs``.
+    """
+    secret_file = tmp_path / "config" / "production.key"
+    secret_file.parent.mkdir(parents=True)
+    secret_file.write_text("KEY")
+    secret_dir = tmp_path / "private"
+    secret_dir.mkdir()
+    (secret_dir / "data").write_text("x")
+
+    backend = _make_backend()
+    policy = _make_policy(
+        tmp_path,
+        allow_hidden=[".venv"],
+        mask_paths=[secret_file.resolve(strict=False), secret_dir.resolve(strict=False)],
+    )
+    argv = backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, tmp_path)
+
+    assert _has_pair(argv, "--bind-try", "/dev/null", str(secret_file.resolve(strict=False))), (
+        "Explicit mask_paths file must be masked with --bind-try /dev/null."
+    )
+    assert _has_pair_single_dest(argv, "--tmpfs", str(secret_dir.resolve(strict=False))), (
+        "Explicit mask_paths directory must be masked with --tmpfs."
+    )
 
 
 def test_dotfile_masking_skips_target_that_vanished_after_scan(

--- a/tests/inner/test_cwd_scan.py
+++ b/tests/inner/test_cwd_scan.py
@@ -41,6 +41,7 @@ def _scan(
     safe_roots: list[Path] | None = None,
     max_entries: int = _DEFAULT_MAX,
     overflow: str = "error",
+    recursive: bool = True,
     deprioritize_names: list[str] | None = None,
 ) -> list[MaskedEntry]:
     """
@@ -65,6 +66,10 @@ def _scan(
         cap/overflow tests can assert on the raised :class:`OSError`;
         note this differs from the production default (``"warn"``),
         which is pinned in the spec-parser tests instead.
+    :param recursive: Whether the walker descends into subdirectories.
+        Default ``True`` here so the existing recursive-behaviour
+        tests keep passing; note the production default is ``False``
+        (top-level only), pinned in the spec-parser tests.
     :param deprioritize_names: Directory basenames walked last.
         ``None`` (the default) lets the walker apply its own default
         (``("node_modules",)``); pass ``[]`` to disable
@@ -83,6 +88,7 @@ def _scan(
             safe_roots=roots,
             max_entries=max_entries,
             overflow=overflow,
+            recursive=recursive,
         )
     return scan_cwd_mask_entries(
         cwd.resolve(strict=False),
@@ -90,6 +96,7 @@ def _scan(
         safe_roots=roots,
         max_entries=max_entries,
         overflow=overflow,
+        recursive=recursive,
         deprioritize_names=deprioritize_names,
     )
 
@@ -242,6 +249,52 @@ def test_nested_dotfile_is_marked(tmp_path: Path) -> None:
     assert entry.kind == "file"
     # Sibling non-dotfile stays visible.
     assert _entry_for(entries, nested_dir / "main.py") is None
+
+
+def test_non_recursive_masks_top_level_only(tmp_path: Path) -> None:
+    """
+    With ``recursive=False`` the walker masks top-level dotfiles but
+    leaves dotfiles nested below the top level visible. This is the
+    scalable production default: top-level ``.env`` is still hidden,
+    but the walker never descends ``cwd/services/api``.
+    """
+    top_secret = tmp_path / ".env"
+    top_secret.write_text("TOP=secret")
+    nested_dir = tmp_path / "services" / "api"
+    nested_dir.mkdir(parents=True)
+    nested_secret = nested_dir / ".env"
+    nested_secret.write_text("DB_PASSWORD=secret")
+
+    entries = _scan(tmp_path, allow_hidden=[".venv"], recursive=False)
+
+    top_entry = _entry_for(entries, top_secret)
+    assert top_entry is not None
+    assert top_entry.kind == "file"
+    assert _entry_for(entries, nested_secret) is None, (
+        "Non-recursive scan must not descend into subdirectories; nested .env should stay visible."
+    )
+
+
+def test_non_recursive_ignores_nested_escaping_symlink(tmp_path: Path) -> None:
+    """
+    The symlink-escape defense is depth-1 in non-recursive mode: a
+    top-level escaping symlink is masked but one nested under a
+    subdirectory is not (the walker never reaches it).
+    """
+    target = Path("/etc/shadow")
+    if not target.exists():
+        pytest.skip("/etc/shadow not present on this host")
+    top_link = tmp_path / "leak"
+    top_link.symlink_to(target)
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    nested_link = sub / "leak"
+    nested_link.symlink_to(target)
+
+    entries = _scan(tmp_path, allow_hidden=[".venv"], recursive=False)
+
+    assert _entry_for(entries, top_link) is not None
+    assert _entry_for(entries, nested_link) is None
 
 
 def test_walker_prunes_at_masked_dotdir(tmp_path: Path) -> None:

--- a/tests/inner/test_sandbox.py
+++ b/tests/inner/test_sandbox.py
@@ -254,6 +254,31 @@ def test_sandbox_policy_round_trips_deny_unix_socket_paths() -> None:
     assert SandboxPolicy.from_jsonable(_noop_policy().to_jsonable()).deny_unix_socket_paths is None
 
 
+def test_sandbox_policy_round_trips_mask_and_recursive_fields() -> None:
+    """``cwd_hidden_scan_recursive`` + ``mask_paths`` survive the wire.
+
+    Both fields cross the parent/helper boundary as JSON. If either
+    dropped out of ``to_jsonable`` / ``from_jsonable`` the helper would
+    decode the recursive flag as ``False`` and the explicit masks as
+    ``None`` — silently weakening the sandbox view.
+    """
+    from pathlib import Path
+
+    policy = _noop_policy()
+    policy.cwd_hidden_scan_recursive = True
+    policy.mask_paths = [Path("/work/config/production.key")]
+
+    decoded = SandboxPolicy.from_jsonable(policy.to_jsonable())
+
+    assert decoded.cwd_hidden_scan_recursive is True
+    assert decoded.mask_paths == [Path("/work/config/production.key")]
+    # Old payloads (no key) and unset policies must decode to the safe
+    # defaults: non-recursive and no explicit masks.
+    baseline = SandboxPolicy.from_jsonable(_noop_policy().to_jsonable())
+    assert baseline.cwd_hidden_scan_recursive is False
+    assert baseline.mask_paths is None
+
+
 def test_with_denied_unix_sockets_resolves_dedupes_and_is_pure() -> None:
     """``with_denied_unix_sockets`` resolves + de-duplicates the socket
     paths and never mutates the input policy.

--- a/tests/inner/test_seatbelt_sandbox.py
+++ b/tests/inner/test_seatbelt_sandbox.py
@@ -75,6 +75,8 @@ def _make_policy(
     read_roots: list[Path] | None = None,
     egress_relay_port: int | None = None,
     egress_socket_path: str | None = None,
+    cwd_hidden_scan_recursive: bool | None = None,
+    mask_paths: list[Path] | None = None,
 ) -> SandboxPolicy:
     """
     Build a :class:`SandboxPolicy` directly without going through the
@@ -98,20 +100,30 @@ def _make_policy(
         Unix-socket allow rules.
     :param egress_socket_path: Filesystem path of the parent-side
         Unix socket the relay forwards to.
+    :param cwd_hidden_scan_recursive: Override for the recursive-walk
+        flag; ``None`` keeps the dataclass default (``False``,
+        top-level only).
+    :param mask_paths: Explicit absolute paths to mask; ``None`` keeps
+        the dataclass default (no explicit masks).
     :returns: A populated :class:`SandboxPolicy`.
     """
     del cwd
-    return SandboxPolicy(
-        backend_type="darwin_seatbelt",
-        active=True,
-        read_roots=read_roots,
-        write_roots=write_roots if write_roots is not None else [],
-        write_files=[],
-        allow_network=allow_network,
-        cwd_allow_hidden=allow_hidden,
-        egress_relay_port=egress_relay_port,
-        egress_socket_path=egress_socket_path,
-    )
+    kwargs: dict[str, object] = {
+        "backend_type": "darwin_seatbelt",
+        "active": True,
+        "read_roots": read_roots,
+        "write_roots": write_roots if write_roots is not None else [],
+        "write_files": [],
+        "allow_network": allow_network,
+        "cwd_allow_hidden": allow_hidden,
+        "egress_relay_port": egress_relay_port,
+        "egress_socket_path": egress_socket_path,
+    }
+    if cwd_hidden_scan_recursive is not None:
+        kwargs["cwd_hidden_scan_recursive"] = cwd_hidden_scan_recursive
+    if mask_paths is not None:
+        kwargs["mask_paths"] = mask_paths
+    return SandboxPolicy(**kwargs)  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------
@@ -755,6 +767,73 @@ def test_profile_dotfile_mask_uses_deny_rules(tmp_path: Path) -> None:
         "intended profile order is cwd-allow first, deny mask "
         "after, even though SBPL deny-wins doesn't depend on order."
     )
+
+
+def test_profile_dotfile_mask_non_recursive_default(tmp_path: Path) -> None:
+    """
+    With the production default (``cwd_hidden_scan_recursive=False``)
+    the SBPL profile denies top-level dotfiles but does NOT emit a
+    deny for a dotfile nested below the top level.
+    """
+    (tmp_path / ".env").write_text("TOP=1")
+    nested = tmp_path / "services" / "api"
+    nested.mkdir(parents=True)
+    (nested / ".env").write_text("DB=1")
+
+    cwd = tmp_path.resolve(strict=False)
+    policy = _make_policy(tmp_path, allow_hidden=[".venv"])
+    profile = _build_profile(policy, cwd)
+
+    top_deny = f'(deny file-read* file-write* (literal "{cwd / ".env"}"))'
+    nested_deny = f'(deny file-read* file-write* (literal "{cwd / "services" / "api" / ".env"}"))'
+    assert top_deny in profile, "Top-level .env must still be denied in non-recursive mode."
+    assert nested_deny not in profile, (
+        "Non-recursive default must not descend into subdirectories; "
+        "nested .env must stay visible."
+    )
+
+
+def test_profile_dotfile_mask_recursive_opt_in(tmp_path: Path) -> None:
+    """
+    Opting into ``cwd_hidden_scan_recursive=True`` restores the deep
+    walk: a nested dotfile gets its own literal deny.
+    """
+    nested = tmp_path / "services" / "api"
+    nested.mkdir(parents=True)
+    (nested / ".env").write_text("DB=1")
+
+    cwd = tmp_path.resolve(strict=False)
+    policy = _make_policy(tmp_path, allow_hidden=[".venv"], cwd_hidden_scan_recursive=True)
+    profile = _build_profile(policy, cwd)
+
+    nested_deny = f'(deny file-read* file-write* (literal "{cwd / "services" / "api" / ".env"}"))'
+    assert nested_deny in profile, "Recursive opt-in should deny the nested .env."
+
+
+def test_profile_mask_paths_denies_explicit_file_and_dir(tmp_path: Path) -> None:
+    """
+    Explicit ``mask_paths`` entries produce denies regardless of name
+    or depth: a plain file gets a ``(literal ...)`` deny and a
+    directory gets a ``(subpath ...)`` deny.
+    """
+    secret_file = tmp_path / "config" / "production.key"
+    secret_file.parent.mkdir(parents=True)
+    secret_file.write_text("KEY")
+    secret_dir = tmp_path / "private"
+    secret_dir.mkdir()
+
+    cwd = tmp_path.resolve(strict=False)
+    policy = _make_policy(
+        tmp_path,
+        allow_hidden=[".venv"],
+        mask_paths=[secret_file.resolve(strict=False), secret_dir.resolve(strict=False)],
+    )
+    profile = _build_profile(policy, cwd)
+
+    file_deny = f'(deny file-read* file-write* (literal "{secret_file.resolve(strict=False)}"))'
+    dir_deny = f'(deny file-read* file-write* (subpath "{secret_dir.resolve(strict=False)}"))'
+    assert file_deny in profile, "Explicit mask_paths file must get a literal deny."
+    assert dir_deny in profile, "Explicit mask_paths directory must get a subpath deny."
 
 
 # ---------------------------------------------------------------------------

--- a/tests/resources/examples/agent_with_os_env_bwrap.yaml
+++ b/tests/resources/examples/agent_with_os_env_bwrap.yaml
@@ -8,15 +8,19 @@
 #   - Read-only cwd by default. The agent can ``sys_os_read`` files
 #     under cwd but every ``sys_os_write`` / ``sys_os_edit`` /
 #     redirect-via-shell attempt is rejected.
-#   - Dotfiles / dotdirs anywhere under cwd are masked recursively.
-#     ``.env``, ``.git/``, ``.aws/``, ``.ssh/``, ``services/api/.env``,
-#     etc. are all invisible inside the sandbox. The default allowlist
-#     passes through ``.venv`` (matched by basename, so nested venvs
-#     work too); extend it with ``cwd_allow_hidden:`` (see below)
-#     for ``.git``, ``.gitignore``, etc.
-#     The recursive scan is bounded by
+#   - Top-level dotfiles / dotdirs under cwd (and under each
+#     ``read_paths`` root) are masked by default. ``.env``, ``.git/``,
+#     ``.aws/``, ``.ssh/`` at the root are invisible inside the
+#     sandbox. Scanning is NON-recursive by default — a nested
+#     ``services/api/.env`` stays visible unless you opt into
+#     ``cwd_hidden_scan_recursive: true`` (see below), which is the
+#     scalable default for medium/large trees. The default allowlist
+#     passes through ``.venv`` (matched by basename); extend it with
+#     ``cwd_allow_hidden:`` (see below) for ``.git``, ``.gitignore``,
+#     etc. When recursion is enabled the scan is bounded by
 #     ``cwd_hidden_scan_max_entries`` (default 50000); behavior at
-#     the cap is controlled by ``cwd_hidden_scan_overflow``.
+#     the cap is controlled by ``cwd_hidden_scan_overflow``. Hide a
+#     specific file/folder by any path via ``mask_paths:`` (below).
 #   - A pre-generated writable scratch directory mounted as
 #     ``$TMPDIR``. Use this for any artifact the agent needs to
 #     produce while keeping the real cwd untouched.
@@ -129,6 +133,25 @@ os_env:
     # respect ignore rules. Entries must be plain names — no ``/``,
     # no ``..``, no absolute paths (validated at spec parse time).
     # cwd_allow_hidden: [".venv", ".git", ".gitignore"]
+
+    # Optional: recurse into subdirectories when masking dotfiles /
+    # escaping symlinks. Default false — only the top level of cwd
+    # and each read_paths root is scanned, which keeps spawn fast on
+    # medium/large projects while still hiding the top-level secrets
+    # (``.env``, ``.git``, ``.aws``, ``.ssh``, ...). Set to true for
+    # untrusted trees where a deeply-nested dotfile (e.g.
+    # ``services/api/.env``) would be an unacceptable leak; the cap /
+    # overflow knobs below then bound the cost of the full walk.
+    # cwd_hidden_scan_recursive: true
+
+    # Optional: explicitly hide specific files/folders regardless of
+    # name or depth (on top of the dotfile mask). Each entry is a
+    # path resolved like read_paths (``~`` expanded, relative to cwd).
+    # Use this to hide a named secret the dotfile masker won't catch,
+    # or a deeply-nested dotfile without turning on full recursion.
+    # mask_paths:
+    #   - config/production.key
+    #   - ~/.config/private
 
     # Optional: cap on the number of filesystem entries the recursive
     # dotfile walker visits under cwd. The walker prunes at masked

--- a/tests/resources/examples/agent_with_os_env_seatbelt.yaml
+++ b/tests/resources/examples/agent_with_os_env_seatbelt.yaml
@@ -9,14 +9,19 @@
 #   - Read-only cwd by default. The agent can ``sys_os_read`` files
 #     under cwd but every ``sys_os_write`` / ``sys_os_edit`` /
 #     redirect-via-shell attempt is rejected with EPERM.
-#   - Dotfiles / dotdirs anywhere under cwd are masked recursively.
-#     ``.env``, ``.git/``, ``.aws/``, ``.ssh/``, ``services/api/.env``,
-#     etc. are all unreadable inside the sandbox. The default allowlist
-#     passes through ``.venv`` (matched by basename, so nested venvs
-#     work too); extend it with ``cwd_allow_hidden:`` for ``.git``,
-#     ``.gitignore``, etc. The recursive scan is bounded by
+#   - Top-level dotfiles / dotdirs under cwd (and under each
+#     ``read_paths`` root) are masked by default. ``.env``, ``.git/``,
+#     ``.aws/``, ``.ssh/`` at the root are unreadable inside the
+#     sandbox. Scanning is NON-recursive by default — a nested
+#     ``services/api/.env`` stays readable unless you opt into
+#     ``cwd_hidden_scan_recursive: true`` (the scalable default for
+#     medium/large trees). The default allowlist passes through
+#     ``.venv`` (matched by basename); extend it with
+#     ``cwd_allow_hidden:`` for ``.git``, ``.gitignore``, etc. When
+#     recursion is enabled the scan is bounded by
 #     ``cwd_hidden_scan_max_entries`` (default 50000); behavior at the
-#     cap is controlled by ``cwd_hidden_scan_overflow``.
+#     cap is controlled by ``cwd_hidden_scan_overflow``. Hide a
+#     specific file/folder by any path via ``mask_paths:``.
 #   - A pre-generated writable scratch directory mounted as
 #     ``$TMPDIR``. Use this for any artifact the agent needs to produce
 #     while keeping the real cwd untouched.
@@ -136,6 +141,21 @@ os_env:
     # any depth. Entries must be plain names — no ``/``, no ``..``,
     # no absolute paths (validated at spec parse time).
     # cwd_allow_hidden: [".venv", ".git", ".gitignore"]
+
+    # Optional: recurse into subdirectories when masking dotfiles /
+    # escaping symlinks. Default false — only the top level of cwd and
+    # each read_paths root is scanned, keeping the SBPL profile small
+    # and spawn fast on medium/large projects while still hiding the
+    # top-level secrets. Set to true for untrusted trees where a
+    # deeply-nested dotfile would be an unacceptable leak.
+    # cwd_hidden_scan_recursive: true
+
+    # Optional: explicitly hide specific files/folders regardless of
+    # name or depth (on top of the dotfile mask). Each entry is a
+    # path resolved like read_paths (``~`` expanded, relative to cwd).
+    # mask_paths:
+    #   - config/production.key
+    #   - ~/.config/private
 
     # Optional: cap on the number of filesystem entries the recursive
     # dotfile walker visits under cwd. ``node_modules`` is walked LAST

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -1842,6 +1842,86 @@ def test_parse_os_env_sandbox_cwd_hidden_scan_defaults(tmp_path: Path) -> None:
     assert spec.os_env is not None and spec.os_env.sandbox is not None
     assert spec.os_env.sandbox.cwd_hidden_scan_max_entries == 50000
     assert spec.os_env.sandbox.cwd_hidden_scan_overflow == "warn"
+    assert spec.os_env.sandbox.cwd_hidden_scan_recursive is False
+    assert spec.os_env.sandbox.mask_paths is None
+
+
+def test_parse_os_env_sandbox_mask_and_recursive_explicit_values(tmp_path: Path) -> None:
+    """
+    Explicit ``cwd_hidden_scan_recursive`` + ``mask_paths`` values
+    pass through to the spec unchanged.
+    """
+    config = {
+        "spec_version": 1,
+        "name": "tuned-mask",
+        "os_env": {
+            "type": "caller_process",
+            "sandbox": {
+                "type": "linux_bwrap",
+                "cwd_hidden_scan_recursive": True,
+                "mask_paths": ["config/production.key", "~/secrets"],
+            },
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+    assert spec.os_env is not None and spec.os_env.sandbox is not None
+    assert spec.os_env.sandbox.cwd_hidden_scan_recursive is True
+    assert spec.os_env.sandbox.mask_paths == ["config/production.key", "~/secrets"]
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    ["yes", 1, ["true"]],
+    ids=["string", "int", "list"],
+)
+def test_parse_os_env_sandbox_cwd_hidden_scan_recursive_validation(
+    tmp_path: Path, bad_value: object
+) -> None:
+    """Non-boolean ``cwd_hidden_scan_recursive`` fails at parse time."""
+    config = {
+        "spec_version": 1,
+        "name": "bad-recursive",
+        "os_env": {
+            "type": "caller_process",
+            "sandbox": {
+                "type": "linux_bwrap",
+                "cwd_hidden_scan_recursive": bad_value,
+            },
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    with pytest.raises(OmnigentError, match=r"must be a boolean"):
+        parse(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "bad_value,match_regex",
+    [
+        ("not-a-list", r"must be a list"),
+        ([123], r"entries must be strings"),
+        ([""], r"must not be empty strings"),
+    ],
+    ids=["not_list", "non_string_entry", "empty_entry"],
+)
+def test_parse_os_env_sandbox_mask_paths_validation(
+    tmp_path: Path, bad_value: object, match_regex: str
+) -> None:
+    """``mask_paths`` must be a list of non-empty strings."""
+    config = {
+        "spec_version": 1,
+        "name": "bad-mask",
+        "os_env": {
+            "type": "caller_process",
+            "sandbox": {
+                "type": "linux_bwrap",
+                "mask_paths": bad_value,
+            },
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    with pytest.raises(OmnigentError, match=match_regex):
+        parse(tmp_path)
 
 
 def test_parse_os_env_sandbox_cwd_hidden_scan_explicit_values(tmp_path: Path) -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

The sandbox hid every dotfile under the working directory by walking the **whole** tree. On a medium-to-large project — or with `read_paths: ["~/"]` — that walk is slow and routinely trips `cwd_hidden_scan_max_entries`, and it masks far more than the secrets it targets. There was also no way to hide a secret whose name does not start with a dot (e.g. `config/production.key`).

This change makes the recursive scan opt-in and adds explicit path masking:

- **`cwd_hidden_scan_recursive` (default `false`)** — scan only the top level of the cwd and each `read_paths` root (including `$HOME` when it is a granted read path). The top-level dotfiles that hold the overwhelming majority of secrets (`.git`, `.env`, `.aws`, `.ssh`, …) are still masked, but the walker no longer descends the whole tree. Set it `true` for untrusted source trees where a deeply nested credential file would be an unacceptable leak; the existing cap / overflow knobs then bound the cost of the full walk.
- **`mask_paths`** — hide a named file or folder regardless of a leading dot, resolved exactly like `read_paths` (`~` expanded, relative paths taken against cwd, `$VAR` **not** expanded). Files are masked as an empty file, folders as an empty view, applied on top of the dotfile mask in every mode.

Both backends enforce the new fields: `linux_bwrap` binds `/dev/null` over masked files and mounts an empty `tmpfs` over masked folders; `darwin_seatbelt` emits `(deny … (literal …))` / `(deny … (subpath …))` rules.

**Behavior change worth calling out:** with the new non-recursive default, a dotfile nested below the first level (e.g. `services/api/.env`) is now readable by the sandboxed helper unless `cwd_hidden_scan_recursive: true` is set. This changes the masking scope for *existing* untrusted-tree sandboxes on upgrade, not just new configs — old configs parse unchanged, only the default scope narrows. Untrusted-tree users should set `cwd_hidden_scan_recursive: true` (or list the sensitive paths in `mask_paths`). Impact on callers that do not use `os_env` sandboxing: none.

**ELI5:** we used to search every drawer in the house for secrets before letting the helper in — slow, and it hid things we did not mean to. Now we lock the obvious top drawers by default, let you name specific drawers to lock, and keep the "search everything" mode as a switch you can flip.

```
cwd/
├── .env              masked  (top-level dotfile)
├── regular.txt       visible
├── config/production.key   masked  (mask_paths, file → empty file)
├── private/          masked  (mask_paths, dir → empty view)
└── services/api/.env visible by default; masked only when recursive=true
```

## Test Plan

Unit tests (macOS):

```
uv run pytest tests/inner/test_cwd_scan.py tests/inner/test_seatbelt_sandbox.py \
  tests/inner/test_sandbox.py tests/spec/test_parser.py -q
# 334 passed, 4 skipped in 5.81s
```

New coverage:
- `test_cwd_scan.py`: `test_non_recursive_masks_top_level_only`, `test_non_recursive_ignores_nested_escaping_symlink`.
- `test_bwrap_sandbox.py`: non-recursive default leaves nested dotfiles, recursive opt-in masks them, `mask_paths` hides an explicit file and dir.
- `test_seatbelt_sandbox.py`: same three cases as SBPL `deny` rules.
- `test_sandbox.py`: `SandboxPolicy` round-trips the two new fields through `to_jsonable`/`from_jsonable`.
- `test_parser.py`: parse/validate `cwd_hidden_scan_recursive` and `mask_paths`.

`linux_bwrap` end-to-end on an Arca (headless Linux) host via `omnigent run agent.yaml --harness pi` (see Demo).

## Demo

Not a visual/UI change, so no screenshot. Terminal transcript of the `linux_bwrap` end-to-end run on a headless Linux (Arca) host — same agent config as the Test Plan (`cwd_hidden_scan_recursive: false`, `mask_paths: [config/production.key, private]`), asking the agent to `cat` each probe file:

```text
regular.txt              -> OK_REGULAR                              (normal file, readable)
.env                     -> cat: .env: Permission denied            (top-level dotfile masked)
config/production.key    -> cat: ...: Permission denied             (mask_paths file)
private/data.txt         -> cat: ...: No such file or directory     (mask_paths dir -> empty tmpfs)
sub/.env                 -> SECRET_NESTED                            (nested dotfile readable: non-recursive default)
```

Flipping `cwd_hidden_scan_recursive: true` additionally masks `sub/.env`, as expected.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the `linux_bwrap` end-to-end run on Arca shown in the Demo (the bwrap tests are Linux-only and do not execute on the macOS dev box); `darwin_seatbelt` is covered by the unit tests plus a local deterministic probe. The one deliberate default change — nested dotfiles now visible unless recursion is enabled — is asserted directly by `test_non_recursive_masks_top_level_only` and the Arca `sub/.env` row.

## Changelog

Sandbox dotfile hiding is now top-level only by default (opt into the full-tree walk with `cwd_hidden_scan_recursive: true`), and `mask_paths` hides named files or folders. Untrusted-tree sandboxes that relied on recursive masking should set `cwd_hidden_scan_recursive: true` on upgrade.