### PR TITLE
fix(e2e-ui): stop racing the mermaid panel chrome in the preview test

### DIFF
--- a/tests/e2e_ui/files/test_markdown_mermaid_preview.py
+++ b/tests/e2e_ui/files/test_markdown_mermaid_preview.py
@@ -81,7 +81,12 @@ def test_mermaid_fence_renders_as_preview_diagram(
 
     mermaid_preview = file_viewer.get_by_test_id("mermaid-preview")
     expect(mermaid_preview).to_be_visible(timeout=10_000)
-    expect(mermaid_preview.locator("svg")).to_be_visible(timeout=10_000)
+    # The panel mounts progressively (copy button, toolbar icons, then diagram),
+    # so a bare `svg` locator is ambiguous and trips Playwright's one-match
+    # strictness. Only the rendered diagram carries aria-roledescription, and CI
+    # can take a while to render it, hence the long timeout.
+    diagram = mermaid_preview.locator("svg[aria-roledescription]")
+    expect(diagram).to_be_visible(timeout=30_000)
     expect(file_viewer.locator("pre > code.language-mermaid")).to_have_count(0)
 
     js_code = file_viewer.locator("pre > code.language-js")


### PR DESCRIPTION
## Related issue

N/A (test regression introduced with #3498; failing on every PR since it merged, e.g. #3524, #3564, #3579)

## Summary

- `test_mermaid_fence_renders_as_preview_diagram` asserts `expect(mermaid_preview.locator("svg")).to_be_visible()`. That locator also matches the panel toolbar's icon svgs (Download diagram / Copy Code / View fullscreen), and Playwright's `to_be_visible()` passes only when exactly ONE element matches; more than one is a strict-mode violation.
- The panel mounts progressively. Instrumenting the real app with a 10ms DOM probe shows the svg count inside `mermaid-preview` go `1 -> 3 -> 7` (plain code block's copy button at ~1.3s, toolbar icons ~56ms later, diagram + zoom controls at ~1.75s). The assert can therefore only pass when a poll lands inside that ~56ms one-svg window. Fast local machines win the race; CI runners poll into the 3-icon state and fail with `strict mode violation: ... resolved to 3 elements` after the 10s timeout. This is why the test passed once on its own PR and then failed on every merge-ref run since (7+ unrelated branches on 2026-07-30, always the same signature).
- Fix: assert the rendered diagram specifically. Only the diagram svg carries `aria-roledescription` (stamped by mermaid, e.g. `flowchart-v2`), so the locator resolves to exactly one element and waits for the thing the test actually cares about. The timeout is raised to 30s because failure artifacts show CI sometimes still rendering (loading spinner / pre-render placeholder) at the 10s mark.

If shard jobs still show this test stalling after this fix, that points at genuinely slow diagram rendering in CI (lazy mermaid chunk + render on 2-core runners), which is a product/perf question, separate from this assertion bug.

## Test Plan

- Reproduced the original failure mode locally: fresh SPA build off main, original test passes only by winning the mount race (verified with the svg-count probe; settled DOM has 7 svgs, so the assert can never pass once the panel is fully mounted).
- Fixed test: 5/5 consecutive green runs against a freshly built SPA + spawned server (`pytest tests/e2e_ui/files/test_markdown_mermaid_preview.py --ui-skip-build`), diagram svg found at ~1.8s.
- Verified selector uniqueness in the settled DOM: of the 7 svgs, only the diagram has `aria-roledescription`.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The change is itself an E2E test fix; manual verification = the 5 consecutive local runs above plus the DOM-probe evidence that the old assertion was racy and the new locator is unique.

This pull request and its description were written by Isaac.
