### PR TITLE
refactor(web): remove type-only import side effects

### DIFF
--- a/web/src/hooks/useMentionBrowser.ts
+++ b/web/src/hooks/useMentionBrowser.ts
@@ -1,6 +1,6 @@
 import { type KeyboardEvent, type RefObject, useRef, useState } from "react";
 
-import { type MentionItem, type MentionState } from "@/lib/composerMentions";
+import type { MentionItem, MentionState } from "@/lib/composerMentions";
 import { composerAttachmentKey } from "@/store/chatStore";
 import type { WorkspaceFile } from "@/hooks/useWorkspaceChangedFiles";
 

--- a/web/src/lib/composerMentions.ts
+++ b/web/src/lib/composerMentions.ts
@@ -1,4 +1,4 @@
-import { type ComposerAttachment } from "@/store/chatStore";
+import type { ComposerAttachment } from "@/store/chatStore";
 import { nativeCodingAgentForHarness } from "@/lib/nativeCodingAgents";
 
 /**

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -3,7 +3,7 @@
 // Covers the Appearance theme picker, the auth-gated Account section, and the
 // Archived sessions list (which moved here out of the sidebar).
 
-import { type ReactNode } from "react";
+import type { ReactNode } from "react";
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -44,7 +44,7 @@ import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import { rehypeGithubAlerts } from "rehype-github-alerts";
 import { mermaid } from "@streamdown/mermaid";
 import { Streamdown } from "streamdown";
-import { type Comment } from "@/hooks/useComments";
+import type { Comment } from "@/hooks/useComments";
 import {
   type FileContentResponse,
   fileContentToBlob,

--- a/web/src/shell/HtmlCommentViewer.tsx
+++ b/web/src/shell/HtmlCommentViewer.tsx
@@ -12,7 +12,7 @@
 import { createPortal } from "react-dom";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { MessageSquarePlusIcon } from "lucide-react";
-import { type Comment } from "@/hooks/useComments";
+import type { Comment } from "@/hooks/useComments";
 import { useCanEdit } from "@/hooks/usePermissions";
 import { getEmbedRoot } from "@/lib/host";
 import { type ActiveSelection, HTML_PREVIEW_SANDBOX } from "./codeViewerHelpers";

--- a/web/src/shell/MobilePanelDrawer.tsx
+++ b/web/src/shell/MobilePanelDrawer.tsx
@@ -13,7 +13,7 @@
 // can't collide with the rail.
 
 import { XIcon } from "lucide-react";
-import { type ReactNode } from "react";
+import type { ReactNode } from "react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -159,7 +159,7 @@ import {
 import { OttoEyes } from "@/components/OttoEyes";
 import { SkillPills } from "@/components/SkillPills";
 import { ComposerMicButton } from "@/components/ComposerMicButton";
-import { type CostControlMode } from "@/components/CostRoutingControl";
+import type { CostControlMode } from "@/components/CostRoutingControl";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { AgentRowTooltip } from "@/components/AgentHoverCard";
 import { CreateAgentDialog } from "./CreateAgentDialog";

--- a/web/src/shell/PdfViewer.tsx
+++ b/web/src/shell/PdfViewer.tsx
@@ -18,12 +18,12 @@ import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
 import { MessageSquarePlusIcon, MinusIcon, PlusIcon } from "lucide-react";
 import { fileContentToBlob, type FileContentResponse } from "@/hooks/useFileContent";
-import { type Comment } from "@/hooks/useComments";
+import type { Comment } from "@/hooks/useComments";
 import { useCanEdit } from "@/hooks/usePermissions";
 import { Button } from "@/components/ui/button";
 import { getEmbedRoot } from "@/lib/host";
 import { cn } from "@/lib/utils";
-import { type ActiveSelection } from "./codeViewerHelpers";
+import type { ActiveSelection } from "./codeViewerHelpers";
 import {
   commentsMatchOffsets,
   decodePdfAnchor,

--- a/web/src/shell/terminalStatus.test.tsx
+++ b/web/src/shell/terminalStatus.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { type ConnectionState } from "@/components/blocks/TerminalSession";
-import { type TerminalInfo } from "@/hooks/useTerminals";
+import type { ConnectionState } from "@/components/blocks/TerminalSession";
+import type { TerminalInfo } from "@/hooks/useTerminals";
 import { deriveTerminalStatus, TerminalStatusBadge } from "./terminalStatus";
 
 afterEach(() => {

--- a/web/src/shell/terminalStatus.tsx
+++ b/web/src/shell/terminalStatus.tsx
@@ -1,5 +1,5 @@
-import { type ConnectionState } from "@/components/blocks/TerminalSession";
-import { type TerminalInfo } from "@/hooks/useTerminals";
+import type { ConnectionState } from "@/components/blocks/TerminalSession";
+import type { TerminalInfo } from "@/hooks/useTerminals";
 import { cn } from "@/lib/utils";
 
 /**

--- a/web/src/shell/useTerminalStatuses.test.tsx
+++ b/web/src/shell/useTerminalStatuses.test.tsx
@@ -1,6 +1,6 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { type TerminalInfo } from "@/hooks/useTerminals";
+import type { TerminalInfo } from "@/hooks/useTerminals";
 import { useTerminalStatuses } from "./useTerminalStatuses";
 
 function terminal(overrides: Partial<TerminalInfo> = {}): TerminalInfo {

--- a/web/src/shell/useTerminalStatuses.ts
+++ b/web/src/shell/useTerminalStatuses.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { type ConnectionState } from "@/components/blocks/TerminalSession";
-import { type TerminalInfo } from "@/hooks/useTerminals";
+import type { ConnectionState } from "@/components/blocks/TerminalSession";
+import type { TerminalInfo } from "@/hooks/useTerminals";
 import { useTerminalActivityStore } from "@/store/terminalActivity";
 import { deriveTerminalStatus, type TerminalStatus } from "./terminalStatus";
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Convert inline-only type imports into top-level `import type` declarations.
- Prevent 16 type-only imports from leaving runtime side-effect imports under TypeScript's module emit.

## Test Plan

- `pnpm --filter web exec oxlint -A all -D 'typescript/no-import-type-side-effects' .`
- `pnpm --filter web exec vitest run src/lib/composerMentions.test.ts src/pages/SettingsPage.test.tsx src/shell/CodeViewer.test.tsx src/shell/HtmlCommentViewer.test.tsx src/shell/NewChatDialog.test.tsx src/shell/FileViewer.test.tsx src/shell/terminalStatus.test.tsx src/shell/useTerminalStatuses.test.tsx`
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing module and UI tests cover the affected imports; 327 tests passed with one expected failure.
