### PR TITLE
docs(deploy): recommend HTTP/2 proxy to avoid multi-window UI stalls

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -177,6 +177,39 @@ remote DB.
 256 MB default does not, so the Fly config pins a 1 GB machine, and the
 Modal app pins `memory=1024` for the same reason.
 
+## Serving: put an HTTP/2 proxy in front for many concurrent views
+
+Each open session in the web UI holds a long-lived streaming HTTP
+response (`GET /v1/sessions/{id}/stream`, `text/event-stream`) for as
+long as the view is on screen. Over **HTTP/1.1 browsers cap concurrent
+connections at ~6 per origin**, and every open stream occupies one of
+those slots. Open a handful of windows or tabs against the same server
+and the pool fills with held-open streams — then every *other* request
+the UI makes (sending a message, the session list, `/health`, auth)
+queues behind the cap and never fires. The symptom is the whole UI
+appearing to freeze across all windows while the server itself is idle;
+in DevTools → Network the stuck requests sit in **Stalled/Queued**, not
+"waiting for server".
+
+**Fix: serve over HTTP/2.** HTTP/2 multiplexes every stream over one
+connection, so the per-origin cap stops mattering. `uvicorn` (the
+server's ASGI server) speaks HTTP/1.1 only, so HTTP/2 comes from a
+reverse proxy that terminates TLS in front of it — which most real
+deploys already have:
+
+- **The bundled Caddy overlay** (`docker/docker-compose.https.yaml`)
+  gives you this for free — Caddy negotiates HTTP/2 (and HTTP/3) over
+  TLS via ALPN with no extra config. See
+  [`docker/README.md`](docker/README.md#multi-user-mode-oidc).
+- **The one-click platforms** (Render, Railway, Fly, Cloudflare) and
+  managed **Databricks** terminate TLS with HTTP/2 at their edge, so
+  they're already covered.
+
+The gap is only when you expose the raw `:8000` HTTP/1.1 port directly
+to browsers (e.g. `docker compose up` with no proxy, reached over
+plain HTTP). That's fine for a single window; put a proxy in front once
+you or your team routinely open several.
+
 ## Execution model
 
 Omnigent runs in two pieces that talk to each other over a

--- a/deploy/docker/Caddyfile
+++ b/deploy/docker/Caddyfile
@@ -5,6 +5,13 @@
 # over the internal docker network — the omnigent container is no
 # longer directly exposed to the host.
 #
+# Fronting the server with Caddy also gives you HTTP/2 (negotiated over
+# TLS via ALPN, no extra config). That matters beyond HTTPS: each open
+# session in the web UI holds a long-lived event-stream connection, and
+# HTTP/1.1's ~6-connections-per-origin cap makes the UI stall once a
+# user opens several windows/tabs. HTTP/2 multiplexes them over one
+# connection, so this proxy is the fix. See ../README.md ("Serving").
+#
 # No ACME email is required: Let's Encrypt allows anonymous account
 # registration, so the cert issues without one. If you WANT expiry /
 # renewal notices, add a global email option above the site block:


### PR DESCRIPTION
## Related issue

N/A

## Summary

Multiple web-UI windows/tabs against the same server can make the whole
UI appear to freeze, even while the server is idle. Root cause is
client-side, not server exhaustion: each open session holds a
long-lived streaming HTTP response (`GET /v1/sessions/{id}/stream`,
`text/event-stream`) for as long as the view is on screen, and over
**HTTP/1.1 browsers cap concurrent connections at ~6 per origin**. Open
a handful of windows and the pool fills with held-open streams; every
other request (send message, session list, `/health`, auth) then queues
behind the cap and never fires.

The fix is to serve over **HTTP/2**, which multiplexes all streams over
one connection so the per-origin cap stops mattering. `uvicorn` speaks
HTTP/1.1 only, so HTTP/2 comes from a TLS-terminating reverse proxy —
which the bundled Caddy overlay (`docker/docker-compose.https.yaml`) and
every managed platform (Render/Railway/Fly/Cloudflare/Databricks)
already provide. The only real gap was documentation: nothing told
operators that fronting the raw `:8000` HTTP/1.1 port with a proxy is
also the cure for the multi-window stall.

This PR is **docs-only** — no server behavior change:
- New "Serving" section in `deploy/README.md` explaining the symptom,
  the ~6-connection cap, and the HTTP/2 fix (with a DevTools
  Stalled/Queued tell for confirming it).
- A pointer comment in `deploy/docker/Caddyfile` noting the overlay
  already delivers HTTP/2 and links back to the README.

## Test Plan

Docs-only. Verified the new relative links/anchors resolve
(`docker/README.md#multi-user-mode-oidc`, `../README.md`) and that no
added lines carry trailing whitespace. `pre-commit` isn't installed in
this environment, so the hook wasn't run here; the changed files are
Markdown + a config comment only.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Docs-only change (deploy README + a Caddyfile comment). No code paths
affected, so no automated coverage applies. Manually verified the links,
anchors, and whitespace as noted in the Test Plan.

This pull request and its description were written by Isaac.
