### PR TITLE
refactor(web): standardize production array types

### DIFF
--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -181,7 +181,7 @@ function formatTokenCount(tokens: number): string {
  * Token buckets shown per model in the ``usage_by_model`` section, mapping
  * the ``ModelUsage`` field to its row label. Cost is rendered separately.
  */
-const MODEL_TOKEN_ROWS: ReadonlyArray<{ key: keyof ModelUsage; label: string }> = [
+const MODEL_TOKEN_ROWS: readonly { key: keyof ModelUsage; label: string }[] = [
   { key: "inputTokens", label: "Input" },
   { key: "outputTokens", label: "Output" },
   { key: "cacheReadInputTokens", label: "Cache read" },

--- a/web/src/components/ComposerMicButton.tsx
+++ b/web/src/components/ComposerMicButton.tsx
@@ -48,7 +48,7 @@ const getRecognitionCtor = (): SpeechRecognitionCtor | null => {
 };
 
 // FFT bin ranges per bar, weighted toward voice frequencies (~100Hz–3kHz).
-const BAR_BINS: ReadonlyArray<readonly [number, number]> = [
+const BAR_BINS: readonly (readonly [number, number])[] = [
   [1, 3],
   [3, 6],
   [6, 10],

--- a/web/src/components/SkillPills.tsx
+++ b/web/src/components/SkillPills.tsx
@@ -22,7 +22,7 @@ export function SkillPills({
   skills,
   onPick,
 }: {
-  skills: ReadonlyArray<{ name: string; description: string }>;
+  skills: readonly { name: string; description: string }[];
   onPick: (name: string) => void;
 }) {
   if (skills.length === 0) return null;

--- a/web/src/hooks/useWorkspaceChangedFiles.ts
+++ b/web/src/hooks/useWorkspaceChangedFiles.ts
@@ -178,7 +178,7 @@ export async function isRunnerUnavailable503(res: Response): Promise<boolean> {
 
 interface ChangedFilesResponse {
   object: "list";
-  data: Array<{
+  data: {
     path: string;
     name: string;
     status: "created" | "modified" | "deleted";
@@ -186,7 +186,7 @@ interface ChangedFilesResponse {
     modified_at: number | null;
     lines_added: number | null;
     lines_removed: number | null;
-  }>;
+  }[];
   has_more: boolean;
 }
 
@@ -290,14 +290,14 @@ export interface WorkspaceAllFilesResult {
 
 interface FilesystemListResponse {
   object: "list";
-  data: Array<{
+  data: {
     id: string;
     name: string;
     path: string;
     type: string;
     bytes: number | null;
     modified_at: number | null;
-  }>;
+  }[];
   has_more: boolean;
 }
 

--- a/web/src/lib/blockStream.ts
+++ b/web/src/lib/blockStream.ts
@@ -268,7 +268,7 @@ function* closeText(state: ReducerState, itemId: string | null = null): Generato
   state.fullText = "";
 }
 
-function outputTextFromMessageContent(content: Array<Record<string, unknown>>): string {
+function outputTextFromMessageContent(content: Record<string, unknown>[]): string {
   let text = "";
   for (const block of content) {
     if (block.type !== "output_text") continue;

--- a/web/src/lib/conversationItems.ts
+++ b/web/src/lib/conversationItems.ts
@@ -64,8 +64,8 @@ export interface ErrorItem extends BaseItem {
 export interface ReasoningItem extends BaseItem {
   type: "reasoning";
   model: string;
-  summary: Array<{ type: string; text: string }>;
-  content?: Array<{ type: string; text: string }>;
+  summary: { type: string; text: string }[];
+  content?: { type: string; text: string }[];
 }
 
 /** The provider-native tool item types the runtime persists today. */

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -287,7 +287,7 @@ export interface NativeToolCall {
 /** The final assistant message from `output_item.done` (type `message`). */
 export interface MessageDone {
   type: "message_done";
-  content: Array<Record<string, unknown>>;
+  content: Record<string, unknown>[];
   itemId: string;
   responseId: string;
 }
@@ -565,11 +565,11 @@ export interface SessionAgentChangedEvent {
 export interface SessionTodosEvent {
   type: "session_todos";
   conversationId: string;
-  todos: Array<{
+  todos: {
     content: string;
     status: "pending" | "in_progress" | "completed";
     activeForm: string;
-  }>;
+  }[];
 }
 
 /**

--- a/web/src/lib/inbox.ts
+++ b/web/src/lib/inbox.ts
@@ -33,7 +33,7 @@ export interface InboxItem {
 export interface InboxSource {
   row: Conversation;
   /** Raw `response.elicitation_request` event dicts from `Session.pendingElicitations`. */
-  pendingElicitations: Array<Record<string, unknown>>;
+  pendingElicitations: Record<string, unknown>[];
   /** Whether the snapshot viewer may accept privileged actions. */
   canApprove?: boolean;
 }

--- a/web/src/lib/sessionListCache.ts
+++ b/web/src/lib/sessionListCache.ts
@@ -313,9 +313,7 @@ export function removeIdsFromPages(
  *   skipped.
  * @returns Deduplicated conversation ids.
  */
-export function collectConversationIds(
-  datas: Array<ConversationsInfiniteData | undefined>,
-): string[] {
+export function collectConversationIds(datas: (ConversationsInfiniteData | undefined)[]): string[] {
   const ids = new Set<string>();
   for (const data of datas) {
     if (!data) continue;

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -166,18 +166,18 @@ interface SessionResponseWire {
    * SSE event the chat would have received live — same fields the
    * `sse.ts` parser already handles.
    */
-  pending_elicitations?: Array<Record<string, unknown>>;
+  pending_elicitations?: Record<string, unknown>[];
   /**
    * Un-consumed web-composer user messages on native-terminal sessions
    * at snapshot time, each ``{pending_id, content}``. Replayed so a
    * client that posted then navigated away / rebound re-hydrates the
    * optimistic bubble. Empty for non-native sessions.
    */
-  pending_inputs?: Array<{
+  pending_inputs?: {
     pending_id: string;
     content: MessageContentBlock[];
     created_by?: string;
-  }>;
+  }[];
   /**
    * Numeric permission level (1=read, 2=edit, 3=manage, 4=owner) the
    * authenticated user holds on this session. Optional on the wire
@@ -201,11 +201,11 @@ interface SessionResponseWire {
    */
   sub_agent_name?: string | null;
   kind?: "default" | "sub_agent" | null;
-  todos?: Array<{
+  todos?: {
     content: string;
     status: "pending" | "in_progress" | "completed";
     activeForm: string;
-  }>;
+  }[];
   /**
    * Skills the bound agent can invoke — bundled + host-discovered
    * (subject to the spec's ``skills_filter``). Just name + one-line

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -191,7 +191,7 @@ export function* parseEventLines(lines: Iterable<string>): Iterable<StreamEvent>
 }
 
 /** Token/cost bucket keys on a `ModelUsage`, mapping wire (snake) to camel. */
-const MODEL_USAGE_FIELDS: ReadonlyArray<{ wire: string; camel: keyof ModelUsage }> = [
+const MODEL_USAGE_FIELDS: readonly { wire: string; camel: keyof ModelUsage }[] = [
   { wire: "input_tokens", camel: "inputTokens" },
   { wire: "output_tokens", camel: "outputTokens" },
   { wire: "total_tokens", camel: "totalTokens" },
@@ -1011,7 +1011,7 @@ function parseOutputItem(data: Record<string, unknown>): StreamEvent | null {
     const content = rec.content;
     return {
       type: "message_done",
-      content: Array.isArray(content) ? (content as Array<Record<string, unknown>>) : [],
+      content: Array.isArray(content) ? (content as Record<string, unknown>[]) : [],
       itemId,
       responseId,
     } satisfies MessageDone;
@@ -1144,7 +1144,7 @@ function responseFromJson(d: Record<string, unknown>): Response {
     id: String(d.id ?? ""),
     status: String(d.status ?? ""),
     model: String(d.model ?? ""),
-    output: Array.isArray(d.output) ? (d.output as Array<Record<string, unknown>>) : [],
+    output: Array.isArray(d.output) ? (d.output as Record<string, unknown>[]) : [],
     createdAt: Number(d.created_at ?? 0),
     completedAt: d.completed_at != null ? Number(d.completed_at) : null,
     previousResponseId: d.previous_response_id != null ? String(d.previous_response_id) : null,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -96,7 +96,7 @@ export interface Response {
   /** "queued" | "in_progress" | "completed" | "failed" | "incomplete" | "cancelled". */
   status: string;
   model: string;
-  output?: Array<Record<string, unknown>>;
+  output?: Record<string, unknown>[];
   createdAt?: number;
   completedAt?: number | null;
   previousResponseId?: string | null;
@@ -353,7 +353,7 @@ export interface Session {
    * raw SSE shape so the existing `sse.ts` parser can fold them
    * back into the block stream.
    */
-  pendingElicitations?: Array<Record<string, unknown>>;
+  pendingElicitations?: Record<string, unknown>[];
   /**
    * Un-consumed web-composer user messages on native-terminal
    * sessions at snapshot time. Replayed so a client that posted then
@@ -404,11 +404,11 @@ export interface Session {
    * build time so the panel survives page refresh. Empty array for
    * non-claude-native sessions or before the first turn creates todos.
    */
-  todos?: Array<{
+  todos?: {
     content: string;
     status: "pending" | "in_progress" | "completed";
     activeForm: string;
-  }>;
+  }[];
   /**
    * Skills the bound agent has access to (bundled + host-discovered,
    * subject to the spec's ``skills_filter``). Populated by the

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3624,7 +3624,7 @@ interface ComposerProps {
  * :returns: Merged ``Record<command, description>``.
  */
 export function buildSlashCommandMap(
-  skills: ReadonlyArray<{ name: string; description: string }>,
+  skills: readonly { name: string; description: string }[],
   showEffort: boolean,
   showModel: boolean,
   showCompact = true,
@@ -3658,7 +3658,7 @@ export function buildSlashCommandMap(
  * :returns: A ``Set`` of slash-prefixed names.
  */
 export function buildSlashCommandWithArgsSet(
-  skills: ReadonlyArray<{ name: string; description: string }>,
+  skills: readonly { name: string; description: string }[],
   showEffort: boolean,
   showModel: boolean,
 ): Set<string> {
@@ -6032,7 +6032,7 @@ function useResolvedComposerModel(
     modelPickerKind === "kiro" ||
     modelPickerKind === "pi" ||
     modelPickerKind === "opencode";
-  const modelOptions: ReadonlyArray<{ id: string; label?: string; displayName?: string }> =
+  const modelOptions: readonly { id: string; label?: string; displayName?: string }[] =
     usesServerModelOptions ? codexModelOptions : [];
   const isNativeModelPicker = modelPickerKind !== null;
 

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -737,7 +737,7 @@ export function deriveRepoName(url: string): string | null {
  */
 export function matchSkillInvocation(
   text: string,
-  skills: ReadonlyArray<{ name: string }>,
+  skills: readonly { name: string }[],
 ): { name: string; args: string } | null {
   const trimmed = text.trim();
   if (!isSlashCommandText(trimmed)) return null;

--- a/web/src/shell/TableBubbleMenu.tsx
+++ b/web/src/shell/TableBubbleMenu.tsx
@@ -120,7 +120,7 @@ export function moveColumnToIndex(
  * contains `y`, or -1 if none.
  */
 export function rowIndexAtY(
-  rowRects: ReadonlyArray<{ top: number; bottom: number }>,
+  rowRects: readonly { top: number; bottom: number }[],
   y: number,
 ): number {
   for (let i = 0; i < rowRects.length; i++) {
@@ -134,7 +134,7 @@ export function rowIndexAtY(
  * or -1 if none.
  */
 export function colIndexAtX(
-  cellRects: ReadonlyArray<{ left: number; right: number; cellIndex: number }>,
+  cellRects: readonly { left: number; right: number; cellIndex: number }[],
   x: number,
 ): number {
   for (const r of cellRects) {

--- a/web/src/shell/htmlCommentBridge.ts
+++ b/web/src/shell/htmlCommentBridge.ts
@@ -163,8 +163,8 @@ function anchorPattern(trimmed: string): string {
  * skips these so the source's Nth match lines up with the Nth *rendered* match
  * the in-frame bridge counts (which walks only body text nodes).
  */
-function nonRenderedRanges(source: string): Array<[number, number]> {
-  const ranges: Array<[number, number]> = [];
+function nonRenderedRanges(source: string): [number, number][] {
+  const ranges: [number, number][] = [];
   const collect = (re: RegExp) => {
     for (const m of source.matchAll(re)) {
       if (m.index !== undefined) ranges.push([m.index, m.index + m[0].length]);
@@ -178,7 +178,7 @@ function nonRenderedRanges(source: string): Array<[number, number]> {
 }
 
 /** Whether `index` falls inside any (sorted) non-rendered range. */
-function inNonRendered(index: number, ranges: Array<[number, number]>): boolean {
+function inNonRendered(index: number, ranges: [number, number][]): boolean {
   for (const [start, end] of ranges) {
     if (index < start) break;
     if (index < end) return true;

--- a/web/src/shell/pdfCommentHelpers.ts
+++ b/web/src/shell/pdfCommentHelpers.ts
@@ -112,13 +112,13 @@ export function highlightRectsForPage(
   page: number,
   comments: Comment[],
   activeSelection: ActiveSelection | null,
-): Array<{ key: string; rects: PdfNormalizedRect[]; active: boolean; comment?: Comment }> {
-  const out: Array<{
+): { key: string; rects: PdfNormalizedRect[]; active: boolean; comment?: Comment }[] {
+  const out: {
     key: string;
     rects: PdfNormalizedRect[];
     active: boolean;
     comment?: Comment;
-  }> = [];
+  }[] = [];
 
   for (const c of comments) {
     const anchor = decodePdfAnchor(c.anchor_content);

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -471,11 +471,11 @@ export interface ChatState {
    * `session.todos` SSE events. Empty array for non-claude-native
    * sessions or before the first poll tick from the forwarder.
    */
-  todos: Array<{
+  todos: {
     content: string;
     status: "pending" | "in_progress" | "completed";
     activeForm: string;
-  }>;
+  }[];
   /**
    * Skills the bound agent can invoke (bundled + host-discovered).
    * Populated from the session snapshot on bind; empty array
@@ -2508,11 +2508,11 @@ async function bindStream(
         tokensUsed: session.lastTotalTokens ?? null,
         sessionCostUsd: session.totalCostUsd ?? null,
         sessionUsageByModel: session.usageByModel ?? null,
-        todos: (session.todos ?? []) as Array<{
+        todos: (session.todos ?? []) as {
           content: string;
           status: "pending" | "in_progress" | "completed";
           activeForm: string;
-        }>,
+        }[],
       };
     });
     racedNativeModelOptions.delete(id);


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Replace 34 production `Array<T>` and `ReadonlyArray<T>` annotations with the project-standard shorthand syntax.
- Preserve readonly and union semantics while clearing every production `typescript/array-type` diagnostic.

**ELI5:** Array types now use one shorter, consistent spelling.

```text
Array<T> -> T[]
ReadonlyArray<T> -> readonly T[]
```

## Test Plan

- `pnpm --filter web exec oxlint -A all -D 'typescript/array-type' .` (only test-file diagnostics remain)
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `pnpm --filter web exec vitest run` (4,786 passed, 3 expected failures, 1 skipped)
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The full web unit suite passes; these are type-annotation-only changes.