### PR TITLE
fix(docker): wire ProjectStore in Docker entrypoint

### DIFF
--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -309,6 +309,7 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
         SqlAlchemyPermissionStore,
     )
     from omnigent.stores.policy_store.sqlalchemy_store import SqlAlchemyPolicyStore
+    from omnigent.stores.project_store.sqlalchemy_store import SqlAlchemyProjectStore
     from omnigent.stores.scheduled_task_store.sqlalchemy_store import (
         SqlAlchemyScheduledTaskStore,
     )
@@ -323,6 +324,7 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
     host_store = HostStore(database_url)
     policy_store = SqlAlchemyPolicyStore(database_url)
     scheduled_task_store = SqlAlchemyScheduledTaskStore(database_url)
+    project_store = SqlAlchemyProjectStore(database_url)
     # Fail startup loud on a malformed `sandbox:` section (an operator
     # typo should not surface as a runtime 502 on the first managed
     # session); the startup catch-all below logs it.
@@ -419,6 +421,7 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
         policy_store=policy_store,
         host_store=host_store,
         scheduled_task_store=scheduled_task_store,
+        project_store=project_store,
         auth_provider=auth_provider,
         account_store=account_store,
         # Non-secret auth settings from the config file (admins are the


### PR DESCRIPTION
## Related issue

Closes #3101

## Summary

`deploy/docker/entrypoint.py` builds the application's stores but never
constructed a `ProjectStore`, so `create_app` received `project_store=None` and
skipped the `if project_store is not None:` mount at `omnigent/server/app.py`.
In the published image — and the Kubernetes manifests that run it — the
first-class Projects endpoints simply do not exist, while the bundled SPA calls
them unconditionally.

This is the two-line wiring the issue suggests: construct the store alongside
the others and pass it to `create_app`. `init_runtime` does not take it, so
nothing else changes.

Worth noting the issue's follow-up still stands — `cli.py` and `entrypoint.py`
build their stores independently, which is what produced this and #2386 before
it. This PR only restores Projects; it does not remove the divergence.

## Test Plan

Built the image from this branch and ran it against the compose stack in
`deploy/docker/` (Postgres, external-runner mode):

- Before: `POST /v1/projects` → `405`, and `/openapi.json` listed only
  `/v1/sessions/projects`.
- After: `/openapi.json` lists `/v1/projects` (`GET`, `POST`) and
  `/v1/projects/{project_id}` (`GET`, `PATCH`, `DELETE`); unauthenticated
  `POST /v1/projects` → `401`, confirming the route is mounted.
- Creating, renaming and deleting a project from the sidebar all work; before
  the fix they failed.
- `alembic_version` unchanged — the `projects` tables were already migrated, only
  the mount was missing.

One small correction to the issue's repro: in this deployment `POST /v1/projects`
returns `405`, not `404`, because the SPA catch-all matches the path for `GET`
and FastAPI reports the method as disallowed. `GET /v1/projects` does 404 as
described.

## Demo

N/A — no UI change; the sidebar's existing Projects UI starts working.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified by hand against the built image, as described in the Test Plan: the
routes are absent before the change and present after, and project
create/rename/delete work from the UI. Happy to add a startup assertion that the
Docker entrypoint passes every store `create_app` accepts, if you'd prefer the
divergence covered by a test rather than caught by review — that would also cover
the follow-up in #3101.

## Changelog

Projects can be created, renamed and deleted when running the Docker or Kubernetes server image