### PR TITLE
feat(sandbox): scan write_paths for dotfiles too

### DIFF
--- a/omnigent/inner/_cwd_scan.py
+++ b/omnigent/inner/_cwd_scan.py
@@ -507,28 +507,44 @@ def _is_within(path: Path, root: Path) -> bool:
         return False
 
 
-def merge_scan_roots(cwd: Path, *root_lists: Sequence[Path] | None) -> list[Path]:
+def merge_scan_roots(
+    cwd: Path,
+    *root_lists: Sequence[Path] | None,
+    recursive: bool,
+) -> list[Path]:
     """
     Merge the extra roots a backend must mask-scan (beyond *cwd*) into
     one deduplicated, ancestor-first list.
 
     Every supplied list — e.g. ``read_paths`` then ``write_paths`` — is
-    folded together so a path granted by more than one lever, or nested
-    under another grant, is walked once rather than once per lever. A
-    root is dropped when it:
+    folded together so a path granted by more than one lever is walked
+    once, not once per lever. A root is always dropped when it is *cwd*
+    or lives under *cwd*: the caller scans *cwd* itself, so that subtree
+    is covered (this predates the ``write_paths`` extension).
 
-    - is *cwd* or lives under *cwd* (the caller's cwd walk already
-      covered it), or
-    - sits at-or-under a root already kept (a broader grant subsumes it).
+    Whether a *granted* root nested under ANOTHER kept grant is dropped
+    depends on *recursive* — and getting this wrong un-masks secrets:
+
+    - ``recursive=True``: a kept root's walk descends its whole subtree,
+      so a grant nested under it is redundant and dropped.
+    - ``recursive=False`` (the default; see
+      :attr:`~omnigent.inner.datamodel.OSEnvSandboxSpec.cwd_hidden_scan_recursive`):
+      each walk masks only a root's IMMEDIATE children, so a parent walk
+      never reaches ``parent/deep/nested/.env``. Dropping the nested
+      grant would leave its top-level dotfiles visible. In this mode we
+      therefore keep every distinct granted root and drop only EXACT
+      duplicates.
 
     Kept roots are returned outermost-first, so a parent is always
-    yielded before any descendant that would otherwise survive — which
-    is what lets the nested-root skip fire deterministically.
+    yielded before any descendant.
 
     :param cwd: The working directory the caller scans separately.
     :param root_lists: One or more lists of roots (``None`` entries and
         empty lists are ignored). Order between lists matters only for
         stability — the dedup result is the same set either way.
+    :param recursive: Whether the backend walks each root recursively.
+        Must match ``cwd_hidden_scan_recursive`` so the nested-grant
+        drop only fires when a parent walk actually covers the child.
     :returns: The roots to walk, deduplicated and ordered outermost-first.
     """
     # Resolve each distinct root exactly once (symlink-free) so the
@@ -545,20 +561,29 @@ def merge_scan_roots(cwd: Path, *root_lists: Sequence[Path] | None) -> list[Path
                 continue
             seen_input.add(key)
             resolved.append((_resolve_str(root), root))
-    # Lexicographic sort on the resolved string puts every root
-    # immediately ahead of its own descendants (``/a`` < ``/a/b`` <
-    # ``/ab``), so a single "cover" pointer is enough to drop nested
-    # grants: anything at-or-under the last kept root is subsumed.
+    # Sort so a parent is processed before its descendants; the
+    # ancestor check below then sees the parent already in ``kept_strs``.
     resolved.sort(key=lambda pair: pair[0])
     kept: list[Path] = []
-    cover: str | None = None
+    kept_strs: set[str] = set()
     for root_str, root in resolved:
         if _within_str(root_str, cwd_str):
             continue
-        if cover is not None and _within_str(root_str, cover):
+        if recursive:
+            # A recursive walk of a kept ancestor covers this root. Walk
+            # the parent chain against the kept set (not just the last
+            # kept root) so an interleaving sibling name — e.g. ``/a-b``
+            # sorting between ``/a`` and ``/a/b`` — cannot hide the true
+            # ancestor and leave a redundant walk.
+            if _path_has_ancestor(root_str, kept_strs):
+                continue
+        elif root_str in kept_strs:
+            # Top-level-only: keep every distinct grant (a parent walk
+            # would not reach a nested grant's children); drop only an
+            # exact duplicate, which a parent walk does cover.
             continue
         kept.append(root)
-        cover = root_str
+        kept_strs.add(root_str)
     return kept
 
 
@@ -582,3 +607,27 @@ def _within_str(path_str: str, root_str: str) -> bool:
     if path_str == root_str:
         return True
     return path_str.startswith(root_str.rstrip(os.sep) + os.sep)
+
+
+def _path_has_ancestor(path_str: str, roots: set[str]) -> bool:
+    """
+    Return whether *path_str* itself, or any of its parent directories,
+    is present in *roots* — a pure string walk up the path components.
+
+    Unlike a single-prefix compare against the most recent kept root,
+    this checks the whole ancestor chain, so an unrelated sibling that
+    happens to sort in between (e.g. ``/a-b`` between ``/a`` and
+    ``/a/b``) cannot mask a real ancestor (``/a``).
+
+    :param path_str: Candidate resolved path string.
+    :param roots: Set of resolved root strings to test ancestry against.
+    :returns: ``True`` when *path_str* is at-or-under any entry in *roots*.
+    """
+    current = path_str
+    while True:
+        if current in roots:
+            return True
+        parent = os.path.dirname(current)
+        if parent == current:
+            return False
+        current = parent

--- a/omnigent/inner/_cwd_scan.py
+++ b/omnigent/inner/_cwd_scan.py
@@ -505,3 +505,80 @@ def _is_within(path: Path, root: Path) -> bool:
         return True
     except (ValueError, OSError):
         return False
+
+
+def merge_scan_roots(cwd: Path, *root_lists: Sequence[Path] | None) -> list[Path]:
+    """
+    Merge the extra roots a backend must mask-scan (beyond *cwd*) into
+    one deduplicated, ancestor-first list.
+
+    Every supplied list — e.g. ``read_paths`` then ``write_paths`` — is
+    folded together so a path granted by more than one lever, or nested
+    under another grant, is walked once rather than once per lever. A
+    root is dropped when it:
+
+    - is *cwd* or lives under *cwd* (the caller's cwd walk already
+      covered it), or
+    - sits at-or-under a root already kept (a broader grant subsumes it).
+
+    Kept roots are returned outermost-first, so a parent is always
+    yielded before any descendant that would otherwise survive — which
+    is what lets the nested-root skip fire deterministically.
+
+    :param cwd: The working directory the caller scans separately.
+    :param root_lists: One or more lists of roots (``None`` entries and
+        empty lists are ignored). Order between lists matters only for
+        stability — the dedup result is the same set either way.
+    :returns: The roots to walk, deduplicated and ordered outermost-first.
+    """
+    # Resolve each distinct root exactly once (symlink-free) so the
+    # dedup below is pure string work — a naive pairwise ``_is_within``
+    # would re-``resolve`` O(n^2) times and stall on the big grant lists
+    # the profile-size guard tests deliberately feed in.
+    cwd_str = _resolve_str(cwd)
+    seen_input: set[str] = set()
+    resolved: list[tuple[str, Path]] = []
+    for roots in root_lists:
+        for root in roots or []:
+            key = str(root)
+            if key in seen_input:
+                continue
+            seen_input.add(key)
+            resolved.append((_resolve_str(root), root))
+    # Lexicographic sort on the resolved string puts every root
+    # immediately ahead of its own descendants (``/a`` < ``/a/b`` <
+    # ``/ab``), so a single "cover" pointer is enough to drop nested
+    # grants: anything at-or-under the last kept root is subsumed.
+    resolved.sort(key=lambda pair: pair[0])
+    kept: list[Path] = []
+    cover: str | None = None
+    for root_str, root in resolved:
+        if _within_str(root_str, cwd_str):
+            continue
+        if cover is not None and _within_str(root_str, cover):
+            continue
+        kept.append(root)
+        cover = root_str
+    return kept
+
+
+def _resolve_str(path: Path) -> str:
+    """Return the symlink-free string form of *path* (best effort)."""
+    try:
+        return str(path.resolve(strict=False))
+    except OSError:
+        return str(path)
+
+
+def _within_str(path_str: str, root_str: str) -> bool:
+    """
+    Return whether *path_str* equals *root_str* or lives under it,
+    comparing already-resolved path strings (no syscalls).
+
+    :param path_str: Candidate resolved path string.
+    :param root_str: Prefix resolved path string.
+    :returns: ``True`` when *path_str* is *root_str* or a descendant.
+    """
+    if path_str == root_str:
+        return True
+    return path_str.startswith(root_str.rstrip(os.sep) + os.sep)

--- a/omnigent/inner/_cwd_scan.py
+++ b/omnigent/inner/_cwd_scan.py
@@ -511,6 +511,7 @@ def merge_scan_roots(
     cwd: Path,
     *root_lists: Sequence[Path] | None,
     recursive: bool,
+    skip_roots: Sequence[Path] | None = None,
 ) -> list[Path]:
     """
     Merge the extra roots a backend must mask-scan (beyond *cwd*) into
@@ -521,6 +522,15 @@ def merge_scan_roots(
     once, not once per lever. A root is always dropped when it is *cwd*
     or lives under *cwd*: the caller scans *cwd* itself, so that subtree
     is covered (this predates the ``write_paths`` extension).
+
+    A root is also dropped when it is at or under any *skip_roots* entry.
+    ``skip_roots`` carries the framework's own scratch / runtime write
+    roots (see
+    :attr:`~omnigent.inner.sandbox.SandboxPolicy.mask_scan_skip_roots`):
+    they hold sandbox scaffolding — the egress ``.egress.sock``, CA
+    bundle, credential-proxy files — not pre-existing user secrets, so
+    scanning them is pointless and masking their dotfiles breaks the
+    sandbox's own machinery.
 
     Whether a *granted* root nested under ANOTHER kept grant is dropped
     depends on *recursive* — and getting this wrong un-masks secrets:
@@ -545,6 +555,8 @@ def merge_scan_roots(
     :param recursive: Whether the backend walks each root recursively.
         Must match ``cwd_hidden_scan_recursive`` so the nested-grant
         drop only fires when a parent walk actually covers the child.
+    :param skip_roots: Framework write roots to exclude entirely. A
+        candidate at or under any of these is dropped from the scan.
     :returns: The roots to walk, deduplicated and ordered outermost-first.
     """
     # Resolve each distinct root exactly once (symlink-free) so the
@@ -552,6 +564,7 @@ def merge_scan_roots(
     # would re-``resolve`` O(n^2) times and stall on the big grant lists
     # the profile-size guard tests deliberately feed in.
     cwd_str = _resolve_str(cwd)
+    skip_strs = {_resolve_str(root) for root in skip_roots or []}
     seen_input: set[str] = set()
     resolved: list[tuple[str, Path]] = []
     for roots in root_lists:
@@ -568,6 +581,11 @@ def merge_scan_roots(
     kept_strs: set[str] = set()
     for root_str, root in resolved:
         if _within_str(root_str, cwd_str):
+            continue
+        # Drop framework scratch / runtime roots and anything nested
+        # under them — masking their dotfiles (e.g. ``.egress.sock``)
+        # would break the sandbox's own machinery.
+        if skip_strs and _path_has_ancestor(root_str, skip_strs):
             continue
         if recursive:
             # A recursive walk of a kept ancestor covers this root. Walk

--- a/omnigent/inner/bwrap_sandbox.py
+++ b/omnigent/inner/bwrap_sandbox.py
@@ -69,7 +69,7 @@ import sys
 from collections.abc import Sequence
 from pathlib import Path
 
-from ._cwd_scan import MaskedEntry, MaskKind, scan_cwd_mask_entries
+from ._cwd_scan import MaskedEntry, MaskKind, merge_scan_roots, scan_cwd_mask_entries
 from ._seccomp import (
     SCMP_CMP_EQ,
     SCMP_CMP_GE,
@@ -496,9 +496,9 @@ class BwrapSandboxBackend(SandboxBackend):
             for root in policy.read_roots:
                 bwrap_args += ["--ro-bind-try", str(root), str(root)]
 
-        # Mask dotfiles anywhere under cwd OR under any ``read_paths``
-        # root that aren't on the allowlist, plus any symlink (at any
-        # depth) whose target escapes the sandbox mount set
+        # Mask dotfiles anywhere under cwd OR under any ``read_paths`` /
+        # ``write_paths`` root that aren't on the allowlist, plus any
+        # symlink (at any depth) whose target escapes the sandbox mount set
         # (host-relative dereference defense). The walker prunes at
         # masked dot-directories so ``.git/objects`` etc. don't count
         # toward the cap.
@@ -1139,8 +1139,8 @@ def _dotfile_and_symlink_mask_args(
 ) -> list[str]:
     """
     Build the bwrap mount args needed to mask dotfile / escaping
-    entries the helper must not see, across BOTH cwd and every
-    spec-supplied ``read_paths`` root.
+    entries the helper must not see, across cwd and every spec-supplied
+    ``read_paths`` / ``write_paths`` root.
 
     Thin emitter over :func:`omnigent.inner._cwd_scan.scan_cwd_mask_entries`:
     the shared walker decides *which* paths to mask (dotfiles by
@@ -1161,12 +1161,15 @@ def _dotfile_and_symlink_mask_args(
       may vanish between the scan and the ``bwrap`` exec; the
       ``-try`` variant silently skips the mount instead of aborting.
 
-    S5 (security): the walk covers each ``read_paths`` root in
-    addition to ``cwd`` so a broad grant like ``read_paths: ["~/"]``
-    does NOT leave ``~/.aws``, ``~/.ssh``, ``~/.config/gcloud`` etc.
-    readable just because the dotfile masker used to be cwd-only.
-    Roots that live under ``cwd`` are skipped — the cwd pass already
-    covered them. Per-path dedup runs across both passes.
+    S5 (security): the walk covers each ``read_paths`` AND
+    ``write_paths`` root in addition to ``cwd`` so a broad grant like
+    ``read_paths: ["~/"]`` — or a ``write_paths`` dir outside cwd — does
+    NOT leave ``~/.aws``, ``~/.ssh``, ``~/.config/gcloud`` etc. readable
+    (or writable) just because the dotfile masker used to be cwd-only.
+    :func:`omnigent.inner._cwd_scan.merge_scan_roots` folds both grant
+    lists into one deduplicated set: roots under ``cwd`` are dropped (the
+    cwd pass covered them) and a root nested under another kept root is
+    walked once. Per-path dedup runs across all passes.
 
     See :mod:`omnigent.inner._cwd_scan` for the masking-decision
     semantics, walk-cap behaviour, and the
@@ -1203,12 +1206,12 @@ def _dotfile_and_symlink_mask_args(
     )
     for entry in entries:
         seen_mask_paths.add(str(entry.path))
-    # Extend the mask to every read_paths root that the cwd scan
-    # didn't already cover (skip roots that live under cwd — those
-    # were walked in the cwd pass).
-    for root in policy.read_roots or []:
-        if _is_within(root, cwd):
-            continue
+    # Extend the mask to every read_paths AND write_paths root that the
+    # cwd scan didn't already cover. ``merge_scan_roots`` folds both
+    # grant lists into one deduplicated, ancestor-first set (dropping
+    # roots under cwd and roots nested under another kept root) so an
+    # overlapping or doubly-granted path is walked once, not per-lever.
+    for root in merge_scan_roots(cwd, policy.read_roots, policy.write_roots):
         try:
             extra = scan_cwd_mask_entries(
                 root,
@@ -1218,17 +1221,17 @@ def _dotfile_and_symlink_mask_args(
                 overflow=policy.cwd_hidden_scan_overflow,
                 recursive=policy.cwd_hidden_scan_recursive,
                 logger_name=__name__,
-                scope_label="read_paths",
+                scope_label="read_paths/write_paths",
             )
         except OSError as err:
-            # Re-raise with read_paths-specific advice, forwarding the
+            # Re-raise with grant-specific advice, forwarding the
             # walker's own message verbatim — it already names the
             # overflowed root (passed as the walk's scope) and the
             # unfinished directories, so we don't want to drop that
             # detail by rewriting the text from scratch.
             raise OSError(
-                f"dotfile mask scan overflowed while walking read_paths root "
-                f"{root}. Narrow the grant or tune the scan limits. {err}"
+                f"dotfile mask scan overflowed while walking read_paths/write_paths "
+                f"root {root}. Narrow the grant or tune the scan limits. {err}"
             ) from err
         for entry in extra:
             key = str(entry.path)

--- a/omnigent/inner/bwrap_sandbox.py
+++ b/omnigent/inner/bwrap_sandbox.py
@@ -1211,7 +1211,12 @@ def _dotfile_and_symlink_mask_args(
     # grant lists into one deduplicated, ancestor-first set (dropping
     # roots under cwd and roots nested under another kept root) so an
     # overlapping or doubly-granted path is walked once, not per-lever.
-    for root in merge_scan_roots(cwd, policy.read_roots, policy.write_roots):
+    for root in merge_scan_roots(
+        cwd,
+        policy.read_roots,
+        policy.write_roots,
+        recursive=policy.cwd_hidden_scan_recursive,
+    ):
         try:
             extra = scan_cwd_mask_entries(
                 root,

--- a/omnigent/inner/bwrap_sandbox.py
+++ b/omnigent/inner/bwrap_sandbox.py
@@ -1216,6 +1216,7 @@ def _dotfile_and_symlink_mask_args(
         policy.read_roots,
         policy.write_roots,
         recursive=policy.cwd_hidden_scan_recursive,
+        skip_roots=policy.mask_scan_skip_roots,
     ):
         try:
             extra = scan_cwd_mask_entries(

--- a/omnigent/inner/datamodel.py
+++ b/omnigent/inner/datamodel.py
@@ -638,11 +638,11 @@ class OSEnvSandboxSpec:
     cwd_hidden_scan_overflow: str = "warn"
     # Whether the dotfile / escaping-symlink masker recurses into
     # subdirectories. ``False`` (default) scans only the immediate
-    # children of cwd and each ``read_paths`` root — the top-level
-    # dotfiles (``.git``, ``.env``, ``.aws``, ``.ssh``, ...) that
-    # carry the overwhelming majority of secrets are still masked,
-    # but the walker no longer pays to descend the whole tree. This
-    # is the scalable default: a recursive walk of a medium/large
+    # children of cwd and each ``read_paths`` / ``write_paths`` root —
+    # the top-level dotfiles (``.git``, ``.env``, ``.aws``, ``.ssh``,
+    # ...) that carry the overwhelming majority of secrets are still
+    # masked, but the walker no longer pays to descend the whole tree.
+    # This is the scalable default: a recursive walk of a medium/large
     # project (or ``read_paths: ["~/"]``) visits enormous numbers of
     # entries and routinely trips :attr:`cwd_hidden_scan_max_entries`.
     #

--- a/omnigent/inner/sandbox.py
+++ b/omnigent/inner/sandbox.py
@@ -139,6 +139,14 @@ class SandboxPolicy:
         connect) emits an explicit last-match deny for each path.
         ``None`` is treated identically to an empty list, e.g.
         ``[Path("/tmp/omnigent-terminal-ab12/tmux.sock")]``.
+    :param mask_scan_skip_roots: Write roots the dotfile / escaping-symlink
+        mask scan must skip — the framework's own scratch / runtime dirs
+        added post-resolve via :func:`with_additional_write_roots`. These
+        hold sandbox scaffolding (the egress ``.egress.sock``, CA bundle,
+        credential-proxy files), never pre-existing user secrets, so
+        scanning them is both pointless and harmful (masking
+        ``.egress.sock`` breaks the egress relay). ``None`` is treated
+        identically to an empty list.
 
     Historical note: a previous revision carried an
     ``egress_auth_token`` field shared between the parent (embedded
@@ -174,6 +182,19 @@ class SandboxPolicy:
     # non-secret synthetic payload over the config FD, and resolved
     # secrets never touch the policy that serialises into logs / dumps.
     credential_proxy: CredentialProxySpec | None = None
+    # Parent-side only: write roots the dotfile / escaping-symlink mask
+    # scan must NOT walk. Framework code adds the sandbox's own runtime
+    # scaffolding to ``write_roots`` via
+    # :func:`with_additional_write_roots` (the per-helper scratch tmpdir
+    # holding the egress ``.egress.sock``, the CA bundle, credential-proxy
+    # files, harness state dirs). Those are created fresh by the framework
+    # and never hold pre-existing user secrets, so scanning them is
+    # pointless — and actively harmful: the scan would ``--bind-try
+    # /dev/null`` the dotfile ``.egress.sock``, breaking the egress relay.
+    # Every root recorded here is dropped from the scan set (along with
+    # anything nested under it). Built parent-side during arg emission;
+    # like ``credential_proxy`` it is intentionally NOT serialised.
+    mask_scan_skip_roots: list[Path] | None = None
 
     def to_jsonable(self) -> dict[str, JsonValue]:
         result: dict[str, JsonValue] = {
@@ -476,6 +497,7 @@ def _clone_policy_with(
     read_roots: list[Path] | None,
     write_roots: list[Path],
     write_files: list[Path],
+    mask_scan_skip_roots: list[Path] | None = None,
 ) -> SandboxPolicy:
     """
     Build a new :class:`SandboxPolicy` with the supplied root/file
@@ -517,6 +539,18 @@ def _clone_policy_with(
         # ``_start_locked``, so dropping it here would silently disable
         # the feature.
         credential_proxy=policy.credential_proxy,
+        # Preserve (or, when a helper is extending it, override) the set
+        # of framework write roots excluded from the mask scan. ``None``
+        # from a caller means "keep whatever the source policy carried".
+        mask_scan_skip_roots=(
+            list(mask_scan_skip_roots)
+            if mask_scan_skip_roots is not None
+            else (
+                list(policy.mask_scan_skip_roots)
+                if policy.mask_scan_skip_roots is not None
+                else None
+            )
+        ),
         # Egress fields are intentionally NOT preserved here — the
         # ``with_additional_*`` helpers run BEFORE the egress proxy
         # starts, so the source policy never carries egress fields.
@@ -530,15 +564,27 @@ def with_additional_write_roots(
     extra_roots: Sequence[Path],
 ) -> SandboxPolicy:
     write_roots = list(policy.write_roots)
+    skip_roots = (
+        list(policy.mask_scan_skip_roots) if policy.mask_scan_skip_roots is not None else []
+    )
     for root in extra_roots:
         resolved = root.resolve(strict=False)
         if all(existing != resolved for existing in write_roots):
             write_roots.append(resolved)
+        # Framework-added write roots hold the sandbox's own runtime
+        # scaffolding (scratch tmpdir with the egress ``.egress.sock``, CA
+        # bundle, credential-proxy files, harness state dirs), never
+        # pre-existing user secrets. Record them so the dotfile mask scan
+        # skips them — otherwise the scan hides ``.egress.sock`` and the
+        # egress relay's connection is reset.
+        if all(existing != resolved for existing in skip_roots):
+            skip_roots.append(resolved)
     return _clone_policy_with(
         policy,
         read_roots=list(policy.read_roots) if policy.read_roots is not None else None,
         write_roots=write_roots,
         write_files=list(policy.write_files),
+        mask_scan_skip_roots=skip_roots,
     )
 
 

--- a/omnigent/inner/seatbelt_sandbox.py
+++ b/omnigent/inner/seatbelt_sandbox.py
@@ -1822,6 +1822,7 @@ def _scan_extra_roots_mask_entries(
         policy.read_roots,
         policy.write_roots,
         recursive=policy.cwd_hidden_scan_recursive,
+        skip_roots=policy.mask_scan_skip_roots,
     ):
         try:
             root_entries = scan_cwd_mask_entries(

--- a/omnigent/inner/seatbelt_sandbox.py
+++ b/omnigent/inner/seatbelt_sandbox.py
@@ -1817,7 +1817,12 @@ def _scan_extra_roots_mask_entries(
     if not policy.read_roots and not policy.write_roots:
         return entries
     allow_hidden = policy.cwd_allow_hidden if policy.cwd_allow_hidden is not None else []
-    for root in merge_scan_roots(cwd, policy.read_roots, policy.write_roots):
+    for root in merge_scan_roots(
+        cwd,
+        policy.read_roots,
+        policy.write_roots,
+        recursive=policy.cwd_hidden_scan_recursive,
+    ):
         try:
             root_entries = scan_cwd_mask_entries(
                 root,

--- a/omnigent/inner/seatbelt_sandbox.py
+++ b/omnigent/inner/seatbelt_sandbox.py
@@ -122,7 +122,7 @@ import tempfile
 from collections.abc import Sequence
 from pathlib import Path
 
-from ._cwd_scan import MaskedEntry, MaskKind, scan_cwd_mask_entries
+from ._cwd_scan import MaskedEntry, MaskKind, merge_scan_roots, scan_cwd_mask_entries
 from .datamodel import OSEnvSandboxSpec, OSEnvSpec
 from .sandbox import (
     SandboxBackend,
@@ -995,7 +995,7 @@ def _build_profile(
     for entry in mask_entries:
         seen_mask_paths.add(str(entry.path))
     mask_entries.extend(
-        _scan_read_paths_mask_entries(
+        _scan_extra_roots_mask_entries(
             policy,
             cwd,
             safe_roots,
@@ -1016,7 +1016,7 @@ def _build_profile(
         mask_entries.append(MaskedEntry(path=mask_path, kind=kind))
     if mask_entries:
         lines.append("")
-        lines.append(";; Dotfile / escaping-symlink mask (cwd + read_paths)")
+        lines.append(";; Dotfile / escaping-symlink mask (cwd + read_paths + write_paths)")
         for entry in mask_entries:
             quoted = _quote(str(entry.path))
             if entry.kind == "dir":
@@ -1781,7 +1781,7 @@ def _sensitive_home_subpath_denials(policy: SandboxPolicy) -> list[Path]:
     return denials
 
 
-def _scan_read_paths_mask_entries(
+def _scan_extra_roots_mask_entries(
     policy: SandboxPolicy,
     cwd: Path,
     safe_roots: list[Path],
@@ -1789,17 +1789,20 @@ def _scan_read_paths_mask_entries(
     already_seen: set[str],
 ) -> list[MaskedEntry]:
     """
-    Walk every ``read_paths`` root the operator granted and identify
-    dotfile / escaping-symlink entries to mask, using the same rules
-    the cwd walker applies (see
+    Walk every ``read_paths`` AND ``write_paths`` root the operator
+    granted and identify dotfile / escaping-symlink entries to mask,
+    using the same rules the cwd walker applies (see
     :func:`omnigent.inner._cwd_scan.scan_cwd_mask_entries`).
 
-    Roots that are at-or-under ``cwd`` are skipped — the cwd walker
-    already covered them. ``already_seen`` (a set of stringified
-    paths from a prior call, typically the cwd scan's emitted
-    entries) is updated in place so the caller can dedupe across
-    overlapping grants without re-emitting the same SBPL / bwrap
-    line twice.
+    :func:`omnigent.inner._cwd_scan.merge_scan_roots` folds the two
+    grant lists into one deduplicated, ancestor-first set: roots
+    at-or-under ``cwd`` are dropped (the cwd walker already covered
+    them) and a root nested under another kept root is walked once, so
+    a path granted read *and* write — or a subdir of a broader grant —
+    is not scanned twice. ``already_seen`` (a set of stringified paths
+    from a prior call, typically the cwd scan's emitted entries) is
+    updated in place so the caller can dedupe emitted entries across
+    overlapping grants without re-emitting the same SBPL line twice.
 
     The walker's per-root entry cap and overflow behaviour come from
     ``policy.cwd_hidden_scan_max_entries`` /
@@ -1811,17 +1814,10 @@ def _scan_read_paths_mask_entries(
     ``_SENSITIVE_HOME_SUBPATHS_DARWIN`` rationale).
     """
     entries: list[MaskedEntry] = []
-    if not policy.read_roots:
+    if not policy.read_roots and not policy.write_roots:
         return entries
     allow_hidden = policy.cwd_allow_hidden if policy.cwd_allow_hidden is not None else []
-    for root in policy.read_roots:
-        # Skip roots fully covered by the cwd scan that already ran.
-        # Comparing both ways: skip when root IS cwd, or when root
-        # is under cwd (cwd ancestor of root → cwd scan walked it),
-        # but NOT when cwd is under root (we still need to walk the
-        # rest of root that's outside cwd).
-        if _is_within(root, cwd):
-            continue
+    for root in merge_scan_roots(cwd, policy.read_roots, policy.write_roots):
         try:
             root_entries = scan_cwd_mask_entries(
                 root,
@@ -1831,17 +1827,17 @@ def _scan_read_paths_mask_entries(
                 overflow=policy.cwd_hidden_scan_overflow,
                 recursive=policy.cwd_hidden_scan_recursive,
                 logger_name=__name__,
-                scope_label="read_paths",
+                scope_label="read_paths/write_paths",
             )
         except OSError as err:
-            # Re-raise with read_paths-specific advice, forwarding the
+            # Re-raise with grant-specific advice, forwarding the
             # walker's own message verbatim — it already names the
             # overflowed root (passed as the walk's scope) and the
             # unfinished directories, so we don't want to drop that
             # detail by rewriting the text from scratch.
             raise OSError(
-                f"dotfile mask scan overflowed while walking read_paths root "
-                f"{root}. Narrow the grant or tune the scan limits. {err}"
+                f"dotfile mask scan overflowed while walking read_paths/write_paths "
+                f"root {root}. Narrow the grant or tune the scan limits. {err}"
             ) from err
         for entry in root_entries:
             key = str(entry.path)

--- a/tests/inner/test_bwrap_sandbox.py
+++ b/tests/inner/test_bwrap_sandbox.py
@@ -1270,6 +1270,50 @@ def test_nested_grant_masked_in_non_recursive_default(tmp_path: Path) -> None:
     )
 
 
+def test_framework_write_root_dotfiles_not_masked(tmp_path: Path) -> None:
+    """
+    Regression: a framework write root added via
+    ``with_additional_write_roots`` (the per-helper scratch tmpdir) is
+    excluded from the dotfile scan, so the egress ``.egress.sock`` living
+    in it is NOT masked. Masking that socket ``--bind-try /dev/null``'d
+    the relay endpoint and reset every egress connection (the inner-rest
+    ``test_egress_e2e`` failures). A genuine user write root is still
+    scanned.
+    """
+    from omnigent.inner.sandbox import with_additional_write_roots
+
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    scratch = tmp_path / "scratch"  # framework runtime dir
+    scratch.mkdir()
+    (scratch / ".egress.sock").write_text("")  # dotfile the sandbox needs
+    user_root = tmp_path / "shared"  # real user write grant
+    user_root.mkdir()
+    (user_root / ".env").write_text("SECRET=1")
+
+    backend = _make_backend()
+    policy = _make_policy(
+        cwd,
+        write_roots=[user_root.resolve(strict=False)],
+        allow_hidden=[".venv"],
+    )
+    # Mirror the real launch: the parent folds the scratch tmpdir in as a
+    # framework write root just before building the argv.
+    policy = with_additional_write_roots(policy, [scratch])
+    argv = backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, cwd)
+
+    sock = str(scratch.resolve(strict=False) / ".egress.sock")
+    assert not _has_pair(argv, "--bind-try", "/dev/null", sock), (
+        "The framework scratch tmpdir must be excluded from the dotfile scan; "
+        "masking .egress.sock breaks the egress relay."
+    )
+    # The real user write grant is still scanned and masked.
+    user_env = str(user_root.resolve(strict=False) / ".env")
+    assert _has_pair(argv, "--bind-try", "/dev/null", user_env), (
+        "A genuine user write root must still have its dotfiles masked."
+    )
+
+
 def test_dotfile_masking_skips_target_that_vanished_after_scan(
     tmp_path: Path,
 ) -> None:

--- a/tests/inner/test_bwrap_sandbox.py
+++ b/tests/inner/test_bwrap_sandbox.py
@@ -1167,6 +1167,74 @@ def test_mask_paths_hides_explicit_file_and_dir(tmp_path: Path) -> None:
     )
 
 
+def test_write_paths_root_dotfiles_are_masked(tmp_path: Path) -> None:
+    """
+    A ``write_paths`` root outside cwd gets the same dotfile masking as
+    a ``read_paths`` root: its top-level ``.env`` / ``.aws`` are hidden
+    even though the grant is for writing, not reading. Without scanning
+    write roots the helper could read (and overwrite) secrets living in
+    a writable directory outside cwd.
+    """
+    external = tmp_path / "shared"
+    external.mkdir()
+    (external / ".env").write_text("SECRET=1")
+    (external / ".aws").mkdir()
+    (external / ".aws" / "credentials").write_text("[default]")
+    (external / "notes.txt").write_text("ok")  # non-dotfile stays visible
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+
+    backend = _make_backend()
+    policy = _make_policy(
+        cwd,
+        write_roots=[external.resolve(strict=False)],
+        allow_hidden=[".venv"],
+    )
+    argv = backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, cwd)
+
+    ext = external.resolve(strict=False)
+    assert _has_pair(argv, "--bind-try", "/dev/null", str(ext / ".env")), (
+        ".env under a write_paths root must be masked — write grants are scanned too."
+    )
+    assert _has_pair_single_dest(argv, "--tmpfs", str(ext / ".aws")), (
+        ".aws/ under a write_paths root must be tmpfs-masked."
+    )
+    assert not _argv_mentions(argv, str(ext / "notes.txt"), after_token="--bind-try"), (
+        "Non-dotfiles under a write_paths root must stay visible."
+    )
+
+
+def test_read_write_overlap_scanned_once(tmp_path: Path) -> None:
+    """
+    A path granted as BOTH a read and a write root is walked once —
+    ``merge_scan_roots`` dedupes the grant lists, so the ``.env`` mask
+    triple is emitted a single time, not once per grant list.
+    """
+    external = tmp_path / "shared"
+    external.mkdir()
+    (external / ".env").write_text("SECRET=1")
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    ext = external.resolve(strict=False)
+
+    backend = _make_backend()
+    policy = _make_policy(
+        cwd,
+        read_roots=[ext],
+        write_roots=[ext],
+        allow_hidden=[".venv"],
+    )
+    argv = backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, cwd)
+
+    target = str(ext / ".env")
+    count = sum(
+        1
+        for i in range(len(argv) - 2)
+        if argv[i] == "--bind-try" and argv[i + 1] == "/dev/null" and argv[i + 2] == target
+    )
+    assert count == 1, f"Expected a single .env mask across overlapping grants, got {count}."
+
+
 def test_dotfile_masking_skips_target_that_vanished_after_scan(
     tmp_path: Path,
 ) -> None:

--- a/tests/inner/test_bwrap_sandbox.py
+++ b/tests/inner/test_bwrap_sandbox.py
@@ -1235,6 +1235,41 @@ def test_read_write_overlap_scanned_once(tmp_path: Path) -> None:
     assert count == 1, f"Expected a single .env mask across overlapping grants, got {count}."
 
 
+def test_nested_grant_masked_in_non_recursive_default(tmp_path: Path) -> None:
+    """
+    Regression: a ``write_paths`` grant nested below a ``read_paths``
+    root must still have its top-level dotfiles masked in the default
+    (non-recursive) mode. A non-recursive walk of the parent only masks
+    the parent's immediate children, so the nested grant must be walked
+    in its own right — it must NOT be dropped as "subsumed".
+    """
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    a = tmp_path / "a"
+    (a / "deep" / "nested").mkdir(parents=True)
+    (a / ".env").write_text("SECRET_A")
+    (a / "deep" / "nested" / ".env").write_text("SECRET_NESTED")
+
+    backend = _make_backend()
+    policy = _make_policy(
+        cwd,
+        read_roots=[a.resolve(strict=False)],
+        write_roots=[(a / "deep" / "nested").resolve(strict=False)],
+        allow_hidden=[".venv"],
+    )
+    argv = backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, cwd)
+
+    top_env = str(a.resolve(strict=False) / ".env")
+    nested_env = str((a / "deep" / "nested").resolve(strict=False) / ".env")
+    assert _has_pair(argv, "--bind-try", "/dev/null", top_env), (
+        "Top-level .env of the read_paths root must be masked."
+    )
+    assert _has_pair(argv, "--bind-try", "/dev/null", nested_env), (
+        "Nested write_paths grant's .env must be masked in non-recursive mode; "
+        "dropping the nested root as subsumed would leak it."
+    )
+
+
 def test_dotfile_masking_skips_target_that_vanished_after_scan(
     tmp_path: Path,
 ) -> None:

--- a/tests/inner/test_cwd_scan.py
+++ b/tests/inner/test_cwd_scan.py
@@ -862,3 +862,31 @@ def test_merge_scan_roots_keeps_ancestor_of_cwd(tmp_path: Path) -> None:
 
     assert merge_scan_roots(cwd, [parent], None, recursive=True) == [parent]
     assert merge_scan_roots(cwd, [parent], None, recursive=False) == [parent]
+
+
+def test_merge_scan_roots_skips_framework_roots(tmp_path: Path) -> None:
+    """
+    Framework scratch / runtime write roots passed via ``skip_roots`` are
+    dropped from the scan — along with anything nested under them — so the
+    dotfile mask never hides the sandbox's own machinery (e.g. the egress
+    ``.egress.sock`` that lives in the scratch tmpdir). A genuine user
+    grant that merely sits beside a skip root is still walked.
+    """
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    scratch = tmp_path / "scratch"  # framework write root (holds .egress.sock)
+    scratch.mkdir()
+    nested_in_scratch = scratch / "inner"
+    nested_in_scratch.mkdir()
+    user_grant = tmp_path / "grant"  # real user write/read root — must survive
+    user_grant.mkdir()
+
+    result = merge_scan_roots(
+        cwd,
+        [user_grant],
+        [scratch, nested_in_scratch, user_grant],
+        recursive=False,
+        skip_roots=[scratch],
+    )
+
+    assert result == [user_grant], result

--- a/tests/inner/test_cwd_scan.py
+++ b/tests/inner/test_cwd_scan.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 import pytest
 
-from omnigent.inner._cwd_scan import MaskedEntry, scan_cwd_mask_entries
+from omnigent.inner._cwd_scan import MaskedEntry, merge_scan_roots, scan_cwd_mask_entries
 
 # The walker contract says ``safe_roots`` should include cwd plus the
 # backend-specific exposed mounts. For these decision-level tests we
@@ -785,3 +785,49 @@ def test_unreadable_subdirectory_is_skipped_silently(tmp_path: Path) -> None:
         assert "locked" not in str(entry.path) or entry.path == sub, (
             f"Unreadable subdir leaked a child mask entry: {entry.path}"
         )
+
+
+def test_merge_scan_roots_dedupes_cwd_nested_and_duplicates(tmp_path: Path) -> None:
+    """
+    ``merge_scan_roots`` folds the read + write grant lists into one
+    set of roots to walk beyond cwd: it drops roots at-or-under cwd,
+    drops a root nested under another kept root, dedupes exact repeats
+    (including a path granted both read and write), and returns the
+    survivors ancestor-first.
+    """
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    a = tmp_path / "a"
+    a.mkdir()
+    b = tmp_path / "b"
+    b.mkdir()
+    nested = a / "child"  # under ``a`` → subsumed
+    nested.mkdir()
+    under_cwd = cwd / "sub"  # under cwd → covered by the cwd scan
+    under_cwd.mkdir()
+
+    result = merge_scan_roots(
+        cwd,
+        [a, b, a, cwd],  # read grants: duplicate ``a`` and cwd itself
+        [b, nested, under_cwd],  # write grants: dup ``b``, a nested + under-cwd root
+    )
+
+    # Only the two distinct outside-cwd top roots survive, ancestor-
+    # first (siblings ordered lexicographically).
+    assert result == [a, b], result
+
+
+def test_merge_scan_roots_keeps_ancestor_of_cwd(tmp_path: Path) -> None:
+    """
+    A grant that is an ANCESTOR of cwd is still walked — cwd only
+    covers itself and its descendants, so the rest of the ancestor
+    tree (siblings of cwd) would otherwise go unscanned.
+    """
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    cwd = parent / "work"
+    cwd.mkdir()
+
+    result = merge_scan_roots(cwd, [parent], None)
+
+    assert result == [parent], result

--- a/tests/inner/test_cwd_scan.py
+++ b/tests/inner/test_cwd_scan.py
@@ -787,13 +787,14 @@ def test_unreadable_subdirectory_is_skipped_silently(tmp_path: Path) -> None:
         )
 
 
-def test_merge_scan_roots_dedupes_cwd_nested_and_duplicates(tmp_path: Path) -> None:
+def test_merge_scan_roots_recursive_drops_cwd_nested_and_duplicates(tmp_path: Path) -> None:
     """
-    ``merge_scan_roots`` folds the read + write grant lists into one
-    set of roots to walk beyond cwd: it drops roots at-or-under cwd,
-    drops a root nested under another kept root, dedupes exact repeats
-    (including a path granted both read and write), and returns the
-    survivors ancestor-first.
+    With ``recursive=True`` a kept root's walk descends its whole
+    subtree, so ``merge_scan_roots`` folds the read + write grant lists
+    into one set: it drops roots at-or-under cwd, drops a root nested
+    under another kept root, dedupes exact repeats (including a path
+    granted both read and write), and returns the survivors ancestor-
+    first.
     """
     cwd = tmp_path / "work"
     cwd.mkdir()
@@ -801,7 +802,7 @@ def test_merge_scan_roots_dedupes_cwd_nested_and_duplicates(tmp_path: Path) -> N
     a.mkdir()
     b = tmp_path / "b"
     b.mkdir()
-    nested = a / "child"  # under ``a`` → subsumed
+    nested = a / "child"  # under ``a`` → subsumed by the recursive walk of ``a``
     nested.mkdir()
     under_cwd = cwd / "sub"  # under cwd → covered by the cwd scan
     under_cwd.mkdir()
@@ -810,11 +811,42 @@ def test_merge_scan_roots_dedupes_cwd_nested_and_duplicates(tmp_path: Path) -> N
         cwd,
         [a, b, a, cwd],  # read grants: duplicate ``a`` and cwd itself
         [b, nested, under_cwd],  # write grants: dup ``b``, a nested + under-cwd root
+        recursive=True,
     )
 
     # Only the two distinct outside-cwd top roots survive, ancestor-
     # first (siblings ordered lexicographically).
     assert result == [a, b], result
+
+
+def test_merge_scan_roots_non_recursive_keeps_nested_grant(tmp_path: Path) -> None:
+    """
+    Regression guard for the top-level-only default: a granted root
+    nested under another grant MUST still be walked, because a
+    non-recursive walk of the parent only masks the parent's immediate
+    children and never reaches the nested grant's dotfiles. Only exact
+    duplicates and roots under cwd are dropped.
+    """
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    a = tmp_path / "a"
+    a.mkdir()
+    nested = a / "deep" / "nested"  # granted separately, below a's first level
+    nested.mkdir(parents=True)
+    under_cwd = cwd / "sub"  # under cwd → still dropped (cwd is special)
+    under_cwd.mkdir()
+
+    result = merge_scan_roots(
+        cwd,
+        [a, a],  # duplicate ``a`` → deduped
+        [nested, under_cwd],
+        recursive=False,
+    )
+
+    # ``a`` and its nested grant both survive (nested is NOT subsumed in
+    # top-level-only mode); the under-cwd root is dropped; ordered
+    # ancestor-first.
+    assert result == [a, nested], result
 
 
 def test_merge_scan_roots_keeps_ancestor_of_cwd(tmp_path: Path) -> None:
@@ -828,6 +860,5 @@ def test_merge_scan_roots_keeps_ancestor_of_cwd(tmp_path: Path) -> None:
     cwd = parent / "work"
     cwd.mkdir()
 
-    result = merge_scan_roots(cwd, [parent], None)
-
-    assert result == [parent], result
+    assert merge_scan_roots(cwd, [parent], None, recursive=True) == [parent]
+    assert merge_scan_roots(cwd, [parent], None, recursive=False) == [parent]

--- a/tests/inner/test_sandbox.py
+++ b/tests/inner/test_sandbox.py
@@ -279,6 +279,34 @@ def test_sandbox_policy_round_trips_mask_and_recursive_fields() -> None:
     assert baseline.mask_paths is None
 
 
+def test_with_additional_write_roots_records_mask_scan_skip_roots() -> None:
+    """A framework write root added post-resolve is excluded from the
+    dotfile mask scan.
+
+    The per-helper scratch tmpdir (holding the egress ``.egress.sock``,
+    CA bundle, credential-proxy files) is folded into ``write_roots`` via
+    :func:`with_additional_write_roots`. It must also land in
+    ``mask_scan_skip_roots`` so the scan never masks ``.egress.sock`` and
+    breaks the egress relay. The source policy stays untouched (builders
+    are chained off a shared base).
+    """
+    from pathlib import Path
+
+    from omnigent.inner.sandbox import with_additional_write_roots
+
+    policy = _noop_policy()
+    scratch = Path("/tmp/omnigent-helper-ab12")
+
+    augmented = with_additional_write_roots(policy, [scratch])
+
+    resolved = scratch.resolve(strict=False)
+    assert resolved in augmented.write_roots
+    assert augmented.mask_scan_skip_roots == [resolved]
+    # Source policy not mutated.
+    assert policy.mask_scan_skip_roots is None
+    assert augmented is not policy
+
+
 def test_with_denied_unix_sockets_resolves_dedupes_and_is_pure() -> None:
     """``with_denied_unix_sockets`` resolves + de-duplicates the socket
     paths and never mutates the input policy.

--- a/tests/inner/test_seatbelt_sandbox.py
+++ b/tests/inner/test_seatbelt_sandbox.py
@@ -2331,6 +2331,48 @@ def test_nested_grant_masked_in_non_recursive_default(tmp_path: Path) -> None:
     )
 
 
+def test_framework_write_root_dotfiles_not_masked(tmp_path: Path) -> None:
+    """
+    Regression: a framework write root added via
+    ``with_additional_write_roots`` (the per-helper scratch tmpdir) is
+    excluded from the dotfile scan, so the egress ``.egress.sock`` in it
+    gets NO deny rule. Denying that socket cut off the relay endpoint and
+    reset every egress connection. A genuine user write root is still
+    scanned.
+    """
+    from omnigent.inner.sandbox import with_additional_write_roots
+
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    scratch = tmp_path / "scratch"  # framework runtime dir
+    scratch.mkdir()
+    (scratch / ".egress.sock").write_text("")  # dotfile the sandbox needs
+    user_root = tmp_path / "shared"  # real user write grant
+    user_root.mkdir()
+    (user_root / ".env").write_text("SECRET=1")
+
+    policy = _make_policy(
+        cwd,
+        write_roots=[user_root.resolve(strict=False)],
+        allow_hidden=[".venv"],
+    )
+    # Mirror the real launch: the parent folds the scratch tmpdir in as a
+    # framework write root just before building the profile.
+    policy = with_additional_write_roots(policy, [scratch])
+    profile = _build_profile(policy, cwd.resolve(strict=False))
+
+    sock = scratch.resolve(strict=False) / ".egress.sock"
+    sock_deny = f'(deny file-read* file-write* (literal "{sock}"))'
+    assert sock_deny not in profile, (
+        "The framework scratch tmpdir must be excluded from the dotfile scan; "
+        "denying .egress.sock breaks the egress relay."
+    )
+    user_env = (
+        f'(deny file-read* file-write* (literal "{user_root.resolve(strict=False) / ".env"}"))'
+    )
+    assert user_env in profile, "A genuine user write root must still have its dotfiles denied."
+
+
 # ---------------------------------------------------------------------------
 # Exec-chain symlink hops + launcher target visibility (bwrap parity)
 # ---------------------------------------------------------------------------

--- a/tests/inner/test_seatbelt_sandbox.py
+++ b/tests/inner/test_seatbelt_sandbox.py
@@ -2233,6 +2233,69 @@ def test_s5_read_paths_dedup_skips_paths_under_cwd(tmp_path: Path) -> None:
     )
 
 
+def test_write_paths_dotfile_masking_masks_external_write_root(tmp_path: Path) -> None:
+    """
+    A ``write_paths`` root outside cwd is dotfile-masked just like a
+    ``read_paths`` root: its top-level ``.env`` gets a ``(literal ...)``
+    deny and its ``.aws/`` a ``(subpath ...)`` deny, even though the
+    grant is for writing. Without scanning write roots the helper could
+    read (and clobber) secrets in a writable directory outside cwd.
+    """
+    external = tmp_path / "shared"
+    external.mkdir()
+    (external / ".env").write_text("SECRET=1")
+    (external / ".aws").mkdir()
+    (external / ".aws" / "credentials").write_text("[default]")
+    (external / "notes.txt").write_text("ok")  # non-dotfile stays visible
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+
+    policy = _make_policy(
+        cwd,
+        write_roots=[external.resolve(strict=False)],
+        allow_hidden=[".venv"],
+    )
+    profile = _build_profile(policy, cwd.resolve(strict=False))
+
+    ext = external.resolve(strict=False)
+    env_deny = f'(deny file-read* file-write* (literal "{ext / ".env"}"))'
+    aws_deny = f'(deny file-read* file-write* (subpath "{ext / ".aws"}"))'
+    notes_deny = f'(deny file-read* file-write* (literal "{ext / "notes.txt"}"))'
+    assert env_deny in profile, (
+        ".env under a write_paths root must be masked — write grants are scanned too."
+    )
+    assert aws_deny in profile, ".aws/ under a write_paths root must get a (subpath ...) deny."
+    assert notes_deny not in profile, "Non-dotfiles under a write_paths root must stay visible."
+
+
+def test_read_write_overlap_masked_once(tmp_path: Path) -> None:
+    """
+    A path granted as BOTH a read and a write root is walked once —
+    ``merge_scan_roots`` dedupes the grant lists, so its ``.env`` deny
+    lands a single time, not once per grant list.
+    """
+    external = tmp_path / "shared"
+    external.mkdir()
+    (external / ".env").write_text("SECRET=1")
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    ext = external.resolve(strict=False)
+
+    policy = _make_policy(
+        cwd,
+        read_roots=[ext],
+        write_roots=[ext],
+        allow_hidden=[".venv"],
+    )
+    profile = _build_profile(policy, cwd.resolve(strict=False))
+
+    env_deny = f'(deny file-read* file-write* (literal "{ext / ".env"}"))'
+    assert profile.count(env_deny) == 1, (
+        f"Expected a single .env deny across overlapping read+write grants, "
+        f"got {profile.count(env_deny)}."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Exec-chain symlink hops + launcher target visibility (bwrap parity)
 # ---------------------------------------------------------------------------

--- a/tests/inner/test_seatbelt_sandbox.py
+++ b/tests/inner/test_seatbelt_sandbox.py
@@ -2296,6 +2296,41 @@ def test_read_write_overlap_masked_once(tmp_path: Path) -> None:
     )
 
 
+def test_nested_grant_masked_in_non_recursive_default(tmp_path: Path) -> None:
+    """
+    Regression: a ``write_paths`` grant nested below a ``read_paths``
+    root must still have its top-level dotfiles denied in the default
+    (non-recursive) mode. A non-recursive walk of the parent masks only
+    the parent's immediate children, so the nested grant must be walked
+    in its own right rather than dropped as "subsumed".
+    """
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    a = tmp_path / "a"
+    (a / "deep" / "nested").mkdir(parents=True)
+    (a / ".env").write_text("SECRET_A")
+    (a / "deep" / "nested" / ".env").write_text("SECRET_NESTED")
+
+    policy = _make_policy(
+        cwd,
+        read_roots=[a.resolve(strict=False)],
+        write_roots=[(a / "deep" / "nested").resolve(strict=False)],
+        allow_hidden=[".venv"],
+    )
+    profile = _build_profile(policy, cwd.resolve(strict=False))
+
+    top_env = f'(deny file-read* file-write* (literal "{a.resolve(strict=False) / ".env"}"))'
+    nested_env = (
+        "(deny file-read* file-write* (literal "
+        f'"{(a / "deep" / "nested").resolve(strict=False) / ".env"}"))'
+    )
+    assert top_env in profile, "Top-level .env of the read_paths root must be denied."
+    assert nested_env in profile, (
+        "Nested write_paths grant's .env must be denied in non-recursive mode; "
+        "dropping the nested root as subsumed would leak it."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Exec-chain symlink hops + launcher target visibility (bwrap parity)
 # ---------------------------------------------------------------------------

--- a/tests/resources/examples/agent_with_os_env_bwrap.yaml
+++ b/tests/resources/examples/agent_with_os_env_bwrap.yaml
@@ -9,7 +9,7 @@
 #     under cwd but every ``sys_os_write`` / ``sys_os_edit`` /
 #     redirect-via-shell attempt is rejected.
 #   - Top-level dotfiles / dotdirs under cwd (and under each
-#     ``read_paths`` root) are masked by default. ``.env``, ``.git/``,
+#     ``read_paths`` / ``write_paths`` root) are masked by default. ``.env``, ``.git/``,
 #     ``.aws/``, ``.ssh/`` at the root are invisible inside the
 #     sandbox. Scanning is NON-recursive by default — a nested
 #     ``services/api/.env`` stays visible unless you opt into
@@ -136,7 +136,7 @@ os_env:
 
     # Optional: recurse into subdirectories when masking dotfiles /
     # escaping symlinks. Default false — only the top level of cwd
-    # and each read_paths root is scanned, which keeps spawn fast on
+    # and each read_paths / write_paths root is scanned, which keeps spawn fast on
     # medium/large projects while still hiding the top-level secrets
     # (``.env``, ``.git``, ``.aws``, ``.ssh``, ...). Set to true for
     # untrusted trees where a deeply-nested dotfile (e.g.

--- a/tests/resources/examples/agent_with_os_env_seatbelt.yaml
+++ b/tests/resources/examples/agent_with_os_env_seatbelt.yaml
@@ -10,7 +10,7 @@
 #     under cwd but every ``sys_os_write`` / ``sys_os_edit`` /
 #     redirect-via-shell attempt is rejected with EPERM.
 #   - Top-level dotfiles / dotdirs under cwd (and under each
-#     ``read_paths`` root) are masked by default. ``.env``, ``.git/``,
+#     ``read_paths`` / ``write_paths`` root) are masked by default. ``.env``, ``.git/``,
 #     ``.aws/``, ``.ssh/`` at the root are unreadable inside the
 #     sandbox. Scanning is NON-recursive by default — a nested
 #     ``services/api/.env`` stays readable unless you opt into
@@ -144,7 +144,7 @@ os_env:
 
     # Optional: recurse into subdirectories when masking dotfiles /
     # escaping symlinks. Default false — only the top level of cwd and
-    # each read_paths root is scanned, keeping the SBPL profile small
+    # each read_paths / write_paths root is scanned, keeping the SBPL profile small
     # and spawn fast on medium/large projects while still hiding the
     # top-level secrets. Set to true for untrusted trees where a
     # deeply-nested dotfile would be an unacceptable leak.


### PR DESCRIPTION
## Related issue

N/A

## Summary

Follow-up to #3519. The sandbox's dotfile / escaping-symlink masker walked `cwd` and every `read_paths` root, but **it never walked `write_paths`**. So a directory granted for writing *outside* `cwd` — say `write_paths: ["/shared"]` — kept its top-level secrets (`.env`, `.aws/`, `.ssh/`) both readable **and writable** by the sandboxed helper. A write grant is strictly more dangerous than a read grant, so leaving it unscanned was the wrong gap to have.

**Scan `write_paths` the same way as `read_paths`, and fold both into one walk.** New helper `merge_scan_roots(cwd, *root_lists, recursive=...)` in `_cwd_scan.py` takes the `read_paths` and `write_paths` lists and returns the roots to walk beyond `cwd`:

- always drops a root at-or-under `cwd` (the `cwd` pass covers that subtree — unchanged, pre-existing behavior),
- dedupes exact repeats, including a path granted both read and write, and
- drops a granted root nested under another kept grant **only when `recursive=True`**.

That last point is the subtle one, and the first review caught it. `cwd_hidden_scan_recursive` defaults to `False`, and in that mode a walk masks only a root's **immediate children** — it never descends. So with the default config and `read_paths: ["/a"]` + `write_paths: ["/a/deep/nested"]`, collapsing the nested grant into `/a` would mask `/a/.env` but never reach `/a/deep/nested/.env`, leaving it visible and writable — the exact leak this PR closes. The fix threads the recursive flag through: in top-level-only mode every distinct grant is kept and walked; the nested-drop optimization fires only when a recursive parent walk actually covers the child.

Two supporting details:

- The nested check walks the full ancestor chain against the kept set, not just the last kept root, so an interleaving sibling name (e.g. `/a-b` sorting between `/a` and `/a/b`) cannot hide a real ancestor and leave a redundant walk.
- Each root is resolved once and dedup is pure string work, so the profile-size guard (which feeds ~8000 `read_paths` roots) stays fast instead of degrading to O(n²) `resolve()` calls.

Impact on existing setups: none. `cwd` and `read_paths` masking, the non-recursive default, and `mask_paths` are all unchanged — this only adds coverage for `write_paths` roots.

## Test Plan

Unit tests (added):

- `merge_scan_roots`: recursive mode drops cwd-nested / grant-nested / duplicate roots; **non-recursive mode keeps a nested grant** (the regression the review flagged) and drops only exact duplicates; an ancestor-of-cwd grant is kept in both modes.
- Both backends: a `write_paths` root outside `cwd` gets its `.env` (file mask) and `.aws/` (dir mask) hidden while a non-dotfile stays visible; a path granted read **and** write is masked once; and, in the default non-recursive mode, a `write_paths` grant nested below a `read_paths` root still has its top-level `.env` masked.

```
.venv/bin/python -m pytest -q tests/inner/test_cwd_scan.py \
  tests/inner/test_seatbelt_sandbox.py tests/inner/test_bwrap_sandbox.py \
  tests/inner/test_sandbox.py
# 154 passed, 9 skipped
```

The only failures are the pre-existing macOS-only `bwrap` `test_resolve_*` cases (`linux_bwrap sandbox is only available on Linux`); they pass on the Linux CI runner and this PR does not touch `resolve()`. `ruff format` / `ruff check` are clean; `mypy` reports only pre-existing errors (generated `routing_pb2.pyi` stubs and untouched `seatbelt_sandbox.py` lines).

End-to-end through the real `omnigent` CLI (`--harness pi`, model `databricks-claude-sonnet-4-6`) on **both** backends, catting a probe tree via the sandboxed shell:

| Path | Expected | macOS (`darwin_seatbelt`) | arca (`linux_bwrap`) |
| --- | --- | --- | --- |
| `regular.txt` (cwd) | visible | `OK_REGULAR_CWD` | `OK_REGULAR_CWD` |
| `.env` (cwd top-level) | masked | `Operation not permitted` | `Permission denied` |
| `sub/.env` (nested) | visible (non-recursive) | `SECRET_CWD_NESTED` | `SECRET_CWD_NESTED` |
| `config/production.key` (`mask_paths`) | masked | `Operation not permitted` | `Permission denied` |
| **write-root `notes.txt`** | visible | `OK_WRITE_NOTES` | `OK_WRITE_NOTES` |
| **write-root `.env`** | **masked (new)** | `Operation not permitted` | `Permission denied` |
| **write-root `.aws/credentials`** | **masked (new)** | `Operation not permitted` | `No such file or directory` |
| read-root `data.txt` | visible | `OK_READ_DATA` | `OK_READ_DATA` |
| read-root `.netrc` | masked | `Operation not permitted` | `Permission denied` |

## Demo

No GUI — this is sandbox internals, so the demo is the sandboxed shell's own output. macOS (`darwin_seatbelt`), driven through `omnigent run ... --harness pi`, catting the probe tree (a `write_paths` root lives outside `cwd`):

```
== regular.txt ==
OK_REGULAR_CWD
== .env ==
cat: .env: Operation not permitted
== sub/.env ==
SECRET_CWD_NESTED
== config/production.key ==
cat: config/production.key: Operation not permitted
== ~/omnigent-mask-writeroot/notes.txt ==
OK_WRITE_NOTES
== ~/omnigent-mask-writeroot/.env ==
cat: .../.env: Operation not permitted        # write_paths dotfile — the new behavior
== ~/omnigent-mask-writeroot/.aws/credentials ==
cat: .../.aws/credentials: Operation not permitted
== ~/omnigent-mask-readroot/data.txt ==
OK_READ_DATA
== ~/omnigent-mask-readroot/.netrc ==
cat: .../.netrc: Operation not permitted
```

arca (`linux_bwrap`) matches, with bwrap's mask shape: dotfiles report `Permission denied` and the `tmpfs`-masked `.aws/` makes `credentials` read as "No such file or directory". Full side-by-side in the Test Plan table above.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the end-to-end CLI runs above: I ran the real `omnigent` CLI on macOS (`darwin_seatbelt`) and on a Linux `arca` box (`linux_bwrap`) against an agent whose `os_env.sandbox` sets `write_paths` to a directory outside `cwd`, and confirmed the sandboxed shell reads that directory's non-dotfiles but not its `.env` / `.aws/`. Unit tests cover the same behavior, the non-recursive nested-grant regression, and the `merge_scan_roots` dedup logic for CI.

## Changelog

Sandbox now hides dotfiles (`.env`, `.aws`, `.ssh`, ...) under `write_paths` roots, not just `cwd` and `read_paths`