### PR TITLE
refactor(web): avoid reassigning node view parameter

### DIFF
--- a/web/src/shell/TipTapWorkspaceImage.ts
+++ b/web/src/shell/TipTapWorkspaceImage.ts
@@ -252,6 +252,7 @@ export function createWorkspaceImageExtension(
       };
       return ({ node, HTMLAttributes }) => {
         const img = document.createElement("img");
+        let currentNode = node;
         for (const [key, value] of Object.entries(HTMLAttributes)) {
           // src is handled below: workspace paths must go through the
           // authenticated fetch, never directly onto the DOM.
@@ -296,7 +297,7 @@ export function createWorkspaceImageExtension(
           // src change returns false so the view is destroyed (revoking the
           // old URL) and recreated, refetching through the path above.
           update(newNode) {
-            if (newNode.type !== node.type || newNode.attrs.src !== src) return false;
+            if (newNode.type !== currentNode.type || newNode.attrs.src !== src) return false;
             for (const [key, value] of Object.entries(newNode.attrs)) {
               if (key === "src") continue;
               if (value == null) {
@@ -308,7 +309,7 @@ export function createWorkspaceImageExtension(
                 applyAttr(img, key, value);
               }
             }
-            node = newNode;
+            currentNode = newNode;
             return true;
           },
           destroy() {


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Track the active TipTap image node with a local variable rather than reassigning the node-view callback parameter.
- Preserve node-view update behavior while removing the `no-param-reassign` lint violation.

## Test Plan

- `pnpm --filter web exec oxlint -A all -D 'eslint/no-param-reassign' .`
- `pnpm --filter web exec vitest run src/shell/TipTapWorkspaceImage.test.ts`
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing TipTap workspace-image test suite passes with no behavior change.
