### PR TITLE
refactor(web): consolidate duplicate imports

### DIFF
--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -19,9 +19,10 @@ import {
   useCreateMcpServer,
   useDeleteMcpServer,
   useUpdateMcpServer,
+  type Agent,
+  type McpServerSummary,
   type UpsertMcpServerInput,
 } from "@/hooks/useAgents";
-import type { Agent, McpServerSummary } from "@/hooks/useAgents";
 import type { ModelUsage } from "@/lib/types";
 import { showToast } from "@/components/ui/toast";
 import {

--- a/web/src/components/CostRoutingControl.test.tsx
+++ b/web/src/components/CostRoutingControl.test.tsx
@@ -1,6 +1,5 @@
-import { afterEach } from "vitest";
 import { cleanup } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { isCostRoutingSession, shortModelName } from "./CostRoutingControl";
 
 afterEach(cleanup);

--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -8,7 +8,6 @@
 
 import { Terminal } from "@xterm/xterm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ConnectionState } from "./TerminalSession";
 import {
   SHIFT_ENTER_CSI_U,
   SYNC_ECHO_MAX_BYTES,
@@ -23,6 +22,7 @@ import {
   shouldEchoSynchronously,
   terminalTheme,
   terminalKeyEventPayload,
+  type ConnectionState,
   wheelReportPayload,
   type WheelMouseState,
   type WheelScreenMetrics,

--- a/web/src/hooks/useResizableInlinePanel.ts
+++ b/web/src/hooks/useResizableInlinePanel.ts
@@ -5,8 +5,7 @@
 // ExecutionLogsPanel / FilesPanelDrawer — those open at ~50 % by default
 // while the inline panel starts at a compact sidebar width.
 
-import { useCallback, useEffect, useRef } from "react";
-import { useSyncExternalStore } from "react";
+import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
 import { readSessionWorkspaceState, writeSessionWorkspaceState } from "@/lib/sessionWorkspaceState";
 
 const MIN_WIDTH_PX = 240;

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import type { RenderItem } from "@/lib/renderItems";
+import type { Bubble, RenderItem } from "@/lib/renderItems";
 import type { ToolExecution } from "@/lib/blocks";
-import type { Bubble } from "@/lib/renderItems";
 import {
   BUILTIN_SLASH_COMMANDS,
   isSlashCommandText,

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -100,8 +100,7 @@ import {
   type ProjectPrefillConfig,
   type ProjectPrefillState,
 } from "./projectPrefill";
-import { getCliServerUrl } from "@/lib/host";
-import { getOmnigentHostConfig } from "@/lib/host";
+import { getCliServerUrl, getOmnigentHostConfig } from "@/lib/host";
 import { readLastAgentId, writeLastAgentId } from "@/lib/agentPreferences";
 import {
   readLastHostChoice,

--- a/web/src/shell/Sidebar.shiftSelect.test.tsx
+++ b/web/src/shell/Sidebar.shiftSelect.test.tsx
@@ -9,7 +9,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Conversation } from "@/hooks/useConversations";
 
 // ── Pure unit tests ─────────────────────────────────────────────────────────
-import { computeShiftSelectRange } from "./Sidebar";
+import { computeShiftSelectRange, Sidebar } from "./Sidebar";
 
 describe("computeShiftSelectRange", () => {
   const ids = ["a", "b", "c", "d", "e"];
@@ -105,7 +105,6 @@ vi.mock("@/hooks/useConversations", () => ({
 vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));
 
 import { useConversations } from "@/hooks/useConversations";
-import { Sidebar } from "./Sidebar";
 
 const useConvMock = vi.mocked(useConversations);
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Consolidate duplicate value and type imports across seven web modules.
- Clear the `import/no-duplicates` lint baseline without changing module behavior.

## Test Plan

- `pnpm --filter web exec oxlint -A all -D 'import/no-duplicates' .`
- `pnpm --filter web exec vitest run src/components/CostRoutingControl.test.tsx src/hooks/useResizableInlinePanel.test.tsx src/shell/NewChatDialog.test.tsx src/components/blocks/TerminalSession.test.ts src/components/AgentInfo.test.tsx src/shell/Sidebar.shiftSelect.test.tsx src/pages/ChatPage.test.ts`
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing tests for all seven affected modules pass with unchanged behavior.
