### PR TITLE
fix(web): clear one-off correctness warnings

### DIFF
--- a/web/electron/src/url.js
+++ b/web/electron/src/url.js
@@ -63,8 +63,8 @@
     let url;
     try {
       url = new URL(withScheme);
-    } catch (e) {
-      throw new Error(`invalid URL: ${e.message}`);
+    } catch (error) {
+      throw new Error(`invalid URL: ${error.message}`, { cause: error });
     }
     if (url.protocol !== "http:" && url.protocol !== "https:") {
       throw new Error(`unsupported scheme '${url.protocol}' (use http/https)`);

--- a/web/electron/test/url.test.js
+++ b/web/electron/test/url.test.js
@@ -70,6 +70,17 @@ describe("normalizeUrl", () => {
   it("rejects a non-http(s) scheme", () => {
     assert.throws(() => normalizeUrl("ftp://example.com"), /unsupported scheme/);
   });
+
+  it("preserves the parser error when rejecting an invalid URL", () => {
+    assert.throws(
+      () => normalizeUrl("http://["),
+      (error) => {
+        assert.match(error.message, /invalid URL/);
+        assert.ok(error.cause instanceof TypeError);
+        return true;
+      },
+    );
+  });
 });
 
 describe("isPlainHttpRemote", () => {

--- a/web/src/components/icons/HermesIcon.tsx
+++ b/web/src/components/icons/HermesIcon.tsx
@@ -8,7 +8,7 @@ import type { SVGProps } from "react";
 // symmetry, so the two snakes open the caduceus' twin lens loops.
 export function HermesIcon(props: SVGProps<SVGSVGElement>) {
   // One wing (two feathers) spreading from the top of the staff.
-  const wing = "M11.5 5.9 C 9 4.7 6.4 4.7 4.8 5.7 " + "M11.5 7.3 C 9.4 6.6 7.2 6.8 5.8 7.9";
+  const wing = "M11.5 5.9 C 9 4.7 6.4 4.7 4.8 5.7 M11.5 7.3 C 9.4 6.6 7.2 6.8 5.8 7.9";
   // One serpent weaving down the staff: it bows out, crosses the centre, bows
   // back the other way, and converges at the foot. Mirrored, the two snakes
   // weave the entwined caduceus.


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Preserve the original URL parser exception as the `cause` when desktop URL normalization reports invalid input.
- Add regression coverage for the preserved parser cause.
- Replace the Hermes icon's literal-only SVG path concatenation with the equivalent single literal.

## Test Plan

- `node --test electron/test/url.test.js` (22 tests passed)
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `pnpm --filter web run test:coverage` (268 files passed, 4,767 tests passed)
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`
- Verified `eslint/no-useless-concat` and `eslint/preserve-caught-error` report zero warnings.

## Demo

N/A — internal lint and error-diagnostic cleanup with no visual behavior changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The URL helper test now verifies both the normalized error message and its original parser cause.

## Changelog

N/A — internal lint cleanup.
