### PR TITLE
refactor(electron): modernize updater property checks

### DIFF
--- a/web/electron/src/desktop_updater.js
+++ b/web/electron/src/desktop_updater.js
@@ -122,16 +122,13 @@ function createDesktopUpdater({
   function setConfig(patch = {}) {
     const settings = loadSettings();
     const next = { ...settings };
-    if (Object.prototype.hasOwnProperty.call(patch, "mode") && UPDATE_MODES.has(patch.mode)) {
+    if (Object.hasOwn(patch, "mode") && UPDATE_MODES.has(patch.mode)) {
       next.update_mode = patch.mode;
     }
-    if (
-      Object.prototype.hasOwnProperty.call(patch, "autoInstall") &&
-      typeof patch.autoInstall === "boolean"
-    ) {
+    if (Object.hasOwn(patch, "autoInstall") && typeof patch.autoInstall === "boolean") {
       next.update_auto_install = patch.autoInstall;
     }
-    if (Object.prototype.hasOwnProperty.call(patch, "skippedVersion")) {
+    if (Object.hasOwn(patch, "skippedVersion")) {
       next.update_skipped_version =
         typeof patch.skippedVersion === "string" ? patch.skippedVersion : null;
     }


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Replace legacy `Object.prototype.hasOwnProperty.call` checks with `Object.hasOwn`.
- Clear the Electron updater's `prefer-object-has-own` lint baseline without changing config-patch behavior.

## Test Plan

- `pnpm --dir web/electron test -- test/desktop_updater.test.js`
- `pnpm --filter web exec oxlint -A all -D 'eslint/prefer-object-has-own' .`
- `pnpm --filter web run lint`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing desktop-updater suite covers config patch persistence and ignored fields.
