### PR TITLE
refactor(web): break terminal hook import cycle

### DIFF
--- a/web/src/hooks/useTerminals.ts
+++ b/web/src/hooks/useTerminals.ts
@@ -3,36 +3,9 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { authenticatedFetch } from "../lib/identity";
 import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
+import { terminalInfoFromResource, terminalsQueryKey, type TerminalInfo } from "@/lib/terminals";
 
-/**
- * UI-facing terminal record.
- *
- * The wire response from ``GET /v1/sessions/{id}/resources/terminals``
- * is a richer ``session.resource``-shaped envelope; this struct lifts
- * the fields the UI actually renders and addresses (``id`` for
- * attach/close/tab keys, ``name``/``session`` for display).
- */
-export interface TerminalInfo {
-  /**
-   * Opaque, stable resource id, e.g. ``"terminal_bash_s1"``. Used as
-   * the addressing key for WS attach, close, and tab identity.
-   */
-  id: string;
-  /** Terminal name from the spec, e.g. ``"bash"``. From ``metadata.terminal_name``. */
-  name: string;
-  /** Session key, e.g. ``"s1"``. From ``metadata.session_key``. */
-  session: string;
-  /** Whether the underlying tmux session is currently running. */
-  running: boolean;
-  /**
-   * Web-attach transport for this terminal, from
-   * ``metadata.terminal_transport``: ``"control"`` (tmux control mode —
-   * native browser scrollback + selection) or ``"pty"`` (the legacy forked
-   * ``tmux attach`` stream). ``undefined`` when the server omits it (older
-   * server / treat as PTY).
-   */
-  transport?: "control" | "pty";
-}
+export { terminalInfoFromResource, terminalsQueryKey, type TerminalInfo } from "@/lib/terminals";
 
 /**
  * Stable tab-id for a terminal, used as the Tabs trigger value.
@@ -118,19 +91,6 @@ export function inventoryTerminals(
   return terminals.filter((t) => !AGENT_TERMINAL_IDS.has(t.id));
 }
 
-/**
- * TanStack Query key for a conversation's terminals.
- *
- * Exported so the chatStore SSE handler can target the same cache
- * entry when applying ``session.resource.{created,deleted}`` updates.
- *
- * :param conversationId: Session/conversation identifier.
- * :returns: Tuple identifying the cache entry.
- */
-export function terminalsQueryKey(conversationId: string): readonly unknown[] {
-  return ["conversation", conversationId, "terminals"];
-}
-
 interface UseTerminalsResult {
   terminals: TerminalInfo[];
   isLoading: boolean;
@@ -183,54 +143,6 @@ interface UseTerminalsOptions {
    * window: it stops the instant a terminal lands (or pending clears).
    */
   reconcileWhilePending?: boolean;
-}
-
-/**
- * Convert a single terminal-resource wire dict into the UI-facing
- * :class:`TerminalInfo`.
- *
- * The sole producer is the SSE-driven cache updater
- * (``applyTerminalCreated`` in the chatStore), which receives the
- * resource dict from ``session.resource.created`` events — both the
- * live deltas and the snapshot-on-connect replay.
- *
- * :param resource: Wire-shape resource dict from
- *     ``session.resource.created``. ``Record<string, unknown>`` to
- *     accommodate the SSE handler's permissive payload.
- * :returns: The mapped :class:`TerminalInfo`, or ``null`` when the
- *     resource lacks the minimum required fields.
- */
-export function terminalInfoFromResource(resource: Record<string, unknown>): TerminalInfo | null {
-  const id = resource.id;
-  if (typeof id !== "string" || !id) return null;
-  const rawMetadata = resource.metadata;
-  const metadata =
-    rawMetadata && typeof rawMetadata === "object" && !Array.isArray(rawMetadata)
-      ? (rawMetadata as Record<string, unknown>)
-      : {};
-  const terminalName = metadata.terminal_name;
-  const sessionKey = metadata.session_key;
-  const running = metadata.running;
-  const rawTransport = metadata.terminal_transport;
-  const transport = rawTransport === "control" || rawTransport === "pty" ? rawTransport : undefined;
-  const fallbackName = resource.name;
-  return {
-    id,
-    // metadata.terminal_name / metadata.session_key are the canonical
-    // wire location for these display fields under the resources API.
-    // Fall back to the resource ``name`` for terminal_name so a server
-    // that omits metadata still renders something recognizable; empty
-    // string for session is acceptable because the UI dedupes by id.
-    name:
-      typeof terminalName === "string" && terminalName
-        ? terminalName
-        : typeof fallbackName === "string"
-          ? fallbackName
-          : "",
-    session: typeof sessionKey === "string" ? sessionKey : "",
-    running: typeof running === "boolean" ? running : false,
-    transport,
-  };
 }
 
 // Status codes that mean "no terminal yet / runner not reachable" rather

--- a/web/src/lib/terminals.ts
+++ b/web/src/lib/terminals.ts
@@ -1,0 +1,47 @@
+/** UI-facing terminal record returned by the session resources API. */
+export interface TerminalInfo {
+  /** Opaque, stable resource id used for addressing and tab keys. */
+  id: string;
+  /** Terminal name from the spec, e.g. ``"bash"``. */
+  name: string;
+  /** Session key, e.g. ``"s1"``. */
+  session: string;
+  /** Whether the underlying tmux session is currently running. */
+  running: boolean;
+  /** Web-attach transport, when supplied by the server. */
+  transport?: "control" | "pty";
+}
+
+/** TanStack Query key for a conversation's terminal resources. */
+export function terminalsQueryKey(conversationId: string): readonly unknown[] {
+  return ["conversation", conversationId, "terminals"];
+}
+
+/** Convert a terminal resource wire payload into the UI-facing record. */
+export function terminalInfoFromResource(resource: Record<string, unknown>): TerminalInfo | null {
+  const id = resource.id;
+  if (typeof id !== "string" || !id) return null;
+  const rawMetadata = resource.metadata;
+  const metadata =
+    rawMetadata && typeof rawMetadata === "object" && !Array.isArray(rawMetadata)
+      ? (rawMetadata as Record<string, unknown>)
+      : {};
+  const terminalName = metadata.terminal_name;
+  const sessionKey = metadata.session_key;
+  const running = metadata.running;
+  const rawTransport = metadata.terminal_transport;
+  const transport = rawTransport === "control" || rawTransport === "pty" ? rawTransport : undefined;
+  const fallbackName = resource.name;
+  return {
+    id,
+    name:
+      typeof terminalName === "string" && terminalName
+        ? terminalName
+        : typeof fallbackName === "string"
+          ? fallbackName
+          : "",
+    session: typeof sessionKey === "string" ? sessionKey : "",
+    running: typeof running === "boolean" ? running : false,
+    transport,
+  };
+}

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -83,11 +83,7 @@ import { sessionItemsQueryKey } from "@/hooks/useSessionItems";
 import type { Conversation, ConversationsPage } from "@/hooks/useConversations";
 import type { ConversationsInfiniteData } from "@/lib/sessionListCache";
 import { useTerminalActivityStore } from "./terminalActivity";
-import {
-  terminalInfoFromResource,
-  terminalsQueryKey,
-  type TerminalInfo,
-} from "@/hooks/useTerminals";
+import { terminalInfoFromResource, terminalsQueryKey, type TerminalInfo } from "@/lib/terminals";
 import type {
   ContentBlock,
   ModelUsage,


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Move terminal cache types and wire-payload mapping into a framework-independent library module.
- Re-export the existing hook API so terminal callers remain unchanged.
- Let `chatStore` consume the shared contract directly, removing the import cycle through `RunnerHealthProvider`.

## Test Plan

- `pnpm --filter web exec oxlint -A all -D 'import/no-cycle' .`
- `pnpm --filter web exec vitest run src/hooks/useTerminals.test.ts src/hooks/RunnerHealthProvider.test.tsx src/store/chatStore.test.ts`
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing terminal, runner-health, and chat-store suites cover the moved shared contract.
