### PR TITLE
refactor(web): remove dynamic object deletions

### DIFF
--- a/web/src/hooks/useUnseenConversations.ts
+++ b/web/src/hooks/useUnseenConversations.ts
@@ -39,7 +39,7 @@ type LastSeenMap = Record<string, number>;
 // The browser-durable read-state, hydrated from localStorage at module
 // load, raised (never lowered) by the server seed, and updated
 // optimistically on each mutation before the best-effort PUT lands.
-const lastSeenMap: LastSeenMap = {};
+let lastSeenMap: LastSeenMap = {};
 const explicitlyUnread = new Set<string>();
 
 // localStorage persistence. Best-effort everywhere: storage can be
@@ -199,7 +199,7 @@ export function useSeedReadState(conversations: readonly ReadStateSeed[] | undef
  * Not used in production.
  */
 export function resetReadStateForTests(): void {
-  for (const id of Object.keys(lastSeenMap)) delete lastSeenMap[id];
+  lastSeenMap = {};
   explicitlyUnread.clear();
   seeded.clear();
   hydrated = false;

--- a/web/src/lib/harnessPreferences.ts
+++ b/web/src/lib/harnessPreferences.ts
@@ -46,11 +46,12 @@ export function writeLastHarness(agentId: string | null | undefined, harness: st
   try {
     const map = readMap();
     if (harness === null) {
-      delete map[agentId];
+      const { [agentId]: _removedHarness, ...remainingHarnesses } = map;
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(remainingHarnesses));
     } else {
       map[agentId] = harness;
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
     }
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
   } catch {
     // localStorage quota or access errors shouldn't break the composer.
   }

--- a/web/src/lib/panelSizePreferences.ts
+++ b/web/src/lib/panelSizePreferences.ts
@@ -79,7 +79,9 @@ function writePanelSizePreferences(prefs: PanelSizePreferences): void {
 export function writePanelSizePreference(key: PanelSizePreferenceKey, width: number | null): void {
   const prefs = readPanelSizePreferences();
   if (width === null) {
-    delete prefs[key];
+    const { [key]: _removedPreference, ...remainingPreferences } = prefs;
+    writePanelSizePreferences(remainingPreferences);
+    return;
   } else if (isValidWidth(width)) {
     prefs[key] = width;
   } else {

--- a/web/src/pages/InboxPage.tsx
+++ b/web/src/pages/InboxPage.tsx
@@ -139,9 +139,7 @@ export function InboxPage() {
       const pendingIds = new Set(items.map((i) => i.elicitation.elicitationId));
       const stale = Object.keys(prev).filter((id) => pendingIds.has(id));
       if (stale.length === 0) return prev;
-      const next = { ...prev };
-      for (const id of stale) delete next[id];
-      return next;
+      return Object.fromEntries(Object.entries(prev).filter(([id]) => !pendingIds.has(id)));
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [snapshotVersionKey]);
@@ -181,9 +179,8 @@ export function InboxPage() {
           // Roll back to pending so the buttons reappear and the user
           // can retry — same recovery the chat store uses.
           setResponded((prev) => {
-            const next = { ...prev };
-            delete next[elicitationId];
-            return next;
+            const { [elicitationId]: _respondedVerdict, ...pendingVerdicts } = prev;
+            return pendingVerdicts;
           });
         },
       );


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Replace dynamic object deletions in preference and inbox state updates with immutable omission.
- Reset the test-only unseen-conversation map by replacing its private state object.

## Test Plan

- `pnpm --filter web exec oxlint -A all -D 'typescript/no-dynamic-delete' src/lib/panelSizePreferences.ts src/lib/harnessPreferences.ts src/hooks/useUnseenConversations.ts src/pages/InboxPage.tsx`
- `pnpm --filter web exec vitest run src/lib/panelSizePreferences.test.ts src/lib/harnessPreferences.test.ts src/hooks/useUnseenConversations.test.ts src/pages/InboxPage.test.tsx`
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing preference, unread-state, and inbox tests cover the unchanged removal behavior.
