### PR TITLE
refactor(web): separate ignored stream event cases

### DIFF
--- a/web/src/lib/blockStream.ts
+++ b/web/src/lib/blockStream.ts
@@ -903,6 +903,8 @@ function* processEvent(state: ReducerState, event: StreamEvent): Generator<AnyBl
     case "session_mcp_startup":
     case "session_input_consumed":
     case "session_created":
+      return;
+
     // Mutates an existing block in the chat-store; see
     // `handleSessionEvent`.
     case "elicitation_resolved":


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Give `session_created` its own return in the stream reducer.
- Keep `elicitation_resolved` documented as a chat-store-owned event while removing the intentional switch fallthrough.

## Test Plan

- `pnpm --filter web exec oxlint -A all -D 'eslint/no-fallthrough' .`
- `pnpm --filter web exec vitest run src/lib/blockStream.test.ts`
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing block-stream reducer test suite passes with no behavior change.
