### PR TITLE
fix(web): clear no-shadow lint warnings

### DIFF
--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -941,11 +941,11 @@ function hardenOauthPopup(child) {
  * (re-pointing an existing window) so the mount-aware join is in one place.
  *
  * @param {string} serverUrl A normalized server URL (origin or origin+mount).
- * @param {string} path An absolute in-app path beginning with ``/``.
+ * @param {string} routePath An absolute in-app path beginning with ``/``.
  * @returns {string}
  */
-function resolveServerPath(serverUrl, path) {
-  return serverUrl.replace(/\/+$/, "") + (path.startsWith("/") ? path : "/" + path);
+function resolveServerPath(serverUrl, routePath) {
+  return serverUrl.replace(/\/+$/, "") + (routePath.startsWith("/") ? routePath : "/" + routePath);
 }
 
 /**
@@ -957,13 +957,13 @@ function resolveServerPath(serverUrl, path) {
  *
  * @param {BrowserWindow} win
  * @param {string} serverUrl Clean server URL (origin or origin+mount).
- * @param {string} [path] Optional basename-less in-app path (e.g. ``/c/<id>``).
+ * @param {string} [routePath] Optional basename-less in-app path (e.g. ``/c/<id>``).
  * @returns {Promise<void>}
  */
-function loadServerUrl(win, serverUrl, path) {
+function loadServerUrl(win, serverUrl, routePath) {
   pinWindow(win, originOf(serverUrl));
   setWindowServerUrl(win, serverUrl);
-  return win.loadURL(path ? resolveServerPath(serverUrl, path) : serverUrl);
+  return win.loadURL(routePath ? resolveServerPath(serverUrl, routePath) : serverUrl);
 }
 
 /**
@@ -2563,13 +2563,13 @@ function focusAndRestore(win) {
  * defense-in-depth on top of that.
  *
  * @param {BrowserWindow | null | undefined} win
- * @param {string} path
+ * @param {string} routePath
  */
-function sendOpenPath(win, path) {
+function sendOpenPath(win, routePath) {
   if (!win || win.isDestroyed()) return;
-  console.log(`[omnigent] deep-link: send open-path ${path}`);
+  console.log(`[omnigent] deep-link: send open-path ${routePath}`);
   try {
-    win.webContents.send("omnigent:open-path", path);
+    win.webContents.send("omnigent:open-path", routePath);
   } catch {
     // Window torn down between the check and the send; ignore.
   }

--- a/web/electron/src/omnigent_cli.js
+++ b/web/electron/src/omnigent_cli.js
@@ -241,10 +241,10 @@ function localServerStatus() {
 async function localServerHealthy(timeoutMs = 1500) {
   const rec = readLocalServerPidfile();
   if (!rec || !isPidAlive(rec.pid)) return null;
-  const url = `http://127.0.0.1:${rec.port}`;
+  const localUrl = `http://127.0.0.1:${rec.port}`;
   try {
-    const resp = await fetch(`${url}/health`, { signal: AbortSignal.timeout(timeoutMs) });
-    if (resp.ok) return { url, pid: rec.pid, port: rec.port };
+    const resp = await fetch(`${localUrl}/health`, { signal: AbortSignal.timeout(timeoutMs) });
+    if (resp.ok) return { url: localUrl, pid: rec.pid, port: rec.port };
   } catch {
     // Refused / unreachable / timed out → not a healthy server we can reuse.
   }

--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -1600,8 +1600,8 @@ export function AgentInfoButton({ agent, sessionId }: AgentInfoProps) {
           sessionId={sessionId}
           mcpDirty={mcpDirty}
           onMcpDirtyChange={setMcpDirty}
-          onSubdialogOpenChange={(open) => {
-            subdialogOpenRef.current = open;
+          onSubdialogOpenChange={(isOpen) => {
+            subdialogOpenRef.current = isOpen;
           }}
         />
       </PopoverContent>

--- a/web/src/embed.tsx
+++ b/web/src/embed.tsx
@@ -163,9 +163,9 @@ function OmnigentProviders({
   // one-time side effects (wire the chat store to that client + resolve
   // identity). `initChatStore` only stashes the client for later cache
   // invalidation, so doing this in a mount-once initializer is fine.
-  const queryClient = useQueryClient();
+  const hostQueryClient = useQueryClient();
   useState(() => {
-    initChatStore(queryClient);
+    initChatStore(hostQueryClient);
     void resolveIdentity();
     return null;
   });

--- a/web/src/hooks/SessionUpdatesProvider.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.tsx
@@ -183,10 +183,10 @@ export function SessionUpdatesProvider({ children }: { children: ReactNode }) {
     const childEntries = queryClient.getQueriesData<ChildSessionInfo[]>({
       queryKey: ["conversation"],
     });
-    for (const [key, children] of childEntries) {
+    for (const [key, childSessions] of childEntries) {
       // Only ["conversation", <id>, "child_sessions"] entries carry child lists.
-      if (Array.isArray(key) && key[2] === "child_sessions" && Array.isArray(children)) {
-        for (const child of children) {
+      if (Array.isArray(key) && key[2] === "child_sessions" && Array.isArray(childSessions)) {
+        for (const child of childSessions) {
           if (!ids.includes(child.id)) ids.push(child.id);
         }
       }

--- a/web/src/lib/askUserQuestion.ts
+++ b/web/src/lib/askUserQuestion.ts
@@ -135,13 +135,13 @@ export function parseAskUserQuestionPreview(preview: string): AskUserQuestionPay
       const label = optRec.label;
       if (typeof label !== "string" || !label) continue;
       const description = optRec.description;
-      const preview = optRec.preview;
+      const optionPreview = optRec.preview;
       const option: ClaudeQuestionOption = {
         label,
         description: typeof description === "string" ? description : "",
       };
-      if (typeof preview === "string" && preview) {
-        option.preview = preview;
+      if (typeof optionPreview === "string" && optionPreview) {
+        option.preview = optionPreview;
       }
       options.push(option);
     }

--- a/web/src/lib/idleTransitions.test.ts
+++ b/web/src/lib/idleTransitions.test.ts
@@ -131,8 +131,8 @@ describe("detectNewElicitations", () => {
 
   it("treats missing count as 0", () => {
     const prev = new Map([["a", 0]]);
-    const conv = { ...convE("a", 0), pending_elicitations_count: undefined };
-    expect(detectNewElicitations(prev, [conv])).toEqual([]);
+    const conversation = { ...convE("a", 0), pending_elicitations_count: undefined };
+    expect(detectNewElicitations(prev, [conversation])).toEqual([]);
   });
 });
 

--- a/web/src/lib/permissionsApi.ts
+++ b/web/src/lib/permissionsApi.ts
@@ -146,8 +146,8 @@ export async function grantPermission(
     },
   );
   if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    throw new Error(body?.error?.message ?? `${res.status} ${res.statusText}`);
+    const responseBody = await res.json().catch(() => ({}));
+    throw new Error(responseBody?.error?.message ?? `${res.status} ${res.statusText}`);
   }
   return (await res.json()) as Permission;
 }

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -1709,9 +1709,9 @@ describe("Composer config gear", () => {
         })}
       />,
     );
-    const textarea = document.querySelector("textarea") as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "/model" } });
-    fireEvent.keyDown(textarea, { key: "Enter", code: "Enter" });
+    const modelTextarea = document.querySelector("textarea") as HTMLTextAreaElement;
+    fireEvent.change(modelTextarea, { target: { value: "/model" } });
+    fireEvent.keyDown(modelTextarea, { key: "Enter", code: "Enter" });
     // Give the nonce effect a tick; the modal must stay closed.
     await waitFor(() => expect(gear()).toHaveAttribute("aria-disabled", "true"));
     expect(screen.queryByTestId("composer-config-modal")).toBeNull();

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -521,7 +521,7 @@ const elicitItem = (id: string, status: "pending" | "responded"): RenderItem => 
   response: status === "responded" ? { action: "accept" } : null,
 });
 const pendingIds = (items: RenderItem[]): string[] =>
-  items.map((it) => (it.kind === "elicitation" ? it.elicitationId : ""));
+  items.map((item) => (item.kind === "elicitation" ? item.elicitationId : ""));
 
 describe("collectPendingElicitations", () => {
   it("collects pending cards across bubbles in document order (newest last)", () => {
@@ -555,7 +555,7 @@ describe("stripPendingElicitations", () => {
     const bubbles = [assistantWith("a1", [elicitItem("e1", "pending"), textItem("t1")])];
     const stripped = stripPendingElicitations(bubbles);
     const a1 = stripped[0] as Extract<Bubble, { kind: "assistant" }>;
-    expect(a1.items.map((it) => it.kind)).toEqual(["text"]);
+    expect(a1.items.map((item) => item.kind)).toEqual(["text"]);
   });
 
   it("leaves answered cards inline", () => {

--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -1485,8 +1485,8 @@ function FileViewerBody({
       </div>
       <Dialog
         open={pendingAction !== null}
-        onOpenChange={(open) => {
-          if (!open) setPendingAction(null);
+        onOpenChange={(isOpen) => {
+          if (!isOpen) setPendingAction(null);
         }}
       >
         <DialogContent showCloseButton={false}>

--- a/web/src/shell/MarkdownEditorToolbar.tsx
+++ b/web/src/shell/MarkdownEditorToolbar.tsx
@@ -107,15 +107,15 @@ function TableBtn({ editor }: { editor: Editor | null }) {
           {hovered.rows > 0 ? `${hovered.rows} × ${hovered.cols} table` : "Insert table"}
         </p>
         <div className="flex flex-col gap-0.5">
-          {Array.from({ length: MAX }, (_, r) => (
-            <div key={r} className="flex gap-0.5">
-              {Array.from({ length: MAX }, (_, c) => (
+          {Array.from({ length: MAX }, (_, rowIndex) => (
+            <div key={rowIndex} className="flex gap-0.5">
+              {Array.from({ length: MAX }, (__, columnIndex) => (
                 <button
-                  key={c}
+                  key={columnIndex}
                   type="button"
-                  aria-label={`Insert ${r + 1}×${c + 1} table`}
+                  aria-label={`Insert ${rowIndex + 1}×${columnIndex + 1} table`}
                   onMouseDown={(e) => e.preventDefault()}
-                  onMouseEnter={() => setHovered({ rows: r + 1, cols: c + 1 })}
+                  onMouseEnter={() => setHovered({ rows: rowIndex + 1, cols: columnIndex + 1 })}
                   onClick={() => {
                     // Use stable loop indices rather than async hovered state to
                     // avoid a 0×0 insert on fast clicks before state flushes.
@@ -123,8 +123,8 @@ function TableBtn({ editor }: { editor: Editor | null }) {
                       ?.chain()
                       .focus()
                       .insertTable({
-                        rows: r + 1,
-                        cols: c + 1,
+                        rows: rowIndex + 1,
+                        cols: columnIndex + 1,
                         withHeaderRow: true,
                       })
                       .run();
@@ -132,7 +132,7 @@ function TableBtn({ editor }: { editor: Editor | null }) {
                   }}
                   className={cn(
                     "h-5 w-5 cursor-pointer rounded-sm border transition-colors",
-                    r < hovered.rows && c < hovered.cols
+                    rowIndex < hovered.rows && columnIndex < hovered.cols
                       ? "border-primary bg-primary/20"
                       : "border-border bg-muted hover:border-primary/50 hover:bg-primary/10",
                   )}

--- a/web/src/shell/TableBubbleMenu.tsx
+++ b/web/src/shell/TableBubbleMenu.tsx
@@ -97,7 +97,9 @@ export function moveColumnToIndex(
     const row = node.child(r);
     if (fromCol < 0 || fromCol >= row.childCount) return row;
     if (toCol < 0 || toCol >= row.childCount) return row;
-    const cells = Array.from({ length: row.childCount }, (_, c) => row.child(c));
+    const cells = Array.from({ length: row.childCount }, (__, columnIndex) =>
+      row.child(columnIndex),
+    );
     const [cell] = cells.splice(fromCol, 1);
     cells.splice(toCol, 0, cell);
     return row.type.create(row.attrs, Fragment.fromArray(cells));

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -1276,7 +1276,7 @@ describe("chatStore — switchTo", () => {
     // The window is healthy: a fresh scroll-up still pages correctly.
     await useChatStore.getState().loadMoreHistory();
     expect(useChatStore.getState().blocks.map((b) => b.ctx.itemId)).toEqual([
-      ...itemsA.slice(0, SESSION_HISTORY_PAGE_SIZE).map((it) => it.id),
+      ...itemsA.slice(0, SESSION_HISTORY_PAGE_SIZE).map((item) => item.id),
       ...windowIds,
     ]);
   });
@@ -1303,13 +1303,13 @@ describe("chatStore — switchTo", () => {
     // kept across the rebind — without itemId dedupe each would render twice.
     await useChatStore.getState().loadMoreHistory();
     expect(useChatStore.getState().blocks.map((b) => b.ctx.itemId)).toEqual(
-      items.slice(SESSION_HISTORY_PAGE_SIZE).map((it) => it.id),
+      items.slice(SESSION_HISTORY_PAGE_SIZE).map((item) => item.id),
     );
 
     // The cursor advanced through the overlap, so the oldest page loads next.
     await useChatStore.getState().loadMoreHistory();
     expect(useChatStore.getState().blocks.map((b) => b.ctx.itemId)).toEqual(
-      items.map((it) => it.id),
+      items.map((item) => item.id),
     );
   });
 
@@ -1353,7 +1353,7 @@ describe("chatStore — switchTo", () => {
     // Scroll-up still works: the older page actually fetches and prepends.
     await useChatStore.getState().loadMoreHistory();
     expect(useChatStore.getState().blocks.map((b) => b.ctx.itemId)).toEqual([
-      ...items.slice(0, SESSION_HISTORY_PAGE_SIZE).map((it) => it.id),
+      ...items.slice(0, SESSION_HISTORY_PAGE_SIZE).map((item) => item.id),
       ...windowIds,
     ]);
   });
@@ -1553,7 +1553,7 @@ describe("chatStore — switchTo", () => {
       .getState()
       .blocks.map((b) => b.ctx.itemId)
       .filter((iid): iid is string => Boolean(iid));
-    const seededIds = items.map((it) => it.id);
+    const seededIds = items.map((item) => item.id);
     const suffix = seededIds.slice(seededIds.length - loadedIds.length);
     expect(loadedIds).toEqual(suffix);
     expect(loadedIds.length).toBeGreaterThan(2 * SESSION_HISTORY_PAGE_SIZE);
@@ -6992,8 +6992,8 @@ describe("chatStore — startStreamPump reconnect loop", () => {
     // newest page covers only the last 20, so pre-fix the 25 oldest gap
     // items would sit in a hole no code path could ever fetch.
     expect(state.blocks.map((b) => b.ctx.itemId)).toEqual([
-      ...windowItems.map((it) => it.id),
-      ...gap.map((it) => it.id),
+      ...windowItems.map((item) => item.id),
+      ...gap.map((item) => item.id),
     ]);
     // Backfill is not a re-hydrate: the scroll-up cursor is untouched.
     expect(state.oldestItemId).toBe(windowItems[0]!.id);
@@ -7036,7 +7036,7 @@ describe("chatStore — startStreamPump reconnect loop", () => {
     // The window was replaced wholesale with the newest page, exactly as a
     // cold bind would load it — not left with a mid-transcript hole.
     expect(state.blocks.map((b) => b.ctx.itemId)).toEqual(
-      gap.slice(-SESSION_HISTORY_PAGE_SIZE).map((it) => it.id),
+      gap.slice(-SESSION_HISTORY_PAGE_SIZE).map((item) => item.id),
     );
     // The cursor was rewound to the fresh window's top, so everything older
     // (the rest of the gap included) is reachable again by paging up.
@@ -7045,7 +7045,7 @@ describe("chatStore — startStreamPump reconnect loop", () => {
 
     await useChatStore.getState().loadMoreHistory();
     expect(useChatStore.getState().blocks.map((b) => b.ctx.itemId)).toEqual(
-      gap.slice(-2 * SESSION_HISTORY_PAGE_SIZE).map((it) => it.id),
+      gap.slice(-2 * SESSION_HISTORY_PAGE_SIZE).map((item) => item.id),
     );
 
     const last = sinks[1]!;
@@ -7160,7 +7160,7 @@ describe("chatStore — startStreamPump reconnect loop", () => {
     await useChatStore.getState().loadMoreHistory();
     const fresh = useChatStore.getState();
     expect(fresh.blocks.map((b) => b.ctx.itemId)).toEqual(
-      gap.slice(-2 * SESSION_HISTORY_PAGE_SIZE).map((it) => it.id),
+      gap.slice(-2 * SESSION_HISTORY_PAGE_SIZE).map((item) => item.id),
     );
 
     // The stale page resolves: the conversation id matches again, so only
@@ -7173,7 +7173,7 @@ describe("chatStore — startStreamPump reconnect loop", () => {
     // re-hydrate fallback, which rewound the scroll-up cursor to the
     // window top and bumped the generation (voiding future legit pages).
     expect(state.blocks.map((b) => b.ctx.itemId)).toEqual(
-      gap.slice(-2 * SESSION_HISTORY_PAGE_SIZE).map((it) => it.id),
+      gap.slice(-2 * SESSION_HISTORY_PAGE_SIZE).map((item) => item.id),
     );
     expect(state.oldestItemId).toBe(gap.at(-2 * SESSION_HISTORY_PAGE_SIZE)!.id);
     expect(state.historyGeneration).toBe(fresh.historyGeneration);
@@ -7183,7 +7183,7 @@ describe("chatStore — startStreamPump reconnect loop", () => {
     // this would still show only 40 items.
     await useChatStore.getState().loadMoreHistory();
     expect(useChatStore.getState().blocks.map((b) => b.ctx.itemId)).toEqual(
-      gap.slice(-3 * SESSION_HISTORY_PAGE_SIZE).map((it) => it.id),
+      gap.slice(-3 * SESSION_HISTORY_PAGE_SIZE).map((item) => item.id),
     );
 
     // Unpark the orphaned pump so the awaited loop can exit.
@@ -7261,7 +7261,7 @@ describe("chatStore — startStreamPump reconnect loop", () => {
     // The fresh fetch returns ITEMS only — dropping these blocks would lose
     // the pending ApprovalCard (and the failure reason) with no way back.
     expect(state.blocks.map((b) => b.ctx.itemId ?? b.type)).toEqual([
-      ...gap.slice(-SESSION_HISTORY_PAGE_SIZE).map((it) => it.id),
+      ...gap.slice(-SESSION_HISTORY_PAGE_SIZE).map((item) => item.id),
       "elicitation",
       "error",
     ]);


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Rename shadowed locals, callback parameters, and route arguments across the web and Electron code.
- Remove all 29 `no-shadow` warnings without changing control flow or public APIs.
- Reduce the web lint baseline from 126 warnings to 97; no new lint gate is added in this cleanup PR.

**ELI5:** Distinct names make it clear which value each scope uses, instead of reusing a nearby name and hiding it.

```text
outer name + inner same name -> ambiguous scope
outer name + precise inner name -> explicit scope
```

## Test Plan

- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `pnpm --filter web run test:coverage` (4,767 passed, 3 expected failures, 1 skipped)
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A — non-visual lint cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The full web coverage suite and repository pre-commit suite pass.