### PR TITLE
feat(web): select Codex model before launch

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1840,7 +1840,52 @@ class HostProcess:
         resolves its own catalog at launch, and the in-session picker
         re-reads that authoritative snapshot after bind.
         """
-        if canonicalize_harness(frame.harness) != "claude-native":
+        harness = canonicalize_harness(frame.harness) or frame.harness
+        if harness == "codex-native":
+            try:
+                from omnigent.codex_native_app_server import resolve_native_codex_launch
+                from omnigent.model_catalog import list_models_for_worker
+                from omnigent.spec.types import AgentSpec, ExecutorSpec
+
+                launch = await asyncio.to_thread(resolve_native_codex_launch, model=None)
+                spec = AgentSpec(
+                    spec_version=1,
+                    name="codex-native-prelaunch",
+                    executor=ExecutorSpec(
+                        type="omnigent",
+                        config={
+                            "harness": "codex-native",
+                            **({"profile": launch.profile} if launch.profile else {}),
+                        },
+                    ),
+                )
+                listing = await asyncio.to_thread(list_models_for_worker, spec, "codex-native")
+                default_model = launch.model
+                default_id = (
+                    default_model if default_model in {m.id for m in listing.models} else None
+                )
+                models = [
+                    {
+                        "id": model.id,
+                        "displayName": model.id,
+                        **({"isDefault": True} if model.id == default_id else {}),
+                    }
+                    for model in listing.models
+                ]
+            except Exception:
+                _logger.exception("Failed to resolve pre-launch Codex model options")
+                return HostModelOptionsResultFrame(
+                    request_id=frame.request_id,
+                    status="failed",
+                    error="failed to resolve Codex model options",
+                )
+            return HostModelOptionsResultFrame(
+                request_id=frame.request_id,
+                status="ok",
+                models=models,
+            )
+
+        if harness != "claude-native":
             return HostModelOptionsResultFrame(
                 request_id=frame.request_id,
                 status="failed",

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1844,7 +1844,7 @@ class HostProcess:
         if harness == "codex-native":
             try:
                 from omnigent.codex_native_app_server import resolve_native_codex_launch
-                from omnigent.model_catalog import list_models_for_worker
+                from omnigent.model_catalog import list_models_for_worker, resolve_catalog_model
                 from omnigent.spec.types import AgentSpec, ExecutorSpec
 
                 launch = await asyncio.to_thread(resolve_native_codex_launch, model=None)
@@ -1861,6 +1861,14 @@ class HostProcess:
                 )
                 listing = await asyncio.to_thread(list_models_for_worker, spec, "codex-native")
                 default_model = launch.model
+                if default_model is None and launch.profile is not None:
+                    default_model = (
+                        await asyncio.to_thread(
+                            resolve_catalog_model,
+                            "databricks",
+                            family="openai",
+                        )
+                    ).model_id
                 default_id = (
                     default_model if default_model in {m.id for m in listing.models} else None
                 )

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -1032,6 +1032,84 @@ async def _drive_model_effort(base_url: str, session_id: str) -> None:
             await browser.close()
 
 
+def test_start_session_select_codex_model(seeded_session: tuple[str, str]) -> None:
+    """The host-resolved Codex model reaches the create request."""
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_codex_model(base_url, session_id))
+
+
+async def _drive_codex_model(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            await _register_common_routes(
+                page,
+                created_session_id=session_id,
+                create_bodies=create_bodies,
+                agents_body=_codex_native_agents_body(),
+            )
+
+            async def handle_agent_scan(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"data": []}),
+                )
+
+            async def handle_model_options(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps(
+                        {
+                            "models": [
+                                {
+                                    "id": "gpt-live-default",
+                                    "displayName": "GPT Live Default",
+                                    "isDefault": True,
+                                },
+                                {"id": "gpt-live-fast", "displayName": "GPT Live Fast"},
+                            ]
+                        }
+                    ),
+                )
+
+            await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+            await page.route(
+                f"**/v1/hosts/{_HOST_ID}/harnesses/codex-native/model-options",
+                handle_model_options,
+            )
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            await _open_entry_config(page, "ag_codex_e2e")
+            model = page.get_by_test_id("new-chat-landing-config-model")
+            await expect(model).to_contain_text("Default (gpt-live-default)")
+            await _pick_config_select(page, "new-chat-landing-config-model", "gpt-live-fast")
+            await _save_config(page)
+
+            await page.get_by_test_id("new-chat-landing-input").fill("set up the project")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            await _wait_until(lambda: len(create_bodies) == 1)
+            body = create_bodies[0]
+            assert body["agent_id"] == "ag_codex_e2e", body
+            assert body.get("model_override") == "gpt-live-fast", body
+            assert body.get("reasoning_effort") is None, body
+        finally:
+            await browser.close()
+
+
 def test_start_session_select_approval_mode(seeded_session: tuple[str, str]) -> None:
     """Picking a non-default approval preset rides along to the create call.
 

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -7,6 +7,7 @@ import logging
 import subprocess
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -180,6 +181,60 @@ async def test_handle_model_options_does_not_invent_codex_default(
     )
 
     assert result.models == [{"id": "gpt-live", "displayName": "gpt-live"}]
+
+
+async def test_handle_model_options_uses_databricks_catalog_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Databricks profile path labels its effective catalog default."""
+    from omnigent import codex_native_app_server
+    from omnigent.model_catalog import ModelEntry, ModelListing
+
+    monkeypatch.setattr(
+        "omnigent.model_catalog.list_models_for_worker",
+        lambda spec, harness: ModelListing(
+            source="gateway",
+            verified=True,
+            models=(
+                ModelEntry(id="databricks-gpt-default", family="openai"),
+                ModelEntry(id="databricks-gpt-fast", family="openai"),
+            ),
+            note="test catalog",
+        ),
+    )
+
+    def _fake_resolve_catalog_model(provider: str, *, family: str) -> SimpleNamespace:
+        assert provider == "databricks"
+        assert family == "openai"
+        return SimpleNamespace(model_id="databricks-gpt-default")
+
+    monkeypatch.setattr(
+        "omnigent.model_catalog.resolve_catalog_model",
+        _fake_resolve_catalog_model,
+    )
+    monkeypatch.setattr(
+        codex_native_app_server,
+        "resolve_native_codex_launch",
+        lambda *, model: codex_native_app_server.NativeCodexLaunch(
+            config_overrides=[],
+            model=None,
+            profile="oss",
+        ),
+    )
+    host = _make_host_process()
+
+    result = await host._handle_model_options(
+        HostModelOptionsFrame(request_id="req_models", harness="codex-native"),
+    )
+
+    assert result.models == [
+        {
+            "id": "databricks-gpt-default",
+            "displayName": "databricks-gpt-default",
+            "isDefault": True,
+        },
+        {"id": "databricks-gpt-fast", "displayName": "databricks-gpt-fast"},
+    ]
 
 
 async def test_handle_model_options_rejects_unsupported_harness() -> None:

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -99,6 +99,104 @@ async def test_handle_model_options_uses_host_claude_configuration(
     )
 
 
+async def test_handle_model_options_uses_codex_provider_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Codex launch picker comes from the host's resolved provider catalog."""
+    from omnigent import codex_native_app_server
+    from omnigent.model_catalog import ModelEntry, ModelListing
+
+    def _fake_list_models_for_worker(spec: object, harness: str) -> ModelListing:
+        assert harness == "codex-native"
+        assert spec.executor.config["profile"] == "oss"
+        return ModelListing(
+            source="static",
+            verified=False,
+            models=(
+                ModelEntry(id="gpt-live-default", family="openai"),
+                ModelEntry(id="gpt-live-fast", family="openai"),
+            ),
+            note="test catalog",
+        )
+
+    monkeypatch.setattr(
+        "omnigent.model_catalog.list_models_for_worker",
+        _fake_list_models_for_worker,
+    )
+    monkeypatch.setattr(
+        codex_native_app_server,
+        "resolve_native_codex_launch",
+        lambda *, model: codex_native_app_server.NativeCodexLaunch(
+            config_overrides=[],
+            model="gpt-live-fast",
+            profile="oss",
+        ),
+    )
+    host = _make_host_process()
+
+    result = await host._handle_model_options(
+        HostModelOptionsFrame(request_id="req_models", harness="codex-native"),
+    )
+
+    assert result == HostModelOptionsResultFrame(
+        request_id="req_models",
+        status="ok",
+        models=[
+            {"id": "gpt-live-default", "displayName": "gpt-live-default"},
+            {"id": "gpt-live-fast", "displayName": "gpt-live-fast", "isDefault": True},
+        ],
+    )
+
+
+async def test_handle_model_options_does_not_invent_codex_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A catalog entry is not a default unless Codex resolves it as one."""
+    from omnigent import codex_native_app_server
+    from omnigent.model_catalog import ModelEntry, ModelListing
+
+    monkeypatch.setattr(
+        "omnigent.model_catalog.list_models_for_worker",
+        lambda spec, harness: ModelListing(
+            source="static",
+            verified=False,
+            models=(ModelEntry(id="gpt-live", family="openai"),),
+            note="test catalog",
+        ),
+    )
+    monkeypatch.setattr(
+        codex_native_app_server,
+        "resolve_native_codex_launch",
+        lambda *, model: codex_native_app_server.NativeCodexLaunch(
+            config_overrides=[],
+            model=None,
+            profile=None,
+        ),
+    )
+    host = _make_host_process()
+
+    result = await host._handle_model_options(
+        HostModelOptionsFrame(request_id="req_models", harness="codex-native"),
+    )
+
+    assert result.models == [{"id": "gpt-live", "displayName": "gpt-live"}]
+
+
+async def test_handle_model_options_rejects_unsupported_harness() -> None:
+    """Only launch paths with host-resolved model catalogs are accepted."""
+    host = _make_host_process()
+
+    result = await host._handle_model_options(
+        HostModelOptionsFrame(request_id="req_models", harness="cursor-native"),
+    )
+
+    assert result == HostModelOptionsResultFrame(
+        request_id="req_models",
+        status="failed",
+        error="model options are unsupported for harness 'cursor-native'",
+    )
+
+
 def _make_host_process() -> HostProcess:
     """Create a HostProcess with a test identity.
 

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -642,19 +642,28 @@ function setupLandingMocks() {
     data: undefined,
   } as unknown as ReturnType<typeof useHostWorktrees>);
   mockHosts([host("online")]);
-  useHostModelOptionsMock.mockReturnValue({
-    data: [
-      { id: "opus", model: "system.ai.claude-opus-4-8[1m]", displayName: "Opus 4.8" },
-      {
-        id: "sonnet",
-        model: "system.ai.claude-sonnet-4-6[1m]",
-        displayName: "Sonnet 4.6",
-      },
-      { id: "haiku", model: "system.ai.claude-haiku-4-5", displayName: "Haiku 4.5" },
-    ],
-    isLoading: false,
-    isError: false,
-  } as unknown as ReturnType<typeof useHostModelOptions>);
+  useHostModelOptionsMock.mockImplementation(
+    (_hostId, harness) =>
+      ({
+        data:
+          harness === "codex-native"
+            ? [
+                { id: "databricks-gpt-5-5", displayName: "GPT-5.5", isDefault: true },
+                { id: "databricks-gpt-5-6", displayName: "GPT-5.6" },
+              ]
+            : [
+                { id: "opus", model: "system.ai.claude-opus-4-8[1m]", displayName: "Opus 4.8" },
+                {
+                  id: "sonnet",
+                  model: "system.ai.claude-sonnet-4-6[1m]",
+                  displayName: "Sonnet 4.6",
+                },
+                { id: "haiku", model: "system.ai.claude-haiku-4-5", displayName: "Haiku 4.5" },
+              ],
+        isLoading: false,
+        isError: false,
+      }) as unknown as ReturnType<typeof useHostModelOptions>,
+  );
   mockAgents([
     {
       id: "a1",
@@ -1063,10 +1072,51 @@ describe("NewChatLandingScreen", () => {
     renderLanding();
     // Open Codex's (a2) config modal — it carries the approval-mode select.
     openAgentConfig("a2");
+    expect(screen.getByTestId("new-chat-landing-config-model")).toBeTruthy();
     expect(screen.getByTestId("new-chat-landing-config-approval")).toBeTruthy();
     openSelect("new-chat-landing-config-approval");
     expect(screen.getByText("Full access")).toBeTruthy();
     expect(screen.getByText("Read only")).toBeTruthy();
+  });
+
+  it("sends the selected Codex launch model without changing Claude's remembered model", async () => {
+    authenticatedFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+    renderLanding();
+
+    openAgentConfig("a2");
+    openSelect("new-chat-landing-config-model");
+    expect(screen.getAllByText("Default (databricks-gpt-5-5)").length).toBeGreaterThan(0);
+    expect(screen.getByText("databricks-gpt-5-6")).toBeTruthy();
+    fireEvent.click(screen.getByText("databricks-gpt-5-6"));
+    saveConfig();
+
+    // The Codex model is remembered under codex-native only; Claude Code's
+    // picker should reopen on its own Default instead of inheriting the GPT id.
+    openAgentConfig("a1");
+    expect(screen.getByTestId("new-chat-landing-config-model").textContent).toContain("Default");
+    expect(screen.getByTestId("new-chat-landing-config-model").textContent).not.toContain(
+      "databricks-gpt-5-6",
+    );
+    saveConfig();
+
+    openAgentConfig("a2");
+    expect(screen.getByTestId("new-chat-landing-config-model").textContent).toContain(
+      "databricks-gpt-5-6",
+    );
+    saveConfig();
+    fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
+      target: { value: "run the build" },
+    });
+    fireEvent.submit(screen.getByTestId("new-chat-landing-composer"));
+    await waitFor(() => expect(authenticatedFetchMock).toHaveBeenCalledTimes(1));
+    const [, init] = authenticatedFetchMock.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>;
+    expect(body.model_override).toBe("databricks-gpt-5-6");
+    expect(body.reasoning_effort).toBeUndefined();
+    expect(useHostModelOptionsMock).toHaveBeenCalledWith("host_1", "codex-native", true);
   });
 
   it("arms codex full bypass via the Approval dropdown and shows the warning banner", () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -145,6 +145,7 @@ import { useHostWorktrees } from "@/hooks/useHostWorktrees";
 import { useNativeServerSwitcherForMainSurface } from "@/hooks/useNativeServerSwitcher";
 import type { WorkspaceFile } from "@/hooks/useWorkspaceChangedFiles";
 import type { Conversation } from "@/hooks/useConversations";
+import type { NativeModelOption } from "@/lib/types";
 import { useProjectConfig, useProjects, moveConversationToProject } from "@/hooks/useConversations";
 import { FileMentionMenu } from "@/components/FileMentionMenu";
 import { useMentionBrowser } from "@/hooks/useMentionBrowser";
@@ -304,6 +305,22 @@ const CODEX_NATIVE_BYPASS_APPROVAL_OPTION = {
   description: "Runs Codex with no approval prompts and no command sandbox",
   args: [] as string[],
 };
+
+function displayModelId(option: Pick<NativeModelOption, "id">): string {
+  return option.id;
+}
+
+function displayModelName(option: Pick<NativeModelOption, "id" | "displayName">): string {
+  return option.displayName ?? option.id;
+}
+
+function defaultModelLabel(
+  options: readonly Pick<NativeModelOption, "id" | "displayName" | "isDefault">[],
+  display: (option: Pick<NativeModelOption, "id" | "displayName">) => string,
+): string {
+  const dflt = options.find((option) => option.isDefault);
+  return dflt ? `Default (${display(dflt)})` : "Default";
+}
 
 function HostOption({ host, subtitle }: { host: Host; subtitle?: string }) {
   const isOnline = host.status === "online";
@@ -1225,6 +1242,8 @@ function HarnessConfigModal({
   pickedModel,
   claudeModelOptions,
   claudeModelsLoading,
+  codexModelOptions,
+  codexModelsLoading,
   pickedEffort,
   pickedHarness,
   costControlMode,
@@ -1249,8 +1268,10 @@ function HarnessConfigModal({
   cursorExecMode: string;
   bypassSandbox: boolean;
   pickedModel: string;
-  claudeModelOptions: readonly { id: string; displayName: string }[];
+  claudeModelOptions: readonly Pick<NativeModelOption, "id" | "displayName" | "isDefault">[];
   claudeModelsLoading: boolean;
+  codexModelOptions: readonly Pick<NativeModelOption, "id" | "displayName" | "isDefault">[];
+  codexModelsLoading: boolean;
   pickedEffort: string;
   pickedHarness: string | null;
   costControlMode: CostControlMode;
@@ -1271,6 +1292,9 @@ function HarnessConfigModal({
   const hasApproval = nativeAgentHasCapability(agent, "approvalMode");
   const hasCursor = nativeAgentHasCapability(agent, "cursorMode");
   const isCodex = entryHarness === "codex-native";
+  const modelOptions = isCodex ? codexModelOptions : claudeModelOptions;
+  const modelsLoading = isCodex ? codexModelsLoading : claudeModelsLoading;
+  const modelDisplay = isCodex ? displayModelId : displayModelName;
   const brainDefault =
     agent.harness != null && agent.harness in brainHarnessLabels ? agent.harness : null;
 
@@ -1338,9 +1362,14 @@ function HarnessConfigModal({
           mode: draftPermission,
         });
     } else if (hasApproval) {
+      if (isCodex) setPickedModel(draftModel);
       setApprovalMode(draftApproval);
       setBypassSandbox(draftBypass);
-      if (entryHarness) writeHarnessOption(entryHarness, { mode: draftApproval });
+      if (entryHarness)
+        writeHarnessOption(entryHarness, {
+          mode: draftApproval,
+          ...(isCodex ? { model: draftModel } : {}),
+        });
     } else if (hasCursor) {
       setCursorExecMode(draftCursor);
       if (entryHarness) writeHarnessOption(entryHarness, { mode: draftCursor });
@@ -1470,6 +1499,42 @@ function HarnessConfigModal({
                 />
               </ConfigRow>
             </>
+          )}
+
+          {hasApproval && isCodex && (
+            <ConfigRow label="Model" description="Underlying LLM">
+              <Select value={modelValue} onValueChange={onModelChange}>
+                <SelectTrigger
+                  className="w-full"
+                  data-testid="new-chat-landing-config-model"
+                  aria-label="Model"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent
+                  position="popper"
+                  align="start"
+                  className="[&_[data-slot=select-item]]:pl-2.5"
+                >
+                  <SelectItem value={MODEL_SELECT_DEFAULT}>
+                    {defaultModelLabel(modelOptions, modelDisplay)}
+                  </SelectItem>
+                  {modelOptions.map((m) => (
+                    <SelectItem key={m.id} value={m.id}>
+                      {displayModelId(m)}
+                    </SelectItem>
+                  ))}
+                  {modelsLoading && (
+                    <div className="px-2.5 py-1 text-xs text-muted-foreground">Loading models…</div>
+                  )}
+                  {!modelsLoading && modelOptions.length === 0 && (
+                    <div className="px-2.5 py-1 text-xs text-muted-foreground">
+                      Models unavailable
+                    </div>
+                  )}
+                </SelectContent>
+              </Select>
+            </ConfigRow>
           )}
 
           {hasApproval && (
@@ -1766,6 +1831,11 @@ export function NewChatLandingScreen() {
     "claude-native",
     !sandboxSelected,
   );
+  const { data: hostCodexModelOptions, isLoading: hostCodexModelsLoading } = useHostModelOptions(
+    selectedHostId,
+    "codex-native",
+    !sandboxSelected,
+  );
   const claudeModelOptions = useMemo(
     () =>
       sandboxSelected
@@ -1778,6 +1848,10 @@ export function NewChatLandingScreen() {
             displayName: option.displayName ?? option.id,
           })),
     [hostClaudeModelOptions, sandboxSelected],
+  );
+  const codexModelOptions = useMemo(
+    () => (sandboxSelected ? [] : (hostCodexModelOptions ?? [])),
+    [hostCodexModelOptions, sandboxSelected],
   );
   // Desktop-shell host status for THIS machine (null outside Electron), so the
   // picker can tag the current machine and offer to auto-connect it.
@@ -2218,7 +2292,17 @@ export function NewChatLandingScreen() {
           ? CODEX_NATIVE_BYPASS_APPROVAL_OPTION.label
           : (CODEX_NATIVE_APPROVAL_MODES.find((m) => m.value === approvalMode)?.label ??
             approvalMode);
-      return [{ label: "Approval", value: approvalValue }, ...routingRow];
+      const modelRows = isCodex
+        ? [
+            {
+              label: "Model",
+              value:
+                codexModelOptions.find((m) => m.id === pickedModel)?.id ??
+                defaultModelLabel(codexModelOptions, displayModelId),
+            },
+          ]
+        : [];
+      return [...modelRows, { label: "Approval", value: approvalValue }, ...routingRow];
     }
     if (supportsCursorMode) {
       const modeValue =
@@ -2243,6 +2327,7 @@ export function NewChatLandingScreen() {
     routingOn,
     pickedModel,
     claudeModelOptions,
+    codexModelOptions,
     pickedEffort,
     permissionMode,
     approvalMode,
@@ -2309,13 +2394,20 @@ export function NewChatLandingScreen() {
       );
     } else if (supportsApprovalMode) {
       setApprovalMode(resolve(CODEX_NATIVE_APPROVAL_MODES, CODEX_NATIVE_DEFAULT_APPROVAL_MODE));
+      setPickedModel(
+        selectedNativeHarness === "codex-native" &&
+          stored.model != null &&
+          codexModelOptions.some((m) => m.id === stored.model)
+          ? stored.model
+          : "",
+      );
     } else if (supportsCursorMode) {
       setCursorExecMode(resolve(CURSOR_NATIVE_EXEC_MODES, CURSOR_NATIVE_DEFAULT_EXEC_MODE));
     }
     // Reseed on harness changes and when the selected host's catalog resolves;
     // capability flags are derived from the same harness and stay omitted.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedNativeHarness, claudeModelOptions]);
+  }, [selectedNativeHarness, claudeModelOptions, codexModelOptions]);
   // Native-terminal agents interpret slash commands inside their own CLI
   // (the runner injects the text verbatim), so the landing composer must
   // not intercept them — no skills menu, no slash_command routing.
@@ -2805,6 +2897,7 @@ export function NewChatLandingScreen() {
       // straight to that dir, which also sidesteps the "branch already
       // exists" guard.
       const agent = agentList.find((a) => a.id === effectiveAgentId);
+      const nativeAgent = nativeCodingAgentForAvailableAgent(agent);
       const nativeLabels = nativeWrapperLabelsForAgent(agent);
       const agentSupportsPermissionMode = nativeAgentHasCapability(agent, "permissionMode");
       const agentSupportsApprovalMode = nativeAgentHasCapability(agent, "approvalMode");
@@ -2889,11 +2982,14 @@ export function NewChatLandingScreen() {
                     ? (CURSOR_NATIVE_EXEC_MODES.find((m) => m.value === cursorExecMode)?.args ?? [])
                     : undefined,
             // Model + reasoning effort, persisted on the session row before
-            // the runner launches. Only claude-native surfaces the picker, so
-            // only its agents carry the choice; the runner reads them as
-            // `--model` / `--effort` at terminal launch. An unselected ("")
-            // knob is omitted so Claude Code keeps its own configured model.
-            model_override: agentSupportsPermissionMode && pickedModel ? pickedModel : undefined,
+            // the runner launches. Claude and Codex read model_override at
+            // terminal launch; an unselected ("") knob is omitted so the
+            // harness keeps its own configured/default model.
+            model_override:
+              (agentSupportsPermissionMode || nativeAgent?.harness === "codex-native") &&
+              pickedModel
+                ? pickedModel
+                : undefined,
             reasoning_effort:
               agentSupportsPermissionMode && pickedEffort ? pickedEffort : undefined,
             // Smart routing toggle — server-side. The "Auto" harness always
@@ -3371,6 +3467,10 @@ export function NewChatLandingScreen() {
                     claudeModelOptions={claudeModelOptions}
                     claudeModelsLoading={
                       !sandboxSelected && selectedHostId !== null && hostClaudeModelsLoading
+                    }
+                    codexModelOptions={codexModelOptions}
+                    codexModelsLoading={
+                      !sandboxSelected && selectedHostId !== null && hostCodexModelsLoading
                     }
                     pickedEffort={pickedEffort}
                     pickedHarness={pickedHarness}


### PR DESCRIPTION
## Related issue

Closes #3537

## Summary

- Add a Codex model picker to New Chat so users can choose the launch model before the first turn runs.
- Resolve available models and the effective default from the selected host's existing provider/catalog path, without adding production model IDs.
- Remember model selections per harness and persist an explicit Codex choice as `model_override` before runner launch.

**ELI5:** New Chat now asks the selected machine which Codex models it can run. Choosing one pins that model for the new session; choosing Default leaves provider fallback behavior unchanged.

```mermaid
flowchart LR
  A[Select host and Codex] --> B[Host model-options endpoint]
  B --> C[Resolved provider catalog]
  C --> D[New Chat model picker]
  D -->|Explicit model| E[Create session with model_override]
  D -->|Default| F[Create session without override]
```

## Test Plan

- `.venv/bin/pre-commit run --all-files`
- `uv run pytest tests/host/test_connect.py -q`
- `env NODE_OPTIONS=--no-experimental-webstorage uv run pytest tests/e2e_ui/start_session/test_start_session.py::test_start_session_select_codex_model -q`
- `env NODE_OPTIONS=--no-experimental-webstorage pnpm --filter web exec vitest run src/shell/NewChatDialog.test.tsx`
- `pnpm --filter web run type-check`

## Demo

Not captured in this terminal-only session. The Codex model picker flow is covered by the focused Playwright test above.

<img width="972" height="816" alt="image" src="https://github.com/user-attachments/assets/71e779ef-326d-44a7-a903-7a8412f628ce" />

<img width="972" height="816" alt="image" src="https://github.com/user-attachments/assets/33a62998-e023-4ac0-a1e5-d0a58f5a8029" />




## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused host, component, and Playwright tests cover catalog resolution, effective-default labeling, harness-scoped persistence, and the create payload.

## Changelog

Choose a Codex model before starting a Web UI session
