### PR TITLE
fix(web): use named Tiptap imports

### DIFF
--- a/web/src/shell/MarkdownCommentPlugin.test.tsx
+++ b/web/src/shell/MarkdownCommentPlugin.test.tsx
@@ -21,7 +21,7 @@ import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Editor } from "@tiptap/core";
 import { Markdown } from "@tiptap/markdown";
-import StarterKit from "@tiptap/starter-kit";
+import { StarterKit } from "@tiptap/starter-kit";
 import type { RefObject } from "react";
 import type { Comment } from "@/hooks/useComments";
 import type { ActiveSelection } from "./codeViewerHelpers";

--- a/web/src/shell/MarkdownRichTextViewer.blockquoteCrash.test.ts
+++ b/web/src/shell/MarkdownRichTextViewer.blockquoteCrash.test.ts
@@ -19,7 +19,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Editor } from "@tiptap/core";
-import StarterKit from "@tiptap/starter-kit";
+import { StarterKit } from "@tiptap/starter-kit";
 import { Table, TableRow, TableCell, TableHeader } from "@tiptap/extension-table";
 import { TaskItem, TaskList } from "@tiptap/extension-list";
 import { Markdown } from "@tiptap/markdown";

--- a/web/src/shell/MarkdownRichTextViewer.integration.test.tsx
+++ b/web/src/shell/MarkdownRichTextViewer.integration.test.tsx
@@ -80,7 +80,7 @@ vi.mock("@tiptap/react", () => ({
 
 // Extensions / sibling components the viewer imports — irrelevant to the wiring.
 vi.mock("@tiptap/markdown", () => ({ Markdown: { configure: vi.fn().mockReturnValue({}) } }));
-vi.mock("@tiptap/starter-kit", () => ({ default: { configure: vi.fn().mockReturnValue({}) } }));
+vi.mock("@tiptap/starter-kit", () => ({ StarterKit: { configure: vi.fn().mockReturnValue({}) } }));
 vi.mock("@tiptap/extension-table", () => ({
   Table: { configure: vi.fn().mockReturnValue({}) },
   TableRow: {},

--- a/web/src/shell/MarkdownRichTextViewer.listItemCrash.test.ts
+++ b/web/src/shell/MarkdownRichTextViewer.listItemCrash.test.ts
@@ -22,7 +22,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Editor } from "@tiptap/core";
-import StarterKit from "@tiptap/starter-kit";
+import { StarterKit } from "@tiptap/starter-kit";
 import { Table, TableRow, TableCell, TableHeader } from "@tiptap/extension-table";
 import { ListItem, TaskItem, TaskList } from "@tiptap/extension-list";
 import { Markdown } from "@tiptap/markdown";

--- a/web/src/shell/MarkdownRichTextViewer.looseImageCrash.test.ts
+++ b/web/src/shell/MarkdownRichTextViewer.looseImageCrash.test.ts
@@ -27,7 +27,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Editor } from "@tiptap/core";
-import StarterKit from "@tiptap/starter-kit";
+import { StarterKit } from "@tiptap/starter-kit";
 import { Table, TableRow, TableCell, TableHeader } from "@tiptap/extension-table";
 import { ListItem, TaskItem, TaskList } from "@tiptap/extension-list";
 import { Markdown } from "@tiptap/markdown";

--- a/web/src/shell/MarkdownRichTextViewer.teardown.test.tsx
+++ b/web/src/shell/MarkdownRichTextViewer.teardown.test.tsx
@@ -103,7 +103,7 @@ vi.mock("@tiptap/react", () => ({
 }));
 
 vi.mock("@tiptap/markdown", () => ({ Markdown: { configure: vi.fn().mockReturnValue({}) } }));
-vi.mock("@tiptap/starter-kit", () => ({ default: { configure: vi.fn().mockReturnValue({}) } }));
+vi.mock("@tiptap/starter-kit", () => ({ StarterKit: { configure: vi.fn().mockReturnValue({}) } }));
 vi.mock("@tiptap/extension-table", () => ({
   Table: { configure: vi.fn().mockReturnValue({}) },
   TableRow: {},

--- a/web/src/shell/MarkdownRichTextViewer.test.tsx
+++ b/web/src/shell/MarkdownRichTextViewer.test.tsx
@@ -24,7 +24,7 @@ vi.mock("@tiptap/react", () => ({
 vi.mock("@tiptap/markdown", () => ({
   Markdown: { configure: vi.fn().mockReturnValue({}) },
 }));
-vi.mock("@tiptap/starter-kit", () => ({ default: { configure: vi.fn().mockReturnValue({}) } }));
+vi.mock("@tiptap/starter-kit", () => ({ StarterKit: { configure: vi.fn().mockReturnValue({}) } }));
 vi.mock("@tiptap/extension-table", () => ({
   Table: { configure: vi.fn().mockReturnValue({}) },
   TableRow: {},

--- a/web/src/shell/MarkdownRichTextViewer.tsx
+++ b/web/src/shell/MarkdownRichTextViewer.tsx
@@ -19,7 +19,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AlertTriangleIcon, Check, Copy, MessageSquareOffIcon } from "lucide-react";
 import { useEditor, EditorContent } from "@tiptap/react";
-import StarterKit from "@tiptap/starter-kit";
+import { StarterKit } from "@tiptap/starter-kit";
 import { Table, TableRow, TableCell, TableHeader } from "@tiptap/extension-table";
 import { ListItem, TaskItem, TaskList } from "@tiptap/extension-list";
 import { Markdown } from "@tiptap/markdown";

--- a/web/src/shell/MarkdownSearchBar.test.tsx
+++ b/web/src/shell/MarkdownSearchBar.test.tsx
@@ -8,7 +8,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Editor } from "@tiptap/core";
 import { Markdown } from "@tiptap/markdown";
-import StarterKit from "@tiptap/starter-kit";
+import { StarterKit } from "@tiptap/starter-kit";
 import { createRef } from "react";
 import type { RefObject } from "react";
 import { MarkdownSearchBar } from "./MarkdownSearchBar";

--- a/web/src/shell/TableBubbleMenu.test.tsx
+++ b/web/src/shell/TableBubbleMenu.test.tsx
@@ -20,7 +20,7 @@ import { createRef } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { Editor } from "@tiptap/core";
 import { Table, TableCell, TableHeader, TableRow } from "@tiptap/extension-table";
-import StarterKit from "@tiptap/starter-kit";
+import { StarterKit } from "@tiptap/starter-kit";
 import { TableHandles } from "./TableBubbleMenu";
 
 /** Minimal 3×3 table: one header row + two body rows. */

--- a/web/src/shell/TipTapCommentExtension.test.ts
+++ b/web/src/shell/TipTapCommentExtension.test.ts
@@ -17,7 +17,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Editor } from "@tiptap/core";
 import { Markdown } from "@tiptap/markdown";
-import StarterKit from "@tiptap/starter-kit";
+import { StarterKit } from "@tiptap/starter-kit";
 import { PluginKey } from "@tiptap/pm/state";
 import type { RefObject } from "react";
 import type { Comment } from "@/hooks/useComments";

--- a/web/src/shell/TipTapGitHubAlert.test.ts
+++ b/web/src/shell/TipTapGitHubAlert.test.ts
@@ -13,7 +13,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { Editor } from "@tiptap/core";
 import { Markdown } from "@tiptap/markdown";
-import StarterKit from "@tiptap/starter-kit";
+import { StarterKit } from "@tiptap/starter-kit";
 import { extractAlert, GitHubAlertBlockquote, toBlockContent } from "./TipTapGitHubAlert";
 
 let editor: Editor | null = null;

--- a/web/src/shell/TipTapHtmlPassthrough.test.ts
+++ b/web/src/shell/TipTapHtmlPassthrough.test.ts
@@ -14,7 +14,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Editor } from "@tiptap/core";
 import { Markdown } from "@tiptap/markdown";
-import StarterKit from "@tiptap/starter-kit";
+import { StarterKit } from "@tiptap/starter-kit";
 import { Table, TableCell, TableHeader, TableRow } from "@tiptap/extension-table";
 import { createWorkspaceImageExtension, ImageAwareLink } from "./TipTapWorkspaceImage";
 import { GitHubAlertBlockquote } from "./TipTapGitHubAlert";

--- a/web/src/shell/TipTapSearchExtension.test.ts
+++ b/web/src/shell/TipTapSearchExtension.test.ts
@@ -14,7 +14,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { Editor } from "@tiptap/core";
 import { Markdown } from "@tiptap/markdown";
-import StarterKit from "@tiptap/starter-kit";
+import { StarterKit } from "@tiptap/starter-kit";
 import { PluginKey } from "@tiptap/pm/state";
 import type { RefObject } from "react";
 import {

--- a/web/src/shell/TipTapTaskList.test.ts
+++ b/web/src/shell/TipTapTaskList.test.ts
@@ -18,7 +18,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { Editor } from "@tiptap/core";
 import { Markdown } from "@tiptap/markdown";
 import { TaskItem, TaskList } from "@tiptap/extension-list";
-import StarterKit from "@tiptap/starter-kit";
+import { StarterKit } from "@tiptap/starter-kit";
 
 let editor: Editor | null = null;
 let host: HTMLElement | null = null;

--- a/web/src/shell/TipTapWorkspaceImage.test.ts
+++ b/web/src/shell/TipTapWorkspaceImage.test.ts
@@ -14,7 +14,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Editor } from "@tiptap/core";
 import { Markdown } from "@tiptap/markdown";
-import StarterKit from "@tiptap/starter-kit";
+import { StarterKit } from "@tiptap/starter-kit";
 import {
   createWorkspaceImageExtension,
   ImageAwareLink,

--- a/web/src/shell/TipTapWorkspaceImage.ts
+++ b/web/src/shell/TipTapWorkspaceImage.ts
@@ -14,8 +14,8 @@
 // images re-serialise with normalised attribute order/quoting, so the
 // guarantee is attribute preservation, not whole-tag byte identity.)
 
-import Image from "@tiptap/extension-image";
-import Link from "@tiptap/extension-link";
+import { Image } from "@tiptap/extension-image";
+import { Link } from "@tiptap/extension-link";
 import type { AnyExtension } from "@tiptap/core";
 import { fetchFileContent, fileContentToBlob } from "@/hooks/useFileContent";
 

--- a/web/src/shell/tableActions.test.ts
+++ b/web/src/shell/tableActions.test.ts
@@ -14,7 +14,7 @@ import { Editor } from "@tiptap/core";
 import { Table, TableCell, TableHeader, TableRow } from "@tiptap/extension-table";
 import { Markdown } from "@tiptap/markdown";
 import { TextSelection } from "@tiptap/pm/state";
-import StarterKit from "@tiptap/starter-kit";
+import { StarterKit } from "@tiptap/starter-kit";
 import {
   freshCellPos,
   moveRowToIndex,


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Replace Tiptap default imports with the packages' equivalent named exports.
- Update three `MarkdownRichTextViewer` test mocks to expose the same named `StarterKit` contract.
- Remove all 16 `import/no-named-as-default` warnings, reducing this branch's lint baseline from 126 warnings to 110. This PR is independent of #3540 and can merge in either order.

**ELI5:** The packages expose both a default and a clearly named export. Using the named form makes the imported symbol unambiguous to readers and lint tooling.

```text
default import -> inferred symbol name
named import   -> explicit package contract
```

## Test Plan

- `pnpm --filter web run type-check`
- `pnpm --filter web run test:coverage` (4,767 passed, 3 expected failures, 1 skipped)
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A — non-visual import cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The full web coverage suite and repository pre-commit suite pass.