### PR TITLE
fix(repl): guard the startup theme picker's termios path on Windows

### DIFF
--- a/omnigent/repl/_theme_picker.py
+++ b/omnigent/repl/_theme_picker.py
@@ -189,7 +189,11 @@ def _detect_terminal_background() -> Literal["dark", "light"] | None:
 
     :returns: ``"dark"``, ``"light"``, or ``None`` on failure.
     """
-    if not sys.stdin.isatty() or not sys.stdout.isatty():
+    # ``termios`` is POSIX-only, and the OSC 11 exchange below needs raw-mode
+    # terminal control it provides, so Windows cannot detect the background
+    # this way. Fall back to "unknown" (``None``) instead of importing termios,
+    # which does not exist on Windows and would raise ``ModuleNotFoundError``.
+    if sys.platform == "win32" or not sys.stdin.isatty() or not sys.stdout.isatty():
         return None
 
     import select
@@ -306,7 +310,11 @@ def startup_theme_picker(
     detected = _detect_terminal_background()
     selected = 0 if detected == "dark" else 1  # dark=0, light=1
 
-    if not sys.stdin.isatty():
+    # The interactive picker below drives the terminal through POSIX-only
+    # ``termios``/``tty``, so on Windows (and any non-tty) skip it and persist
+    # the detected-or-default theme rather than importing termios, which is
+    # absent on Windows and would raise ``ModuleNotFoundError`` at startup.
+    if sys.platform == "win32" or not sys.stdin.isatty():
         # Non-interactive — use detected or default to light.
         theme = DARK_THEME if detected == "dark" else LIGHT_THEME
         update_user_config(theme=theme.name)

--- a/tests/repl/test_theme_picker.py
+++ b/tests/repl/test_theme_picker.py
@@ -226,3 +226,72 @@ def test_startup_picker_non_tty_respects_dark_detection(
     assert result is DARK_THEME
     config = (tmp_path / ".omnigent" / "config.yaml").read_text(encoding="utf-8")
     assert "theme: dark" in config
+
+
+# ── Windows: no crash on the POSIX-only termios path ──────────────────────────
+
+
+def _block_termios(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``import termios`` raise, as it does on Windows.
+
+    Reproduces the ``ModuleNotFoundError: No module named 'termios'`` that
+    crashed ``omni`` at startup on native Windows (issues #2993, #3251, #3359,
+    and duplicates): if either code path below still reaches ``import termios``
+    on a Windows tty, the import raises here instead of being silently masked by
+    the Linux CI runner that does have termios.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "termios":
+            raise ModuleNotFoundError("No module named 'termios'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+
+def test_detect_terminal_background_returns_none_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Background detection degrades to ``None`` on Windows, not a termios crash.
+
+    A real Windows terminal is a tty, so the ``isatty`` guard alone did not
+    cover it; the Windows guard must return before importing termios.
+    """
+    from omnigent.repl._theme_picker import _detect_terminal_background
+
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    _block_termios(monkeypatch)
+
+    assert _detect_terminal_background() is None
+
+
+def test_startup_picker_does_not_crash_on_windows(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The startup picker persists a default theme on Windows instead of crashing.
+
+    Regression for the ``omni setup``/startup ``ModuleNotFoundError: No module
+    named 'termios'`` on native Windows: the interactive picker is POSIX-only,
+    so a Windows tty must take the non-interactive fallback.
+    """
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr(
+        "omnigent.repl._theme_picker._detect_terminal_background",
+        lambda: None,
+    )
+    _block_termios(monkeypatch)
+
+    import io
+
+    result = startup_theme_picker(out=io.StringIO())
+    assert result is LIGHT_THEME
+    config = (tmp_path / ".omnigent" / "config.yaml").read_text(encoding="utf-8")
+    assert "theme: light" in config


### PR DESCRIPTION
## Summary

The startup theme picker imports the POSIX-only `termios` module, guarded only by an `isatty` check. A real Windows terminal is a tty, so on native Windows the picker reaches `import termios` and crashes the whole CLI at startup with `ModuleNotFoundError: No module named 'termios'`.

This guards both termios paths in `_theme_picker.py` on `sys.platform == "win32"` (the form the `ws_bridge` and `claude_native` termios imports already use): `_detect_terminal_background` falls back to "unknown", and `startup_theme_picker` takes the non-interactive branch and persists the detected-or-default theme.

This is a different code path from the onboarding interactive-select menus that #2684 and #3081 address. Those got their Windows guard; the theme picker was missed, which is why the startup crash still recurs. (An earlier version of this fix, #3509, was auto-closed as a duplicate because it also referenced #2269, which #2684 claims - this one references only the theme-picker crash reports.)

## Test Plan

`uv run pytest tests/repl/test_theme_picker.py`. Reproduced on Windows: the win32 guard returns cleanly where the isatty-only path raises. Added a regression test that blocks the termios import (as Windows does) with a tty, so either path re-reaching termios fails on the Linux runner too.

## Related issue

Closes #2919, #3251, #3359, #3052, #3023 (the startup `ModuleNotFoundError: termios` on Windows, theme-picker path).

## Type of change

Bug fix.

## Demo

N/A, backend crash fix with no UI change.
