### PR TITLE
[models] Route wire compatibility from catalogs

### DIFF
--- a/dev/lint/hardcoded_model_allowlist.txt
+++ b/dev/lint/hardcoded_model_allowlist.txt
@@ -53,11 +53,5 @@ omnigent/onboarding/wizard.py databricks-gpt-5-4 1
 omnigent/onboarding/wizard.py gpt-4o 1
 omnigent/policies/builtins/routing.py databricks-claude-opus-4-6 1
 omnigent/policies/builtins/routing.py o3 1
-omnigent/server/smart_routing.py databricks-claude-haiku-4-5 1
-omnigent/server/smart_routing.py databricks-gpt-5-5 1
-omnigent/server/smart_routing.py databricks-gpt-5-5-pro 1
-omnigent/server/smart_routing.py databricks-gpt-5-6-luna 1
-omnigent/server/smart_routing.py databricks-gpt-5-6-sol 1
-omnigent/server/smart_routing.py databricks-gpt-5-6-terra 1
 omnigent/tools/builtins/spawn.py databricks-claude-opus-4-8 1
 omnigent/tools/builtins/spawn.py system.ai.glm-5-2 1

--- a/docs/model-hardcoding-plan.md
+++ b/docs/model-hardcoding-plan.md
@@ -141,9 +141,10 @@ source. Provider-relative cost metadata orders candidates for the stable `fast`,
 cost is unknown. If discovery is unavailable, routing skips the override and the
 harness keeps the provider-resolved default instead of consulting a stale table.
 
-The remaining exact compatibility exclusions in smart routing are temporary
-wire-API workarounds. They stay isolated until catalog wire metadata can express
-the affected harness constraints without model-name checks.
+Smart routing retains the runner's normalized wire metadata when building the
+id-only candidate set expected by routing clients. Compatibility post-processing
+uses those catalog facts and treats missing metadata from older runners as
+unknown instead of inferring protocol support from model names.
 
 ## Kiro Picker Migration
 

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -44,7 +44,13 @@ import httpx
 from cachetools import TTLCache
 
 from omnigent._platform import default_shell_argv
-from omnigent.model_metadata import ModelCapability, ModelCostTier, ModelIntent, ModelMetadata
+from omnigent.model_metadata import (
+    ModelCapability,
+    ModelCostTier,
+    ModelIntent,
+    ModelMetadata,
+    ModelWireAPI,
+)
 from omnigent.model_override import model_family_mismatch
 from omnigent.model_resolver import (
     ModelResolution,
@@ -1149,15 +1155,33 @@ def _fetch_databricks_uc_listing(
         if not name:
             continue
         api_types = service.get("supported_api_types", [])
-        has_chat = any("chat" in t for t in api_types)
-        has_embed = any("embed" in t.lower() for t in api_types)
+        normalized_api_types = {
+            api_type.lower() for api_type in api_types if isinstance(api_type, str)
+        }
+        has_chat = any("chat" in api_type for api_type in normalized_api_types)
+        has_embed = any("embed" in api_type for api_type in normalized_api_types)
         if not has_chat or has_embed:
             continue
         from omnigent.pi_native_credentials import _unsupported_in_pi
 
         if _unsupported_in_pi(name.lower()):
             continue
-        models.append(ModelEntry(id=name, family=model_family_token(name)))
+        wire_apis: set[ModelWireAPI] = set()
+        if any("chat/completions" in api_type for api_type in normalized_api_types):
+            wire_apis.add(ModelWireAPI.OPENAI_CHAT)
+        if "openai/v1/responses" in normalized_api_types:
+            wire_apis.add(ModelWireAPI.OPENAI_RESPONSES)
+        if any(
+            "anthropic" in api_type and "messages" in api_type for api_type in normalized_api_types
+        ):
+            wire_apis.add(ModelWireAPI.ANTHROPIC_MESSAGES)
+        models.append(
+            ModelEntry(
+                id=name,
+                family=model_family_token(name),
+                metadata=ModelMetadata(wire_apis=frozenset(wire_apis)),
+            )
+        )
     return ModelListing(
         source="gateway",
         verified=True,

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -16,7 +16,7 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
-from omnigent.model_metadata import ModelCostTier, ModelIntent
+from omnigent.model_metadata import ModelCostTier, ModelIntent, ModelWireAPI
 
 if TYPE_CHECKING:
     import httpx  # used in type annotations only; runtime import is lazy in fetch_runner_models
@@ -70,22 +70,45 @@ class RoutingClient(Protocol):
 # ── Helpers ────────────────────────────────────────────────────────────────
 
 
-async def fetch_runner_models(
+@dataclass(frozen=True)
+class _RunnerModel:
+    """Model metadata retained from the runner catalog for routing decisions."""
+
+    id: str
+    family: str | None
+    cost_tier: str | None
+    wire_apis: frozenset[ModelWireAPI]
+
+
+def _catalog_wire_apis(raw: object) -> frozenset[ModelWireAPI]:
+    """Parse known wire values while ignoring older or future vocabulary."""
+    if not isinstance(raw, list):
+        return frozenset()
+    wire_apis: set[ModelWireAPI] = set()
+    for value in raw:
+        if not isinstance(value, str):
+            continue
+        try:
+            wire_apis.add(ModelWireAPI(value))
+        except ValueError:
+            continue
+    return frozenset(wire_apis)
+
+
+async def _fetch_runner_catalog(
     session_id: str,
     runner_client: httpx.AsyncClient,
-) -> dict[str, list[str]] | None:
+) -> dict[str, list[_RunnerModel]] | None:
     """Fetch live model availability from the runner's ``/v1/sessions/{id}/models`` endpoint.
 
-    Converts the ``sys_list_models``-shaped catalog into the harness →
-    model-id-list format expected by :class:`RoutingClient`. Models with
-    provider-relative cost metadata are ordered economy → standard → premium;
-    catalog order remains the deterministic tie-breaker.
+    Parses the ``sys_list_models``-shaped catalog while retaining compatibility
+    metadata. Models with provider-relative cost metadata are ordered economy →
+    standard → premium; catalog order remains the deterministic tie-breaker.
 
     :param session_id: Session/conversation identifier.
     :param runner_client: Async HTTP client pointed at the runner.
-    :returns: ``{harness: [model_id, ...]}`` ordered cheapest → most
-        powerful, or ``None`` when the endpoint is unavailable or the
-        response cannot be parsed.
+    :returns: Worker names mapped to ordered model metadata, or ``None`` when
+        the endpoint is unavailable or the response cannot be parsed.
     """
     import httpx as _httpx
 
@@ -103,7 +126,7 @@ async def fetch_runner_models(
     if not workers:
         return None
 
-    result: dict[str, list[str]] = {}
+    result: dict[str, list[_RunnerModel]] = {}
     for worker_name, row in workers.items():
         if not isinstance(row, dict):
             continue
@@ -115,22 +138,49 @@ async def fetch_runner_models(
             ModelCostTier.STANDARD.value: 1,
             ModelCostTier.PREMIUM.value: 2,
         }
-        indexed_models = [
-            (index, model)
-            for index, model in enumerate(models_raw)
-            if isinstance(model, dict) and isinstance(model.get("id"), str)
-        ]
+        indexed_models: list[tuple[int, _RunnerModel]] = []
+        for index, model in enumerate(models_raw):
+            if not isinstance(model, dict) or not isinstance(model.get("id"), str):
+                continue
+            indexed_models.append(
+                (
+                    index,
+                    _RunnerModel(
+                        id=model["id"],
+                        family=model.get("family")
+                        if isinstance(model.get("family"), str)
+                        else None,
+                        cost_tier=(
+                            model.get("cost_tier")
+                            if isinstance(model.get("cost_tier"), str)
+                            else None
+                        ),
+                        wire_apis=_catalog_wire_apis(model.get("wire_apis")),
+                    ),
+                )
+            )
         ordered_models = sorted(
             indexed_models,
             key=lambda item: (
-                cost_order.get(item[1].get("cost_tier"), len(cost_order)),
+                cost_order.get(item[1].cost_tier, len(cost_order)),
                 item[0],
             ),
         )
-        ids = [model["id"] for _, model in ordered_models]
-        if ids:
-            result[worker_name] = ids
+        models = [model for _, model in ordered_models]
+        if models:
+            result[worker_name] = models
     return result or None
+
+
+async def fetch_runner_models(
+    session_id: str,
+    runner_client: httpx.AsyncClient,
+) -> dict[str, list[str]] | None:
+    """Return the runner catalog in the id-only routing-client shape."""
+    catalog = await _fetch_runner_catalog(session_id, runner_client)
+    if catalog is None:
+        return None
+    return {worker: [model.id for model in models] for worker, models in catalog.items()}
 
 
 def _flatten_models(available_models: dict[str, list[str]]) -> list[str]:
@@ -585,63 +635,38 @@ _WORKER_NAME_TO_HARNESS: dict[str, str] = {
     "pi": "pi",
 }
 
-# Per-harness (harness, model) incompatibilities corrected AFTER the router
-# verdict. We do NOT prune these from the candidate set sent to the router —
-# the external task_v0 router enforces a required model set and 400s if any
-# required model is absent, so the full set must be offered. Instead, when the
-# router picks one of these pairs, _redirect_incompatible_pick moves it to a
-# harness that can actually run the model.
-#
-# The pi harness reaches Databricks two incompatible ways for these families:
-#   - Claude models ride pi's Anthropic Messages gateway, whose request path
-#     adds an ``eager_input_streaming`` field the serving endpoint rejects with
-#     a 400 when tools are present.
-#   - The gpt-5.5 / gpt-5.6 reasoning models ride pi's openai-completions path
-#     (``/chat/completions``); Databricks applies a default ``reasoning_effort``
-#     there and rejects tool calls with "Function tools with reasoning_effort
-#     are not supported for gpt-5.5 ... use /v1/responses or set reasoning_effort
-#     to 'none'." pi's provider can't send that override, so tool turns 400.
-# claude-sdk serves Claude and codex serves gpt-5.5+ (Responses API); the
-# gpt-5.4 family works on pi and is left alone.
-_HARNESS_EXCLUDED_MODELS: dict[str, tuple[str, ...]] = {
-    "pi": (
-        "databricks-claude-haiku-4-5",
-        "databricks-gpt-5-5",
-        "databricks-gpt-5-5-pro",
-        "databricks-gpt-5-6-luna",
-        "databricks-gpt-5-6-terra",
-        "databricks-gpt-5-6-sol",
-    ),
-}
 
-
-def _redirect_incompatible_pick(harness: str | None, model: str) -> str | None:
+def _redirect_incompatible_pick(
+    harness: str | None,
+    model: str,
+    harness_catalog: dict[str, list[_RunnerModel]],
+) -> str | None:
     """Redirect a router verdict off a harness that can't serve *model*.
 
-    Some external routers ignore the candidate set we send and return a
-    ``(harness, model)`` pair we deliberately excluded (see
-    :data:`_HARNESS_EXCLUDED_MODELS`). Since we can't stop the router from
-    choosing it, redirect the pick to a harness that CAN serve the model:
-
-    - a Claude model on pi → ``claude-sdk``
-    - a gpt-5.5/5.6 reasoning model on pi → ``codex`` (Responses API)
+    Pi speaks Anthropic Messages for Claude-family models. When the runner
+    catalog explicitly reports that the selected endpoint does not accept that
+    wire, move the verdict to ``claude-sdk``. Unknown metadata from an older
+    runner is not treated as incompatible.
 
     :param harness: The router's chosen harness id (may be ``None``).
     :param model: The router's chosen model id.
+    :param harness_catalog: Catalog metadata keyed by normalized harness id.
     :returns: A replacement harness id, or the original *harness* when the
         pick is already compatible.
     """
-    if harness is None:
-        return None
-    excluded = _HARNESS_EXCLUDED_MODELS.get(harness, ())
-    if model not in excluded:
+    if harness != "pi":
         return harness
-    lower = model.lower()
-    if "claude" in lower:
+    entry = next(
+        (candidate for candidate in harness_catalog.get(harness, ()) if candidate.id == model),
+        None,
+    )
+    if (
+        entry is not None
+        and entry.family == "claude"
+        and entry.wire_apis
+        and ModelWireAPI.ANTHROPIC_MESSAGES not in entry.wire_apis
+    ):
         return "claude-sdk"
-    if "gpt" in lower:
-        return "codex"
-    # Unknown family on an excluding harness — leave as-is rather than guess.
     return harness
 
 
@@ -687,9 +712,9 @@ async def route_session_harness(
     # for a sub-agent) so the candidate set is the full spawnable-worker map,
     # independent of whether the routed session is top-level or a sub-agent.
     _catalog_sid = catalog_session_id or session_id
-    live_catalog: dict[str, list[str]] | None = None
+    live_catalog: dict[str, list[_RunnerModel]] | None = None
     if _catalog_sid and runner_client is not None:
-        live_catalog = await fetch_runner_models(_catalog_sid, runner_client)
+        live_catalog = await _fetch_runner_catalog(_catalog_sid, runner_client)
 
     # NOTE: we do NOT filter incompatible (harness, model) pairs out of the
     # candidate set here. The external router (task_v0) enforces a required
@@ -698,14 +723,16 @@ async def route_session_harness(
     # and correct an incompatible verdict afterward via
     # _redirect_incompatible_pick.
     harness_models: dict[str, list[str]] = {}
+    harness_catalog: dict[str, list[_RunnerModel]] = {}
     if live_catalog:
-        for worker_name, worker_models in live_catalog.items():
+        for worker_name, worker_catalog in live_catalog.items():
             harness = _WORKER_NAME_TO_HARNESS.get(worker_name)
             if harness is None or harness not in _AUTO_ROUTING_HARNESSES:
                 continue
-            if worker_models:
+            if worker_catalog:
                 # First worker wins for a given harness id (dedupe).
-                harness_models.setdefault(harness, worker_models)
+                harness_catalog.setdefault(harness, worker_catalog)
+                harness_models.setdefault(harness, [entry.id for entry in worker_catalog])
 
     if not harness_models:
         return None, None, None, "No discovered routable harnesses are available on this runner."
@@ -751,11 +778,9 @@ async def route_session_harness(
                 chosen_harness = h
                 break
 
-    # Redirect an incompatible (harness, model) pick the router may have
-    # returned despite our filtered candidate set (some external routers
-    # ignore it): a Claude model or gpt-5.5+ reasoning model on pi is
-    # redirected to claude-sdk / codex respectively.
-    _redirected = _redirect_incompatible_pick(chosen_harness, result.model)
+    # Redirect a catalog-proven wire mismatch after routing so the complete
+    # candidate set still reaches external routers that require it.
+    _redirected = _redirect_incompatible_pick(chosen_harness, result.model, harness_catalog)
     if _redirected != chosen_harness:
         _logger.info(
             "smart_routing: redirecting incompatible pick harness=%s model=%s -> harness=%s",

--- a/tests/server/test_smart_routing.py
+++ b/tests/server/test_smart_routing.py
@@ -102,17 +102,27 @@ def _catalog_client() -> MagicMock:
         "self": _TEST_MODELS["claude-sdk"],
     }
     response = MagicMock()
-    response.json.return_value = {
-        "workers": {
-            worker: {
-                "source": "catalog",
-                "verified": True,
-                "models": [{"id": model} for model in models],
-                "note": "",
-            }
-            for worker, models in workers.items()
+    catalog_workers: dict[str, dict[str, Any]] = {}
+    for worker, models in workers.items():
+        entries: list[dict[str, Any]] = []
+        for model in models:
+            entry: dict[str, Any] = {"id": model}
+            if worker == "pi":
+                if "claude" in model:
+                    entry.update(family="claude", wire_apis=["openai-chat"])
+                elif "gpt" in model:
+                    entry.update(
+                        family="openai",
+                        wire_apis=["openai-chat", "openai-responses"],
+                    )
+            entries.append(entry)
+        catalog_workers[worker] = {
+            "source": "catalog",
+            "verified": True,
+            "models": entries,
+            "note": "",
         }
-    }
+    response.json.return_value = {"workers": catalog_workers}
     response.raise_for_status = MagicMock()
     client = MagicMock()
     client.get = AsyncMock(return_value=response)
@@ -1156,12 +1166,11 @@ async def test_route_session_harness_returns_none_for_empty_message() -> None:
 
 @pytest.mark.asyncio
 async def test_route_session_harness_sends_full_candidate_set_unfiltered() -> None:
-    """The candidate set sent to the router is NOT pruned of incompatible models.
+    """The candidate set sent to the router is not pruned before selection.
 
     The external task_v0 router enforces a required model set and 400s if any
-    required model is missing, so we must offer the full list (including
-    gpt-5.5/5.6 and Claude models under pi) and correct an incompatible verdict
-    afterward via the redirect, not by filtering candidates.
+    required model is missing, so compatibility metadata is applied to its
+    verdict rather than filtering the candidates sent to it.
     """
     pi_models: list[str] = []
 
@@ -1177,36 +1186,30 @@ async def test_route_session_harness_sends_full_candidate_set_unfiltered() -> No
         await route_session_harness(
             "hello", session_id="conv_123", runner_client=_catalog_client()
         )
-    # The excluded-on-pi models are still SENT (router requires the full set);
-    # incompatibility is handled post-verdict by the redirect.
+    # Every discovered Pi model is still sent to the router.
     assert "databricks-claude-haiku-4-5" in pi_models
     assert "databricks-gpt-5-5" in pi_models
 
 
 @pytest.mark.asyncio
-async def test_route_session_harness_redirects_incompatible_router_pick() -> None:
-    """A router that ignores our candidate set and picks pi+gpt-5.5 is redirected.
-
-    Some external routers return a (harness, model) pair we excluded. The
-    verdict post-processing must redirect gpt-5.5 off pi to codex.
-    """
-    # Router returns pi + gpt-5-5 (an excluded, incompatible pair).
+async def test_route_session_harness_keeps_responses_capable_model_on_pi() -> None:
+    """Pi can keep a model whose catalog advertises the Responses wire."""
     expected = RoutingResult(
-        model="databricks-gpt-5-5", rationale="picked despite exclusion", harness="pi"
+        model="databricks-gpt-5-5", rationale="responses-capable", harness="pi"
     )
     caps = _FakeCaps(routing_client=_FakeRoutingClient(expected))
     with patch("omnigent.runtime._globals._caps", new=caps):
         harness, model, _verdict, error = await route_session_harness(
             "do something", session_id="conv_123", runner_client=_catalog_client()
         )
-    assert harness == "codex", f"gpt-5.5 on pi should redirect to codex, got {harness!r}"
+    assert harness == "pi"
     assert model == "databricks-gpt-5-5"
     assert error is None
 
 
 @pytest.mark.asyncio
 async def test_route_session_harness_redirects_claude_on_pi_to_claude_sdk() -> None:
-    """A router pick of a Claude model on pi is redirected to claude-sdk."""
+    """A Claude endpoint without Messages support is redirected off Pi."""
     expected = RoutingResult(model="databricks-claude-haiku-4-5", rationale="cheap", harness="pi")
     caps = _FakeCaps(routing_client=_FakeRoutingClient(expected))
     with patch("omnigent.runtime._globals._caps", new=caps):
@@ -1214,6 +1217,25 @@ async def test_route_session_harness_redirects_claude_on_pi_to_claude_sdk() -> N
             "quick q", session_id="conv_123", runner_client=_catalog_client()
         )
     assert harness == "claude-sdk", f"claude on pi should redirect to claude-sdk, got {harness!r}"
+    assert model == "databricks-claude-haiku-4-5"
+    assert error is None
+
+
+@pytest.mark.asyncio
+async def test_route_session_harness_keeps_unknown_pi_compatibility() -> None:
+    """Missing wire metadata from an older runner does not imply incompatibility."""
+    expected = RoutingResult(model="databricks-claude-haiku-4-5", rationale="cheap", harness="pi")
+    client = _catalog_client()
+    payload = client.get.return_value.json.return_value
+    payload["workers"]["pi"]["models"][0].pop("wire_apis")
+    caps = _FakeCaps(routing_client=_FakeRoutingClient(expected))
+
+    with patch("omnigent.runtime._globals._caps", new=caps):
+        harness, model, _verdict, error = await route_session_harness(
+            "quick q", session_id="conv_123", runner_client=client
+        )
+
+    assert harness == "pi"
     assert model == "databricks-claude-haiku-4-5"
     assert error is None
 

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -563,6 +563,12 @@ def test_databricks_listing_filters_to_chat_llms(
     assert by_id["system.ai.claude-sonnet-4-6"].family == "claude"
     assert by_id["system.ai.gpt-5-4"].family == "openai"
     assert by_id["system.ai.meta-llama-3-3-70b-instruct"].family == "other"
+    assert by_id["system.ai.claude-sonnet-4-6"].metadata.wire_apis == frozenset(
+        {ModelWireAPI.OPENAI_CHAT}
+    )
+    assert by_id["system.ai.gpt-5-4"].metadata.wire_apis == frozenset(
+        {ModelWireAPI.OPENAI_CHAT, ModelWireAPI.OPENAI_RESPONSES}
+    )
 
 
 def test_databricks_listing_skips_explicitly_non_ready_endpoints(


### PR DESCRIPTION
## Related issue

Part of #3426

## Summary

- Normalize Databricks Unity Catalog `supported_api_types` into `ModelWireAPI` metadata and retain it through runner catalog parsing.
- Replace six exact Pi model exclusions with a catalog-backed Claude wire compatibility check; Responses-capable GPT models remain on Pi's supported Responses path.
- Treat missing metadata from older runners as unknown, ratchet the hardcode baseline, and document the migrated boundary.

**ELI5:** The router now asks the catalog which protocol a model endpoint accepts instead of recognizing specific model release names.

```text
UC supported_api_types -> ModelWireAPI -> runner catalog -> compatibility check
                                      \-> id-only list -> routing client
```

## Test Plan

- `uv run --no-sync pytest -q tests/test_model_catalog.py tests/server/test_smart_routing.py` — 104 passed.
- `uv run --no-sync pytest -q tests/inner/test_pi_executor.py::test_models_json_uses_oss_verified_gpt_55_caps tests/test_pi_native_credentials.py::test_databricks_profile_registers_gpt_provider` — 2 passed.
- `uv run --no-sync pytest -q tests/inner/test_pi_executor.py tests/test_pi_native_credentials.py -k 'responses or provider_for_model or model_lists'` — 5 passed.
- Changed-file pre-commit suite passed, including Ruff and the hardcoded-model lint. Repository-wide pre-commit passed relevant hooks; the existing stale `omnigent/api/routing/v1/routing_pb2.py` check remains unrelated.

## Demo

N/A — non-visual routing/catalog refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused tests cover UC wire normalization, Responses-capable Pi routing, Claude wire mismatch redirection, and older-runner payloads without wire metadata.
