### PR TITLE
docs: fix sessions route reference

### DIFF
--- a/.claude/skills/polly-e2e-dev/SKILL.md
+++ b/.claude/skills/polly-e2e-dev/SKILL.md
@@ -198,7 +198,7 @@ side effects.
 - **Orchestration skills:** `examples/polly/skills/{investigate,fanout,cross-review}/SKILL.md`
 - **Guardrail policies:** `omnigent/inner/nessie/policies.py`
 - **Runner-side gate:** `omnigent/runner/policy.py`; server-side tool-call
-  enforcement: `omnigent/server/routes/sessions.py`
+  enforcement: `omnigent/server/routes/sessions/`
 - **Mock LLM server:** `tests/server/integration/mock_llm_server.py`
 
 ```bash


### PR DESCRIPTION
## Related issue

N/A — documentation-only correction.

## Summary

- Replace the stale `omnigent/server/routes/sessions.py` reference with the current `omnigent/server/routes/sessions/` package.
- Keep the Polly E2E skill aligned with the repository layout.

UnRot v0.5.4 identified this stale reference during an open-source agent-config scan. I verified the replacement directory and its route modules in the current tree.

## Test Plan

- Confirmed `omnigent/server/routes/sessions/` exists and is tracked.
- Ran `unrot check . --rules broken-refs`; the stale `.py` reference is no longer reported.

## Demo

N/A — non-visual documentation change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified the current package path directly and rescanned the instruction file. Automated behavior tests are unnecessary because this changes one documentation path only.
