### PR TITLE
test(web): type sidebar project session fixtures

### DIFF
--- a/web/src/shell/Sidebar.shiftSelect.test.tsx
+++ b/web/src/shell/Sidebar.shiftSelect.test.tsx
@@ -47,7 +47,9 @@ describe("computeShiftSelectRange", () => {
 
 const { projectsMock, conversationsRef, projectSessionsMock } = vi.hoisted(() => ({
   projectsMock: [] as string[],
-  conversationsRef: { current: [] as { id: string; labels?: Record<string, string> }[] },
+  conversationsRef: {
+    current: [] as { id: string; labels?: Record<string, string>; archived?: boolean }[],
+  },
   projectSessionsMock: { current: {} as Record<string, unknown[]> },
 }));
 
@@ -75,7 +77,7 @@ vi.mock("@/hooks/useConversations", () => ({
       ? []
       : (override ??
         conversationsRef.current.filter(
-          (c) => (c.labels?.omni_project ?? null) === project && (c as any).archived !== true,
+          (c) => (c.labels?.omni_project ?? null) === project && c.archived !== true,
         ));
     return {
       data: enabled

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -41,7 +41,9 @@ const {
   // mock derives each folder's rows from this by label, mirroring the server's
   // ?project= filter — so tests that seed project sessions via the global list
   // keep working without a separate per-project fixture.
-  conversationsRef: { current: [] as { id: string; labels?: Record<string, string> }[] },
+  conversationsRef: {
+    current: [] as { id: string; labels?: Record<string, string>; archived?: boolean }[],
+  },
   // Server-authoritative pinned ids. Kept in a ref (not the legacy localStorage
   // key, which the one-time migration clears on mount) so a seeded pin survives
   // the first render. `seedPins` sets it; the toggle mock mutates it.
@@ -111,7 +113,7 @@ vi.mock("@/hooks/useConversations", () => ({
       ? []
       : (override ??
         conversationsRef.current.filter(
-          (c) => (c.labels?.omni_project ?? null) === project && (c as any).archived !== true,
+          (c) => (c.labels?.omni_project ?? null) === project && c.archived !== true,
         ));
     return {
       data: enabled


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add the optional `archived` field to Sidebar project-session test fixtures.
- Remove redundant `any` casts when filtering archived fixture rows.

## Test Plan

- `pnpm --filter web exec oxlint -A all -D 'typescript/no-explicit-any' src/shell/Sidebar.test.tsx src/shell/Sidebar.shiftSelect.test.tsx`
- `pnpm --filter web exec vitest run src/shell/Sidebar.test.tsx src/shell/Sidebar.shiftSelect.test.tsx`
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing Sidebar integration and shift-selection tests cover the typed test fixtures.
