### PR TITLE
fix(sessions): expose created_at on flat items and input.consumed

### DIFF
--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -773,6 +773,7 @@ class ConversationItem(BaseModel):
             "response_id": self.response_id,
             "type": self.type,
             "status": self.status,
+            "created_at": self.created_at,
             **self.data.model_dump(exclude_none=True, by_alias=True),
             # created_by is present only for human-authored items;
             # omitted (not null) for agent/tool/system messages so the

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -1408,6 +1408,7 @@ def _publish_input_consumed(
             type=item.type,
             data=item.data.model_dump() if item.data is not None else {},
             created_by=item.created_by,
+            created_at=item.created_at,
             cleared_pending_id=cleared_pending_id,
         ),
     )

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2948,6 +2948,8 @@ class SessionInputConsumedPayload(BaseModel):
         e.g. ``"alice@example.com"``. ``None`` for agent/tool/system
         items and single-user mode. Mirrors
         :meth:`ConversationItem.to_api_dict` for live attribution.
+    :param created_at: Unix epoch seconds when the item was persisted.
+        Mirrors :class:`ConversationItem.created_at` for live clients.
     :param cleared_pending_id: When this consumed message drains a
         :mod:`omnigent.runtime.pending_inputs` entry (a native-
         terminal web message round-tripping back from the transcript),
@@ -2963,6 +2965,7 @@ class SessionInputConsumedPayload(BaseModel):
     # (matches :class:`SessionEventInput.data`).
     data: dict[str, Any]
     created_by: str | None = None
+    created_at: int | None = None
     cleared_pending_id: str | None = None
 
     model_config = ConfigDict(extra="ignore")

--- a/tests/entities/test_conversation.py
+++ b/tests/entities/test_conversation.py
@@ -11,14 +11,14 @@ from omnigent.entities.conversation import (
 )
 
 
-def _message_item(created_by: str | None) -> ConversationItem:
+def _message_item(created_by: str | None, created_at: int = 0) -> ConversationItem:
     """Build a persisted user-message item with the given author."""
     return ConversationItem(
         id="msg_1",
         type="message",
         status="completed",
         response_id="resp_1",
-        created_at=0,
+        created_at=created_at,
         data=MessageData(
             role="user",
             content=[{"type": "input_text", "text": "hi"}],
@@ -31,6 +31,12 @@ def test_to_api_dict_exposes_created_by_when_set() -> None:
     """A human-authored item surfaces ``created_by`` in the API shape."""
     api = _message_item("alice@example.com").to_api_dict()
     assert api["created_by"] == "alice@example.com"
+
+
+def test_to_api_dict_exposes_created_at() -> None:
+    """Flat API items carry the persisted creation timestamp."""
+    api = _message_item(None, created_at=1_704_067_200).to_api_dict()
+    assert api["created_at"] == 1_704_067_200
 
 
 def test_to_api_dict_omits_created_by_when_none() -> None:


### PR DESCRIPTION
## Summary
- Include `ConversationItem.created_at` in `to_api_dict()` so `/sessions/{id}/items` and `output_item.done` carry message timestamps
- Add `created_at` to `session.input.consumed` SSE payload for live user messages

## Motivation
Hive (and other clients) need server-authoritative message times instead of client-side clock stamping. Historical items loaded via the flat items API were missing `created_at` even though the field exists on `ConversationItem`.

## Test plan
- [x] `test_to_api_dict_exposes_created_at` in `tests/entities/test_conversation.py`
- [ ] Verify `GET /sessions/{id}/items` returns `created_at` per item
- [ ] Verify `session.input.consumed` includes `created_at` on new user messages

Made with [Cursor](https://cursor.com)