### PR TITLE
Sandbox Polly and Debby OS access

### DIFF
--- a/examples/debby/agents/claude/config.yaml
+++ b/examples/debby/agents/claude/config.yaml
@@ -13,15 +13,14 @@ executor:
   config:
     harness: claude-sdk
 
-# Declaring ``os_env`` registers the ``sys_os_read`` / ``sys_os_write`` /
-# ``sys_os_edit`` / ``sys_os_shell`` tools (filesystem access comes bundled with
-# a shell). ``sandbox: type: none`` runs unsandboxed in the caller's working
-# directory.
+# Filesystem tools can access the writable workspace, while the platform
+# sandbox keeps the rest of the host filesystem hidden.
 os_env:
   type: caller_process
   cwd: .
   sandbox:
-    type: none
+    write_paths: [.]
+    cwd_allow_hidden: [.git, .github, .venv]
 
 # Same blast-radius guardrail Polly's sub-agents use, so the shell behaves
 # identically: the catastrophic set (force-push, ``rm -rf /``, hard-reset to a

--- a/examples/debby/agents/gpt/config.yaml
+++ b/examples/debby/agents/gpt/config.yaml
@@ -21,15 +21,14 @@ executor:
   config:
     harness: codex
 
-# Declaring ``os_env`` registers the ``sys_os_read`` / ``sys_os_write`` /
-# ``sys_os_edit`` / ``sys_os_shell`` tools (filesystem access comes bundled with
-# a shell). ``sandbox: type: none`` runs unsandboxed in the caller's working
-# directory.
+# Filesystem tools can access the writable workspace, while the platform
+# sandbox keeps the rest of the host filesystem hidden.
 os_env:
   type: caller_process
   cwd: .
   sandbox:
-    type: none
+    write_paths: [.]
+    cwd_allow_hidden: [.git, .github, .venv]
 
 # Same blast-radius guardrail Polly's sub-agents use, so the shell behaves
 # identically: the catastrophic set (force-push, ``rm -rf /``, hard-reset to a

--- a/examples/debby/config.yaml
+++ b/examples/debby/config.yaml
@@ -116,17 +116,14 @@ prompt: |
 async: true
 cancellable: true
 
-# Debby orchestrates the two responders and formats their output. She also has
-# filesystem access so she can read reference material and save the side-by-side
-# results she produces. Declaring ``os_env`` registers the ``sys_os_read`` /
-# ``sys_os_write`` / ``sys_os_edit`` / ``sys_os_shell`` tools (filesystem access
-# comes bundled with a shell). ``sandbox: type: none`` runs unsandboxed in the
-# caller's working directory.
+# Debby can read reference material and save results in the workspace. The
+# platform sandbox keeps paths outside that workspace hidden.
 os_env:
   type: caller_process
   cwd: .
   sandbox:
-    type: none
+    write_paths: [.]
+    cwd_allow_hidden: [.git, .github, .venv]
 
 # Same blast-radius guardrail Polly uses, so Debby's shell behaves identically:
 # the catastrophic set (force-push, ``rm -rf /``, hard-reset to a remote ref) is

--- a/examples/polly/agents/claude_code/config.yaml
+++ b/examples/polly/agents/claude_code/config.yaml
@@ -49,7 +49,8 @@ os_env:
   type: caller_process
   cwd: .
   sandbox:
-    type: none
+    write_paths: [.]
+    cwd_allow_hidden: [.agents, .claude, .codex, .git, .github, .polly, .venv, .worktrees]
 
 # Implementers open their own PRs, so push / gh pr create are allowed
 # (gate_pushes: false). Only the catastrophic set (force-push, rm -rf /,

--- a/examples/polly/agents/codex/config.yaml
+++ b/examples/polly/agents/codex/config.yaml
@@ -49,7 +49,8 @@ os_env:
   type: caller_process
   cwd: .
   sandbox:
-    type: none
+    write_paths: [.]
+    cwd_allow_hidden: [.agents, .claude, .codex, .git, .github, .polly, .venv, .worktrees]
 
 # Implementers open their own PRs, so push / gh pr create are allowed
 # (gate_pushes: false). Only the catastrophic set (force-push, rm -rf /,

--- a/examples/polly/agents/cursor/config.yaml
+++ b/examples/polly/agents/cursor/config.yaml
@@ -59,7 +59,8 @@ os_env:
   type: caller_process
   cwd: .
   sandbox:
-    type: none
+    write_paths: [.]
+    cwd_allow_hidden: [.agents, .claude, .codex, .git, .github, .polly, .venv, .worktrees]
 
 # Implementers open their own PRs, so push / gh pr create are allowed
 # (gate_pushes: false). Only the catastrophic set (force-push, rm -rf /,

--- a/examples/polly/agents/hermes/config.yaml
+++ b/examples/polly/agents/hermes/config.yaml
@@ -49,7 +49,8 @@ os_env:
   type: caller_process
   cwd: .
   sandbox:
-    type: none
+    write_paths: [.]
+    cwd_allow_hidden: [.agents, .claude, .codex, .git, .github, .polly, .venv, .worktrees]
 
 # Implementers open their own PRs, so push / gh pr create are allowed
 # (gate_pushes: false). Only the catastrophic set (force-push, rm -rf /,

--- a/examples/polly/agents/opencode/config.yaml
+++ b/examples/polly/agents/opencode/config.yaml
@@ -50,7 +50,8 @@ os_env:
   type: caller_process
   cwd: .
   sandbox:
-    type: none
+    write_paths: [.]
+    cwd_allow_hidden: [.agents, .claude, .codex, .git, .github, .polly, .venv, .worktrees]
 
 # Implementers open their own PRs, so push / gh pr create are allowed
 # (gate_pushes: false). Only the catastrophic set (force-push, rm -rf /,

--- a/examples/polly/agents/pi/config.yaml
+++ b/examples/polly/agents/pi/config.yaml
@@ -48,7 +48,8 @@ os_env:
   type: caller_process
   cwd: .
   sandbox:
-    type: none
+    write_paths: [.]
+    cwd_allow_hidden: [.agents, .claude, .codex, .git, .github, .polly, .venv, .worktrees]
 
 # Implementers open their own PRs, so push / gh pr create are allowed
 # (gate_pushes: false). Only the catastrophic set (force-push, rm -rf /,

--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -293,13 +293,14 @@ async: true
 cancellable: true
 timers: true
 
-# polly runs unsandboxed: it only orchestrates (git, registry, gates) and
-# dispatches sub-agents. The coding sub-agents run in their own worktrees.
+# Polly can write the workspace and its orchestration metadata, while the
+# platform sandbox keeps the rest of the host filesystem hidden.
 os_env:
   type: caller_process
   cwd: .
   sandbox:
-    type: none
+    write_paths: [.]
+    cwd_allow_hidden: [.git, .github, .polly, .venv, .worktrees]
 
 # Generic shell terminals for long-running processes (dev servers, watchers, log
 # tails) and ad-hoc shell when sys_os_shell's blocking model doesn't fit. NOT
@@ -309,19 +310,11 @@ terminals:
   shell:
     command: bash
     allow_cwd_override: true
-    os_env:
-      type: caller_process
-      cwd: .
-      sandbox:
-        type: none
+    os_env: inherit
   zsh:
     command: zsh
     allow_cwd_override: true
-    os_env:
-      type: caller_process
-      cwd: .
-      sandbox:
-        type: none
+    os_env: inherit
 
 tools:
   # Coding sub-agents — see agents/<name>/. claude_code, codex, opencode,

--- a/tests/e2e/omnigent/test_example_debby.py
+++ b/tests/e2e/omnigent/test_example_debby.py
@@ -74,11 +74,17 @@ def test_debby_debate_skill_present(debby_spec: AgentSpec) -> None:
 def test_debby_has_os_env(debby_spec: AgentSpec) -> None:
     """
     Debby carries an ``os_env`` block so the bridged ``sys_os_*`` tools register
-    for the brainstorming surface. The shipped sandbox is ``type: none`` so the
-    bundle loads on macOS too. Dropping ``os_env`` would leave the heads with no
-    file/shell tools at all.
+    for the brainstorming surface. Every OS environment uses the platform
+    sandbox so paths outside the workspace, including unrelated files under
+    ``$HOME``, remain hidden. Dropping ``os_env`` would leave the heads with no
+    file/shell tools; using ``type: none`` would expose the host filesystem.
     """
     assert debby_spec.os_env is not None
     assert debby_spec.os_env.type == "caller_process"
     assert debby_spec.os_env.sandbox is not None
-    assert debby_spec.os_env.sandbox.type == "none"
+    assert debby_spec.os_env.sandbox.type != "none"
+
+    for head in debby_spec.sub_agents:
+        assert head.os_env is not None, head.name
+        assert head.os_env.sandbox is not None, head.name
+        assert head.os_env.sandbox.type != "none", head.name

--- a/tests/e2e/omnigent/test_example_polly.py
+++ b/tests/e2e/omnigent/test_example_polly.py
@@ -136,6 +136,27 @@ def test_pi_subagent_is_headless_scaffold_worker(polly_spec: AgentSpec) -> None:
     assert pi.os_env.type == "caller_process"
 
 
+def test_all_os_environments_are_sandboxed(polly_spec: AgentSpec) -> None:
+    """Polly and every worker must be isolated from the host filesystem.
+
+    The workspace remains writable for coding, but an active platform sandbox
+    keeps paths outside it (including unrelated files under ``$HOME``) hidden.
+    Shell terminals inherit the same policy so they cannot bypass the tool
+    sandbox.
+    """
+    assert polly_spec.os_env is not None
+    assert polly_spec.os_env.sandbox is not None
+    assert polly_spec.os_env.sandbox.type != "none"
+
+    for name, terminal in (polly_spec.terminals or {}).items():
+        assert terminal.os_env == "inherit", name
+
+    for worker in polly_spec.sub_agents:
+        assert worker.os_env is not None, worker.name
+        assert worker.os_env.sandbox is not None, worker.name
+        assert worker.os_env.sandbox.type != "none", worker.name
+
+
 def test_spine_skills_present(polly_spec: AgentSpec) -> None:
     """All spine skills are discovered from skills/<name>/SKILL.md."""
     assert sorted(s.name for s in polly_spec.skills) == [

--- a/tests/e2e/omnigent/test_polly_debby_os_sandboxing.py
+++ b/tests/e2e/omnigent/test_polly_debby_os_sandboxing.py
@@ -1,0 +1,95 @@
+"""OS-level filesystem isolation for the bundled Polly and Debby agents."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from omnigent.inner.os_env import create_os_environment
+from omnigent.spec import load
+
+_REPO = Path(__file__).resolve().parents[3]
+_SANDBOX_SYSTEM_ROOTS = (Path("/usr"), Path("/bin"), Path("/sbin"))
+
+
+def _extra_git_read_paths() -> list[str]:
+    """Return non-system git binary roots needed by this host's sandbox."""
+    git_paths = {
+        Path(path).resolve().parent
+        for path in (shutil.which("git"), shutil.which("git", path=os.defpath))
+        if path is not None
+    }
+    return [
+        str(path)
+        for path in sorted(git_paths)
+        if not any(path == root or path.is_relative_to(root) for root in _SANDBOX_SYSTEM_ROOTS)
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bundle_name", ["polly", "debby"])
+async def test_bundle_shell_cannot_read_host_file_outside_workspace(
+    bundle_name: str,
+    tmp_path: Path,
+) -> None:
+    """A real sandboxed shell can use the workspace but cannot read its sibling."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    visible = workspace / "visible.txt"
+    visible.write_text("workspace-visible", encoding="utf-8")
+    secret = tmp_path / "host-secret.txt"
+    secret.write_text("must-not-leak", encoding="utf-8")
+
+    spec = load(_REPO / "examples" / bundle_name)
+    assert spec.os_env is not None
+    assert spec.os_env.sandbox is not None
+    sandbox = replace(spec.os_env.sandbox, read_paths=[str(_REPO)])
+    os_env = create_os_environment(replace(spec.os_env, cwd=str(workspace), sandbox=sandbox))
+    assert os_env is not None
+    try:
+        control = await os_env.shell("cat visible.txt")
+        escaped = await os_env.shell(f"cat {shlex.quote(str(secret))}")
+    finally:
+        os_env.close()
+
+    assert control.get("stdout") == "workspace-visible"
+    assert control.get("exit_code") == 0
+    assert "must-not-leak" not in escaped.get("stdout", "")
+    assert escaped.get("exit_code") != 0
+
+
+@pytest.mark.asyncio
+async def test_polly_sandbox_supports_git_worktree_orchestration(tmp_path: Path) -> None:
+    """Polly can still create its registry and isolated coding worktrees."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    spec = load(_REPO / "examples" / "polly")
+    assert spec.os_env is not None
+    assert spec.os_env.sandbox is not None
+    sandbox = replace(
+        spec.os_env.sandbox,
+        read_paths=[str(_REPO), *_extra_git_read_paths()],
+    )
+    os_env = create_os_environment(replace(spec.os_env, cwd=str(workspace), sandbox=sandbox))
+    assert os_env is not None
+    try:
+        result = await os_env.shell(
+            "git init -q && "
+            "git -c user.name=Polly -c user.email=polly@example.com "
+            "commit -q --allow-empty -m init && "
+            "mkdir -p .polly && printf '{}\\n' > .polly/registry.json && "
+            "git worktree add -q .worktrees/task -b polly/task && "
+            "git -C .worktrees/task status --short"
+        )
+    finally:
+        os_env.close()
+
+    assert result.get("exit_code") == 0, result
+    assert (workspace / ".polly" / "registry.json").is_file()
+    assert (workspace / ".worktrees" / "task" / ".git").is_file()


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Enable the platform-default OS sandbox for Polly, Debby, every bundled worker, and Polly's shell terminals.
- Keep the workspace writable while granting only the hidden repository paths required for git, PR templates, orchestration state, and worktrees.
- Add regression coverage that launches real OS sandbox helpers, verifies host files stay hidden, and proves Polly can still create git worktrees.

Root cause: the bundled configs explicitly set `sandbox.type: none` when filesystem access was introduced for convenience. That exposed the caller's full host filesystem even though the agents only needed the current workspace.

ELI5: Polly and Debby now get a key to the project room, not the whole house.

```text
Host filesystem
├── workspace        read/write
│   ├── .git         explicitly visible
│   ├── .polly       explicitly visible
│   └── .worktrees   explicitly visible
└── everything else hidden by bwrap/Seatbelt
```

## Test Plan

- `.venv/bin/pytest tests/e2e/omnigent/test_example_polly.py tests/e2e/omnigent/test_example_debby.py tests/e2e/omnigent/test_example_os_sandboxing.py tests/e2e/test_polly_e2e.py -q` — 23 passed.
- `.venv/bin/pytest tests/spec/test_debby_example.py tests/server/test_builtin_bundles.py -q` — 17 passed.
- `.venv/bin/pre-commit run --all-files` — passed.
- Real local Polly session with the shipped bundle and a configured Codex provider: workspace read exited 0; host marker read exited 1; marker text was not visible.
- Real local Debby two-head session: GPT produced the same 0/1 sandbox result; the Claude head could not start because the existing configured Claude/Databricks credential returned 401. Debby completed and surfaced the partial failure correctly.
- Default Claude-brain launch was also attempted and confirmed blocked by that pre-existing provider-auth 401 before any tool execution.

## Demo

N/A — non-visual security/configuration change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification used real local Polly and Debby sessions with configured providers and a harmless marker outside the workspace. The working Codex paths could read the workspace but could not read or reveal the marker. The configured Claude path returned a pre-existing 401 before reaching tools.

## Changelog

Polly and Debby now isolate filesystem access to the current workspace by default.
