### PR TITLE
fix(harnesses): resolve native CLI launch via the readiness ladder, not bare shutil.which

### DIFF
--- a/omnigent/_platform.py
+++ b/omnigent/_platform.py
@@ -20,6 +20,7 @@ import logging
 import os
 import shutil
 import sys
+from collections.abc import Callable
 from contextlib import suppress
 from pathlib import Path
 
@@ -68,7 +69,12 @@ def _parse_node_version(name: str) -> tuple[int, ...]:
         return ()
 
 
-def resolve_cli_binary(name: str, *, env_var: str | None = None) -> str | None:
+def resolve_cli_binary(
+    name: str,
+    *,
+    env_var: str | None = None,
+    which: Callable[[str], str | None] | None = None,
+) -> str | None:
     """Resolve a CLI binary that may live off the process ``PATH``.
 
     Checks an optional ``env_var`` override first (an explicit path or a name
@@ -81,12 +87,16 @@ def resolve_cli_binary(name: str, *, env_var: str | None = None) -> str | None:
     :param name: The binary name, e.g. ``"codex"`` or ``"claude"``.
     :param env_var: Optional env var holding an override path/name, e.g.
         ``"OMNIGENT_CODEX_PATH"``.
+    :param which: PATH-lookup hook, defaulting to :func:`shutil.which`. The
+        native harness resolvers thread their own test seam through here; the
+        fallback ladder always uses the real filesystem.
     :returns: An absolute path to the executable, or ``None``.
     """
+    which = shutil.which if which is None else which
     if env_var:
         override = os.environ.get(env_var, "").strip()
         if override:
-            resolved = shutil.which(override)
+            resolved = which(override)
             if resolved:
                 return resolved
             if os.access(override, os.X_OK) and os.path.isfile(override):
@@ -100,7 +110,7 @@ def resolve_cli_binary(name: str, *, env_var: str | None = None) -> str | None:
                 override,
                 name,
             )
-    on_path = shutil.which(name)
+    on_path = which(name)
     if on_path is not None:
         return on_path
     for directory in _cli_fallback_dirs():

--- a/omnigent/cursor_native.py
+++ b/omnigent/cursor_native.py
@@ -30,6 +30,7 @@ import httpx
 import yaml
 
 from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
+from omnigent._platform import resolve_cli_binary
 from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
 from omnigent._wrapper_labels import CURSOR_NATIVE_WRAPPER_VALUE as _WRAPPER_LABEL_VALUE
 from omnigent._wrapper_labels import WRAPPER_LABEL_KEY as _WRAPPER_LABEL_KEY
@@ -164,7 +165,7 @@ def resolve_cursor_executable(
     env = os.environ if env is None else env
     which = shutil.which if which is None else which
     command = _configured_cursor_command(env)
-    resolved = which(command)
+    resolved = resolve_cli_binary(command, which=which)
     if resolved is None:
         raise click.ClickException(
             "Native Cursor requires the 'cursor-agent' CLI on PATH. Install it with: "

--- a/omnigent/goose_native.py
+++ b/omnigent/goose_native.py
@@ -32,6 +32,7 @@ import httpx
 import yaml
 
 from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
+from omnigent._platform import resolve_cli_binary
 from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
 from omnigent._wrapper_labels import GOOSE_NATIVE_WRAPPER_VALUE as _WRAPPER_LABEL_VALUE
 from omnigent._wrapper_labels import WRAPPER_LABEL_KEY as _WRAPPER_LABEL_KEY
@@ -129,7 +130,7 @@ def resolve_goose_executable(
     env = os.environ if env is None else env
     which = shutil.which if which is None else which
     command = _configured_goose_command(env)
-    resolved = which(command)
+    resolved = resolve_cli_binary(command, which=which)
     if resolved is None:
         install_url = "https://github.com/block/goose/releases/download/stable/download_cli.sh"
         raise click.ClickException(

--- a/omnigent/hermes_native.py
+++ b/omnigent/hermes_native.py
@@ -31,6 +31,7 @@ import httpx
 import yaml
 
 from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
+from omnigent._platform import resolve_cli_binary
 from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
 from omnigent._wrapper_labels import HERMES_NATIVE_WRAPPER_VALUE as _WRAPPER_LABEL_VALUE
 from omnigent._wrapper_labels import WRAPPER_LABEL_KEY as _WRAPPER_LABEL_KEY
@@ -128,7 +129,7 @@ def resolve_hermes_executable(
     env = os.environ if env is None else env
     which = shutil.which if which is None else which
     command = _configured_hermes_command(env)
-    resolved = which(command)
+    resolved = resolve_cli_binary(command, which=which)
     if resolved is None:
         install_url = "https://hermes-agent.nousresearch.com/install.sh"
         raise click.ClickException(

--- a/omnigent/kimi_native.py
+++ b/omnigent/kimi_native.py
@@ -29,6 +29,7 @@ import httpx
 import yaml
 
 from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
+from omnigent._platform import resolve_cli_binary
 from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
 from omnigent._wrapper_labels import KIMI_NATIVE_WRAPPER_VALUE as _WRAPPER_LABEL_VALUE
 from omnigent._wrapper_labels import WRAPPER_LABEL_KEY as _WRAPPER_LABEL_KEY
@@ -135,7 +136,7 @@ def resolve_kimi_executable(
     env = os.environ if env is None else env
     which = shutil.which if which is None else which
     command = _configured_kimi_command(env)
-    resolved = which(command)
+    resolved = resolve_cli_binary(command, which=which)
     if resolved is None:
         raise click.ClickException(
             "Native Kimi requires the 'kimi' CLI on PATH. Install it with: "

--- a/omnigent/kiro_native.py
+++ b/omnigent/kiro_native.py
@@ -18,6 +18,7 @@ import httpx
 import yaml
 
 from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
+from omnigent._platform import resolve_cli_binary
 from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
 from omnigent._wrapper_labels import KIRO_NATIVE_WRAPPER_VALUE as _WRAPPER_LABEL_VALUE
 from omnigent._wrapper_labels import WRAPPER_LABEL_KEY as _WRAPPER_LABEL_KEY
@@ -115,7 +116,7 @@ def resolve_kiro_executable(
     env = os.environ if env is None else env
     which = shutil.which if which is None else which
     command = _configured_kiro_command(env)
-    resolved = which(command)
+    resolved = resolve_cli_binary(command, which=which)
     if resolved is None:
         raise click.ClickException(
             "Native Kiro requires the 'kiro-cli' CLI on PATH. Install and login to "

--- a/omnigent/pi_native.py
+++ b/omnigent/pi_native.py
@@ -18,6 +18,7 @@ import httpx
 import yaml
 
 from omnigent._native_resume_hint import echo_native_resume_hint
+from omnigent._platform import resolve_cli_binary
 from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
 from omnigent._wrapper_labels import PI_NATIVE_WRAPPER_VALUE as _WRAPPER_LABEL_VALUE
 from omnigent._wrapper_labels import WRAPPER_LABEL_KEY as _WRAPPER_LABEL_KEY
@@ -124,7 +125,7 @@ def resolve_pi_executable(
     env = os.environ if env is None else env
     which = shutil.which if which is None else which
     command = _configured_pi_command(env)
-    resolved = which(command)
+    resolved = resolve_cli_binary(command, which=which)
     if resolved is None:
         raise click.ClickException(
             "Native Pi requires the 'pi' CLI on PATH. Install Pi, add it to PATH, "

--- a/omnigent/qwen_native.py
+++ b/omnigent/qwen_native.py
@@ -32,6 +32,7 @@ import httpx
 import yaml
 
 from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
+from omnigent._platform import resolve_cli_binary
 from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
 from omnigent._wrapper_labels import QWEN_NATIVE_WRAPPER_VALUE as _WRAPPER_LABEL_VALUE
 from omnigent._wrapper_labels import WRAPPER_LABEL_KEY as _WRAPPER_LABEL_KEY
@@ -129,7 +130,7 @@ def resolve_qwen_executable(
     env = os.environ if env is None else env
     which = shutil.which if which is None else which
     command = _configured_qwen_command(env)
-    resolved = which(command)
+    resolved = resolve_cli_binary(command, which=which)
     if resolved is None:
         raise click.ClickException(
             "Native qwen requires the 'qwen' CLI on PATH. Install it with: "

--- a/tests/test_goose_native.py
+++ b/tests/test_goose_native.py
@@ -24,9 +24,35 @@ def test_resolve_goose_executable_honors_path_override() -> None:
 
 
 def test_resolve_goose_executable_missing_raises_with_hint() -> None:
+    from omnigent import _platform
+
     with pytest.raises(click.ClickException) as exc:
-        gn.resolve_goose_executable(env={}, which=lambda _cmd: None)
+        # No PATH hit and an empty fallback ladder, so the CLI is truly absent.
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(_platform, "_cli_fallback_dirs", tuple)
+            gn.resolve_goose_executable(env={}, which=lambda _cmd: None)
     assert "block-goose-cli" in str(exc.value)
+
+
+def test_resolve_goose_executable_uses_fallback_ladder(monkeypatch, tmp_path) -> None:
+    """Regression for #3341: a CLI installed in a global install dir that is not
+    on ``PATH`` (e.g. an npm-global bin dir the daemon's frozen ``PATH`` omits)
+    is now found at launch via the same ``resolve_cli_binary`` ladder readiness
+    and the SDK executors use, so a green readiness badge implies a launchable
+    binary. Before, the bare ``shutil.which`` lookup raised despite the CLI
+    being installed. Representative of all seven native ``resolve_*_executable``
+    functions, which share this pattern."""
+    from omnigent import _platform
+
+    fallback = tmp_path / "bin"
+    fallback.mkdir()
+    goose = fallback / "goose"
+    goose.write_text("#!/bin/sh\n")
+    goose.chmod(0o755)
+    monkeypatch.setattr(_platform, "_cli_fallback_dirs", lambda: (fallback,))
+    # Not on PATH (which returns None), but present in the ladder dir.
+    resolved = gn.resolve_goose_executable(env={}, which=lambda _cmd: None)
+    assert resolved == str(goose)
 
 
 def test_build_goose_launch_argv() -> None:


### PR DESCRIPTION
## Summary

The seven native launch resolvers (pi, hermes, kimi, cursor, goose, kiro, qwen) used a bare `shutil.which`, so a CLI installed only in an nvm/npm/homebrew bin dir off the daemon's frozen PATH passes the readiness badge but fails at launch.  <br>This routes them through the same `resolve_cli_binary` ladder that readiness and the SDK executors already use, so a green badge means a launchable binary.

## Test Plan

* Red-green test in `tests/test_goose_native.py` (representative of all seven): a `goose` in a ladder dir not on PATH now resolves instead of raising, and fails on the pre-fix resolver.
* `pytest tests/inner/test_proc_and_platform.py tests/test_goose_native.py`, 32 passed.

## Demo

N/A, backend resolver change with no visual surface.

## Type of change

- [X] Bug fix

Closes omnigent-ai/omnigent#3341