### PR TITLE
feat(web): add zoom controls to subagent graph panel

### DIFF
--- a/web/src/shell/SubagentsGraphView.tsx
+++ b/web/src/shell/SubagentsGraphView.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { NodeTypes, NodeProps, Node } from "@xyflow/react";
-import { ReactFlow, Background, Position, Handle } from "@xyflow/react";
+import { ReactFlow, Background, Position, Handle, useReactFlow } from "@xyflow/react";
 import { useLocation, useNavigate } from "@/lib/routing";
 import { RunningDot } from "@/components/RunningDot";
 import { Badge } from "@/components/ui/badge";
+import { ZoomInIcon, ZoomOutIcon, Maximize2Icon } from "lucide-react";
 import { MAX_TREE_DEPTH, useChildSessions, type ChildSessionInfo } from "@/hooks/useChildSessions";
 import { useSession } from "@/hooks/useSession";
 import { cn } from "@/lib/utils";
@@ -86,6 +87,25 @@ function AgentNodeComponent({ data }: NodeProps<Node<AgentNodeData>>) {
         className="!bg-muted-foreground/40 !w-1.5 !h-1.5 !border-0"
       />
     </>
+  );
+}
+
+function ZoomControls() {
+  const { zoomIn, zoomOut, fitView } = useReactFlow();
+  const btnClass =
+    "flex items-center justify-center size-7 rounded-md border bg-card text-muted-foreground shadow-sm hover:bg-accent hover:text-accent-foreground transition-colors";
+  return (
+    <div className="absolute bottom-3 right-3 z-10 flex flex-col gap-1">
+      <button type="button" className={btnClass} onClick={() => zoomIn({ duration: 200 })} aria-label="Zoom in">
+        <ZoomInIcon className="size-4" />
+      </button>
+      <button type="button" className={btnClass} onClick={() => zoomOut({ duration: 200 })} aria-label="Zoom out">
+        <ZoomOutIcon className="size-4" />
+      </button>
+      <button type="button" className={btnClass} onClick={() => fitView({ duration: 200, padding: 0.3 })} aria-label="Fit view">
+        <Maximize2Icon className="size-4" />
+      </button>
+    </div>
   );
 }
 
@@ -209,10 +229,11 @@ export function SubagentsGraphView({ conversationId, rootSessionId }: SubagentsG
           nodesConnectable={false}
           elementsSelectable={false}
           proOptions={{ hideAttribution: true }}
-          minZoom={0.3}
-          maxZoom={1.5}
+          minZoom={0.1}
+          maxZoom={3}
         >
           <Background bgColor="var(--card)" />
+          <ZoomControls />
         </ReactFlow>
       </div>
       {rootChildren.map((child) => (

--- a/web/src/shell/SubagentsGraphView.tsx
+++ b/web/src/shell/SubagentsGraphView.tsx
@@ -96,13 +96,28 @@ function ZoomControls() {
     "flex items-center justify-center size-7 rounded-md border bg-card text-muted-foreground shadow-sm hover:bg-accent hover:text-accent-foreground transition-colors";
   return (
     <div className="absolute bottom-3 right-3 z-10 flex flex-col gap-1">
-      <button type="button" className={btnClass} onClick={() => zoomIn({ duration: 200 })} aria-label="Zoom in">
+      <button
+        type="button"
+        className={btnClass}
+        onClick={() => zoomIn({ duration: 200 })}
+        aria-label="Zoom in"
+      >
         <ZoomInIcon className="size-4" />
       </button>
-      <button type="button" className={btnClass} onClick={() => zoomOut({ duration: 200 })} aria-label="Zoom out">
+      <button
+        type="button"
+        className={btnClass}
+        onClick={() => zoomOut({ duration: 200 })}
+        aria-label="Zoom out"
+      >
         <ZoomOutIcon className="size-4" />
       </button>
-      <button type="button" className={btnClass} onClick={() => fitView({ duration: 200, padding: 0.3 })} aria-label="Fit view">
+      <button
+        type="button"
+        className={btnClass}
+        onClick={() => fitView({ duration: 200, padding: 0.3 })}
+        aria-label="Fit view"
+      >
         <Maximize2Icon className="size-4" />
       </button>
     </div>


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add zoom in (+), zoom out (-), and fit-to-view buttons to the bottom-right corner of the subagent graph panel using ReactFlow's `useReactFlow` hook.
- Widen the zoom range from 0.3–1.5x to 0.1–3x so users can zoom in closer to read small nodes or zoom out further for large graphs.

## Test Plan

1. Open a session with subagents and switch to the Graph view.
2. Verify three buttons appear at the bottom-right: zoom in, zoom out, and fit-to-view.
3. Click each button and confirm smooth animated zoom/fit behavior.
4. Verify scroll-wheel zoom works within the expanded 0.1x–3x range.
5. Confirm existing graph interactions (pan, node click navigation) still work.

## Demo

<!-- Attach a screenshot or recording of the zoom controls in action -->

[Kooha-2026-07-30-13-36-15.webm](https://github.com/user-attachments/assets/0d13bb46-944a-4a9e-bccc-4bf7ca79bae9)


## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified that zoom in/out/fit-view buttons render correctly, animate smoothly, and do not interfere with existing pan/click interactions. The change is purely additive UI (three buttons calling ReactFlow's built-in zoom API) with no new logic paths that warrant unit tests.

## Changelog

Subagent graph panel now has zoom in, zoom out, and fit-to-view buttons for easier navigation of large agent trees