### PR TITLE
Add product-analytics abstraction to web frontend

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,28 +1,56 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, type ComponentType } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
-import { ChatPage } from "@/pages/ChatPage";
-import { NotFoundPage } from "@/pages/NotFoundPage";
+import { ChatPage as ChatPageImpl } from "@/pages/ChatPage";
+import { NotFoundPage as NotFoundPageImpl } from "@/pages/NotFoundPage";
+import { useOmnigentPageView } from "@/lib/analytics";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { AppShell } from "@/shell/AppShell";
 
-// Lazy-load the accounts pages so the bundle a header / OIDC
-// deploy ships (where accounts is off) doesn't include them in the
-// main entry chunk. They're separate chunks that only download
-// when the user actually navigates to /login or /register — which
-// never happens in non-accounts deploys because the route table
-// below doesn't register them. (Members / Policies are lazy-loaded
-// too, but inside SettingsPage now that they're settings
-// sub-categories rather than standalone routes.)
-const LoginPage = lazy(() => import("@/pages/LoginPage").then((m) => ({ default: m.LoginPage })));
-const RegisterPage = lazy(() =>
-  import("@/pages/RegisterPage").then((m) => ({ default: m.RegisterPage })),
+// Bind a page component to its analytics page-view id. Declaring the id here,
+// beside the component, keeps the route table clean and means no route ships
+// without one. Re-fires on pathname change (see useOmnigentPageView), so a page
+// kept mounted across a param change (ChatPage across `/` ↔ `/c/:id`) still emits
+// one view per destination under the same id.
+//
+// SettingsPage opts out (stays unwrapped): its id is param-derived
+// (`settings.<section>`), so it calls useOmnigentPageView itself.
+function withPageView<P extends object>(id: string, Component: ComponentType<P>): ComponentType<P> {
+  return function WithPageView(props: P) {
+    useOmnigentPageView(id);
+    return <Component {...props} />;
+  };
+}
+
+// Every `*Page` here is wrapped with its page-view id. Accounts pages stay lazy
+// so a non-accounts (header / OIDC) deploy doesn't ship them in the main chunk —
+// their routes aren't registered there, so the chunk never downloads. (Members /
+// Policies are lazy inside SettingsPage now that they're settings sub-categories.)
+const ChatPage = withPageView("chat", ChatPageImpl);
+const NotFoundPage = withPageView("not_found", NotFoundPageImpl);
+const LoginPage = withPageView(
+  "login",
+  lazy(() => import("@/pages/LoginPage").then((m) => ({ default: m.LoginPage }))),
 );
-const SetupPage = lazy(() => import("@/pages/SetupPage").then((m) => ({ default: m.SetupPage })));
-const ApprovePage = lazy(() =>
-  import("@/pages/ApprovePage").then((m) => ({ default: m.ApprovePage })),
+const RegisterPage = withPageView(
+  "register",
+  lazy(() => import("@/pages/RegisterPage").then((m) => ({ default: m.RegisterPage }))),
 );
-const InboxPage = lazy(() => import("@/pages/InboxPage").then((m) => ({ default: m.InboxPage })));
-const TasksPage = lazy(() => import("@/pages/TasksPage").then((m) => ({ default: m.TasksPage })));
+const SetupPage = withPageView(
+  "setup",
+  lazy(() => import("@/pages/SetupPage").then((m) => ({ default: m.SetupPage }))),
+);
+const ApprovePage = withPageView(
+  "approve",
+  lazy(() => import("@/pages/ApprovePage").then((m) => ({ default: m.ApprovePage }))),
+);
+const InboxPage = withPageView(
+  "inbox",
+  lazy(() => import("@/pages/InboxPage").then((m) => ({ default: m.InboxPage }))),
+);
+const TasksPage = withPageView(
+  "tasks",
+  lazy(() => import("@/pages/TasksPage").then((m) => ({ default: m.TasksPage }))),
+);
 const SettingsPage = lazy(() =>
   import("@/pages/SettingsPage").then((m) => ({ default: m.SettingsPage })),
 );

--- a/web/src/components/ui/button.test.tsx
+++ b/web/src/components/ui/button.test.tsx
@@ -11,12 +11,16 @@
 // jsdom can't compute Tailwind styles, so geometry isn't directly testable;
 // these tests pin the class-level invariant that produced the bug.
 
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { Button, buttonVariants } from "./button";
+import { setOmnigentHostConfig } from "@/lib/host";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  setOmnigentHostConfig({});
+});
 
 // Matches a Tailwind translate utility (`translate-y-px`, `-translate-x-1/2`,
 // `translate-3`), bare or behind variant prefixes (`active:translate-y-px`).
@@ -104,5 +108,33 @@ describe("Button loading state", () => {
     );
     expect(screen.getByRole("link")).toBeInTheDocument();
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+});
+
+describe("Button analytics (componentId)", () => {
+  it("reports a click to the host sink and still calls the caller's onClick", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+    const onClick = vi.fn();
+    render(
+      <Button componentId="composer.send" onClick={onClick}>
+        Send
+      </Button>,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(analytics).toHaveBeenCalledExactlyOnceWith({
+      type: "click",
+      componentId: "composer.send",
+      componentKind: "button",
+    });
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("emits nothing when componentId is absent", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+    render(<Button>Send</Button>);
+    fireEvent.click(screen.getByRole("button"));
+    expect(analytics).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -4,6 +4,7 @@ import * as Slot from "radix-ui/slot";
 
 import { cn } from "@/lib/utils";
 import { Spinner } from "@/components/ui/spinner";
+import { useOmnigentAnalytics } from "@/lib/analytics";
 
 // The pressed-state nudge uses the `transform` property (not translate-y-px)
 // so it composes with `translate`-based positioning: a caller centering the
@@ -59,6 +60,10 @@ const Button = React.forwardRef<
       // keeping its width — the label stays in flow but hidden, so a
       // submitting button doesn't grow and shove its neighbours.
       loading?: boolean;
+      // Opt-in analytics id. When set, a click is reported to the host sink
+      // (see `lib/analytics.ts`); when absent the button emits nothing, so
+      // un-instrumented call sites are unchanged.
+      componentId?: string;
     }
 >(function Button(
   {
@@ -68,12 +73,21 @@ const Button = React.forwardRef<
     asChild = false,
     loading = false,
     disabled,
+    componentId,
+    onClick,
     children,
     ...props
   },
   ref,
 ) {
   const Comp = asChild ? Slot.Root : "button";
+  const { trackClick } = useOmnigentAnalytics();
+  const handleClick = componentId
+    ? (e: React.MouseEvent<HTMLButtonElement>) => {
+        trackClick(componentId, "button");
+        onClick?.(e);
+      }
+    : onClick;
 
   // With asChild the child is the rendered element (e.g. a Radix trigger or an
   // <a>); we can't inject an overlay without breaking Slot's single-child
@@ -86,9 +100,11 @@ const Button = React.forwardRef<
       data-slot="button"
       data-variant={variant}
       data-size={size}
+      data-component-id={componentId}
       className={cn(buttonVariants({ variant, size, className }))}
       disabled={disabled || showLoading}
       aria-busy={showLoading || undefined}
+      onClick={handleClick}
       {...props}
     >
       {showLoading ? (

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -1,14 +1,31 @@
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
+import { useOmnigentAnalytics } from "@/lib/analytics";
 
-const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-  ({ className, type, ...props }, ref) => {
-    return (
+const Input = React.forwardRef<
+  HTMLInputElement,
+  React.ComponentProps<"input"> & {
+    // Opt-in analytics id. When set, a value-change is reported to the host
+    // sink (see `lib/analytics.ts`). The value itself is redacted by default
+    // (input text is treated as PII); only that the field changed is sent.
+    componentId?: string;
+  }
+>(({ className, type, componentId, onChange, ...props }, ref) => {
+  const { trackValueChange } = useOmnigentAnalytics();
+  const handleChange = componentId
+    ? (e: React.ChangeEvent<HTMLInputElement>) => {
+        trackValueChange(componentId, "input");
+        onChange?.(e);
+      }
+    : onChange;
+  return (
       <input
         ref={ref}
         type={type}
         data-slot="input"
+        data-component-id={componentId}
+        onChange={handleChange}
         className={cn(
           "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
           className,

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -20,21 +20,20 @@ const Input = React.forwardRef<
       }
     : onChange;
   return (
-      <input
-        ref={ref}
-        type={type}
-        data-slot="input"
-        data-component-id={componentId}
-        onChange={handleChange}
-        className={cn(
-          "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
-          className,
-        )}
-        {...props}
-      />
-    );
-  },
-);
+    <input
+      ref={ref}
+      type={type}
+      data-slot="input"
+      data-component-id={componentId}
+      onChange={handleChange}
+      className={cn(
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    />
+  );
+});
 
 Input.displayName = "Input";
 

--- a/web/src/lib/analytics.test.tsx
+++ b/web/src/lib/analytics.test.tsx
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, renderHook, act } from "@testing-library/react";
+import { MemoryRouter, useNavigate } from "react-router-dom";
+import type { ReactNode } from "react";
+
+import { setOmnigentHostConfig, type OmnigentAnalyticsEvent } from "@/lib/host";
+import { emitOmnigentAnalytics, useOmnigentAnalytics, useOmnigentPageView } from "@/lib/analytics";
+
+afterEach(() => {
+  // Reset the module-singleton host config between tests. The empty-config
+  // guard only blocks clobbering a fetcher, so an analytics-only reset clears.
+  setOmnigentHostConfig({});
+});
+
+describe("emitOmnigentAnalytics", () => {
+  it("is a no-op when no host sink is configured", () => {
+    // No throw, nothing to observe — standalone behavior.
+    expect(() => emitOmnigentAnalytics({ type: "click", componentId: "x" })).not.toThrow();
+  });
+
+  it("forwards the event to the host sink when configured", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+    const event: OmnigentAnalyticsEvent = {
+      type: "click",
+      componentId: "x",
+      componentKind: "button",
+    };
+    emitOmnigentAnalytics(event);
+    expect(analytics).toHaveBeenCalledExactlyOnceWith(event);
+  });
+});
+
+describe("useOmnigentAnalytics", () => {
+  it("redacts field values by default and forwards only when declared PII-free", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+    const { result } = renderHook(() => useOmnigentAnalytics());
+
+    result.current.trackValueChange("field", "input", "secret text");
+    expect(analytics).toHaveBeenLastCalledWith({
+      type: "value_change",
+      componentId: "field",
+      componentKind: "input",
+      value: undefined,
+    });
+
+    result.current.trackValueChange("filter", "select", "active", { valueHasNoPii: true });
+    expect(analytics).toHaveBeenLastCalledWith({
+      type: "value_change",
+      componentId: "filter",
+      componentKind: "select",
+      value: "active",
+    });
+  });
+});
+
+describe("useOmnigentPageView", () => {
+  // useOmnigentPageView reads useLocation, so it needs a router. Render at a
+  // fixed path and let a rerender's `path` prop drive navigation.
+  const atPath = (path: string) => {
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <MemoryRouter initialEntries={[path]}>{children}</MemoryRouter>
+    );
+    return Wrapper;
+  };
+
+  it("fires exactly one page_view on mount", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+    renderHook(() => useOmnigentPageView("chat"), { wrapper: atPath("/c/a") });
+    expect(analytics).toHaveBeenCalledExactlyOnceWith({ type: "page_view", pageId: "chat" });
+  });
+
+  it("does not re-fire on re-render at the same path", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+    const { rerender } = renderHook(() => useOmnigentPageView("chat"), { wrapper: atPath("/c/a") });
+    rerender();
+    expect(analytics).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fires under the same pageId when the pathname changes (chat /c/a -> /c/b)", () => {
+    const analytics = vi.fn();
+    setOmnigentHostConfig({ analytics });
+    // One mounted component (like ChatPage) that navigates between conversations
+    // in place. The hook must re-emit on the pathname change even though pageId
+    // stays "chat" — the regression this guards against.
+    let navigate: ReturnType<typeof useNavigate>;
+    function ChatLike() {
+      useOmnigentPageView("chat");
+      navigate = useNavigate();
+      return null;
+    }
+    render(
+      <MemoryRouter initialEntries={["/c/a"]}>
+        <ChatLike />
+      </MemoryRouter>,
+    );
+    expect(analytics).toHaveBeenCalledTimes(1);
+    act(() => navigate("/c/b"));
+    expect(analytics).toHaveBeenCalledTimes(2);
+    expect(analytics).toHaveBeenLastCalledWith({ type: "page_view", pageId: "chat" });
+  });
+});

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1,0 +1,101 @@
+/**
+ * Product-analytics abstraction.
+ *
+ * Inversion of control: the app emits high-level events (clicks, field
+ * value-changes, page views) and the *host* decides what to do with them via
+ * `OmnigentHostConfig.analytics` (see `lib/host.ts`). When no host sink is
+ * configured — standalone web, or before the host wires it — every emit is a
+ * no-op, so the app records nothing on its own. This mirrors the `searchUsers`
+ * IoC pattern.
+ *
+ * Distinct from `lib/telemetry.ts`, which is low-level OpenTelemetry HTTP
+ * tracing; this module is user-action analytics keyed by a stable componentId.
+ *
+ * PII: field values are redacted by default. A value is only forwarded when the
+ * call site explicitly declares it PII-free (`{ valueHasNoPii: true }`), and
+ * even then free-form strings should be avoided — prefer enumerable values.
+ */
+
+import { useEffect, useMemo, useRef } from "react";
+import {
+  getOmnigentAnalytics,
+  type OmnigentAnalyticsEvent,
+  type OmnigentComponentKind,
+} from "@/lib/host";
+import { useLocation } from "@/lib/routing";
+
+/**
+ * Emit one analytics event to the host sink. No-op when no host is configured.
+ * Safe to call from anywhere (event handlers, effects) — it is not a hook.
+ */
+export function emitOmnigentAnalytics(event: OmnigentAnalyticsEvent): void {
+  getOmnigentAnalytics()?.(event);
+}
+
+export interface TrackValueChangeOptions {
+  /**
+   * Set true ONLY when the value is known non-PII (e.g. a selection from a
+   * fixed set, a boolean toggle, a count). When false/omitted the value is
+   * dropped and only the fact that the field changed is reported.
+   */
+  valueHasNoPii?: boolean;
+}
+
+export interface OmnigentAnalytics {
+  trackClick: (componentId: string, componentKind?: OmnigentComponentKind) => void;
+  trackValueChange: (
+    componentId: string,
+    componentKind?: OmnigentComponentKind,
+    value?: string | number | boolean,
+    options?: TrackValueChangeOptions,
+  ) => void;
+}
+
+/**
+ * Stable analytics callbacks for use in components. The returned object is
+ * referentially stable for the lifetime of the component (the sink is read
+ * lazily inside each call), so it's safe in effect/callback deps.
+ */
+export function useOmnigentAnalytics(): OmnigentAnalytics {
+  return useMemo<OmnigentAnalytics>(
+    () => ({
+      trackClick: (componentId, componentKind) =>
+        emitOmnigentAnalytics({ type: "click", componentId, componentKind }),
+      trackValueChange: (componentId, componentKind, value, options) =>
+        emitOmnigentAnalytics({
+          type: "value_change",
+          componentId,
+          componentKind,
+          // Redact by default: only forward the value when the caller vouches
+          // it carries no PII.
+          value: options?.valueHasNoPii ? value : undefined,
+        }),
+    }),
+    [],
+  );
+}
+
+/**
+ * Report a page view for the given stable `pageId`. Each page calls this at the
+ * top of its body with its own explicit id (e.g. `useOmnigentPageView("chat")`)
+ * — the page is the source of truth for its id, so there's no central route→id
+ * table.
+ *
+ * Re-fires whenever the URL pathname changes, even if `pageId` is unchanged —
+ * matching the Databricks unified router, where a same-page param change (chat
+ * `/c/a` → `/c/b`) is still a distinct page view. So a component that stays
+ * mounted across such a navigation (ChatPage does) still emits one page view per
+ * destination, all under the same `pageId`.
+ */
+export function useOmnigentPageView(pageId: string): void {
+  const { pathname } = useLocation();
+  const lastFired = useRef<string | null>(null);
+  useEffect(() => {
+    // Key on pageId + pathname so a mounted page re-emits on a param change but
+    // not on unrelated re-renders.
+    const key = `${pageId} ${pathname}`;
+    if (lastFired.current === key) return;
+    lastFired.current = key;
+    emitOmnigentAnalytics({ type: "page_view", pageId });
+  }, [pageId, pathname]);
+}

--- a/web/src/lib/host.ts
+++ b/web/src/lib/host.ts
@@ -147,7 +147,7 @@ export function getOmnigentUserSearch(): OmnigentHostConfig["searchUsers"] {
  * Consumers use the absence to stay inert (emit nothing).
  */
 export function getOmnigentAnalytics(): OmnigentHostConfig["analytics"] {
-  return _config.analytics;
+  return hostConfig.analytics;
 }
 
 /**

--- a/web/src/lib/host.ts
+++ b/web/src/lib/host.ts
@@ -24,6 +24,32 @@ export interface UserSuggestion {
   displayName?: string;
 }
 
+/**
+ * The kind of UI element an analytics event came from. A small, closed set kept
+ * intentionally host-agnostic — the host maps each value onto whatever its own
+ * telemetry taxonomy uses. Omitted when the element doesn't fit any of these.
+ */
+export type OmnigentComponentKind =
+  "button" | "link" | "input" | "textarea" | "checkbox" | "toggle" | "select";
+
+/**
+ * A product-analytics event forwarded to the host. Each carries a stable,
+ * caller-chosen `componentId` / `pageId` so the host can attribute the action.
+ *
+ * PII: `value` on a value-change is only ever set when the emitting call site
+ * explicitly declares the value PII-free (see `useOmnigentAnalytics` in
+ * `lib/analytics.ts`). Free-form field text is never forwarded.
+ */
+export type OmnigentAnalyticsEvent =
+  | { type: "click"; componentId: string; componentKind?: OmnigentComponentKind }
+  | {
+      type: "value_change";
+      componentId: string;
+      componentKind?: OmnigentComponentKind;
+      value?: string | number | boolean;
+    }
+  | { type: "page_view"; pageId: string };
+
 export interface OmnigentHostConfig {
   /**
    * Maps an web API path (always starting with `/v1`, `/health`, or
@@ -41,6 +67,15 @@ export interface OmnigentHostConfig {
    * logic and returns the suggestions to display.
    */
   searchUsers?: (query: string, options?: { signal?: AbortSignal }) => Promise<UserSuggestion[]>;
+  /**
+   * Optional product-analytics sink. When supplied by the host, the app's
+   * instrumented components forward clicks, field value-changes, and page views
+   * here (see `lib/analytics.ts`); when omitted (standalone, or before the host
+   * wires it) every emit is a no-op — the app records nothing on its own. The
+   * host owns transport, batching, and any PII policy beyond the app's default
+   * value redaction.
+   */
+  analytics?: (event: OmnigentAnalyticsEvent) => void;
   /**
    * Maps an web WS path (e.g.
    * `/v1/sessions/{id}/resources/terminals/{tid}/attach`) to a fully
@@ -105,6 +140,14 @@ export function getOmnigentHostConfig(): OmnigentHostConfig {
  */
 export function getOmnigentUserSearch(): OmnigentHostConfig["searchUsers"] {
   return hostConfig.searchUsers;
+}
+
+/**
+ * The host-provided analytics sink, or `undefined` when none is configured.
+ * Consumers use the absence to stay inert (emit nothing).
+ */
+export function getOmnigentAnalytics(): OmnigentHostConfig["analytics"] {
+  return _config.analytics;
 }
 
 /**

--- a/web/src/lib/routing.tsx
+++ b/web/src/lib/routing.tsx
@@ -23,7 +23,9 @@
 
 import {
   type ComponentPropsWithoutRef,
+  type ComponentType,
   type ReactNode,
+  type RefAttributes,
   createContext,
   forwardRef,
   useContext,
@@ -44,12 +46,20 @@ import {
  * react-router-dom so call sites are identical and any host implementation
  * must conform to the same shapes (the adapter's job).
  */
+/**
+ * Link props: react-router-dom's `LinkProps` plus an optional `componentId` an
+ * embedding host can use for per-link analytics. Standalone ignores it; the
+ * Databricks host maps it to a namespaced analytics id (see the routing IoC
+ * override). Optional so existing call sites are unchanged.
+ */
+export type OmnigentLinkProps = ComponentPropsWithoutRef<typeof RRLink> & { componentId?: string };
+
 export interface RoutingApi {
   useNavigate: typeof useRRNavigate;
   useParams: typeof useRRParams;
   useSearchParams: typeof useRRSearchParams;
   useLocation: typeof useRRLocation;
-  Link: typeof RRLink;
+  Link: ComponentType<OmnigentLinkProps & RefAttributes<HTMLAnchorElement>>;
   Outlet: typeof RROutlet;
   /**
    * Rebase an app-absolute path (`/c/:id`) the same way `navigate()`/`<Link>`
@@ -60,13 +70,23 @@ export interface RoutingApi {
   rebasePath: (path: string) => string;
 }
 
+// Standalone Link: react-router-dom's Link, minus the host-only `componentId`
+// (standalone has no analytics sink; passing it to a real <a> would warn on an
+// unknown DOM attribute).
+const StandaloneLink = forwardRef<HTMLAnchorElement, OmnigentLinkProps>(function StandaloneLink(
+  { componentId: _componentId, ...props },
+  ref,
+) {
+  return <RRLink ref={ref} {...props} />;
+});
+
 /** Default implementation: plain react-router-dom. */
 export const reactRouterRouting: RoutingApi = {
   useNavigate: useRRNavigate,
   useParams: useRRParams,
   useSearchParams: useRRSearchParams,
   useLocation: useRRLocation,
-  Link: RRLink,
+  Link: StandaloneLink,
   Outlet: RROutlet,
   rebasePath: (path) => path,
 };
@@ -129,7 +149,7 @@ export function basenamedRouting(
         return navigate(rebaseTo(to, basename), options);
       }) as ReturnType<typeof useRRNavigate>;
     },
-    Link: forwardRef<HTMLAnchorElement, ComponentPropsWithoutRef<typeof RRLink>>((props, ref) => {
+    Link: forwardRef<HTMLAnchorElement, OmnigentLinkProps>((props, ref) => {
       const Impl = base.Link;
       return <Impl ref={ref} {...props} to={rebaseTo(props.to, basename)} />;
     }),
@@ -172,12 +192,10 @@ export const useLocation: typeof useRRLocation = () => useRouting().useLocation(
  */
 export const useRebasePath = (): ((path: string) => string) => useRouting().rebasePath;
 
-export const Link = forwardRef<HTMLAnchorElement, ComponentPropsWithoutRef<typeof RRLink>>(
-  (props, ref) => {
-    const { Link: Impl } = useRouting();
-    return <Impl ref={ref} {...props} />;
-  },
-);
+export const Link = forwardRef<HTMLAnchorElement, OmnigentLinkProps>((props, ref) => {
+  const { Link: Impl } = useRouting();
+  return <Impl ref={ref} {...props} />;
+});
 Link.displayName = "Link";
 
 export const Outlet: typeof RROutlet = (props) => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -5212,6 +5212,7 @@ export function Composer({
             <Button
               type="submit"
               size="icon"
+              componentId="chat.composer.send"
               variant={showInterruptButton ? "destructive" : "default"}
               // Send button fades more decisively when there's no draft —
               // overrides the base 50% disabled-opacity so the affordance

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -81,6 +81,7 @@ import { KeyboardShortcutsList } from "@/components/KeyboardShortcutsDialog";
 import { changePassword, logout } from "@/lib/accountsApi";
 import { getCurrentIsAdmin, resolveIdentity } from "@/lib/identity";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
+import { useOmnigentPageView } from "@/lib/analytics";
 import {
   type Conversation,
   useArchiveConversation,
@@ -197,6 +198,10 @@ export function SettingsPage() {
   // login_url; gates the Account section so SSO users get it too.
   const hasAuthSession = info !== "loading" && info.login_url !== null;
   const { section } = useSettingsRoute();
+  // Per-section page view: `settings.appearance`, `settings.account`, etc. The
+  // hook re-keys on pathname, so switching sections re-fires under the new id.
+  // `section` is a closed SettingsSectionId union (no PII / unbounded values).
+  useOmnigentPageView(`settings.${section}`);
 
   // Members / Policies are admin-only management surfaces that own their full
   // layout (their own PageScroll + admin gating), so they render directly —

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -170,6 +170,7 @@ export function TasksPage() {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search automations…"
+            componentId="tasks.search"
             data-testid="tasks-search"
             className="pl-9"
           />

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -3132,6 +3132,7 @@ function ConversationRow({
   const rowLink = (
     <Link
       to={selectionMode ? "#" : `/c/${conversation.id}`}
+      componentId="sidebar.conversation_switcher"
       className={cn(
         "sidebar-compact-text relative flex h-7 flex-col justify-center rounded-[var(--radius-otto-sm)] py-0.5 pl-2 text-left text-foreground transition-colors",
         SIDEBAR_HOVER_HIGHLIGHT,

--- a/web/src/shell/settingsNav.tsx
+++ b/web/src/shell/settingsNav.tsx
@@ -224,7 +224,7 @@ export function SettingsSidebarBody({
           but we keep the overlay OPEN so mobile lands on that list rather than
           closing onto the content behind it. On desktop onNavClick is a no-op
           (persistent card), so dropping it changes nothing there. */}
-          <Link to={settingsReturnPath}>
+          <Link to={settingsReturnPath} componentId="settings.back_to_omnigent">
             <ArrowLeftIcon className="size-4" />
             Back to Omnigent
           </Link>


### PR DESCRIPTION
## Related issue

N/A

## Summary

Adds an opt-in, host-injected **product-analytics seam** so an embedding host can collect user actions (clicks, field value-changes, page views) keyed by a stable `componentId`. Fully inert standalone: when no host sink is configured via `OmnigentHostConfig.analytics`, every emit is a no-op, so the standalone build's behaviour is unchanged.

Distinct from `lib/telemetry.ts` (low-level OpenTelemetry HTTP tracing) — this is application-level user-action analytics.

- **`lib/host.ts`** — `OmnigentAnalyticsEvent` type + optional `analytics` sink on `OmnigentHostConfig` + `getOmnigentAnalytics()` getter (mirrors the existing `searchUsers` IoC pattern).
- **`lib/analytics.ts`** — `emitOmnigentAnalytics` (no-op when unset), `useOmnigentAnalytics` (`trackClick` / `trackValueChange`, values redacted by default for PII), and `useOmnigentPageView` (re-fires on pathname change, matching the unified router's same-page-param behaviour).
- **`components/ui/{button,input}.tsx`** — optional `componentId` prop that reports clicks / value-changes when set; nothing fires when absent (opt-in, zero change for un-instrumented call sites).
- **`lib/routing.tsx`** — optional `componentId` on `Link` (`OmnigentLinkProps`) so a link can opt into per-link analytics; the standalone Link strips it.
- **`App.tsx`** — `withPageView(id, Component)` HOC binds each page's page-view id at its declaration, keeping the route table clean; `SettingsPage` opts out and calls `useOmnigentPageView` itself (param-derived `settings.<section>` id) as the escape hatch.
- Example `componentId`s wired up: chat composer send, tasks search, sidebar conversation switcher, and the settings "Back to Omnigent" link.

### ELI5

The app can now say "a user clicked *this* button" or "a user opened *this* page", tagged with a stable name. On its own it does nothing — it just hands those events to whoever is hosting the app (if anyone). Standalone, nobody's listening, so nothing happens.

```
component (componentId) ──► useOmnigentAnalytics / useOmnigentPageView
                              └─► emitOmnigentAnalytics
                                    └─► getOmnigentAnalytics()?  ──► host sink   (embedded)
                                                              └──► no-op        (standalone)
```

## Test Plan

`pnpm --dir web test` (vitest). New / updated unit tests:

- **`lib/analytics.test.tsx`** — `emitOmnigentAnalytics` no-ops with no host sink and forwards when configured; `useOmnigentAnalytics` redacts field values by default and only forwards when the call site declares them PII-free; `useOmnigentPageView` fires once on mount, doesn't re-fire on same-path re-render, and re-fires under the same `pageId` when the pathname changes (`/c/a` → `/c/b`).
- **`components/ui/button.test.tsx`** — a `componentId` button reports a click to the host sink and still calls the caller's `onClick`; emits nothing when `componentId` is absent.
- Existing `lib/routing.test.tsx`, `shell/Sidebar.test.tsx`, and page tests continue to pass with the widened `Link` type and the wired example call sites.

`pnpm --dir web type-check` is clean.

## Demo

N/A — no visible UI change (analytics is non-visual; instrumentation is inert standalone).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the analytics abstraction end to end (sink no-op/forward, PII redaction, page-view firing/re-firing) and the componentId-aware Button. The `withPageView` HOC is a thin wrapper over the already-tested `useOmnigentPageView`, so it has no separate test.

<!-- Changelog section omitted: no user-facing behaviour change (opt-in analytics plumbing, inert standalone). -->
