### PR TITLE
refactor(web): split websocket handler cleanup

### DIFF
--- a/web/src/lib/sessionUpdatesSocket.ts
+++ b/web/src/lib/sessionUpdatesSocket.ts
@@ -102,7 +102,10 @@ class SessionUpdatesSocket {
     this.ws = null;
     if (ws) {
       // Drop handlers first so the close doesn't schedule a reconnect.
-      ws.onopen = ws.onmessage = ws.onerror = ws.onclose = null;
+      ws.onopen = null;
+      ws.onmessage = null;
+      ws.onerror = null;
+      ws.onclose = null;
       ws.close();
     }
     this.setConnected(false);


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Split chained WebSocket event-handler cleanup into explicit assignments.
- Preserve reconnect suppression before closing the socket.

## Test Plan

- `pnpm --filter web exec oxlint -A all -D 'eslint/no-multi-assign' .`
- `pnpm --filter web exec vitest run src/lib/sessionUpdatesSocket.test.ts`
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing session-updates socket tests cover connection teardown behavior.
