### PR TITLE
refactor(web): infer default parameter types

### DIFF
--- a/web/src/hooks/useCommandPaletteHotkey.ts
+++ b/web/src/hooks/useCommandPaletteHotkey.ts
@@ -39,7 +39,7 @@ function focusOwnsHotkey(): boolean {
  * @param enabled  Pass `false` to disable the hotkey (e.g. embedded mode, where
  *   ⌘K belongs to the host page). Defaults to enabled.
  */
-export function useCommandPaletteHotkey(onToggle: () => void, enabled: boolean = true): void {
+export function useCommandPaletteHotkey(onToggle: () => void, enabled = true): void {
   // Held in a ref so the bound handler always calls the latest closure without
   // re-registering on every render.
   const latest = useRef(onToggle);

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -271,8 +271,8 @@ async function fetchConversationsPage({
  * the Archived settings view's project filter.
  */
 export function useConversations(
-  searchQuery: string = "",
-  includeArchived: boolean = false,
+  searchQuery = "",
+  includeArchived = false,
   options: UseConversationsOptions = {},
   project?: string,
 ) {

--- a/web/src/hooks/useScheduledTasks.ts
+++ b/web/src/hooks/useScheduledTasks.ts
@@ -58,7 +58,7 @@ export function useScheduledTasks() {
  * One task's run history (most-recent-first). `enabled` gates the fetch so an
  * unexpanded row costs nothing.
  */
-export function useScheduledTaskRuns(id: string, enabled: boolean = true) {
+export function useScheduledTaskRuns(id: string, enabled = true) {
   return useQuery<ScheduledTaskRun[]>({
     queryKey: scheduledTaskRunsKey(id),
     queryFn: () => listScheduledTaskRuns(id),

--- a/web/src/hooks/useVoiceDictationHotkey.ts
+++ b/web/src/hooks/useVoiceDictationHotkey.ts
@@ -41,7 +41,7 @@ function focusOwnsHotkey(): boolean {
  * @param enabled  Pass `false` to skip binding (e.g. the secondary composer in
  *   the New Chat dialog, so two mics don't fight for the device). Defaults on.
  */
-export function useVoiceDictationHotkey(onToggle: () => void, enabled: boolean = true): void {
+export function useVoiceDictationHotkey(onToggle: () => void, enabled = true): void {
   // Held in a ref so the bound handler always calls the latest closure without
   // re-registering on every render (onToggle changes as listening state flips).
   const latest = useRef(onToggle);

--- a/web/src/lib/ime.ts
+++ b/web/src/lib/ime.ts
@@ -7,10 +7,7 @@ type ImeKeyboardEvent = {
   };
 };
 
-export function isImeCompositionKeyEvent(
-  event: ImeKeyboardEvent,
-  isComposing: boolean = false,
-): boolean {
+export function isImeCompositionKeyEvent(event: ImeKeyboardEvent, isComposing = false): boolean {
   return (
     isComposing ||
     event.nativeEvent.isComposing === true ||

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3627,7 +3627,7 @@ export function buildSlashCommandMap(
   skills: ReadonlyArray<{ name: string; description: string }>,
   showEffort: boolean,
   showModel: boolean,
-  showCompact: boolean = true,
+  showCompact = true,
 ): Record<string, string> {
   const m: Record<string, string> = {};
   for (const [name, description] of Object.entries(BUILTIN_SLASH_COMMANDS)) {


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Remove redundant primitive type annotations from defaulted parameters.
- Clear the `no-inferrable-types` lint baseline while preserving the inferred `string` and `boolean` contracts.

## Test Plan

- `pnpm --filter web exec oxlint -A all -D 'typescript/no-inferrable-types' .`
- `pnpm --filter web exec vitest run src/hooks/useScheduledTasks.test.tsx src/hooks/useVoiceDictationHotkey.test.tsx src/hooks/useCommandPaletteHotkey.test.tsx src/hooks/useConversations.test.ts src/lib/ime.test.ts src/pages/ChatPage.test.ts`
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing hook, conversation, IME, and slash-command tests cover the unchanged defaults.
