### PR TITLE
refactor(web): remove redundant React child handling

### DIFF
--- a/web/src/components/AgentHoverCard.test.tsx
+++ b/web/src/components/AgentHoverCard.test.tsx
@@ -30,7 +30,9 @@ describe("AgentHoverCard", () => {
   it("wraps the trigger when the agent has a description", () => {
     render(
       <AgentHoverCard agent={agent({ description: "Plans and splits up the work." })}>
-        <button data-testid="trigger">Some Agent</button>
+        <button type="button" data-testid="trigger">
+          Some Agent
+        </button>
       </AgentHoverCard>,
     );
     expect(screen.getByTestId("trigger")).toHaveAttribute("data-slot", "hover-card-trigger");
@@ -40,7 +42,9 @@ describe("AgentHoverCard", () => {
     // Nothing to show → no wrapper, so an empty flyout can never open.
     render(
       <AgentHoverCard agent={agent({ description: null })}>
-        <button data-testid="trigger">Some Agent</button>
+        <button type="button" data-testid="trigger">
+          Some Agent
+        </button>
       </AgentHoverCard>,
     );
     expect(screen.getByTestId("trigger")).not.toHaveAttribute("data-slot", "hover-card-trigger");
@@ -51,7 +55,9 @@ describe("AgentHoverCard", () => {
     // a flyout with an empty body.
     render(
       <AgentHoverCard agent={agent({ description: "" })}>
-        <button data-testid="trigger">Some Agent</button>
+        <button type="button" data-testid="trigger">
+          Some Agent
+        </button>
       </AgentHoverCard>,
     );
     expect(screen.getByTestId("trigger")).not.toHaveAttribute("data-slot", "hover-card-trigger");

--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -12,7 +12,6 @@
 
 import { createPortal } from "react-dom";
 import {
-  Children,
   isValidElement,
   lazy,
   Suspense,
@@ -159,7 +158,7 @@ function MermaidPreview({ source }: { source: string }) {
 // adds no attack surface. Only literal integer pixel values are forwarded.
 const MARKDOWN_COMPONENTS: Components = {
   pre({ children, ...props }) {
-    const child = Children.count(children) === 1 && isValidElement(children) ? children : null;
+    const child = isValidElement(children) ? children : null;
     if (
       isValidElement<{ className?: string; children?: ReactNode }>(child) &&
       child.props.className?.split(/\s+/).includes("language-mermaid")


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Simplify `CodeViewer` child handling by relying on `isValidElement`.
- Add explicit button types to hover-card test triggers.

## Test Plan

- `pnpm --filter web exec oxlint -A all -D 'react/no-react-children' -D 'react/button-has-type' .`
- `pnpm --filter web exec vitest run src/shell/CodeViewer.test.tsx src/components/AgentHoverCard.test.tsx`
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `pnpm --filter web run test:coverage`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing `CodeViewer` and `AgentHoverCard` tests pass without behavior changes.
