### PR TITLE
fix(web): remove dangling underscore names

### DIFF
--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -87,7 +87,7 @@ const ICON_PNG = path.join(__dirname, "..", "icons", "icon.png");
 
 /**
  * Quit-safety timeouts (see the before-quit handler near the end of this
- * file). `let` (not const) so tests can shrink them via __test.setQuitTimeouts
+ * file). `let` (not const) so tests can shrink them via testApi.setQuitTimeouts
  * to exercise the force-exit safety nets without waiting seconds in real
  * time. Production code never writes them.
  */
@@ -370,8 +370,8 @@ function registerLocalhostAccess() {
 // never a tight loop. In the normal case the gate full-page-redirects the
 // reload's top-level navigation to its login page, so no further API calls
 // (hence no further redirects) fire anyway.
-const _lastExpiryReloadAt = new WeakMap();
-const _EXPIRY_RELOAD_MIN_INTERVAL_MS = 15_000;
+const lastExpiryReloadAt = new WeakMap();
+const EXPIRY_RELOAD_MIN_INTERVAL_MS = 15_000;
 
 /**
  * Recover the desktop window when the workspace SSO session expires.
@@ -386,9 +386,9 @@ function registerSessionExpiryAccess() {
     const now = Date.now();
     for (const [win, state] of windows) {
       if (state.origin !== origin || win.isDestroyed()) continue;
-      const last = _lastExpiryReloadAt.get(win) ?? 0;
-      if (now - last < _EXPIRY_RELOAD_MIN_INTERVAL_MS) continue;
-      _lastExpiryReloadAt.set(win, now);
+      const last = lastExpiryReloadAt.get(win) ?? 0;
+      if (now - last < EXPIRY_RELOAD_MIN_INTERVAL_MS) continue;
+      lastExpiryReloadAt.set(win, now);
       win.webContents.reload();
     }
   });
@@ -2838,9 +2838,9 @@ if (!gotLock) {
     // subsequent spawn/execFile call inherits it. Runs before resolvedCliPath()
     // (a PATH consumer) and any host spawn, so the ordering guarantee is implicit.
     const { resolveLoginShellPath, mergePath } = require("./loginShellPath");
-    const _loginPath = resolveLoginShellPath();
-    if (_loginPath) {
-      process.env.PATH = mergePath(process.env.PATH, _loginPath);
+    const loginPath = resolveLoginShellPath();
+    if (loginPath) {
+      process.env.PATH = mergePath(process.env.PATH, loginPath);
     }
     // Resolve the CLI path once at startup so the first status/control call is
     // instant (primes the in-memory cache in resolvedCliPath); also lets the

--- a/web/electron/test/update-main.test.js
+++ b/web/electron/test/update-main.test.js
@@ -138,7 +138,7 @@ function loadMainHarness({
   // into the menu, the IPC surface, and the before-quit install handoff.
   const source =
     fs.readFileSync(mainPath, "utf8") +
-    '\nmodule.exports.__test = { buildMenu, registerIpc, windows, updater, setQuitTimeouts: (o) => { if (typeof (o && o.cleanup) === "number") quitCleanupTimeoutMs = o.cleanup; if (typeof (o && o.installFallback) === "number") quitInstallFallbackMs = o.installFallback; } }';
+    '\nmodule.exports.testApi = { buildMenu, registerIpc, windows, updater, setQuitTimeouts: (o) => { if (typeof (o && o.cleanup) === "number") quitCleanupTimeoutMs = o.cleanup; if (typeof (o && o.installFallback) === "number") quitInstallFallbackMs = o.installFallback; } }';
 
   const module = { exports: {} };
   const sandbox = {
@@ -174,14 +174,14 @@ function loadMainHarness({
   };
 
   vm.runInNewContext(source, sandbox, { filename: mainPath });
-  module.exports.__test.windows.set(win, {
+  module.exports.testApi.windows.set(win, {
     origin: "https://server.example",
     serverUrl: "https://server.example/app",
     badgeCount: 0,
   });
 
   return {
-    api: module.exports.__test,
+    api: module.exports.testApi,
     appEvents,
     autoUpdater,
     calls,

--- a/web/src/components/blocks/BlockRenderer.tsx
+++ b/web/src/components/blocks/BlockRenderer.tsx
@@ -412,13 +412,13 @@ function renderToolRunFragment(
   return renderItem(fragment.tool, runStart + fragment.index, false);
 }
 
-const _ADVISE_MODELS_NAMES = new Set(["sys_advise_models", "mcp__omnigent__sys_advise_models"]);
-const _SESSION_SEND_NAMES = new Set(["sys_session_send", "mcp__omnigent__sys_session_send"]);
+const ADVISE_MODELS_NAMES = new Set(["sys_advise_models", "mcp__omnigent__sys_advise_models"]);
+const SESSION_SEND_NAMES = new Set(["sys_session_send", "mcp__omnigent__sys_session_send"]);
 
 function isPersistentToolCard(item: RenderItem): boolean {
   return (
     item.kind === "tool" &&
-    (_ADVISE_MODELS_NAMES.has(item.execution.name) || _SESSION_SEND_NAMES.has(item.execution.name))
+    (ADVISE_MODELS_NAMES.has(item.execution.name) || SESSION_SEND_NAMES.has(item.execution.name))
   );
 }
 
@@ -481,7 +481,7 @@ function renderItem(
     case "tool":
       // Intelligent routing's fan-out sizing gets a structured plan card
       // instead of the generic name(json) row + raw-JSON expansion.
-      if (_ADVISE_MODELS_NAMES.has(item.execution.name)) {
+      if (ADVISE_MODELS_NAMES.has(item.execution.name)) {
         return (
           <SmartRoutingCard
             key={key}

--- a/web/src/hooks/useIdleNotifications.test.tsx
+++ b/web/src/hooks/useIdleNotifications.test.tsx
@@ -47,7 +47,7 @@ import {
 import { isNativeShell, onNativeNotificationActivated, setBadgeCount } from "@/lib/nativeBridge";
 import { fetchLastAssistantText } from "@/lib/lastAssistantText";
 import {
-  __resetReadStateForTests,
+  resetReadStateForTests,
   markConversationSeen,
   seedReadState,
 } from "@/hooks/useUnseenConversations";
@@ -139,7 +139,7 @@ beforeEach(() => {
   // NOT mocked); start each test with a clean slate, and seed an empty list
   // to flip `hydrated` so markConversationSeen writes (it is gated until the
   // first seed to avoid the reload-clobber race).
-  __resetReadStateForTests();
+  resetReadStateForTests();
   seedReadState([]);
 });
 

--- a/web/src/hooks/useSeenComments.ts
+++ b/web/src/hooks/useSeenComments.ts
@@ -54,29 +54,29 @@ function writeSeenMap(map: SeenMap): void {
 // getSnapshot returns a referentially-equal Set while the stored value
 // is unchanged (useSyncExternalStore requires a stable snapshot), yet
 // self-heals when storage changes underneath (another tab, test reset).
-let _cachedRaw: string | null = null;
-let _cachedSet: ReadonlySet<string> = new Set();
-const _listeners = new Set<() => void>();
+let cachedRaw: string | null = null;
+let cachedSet: ReadonlySet<string> = new Set();
+const listeners = new Set<() => void>();
 
 /** Current set of seen comment ids, as persisted in localStorage. */
 export function getSeenCommentIds(): ReadonlySet<string> {
-  if (typeof window === "undefined") return _cachedSet;
+  if (typeof window === "undefined") return cachedSet;
   let raw: string | null = null;
   try {
     raw = window.localStorage.getItem(STORAGE_KEY);
   } catch {
     // Access errors (e.g. disabled storage) fall through to the cache.
   }
-  if (raw !== _cachedRaw) {
-    _cachedRaw = raw;
-    _cachedSet = new Set(Object.keys(readSeenMap()));
+  if (raw !== cachedRaw) {
+    cachedRaw = raw;
+    cachedSet = new Set(Object.keys(readSeenMap()));
   }
-  return _cachedSet;
+  return cachedSet;
 }
 
 function subscribe(listener: () => void): () => void {
-  _listeners.add(listener);
-  // Same-tab writes notify through _listeners (markCommentsSeen).
+  listeners.add(listener);
+  // Same-tab writes notify through listeners (markCommentsSeen).
   // Writes from OTHER tabs only surface as the window `storage` event
   // (the browser fires it in every tab except the writer) — without
   // this, an inbox tab keeps listing a comment that a second tab's
@@ -88,7 +88,7 @@ function subscribe(listener: () => void): () => void {
   };
   window.addEventListener("storage", onStorage);
   return () => {
-    _listeners.delete(listener);
+    listeners.delete(listener);
     window.removeEventListener("storage", onStorage);
   };
 }
@@ -117,7 +117,7 @@ export function markCommentsSeen(commentIds: string[]): void {
   } else {
     writeSeenMap(map);
   }
-  _listeners.forEach((listener) => listener());
+  listeners.forEach((listener) => listener());
 }
 
 /** Reactive set of seen comment ids (current tab + persisted). */

--- a/web/src/hooks/useTerminals.ts
+++ b/web/src/hooks/useTerminals.ts
@@ -238,7 +238,7 @@ export function terminalInfoFromResource(resource: Record<string, unknown>): Ter
 // first loads. We treat these as an empty list (the live SSE
 // ``session.resource.created`` event fills it in once the terminal lands)
 // instead of throwing, so React Query does not enter an error state.
-const _SOFT_TERMINAL_LIST_STATUSES = new Set([404, 409, 502, 503]);
+const SOFT_TERMINAL_LIST_STATUSES = new Set([404, 409, 502, 503]);
 
 /**
  * Fetch the current terminal resources for a conversation over HTTP.
@@ -265,14 +265,14 @@ const _SOFT_TERMINAL_LIST_STATUSES = new Set([404, 409, 502, 503]);
  * :param conversationId: Session/conversation identifier,
  *     e.g. ``"conv_abc123"``.
  * :returns: The mapped terminals, or an empty array when the runner is
- *     not yet reachable (see :data:`_SOFT_TERMINAL_LIST_STATUSES`).
+ *     not yet reachable (see :data:`SOFT_TERMINAL_LIST_STATUSES`).
  * :raises Error: On a non-soft HTTP error status.
  */
 export async function fetchTerminals(conversationId: string): Promise<TerminalInfo[]> {
   const res = await authenticatedFetch(
     `/v1/sessions/${encodeURIComponent(conversationId)}/resources/terminals?order=asc&limit=1000`,
   );
-  if (_SOFT_TERMINAL_LIST_STATUSES.has(res.status)) return [];
+  if (SOFT_TERMINAL_LIST_STATUSES.has(res.status)) return [];
   if (!res.ok) throw new Error(`terminals fetch failed: ${res.status} ${res.statusText}`);
   const json = (await res.json()) as { data?: unknown };
   const rows = Array.isArray(json.data) ? json.data : [];

--- a/web/src/hooks/useUnseenConversations.ts
+++ b/web/src/hooks/useUnseenConversations.ts
@@ -198,7 +198,7 @@ export function useSeedReadState(conversations: readonly ReadStateSeed[] | undef
  * between tests (the mirror is intentionally module-scoped, not React state).
  * Not used in production.
  */
-export function __resetReadStateForTests(): void {
+export function resetReadStateForTests(): void {
   for (const id of Object.keys(lastSeenMap)) delete lastSeenMap[id];
   explicitlyUnread.clear();
   seeded.clear();

--- a/web/src/lib/accountsApi.ts
+++ b/web/src/lib/accountsApi.ts
@@ -328,7 +328,7 @@ export interface AdminFailure {
  * Network failures collapse to ``status: 0`` per the convention
  * already established by :func:`login`.
  */
-async function _admin<T extends { ok: true }>(
+async function adminRequest<T extends { ok: true }>(
   doFetch: () => Promise<Response>,
   toSuccess: (body: unknown) => Omit<T, "ok">,
 ): Promise<T | AdminFailure> {
@@ -381,7 +381,7 @@ export async function listUsers(): Promise<AccountListEntry[] | null> {
  * :returns: The new token + the URL to share, or a typed failure.
  */
 export async function createInvite(isAdmin: boolean): Promise<InviteCreated | AdminFailure> {
-  return _admin<InviteCreated>(
+  return adminRequest<InviteCreated>(
     () =>
       fetch("/auth/invite", {
         method: "POST",
@@ -439,7 +439,7 @@ export async function deleteUser(userId: string): Promise<{ ok: true } | AdminFa
  * is responsible for DM-ing it to the user out-of-band.
  */
 export async function resetUserPassword(userId: string): Promise<PasswordReset | AdminFailure> {
-  return _admin<PasswordReset>(
+  return adminRequest<PasswordReset>(
     () =>
       fetch(`/auth/users/${encodeURIComponent(userId)}/reset`, {
         method: "POST",

--- a/web/src/lib/agentLabels.ts
+++ b/web/src/lib/agentLabels.ts
@@ -98,11 +98,11 @@ export function useBrainHarnessLabels(smartRoutingEnabled = false): Record<strin
   return { [AUTO_HARNESS_ID]: "Auto", ...base };
 }
 
-const _NO_SETUP_STEPS: Record<string, SetupStepWire[]> = {};
+const NO_SETUP_STEPS: Record<string, SetupStepWire[]> = {};
 
 /** harness id → the server's ordered setup steps (for the setup dialog). */
 export function useHarnessSetupSteps(): Record<string, SetupStepWire[]> {
-  return useHarnessCatalog((c) => c.setupSteps, _NO_SETUP_STEPS);
+  return useHarnessCatalog((c) => c.setupSteps, NO_SETUP_STEPS);
 }
 
 /**

--- a/web/src/lib/capabilities.ts
+++ b/web/src/lib/capabilities.ts
@@ -30,7 +30,7 @@ import { hostFetch } from "./host";
  * an unknown/missing value.
  */
 export type SharingMode = "on" | "read_only" | "restricted_read_only" | "off";
-const _SHARING_MODES: readonly SharingMode[] = ["on", "read_only", "restricted_read_only", "off"];
+const SHARING_MODES: readonly SharingMode[] = ["on", "read_only", "restricted_read_only", "off"];
 
 /** Shape of the response from ``GET /v1/info``. */
 export interface ServerInfo {
@@ -129,7 +129,7 @@ export interface ServerInfo {
 }
 
 /** Sentinel used when the probe fails — accounts is off, no login URL. */
-const _OFF: ServerInfo = {
+const FALLBACK_SERVER_INFO: ServerInfo = {
   accounts_enabled: false,
   // Fail to multi-user: a failed probe must not hide account/sharing chrome.
   single_user: false,
@@ -149,21 +149,21 @@ const _OFF: ServerInfo = {
   dictation_available: false,
 };
 
-let _cached: ServerInfo | null = null;
-let _pending: Promise<ServerInfo> | null = null;
+let cachedServerInfo: ServerInfo | null = null;
+let pendingServerInfo: Promise<ServerInfo> | null = null;
 
 /**
  * Fetch ``/v1/info`` once and cache the result.
  *
- * Resolves to ``_OFF`` on any failure (network error, non-JSON,
+ * Resolves to ``FALLBACK_SERVER_INFO`` on any failure (network error, non-JSON,
  * 5xx). The frontend treats "no probe result" as "accounts is
  * off" — failing closed prevents the accounts UI from rendering
  * against a server that doesn't actually support it.
  */
 export async function resolveServerInfo(): Promise<ServerInfo> {
-  if (_cached !== null) return _cached;
-  if (_pending !== null) return _pending;
-  _pending = (async () => {
+  if (cachedServerInfo !== null) return cachedServerInfo;
+  if (pendingServerInfo !== null) return pendingServerInfo;
+  pendingServerInfo = (async () => {
     try {
       // Route through the host transport (`hostFetch`) so the embed hits the
       // proxied omnigent API; standalone `hostFetch` falls back to plain
@@ -171,7 +171,7 @@ export async function resolveServerInfo(): Promise<ServerInfo> {
       const res = await hostFetch("/v1/info");
       if (res.ok) {
         const data = (await res.json()) as Partial<ServerInfo>;
-        _cached = {
+        cachedServerInfo = {
           accounts_enabled: data.accounts_enabled === true,
           single_user: data.single_user === true,
           login_url: typeof data.login_url === "string" ? data.login_url : null,
@@ -180,7 +180,7 @@ export async function resolveServerInfo(): Promise<ServerInfo> {
           managed_sandboxes_enabled: data.managed_sandboxes_enabled === true,
           sandbox_provider:
             typeof data.sandbox_provider === "string" ? data.sandbox_provider : null,
-          sharing_mode: _SHARING_MODES.includes(data.sharing_mode as SharingMode)
+          sharing_mode: SHARING_MODES.includes(data.sharing_mode as SharingMode)
             ? (data.sharing_mode as SharingMode)
             : "on",
           // Fail open: only an explicit false disables the public toggle.
@@ -193,15 +193,15 @@ export async function resolveServerInfo(): Promise<ServerInfo> {
             : [],
           dictation_available: data.dictation_available === true,
         };
-        return _cached;
+        return cachedServerInfo;
       }
     } catch {
       // Network failure — fall through to the off sentinel.
     }
-    _cached = _OFF;
-    return _cached;
+    cachedServerInfo = FALLBACK_SERVER_INFO;
+    return cachedServerInfo;
   })();
-  return _pending;
+  return pendingServerInfo;
 }
 
 /**
@@ -214,7 +214,7 @@ export async function resolveServerInfo(): Promise<ServerInfo> {
  * than calling this directly.
  */
 export function getCachedServerInfo(): ServerInfo | null {
-  return _cached;
+  return cachedServerInfo;
 }
 
 /**
@@ -235,7 +235,7 @@ export function isSingleUserMode(info: ServerInfo | "loading"): boolean {
  * not listed here fall back to a title-cased id so a newly-wired
  * provider still reads sensibly without a frontend change.
  */
-const _SANDBOX_PROVIDER_NAMES: Record<string, string> = {
+const SANDBOX_PROVIDER_NAMES: Record<string, string> = {
   modal: "Modal",
   lakebox: "Databricks",
   daytona: "Daytona",
@@ -253,6 +253,6 @@ const _SANDBOX_PROVIDER_NAMES: Record<string, string> = {
 export function sandboxOptionLabel(provider: string | null): string {
   if (!provider) return "New Sandbox";
   const name =
-    _SANDBOX_PROVIDER_NAMES[provider] ?? provider.charAt(0).toUpperCase() + provider.slice(1);
+    SANDBOX_PROVIDER_NAMES[provider] ?? provider.charAt(0).toUpperCase() + provider.slice(1);
   return `${name} Sandbox`;
 }

--- a/web/src/lib/dictation.ts
+++ b/web/src/lib/dictation.ts
@@ -144,15 +144,15 @@ class Pcm16Downsampler extends AudioWorkletProcessor {
 registerProcessor("omnigent-pcm16-downsampler", Pcm16Downsampler);
 `;
 
-let _workletUrl: string | null = null;
+let cachedWorkletUrl: string | null = null;
 
 function workletUrl(): string {
-  if (_workletUrl === null) {
-    _workletUrl = URL.createObjectURL(
+  if (cachedWorkletUrl === null) {
+    cachedWorkletUrl = URL.createObjectURL(
       new Blob([WORKLET_SOURCE], { type: "application/javascript" }),
     );
   }
-  return _workletUrl;
+  return cachedWorkletUrl;
 }
 
 /**

--- a/web/src/lib/host.ts
+++ b/web/src/lib/host.ts
@@ -82,8 +82,8 @@ export interface OmnigentHostConfig {
   };
 }
 
-let _config: OmnigentHostConfig = {};
-let _embedRoot: HTMLElement | null = null;
+let hostConfig: OmnigentHostConfig = {};
+let embedRoot: HTMLElement | null = null;
 
 export function setOmnigentHostConfig(config: OmnigentHostConfig): void {
   // Guard: never clobber an already-installed fetcher with an empty config.
@@ -91,12 +91,12 @@ export function setOmnigentHostConfig(config: OmnigentHostConfig): void {
   // default/empty props on concurrent or Suspense renders; without this guard
   // such a render would wipe the host transport and API calls would fall back
   // to bare same-origin paths.
-  if (!config?.fetcher && _config.fetcher) return;
-  _config = config ?? {};
+  if (!config?.fetcher && hostConfig.fetcher) return;
+  hostConfig = config ?? {};
 }
 
 export function getOmnigentHostConfig(): OmnigentHostConfig {
-  return _config;
+  return hostConfig;
 }
 
 /**
@@ -104,7 +104,7 @@ export function getOmnigentHostConfig(): OmnigentHostConfig {
  * configured. Consumers use the absence to stay inert (plain text input).
  */
 export function getOmnigentUserSearch(): OmnigentHostConfig["searchUsers"] {
-  return _config.searchUsers;
+  return hostConfig.searchUsers;
 }
 
 /**
@@ -112,7 +112,7 @@ export function getOmnigentUserSearch(): OmnigentHostConfig["searchUsers"] {
  * configured. Absence means the relative URL is used unchanged.
  */
 export function getOmnigentTransformShareLink(): OmnigentHostConfig["transformShareLink"] {
-  return _config.transformShareLink;
+  return hostConfig.transformShareLink;
 }
 
 /**
@@ -122,11 +122,11 @@ export function getOmnigentTransformShareLink(): OmnigentHostConfig["transformSh
  * Returns null in standalone mode, where Radix falls back to `document.body`.
  */
 export function setEmbedRoot(el: HTMLElement | null): void {
-  _embedRoot = el;
+  embedRoot = el;
 }
 
 export function getEmbedRoot(): HTMLElement | null {
-  return _embedRoot;
+  return embedRoot;
 }
 
 /**
@@ -134,15 +134,15 @@ export function getEmbedRoot(): HTMLElement | null {
  * otherwise calls native `fetch` with the path unchanged (standalone).
  */
 export function hostFetch(path: string, init?: RequestInit): Promise<Response> {
-  if (_config.fetcher) {
-    return _config.fetcher(path, init);
+  if (hostConfig.fetcher) {
+    return hostConfig.fetcher(path, init);
   }
   return fetch(path, init);
 }
 
 export function resolveWebSocketUrl(path: string): string {
-  if (_config.resolveWebSocketUrl) {
-    return _config.resolveWebSocketUrl(path);
+  if (hostConfig.resolveWebSocketUrl) {
+    return hostConfig.resolveWebSocketUrl(path);
   }
   const scheme = window.location.protocol === "https:" ? "wss:" : "ws:";
   return `${scheme}//${window.location.host}${path}`;
@@ -155,5 +155,5 @@ export function resolveWebSocketUrl(path: string): string {
  */
 export function getCliServerUrl(): string {
   const origin = typeof window !== "undefined" ? window.location.origin : "";
-  return origin + (_config.cliServerUrlSuffix ?? "");
+  return origin + (hostConfig.cliServerUrlSuffix ?? "");
 }

--- a/web/src/lib/identity.test.ts
+++ b/web/src/lib/identity.test.ts
@@ -4,7 +4,7 @@
 // `identity.ts` keeps its cached user id at module scope (the entire
 // app shares one identity), so each test calls `vi.resetModules()` and
 // re-imports to start from a clean slate. Otherwise tests would leak
-// state into each other through the cached `_currentUserId`.
+// state into each other through the cached `currentUserId`.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/web/src/lib/identity.ts
+++ b/web/src/lib/identity.ts
@@ -22,20 +22,20 @@ import { getOmnigentHostConfig, hostFetch } from "./host";
 // not a real actor, so never used as an author label.
 const RESERVED_USER_LOCAL = "local";
 
-let _currentUserId: string | null = null;
+let currentUserId: string | null = null;
 // Admin flag from the same `/v1/me` probe. Mode-agnostic (the shared
 // `users.is_admin` column), so the SPA can gate admin chrome in EVERY
 // auth mode — including OIDC/SSO, where the accounts-only `/auth/me`
 // endpoint doesn't exist. Defaults false until the probe resolves.
-let _currentIsAdmin = false;
-let _resolved = false;
-let _resolvePromise: Promise<string | null> | null = null;
+let currentIsAdmin = false;
+let identityResolved = false;
+let identityPromise: Promise<string | null> | null = null;
 // Cache the server-provided login URL on the first /v1/me probe so
 // later session-expiry redirects in authenticatedFetch hit the right
 // path per provider — "/login" for accounts, "/auth/login" for OIDC.
 // Hardcoding "/login" here previously sent OIDC users to an accounts
 // password form that had no connection to their IdP.
-let _serverLoginUrl: string | null = null;
+let serverLoginUrl: string | null = null;
 
 /**
  * Whether the current page IS the login or register page, so we
@@ -49,7 +49,7 @@ let _serverLoginUrl: string | null = null;
  * OIDC server-side path (``/auth/login``) so the guard covers
  * every mode.
  */
-function _isOnLoginPath(): boolean {
+function isOnLoginPath(): boolean {
   const path = window.location.pathname;
   return path === "/login" || path === "/register" || path.startsWith("/auth/login");
 }
@@ -62,9 +62,9 @@ function _isOnLoginPath(): boolean {
  * redirects the browser to the login page.
  */
 export async function resolveIdentity(): Promise<string | null> {
-  if (_resolved) return _currentUserId;
-  if (_resolvePromise) return _resolvePromise;
-  _resolvePromise = (async () => {
+  if (identityResolved) return currentUserId;
+  if (identityPromise) return identityPromise;
+  identityPromise = (async () => {
     try {
       const res = await hostFetch("/v1/me");
       if (res.status === 401) {
@@ -78,8 +78,8 @@ export async function resolveIdentity(): Promise<string | null> {
             login_url?: string;
           };
           if (data.login_url) {
-            _serverLoginUrl = data.login_url;
-            if (!_isOnLoginPath()) {
+            serverLoginUrl = data.login_url;
+            if (!isOnLoginPath()) {
               const returnTo = encodeURIComponent(
                 window.location.pathname + window.location.search,
               );
@@ -96,21 +96,21 @@ export async function resolveIdentity(): Promise<string | null> {
           user_id: string | null;
           is_admin?: boolean;
         };
-        _currentUserId = data.user_id;
-        _currentIsAdmin = data.is_admin ?? false;
+        currentUserId = data.user_id;
+        currentIsAdmin = data.is_admin ?? false;
       }
     } catch {
       // Server unreachable — leave as null.
     }
-    _resolved = true;
-    return _currentUserId;
+    identityResolved = true;
+    return currentUserId;
   })();
-  return _resolvePromise;
+  return identityPromise;
 }
 
 /** Return the cached user ID (null before resolveIdentity completes). */
 export function getCurrentUserId(): string | null {
-  return _currentUserId;
+  return currentUserId;
 }
 
 /**
@@ -119,7 +119,7 @@ export function getCurrentUserId(): string | null {
  * AND OIDC. Returns false before `resolveIdentity` completes.
  */
 export function getCurrentIsAdmin(): boolean {
-  return _currentIsAdmin;
+  return currentIsAdmin;
 }
 
 /**
@@ -128,10 +128,10 @@ export function getCurrentIsAdmin(): boolean {
  * resolves and for the `"local"` sentinel, so those stay unlabeled.
  */
 export function getCurrentAuthorId(): string | null {
-  if (_currentUserId === null || _currentUserId === RESERVED_USER_LOCAL) {
+  if (currentUserId === null || currentUserId === RESERVED_USER_LOCAL) {
     return null;
   }
-  return _currentUserId;
+  return currentUserId;
 }
 
 /**
@@ -146,12 +146,8 @@ export async function authenticatedFetch(
   init?: RequestInit,
 ): Promise<Response> {
   const headers = new Headers(init?.headers);
-  if (
-    _currentUserId &&
-    _currentUserId !== RESERVED_USER_LOCAL &&
-    !headers.has("X-Forwarded-Email")
-  ) {
-    headers.set("X-Forwarded-Email", _currentUserId);
+  if (currentUserId && currentUserId !== RESERVED_USER_LOCAL && !headers.has("X-Forwarded-Email")) {
+    headers.set("X-Forwarded-Email", currentUserId);
   }
   // Bypass the browser HTTP cache for all API calls. Session
   // endpoints (GET /v1/sessions/{id}) carry volatile in-memory state
@@ -173,7 +169,7 @@ export async function authenticatedFetch(
     res.status === 401 &&
     !input.toString().includes("/v1/me") &&
     !input.toString().includes("/auth/") &&
-    !_isOnLoginPath()
+    !isOnLoginPath()
   ) {
     // Session expired or cookie invalid — redirect to login IFF the
     // server actually has a login page. Don't redirect on /auth/*
@@ -185,9 +181,9 @@ export async function authenticatedFetch(
     // **null for header mode (no login)**. In header mode a stray 401
     // must NOT bounce the user to a phantom /login form — header is
     // the default for a bare local server, so we surface the 401 to
-    // the caller instead. (_serverLoginUrl from the /v1/me probe is a
+    // the caller instead. (serverLoginUrl from the /v1/me probe is a
     // fallback for the brief window before capabilities resolves.)
-    const loginUrl = getCachedServerInfo()?.login_url ?? _serverLoginUrl;
+    const loginUrl = getCachedServerInfo()?.login_url ?? serverLoginUrl;
     if (loginUrl) {
       window.location.href = `${loginUrl}?return_to=${encodeURIComponent(window.location.pathname + window.location.search)}`;
     }

--- a/web/src/lib/terminalThemePreferences.ts
+++ b/web/src/lib/terminalThemePreferences.ts
@@ -81,8 +81,8 @@ export function resolveTerminalIsDark(mode: TerminalThemeMode, appIsDark: boolea
     case "dark":
       return true;
     default: {
-      const _exhaustive: never = mode;
-      return _exhaustive;
+      const exhaustive: never = mode;
+      return exhaustive;
     }
   }
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -82,7 +82,7 @@ applyThemePalette(readThemePalette());
 // missing server doesn't deadlock first paint. We add a small
 // safety timeout (1.5s) so users on a flaky network still get
 // something on screen.
-const _bootProbe: Promise<ServerInfo> = Promise.race([
+const bootProbe: Promise<ServerInfo> = Promise.race([
   resolveServerInfo(),
   new Promise<ServerInfo>((resolve) =>
     setTimeout(
@@ -108,7 +108,7 @@ const _bootProbe: Promise<ServerInfo> = Promise.race([
   ),
 ]);
 
-void _bootProbe.then((info) => {
+void bootProbe.then((info) => {
   createRoot(document.getElementById("root")!).render(
     <StrictMode>
       <CapabilitiesProvider info={info}>

--- a/web/src/shell/MonacoCodeEditor.autosave.test.tsx
+++ b/web/src/shell/MonacoCodeEditor.autosave.test.tsx
@@ -47,7 +47,7 @@ interface FakeEditor {
   getContribution: () => null;
   /** Test-only: set getValue() without firing onChange (mirrors a user keystroke
    *  landing in the buffer; the test fires onChange separately). */
-  __set: (v: string) => void;
+  setValueForTest: (v: string) => void;
 }
 
 function makeFakeEditor(initial: string): FakeEditor {
@@ -80,7 +80,7 @@ function makeFakeEditor(initial: string): FakeEditor {
     restoreViewState: () => {},
     getAction: () => ({ run: () => {} }),
     getContribution: () => null,
-    __set: (v) => {
+    setValueForTest: (v) => {
       value = v;
     },
   };
@@ -170,7 +170,7 @@ async function renderMounted(el: React.ReactElement) {
 
 // Drive a user edit: update the buffer, then fire the captured onChange.
 async function fireEdit(value: string) {
-  fakeEditor!.__set(value);
+  fakeEditor!.setValueForTest(value);
   await act(async () => {
     h.onChange?.(value, {});
   });

--- a/web/src/shell/MonacoCodeEditor.teardown.test.tsx
+++ b/web/src/shell/MonacoCodeEditor.teardown.test.tsx
@@ -40,7 +40,7 @@ interface FakeEditor {
   restoreViewState: () => void;
   getAction: () => { run: () => void };
   getContribution: () => null;
-  __set: (v: string) => void;
+  setValueForTest: (v: string) => void;
 }
 
 function makeFakeEditor(initial: string): FakeEditor {
@@ -60,7 +60,7 @@ function makeFakeEditor(initial: string): FakeEditor {
     restoreViewState: () => {},
     getAction: () => ({ run: () => {} }),
     getContribution: () => null,
-    __set: (v) => {
+    setValueForTest: (v) => {
       value = v;
     },
   };
@@ -143,7 +143,7 @@ async function renderMounted(el: React.ReactElement) {
 
 // Drive an edit + fire the debounce so a save goes in flight (deferred write).
 async function editAndStartSave() {
-  fakeEditor!.__set(EDITED);
+  fakeEditor!.setValueForTest(EDITED);
   await act(async () => {
     h.onChange?.(EDITED, {});
   });

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -131,7 +131,7 @@ vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }
 vi.mock("@/lib/serverOrigin", () => ({ isCurrentServerLocal: () => false }));
 
 import { type Conversation, useConversations } from "@/hooks/useConversations";
-import { __resetReadStateForTests, seedReadState } from "@/hooks/useUnseenConversations";
+import { resetReadStateForTests, seedReadState } from "@/hooks/useUnseenConversations";
 import { Sidebar } from "./Sidebar";
 
 const useConvMock = vi.mocked(useConversations);
@@ -242,7 +242,7 @@ beforeEach(() => {
   mocks.pinnedStore.set([]);
   // The read-state mirror is module-level (in-memory), so reset it between
   // tests to avoid a mark-unread leaking into later rows.
-  __resetReadStateForTests();
+  resetReadStateForTests();
   mockConversations([CONV]);
 });
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Rename module caches, constants, helpers, and Electron locals that used unnecessary leading underscores.
- Give test-only seams explicit names such as `resetReadStateForTests`, `setValueForTest`, and `testApi` while preserving their existing scope and behavior.
- Clear all 32 `no-underscore-dangle` warnings without adding lint allowlists or suppressions.

**ELI5:** These names were wearing “private” underscores even though module scope already keeps them private. This PR removes the extra marker and uses descriptive names instead.

```text
_moduleCache / __testHook -> moduleCache / testHookForTests
same scope + same behavior -> clearer names + zero warnings
```

## Test Plan

- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `pnpm --filter web run test:coverage` (268 files passed, 4,768 tests passed)
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`
- Verified `eslint/no-underscore-dangle` reports zero warnings and the latest-main lint inventory drops from 61 to 29.

## Demo

N/A — internal naming cleanup with no visual behavior changes.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The full web suite covers the renamed identity, capability, host, comment-state, dictation, Monaco, terminal, and Electron update paths.

## Changelog

N/A — internal lint cleanup.
