### PR TITLE
[models] Route Pi wire APIs from catalog metadata

### DIFF
--- a/docs/model-hardcoding-plan.md
+++ b/docs/model-hardcoding-plan.md
@@ -159,6 +159,14 @@ An explicit Anthropic `[1m]` marker remains self-describing metadata, and an
 uncatalogued/offline model keeps the conservative 128K fallback rather than a
 release-specific guess.
 
+## Pi Wire Routing
+
+Pi gateway configuration consumes the same normalized Unity Catalog model
+service metadata. Databricks GPT models use the Responses or Chat surface the
+catalog advertises, while generic OpenAI-compatible providers honor their
+configured wire. If Databricks discovery is unavailable, an unknown GPT uses
+Responses rather than a release-specific completions allowlist.
+
 ## Kiro Picker Migration
 
 The Kiro Web picker now runs `kiro-cli chat --list-models --format json` on the

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -54,6 +54,11 @@ from omnigent.inner.native_attachments import parse_data_uri
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 from omnigent.model_metadata import ModelWireAPI
 from omnigent.onboarding.provider_config import CHAT_WIRE_API, RESPONSES_WIRE_API
+from omnigent.pi_model_compatibility import SYSTEM_AI_RESPONSES_KEYWORDS
+from omnigent.pi_native_credentials import (
+    _databricks_workspace_url_for_gateway,
+    _is_databricks_ai_gateway_url,
+)
 from omnigent.runner.identity import OMNIGENT_SESSION_ENV_VAR
 from omnigent.spec.types import RetryPolicy
 
@@ -751,8 +756,6 @@ def _build_models_json(
     codex_gateway_url = f"{h}/ai-gateway/codex/v1"
     mlflow_gateway_url = f"{h}/ai-gateway/mlflow/v1"
     raw_openai_base_url = (base_urls or {}).get("openai")
-    from omnigent.pi_native_credentials import _is_databricks_ai_gateway_url
-
     is_databricks_openai_gateway = bool(
         raw_openai_base_url
         and (
@@ -919,11 +922,9 @@ def _pi_needs_responses_api(
     finish reason Pi requires. Unknown GPT metadata fails toward Responses,
     which is the forward-compatible tool-capable surface.
     """
-    from omnigent.pi_native_credentials import _SYSTEM_AI_MODEL_KEYWORDS
-
     lower = model.lower()
     if lower.startswith("system.ai.") and any(
-        keyword in lower for keyword in _SYSTEM_AI_MODEL_KEYWORDS
+        keyword in lower for keyword in SYSTEM_AI_RESPONSES_KEYWORDS
     ):
         return True
     if wire_apis is not None:
@@ -1964,8 +1965,6 @@ class PiExecutor(Executor):
         """Return the configured wire only for a non-Databricks gateway."""
         openai_base_url = (self._base_urls_override or {}).get("openai")
         if openai_base_url:
-            from omnigent.pi_native_credentials import _is_databricks_ai_gateway_url
-
             is_databricks_gateway = (
                 "/ai-gateway/" in openai_base_url or _is_databricks_ai_gateway_url(openai_base_url)
             )
@@ -1977,8 +1976,6 @@ class PiExecutor(Executor):
         """Return the workspace API origin for Databricks catalog discovery."""
         if self._gateway_uses_databricks_profile:
             return self._databricks_host
-        from omnigent.pi_native_credentials import _databricks_workspace_url_for_gateway
-
         candidates = [
             *(self._base_urls_override or {}).values(),
             self._base_url_override,

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -43,7 +43,7 @@ import shutil
 import subprocess
 import tempfile
 from asyncio import Queue, Task
-from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, TypeAlias
 from urllib.parse import urlparse as _urlparse
@@ -52,6 +52,8 @@ from omnigent import model_catalog
 from omnigent.inner.agent_env import clean_agent_env
 from omnigent.inner.native_attachments import parse_data_uri
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
+from omnigent.model_metadata import ModelWireAPI
+from omnigent.onboarding.provider_config import CHAT_WIRE_API, RESPONSES_WIRE_API
 from omnigent.runner.identity import OMNIGENT_SESSION_ENV_VAR
 from omnigent.spec.types import RetryPolicy
 
@@ -563,7 +565,7 @@ def _find_pi_cli() -> str | None:
 # a static id — in which case _build_models_json's append is skipped, so the
 # capability has to be declared here too or attached images are silently
 # dropped (#515/#516).
-_DATABRICKS_RESPONSES_MODELS = [
+_DATABRICKS_OPENAI_MODELS = [
     {
         "id": "databricks-gpt-5-4-mini",
         "name": "GPT-5.4 Mini",
@@ -710,6 +712,8 @@ def _build_models_json(
     token: str,
     base_urls: dict[str, str] | None = None,
     model: str | None = None,
+    model_wire_apis: Mapping[str, frozenset[ModelWireAPI]] | None = None,
+    openai_wire_api: str | None = None,
 ) -> dict[str, Any]:  # type: ignore[explicit-any]
     # Pi's models.json mixes str/int/bool/list/dict across provider configs;
     # see _DATABRICKS_*_MODELS and the compat/authHeader shapes below. The
@@ -736,6 +740,10 @@ def _build_models_json(
         same shape ucode writes) under the provider
         :func:`_pi_provider_for_model` routes it to when absent from the
         static list. ``None`` skips registration (Pi picks its default).
+    :param model_wire_apis: Databricks model ids mapped to catalog-reported
+        wire surfaces. Missing GPT metadata defaults to Responses.
+    :param openai_wire_api: Configured wire for a generic OpenAI-compatible
+        provider. ``None`` defaults generic providers to Chat Completions.
     :returns: Pi ``models.json`` contents.
     """
     h = host.rstrip("/")
@@ -743,18 +751,29 @@ def _build_models_json(
     codex_gateway_url = f"{h}/ai-gateway/codex/v1"
     mlflow_gateway_url = f"{h}/ai-gateway/mlflow/v1"
     raw_openai_base_url = (base_urls or {}).get("openai")
-    # ucode's ``openai`` gateway is the Codex Responses gateway
-    # (``.../ai-gateway/codex/v1``), which 404s pi's openai-completions
-    # ``/chat/completions`` POST. Re-route only that case to serving-endpoints;
-    # generic providers (no ``/ai-gateway/codex``) pass through.
-    if raw_openai_base_url and "/ai-gateway/codex" in raw_openai_base_url:
+    from omnigent.pi_native_credentials import _is_databricks_ai_gateway_url
+
+    is_databricks_openai_gateway = bool(
+        raw_openai_base_url
+        and (
+            "/ai-gateway/" in raw_openai_base_url
+            or _is_databricks_ai_gateway_url(raw_openai_base_url)
+        )
+    )
+    # Databricks Codex URLs only accept Responses; Chat uses the workspace.
+    if raw_openai_base_url and is_databricks_openai_gateway:
         openai_base_url = serving_endpoints_url
     else:
         openai_base_url = raw_openai_base_url or serving_endpoints_url
     # For non-Databricks providers (e.g. OpenAI API key, LiteLLM) the
     # /ai-gateway/* paths don't exist — use the generic base URL for all paths.
-    is_generic_provider = bool(raw_openai_base_url and "/ai-gateway/" not in raw_openai_base_url)
-    if is_generic_provider:
+    is_generic_provider = bool(raw_openai_base_url and not is_databricks_openai_gateway)
+    generic_openai_wire_api = openai_wire_api or CHAT_WIRE_API if is_generic_provider else None
+    wire_catalog = model_wire_apis or {}
+    if is_databricks_openai_gateway:
+        assert raw_openai_base_url is not None
+        codex_gateway_url = raw_openai_base_url
+    elif is_generic_provider:
         codex_gateway_url = openai_base_url
         mlflow_gateway_url = openai_base_url
     claude_base_url = (base_urls or {}).get("claude") or f"{h}/serving-endpoints/anthropic"
@@ -778,8 +797,12 @@ def _build_models_json(
                 "compat": _openai_responses_compat,
                 "models": [
                     m
-                    for m in _DATABRICKS_RESPONSES_MODELS
-                    if isinstance(m.get("id"), str) and _pi_needs_responses_api(m["id"])
+                    for m in _DATABRICKS_OPENAI_MODELS
+                    if isinstance((model_id := m.get("id")), str)
+                    and _pi_needs_responses_api(
+                        model_id,
+                        wire_catalog.get(model_id.lower()),
+                    )
                 ],
             },
             # Older GPT models → OpenAI Chat Completions at serving-endpoints.
@@ -790,8 +813,12 @@ def _build_models_json(
                 "compat": _openai_responses_compat,
                 "models": [
                     m
-                    for m in _DATABRICKS_RESPONSES_MODELS
-                    if not (isinstance(m.get("id"), str) and _pi_needs_responses_api(m["id"]))
+                    for m in _DATABRICKS_OPENAI_MODELS
+                    if isinstance((model_id := m.get("id")), str)
+                    and not _pi_needs_responses_api(
+                        model_id,
+                        wire_catalog.get(model_id.lower()),
+                    )
                 ],
             },
             # Claude models → Anthropic Messages API.
@@ -838,7 +865,13 @@ def _build_models_json(
         },
     }
     if model is not None:
-        provider = config["providers"][_pi_provider_for_model(model)]
+        provider = config["providers"][
+            _pi_provider_for_model(
+                model,
+                wire_catalog.get(model.lower()),
+                generic_openai_wire_api=generic_openai_wire_api,
+            )
+        ]
         if not any(entry.get("id") == model for entry in provider["models"]):
             # Rebind (don't append): the static lists are module-level
             # constants shared across builds, so in-place mutation would
@@ -875,36 +908,69 @@ def _pi_model_is_reasoning(model: str) -> bool:
     return any(fragment in lower for fragment in _PI_REASONING_MODEL_FRAGMENTS)
 
 
-def _pi_needs_responses_api(model: str) -> bool:
-    """Return True when a model requires the Responses API at /ai-gateway/codex/v1.
+def _pi_needs_responses_api(
+    model: str,
+    wire_apis: frozenset[ModelWireAPI] | None = None,
+) -> bool:
+    """Return whether Pi should use the Databricks Responses surface.
 
-    Covers two cases:
-    - Newer GPT models that reject function tools via /chat/completions.
-    - Kimi/inkling/qwen3/glm (system.ai.* ids) that need the Responses API to
-      avoid the missing finish_reason issue on /chat/completions.
+    Catalog metadata is authoritative when available. The system-model family
+    fallback remains for endpoints whose documented chat surface omits the
+    finish reason Pi requires. Unknown GPT metadata fails toward Responses,
+    which is the forward-compatible tool-capable surface.
     """
-    from omnigent.pi_native_credentials import _SYSTEM_AI_MODEL_KEYWORDS, _needs_responses_api
+    from omnigent.pi_native_credentials import _SYSTEM_AI_MODEL_KEYWORDS
 
     lower = model.lower()
-    # system.ai.* ids: only kimi/inkling/qwen3/glm variants need Responses API.
-    # Claude/llama system.ai.* ids route to their own providers (Anthropic, completions).
-    if lower.startswith("system.ai.") and any(kw in lower for kw in _SYSTEM_AI_MODEL_KEYWORDS):
+    if lower.startswith("system.ai.") and any(
+        keyword in lower for keyword in _SYSTEM_AI_MODEL_KEYWORDS
+    ):
         return True
-    return _needs_responses_api(lower)
+    if wire_apis is not None:
+        return ModelWireAPI.OPENAI_RESPONSES in wire_apis
+    return "gpt" in lower
 
 
-def _pi_provider_for_model(model: str) -> str:
+def _pi_provider_for_model(
+    model: str,
+    wire_apis: frozenset[ModelWireAPI] | None = None,
+    *,
+    generic_openai_wire_api: str | None = None,
+) -> str:
     """Return the Pi provider name to use for a given Databricks model."""
     lower = model.lower()
     if "claude" in lower:
         return "databricks-anthropic"
+    if generic_openai_wire_api is not None:
+        if generic_openai_wire_api == RESPONSES_WIRE_API:
+            return "databricks-openai"
+        return "databricks-completions"
     if lower.startswith("system.ai."):
-        # system.ai.* ids never work at serving-endpoints — always use a gateway path.
-        # kimi/inkling/qwen3/glm → Responses API; others (Llama, Gemini, GPT) → mlflow.
-        return "databricks-openai" if _pi_needs_responses_api(model) else "databricks-mlflow"
+        return (
+            "databricks-openai"
+            if _pi_needs_responses_api(model, wire_apis)
+            else "databricks-mlflow"
+        )
     if "gpt" in lower:
-        return "databricks-openai" if _pi_needs_responses_api(model) else "databricks"
+        return "databricks-openai" if _pi_needs_responses_api(model, wire_apis) else "databricks"
     return "databricks-completions"
+
+
+def _databricks_model_wire_catalog(
+    models: Sequence[model_catalog.ModelEntry],
+) -> dict[str, frozenset[ModelWireAPI]]:
+    """Index UC wire metadata by both system and serving-endpoint aliases."""
+    catalog: dict[str, frozenset[ModelWireAPI]] = {}
+    for model in models:
+        model_id = model.id.lower()
+        aliases = {model_id}
+        if model_id.startswith("system.ai."):
+            aliases.add(f"databricks-{model_id.removeprefix('system.ai.')}")
+        elif model_id.startswith("databricks-"):
+            aliases.add(f"system.ai.{model_id.removeprefix('databricks-')}")
+        for alias in aliases:
+            catalog[alias] = model.metadata.wire_apis
+    return catalog
 
 
 async def _create_subprocess_exec(*args: Any, **kwargs: Any) -> asyncio.subprocess.Process:  # type: ignore[explicit-any]
@@ -1598,6 +1664,7 @@ class PiExecutor(Executor):
         gateway_host: str | None = None,
         base_url_override: str | None = None,
         base_urls_override: dict[str, str] | None = None,
+        openai_wire_api: str | None = None,
         gateway_auth_command: str | None = None,
         retry_policy: RetryPolicy | None = None,
         bundle_dir: pathlib.Path | None = None,
@@ -1633,6 +1700,9 @@ class PiExecutor(Executor):
             the Databricks profile credentials.
         :param base_urls_override: ucode-provided Pi gateway URLs keyed by
             model family, e.g. ``{"claude": "...", "openai": "..."}``.
+        :param openai_wire_api: Configured generic-provider OpenAI wire,
+            ``"responses"`` or ``"chat"``. Databricks ignores this and uses
+            live Unity Catalog metadata.
         :param gateway_auth_command: Shell command that prints a bearer token,
             e.g.
             ``"databricks auth token --host https://example.databricks.com ..."``
@@ -1673,6 +1743,10 @@ class PiExecutor(Executor):
         self._gateway_host_override = gateway_host.rstrip("/") if gateway_host else None
         self._base_url_override = base_url_override
         self._base_urls_override = base_urls_override
+        if openai_wire_api not in (None, RESPONSES_WIRE_API, CHAT_WIRE_API):
+            raise ValueError(f"unsupported Pi OpenAI wire API: {openai_wire_api!r}")
+        self._openai_wire_api = openai_wire_api
+        self._gateway_model_wire_apis: dict[str, frozenset[ModelWireAPI]] | None = None
         self._gateway_auth_command = gateway_auth_command
         # Retry policy → Pi's .pi/settings.json before subprocess spawn.
         # See ``RetryPolicy.pi.settings()`` for the schema. Pi natively
@@ -1755,6 +1829,9 @@ class PiExecutor(Executor):
         # generic-provider paths the producer resolves a concrete model.
         self._gateway_uses_databricks_profile = bool(
             gateway and self._gateway_host_override is None and base_url_override is None
+        )
+        self._gateway_workspace_url = (
+            self._gateway_model_service_workspace_url() if gateway else None
         )
 
         # Apply sandbox.
@@ -1883,6 +1960,66 @@ class PiExecutor(Executor):
             return resolution.model_id
         return model
 
+    def _generic_openai_wire_api(self) -> str | None:
+        """Return the configured wire only for a non-Databricks gateway."""
+        openai_base_url = (self._base_urls_override or {}).get("openai")
+        if openai_base_url:
+            from omnigent.pi_native_credentials import _is_databricks_ai_gateway_url
+
+            is_databricks_gateway = (
+                "/ai-gateway/" in openai_base_url or _is_databricks_ai_gateway_url(openai_base_url)
+            )
+            if not is_databricks_gateway:
+                return self._openai_wire_api or CHAT_WIRE_API
+        return None
+
+    def _gateway_model_service_workspace_url(self) -> str | None:
+        """Return the workspace API origin for Databricks catalog discovery."""
+        if self._gateway_uses_databricks_profile:
+            return self._databricks_host
+        from omnigent.pi_native_credentials import _databricks_workspace_url_for_gateway
+
+        candidates = [
+            *(self._base_urls_override or {}).values(),
+            self._base_url_override,
+            self._gateway_host_override,
+        ]
+        for candidate in candidates:
+            if not candidate:
+                continue
+            workspace_url = _databricks_workspace_url_for_gateway(
+                candidate,
+                profile=self._databricks_profile,
+            )
+            if workspace_url is not None:
+                return workspace_url
+        return None
+
+    async def _load_gateway_model_wire_apis(self) -> dict[str, frozenset[ModelWireAPI]]:
+        """Fetch Databricks model wire metadata once per executor."""
+        if self._gateway_model_wire_apis is not None:
+            return self._gateway_model_wire_apis
+        workspace_url = self._gateway_workspace_url if self._gateway else None
+        if workspace_url is None:
+            self._gateway_model_wire_apis = {}
+            return self._gateway_model_wire_apis
+        try:
+            models = await run_sync_on_thread(
+                model_catalog.fetch_databricks_model_service_entries,
+                workspace_url,
+                self._databricks_token,
+            )
+        except Exception:  # noqa: BLE001 — catalog outage uses conservative routing
+            logger.warning(
+                "Pi could not fetch Databricks model wire metadata; "
+                "unknown GPT models will use Responses",
+                exc_info=True,
+            )
+            self._gateway_model_wire_apis = {}
+            return self._gateway_model_wire_apis
+        self._gateway_model_wire_apis = _databricks_model_wire_catalog(models)
+        return self._gateway_model_wire_apis
+
     async def _ensure_tool_server(self, tools: list[ToolSpec]) -> int | None:
         """Start the TCP tool server if there are Omnigent tools to bridge."""
         if not tools:
@@ -1956,10 +2093,12 @@ class PiExecutor(Executor):
         if self._gateway:
             effective_model = model
             models_json = _build_models_json(
-                self._databricks_host,
+                self._gateway_workspace_url or self._databricks_host,
                 self._databricks_token,
                 self._base_urls_override,
                 model=effective_model,
+                model_wire_apis=self._gateway_model_wire_apis,
+                openai_wire_api=self._openai_wire_api,
             )
             models_path = os.path.join(tmp_dir, "models.json")
             with open(models_path, "w") as f:
@@ -2060,6 +2199,8 @@ class PiExecutor(Executor):
         ):
             return state.rpc
 
+        wire_catalog = await self._load_gateway_model_wire_apis()
+
         if state.rpc is not None:
             await state.rpc.close()
 
@@ -2079,7 +2220,11 @@ class PiExecutor(Executor):
         # the model from our custom provider in models.json.
         pi_model: str | None
         if self._gateway and effective_model:
-            provider = _pi_provider_for_model(effective_model)
+            provider = _pi_provider_for_model(
+                effective_model,
+                wire_catalog.get(effective_model.lower()),
+                generic_openai_wire_api=self._generic_openai_wire_api(),
+            )
             pi_model = f"{provider}/{effective_model}"
         else:
             pi_model = effective_model

--- a/omnigent/inner/pi_harness.py
+++ b/omnigent/inner/pi_harness.py
@@ -33,6 +33,8 @@ Env vars read at startup:
 - ``HARNESS_PI_GATEWAY_BASE_URLS``: JSON object of gateway base
   URLs keyed by model family, e.g.
   ``{"claude": "https://example.databricks.com/ai-gateway/anthropic"}``.
+- ``HARNESS_PI_GATEWAY_OPENAI_WIRE_API``: ``"responses"`` or ``"chat"``
+  for a configured generic OpenAI-compatible provider.
 - ``HARNESS_PI_CWD``: working directory the executor launches
   the Pi CLI in. ``None`` falls back to ``OMNIGENT_RUNNER_WORKSPACE`` if set,
   then to the subprocess's inherited cwd.
@@ -98,6 +100,7 @@ _ENV_BUNDLE_DIR = "HARNESS_PI_BUNDLE_DIR"
 _ENV_AGENT_NAME = "HARNESS_PI_AGENT_NAME"
 _ENV_GATEWAY_BASE_URL = "HARNESS_PI_GATEWAY_BASE_URL"
 _ENV_GATEWAY_BASE_URLS = "HARNESS_PI_GATEWAY_BASE_URLS"
+_ENV_GATEWAY_OPENAI_WIRE_API = "HARNESS_PI_GATEWAY_OPENAI_WIRE_API"
 _ENV_GATEWAY_AUTH_COMMAND = "HARNESS_PI_GATEWAY_AUTH_COMMAND"
 _ENV_GATEWAY_AUTH_REFRESH_INTERVAL_MS = "HARNESS_PI_GATEWAY_AUTH_REFRESH_INTERVAL_MS"
 
@@ -226,6 +229,7 @@ def _build_pi_executor() -> Executor:
         gateway_host=os.environ.get(_ENV_GATEWAY_HOST) or None,
         base_url_override=os.environ.get(_ENV_GATEWAY_BASE_URL) or None,
         base_urls_override=_resolve_gateway_base_urls(),
+        openai_wire_api=os.environ.get(_ENV_GATEWAY_OPENAI_WIRE_API) or None,
         gateway_auth_command=os.environ.get(_ENV_GATEWAY_AUTH_COMMAND) or None,
         bundle_dir=bundle_dir,
         agent_name=agent_name,

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -67,6 +67,7 @@ from omnigent.onboarding.provider_config import (
     SUBSCRIPTION_KIND,
     ProviderEntry,
 )
+from omnigent.pi_model_compatibility import unsupported_in_pi
 from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
 
 if TYPE_CHECKING:
@@ -1134,8 +1135,6 @@ def _fetch_databricks_uc_listing(
     :raises OSError: When the profile resolves no credentials.
     """
     creds = resolve_databricks_workspace(provider.profile)
-    from omnigent.pi_native_credentials import _unsupported_in_pi
-
     models = tuple(
         model
         for model in fetch_databricks_model_service_entries(
@@ -1143,7 +1142,7 @@ def _fetch_databricks_uc_listing(
             creds.token,
             transport=transport,
         )
-        if not _unsupported_in_pi(model.id.lower())
+        if not unsupported_in_pi(model.id.lower())
     )
     return ModelListing(
         source="gateway",

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -1134,10 +1134,50 @@ def _fetch_databricks_uc_listing(
     :raises OSError: When the profile resolves no credentials.
     """
     creds = resolve_databricks_workspace(provider.profile)
+    from omnigent.pi_native_credentials import _unsupported_in_pi
+
+    models = tuple(
+        model
+        for model in fetch_databricks_model_service_entries(
+            creds.host,
+            creds.token,
+            transport=transport,
+        )
+        if not _unsupported_in_pi(model.id.lower())
+    )
+    return ModelListing(
+        source="gateway",
+        verified=True,
+        models=models,
+        note=(
+            "LLM model services on the Databricks workspace "
+            f"(profile {provider.profile or 'DEFAULT'!r})"
+        ),
+    )
+
+
+def fetch_databricks_model_service_entries(
+    workspace_url: str,
+    token: str,
+    *,
+    transport: httpx.BaseTransport | None = None,
+) -> tuple[ModelEntry, ...]:
+    """Fetch normalized Unity Catalog model-service metadata.
+
+    This is the shared parser for worker model enumeration and Pi gateway
+    configuration. It reports provider wire surfaces without deciding which
+    one a harness should prefer.
+
+    :param workspace_url: Databricks workspace base URL.
+    :param token: Workspace bearer token.
+    :param transport: Optional httpx transport override for tests.
+    :returns: LLM model-service entries with normalized wire metadata.
+    :raises httpx.HTTPError: On transport or HTTP failures.
+    """
     with httpx.Client(transport=transport, timeout=_HTTP_TIMEOUT_S) as client:
         resp = client.get(
-            f"{creds.host}/api/2.1/unity-catalog/model-services",
-            headers={"Authorization": f"Bearer {creds.token}"},
+            f"{workspace_url.rstrip('/')}/api/2.1/unity-catalog/model-services",
+            headers={"Authorization": f"Bearer {token}"},
         )
         resp.raise_for_status()
         payload = resp.json()
@@ -1146,7 +1186,9 @@ def _fetch_databricks_uc_listing(
     for service in services if isinstance(services, list) else []:
         if not isinstance(service, dict):
             continue
-        raw_name = service.get("name", "")
+        raw_name = service.get("name")
+        if not isinstance(raw_name, str):
+            continue
         name = (
             raw_name.replace("model-services/", "")
             if raw_name.startswith("model-services/")
@@ -1154,18 +1196,12 @@ def _fetch_databricks_uc_listing(
         )
         if not name:
             continue
-        api_types = service.get("supported_api_types", [])
+        api_types = service.get("supported_api_types")
         normalized_api_types = {
-            api_type.lower() for api_type in api_types if isinstance(api_type, str)
+            api_type.lower()
+            for api_type in (api_types if isinstance(api_types, list) else [])
+            if isinstance(api_type, str)
         }
-        has_chat = any("chat" in api_type for api_type in normalized_api_types)
-        has_embed = any("embed" in api_type for api_type in normalized_api_types)
-        if not has_chat or has_embed:
-            continue
-        from omnigent.pi_native_credentials import _unsupported_in_pi
-
-        if _unsupported_in_pi(name.lower()):
-            continue
         wire_apis: set[ModelWireAPI] = set()
         if any("chat/completions" in api_type for api_type in normalized_api_types):
             wire_apis.add(ModelWireAPI.OPENAI_CHAT)
@@ -1175,6 +1211,8 @@ def _fetch_databricks_uc_listing(
             "anthropic" in api_type and "messages" in api_type for api_type in normalized_api_types
         ):
             wire_apis.add(ModelWireAPI.ANTHROPIC_MESSAGES)
+        if not wire_apis:
+            continue
         models.append(
             ModelEntry(
                 id=name,
@@ -1182,15 +1220,7 @@ def _fetch_databricks_uc_listing(
                 metadata=ModelMetadata(wire_apis=frozenset(wire_apis)),
             )
         )
-    return ModelListing(
-        source="gateway",
-        verified=True,
-        models=tuple(models),
-        note=(
-            "LLM model services on the Databricks workspace "
-            f"(profile {provider.profile or 'DEFAULT'!r})"
-        ),
-    )
+    return tuple(models)
 
 
 def _models_url(base_url: str) -> str:

--- a/omnigent/pi_model_compatibility.py
+++ b/omnigent/pi_model_compatibility.py
@@ -1,0 +1,16 @@
+"""Pi-specific model compatibility fallbacks absent from catalog metadata."""
+
+from __future__ import annotations
+
+# These system models omit the finish reason Pi requires on Chat Completions.
+# ``glm-`` avoids matching vendor-direct ids without a system.ai alias.
+SYSTEM_AI_RESPONSES_KEYWORDS: tuple[str, ...] = ("kimi", "inkling", "qwen3", "glm-")
+
+
+def unsupported_in_pi(model_id_lower: str) -> bool:
+    """Return whether Pi cannot parse the model's response content.
+
+    These endpoints return typed-array content that Pi renders as
+    ``[object Object]``; their available alternate wires do not fix it.
+    """
+    return "gemini-2-5" in model_id_lower or "gpt-oss" in model_id_lower

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shlex
+import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -42,6 +44,11 @@ from omnigent.onboarding.provider_config import (
     default_provider_for_harness,
     load_config,
 )
+from omnigent.pi_model_compatibility import (
+    SYSTEM_AI_RESPONSES_KEYWORDS,
+    unsupported_in_pi,
+)
+from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
 
 if TYPE_CHECKING:
     # Annotation-only import (the runtime import is lazy inside the function,
@@ -68,15 +75,6 @@ _PI_OPENAI_PROVIDER_ID = "omnigent-openai"
 # work via /chat/completions: Kimi, Llama, GLM, Gemini, older GPT models).
 _PI_COMPLETIONS_PROVIDER_ID = "omnigent-completions"
 _PI_MLFLOW_PROVIDER_ID = "omnigent-mlflow"
-
-# Keyword fragments that identify Databricks serving-endpoint models which
-# require the Responses API. These models don't send finish_reason via
-# /chat/completions but work correctly via /ai-gateway/codex/v1/responses
-# using their system.ai.* alias (derived by stripping "databricks-" prefix).
-# Use specific enough fragments to avoid false-positives (e.g. bare "glm" would
-# match "zai-org-glm-4-7" which has no system.ai.* alias; "glm-" avoids that).
-_SYSTEM_AI_MODEL_KEYWORDS: tuple[str, ...] = ("kimi", "inkling", "qwen3", "glm-")
-
 
 # Databricks AI Gateway Anthropic Messages surface. Pi speaks this protocol
 # natively (``api: anthropic-messages``); the gateway authenticates with a
@@ -170,8 +168,6 @@ def _databricks_workspace_url_for_gateway(
     if _DATABRICKS_AI_GATEWAY_LABEL not in hostname.lower().split("."):
         return f"https://{hostname}"
     try:
-        from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
-
         return resolve_databricks_workspace(profile).host
     except Exception:  # noqa: BLE001 — absent profile disables optional discovery
         return None
@@ -233,7 +229,7 @@ class PiProviderConfig:
             if (
                 not any(m.get("id") == self.model for m in models)
                 and not in_additional
-                and not _unsupported_in_pi(self.model.lower())
+                and not unsupported_in_pi(self.model.lower())
             ):
                 models.append({"id": self.model, "input": ["text", "image"]})
         else:
@@ -287,8 +283,6 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
     completions_models: list[dict[str, Any]] = []
     gemini_models: list[dict[str, Any]] = []
     try:
-        from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
-
         creds = resolve_databricks_workspace(entry.profile)
     except Exception:  # noqa: BLE001 — credential failure must not break launch
         _LOGGER.info(
@@ -398,9 +392,6 @@ def _run_auth_command(auth_command: str, *, timeout: float = 15.0) -> str | None
     :returns: Stripped stdout (the token), or ``None`` when the command
         fails, times out, or produces empty output.
     """
-    import shlex
-    import subprocess
-
     try:
         result = subprocess.run(
             shlex.split(auth_command),
@@ -413,21 +404,6 @@ def _run_auth_command(auth_command: str, *, timeout: float = 15.0) -> str | None
         return result.stdout.strip() or None
     except Exception:  # noqa: BLE001 — any subprocess failure should just return None
         return None
-
-
-def _unsupported_in_pi(model_id_lower: str) -> bool:
-    """Return True for models Pi can't handle at all.
-
-    - gemini-2-5: returns ``content`` as a typed array with ``thoughtSignature``
-      that Pi's completions handler mangles; Responses API returns 400 for it.
-    - gpt-oss: returns typed-array content that Pi's openai-completions handler
-      can't parse (same ``[object Object]`` issue as gemini-2-5).
-
-    Other Gemini variants route via /ai-gateway/mlflow/v1/chat/completions.
-
-    Expects a pre-lowercased model id.
-    """
-    return "gemini-2-5" in model_id_lower or "gpt-oss" in model_id_lower
 
 
 def _fetch_pi_model_lists(
@@ -481,11 +457,11 @@ def _fetch_pi_model_lists(
         if "deepseek" in name_lower:
             entry["reasoning"] = True
         needs_responses = ModelWireAPI.OPENAI_RESPONSES in model.metadata.wire_apis or any(
-            keyword in name_lower for keyword in _SYSTEM_AI_MODEL_KEYWORDS
+            keyword in name_lower for keyword in SYSTEM_AI_RESPONSES_KEYWORDS
         )
         if "claude" in name_lower:
             claude.append(entry)
-        elif _unsupported_in_pi(name_lower):
+        elif unsupported_in_pi(name_lower):
             pass  # exclude (e.g. gemini-2-5 thinking models)
         elif needs_responses:
             # Responses API: GPT models that need it + kimi/inkling/qwen3/glm keywords.
@@ -599,7 +575,6 @@ def _cli_config_databricks_transport(entry: ProviderEntry) -> CodexConfigTranspo
         # Try to build a !command using the SDK, same as the databricks-kind path.
         try:
             from omnigent.inner.codex_executor import _databricks_codex_auth_command
-            from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
 
             ws = resolve_databricks_workspace(None)
             auth_cmd = _databricks_codex_auth_command(ws.host, None)

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from omnigent import model_catalog
+from omnigent.model_metadata import ModelWireAPI
 from omnigent.model_override import normalize_model_for_provider
 from omnigent.onboarding.provider_config import (
     CHAT_WIRE_API,
@@ -143,6 +144,37 @@ def _is_databricks_ai_gateway_url(base_url: str) -> bool:
     # Shape 2: workspace hostname + /ai-gateway/ path prefix.
     path = parsed.path or ""
     return path.startswith("/ai-gateway/")
+
+
+def _databricks_workspace_url_for_gateway(
+    base_url: str,
+    *,
+    profile: str | None = None,
+) -> str | None:
+    """Resolve the workspace API origin behind a Databricks AI Gateway URL.
+
+    Workspace-hosted gateways already expose the workspace hostname. Dedicated
+    ``ai-gateway`` subdomains require the configured Databricks profile because
+    the gateway hostname itself does not serve workspace APIs.
+
+    :param base_url: Gateway protocol URL or origin.
+    :param profile: Optional Databricks profile for dedicated gateway hosts.
+    :returns: Workspace origin, or ``None`` for non-Databricks/unresolved URLs.
+    """
+    if not _is_databricks_ai_gateway_url(base_url):
+        return None
+    parsed = urlparse(base_url)
+    hostname = parsed.hostname
+    if hostname is None:
+        return None
+    if _DATABRICKS_AI_GATEWAY_LABEL not in hostname.lower().split("."):
+        return f"https://{hostname}"
+    try:
+        from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
+
+        return resolve_databricks_workspace(profile).host
+    except Exception:  # noqa: BLE001 — absent profile disables optional discovery
+        return None
 
 
 @dataclass(frozen=True)
@@ -383,44 +415,6 @@ def _run_auth_command(auth_command: str, *, timeout: float = 15.0) -> str | None
         return None
 
 
-# GPT model versions known to work fine with /chat/completions + function tools.
-# Any GPT model NOT in this set defaults to the Responses API (safer default for
-# newer models we haven't explicitly tested with completions).
-# These token fragments identify GPT models that work fine with
-# /chat/completions + function tools. Any GPT model whose id does NOT contain
-# one of these tokens defaults to the Responses API (safer for new models).
-# Use specific enough tokens so "gpt-5" doesn't match "gpt-5-5".
-_GPT_COMPLETIONS_COMPATIBLE: frozenset[str] = frozenset(
-    {
-        "gpt-5-4",  # gpt-5-4, gpt-5-4-mini, gpt-5-4-nano
-        "gpt-5-2",
-        "gpt-5-1",
-        "gpt-5-mini",
-        "gpt-5-nano",
-        "gpt-oss",
-    }
-)
-
-
-def _needs_responses_api(model_id_lower: str) -> bool:
-    """Return True when a GPT model requires the Responses API for tools.
-
-    Some GPT models reject function tool calls via ``/chat/completions`` with
-    400; they work via the AI Gateway Responses API instead. Rather than
-    maintaining a denylist of newer versions, we maintain an allowlist of models
-    known to work with completions. Any GPT model not in the allowlist defaults
-    to the Responses API — safer for new models we haven't tested.
-
-    Non-GPT models are handled separately (Kimi/inkling/Qwen3 routed via
-    system.ai.* Responses API; Gemini excluded via _unsupported_in_pi).
-
-    Expects a pre-lowercased model id.
-    """
-    if "gpt" not in model_id_lower:
-        return False
-    return not any(token in model_id_lower for token in _GPT_COMPLETIONS_COMPATIBLE)
-
-
 def _unsupported_in_pi(model_id_lower: str) -> bool:
     """Return True for models Pi can't handle at all.
 
@@ -463,16 +457,8 @@ def _fetch_pi_model_lists(
     :returns: ``(claude_models, gpt_responses_models, completions_models, gemini_models)`` —
         Pi model entry dicts ready to write into ``models.json``.
     """
-    import httpx
-
     try:
-        with httpx.Client(timeout=10.0) as client:
-            resp = client.get(
-                f"{workspace_url.rstrip('/')}/api/2.1/unity-catalog/model-services",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-            resp.raise_for_status()
-            payload = resp.json()
+        models = model_catalog.fetch_databricks_model_service_entries(workspace_url, token)
     except Exception:  # noqa: BLE001 — HTTP/network failure → empty
         _LOGGER.warning(
             "pi-native: could not fetch Databricks model list; "
@@ -481,42 +467,21 @@ def _fetch_pi_model_lists(
         )
         return [], [], [], []
 
-    services = payload.get("model_services") if isinstance(payload, dict) else None
     claude: list[dict[str, Any]] = []
     gpt_responses: list[dict[str, Any]] = []
     completions: list[dict[str, Any]] = []
     gemini: list[dict[str, Any]] = []
 
-    for service in services if isinstance(services, list) else []:
-        if not isinstance(service, dict):
-            continue
-        raw_name = service.get("name", "")
-        # Name format: "model-services/system.ai.<model>"
-        name = (
-            raw_name.replace("model-services/", "")
-            if raw_name.startswith("model-services/")
-            else raw_name
-        )
-        if not name:
-            continue
+    for model in models:
+        name = model.id
         name_lower = name.lower()
-        # Filter to chat-capable LLM endpoints (exclude embeddings/rerankers).
-        api_types = service.get("supported_api_types", [])
-        has_chat = any("chat" in t for t in api_types)
-        has_embedding = any("embed" in t.lower() for t in api_types)
-        if not has_chat or has_embedding:
-            continue
-        # Models that support the Responses API use it directly.
-        has_responses = "openai/v1/responses" in api_types
         entry: dict[str, Any] = {"id": name, "input": ["text", "image"]}
         # DeepSeek streams on reasoning_content; needs reasoning:true so Pi reads
         # from that channel. GLM/kimi/inkling now use Responses API, not needed.
         if "deepseek" in name_lower:
             entry["reasoning"] = True
-        needs_responses = (
-            has_responses
-            or _needs_responses_api(name_lower)
-            or any(kw in name_lower for kw in _SYSTEM_AI_MODEL_KEYWORDS)
+        needs_responses = ModelWireAPI.OPENAI_RESPONSES in model.metadata.wire_apis or any(
+            keyword in name_lower for keyword in _SYSTEM_AI_MODEL_KEYWORDS
         )
         if "claude" in name_lower:
             claude.append(entry)
@@ -716,28 +681,14 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
     gpt_models: list[dict[str, Any]] = []
     completions_models: list[dict[str, Any]] = []
     gemini_models: list[dict[str, Any]] = []
-    # Derive the workspace URL for the serving-endpoints API call.
-    # For dedicated-subdomain URLs (ai-gateway.cloud.databricks.com), the
-    # real workspace hostname must come from ~/.databrickscfg. For
-    # workspace-hosted gateway URLs (workspace.cloud.databricks.com/ai-gateway/),
-    # the transport's own hostname IS the workspace.
     parsed_gateway = urlparse(transport.base_url)
     gateway_labels = (parsed_gateway.hostname or "").split(".")
-    if _DATABRICKS_AI_GATEWAY_LABEL in gateway_labels:
-        # Dedicated subdomain: derive workspace from ~/.databrickscfg DEFAULT.
-        real_workspace_url: str | None = None
-        try:
-            from omnigent.runtime.credentials.databricks import resolve_databricks_workspace
-
-            real_workspace_url = resolve_databricks_workspace(None).host
-        except Exception:  # noqa: BLE001 — no .databrickscfg → skip listing
-            _LOGGER.info(
-                "pi-native: cli-config path could not resolve workspace URL "
-                "for model listing; Pi will show only the selected model"
-            )
-    else:
-        # Workspace-hosted gateway: the transport hostname is the workspace.
-        real_workspace_url = f"https://{parsed_gateway.hostname}"
+    real_workspace_url = _databricks_workspace_url_for_gateway(transport.base_url)
+    if real_workspace_url is None:
+        _LOGGER.info(
+            "pi-native: cli-config path could not resolve workspace URL "
+            "for model listing; Pi will show only the selected model"
+        )
     if real_workspace_url and transport.auth_command:
         token = _run_auth_command(transport.auth_command)
         if token:

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -870,6 +870,8 @@ def _apply_provider_to_pi(env: dict[str, str], entry: ProviderEntry) -> None:
     assert auth_source is not None  # base_urls non-empty ⇒ one family resolved
     env[_HARNESS_GATEWAY_FLAG["pi"]] = "true"
     env["HARNESS_PI_GATEWAY_BASE_URLS"] = json.dumps(base_urls, sort_keys=True)
+    if openai is not None and openai.wire_api is not None:
+        env["HARNESS_PI_GATEWAY_OPENAI_WIRE_API"] = openai.wire_api
     env["HARNESS_PI_GATEWAY_HOST"] = _origin_of(next(iter(base_urls.values())))
     env["HARNESS_PI_GATEWAY_AUTH_COMMAND"] = _provider_auth_command(auth_source)
     # Model precedence: spec model > provider ``models.default`` > catalog

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -3063,7 +3063,7 @@ def test_dedicated_gateway_fetches_wire_catalog_from_workspace_host() -> None:
             return_value="gateway-token",
         ),
         patch(
-            "omnigent.runtime.credentials.databricks.resolve_databricks_workspace",
+            "omnigent.pi_native_credentials.resolve_databricks_workspace",
             return_value=SimpleNamespace(host="https://workspace.cloud.databricks.com"),
         ),
         patch(

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -30,6 +30,7 @@ from omnigent.inner.executor import (
 from omnigent.inner.pi_executor import (
     PiExecutor,
     _build_models_json,
+    _databricks_model_wire_catalog,
     _generate_extension_js,
     _pi_provider_for_model,
     _PiRpcSession,
@@ -39,6 +40,8 @@ from omnigent.inner.pi_executor import (
     _split_pi_prompt,
     _ToolServer,
 )
+from omnigent.model_catalog import ModelEntry
+from omnigent.model_metadata import ModelMetadata, ModelWireAPI
 from omnigent.runtime.harnesses._scaffold import PolicyVerdictPayload
 
 
@@ -341,7 +344,41 @@ def test_sanitize_real_sys_session_send_args_collapses_to_object() -> None:
 
 class TestPiProviderForModel(unittest.TestCase):
     def test_gpt_model(self):
-        self.assertEqual(_pi_provider_for_model("databricks-gpt-5-4-mini"), "databricks")
+        self.assertEqual(_pi_provider_for_model("databricks-gpt-5-4-mini"), "databricks-openai")
+
+    def test_catalog_chat_only_gpt_model(self):
+        self.assertEqual(
+            _pi_provider_for_model(
+                "databricks-gpt-next",
+                frozenset({ModelWireAPI.OPENAI_CHAT}),
+            ),
+            "databricks",
+        )
+
+    def test_catalog_responses_gpt_model(self):
+        self.assertEqual(
+            _pi_provider_for_model(
+                "databricks-gpt-next",
+                frozenset({ModelWireAPI.OPENAI_RESPONSES}),
+            ),
+            "databricks-openai",
+        )
+
+    def test_generic_provider_uses_configured_wire(self):
+        self.assertEqual(
+            _pi_provider_for_model(
+                "gpt-next",
+                generic_openai_wire_api="chat",
+            ),
+            "databricks-completions",
+        )
+        self.assertEqual(
+            _pi_provider_for_model(
+                "gpt-next",
+                generic_openai_wire_api="responses",
+            ),
+            "databricks-openai",
+        )
 
     def test_claude_model(self):
         self.assertEqual(
@@ -547,6 +584,44 @@ class TestBuildModelsJson(unittest.TestCase):
         p = result["providers"]
         self.assertEqual(p["databricks"]["baseUrl"], "https://openrouter.ai/api/v1")
         self.assertEqual(p["databricks-completions"]["baseUrl"], "https://openrouter.ai/api/v1")
+
+    def test_generic_openai_model_uses_configured_responses_wire(self):
+        result = _build_models_json(
+            "https://unused.example.com",
+            "tok",
+            {"openai": "https://gateway.example.com/v1"},
+            model="vendor/model-next",
+            openai_wire_api="responses",
+        )
+
+        responses = result["providers"]["databricks-openai"]
+        self.assertEqual(responses["baseUrl"], "https://gateway.example.com/v1")
+        self.assertIn("vendor/model-next", [entry["id"] for entry in responses["models"]])
+
+    def test_dedicated_gateway_uses_catalog_wire_and_workspace_chat_url(self):
+        result = _build_models_json(
+            "https://workspace.cloud.databricks.com",
+            "tok",
+            {
+                "openai": "https://123.ai-gateway.cloud.databricks.com/codex/v1",
+            },
+            model="databricks-gpt-next",
+            model_wire_apis={
+                "databricks-gpt-next": frozenset({ModelWireAPI.OPENAI_CHAT}),
+            },
+            openai_wire_api="responses",
+        )
+
+        chat = result["providers"]["databricks"]
+        self.assertEqual(
+            chat["baseUrl"],
+            "https://workspace.cloud.databricks.com/serving-endpoints",
+        )
+        self.assertIn("databricks-gpt-next", [entry["id"] for entry in chat["models"]])
+        self.assertEqual(
+            result["providers"]["databricks-openai"]["baseUrl"],
+            "https://123.ai-gateway.cloud.databricks.com/codex/v1",
+        )
 
     def test_api_key_set(self):
         result = _build_models_json("https://host.example.com", "mytoken")
@@ -2929,6 +3004,108 @@ def test_profile_gateway_default_does_not_clobber_explicit_model() -> None:
     assert _run(executor._resolve_model(ExecutorConfig(model=None))) == "databricks-gpt-5-4"
 
 
+def test_gateway_wire_catalog_fetches_once_and_indexes_aliases() -> None:
+    """The inner Pi executor reuses UC metadata for endpoint-style model ids."""
+    responses = frozenset({ModelWireAPI.OPENAI_RESPONSES})
+    entries = (
+        ModelEntry(
+            id="system.ai.gpt-next",
+            family="openai",
+            metadata=ModelMetadata(wire_apis=responses),
+        ),
+    )
+    with (
+        patch("omnigent.inner.pi_executor._find_pi_cli", return_value="/usr/bin/pi"),
+        patch(
+            "omnigent.inner.pi_executor._read_databrickscfg",
+            return_value=DatabricksCredentials(host="https://h.example.com", token="tok"),
+        ),
+        patch(
+            "omnigent.model_catalog.fetch_databricks_model_service_entries",
+            return_value=entries,
+        ) as fetch,
+    ):
+        executor = PiExecutor(gateway=True)
+        first = _run(executor._load_gateway_model_wire_apis())
+        second = _run(executor._load_gateway_model_wire_apis())
+
+    assert first["databricks-gpt-next"] == responses
+    assert second is first
+    fetch.assert_called_once_with("https://h.example.com", "tok")
+
+
+def test_gateway_wire_catalog_failure_is_cached() -> None:
+    """A catalog outage does not delay every later Pi subprocess startup."""
+    with (
+        patch("omnigent.inner.pi_executor._find_pi_cli", return_value="/usr/bin/pi"),
+        patch(
+            "omnigent.inner.pi_executor._read_databrickscfg",
+            return_value=DatabricksCredentials(host="https://h.example.com", token="tok"),
+        ),
+        patch(
+            "omnigent.model_catalog.fetch_databricks_model_service_entries",
+            side_effect=OSError("offline"),
+        ) as fetch,
+    ):
+        executor = PiExecutor(gateway=True)
+        assert _run(executor._load_gateway_model_wire_apis()) == {}
+        assert _run(executor._load_gateway_model_wire_apis()) == {}
+
+    fetch.assert_called_once_with("https://h.example.com", "tok")
+
+
+def test_dedicated_gateway_fetches_wire_catalog_from_workspace_host() -> None:
+    """Dedicated gateway hosts resolve their workspace before UC discovery."""
+    with (
+        patch("omnigent.inner.pi_executor._find_pi_cli", return_value="/usr/bin/pi"),
+        patch(
+            "omnigent.inner.pi_executor._fetch_shell_command_token",
+            return_value="gateway-token",
+        ),
+        patch(
+            "omnigent.runtime.credentials.databricks.resolve_databricks_workspace",
+            return_value=SimpleNamespace(host="https://workspace.cloud.databricks.com"),
+        ),
+        patch(
+            "omnigent.model_catalog.fetch_databricks_model_service_entries",
+            return_value=(),
+        ) as fetch,
+    ):
+        executor = PiExecutor(
+            gateway=True,
+            gateway_host="https://123.ai-gateway.cloud.databricks.com",
+            base_urls_override={"claude": "https://123.ai-gateway.cloud.databricks.com/anthropic"},
+            gateway_auth_command="printf token",
+        )
+        _run(executor._load_gateway_model_wire_apis())
+
+    fetch.assert_called_once_with(
+        "https://workspace.cloud.databricks.com",
+        "gateway-token",
+    )
+
+
+def test_generic_anthropic_gateway_skips_databricks_wire_catalog() -> None:
+    """A generic provider must not receive Databricks workspace API requests."""
+    with (
+        patch("omnigent.inner.pi_executor._find_pi_cli", return_value="/usr/bin/pi"),
+        patch(
+            "omnigent.inner.pi_executor._fetch_shell_command_token",
+            return_value="provider-key",
+        ),
+        patch("omnigent.model_catalog.fetch_databricks_model_service_entries") as fetch,
+    ):
+        executor = PiExecutor(
+            gateway=True,
+            gateway_host="https://anthropic.example.com",
+            base_urls_override={"claude": "https://anthropic.example.com/v1"},
+            gateway_auth_command="printf token",
+        )
+        assert _run(executor._load_gateway_model_wire_apis()) == {}
+
+    fetch.assert_not_called()
+
+
 def test_ucode_gateway_host_path_does_not_inject_default_model() -> None:
     """
     On the ucode-cached gateway path (gateway host + auth command supplied
@@ -2977,7 +3154,17 @@ def test_models_json_lists_only_gateway_verified_models() -> None:
     Anthropic passthrough, the llama endpoint 404s) fails at request time
     for anyone who selects it.
     """
-    models = _build_models_json("https://host.example.com", "tok")
+    wire_catalog = {
+        "databricks-gpt-5-4-mini": frozenset({ModelWireAPI.OPENAI_CHAT}),
+        "databricks-gpt-5-4": frozenset({ModelWireAPI.OPENAI_CHAT}),
+        "databricks-gpt-5-5": frozenset({ModelWireAPI.OPENAI_RESPONSES}),
+        "databricks-gpt-5-5-pro": frozenset({ModelWireAPI.OPENAI_RESPONSES}),
+    }
+    models = _build_models_json(
+        "https://host.example.com",
+        "tok",
+        model_wire_apis=wire_catalog,
+    )
     providers = models["providers"]
     anthropic_ids = [m["id"] for m in providers["databricks-anthropic"]["models"]]
     assert anthropic_ids == [
@@ -3000,6 +3187,36 @@ def test_models_json_lists_only_gateway_verified_models() -> None:
     # The llama serving endpoint no longer exists; the provider stays as
     # the routing home for future non-Claude/GPT endpoints.
     assert providers["databricks-completions"]["models"] == []
+
+
+def test_models_json_unknown_gpt_metadata_fails_toward_responses() -> None:
+    """An offline catalog never sends a newly released GPT to Chat by guess."""
+    models = _build_models_json("https://host.example.com", "tok")
+
+    assert models["providers"]["databricks"]["models"] == []
+    assert [model["id"] for model in models["providers"]["databricks-openai"]["models"]] == [
+        "databricks-gpt-5-4-mini",
+        "databricks-gpt-5-4",
+        "databricks-gpt-5-5",
+        "databricks-gpt-5-5-pro",
+    ]
+
+
+def test_databricks_wire_catalog_indexes_system_and_endpoint_aliases() -> None:
+    """UC system ids supply wire metadata for serving-endpoint aliases."""
+    wire_apis = frozenset({ModelWireAPI.OPENAI_RESPONSES})
+    catalog = _databricks_model_wire_catalog(
+        [
+            ModelEntry(
+                id="system.ai.gpt-next",
+                family="openai",
+                metadata=ModelMetadata(wire_apis=wire_apis),
+            )
+        ]
+    )
+
+    assert catalog["system.ai.gpt-next"] == wire_apis
+    assert catalog["databricks-gpt-next"] == wire_apis
 
 
 def test_models_json_uses_oss_verified_gpt_55_caps() -> None:

--- a/tests/inner/test_pi_harness.py
+++ b/tests/inner/test_pi_harness.py
@@ -80,6 +80,7 @@ def test_executor_factory_reads_env_vars(
             }
         ),
     )
+    monkeypatch.setenv("HARNESS_PI_GATEWAY_OPENAI_WIRE_API", "responses")
     monkeypatch.setenv("HARNESS_PI_GATEWAY_AUTH_COMMAND", "printf token")
     monkeypatch.setenv("HARNESS_PI_CWD", "/tmp/test-cwd")
     monkeypatch.setenv("HARNESS_PI_PATH", "/usr/local/bin/pi")
@@ -99,6 +100,7 @@ def test_executor_factory_reads_env_vars(
         gateway_host: str | None,
         base_url_override: str | None,
         base_urls_override: dict[str, str] | None,
+        openai_wire_api: str | None,
         gateway_auth_command: str | None,
         **_kwargs: Any,
     ) -> None:
@@ -111,6 +113,7 @@ def test_executor_factory_reads_env_vars(
         captured["gateway_host"] = gateway_host
         captured["base_url_override"] = base_url_override
         captured["base_urls_override"] = base_urls_override
+        captured["openai_wire_api"] = openai_wire_api
         captured["gateway_auth_command"] = gateway_auth_command
 
     with patch(
@@ -130,6 +133,7 @@ def test_executor_factory_reads_env_vars(
         "claude": "https://example.databricks.com/ai-gateway/anthropic",
         "openai": "https://example.databricks.com/ai-gateway/codex/v1",
     }
+    assert captured["openai_wire_api"] == "responses"
     assert captured["gateway_auth_command"] == "printf token"
     assert captured["cwd"] == "/tmp/test-cwd"
     assert captured["pi_path"] == "/usr/local/bin/pi"

--- a/tests/runtime/test_provider_spawn_env.py
+++ b/tests/runtime/test_provider_spawn_env.py
@@ -148,7 +148,13 @@ def _make_spec(
     )
 
 
-def _key_family(base_url: str, api_key: str, default_model: str) -> dict[str, object]:
+def _key_family(
+    base_url: str,
+    api_key: str,
+    default_model: str,
+    *,
+    wire_api: str | None = None,
+) -> dict[str, object]:
     """
     Build a single provider-family config block (inline static key).
 
@@ -158,11 +164,14 @@ def _key_family(base_url: str, api_key: str, default_model: str) -> dict[str, ob
     :param default_model: The family's ``models.default``, e.g. ``"gpt-4o"``.
     :returns: A family mapping ready to nest under a provider entry.
     """
-    return {
+    family: dict[str, object] = {
         "base_url": base_url,
         "api_key": api_key,
         "models": {"default": default_model},
     }
+    if wire_api is not None:
+        family["wire_api"] = wire_api
+    return family
 
 
 def _anthropic_default_config() -> dict[str, object]:
@@ -492,6 +501,23 @@ def test_pi_uses_anthropic_global_default(config_home: Path) -> None:
     assert env["HARNESS_PI_GATEWAY_HOST"] == "https://anthropic.example.com"
     assert env["HARNESS_PI_GATEWAY_AUTH_COMMAND"] == "printf %s sk-ant-secret"
     assert env["HARNESS_PI_MODEL"] == "claude-default-model"
+
+
+def test_pi_threads_generic_openai_wire_api(config_home: Path) -> None:
+    """Pi routes a generic OpenAI provider using configured wire metadata."""
+    config = _openai_default_config()
+    provider = config["providers"]["vendor-openai"]
+    provider["openai"] = _key_family(
+        "https://openai.example.com/v1",
+        "sk-oai-secret",
+        "gpt-default-model",
+        wire_api="responses",
+    )
+    _write_config(config_home, config)
+
+    env = _build_pi_spawn_env(_make_spec(harness="pi"), workdir=None)
+
+    assert env["HARNESS_PI_GATEWAY_OPENAI_WIRE_API"] == "responses"
 
 
 # ── Named ProviderAuth selection ───────────────────────────────────────────

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -497,10 +497,11 @@ def _databricks_transport(
 
     _UC_PAGE = {
         "model_services": [
-            _uc_service("system.ai.claude-sonnet-4-6", ["mlflow/v1/chat/completions"]),
+            _uc_service("system.ai.claude-sonnet-4-6", ["anthropic/v1/messages"]),
             _uc_service(
                 "system.ai.gpt-5-4", ["mlflow/v1/chat/completions", "openai/v1/responses"]
             ),
+            _uc_service("system.ai.gpt-responses-only", ["openai/v1/responses"]),
             _uc_service("system.ai.meta-llama-3-3-70b-instruct", ["mlflow/v1/chat/completions"]),
             _uc_service("system.ai.qwen3-embedding", ["mlflow/v1/embeddings"]),
         ]
@@ -530,10 +531,10 @@ def _stub_workspace_creds(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-def test_databricks_listing_filters_to_chat_llms(
+def test_databricks_listing_filters_to_llm_wire_surfaces(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """The gateway listing keeps chat LLM endpoints and tags families.
+    """The gateway listing keeps supported LLM wires and tags families.
 
     The embeddings endpoint must be excluded — including it would let an
     orchestrator dispatch a worker onto a non-chat endpoint.
@@ -558,16 +559,20 @@ def test_databricks_listing_filters_to_chat_llms(
     assert set(by_id) == {
         "system.ai.claude-sonnet-4-6",
         "system.ai.gpt-5-4",
+        "system.ai.gpt-responses-only",
         "system.ai.meta-llama-3-3-70b-instruct",
     }
     assert by_id["system.ai.claude-sonnet-4-6"].family == "claude"
     assert by_id["system.ai.gpt-5-4"].family == "openai"
     assert by_id["system.ai.meta-llama-3-3-70b-instruct"].family == "other"
     assert by_id["system.ai.claude-sonnet-4-6"].metadata.wire_apis == frozenset(
-        {ModelWireAPI.OPENAI_CHAT}
+        {ModelWireAPI.ANTHROPIC_MESSAGES}
     )
     assert by_id["system.ai.gpt-5-4"].metadata.wire_apis == frozenset(
         {ModelWireAPI.OPENAI_CHAT, ModelWireAPI.OPENAI_RESPONSES}
+    )
+    assert by_id["system.ai.gpt-responses-only"].metadata.wire_apis == frozenset(
+        {ModelWireAPI.OPENAI_RESPONSES}
     )
 
 
@@ -633,6 +638,7 @@ def test_databricks_listing_skips_explicitly_non_ready_endpoints(
             {
                 "system.ai.claude-sonnet-4-6",
                 "system.ai.gpt-5-4",
+                "system.ai.gpt-responses-only",
                 "system.ai.meta-llama-3-3-70b-instruct",
             },
             id="pi-everything",

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -78,7 +78,6 @@ def test_databricks_unresolvable_credentials_sets_warning(
     session is worse than a visible notice — so the resolver flags it.
     """
     from omnigent.inner import databricks_executor
-    from omnigent.runtime.credentials import databricks as rt_databricks
 
     monkeypatch.setattr(
         databricks_executor,
@@ -89,7 +88,7 @@ def test_databricks_unresolvable_credentials_sets_warning(
     def _boom(profile: str | None):
         raise OSError("refresh token is invalid")
 
-    monkeypatch.setattr(rt_databricks, "resolve_databricks_workspace", _boom)
+    monkeypatch.setattr(creds, "resolve_databricks_workspace", _boom)
 
     provider = creds.resolve_pi_native_provider(config_loader=_databricks_config)
 
@@ -112,7 +111,7 @@ def test_databricks_model_list_failure_has_no_warning(
         lambda profile: "https://wkspc.example.com/",
     )
     monkeypatch.setattr(
-        rt_databricks,
+        creds,
         "resolve_databricks_workspace",
         lambda profile: rt_databricks.WorkspaceCreds(
             host="https://wkspc.example.com", token="tok"
@@ -732,7 +731,7 @@ def test_workspace_url_for_dedicated_gateway_uses_profile(
             token="unused",
         )
 
-    monkeypatch.setattr(db_creds_mod, "resolve_databricks_workspace", resolve)
+    monkeypatch.setattr(creds, "resolve_databricks_workspace", resolve)
 
     assert (
         creds._databricks_workspace_url_for_gateway(
@@ -942,7 +941,7 @@ def test_databricks_profile_registers_gpt_provider(monkeypatch: pytest.MonkeyPat
     from omnigent.runtime.credentials import databricks as db_creds_mod
 
     monkeypatch.setattr(
-        db_creds_mod,
+        creds,
         "resolve_databricks_workspace",
         lambda profile: db_creds_mod.WorkspaceCreds(host="https://wkspc.example.com", token="tok"),
     )
@@ -992,7 +991,7 @@ def test_cli_config_databricks_registers_gpt_provider(
     from omnigent.runtime.credentials import databricks as db_creds_mod
 
     monkeypatch.setattr(
-        db_creds_mod,
+        creds,
         "resolve_databricks_workspace",
         lambda profile: db_creds_mod.WorkspaceCreds(
             host="https://dbc-a5d4177a-49dc.cloud.databricks.com", token="sdk-tok"

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -719,6 +719,35 @@ def test_is_databricks_ai_gateway_url_rejects_lookalikes(gateway_url: str) -> No
     assert creds._is_databricks_ai_gateway_url(gateway_url) is False
 
 
+def test_workspace_url_for_dedicated_gateway_uses_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dedicated AI Gateway origin is not itself a workspace API host."""
+    from omnigent.runtime.credentials import databricks as db_creds_mod
+
+    def resolve(profile: str | None) -> db_creds_mod.WorkspaceCreds:
+        assert profile == "prod"
+        return db_creds_mod.WorkspaceCreds(
+            host="https://workspace.cloud.databricks.com",
+            token="unused",
+        )
+
+    monkeypatch.setattr(db_creds_mod, "resolve_databricks_workspace", resolve)
+
+    assert (
+        creds._databricks_workspace_url_for_gateway(
+            "https://123.ai-gateway.cloud.databricks.com/anthropic",
+            profile="prod",
+        )
+        == "https://workspace.cloud.databricks.com"
+    )
+
+
+def test_workspace_url_for_generic_provider_is_none() -> None:
+    """Generic compatible providers are not probed through Databricks APIs."""
+    assert creds._databricks_workspace_url_for_gateway("https://api.anthropic.com/v1") is None
+
+
 def test_anthropic_family_ignores_wire_api() -> None:
     """The Anthropic family always uses anthropic-messages, ignoring wire_api.
 
@@ -1022,6 +1051,8 @@ def test_fetch_pi_model_lists_parses_serving_endpoints() -> None:
             _make_service(
                 "system.ai.gpt-5-4", ["mlflow/v1/chat/completions", "openai/v1/responses"]
             ),
+            # Future GPT metadata, deliberately Chat-only.
+            _make_service("system.ai.gpt-chat-only", ["mlflow/v1/chat/completions"]),
             # Llama - chat only
             _make_service("system.ai.llama-4-maverick", ["mlflow/v1/chat/completions"]),
             # Kimi - chat only (no Responses API per UC metadata)
@@ -1061,6 +1092,7 @@ def test_fetch_pi_model_lists_parses_serving_endpoints() -> None:
     # Llama routes to mlflow gateway (system.ai.* ids 404 at serving-endpoints).
     mlflow_ids = [m["id"] for m in _gemini]
     assert "system.ai.llama-4-maverick" in mlflow_ids
+    assert "system.ai.gpt-chat-only" in mlflow_ids
     completions_ids = [m["id"] for m in completions]
     assert not completions_ids  # no completions-only models in this test payload
     # Embedding excluded


### PR DESCRIPTION
## Related issue

Part of #3426

## Summary

- Replace Pi's release-specific GPT Chat Completions allowlist with normalized Unity Catalog `ModelWireAPI` metadata shared by native and inner Pi execution.
- Thread configured generic-provider wire metadata through the harness; unknown Databricks GPTs conservatively use Responses when discovery is unavailable.
- Resolve dedicated AI Gateway hosts back to their workspace API origin and skip Databricks discovery entirely for generic providers.

**ELI5:** Pi now asks the workspace which API a model supports instead of guessing from the model's release name.

```text
Unity Catalog model services ──> ModelWireAPI ──> Pi Chat / Responses provider
configured generic wire ────────────────────────> Pi Chat / Responses provider
catalog unavailable + unknown GPT ──────────────> Responses fallback
```

## Test Plan

- `uv run --no-sync pytest -q tests/inner/test_pi_harness.py tests/inner/test_pi_executor.py tests/test_model_catalog.py tests/test_pi_native_credentials.py tests/runtime/test_provider_spawn_env.py::test_pi_threads_generic_openai_wire_api` (276 passed)
- Isolated `tests/runtime/test_pi_spawn_env.py` with a clean `HOME` / config (5 passed)
- `pre-commit run --all-files`
- Queried the production Unity Catalog model-services endpoint and verified GPT Responses, Claude Messages, and Chat-only metadata normalization.

## Demo

N/A — backend model routing only.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified the production Unity Catalog payload and confirmed dedicated AI Gateway discovery uses the real workspace API host without sending Databricks discovery requests to generic providers.

## Changelog

Pi now routes Databricks models through the API advertised by the live model catalog instead of a release-specific model allowlist.
