### PR TITLE
[models] Resolve context windows from catalogs

### DIFF
--- a/dev/lint/hardcoded_model_allowlist.txt
+++ b/dev/lint/hardcoded_model_allowlist.txt
@@ -36,9 +36,6 @@ omnigent/inner/pi_executor.py databricks-gpt-5-4 1
 omnigent/inner/pi_executor.py databricks-gpt-5-4-mini 1
 omnigent/inner/pi_executor.py databricks-gpt-5-5 1
 omnigent/inner/pi_executor.py databricks-gpt-5-5-pro 1
-omnigent/llms/context_window.py o1 1
-omnigent/llms/context_window.py o3 1
-omnigent/llms/context_window.py o4 1
 omnigent/model_catalog.py claude-fable-5 1
 omnigent/model_catalog.py claude-haiku-4-5 1
 omnigent/model_catalog.py claude-opus-4-8 1

--- a/docs/model-hardcoding-plan.md
+++ b/docs/model-hardcoding-plan.md
@@ -145,6 +145,19 @@ The remaining exact compatibility exclusions in smart routing are temporary
 wire-API workarounds. They stay isolated until catalog wire metadata can express
 the affected harness constraints without model-name checks.
 
+## Context Window Migration
+
+Context sizing and pricing now share the onboarding/model-resolver MLflow
+catalog cache. Stable family patterns locate a bounded provider catalog, while
+provider-qualified and vendor-namespaced ids route directly to their catalog
+source. Exact catalog metadata wins; family-prefix matches are accepted only
+when every candidate agrees on the requested field.
+
+The stale exact-id Qwen window table and duplicate catalog downloader are gone.
+An explicit Anthropic `[1m]` marker remains self-describing metadata, and an
+uncatalogued/offline model keeps the conservative 128K fallback rather than a
+release-specific guess.
+
 ## Kiro Picker Migration
 
 The Kiro Web picker now runs `kiro-cli chat --list-models --format json` on the

--- a/omnigent/llms/context_window.py
+++ b/omnigent/llms/context_window.py
@@ -1,120 +1,42 @@
 """
 Context window resolution for LLM models.
 
-Provides :func:`get_model_context_window` which resolves a model's
-context window size via multiple backends (env var override, litellm
-registry, MLflow GitHub Release catalog) with a conservative 128K
-fallback.
+Provides :func:`get_model_context_window` which resolves a model's context
+window from the shared MLflow catalog, then optional local metadata, with a
+conservative 128K fallback.
 """
 
 from __future__ import annotations
 
 import os
-import threading
 from dataclasses import dataclass
 from typing import Any
 
-import cachetools
-
-_MLFLOW_CATALOG_URL = (
-    "https://github.com/mlflow/mlflow/releases/download/model-catalog%2Flatest/{provider}.json"
-)
-
-# Process-level cache of the per-provider MLflow catalog. The catalog is
-# a remote GitHub release asset that changes at most a few times a day,
-# but the response builder for ``GET /v1/sessions/{id}`` calls
-# ``get_model_context_window`` on every snapshot — without this cache,
-# every conversation load for a provider-prefixed model (claude-*, gpt-*,
-# databricks-*, …) paid a ~490ms uncached ``urlopen`` to GitHub. A 1-hour
-# TTL keeps it fresh enough while collapsing that to one fetch per
-# provider per hour. ``maxsize`` comfortably exceeds the provider count.
-# Guarded by a lock because the fetch runs under ``asyncio.to_thread``,
-# so concurrent requests can race the same key.
-_CATALOG_TTL_SECONDS = 3600
-_catalog_cache: cachetools.TTLCache[str, dict[str, object] | None] = cachetools.TTLCache(
-    maxsize=32, ttl=_CATALOG_TTL_SECONDS
-)
-_catalog_cache_lock = threading.Lock()
-# Sentinel distinguishing "absent from cache" from a cached ``None``
-# (a cached fetch failure). ``object()`` is unique so it can never
-# collide with a real catalog value.
-_CATALOG_MISS = object()
-
-_MODEL_PREFIX_TO_PROVIDER: dict[str, str] = {
-    "databricks-": "databricks",
-    "gpt-": "openai",
-    "o1-": "openai",
-    "o3-": "openai",
-    "o4-": "openai",
-    "claude-": "anthropic",
-    "gemini-": "google",
-    "llama-": "meta",
-    "mistral-": "mistral",
-}
+from omnigent.onboarding.providers import ModelInfo, find_catalog_models
 
 _DEFAULT_CONTEXT_WINDOW: int = 128_000
 
-# Omnigent's authoritative context-window registry, consulted BEFORE litellm
-# and the MLflow catalog (see :func:`get_model_context_window`). The upstream
-# backends mis-size or omit several ids we actually serve, and offline both
-# collapse to the conservative 128K default — so for those models this registry
-# is our single source of truth, not a last-resort fallback. Keyed by the
-# *normalized* base id (provider prefix and OpenRouter ``:tag`` suffix stripped,
-# lowercased; the ``[1m]`` beta marker is PRESERVED so the 1M variant stays
-# distinct from its base — see :func:`_registry_context_window`). A spec's
-# ``executor.context_window`` still overrides everything.
-#
-# Covered today:
-#  - Qwen models (absent from litellm + the MLflow catalog) — published Alibaba
-#    Cloud Model Studio / DashScope maxima.
-#  - Anthropic 1M-context beta ids (the ``[1m]`` suffix) — handled by a rule in
-#    :func:`_registry_context_window` rather than enumerated per base model.
-_CONTEXT_WINDOW_REGISTRY: dict[str, int] = {
-    "qwen3-coder-plus": 1_048_576,  # DashScope coding-plan default: 1M tokens
-    "qwen3-coder-flash": 1_048_576,  # served flash variant: 1M tokens
-    "qwen3-coder": 262_144,  # 480B open weights: 256K native (1M w/ YaRN)
-    "qwen-plus": 131_072,
-    "qwen-max": 131_072,
-    "qwen-turbo": 1_008_192,
-    "qwen-flash": 1_000_000,
-}
-
-# The Anthropic 1M-context beta encodes its window in the model id via a
-# trailing ``[1m]`` marker (e.g. ``claude-opus-4-8[1m]``). Neither litellm nor
-# the MLflow catalog keys on the bracketed form, so without this it resolves to
-# the 128K default — under-sizing both the context meter and the compaction /
-# overflow threshold by ~8x. The suffix *is* the window, so we read it directly
-# rather than stripping it (the base id may legitimately have a smaller window).
 _ANTHROPIC_1M_BETA_SUFFIX = "[1m]"
 _ANTHROPIC_1M_BETA_WINDOW = 1_000_000
 
 
-def _registry_context_window(model: str) -> int | None:
-    """Resolve a model's context window from Omnigent's authoritative registry.
-
-    Consulted BEFORE litellm and the MLflow catalog. Normalizes the id the way
-    model strings reach us — a provider prefix (``qwen/qwen3-coder``,
-    ``openrouter/qwen/qwen3-coder``) and an OpenRouter-style ``:tag`` suffix
-    (``qwen3-coder:free``) — down to the bare id, lowercased, with the ``[1m]``
-    beta marker preserved.
-
-    Resolution: an exact :data:`_CONTEXT_WINDOW_REGISTRY` entry, then the
-    Anthropic 1M-context beta rule (a trailing ``[1m]`` on a Claude id →
-    1,000,000). The rule is scoped to Claude ids so a custom/self-hosted model
-    that merely happens to end in ``[1m]`` isn't force-sized to 1M.
-
-    :param model: The model identifier (any namespacing).
-    :returns: The context window in tokens, or ``None`` when the model isn't in
-        our registry (caller falls back to litellm / the catalog / the default).
-    """
+def _encoded_context_window(model: str) -> int | None:
+    """Read a context size explicitly encoded in a provider model id."""
     bare = model.rsplit("/", 1)[-1].split(":", 1)[0].strip().lower()
-    if bare in _CONTEXT_WINDOW_REGISTRY:
-        return _CONTEXT_WINDOW_REGISTRY[bare]
-    # ``[1m]`` is an Anthropic-only beta convention, so gate on Claude ids
-    # (covers ``claude-*`` and ``databricks-claude-*``); other providers fall
-    # through to litellm/catalog rather than being forced to 1M.
     if "claude" in bare and bare.endswith(_ANTHROPIC_1M_BETA_SUFFIX):
         return _ANTHROPIC_1M_BETA_WINDOW
+    return None
+
+
+def _catalog_context_window(model: str) -> int | None:
+    """Return catalog context metadata when every matching entry agrees."""
+    windows = {
+        candidate.max_input_tokens
+        for candidate in find_catalog_models(model)
+        if candidate.max_input_tokens is not None
+    }
+    if len(windows) == 1:
+        return next(iter(windows))
     return None
 
 
@@ -132,159 +54,6 @@ _FALLBACK_CACHE_READ_INPUT_RATIO: float = 0.10
 _FALLBACK_CACHE_WRITE_INPUT_RATIO: float = 1.25
 
 
-def _infer_provider(bare: str) -> str | None:
-    """
-    Infer the MLflow provider name from a bare model identifier.
-
-    Checks ``_MODEL_PREFIX_TO_PROVIDER`` with longest-prefix-first
-    matching.
-
-    :param bare: Model name without provider prefix, e.g.
-        ``"databricks-gpt-5-5"`` or ``"gpt-4o"``.
-    :returns: Provider name (e.g. ``"databricks"``), or ``None``
-        when the prefix is not recognised.
-    """
-    for prefix, provider in sorted(
-        _MODEL_PREFIX_TO_PROVIDER.items(), key=lambda kv: len(kv[0]), reverse=True
-    ):
-        if bare.startswith(prefix):
-            return provider
-    return None
-
-
-def _download_mlflow_provider_catalog(provider: str) -> dict[str, object] | None:
-    """
-    Download the MLflow GitHub Release catalog JSON for *provider*.
-
-    Downloads ``_MLFLOW_CATALOG_URL.format(provider=provider)``,
-    following the GitHub redirect to the release-assets CDN. Returns
-    the parsed ``models`` dict (mapping model name to entry) on
-    success, ``None`` on any network or parse error. This is the raw
-    network call; callers should go through
-    :func:`_fetch_mlflow_provider_catalog` for the cached path.
-
-    :param provider: Provider name, e.g. ``"databricks"`` or
-        ``"openai"``.
-    :returns: Dict of model-name to catalog entry, or ``None`` on
-        failure.
-    """
-    import json
-    import urllib.request
-
-    url = _MLFLOW_CATALOG_URL.format(provider=provider)
-    try:
-        with urllib.request.urlopen(url, timeout=5) as resp:
-            data: dict[str, object] = json.loads(resp.read())
-        models = data.get("models")
-        return dict(models) if isinstance(models, dict) else None
-    except Exception:
-        return None
-
-
-def _fetch_mlflow_provider_catalog(provider: str) -> dict[str, object] | None:
-    """
-    Return the MLflow catalog for *provider*, cached process-wide.
-
-    Wraps :func:`_download_mlflow_provider_catalog` with a 1-hour TTL
-    cache so the per-request GitHub fetch (~490ms) is paid at most once
-    per provider per hour instead of on every ``GET /v1/sessions/{id}``
-    snapshot. A ``None`` result (network error / missing asset) is also
-    cached, so a transient outage doesn't make every subsequent request
-    re-pay the timeout for an hour — acceptable since the caller falls
-    back to the 128K default and the window is refreshed on TTL expiry.
-
-    :param provider: Provider name, e.g. ``"databricks"`` or
-        ``"openai"``.
-    :returns: Dict of model-name to catalog entry, or ``None`` on
-        failure.
-    """
-    with _catalog_cache_lock:
-        cached = _catalog_cache.get(provider, _CATALOG_MISS)
-        if cached is not _CATALOG_MISS:
-            return cached
-    # Network call outside the lock so a slow fetch for one provider
-    # doesn't block lookups for another.
-    result = _download_mlflow_provider_catalog(provider)
-    with _catalog_cache_lock:
-        _catalog_cache[provider] = result
-    return result
-
-
-def _fetch_context_window_from_mlflow(model: str) -> int | None:
-    """
-    Look up a model's context window via the MLflow GitHub Release
-    catalog.
-
-    Fetches the per-provider JSON file (one HTTP request per
-    provider) and reads ``context_window.max_input``. Strategy:
-
-    1. Infer the provider from the model name (explicit
-       ``provider/`` prefix or ``_MODEL_PREFIX_TO_PROVIDER`` table).
-    2. Fetch ``{provider}.json`` from the MLflow release asset CDN.
-    3. Exact name match in the ``models`` dict.
-    4. Family-prefix retry: strip the last hyphen component and
-       search the same provider catalog. Accepted only when **all**
-       prefix-matched entries share the same ``max_input``.
-
-    Times out after 5 seconds; any network or parse error returns
-    ``None``.
-
-    :param model: Model identifier, e.g. ``"databricks-gpt-5-5"``
-        or ``"openai/gpt-4o"``.
-    :returns: ``max_input + max_output`` from the catalog entry
-        in tokens, or ``None`` when the model cannot be resolved.
-    """
-    if os.environ.get("OMNIGENT_DISABLE_CATALOG_LOOKUP") == "1":
-        return None
-
-    if "/" in model:
-        explicit_provider, bare = model.split("/", 1)
-        provider = explicit_provider
-    else:
-        bare = model
-        provider = _infer_provider(bare)
-
-    if provider is None:
-        return None
-
-    models = _fetch_mlflow_provider_catalog(provider)
-    if models is None:
-        return None
-
-    def _total(cw: object) -> int | None:
-        """Sum max_input + max_output from a context_window dict."""
-        if not isinstance(cw, dict):
-            return None
-        max_input = cw.get("max_input")
-        if max_input is None:
-            return None
-        return int(max_input) + int(cw.get("max_output") or 0)
-
-    entry = models.get(bare)
-    if entry is not None and isinstance(entry, dict):
-        val = _total(entry.get("context_window"))
-        if val is not None:
-            return val
-
-    if "-" in bare:
-        prefix = bare.rsplit("-", 1)[0]
-        matched = {
-            name: e
-            for name, e in models.items()
-            if name.startswith(prefix) and isinstance(e, dict)
-        }
-        if matched:
-            windows = {
-                _total(e.get("context_window"))
-                for e in matched.values()
-                if _total(e.get("context_window")) is not None
-            }
-            if len(windows) == 1:
-                return int(next(iter(windows)))  # type: ignore[arg-type]
-
-    return None
-
-
 def get_model_context_window(model: str) -> int:
     """
     Look up the model's context window size in tokens.
@@ -293,16 +62,12 @@ def get_model_context_window(model: str) -> int:
 
     1. ``AP_CONTEXT_WINDOW_OVERRIDE`` env var — overrides everything.
        Supports custom/self-hosted models and e2e compaction tests.
-    2. :func:`_registry_context_window` — Omnigent's own authoritative
-       registry (Qwen models, Anthropic ``[1m]`` beta). Supersedes the
-       upstream backends, which mis-size or omit these ids and collapse to
-       the 128K default offline.
-    3. ``litellm.get_model_info()`` — fast, local, no network. Also
+    2. :func:`_encoded_context_window` — explicit provider metadata carried
+       in the model id, currently Anthropic's ``[1m]`` beta marker.
+    3. Shared MLflow catalog metadata. This is the authoritative dynamic
+       source and reuses the onboarding/model-resolver cache.
+    4. ``litellm.get_model_info()`` — optional local metadata. Also
        tried with the ``databricks/`` prefix for Databricks models.
-    4. MLflow GitHub Release catalog — per-provider JSON fetched from
-       ``github.com/mlflow/mlflow/releases``. Covers models not yet
-       in litellm's bundled registry, with a family-prefix fallback
-       for newly released variants.
     5. ``_DEFAULT_CONTEXT_WINDOW`` (128 K) — conservative fallback.
 
     :param model: The model identifier, e.g. ``"openai/gpt-4o"`` or
@@ -312,17 +77,16 @@ def get_model_context_window(model: str) -> int:
     override = os.environ.get("AP_CONTEXT_WINDOW_OVERRIDE")
     if override is not None:
         return int(override)
-    # Our registry supersedes the upstream backends: litellm and the MLflow
-    # catalog mis-size or omit ids we serve (the Anthropic ``[1m]`` beta resolves
-    # to 128K; Qwen models are absent), and offline both collapse to the 128K
-    # default. Consult ours first.
-    registered = _registry_context_window(model)
-    if registered is not None:
-        return registered
+    encoded = _encoded_context_window(model)
+    if encoded is not None:
+        return encoded
+    catalog_window = _catalog_context_window(model)
+    if catalog_window is not None:
+        return catalog_window
     try:
         import litellm
     except ImportError:
-        return _fetch_context_window_from_mlflow(model) or _DEFAULT_CONTEXT_WINDOW
+        return _DEFAULT_CONTEXT_WINDOW
     try:
         info = litellm.get_model_info(model)
         if info:
@@ -340,7 +104,7 @@ def get_model_context_window(model: str) -> int:
                     return int(limit)
         except Exception:
             pass
-    return _fetch_context_window_from_mlflow(model) or _DEFAULT_CONTEXT_WINDOW
+    return _DEFAULT_CONTEXT_WINDOW
 
 
 def resolve_effective_context_window(
@@ -421,9 +185,8 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
 
     Returns prices per token (not per million), including cache-read /
     cache-write rates when the catalog publishes them. Uses the same
-    provider-inference and catalog-fetch logic as
-    :func:`_fetch_context_window_from_mlflow`, with the same
-    family-prefix fallback for newly released model variants.
+    shared catalog lookup as :func:`get_model_context_window`, including the
+    same unambiguous family-prefix fallback for newly released variants.
 
     :param model: Model identifier, e.g. ``"anthropic/claude-sonnet-4-6"``
         or ``"databricks-gpt-5-5"``.
@@ -431,76 +194,31 @@ def fetch_model_pricing(model: str) -> ModelPricing | None:
         unavailable (network error, model not in catalog, or catalog
         entry lacks input/output pricing data).
     """
-    if os.environ.get("OMNIGENT_DISABLE_CATALOG_LOOKUP") == "1":
-        return None
 
-    if "/" in model:
-        _explicit_provider, bare = model.split("/", 1)
-        provider = _explicit_provider
-    else:
-        bare = model
-        provider = _infer_provider(bare)
-
-    if provider is None:
-        return None
-
-    models = _fetch_mlflow_provider_catalog(provider)
-    if models is None:
-        return None
-
-    def _extract(entry: object) -> ModelPricing | None:
-        """Extract per-token pricing (incl. cache rates) from a catalog entry."""
-        if not isinstance(entry, dict):
+    def _extract(info: ModelInfo) -> ModelPricing | None:
+        """Convert shared per-million catalog prices to per-token values."""
+        if info.input_price is None or info.output_price is None:
             return None
-        pricing = entry.get("pricing")
-        if not isinstance(pricing, dict):
-            return None
-        input_ppm = pricing.get("input_per_million_tokens")
-        output_ppm = pricing.get("output_per_million_tokens")
-        if input_ppm is None or output_ppm is None:
-            return None
-        cache_read_ppm = pricing.get("cache_read_per_million_tokens")
-        cache_write_ppm = pricing.get("cache_write_per_million_tokens")
         return ModelPricing(
-            input_per_token=float(input_ppm) / 1_000_000,
-            output_per_token=float(output_ppm) / 1_000_000,
+            input_per_token=float(info.input_price) / 1_000_000,
+            output_per_token=float(info.output_price) / 1_000_000,
             cache_read_per_token=(
-                float(cache_read_ppm) / 1_000_000 if cache_read_ppm is not None else None
+                float(info.cache_read_price) / 1_000_000
+                if info.cache_read_price is not None
+                else None
             ),
             cache_write_per_token=(
-                float(cache_write_ppm) / 1_000_000 if cache_write_ppm is not None else None
+                float(info.cache_write_price) / 1_000_000
+                if info.cache_write_price is not None
+                else None
             ),
         )
 
-    entry = models.get(bare)
-    if entry is not None:
-        result = _extract(entry)
-        if result is not None:
-            return result
-
-    # Family-prefix fallback: strip last hyphen segment and look for
-    # entries that share the same pricing.
-    if "-" in bare:
-        prefix = bare.rsplit("-", 1)[0]
-        matched = [e for name, e in models.items() if name.startswith(prefix)]
-        prices = {_extract(e) for e in matched if _extract(e) is not None}
-        if len(prices) == 1:
-            return next(iter(prices))
-
-    # Databricks-gateway alias fallback. A model served through the
-    # Databricks gateway is reported as ``databricks-<base>`` (e.g.
-    # ``databricks-claude-opus-4-8``), but the Databricks provider catalog
-    # may not list every such alias even when the *underlying* provider
-    # catalog prices the base model (anthropic's ``claude-opus-4-8`` is
-    # priced; the databricks alias is not). Retry once with the de-prefixed
-    # base so the underlying provider's pricing applies. Only the known
-    # ``databricks-`` prefix is stripped, and the base never re-infers
-    # ``databricks`` (it has no such prefix), so this can't recurse.
-    if provider == "databricks" and bare.startswith("databricks-"):
-        base = bare[len("databricks-") :]
-        if base and base != bare:
-            return fetch_model_pricing(base)
-
+    prices = {
+        price for info in find_catalog_models(model) if (price := _extract(info)) is not None
+    }
+    if len(prices) == 1:
+        return next(iter(prices))
     return None
 
 

--- a/omnigent/onboarding/providers/__init__.py
+++ b/omnigent/onboarding/providers/__init__.py
@@ -42,6 +42,8 @@ class ModelInfo:
     :param max_output_tokens: Maximum output tokens, or ``None``.
     :param input_price: Input price per million tokens, or ``None``.
     :param output_price: Output price per million tokens, or ``None``.
+    :param cache_read_price: Cache-read price per million tokens, or ``None``.
+    :param cache_write_price: Cache-write price per million tokens, or ``None``.
     """
 
     name: str
@@ -55,6 +57,8 @@ class ModelInfo:
     max_output_tokens: int | None = None
     input_price: float | None = None
     output_price: float | None = None
+    cache_read_price: float | None = None
+    cache_write_price: float | None = None
 
 
 @dataclass
@@ -381,10 +385,105 @@ def get_models(provider: str) -> list[ModelInfo]:
                     max_output_tokens=context.get("max_output"),
                     input_price=pricing.get("input_per_million_tokens"),
                     output_price=pricing.get("output_per_million_tokens"),
+                    cache_read_price=pricing.get("cache_read_per_million_tokens"),
+                    cache_write_price=pricing.get("cache_write_per_million_tokens"),
                 )
             )
 
     return models
+
+
+_MODEL_PROVIDER_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"^claude-", re.IGNORECASE), "anthropic"),
+    (re.compile(r"^(?:gpt-|o\d(?:-|$))", re.IGNORECASE), "openai"),
+    (re.compile(r"^gemini-", re.IGNORECASE), "gemini"),
+    (re.compile(r"^qwen(?:\d|-)", re.IGNORECASE), "dashscope"),
+    (re.compile(r"^llama-", re.IGNORECASE), "meta_llama"),
+    (re.compile(r"^mistral-", re.IGNORECASE), "mistral"),
+)
+
+
+def _inferred_catalog_provider(model: str) -> str | None:
+    """Infer a catalog file from a stable vendor-family prefix."""
+    for pattern, provider in _MODEL_PROVIDER_PATTERNS:
+        if pattern.match(model):
+            return provider
+    return None
+
+
+def _catalog_lookup_targets(model: str) -> list[tuple[str, str]]:
+    """Return bounded provider/id pairs for a model catalog lookup."""
+    normalized = model.split(":", 1)[0].strip()
+    known_providers = set(get_all_providers())
+    targets: list[tuple[str, str]] = []
+
+    def _add(provider: str | None, model_id: str) -> None:
+        if provider is not None and (provider, model_id) not in targets:
+            targets.append((provider, model_id))
+
+    if "/" in normalized:
+        namespace, bare = normalized.split("/", 1)
+        provider = namespace.lower()
+        if provider in known_providers:
+            _add(provider, bare)
+            if provider == "databricks" and bare.lower().startswith("databricks-"):
+                base = bare[len("databricks-") :]
+                _add(_inferred_catalog_provider(base), base)
+        else:
+            _add("openrouter", normalized)
+            _add(_inferred_catalog_provider(bare), bare)
+        return targets
+
+    if normalized.lower().startswith("databricks-"):
+        _add("databricks", normalized)
+        base = normalized[len("databricks-") :]
+        _add(_inferred_catalog_provider(base), base)
+    else:
+        _add(_inferred_catalog_provider(normalized), normalized)
+    _add("openrouter", normalized)
+    return targets
+
+
+def find_catalog_models(model: str) -> list[ModelInfo]:
+    """Find exact or unambiguous-family candidates in the shared catalog.
+
+    Provider-qualified ids query that provider directly. Vendor-namespaced ids
+    query OpenRouter, while bare ids use stable family-to-provider routing with
+    OpenRouter as a bounded fallback. Exact matches win; otherwise all entries
+    sharing the id without its final hyphen segment are returned so callers can
+    accept a field only when every candidate reports the same value.
+
+    :param model: Provider-local, provider-qualified, or vendor-namespaced id.
+    :returns: One exact match, compatible family-prefix matches, or an empty list.
+    """
+    family_matches: list[ModelInfo] = []
+    for provider, lookup_id in _catalog_lookup_targets(model):
+        models = get_models(provider)
+        lookup_lower = lookup_id.lower()
+        for candidate in models:
+            names = {candidate.name.lower()}
+            if provider == "openrouter":
+                names.add(candidate.name.rsplit("/", 1)[-1].lower())
+            if lookup_lower in names:
+                return [candidate]
+        if "-" not in lookup_id:
+            continue
+        prefixes = {lookup_lower.rsplit("-", 1)[0]}
+        if provider == "openrouter":
+            prefixes.add(lookup_lower.rsplit("/", 1)[-1].rsplit("-", 1)[0])
+        family_matches.extend(
+            candidate
+            for candidate in models
+            if any(
+                candidate_name.startswith(prefix)
+                for prefix in prefixes
+                for candidate_name in (
+                    candidate.name.lower(),
+                    candidate.name.rsplit("/", 1)[-1].lower(),
+                )
+            )
+        )
+    return family_matches
 
 
 def get_chat_models(provider: str) -> list[ModelInfo]:

--- a/tests/llms/test_context_window.py
+++ b/tests/llms/test_context_window.py
@@ -15,12 +15,14 @@ import pytest
 from omnigent.llms import context_window
 from omnigent.llms.context_window import (
     ModelPricing,
-    _registry_context_window,
+    _catalog_context_window,
+    _encoded_context_window,
     compute_llm_cost,
     fetch_model_pricing,
     get_model_context_window,
     resolve_effective_context_window,
 )
+from omnigent.onboarding.providers import ModelInfo
 
 
 def test_resolve_effective_context_window_prefers_declared_window(
@@ -185,22 +187,19 @@ def test_fetch_model_pricing_parses_cache_rates(monkeypatch: pytest.MonkeyPatch)
     cache-accurate. A failure means the cache rates were dropped and
     cost would fall back to the derived input-ratio default.
     """
-    # Catalog lookup is disabled globally in tests (conftest); re-enable
-    # for this one and stub the network fetch with a cache-priced entry.
-    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
     monkeypatch.setattr(
         context_window,
-        "_fetch_mlflow_provider_catalog",
-        lambda provider: {
-            "claude-x": {
-                "pricing": {
-                    "input_per_million_tokens": 2.5,
-                    "output_per_million_tokens": 10.0,
-                    "cache_read_per_million_tokens": 0.25,
-                    "cache_write_per_million_tokens": 3.125,
-                }
-            }
-        },
+        "find_catalog_models",
+        lambda _model: [
+            ModelInfo(
+                name="catalog-model",
+                provider="provider",
+                input_price=2.5,
+                output_price=10.0,
+                cache_read_price=0.25,
+                cache_write_price=3.125,
+            )
+        ],
     )
     pricing = fetch_model_pricing("anthropic/claude-x")
     assert pricing is not None
@@ -221,18 +220,17 @@ def test_fetch_model_pricing_omits_cache_rates_when_absent(
     the standard ratios. If these came back as ``0.0`` instead of ``None``,
     cache tokens would be billed free.
     """
-    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
     monkeypatch.setattr(
         context_window,
-        "_fetch_mlflow_provider_catalog",
-        lambda provider: {
-            "gpt-x": {
-                "pricing": {
-                    "input_per_million_tokens": 1.25,
-                    "output_per_million_tokens": 10.0,
-                }
-            }
-        },
+        "find_catalog_models",
+        lambda _model: [
+            ModelInfo(
+                name="catalog-model",
+                provider="provider",
+                input_price=1.25,
+                output_price=10.0,
+            )
+        ],
     )
     pricing = fetch_model_pricing("openai/gpt-x")
     assert pricing is not None
@@ -254,31 +252,18 @@ def test_fetch_model_pricing_databricks_alias_falls_back_to_base_model(
     gateway (which defaults to ``databricks-claude-opus-4-8``) would show
     "unpriced" — the exact gap reported for the debbie/debby supervisors.
     """
-    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
-
-    def _catalog(provider: str) -> dict[str, Any] | None:
-        """Databricks catalog lacks opus; the base (anthropic) catalog prices it."""
-        if provider == "databricks":
-            # Has some databricks models, but NOT the opus alias under test.
-            return {
-                "databricks-claude-sonnet-4-6": {
-                    "pricing": {
-                        "input_per_million_tokens": 3.0,
-                        "output_per_million_tokens": 15.0,
-                    }
-                }
-            }
-        # The underlying provider (anthropic) prices the de-prefixed base.
-        return {
-            "claude-opus-4-8": {
-                "pricing": {
-                    "input_per_million_tokens": 15.0,
-                    "output_per_million_tokens": 75.0,
-                }
-            }
-        }
-
-    monkeypatch.setattr(context_window, "_fetch_mlflow_provider_catalog", _catalog)
+    monkeypatch.setattr(
+        context_window,
+        "find_catalog_models",
+        lambda _model: [
+            ModelInfo(
+                name="catalog-model",
+                provider="anthropic",
+                input_price=15.0,
+                output_price=75.0,
+            )
+        ],
+    )
 
     pricing = fetch_model_pricing("databricks-claude-opus-4-8")
     assert pricing is not None, (
@@ -291,122 +276,85 @@ def test_fetch_model_pricing_databricks_alias_falls_back_to_base_model(
     assert pricing.output_per_token == pytest.approx(75e-6)
 
 
-def test_provider_catalog_is_cached_across_calls(
+def test_catalog_context_window_uses_max_input_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """
-    The per-provider catalog is downloaded once, then served from cache.
+    """Context sizing uses the catalog's normalized max-input field."""
+    monkeypatch.setattr(
+        context_window,
+        "find_catalog_models",
+        lambda _model: [
+            ModelInfo(
+                name="catalog-model",
+                provider="provider",
+                max_input_tokens=997_952,
+                max_output_tokens=65_536,
+            )
+        ],
+    )
 
-    This pins the perf fix: the response builder calls
-    ``get_model_context_window`` on every ``GET /v1/sessions/{id}``
-    snapshot, and each call used to re-issue a ~490ms GitHub fetch.
-    With the TTL cache, repeated lookups for the same provider must hit
-    the network exactly once. A regression (cache removed) would show as
-    a download count > 1. Asserting the resolved window also proves the
-    cached payload still flows through the resolver unchanged.
-    """
-    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
-    # Clear any residue from earlier tests so the count starts clean.
-    context_window._catalog_cache.clear()
-    calls: list[str] = []
-
-    def _fake_download(provider: str) -> dict[str, Any]:
-        """Record each network hit and return a one-model catalog."""
-        calls.append(provider)
-        return {"claude-z": {"context_window": {"max_input": 200_000, "max_output": 8_192}}}
-
-    monkeypatch.setattr(context_window, "_download_mlflow_provider_catalog", _fake_download)
-
-    # litellm resolves many real names; force the catalog path by using a
-    # name it won't know, so the fetch is exercised deterministically.
-    first = context_window.get_model_context_window("claude-z")
-    second = context_window.get_model_context_window("claude-z")
-    assert first == 208_192  # max_input + max_output from the stub
-    assert second == 208_192
-    # Exactly one network download despite two resolver calls.
-    assert calls == ["anthropic"]
+    assert _catalog_context_window("catalog-model") == 997_952
 
 
-def test_provider_catalog_caches_fetch_failure(
+def test_catalog_context_window_rejects_ambiguous_family_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """
-    A failed download (``None``) is cached too, not retried every call.
+    """A family fallback is used only when every catalog entry agrees."""
+    monkeypatch.setattr(
+        context_window,
+        "find_catalog_models",
+        lambda _model: [
+            ModelInfo(name="family-a", provider="provider", max_input_tokens=100_000),
+            ModelInfo(name="family-b", provider="provider", max_input_tokens=200_000),
+        ],
+    )
 
-    A transient GitHub outage returns ``None``; without caching that
-    result, every subsequent snapshot would re-pay the 5s timeout for an
-    hour. Pinning that ``None`` is cached keeps a single failure from
-    amplifying into per-request latency. The caller still falls back to
-    the 128K default, which this also checks.
-    """
-    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
-    context_window._catalog_cache.clear()
-    calls: list[str] = []
-
-    def _fail(provider: str) -> None:
-        """Record the hit and simulate a network/parse failure (returns None)."""
-        calls.append(provider)
-
-    monkeypatch.setattr(context_window, "_download_mlflow_provider_catalog", _fail)
-    first = context_window.get_model_context_window("claude-z")
-    second = context_window.get_model_context_window("claude-z")
-    assert first == 128_000  # _DEFAULT_CONTEXT_WINDOW fallback
-    assert second == 128_000
-    assert calls == ["anthropic"]
+    assert _catalog_context_window("family-new") is None
 
 
-# ---------------------------------------------------------------------------
-# Omnigent's authoritative context-window registry (supersedes litellm/catalog)
-# ---------------------------------------------------------------------------
-
-
-def test_registry_context_window_normalizes_id() -> None:
-    """The registry strips provider prefixes and ``:tag`` suffixes before matching."""
-    assert _registry_context_window("qwen3-coder-plus") == 1_048_576
-    assert _registry_context_window("qwen/qwen3-coder") == 262_144
-    assert _registry_context_window("qwen3-coder:free") == 262_144
-    assert _registry_context_window("openrouter/qwen/qwen3-coder:free") == 262_144
-    assert _registry_context_window("QWEN3-CODER-PLUS") == 1_048_576  # case-insensitive
-    # A model the registry doesn't own → None (caller falls back to litellm).
-    assert _registry_context_window("qwen-nonexistent-xyz") is None
-    assert _registry_context_window("gpt-5.4") is None
-
-
-def test_registry_resolves_anthropic_1m_beta_suffix() -> None:
-    """The Anthropic ``[1m]`` beta marker resolves to a 1M window via the registry.
+def test_encoded_context_window_resolves_anthropic_1m_beta_suffix() -> None:
+    """The Anthropic ``[1m]`` beta marker resolves to a 1M window.
 
     The suffix *is* the window — we read it, not strip it — so any
     ``<model>[1m]`` resolves to 1,000,000 while the bare base defers to the
     upstream backends (which may size it differently).
     """
-    assert _registry_context_window("claude-opus-4-8[1m]") == 1_000_000
-    assert _registry_context_window("anthropic/claude-opus-4-8[1m]") == 1_000_000
-    assert _registry_context_window("claude-sonnet-4-6[1m]") == 1_000_000
-    assert _registry_context_window("CLAUDE-OPUS-4-8[1M]") == 1_000_000  # case-insensitive
+    assert _encoded_context_window("claude-opus-4-8[1m]") == 1_000_000
+    assert _encoded_context_window("anthropic/claude-opus-4-8[1m]") == 1_000_000
+    assert _encoded_context_window("claude-sonnet-4-6[1m]") == 1_000_000
+    assert _encoded_context_window("CLAUDE-OPUS-4-8[1M]") == 1_000_000
     # Databricks-hosted Claude (contains "claude") also resolves.
-    assert _registry_context_window("databricks-claude-opus-4-8[1m]") == 1_000_000
-    # Without the suffix the registry defers (None → caller uses litellm/catalog).
-    assert _registry_context_window("claude-opus-4-8") is None
+    assert _encoded_context_window("databricks-claude-opus-4-8[1m]") == 1_000_000
+    # Without the suffix the encoded path defers to catalog metadata.
+    assert _encoded_context_window("claude-opus-4-8") is None
     # The rule is Claude-scoped: a non-Claude id ending in [1m] is NOT forced to
     # 1M (it defers to litellm/catalog), so custom/self-hosted ids are safe.
-    assert _registry_context_window("my-local-model[1m]") is None
-    assert _registry_context_window("gpt-5.4[1m]") is None
+    assert _encoded_context_window("my-local-model[1m]") is None
+    assert _encoded_context_window("gpt-5.4[1m]") is None
 
 
-def test_get_model_context_window_uses_registry_first(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Registry-curated ids resolve to their window with NO network.
-
-    Catalog lookup is disabled to prove hermeticity: the registry is consulted
-    before litellm and the catalog, so qwen models and the Anthropic ``[1m]``
-    beta resolve correctly even offline (the meter / overflow-threshold
-    bug was that these collapsed to the 128K default).
-    """
-    monkeypatch.setenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", "1")
+def test_get_model_context_window_prefers_catalog_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dynamic catalog metadata replaces the removed exact-id registry."""
     monkeypatch.delenv("AP_CONTEXT_WINDOW_OVERRIDE", raising=False)
-    # Anthropic 1M beta: resolves via the registry, not the 128K default.
+    monkeypatch.setattr(
+        context_window,
+        "find_catalog_models",
+        lambda _model: [
+            ModelInfo(name="catalog-model", provider="provider", max_input_tokens=997_952)
+        ],
+    )
+
+    assert get_model_context_window("catalog-model") == 997_952
+
+
+def test_get_model_context_window_encoded_and_offline_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Encoded metadata remains available offline; unknown ids stay conservative."""
+    monkeypatch.delenv("AP_CONTEXT_WINDOW_OVERRIDE", raising=False)
+    monkeypatch.setattr(context_window, "find_catalog_models", lambda _model: [])
     assert get_model_context_window("claude-opus-4-8[1m]") == 1_000_000
     assert get_model_context_window("anthropic/claude-opus-4-8[1m]") == 1_000_000
-    # Qwen: curated window, not the default.
-    assert get_model_context_window("qwen3-coder-plus") == 1_048_576
-    # A model the registry doesn't own still falls back to the conservative default.
-    assert get_model_context_window("qwen-nonexistent-xyz") == 128_000
+    assert get_model_context_window("uncatalogued-model") == 128_000

--- a/tests/onboarding/test_providers.py
+++ b/tests/onboarding/test_providers.py
@@ -9,6 +9,7 @@ from omnigent.onboarding.providers import (
     ModelInfo,
     ProviderConfig,
     default_chat_model,
+    find_catalog_models,
     get_all_providers,
     get_chat_models,
     get_models,
@@ -25,6 +26,12 @@ _FAKE_CATALOG: dict[str, dict] = {
                 "mode": "chat",
                 "capabilities": {"function_calling": True},
                 "context_window": {"max_input": 200000, "max_output": 32000},
+                "pricing": {
+                    "input_per_million_tokens": 15.0,
+                    "output_per_million_tokens": 75.0,
+                    "cache_read_per_million_tokens": 1.5,
+                    "cache_write_per_million_tokens": 18.75,
+                },
             },
             "claude-sonnet-4-6": {
                 "mode": "chat",
@@ -78,6 +85,16 @@ _FAKE_CATALOG: dict[str, dict] = {
                 "capabilities": {"function_calling": True},
                 "context_window": {"max_input": 128000, "max_output": 16384},
             },
+            "qwen/qwen3-coder": {
+                "mode": "chat",
+                "capabilities": {"function_calling": True},
+                "context_window": {"max_input": 262100, "max_output": 262100},
+            },
+            "qwen/qwen3-coder-plus": {
+                "mode": "chat",
+                "capabilities": {"function_calling": True},
+                "context_window": {"max_input": 997952, "max_output": 65536},
+            },
         }
     },
     "gemini": {
@@ -90,6 +107,8 @@ _FAKE_CATALOG: dict[str, dict] = {
         }
     },
 }
+
+_REAL_FETCH_PROVIDER_CATALOG = _providers_mod._fetch_provider_catalog
 
 
 @pytest.fixture(autouse=True)
@@ -178,6 +197,75 @@ def test_get_models_anthropic_returns_models() -> None:
         assert m.provider == "anthropic", (
             f"Model {m.name!r} has provider={m.provider!r}, expected 'anthropic'."
         )
+
+
+def test_get_models_preserves_context_and_cache_pricing_metadata() -> None:
+    """Shared model metadata includes fields needed by sizing and cost callers."""
+    model = next(model for model in get_models("anthropic") if model.name == "claude-opus-4-8")
+
+    assert model.max_input_tokens == 200000
+    assert model.max_output_tokens == 32000
+    assert model.input_price == 15.0
+    assert model.output_price == 75.0
+    assert model.cache_read_price == 1.5
+    assert model.cache_write_price == 18.75
+
+
+@pytest.mark.parametrize(
+    ("model_id", "provider", "name"),
+    [
+        ("anthropic/claude-opus-4-8", "anthropic", "claude-opus-4-8"),
+        ("ANTHROPIC/CLAUDE-OPUS-4-8", "anthropic", "claude-opus-4-8"),
+        ("claude-opus-4-8", "anthropic", "claude-opus-4-8"),
+        ("qwen/qwen3-coder", "openrouter", "qwen/qwen3-coder"),
+        ("qwen3-coder", "openrouter", "qwen/qwen3-coder"),
+        ("databricks-claude-opus-4-8", "anthropic", "claude-opus-4-8"),
+        ("databricks/databricks-claude-opus-4-8", "anthropic", "claude-opus-4-8"),
+        ("DATABRICKS-CLAUDE-OPUS-4-8", "anthropic", "claude-opus-4-8"),
+    ],
+)
+def test_find_catalog_models_resolves_provider_and_vendor_namespaces(
+    model_id: str,
+    provider: str,
+    name: str,
+) -> None:
+    """Catalog lookup uses provider metadata without exact release mappings."""
+    matches = find_catalog_models(model_id)
+
+    assert [(match.provider, match.name) for match in matches] == [(provider, name)]
+
+
+def test_find_catalog_models_matches_vendor_namespaced_families() -> None:
+    """OpenRouter family fallback preserves the vendor namespace."""
+    matches = find_catalog_models("qwen/qwen3-coder-new")
+
+    assert [(match.provider, match.name) for match in matches] == [
+        ("openrouter", "qwen/qwen3-coder"),
+        ("openrouter", "qwen/qwen3-coder-plus"),
+    ]
+
+
+def test_shared_provider_catalog_caches_success_and_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shared TTL cache absorbs repeated lookups, including failures."""
+    monkeypatch.delenv("OMNIGENT_DISABLE_CATALOG_LOOKUP", raising=False)
+    _providers_mod._catalog_cache.clear()
+    calls: list[str] = []
+
+    def _download(provider: str) -> dict | None:
+        calls.append(provider)
+        if provider == "anthropic":
+            return _FAKE_CATALOG[provider]
+        return None
+
+    monkeypatch.setattr(_providers_mod, "_download_provider_catalog", _download)
+
+    assert _REAL_FETCH_PROVIDER_CATALOG("anthropic")
+    assert _REAL_FETCH_PROVIDER_CATALOG("anthropic")
+    assert _REAL_FETCH_PROVIDER_CATALOG("xai") == {}
+    assert _REAL_FETCH_PROVIDER_CATALOG("xai") == {}
+    assert calls == ["anthropic", "xai"]
 
 
 def test_get_chat_models_filters_to_chat_mode() -> None:


### PR DESCRIPTION
## Related issue

Part of #3426

## Summary

- Replace the stale exact Qwen context-window table with live MLflow catalog metadata, while retaining the self-describing Anthropic `[1m]` marker and conservative 128K offline fallback.
- Reuse the shared provider catalog cache for context sizing and pricing, including provider-qualified IDs, OpenRouter vendor namespaces, and Databricks aliases.
- Ratchet the hardcoded-model baseline and document the migration boundary.

**ELI5:** instead of teaching Omnigent every model's size by hand, ask the shared catalog and only use a safe default when the catalog cannot answer.

```text
explicit override -> encoded [1m] -> shared MLflow catalog -> LiteLLM -> 128K fallback
                                      |
                                      +-> context + pricing metadata
```

## Test Plan

- `uv run --no-sync pytest -q tests/onboarding/test_providers.py tests/llms/test_context_window.py` (59 passed)
- `uv run --no-sync pytest -q tests/test_model_catalog.py tests/runtime/test_compaction.py tests/server/integration/test_sessions_model_override.py` (110 passed)
- `pre-commit run --files dev/lint/hardcoded_model_allowlist.txt docs/model-hardcoding-plan.md omnigent/llms/context_window.py omnigent/onboarding/providers/__init__.py tests/llms/test_context_window.py tests/onboarding/test_providers.py`
- `pre-commit run --all-files` passes except the pre-existing stale `omnigent/api/routing/v1/routing_pb2.py` binding.
- Queried the live MLflow catalog for Qwen, OpenRouter, and Databricks-alias resolution.

## Demo

N/A — non-visual model metadata refactor.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified live MLflow results for a DashScope Qwen model, an OpenRouter vendor-namespaced model, and a provider-qualified Databricks alias. Existing compaction and session-override integration tests pass unchanged.

## Changelog

Model context limits now follow live provider catalog maximum-input metadata instead of adding output capacity or relying on stale built-in model IDs.

