### PR TITLE
chore(inner): collapse declared_passthrough duplication, document deny-by-default agent env

### DIFF
--- a/docs/POLICIES.md
+++ b/docs/POLICIES.md
@@ -209,7 +209,28 @@ Forces a specific sandbox configuration on agent start.
 | `allow_network` | boolean | `true` | Allow network access |
 | `write_paths` | string[] | `null` | Writable paths (null inherits agent config) |
 | `read_paths` | string[] | `null` | Read-only paths (null inherits agent config) |
-| `env_passthrough` | string[] | `null` | Env vars allowed through sandbox |
+| `env_passthrough` | string[] | `null` | Env vars allowed through to the agent process (see below) |
+
+`env_passthrough` is the escape hatch for an agent that authenticates from an
+environment variable. Agent CLIs are spawned with a **deny-by-default**
+environment: the shared base (`HOME`, `PATH`, proxy/TLS, locale, `TMPDIR`, the
+Omnigent session marker) plus the harness's own variable family, and nothing
+else. A host secret belonging to some other provider is not inherited.
+
+That means an ambient key which used to reach the CLI implicitly now has to be
+declared. Two cases worth knowing:
+
+- **A generic ACP agent** (`type: acp`) gets no vendor family at all, because
+  Omnigent cannot know which vendor an arbitrary agent belongs to. Gemini via
+  ACP needs `env_passthrough: ["GEMINI_API_KEY"]`.
+- **Goose** owns `GOOSE_*` only. Goose configured through Omnigent's
+  provider/gateway routing is unaffected, but a goose set up against an ambient
+  provider key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, ...) needs that name
+  declared here.
+
+An agent that fails during its `initialize` handshake for no obvious reason is
+worth checking against this first; the ACP executor logs a hint pointing back at
+this field.
 
 #### `deny_pii_in_llm_request`
 

--- a/omnigent/inner/agent_env.py
+++ b/omnigent/inner/agent_env.py
@@ -101,9 +101,12 @@ def declared_passthrough(os_env: object | None) -> tuple[str, ...]:
     """Env-var names the spec declared for passthrough.
 
     Lives on ``os_env.sandbox.env_passthrough``. Returns an empty tuple when
-    any link in that chain is absent. Duplicated from
-    ``codex_executor._declared_passthrough`` so non-codex harnesses do not have
-    to import the codex module to read a field that belongs to the sandbox spec.
+    any link in that chain is absent.
+
+    Lives here rather than in any one executor so no harness has to import a
+    sibling harness's module to read a field that belongs to the sandbox spec.
+    Duck-typed on purpose: the only contract is the ``sandbox.env_passthrough``
+    chain, so a caller holding a partially-built or stubbed spec is fine.
     """
     sandbox = getattr(os_env, "sandbox", None) if os_env is not None else None
     names = getattr(sandbox, "env_passthrough", None) if sandbox is not None else None

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -24,7 +24,7 @@ from typing import Any, Protocol, TypeAlias
 
 from omnigent import model_catalog
 from omnigent._platform import resolve_cli_binary
-from omnigent.inner.agent_env import clean_agent_env
+from omnigent.inner.agent_env import clean_agent_env, declared_passthrough
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 from omnigent.reasoning_effort import CODEX_EFFORTS, EFFORT_ALIASES, validate_effort
 from omnigent.spec.types import RetryPolicy
@@ -394,18 +394,6 @@ def _clean_codex_env(extra_allow: Iterable[str] = ()) -> dict[str, str]:
         deny_exact=_CODEX_ENV_DENY_EXACT,
         extra_allowed=extra_allow,
     )
-
-
-def _declared_passthrough(os_env: OSEnvSpec | None) -> tuple[str, ...]:
-    """Env-var names an agent declared for tool passthrough.
-
-    Lives on ``os_env.sandbox.env_passthrough`` (an
-    :class:`OSEnvSandboxSpec` field), not on ``OSEnvSpec`` directly.
-    Returns an empty tuple when any link in that chain is absent.
-    """
-    if os_env is not None and os_env.sandbox is not None and os_env.sandbox.env_passthrough:
-        return tuple(os_env.sandbox.env_passthrough)
-    return ()
 
 
 def codex_skill_sources(bundle_dir: Path | None, home: Path) -> list[Path]:
@@ -2311,7 +2299,7 @@ class CodexExecutor(Executor):
                 f"nvm-managed bin dir), set {_CODEX_PATH_ENV}=/path/to/codex."
             )
         self._codex_path = resolved_codex
-        self._env = _clean_codex_env(_declared_passthrough(self._os_env_spec))
+        self._env = _clean_codex_env(declared_passthrough(self._os_env_spec))
         # Retry policy → OpenAI SDK env vars (Codex uses the OpenAI
         # SDK internally). Speculative — empirical audit pending.
         self._retry_policy = retry_policy if retry_policy is not None else RetryPolicy()

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -3241,7 +3241,9 @@ def test_clean_codex_env_deny_wins_over_extra_allow(monkeypatch):
 
 
 def test_declared_passthrough_reads_sandbox_env_passthrough():
-    from omnigent.inner.codex_executor import _declared_passthrough
+    # Codex consumes the shared helper in agent_env rather than keeping its own
+    # copy; this still covers the codex spawn path's source of extra_allowed.
+    from omnigent.inner.agent_env import declared_passthrough as _declared_passthrough
     from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
 
     # env_passthrough lives on os_env.sandbox, not os_env directly


### PR DESCRIPTION
Follow-up to the non-blocking review notes on #3479.

## 1. `declared_passthrough` duplication

`codex_executor._declared_passthrough` was byte-equivalent to `agent_env.declared_passthrough`. The docstring justified the copy as avoiding a codex import from non-codex harnesses, but codex already imports `agent_env` for `clean_agent_env`, so the reason no longer applies. Removed the local copy; `agent_env`'s docstring no longer describes itself as duplicated from codex.

`test_declared_passthrough_reads_sandbox_env_passthrough` is repointed at the shared helper rather than deleted, so the codex spawn path's source of `extra_allowed` stays covered.

## 2. Deny-by-default env is now documented

The migration note for #3479 only ever lived in a PR description. `docs/POLICIES.md` now explains, next to the `env_passthrough` row, that agent CLIs are spawned with the shared base plus their own family and nothing else — and the two cases that actually bite:

- a generic ACP agent gets no vendor family, so gemini-over-ACP needs `env_passthrough: ["GEMINI_API_KEY"]`
- goose owns `GOOSE_*` only, so a goose authenticated by an ambient provider key rather than gateway routing needs that name declared

Plus a pointer to the `initialize`-failure warning, since that is the symptom an operator sees.

## Not changed: `NODE_EXTRA_CA_CERTS`

The review correctly noted this widens codex's set, and that my "preserved exactly" claim on #3479 was therefore wrong — codex's original `allow_exact` had no `NODE_` entry. I've acknowledged that on #3479. I'm proposing it stays as-is: it is a CA path, not a credential, and removing it costs corporate-CA users TLS on every Node harness without its own `NODE_` family. Happy to drop it if you'd rather keep codex byte-identical.

## Tests

141 passed on the two directly affected files; 1901 passed / 32 skipped across the executor selection, with one pre-existing order-dependent failure that reproduces on unmodified `main`. `ruff check` and `ruff format --check` clean.