### PR TITLE
test(web): use explicit module type imports

### DIFF
--- a/web/src/components/AgentInfo.test.tsx
+++ b/web/src/components/AgentInfo.test.tsx
@@ -1,3 +1,5 @@
+import type * as IdentityModule from "@/lib/identity";
+
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -50,7 +52,7 @@ vi.mock("@/hooks/usePermissions", () => ({
   usePermissions: () => ({ data: grantsData.current }),
 }));
 vi.mock("@/lib/identity", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/lib/identity")>()),
+  ...(await importOriginal<typeof IdentityModule>()),
   getCurrentUserId: () => viewerData.current,
 }));
 vi.mock("@/lib/clipboard", () => ({ copyText: copyTextMock }));

--- a/web/src/components/PermissionsModal.test.tsx
+++ b/web/src/components/PermissionsModal.test.tsx
@@ -1,3 +1,5 @@
+import type * as HostModule from "@/lib/host";
+
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -24,7 +26,7 @@ vi.mock("qrcode.react", () => ({
 // Host config is read-once at render to decide plain-input vs combobox and to
 // transform the share link. Mock both getters so we can drive each branch.
 vi.mock("@/lib/host", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/host")>();
+  const actual = await importOriginal<typeof HostModule>();
   return {
     ...actual,
     getOmnigentUserSearch: vi.fn(() => undefined),

--- a/web/src/components/PresenceAvatars.test.tsx
+++ b/web/src/components/PresenceAvatars.test.tsx
@@ -1,3 +1,5 @@
+import type * as IdentityModule from "@/lib/identity";
+
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -9,7 +11,7 @@ import { useChatStore } from "@/store/chatStore";
 // the module's other exports real — chatStore (imported transitively)
 // pulls authenticatedFetch from the same module.
 vi.mock("@/lib/identity", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/lib/identity")>()),
+  ...(await importOriginal<typeof IdentityModule>()),
   getCurrentAuthorId: () => "self@example.com",
 }));
 

--- a/web/src/components/blocks/TerminalView.test.tsx
+++ b/web/src/components/blocks/TerminalView.test.tsx
@@ -6,6 +6,8 @@
 // callback directly, while still pinning the pure URL builder contract
 // the server cares about.
 
+import type * as TerminalSessionModule from "./TerminalSession";
+
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -31,7 +33,7 @@ const terminalSessionMock = vi.hoisted(() => ({
 vi.mock("./TerminalSession", async (importOriginal) => ({
   // Keep the real module (isUnexpectedTerminalClose and friends) —
   // only the session class itself is replaced.
-  ...(await importOriginal<typeof import("./TerminalSession")>()),
+  ...(await importOriginal<typeof TerminalSessionModule>()),
   TerminalSession: class {
     dispose = vi.fn();
     setTheme = vi.fn();

--- a/web/src/components/goal/GoalDialog.test.tsx
+++ b/web/src/components/goal/GoalDialog.test.tsx
@@ -1,3 +1,5 @@
+import type * as GoalApiModule from "@/lib/goalApi";
+
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GoalDialog, parseGoalBudget } from "./GoalDialog";
@@ -5,7 +7,7 @@ import type { Goal } from "@/lib/goalApi";
 import { clearGoal, getGoal, setGoal, updateGoalStatus } from "@/lib/goalApi";
 
 vi.mock("@/lib/goalApi", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/goalApi")>();
+  const actual = await importOriginal<typeof GoalApiModule>();
   return {
     ...actual,
     clearGoal: vi.fn(),

--- a/web/src/components/goal/useGoalState.test.tsx
+++ b/web/src/components/goal/useGoalState.test.tsx
@@ -1,10 +1,12 @@
+import type * as GoalApiModule from "@/lib/goalApi";
+
 import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getGoal, type Goal } from "@/lib/goalApi";
 import { useGoalState } from "./useGoalState";
 
 vi.mock("@/lib/goalApi", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/goalApi")>();
+  const actual = await importOriginal<typeof GoalApiModule>();
   return { ...actual, getGoal: vi.fn() };
 });
 

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.test.tsx
@@ -6,6 +6,9 @@
 // The agent/host hooks and the create mutation are mocked; WorkspacePicker is
 // stubbed (its filesystem browsing is out of scope here).
 
+import type * as NativeCodingAgentsModule from "@/lib/nativeCodingAgents";
+import type * as ScheduledTasksApiModule from "@/lib/scheduledTasksApi";
+
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -114,7 +117,7 @@ vi.mock("@/shell/NewChatDialog", () => ({
 // nativeAgentHasCapability(claude-native, "permissionMode") must be true so the
 // model/effort knobs map onto the payload; polly (claude-sdk) has no knobs.
 vi.mock("@/lib/nativeCodingAgents", async (orig) => {
-  const actual = await orig<typeof import("@/lib/nativeCodingAgents")>();
+  const actual = await orig<typeof NativeCodingAgentsModule>();
   return {
     ...actual,
     isNativeCodingAgent: (a: AvailableAgent) => a?.name === "claude-native-ui",
@@ -170,7 +173,7 @@ function renderDialog(onOpenChange: (open: boolean) => void = vi.fn()) {
   return render(<CreateScheduledTaskDialog open onOpenChange={onOpenChange} />);
 }
 
-function scheduledTask(overrides: Partial<import("@/lib/scheduledTasksApi").ScheduledTask> = {}) {
+function scheduledTask(overrides: Partial<ScheduledTasksApiModule.ScheduledTask> = {}) {
   return {
     id: "st_1",
     name: "Morning brief",
@@ -191,7 +194,7 @@ function scheduledTask(overrides: Partial<import("@/lib/scheduledTasksApi").Sche
     lastRunConversationId: null,
     nextRunAt: null,
     ...overrides,
-  } satisfies import("@/lib/scheduledTasksApi").ScheduledTask;
+  } satisfies ScheduledTasksApiModule.ScheduledTask;
 }
 
 describe("agent picker readiness (needs-setup badges)", () => {

--- a/web/src/hooks/useUnseenConversations.test.ts
+++ b/web/src/hooks/useUnseenConversations.test.ts
@@ -1,3 +1,5 @@
+import type * as UseUnseenConversationsModule from "./useUnseenConversations";
+
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -8,7 +10,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const { authFetch } = vi.hoisted(() => ({ authFetch: vi.fn() }));
 vi.mock("@/lib/identity", () => ({ authenticatedFetch: authFetch }));
 
-type Mod = typeof import("./useUnseenConversations");
+type Mod = typeof UseUnseenConversationsModule;
 
 /**
  * The module keeps its read-state mirror in module-level singletons

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -1,3 +1,9 @@
+import type * as UseWorkspaceChangedFilesModule from "@/hooks/useWorkspaceChangedFiles";
+import type * as UseSessionModule from "@/hooks/useSession";
+import type * as UseHostsModule from "@/hooks/useHosts";
+import type * as RunnerHealthProviderModule from "@/hooks/RunnerHealthProvider";
+import type * as AgentLabelsModule from "@/lib/agentLabels";
+
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -7,7 +13,7 @@ import { useChatStore } from "@/store/chatStore";
 // mentions). These slash-command tests don't exercise that, so stub the hook
 // to avoid needing a QueryClientProvider around every bare render.
 vi.mock("@/hooks/useWorkspaceChangedFiles", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/hooks/useWorkspaceChangedFiles")>();
+  const actual = await importOriginal<typeof UseWorkspaceChangedFilesModule>();
   return {
     ...actual,
     useWorkspaceAllFiles: () => ({ data: undefined }),
@@ -18,19 +24,19 @@ vi.mock("@/hooks/useWorkspaceChangedFiles", async (importOriginal) => {
 // session's host binding via TanStack Query. Stub the hooks so it self-hides
 // (no host bound) without needing a QueryClient provider around these renders.
 vi.mock("@/hooks/useSession", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/hooks/useSession")>()),
+  ...(await importOriginal<typeof UseSessionModule>()),
   useSession: () => ({ session: { hostId: null }, isLoading: false, error: null }),
 }));
 vi.mock("@/hooks/useHosts", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/hooks/useHosts")>()),
+  ...(await importOriginal<typeof UseHostsModule>()),
   useHosts: () => ({ data: [] }),
 }));
 vi.mock("@/hooks/RunnerHealthProvider", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/hooks/RunnerHealthProvider")>()),
+  ...(await importOriginal<typeof RunnerHealthProviderModule>()),
   useSessionHostOnline: () => undefined,
 }));
 vi.mock("@/lib/agentLabels", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/lib/agentLabels")>()),
+  ...(await importOriginal<typeof AgentLabelsModule>()),
   useBrainHarnessLabels: () => ({
     "claude-sdk": "Claude SDK",
     codex: "Codex",

--- a/web/src/pages/ChatPage.mention.test.tsx
+++ b/web/src/pages/ChatPage.mention.test.tsx
@@ -1,3 +1,9 @@
+import type * as UseWorkspaceChangedFilesModule from "@/hooks/useWorkspaceChangedFiles";
+import type * as UseSessionModule from "@/hooks/useSession";
+import type * as UseHostsModule from "@/hooks/useHosts";
+import type * as RunnerHealthProviderModule from "@/hooks/RunnerHealthProvider";
+import type * as AgentLabelsModule from "@/lib/agentLabels";
+
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -34,7 +40,7 @@ function resetWorkspaceMock() {
   ws.dirLoading = false;
 }
 vi.mock("@/hooks/useWorkspaceChangedFiles", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/hooks/useWorkspaceChangedFiles")>();
+  const actual = await importOriginal<typeof UseWorkspaceChangedFilesModule>();
   return {
     ...actual,
     useWorkspaceAllFiles: () => ({
@@ -51,19 +57,19 @@ vi.mock("@/hooks/useWorkspaceChangedFiles", async (importOriginal) => {
 // session's host binding via TanStack Query. Stub the hooks so it self-hides
 // (no host bound) without needing a QueryClient provider around these renders.
 vi.mock("@/hooks/useSession", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/hooks/useSession")>()),
+  ...(await importOriginal<typeof UseSessionModule>()),
   useSession: () => ({ session: { hostId: null }, isLoading: false, error: null }),
 }));
 vi.mock("@/hooks/useHosts", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/hooks/useHosts")>()),
+  ...(await importOriginal<typeof UseHostsModule>()),
   useHosts: () => ({ data: [] }),
 }));
 vi.mock("@/hooks/RunnerHealthProvider", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/hooks/RunnerHealthProvider")>()),
+  ...(await importOriginal<typeof RunnerHealthProviderModule>()),
   useSessionHostOnline: () => undefined,
 }));
 vi.mock("@/lib/agentLabels", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/lib/agentLabels")>()),
+  ...(await importOriginal<typeof AgentLabelsModule>()),
   useBrainHarnessLabels: () => ({
     "claude-sdk": "Claude SDK",
     codex: "Codex",

--- a/web/src/pages/ChatPage.statusLine.test.tsx
+++ b/web/src/pages/ChatPage.statusLine.test.tsx
@@ -1,3 +1,9 @@
+import type * as UseWorkspaceChangedFilesModule from "@/hooks/useWorkspaceChangedFiles";
+import type * as UseSessionModule from "@/hooks/useSession";
+import type * as UseHostsModule from "@/hooks/useHosts";
+import type * as RunnerHealthProviderModule from "@/hooks/RunnerHealthProvider";
+import type * as AgentLabelsModule from "@/lib/agentLabels";
+
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -7,7 +13,7 @@ import { useChatStore } from "@/store/chatStore";
 // mentions); these status-line tests don't exercise it, so stub the hook to
 // avoid wrapping every render in a QueryClientProvider.
 vi.mock("@/hooks/useWorkspaceChangedFiles", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/hooks/useWorkspaceChangedFiles")>();
+  const actual = await importOriginal<typeof UseWorkspaceChangedFilesModule>();
   return {
     ...actual,
     useWorkspaceAllFiles: () => ({ data: undefined }),
@@ -26,19 +32,19 @@ const { useSessionMock, useHostsMock, useSessionHostOnlineMock } = vi.hoisted(()
   useSessionHostOnlineMock: vi.fn(),
 }));
 vi.mock("@/hooks/useSession", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/hooks/useSession")>()),
+  ...(await importOriginal<typeof UseSessionModule>()),
   useSession: (id: string | null | undefined) => useSessionMock(id),
 }));
 vi.mock("@/hooks/useHosts", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/hooks/useHosts")>()),
+  ...(await importOriginal<typeof UseHostsModule>()),
   useHosts: (opts: unknown) => useHostsMock(opts),
 }));
 vi.mock("@/hooks/RunnerHealthProvider", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/hooks/RunnerHealthProvider")>()),
+  ...(await importOriginal<typeof RunnerHealthProviderModule>()),
   useSessionHostOnline: (id: string | undefined) => useSessionHostOnlineMock(id),
 }));
 vi.mock("@/lib/agentLabels", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/lib/agentLabels")>()),
+  ...(await importOriginal<typeof AgentLabelsModule>()),
   useBrainHarnessLabels: () => ({
     "claude-sdk": "Claude SDK",
     codex: "Codex",

--- a/web/src/pages/InboxPage.test.tsx
+++ b/web/src/pages/InboxPage.test.tsx
@@ -11,6 +11,8 @@
 // component that just exposes an Accept button wired to its `onSubmit`, which
 // lets us drive the approve/rollback path without the real card's internals.
 
+import type * as UseConversationsModule from "@/hooks/useConversations";
+
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -47,7 +49,7 @@ vi.mock("@/components/blocks/ApprovalCard", () => ({
 }));
 
 vi.mock("@/hooks/useConversations", async (importActual) => ({
-  ...(await importActual<typeof import("@/hooks/useConversations")>()),
+  ...(await importActual<typeof UseConversationsModule>()),
   useConversations: vi.fn(),
 }));
 vi.mock("@/hooks/useCommentInbox", () => ({ useCommentInbox: vi.fn() }));

--- a/web/src/shell/AddAgentDialog.test.tsx
+++ b/web/src/shell/AddAgentDialog.test.tsx
@@ -1,3 +1,5 @@
+import type * as ReactRouterDomModule from "react-router-dom";
+
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
@@ -9,7 +11,7 @@ import { createSession } from "@/lib/sessionsApi";
 
 const navigateMock = vi.fn();
 vi.mock("react-router-dom", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("react-router-dom")>();
+  const actual = await importOriginal<typeof ReactRouterDomModule>();
   return { ...actual, useNavigate: () => navigateMock };
 });
 vi.mock("@/hooks/useAvailableAgents", () => ({

--- a/web/src/shell/AppShell.subagent-nav.test.tsx
+++ b/web/src/shell/AppShell.subagent-nav.test.tsx
@@ -19,6 +19,10 @@
 // mock used by AppShell.test.tsx) so we can drive a real ``<Link>``
 // click through the router and observe the resulting rail-tab state.
 
+import type * as UseTerminalsModule from "@/hooks/useTerminals";
+import type * as UseChildSessionsModule from "@/hooks/useChildSessions";
+import type * as UseSessionModule from "@/hooks/useSession";
+
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
@@ -34,7 +38,7 @@ vi.mock("@/hooks/useConversations", () => ({
 vi.mock("@/hooks/useTerminals", async (importOriginal) => ({
   // Keep the real module (inventoryTerminals etc.) — only the
   // network-backed hook is replaced.
-  ...(await importOriginal<typeof import("@/hooks/useTerminals")>()),
+  ...(await importOriginal<typeof UseTerminalsModule>()),
   useTerminals: vi.fn(() => ({ terminals: [], isLoading: false, error: null })),
 }));
 vi.mock("@/hooks/useWorkspaceChangedFiles", () => ({
@@ -52,7 +56,7 @@ vi.mock("@/hooks/useChildSessions", async (importOriginal) => ({
   // Keep the real module — childSessionsQueryKey, MAX_TREE_DEPTH, and
   // cachedTreeContains (which reads the query cache seeded below) stay
   // genuine; only the hook is replaced.
-  ...(await importOriginal<typeof import("@/hooks/useChildSessions")>()),
+  ...(await importOriginal<typeof UseChildSessionsModule>()),
   useChildSessions: vi.fn(() => ({ children: [], isLoading: false, error: null })),
 }));
 vi.mock("@/hooks/useSession", async (importOriginal) => ({
@@ -60,7 +64,7 @@ vi.mock("@/hooks/useSession", async (importOriginal) => ({
   // top-level session it resolves without fetching, and during the
   // navigation race (parentSessionId undefined) it stays null, which
   // is exactly the production behavior the sticky root rides out.
-  ...(await importOriginal<typeof import("@/hooks/useSession")>()),
+  ...(await importOriginal<typeof UseSessionModule>()),
   useSession: vi.fn(() => ({ session: null, isLoading: false, error: null })),
 }));
 vi.mock("@/hooks/useAgents", () => ({

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -1,3 +1,7 @@
+import type * as UseTerminalsModule from "@/hooks/useTerminals";
+import type * as UseChildSessionsModule from "@/hooks/useChildSessions";
+import type * as UseSessionModule from "@/hooks/useSession";
+
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import {
@@ -23,7 +27,7 @@ vi.mock("@/hooks/useTerminals", async (importOriginal) => ({
   // Keep the real module (inventoryTerminals, EMBEDDED_REPL_TERMINAL_ID)
   // — the REPL rail-inventory tests exercise the real filter; only the
   // network-backed hook is replaced.
-  ...(await importOriginal<typeof import("@/hooks/useTerminals")>()),
+  ...(await importOriginal<typeof UseTerminalsModule>()),
   useTerminals: vi.fn(() => ({ terminals: [], isLoading: false, error: null })),
 }));
 
@@ -35,14 +39,14 @@ vi.mock("@/hooks/useWorkspaceChangedFiles", () => ({
 vi.mock("@/hooks/useChildSessions", async (importOriginal) => ({
   // Keep the real module (childSessionsQueryKey, MAX_TREE_DEPTH,
   // cachedTreeContains) — only the hook is replaced.
-  ...(await importOriginal<typeof import("@/hooks/useChildSessions")>()),
+  ...(await importOriginal<typeof UseChildSessionsModule>()),
   useChildSessions: vi.fn(() => ({ children: [], isLoading: false, error: null })),
 }));
 
 vi.mock("@/hooks/useSession", async (importOriginal) => ({
   // useRootSessionId stays real — with useSession mocked to a null /
   // top-level session it resolves synchronously without fetching.
-  ...(await importOriginal<typeof import("@/hooks/useSession")>()),
+  ...(await importOriginal<typeof UseSessionModule>()),
   useSession: vi.fn(() => ({ session: null, isLoading: false, error: null })),
 }));
 

--- a/web/src/shell/ExecutionLogsPanel.test.tsx
+++ b/web/src/shell/ExecutionLogsPanel.test.tsx
@@ -5,6 +5,8 @@
 // items-list states (loading / error / empty / populated), and per-item
 // expand/collapse.
 
+import type * as UseChildSessionsModule from "@/hooks/useChildSessions";
+
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChildSessionInfo } from "@/hooks/useChildSessions";
@@ -28,7 +30,7 @@ const h = vi.hoisted(() => ({
 vi.mock("@/hooks/useChildSessions", async (importOriginal) => {
   // Keep the real key helpers (executionLogTabKey / MAIN_EXECUTION_LOG_KEY) so
   // the panel's entry keys match what initialKey passes in.
-  const actual = await importOriginal<typeof import("@/hooks/useChildSessions")>();
+  const actual = await importOriginal<typeof UseChildSessionsModule>();
   return { ...actual, useChildSessions: () => ({ children: h.children }) };
 });
 

--- a/web/src/shell/ForkSessionDialog.test.tsx
+++ b/web/src/shell/ForkSessionDialog.test.tsx
@@ -1,3 +1,6 @@
+import type * as ReactRouterDomModule from "react-router-dom";
+import type * as WorkspacePickerModule from "./WorkspacePicker";
+
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
@@ -19,7 +22,7 @@ import { checkHostDirectory, useHostFilesystem } from "@/hooks/useHostFilesystem
 
 const navigateMock = vi.fn();
 vi.mock("react-router-dom", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("react-router-dom")>();
+  const actual = await importOriginal<typeof ReactRouterDomModule>();
   return { ...actual, useNavigate: () => navigateMock };
 });
 vi.mock("@/lib/sessionsApi", () => ({ forkSession: vi.fn(), launchRunner: vi.fn() }));
@@ -39,7 +42,7 @@ vi.mock("@/hooks/useHostFilesystem", () => ({
 // directory being prefilled from the source, so the real picker never opens —
 // stub it anyway to keep its filesystem fetch out of the test.
 vi.mock("./WorkspacePicker", async (importActual) => ({
-  ...(await importActual<typeof import("./WorkspacePicker")>()),
+  ...(await importActual<typeof WorkspacePickerModule>()),
   WorkspacePicker: ({ onSelect }: { onSelect: (p: string) => void }) => (
     <button type="button" data-testid="mock-pick-workspace" onClick={() => onSelect("/picked")}>
       pick

--- a/web/src/shell/InlineTerminalsSection.test.tsx
+++ b/web/src/shell/InlineTerminalsSection.test.tsx
@@ -1,3 +1,5 @@
+import type * as UseTerminalsModule from "@/hooks/useTerminals";
+
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type TerminalInfo, useTerminals } from "@/hooks/useTerminals";
@@ -8,7 +10,7 @@ import { InlineTerminalsSection } from "./InlineTerminalsSection";
 vi.mock("@/hooks/useTerminals", async (importOriginal) => ({
   // Keep the real module (inventoryTerminals etc.) — only the
   // network-backed hook is replaced.
-  ...(await importOriginal<typeof import("@/hooks/useTerminals")>()),
+  ...(await importOriginal<typeof UseTerminalsModule>()),
   useTerminals: vi.fn(),
 }));
 

--- a/web/src/shell/MainTerminalView.test.tsx
+++ b/web/src/shell/MainTerminalView.test.tsx
@@ -1,3 +1,5 @@
+import type * as UseTerminalsModule from "@/hooks/useTerminals";
+
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type TerminalInfo, useTerminals } from "@/hooks/useTerminals";
@@ -27,7 +29,7 @@ vi.mock("@/components/blocks/TerminalView", () => ({
 vi.mock("@/hooks/useTerminals", async (importOriginal) => ({
   // Keep the real module (AGENT_TERMINAL_IDS, terminalTabKey) —
   // only the network-backed hook is replaced.
-  ...(await importOriginal<typeof import("@/hooks/useTerminals")>()),
+  ...(await importOriginal<typeof UseTerminalsModule>()),
   useTerminals: vi.fn(),
 }));
 

--- a/web/src/shell/MarkdownRichTextViewer.blockquoteCrash.test.ts
+++ b/web/src/shell/MarkdownRichTextViewer.blockquoteCrash.test.ts
@@ -17,6 +17,8 @@
  * image extension's HTTP boundary (fetchFileContent) is mocked.
  */
 
+import type * as UseFileContentModule from "@/hooks/useFileContent";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Editor } from "@tiptap/core";
 import { StarterKit } from "@tiptap/starter-kit";
@@ -28,7 +30,7 @@ import { GitHubAlertBlockquote } from "./TipTapGitHubAlert";
 import { HtmlPassthrough } from "./TipTapHtmlPassthrough";
 
 vi.mock("@/hooks/useFileContent", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/hooks/useFileContent")>();
+  const actual = await importOriginal<typeof UseFileContentModule>();
   return { ...actual, fetchFileContent: vi.fn().mockResolvedValue(undefined) };
 });
 

--- a/web/src/shell/MarkdownRichTextViewer.listItemCrash.test.ts
+++ b/web/src/shell/MarkdownRichTextViewer.listItemCrash.test.ts
@@ -20,6 +20,8 @@
  * extension stack from MarkdownRichTextViewer so a regression fails here.
  */
 
+import type * as UseFileContentModule from "@/hooks/useFileContent";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Editor } from "@tiptap/core";
 import { StarterKit } from "@tiptap/starter-kit";
@@ -34,7 +36,7 @@ import { HtmlPassthrough } from "./TipTapHtmlPassthrough";
 const SafeListItem = ListItem.extend({ content: "block+" });
 
 vi.mock("@/hooks/useFileContent", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/hooks/useFileContent")>();
+  const actual = await importOriginal<typeof UseFileContentModule>();
   return { ...actual, fetchFileContent: vi.fn().mockResolvedValue(undefined) };
 });
 

--- a/web/src/shell/MarkdownRichTextViewer.looseImageCrash.test.ts
+++ b/web/src/shell/MarkdownRichTextViewer.looseImageCrash.test.ts
@@ -25,6 +25,8 @@
  * MarkdownRichTextViewer so a regression fails here.
  */
 
+import type * as UseFileContentModule from "@/hooks/useFileContent";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Editor } from "@tiptap/core";
 import { StarterKit } from "@tiptap/starter-kit";
@@ -43,7 +45,7 @@ installMarkdownParserPatch();
 const SafeListItem = ListItem.extend({ content: "block+" });
 
 vi.mock("@/hooks/useFileContent", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/hooks/useFileContent")>();
+  const actual = await importOriginal<typeof UseFileContentModule>();
   return { ...actual, fetchFileContent: vi.fn().mockResolvedValue(undefined) };
 });
 

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -1,3 +1,6 @@
+import type * as UseConversationsModule from "@/hooks/useConversations";
+import type * as AgentLabelsModule from "@/lib/agentLabels";
+
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
@@ -89,13 +92,13 @@ vi.mock("@/hooks/RunnerHealthProvider", () => ({
 // empty list so it doesn't fire its own authenticatedFetch (which would land
 // at mock.calls[0] and skew these create-POST call assertions).
 vi.mock("@/hooks/useConversations", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/hooks/useConversations")>()),
+  ...(await importOriginal<typeof UseConversationsModule>()),
   useProjects: () => ({ data: [] }),
 }));
 // Dynamic harness-label fetching is covered separately. Keep it synchronous
 // here so exact create-POST call-count assertions only observe the POST.
 vi.mock("@/lib/agentLabels", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/lib/agentLabels")>()),
+  ...(await importOriginal<typeof AgentLabelsModule>()),
   useBrainHarnessLabels: () => ({
     "claude-sdk": "Claude SDK",
     codex: "Codex",

--- a/web/src/shell/NewChatDialog.projectPrefill.test.tsx
+++ b/web/src/shell/NewChatDialog.projectPrefill.test.tsx
@@ -1,3 +1,6 @@
+import type * as UseConversationsModule from "@/hooks/useConversations";
+import type * as AgentLabelsModule from "@/lib/agentLabels";
+
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
@@ -60,12 +63,12 @@ vi.mock("@/hooks/RunnerHealthProvider", () => ({
 // The project list + config are the unit under test's inputs — stub the hooks
 // so each case controls them without HTTP-layer plumbing.
 vi.mock("@/hooks/useConversations", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/hooks/useConversations")>()),
+  ...(await importOriginal<typeof UseConversationsModule>()),
   useProjects: vi.fn(),
   useProjectConfig: vi.fn(),
 }));
 vi.mock("@/lib/agentLabels", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/lib/agentLabels")>()),
+  ...(await importOriginal<typeof AgentLabelsModule>()),
   useBrainHarnessLabels: () => ({}),
   // Stub so the setup dialog's hook doesn't fire its own /v1/harnesses fetch
   // (which would skew the create-flow call-count assertions here).

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1,3 +1,8 @@
+import type * as IdentityModule from "@/lib/identity";
+import type * as UseConversationsModule from "@/hooks/useConversations";
+import type * as AgentLabelsModule from "@/lib/agentLabels";
+import type * as ChatStoreModule from "@/store/chatStore";
+
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
@@ -43,7 +48,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 // Only authenticatedFetch is stubbed (the create POST under test);
 // the module's other exports stay real for any other consumer in the tree.
 vi.mock("@/lib/identity", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/lib/identity")>()),
+  ...(await importOriginal<typeof IdentityModule>()),
   authenticatedFetch: vi.fn(),
 }));
 vi.mock("@/hooks/useHosts", () => ({
@@ -87,7 +92,7 @@ vi.mock("@/hooks/RunnerHealthProvider", () => ({
 // empty list so it doesn't fire its own authenticatedFetch (which would skew
 // the create-POST call-count / call-order assertions below).
 vi.mock("@/hooks/useConversations", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/hooks/useConversations")>()),
+  ...(await importOriginal<typeof UseConversationsModule>()),
   // Empty projects list → no ?project= name resolves to an id, so the project
   // prefill stays inert and the generic host/workspace defaults under test apply.
   useProjects: () => ({ data: [] }),
@@ -95,7 +100,7 @@ vi.mock("@/hooks/useConversations", async (importOriginal) => ({
 // The harness-label catalog is not under test here. Keep it synchronous so
 // create-session fetch assertions only observe the POST/PATCH calls they own.
 vi.mock("@/lib/agentLabels", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/lib/agentLabels")>()),
+  ...(await importOriginal<typeof AgentLabelsModule>()),
   useBrainHarnessLabels: () => ({
     "claude-sdk": "Claude SDK",
     codex: "Codex",
@@ -131,7 +136,7 @@ vi.mock("@/lib/agentLabels", async (importOriginal) => ({
 // tests can assert the prepended attachment marker. Everything else
 // (composerAttachmentKey, useChatStore, …) stays real for the render tree.
 vi.mock("@/store/chatStore", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/store/chatStore")>()),
+  ...(await importOriginal<typeof ChatStoreModule>()),
   setPendingInitialPrompt: vi.fn(),
 }));
 

--- a/web/src/shell/Sidebar.stop.test.tsx
+++ b/web/src/shell/Sidebar.stop.test.tsx
@@ -5,6 +5,8 @@
 // confirms through a dialog before firing the stop mutation. See
 // ConversationRow in Sidebar.tsx.
 
+import type * as RunnerHealthProviderModule from "@/hooks/RunnerHealthProvider";
+
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
@@ -54,7 +56,7 @@ vi.mock("@/hooks/useConversations", () => ({
 }));
 
 vi.mock("@/hooks/RunnerHealthProvider", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/hooks/RunnerHealthProvider")>()),
+  ...(await importOriginal<typeof RunnerHealthProviderModule>()),
   useSessionRunnerOnline: (id: string | undefined) => mocks.runnerOnline(id),
 }));
 

--- a/web/src/shell/Sidebar.subagentHighlight.test.tsx
+++ b/web/src/shell/Sidebar.subagentHighlight.test.tsx
@@ -14,6 +14,8 @@
 // per-session snapshot API so the REAL useSession / useRootSessionId chain
 // resolves the child up to its root.
 
+import type * as SessionsApiModule from "@/lib/sessionsApi";
+
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
@@ -55,7 +57,7 @@ vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }
 // The snapshot API feeds the real useSession / useRootSessionId walk: the
 // child reports its parent, the parent reports null (top-level).
 vi.mock("@/lib/sessionsApi", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/lib/sessionsApi")>()),
+  ...(await importOriginal<typeof SessionsApiModule>()),
   getSessionSlim: vi.fn(),
 }));
 

--- a/web/src/shell/SubagentsGraphView.test.tsx
+++ b/web/src/shell/SubagentsGraphView.test.tsx
@@ -1,3 +1,5 @@
+import type * as UseChildSessionsModule from "@/hooks/useChildSessions";
+
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -31,7 +33,7 @@ vi.mock("./SubagentsGraphView", () => ({
 }));
 
 vi.mock("@/hooks/useChildSessions", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/hooks/useChildSessions")>()),
+  ...(await importOriginal<typeof UseChildSessionsModule>()),
   useChildSessions: vi.fn(),
 }));
 

--- a/web/src/shell/SubagentsPanel.test.tsx
+++ b/web/src/shell/SubagentsPanel.test.tsx
@@ -1,3 +1,5 @@
+import type * as UseChildSessionsModule from "@/hooks/useChildSessions";
+
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import {
   BookOpenIcon,
@@ -18,7 +20,7 @@ import { iconForAgentType, SubagentsPanel } from "./SubagentsPanel";
 vi.mock("@/hooks/useChildSessions", async (importOriginal) => ({
   // Keep the real module (MAX_TREE_DEPTH and friends) — only the
   // hook itself is replaced.
-  ...(await importOriginal<typeof import("@/hooks/useChildSessions")>()),
+  ...(await importOriginal<typeof UseChildSessionsModule>()),
   useChildSessions: vi.fn(),
 }));
 

--- a/web/src/shell/TerminalsPanel.test.tsx
+++ b/web/src/shell/TerminalsPanel.test.tsx
@@ -1,3 +1,5 @@
+import type * as UseTerminalsModule from "@/hooks/useTerminals";
+
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type TerminalInfo, useTerminals } from "@/hooks/useTerminals";
@@ -25,7 +27,7 @@ vi.mock("@/components/blocks/TerminalView", () => ({
 vi.mock("@/hooks/useTerminals", async (importOriginal) => ({
   // Keep the real module (inventoryTerminals etc.) — only the
   // network-backed hook is replaced.
-  ...(await importOriginal<typeof import("@/hooks/useTerminals")>()),
+  ...(await importOriginal<typeof UseTerminalsModule>()),
   useTerminals: vi.fn(),
 }));
 

--- a/web/src/shell/TipTapHtmlPassthrough.test.ts
+++ b/web/src/shell/TipTapHtmlPassthrough.test.ts
@@ -11,6 +11,8 @@
  * viewer mounts (only the HTTP boundary is mocked).
  */
 
+import type * as UseFileContentModule from "@/hooks/useFileContent";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Editor } from "@tiptap/core";
 import { Markdown } from "@tiptap/markdown";
@@ -22,7 +24,7 @@ import { HtmlPassthrough } from "./TipTapHtmlPassthrough";
 import { installMarkdownSerializerPatch } from "./tiptapMarkdownPatches";
 
 vi.mock("@/hooks/useFileContent", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/hooks/useFileContent")>();
+  const actual = await importOriginal<typeof UseFileContentModule>();
   return { ...actual, fetchFileContent: vi.fn().mockResolvedValue(new Promise(() => {})) };
 });
 

--- a/web/src/shell/TipTapWorkspaceImage.test.ts
+++ b/web/src/shell/TipTapWorkspaceImage.test.ts
@@ -11,6 +11,8 @@
  * mocked, returning a real FileContentResponse-shaped object.
  */
 
+import type * as UseFileContentModule from "@/hooks/useFileContent";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Editor } from "@tiptap/core";
 import { Markdown } from "@tiptap/markdown";
@@ -24,7 +26,7 @@ import {
 import type { FileContentResponse } from "@/hooks/useFileContent";
 
 vi.mock("@/hooks/useFileContent", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/hooks/useFileContent")>();
+  const actual = await importOriginal<typeof UseFileContentModule>();
   // Keep the real fileContentToBlob (the decode logic under test); only the
   // network call is faked.
   return { ...actual, fetchFileContent: vi.fn() };

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -15,6 +15,8 @@
 // Session metadata and item pages are shimmed through `seedSession`
 // helpers so tests can model capped snapshots and full transcripts.
 
+import type * as IdentityModule from "@/lib/identity";
+
 import { type InfiniteData, QueryClient } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Conversation, ConversationsPage } from "@/hooks/useConversations";
@@ -70,7 +72,7 @@ const realSend = useChatStore.getState().send;
 // per-test `mockReturnValue` works; reset in afterEach so a stubbed
 // identity never leaks across tests.
 vi.mock("@/lib/identity", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/identity")>();
+  const actual = await importOriginal<typeof IdentityModule>();
   return { ...actual, getCurrentAuthorId: vi.fn<() => string | null>(() => null) };
 });
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Replace 57 inline `import()` type annotations in web tests with explicit namespace type imports.
- Preserve runtime mock behavior while clearing every test diagnostic from `typescript/consistent-type-imports`.

**ELI5:** Tests now declare module shapes up front instead of looking them up inline each time.

```text
inline module type query -> explicit type-only import -> typed mock loader
```

## Test Plan

- `pnpm --filter web exec oxlint -A all -D 'typescript/consistent-type-imports' .` (only the unrelated production `CodeViewer.tsx` diagnostic remains)
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `pnpm --filter web exec vitest run <33 changed test files>` (1,193 passed, 1 expected failure)
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

All 33 changed test files pass; this is a type-only test cleanup with no runtime behavior change.