### PR TITLE
fix(sessions): wait out a host-confirmed-alive runner before relaunching

### DIFF
--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -256,6 +256,19 @@ _NATIVE_POLICY_NOT_ENFORCED_CODE = "native_policy_not_enforced"
 _HOST_BOUND_RUNNER_CONNECT_GRACE_S = 10.0
 
 
+# How long to keep waiting for a host-bound runner once the host has
+# confirmed the process is ``alive``. The short grace above is tuned for the
+# common case where the tunnel is milliseconds behind the launch; a cold boot
+# (image pull, interpreter start, harness init) can outlast it while the host
+# still holds the runner's ``Popen``. Abandoning that runner rotates the
+# binding and races a replacement, so an ``alive`` verdict waits this long
+# instead of expiring at the grace. 60s matches the budget the CLI already
+# allows a runner to come online in (``DAEMON_RUNNER_ONLINE_TIMEOUT_S``),
+# restated here rather than imported so this leaf module stays free of the
+# CLI-side module tree.
+_HOST_BOUND_RUNNER_ALIVE_CONNECT_TIMEOUT_S = 60.0
+
+
 _HOST_RELAUNCH_RUNNER_CONNECT_TIMEOUT_S = 30.0
 
 
@@ -739,6 +752,7 @@ __all__ = [
     "_HARNESS_PRE_RESOLVED_ELICITATION_MAX_ENTRIES",
     "_HARNESS_PRE_RESOLVED_ELICITATION_TTL_S",
     "_HOOK_ELICITATION_ID_RE",
+    "_HOST_BOUND_RUNNER_ALIVE_CONNECT_TIMEOUT_S",
     "_HOST_BOUND_RUNNER_CONNECT_GRACE_S",
     "_HOST_LAUNCH_RESULT_TIMEOUT_S",
     "_HOST_RELAUNCH_RUNNER_CONNECT_TIMEOUT_S",

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -3849,10 +3849,12 @@ async def _query_host_runner_status(
     Ask a host whether a runner's process is alive, dead, or unknown.
 
     The host owns runner-process liveness (it holds the ``Popen``), so it
-    can answer the one question the server's tunnel registry cannot: is an
-    absent-from-the-tunnel runner still coming (booting) or gone for good
-    (stopped, crashed, or lost to a host restart)? Used before the connect
-    grace so the dispatch path waits only for a runner that is coming.
+    can answer the one question the server's tunnel registry cannot: is the
+    process behind an absent-from-the-tunnel runner still held (``alive``)
+    or gone for good (stopped, crashed, or lost to a host restart)? Raced
+    against the connect grace so the verdict can shorten the wait for a
+    runner that is gone, or extend it to the caller's bounded budget for one
+    the host still holds.
 
     :param host_conn: Live host connection to query.
     :param host_registry: Registry used to enqueue the outbound frame.
@@ -3882,9 +3884,9 @@ async def _query_host_runner_status(
     except asyncio.TimeoutError:
         return None
     except Exception:  # noqa: BLE001
-        # Defensive: this query only ever *speeds up* the connect grace, so
-        # any unexpected failure (e.g. the future resolved with an error)
-        # must degrade to "no verdict" and fall back to the wait rather than
+        # Defensive: this query only ever *adjusts* the connect wait, so any
+        # unexpected failure (e.g. the future resolved with an error) must
+        # degrade to "no verdict" and fall back to the plain grace rather than
         # break the message POST. CancelledError is a BaseException and still
         # propagates, so the race helper's cancel/drain is unaffected.
         _logger.warning(

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -2170,6 +2170,13 @@ async def _wait_for_host_bound_runner_client(
     slow yields no verdict at all and the plain connect grace runs its
     normal course.
 
+    The extension is per-dispatch, so its cost is paid per in-flight message
+    rather than once per session. Messages that overlap against the same
+    wedged binding each wait the full budget, because none of them observes
+    the rotated ``runner_id`` until the first relaunch has completed and
+    written it. Sequential messages do not compound this: once that relaunch
+    rotates the binding, later dispatches address the new runner.
+
     :param session_id: Session/conversation identifier.
     :param runner_router: The ``RunnerRouter`` instance, or ``None``.
     :param tunnel_registry: The server's ``TunnelRegistry``, or ``None``.

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -2153,19 +2153,22 @@ async def _wait_for_host_bound_runner_client(
       crashed, or lost to a host restart). That means it will never
       connect, so the wait ends immediately and the caller relaunches
       without burning the rest of the grace.
-    * An ``alive`` verdict is the opposite signal: the host still holds the
-      runner's process, so the tunnel is coming and the only question is
-      when. A cold boot can outlast the short grace, and giving up on it
-      rotates the binding and races a replacement runner, so the wait runs
-      to ``alive_timeout_s`` instead of expiring at ``timeout_s``. A crash
-      report landing meanwhile still ends it early, via the connect wait's
-      own short-circuit.
+    * An ``alive`` verdict points the other way. It does not promise the
+      tunnel is coming — only that the host still holds a running process,
+      which may yet register, or may be wedged. A cold boot can outlast the
+      short grace, and abandoning it there rotates the binding and races a
+      replacement runner, so the wait runs to ``alive_timeout_s`` instead of
+      expiring at ``timeout_s``. ``alive_timeout_s`` is what bounds a process
+      that is held but never registers. A crash report landing meanwhile
+      still ends the wait early, via the connect wait's own short-circuit.
 
-    Running the query *alongside* the wait rather than before it is what
-    keeps the query strictly a speed-up: a host that is too old to answer,
-    slow, or silent (verdict ``None`` / ``"alive"``) never shortcuts the
-    wait, so the connect grace runs its normal course with no added
-    latency.
+    Running the query *alongside* the wait rather than before it keeps its
+    cost off the fast path: a runner that registers promptly is returned by
+    the connect wait and the verdict never matters. The verdict can then
+    shorten the wait (``dead``/``unknown``) or extend it to the bounded
+    budget (``alive``), while a host that is offline, too old to answer, or
+    slow yields no verdict at all and the plain connect grace runs its
+    normal course.
 
     :param session_id: Session/conversation identifier.
     :param runner_router: The ``RunnerRouter`` instance, or ``None``.
@@ -2217,10 +2220,10 @@ async def _wait_for_host_bound_runner_client(
             # No usable verdict (an unavailable/too-old/slow host, or no alive
             # budget configured): let the connect grace run its normal course.
             return connect_task.result() if connect_task in done else await connect_task
-        # The host still holds this runner's process, so the tunnel is coming
-        # and only the timing is in doubt. Let the grace finish, then spend
-        # what is left of the larger budget rather than rotating the binding
-        # and racing a replacement. A crash report arriving meanwhile still
+        # The host still holds this runner's process, so it has not been ruled
+        # out and may yet register. Let the grace finish, then spend what is
+        # left of the larger budget rather than rotating the binding and
+        # racing a replacement. A crash report arriving meanwhile still
         # ends the wait early — ``_wait_for_runner_client`` short-circuits on
         # it, so that case needs no separate check here.
         if connect_task not in done:

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -2135,6 +2135,7 @@ async def _wait_for_host_bound_runner_client(
     runner_exit_reports: RunnerExitReports | None,
     host_conn: HostConnection,
     host_registry: HostRegistry,
+    alive_timeout_s: float | None = None,
 ) -> httpx.AsyncClient | None:
     """
     Wait for a host-bound runner to connect, ending early if the host
@@ -2152,6 +2153,13 @@ async def _wait_for_host_bound_runner_client(
       crashed, or lost to a host restart). That means it will never
       connect, so the wait ends immediately and the caller relaunches
       without burning the rest of the grace.
+    * An ``alive`` verdict is the opposite signal: the host still holds the
+      runner's process, so the tunnel is coming and the only question is
+      when. A cold boot can outlast the short grace, and giving up on it
+      rotates the binding and races a replacement runner, so the wait runs
+      to ``alive_timeout_s`` instead of expiring at ``timeout_s``. A crash
+      report landing meanwhile still ends it early, via the connect wait's
+      own short-circuit.
 
     Running the query *alongside* the wait rather than before it is what
     keeps the query strictly a speed-up: a host that is too old to answer,
@@ -2168,6 +2176,11 @@ async def _wait_for_host_bound_runner_client(
         connect wait to abort early on a reported death.
     :param host_conn: Live host connection to query for liveness.
     :param host_registry: Registry used to enqueue the query frame.
+    :param alive_timeout_s: Total seconds to allow a host-confirmed-alive
+        runner, inclusive of ``timeout_s``. ``None`` keeps the plain grace.
+        Budgeted by subtraction rather than elapsed time, so a connect wait
+        that ends early (a crash report) spends less than the full total —
+        never more.
     :returns: The runner HTTP client if it connected, otherwise ``None``
         (timed out, crash report, or host-confirmed dead/unknown).
     """
@@ -2189,17 +2202,50 @@ async def _wait_for_host_bound_runner_client(
             {connect_task, status_task},
             return_when=asyncio.FIRST_COMPLETED,
         )
-        # The connect settling is authoritative (client, timeout, or crash
-        # report) — the host's opinion no longer matters once it lands.
-        if connect_task in done:
+        # A connected runner is ground truth and always wins.
+        if connect_task in done and connect_task.result() is not None:
             return connect_task.result()
-        # Only the status query has resolved so far.
-        if status_task.result() in ("dead", "unknown"):
+        # ``asyncio.wait`` can report both tasks in the same turn, so read the
+        # verdict whenever it is available rather than only when the connect
+        # is still pending — otherwise a grace that expires alongside an
+        # ``alive`` answer would discard that answer and relaunch.
+        verdict = status_task.result() if status_task in done else None
+        if verdict in ("dead", "unknown"):
             # Host confirms the runner will never connect — stop waiting.
             return None
-        # No verdict ("alive" or an unavailable/too-old/slow host): let the
-        # connect grace run to its natural conclusion.
-        return await connect_task
+        if verdict != "alive" or alive_timeout_s is None:
+            # No usable verdict (an unavailable/too-old/slow host, or no alive
+            # budget configured): let the connect grace run its normal course.
+            return connect_task.result() if connect_task in done else await connect_task
+        # The host still holds this runner's process, so the tunnel is coming
+        # and only the timing is in doubt. Let the grace finish, then spend
+        # what is left of the larger budget rather than rotating the binding
+        # and racing a replacement. A crash report arriving meanwhile still
+        # ends the wait early — ``_wait_for_runner_client`` short-circuits on
+        # it, so that case needs no separate check here.
+        if connect_task not in done:
+            client = await connect_task
+            if client is not None:
+                return client
+        remaining_s = alive_timeout_s - timeout_s
+        if remaining_s <= 0:
+            return None
+        _logger.info(
+            "Host reports runner %s alive for session %s but its tunnel is not "
+            "registered after %.1fs; waiting up to %.1fs more before relaunching",
+            runner_id,
+            session_id,
+            timeout_s,
+            remaining_s,
+        )
+        return await _wait_for_runner_client(
+            session_id,
+            runner_router,
+            tunnel_registry,
+            runner_id=runner_id,
+            timeout_s=remaining_s,
+            runner_exit_reports=runner_exit_reports,
+        )
     finally:
         outstanding = [t for t in (connect_task, status_task) if not t.done()]
         for task in outstanding:

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -1087,12 +1087,13 @@ def register_events_routes(
             # that wait early when the runner is not actually coming. The
             # host owns runner-process liveness (it holds the Popen), so we
             # race a ``host.runner_status`` query against the connect grace:
-            # a booting runner connects (or reads "alive") and we forward,
-            # while one that was stopped, crashed, or lost to a host restart
-            # reads "dead"/"unknown" and cuts the wait short so the relaunch
-            # below runs at once. A host that is offline, too old to answer,
-            # or slow yields no verdict and the grace runs its normal
-            # course, so the query only ever speeds up the cold path.
+            # one that was stopped, crashed, or lost to a host restart reads
+            # "dead"/"unknown" and cuts the wait short so the relaunch below
+            # runs at once, while a runner the host still holds reads "alive"
+            # and the wait stretches to the runner-online budget — a cold
+            # boot outlasting the grace must not be abandoned and replaced.
+            # A host that is offline, too old to answer, or slow yields no
+            # verdict and the grace runs its normal course.
             from omnigent.server.routes import sessions as _sf
 
             if conv.runner_id is not None and _sf._HOST_BOUND_RUNNER_CONNECT_GRACE_S > 0:
@@ -1113,6 +1114,7 @@ def register_events_routes(
                         runner_exit_reports=runner_exit_reports,
                         host_conn=_grace_host_conn,
                         host_registry=_grace_host_reg,
+                        alive_timeout_s=_sf._HOST_BOUND_RUNNER_ALIVE_CONNECT_TIMEOUT_S,
                     )
                 else:
                     # Host tunnel absent: no one to query, so this is the

--- a/tests/server/integration/test_session_host_launch.py
+++ b/tests/server/integration/test_session_host_launch.py
@@ -1183,9 +1183,10 @@ async def test_host_session_message_waits_for_bound_runner_before_relaunch(
         f"recorded runner POSTs were {runner_paths!r}"
     )
     event_paths = [path for path in runner_paths if path.endswith("/events")]
-    assert event_paths, (
-        f"the user message should be forwarded after session init; "
-        f"recorded runner POSTs were {runner_paths!r}"
+    assert len(event_paths) == 1, (
+        f"the user message should be forwarded exactly once after session "
+        f"init; a second forward would mean the message was replayed onto a "
+        f"replacement runner. Recorded runner POSTs were {runner_paths!r}"
     )
     assert init_bodies and init_bodies[0]["session_id"] == session_id, (
         f"session-init body should target {session_id!r}; got {init_bodies!r}"

--- a/tests/server/routes/test_runner_connect_wait.py
+++ b/tests/server/routes/test_runner_connect_wait.py
@@ -97,3 +97,148 @@ async def test_wait_without_report_runs_to_timeout() -> None:
     # Timed out with no connection and no report → None, after waiting.
     assert result is None
     assert registry.waited == [("runner_slow", 0.1)]
+
+
+class _ScriptedConnectWaits:
+    """Scripted stand-in for the runner-connect wait.
+
+    Returns the queued outcome for each successive call and records the
+    timeout it was given, so a test can assert both the number of waits and
+    the budget each one received without any wall-clock sleeping.
+
+    :param outcomes: Outcome per call, in order. ``None`` models "the wait
+        expired with no runner"; anything else is returned as the client.
+    """
+
+    def __init__(self, outcomes: list[object | None]) -> None:
+        """Initialize with the scripted outcomes.
+
+        :param outcomes: Outcome per call, in order.
+        """
+        self._outcomes = list(outcomes)
+        self.timeouts: list[float] = []
+
+    async def __call__(
+        self,
+        session_id: str,
+        runner_router: object,
+        tunnel_registry: object,
+        *,
+        runner_id: str,
+        timeout_s: float,
+        runner_exit_reports: object = None,
+    ) -> object | None:
+        """Record the budget and return the next scripted outcome.
+
+        :param session_id: Session id (unused).
+        :param runner_router: Router (unused).
+        :param tunnel_registry: Registry (unused).
+        :param runner_id: Runner id (unused).
+        :param timeout_s: Budget this wait was given; recorded.
+        :param runner_exit_reports: Report store (unused).
+        :returns: The next scripted outcome.
+        """
+        del session_id, runner_router, tunnel_registry, runner_id, runner_exit_reports
+        self.timeouts.append(timeout_s)
+        return self._outcomes.pop(0)
+
+
+async def _call_host_bound_wait(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    connect: _ScriptedConnectWaits,
+    status_suspends: bool,
+) -> object | None:
+    """Drive ``_wait_for_host_bound_runner_client`` over scripted collaborators.
+
+    :param monkeypatch: Pytest patcher.
+    :param connect: Scripted connect-wait stand-in.
+    :param status_suspends: When ``True`` the status query yields once, so the
+        connect settles first; when ``False`` both resolve in the same wait
+        turn (the simultaneous-completion case).
+    :returns: Whatever the wait returns.
+    """
+    from omnigent.server.routes._sessions import orchestration
+
+    async def _alive_status(*args: object, **kwargs: object) -> str:
+        """Answer the host liveness query with ``alive``.
+
+        :param args: Ignored positional args.
+        :param kwargs: Ignored keyword args.
+        :returns: ``"alive"``.
+        """
+        del args, kwargs
+        if status_suspends:
+            # Yield once so the connect wait reaches ``done`` first.
+            await asyncio.sleep(0)
+        return "alive"
+
+    monkeypatch.setattr(orchestration, "_wait_for_runner_client", connect)
+    monkeypatch.setattr(orchestration, "_query_host_runner_status", _alive_status)
+
+    return await orchestration._wait_for_host_bound_runner_client(
+        "conv_x",
+        None,
+        None,
+        runner_id="runner_booting",
+        timeout_s=10.0,
+        runner_exit_reports=None,
+        host_conn=object(),  # type: ignore[arg-type] — patched query ignores it
+        host_registry=object(),  # type: ignore[arg-type]
+        alive_timeout_s=60.0,
+    )
+
+
+async def test_alive_verdict_waits_out_the_remaining_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ``alive`` runner gets the grace, then the rest of the budget.
+
+    The cold-boot case: the host still holds the runner's process, so the
+    tunnel is coming and only the timing is in doubt. Expiring at the grace
+    rotates the binding and races a replacement, which is what produced
+    ``runner_unavailable`` with nothing persisted.
+
+    Scripted budgets prove the split without waiting: the grace-length wait
+    (10) comes back empty, then a second wait for the remainder (50) returns
+    the original runner's client.
+
+    Mutation check: drop the ``alive`` extension and only ``[10.0]`` is
+    recorded and ``None`` is returned, failing both assertions.
+    """
+    sentinel = object()
+    connect = _ScriptedConnectWaits([None, sentinel])
+
+    result = await _call_host_bound_wait(monkeypatch, connect=connect, status_suspends=True)
+
+    assert result is sentinel, "the original binding's client must be returned, not None"
+    assert connect.timeouts == [10.0, 50.0], (
+        f"expected the grace then the remaining budget; got {connect.timeouts!r}"
+    )
+
+
+async def test_alive_verdict_survives_simultaneous_connect_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A grace that expires in the same turn as ``alive`` keeps the verdict.
+
+    ``asyncio.wait`` can report both the connect wait and the status query as
+    done together. Reading the connect result first and returning it would
+    throw away an ``alive`` answer that arrived simultaneously, relaunching a
+    runner the host had just confirmed was still coming up.
+
+    Mutation check: return the connect result whenever it is done (ignoring a
+    same-turn verdict) and this records only ``[10.0]`` and returns ``None``.
+    """
+    sentinel = object()
+    connect = _ScriptedConnectWaits([None, sentinel])
+
+    result = await _call_host_bound_wait(monkeypatch, connect=connect, status_suspends=False)
+
+    assert result is sentinel, (
+        "a same-turn 'alive' verdict must still extend the wait; returning "
+        "None here means the verdict was discarded"
+    )
+    assert connect.timeouts == [10.0, 50.0], (
+        f"expected the grace then the remaining budget; got {connect.timeouts!r}"
+    )

--- a/tests/server/routes/test_runner_connect_wait.py
+++ b/tests/server/routes/test_runner_connect_wait.py
@@ -99,23 +99,32 @@ async def test_wait_without_report_runs_to_timeout() -> None:
     assert registry.waited == [("runner_slow", 0.1)]
 
 
-class _ScriptedConnectWaits:
-    """Scripted stand-in for the runner-connect wait.
+class _GatedConnectWaits:
+    """Connect-wait stand-in whose first wait is released by an event.
 
-    Returns the queued outcome for each successive call and records the
-    timeout it was given, so a test can assert both the number of waits and
-    the budget each one received without any wall-clock sleeping.
+    Makes the race ordering explicit instead of scheduler-dependent: the
+    first wait blocks until *release* is set, so a test can guarantee the
+    liveness verdict has already resolved before the grace-length wait
+    reports back. Each call records the budget it was handed.
 
-    :param outcomes: Outcome per call, in order. ``None`` models "the wait
+    :param outcomes: Outcome per call, in order. ``None`` models "this wait
         expired with no runner"; anything else is returned as the client.
+    :param release: Event gating the first call, or ``None`` to let every
+        call return without suspending.
     """
 
-    def __init__(self, outcomes: list[object | None]) -> None:
-        """Initialize with the scripted outcomes.
+    def __init__(
+        self,
+        outcomes: list[object | None],
+        release: asyncio.Event | None = None,
+    ) -> None:
+        """Initialize with the scripted outcomes and optional gate.
 
         :param outcomes: Outcome per call, in order.
+        :param release: Event gating the first call, if any.
         """
         self._outcomes = list(outcomes)
+        self._release = release
         self.timeouts: list[float] = []
 
     async def __call__(
@@ -128,7 +137,7 @@ class _ScriptedConnectWaits:
         timeout_s: float,
         runner_exit_reports: object = None,
     ) -> object | None:
-        """Record the budget and return the next scripted outcome.
+        """Record the budget, wait for the gate, return the next outcome.
 
         :param session_id: Session id (unused).
         :param runner_router: Router (unused).
@@ -139,23 +148,26 @@ class _ScriptedConnectWaits:
         :returns: The next scripted outcome.
         """
         del session_id, runner_router, tunnel_registry, runner_id, runner_exit_reports
+        first = not self.timeouts
         self.timeouts.append(timeout_s)
+        if first and self._release is not None:
+            await self._release.wait()
         return self._outcomes.pop(0)
 
 
 async def _call_host_bound_wait(
     monkeypatch: pytest.MonkeyPatch,
     *,
-    connect: _ScriptedConnectWaits,
-    status_suspends: bool,
+    connect: _GatedConnectWaits,
+    on_status: asyncio.Event | None,
 ) -> object | None:
     """Drive ``_wait_for_host_bound_runner_client`` over scripted collaborators.
 
     :param monkeypatch: Pytest patcher.
-    :param connect: Scripted connect-wait stand-in.
-    :param status_suspends: When ``True`` the status query yields once, so the
-        connect settles first; when ``False`` both resolve in the same wait
-        turn (the simultaneous-completion case).
+    :param connect: Gated connect-wait stand-in.
+    :param on_status: Event the liveness query sets once it has answered
+        ``alive``, used to release *connect*'s first wait. ``None`` leaves the
+        query with no side effect.
     :returns: Whatever the wait returns.
     """
     from omnigent.server.routes._sessions import orchestration
@@ -168,9 +180,8 @@ async def _call_host_bound_wait(
         :returns: ``"alive"``.
         """
         del args, kwargs
-        if status_suspends:
-            # Yield once so the connect wait reaches ``done`` first.
-            await asyncio.sleep(0)
+        if on_status is not None:
+            on_status.set()
         return "alive"
 
     monkeypatch.setattr(orchestration, "_wait_for_runner_client", connect)
@@ -194,22 +205,26 @@ async def test_alive_verdict_waits_out_the_remaining_budget(
 ) -> None:
     """An ``alive`` runner gets the grace, then the rest of the budget.
 
-    The cold-boot case: the host still holds the runner's process, so the
-    tunnel is coming and only the timing is in doubt. Expiring at the grace
-    rotates the binding and races a replacement, which is what produced
-    ``runner_unavailable`` with nothing persisted.
+    The cold-boot case: the host still holds the runner's process, so it may
+    yet register and the grace alone cannot tell. Expiring there rotates the
+    binding and launches a replacement, leaving two runners racing for one
+    session — and the message failing if the replacement also misses its
+    rendezvous.
 
-    Scripted budgets prove the split without waiting: the grace-length wait
-    (10) comes back empty, then a second wait for the remainder (50) returns
-    the original runner's client.
+    Ordering is explicit rather than scheduler-dependent: the grace-length
+    wait is gated on the verdict having been answered, so ``alive`` is
+    resolved before that wait reports empty. Scripted budgets then prove the
+    split — 10 for the grace, 50 for the remainder — and the original
+    runner's client is returned.
 
     Mutation check: drop the ``alive`` extension and only ``[10.0]`` is
     recorded and ``None`` is returned, failing both assertions.
     """
+    answered = asyncio.Event()
     sentinel = object()
-    connect = _ScriptedConnectWaits([None, sentinel])
+    connect = _GatedConnectWaits([None, sentinel], release=answered)
 
-    result = await _call_host_bound_wait(monkeypatch, connect=connect, status_suspends=True)
+    result = await _call_host_bound_wait(monkeypatch, connect=connect, on_status=answered)
 
     assert result is sentinel, "the original binding's client must be returned, not None"
     assert connect.timeouts == [10.0, 50.0], (
@@ -222,23 +237,27 @@ async def test_alive_verdict_survives_simultaneous_connect_timeout(
 ) -> None:
     """A grace that expires in the same turn as ``alive`` keeps the verdict.
 
-    ``asyncio.wait`` can report both the connect wait and the status query as
-    done together. Reading the connect result first and returning it would
-    throw away an ``alive`` answer that arrived simultaneously, relaunching a
-    runner the host had just confirmed was still coming up.
+    Neither stand-in suspends, so both the connect wait and the liveness
+    query finish before ``asyncio.wait``'s waiter is resumed — completing a
+    future schedules its done-callbacks through ``call_soon`` rather than
+    running them inline, so the waiter observes both in the done set. That is
+    the case where reading the connect result first would throw away an
+    ``alive`` answer that arrived alongside it and relaunch a runner the host
+    had just reported as still held.
 
     Mutation check: return the connect result whenever it is done (ignoring a
     same-turn verdict) and this records only ``[10.0]`` and returns ``None``.
     """
     sentinel = object()
-    connect = _ScriptedConnectWaits([None, sentinel])
+    connect = _GatedConnectWaits([None, sentinel])  # ungated: never suspends
 
-    result = await _call_host_bound_wait(monkeypatch, connect=connect, status_suspends=False)
+    result = await _call_host_bound_wait(monkeypatch, connect=connect, on_status=None)
 
     assert result is sentinel, (
         "a same-turn 'alive' verdict must still extend the wait; returning "
         "None here means the verdict was discarded"
     )
     assert connect.timeouts == [10.0, 50.0], (
-        f"expected the grace then the remaining budget; got {connect.timeouts!r}"
+        f"the extension must run even though the connect wait had already "
+        f"settled; got {connect.timeouts!r}"
     )

--- a/tests/server/routes/test_runner_status_query.py
+++ b/tests/server/routes/test_runner_status_query.py
@@ -1,12 +1,14 @@
 """Tests for ``_query_host_runner_status`` — the host-owned liveness query.
 
-The host owns runner-process liveness (it holds the ``Popen``). Before the
-message-dispatch connect grace, the server asks the host whether an
-absent-from-the-tunnel runner is still coming (``alive``) or gone for good
-(``dead`` / ``unknown``). A verdict of ``None`` means "no authoritative
+The host owns runner-process liveness (it holds the ``Popen``). Raced against
+the message-dispatch connect grace, the server asks the host whether the
+process behind an absent-from-the-tunnel runner is still held (``alive``) or
+gone for good (``dead`` / ``unknown``). A ``dead``/``unknown`` verdict
+shortens the wait so the relaunch runs at once; an ``alive`` one extends it
+to the caller's bounded runner-online budget rather than abandoning a runner
+that may still register. A verdict of ``None`` means "no authoritative
 answer" (host too old, slow, or the connection dropped), and the caller
-falls back to the plain grace wait — so the query can only ever speed up
-the cold path, never slow it down.
+falls back to the plain grace wait unchanged.
 """
 
 from __future__ import annotations
@@ -172,9 +174,9 @@ async def test_query_connection_error_returns_none() -> None:
 async def test_query_future_exception_returns_none() -> None:
     """A future resolved with an exception degrades to ``None``, not a raise.
 
-    Defensive contract: the query only ever speeds up the connect grace, so
-    an unexpected failure must fall back to the wait rather than surface as
-    a 500 on the message POST.
+    Defensive contract: the query only ever adjusts the connect wait, so an
+    unexpected failure must fall back to the plain grace rather than surface
+    as a 500 on the message POST.
     """
     conn = _FakeHostConn()
     registry = _FaultingRegistry()

--- a/tests/server/routes/test_sessions_facade_exports.py
+++ b/tests/server/routes/test_sessions_facade_exports.py
@@ -34,6 +34,8 @@ def test_harness_override_executor_type_reexported() -> None:
     [
         "_HOST_RUNNER_STATUS_TIMEOUT_S",
         "_HOST_RELAUNCH_RUNNER_CONNECT_TIMEOUT_S",
+        "_HOST_BOUND_RUNNER_CONNECT_GRACE_S",
+        "_HOST_BOUND_RUNNER_ALIVE_CONNECT_TIMEOUT_S",
     ],
 )
 def test_timeout_constants_reexported(name: str) -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

Split out of #3117 at maintainer request — this is core `_sessions` dispatch behaviour and unrelated to the Nimble tools it was sitting on top of. Same two commits, same code, now with its own review trail.

A host-bound session's runner can still be cold-booting when the first message arrives: the host holds its process, but its tunnel is not registered with the router yet. The dispatch gate waited a fixed 10s grace for that registration, then treated the runner as gone — rotating the session's `runner_id` and asking the host to launch a replacement, which then had to win its own rendezvous. Both processes could come online moments later with the message already failed.

`host.runner_status` was already raced against that grace to shorten it on `dead`/`unknown`. An `alive` verdict now extends it instead, to a 60s bounded budget:

```
                          ┌─ dead / unknown ──→ stop now, relaunch (unchanged)
message → connect grace ──┼─ no verdict ──────→ plain 10s grace (unchanged)
          + status query  └─ alive ───────────→ wait to 60s, then relaunch   ← new
```

Second defect in the same race: `asyncio.wait` can report the connect wait and the status query done in the same turn, and the connect result was read first — so a grace expiring alongside `alive` discarded the verdict and relaunched anyway. A connected runner stays authoritative; a `None` result no longer outranks a simultaneous verdict.

Unchanged: the replacement rendezvous timeout (30s), the `dead`/`unknown` fast path, the no-verdict path, and the crash-report short-circuit.

### The trade-off reviewers should weigh

This is deliberate and worth explicit sign-off rather than being buried.

`alive` does not prove the tunnel is coming — only that the host still holds a running process. A **wedged** runner (held but never registering) therefore now costs up to 60s on the message path before the relaunch fires, where it previously cost 10s. That is the price for not abandoning a healthy cold boot.

What bounds it: the budget is a hard ceiling, not a poll loop; `dead`/`unknown` and crash reports still exit immediately; and a host that cannot answer keeps the old 10s behaviour. What it does **not** do: reap the wedged process. Routing keys off the conversation's current binding, so a late-registering original receives nothing and cannot double-forward the message — but it is left running on the host, and a subsequent message pays the wait again while the host keeps answering `alive`. Reaping is a separate, narrower change and is not attempted here.

One more cost worth naming: the budget is per-dispatch, not per-session. Messages that overlap against the same wedged binding each wait it out, because none of them sees the rotated `runner_id` until the first relaunch has written it. Sequential messages do not compound — once that relaunch rotates the binding, later dispatches address the new runner.

If reviewers prefer a smaller ceiling, `_HOST_BOUND_RUNNER_ALIVE_CONNECT_TIMEOUT_S` is a single constant; 60s was chosen to match the budget the CLI already allows a runner to come online in.

## Test Plan

```
pytest tests/server/routes/test_runner_connect_wait.py \
       tests/server/routes/test_sessions_facade_exports.py \
       tests/server/routes/test_runner_status_query.py \
       tests/server/integration/test_session_host_launch.py
33 passed
```

- `tests/server/routes -k "session or runner or host"` — 499 passed, 6 failed. All six are in `test_sessions_snapshot.py` and reproduce identically on a clean checkout of this base with none of these changes (495 passed there, the difference being the 4 tests added here), so they are pre-existing on `main` rather than from this change.
- `ruff check` / `ruff format --check` clean on all touched files. `mypy` on the three touched source files reports the same 65 pre-existing errors as this base does without the change (verified against a clean worktree).
- Both new unit tests were mutation-checked: reverting either the `alive` extension or the simultaneous-verdict fix makes each of them fail.

New coverage:
- `test_alive_verdict_waits_out_the_remaining_budget` — the grace-length wait is gated on the verdict having been answered, so ordering is causal rather than scheduler-dependent; asserts the 10-then-50 split and that the original runner's client is returned.
- `test_alive_verdict_survives_simultaneous_connect_timeout` — the same-turn case.
- The existing route-level test now requires the message to be forwarded **exactly once**, so a replay onto a replacement runner fails it.
- The new budget is added to the facade re-export guard, so a missing export fails at collection rather than at runtime.

## Demo

N/A — no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — automated coverage above.

## Changelog

A message to a session whose runner is still starting up no longer replaces that runner and fails the message.
