### PR TITLE
Add force override for chat imports

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4824,11 +4824,17 @@ def resume(
         "local server, or a newly started local server."
     ),
 )
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Replace a previously imported chat from the same harness session.",
+)
 def import_session_command(
     harness: str,
     source_session_id: str | None,
     recent_session_count: int | None,
     server: str | None,
+    force: bool,
 ) -> None:
     """Import chats from supported local coding harnesses.
 
@@ -4836,7 +4842,8 @@ def import_session_command(
     as a normal session. Qwen, Kiro, and Kimi currently preserve visible
     messages but not native tool activity; OpenCode and Pi preserve exported
     tool activity. Use --session for one chat or --last for a bounded batch. A
-    source session can only be imported once.
+    source session can only be imported once unless --force is used to replace
+    the previous import.
 
     \b
     Examples:
@@ -4845,6 +4852,7 @@ def import_session_command(
       omnigent import --harness opencode --session <session-id>
       omnigent import --harness qwen --session <session-id>
       omnigent import --harness claude --last 10
+      omnigent import --harness claude --session <session-id> --force
     """
     import httpx
 
@@ -4903,6 +4911,7 @@ def import_session_command(
             "source": imported.source,
             "external_session_id": imported.external_session_id,
             "workspace": imported.workspace,
+            "force": force,
             "items": [
                 {
                     "type": item.type,

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -55,6 +55,7 @@ class ImportSessionRequest(BaseModel):
     source: ImportSource
     external_session_id: str = Field(min_length=1, max_length=128)
     workspace: str | None = Field(default=None, max_length=2048)
+    force: bool = False
     items: list[ImportItemInput] = Field(min_length=1, max_length=100_000)
 
     @field_validator("external_session_id")
@@ -132,7 +133,7 @@ def create_imports_router(
         request: Request,
         response: Response,
     ) -> ImportSessionResponse:
-        """Import one normalized transcript, rejecting duplicate sources."""
+        """Import one normalized transcript, optionally replacing its prior import."""
         user_id = require_user(request, auth_provider)
         items = [item.to_item() for item in body.items]
         existing = await asyncio.to_thread(
@@ -148,10 +149,11 @@ def create_imports_router(
                 permission_store,
                 conversation_store,
             )
-            raise OmnigentError(
-                f"This {body.source} session has already been imported as {existing.id}",
-                code=ErrorCode.CONFLICT,
-            )
+            if not body.force:
+                raise OmnigentError(
+                    f"This {body.source} session has already been imported as {existing.id}",
+                    code=ErrorCode.CONFLICT,
+                )
 
         native_agent = native_coding_agent_for_harness(f"{body.source}-native")
         if native_agent is None:
@@ -165,6 +167,9 @@ def create_imports_router(
                 f"The {native_agent.display_name} built-in agent is unavailable",
                 code=ErrorCode.INTERNAL_ERROR,
             )
+
+        if existing is not None:
+            await conversation_store.delete_conversation(existing.id)
 
         try:
             conversation = await asyncio.to_thread(

--- a/openapi.json
+++ b/openapi.json
@@ -1781,6 +1781,11 @@
             "title": "External Session Id",
             "type": "string"
           },
+          "force": {
+            "default": false,
+            "title": "Force",
+            "type": "boolean"
+          },
           "items": {
             "items": {
               "$ref": "#/components/schemas/ImportItemInput"
@@ -7747,7 +7752,7 @@
     },
     "/v1/imports": {
       "post": {
-        "description": "Import one normalized transcript, rejecting duplicate sources.",
+        "description": "Import one normalized transcript, optionally replacing its prior import.",
         "operationId": "import_session_v1_imports_post",
         "requestBody": {
           "content": {

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -73,6 +73,7 @@ def test_import_command_loads_local_session_and_posts_normalized_items(tmp_path:
         "source": "claude",
         "external_session_id": session_id,
         "workspace": "/repo",
+        "force": False,
         "items": [
             {
                 "type": "message",
@@ -84,6 +85,30 @@ def test_import_command_loads_local_session_and_posts_normalized_items(tmp_path:
             }
         ],
     }
+
+
+@respx.mock
+def test_import_command_sends_force_override(tmp_path: Path) -> None:
+    """The force flag asks the server to replace the previous source import."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345679"
+    _write_claude_transcript(tmp_path, session_id, text="updated prompt")
+    route = respx.post(f"{_BASE}/v1/imports").mock(
+        return_value=httpx.Response(
+            201,
+            json={"session_id": "conv_replaced", "status": "imported", "item_count": 1},
+        )
+    )
+
+    with patch("omnigent.cli._resolve_attach_server", return_value=_BASE):
+        result = CliRunner().invoke(
+            cli,
+            ["import", "--harness", "claude", "--session", session_id, "--force"],
+            env={"HOME": str(tmp_path)},
+        )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(route.calls.last.request.content)["force"] is True
+    assert "conv_replaced" in result.output
 
 
 def test_import_command_rejects_cursor() -> None:

--- a/tests/e2e/test_chat_import_e2e.py
+++ b/tests/e2e/test_chat_import_e2e.py
@@ -199,6 +199,48 @@ def _write_opencode_cli_fixture(home: Path) -> tuple[Path, str]:
     return bin_dir, session_id
 
 
+def _write_force_import_fixture(home: Path, harness: str, text: str) -> str:
+    """Write an updateable Claude or Codex transcript for force-import coverage."""
+    session_id = f"019f8888-0001-7000-8000-00000000000{1 if harness == 'claude' else 2}"
+    if harness == "claude":
+        transcript = home / ".claude" / "projects" / "-repo" / f"{session_id}.jsonl"
+        records = [
+            {
+                "type": "user",
+                "uuid": "user-1",
+                "cwd": "/repo",
+                "message": {"role": "user", "content": text},
+            }
+        ]
+    else:
+        transcript = (
+            home
+            / ".codex"
+            / "sessions"
+            / "2026"
+            / "07"
+            / "16"
+            / f"rollout-2026-07-16T00-00-01-{session_id}.jsonl"
+        )
+        records = [
+            {"type": "session_meta", "payload": {"id": session_id, "cwd": "/repo"}},
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": text}],
+                },
+            },
+        ]
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records),
+        encoding="utf-8",
+    )
+    return session_id
+
+
 def test_cli_imports_claude_chat_into_live_server(live_server: str, tmp_path: Path) -> None:
     """The real CLI and server create a readable session from Claude JSONL."""
     source_session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
@@ -395,6 +437,7 @@ def test_cli_imports_recent_codex_chats_as_batch(live_server: str, tmp_path: Pat
     env.update(
         {
             "HOME": str(tmp_path),
+            "CODEX_HOME": str(tmp_path / ".codex"),
             "OMNIGENT_CONFIG_HOME": str(tmp_path / "config"),
             "OMNIGENT_DATA_DIR": str(tmp_path / "omnigent-data"),
         }
@@ -434,6 +477,72 @@ def test_cli_imports_recent_codex_chats_as_batch(live_server: str, tmp_path: Pat
         )
         session.raise_for_status()
         assert session.json()["external_session_id"] == source_id
+
+
+@pytest.mark.parametrize("harness", ["claude", "codex"])
+def test_cli_force_replaces_imported_chat(
+    live_server: str,
+    tmp_path: Path,
+    harness: str,
+) -> None:
+    """The real CLI and server replace Claude and Codex imports in place."""
+    source_session_id = _write_force_import_fixture(tmp_path, harness, "old prompt")
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path),
+            "CODEX_HOME": str(tmp_path / ".codex"),
+            "OMNIGENT_CONFIG_HOME": str(tmp_path / "config"),
+            "OMNIGENT_DATA_DIR": str(tmp_path / "omnigent-data"),
+        }
+    )
+    command = [
+        sys.executable,
+        "-m",
+        "omnigent",
+        "import",
+        "--harness",
+        harness,
+        "--session",
+        source_session_id,
+        "--server",
+        live_server,
+    ]
+    first = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    first_match = re.search(r"into (\S+)\.", first.stdout)
+    assert first_match is not None, first.stdout
+
+    _write_force_import_fixture(tmp_path, harness, "new prompt")
+    replaced = subprocess.run(
+        [*command, "--force"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    replaced_match = re.search(r"into (\S+)\.", replaced.stdout)
+    assert replaced_match is not None, replaced.stdout
+    assert replaced_match.group(1) == first_match.group(1)
+
+    session_id = replaced_match.group(1)
+    session = httpx.get(
+        f"{live_server}/v1/sessions/{session_id}",
+        params={"include_items": "false", "include_liveness": "false"},
+        timeout=10,
+    )
+    session.raise_for_status()
+    assert session.json()["title"] == "new prompt"
+    items = httpx.get(f"{live_server}/v1/sessions/{session_id}/items", timeout=10)
+    items.raise_for_status()
+    assert [item["content"][0]["text"] for item in items.json()["data"]] == ["new prompt"]
 
 
 @pytest.mark.parametrize("harness", ["qwen", "kiro", "pi", "kimi"])

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -108,6 +108,57 @@ async def test_concurrent_identical_imports_return_one_session(
     assert imported is not None
 
 
+async def test_force_import_replaces_existing_session(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """A forced retry replaces the transcript while retaining its stable id."""
+    _seed_claude_agent(db_uri)
+    payload = {
+        "source": "claude",
+        "external_session_id": "claude-force-1",
+        "workspace": "/repo/old",
+        "items": [
+            {
+                "type": "message",
+                "response_id": "claude:old",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "old prompt"}],
+                },
+            }
+        ],
+    }
+    created = await client.post("/v1/imports", json=payload)
+    payload["force"] = True
+    payload["workspace"] = "/repo/new"
+    payload["items"] = [
+        {
+            "type": "message",
+            "response_id": "claude:new",
+            "data": {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "new prompt"}],
+            },
+        }
+    ]
+
+    replaced = await client.post("/v1/imports", json=payload)
+
+    assert created.status_code == 201
+    assert replaced.status_code == 201
+    assert replaced.json()["session_id"] == created.json()["session_id"]
+    conversation = SqlAlchemyConversationStore(db_uri).get_conversation(
+        replaced.json()["session_id"]
+    )
+    assert conversation is not None
+    assert conversation.workspace == "/repo/new"
+    assert conversation.title == "new prompt"
+    items = await client.get(f"/v1/sessions/{conversation.id}/items")
+    assert items.status_code == 200
+    assert [item["content"][0]["text"] for item in items.json()["data"]] == ["new prompt"]
+
+
 async def test_import_session_rejects_empty_history(client: httpx.AsyncClient) -> None:
     """An empty parser result cannot create a permanently claimed session."""
     response = await client.post(


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add `omnigent import --force` to replace a chat previously imported from the same harness session.
- Keep the stable Omnigent session ID while refreshing its workspace, title, and transcript.
- Require owner access before replacing an import and retain the existing duplicate guard when `--force` is absent.

ELI5: imports are snapshots. Normally Omnigent protects an existing snapshot; `--force` explicitly swaps it for the latest local transcript.

```text
local Claude/Codex chat -> omnigent import --force -> owner check -> replace stable session
```

## Test Plan

- `uv run pytest -q tests/cli/test_import.py tests/server/routes/test_imports.py` (14 passed)
- `uv run pytest -q -n 2 tests/e2e/test_chat_import_e2e.py` (10 passed)
- Ran local-only E2E coverage against the latest genuine Claude Code and Codex transcripts using a fresh live server; normal import, duplicate rejection, forced replacement, and readable items all passed (2 passed)
- Re-ran the real Claude Code flow directly against this branch's `omnigent` executable and a fresh loopback server backed by temporary SQLite storage:
  - `omnigent import --harness claude --session <real-id>` imported 4 items
  - `omnigent import --harness claude --session <real-id> --force` imported 4 items into the same stable Omnigent session ID
  - Both import requests returned `201 Created`; session and item reads returned `200 OK`
  - The external Claude session ID matched and all four imported items were readable messages
  - The temporary server shut down cleanly after verification
- `uv run --no-sync pre-commit run --all-files` (passed)

## Demo

N/A — CLI/API change with automated and real-chat E2E coverage.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification used genuine local Claude Code and Codex transcripts without printing their contents. The latest Claude run used this branch's real CLI against an isolated local server: both the initial and forced imports returned `201`, produced four readable items, and resolved to the same stable Omnigent session ID.

## Changelog

`omnigent import --force` replaces a previously imported chat with the latest local transcript.
