### PR TITLE
fix(web): keep user bubble hooks unconditional

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3121,6 +3121,9 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
   // markers (no input_file block), so surface them as chips — otherwise the
   // marker is stripped and the user can't see what they attached.
   const mentionedChips = extractAttachedPaths(bubble.content);
+  // Equality selector so Zustand only re-renders the matching bubble.
+  const flashing = useChatStore((s) => s.flashItemId === bubble.itemId);
+  const { isCopied, handleCopy } = useCopyMessage(() => text);
   // Runtime-injected `[System: ...]` notifications (task completion,
   // timer firings, terminal idle) ride in on role=user. When the content
   // is a pure system marker — no attached images or files — swap the
@@ -3133,9 +3136,6 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
   // circle + author-tinted bubble, not an email label.
   const author = bubble.createdBy;
   const showAuthorBadge = shouldShowAuthorBadge(author, getCurrentAuthorId(), isSessionShared);
-  // Equality selector so Zustand only re-renders the matching bubble.
-  const flashing = useChatStore((s) => s.flashItemId === bubble.itemId);
-  const { isCopied, handleCopy } = useCopyMessage(() => text);
 
   return (
     <Message

--- a/web/src/pages/ChatPage.userBubble.test.tsx
+++ b/web/src/pages/ChatPage.userBubble.test.tsx
@@ -101,6 +101,22 @@ describe("UserBubble markdown rendering", () => {
   });
 });
 
+describe("UserBubble system messages", () => {
+  it("keeps hook order stable when a system message becomes a regular message", () => {
+    const { rerender } = renderBubble(userBubble("[System: timer build fired]"));
+    expect(screen.getByTestId("system-message")).toBeInTheDocument();
+
+    rerender(
+      <FileViewerContext.Provider value={FILE_VIEWER_NOOP}>
+        <BubbleView bubble={userBubble("build finished")} />
+      </FileViewerContext.Provider>,
+    );
+
+    expect(screen.queryByTestId("system-message")).toBeNull();
+    expect(screen.getByText("build finished")).toBeInTheDocument();
+  });
+});
+
 describe("AssistantBubble lifecycle rendering", () => {
   it("shows an interrupted indicator for cancelled assistant bubbles", () => {
     renderBubble(assistantBubble("cancelled"));

--- a/web/src/shell/TerminalsPanel.test.tsx
+++ b/web/src/shell/TerminalsPanel.test.tsx
@@ -47,7 +47,7 @@ function makeTerminal(id: string, name: string, session: string): TerminalInfo {
   };
 }
 
-function useTerminalList(terminals: TerminalInfo[]) {
+function mockTerminalList(terminals: TerminalInfo[]) {
   useTerminalsMock.mockReturnValue({
     terminals,
     isLoading: false,
@@ -67,7 +67,7 @@ function renderPanel({
   readOnly?: boolean;
   terminals?: TerminalInfo[];
 } = {}) {
-  useTerminalList(terminals);
+  mockTerminalList(terminals);
   return render(
     <TerminalsPanel
       open


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Run `UserBubble` hooks before the system-message early return so React sees the same hook order on every render.
- Rename a test setup helper whose `use*` name made it look like an invalid hook call.
- Add a regression test that transitions the same bubble from a system marker to regular content.

**ELI5:** React assigns hooks fixed numbered slots. The early return skipped two slots for system messages, so changing that bubble later could shift the numbering and crash. The hooks now reserve their slots before either rendering path is chosen.

```text
Before: shared hooks -> system early return -> remaining hooks
After:  all hooks -------------------------> choose render path
```

## Test Plan

- `pnpm --filter web exec oxlint -A all -D 'react-hooks/rules-of-hooks' .`
- `pnpm --filter web exec vitest run src/pages/ChatPage.userBubble.test.tsx src/shell/TerminalsPanel.test.tsx`
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `pnpm --filter web run test:coverage`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A — non-visual correctness fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new regression rerenders one `UserBubble` across the early-return boundary. The full web suite passes with 4,772 tests, and the hooks rule reports zero diagnostics across the web package.

## Changelog

User messages no longer risk a React hook-order crash when changing from a system marker to regular content.
