### PR TITLE
refactor(electron): document swallowed detach races

### DIFF
--- a/web/electron/src/browserViewRegistry.js
+++ b/web/electron/src/browserViewRegistry.js
@@ -208,7 +208,9 @@ function createBrowserViewRegistry({
         if (prev) {
           try {
             detachFromHost(prev.view);
-          } catch {}
+          } catch {
+            /* view already detached */
+          }
         }
         activeConversationId = null;
         sendToRenderer("browser-host-active-changed", { conversationId: null });
@@ -224,7 +226,9 @@ function createBrowserViewRegistry({
         if (prev) {
           try {
             detachFromHost(prev.view);
-          } catch {}
+          } catch {
+            /* view already detached */
+          }
         }
         activeConversationId = null;
         sendToRenderer("browser-host-active-changed", { conversationId: null });
@@ -263,7 +267,9 @@ function createBrowserViewRegistry({
     if (activeConversationId === conversationId) {
       try {
         detachFromHost(entry.view);
-      } catch {}
+      } catch {
+        /* view already detached */
+      }
       activeConversationId = null;
     }
     // Detach any design-mode listeners before closing the webContents, so a


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Document the intentional browser-view teardown races in three catch blocks.
- Remove the Electron `no-empty` lint baseline without changing detach behavior.

## Test Plan

- `pnpm --dir web/electron test -- test/browserViewRegistry.test.js`
- `pnpm --filter web exec oxlint -A all -D 'eslint/no-empty' .`
- `pnpm --filter web run lint`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The browser-view registry tests cover detach and close lifecycle behavior.
