### PR TITLE
fix(web): use stable React list keys

### DIFF
--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -661,9 +661,15 @@ interface McpFormState {
   description: string;
   url: string;
   /** Key-value pairs for HTTP headers. Values from existing servers are "[REDACTED]". */
-  headers: { key: string; value: string }[];
+  headers: { id: string; key: string; value: string }[];
   command: string;
   argsText: string;
+}
+
+let nextMcpHeaderId = 0;
+
+function mcpHeader(key = "", value = "") {
+  return { id: `mcp-header-${nextMcpHeaderId++}`, key, value };
 }
 
 const EMPTY_MCP_FORM: McpFormState = {
@@ -684,7 +690,7 @@ function mcpFormFromServer(server: McpServerSummary): McpFormState {
     transport: server.transport === "stdio" ? "stdio" : "http",
     description: server.description ?? "",
     url: server.url ?? "",
-    headers: Object.entries(server.headers ?? {}).map(([key, value]) => ({ key, value })),
+    headers: Object.entries(server.headers ?? {}).map(([key, value]) => mcpHeader(key, value)),
     command: server.command ?? "",
     argsText: (server.args ?? []).join("\n"),
   };
@@ -932,7 +938,7 @@ function McpServerManagerDialog({
                       onClick={() =>
                         setForm((prev) => ({
                           ...prev,
-                          headers: [...prev.headers, { key: "", value: "" }],
+                          headers: [...prev.headers, mcpHeader()],
                         }))
                       }
                       className="rounded p-0.5 hover:bg-muted"
@@ -942,7 +948,7 @@ function McpServerManagerDialog({
                     </button>
                   </div>
                   {form.headers.map((header, i) => (
-                    <div key={i} className="flex items-center gap-1">
+                    <div key={header.id} className="flex items-center gap-1">
                       <Input
                         value={header.key}
                         onChange={(e) =>

--- a/web/src/lib/attachments.test.ts
+++ b/web/src/lib/attachments.test.ts
@@ -1,11 +1,26 @@
 import { describe, expect, it } from "vitest";
-import { ATTACHMENT_SIZE_LIMITS_MB, classifyAttachment, validateAttachments } from "./attachments";
+import {
+  ATTACHMENT_SIZE_LIMITS_MB,
+  attachmentKey,
+  classifyAttachment,
+  validateAttachments,
+} from "./attachments";
 
 function makeFile(name: string, type: string, bytes = 10): File {
   return new File([new Uint8Array(bytes)], name, { type });
 }
 
 const MB = 1024 * 1024;
+
+describe("attachmentKey", () => {
+  it("is stable per File object and distinct for equivalent files", () => {
+    const first = makeFile("a.png", "image/png");
+    const second = makeFile("a.png", "image/png");
+
+    expect(attachmentKey(first)).toBe(attachmentKey(first));
+    expect(attachmentKey(first)).not.toBe(attachmentKey(second));
+  });
+});
 
 describe("classifyAttachment", () => {
   it("classifies images by MIME", () => {

--- a/web/src/lib/attachments.ts
+++ b/web/src/lib/attachments.ts
@@ -19,6 +19,17 @@ export const ATTACHMENT_SIZE_LIMITS_MB = {
 
 export type AttachmentCategory = keyof typeof ATTACHMENT_SIZE_LIMITS_MB;
 
+const attachmentIds = new WeakMap<File, string>();
+let nextAttachmentId = 0;
+
+export function attachmentKey(file: File): string {
+  const existing = attachmentIds.get(file);
+  if (existing) return existing;
+  const id = `attachment-${nextAttachmentId++}`;
+  attachmentIds.set(file, id);
+  return id;
+}
+
 // Text-bearing application/* MIME types (the rest of the text-like surface
 // is text/*). Mirrors _TEXT_LIKE_APPLICATION_MIMES on the server.
 const TEXT_LIKE_APPLICATION_MIMES = new Set([

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -1378,7 +1378,13 @@ describe("Composer reply-quote focus", () => {
     ta.blur();
     expect(document.activeElement).not.toBe(ta);
 
-    rerender(<Composer {...composerProps({ replyQuotes: ["selected response text"] })} />);
+    rerender(
+      <Composer
+        {...composerProps({
+          replyQuotes: [{ id: "quote-1", text: "selected response text" }],
+        })}
+      />,
+    );
     expect(document.activeElement).toBe(ta);
   });
 
@@ -1386,13 +1392,20 @@ describe("Composer reply-quote focus", () => {
     // Removing a chip (the X button) shrinks the count — the effect only
     // fires when the count grows, so focus must stay put.
     const { rerender } = render(
-      <Composer {...composerProps({ replyQuotes: ["first", "second"] })} />,
+      <Composer
+        {...composerProps({
+          replyQuotes: [
+            { id: "quote-1", text: "first" },
+            { id: "quote-2", text: "second" },
+          ],
+        })}
+      />,
     );
     const ta = textarea();
     ta.blur();
     expect(document.activeElement).not.toBe(ta);
 
-    rerender(<Composer {...composerProps({ replyQuotes: ["first"] })} />);
+    rerender(<Composer {...composerProps({ replyQuotes: [{ id: "quote-1", text: "first" }] })} />);
     expect(document.activeElement).not.toBe(ta);
   });
 });

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -62,7 +62,7 @@ import { OttoIcon } from "@/components/icons/OttoIcon";
 import { cn } from "@/lib/utils";
 import { QueuedMessagesStrip } from "@/pages/QueuedMessagesStrip";
 import { TurnRail, type Turn } from "@/pages/TurnRail";
-import { validateAttachments } from "@/lib/attachments";
+import { attachmentKey, validateAttachments } from "@/lib/attachments";
 import { useSurfaceFrontmost } from "@/hooks/useNativeServerSwitcher";
 import {
   isIOSShell,
@@ -1565,7 +1565,8 @@ function MainAgentSurface({
   }, [nav]);
 
   // Active reply quotes — each "Reply ↵" click appends; consumed by Composer.
-  const [replyQuotes, setReplyQuotes] = useState<string[]>([]);
+  const [replyQuotes, setReplyQuotes] = useState<ReplyQuote[]>([]);
+  const nextReplyQuoteId = useRef(0);
 
   // Ref forwarded to SelectionPopup to scope selection detection to the
   // conversation area, preventing selections in the composer from triggering
@@ -1833,7 +1834,12 @@ function MainAgentSurface({
       {/* Floating reply button — scoped to the conversation container. */}
       <SelectionPopup
         containerRef={conversationRef}
-        onReply={(text) => setReplyQuotes((prev) => [...prev, text])}
+        onReply={(text) =>
+          setReplyQuotes((prev) => [
+            ...prev,
+            { id: `reply-quote-${nextReplyQuoteId.current++}`, text },
+          ])
+        }
       />
 
       <Composer
@@ -3171,11 +3177,11 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
           {/* Inline image previews */}
           {images.length > 0 && (
             <div className="mb-1.5 flex flex-wrap gap-2">
-              {images.map((img, i) =>
+              {images.map((img) =>
                 img.file_id.startsWith("pending:") ? (
                   // Upload in-flight — show a chip placeholder
                   <span
-                    key={i}
+                    key={img.file_id}
                     className="flex items-center gap-1 rounded-full border border-border bg-muted px-2 py-0.5 text-xs text-muted-foreground"
                   >
                     <ImageIcon className="size-3 shrink-0" />
@@ -3186,7 +3192,7 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
                 ) : (
                   // Uploaded — render the actual image
                   <SessionImage
-                    key={i}
+                    key={img.file_id}
                     path={
                       sessionId
                         ? `/v1/sessions/${encodeURIComponent(sessionId)}/resources/files/${encodeURIComponent(img.file_id)}/content`
@@ -3202,9 +3208,9 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
           {/* Non-image file chips */}
           {fileChips.length > 0 && (
             <div className="mb-1.5 flex flex-wrap gap-1.5">
-              {fileChips.map((att, i) => (
+              {fileChips.map((att) => (
                 <span
-                  key={i}
+                  key={att.file_id}
                   className="flex items-center gap-1 rounded-full border border-border bg-muted px-2 py-0.5 text-xs text-muted-foreground"
                 >
                   <FileTextIcon className="size-3 shrink-0" />
@@ -3340,6 +3346,11 @@ function AssistantBubble({
   );
 }
 
+interface ReplyQuote {
+  id: string;
+  text: string;
+}
+
 interface ComposerProps {
   status: "idle" | "streaming";
   /** Local stream OR cross-client `session.status: running`. */
@@ -3370,7 +3381,7 @@ interface ComposerProps {
    */
   readOnlyReason: string | null;
   /** Quoted texts to prepend to the next message (one per "Reply ↵" click). */
-  replyQuotes: string[];
+  replyQuotes: ReplyQuote[];
   /** Removes the quote at the given index without submitting. */
   onRemoveQuote: (index: number) => void;
   /** Clears all quotes (called after submit). */
@@ -4486,8 +4497,8 @@ export function Composer({
     const quotePreamble =
       replyQuotes.length > 0
         ? replyQuotes
-            .map((q) =>
-              q
+            .map((quote) =>
+              quote.text
                 .split("\n")
                 .map((line) => `> ${line}`)
                 .join("\n"),
@@ -4743,10 +4754,10 @@ export function Composer({
         {replyQuotes.length > 0 && (
           <div className="flex flex-col gap-1.5 px-4 pt-3 pb-0">
             {replyQuotes.map((quote, i) => (
-              <div key={i} className="flex items-start gap-2">
+              <div key={quote.id} className="flex items-start gap-2">
                 <div className="min-w-0 flex-1 bg-muted/40 rounded-md border-l-2 border-l-primary/60 px-2 py-1.5 text-xs text-muted-foreground">
                   <span className="block truncate">
-                    {quote.length > 120 ? `${quote.slice(0, 120)}…` : quote}
+                    {quote.text.length > 120 ? `${quote.text.slice(0, 120)}…` : quote.text}
                   </span>
                 </div>
                 <button
@@ -4866,7 +4877,7 @@ export function Composer({
           <div className="flex flex-wrap gap-1.5 px-4 pb-2">
             {files.map((file, i) => (
               <span
-                key={i}
+                key={attachmentKey(file)}
                 className="flex items-center gap-1 rounded-full border border-border bg-muted px-2 py-0.5 text-xs text-muted-foreground"
               >
                 {file.type.startsWith("image/") ? (

--- a/web/src/shell/FolderTree.tsx
+++ b/web/src/shell/FolderTree.tsx
@@ -26,13 +26,12 @@ function IndentGuides({ depth }: { depth: number }) {
   if (depth <= 0) return null;
   return (
     <>
-      {Array.from({ length: depth }).map((_, i) => (
+      {Array.from({ length: depth }, (_, level) => indentFor(level) + GUIDE_OFFSET).map((left) => (
         <span
-          // biome-ignore lint/suspicious/noArrayIndexKey: fixed positional guides
-          key={i}
+          key={left}
           aria-hidden
           className="pointer-events-none absolute top-0 bottom-0 w-px bg-border"
-          style={{ left: `${indentFor(i) + GUIDE_OFFSET}px` }}
+          style={{ left: `${left}px` }}
         />
       ))}
     </>

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -68,6 +68,7 @@ import {
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { authenticatedFetch } from "@/lib/identity";
 import { isImeCompositionKeyEvent } from "@/lib/ime";
+import { attachmentKey } from "@/lib/attachments";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { HarnessSetupDialog } from "@/shell/HarnessSetupDialog";
@@ -3246,7 +3247,7 @@ export function NewChatLandingScreen() {
               <div className="flex flex-wrap gap-1.5 px-4 pb-2">
                 {files.map((file, i) => (
                   <span
-                    key={i}
+                    key={attachmentKey(file)}
                     className="flex items-center gap-1 rounded-full border border-border bg-muted px-2 py-0.5 text-xs text-muted-foreground"
                   >
                     {file.type.startsWith("image/") ? (

--- a/web/src/shell/PdfViewer.tsx
+++ b/web/src/shell/PdfViewer.tsx
@@ -92,9 +92,9 @@ function PdfCommentHighlights({
   return (
     <div className="pdf-comment-layer" aria-hidden>
       {highlights.map((h) =>
-        h.rects.map((rect, i) => (
+        h.rects.map((rect) => (
           <div
-            key={`${h.key}-${i}`}
+            key={`${h.key}-${rect.x}-${rect.y}-${rect.w}-${rect.h}`}
             className={cn("pdf-comment", h.active && "pdf-comment-active")}
             style={{
               left: `${rect.x * 100}%`,

--- a/web/src/shell/TableBubbleMenu.tsx
+++ b/web/src/shell/TableBubbleMenu.tsx
@@ -189,8 +189,8 @@ function setCursorToCell(editor: Editor, rowIndex: number, colIndex: number): vo
 // ---------------------------------------------------------------------------
 
 type MenuItemDef =
-  | { label: string; icon: React.ReactNode; onClick: () => void; destructive?: boolean }
-  | { separator: true };
+  | { id: string; label: string; icon: React.ReactNode; onClick: () => void; destructive?: boolean }
+  | { id: string; separator: true };
 
 function HandleMenu({
   items,
@@ -226,12 +226,12 @@ function HandleMenu({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
-      {items.map((item, i) =>
+      {items.map((item) =>
         "separator" in item ? (
-          <div key={i} className="mx-2 my-1 h-px bg-border" />
+          <div key={item.id} className="mx-2 my-1 h-px bg-border" />
         ) : (
           <button
-            key={i}
+            key={item.id}
             type="button"
             onMouseDown={(e) => e.preventDefault()}
             onClick={() => {
@@ -685,6 +685,7 @@ export function TableHandles({
   // Build row menu items (Insert / Delete only — drag handles Move)
   const buildRowItems = (h: HandlePos): MenuItemDef[] => [
     {
+      id: "insert-row-above",
       label: "Insert row above",
       icon: <span className="text-[10px] font-bold">↑</span>,
       onClick: () => {
@@ -693,6 +694,7 @@ export function TableHandles({
       },
     },
     {
+      id: "insert-row-below",
       label: "Insert row below",
       icon: <span className="text-[10px] font-bold">↓</span>,
       onClick: () => {
@@ -700,8 +702,9 @@ export function TableHandles({
         editor.chain().focus().addRowAfter().run();
       },
     },
-    { separator: true },
+    { id: "row-actions-separator", separator: true },
     {
+      id: "delete-row",
       label: "Delete row",
       icon: <Trash2 className="size-3.5" />,
       destructive: true,
@@ -715,6 +718,7 @@ export function TableHandles({
   // Build column menu items (Insert / Delete only — drag handles Move)
   const buildColItems = (h: HandlePos): MenuItemDef[] => [
     {
+      id: "insert-column-before",
       label: "Insert column before",
       icon: <span className="text-[10px] font-bold">←</span>,
       onClick: () => {
@@ -723,6 +727,7 @@ export function TableHandles({
       },
     },
     {
+      id: "insert-column-after",
       label: "Insert column after",
       icon: <span className="text-[10px] font-bold">→</span>,
       onClick: () => {
@@ -730,8 +735,9 @@ export function TableHandles({
         editor.chain().focus().addColumnAfter().run();
       },
     },
-    { separator: true },
+    { id: "column-actions-separator", separator: true },
     {
+      id: "delete-column",
       label: "Delete column",
       icon: <Trash2 className="size-3.5" />,
       destructive: true,
@@ -972,6 +978,7 @@ export function TableHandles({
         <HandleMenu
           items={[
             {
+              id: "delete-table",
               label: "Delete table",
               icon: <Trash2 className="size-3.5" />,
               destructive: true,

--- a/web/src/shell/codeViewerRendering.tsx
+++ b/web/src/shell/codeViewerRendering.tsx
@@ -7,6 +7,7 @@ import type { ThemedToken } from "shiki";
 interface TextSegment {
   text: string;
   isMatch: boolean;
+  offset: number;
 }
 
 function splitAtMatches(text: string, query: string): TextSegment[] {
@@ -17,11 +18,11 @@ function splitAtMatches(text: string, query: string): TextSegment[] {
   while (pos <= text.length) {
     const idx = lower.indexOf(qLower, pos);
     if (idx === -1) {
-      if (pos < text.length) segments.push({ text: text.slice(pos), isMatch: false });
+      if (pos < text.length) segments.push({ text: text.slice(pos), isMatch: false, offset: pos });
       break;
     }
-    if (idx > pos) segments.push({ text: text.slice(pos, idx), isMatch: false });
-    segments.push({ text: text.slice(idx, idx + query.length), isMatch: true });
+    if (idx > pos) segments.push({ text: text.slice(pos, idx), isMatch: false, offset: pos });
+    segments.push({ text: text.slice(idx, idx + query.length), isMatch: true, offset: idx });
     pos = idx + query.length;
   }
   return segments;
@@ -52,11 +53,11 @@ export function renderLineTokens(
   searchQuery: string,
   isCurrentMatch: boolean,
 ): React.ReactNode {
-  return tokens.map((token, ti) => {
+  return tokens.map((token) => {
     const style = buildTokenStyle(token);
     if (!searchQuery) {
       return (
-        <span key={ti} className="dark:!text-[var(--shiki-dark)]" style={style}>
+        <span key={token.offset} className="dark:!text-[var(--shiki-dark)]" style={style}>
           {token.content}
         </span>
       );
@@ -64,17 +65,17 @@ export function renderLineTokens(
     const parts = splitAtMatches(token.content, searchQuery);
     if (parts.length === 1 && !parts[0].isMatch) {
       return (
-        <span key={ti} className="dark:!text-[var(--shiki-dark)]" style={style}>
+        <span key={token.offset} className="dark:!text-[var(--shiki-dark)]" style={style}>
           {token.content}
         </span>
       );
     }
     return (
-      <span key={ti} className="dark:!text-[var(--shiki-dark)]" style={style}>
-        {parts.map((seg, si) =>
+      <span key={token.offset} className="dark:!text-[var(--shiki-dark)]" style={style}>
+        {parts.map((seg) =>
           seg.isMatch ? (
             <mark
-              key={si}
+              key={token.offset + seg.offset}
               className={
                 isCurrentMatch
                   ? "rounded-sm bg-orange-400 text-black"


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Replace array-index React keys with stable identities for table actions, MCP header rows, message attachments, reply quotes, syntax tokens, folder guides, and PDF highlights.
- Add duplicate-safe `File` object identities and a focused unit test so two equivalent attachments still receive distinct keys.
- Remove all 15 `react/no-array-index-key` warnings, reducing this branch's lint baseline from 126 warnings to 111. This PR is independent of #3540 and #3542.

**ELI5:** React uses keys to remember which rendered item is which. Stable keys prevent it from confusing neighboring rows when an item is inserted or removed.

```text
array position key -> identity changes after removal
stable item key    -> identity follows the item
```

## Test Plan

- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `pnpm --filter web run test:coverage` (4,768 passed, 3 expected failures, 1 skipped)
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A — non-visual rendering correctness cleanup.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The full web coverage suite and repository pre-commit suite pass.