### PR TITLE
test(web): standardize array type syntax

### DIFF
--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -412,9 +412,9 @@ class FakeWebSocket {
   static instances: FakeWebSocket[] = [];
   readyState = 0;
   binaryType = "blob";
-  sent: Array<string | Uint8Array> = [];
+  sent: (string | Uint8Array)[] = [];
   closed = false;
-  private listeners: Record<string, Array<(ev: unknown) => void>> = {};
+  private listeners: Record<string, ((ev: unknown) => void)[]> = {};
   url: string;
 
   constructor(url: string) {

--- a/web/src/components/blocks/TerminalView.test.tsx
+++ b/web/src/components/blocks/TerminalView.test.tsx
@@ -21,13 +21,13 @@ import {
 } from "./TerminalView";
 
 const terminalSessionMock = vi.hoisted(() => ({
-  instances: [] as Array<{
+  instances: [] as {
     url: string;
     nativeSelection: boolean;
     onState: (state: ConnectionState) => void;
     dispose: ReturnType<typeof vi.fn>;
     setTheme: ReturnType<typeof vi.fn>;
-  }>,
+  }[],
 }));
 
 vi.mock("./TerminalSession", async (importOriginal) => ({

--- a/web/src/components/pwa/useServiceWorkerUpdate.test.tsx
+++ b/web/src/components/pwa/useServiceWorkerUpdate.test.tsx
@@ -6,7 +6,7 @@ const { FakeWorkbox } = vi.hoisted(() => {
   class FakeWorkboxImpl {
     static instances: FakeWorkboxImpl[] = [];
     scriptURL: string;
-    listeners: Record<string, Array<() => void>> = {};
+    listeners: Record<string, (() => void)[]> = {};
     register = vi.fn().mockResolvedValue(undefined);
     messageSkipWaiting = vi.fn();
     constructor(scriptURL: string) {

--- a/web/src/hooks/useApproveHotkey.test.tsx
+++ b/web/src/hooks/useApproveHotkey.test.tsx
@@ -6,7 +6,7 @@ import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const submitApproval = vi.fn();
-let blocks: Array<Record<string, unknown>> = [];
+let blocks: Record<string, unknown>[] = [];
 vi.mock("@/store/chatStore", () => ({
   useChatStore: { getState: () => ({ blocks, submitApproval }) },
 }));

--- a/web/src/hooks/useHosts.test.tsx
+++ b/web/src/hooks/useHosts.test.tsx
@@ -345,7 +345,7 @@ describe("useInstallHarness + useInstallingHarnesses (concurrent installs)", () 
     );
     await waitFor(() => expect(result.current.installing.has("codex-native")).toBe(false));
     expect(result.current.installing.has("pi-native")).toBe(true); // Pi still going
-    const hosts = client.getQueryData<Array<{ configured_harnesses?: Record<string, unknown> }>>([
+    const hosts = client.getQueryData<{ configured_harnesses?: Record<string, unknown> }[]>([
       "hosts",
       { includeSandbox: false },
     ]);
@@ -355,7 +355,7 @@ describe("useInstallHarness + useInstallingHarnesses (concurrent installs)", () 
     // both harnesses' final readiness.
     pi.resolve(installResult("pi-native", { "codex-native": "needs-auth", "pi-native": true }));
     await waitFor(() => expect(result.current.installing.has("pi-native")).toBe(false));
-    const hosts2 = client.getQueryData<Array<{ configured_harnesses?: Record<string, unknown> }>>([
+    const hosts2 = client.getQueryData<{ configured_harnesses?: Record<string, unknown> }[]>([
       "hosts",
       { includeSandbox: false },
     ]);
@@ -462,7 +462,7 @@ describe("useStoreCredential", () => {
     result.current.mutate({ harness: "codex-native", kind: "key", secret: "sk" });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    const hosts = client.getQueryData<Array<{ configured_harnesses?: Record<string, unknown> }>>([
+    const hosts = client.getQueryData<{ configured_harnesses?: Record<string, unknown> }[]>([
       "hosts",
       { includeSandbox: false },
     ]);

--- a/web/src/hooks/useWorkspaceChangedFiles.test.tsx
+++ b/web/src/hooks/useWorkspaceChangedFiles.test.tsx
@@ -440,7 +440,7 @@ describe("useWorkspaceEnvironment gating", () => {
   it("marks the environment unavailable when the server omits metadata.root", async () => {
     onlineMock.mockReturnValue(true);
     fetchMock.mockResolvedValue(jsonResponse({ metadata: {} }));
-    const results: Array<{ available: boolean; root: string | null; home: string | null }> = [];
+    const results: { available: boolean; root: string | null; home: string | null }[] = [];
 
     render(
       <Wrap>
@@ -459,7 +459,7 @@ describe("useWorkspaceEnvironment gating", () => {
     fetchMock.mockResolvedValue(
       jsonResponse({ metadata: { root: "/home/u/ws", home: "/home/u" } }),
     );
-    const results: Array<{ available: boolean; root: string | null; home: string | null }> = [];
+    const results: { available: boolean; root: string | null; home: string | null }[] = [];
 
     render(
       <Wrap>

--- a/web/src/lib/idleTransitions.test.ts
+++ b/web/src/lib/idleTransitions.test.ts
@@ -244,7 +244,7 @@ describe("computeUnreadBadgeIds", () => {
   it("passes each session's id, updated_at, and status to the predicate", () => {
     // The hook wires isConversationUnseen here; wrong arguments would make
     // the localStorage lookup miss and the badge silently read 0.
-    const calls: Array<{ id: string; updatedAt: number; status: string | undefined }> = [];
+    const calls: { id: string; updatedAt: number; status: string | undefined }[] = [];
     computeUnreadBadgeIds(
       [convB("a", { updatedAt: 42, status: "failed" })],
       undefined,

--- a/web/src/lib/sessionsApi.test.ts
+++ b/web/src/lib/sessionsApi.test.ts
@@ -818,7 +818,7 @@ describe("fetchInitialHistoryWindow", () => {
       content: [{ type: "output_text", text: id }],
     };
   }
-  function pageBody(dataNewestFirst: Array<{ id: string }>, hasMore: boolean): Response {
+  function pageBody(dataNewestFirst: { id: string }[], hasMore: boolean): Response {
     return mockJsonResponse({
       object: "list",
       data: dataNewestFirst,

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -377,13 +377,13 @@ function renderShell(path: string, info?: ServerInfo) {
 }
 
 function mockConversations(
-  convs: Array<{
+  convs: {
     id: string;
     permission_level: number | null;
     labels?: Record<string, string>;
     host_id?: string | null;
     runner_id?: string | null;
-  }>,
+  }[],
 ) {
   useConvMock.mockReturnValue({
     data: {

--- a/web/src/shell/SubagentsGraphView.test.tsx
+++ b/web/src/shell/SubagentsGraphView.test.tsx
@@ -249,7 +249,7 @@ describe("activityDotClassName (shared list/graph palette)", () => {
   // color the dot from the same ``activityDotClassName``, so the rendered dot
   // is identical in both views.
   it("classifies list and graph identically for each status", () => {
-    const cases: Array<{ child: ChildSessionInfo; expected: string }> = [
+    const cases: { child: ChildSessionInfo; expected: string }[] = [
       {
         child: childInfo({ id: "launching", current_task_status: "launching" }),
         expected: "bg-session-active/70",

--- a/web/src/shell/SubagentsPanel.test.tsx
+++ b/web/src/shell/SubagentsPanel.test.tsx
@@ -119,7 +119,7 @@ function mockChildTree(tree: Record<string, ChildSessionInfo[]>) {
 
 /** Agent-type → category-icon expectations. Order-sensitive cases (review
  *  before code, test before code) guard the substring precedence. */
-const ICON_CASES: Array<[string | null, ReturnType<typeof iconForAgentType>]> = [
+const ICON_CASES: [string | null, ReturnType<typeof iconForAgentType>][] = [
   ["Explore", SearchIcon],
   ["deep-researcher", BookOpenIcon],
   ["planner", CompassIcon],
@@ -334,12 +334,12 @@ describe("SubagentsPanel", () => {
     expect(screen.queryByTestId("add-agent-dialog")).toBeNull();
   });
 
-  const AGENT_KIND_CASES: Array<{
+  const AGENT_KIND_CASES: {
     name: string;
     labels: Record<string, string>;
     agentName?: string | null;
     expectedKind: string;
-  }> = [
+  }[] = [
     {
       name: "claude-native wrapper → claude-native marker",
       labels: { "omnigent.wrapper": "claude-code-native-ui" },

--- a/web/src/shell/WorkspacePathField.test.tsx
+++ b/web/src/shell/WorkspacePathField.test.tsx
@@ -40,12 +40,12 @@ function mockListing(
 
 describe("splitTypedPath", () => {
   // input -> { dir (directory to list, "" = home), partial (prefix) }
-  const cases: Array<{
+  const cases: {
     name: string;
     input: string;
     dir: string;
     partial: string;
-  }> = [
+  }[] = [
     {
       name: "empty input lists home with no filter",
       input: "",

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -176,10 +176,10 @@ let client: QueryClient;
 const fetchMock = vi.fn();
 let sessionSnapshots: Map<string, ConversationItem[]>;
 let sessionItems: Map<string, ConversationItem[]>;
-let sessionPendingElicitations: Map<string, Array<Record<string, unknown>>>;
+let sessionPendingElicitations: Map<string, Record<string, unknown>[]>;
 let sessionPendingInputs: Map<
   string,
-  Array<{ pending_id: string; content: unknown[]; created_by?: string }>
+  { pending_id: string; content: unknown[]; created_by?: string }[]
 >;
 // Per-session cost-control switch the snapshot/PATCH handlers serve;
 // absent key = unset (the wire field comes back null).
@@ -410,13 +410,13 @@ function seedSessionItems(id: string, items: ConversationItem[] = []): void {
   sessionItems.set(id, items);
 }
 
-function seedPendingElicitations(id: string, events: Array<Record<string, unknown>>): void {
+function seedPendingElicitations(id: string, events: Record<string, unknown>[]): void {
   sessionPendingElicitations.set(id, events);
 }
 
 function seedPendingInputs(
   id: string,
-  inputs: Array<{ pending_id: string; content: unknown[]; created_by?: string }>,
+  inputs: { pending_id: string; content: unknown[]; created_by?: string }[],
 ): void {
   sessionPendingInputs.set(id, inputs);
 }
@@ -1561,7 +1561,7 @@ describe("chatStore — send (first-send ordering)", () => {
     // Control /events resolution: each POST returns a deferred promise so the
     // test can hold the first one open and observe whether the next fires.
     const eventBodies: string[] = [];
-    const resolvers: Array<() => void> = [];
+    const resolvers: (() => void)[] = [];
     fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();
       if (url === "/v1/sessions/conv_x/events" && init?.method === "POST") {
@@ -3580,7 +3580,7 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
      */
     function seedSnapshotSkills(
       seedId: string,
-      skills: Array<{ name: string; description: string }>,
+      skills: { name: string; description: string }[],
     ): void {
       fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
         const url = typeof input === "string" ? input : input.toString();
@@ -5149,7 +5149,7 @@ describe("chatStore — bindStream sticky-pref handoff", () => {
     model_override?: string | null;
     cost_control_mode_override?: "on" | "off" | null;
     parent_session_id?: string | null;
-    model_options?: Array<Record<string, unknown>>;
+    model_options?: Record<string, unknown>[];
   }
 
   /** Override the snapshot GET so a test can inject labels + overrides. */
@@ -5176,7 +5176,7 @@ describe("chatStore — bindStream sticky-pref handoff", () => {
     });
   }
 
-  function patchCallsFor(id: string): Array<Record<string, unknown>> {
+  function patchCallsFor(id: string): Record<string, unknown>[] {
     return fetchMock.mock.calls
       .filter(([u, init]) => {
         const url = typeof u === "string" ? u : u.toString();
@@ -7077,7 +7077,7 @@ describe("chatStore — startStreamPump reconnect loop", () => {
   }
 
   /** The `live:<messageId>` provisional preview blocks currently rendered. */
-  function livePreviews(): Array<Extract<AnyBlock, { type: "text_done" }>> {
+  function livePreviews(): Extract<AnyBlock, { type: "text_done" }>[] {
     return useChatStore
       .getState()
       .blocks.filter(
@@ -8629,7 +8629,7 @@ describe("chatStore — client-side message queue", () => {
 
 describe("chatStore — background cross-session flush", () => {
   /** /events POSTs the flush fired, as (conversationId, text) pairs. */
-  const eventPosts = (): Array<{ id: string; text: string }> =>
+  const eventPosts = (): { id: string; text: string }[] =>
     fetchMock.mock.calls
       .filter(
         ([u, init]) =>


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Replace 27 test-only `Array<T>` annotations with shorthand array syntax.
- Complete the test half of the `typescript/array-type` cleanup without changing fixtures or assertions.

**ELI5:** Test types now spell arrays the same way as production code.

```text
Array<T> -> T[]
```

## Test Plan

- `pnpm --filter web exec oxlint -A all -D 'typescript/array-type' .` (no test-file diagnostics remain)
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- Focused Vitest run for all 13 changed test files (740 passed)
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

All changed test files pass; these are type-annotation-only changes.