### PR TITLE
refactor(web): remove redundant JSX fragments

### DIFF
--- a/web/src/components/AgentHoverCard.tsx
+++ b/web/src/components/AgentHoverCard.tsx
@@ -52,7 +52,7 @@ export function AgentHoverCard({
   agent: AvailableAgent;
   children: React.ReactNode;
 }) {
-  if (!agent.description) return <>{children}</>;
+  if (!agent.description) return children;
 
   return (
     // openDelay matches the screenshot's feel — a brief pause before the
@@ -101,7 +101,7 @@ export function AgentRowTooltip({
   agent: AvailableAgent;
   children: React.ReactNode;
 }) {
-  if (!agent.description) return <>{children}</>;
+  if (!agent.description) return children;
 
   return (
     <Tooltip>

--- a/web/src/components/blocks/BlockRenderer.tsx
+++ b/web/src/components/blocks/BlockRenderer.tsx
@@ -363,7 +363,7 @@ export function BlockRenderer({ items, sessionStatus, canApprove = true }: Block
     previousRenderedItemWasText = item.kind === "text";
   }
 
-  return <>{rendered}</>;
+  return rendered;
 }
 
 /**

--- a/web/src/hooks/QueueFlushProvider.tsx
+++ b/web/src/hooks/QueueFlushProvider.tsx
@@ -44,5 +44,5 @@ export function QueueFlushProvider({ children }: { children: ReactNode }) {
     return unsubscribe;
   }, [queryClient, flushBackgroundQueues]);
 
-  return <>{children}</>;
+  return children;
 }

--- a/web/src/hooks/SessionUpdatesProvider.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.tsx
@@ -331,5 +331,5 @@ export function SessionUpdatesProvider({ children }: { children: ReactNode }) {
     };
   }, [queryClient, pushWatched]);
 
-  return <>{children}</>;
+  return children;
 }

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -103,7 +103,7 @@ vi.mock("@/hooks/useConversations", async () => {
 // so the stub lifts it from the trigger child onto the native <select>.
 vi.mock("@/components/ui/select", async () => {
   const { Children, isValidElement } = await import("react");
-  const SelectTrigger = ({ children }: { children?: ReactNode }) => <>{children}</>;
+  const SelectTrigger = ({ children }: { children?: ReactNode }) => children;
   const Select = ({
     value,
     onValueChange,
@@ -133,7 +133,7 @@ vi.mock("@/components/ui/select", async () => {
     Select,
     SelectTrigger,
     SelectValue: () => null,
-    SelectContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+    SelectContent: ({ children }: { children: ReactNode }) => children,
     SelectItem: ({ value, children }: { value: string; children: ReactNode }) => (
       <option value={value}>{children}</option>
     ),

--- a/web/src/shell/FileViewer.test.tsx
+++ b/web/src/shell/FileViewer.test.tsx
@@ -129,7 +129,7 @@ vi.mock("@/hooks/useResizablePanel", () => ({
 }));
 
 vi.mock("@/hooks/CommentSenderContext", () => ({
-  CommentSenderProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  CommentSenderProvider: ({ children }: { children: React.ReactNode }) => children,
   useOptionalCommentSender: vi.fn(() => null),
 }));
 

--- a/web/src/shell/ResumeWithDirectoryDialog.test.tsx
+++ b/web/src/shell/ResumeWithDirectoryDialog.test.tsx
@@ -54,9 +54,9 @@ vi.mock("@/components/ui/select", () => ({
       {children}
     </select>
   ),
-  SelectTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SelectTrigger: ({ children }: { children: ReactNode }) => children,
   SelectValue: () => null,
-  SelectContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SelectContent: ({ children }: { children: ReactNode }) => children,
   SelectItem: ({ value, children }: { value: string; children: ReactNode }) => (
     <option value={value}>{children}</option>
   ),

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -801,35 +801,33 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
                 onExit={exitSelectionMode}
               />
             ) : (
-              <>
-                <Button
-                  asChild
-                  variant="ghost"
-                  className={cn(
-                    "sidebar-compact-text h-7 w-full justify-start gap-2 rounded-[var(--radius-otto-button)] border-0 px-2 font-normal",
-                    SIDEBAR_HOVER_HIGHLIGHT,
-                    isInboxPage && SIDEBAR_ACTIVE_HIGHLIGHT,
+              <Button
+                asChild
+                variant="ghost"
+                className={cn(
+                  "sidebar-compact-text h-7 w-full justify-start gap-2 rounded-[var(--radius-otto-button)] border-0 px-2 font-normal",
+                  SIDEBAR_HOVER_HIGHLIGHT,
+                  isInboxPage && SIDEBAR_ACTIVE_HIGHLIGHT,
+                )}
+                data-testid="inbox-button"
+              >
+                <Link to="/inbox" onClick={onNavClick}>
+                  <InboxIcon className="size-3.5 text-muted-foreground" />
+                  Inbox
+                  {inboxCount > 0 && (
+                    <span
+                      aria-label={
+                        inboxCount === 1
+                          ? "1 inbox item waiting"
+                          : `${inboxCount} inbox items waiting`
+                      }
+                      className="ml-auto inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-warning/15 px-1 text-10 font-medium text-warning tabular-nums"
+                    >
+                      {inboxCount}
+                    </span>
                   )}
-                  data-testid="inbox-button"
-                >
-                  <Link to="/inbox" onClick={onNavClick}>
-                    <InboxIcon className="size-3.5 text-muted-foreground" />
-                    Inbox
-                    {inboxCount > 0 && (
-                      <span
-                        aria-label={
-                          inboxCount === 1
-                            ? "1 inbox item waiting"
-                            : `${inboxCount} inbox items waiting`
-                        }
-                        className="ml-auto inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-warning/15 px-1 text-10 font-medium text-warning tabular-nums"
-                      >
-                        {inboxCount}
-                      </span>
-                    )}
-                  </Link>
-                </Button>
-              </>
+                </Link>
+              </Button>
             )}
           </div>
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Remove 11 single-child JSX fragments from providers, component fallbacks, and test stubs.
- Return the existing child or rendered array directly, preserving the rendered tree.
- Clear the complete `react/jsx-no-useless-fragment` diagnostic set.

**ELI5:** Each fragment was an empty wrapper around one thing. Removing the wrapper leaves the same thing on screen.

## Test Plan

- `pnpm --filter web exec oxlint -A all -D react/jsx-no-useless-fragment .`
- 225 focused component and provider tests
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `pnpm --filter web run test:coverage`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A — internal JSX cleanup with no visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused suite passes 225 tests, the full web suite passes 4,781 tests, and the dedicated lint rule has zero diagnostics.

## Changelog

N/A — internal code-quality cleanup only.