### PR TITLE
refactor(web): standardize generic constructors

### DIFF
--- a/web/src/lib/nativeCodingAgents.ts
+++ b/web/src/lib/nativeCodingAgents.ts
@@ -157,13 +157,13 @@ export const NATIVE_CODING_AGENTS = [
   },
 ] as const satisfies readonly NativeCodingAgentSpec[];
 
-const BY_AGENT_NAME: Map<string, NativeCodingAgentSpec> = new Map(
+const BY_AGENT_NAME = new Map<string, NativeCodingAgentSpec>(
   NATIVE_CODING_AGENTS.map((agent) => [agent.agentName, agent]),
 );
-const BY_HARNESS: Map<string, NativeCodingAgentSpec> = new Map(
+const BY_HARNESS = new Map<string, NativeCodingAgentSpec>(
   NATIVE_CODING_AGENTS.map((agent) => [agent.harness, agent]),
 );
-const BY_WRAPPER: Map<string, NativeCodingAgentSpec> = new Map(
+const BY_WRAPPER = new Map<string, NativeCodingAgentSpec>(
   NATIVE_CODING_AGENTS.map((agent) => [agent.wrapperLabel, agent]),
 );
 

--- a/web/src/shell/subagentGraphLayout.ts
+++ b/web/src/shell/subagentGraphLayout.ts
@@ -136,7 +136,7 @@ export function buildTree(
   rootPreview: string | null,
   childrenMap: Map<string, ChildSessionInfo[]>,
   depth: number,
-  visited: Set<string> = new Set(),
+  visited = new Set<string>(),
 ): TreeNode {
   visited.add(rootId);
   const children = childrenMap.get(rootId) ?? [];


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Move `Map` and `Set` type arguments onto their constructors.
- Clear the `consistent-generic-constructors` lint baseline without changing runtime behavior.

## Test Plan

- `pnpm --filter web exec oxlint -A all -D 'typescript/consistent-generic-constructors' .`
- `pnpm --filter web exec vitest run src/lib/nativeCodingAgents.test.ts src/shell/SubagentsGraphView.test.tsx`
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing native-agent lookup and subagent graph tests cover the unchanged behavior.
