### PR TITLE
refactor(web): mark file hook as type-only

### DIFF
--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -48,7 +48,7 @@ import type { Comment } from "@/hooks/useComments";
 import {
   type FileContentResponse,
   fileContentToBlob,
-  useFileContent,
+  type useFileContent,
 } from "@/hooks/useFileContent";
 import { useCanEdit } from "@/hooks/usePermissions";
 import { cn } from "@/lib/utils";


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Mark the `useFileContent` symbol as type-only in `CodeViewer`.
- Clear the final production `typescript/consistent-type-imports` diagnostic without changing runtime imports.

## Test Plan

- `pnpm --filter web exec oxlint -A all -D 'typescript/consistent-type-imports' .`
- `pnpm --filter web exec oxlint -A all -D 'typescript/no-import-type-side-effects' .`
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `pnpm --filter web exec vitest run src/shell/CodeViewer.test.tsx` (40 passed)
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing CodeViewer suite covers the affected module; this is a type-only import change.