### PR TITLE
fix(fork): prefetch agent harness so custom agents appear in fork picker

### DIFF
--- a/web/src/shell/ForkSessionDialog.test.tsx
+++ b/web/src/shell/ForkSessionDialog.test.tsx
@@ -6,7 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ForkSessionDialog } from "./ForkSessionDialog";
 import { forkSession, launchRunner } from "@/lib/sessionsApi";
-import { useAvailableAgents } from "@/hooks/useAvailableAgents";
+import { useAvailableAgents, prefetchAvailableAgentDetails } from "@/hooks/useAvailableAgents";
 import { useSessionAgent } from "@/hooks/useAgents";
 import { useHosts, type Host } from "@/hooks/useHosts";
 import { useDirectorySessions } from "@/hooks/useDirectorySessions";
@@ -48,6 +48,7 @@ const useHostsMock = vi.mocked(useHosts);
 const useDirectorySessionsMock = vi.mocked(useDirectorySessions);
 const useRunnerHealthMock = vi.mocked(useRunnerHealthRegistration);
 const useHostFilesystemMock = vi.mocked(useHostFilesystem);
+const prefetchAvailableAgentDetailsMock = vi.mocked(prefetchAvailableAgentDetails);
 
 function host(overrides: Partial<Host> = {}): Host {
   return {
@@ -154,6 +155,7 @@ beforeEach(() => {
   forkSessionMock.mockReset();
   launchRunnerMock.mockReset();
   navigateMock.mockReset();
+  prefetchAvailableAgentDetailsMock.mockReset();
   setAgents(AVAILABLE_AGENTS, "claude-sdk");
   // Defaults for the coding-fork wiring; the non-coding tests don't render
   // these fields but the hooks still run (with isCodingSource false).
@@ -429,6 +431,30 @@ describe("ForkSessionDialog", () => {
 
     expect(screen.getByTestId("fork-session-agent-option-ag_opencode")).toBeInTheDocument();
     expect(screen.getByTestId("fork-session-agent-option-ag_hermes")).toBeInTheDocument();
+  });
+
+  it("prefetches harness details for all agents on mount so custom agents appear", async () => {
+    // Custom agents discovered from session scans start with harness=null and
+    // a sessionId. Without eager prefetch, forkTargetCarriesHistory(null)
+    // returns false and they never appear in the fork picker.
+    const customAgent = {
+      id: "ag_custom",
+      name: "my-agent",
+      display_name: "My Agent",
+      description: null,
+      harness: null,
+      sessionId: "conv_custom",
+    };
+    setAgents([...AVAILABLE_AGENTS, customAgent], "claude-sdk");
+
+    renderDialog();
+
+    await waitFor(() =>
+      expect(prefetchAvailableAgentDetailsMock).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "ag_custom" }),
+        expect.anything(),
+      ),
+    );
   });
 
   it("passes the chosen agent_id when switching agent", async () => {

--- a/web/src/shell/ForkSessionDialog.tsx
+++ b/web/src/shell/ForkSessionDialog.tsx
@@ -29,7 +29,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { forkSession, launchRunner } from "@/lib/sessionsApi";
-import { useAvailableAgents } from "@/hooks/useAvailableAgents";
+import { useAvailableAgents, prefetchAvailableAgentDetails } from "@/hooks/useAvailableAgents";
 import { partitionAgentsByKind } from "@/lib/agentGrouping";
 import { useSessionAgent } from "@/hooks/useAgents";
 import { useHosts, type Host } from "@/hooks/useHosts";
@@ -237,6 +237,17 @@ export function ForkSessionForm({
     sourceAgentBaseName ??
     sourceAgentName ??
     "the original agent";
+
+  // Eagerly prefetch harness/description for session-discovered agents (those
+  // with harness=null and a sessionId). Without this, forkTargetCarriesHistory
+  // returns false for all of them and custom agents never appear in the picker.
+  // prefetchAvailableAgentDetails is a no-op for agents whose harness is already
+  // known, so re-running on every agents change is safe.
+  useEffect(() => {
+    for (const agent of agents ?? []) {
+      void prefetchAvailableAgentDetails(agent, queryClient);
+    }
+  }, [agents, queryClient]);
 
   // Switch targets, excluding:
   //   1. the source's OWN agent — "Same as source" already represents


### PR DESCRIPTION
## Summary

- Custom agents discovered from session scans start with `harness: null` (details filled lazily on hover via `prefetchAvailableAgentDetails`).
- The fork picker filters candidates with `forkTargetCarriesHistory(a.harness)`, which returns `false` for `null`, silently excluding all un-hovered custom agents.
- The new-session picker doesn't do harness filtering, so custom agents appear there fine — hence the asymmetry Brian reported.

**Fix:** call `prefetchAvailableAgentDetails` for all agents when `ForkSessionForm` mounts. This is the same pattern `NewChatDialog` uses on dropdown open. The helper is a no-op for agents whose harness is already known.

Reported in: https://databricks.slack.com/archives/C0B43DFFNJZ/p1785296701806399

## Test Plan

- New unit test in `ForkSessionDialog.test.tsx` verifies that `prefetchAvailableAgentDetails` is called for a session-discovered agent (`harness: null`, `sessionId` set) on mount.
- All 27 existing `ForkSessionDialog` tests still pass.
- Manual: open fork dialog on a session in an account that has a custom agent registered via `omnigent run` — the agent should now appear in the fork picker's custom agents section.

## Demo

N/A — picker content change, no visual diff.

## Type of change

- [x] Bug fix

## Test coverage

- [x] Unit tests added/updated