### PR TITLE
Map imported Claude sessions to worktrees

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5628,6 +5628,22 @@ def resume(
     help="Import the N most recently modified parent sessions (maximum 50).",
 )
 @click.option(
+    "--worktree",
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=None,
+    metavar="PATH",
+    help=(
+        "Existing worktree to associate with one Claude Code session. "
+        "Requires --harness claude and --session."
+    ),
+)
+@click.option(
     "--server",
     default=None,
     help=(
@@ -5644,6 +5660,7 @@ def import_session_command(
     harness: str,
     source_session_id: str | None,
     recent_session_count: int | None,
+    worktree: Path | None,
     server: str | None,
     force: bool,
 ) -> None:
@@ -5658,7 +5675,7 @@ def import_session_command(
 
     \b
     Examples:
-      omnigent import --harness claude --session <session-id>
+      omnigent import --harness claude --session <session-id> --worktree /path/to/worktree
       omnigent import --harness codex --session <session-id>
       omnigent import --harness opencode --session <session-id>
       omnigent import --harness qwen --session <session-id>
@@ -5682,6 +5699,12 @@ def import_session_command(
 
     source = cast(ImportSource, harness.lower())
     is_batch = recent_session_count is not None
+    if worktree is not None and source != "claude":
+        raise click.UsageError("--worktree is currently supported only with --harness claude.")
+    if worktree is not None and is_batch:
+        raise click.UsageError(
+            "--worktree requires --session; import each Claude Code session with its worktree."
+        )
     if recent_session_count is not None:
         try:
             recent_ids = list_recent_local_session_ids(source, limit=recent_session_count)
@@ -5718,10 +5741,11 @@ def import_session_command(
             click.echo(f"Failed {current_source_session_id}: {exc}", err=True)
             continue
 
+        workspace = str(worktree) if worktree is not None else imported.workspace
         payload = {
             "source": imported.source,
             "external_session_id": imported.external_session_id,
-            "workspace": imported.workspace,
+            "workspace": workspace,
             "force": force,
             "items": [
                 {
@@ -5772,6 +5796,10 @@ def import_session_command(
                 err=True,
             )
             continue
+        if source == "claude" and workspace is not None:
+            from omnigent.claude_native_state import write_launch_state
+
+            write_launch_state(session_id, str(Path(workspace).resolve()))
         imported_count += 1
         if is_batch:
             click.echo(

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -11,6 +11,7 @@ import httpx
 import respx
 from click.testing import CliRunner
 
+from omnigent.claude_native_state import read_launch_state
 from omnigent.cli import _CLICK_SUBCOMMANDS, cli
 from omnigent.session_import.models import SessionImportNotFoundError
 
@@ -109,6 +110,90 @@ def test_import_command_sends_force_override(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     assert json.loads(route.calls.last.request.content)["force"] is True
     assert "conv_replaced" in result.output
+
+
+@respx.mock
+def test_import_command_maps_claude_session_to_selected_worktree(tmp_path: Path) -> None:
+    """A Claude import persists its worktree for server and local resume paths."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345679"
+    _write_claude_transcript(tmp_path, session_id, text="continue in my worktree")
+    worktree = tmp_path / "repo-worktrees" / "feature-import"
+    worktree.mkdir(parents=True)
+    state_root = tmp_path / "claude-native-state"
+    route = respx.post(f"{_BASE}/v1/imports").mock(
+        return_value=httpx.Response(
+            201,
+            json={"session_id": "conv_worktree", "status": "imported", "item_count": 1},
+        )
+    )
+
+    with patch("omnigent.cli._resolve_attach_server", return_value=_BASE):
+        result = CliRunner().invoke(
+            cli,
+            [
+                "import",
+                "--harness",
+                "claude",
+                "--session",
+                session_id,
+                "--worktree",
+                str(worktree),
+            ],
+            env={
+                "HOME": str(tmp_path),
+                "OMNIGENT_CLAUDE_NATIVE_STATE_DIR": str(state_root),
+            },
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(route.calls.last.request.content)
+    assert payload["workspace"] == str(worktree.resolve())
+    with patch.dict(
+        os.environ,
+        {"OMNIGENT_CLAUDE_NATIVE_STATE_DIR": str(state_root)},
+    ):
+        state = read_launch_state("conv_worktree")
+    assert state is not None
+    assert state.working_directory == str(worktree.resolve())
+
+
+def test_import_command_scopes_worktree_override_to_single_claude_session(
+    tmp_path: Path,
+) -> None:
+    """Codex and batch imports remain out of scope for worktree overrides."""
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    runner = CliRunner()
+
+    codex = runner.invoke(
+        cli,
+        [
+            "import",
+            "--harness",
+            "codex",
+            "--session",
+            "019f7777-0001-7000-8000-000000000001",
+            "--worktree",
+            str(worktree),
+        ],
+    )
+    batch = runner.invoke(
+        cli,
+        [
+            "import",
+            "--harness",
+            "claude",
+            "--last",
+            "2",
+            "--worktree",
+            str(worktree),
+        ],
+    )
+
+    assert codex.exit_code == 2
+    assert "supported only with --harness claude" in codex.output
+    assert batch.exit_code == 2
+    assert "import each Claude Code session with its worktree" in batch.output
 
 
 def test_import_command_rejects_cursor() -> None:

--- a/tests/e2e/test_chat_import_e2e.py
+++ b/tests/e2e/test_chat_import_e2e.py
@@ -242,7 +242,7 @@ def _write_force_import_fixture(home: Path, harness: str, text: str) -> str:
 
 
 def test_cli_imports_claude_chat_into_live_server(live_server: str, tmp_path: Path) -> None:
-    """The real CLI and server create a readable session from Claude JSONL."""
+    """The real CLI and server map a Claude session to a selected worktree."""
     source_session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
     transcript = tmp_path / ".claude" / "projects" / "-repo" / f"{source_session_id}.jsonl"
     transcript.parent.mkdir(parents=True)
@@ -273,12 +273,15 @@ def test_cli_imports_claude_chat_into_live_server(live_server: str, tmp_path: Pa
         ),
         encoding="utf-8",
     )
+    worktree = tmp_path / "repo-worktrees" / "feature-import"
+    worktree.mkdir(parents=True)
     env = os.environ.copy()
     env.update(
         {
             "HOME": str(tmp_path),
             "OMNIGENT_CONFIG_HOME": str(tmp_path / "config"),
             "OMNIGENT_DATA_DIR": str(tmp_path / "omnigent-data"),
+            "OMNIGENT_CLAUDE_NATIVE_STATE_DIR": str(tmp_path / "claude-native-state"),
         }
     )
 
@@ -292,6 +295,8 @@ def test_cli_imports_claude_chat_into_live_server(live_server: str, tmp_path: Pa
             "claude",
             "--session",
             source_session_id,
+            "--worktree",
+            str(worktree),
             "--server",
             live_server,
         ],
@@ -313,7 +318,7 @@ def test_cli_imports_claude_chat_into_live_server(live_server: str, tmp_path: Pa
     session.raise_for_status()
     session_data = session.json()
     assert session_data["external_session_id"] == source_session_id
-    assert session_data["workspace"] == "/repo"
+    assert session_data["workspace"] == str(worktree.resolve())
     assert session_data["title"] == "inspect TODO.md"
     items = httpx.get(f"{live_server}/v1/sessions/{session_id}/items", timeout=10)
     items.raise_for_status()


### PR DESCRIPTION
## Related issue

N/A — requested follow-up to Claude Code session imports.

## Summary

Claude Code sessions imported into Omnigent can now be assigned to an existing worktree with `--worktree PATH`. The importer stores that path on the Omnigent session and in Claude's local launch state, so `omnigent claude --resume <session-id>` reopens the native conversation in the intended checkout.

- Add a Claude-only, single-session `--worktree` option to `omnigent import`.
- Preserve Codex behavior for a separate follow-up PR.
- Cover the CLI contract, resume-state persistence, and live-server import path.

ELI5: importing saves both the chat and which checkout it belongs to, so resuming it takes Claude back to the right folder.

```mermaid
flowchart LR
    A["Claude Code transcript"] --> B["omnigent import --worktree PATH"]
    B --> C["Omnigent session workspace"]
    B --> D["Local Claude launch state"]
    C --> E["omnigent claude --resume"]
    D --> E
    E --> F["Existing worktree"]
```

## Test Plan

- `env -u CODEX_HOME .venv/bin/pytest tests/cli/test_import.py tests/e2e/test_chat_import_e2e.py -q` — 19 passed.
- `.venv/bin/pre-commit run --files omnigent/cli.py tests/cli/test_import.py tests/e2e/test_chat_import_e2e.py` — passed.
- Imported real Claude Code session `a66144c5-d465-481d-a2ee-eb9e751c517f` into an isolated local Omnigent server with this worktree selected; the command returned session `b8e2c8f040c336214dc118ff4e30a46e`.
- Ran `omnigent claude --resume b8e2c8f040c336214dc118ff4e30a46e`; Claude restored the prior native conversation in the selected worktree and answered a fresh turn with `OMNIGENT_MANUAL_RESUME_PR_OK`. The Omnigent items API contained both the user turn and matching assistant response.

## Demo

N/A — CLI/backend change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification used a real Claude Code transcript and the real Claude TUI, not a mocked response. It confirmed the imported session stored `/home/sabhya.chhabria/.codex/worktrees/2a35/omnigent` as its workspace, resumed the source Claude session ID, produced a new assistant reply, and mirrored that reply into Omnigent. The disposable session, server, host daemon, and terminal were cleaned up afterward.

## Changelog

Assign an existing worktree when importing a Claude Code session with `omnigent import --worktree`.
