### PR TITLE
ci(web): reject TypeScript lint warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
       - id: web-oxlint
         name: web oxlint
         language: system
-        entry: bash -c 'test -x web/node_modules/.bin/oxlint && cd web && node_modules/.bin/oxlint .'
+        entry: bash -c 'test -x web/node_modules/.bin/oxlint && cd web && node_modules/.bin/oxlint --deny-warnings .'
         files: ^(web/.*\.[cm]?[jt]sx?|web/\.oxlintrc\.json|web/package\.json|pnpm-lock\.yaml)$
         pass_filenames: false
 

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
     "build:embed": "vite build --config vite.embed.config.ts",
     "type-check": "tsc -b",
     "preview": "vite preview",
-    "lint": "oxlint .",
+    "lint": "oxlint --deny-warnings .",
     "lint:fix": "oxlint --fix .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Reject any TypeScript lint warning instead of allowing warnings to accumulate silently.
- Apply the same zero-warning policy through `pnpm --filter web run lint` and the `web-oxlint` pre-commit hook.

## Test Plan

- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `pnpm --filter web run test:coverage`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`
- Verified a warning-only probe exits `0` without `--deny-warnings` and exits `1` with the new gate.

## Demo

N/A — CI and pre-commit enforcement only.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified the clean 621-file lint baseline passes and a synthetic warning fails only when the new zero-warning gate is enabled. The existing web suite passes with 4,771 tests.

## Changelog

N/A — internal CI enforcement only.
