### PR TITLE
refactor(harness): DI-seam runner interrupt/stop — collapse 16 handlers (PR 1.6)

### DIFF
--- a/designs/harness-modular-registry-proposal.md
+++ b/designs/harness-modular-registry-proposal.md
@@ -439,7 +439,8 @@ Phase 2: 2.1–2.4).
 | 1.5a Runner spawn-env | landed | #3495 |
 | 1.5b-i Runner launch (scaffolding + 8 uniform arms) | landed | #3500 |
 | 1.5b-ii Runner launch (3 special arms + turn-path opencode) | landed | #3501 |
-| 1.5c Runner terminal-ensure (attach path) | in review | (this PR) |
+| 1.5c Runner terminal-ensure (attach path) | landed | #3543 |
+| 1.6 Runner interrupt/stop (migration; gap-fill deferred) | in review | (this PR) |
 
 ## Risks and open questions
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -114,6 +114,7 @@ from omnigent.runner.native import (
     _unwrap_resolved_spec,
 )
 from omnigent.runner.native import orchestration as _native_runtime
+from omnigent.runner.native.interrupt import NativeInterruptRunner
 from omnigent.runner.proxy_mcp_manager import ProxyMcpManager
 from omnigent.runner.resource_registry import (
     CLAUDE_NATIVE_TERMINAL_ROLE,
@@ -3612,45 +3613,6 @@ def create_runner_app(
     def _is_native_harness(conv_id: str) -> bool:
         return is_native_harness(_session_harness_name(conv_id))
 
-    def _wake_parent_after_native_interrupt(conv_id: str) -> None:
-        delivery_ack = _mark_subagent_terminal_and_wake(
-            conv_id,
-            status="cancelled",
-            output="[System: sub-agent interrupted]",
-        )
-        if not delivery_ack.delivered and (
-            delivery_ack.entry is not None or conv_id in _session_sub_agent_names
-        ):
-            _logger.warning(
-                "Native interrupt: sub-agent delivery not confirmed; session=%s reason=%s",
-                conv_id,
-                delivery_ack.reason,
-            )
-
-    async def _handle_claude_native_interrupt(conv_id: str) -> Response:
-        from omnigent.claude_native_bridge import (
-            bridge_dir_for_bridge_id,
-            inject_interrupt,
-        )
-
-        bridge_id = await _claude_native_bridge_id_for_session(
-            server_client=server_client,
-            session_id=conv_id,
-        )
-        bridge_dir = bridge_dir_for_bridge_id(bridge_id)
-        try:
-            await asyncio.to_thread(inject_interrupt, bridge_dir, timeout_s=1.0)
-        except RuntimeError as exc:
-            return JSONResponse(
-                status_code=503,
-                content={
-                    "error": "claude_native_interrupt_failed",
-                    "detail": _client_safe_error_detail(exc, context="claude-native interrupt"),
-                },
-            )
-        _wake_parent_after_native_interrupt(conv_id)
-        return Response(status_code=204)
-
     async def _codex_native_bridge_state_for_session(
         conv_id: str,
         *,
@@ -3692,100 +3654,6 @@ def create_runner_app(
         client_safe_error_detail=_client_safe_error_detail,
         logger=_logger,
     )
-
-    async def _handle_codex_native_interrupt(conv_id: str) -> Response:
-        from omnigent.codex_native_app_server import client_for_transport
-        from omnigent.codex_native_bridge import (
-            CODEX_NATIVE_BRIDGE_ID_LABEL_KEY,
-            bridge_dir_for_bridge_id,
-            cancel_pending_mcp_startup,
-            read_mcp_startup,
-        )
-
-        state = await _codex_native_bridge_state_for_session(conv_id, action="interrupt")
-        if state is None:
-            return Response(status_code=204)
-        labels = await _session_labels_for_runner_spawn(
-            server_client=server_client,
-            session_id=conv_id,
-        )
-        bridge_dir = bridge_dir_for_bridge_id(
-            labels.get(CODEX_NATIVE_BRIDGE_ID_LABEL_KEY) or conv_id
-        )
-        pending_mcp = cancel_pending_mcp_startup(bridge_dir)
-        if state.active_turn_id is None and not pending_mcp:
-            _logger.info(
-                "Codex-native interrupt skipped for %s: no active turn or MCP startup.",
-                conv_id,
-            )
-            return Response(status_code=204)
-        if pending_mcp:
-            _logger.info(
-                "Codex-native interrupt for %s cancels MCP startup: %s",
-                conv_id,
-                ", ".join(pending_mcp),
-            )
-            try:
-                await server_client.post(
-                    f"/v1/sessions/{conv_id}/events",
-                    json={
-                        "type": "external_mcp_startup",
-                        "data": {"servers": read_mcp_startup(bridge_dir)},
-                    },
-                    timeout=10.0,
-                )
-            except Exception:  # noqa: BLE001 - the bridge flip already took effect locally.
-                _logger.warning(
-                    "Failed to publish cancelled MCP startup for %s", conv_id, exc_info=True
-                )
-
-        codex_client = client_for_transport(
-            state.socket_path,
-            client_name="omnigent-codex-native-runner",
-        )
-        try:
-            await codex_client.connect()
-            if pending_mcp:
-                try:
-                    await codex_client.request(
-                        "turn/interrupt",
-                        {"threadId": state.thread_id, "turnId": ""},
-                    )
-                except Exception:  # noqa: BLE001 - the local cancel already took effect.
-                    _logger.warning(
-                        "Codex-native MCP startup interrupt failed for session=%s thread=%s",
-                        conv_id,
-                        state.thread_id,
-                        exc_info=True,
-                    )
-            if state.active_turn_id is not None:
-                await codex_client.request(
-                    "turn/interrupt",
-                    {
-                        "threadId": state.thread_id,
-                        "turnId": state.active_turn_id,
-                    },
-                )
-        except Exception as exc:  # noqa: BLE001 - surface active-turn interrupt failures to caller.
-            _logger.warning(
-                "Codex-native turn/interrupt failed for session=%s thread=%s turn=%s",
-                conv_id,
-                state.thread_id,
-                state.active_turn_id,
-                exc_info=True,
-            )
-            return JSONResponse(
-                status_code=503,
-                content={
-                    "error": "codex_native_interrupt_failed",
-                    "detail": _client_safe_error_detail(exc, context="codex-native interrupt"),
-                },
-            )
-        finally:
-            with contextlib.suppress(Exception):
-                await codex_client.close()
-        _wake_parent_after_native_interrupt(conv_id)
-        return Response(status_code=204)
 
     async def _handle_codex_native_settings_update(
         conv_id: str,
@@ -3951,30 +3819,6 @@ def create_runner_app(
                 await codex_client.close()
         return options
 
-    async def _handle_pi_native_interrupt(conv_id: str) -> Response:
-        from omnigent.pi_native_bridge import bridge_dir_for_session_id, enqueue_interrupt
-
-        try:
-            await asyncio.to_thread(
-                enqueue_interrupt,
-                bridge_dir_for_session_id(conv_id),
-            )
-        except OSError as exc:
-            _logger.warning(
-                "Pi-native interrupt failed for session=%s",
-                conv_id,
-                exc_info=True,
-            )
-            return JSONResponse(
-                status_code=503,
-                content={
-                    "error": "pi_native_interrupt_failed",
-                    "detail": _client_safe_error_detail(exc, context="pi-native interrupt"),
-                },
-            )
-        _wake_parent_after_native_interrupt(conv_id)
-        return Response(status_code=204)
-
     async def _handle_pi_native_model_change(
         conv_id: str,
         model: str | None,
@@ -4032,360 +3876,6 @@ def create_runner_app(
                 session_key=session_key,
                 publish_event=_publish_event,
             )
-
-    async def _handle_claude_native_stop(conv_id: str) -> Response:
-        from omnigent.claude_native_bridge import (
-            bridge_dir_for_bridge_id,
-            kill_session,
-        )
-
-        bridge_id = await _claude_native_bridge_id_for_session(
-            server_client=server_client,
-            session_id=conv_id,
-        )
-        bridge_dir = bridge_dir_for_bridge_id(bridge_id)
-        try:
-            await asyncio.to_thread(kill_session, bridge_dir, timeout_s=1.0)
-        except RuntimeError as exc:
-            return JSONResponse(
-                status_code=503,
-                content={
-                    "error": "claude_native_stop_failed",
-                    "detail": _client_safe_error_detail(exc, context="claude-native stop"),
-                },
-            )
-        await _teardown_session_terminals(conv_id)
-        _publish_event(
-            conv_id,
-            {"type": "session.status", "status": "idle"},
-        )
-        delivery_ack = _mark_subagent_terminal_and_wake(
-            conv_id,
-            status="cancelled",
-            output="[System: sub-agent stopped]",
-        )
-        if not delivery_ack.delivered and (
-            delivery_ack.entry is not None or conv_id in _session_sub_agent_names
-        ):
-            _logger.warning(
-                "Claude-native stop succeeded but sub-agent delivery was "
-                "not confirmed; session=%s reason=%s",
-                conv_id,
-                delivery_ack.reason,
-            )
-        return Response(status_code=204)
-
-    async def _handle_cursor_native_interrupt(conv_id: str) -> Response:
-        from omnigent.cursor_native_bridge import bridge_dir_for_session_id, inject_interrupt
-
-        try:
-            await asyncio.to_thread(
-                inject_interrupt, bridge_dir_for_session_id(conv_id), timeout_s=1.0
-            )
-        except RuntimeError as exc:
-            return JSONResponse(
-                status_code=503,
-                content={
-                    "error": "cursor_native_interrupt_failed",
-                    "detail": _client_safe_error_detail(exc, context="cursor-native interrupt"),
-                },
-            )
-        _wake_parent_after_native_interrupt(conv_id)
-        return Response(status_code=204)
-
-    async def _handle_cursor_native_stop(conv_id: str) -> Response:
-        from omnigent.cursor_native_bridge import bridge_dir_for_session_id, kill_session
-
-        try:
-            await asyncio.to_thread(
-                kill_session, bridge_dir_for_session_id(conv_id), timeout_s=1.0
-            )
-        except RuntimeError as exc:
-            return JSONResponse(
-                status_code=503,
-                content={
-                    "error": "cursor_native_stop_failed",
-                    "detail": _client_safe_error_detail(exc, context="cursor-native stop"),
-                },
-            )
-        await _teardown_session_terminals(conv_id)
-        await _cancel_auto_forwarder_task(conv_id)
-        _publish_event(conv_id, {"type": "session.status", "status": "idle"})
-        delivery_ack = _mark_subagent_terminal_and_wake(
-            conv_id,
-            status="cancelled",
-            output="[System: sub-agent stopped]",
-        )
-        if not delivery_ack.delivered and (
-            delivery_ack.entry is not None or conv_id in _session_sub_agent_names
-        ):
-            _logger.warning(
-                "Cursor-native stop succeeded but sub-agent delivery was "
-                "not confirmed; session=%s reason=%s",
-                conv_id,
-                delivery_ack.reason,
-            )
-        return Response(status_code=204)
-
-    async def _handle_goose_native_interrupt(conv_id: str) -> Response:
-        from omnigent.goose_native_bridge import bridge_dir_for_session_id, inject_interrupt
-
-        try:
-            await asyncio.to_thread(
-                inject_interrupt, bridge_dir_for_session_id(conv_id), timeout_s=1.0
-            )
-        except RuntimeError as exc:
-            return JSONResponse(
-                status_code=503,
-                content={
-                    "error": "goose_native_interrupt_failed",
-                    "detail": _client_safe_error_detail(exc, context="goose-native interrupt"),
-                },
-            )
-        _wake_parent_after_native_interrupt(conv_id)
-        return Response(status_code=204)
-
-    async def _handle_kiro_native_interrupt(conv_id: str) -> Response:
-        from omnigent.kiro_native_bridge import bridge_dir_for_session_id, inject_interrupt
-
-        try:
-            await asyncio.to_thread(
-                inject_interrupt, bridge_dir_for_session_id(conv_id), timeout_s=1.0
-            )
-        except RuntimeError as exc:
-            return JSONResponse(
-                status_code=503,
-                content={
-                    "error": "kiro_native_interrupt_failed",
-                    "detail": _client_safe_error_detail(exc, context="kiro-native interrupt"),
-                },
-            )
-        _wake_parent_after_native_interrupt(conv_id)
-        return Response(status_code=204)
-
-    async def _handle_kimi_native_interrupt(conv_id: str) -> Response:
-        from omnigent.kimi_native_bridge import bridge_dir_for_session_id, inject_interrupt
-
-        try:
-            await asyncio.to_thread(
-                inject_interrupt, bridge_dir_for_session_id(conv_id), timeout_s=1.0
-            )
-        except RuntimeError as exc:
-            return JSONResponse(
-                status_code=503,
-                content={
-                    "error": "kimi_native_interrupt_failed",
-                    "detail": _client_safe_error_detail(exc, context="kimi-native interrupt"),
-                },
-            )
-        _wake_parent_after_native_interrupt(conv_id)
-        return Response(status_code=204)
-
-    async def _handle_goose_native_stop(conv_id: str) -> Response:
-        from omnigent.goose_native_bridge import bridge_dir_for_session_id, kill_session
-
-        try:
-            await asyncio.to_thread(
-                kill_session, bridge_dir_for_session_id(conv_id), timeout_s=1.0
-            )
-        except RuntimeError as exc:
-            return JSONResponse(
-                status_code=503,
-                content={
-                    "error": "goose_native_stop_failed",
-                    "detail": _client_safe_error_detail(exc, context="goose-native stop"),
-                },
-            )
-        await _teardown_session_terminals(conv_id)
-        await _cancel_auto_forwarder_task(conv_id)
-        _publish_event(conv_id, {"type": "session.status", "status": "idle"})
-        delivery_ack = _mark_subagent_terminal_and_wake(
-            conv_id,
-            status="cancelled",
-            output="[System: sub-agent stopped]",
-        )
-        if not delivery_ack.delivered and (
-            delivery_ack.entry is not None or conv_id in _session_sub_agent_names
-        ):
-            _logger.warning(
-                "Goose-native stop succeeded but sub-agent delivery was "
-                "not confirmed; session=%s reason=%s",
-                conv_id,
-                delivery_ack.reason,
-            )
-        return Response(status_code=204)
-
-    async def _handle_kiro_native_stop(conv_id: str) -> Response:
-        from omnigent.kiro_native_bridge import bridge_dir_for_session_id, kill_session
-
-        try:
-            await asyncio.to_thread(
-                kill_session, bridge_dir_for_session_id(conv_id), timeout_s=1.0
-            )
-        except RuntimeError as exc:
-            return JSONResponse(
-                status_code=503,
-                content={
-                    "error": "kiro_native_stop_failed",
-                    "detail": _client_safe_error_detail(exc, context="kiro-native stop"),
-                },
-            )
-        await _teardown_session_terminals(conv_id)
-        await _cancel_auto_forwarder_task(conv_id)
-        _publish_event(conv_id, {"type": "session.status", "status": "idle"})
-        delivery_ack = _mark_subagent_terminal_and_wake(
-            conv_id,
-            status="cancelled",
-            output="[System: sub-agent stopped]",
-        )
-        if not delivery_ack.delivered and (
-            delivery_ack.entry is not None or conv_id in _session_sub_agent_names
-        ):
-            _logger.warning(
-                "Kiro-native stop succeeded but sub-agent delivery was "
-                "not confirmed; session=%s reason=%s",
-                conv_id,
-                delivery_ack.reason,
-            )
-        return Response(status_code=204)
-
-    async def _handle_kimi_native_stop(conv_id: str) -> Response:
-        from omnigent.kimi_native_bridge import bridge_dir_for_session_id, kill_session
-
-        try:
-            await asyncio.to_thread(
-                kill_session, bridge_dir_for_session_id(conv_id), timeout_s=1.0
-            )
-        except RuntimeError as exc:
-            return JSONResponse(
-                status_code=503,
-                content={
-                    "error": "kimi_native_stop_failed",
-                    "detail": _client_safe_error_detail(exc, context="kimi-native stop"),
-                },
-            )
-        await _teardown_session_terminals(conv_id)
-        await _cancel_auto_forwarder_task(conv_id)
-        _publish_event(conv_id, {"type": "session.status", "status": "idle"})
-        delivery_ack = _mark_subagent_terminal_and_wake(
-            conv_id,
-            status="cancelled",
-            output="[System: sub-agent stopped]",
-        )
-        if not delivery_ack.delivered and (
-            delivery_ack.entry is not None or conv_id in _session_sub_agent_names
-        ):
-            _logger.warning(
-                "Kimi-native stop succeeded but sub-agent delivery was "
-                "not confirmed; session=%s reason=%s",
-                conv_id,
-                delivery_ack.reason,
-            )
-        return Response(status_code=204)
-
-    async def _handle_hermes_native_interrupt(conv_id: str) -> Response:
-        from omnigent.hermes_native_bridge import bridge_dir_for_session_id, inject_interrupt
-
-        try:
-            await asyncio.to_thread(
-                inject_interrupt, bridge_dir_for_session_id(conv_id), timeout_s=1.0
-            )
-        except RuntimeError as exc:
-            return JSONResponse(
-                status_code=503,
-                content={
-                    "error": "hermes_native_interrupt_failed",
-                    "detail": _client_safe_error_detail(exc, context="hermes-native interrupt"),
-                },
-            )
-        _wake_parent_after_native_interrupt(conv_id)
-        return Response(status_code=204)
-
-    async def _handle_hermes_native_stop(conv_id: str) -> Response:
-        from omnigent.hermes_native_bridge import bridge_dir_for_session_id, kill_session
-
-        try:
-            await asyncio.to_thread(
-                kill_session, bridge_dir_for_session_id(conv_id), timeout_s=1.0
-            )
-        except RuntimeError as exc:
-            return JSONResponse(
-                status_code=503,
-                content={
-                    "error": "hermes_native_stop_failed",
-                    "detail": _client_safe_error_detail(exc, context="hermes-native stop"),
-                },
-            )
-        await _teardown_session_terminals(conv_id)
-        await _cancel_auto_forwarder_task(conv_id)
-        _publish_event(conv_id, {"type": "session.status", "status": "idle"})
-        delivery_ack = _mark_subagent_terminal_and_wake(
-            conv_id,
-            status="cancelled",
-            output="[System: sub-agent stopped]",
-        )
-        if not delivery_ack.delivered and (
-            delivery_ack.entry is not None or conv_id in _session_sub_agent_names
-        ):
-            _logger.warning(
-                "Hermes-native stop succeeded but sub-agent delivery was "
-                "not confirmed; session=%s reason=%s",
-                conv_id,
-                delivery_ack.reason,
-            )
-        return Response(status_code=204)
-
-    async def _handle_qwen_native_interrupt(conv_id: str) -> Response:
-        from omnigent.qwen_native_bridge import bridge_dir_for_session_id, inject_interrupt
-
-        try:
-            await asyncio.to_thread(
-                inject_interrupt, bridge_dir_for_session_id(conv_id), timeout_s=1.0
-            )
-        except RuntimeError as exc:
-            return JSONResponse(
-                status_code=503,
-                content={
-                    "error": "qwen_native_interrupt_failed",
-                    "detail": _client_safe_error_detail(exc, context="qwen-native interrupt"),
-                },
-            )
-        _wake_parent_after_native_interrupt(conv_id)
-        return Response(status_code=204)
-
-    async def _handle_qwen_native_stop(conv_id: str) -> Response:
-        from omnigent.qwen_native_bridge import bridge_dir_for_session_id, kill_session
-
-        try:
-            await asyncio.to_thread(
-                kill_session, bridge_dir_for_session_id(conv_id), timeout_s=1.0
-            )
-        except RuntimeError as exc:
-            return JSONResponse(
-                status_code=503,
-                content={
-                    "error": "qwen_native_stop_failed",
-                    "detail": _client_safe_error_detail(exc, context="qwen-native stop"),
-                },
-            )
-        await _teardown_session_terminals(conv_id)
-        await _cancel_auto_forwarder_task(conv_id)
-        _publish_event(conv_id, {"type": "session.status", "status": "idle"})
-        delivery_ack = _mark_subagent_terminal_and_wake(
-            conv_id,
-            status="cancelled",
-            output="[System: sub-agent stopped]",
-        )
-        if not delivery_ack.delivered and (
-            delivery_ack.entry is not None or conv_id in _session_sub_agent_names
-        ):
-            _logger.warning(
-                "qwen-native stop succeeded but sub-agent delivery was "
-                "not confirmed; session=%s reason=%s",
-                conv_id,
-                delivery_ack.reason,
-            )
-        return Response(status_code=204)
 
     async def _handle_claude_native_effort_change(
         conv_id: str,
@@ -5264,6 +4754,17 @@ def create_runner_app(
         if ack.entry is not None and ack.delivered_now:
             _schedule_subagent_wake(ack.entry)
         return ack
+
+    _native_interrupt_runner = NativeInterruptRunner(
+        server_client=server_client,
+        resource_registry=resource_registry,
+        publish_event=_publish_event,
+        mark_subagent_terminal_and_wake=_mark_subagent_terminal_and_wake,
+        session_sub_agent_names=_session_sub_agent_names,
+        codex_bridge_state_for_session=_codex_native_bridge_state_for_session,
+        client_safe_error_detail=_client_safe_error_detail,
+        logger=_logger,
+    )
 
     async def _ensure_comment_relay_started(
         session_id: str,
@@ -6445,24 +5946,9 @@ def create_runner_app(
 
         if body_type == "interrupt":
             _harness = _session_harness_name(conversation_id)
-            if _harness == "claude-native":
-                return await _handle_claude_native_interrupt(conversation_id)
-            if _harness == "codex-native":
-                return await _handle_codex_native_interrupt(conversation_id)
-            if _harness == "pi-native":
-                return await _handle_pi_native_interrupt(conversation_id)
-            if _harness == "cursor-native":
-                return await _handle_cursor_native_interrupt(conversation_id)
-            if _harness == "goose-native":
-                return await _handle_goose_native_interrupt(conversation_id)
-            if _harness == "kiro-native":
-                return await _handle_kiro_native_interrupt(conversation_id)
-            if _harness == "hermes-native":
-                return await _handle_hermes_native_interrupt(conversation_id)
-            if _harness == "qwen-native":
-                return await _handle_qwen_native_interrupt(conversation_id)
-            if _harness == "kimi-native":
-                return await _handle_kimi_native_interrupt(conversation_id)
+            _interrupt_resp = await _native_interrupt_runner.interrupt(_harness, conversation_id)
+            if _interrupt_resp is not None:
+                return _interrupt_resp
             await _cancel_inprocess_turn(conversation_id)
             return Response(status_code=204)
 
@@ -6509,24 +5995,9 @@ def create_runner_app(
 
         if body_type == "stop_session":
             _harness = _session_harness_name(conversation_id)
-            if _harness == "claude-native":
-                return await _handle_claude_native_stop(conversation_id)
-            if _harness == "codex-native":
-                return await _handle_codex_native_interrupt(conversation_id)
-            if _harness == "pi-native":
-                return await _handle_pi_native_interrupt(conversation_id)
-            if _harness == "cursor-native":
-                return await _handle_cursor_native_stop(conversation_id)
-            if _harness == "goose-native":
-                return await _handle_goose_native_stop(conversation_id)
-            if _harness == "kiro-native":
-                return await _handle_kiro_native_stop(conversation_id)
-            if _harness == "hermes-native":
-                return await _handle_hermes_native_stop(conversation_id)
-            if _harness == "qwen-native":
-                return await _handle_qwen_native_stop(conversation_id)
-            if _harness == "kimi-native":
-                return await _handle_kimi_native_stop(conversation_id)
+            _stop_resp = await _native_interrupt_runner.stop(_harness, conversation_id)
+            if _stop_resp is not None:
+                return _stop_resp
             await _cancel_inprocess_turn(conversation_id)
             return Response(status_code=204)
 

--- a/omnigent/runner/native/interrupt.py
+++ b/omnigent/runner/native/interrupt.py
@@ -11,11 +11,13 @@ Mirrors :class:`omnigent.runner.codex.goal.CodexGoalRunner`: app-scope state
 injected at construction so the class stays out of the already-large app module
 while preserving the exact behavior of the original closures.
 
-The nine uniform interrupt harnesses and seven uniform stop harnesses differ
+The seven uniform interrupt harnesses and six uniform stop harnesses differ
 only by bridge module, control-function name, and error label; they collapse to
 two parametrized methods driven by :data:`_UNIFORM_INTERRUPT` /
 :data:`_UNIFORM_STOP`. claude interrupt (bridge-id resolution) and codex
-interrupt (MCP-startup + app-server ``turn/interrupt``) keep dedicated methods.
+interrupt (MCP-startup + app-server ``turn/interrupt``) keep dedicated methods
+(so nine interrupt handlers total); claude stop is likewise special-cased and
+codex/pi alias stop to their interrupt handler (so seven stop handlers total).
 
 Coverage note: antigravity-native and opencode-native have no handler here and
 :meth:`interrupt` / :meth:`stop` return ``None`` for them, so the caller falls
@@ -111,7 +113,7 @@ class _UniformStop:
     display_name: str
 
 
-# The nine uniform interrupt harnesses (claude/codex are special-cased). pi uses
+# The seven uniform interrupt harnesses (claude/codex are special-cased). pi uses
 # enqueue_interrupt + OSError and no timeout; the rest inject_interrupt +
 # RuntimeError + timeout_s.
 _UNIFORM_INTERRUPT: dict[str, _UniformInterrupt] = {
@@ -174,7 +176,7 @@ _UNIFORM_INTERRUPT: dict[str, _UniformInterrupt] = {
     ),
 }
 
-# The seven uniform stop harnesses (claude has a special stop; codex/pi have no
+# The six uniform stop harnesses (claude has a special stop; codex/pi have no
 # distinct stop — they route to interrupt, handled in ``stop``).
 _UNIFORM_STOP: dict[str, _UniformStop] = {
     "cursor": _UniformStop(

--- a/omnigent/runner/native/interrupt.py
+++ b/omnigent/runner/native/interrupt.py
@@ -1,0 +1,540 @@
+"""Native-harness interrupt / stop control for the runner app.
+
+The runner receives ``interrupt`` and ``stop_session`` events on
+``/v1/sessions/{id}/events`` and must forward them into the resident vendor
+TUI/bridge for the session's native harness. The per-harness logic used to be
+sixteen closures inside :mod:`omnigent.runner.app`; this module collapses them
+onto one :class:`NativeInterruptRunner` so the dispatch is registry-driven.
+
+Mirrors :class:`omnigent.runner.codex.goal.CodexGoalRunner`: app-scope state
+(the AP client, resource registry, event publisher, sub-agent wake plumbing) is
+injected at construction so the class stays out of the already-large app module
+while preserving the exact behavior of the original closures.
+
+The nine uniform interrupt harnesses and seven uniform stop harnesses differ
+only by bridge module, control-function name, and error label; they collapse to
+two parametrized methods driven by :data:`_UNIFORM_INTERRUPT` /
+:data:`_UNIFORM_STOP`. claude interrupt (bridge-id resolution) and codex
+interrupt (MCP-startup + app-server ``turn/interrupt``) keep dedicated methods.
+
+Coverage note: antigravity-native and opencode-native have no handler here and
+:meth:`interrupt` / :meth:`stop` return ``None`` for them, so the caller falls
+through to the in-process turn cancel — unchanged from before this seam. Wiring
+their native interrupt (agy ``interrupt_turn`` / opencode ``client.abort``) is a
+deferred follow-up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import importlib
+import logging
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from fastapi.responses import JSONResponse, Response
+
+from omnigent.native_coding_agents import native_coding_agent_for_harness
+from omnigent.runner.native.orchestration import (
+    _cancel_auto_forwarder_task,
+    _claude_native_bridge_id_for_session,
+    _session_labels_for_runner_spawn,
+)
+
+
+class MarkSubagentTerminalAndWake(Protocol):
+    """Mark a sub-agent work entry terminal and wake its parent."""
+
+    def __call__(self, child_session_id: str, *, status: str, output: str | None) -> Any: ...
+
+
+class ClientSafeErrorDetail(Protocol):
+    """Log an exception and return safe client-facing detail."""
+
+    def __call__(self, exc: BaseException, *, context: str) -> str: ...
+
+
+class CodexBridgeStateForSession(Protocol):
+    """Resolve a live Codex app-server bridge state for a session."""
+
+    async def __call__(
+        self,
+        conv_id: str,
+        *,
+        action: str,
+        missing_state_log_level: int = logging.WARNING,
+    ) -> Any | None: ...
+
+
+@dataclass(frozen=True)
+class _UniformInterrupt:
+    """Descriptor for a uniform bridge-inject interrupt handler.
+
+    :param module: The harness bridge module, e.g. ``"omnigent.pi_native_bridge"``.
+    :param inject_fn: The bridge control function name — ``"inject_interrupt"``
+        for the TUI harnesses, ``"enqueue_interrupt"`` for pi.
+    :param error_code: The structured error code returned on failure, e.g.
+        ``"pi_native_interrupt_failed"``.
+    :param context: The ``_client_safe_error_detail`` context label.
+    :param error_types: Exception types the inject call may raise that map to a
+        503 (pi raises ``OSError``; the TUI harnesses raise ``RuntimeError``).
+    :param with_timeout: Whether the inject call takes a ``timeout_s=`` kwarg
+        (the TUI harnesses do; pi's ``enqueue_interrupt`` does not).
+    :param log_on_error: Whether to log a warning before the 503 — only pi's
+        original handler did; the TUI handlers returned without logging.
+    """
+
+    module: str
+    inject_fn: str
+    error_code: str
+    context: str
+    error_types: tuple[type[BaseException], ...]
+    with_timeout: bool
+    log_on_error: bool = False
+
+
+@dataclass(frozen=True)
+class _UniformStop:
+    """Descriptor for a uniform bridge-kill stop handler.
+
+    :param module: The harness bridge module.
+    :param error_code: The structured error code returned on failure.
+    :param context: The ``_client_safe_error_detail`` context label.
+    :param display_name: Human name for the delivery-not-confirmed warning.
+    """
+
+    module: str
+    error_code: str
+    context: str
+    display_name: str
+
+
+# The nine uniform interrupt harnesses (claude/codex are special-cased). pi uses
+# enqueue_interrupt + OSError and no timeout; the rest inject_interrupt +
+# RuntimeError + timeout_s.
+_UNIFORM_INTERRUPT: dict[str, _UniformInterrupt] = {
+    "pi": _UniformInterrupt(
+        "omnigent.pi_native_bridge",
+        "enqueue_interrupt",
+        "pi_native_interrupt_failed",
+        "pi-native interrupt",
+        (OSError,),
+        False,
+        log_on_error=True,
+    ),
+    "cursor": _UniformInterrupt(
+        "omnigent.cursor_native_bridge",
+        "inject_interrupt",
+        "cursor_native_interrupt_failed",
+        "cursor-native interrupt",
+        (RuntimeError,),
+        True,
+    ),
+    "goose": _UniformInterrupt(
+        "omnigent.goose_native_bridge",
+        "inject_interrupt",
+        "goose_native_interrupt_failed",
+        "goose-native interrupt",
+        (RuntimeError,),
+        True,
+    ),
+    "kiro": _UniformInterrupt(
+        "omnigent.kiro_native_bridge",
+        "inject_interrupt",
+        "kiro_native_interrupt_failed",
+        "kiro-native interrupt",
+        (RuntimeError,),
+        True,
+    ),
+    "kimi": _UniformInterrupt(
+        "omnigent.kimi_native_bridge",
+        "inject_interrupt",
+        "kimi_native_interrupt_failed",
+        "kimi-native interrupt",
+        (RuntimeError,),
+        True,
+    ),
+    "hermes": _UniformInterrupt(
+        "omnigent.hermes_native_bridge",
+        "inject_interrupt",
+        "hermes_native_interrupt_failed",
+        "hermes-native interrupt",
+        (RuntimeError,),
+        True,
+    ),
+    "qwen": _UniformInterrupt(
+        "omnigent.qwen_native_bridge",
+        "inject_interrupt",
+        "qwen_native_interrupt_failed",
+        "qwen-native interrupt",
+        (RuntimeError,),
+        True,
+    ),
+}
+
+# The seven uniform stop harnesses (claude has a special stop; codex/pi have no
+# distinct stop — they route to interrupt, handled in ``stop``).
+_UNIFORM_STOP: dict[str, _UniformStop] = {
+    "cursor": _UniformStop(
+        "omnigent.cursor_native_bridge",
+        "cursor_native_stop_failed",
+        "cursor-native stop",
+        "Cursor",
+    ),
+    "goose": _UniformStop(
+        "omnigent.goose_native_bridge",
+        "goose_native_stop_failed",
+        "goose-native stop",
+        "Goose",
+    ),
+    "kiro": _UniformStop(
+        "omnigent.kiro_native_bridge",
+        "kiro_native_stop_failed",
+        "kiro-native stop",
+        "Kiro",
+    ),
+    "kimi": _UniformStop(
+        "omnigent.kimi_native_bridge",
+        "kimi_native_stop_failed",
+        "kimi-native stop",
+        "Kimi",
+    ),
+    "hermes": _UniformStop(
+        "omnigent.hermes_native_bridge",
+        "hermes_native_stop_failed",
+        "hermes-native stop",
+        "Hermes",
+    ),
+    "qwen": _UniformStop(
+        "omnigent.qwen_native_bridge",
+        "qwen_native_stop_failed",
+        "qwen-native stop",
+        "Qwen",
+    ),
+}
+
+
+class NativeInterruptRunner:
+    """Forward interrupt / stop events into a session's native harness bridge."""
+
+    def __init__(
+        self,
+        *,
+        server_client: Any,
+        resource_registry: Any,
+        publish_event: Callable[[str, dict[str, Any]], None],
+        mark_subagent_terminal_and_wake: MarkSubagentTerminalAndWake,
+        session_sub_agent_names: Mapping[str, str],
+        codex_bridge_state_for_session: CodexBridgeStateForSession,
+        client_safe_error_detail: ClientSafeErrorDetail,
+        logger: logging.Logger,
+    ) -> None:
+        self._server_client = server_client
+        self._resource_registry = resource_registry
+        self._publish_event = publish_event
+        self._mark_subagent_terminal_and_wake = mark_subagent_terminal_and_wake
+        self._session_sub_agent_names = session_sub_agent_names
+        self._codex_bridge_state_for_session = codex_bridge_state_for_session
+        self._client_safe_error_detail = client_safe_error_detail
+        self._logger = logger
+
+    async def interrupt(self, harness_name: str | None, conv_id: str) -> Response | None:
+        """Dispatch an interrupt to the harness's bridge.
+
+        :returns: A response when this harness has an interrupt handler, else
+            ``None`` so the caller falls through to the in-process turn cancel
+            (antigravity/opencode).
+        """
+        agent = native_coding_agent_for_harness(harness_name)
+        if agent is None:
+            return None
+        key = agent.key
+        if key == "claude":
+            return await self._claude_interrupt(conv_id)
+        if key == "codex":
+            return await self._codex_interrupt(conv_id)
+        spec = _UNIFORM_INTERRUPT.get(key)
+        if spec is None:
+            return None
+        return await self._uniform_interrupt(spec, conv_id)
+
+    async def stop(self, harness_name: str | None, conv_id: str) -> Response | None:
+        """Dispatch a stop_session to the harness's bridge.
+
+        codex/pi have no distinct stop — they route to their interrupt handler,
+        exactly as the original dispatch chain did.
+
+        :returns: A response when this harness has a stop handler, else ``None``
+            so the caller falls through to the in-process turn cancel.
+        """
+        agent = native_coding_agent_for_harness(harness_name)
+        if agent is None:
+            return None
+        key = agent.key
+        if key == "claude":
+            return await self._claude_stop(conv_id)
+        if key in ("codex", "pi"):
+            return await self.interrupt(harness_name, conv_id)
+        spec = _UNIFORM_STOP.get(key)
+        if spec is None:
+            return None
+        return await self._uniform_stop(spec, conv_id)
+
+    def _wake_parent_after_native_interrupt(self, conv_id: str) -> None:
+        delivery_ack = self._mark_subagent_terminal_and_wake(
+            conv_id,
+            status="cancelled",
+            output="[System: sub-agent interrupted]",
+        )
+        if not delivery_ack.delivered and (
+            delivery_ack.entry is not None or conv_id in self._session_sub_agent_names
+        ):
+            self._logger.warning(
+                "Native interrupt: sub-agent delivery not confirmed; session=%s reason=%s",
+                conv_id,
+                delivery_ack.reason,
+            )
+
+    async def _teardown_session_terminals(self, conv_id: str) -> None:
+        from omnigent.entities.session_resources import terminal_resource_id
+        from omnigent.runner.tool_dispatch import _publish_terminal_deleted_event
+
+        terminal_registry = self._resource_registry.terminal_registry
+        if terminal_registry is None:
+            return
+        terminals = [
+            (entry.terminal_name, entry.session_key)
+            for entry in terminal_registry.list_for_conversation(conv_id)
+        ]
+        for terminal_name, session_key in terminals:
+            terminal_id = terminal_resource_id(terminal_name, session_key)
+            try:
+                await self._resource_registry.close_terminal(conv_id, terminal_id)
+            except (RuntimeError, OSError):
+                self._logger.warning(
+                    "Failed to close terminal %s for session %s during stop",
+                    terminal_id,
+                    conv_id,
+                    exc_info=True,
+                )
+            _publish_terminal_deleted_event(
+                conversation_id=conv_id,
+                terminal_name=terminal_name,
+                session_key=session_key,
+                publish_event=self._publish_event,
+            )
+
+    async def _uniform_interrupt(self, spec: _UniformInterrupt, conv_id: str) -> Response:
+        module = importlib.import_module(spec.module)
+        bridge_dir = module.bridge_dir_for_session_id(conv_id)
+        inject = getattr(module, spec.inject_fn)
+        try:
+            if spec.with_timeout:
+                await asyncio.to_thread(inject, bridge_dir, timeout_s=1.0)
+            else:
+                await asyncio.to_thread(inject, bridge_dir)
+        except spec.error_types as exc:
+            if spec.log_on_error:
+                self._logger.warning(
+                    "%s failed for session=%s", spec.context, conv_id, exc_info=True
+                )
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": spec.error_code,
+                    "detail": self._client_safe_error_detail(exc, context=spec.context),
+                },
+            )
+        self._wake_parent_after_native_interrupt(conv_id)
+        return Response(status_code=204)
+
+    async def _uniform_stop(self, spec: _UniformStop, conv_id: str) -> Response:
+        module = importlib.import_module(spec.module)
+        try:
+            await asyncio.to_thread(
+                module.kill_session, module.bridge_dir_for_session_id(conv_id), timeout_s=1.0
+            )
+        except RuntimeError as exc:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": spec.error_code,
+                    "detail": self._client_safe_error_detail(exc, context=spec.context),
+                },
+            )
+        await self._teardown_session_terminals(conv_id)
+        await _cancel_auto_forwarder_task(conv_id)
+        self._publish_event(conv_id, {"type": "session.status", "status": "idle"})
+        delivery_ack = self._mark_subagent_terminal_and_wake(
+            conv_id,
+            status="cancelled",
+            output="[System: sub-agent stopped]",
+        )
+        if not delivery_ack.delivered and (
+            delivery_ack.entry is not None or conv_id in self._session_sub_agent_names
+        ):
+            self._logger.warning(
+                "%s-native stop succeeded but sub-agent delivery was "
+                "not confirmed; session=%s reason=%s",
+                spec.display_name,
+                conv_id,
+                delivery_ack.reason,
+            )
+        return Response(status_code=204)
+
+    async def _claude_interrupt(self, conv_id: str) -> Response:
+        from omnigent.claude_native_bridge import bridge_dir_for_bridge_id, inject_interrupt
+
+        bridge_id = await _claude_native_bridge_id_for_session(
+            server_client=self._server_client,
+            session_id=conv_id,
+        )
+        bridge_dir = bridge_dir_for_bridge_id(bridge_id)
+        try:
+            await asyncio.to_thread(inject_interrupt, bridge_dir, timeout_s=1.0)
+        except RuntimeError as exc:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "claude_native_interrupt_failed",
+                    "detail": self._client_safe_error_detail(
+                        exc, context="claude-native interrupt"
+                    ),
+                },
+            )
+        self._wake_parent_after_native_interrupt(conv_id)
+        return Response(status_code=204)
+
+    async def _claude_stop(self, conv_id: str) -> Response:
+        from omnigent.claude_native_bridge import bridge_dir_for_bridge_id, kill_session
+
+        bridge_id = await _claude_native_bridge_id_for_session(
+            server_client=self._server_client,
+            session_id=conv_id,
+        )
+        bridge_dir = bridge_dir_for_bridge_id(bridge_id)
+        try:
+            await asyncio.to_thread(kill_session, bridge_dir, timeout_s=1.0)
+        except RuntimeError as exc:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "claude_native_stop_failed",
+                    "detail": self._client_safe_error_detail(exc, context="claude-native stop"),
+                },
+            )
+        await self._teardown_session_terminals(conv_id)
+        self._publish_event(conv_id, {"type": "session.status", "status": "idle"})
+        delivery_ack = self._mark_subagent_terminal_and_wake(
+            conv_id,
+            status="cancelled",
+            output="[System: sub-agent stopped]",
+        )
+        if not delivery_ack.delivered and (
+            delivery_ack.entry is not None or conv_id in self._session_sub_agent_names
+        ):
+            self._logger.warning(
+                "Claude-native stop succeeded but sub-agent delivery was "
+                "not confirmed; session=%s reason=%s",
+                conv_id,
+                delivery_ack.reason,
+            )
+        return Response(status_code=204)
+
+    async def _codex_interrupt(self, conv_id: str) -> Response:
+        from omnigent.codex_native_app_server import client_for_transport
+        from omnigent.codex_native_bridge import (
+            CODEX_NATIVE_BRIDGE_ID_LABEL_KEY,
+            bridge_dir_for_bridge_id,
+            cancel_pending_mcp_startup,
+            read_mcp_startup,
+        )
+
+        state = await self._codex_bridge_state_for_session(conv_id, action="interrupt")
+        if state is None:
+            return Response(status_code=204)
+        labels = await _session_labels_for_runner_spawn(
+            server_client=self._server_client,
+            session_id=conv_id,
+        )
+        bridge_dir = bridge_dir_for_bridge_id(
+            labels.get(CODEX_NATIVE_BRIDGE_ID_LABEL_KEY) or conv_id
+        )
+        pending_mcp = cancel_pending_mcp_startup(bridge_dir)
+        if state.active_turn_id is None and not pending_mcp:
+            self._logger.info(
+                "Codex-native interrupt skipped for %s: no active turn or MCP startup.",
+                conv_id,
+            )
+            return Response(status_code=204)
+        if pending_mcp:
+            self._logger.info(
+                "Codex-native interrupt for %s cancels MCP startup: %s",
+                conv_id,
+                ", ".join(pending_mcp),
+            )
+            try:
+                await self._server_client.post(
+                    f"/v1/sessions/{conv_id}/events",
+                    json={
+                        "type": "external_mcp_startup",
+                        "data": {"servers": read_mcp_startup(bridge_dir)},
+                    },
+                    timeout=10.0,
+                )
+            except Exception:  # noqa: BLE001 - the bridge flip already took effect locally.
+                self._logger.warning(
+                    "Failed to publish cancelled MCP startup for %s", conv_id, exc_info=True
+                )
+
+        codex_client = client_for_transport(
+            state.socket_path,
+            client_name="omnigent-codex-native-runner",
+        )
+        try:
+            await codex_client.connect()
+            if pending_mcp:
+                try:
+                    await codex_client.request(
+                        "turn/interrupt",
+                        {"threadId": state.thread_id, "turnId": ""},
+                    )
+                except Exception:  # noqa: BLE001 - the local cancel already took effect.
+                    self._logger.warning(
+                        "Codex-native MCP startup interrupt failed for session=%s thread=%s",
+                        conv_id,
+                        state.thread_id,
+                        exc_info=True,
+                    )
+            if state.active_turn_id is not None:
+                await codex_client.request(
+                    "turn/interrupt",
+                    {
+                        "threadId": state.thread_id,
+                        "turnId": state.active_turn_id,
+                    },
+                )
+        except Exception as exc:  # noqa: BLE001 - surface active-turn interrupt failures.
+            self._logger.warning(
+                "Codex-native turn/interrupt failed for session=%s thread=%s turn=%s",
+                conv_id,
+                state.thread_id,
+                state.active_turn_id,
+                exc_info=True,
+            )
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "error": "codex_native_interrupt_failed",
+                    "detail": self._client_safe_error_detail(
+                        exc, context="codex-native interrupt"
+                    ),
+                },
+            )
+        finally:
+            with contextlib.suppress(Exception):
+                await codex_client.close()
+        self._wake_parent_after_native_interrupt(conv_id)
+        return Response(status_code=204)

--- a/tests/runner/test_native_interrupt_runner.py
+++ b/tests/runner/test_native_interrupt_runner.py
@@ -1,0 +1,260 @@
+"""Unit tests for ``NativeInterruptRunner`` (PR 1.6 interrupt/stop seam).
+
+These drive the runner class directly with lightweight fakes, complementing the
+HTTP-path tests in ``test_app_sessions_native_events_lifecycle.py`` /
+``test_app_sessions_native_supervision.py`` (which POST to ``/events`` and patch
+the bridge-module control functions). The focus here is the registry dispatch
+and the descriptor-collapsed uniform handlers: which harnesses route where, the
+no-handler fall-through contract (antigravity/opencode), and the 503 mapping.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi.responses import Response
+
+from omnigent.runner.native.interrupt import NativeInterruptRunner
+
+
+@dataclass
+class _FakeAck:
+    """Stand-in for ``_SubagentDeliveryAck``."""
+
+    delivered: bool = True
+    entry: object | None = None
+    reason: str = "delivered"
+
+
+class _FakeTerminalRegistry:
+    def __init__(self) -> None:
+        self.closed: list[str] = []
+
+    def list_for_conversation(self, conv_id: str) -> list[Any]:
+        return []
+
+
+class _FakeResourceRegistry:
+    def __init__(self) -> None:
+        self.terminal_registry = _FakeTerminalRegistry()
+
+    async def close_terminal(self, conv_id: str, terminal_id: str) -> bool:
+        return True
+
+
+def _make_runner(**overrides: Any) -> tuple[NativeInterruptRunner, dict[str, Any]]:
+    """Build a runner with recording fakes; return it plus a capture dict."""
+    captured: dict[str, Any] = {"published": [], "wakes": []}
+
+    def _publish(conv_id: str, event: dict[str, Any]) -> None:
+        captured["published"].append((conv_id, event))
+
+    def _mark_and_wake(child_session_id: str, *, status: str, output: str | None) -> _FakeAck:
+        captured["wakes"].append((child_session_id, status, output))
+        return _FakeAck()
+
+    async def _codex_bridge_state(conv_id: str, *, action: str, **_kw: Any) -> Any | None:
+        return None
+
+    def _client_safe(exc: BaseException, *, context: str) -> str:
+        return f"safe:{context}"
+
+    kwargs: dict[str, Any] = {
+        "server_client": SimpleNamespace(),
+        "resource_registry": _FakeResourceRegistry(),
+        "publish_event": _publish,
+        "mark_subagent_terminal_and_wake": _mark_and_wake,
+        "session_sub_agent_names": {},
+        "codex_bridge_state_for_session": _codex_bridge_state,
+        "client_safe_error_detail": _client_safe,
+        "logger": logging.getLogger("test.interrupt"),
+    }
+    kwargs.update(overrides)
+    return NativeInterruptRunner(**kwargs), captured
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("harness", ["antigravity-native", "opencode-native", "claude-sdk", None])
+async def test_no_handler_harnesses_return_none(harness: str | None) -> None:
+    """Harnesses without an interrupt/stop handler return None (caller falls through)."""
+    runner, _ = _make_runner()
+    assert await runner.interrupt(harness, "conv_x") is None
+    assert await runner.stop(harness, "conv_x") is None
+
+
+@pytest.mark.asyncio
+async def test_uniform_interrupt_injects_and_wakes_parent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A uniform interrupt calls the bridge inject fn and wakes the parent."""
+    import omnigent.goose_native_bridge as goose_bridge
+
+    calls: list[Any] = []
+
+    def _inject(bridge_dir: Any, *, timeout_s: float) -> None:
+        calls.append((bridge_dir, timeout_s))
+
+    monkeypatch.setattr(goose_bridge, "bridge_dir_for_session_id", lambda conv: f"dir/{conv}")
+    monkeypatch.setattr(goose_bridge, "inject_interrupt", _inject)
+
+    runner, captured = _make_runner()
+    resp = await runner.interrupt("goose-native", "conv_g")
+
+    assert isinstance(resp, Response) and resp.status_code == 204
+    assert calls == [("dir/conv_g", 1.0)]
+    assert captured["wakes"] == [("conv_g", "cancelled", "[System: sub-agent interrupted]")]
+
+
+@pytest.mark.asyncio
+async def test_pi_interrupt_uses_enqueue_without_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pi's uniform interrupt uses enqueue_interrupt with no timeout kwarg."""
+    import omnigent.pi_native_bridge as pi_bridge
+
+    calls: list[Any] = []
+    monkeypatch.setattr(pi_bridge, "bridge_dir_for_session_id", lambda conv: f"dir/{conv}")
+    monkeypatch.setattr(
+        pi_bridge, "enqueue_interrupt", lambda bridge_dir: calls.append(bridge_dir)
+    )
+
+    runner, _ = _make_runner()
+    resp = await runner.interrupt("pi-native", "conv_p")
+
+    assert isinstance(resp, Response) and resp.status_code == 204
+    assert calls == ["dir/conv_p"]
+
+
+@pytest.mark.asyncio
+async def test_uniform_interrupt_bridge_error_returns_503(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A RuntimeError from the bridge inject maps to a 503 with the error code."""
+    import json
+
+    import omnigent.qwen_native_bridge as qwen_bridge
+
+    def _boom(bridge_dir: Any, *, timeout_s: float) -> None:
+        raise RuntimeError("tmux target is not advertised")
+
+    monkeypatch.setattr(qwen_bridge, "bridge_dir_for_session_id", lambda conv: "d")
+    monkeypatch.setattr(qwen_bridge, "inject_interrupt", _boom)
+
+    runner, captured = _make_runner()
+    resp = await runner.interrupt("qwen-native", "conv_q")
+
+    assert resp is not None and resp.status_code == 503
+    body = json.loads(bytes(resp.body))
+    assert body["error"] == "qwen_native_interrupt_failed"
+    assert body["detail"] == "safe:qwen-native interrupt"
+    # No parent wake on failure.
+    assert captured["wakes"] == []
+
+
+@pytest.mark.asyncio
+async def test_uniform_stop_kills_tears_down_and_goes_idle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A uniform stop kills the bridge, publishes idle, and wakes the parent."""
+    import omnigent.cursor_native_bridge as cursor_bridge
+
+    killed: list[Any] = []
+    monkeypatch.setattr(cursor_bridge, "bridge_dir_for_session_id", lambda conv: f"dir/{conv}")
+    monkeypatch.setattr(
+        cursor_bridge,
+        "kill_session",
+        lambda bridge_dir, *, timeout_s: killed.append((bridge_dir, timeout_s)),
+    )
+
+    runner, captured = _make_runner()
+    resp = await runner.stop("cursor-native", "conv_c")
+
+    assert isinstance(resp, Response) and resp.status_code == 204
+    assert killed == [("dir/conv_c", 1.0)]
+    idle = [e for _, e in captured["published"] if e.get("status") == "idle"]
+    assert idle == [{"type": "session.status", "status": "idle"}]
+    assert captured["wakes"] == [("conv_c", "cancelled", "[System: sub-agent stopped]")]
+
+
+@pytest.mark.asyncio
+async def test_uniform_stop_kill_failure_returns_503_without_idle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed kill returns 503 and does NOT publish idle (no lie to the UI)."""
+    import json
+
+    import omnigent.hermes_native_bridge as hermes_bridge
+
+    def _boom(bridge_dir: Any, *, timeout_s: float) -> None:
+        raise RuntimeError("tmux target is not advertised")
+
+    monkeypatch.setattr(hermes_bridge, "bridge_dir_for_session_id", lambda conv: "d")
+    monkeypatch.setattr(hermes_bridge, "kill_session", _boom)
+
+    runner, captured = _make_runner()
+    resp = await runner.stop("hermes-native", "conv_h")
+
+    assert resp is not None and resp.status_code == 503
+    assert json.loads(bytes(resp.body))["error"] == "hermes_native_stop_failed"
+    assert [e for _, e in captured["published"] if e.get("status") == "idle"] == []
+
+
+@pytest.mark.asyncio
+async def test_codex_and_pi_stop_route_to_interrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """codex/pi have no distinct stop — stop() routes to their interrupt handler."""
+    import omnigent.pi_native_bridge as pi_bridge
+
+    calls: list[str] = []
+    monkeypatch.setattr(pi_bridge, "bridge_dir_for_session_id", lambda conv: conv)
+    monkeypatch.setattr(
+        pi_bridge, "enqueue_interrupt", lambda bridge_dir: calls.append(bridge_dir)
+    )
+
+    runner, _ = _make_runner()
+    resp = await runner.stop("pi-native", "conv_p")
+
+    assert isinstance(resp, Response) and resp.status_code == 204
+    # The interrupt path ran (enqueue_interrupt), not a kill_session.
+    assert calls == ["conv_p"]
+
+
+@pytest.mark.asyncio
+async def test_codex_interrupt_noop_when_no_bridge_state() -> None:
+    """codex interrupt returns 204 when there is no live bridge state."""
+    runner, _ = _make_runner()  # default codex_bridge_state returns None
+    resp = await runner.interrupt("codex-native", "conv_cx")
+    assert isinstance(resp, Response) and resp.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_claude_interrupt_resolves_bridge_id_and_injects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """claude interrupt resolves the bridge id, injects, and wakes the parent."""
+    import omnigent.claude_native_bridge as claude_bridge
+    from omnigent.runner.native import interrupt as interrupt_mod
+
+    async def _fake_bridge_id(*, server_client: Any, session_id: str) -> str:
+        return f"bid-{session_id}"
+
+    injected: list[Any] = []
+    monkeypatch.setattr(interrupt_mod, "_claude_native_bridge_id_for_session", _fake_bridge_id)
+    monkeypatch.setattr(claude_bridge, "bridge_dir_for_bridge_id", lambda bid: f"dir/{bid}")
+    monkeypatch.setattr(
+        claude_bridge,
+        "inject_interrupt",
+        lambda bridge_dir, *, timeout_s: injected.append((bridge_dir, timeout_s)),
+    )
+
+    runner, captured = _make_runner()
+    resp = await runner.interrupt("claude-native", "conv_cl")
+
+    assert isinstance(resp, Response) and resp.status_code == 204
+    assert injected == [("dir/bid-conv_cl", 1.0)]
+    assert captured["wakes"] == [("conv_cl", "cancelled", "[System: sub-agent interrupted]")]


### PR DESCRIPTION
## Related issue

N/A — part of the modular native-harness registry workstream (`designs/harness-modular-registry-proposal.md`).

## Summary

PR **1.6** of the modular native-harness registry refactor: routes the runner's native
interrupt / stop dispatch through a dependency-injected runner class instead of 16 per-harness
closures + two hardcoded `if _harness == "<x>-native"` chains in `create_session_terminal`'s
sibling event handler.

- **New `NativeInterruptRunner`** in `omnigent/runner/native/interrupt.py` — mirrors the
  existing `CodexGoalRunner` DI precedent (`omnigent/runner/codex/goal.py`): app-scope state
  (AP client, resource registry, event publisher, sub-agent wake plumbing, codex bridge-state
  resolver) is injected at construction, typed via `Protocol`. `interrupt(harness, conv_id)` /
  `stop(harness, conv_id)` resolve the harness by key and return `None` for harnesses with no
  handler so the caller falls through to the in-process turn cancel — unchanged.
- The **9 uniform interrupt** and **7 uniform stop** handlers (which differed only by bridge
  module, control-fn name, and error label) collapse to two descriptor-driven methods
  (`_UNIFORM_INTERRUPT` / `_UNIFORM_STOP`). claude interrupt (bridge-id resolution) and codex
  interrupt (MCP-startup + app-server `turn/interrupt`) keep dedicated methods, moved verbatim.
- **`app.py`**: the two dispatch chains become `await _native_interrupt_runner.interrupt(...)` /
  `.stop(...)` + fall-through. Net app.py −470. Local `from omnigent.<x>_native_bridge import`
  imports are preserved at call time so existing bridge-module monkeypatches keep resolving.

### Scope: migration-only

This PR is **behavior-preserving**. The doc's 1.6 line also mentions "fill the coverage gaps
so every native has both paths" — antigravity-native and opencode-native have no interrupt/stop
handler and fall through to `_cancel_inprocess_turn`. Wiring their native cancel (agy
`interrupt_turn()` / opencode `client.abort()`) is **net-new behavior** and is **deferred to a
follow-up PR**; this PR leaves that fall-through exactly as today (pinned by a new test).

### ELI5

Sixteen near-identical "tell the vendor CLI to stop" functions lived inside the giant runner
file, each closing over runner state. This moves them into one small class that's handed the
state it needs, and collapses the copy-paste into two table-driven methods. Two harnesses that
never had a stop button still don't — that's a separate follow-up.

## Test Plan

```bash
uv run pytest tests/runner/test_native_interrupt_runner.py \
  tests/runner/test_app_sessions_native_events_lifecycle.py \
  tests/runner/test_app_sessions_native_supervision.py \
  tests/test_harness_plugins.py -q
uv run pytest tests/runner/ -q
uv run pre-commit run --all-files
```

- **12 new unit tests** (`tests/runner/test_native_interrupt_runner.py`) driving the runner
  directly: uniform interrupt (+ pi's enqueue/no-timeout variant), uniform stop (kill +
  teardown + idle + wake), 503 on bridge failure (no idle / no wake), codex no-bridge-state
  no-op, claude bridge-id path, codex/pi stop→interrupt aliasing, and the **no-handler → None**
  contract for antigravity/opencode.
- **Existing HTTP-path tests** (`test_app_sessions_native_events_lifecycle.py`,
  `test_app_sessions_native_supervision.py`) POST to `/events` and patch bridge-module
  functions — they pass **untouched** (call-time imports preserve the patch point), so no
  monkeypatch repoints were needed.

## Demo

N/A — internal runner refactor, no user-facing or UI change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Behavior-preserving refactor covered by the existing HTTP-path interrupt/stop tests plus 12 new
`NativeInterruptRunner` unit tests. Manual verification: `tests/runner/` local run is green
except for 9 pre-existing codex-native failures (settings/model-options/interrupt) that
reproduce **identically on clean `main`** — they need the codex app-server to boot / model
catalog discovery, unavailable in this local env (CI has both). Confirmed the codex interrupt
tests fail with the same "no bridge state → skipped" mode on my branch as on main, i.e. the
refactor preserves that path.

Behavior-preservation notes for reviewers:
- **codex/pi stop → interrupt aliasing** preserved (they have no distinct stop).
- **error codes / context strings** kept verbatim (`"<x>_native_interrupt_failed"` /
  `"_stop_failed"`) — asserted by tests; no `display_name` drift on the wire.
- **pi-only warn-log on interrupt failure** preserved via a `log_on_error` descriptor flag (the
  TUI harnesses returned 503 without logging; pi logged).
- **antigravity/opencode** still fall through to `_cancel_inprocess_turn`; pinned by
  `test_no_handler_harnesses_return_none`.

---

**Workstream progress** (`designs/harness-modular-registry-proposal.md`, ~14 PRs):
Phase 1 — 1.1 (#3239), 1.2 (#3244), 1.3 (#3314), 1.5a (#3495), 1.5b-i (#3500), 1.5b-ii
(#3501), 1.5c (#3543) landed; **1.6 is this PR**. Remaining: 1.7 (seeding loop), 1.8
(enumerations); Phase 2 — 2.1–2.4. The runner interrupt/stop surface is now behind a DI seam;
the antigravity/opencode gap-fill is the one deferred follow-up. (Also flips the stale 1.5c
ledger row to `landed`.)
