### PR TITLE
fix(web): stabilize React render inputs

### DIFF
--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -1,7 +1,7 @@
 // Agent info surface: the MCP-server and policy badges, and the
 // header info-icon popover that displays them.
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   CheckIcon,
   CopyIcon,
@@ -56,6 +56,10 @@ import { copyText } from "@/lib/clipboard";
 import { useChatStore } from "@/store/chatStore";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { useSessionHostVersion } from "@/hooks/RunnerHealthProvider";
+
+const MCP_SERVERS_UPDATED_TOAST = (
+  <span className="text-sm">MCP servers updated. Restart the session to apply changes.</span>
+);
 
 /**
  * Display label for an agent name: the wrapper alias when mapped, else
@@ -1069,10 +1073,13 @@ function McpServersSection({
   const dirtyControlled = controlledDirty !== undefined;
   const mcpDirty = controlledDirty ?? localDirty;
 
-  function setMcpDirty(dirty: boolean) {
-    if (!dirtyControlled) setLocalDirty(dirty);
-    onDirtyChange?.(dirty);
-  }
+  const setMcpDirty = useCallback(
+    (dirty: boolean) => {
+      if (!dirtyControlled) setLocalDirty(dirty);
+      onDirtyChange?.(dirty);
+    },
+    [dirtyControlled, onDirtyChange],
+  );
 
   const sessionStatus = useChatStore((s) => s.sessionStatus);
   // Clear the dirty flag when the session restarts (launching picks up
@@ -1085,6 +1092,16 @@ function McpServersSection({
   }, [dirtyControlled, sessionId]);
   const canEdit = !!(sessionId && editable);
   const deleteServer = useDeleteMcpServer(canEdit ? sessionId : "");
+  const handleDeleteServer = useCallback(
+    (name: string) =>
+      deleteServer.mutate(name, {
+        onSuccess: () => {
+          setMcpDirty(true);
+          showToast(MCP_SERVERS_UPDATED_TOAST);
+        },
+      }),
+    [deleteServer, setMcpDirty],
+  );
   const showSection = servers.length > 0 || canEdit;
   if (!showSection) return null;
 
@@ -1111,24 +1128,7 @@ function McpServersSection({
         </p>
       )}
       {servers.length > 0 ? (
-        <McpServerList
-          servers={servers}
-          onDelete={
-            canEdit
-              ? (name) =>
-                  deleteServer.mutate(name, {
-                    onSuccess: () => {
-                      setMcpDirty(true);
-                      showToast(
-                        <span className="text-sm">
-                          MCP servers updated. Restart the session to apply changes.
-                        </span>,
-                      );
-                    },
-                  })
-              : undefined
-          }
-        />
+        <McpServerList servers={servers} onDelete={canEdit ? handleDeleteServer : undefined} />
       ) : (
         <p className="text-xs text-muted-foreground">No MCP servers</p>
       )}

--- a/web/src/components/ComposerMicButton.test.tsx
+++ b/web/src/components/ComposerMicButton.test.tsx
@@ -275,6 +275,11 @@ const DICTATION_INFO: ServerInfo = {
   dictation_available: true,
 };
 
+const NO_DICTATION_INFO: ServerInfo = {
+  ...DICTATION_INFO,
+  dictation_available: false,
+};
+
 function renderServerMode(
   props: Partial<React.ComponentProps<typeof ComposerMicButton>> = {},
   info: ServerInfo = DICTATION_INFO,
@@ -303,7 +308,7 @@ describe("ComposerMicButton (server dictation)", () => {
   });
 
   it("renders nothing when neither Web Speech nor the server can help", () => {
-    const { container } = renderServerMode({}, { ...DICTATION_INFO, dictation_available: false });
+    const { container } = renderServerMode({}, NO_DICTATION_INFO);
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -435,7 +440,7 @@ describe("ComposerMicButton (server dictation)", () => {
 
   it("keeps the plain error path when the server offers no dictation", async () => {
     render(
-      <CapabilitiesContext.Provider value={{ ...DICTATION_INFO, dictation_available: false }}>
+      <CapabilitiesContext.Provider value={NO_DICTATION_INFO}>
         <ComposerMicButton onTranscript={vi.fn()} />
       </CapabilitiesContext.Provider>,
     );

--- a/web/src/components/blocks/BlockRenderer.test.tsx
+++ b/web/src/components/blocks/BlockRenderer.test.tsx
@@ -494,6 +494,30 @@ const NOT_FOUND_RESPONSE = {
   json: async () => ({ error: { code: "not_found" } }),
 } as unknown as Response;
 
+interface TestFileViewerContext {
+  openFile: (path: string) => void;
+  isChangedPath: (path: string) => boolean;
+  conversationId: string | undefined;
+  workspaceRoot: string | null;
+  workspaceHome: string | null;
+}
+
+function TestProviders({
+  children,
+  queryClient,
+  fileViewerContext,
+}: {
+  children: ReactNode;
+  queryClient: QueryClient;
+  fileViewerContext: TestFileViewerContext;
+}) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <FileViewerContext.Provider value={fileViewerContext}>{children}</FileViewerContext.Provider>
+    </QueryClientProvider>
+  );
+}
+
 function renderMessage(
   text: string,
   ctx: {
@@ -504,7 +528,7 @@ function renderMessage(
     workspaceHome?: string | null;
   },
 ) {
-  const fullCtx = {
+  const fullCtx: TestFileViewerContext = {
     workspaceRoot: null,
     workspaceHome: null,
     ...ctx,
@@ -513,17 +537,10 @@ function renderMessage(
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: 0 } },
   });
-  function Wrap({ children }: { children: ReactNode }) {
-    return (
-      <QueryClientProvider client={qc}>
-        <FileViewerContext.Provider value={fullCtx}>{children}</FileViewerContext.Provider>
-      </QueryClientProvider>
-    );
-  }
   return render(
-    <Wrap>
+    <TestProviders queryClient={qc} fileViewerContext={fullCtx}>
       <BlockRenderer items={items} sessionStatus="idle" />
-    </Wrap>,
+    </TestProviders>,
   );
 }
 

--- a/web/src/shell/PdfViewer.tsx
+++ b/web/src/shell/PdfViewer.tsx
@@ -46,6 +46,7 @@ pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
 const MIN_SCALE = 0.5;
 const MAX_SCALE = 3;
 const SCALE_STEP = 0.25;
+const EMPTY_COMMENTS: Comment[] = [];
 
 interface FloatingAnchor {
   x: number;
@@ -116,7 +117,7 @@ function PdfCommentHighlights({
 export function PdfViewer({
   data,
   conversationId,
-  comments = [],
+  comments = EMPTY_COMMENTS,
   activeSelection = null,
   onSetActiveSelection,
 }: PdfViewerProps) {

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -1717,67 +1717,16 @@ function ConversationList({
                     title="Projects"
                     collapsed={effectiveCollapsedSections.includes("Projects")}
                     onToggleCollapsed={() => effectiveToggleSectionCollapsed("Projects")}
-                    headerAction={(() => {
-                      const allNames = sections.projectGroups.map((g) => g.name);
-                      // "New project" is always available (even when collapsed) so
-                      // the create-empty flow is reachable; the expand/revert control
-                      // is only meaningful when there are folders and the group is open.
-                      const showExpandControls =
-                        !effectiveCollapsedSections.includes("Projects") && allNames.length > 0;
-                      // Once every folder is open the only useful move is to undo it,
-                      // so the control flips to "revert" — which restores the set open
-                      // before "Expand all", or collapses everything when there's no
-                      // real last state (folders opened by hand). Otherwise it expands.
-                      const allExpanded =
-                        allNames.length > 0 && allNames.every((n) => expandedProjects.includes(n));
-                      return (
-                        // gap-0.5 between the two controls mirrors the row/folder
-                        // icon spacing, so every right-gutter pair lines up.
-                        <div className="flex items-center gap-0.5">
-                          {showExpandControls &&
-                            (allExpanded ? (
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <Button
-                                    type="button"
-                                    variant="ghost"
-                                    size="icon-xs"
-                                    aria-label="Collapse to previous"
-                                    data-testid="revert-projects"
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      revertProjects();
-                                    }}
-                                  >
-                                    <Minimize2Icon className="size-3.5" />
-                                  </Button>
-                                </TooltipTrigger>
-                                <TooltipContent side="bottom">Collapse to previous</TooltipContent>
-                              </Tooltip>
-                            ) : (
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <Button
-                                    type="button"
-                                    variant="ghost"
-                                    size="icon-xs"
-                                    aria-label="Expand all"
-                                    data-testid="expand-all-projects"
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      expandAllProjects(allNames);
-                                    }}
-                                  >
-                                    <Maximize2Icon className="size-3.5" />
-                                  </Button>
-                                </TooltipTrigger>
-                                <TooltipContent side="bottom">Expand all</TooltipContent>
-                              </Tooltip>
-                            ))}
-                          <NewProjectButton onCreated={expandProject} />
-                        </div>
-                      );
-                    })()}
+                    headerAction={
+                      <ProjectHeaderActions
+                        projectNames={sections.projectGroups.map((group) => group.name)}
+                        collapsed={effectiveCollapsedSections.includes("Projects")}
+                        expandedProjects={expandedProjects}
+                        onExpandAll={expandAllProjects}
+                        onRevert={revertProjects}
+                        onProjectCreated={expandProject}
+                      />
+                    }
                   >
                     {sections.projectGroups.map((group) => (
                       <ProjectFolder
@@ -2078,6 +2027,72 @@ function SectionHeader({
         )}
       </button>
     </h2>
+  );
+}
+
+function ProjectHeaderActions({
+  projectNames,
+  collapsed,
+  expandedProjects,
+  onExpandAll,
+  onRevert,
+  onProjectCreated,
+}: {
+  projectNames: string[];
+  collapsed: boolean;
+  expandedProjects: string[];
+  onExpandAll: (projectNames: string[]) => void;
+  onRevert: () => void;
+  onProjectCreated: (projectName: string) => void;
+}) {
+  const showExpandControls = !collapsed && projectNames.length > 0;
+  const allExpanded =
+    projectNames.length > 0 && projectNames.every((name) => expandedProjects.includes(name));
+
+  return (
+    <div className="flex items-center gap-0.5">
+      {showExpandControls &&
+        (allExpanded ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label="Collapse to previous"
+                data-testid="revert-projects"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onRevert();
+                }}
+              >
+                <Minimize2Icon className="size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Collapse to previous</TooltipContent>
+          </Tooltip>
+        ) : (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label="Expand all"
+                data-testid="expand-all-projects"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onExpandAll(projectNames);
+                }}
+              >
+                <Maximize2Icon className="size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Expand all</TooltipContent>
+          </Tooltip>
+        ))}
+      <NewProjectButton onCreated={onProjectCreated} />
+    </div>
   );
 }
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Remove the five remaining React performance lint warnings by hoisting stable provider/default values and extracting the project header actions into a module-level component.
- Memoize the MCP server deletion callback so `McpServerList` receives a stable handler.
- Keep this cleanup independent from the open `#3540` and `#3544` warning cleanups; landed `#3542` is included through the latest `main`.

**ELI5:** React now reuses these values and component definitions instead of rebuilding them while rendering.

```text
Before: render -> create values/functions/components -> children
After:  module constants/components + memoized handlers -> render -> children
```

## Test Plan

- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `pnpm --filter web run test:coverage` (268 files passed, 4,767 tests passed)
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`
- Verified `react/jsx-no-constructed-context-values`, `react/no-unstable-nested-components`, and `react/no-object-type-as-default-prop` report zero warnings.

## Demo

N/A — internal lint cleanup with no visual behavior changes.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing tests exercise the affected components and provider setup; this PR changes reference stability without changing behavior.

## Changelog

N/A — internal lint cleanup.
