### PR TITLE
refactor(web): standardize object type definitions

### DIFF
--- a/web/src/components/ComposerMicButton.test.tsx
+++ b/web/src/components/ComposerMicButton.test.tsx
@@ -26,7 +26,10 @@ import { ComposerMicButton } from "./ComposerMicButton";
 // Controllable DictationSession stand-in for the server-mode tests. The
 // factory reads the mutable spies at call time, so each test installs its
 // own behavior in beforeEach.
-type SessionStub = { stop: () => Promise<string>; cancel: () => void };
+interface SessionStub {
+  stop: () => Promise<string>;
+  cancel: () => void;
+}
 let sessionStartMock: Mock<(events: DictationSessionEvents) => Promise<SessionStub>>;
 let sessionStopMock: Mock<() => Promise<string>>;
 let sessionCancelMock: Mock<() => void>;

--- a/web/src/components/ComposerMicButton.tsx
+++ b/web/src/components/ComposerMicButton.tsx
@@ -57,7 +57,7 @@ const BAR_BINS: ReadonlyArray<readonly [number, number]> = [
 
 const BAR_BASELINE = 0.2;
 
-export type ComposerMicButtonProps = {
+export interface ComposerMicButtonProps {
   onTranscript: (text: string) => void;
   /**
    * Streaming partial transcripts (server dictation only): called with the
@@ -79,7 +79,7 @@ export type ComposerMicButtonProps = {
   /** Fired when Esc ends dictation. The parent should restore the text it
    *  snapshotted in {@link onVoiceStart}, discarding what was dictated. */
   onVoiceDiscard?: () => void;
-};
+}
 
 /** getUserMedia permission failures, distinct from transport failures. */
 const isPermissionError = (error: unknown): boolean =>

--- a/web/src/components/OttoEyes.tsx
+++ b/web/src/components/OttoEyes.tsx
@@ -23,7 +23,10 @@ const EYE_CENTERS = [
   { cx: 413.8, cy: 520.6 },
 ];
 
-type ScreenPoint = { x: number; y: number };
+interface ScreenPoint {
+  x: number;
+  y: number;
+}
 type TextField = HTMLTextAreaElement | HTMLInputElement;
 
 // <input> types that hold text a caret moves through. Buttons, checkboxes,

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -222,12 +222,12 @@ export function shouldEchoSynchronously(byteLength: number, msSinceLastInput: nu
  * (see {@link TerminalSession.writeOutput}).
  */
 // eslint-disable-next-line no-underscore-dangle
-type TerminalCore = {
+interface TerminalCore {
   _core?: {
     writeSync?: (data: Uint8Array, maxSubsequentCalls?: number) => void;
     coreMouseService?: { activeEncoding?: string };
   };
-};
+}
 
 /**
  * Load the WebGL renderer onto *term*, returning the addon or ``null``
@@ -312,13 +312,13 @@ export const WHEEL_REPORTS_MAX_PER_EVENT = 50;
  * does not expose the encoding, so the session feature-detects it from
  * xterm's core mouse service (see ``TerminalSession.sgrMouseEncodingActive``).
  */
-export type WheelMouseState = {
+export interface WheelMouseState {
   mouseTrackingMode: "none" | "x10" | "vt200" | "drag" | "any";
   sgrEncoding: boolean;
-};
+}
 
 /** Screen geometry needed to place and scale a wheel report. */
-export type WheelScreenMetrics = {
+export interface WheelScreenMetrics {
   /** Viewport coordinates of the character grid's top-left corner. */
   left: number;
   top: number;
@@ -327,7 +327,7 @@ export type WheelScreenMetrics = {
   cellHeight: number;
   cols: number;
   rows: number;
-};
+}
 
 /**
  * Build SGR mouse-wheel reports for *lines* scroll steps at cell

--- a/web/src/hooks/useFileContent.test.tsx
+++ b/web/src/hooks/useFileContent.test.tsx
@@ -53,10 +53,10 @@ async function flushMicrotasks() {
   });
 }
 
-type ChatStoreState = {
+interface ChatStoreState {
   conversationId: string | null;
   sessionStatus: "idle" | "running" | "waiting" | "failed";
-};
+}
 
 // `useChatStore` is a selector hook: state in, derived value out.
 // Our consumer reads `s.conversationId` and `s.sessionStatus`.

--- a/web/src/lib/dictation.ts
+++ b/web/src/lib/dictation.ts
@@ -24,14 +24,14 @@ export type DictationEvent =
   | { type: "stopped"; text: string }
   | { type: "error"; message: string };
 
-export type DictationSessionEvents = {
+export interface DictationSessionEvents {
   /** Revisable in-progress utterance (server-throttled to ~6 Hz). */
   onPartial: (text: string) => void;
   /** An utterance completed by a pause; append it and clear the partial. */
   onFinal: (text: string) => void;
   /** Fatal error after start. The session has already cleaned itself up. */
   onError: (message: string) => void;
-};
+}
 
 /**
  * The server was reachable but at its concurrent-take cap (WS close 1013).

--- a/web/src/lib/ime.ts
+++ b/web/src/lib/ime.ts
@@ -1,11 +1,11 @@
 const IME_PROCESSING_KEY_CODE = 229;
 
-type ImeKeyboardEvent = {
+interface ImeKeyboardEvent {
   nativeEvent: {
     isComposing?: boolean;
     keyCode?: number;
   };
-};
+}
 
 export function isImeCompositionKeyEvent(
   event: ImeKeyboardEvent,

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2351,11 +2351,11 @@ export function LatestTurnSpacer({
  * resize-driven `scrollToBottom({preserveScrollPosition})` — fired on every
  * history prepend — bail instead of yanking the view back to the bottom.
  */
-type ConversationScroller = {
+interface ConversationScroller {
   el: HTMLElement;
   state: { isAtBottom: boolean; escapedFromLock: boolean };
   stopScroll: () => void;
-};
+}
 
 /**
  * Lifts the StickToBottom scroll container (and lock controls) out of the

--- a/web/src/pages/TurnRail.tsx
+++ b/web/src/pages/TurnRail.tsx
@@ -20,7 +20,9 @@ export interface Turn {
 }
 
 /** Scroll container for the rail; also drives its own scroll for fetch-on-top. */
-type Scroller = { el: HTMLElement };
+interface Scroller {
+  el: HTMLElement;
+}
 
 // Rail scrollTop below which we treat the user as "near the top" and page in
 // older history — mirrors HistoryAutoLoader's transcript threshold.

--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -787,7 +787,7 @@ function FileViewerBody({
   // rendered as a single dropdown (a "picker" button inline, a submenu when
   // collapsed) rather than one button per choice. Markdown's view-mode picker
   // (Preview / Edit / Source) uses this so it occupies one toolbar slot.
-  type ToolbarOption = {
+  interface ToolbarOption {
     key: string;
     label: string;
     tooltip?: string;
@@ -801,8 +801,8 @@ function FileViewerBody({
     /** Suppress the active check mark — for toggles whose icon already reflects
      * state (e.g. the whitespace eye flips open/closed). */
     noActiveCheck?: boolean;
-  };
-  type ToolbarAction = {
+  }
+  interface ToolbarAction {
     key: string;
     /** Accessible name for the inline icon button. */
     label: string;
@@ -818,7 +818,7 @@ function FileViewerBody({
      * single trigger. Unlike `options`, these are not mutually exclusive and
      * carry no "selected choice" semantics. `onSelect` is ignored. */
     menu?: ToolbarOption[];
-  };
+  }
   const toolbarActions: ToolbarAction[] = [];
   if (lang === "markdown" && viewMode !== "diff") {
     // Markdown is a segmented control over three reachable modes: the rich-text

--- a/web/src/shell/MarkdownEditorToolbar.tableAlign.test.tsx
+++ b/web/src/shell/MarkdownEditorToolbar.tableAlign.test.tsx
@@ -49,7 +49,10 @@ const TOOLBAR_DEFAULTS = {
   isCode: false,
 };
 
-type AlignState = { inTable: boolean; align: string | null };
+interface AlignState {
+  inTable: boolean;
+  align: string | null;
+}
 
 function mockEditorState(align: AlignState) {
   vi.mocked(useEditorState).mockReturnValue({ ...TOOLBAR_DEFAULTS, ...align });

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1589,7 +1589,7 @@ function HarnessConfigModal({
 // message, attachments and picker selections survive the unmount that happens
 // when the user navigates into an existing session and back. Module-scoped,
 // not persisted to storage (a page refresh starts clean); cleared on create.
-type LandingDraft = {
+interface LandingDraft {
   message: string;
   files: File[];
   pickedAgentId: string | null;
@@ -1608,7 +1608,7 @@ type LandingDraft = {
   pickedModel: string;
   pickedEffort: string;
   costControlMode: CostControlMode;
-};
+}
 
 let landingDraft: LandingDraft | null = null;
 

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -2248,7 +2248,7 @@ function ConversationSection({
 // against this — rather than `ComponentProps<typeof DropdownMenuItem>` — lets
 // either family satisfy `MenuComponents` so `ConversationMenuItems` can author
 // the menu body once and render it under either menu kind.
-type MenuItemProps = {
+interface MenuItemProps {
   children?: ReactNode;
   className?: string;
   disabled?: boolean;
@@ -2256,9 +2256,9 @@ type MenuItemProps = {
   // Radix's menu `onSelect` receives a native Event in both families.
   onSelect?: (event: Event) => void;
   "data-testid"?: string;
-};
+}
 
-type MenuComponents = {
+interface MenuComponents {
   Item: ComponentType<MenuItemProps>;
   Separator: ComponentType<{ className?: string }>;
   Sub: ComponentType<{ children?: ReactNode }>;
@@ -2268,7 +2268,7 @@ type MenuComponents = {
     "data-testid"?: string;
   }>;
   SubContent: ComponentType<{ children?: ReactNode; className?: string }>;
-};
+}
 
 // Two stable bundles, one per Radix menu family. Annotated so a future prop
 // divergence surfaces here rather than at the call site.

--- a/web/src/shell/TodoPanel.test.tsx
+++ b/web/src/shell/TodoPanel.test.tsx
@@ -6,11 +6,11 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-type TodoItem = {
+interface TodoItem {
   content: string;
   status: "pending" | "in_progress" | "completed";
   activeForm: string;
-};
+}
 
 // The store is a selector hook: useChatStore((s) => s.todos). Mock it to feed a
 // controllable todos array per test.

--- a/web/src/shell/TodoPanel.tsx
+++ b/web/src/shell/TodoPanel.tsx
@@ -2,11 +2,11 @@ import { CheckCircle2Icon, CircleIcon, CircleDotIcon } from "lucide-react";
 import { useChatStore } from "@/store/chatStore";
 import { cn } from "@/lib/utils";
 
-type TodoItem = {
+interface TodoItem {
   content: string;
   status: "pending" | "in_progress" | "completed";
   activeForm: string;
-};
+}
 
 interface TodoPanelProps {
   frameless?: boolean;


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Convert 19 object-shaped type aliases to interfaces across production and test code.
- Establish a consistent declaration style while preserving unions and other aliases where `type` remains appropriate.

**ELI5:** Plain object shapes now use `interface`; compound types continue using `type`.

```text
object alias -> interface
union/compound alias -> unchanged
```

## Test Plan

- `pnpm --filter web exec oxlint -A all -D 'typescript/consistent-type-definitions' .`
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `pnpm --filter web exec vitest run` (4,786 passed, 3 expected failures, 1 skipped)
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The full web unit suite passes; these are type-declaration-only changes.