### PR TITLE
refactor(web): use function property signatures

### DIFF
--- a/web/src/components/ComposerMicButton.tsx
+++ b/web/src/components/ComposerMicButton.tsx
@@ -14,10 +14,10 @@ interface SpeechRecognitionLike {
   continuous: boolean;
   interimResults: boolean;
   lang: string;
-  start(): void;
-  stop(): void;
-  addEventListener(type: string, listener: (event: Event) => void): void;
-  removeEventListener(type: string, listener: (event: Event) => void): void;
+  start: () => void;
+  stop: () => void;
+  addEventListener: (type: string, listener: (event: Event) => void) => void;
+  removeEventListener: (type: string, listener: (event: Event) => void) => void;
 }
 
 interface SpeechRecognitionEventLike extends Event {

--- a/web/src/lib/presenceIdle.ts
+++ b/web/src/lib/presenceIdle.ts
@@ -19,12 +19,12 @@ export interface PresenceIdleTracker {
    * reconnect recomputing this keeps the flag eventually-correct even
    * if the debounce timer never fired.
    */
-  idleNow(): boolean;
+  idleNow: () => boolean;
   /** Record the flag the live stream connected with, so visibility
    * edges know whether a reconnect is actually needed. */
-  noteReported(idle: boolean): void;
+  noteReported: (idle: boolean) => void;
   /** Wire to `document.visibilitychange` with the new hidden state. */
-  handleVisibilityChange(hidden: boolean): void;
+  handleVisibilityChange: (hidden: boolean) => void;
 }
 
 /**

--- a/web/src/shell/MonacoCodeEditor.tsx
+++ b/web/src/shell/MonacoCodeEditor.tsx
@@ -52,13 +52,13 @@ type EditorOptions = EditorProps["options"];
 // the find widget is open, close it, and subscribe to open/close changes.
 const FIND_CONTROLLER_ID = "editor.contrib.findController";
 interface FindController extends monaco.editor.IEditorContribution {
-  getState(): {
+  getState: () => {
     readonly isRevealed: boolean;
-    onFindReplaceStateChange(listener: (e: { isRevealed: boolean }) => void): {
-      dispose(): void;
+    onFindReplaceStateChange: (listener: (e: { isRevealed: boolean }) => void) => {
+      dispose: () => void;
     };
   };
-  closeFindWidget(): void;
+  closeFindWidget: () => void;
 }
 
 // How long the transient "Saved" badge stays up before the status chip clears

--- a/web/src/shell/tiptapMarkdownPatches.ts
+++ b/web/src/shell/tiptapMarkdownPatches.ts
@@ -35,11 +35,11 @@ const LINE_START_QUOTE = /(^|\n)>/g;
 interface SerializerInternals {
   /** Extension names whose nodes/marks are code contexts (no escaping). */
   codeTypes: Set<string>;
-  encodeTextForMarkdown(
+  encodeTextForMarkdown: (
     text: string,
     node: JSONContent,
     parentNode: JSONContent | undefined,
-  ): string;
+  ) => string;
 }
 
 /**


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Replace 12 interface method declarations with function-valued property signatures.
- Standardize callback surfaces across editor, presence, dictation, and markdown internals without changing runtime implementations.

**ELI5:** Callable interface fields now use one consistent TypeScript spelling.

```text
method(args): result -> method: (args) => result
```

## Test Plan

- `pnpm --filter web exec oxlint -A all -D 'typescript/method-signature-style' .`
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- Focused Vitest suite for presence, dictation, Monaco, and TipTap (84 passed)
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing tests cover the affected interfaces; this is a type-only declaration change.