### PR TITLE
refactor(web): avoid Promise executor return values

### DIFF
--- a/web/electron/test/update-main.test.js
+++ b/web/electron/test/update-main.test.js
@@ -196,7 +196,9 @@ function loadMainHarness({
 }
 
 async function flushPromises() {
-  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => {
+    setImmediate(resolve);
+  });
 }
 
 function plain(value) {
@@ -444,7 +446,9 @@ describe("auto-update main-process wiring", () => {
     assert.equal(harness.calls.appQuit, 1); // still no re-issued quit
     assert.equal(harness.calls.appExit, 0); // fallback not fired yet
 
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 30);
+    });
     assert.equal(harness.calls.appExit, 1); // fallback forced the exit
     assert.equal(harness.calls.appQuit, 1); // never re-issued
   });
@@ -470,7 +474,9 @@ describe("auto-update main-process wiring", () => {
     assert.equal(harness.calls.appQuit, 0); // shutdown hung, no re-issued quit
     assert.equal(harness.calls.appExit, 0); // cap not fired yet
 
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 30);
+    });
     assert.equal(harness.calls.appExit, 1); // cap forced the exit
     assert.equal(harness.calls.appQuit, 0); // never re-issued
   });

--- a/web/src/components/OttoEyes.test.tsx
+++ b/web/src/components/OttoEyes.test.tsx
@@ -7,7 +7,10 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-const nextFrame = () => new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+const nextFrame = () =>
+  new Promise((resolve) => {
+    requestAnimationFrame(() => resolve(undefined));
+  });
 
 // Reads a pupil's live translate() transform, or null before the rAF
 // pipeline has written one.

--- a/web/src/embed.tsx
+++ b/web/src/embed.tsx
@@ -137,9 +137,9 @@ function EmbedCapabilitiesProvider({ children }: { children: ReactNode }) {
     // main.tsx) so the chat UI still paints instead of hanging on "loading".
     void Promise.race([
       resolveServerInfo(),
-      new Promise<ServerInfo>((resolve) =>
-        setTimeout(() => resolve(SERVER_INFO_OFFLINE_FALLBACK), 1500),
-      ),
+      new Promise<ServerInfo>((resolve) => {
+        setTimeout(() => resolve(SERVER_INFO_OFFLINE_FALLBACK), 1500);
+      }),
     ]).then((resolved) => {
       if (alive) setInfo(resolved);
     });

--- a/web/src/hooks/useFileContent.test.tsx
+++ b/web/src/hooks/useFileContent.test.tsx
@@ -48,7 +48,9 @@ function Probe({ id, path }: { id: string | undefined; path: string | null }) {
 }
 
 async function flushMicrotasks() {
-  await new Promise((r) => setTimeout(r, 10));
+  await new Promise((resolve) => {
+    setTimeout(resolve, 10);
+  });
 }
 
 type ChatStoreState = {

--- a/web/src/hooks/useHosts.test.tsx
+++ b/web/src/hooks/useHosts.test.tsx
@@ -260,7 +260,9 @@ describe("useHosts", () => {
     focusManager.setFocused(false);
     focusManager.setFocused(true);
     // Give any (unwanted) refetch a chance to fire, then assert it didn't.
-    await new Promise((r) => setTimeout(r, 50));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     focusManager.setFocused(undefined);
   });
@@ -286,7 +288,9 @@ describe("useInstallHarness + useInstallingHarnesses (concurrent installs)", () 
   // the cache patch must therefore NOT ride on per-call callbacks.
   function deferred<T>() {
     let resolve!: (v: T) => void;
-    const promise = new Promise<T>((r) => (resolve = r));
+    const promise = new Promise<T>((settle) => {
+      resolve = settle;
+    });
     return { promise, resolve };
   }
 

--- a/web/src/loadtest/streamRenderBench.ts
+++ b/web/src/loadtest/streamRenderBench.ts
@@ -123,7 +123,9 @@ async function drain(): Promise<void> {
   // Timer turns must elapse in order to flush each queued stage.
   /* oxlint-disable no-await-in-loop */
   for (let k = 0; k < 4; k += 1) {
-    await new Promise<void>((r) => setTimeout(r, 0));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
   }
   /* oxlint-enable no-await-in-loop */
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -84,7 +84,7 @@ applyThemePalette(readThemePalette());
 // something on screen.
 const bootProbe: Promise<ServerInfo> = Promise.race([
   resolveServerInfo(),
-  new Promise<ServerInfo>((resolve) =>
+  new Promise<ServerInfo>((resolve) => {
     setTimeout(
       () =>
         resolve({
@@ -104,8 +104,8 @@ const bootProbe: Promise<ServerInfo> = Promise.race([
           dictation_available: false,
         }),
       1500,
-    ),
-  ),
+    );
+  }),
 ]);
 
 void bootProbe.then((info) => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2339,7 +2339,10 @@ export function JumpToTopButton({
   const jumpToTop = useCallback(async () => {
     if (!scroller) return;
     const { el, state, stopScroll } = scroller;
-    const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    const nextFrame = () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve());
+      });
     setJumping(true);
     try {
       // Release StickToBottom's bottom-lock. Without this, every history prepend

--- a/web/src/shell/CommentsPanel.test.tsx
+++ b/web/src/shell/CommentsPanel.test.tsx
@@ -465,7 +465,9 @@ function renderWithSelection(
 
 /** Run pending requestAnimationFrame callbacks (the scroll effect defers via rAF). */
 function flushRaf(): Promise<void> {
-  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
 }
 
 describe("CommentsPanel active-comment reveal", () => {

--- a/web/src/shell/FilesPanel.test.tsx
+++ b/web/src/shell/FilesPanel.test.tsx
@@ -1337,7 +1337,12 @@ describe("FilesPanel scroll position persistence", () => {
     // expires), then user scrolls are saved again.
     const expired = performance.now() + SCROLL_RESTORE_BUDGET_MS + 1;
     vi.spyOn(performance, "now").mockReturnValue(expired);
-    await act(() => new Promise((resolve) => requestAnimationFrame(() => resolve(undefined))));
+    await act(
+      () =>
+        new Promise((resolve) => {
+          requestAnimationFrame(() => resolve(undefined));
+        }),
+    );
     vi.mocked(performance.now).mockRestore();
     section.scrollTop = 40;
     fireEvent.scroll(section);

--- a/web/src/shell/useScrollRestore.test.tsx
+++ b/web/src/shell/useScrollRestore.test.tsx
@@ -38,7 +38,12 @@ function mount(scrollKey: string | null, ready = true) {
 let now = 0;
 
 async function nextFrame() {
-  await act(() => new Promise((resolve) => requestAnimationFrame(() => resolve(undefined))));
+  await act(
+    () =>
+      new Promise((resolve) => {
+        requestAnimationFrame(() => resolve(undefined));
+      }),
+  );
 }
 
 // jsdom has no layout (scrollHeight/clientHeight are 0), so a saved offset > 0

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -402,7 +402,10 @@ afterEach(() => {
 });
 
 /** Yield to the microtask queue so background pump kicks off. */
-const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+const tick = () =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
 
 /** Seed the session snapshot returned by GET /v1/sessions/{id}. */
 function seedSession(id: string, items: ConversationItem[] = []): void {
@@ -1150,9 +1153,9 @@ describe("chatStore — switchTo", () => {
 
     await Promise.race([
       useChatStore.getState().switchTo("conv_waiting"),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("switchTo timed out waiting for stalled stream")), 200),
-      ),
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error("switchTo timed out waiting for stalled stream")), 200);
+      }),
     ]);
 
     const elicitation = useChatStore


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Convert 16 Promise executors from expression bodies to block bodies so they do not return timer handles or assignment results that Promises ignore.
- Preserve the same resolution, rejection, timeout, animation-frame, and deferred-test behavior.
- Clear the complete `no-promise-executor-return` diagnostic set across the web package.

**ELI5:** A Promise executor is a setup callback, not a value-returning function. These callbacks accidentally handed back timer IDs or assigned values that were immediately discarded; they now only perform the intended setup.

```text
Before: executor -> schedule work -> return ignored timer/assignment value
After:  executor -> schedule work -> no return value
```

## Test Plan

- `pnpm --filter web exec oxlint -A all -D no-promise-executor-return .`
- 411 focused Vitest tests across affected timer, animation-frame, and deferred-promise paths
- 11 focused Electron updater tests
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `pnpm --filter web run test:coverage`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A — internal Promise callback cleanup with no visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

All 422 focused tests pass, along with the full 4,771-test web suite. The dedicated lint rule reports zero remaining diagnostics.

## Changelog

N/A — internal code-quality cleanup only.
