### PR TITLE
refactor(harness): registry-driven server seeding loop (PR 1.7)

### DIFF
--- a/designs/harness-modular-registry-proposal.md
+++ b/designs/harness-modular-registry-proposal.md
@@ -440,7 +440,8 @@ Phase 2: 2.1–2.4).
 | 1.5b-i Runner launch (scaffolding + 8 uniform arms) | landed | #3500 |
 | 1.5b-ii Runner launch (3 special arms + turn-path opencode) | landed | #3501 |
 | 1.5c Runner terminal-ensure (attach path) | landed | #3543 |
-| 1.6 Runner interrupt/stop (migration; gap-fill deferred) | in review | (this PR) |
+| 1.6 Runner interrupt/stop (migration; gap-fill deferred) | landed | #3568 |
+| 1.7 Server seeding loop | in review | (this PR) |
 
 ## Risks and open questions
 

--- a/omnigent/native_coding_agents.py
+++ b/omnigent/native_coding_agents.py
@@ -7,6 +7,17 @@ from typing import Any
 from omnigent._platform import installed_interactive_shells
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.harness_plugins import (
+    ANTIGRAVITY_NATIVE_CODING_AGENT,
+    CLAUDE_NATIVE_CODING_AGENT,
+    CODEX_NATIVE_CODING_AGENT,
+    CURSOR_NATIVE_CODING_AGENT,
+    GOOSE_NATIVE_CODING_AGENT,
+    HERMES_NATIVE_CODING_AGENT,
+    KIMI_NATIVE_CODING_AGENT,
+    KIRO_NATIVE_CODING_AGENT,
+    OPENCODE_NATIVE_CODING_AGENT,
+    PI_NATIVE_CODING_AGENT,
+    QWEN_NATIVE_CODING_AGENT,
     NativeCodingAgent,
 )
 from omnigent.harness_plugins import (
@@ -19,6 +30,23 @@ _BY_AGENT_NAME = {agent.agent_name: agent for agent in NATIVE_CODING_AGENTS}
 _BY_HARNESS = {agent.harness: agent for agent in NATIVE_CODING_AGENTS}
 _BY_WRAPPER_LABEL = {agent.wrapper_label: agent for agent in NATIVE_CODING_AGENTS}
 _BY_TERMINAL_NAME = {agent.terminal_name: agent for agent in NATIVE_CODING_AGENTS}
+
+# Canonical built-in ``*-native-ui`` agent names, one per tier-1 native harness.
+# Each is the registry row's ``agent_name`` — a named single-source-of-truth
+# handle so seeding and tests reference the built-in by symbol, not a magic
+# string literal. (The startup seeder loops NATIVE_CODING_AGENTS; these give
+# callers that need one specific built-in a stable name.)
+CLAUDE_NATIVE_AGENT_NAME = CLAUDE_NATIVE_CODING_AGENT.agent_name
+CODEX_NATIVE_AGENT_NAME = CODEX_NATIVE_CODING_AGENT.agent_name
+PI_NATIVE_AGENT_NAME = PI_NATIVE_CODING_AGENT.agent_name
+OPENCODE_NATIVE_AGENT_NAME = OPENCODE_NATIVE_CODING_AGENT.agent_name
+CURSOR_NATIVE_AGENT_NAME = CURSOR_NATIVE_CODING_AGENT.agent_name
+KIRO_NATIVE_AGENT_NAME = KIRO_NATIVE_CODING_AGENT.agent_name
+GOOSE_NATIVE_AGENT_NAME = GOOSE_NATIVE_CODING_AGENT.agent_name
+HERMES_NATIVE_AGENT_NAME = HERMES_NATIVE_CODING_AGENT.agent_name
+ANTIGRAVITY_NATIVE_AGENT_NAME = ANTIGRAVITY_NATIVE_CODING_AGENT.agent_name
+QWEN_NATIVE_AGENT_NAME = QWEN_NATIVE_CODING_AGENT.agent_name
+KIMI_NATIVE_AGENT_NAME = KIMI_NATIVE_CODING_AGENT.agent_name
 
 
 def native_coding_agent_for_agent_name(name: str | None) -> NativeCodingAgent | None:

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -28,17 +28,8 @@ from omnigent._platform import resolve_repo_symlink
 from omnigent.db.db_models import InvalidUuidError
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.harness_plugins import (
-    ANTIGRAVITY_NATIVE_CODING_AGENT,
-    CLAUDE_NATIVE_CODING_AGENT,
-    CODEX_NATIVE_CODING_AGENT,
-    CURSOR_NATIVE_CODING_AGENT,
-    GOOSE_NATIVE_CODING_AGENT,
-    HERMES_NATIVE_CODING_AGENT,
-    KIMI_NATIVE_CODING_AGENT,
-    KIRO_NATIVE_CODING_AGENT,
-    OPENCODE_NATIVE_CODING_AGENT,
-    PI_NATIVE_CODING_AGENT,
-    QWEN_NATIVE_CODING_AGENT,
+    NativeHarnessProvider,
+    native_provider_for_key,
 )
 from omnigent.resources import examples as _examples_resources
 from omnigent.runtime import (
@@ -166,17 +157,6 @@ _WEB_UI_ASSET_CACHE_CONTROL = "public, max-age=31536000, immutable"
 _WEB_UI_STATIC_CACHE_CONTROL = "public, max-age=3600"
 _WEB_UI_API_FALLBACK_PREFIXES = frozenset({"api", "auth", "health", "v1"})
 _WEB_UI_GZIP_MINIMUM_SIZE = 1024
-_CLAUDE_NATIVE_AGENT_NAME = CLAUDE_NATIVE_CODING_AGENT.agent_name
-_CODEX_NATIVE_AGENT_NAME = CODEX_NATIVE_CODING_AGENT.agent_name
-_PI_NATIVE_AGENT_NAME = PI_NATIVE_CODING_AGENT.agent_name
-_OPENCODE_NATIVE_AGENT_NAME = OPENCODE_NATIVE_CODING_AGENT.agent_name
-_CURSOR_NATIVE_AGENT_NAME = CURSOR_NATIVE_CODING_AGENT.agent_name
-_KIRO_NATIVE_AGENT_NAME = KIRO_NATIVE_CODING_AGENT.agent_name
-_GOOSE_NATIVE_AGENT_NAME = GOOSE_NATIVE_CODING_AGENT.agent_name
-_HERMES_NATIVE_AGENT_NAME = HERMES_NATIVE_CODING_AGENT.agent_name
-_ANTIGRAVITY_NATIVE_AGENT_NAME = ANTIGRAVITY_NATIVE_CODING_AGENT.agent_name
-_QWEN_NATIVE_AGENT_NAME = QWEN_NATIVE_CODING_AGENT.agent_name
-_KIMI_NATIVE_AGENT_NAME = KIMI_NATIVE_CODING_AGENT.agent_name
 _DEBBY_AGENT_NAME = "debby"
 _POLLY_AGENT_NAME = "polly"
 _UNMATCHED_ROUTE_TEMPLATE = "<unmatched>"
@@ -490,17 +470,7 @@ def _ensure_default_agents(
     :param artifact_store: Store for agent bundles.
     :param agent_cache: Cache for loaded agent specs.
     """
-    _ensure_default_claude_agent(agent_store, artifact_store, agent_cache)
-    _ensure_default_codex_agent(agent_store, artifact_store, agent_cache)
-    _ensure_default_pi_agent(agent_store, artifact_store, agent_cache)
-    _ensure_default_opencode_agent(agent_store, artifact_store, agent_cache)
-    _ensure_default_cursor_agent(agent_store, artifact_store, agent_cache)
-    _ensure_default_kiro_agent(agent_store, artifact_store, agent_cache)
-    _ensure_default_goose_agent(agent_store, artifact_store, agent_cache)
-    _ensure_default_hermes_agent(agent_store, artifact_store, agent_cache)
-    _ensure_default_antigravity_agent(agent_store, artifact_store, agent_cache)
-    _ensure_default_qwen_agent(agent_store, artifact_store, agent_cache)
-    _ensure_default_kimi_native_agent(agent_store, artifact_store, agent_cache)
+    _ensure_default_native_agents(agent_store, artifact_store, agent_cache)
     _ensure_default_debby_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_polly_agent(agent_store, artifact_store, agent_cache)
     _ensure_extra_builtin_agents(agent_store, artifact_store, agent_cache)
@@ -575,434 +545,71 @@ def _ensure_extra_builtin_agents(
         _logger.info("Registered extra built-in agent %r from %s", name, source)
 
 
-def _build_claude_native_bundle() -> bytes:
+def _build_native_bundle(provider: NativeHarnessProvider) -> bytes:
     """
-    Build a gzipped tarball of the claude-native-ui agent spec.
+    Materialize a built-in native agent's spec and tar it (registry-driven).
 
+    Replaces the 11 hand-written ``_build_<x>_native_bundle`` functions: resolves
+    the provider's ``materialize_agent_spec`` hook (``_materialize_<key>_agent_spec``)
+    and runs the same materialize -> bundle -> tar dance they all shared. The
+    per-harness ``model`` variance (codex/kiro/opencode take a keyword-only
+    ``model``; the rest take just ``tmpdir``) is bridged by signature inspection,
+    so the produced bytes are byte-identical to the pre-loop builders (which all
+    passed ``model=None`` where accepted).
+
+    :param provider: The native harness provider row.
     :returns: Gzipped tarball bytes suitable for the artifact store.
     """
+    import inspect
     import tempfile
 
-    from omnigent.claude_native import _materialize_claude_agent_spec
+    from omnigent.native_dispatch import resolve_hook
     from omnigent.spec import materialize_bundle
 
+    materialize = resolve_hook(provider, "materialize_agent_spec")
+    if materialize is None:
+        raise OmnigentError(f"native provider {provider.key!r} has no materialize_agent_spec hook")
     with tempfile.TemporaryDirectory() as tmpdir:
-        spec_path = _materialize_claude_agent_spec(Path(tmpdir))
+        kwargs = {"model": None} if "model" in inspect.signature(materialize).parameters else {}
+        spec_path = materialize(Path(tmpdir), **kwargs)
         bundle_dir = materialize_bundle(spec_path, Path(tmpdir) / "bundle")
         return _tar_gz_dir(bundle_dir)
 
 
-def _ensure_default_claude_agent(
+def _ensure_default_native_agents(
     agent_store: AgentStore,
     artifact_store: ArtifactStore,
     agent_cache: Any,
 ) -> None:
     """
-    Register or refresh the claude-native-ui agent.
+    Register or refresh every built-in native-CLI agent (claude/codex/pi/...).
 
-    Called during server lifespan startup so the Web UI can create
-    host-launched sessions without requiring a prior CLI-initiated
-    session. Content-aware via :func:`_ensure_builtin_agent`: a new
-    wheel with a changed spec refreshes the row in place rather than
-    being ignored.
+    Iterates :data:`NATIVE_CODING_AGENTS` (each carries both ``key`` and
+    ``agent_name``), resolves the matching provider, and seeds it content-aware
+    via :func:`_ensure_builtin_agent`. The agent name is unchanged
+    (``NativeCodingAgent.agent_name``), so :func:`builtin_agent_id` — a pure hash
+    of the name — stays byte-identical and a redeploy does not orphan persisted
+    ``conversation.agent_id`` rows.
 
     :param agent_store: Store for agent metadata.
     :param artifact_store: Store for agent bundles.
     :param agent_cache: Cache for loaded agent specs.
     """
-    _ensure_builtin_agent(
-        agent_store,
-        artifact_store,
-        agent_cache,
-        name=_CLAUDE_NATIVE_AGENT_NAME,
-        bundle_bytes=_build_claude_native_bundle(),
-    )
-
-
-def _build_codex_native_bundle() -> bytes:
-    """
-    Build a gzipped tarball of the codex-native-ui agent spec.
-
-    :returns: Gzipped tarball bytes suitable for the artifact store.
-    """
-    import tempfile
-
-    from omnigent.codex_native import _materialize_codex_agent_spec
-    from omnigent.spec import materialize_bundle
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        spec_path = _materialize_codex_agent_spec(Path(tmpdir), model=None)
-        bundle_dir = materialize_bundle(spec_path, Path(tmpdir) / "bundle")
-        return _tar_gz_dir(bundle_dir)
-
-
-def _ensure_default_codex_agent(
-    agent_store: AgentStore,
-    artifact_store: ArtifactStore,
-    agent_cache: Any,
-) -> None:
-    """
-    Register or refresh the codex-native-ui agent.
-
-    Called during server lifespan startup so the Web UI can offer
-    Codex as a built-in agent alongside Claude. Content-aware via
-    :func:`_ensure_builtin_agent`: a new wheel with a changed spec
-    refreshes the row in place rather than being ignored.
-
-    :param agent_store: Store for agent metadata.
-    :param artifact_store: Store for agent bundles.
-    :param agent_cache: Cache for loaded agent specs.
-    """
-    _ensure_builtin_agent(
-        agent_store,
-        artifact_store,
-        agent_cache,
-        name=_CODEX_NATIVE_AGENT_NAME,
-        bundle_bytes=_build_codex_native_bundle(),
-    )
-
-
-def _build_opencode_native_bundle() -> bytes:
-    """
-    Build a gzipped tarball of the opencode-native-ui agent spec.
-
-    :returns: Gzipped tarball bytes suitable for the artifact store.
-    """
-    import tempfile
-
-    from omnigent.opencode_native import _materialize_opencode_agent_spec
-    from omnigent.spec import materialize_bundle
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        spec_path = _materialize_opencode_agent_spec(Path(tmpdir), model=None)
-        bundle_dir = materialize_bundle(spec_path, Path(tmpdir) / "bundle")
-        return _tar_gz_dir(bundle_dir)
-
-
-def _ensure_default_opencode_agent(
-    agent_store: AgentStore,
-    artifact_store: ArtifactStore,
-    agent_cache: Any,
-) -> None:
-    """
-    Register or refresh the opencode-native-ui agent.
-
-    Called during server lifespan startup so the Web UI can offer OpenCode
-    as a built-in agent alongside Claude / Codex / Pi. Content-aware via
-    :func:`_ensure_builtin_agent`: a new wheel with a changed spec refreshes
-    the row in place rather than being ignored.
-
-    :param agent_store: Store for agent metadata.
-    :param artifact_store: Store for agent bundles.
-    :param agent_cache: Cache for loaded agent specs.
-    """
-    _ensure_builtin_agent(
-        agent_store,
-        artifact_store,
-        agent_cache,
-        name=_OPENCODE_NATIVE_AGENT_NAME,
-        bundle_bytes=_build_opencode_native_bundle(),
-    )
-
-
-def _build_pi_native_bundle() -> bytes:
-    """
-    Build a gzipped tarball of the pi-native-ui agent spec.
-
-    :returns: Gzipped tarball bytes suitable for the artifact store.
-    """
-    import tempfile
-
-    from omnigent.pi_native import _materialize_pi_agent_spec
-    from omnigent.spec import materialize_bundle
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        spec_path = _materialize_pi_agent_spec(Path(tmpdir))
-        bundle_dir = materialize_bundle(spec_path, Path(tmpdir) / "bundle")
-        return _tar_gz_dir(bundle_dir)
-
-
-def _ensure_default_pi_agent(
-    agent_store: AgentStore,
-    artifact_store: ArtifactStore,
-    agent_cache: Any,
-) -> None:
-    """
-    Register or refresh the pi-native-ui agent.
-
-    Called during server lifespan startup so the Web UI can offer Pi as a
-    built-in native-terminal agent. Content-aware via
-    :func:`_ensure_builtin_agent`: a new wheel with a changed spec refreshes
-    the row in place rather than being ignored.
-
-    :param agent_store: Store for agent metadata.
-    :param artifact_store: Store for agent bundles.
-    :param agent_cache: Cache for loaded agent specs.
-    """
-    _ensure_builtin_agent(
-        agent_store,
-        artifact_store,
-        agent_cache,
-        name=_PI_NATIVE_AGENT_NAME,
-        bundle_bytes=_build_pi_native_bundle(),
-    )
-
-
-def _build_cursor_native_bundle() -> bytes:
-    """
-    Build a gzipped tarball of the cursor-native-ui agent spec.
-
-    :returns: Gzipped tarball bytes suitable for the artifact store.
-    """
-    import tempfile
-
-    from omnigent.cursor_native import _materialize_cursor_agent_spec
-    from omnigent.spec import materialize_bundle
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        spec_path = _materialize_cursor_agent_spec(Path(tmpdir))
-        bundle_dir = materialize_bundle(spec_path, Path(tmpdir) / "bundle")
-        return _tar_gz_dir(bundle_dir)
-
-
-def _ensure_default_cursor_agent(
-    agent_store: AgentStore,
-    artifact_store: ArtifactStore,
-    agent_cache: Any,
-) -> None:
-    """
-    Register or refresh the cursor-native-ui agent.
-
-    Called during server lifespan startup so the Web UI offers Cursor as a
-    built-in native-terminal agent on every deployment (not only after the
-    ``omnigent cursor`` CLI first registers it). Content-aware via
-    :func:`_ensure_builtin_agent`.
-
-    :param agent_store: Store for agent metadata.
-    :param artifact_store: Store for agent bundles.
-    :param agent_cache: Cache for loaded agent specs.
-    """
-    _ensure_builtin_agent(
-        agent_store,
-        artifact_store,
-        agent_cache,
-        name=_CURSOR_NATIVE_AGENT_NAME,
-        bundle_bytes=_build_cursor_native_bundle(),
-    )
-
-
-def _build_kiro_native_bundle() -> bytes:
-    """Build a gzipped tarball of the kiro-native-ui agent spec."""
-    import tempfile
-
-    from omnigent.kiro_native import _materialize_kiro_agent_spec
-    from omnigent.spec import materialize_bundle
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        spec_path = _materialize_kiro_agent_spec(Path(tmpdir), model=None)
-        bundle_dir = materialize_bundle(spec_path, Path(tmpdir) / "bundle")
-        return _tar_gz_dir(bundle_dir)
-
-
-def _ensure_default_kiro_agent(
-    agent_store: AgentStore,
-    artifact_store: ArtifactStore,
-    agent_cache: Any,
-) -> None:
-    """Register or refresh the kiro-native-ui agent."""
-    _ensure_builtin_agent(
-        agent_store,
-        artifact_store,
-        agent_cache,
-        name=_KIRO_NATIVE_AGENT_NAME,
-        bundle_bytes=_build_kiro_native_bundle(),
-    )
-
-
-def _build_goose_native_bundle() -> bytes:
-    """Build a gzipped tarball of the goose-native-ui agent spec."""
-    import tempfile
-
-    from omnigent.goose_native import _materialize_goose_agent_spec
-    from omnigent.spec import materialize_bundle
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        spec_path = _materialize_goose_agent_spec(Path(tmpdir))
-        bundle_dir = materialize_bundle(spec_path, Path(tmpdir) / "bundle")
-        return _tar_gz_dir(bundle_dir)
-
-
-def _ensure_default_goose_agent(
-    agent_store: AgentStore,
-    artifact_store: ArtifactStore,
-    agent_cache: Any,
-) -> None:
-    """Register or refresh the goose-native-ui agent."""
-    _ensure_builtin_agent(
-        agent_store,
-        artifact_store,
-        agent_cache,
-        name=_GOOSE_NATIVE_AGENT_NAME,
-        bundle_bytes=_build_goose_native_bundle(),
-    )
-
-
-def _build_hermes_native_bundle() -> bytes:
-    """Build a gzipped tarball of the hermes-native-ui agent spec."""
-    import tempfile
-
-    from omnigent.hermes_native import _materialize_hermes_agent_spec
-    from omnigent.spec import materialize_bundle
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        spec_path = _materialize_hermes_agent_spec(Path(tmpdir))
-        bundle_dir = materialize_bundle(spec_path, Path(tmpdir) / "bundle")
-        return _tar_gz_dir(bundle_dir)
-
-
-def _ensure_default_hermes_agent(
-    agent_store: AgentStore,
-    artifact_store: ArtifactStore,
-    agent_cache: Any,
-) -> None:
-    """Register or refresh the hermes-native-ui agent."""
-    _ensure_builtin_agent(
-        agent_store,
-        artifact_store,
-        agent_cache,
-        name=_HERMES_NATIVE_AGENT_NAME,
-        bundle_bytes=_build_hermes_native_bundle(),
-    )
-
-
-def _ensure_default_antigravity_agent(
-    agent_store: AgentStore,
-    artifact_store: ArtifactStore,
-    agent_cache: Any,
-) -> None:
-    """
-    Register or refresh the antigravity-native-ui agent.
-
-    Called during server lifespan startup so the Web UI can offer Antigravity
-    as a built-in native-terminal agent (the ``agy`` TUI), alongside Claude
-    Code / Codex / Pi. Content-aware via :func:`_ensure_builtin_agent`: a new
-    wheel with a changed spec refreshes the row in place rather than being
-    ignored.
-
-    :param agent_store: Store for agent metadata.
-    :param artifact_store: Store for agent bundles.
-    :param agent_cache: Cache for loaded agent specs.
-    """
-    _ensure_builtin_agent(
-        agent_store,
-        artifact_store,
-        agent_cache,
-        name=_ANTIGRAVITY_NATIVE_AGENT_NAME,
-        bundle_bytes=_build_antigravity_native_bundle(),
-    )
-
-
-def _build_antigravity_native_bundle() -> bytes:
-    """
-    Build a gzipped tarball of the antigravity-native-ui agent spec.
-
-    :returns: Gzipped tarball bytes suitable for the artifact store.
-    """
-    import tempfile
-
-    from omnigent.antigravity_native import _materialize_antigravity_agent_spec
-    from omnigent.spec import materialize_bundle
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        spec_path = _materialize_antigravity_agent_spec(Path(tmpdir))
-        bundle_dir = materialize_bundle(spec_path, Path(tmpdir) / "bundle")
-        return _tar_gz_dir(bundle_dir)
-
-
-def _build_qwen_native_bundle() -> bytes:
-    """
-    Build a gzipped tarball of the qwen-native-ui agent spec.
-
-    :returns: Gzipped tarball bytes suitable for the artifact store.
-    """
-    import tempfile
-
-    from omnigent.qwen_native import _materialize_qwen_agent_spec
-    from omnigent.spec import materialize_bundle
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        spec_path = _materialize_qwen_agent_spec(Path(tmpdir))
-        bundle_dir = materialize_bundle(spec_path, Path(tmpdir) / "bundle")
-        return _tar_gz_dir(bundle_dir)
-
-
-def _ensure_default_qwen_agent(
-    agent_store: AgentStore,
-    artifact_store: ArtifactStore,
-    agent_cache: Any,
-) -> None:
-    """
-    Register or refresh the qwen-native-ui agent.
-
-    Called during server lifespan startup so the Web UI offers Qwen Code as a
-    built-in native-terminal agent on every deployment (not only after the
-    ``omnigent qwen`` CLI first registers it). Content-aware via
-    :func:`_ensure_builtin_agent`.
-
-    :param agent_store: Store for agent metadata.
-    :param artifact_store: Store for agent bundles.
-    :param agent_cache: Cache for loaded agent specs.
-    """
-    _ensure_builtin_agent(
-        agent_store,
-        artifact_store,
-        agent_cache,
-        name=_QWEN_NATIVE_AGENT_NAME,
-        bundle_bytes=_build_qwen_native_bundle(),
-    )
-
-
-def _build_kimi_native_bundle() -> bytes:
-    """
-    Build a gzipped tarball of the kimi-native-ui agent spec.
-
-    :returns: Gzipped tarball bytes suitable for the artifact store.
-    """
-    import tempfile
-
-    from omnigent.kimi_native import _materialize_kimi_agent_spec
-    from omnigent.spec import materialize_bundle
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        spec_path = _materialize_kimi_agent_spec(Path(tmpdir))
-        bundle_dir = materialize_bundle(spec_path, Path(tmpdir) / "bundle")
-        return _tar_gz_dir(bundle_dir)
-
-
-def _ensure_default_kimi_native_agent(
-    agent_store: AgentStore,
-    artifact_store: ArtifactStore,
-    agent_cache: Any,
-) -> None:
-    """
-    Register or refresh the kimi-native-ui agent.
-
-    Called during server lifespan startup so the Web UI offers Kimi as a
-    built-in native-terminal agent on every deployment (not only after the
-    ``omnigent kimi`` CLI first registers it). Content-aware via
-    :func:`_ensure_builtin_agent`.
-
-    :param agent_store: Store for agent metadata.
-    :param artifact_store: Store for agent bundles.
-    :param agent_cache: Cache for loaded agent specs.
-    """
-    _ensure_builtin_agent(
-        agent_store,
-        artifact_store,
-        agent_cache,
-        name=_KIMI_NATIVE_AGENT_NAME,
-        bundle_bytes=_build_kimi_native_bundle(),
-    )
+    from omnigent.native_coding_agents import NATIVE_CODING_AGENTS
+
+    for agent in NATIVE_CODING_AGENTS:
+        provider = native_provider_for_key(agent.key)
+        if provider is None:
+            raise OmnigentError(
+                f"native coding agent {agent.key!r} has no provider row to seed from"
+            )
+        _ensure_builtin_agent(
+            agent_store,
+            artifact_store,
+            agent_cache,
+            name=agent.agent_name,
+            bundle_bytes=_build_native_bundle(provider),
+        )
 
 
 def _build_debby_bundle() -> bytes:

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -570,6 +570,11 @@ def _build_native_bundle(provider: NativeHarnessProvider) -> bytes:
     if materialize is None:
         raise OmnigentError(f"native provider {provider.key!r} has no materialize_agent_spec hook")
     with tempfile.TemporaryDirectory() as tmpdir:
+        # The bridge understands only the ``model`` axis: pass ``model=None`` iff
+        # the materializer declares that parameter, else call it bare. A future
+        # harness whose materializer needs a *different* required kwarg will fail
+        # loud here (missing-argument TypeError at seed time) rather than route —
+        # add that axis explicitly if/when it appears.
         kwargs = {"model": None} if "model" in inspect.signature(materialize).parameters else {}
         spec_path = materialize(Path(tmpdir), **kwargs)
         bundle_dir = materialize_bundle(spec_path, Path(tmpdir) / "bundle")

--- a/tests/e2e/test_host_claude_native_e2e.py
+++ b/tests/e2e/test_host_claude_native_e2e.py
@@ -79,6 +79,7 @@ from pathlib import Path
 import httpx
 import pytest
 
+from omnigent.native_coding_agents import CLAUDE_NATIVE_AGENT_NAME
 from tests._helpers.compat import apply_runner_env, compat_runner_cwd, runner_executable
 from tests.e2e.helpers import POLL_INTERVAL_S
 
@@ -96,10 +97,6 @@ pytestmark = pytest.mark.skipif(
         "OMNIGENT_E2E_CLAUDE_NATIVE=1 (and have `claude` installed + logged in) to run"
     ),
 )
-
-# The built-in agent the server auto-registers for the Web UI's
-# "Claude Code" option (see server.app._ensure_default_agents).
-_CLAUDE_NATIVE_AGENT_NAME = "claude-native-ui"
 
 # Seconds the claude wrapper sleeps before exec'ing the real binary.
 # Must comfortably exceed the runner's launch→inject latency so that,
@@ -265,10 +262,10 @@ def _claude_native_agent_id(client: httpx.Client) -> str:
     resp = client.get("/v1/agents")
     resp.raise_for_status()
     for agent in resp.json()["data"]:
-        if agent["name"] == _CLAUDE_NATIVE_AGENT_NAME:
+        if agent["name"] == CLAUDE_NATIVE_AGENT_NAME:
             return str(agent["id"])
     raise AssertionError(
-        f"{_CLAUDE_NATIVE_AGENT_NAME!r} not registered on the server "
+        f"{CLAUDE_NATIVE_AGENT_NAME!r} not registered on the server "
         "(expected from _ensure_default_agents at startup)"
     )
 

--- a/tests/e2e/test_host_codex_native_e2e.py
+++ b/tests/e2e/test_host_codex_native_e2e.py
@@ -31,10 +31,9 @@ import httpx
 import pytest
 
 from omnigent.entities.session_resources import terminal_resource_id
+from omnigent.native_coding_agents import CODEX_NATIVE_AGENT_NAME
 from tests._helpers.compat import apply_runner_env, compat_runner_cwd, runner_executable
 from tests.e2e.helpers import POLL_INTERVAL_S
-
-_CODEX_NATIVE_AGENT_NAME = "codex-native-ui"
 
 # Marker file the cwd-resolution tests ask Codex to read back. It is placed
 # only in the session's intended cwd (worktree / picked workspace) and never
@@ -114,10 +113,10 @@ def _codex_native_agent_id(client: httpx.Client) -> str:
     resp = client.get("/v1/agents")
     resp.raise_for_status()
     for agent in resp.json()["data"]:
-        if agent["name"] == _CODEX_NATIVE_AGENT_NAME:
+        if agent["name"] == CODEX_NATIVE_AGENT_NAME:
             return str(agent["id"])
     raise AssertionError(
-        f"{_CODEX_NATIVE_AGENT_NAME!r} not registered on the server "
+        f"{CODEX_NATIVE_AGENT_NAME!r} not registered on the server "
         "(expected from _ensure_default_agents at startup)"
     )
 
@@ -511,8 +510,8 @@ def test_codex_native_builtin_registered_at_startup(
     resp = http_client.get("/v1/agents")
     resp.raise_for_status()
     agent_names = {a["name"] for a in resp.json()["data"]}
-    assert _CODEX_NATIVE_AGENT_NAME in agent_names, (
-        f"Expected {_CODEX_NATIVE_AGENT_NAME!r} in built-in agents "
+    assert CODEX_NATIVE_AGENT_NAME in agent_names, (
+        f"Expected {CODEX_NATIVE_AGENT_NAME!r} in built-in agents "
         f"{agent_names}. _ensure_default_native_agents did not run or "
         f"used a different name."
     )
@@ -529,7 +528,7 @@ def test_codex_native_builtin_session_can_be_created(
     resp.raise_for_status()
     agent_id = None
     for agent in resp.json()["data"]:
-        if agent["name"] == _CODEX_NATIVE_AGENT_NAME:
+        if agent["name"] == CODEX_NATIVE_AGENT_NAME:
             agent_id = agent["id"]
             break
     assert agent_id is not None

--- a/tests/e2e/test_host_codex_native_e2e.py
+++ b/tests/e2e/test_host_codex_native_e2e.py
@@ -504,7 +504,7 @@ def test_codex_native_builtin_registered_at_startup(
     """
     The server auto-registers ``codex-native-ui`` as a built-in agent.
 
-    ``_ensure_default_codex_agent`` runs during lifespan startup and
+    ``_ensure_default_native_agents`` runs during lifespan startup and
     inserts the agent into the store. ``GET /v1/agents`` must list it
     so the Web UI new-session picker can offer Codex alongside Claude.
     """
@@ -513,7 +513,7 @@ def test_codex_native_builtin_registered_at_startup(
     agent_names = {a["name"] for a in resp.json()["data"]}
     assert _CODEX_NATIVE_AGENT_NAME in agent_names, (
         f"Expected {_CODEX_NATIVE_AGENT_NAME!r} in built-in agents "
-        f"{agent_names}. _ensure_default_codex_agent did not run or "
+        f"{agent_names}. _ensure_default_native_agents did not run or "
         f"used a different name."
     )
 

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -2318,7 +2318,8 @@ def _create_native_codex_session(base_url: str, runner_id: str) -> str:
     auto-bootstrap: it launches Codex in the session terminal, derives the
     gateway auth from its own credentials, and pre-accepts the first-run
     trust/onboarding prompts — no CLI client required. ``model=None`` lets the
-    configured provider's default model win (matching ``_build_codex_native_bundle``).
+    configured provider's default model win (matching the seeded codex bundle
+    built via ``_build_native_bundle``).
 
     :param base_url: Spawned server base URL.
     :param runner_id: The token-bound runner id to bind.

--- a/tests/server/integration/test_scheduled_tasks_routes.py
+++ b/tests/server/integration/test_scheduled_tasks_routes.py
@@ -17,7 +17,6 @@ from fastapi import FastAPI
 
 from omnigent.db.utils import builtin_agent_id
 from omnigent.runtime.agent_cache import AgentCache
-from omnigent.server import app as server_app
 from omnigent.server.app import create_app
 from omnigent.server.routes import scheduled_tasks as scheduled_tasks_routes
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
@@ -126,7 +125,7 @@ def _create_body(**overrides: object) -> dict[str, object]:
         "name": "nightly triage",
         "prompt": "triage the queue",
         "rrule": _VALID_RRULE,
-        "agent_id": builtin_agent_id(server_app._CLAUDE_NATIVE_AGENT_NAME),
+        "agent_id": builtin_agent_id("claude-native-ui"),
         "timezone": "America/Los_Angeles",
         "workspace": "/repo",
         "host_id": "4b653f6031f35d168cc0b37caa1306d1",

--- a/tests/server/integration/test_scheduled_tasks_routes.py
+++ b/tests/server/integration/test_scheduled_tasks_routes.py
@@ -16,6 +16,7 @@ import pytest_asyncio
 from fastapi import FastAPI
 
 from omnigent.db.utils import builtin_agent_id
+from omnigent.native_coding_agents import CLAUDE_NATIVE_AGENT_NAME
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.server.app import create_app
 from omnigent.server.routes import scheduled_tasks as scheduled_tasks_routes
@@ -125,7 +126,7 @@ def _create_body(**overrides: object) -> dict[str, object]:
         "name": "nightly triage",
         "prompt": "triage the queue",
         "rrule": _VALID_RRULE,
-        "agent_id": builtin_agent_id("claude-native-ui"),
+        "agent_id": builtin_agent_id(CLAUDE_NATIVE_AGENT_NAME),
         "timezone": "America/Los_Angeles",
         "workspace": "/repo",
         "host_id": "4b653f6031f35d168cc0b37caa1306d1",

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -15,6 +15,10 @@ import httpx
 import pytest
 from fastapi import FastAPI
 
+from omnigent.native_coding_agents import (
+    ANTIGRAVITY_NATIVE_AGENT_NAME,
+    QWEN_NATIVE_AGENT_NAME,
+)
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.server import app as server_app
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
@@ -619,9 +623,9 @@ def test_ensure_default_native_agents_seeds_qwen_card(seed_stores: _SeedStores) 
         seed_stores.agent_cache,
     )
 
-    seeded = seed_stores.agent_store.get_by_name("qwen-native-ui")
+    seeded = seed_stores.agent_store.get_by_name(QWEN_NATIVE_AGENT_NAME)
     assert seeded is not None, "qwen-native-ui was not registered"
-    assert seeded.name == "qwen-native-ui"
+    assert seeded.name == QWEN_NATIVE_AGENT_NAME
     # The bundle must be retrievable, not just referenced.
     assert seed_stores.artifact_store.get(seeded.bundle_location) is not None
 
@@ -691,7 +695,7 @@ def test_ensure_default_native_agents_is_idempotent(seed_stores: _SeedStores) ->
         seed_stores.artifact_store,
         seed_stores.agent_cache,
     )
-    first = seed_stores.agent_store.get_by_name("qwen-native-ui")
+    first = seed_stores.agent_store.get_by_name(QWEN_NATIVE_AGENT_NAME)
     assert first is not None
     server_app._ensure_default_native_agents(
         seed_stores.agent_store,
@@ -699,7 +703,7 @@ def test_ensure_default_native_agents_is_idempotent(seed_stores: _SeedStores) ->
         seed_stores.agent_cache,
     )
     page = seed_stores.agent_store.list(limit=100)
-    qwen_rows = [a for a in page.data if a.name == "qwen-native-ui"]
+    qwen_rows = [a for a in page.data if a.name == QWEN_NATIVE_AGENT_NAME]
     assert len(qwen_rows) == 1
     assert qwen_rows[0].id == first.id
     assert qwen_rows[0].version == first.version == 1
@@ -741,9 +745,9 @@ def test_ensure_default_antigravity_agent_seeds_card(seed_stores: _SeedStores) -
         seed_stores.agent_cache,
     )
 
-    seeded = seed_stores.agent_store.get_by_name("antigravity-native-ui")
+    seeded = seed_stores.agent_store.get_by_name(ANTIGRAVITY_NATIVE_AGENT_NAME)
     assert seeded is not None, "antigravity-native-ui was not registered"
-    assert seeded.name == "antigravity-native-ui"
+    assert seeded.name == ANTIGRAVITY_NATIVE_AGENT_NAME
     # Built-ins are session-scope NULL so ``GET /v1/agents`` (which filters on
     # ``session_id IS NULL``) returns them to the picker.
     assert seeded.session_id is None
@@ -769,7 +773,7 @@ def test_ensure_default_agents_includes_antigravity(seed_stores: _SeedStores) ->
         seed_stores.agent_cache,
     )
 
-    assert seed_stores.agent_store.get_by_name("antigravity-native-ui") is not None
+    assert seed_stores.agent_store.get_by_name(ANTIGRAVITY_NATIVE_AGENT_NAME) is not None
 
 
 def test_ensure_default_polly_agent_is_idempotent(seed_stores: _SeedStores) -> None:

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -605,37 +605,37 @@ def test_ensure_extra_builtin_agents_skips_bad_path_and_seeds_good(
     assert seed_stores.agent_store.get_by_name("does-not-exist") is None
 
 
-def test_ensure_default_qwen_agent_seeds_card(seed_stores: _SeedStores) -> None:
+def test_ensure_default_native_agents_seeds_qwen_card(seed_stores: _SeedStores) -> None:
     """
-    Seeding registers qwen-native-ui as a built-in the picker can render.
+    The native seeding loop registers qwen-native-ui as a picker-renderable built-in.
 
     The new-session picker reads built-ins from ``GET /v1/agents``; without this
     seeder Qwen Code only appears after the ``omnigent qwen`` CLI first registers
     it, so it was absent from the Web UI dropdown.
     """
-    server_app._ensure_default_qwen_agent(
+    server_app._ensure_default_native_agents(
         seed_stores.agent_store,
         seed_stores.artifact_store,
         seed_stores.agent_cache,
     )
 
-    seeded = seed_stores.agent_store.get_by_name(server_app._QWEN_NATIVE_AGENT_NAME)
+    seeded = seed_stores.agent_store.get_by_name("qwen-native-ui")
     assert seeded is not None, "qwen-native-ui was not registered"
     assert seeded.name == "qwen-native-ui"
     # The bundle must be retrievable, not just referenced.
     assert seed_stores.artifact_store.get(seeded.bundle_location) is not None
 
 
-def test_ensure_default_qwen_agent_is_idempotent(seed_stores: _SeedStores) -> None:
+def test_ensure_default_native_agents_is_idempotent(seed_stores: _SeedStores) -> None:
     """A second seed call is a no-op — startup runs the seeder every boot."""
-    server_app._ensure_default_qwen_agent(
+    server_app._ensure_default_native_agents(
         seed_stores.agent_store,
         seed_stores.artifact_store,
         seed_stores.agent_cache,
     )
-    first = seed_stores.agent_store.get_by_name(server_app._QWEN_NATIVE_AGENT_NAME)
+    first = seed_stores.agent_store.get_by_name("qwen-native-ui")
     assert first is not None
-    server_app._ensure_default_qwen_agent(
+    server_app._ensure_default_native_agents(
         seed_stores.agent_store,
         seed_stores.artifact_store,
         seed_stores.agent_cache,
@@ -677,13 +677,13 @@ def test_ensure_default_antigravity_agent_seeds_card(seed_stores: _SeedStores) -
     NULL (a built-in) and carry the ``antigravity-native`` harness so the
     runner boots the agy native terminal rather than an SDK harness.
     """
-    server_app._ensure_default_antigravity_agent(
+    server_app._ensure_default_native_agents(
         seed_stores.agent_store,
         seed_stores.artifact_store,
         seed_stores.agent_cache,
     )
 
-    seeded = seed_stores.agent_store.get_by_name(server_app._ANTIGRAVITY_NATIVE_AGENT_NAME)
+    seeded = seed_stores.agent_store.get_by_name("antigravity-native-ui")
     assert seeded is not None, "antigravity-native-ui was not registered"
     assert seeded.name == "antigravity-native-ui"
     # Built-ins are session-scope NULL so ``GET /v1/agents`` (which filters on
@@ -711,9 +711,7 @@ def test_ensure_default_agents_includes_antigravity(seed_stores: _SeedStores) ->
         seed_stores.agent_cache,
     )
 
-    assert (
-        seed_stores.agent_store.get_by_name(server_app._ANTIGRAVITY_NATIVE_AGENT_NAME) is not None
-    )
+    assert seed_stores.agent_store.get_by_name("antigravity-native-ui") is not None
 
 
 def test_ensure_default_polly_agent_is_idempotent(seed_stores: _SeedStores) -> None:

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -626,6 +626,64 @@ def test_ensure_default_native_agents_seeds_qwen_card(seed_stores: _SeedStores) 
     assert seed_stores.artifact_store.get(seeded.bundle_location) is not None
 
 
+def test_ensure_default_native_agents_seeds_every_native_agent(
+    seed_stores: _SeedStores,
+) -> None:
+    """
+    The loop seeds every ``NATIVE_CODING_AGENTS`` entry under its stable id.
+
+    Guards the whole seeded set (not just one card): each native agent must be
+    registered as a session-scope-NULL built-in, keyed by its name-derived
+    :func:`builtin_agent_id`, with a retrievable bundle. A harness dropped from
+    the loop — or seeded under the wrong name/id — is caught here.
+    """
+    from omnigent.db.utils import builtin_agent_id
+    from omnigent.native_coding_agents import NATIVE_CODING_AGENTS
+
+    server_app._ensure_default_native_agents(
+        seed_stores.agent_store,
+        seed_stores.artifact_store,
+        seed_stores.agent_cache,
+    )
+
+    for agent in NATIVE_CODING_AGENTS:
+        seeded = seed_stores.agent_store.get_by_name(agent.agent_name)
+        assert seeded is not None, f"{agent.agent_name} was not registered"
+        assert seeded.id == builtin_agent_id(agent.agent_name)
+        assert seeded.session_id is None, "built-ins must be session-scope NULL"
+        assert seed_stores.artifact_store.get(seeded.bundle_location) is not None
+
+
+def test_ensure_default_native_agents_raises_when_provider_missing(
+    seed_stores: _SeedStores, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A native agent with no provider row raises instead of silently unseeding."""
+    from omnigent.errors import OmnigentError
+
+    monkeypatch.setattr(server_app, "native_provider_for_key", lambda _key: None)
+    with pytest.raises(OmnigentError, match="no provider row to seed from"):
+        server_app._ensure_default_native_agents(
+            seed_stores.agent_store,
+            seed_stores.artifact_store,
+            seed_stores.agent_cache,
+        )
+
+
+def test_build_native_bundle_raises_without_materialize_hook() -> None:
+    """A provider missing its ``materialize_agent_spec`` hook raises loudly."""
+    from omnigent.errors import OmnigentError
+    from omnigent.harness_plugins import NativeHarnessProvider
+
+    provider = NativeHarnessProvider(
+        key="ghost",
+        run_native="omnigent.ghost_native:run_ghost_native",
+        auto_create_terminal="omnigent.runner.native:_launch_ghost",
+        materialize_agent_spec=None,
+    )
+    with pytest.raises(OmnigentError, match="no materialize_agent_spec hook"):
+        server_app._build_native_bundle(provider)
+
+
 def test_ensure_default_native_agents_is_idempotent(seed_stores: _SeedStores) -> None:
     """A second seed call is a no-op — startup runs the seeder every boot."""
     server_app._ensure_default_native_agents(

--- a/tests/server/test_builtin_bundles.py
+++ b/tests/server/test_builtin_bundles.py
@@ -21,20 +21,17 @@ import yaml
 
 from omnigent.errors import OmnigentError
 from omnigent.harness_plugins import native_provider_for_key
+from omnigent.native_coding_agents import NATIVE_CODING_AGENTS as _NATIVE_CODING_AGENTS
 from omnigent.server import app
 from omnigent.spec import load, materialize_bundle
 
 # Native built-ins are seeded through one registry-driven builder,
-# ``_build_native_bundle(provider)`` (PR 1.7). We exercise a representative
-# spread of the model-arg variants: claude/pi (bare tmpdir), codex (required
-# keyword-only model), kiro (defaulted model). Each spec entry is
-# ``<agent_name>.yaml``, proving the right spec was materialized.
-_NATIVE_BUILDERS = [
-    ("claude", "claude-native-ui.yaml"),
-    ("codex", "codex-native-ui.yaml"),
-    ("pi", "pi-native-ui.yaml"),
-    ("kiro", "kiro-native-ui.yaml"),
-]
+# ``_build_native_bundle(provider)`` (PR 1.7). We exercise EVERY native agent
+# (not a sample) so each harness's materialize path — and both model-arg shapes
+# (codex requires keyword-only model, kiro/opencode default it, the rest take
+# just tmpdir) — is covered directly rather than only transitively via e2e.
+# Each spec entry is ``<agent_name>.yaml``, proving the right spec materialized.
+_NATIVE_BUILDERS = [(agent.key, f"{agent.agent_name}.yaml") for agent in _NATIVE_CODING_AGENTS]
 
 # Shipped-example built-ins keep their hand-written named builders. The bool is
 # whether the source is a shipped example a stripped deployment may omit.

--- a/tests/server/test_builtin_bundles.py
+++ b/tests/server/test_builtin_bundles.py
@@ -20,15 +20,25 @@ import pytest
 import yaml
 
 from omnigent.errors import OmnigentError
+from omnigent.harness_plugins import native_provider_for_key
 from omnigent.server import app
 from omnigent.spec import load, materialize_bundle
 
-# (builder attribute, the spec entry that proves the bundle was assembled,
-# whether the source is a shipped example that a stripped deployment may omit)
-_BUILDERS = [
-    ("_build_claude_native_bundle", "claude-native-ui.yaml", False),
-    ("_build_codex_native_bundle", "codex-native-ui.yaml", False),
-    ("_build_kiro_native_bundle", "kiro-native-ui.yaml", False),
+# Native built-ins are seeded through one registry-driven builder,
+# ``_build_native_bundle(provider)`` (PR 1.7). We exercise a representative
+# spread of the model-arg variants: claude/pi (bare tmpdir), codex (required
+# keyword-only model), kiro (defaulted model). Each spec entry is
+# ``<agent_name>.yaml``, proving the right spec was materialized.
+_NATIVE_BUILDERS = [
+    ("claude", "claude-native-ui.yaml"),
+    ("codex", "codex-native-ui.yaml"),
+    ("pi", "pi-native-ui.yaml"),
+    ("kiro", "kiro-native-ui.yaml"),
+]
+
+# Shipped-example built-ins keep their hand-written named builders. The bool is
+# whether the source is a shipped example a stripped deployment may omit.
+_EXAMPLE_BUILDERS = [
     ("_build_debby_bundle", "config.yaml", True),
     ("_build_polly_bundle", "config.yaml", True),
 ]
@@ -53,27 +63,47 @@ def _tar_members(blob: bytes) -> list[str]:
         return [m.name for m in tf.getmembers() if m.isfile()]
 
 
-@pytest.mark.parametrize(("builder", "spec_entry", "shipped_example"), _BUILDERS)
-def test_bundle_builder_produces_valid_tarball(
-    builder: str, spec_entry: str, shipped_example: bool
-) -> None:
-    """Each builder returns a gzip tarball that contains the agent's spec file."""
-    if shipped_example and _shipped_example_missing(builder):
-        pytest.skip(f"{builder} source not packaged in this deployment")
-
-    blob = getattr(app, builder)()
-    assert blob, f"{builder} returned empty bytes."
+def _assert_valid_tarball_with_entry(blob: bytes, spec_entry: str, label: str) -> None:
+    """Assert ``blob`` is a valid gzip tarball containing ``spec_entry``."""
+    assert blob, f"{label} returned empty bytes."
     # Must be a real gzip stream, not just arbitrary bytes.
-    assert gzip.decompress(blob), f"{builder} output is not valid gzip."
-
+    assert gzip.decompress(blob), f"{label} output is not valid gzip."
     members = _tar_members(blob)
     # arcname='.' prefixes every member with './'; match on the trailing path.
     assert any(m.lstrip("./") == spec_entry or m.endswith("/" + spec_entry) for m in members), (
-        f"{builder} tarball is missing its spec entry {spec_entry!r}; members={members!r}."
+        f"{label} tarball is missing its spec entry {spec_entry!r}; members={members!r}."
     )
 
 
-@pytest.mark.parametrize(("builder", "spec_entry", "shipped_example"), _BUILDERS)
+@pytest.mark.parametrize(("key", "spec_entry"), _NATIVE_BUILDERS)
+def test_native_bundle_builder_produces_valid_tarball(key: str, spec_entry: str) -> None:
+    """The registry-driven native builder yields a tarball with the agent's spec."""
+    provider = native_provider_for_key(key)
+    assert provider is not None, f"no native provider for {key!r}"
+    _assert_valid_tarball_with_entry(app._build_native_bundle(provider), spec_entry, key)
+
+
+@pytest.mark.parametrize(("key", "spec_entry"), _NATIVE_BUILDERS)
+def test_native_bundle_builder_is_reproducible(key: str, spec_entry: str) -> None:
+    """The native builder is byte-for-byte reproducible (content-addressable seed)."""
+    provider = native_provider_for_key(key)
+    assert provider is not None, f"no native provider for {key!r}"
+    assert app._build_native_bundle(provider) == app._build_native_bundle(provider), (
+        f"native builder for {key!r} is not byte-for-byte reproducible."
+    )
+
+
+@pytest.mark.parametrize(("builder", "spec_entry", "shipped_example"), _EXAMPLE_BUILDERS)
+def test_bundle_builder_produces_valid_tarball(
+    builder: str, spec_entry: str, shipped_example: bool
+) -> None:
+    """Each shipped-example builder returns a gzip tarball with the agent's spec file."""
+    if shipped_example and _shipped_example_missing(builder):
+        pytest.skip(f"{builder} source not packaged in this deployment")
+    _assert_valid_tarball_with_entry(getattr(app, builder)(), spec_entry, builder)
+
+
+@pytest.mark.parametrize(("builder", "spec_entry", "shipped_example"), _EXAMPLE_BUILDERS)
 def test_bundle_builder_is_reproducible(
     builder: str, spec_entry: str, shipped_example: bool
 ) -> None:
@@ -199,3 +229,57 @@ def test_shipped_example_survives_unknown_harness_sub_agent(
     # itself would have failed validation on the missing-directory check.
     assert "future_worker" not in spec.tools.agents
     assert expected_sub_agents <= set(spec.tools.agents)
+
+
+# ── Byte-stability of built-in agent ids (PR 1.7 seeding loop) ──────────────
+#
+# The startup seeder derives each built-in's id from its NAME via
+# builtin_agent_id (a pure sha256 of "builtin:<name>"). Persisted
+# conversation.agent_id rows point at these ids, so a rename — or a seeding
+# loop that seeds a different name — silently orphans every session on the old
+# agent after a redeploy. This freezes the expected id for every native
+# built-in as it is today; a change here is a loud signal to migrate, not a
+# value to blindly update.
+_EXPECTED_BUILTIN_AGENT_IDS = {
+    "claude-native-ui": "58a1bc5bf0bba6d31ceeb7661f8d751c",
+    "codex-native-ui": "16a06503889b0c3034496821afd41b9e",
+    "pi-native-ui": "a1b7caa17404f6716180ba69aa37c592",
+    "opencode-native-ui": "cf65137fc096a61a6434956c92093549",
+    "cursor-native-ui": "a5fac3a24c1961af2dbb1cafe0a81425",
+    "kiro-native-ui": "cc8fef6623a8792be9c039cf2673ce93",
+    "goose-native-ui": "93dd98c4a79bd26a1dd5dc592ee38afb",
+    "antigravity-native-ui": "db097e89797b66fb7e30699813ae09d2",
+    "qwen-native-ui": "2cffe181a2fc6cf417a49e1cf8b28d77",
+    "kimi-native-ui": "9e7d109e7da66e8b5ed4ec3ecb54cef1",
+    "hermes-native-ui": "32113910cf31fcc63dc96bbde428b97c",
+}
+
+
+def test_native_seed_ids_are_byte_stable() -> None:
+    """Every native built-in seeds under its frozen, name-derived id.
+
+    Guards the redeploy-safety invariant the seeding loop must preserve: the
+    id is a hash of the agent name, so the set of names AND their ids must not
+    drift when the 11 hand-written seed helpers collapse into one loop.
+    """
+    from omnigent.db.utils import builtin_agent_id
+    from omnigent.native_coding_agents import NATIVE_CODING_AGENTS
+
+    actual = {a.agent_name: builtin_agent_id(a.agent_name) for a in NATIVE_CODING_AGENTS}
+    assert actual == _EXPECTED_BUILTIN_AGENT_IDS, (
+        "built-in native agent ids drifted; a redeploy would orphan persisted "
+        "conversation.agent_id rows. Migrate deliberately, do not just update this table."
+    )
+
+
+def test_native_seed_loop_covers_every_native_agent() -> None:
+    """The seeding loop can resolve a provider for every native coding agent.
+
+    A native agent with no provider row would be silently dropped from the
+    seeded set (the loop raises instead — this pins that contract).
+    """
+    from omnigent.harness_plugins import native_provider_for_key
+    from omnigent.native_coding_agents import NATIVE_CODING_AGENTS
+
+    missing = [a.key for a in NATIVE_CODING_AGENTS if native_provider_for_key(a.key) is None]
+    assert missing == [], f"native agents without a provider row to seed from: {missing}"


### PR DESCRIPTION
## Related issue

N/A — part of the modular native-harness registry workstream (`designs/harness-modular-registry-proposal.md`).

## Summary

PR **1.7** of the modular native-harness registry refactor: collapses the server's built-in
native-agent **seeding loop** onto the `NativeHarnessProvider` seam. It's a disjoint hub
(depends on 1.1, not the runner PRs).

- **`omnigent/server/app.py`**: the 11 hand-written `_ensure_default_<x>_agent` helpers + their
  11 `_build_<x>_native_bundle` partners collapse into two registry-driven functions —
  `_build_native_bundle(provider)` (resolves `provider.materialize_agent_spec` via the seam)
  and `_ensure_default_native_agents(...)` (loops `NATIVE_CODING_AGENTS`). Net −455/+146.
- The per-harness `model` arg variance (codex requires a keyword-only `model`; kiro/opencode
  default it; the rest take just `tmpdir`) is bridged by one `inspect.signature` check, so the
  produced bundles are **byte-identical** to the pre-loop builders.
- **debby / polly / `_ensure_extra_builtin_agents`** stay hand-written (shipped-example and
  env-driven paths — not `_materialize_*`).
- The 11 per-harness built-in agent-name constants move out of `server/app.py` (where the
  collapsed loop no longer needs them) into a **shared, public block** in
  `omnigent/native_coding_agents.py` — `CLAUDE_NATIVE_AGENT_NAME` … `KIMI_NATIVE_AGENT_NAME`,
  each `= <registry row>.agent_name`. Seeding and tests reference a single named
  source of truth instead of magic-string literals. (See the follow-up commit note below.)

### Redeploy safety (the core invariant)

`builtin_agent_id(name)` is `sha256("builtin:<name>")[:32]` — a pure hash of the agent **name**.
Persisted `conversation.agent_id` rows point at these ids, so both the seeded **ids** and the
**bundle bytes** must stay byte-identical or a redeploy orphans live sessions. Verified
empirically: `_build_native_bundle(provider)` produces byte-identical tarballs (sha256 match)
to today's named builders for claude/codex/pi/kiro/opencode/qwen — across all three model-arg
variants — and the seeded ids are frozen in a new test.

### ELI5

Eleven copy-pasted "build this agent's starter bundle and register it" pairs in the server
startup became one loop over the harness registry. The agent ids are hashes of their names, and
the names didn't change, so every existing session still points at the right agent after a
redeploy — pinned by a test that freezes the expected ids.

## Test Plan

```bash
uv run pytest tests/server/test_builtin_bundles.py tests/server/test_app.py \
  tests/test_harness_plugins.py -q
uv run pytest tests/server/ -q
uv run pre-commit run --all-files
```

- `test_builtin_bundles.py`: the native `_BUILDERS` cases now drive the generic
  `_build_native_bundle(provider)` (claude/codex/pi/kiro — a spread of the model-arg variants),
  keeping the valid-tarball + reproducibility assertions; debby/polly keep their named-builder
  cases.
- **New pins**: `test_native_seed_ids_are_byte_stable` freezes the 11 expected 32-char ids;
  `test_native_seed_loop_covers_every_native_agent` asserts the loop resolves a provider for
  every `NATIVE_CODING_AGENTS` entry (a dropped harness raises instead of silently unseeding).

## Demo

N/A — internal server-startup refactor, no user-facing or UI change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Behavior-preserving refactor. Beyond the updated/added unit tests, I verified byte-stability
directly: captured sha256 of every named builder's output on `main`, then confirmed
`_build_native_bundle(provider)` reproduces each hash exactly on this branch (claude, codex,
pi, kiro, opencode, qwen — covering bare-`tmpdir`, required-`model`, and defaulted-`model`
signatures). The two stale references to deleted function names in e2e comments/messages
(`test_host_codex_native_e2e.py`, `e2e_ui/conftest.py`) were updated; both were text-only, not
calls.

**Follow-up (`ef98b092`) — shared agent-name constants.** An earlier revision of this PR deleted
the 11 `_<X>_NATIVE_AGENT_NAME` constants outright (the seeding loop uses `agent.agent_name`),
which pushed callers that need one specific built-in onto magic-string literals
(`"claude-native-ui"`, `"qwen-native-ui"`, …) in the tests. That was an overcorrection; they're
now restored as **public** constants in `omnigent/native_coding_agents.py` (the module that
already indexes the registry rows), and every caller — `test_app.py`,
`test_scheduled_tasks_routes.py`, and the two host e2e tests (which previously each redefined
their own local literal) — imports the shared symbol. Net: one registry-derived source of truth,
no magic strings.

---

**Workstream progress** (`designs/harness-modular-registry-proposal.md`, ~14 PRs):
Phase 1 — 1.1 (#3239), 1.2 (#3244), 1.3 (#3314), 1.5a (#3495), 1.5b-i (#3500), 1.5b-ii
(#3501), 1.5c (#3543) landed; 1.6 (#3568) in review; **1.7 is this PR**. Remaining: 1.8
(enumerations); Phase 2 — 2.1–2.4. 1.7 is a disjoint hub — independent of the 1.6 review.
(Also flips the stale 1.5c ledger row to `landed`.)

