### PR TITLE
fix(web): resolve await-in-loop warnings

### DIFF
--- a/web/electron/test/desktop_updater.test.js
+++ b/web/electron/test/desktop_updater.test.js
@@ -253,17 +253,19 @@ describe("desktop_updater — dev feed gating", () => {
     const h = makeUpdater({ settings: { update_mode: "manual" } });
     h.updater.registerIpc();
 
-    for (const channel of [
-      "omnigent:update-check",
-      "omnigent:update-download",
-      "omnigent:update-install",
-      "omnigent:set-update-config",
-    ]) {
-      await assert.rejects(
-        h.ipcHandlers.get(channel)(h.event, { mode: "manual" }),
-        /unavailable in development/,
-      );
-    }
+    await Promise.all(
+      [
+        "omnigent:update-check",
+        "omnigent:update-download",
+        "omnigent:update-install",
+        "omnigent:set-update-config",
+      ].map((channel) =>
+        assert.rejects(
+          h.ipcHandlers.get(channel)(h.event, { mode: "manual" }),
+          /unavailable in development/,
+        ),
+      ),
+    );
     assert.equal(h.calls.showMessageBox.length, 0);
     assert.equal(h.calls.checkForUpdates ?? 0, 0);
     assert.equal(h.calls.downloadUpdate, 0);
@@ -284,12 +286,14 @@ describe("desktop_updater — IPC trust + consent", () => {
       ["omnigent:update-install", []],
       ["omnigent:set-update-config", [{ mode: "manual" }]],
     ];
-    for (const [channel, args] of cases) {
-      await assert.rejects(
-        Promise.resolve().then(() => h.ipcHandlers.get(channel)(h.event, ...args)),
-        /connected server page/,
-      );
-    }
+    await Promise.all(
+      cases.map(([channel, args]) =>
+        assert.rejects(
+          Promise.resolve().then(() => h.ipcHandlers.get(channel)(h.event, ...args)),
+          /connected server page/,
+        ),
+      ),
+    );
   });
 
   it("prompts and runs each privileged action when approved", async () => {

--- a/web/electron/test/update-main.test.js
+++ b/web/electron/test/update-main.test.js
@@ -262,13 +262,15 @@ describe("auto-update main-process wiring", () => {
       ["omnigent:update-install", []],
       ["omnigent:set-update-config", [{ mode: "manual" }]],
     ];
-    for (const [channel, args] of cases) {
-      const handler = harness.ipcHandlers.get(channel);
-      await assert.rejects(
-        Promise.resolve().then(() => handler(harness.events.unpinned, ...args)),
-        /connected server page/,
-      );
-    }
+    await Promise.all(
+      cases.map(([channel, args]) => {
+        const handler = harness.ipcHandlers.get(channel);
+        return assert.rejects(
+          Promise.resolve().then(() => handler(harness.events.unpinned, ...args)),
+          /connected server page/,
+        );
+      }),
+    );
   });
 
   it("prompts for every privileged update channel before running it", async (t) => {
@@ -305,6 +307,8 @@ describe("auto-update main-process wiring", () => {
       },
     ];
 
+    // Harnesses install process-level module mocks and must run one at a time.
+    /* oxlint-disable no-await-in-loop */
     for (const item of cases) {
       const harness = loadMainHarness({
         forceDevUpdateConfig: true,
@@ -327,6 +331,7 @@ describe("auto-update main-process wiring", () => {
       ]);
       item.assertRan(harness);
     }
+    /* oxlint-enable no-await-in-loop */
   });
 
   it("does not let a cached hosting grant bypass update-control consent", async (t) => {
@@ -360,6 +365,8 @@ describe("auto-update main-process wiring", () => {
       },
     ];
 
+    // Harnesses install process-level module mocks and must run one at a time.
+    /* oxlint-disable no-await-in-loop */
     for (const item of cases) {
       const harness = loadMainHarness({
         forceDevUpdateConfig: true,
@@ -382,6 +389,7 @@ describe("auto-update main-process wiring", () => {
       assert.equal(harness.calls.showMessageBox.length, 1, item.channel);
       item.assertBlocked(harness);
     }
+    /* oxlint-enable no-await-in-loop */
   });
 
   it("routes approved update-install through before-quit cleanup to quitAndInstall", async (t) => {

--- a/web/src/components/PermissionsModal.test.tsx
+++ b/web/src/components/PermissionsModal.test.tsx
@@ -315,6 +315,8 @@ describe("PermissionsModal", () => {
     // The manage grant's level is still visible to the viewer as static text.
     expect(screen.getByText("Manage")).toBeInTheDocument();
 
+    // Only one listbox can be open, so each interaction must finish first.
+    /* oxlint-disable no-await-in-loop */
     for (const trigger of triggers) {
       trigger.focus();
       fireEvent.keyDown(trigger, { key: "Enter" });
@@ -327,6 +329,7 @@ describe("PermissionsModal", () => {
       fireEvent.keyDown(listbox, { key: "Escape" });
       await waitFor(() => expect(screen.queryByRole("listbox")).not.toBeInTheDocument());
     }
+    /* oxlint-enable no-await-in-loop */
   });
 
   it("does not fetch permissions when closed", () => {

--- a/web/src/hooks/useAvailableAgents.ts
+++ b/web/src/hooks/useAvailableAgents.ts
@@ -120,6 +120,8 @@ interface SessionListItemWire {
 async function fetchBuiltinAgents(): Promise<AvailableAgent[]> {
   const rows: BuiltinAgentWire[] = [];
   let after: string | null = null;
+  // Each page provides the cursor for the next request.
+  /* oxlint-disable no-await-in-loop */
   do {
     const url = after == null ? "/v1/agents" : `/v1/agents?after=${encodeURIComponent(after)}`;
     const res = await authenticatedFetch(url);
@@ -128,6 +130,7 @@ async function fetchBuiltinAgents(): Promise<AvailableAgent[]> {
     rows.push(...body.data);
     after = body.has_more === true && body.last_id ? body.last_id : null;
   } while (after != null);
+  /* oxlint-enable no-await-in-loop */
 
   return rows.map((a) => ({
     id: a.id,

--- a/web/src/hooks/useHostFilesystem.ts
+++ b/web/src/hooks/useHostFilesystem.ts
@@ -117,7 +117,7 @@ async function fetchHostFilesystem(hostId: string, path: string): Promise<HostDi
   let truncated = false;
   // Sequential by necessity: each page's cursor is the previous
   // page's last entry path, so the requests can't be parallelized.
-  /* oxlint-disable eslint(no-await-in-loop) */
+  /* oxlint-disable no-await-in-loop */
   for (let page = 0; page < MAX_PAGES; page++) {
     const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
     if (after !== null) {
@@ -143,7 +143,7 @@ async function fetchHostFilesystem(hostId: string, path: string): Promise<HostDi
       truncated = true;
     }
   }
-  /* oxlint-enable eslint(no-await-in-loop) */
+  /* oxlint-enable no-await-in-loop */
   return { entries, truncated };
 }
 

--- a/web/src/hooks/useTerminals.test.ts
+++ b/web/src/hooks/useTerminals.test.ts
@@ -164,14 +164,15 @@ describe("fetchTerminals", () => {
     ]);
   });
 
-  it("returns [] for a not-yet-reachable runner (404/409/502/503)", async () => {
-    // These are "no terminal yet", not errors: the live SSE event fills
-    // the rail once the runner binds, so the seed must not throw.
-    for (const status of [404, 409, 502, 503]) {
+  it.each([404, 409, 502, 503])(
+    "returns [] for a not-yet-reachable runner (%i)",
+    async (status) => {
+      // These are "no terminal yet", not errors: the live SSE event fills
+      // the rail once the runner binds, so the seed must not throw.
       fetchMock.mockResolvedValueOnce(mockResponse(null, { ok: false, status }));
       expect(await fetchTerminals("conv_abc")).toEqual([]);
-    }
-  });
+    },
+  );
 
   it("throws on a hard error status so React Query can retry", async () => {
     fetchMock.mockResolvedValueOnce(mockResponse(null, { ok: false, status: 500 }));

--- a/web/src/lib/agentBundle.ts
+++ b/web/src/lib/agentBundle.ts
@@ -209,11 +209,14 @@ async function gzip(data: Uint8Array): Promise<Uint8Array> {
 
   const reader = cs.readable.getReader();
   const chunks: Uint8Array[] = [];
+  // Each read advances the same stream reader.
+  /* oxlint-disable no-await-in-loop */
   for (;;) {
     const { done, value } = await reader.read();
     if (done) break;
     chunks.push(value);
   }
+  /* oxlint-enable no-await-in-loop */
 
   const totalSize = chunks.reduce((sum, c) => sum + c.length, 0);
   const result = new Uint8Array(totalSize);

--- a/web/src/lib/permissionsApi.ts
+++ b/web/src/lib/permissionsApi.ts
@@ -103,6 +103,8 @@ export async function listPermissions(sessionId: string): Promise<Permission[]> 
   // cursor and concatenate so callers always see the full grant list.
   const all: Permission[] = [];
   let after: string | null = null;
+  // Each page provides the cursor for the next request.
+  /* oxlint-disable no-await-in-loop */
   do {
     const path = `/v1/sessions/${encodeURIComponent(sessionId)}/permissions${
       after !== null ? `?after=${encodeURIComponent(after)}` : ""
@@ -116,6 +118,7 @@ export async function listPermissions(sessionId: string): Promise<Permission[]> 
     all.push(...data.permissions);
     after = data.next_cursor;
   } while (after !== null);
+  /* oxlint-enable no-await-in-loop */
   return all;
 }
 

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -859,6 +859,8 @@ function isUserPrompt(item: ConversationItem): boolean {
 export async function fetchInitialHistoryWindow(sessionId: string): Promise<SessionItemsPage> {
   let items: ConversationItem[] = [];
   let hasMore = true;
+  // Each page starts before the cursor returned by the prior page.
+  /* oxlint-disable no-await-in-loop */
   for (let pages = 0; pages < MAX_INITIAL_PAGES; pages++) {
     const cursor = items[0]?.id;
     const page = await fetchSessionItemsPage(sessionId, cursor ? { olderThan: cursor } : {});
@@ -869,6 +871,7 @@ export async function fetchInitialHistoryWindow(sessionId: string): Promise<Sess
     if (items.length >= SESSION_HISTORY_PAGE_SIZE && userCount >= 2) break;
     if (!items[0]?.id) break; // no cursor to page further; avoid a spin
   }
+  /* oxlint-enable no-await-in-loop */
   // If the cap stopped us before the previous user prompt (a pathological
   // single turn spanning >MAX_INITIAL_PAGES pages), `hasMore` stays true so
   // the rest remains reachable via scroll-up — same fallback as the default.

--- a/web/src/loadtest/streamRenderBench.ts
+++ b/web/src/loadtest/streamRenderBench.ts
@@ -120,9 +120,12 @@ function sse(event: string, data: Record<string, unknown>): string {
 
 /** Let the async SSE-parse → reduce pipeline drain queued bytes. */
 async function drain(): Promise<void> {
+  // Timer turns must elapse in order to flush each queued stage.
+  /* oxlint-disable no-await-in-loop */
   for (let k = 0; k < 4; k += 1) {
     await new Promise<void>((r) => setTimeout(r, 0));
   }
+  /* oxlint-enable no-await-in-loop */
 }
 
 /**
@@ -247,6 +250,8 @@ export async function runStreamRenderBench(opts: {
   // Stream the text. Each delta carries a trailing space so the reducer
   // flushes a text_chunk on its 30-char threshold.
   let full = "";
+  // The benchmark drains each delta before sending the next one.
+  /* oxlint-disable no-await-in-loop */
   for (let n = 0; n < contentDeltas; n += 1) {
     const tok = `token${n} of streamed answer `;
     full += tok;
@@ -254,6 +259,7 @@ export async function runStreamRenderBench(opts: {
     await drain();
     if (manual && (n + 1) % blocksPerFrame === 0) manual.fire();
   }
+  /* oxlint-enable no-await-in-loop */
   if (manual) manual.fire(); // flush the partial trailing frame
 
   // Close the response.

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2358,6 +2358,7 @@ export function JumpToTopButton({
       // history or on error. The rAF wait yields a frame for the prepend to
       // commit and for the in-flight flag to settle between pages. The
       // iteration cap is a backstop against a server that never reports done.
+      /* oxlint-disable no-await-in-loop */
       for (let i = 0; i < 1000 && useChatStore.getState().hasMoreHistory; i++) {
         await useChatStore.getState().loadMoreHistory();
         // Keep the lock released — a prepend that briefly lands us near the
@@ -2379,6 +2380,7 @@ export function JumpToTopButton({
         }
         await nextFrame();
       }
+      /* oxlint-enable no-await-in-loop */
     } finally {
       setJumping(false);
     }

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -6952,9 +6952,11 @@ describe("chatStore — startStreamPump reconnect loop", () => {
 
   /** Drain reconcile's sequential await chain under fake timers. */
   async function drainAsync(turns = 25): Promise<void> {
+    /* oxlint-disable no-await-in-loop */
     for (let i = 0; i < turns; i += 1) {
       await vi.advanceTimersByTimeAsync(1);
     }
+    /* oxlint-enable no-await-in-loop */
   }
 
   function gapUser(prefix: string, idx: number): ConversationItem {
@@ -8049,9 +8051,11 @@ describe("chatStore — elicitations across stream drops and re-publishes", () =
 
   /** Drain the pump + reconcile's sequential await chain under fake timers. */
   async function drainAsync(turns = 25): Promise<void> {
+    /* oxlint-disable no-await-in-loop */
     for (let i = 0; i < turns; i += 1) {
       await vi.advanceTimersByTimeAsync(1);
     }
+    /* oxlint-enable no-await-in-loop */
   }
 
   /** Open the stream-pump loop for `id` and drain until the first sink exists. */

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -732,6 +732,19 @@ async function uploadFileBlock(sessionId: string, file: File): Promise<ContentBl
   return block;
 }
 
+async function uploadFileBlocks(
+  sessionId: string,
+  files: readonly File[],
+): Promise<ContentBlock[]> {
+  const blocks: ContentBlock[] = [];
+  // Stop at the first failure so later uploads cannot outlive a requeued send.
+  for (const file of files) {
+    // oxlint-disable-next-line no-await-in-loop
+    blocks.push(await uploadFileBlock(sessionId, file));
+  }
+  return blocks;
+}
+
 // Must match the @keyframes user-msg-flash duration in index.css.
 const FLASH_DURATION_MS = 800;
 const WORKSPACE_INVALIDATION_DEBOUNCE_MS = 750;
@@ -1113,12 +1126,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // the next trigger backs off instead of hammering a failing runner.
       void (async () => {
         await priorSend;
-        const fileBlocks: ContentBlock[] = [];
-        for (const file of head.files ?? []) {
-          // Reuse a prior successful upload so the cooldown-paced retry doesn't
-          // re-upload files that already landed (orphaning the earlier blobs).
-          fileBlocks.push(await uploadFileBlock(conversationId, file));
-        }
+        // Reuse prior successful uploads so cooldown-paced retries do not
+        // orphan blobs that already landed.
+        const fileBlocks = await uploadFileBlocks(conversationId, head.files ?? []);
         const content: ContentBlock[] = [
           ...fileBlocks,
           ...(head.text.trim() ? [{ type: "input_text" as const, text: head.text }] : []),
@@ -1229,12 +1239,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // otherwise). Plain text (if any) appended last. uploadFileBlock reuses
       // a prior successful upload of the same File so a retry after a
       // post-phase failure doesn't re-upload — and orphan — blobs that landed.
-      const fileBlocks: ContentBlock[] = [];
-      if (files && files.length > 0) {
-        for (const file of files) {
-          fileBlocks.push(await uploadFileBlock(sessionId, file));
-        }
-      }
+      const fileBlocks = await uploadFileBlocks(sessionId, files ?? []);
       const serverContent: ContentBlock[] = [
         ...fileBlocks,
         ...(text.trim() ? [{ type: "input_text" as const, text }] : []),
@@ -1919,6 +1924,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
       });
     };
     try {
+      // Each page starts before the cursor returned by the prior page.
+      /* oxlint-disable no-await-in-loop */
       for (let pages = 0; pages < MAX_EAGER_PAGES && hasMore && cursor; pages++) {
         const page = await fetchSessionItemsPage(conversationId, {
           olderThan: cursor,
@@ -1942,6 +1949,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         if (existingUsers + countUsers(older) >= minUserMessages) break;
         if (!page.items[0]?.id) break;
       }
+      /* oxlint-enable no-await-in-loop */
       commit();
     } catch {
       if (stale()) return;
@@ -3020,6 +3028,8 @@ async function reconcileOnReconnect(id: string, set: Setter, get: Getter): Promi
   let items = page.items;
   let hasMore = page.hasMore;
   let covered = !hasMore || items.some((it) => preGapIds.has(it.id));
+  // Each page starts before the cursor returned by the prior page.
+  /* oxlint-disable no-await-in-loop */
   for (let fetched = 1; !covered && fetched < RECONNECT_BACKFILL_MAX_PAGES; fetched += 1) {
     const cursor = items[0]?.id;
     if (!cursor) break;
@@ -3035,6 +3045,7 @@ async function reconcileOnReconnect(id: string, set: Setter, get: Getter): Promi
     covered = !hasMore || older.items.some((it) => preGapIds.has(it.id));
     if (older.items.length === 0) break; // no progress; avoid refetching the same cursor
   }
+  /* oxlint-enable no-await-in-loop */
   if (!covered) {
     await rehydrateWindowOnReconnect(id, session, preGapIds, preGapElicitations, set, get);
     return;


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Audit all 27 `no-await-in-loop` warnings and preserve intentional ordering for cursor pagination, stream/frame draining, reconnect backfill, attachment uploads, and stateful test harnesses.
- Centralize sequential attachment uploads so foreground and background sends share the same stop-on-first-failure behavior.
- Run independent updater rejection assertions concurrently and parameterize terminal status coverage, bringing `no-await-in-loop` from 27 warnings to zero.

**ELI5:** Some async work is a relay race where each step needs the previous result; other checks are independent. This PR labels the relay races and runs only the independent checks together.

```text
Cursor/stream work: step 1 -> result/cursor -> step 2
Independent checks: [check A, check B, check C] -> Promise.all
```

## Test Plan

- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `pnpm --filter web run test:coverage` (268 files passed, 4,771 tests passed)
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`
- Verified `eslint/no-await-in-loop` reports zero warnings and the latest-main lint inventory drops from 66 to 39.

## Demo

N/A — internal lint and test-structure cleanup with no visual behavior changes.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The full web suite covers the affected pagination, reconnect, upload, permissions, terminal, and updater paths; terminal soft-status cases are now individually parameterized.

## Changelog

N/A — internal lint cleanup.
