### PR TITLE
fix(runner): forward reasoning on the background turn

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5522,6 +5522,16 @@ def create_runner_app(
             "role": "user",
             "model": msg_body.get("model", ""),
         }
+        # This path rebuilds the body field by field, so anything on the
+        # inbound body that is not threaded through here is dropped.
+        # Forward a normalised ``{"effort": ...}`` rather than the inbound
+        # object: the harness scaffold types ``reasoning`` as
+        # ``dict[str, str]``, so a non-string sibling key would fail the
+        # turn at decode where today it is simply dropped.
+        _reasoning = msg_body.get("reasoning")
+        _effort = _reasoning.get("effort") if isinstance(_reasoning, dict) else None
+        if isinstance(_effort, str) and _effort:
+            harness_body["reasoning"] = {"effort": _effort}
         if _session_histories[conv]:
             history = _session_histories[conv]
             if any("created_by" in item for item in history):

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -1245,6 +1245,241 @@ async def test_runner_cold_cache_uses_resolved_message_not_stored_file_id() -> N
     assert "file_id" not in flat, f"unresolved file_id present in forwarded history: {flat}"
 
 
+async def _reasoning_spec_resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+    """
+    Resolve a minimal spec on a benign test harness.
+
+    :param agent_id: Agent id the runner resolved (unused).
+    :param session_id: Session id (unused).
+    :returns: A minimal spec whose harness is ``runner-test-resolved``.
+    """
+    del agent_id, session_id
+    return AgentSpec(
+        spec_version=1,
+        name="reasoning-agent",
+        executor=ExecutorSpec(
+            type="omnigent",
+            config={"harness": "runner-test-resolved"},
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_runner_background_turn_forwards_reasoning_to_harness() -> None:
+    """A ``reasoning`` field on the inbound body must reach the harness.
+
+    The background path (no ``?stream=true``) is the one the Omnigent
+    server posts to. It does not forward the inbound body: it rebuilds a
+    fresh ``harness_body`` field by field, so any field not threaded
+    through explicitly is dropped. ``reasoning`` was one of them, which
+    means a turn's reasoning effort could not reach an in-process harness
+    on that path even when the body carried it.
+
+    This asserts the field survives the rebuild, the same way ``model``
+    and the client half of ``tools`` are already taken off the inbound
+    body in that builder.
+    """
+    from omnigent.runner import app as runner_app
+
+    conv = "conv_reasoning_bg"
+    captured: dict[str, Any] = {}
+    reached = asyncio.Event()
+    app = create_runner_app(
+        process_manager=cast(
+            HarnessProcessManager,
+            _ContentCapturingProcessManager(captured, reached),
+        ),
+        spec_resolver=_reasoning_spec_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    runner_app._session_histories_ref.pop(conv, None)
+    try:
+        async with _runner_test_client(app) as http:
+            response = await http.post(
+                # No ``?stream=true`` → background turn, the production
+                # path the Omnigent server uses to forward session messages.
+                f"/v1/sessions/{conv}/events",
+                json={
+                    "type": "message",
+                    "role": "user",
+                    "agent_id": "ag_reasoning",
+                    "model": "x",
+                    "content": [{"type": "input_text", "text": "hi"}],
+                    "reasoning": {"effort": "high"},
+                },
+            )
+            assert response.status_code == 202
+            await asyncio.wait_for(reached.wait(), timeout=10.0)
+    finally:
+        runner_app._session_histories_ref.pop(conv, None)
+
+    body = captured["body"]
+    assert body.get("reasoning") == {"effort": "high"}, (
+        f"reasoning dropped from the rebuilt background-turn body: keys={sorted(body)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_runner_stream_turn_forwards_reasoning_to_harness() -> None:
+    """The ``?stream=true`` branch must keep carrying ``reasoning``.
+
+    That branch passes the inbound body through rather than rebuilding
+    it, so it already carries the field and this passes without the
+    accompanying fix. It is a drift guard, not coverage of a live path:
+    it fails if that branch is ever changed to rebuild the body the way
+    the background path does, which is exactly how the two paths came
+    apart in the first place. Note the stream branch has no production
+    caller today; the Omnigent server always posts without the query
+    parameter.
+    """
+    from omnigent.runner import app as runner_app
+
+    conv = "conv_reasoning_stream"
+    captured: dict[str, Any] = {}
+    reached = asyncio.Event()
+    app = create_runner_app(
+        process_manager=cast(
+            HarnessProcessManager,
+            _ContentCapturingProcessManager(captured, reached),
+        ),
+        spec_resolver=_reasoning_spec_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    runner_app._session_histories_ref.pop(conv, None)
+    try:
+        async with _runner_test_client(app) as http:
+            response = await http.post(
+                f"/v1/sessions/{conv}/events?stream=true",
+                json={
+                    "type": "message",
+                    "role": "user",
+                    "agent_id": "ag_reasoning",
+                    "model": "x",
+                    "content": [{"type": "input_text", "text": "hi"}],
+                    "reasoning": {"effort": "high"},
+                },
+            )
+            assert response.status_code == 200
+            await asyncio.wait_for(reached.wait(), timeout=10.0)
+    finally:
+        runner_app._session_histories_ref.pop(conv, None)
+
+    body = captured["body"]
+    assert body.get("reasoning") == {"effort": "high"}, (
+        f"reasoning lost on the passthrough branch: keys={sorted(body)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_runner_background_turn_normalises_reasoning_to_effort() -> None:
+    """Sibling keys are dropped rather than forwarded to the harness.
+
+    The harness scaffold types ``reasoning`` as ``dict[str, str]``, so a
+    caller that sends a non-string sibling alongside the effort — the
+    shape both the Anthropic and OpenAI reasoning objects use — would
+    fail the turn at decode. Forwarding a normalised object keeps a field
+    that is dropped today from becoming a hard failure.
+    """
+    from omnigent.runner import app as runner_app
+
+    conv = "conv_reasoning_sibling"
+    captured: dict[str, Any] = {}
+    reached = asyncio.Event()
+    app = create_runner_app(
+        process_manager=cast(
+            HarnessProcessManager,
+            _ContentCapturingProcessManager(captured, reached),
+        ),
+        spec_resolver=_reasoning_spec_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    runner_app._session_histories_ref.pop(conv, None)
+    try:
+        async with _runner_test_client(app) as http:
+            response = await http.post(
+                f"/v1/sessions/{conv}/events",
+                json={
+                    "type": "message",
+                    "role": "user",
+                    "agent_id": "ag_reasoning",
+                    "model": "x",
+                    "content": [{"type": "input_text", "text": "hi"}],
+                    "reasoning": {"effort": "high", "budget_tokens": 8000},
+                },
+            )
+            assert response.status_code == 202
+            await asyncio.wait_for(reached.wait(), timeout=10.0)
+    finally:
+        runner_app._session_histories_ref.pop(conv, None)
+
+    body = captured["body"]
+    assert body.get("reasoning") == {"effort": "high"}, (
+        f"non-string sibling forwarded to the harness: {body.get('reasoning')!r}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "reasoning",
+    [
+        pytest.param(None, id="absent"),
+        pytest.param({}, id="empty-dict"),
+        pytest.param({"effort": ""}, id="empty-effort"),
+        pytest.param({"effort": None}, id="null-effort"),
+        pytest.param("high", id="bare-string"),
+    ],
+)
+async def test_runner_background_turn_omits_unusable_reasoning(
+    reasoning: object,
+) -> None:
+    """No ``reasoning`` key is invented from an absent or unusable value.
+
+    Effort is only meaningful when it is a non-empty string, so the
+    builder forwards nothing otherwise rather than handing the harness a
+    value it would have to interpret. This keeps a malformed field from
+    turning a silently dropped value into a failed turn, and pins that a
+    session with no effort set is left alone.
+
+    :param reasoning: Inbound ``reasoning`` value, or ``None`` to omit
+        the key entirely.
+    """
+    from omnigent.runner import app as runner_app
+
+    conv = "conv_reasoning_none"
+    captured: dict[str, Any] = {}
+    reached = asyncio.Event()
+    app = create_runner_app(
+        process_manager=cast(
+            HarnessProcessManager,
+            _ContentCapturingProcessManager(captured, reached),
+        ),
+        spec_resolver=_reasoning_spec_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    payload: dict[str, Any] = {
+        "type": "message",
+        "role": "user",
+        "agent_id": "ag_reasoning",
+        "model": "x",
+        "content": [{"type": "input_text", "text": "hi"}],
+    }
+    if reasoning is not None:
+        payload["reasoning"] = reasoning
+    runner_app._session_histories_ref.pop(conv, None)
+    try:
+        async with _runner_test_client(app) as http:
+            response = await http.post(f"/v1/sessions/{conv}/events", json=payload)
+            assert response.status_code == 202
+            await asyncio.wait_for(reached.wait(), timeout=10.0)
+    finally:
+        runner_app._session_histories_ref.pop(conv, None)
+
+    body = captured["body"]
+    assert "reasoning" not in body, (
+        f"invented a reasoning key from {reasoning!r}: {body.get('reasoning')!r}"
+    )
+
+
 @pytest.mark.asyncio
 async def test_runner_post_returns_503_when_spec_resolver_fails(
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
## Related issue

Closes #3536

## Summary

The background dispatch path — the one the Omnigent server posts to — does not forward the inbound body. `_run_turn_bg_setup_and_stream` rebuilds a fresh `harness_body` field by field, so any field not threaded through explicitly is dropped. `reasoning` is one of them, so a turn's reasoning effort cannot reach an in-process harness on that path even when the body carries it. The `?stream=true` branch passes the inbound body through instead of rebuilding it, so `reasoning` survives there and the gap is invisible from that side.

```text
inbound body --> runner --?stream=true--> harness   (passed through, reasoning survives)
inbound body --> runner --background----> harness   (rebuilt, reasoning dropped)  <- fixed
```

This threads `reasoning` through the rebuilt body, the same way `content`, `model` and the client half of `tools` are already taken off `msg_body` in that builder. It forwards a normalised `{"effort": ...}` rather than the inbound object: the harness scaffold types `reasoning` as `dict[str, str]`, so passing an inbound object through unchecked would let a non-string sibling such as `budget_tokens` fail the turn at decode — turning a field that is silently dropped today into a hard failure.

### Scope — the runner half, and close to inert on its own

Nothing in-tree sets `reasoning` on the body the server forwards, so no product path changes on merge. One exception worth stating plainly: the server spreads a client-supplied event `data` verbatim into the runner body, so a direct API caller that already passes `reasoning` there goes from silently dropped to delivered as of this PR.

#2398 and #3273 would each start setting it server-side, and neither reaches an **in-process** harness until the runner stops dropping the key. The native terminals are unaffected either way — they read the persisted effort over a separate channel. This lands the runner side so the two halves can go in independently, as @ThomasHFWright [scoped it on #2398](https://github.com/omnigent-ai/omnigent/pull/2398#issuecomment-5131739684). I have left the Changelog section out for that reason — the user-facing line belongs on whichever server-side PR lands.

Two notes on reach. `?stream=true` has no production caller today, so the second test is a drift guard rather than coverage of a live path. Of the three other `_run_turn_bg` call sites, crash recovery and the catch-up scan synthesise a minimal `{agent_id, model}` body and carry no effort, so they are unaffected; the buffered follow-up in `_check_and_start_next_turn` replays a real inbound body off the message buffer, so a follow-up queued behind an active turn now carries the same effort as the turn that started it. That is intended, and it goes through the same guard.

### One behaviour change worth calling out, and a question for you

Effort is validated at session create against `EFFORT_VALUES`, the union of every provider's supported efforts. Once the field is actually delivered, an effort that is valid there but outside the target harness's family reaches the executor and fails the turn: `none` and `minimal` on `claude-sdk`, and four of the seven values on `antigravity-native`, whose family is narrower (`{low, medium, high}`). `codex-native` and `copilot` warn and drop instead.

The native path deliberately does not do that — the `effort_change` handler returns 204 when the value is outside the target family, and `test_patch_reasoning_effort_forwards_effort_change_event` case 4 records the intent as "Omnigent no longer filters — it forwards as-is, and the runner-side handler skips injection". Following that convention here would mean gating on the harness's declared `EffortFamily`.

I have not done that in this PR, because nothing currently maps an `EffortFamily` to its value set — every consumer hardcodes its own — so it would mean adding that mapping, which seems like its own change rather than something to fold into a bug fix. It also overlaps with whichever server-side PR lands, since that is where the effort is chosen. Happy to add the guard here if you would rather it live in the runner, or to leave it for a follow-up.

## Test Plan

- `uv run pytest -q tests/runner/test_runner_dispatch.py` gives 150 passed, 1 skipped.
- Removing only the `app.py` hunk fails exactly the two tests that assert the field arrives, and leaves the other six passing.
- Mutation check on the guard: weakening it to `if _reasoning is not None:` fails five of the eight cases, so both the string check and the normalisation are covered rather than assumed.
- Full `tests/runner/` gives 8 failed / 1310 passed — the same eight failures as a pristine baseline at the same base commit (tests that shell out to `git` from a directory that is not a repository).
- Ran `uv run ruff format --check` and `uv run ruff check` on both changed files, plus `lint_no_skipped_tests` and `lint_no_hardcoded_models`.

## Demo

An in-process probe drives `create_runner_app` with a recording harness client, so the panes show the exact body the runner hands the harness.

<img width="1800" height="1476" alt="pr3536demo2testredgreen" src="https://github.com/user-attachments/assets/96a4c8ba-0fa8-4730-b353-98c5399221ae" />

<img width="1520" height="1488" alt="pr3536demo1bodybeforeafter" src="https://github.com/user-attachments/assets/dc905dec-493d-494c-8e47-6a469cd3ac7a" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Eight cases across four tests: the background path carries `reasoning` through the rebuild, a sibling key is normalised away rather than forwarded, the `?stream=true` path still carries the field so the two dispatch paths cannot drift apart, and five parametrised cases pin that no `reasoning` key is invented from a missing, empty, null, non-dict or effort-less value. Manual verification was the in-process probe shown in the Demo section. The tests drive the file's existing `_ContentCapturingProcessManager`, so the only new helper is a small spec resolver, and they sit beside the other body-capture tests.
