### PR TITLE
refactor(electron): simplify fallback window lookup

### DIFF
--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -616,8 +616,7 @@ function broadcastHostStatus() {
 function activeWindow() {
   const focused = BrowserWindow.getFocusedWindow();
   if (focused && windows.has(focused)) return focused;
-  for (const win of windows.keys()) return win;
-  return null;
+  return windows.keys().next().value ?? null;
 }
 
 // Desktop auto-update orchestration lives in its own module; the main process


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Replace the single-iteration fallback loop in `activeWindow()` with a direct first-key lookup.
- Preserve the priority order: focused managed window, otherwise first managed window, otherwise `null`.
- Clear the final `no-unreachable-loop` diagnostic.

## Test Plan

- `pnpm --filter web exec oxlint -A all -D no-unreachable-loop electron/src/main.js`
- `cd web/electron && node --test`
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `pnpm --filter web run test:coverage`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A — internal Electron control-flow cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The full Electron suite passes 221 tests, and the full web suite passes 4,781 tests.

## Changelog

N/A — internal code-quality cleanup only.