### PR TITLE
ci(web): enforce cleaned lint rules

### DIFF
--- a/web/.oxlintrc.json
+++ b/web/.oxlintrc.json
@@ -9,6 +9,7 @@
   "rules": {
     "react/react-in-jsx-scope": "off",
     "import/no-unassigned-import": "off",
+    "no-promise-executor-return": "error",
     "no-restricted-globals": [
       "error",
       {
@@ -16,6 +17,10 @@
         "message": "Don't call the bare global fetch(). Use hostFetch (@/lib/host) or authenticatedFetch (@/lib/identity) so requests route through the embed host transport. The only allowed bare fetch() is the choke point in src/lib/host.ts."
       }
     ],
+    "no-unreachable-loop": "error",
+    "no-useless-assignment": "error",
+    "react/jsx-no-useless-fragment": "error",
+    "react-hooks/rules-of-hooks": "error",
     "no-restricted-imports": [
       "error",
       {

--- a/web/src/hooks/useHostFilesystem.ts
+++ b/web/src/hooks/useHostFilesystem.ts
@@ -208,7 +208,7 @@ export async function checkHostDirectory(hostId: string, path: string): Promise<
   }
   // Host offline / timed out (502/504) or another server failure —
   // surface its detail so the user sees why the check failed.
-  let detail: string | null = null;
+  let detail: string | null;
   try {
     const body = (await res.json()) as { detail?: string };
     detail = typeof body.detail === "string" && body.detail !== "" ? body.detail : null;


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Promote five TypeScript lint rules to errors after their cleanup PRs landed: hook order, dead assignments, Promise executor returns, unreachable loops, and redundant JSX fragments.
- Remove a new dead assignment that slipped in after the original cleanup, demonstrating the need for the gate.
- Keep the existing zero-warning policy so future regressions fail locally and in CI.

**ELI5:** We cleaned the floor, but one piece of litter appeared again. These rules now lock the door so the same litter cannot come back unnoticed.

```text
cleanup PRs -> zero diagnostics -> enabled config rules -> pre-commit + CI rejection
```

## Test Plan

- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `pnpm --filter web exec vitest run src/hooks/useHostFilesystem.test.ts`
- `pnpm --filter web run test:coverage`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A — lint-policy enforcement only.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified the complete configured rule set has zero diagnostics. The full web suite passes with 4,786 tests, and all pre-commit hooks pass.

## Changelog

N/A — internal CI enforcement only.