### PR TITLE
feat(web): support bulk deletion for archived sessions in settings

### DIFF
--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -16,6 +16,8 @@ const mocks = vi.hoisted(() => ({
   theme: "system" as string,
   archiveMutate: vi.fn(),
   deleteMutate: vi.fn(),
+  bulkArchiveMutate: vi.fn(),
+  bulkDeleteMutate: vi.fn(),
   accountsEnabled: true,
   // login_url: non-null for any sign-in mode (accounts OR OIDC), null in
   // header mode. Gates the Account section.
@@ -55,6 +57,7 @@ vi.mock("@/lib/accountsApi", () => ({
 vi.mock("@/lib/identity", () => ({
   resolveIdentity: () => Promise.resolve(mocks.me?.id ?? null),
   getCurrentIsAdmin: () => mocks.me?.is_admin ?? false,
+  getCurrentUserId: () => mocks.me?.id ?? null,
 }));
 vi.mock("@/hooks/useConversations", async () => {
   // A stateful mock that emulates useInfiniteQuery pagination: it tracks how
@@ -104,6 +107,16 @@ vi.mock("@/hooks/useConversations", async () => {
       isPending: false,
     }),
     useStopAndDeleteConversation: () => ({ mutate: mocks.deleteMutate, isPending: false }),
+    useBulkArchiveConversations: () => ({
+      mutate: mocks.bulkArchiveMutate,
+      isPending: false,
+      isError: false,
+    }),
+    useBulkDeleteConversations: () => ({
+      mutate: mocks.bulkDeleteMutate,
+      isPending: false,
+      isError: false,
+    }),
   };
 });
 // Radix Select uses a portal + pointer events jsdom can't drive; stub it to a
@@ -193,6 +206,8 @@ beforeEach(() => {
   mocks.setTheme.mockReset();
   mocks.archiveMutate.mockReset();
   mocks.deleteMutate.mockReset();
+  mocks.bulkArchiveMutate.mockReset();
+  mocks.bulkDeleteMutate.mockReset();
   mocks.fetchNextPage.mockReset();
   mocks.theme = "system";
   mocks.accountsEnabled = true;
@@ -1081,5 +1096,98 @@ describe("SettingsPage", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("enters selection mode and selects rows via click", () => {
+    mocks.conversations = [
+      conv("a1", { archived: true, title: "Chat A" }),
+      conv("a2", { archived: true, title: "Chat B" }),
+    ];
+    renderPage("/settings/archived");
+
+    fireEvent.click(screen.getByTestId("archived-toggle-selection"));
+    const rows = screen.getAllByTestId("archived-row");
+    expect(rows).toHaveLength(2);
+
+    // Clicking a row in selection mode toggles its checkbox.
+    fireEvent.click(rows[0]);
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+
+    fireEvent.click(rows[1]);
+    expect(screen.getByText("2 selected")).toBeInTheDocument();
+
+    // Clicking again deselects.
+    fireEvent.click(rows[0]);
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+  });
+
+  it("bulk-deletes selected archived sessions after confirming", () => {
+    mocks.conversations = [
+      conv("a1", { archived: true, title: "Chat A" }),
+      conv("a2", { archived: true, title: "Chat B" }),
+    ];
+    renderPage("/settings/archived");
+
+    fireEvent.click(screen.getByTestId("archived-toggle-selection"));
+    const rows = screen.getAllByTestId("archived-row");
+    fireEvent.click(rows[0]);
+    fireEvent.click(rows[1]);
+
+    fireEvent.click(screen.getByTestId("archived-bulk-delete"));
+    fireEvent.click(screen.getByRole("button", { name: /Delete 2 session/ }));
+    expect(mocks.bulkDeleteMutate).toHaveBeenCalledWith({ ids: ["a1", "a2"] }, expect.anything());
+  });
+
+  it("bulk-unarchives selected archived sessions", () => {
+    mocks.conversations = [
+      conv("a1", { archived: true, title: "Chat A" }),
+      conv("a2", { archived: true, title: "Chat B" }),
+    ];
+    renderPage("/settings/archived");
+
+    fireEvent.click(screen.getByTestId("archived-toggle-selection"));
+    fireEvent.click(screen.getAllByTestId("archived-row")[0]);
+
+    fireEvent.click(screen.getByTestId("archived-bulk-unarchive"));
+    expect(mocks.bulkArchiveMutate).toHaveBeenCalledWith(
+      { ids: ["a1"], archived: false },
+      expect.anything(),
+    );
+  });
+
+  it("exits selection mode and clears selection", () => {
+    mocks.conversations = [conv("a1", { archived: true, title: "Chat A" })];
+    renderPage("/settings/archived");
+
+    fireEvent.click(screen.getByTestId("archived-toggle-selection"));
+    fireEvent.click(screen.getAllByTestId("archived-row")[0]);
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("archived-exit-selection"));
+    expect(screen.queryByText("1 selected")).toBeNull();
+    expect(screen.queryByTestId("archived-bulk-delete")).toBeNull();
+  });
+
+  it("select-all picks every visible archived row", () => {
+    mocks.conversations = [
+      conv("a1", { archived: true, title: "Chat A" }),
+      conv("a2", { archived: true, title: "Chat B" }),
+      conv("a3", { archived: true, title: "Chat C" }),
+    ];
+    renderPage("/settings/archived");
+
+    fireEvent.click(screen.getByTestId("archived-toggle-selection"));
+    fireEvent.click(screen.getByRole("button", { name: "Select all" }));
+    expect(screen.getByText("3 selected")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Deselect all" }));
+    expect(screen.getByText("None selected")).toBeInTheDocument();
+  });
+
+  it("hides the Select button when there are no archived sessions", () => {
+    mocks.conversations = [conv("conv_active")];
+    renderPage("/settings/archived");
+
+    expect(screen.queryByTestId("archived-toggle-selection")).toBeNull();
   });
 });

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -42,6 +42,7 @@ import {
   ArchiveRestoreIcon,
   AlertTriangleIcon,
   KeyRoundIcon,
+  Loader2Icon,
   LaptopMinimalIcon,
   LogOutIcon,
   MessagesSquareIcon,
@@ -52,9 +53,12 @@ import {
   PanelRightIcon,
   PlusIcon,
   SunIcon,
+  SquareCheckIcon,
+  SquareIcon,
   TerminalIcon,
   Trash2Icon,
   UserCogIcon,
+  XIcon,
 } from "lucide-react";
 import { useTheme } from "next-themes";
 import { PageScroll } from "@/components/PageScroll";
@@ -87,13 +91,15 @@ import {
 } from "@/components/ui/dialog";
 import { KeyboardShortcutsList } from "@/components/KeyboardShortcutsDialog";
 import { changePassword, logout } from "@/lib/accountsApi";
-import { getCurrentIsAdmin, resolveIdentity } from "@/lib/identity";
+import { getCurrentIsAdmin, getCurrentUserId, resolveIdentity } from "@/lib/identity";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { useOmnigentAnalytics, useOmnigentPageView } from "@/lib/analytics";
 import {
   type Conversation,
   useArchiveConversation,
   useArchivedProjectNames,
+  useBulkArchiveConversations,
+  useBulkDeleteConversations,
   useConversations,
   useStopAndDeleteConversation,
 } from "@/hooks/useConversations";
@@ -1900,42 +1906,100 @@ function ArchivedSection() {
   const items =
     project && !projectNames.includes(project) ? [project, ...projectNames] : projectNames;
 
+  // ── Bulk selection ──
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const toggleSelected = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const selectAll = useCallback(() => {
+    setSelectedIds(new Set(archived.map((c) => c.id)));
+  }, [archived]);
+
+  const deselectAll = useCallback(() => {
+    setSelectedIds(new Set());
+  }, []);
+
+  const exitSelectionMode = useCallback(() => {
+    setSelectionMode(false);
+    setSelectedIds(new Set());
+  }, []);
+
+  // Prune stale selections when archived list changes (rows deleted/unarchived).
+  useEffect(() => {
+    setSelectedIds((prev) => {
+      const ids = new Set(archived.map((c) => c.id));
+      const next = new Set([...prev].filter((id) => ids.has(id)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [archived]);
+
   return (
     <Section
       title="Archived sessions"
       description="Sessions you've archived. Restore one to the sidebar, or delete it for good."
     >
-      {items.length > 0 && (
-        <div className="mb-4 flex items-center gap-2">
-          <label htmlFor="archived-project-filter" className="text-ui text-muted-foreground">
-            Project
-          </label>
-          <Select
-            value={projectToSelectValue(project)}
-            onValueChange={(value) => setProject(selectValueToProject(value))}
-          >
-            <SelectTrigger
-              id="archived-project-filter"
-              aria-label="Filter archived sessions by project"
-              data-testid="archived-project-filter"
-              className="w-56"
+      <div className="mb-4 flex items-center gap-2">
+        {items.length > 0 && (
+          <>
+            <label htmlFor="archived-project-filter" className="text-ui text-muted-foreground">
+              Project
+            </label>
+            <Select
+              value={projectToSelectValue(project)}
+              onValueChange={(value) => setProject(selectValueToProject(value))}
             >
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent position="popper" align="start">
-              <SelectItem value={ALL_PROJECTS_VALUE}>All projects</SelectItem>
-              {items.map((name) => (
-                <SelectItem
-                  key={name}
-                  value={projectToSelectValue(name)}
-                  data-testid={`archived-project-option-${name}`}
-                >
-                  {name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+              <SelectTrigger
+                id="archived-project-filter"
+                aria-label="Filter archived sessions by project"
+                data-testid="archived-project-filter"
+                className="w-56"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent position="popper" align="start">
+                <SelectItem value={ALL_PROJECTS_VALUE}>All projects</SelectItem>
+                {items.map((name) => (
+                  <SelectItem
+                    key={name}
+                    value={projectToSelectValue(name)}
+                    data-testid={`archived-project-option-${name}`}
+                  >
+                    {name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </>
+        )}
+        {!selectionMode && archived.length > 0 && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            data-testid="archived-toggle-selection"
+            onClick={() => setSelectionMode(true)}
+          >
+            Select
+          </Button>
+        )}
+      </div>
+
+      {selectionMode && (
+        <ArchivedBulkActionBar
+          selectedIds={selectedIds}
+          allArchived={archived}
+          onSelectAll={selectAll}
+          onDeselectAll={deselectAll}
+          onExit={exitSelectionMode}
+        />
       )}
 
       {listQuery.isLoading ? (
@@ -1957,7 +2021,13 @@ function ArchivedSection() {
                   </h3>
                   <ul className="flex flex-col gap-0.5">
                     {group.conversations.map((conv) => (
-                      <ArchivedRow key={conv.id} conversation={conv} />
+                      <ArchivedRow
+                        key={conv.id}
+                        conversation={conv}
+                        selectionMode={selectionMode}
+                        isSelected={selectedIds.has(conv.id)}
+                        onToggleSelected={toggleSelected}
+                      />
                     ))}
                   </ul>
                 </div>
@@ -1999,12 +2069,177 @@ function ArchivedSection() {
 }
 
 /**
+ * Bulk action bar for the archived-sessions settings section. Modeled on the
+ * sidebar's BulkActionBar but scoped to archived rows — offers Delete and
+ * Unarchive, plus Select all / Deselect all / exit controls.
+ */
+function ArchivedBulkActionBar({
+  selectedIds,
+  allArchived,
+  onSelectAll,
+  onDeselectAll,
+  onExit,
+}: {
+  selectedIds: Set<string>;
+  allArchived: Conversation[];
+  onSelectAll: () => void;
+  onDeselectAll: () => void;
+  onExit: () => void;
+}) {
+  const bulkArchive = useBulkArchiveConversations();
+  const bulkDelete = useBulkDeleteConversations();
+  const [viewerId] = useState(() => getCurrentUserId());
+
+  const ownedSelected = useMemo(() => {
+    return allArchived.filter((c) => {
+      if (!selectedIds.has(c.id)) return false;
+      const owner = c.owner ?? null;
+      return owner === null || owner === viewerId;
+    });
+  }, [allArchived, selectedIds, viewerId]);
+
+  const count = selectedIds.size;
+  const allSelected = count > 0 && count === allArchived.length;
+  const isBusy = bulkArchive.isPending || bulkDelete.isPending;
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+
+  function handleUnarchive() {
+    if (ownedSelected.length === 0) return;
+    bulkArchive.mutate(
+      { ids: ownedSelected.map((c) => c.id), archived: false },
+      { onSuccess: onDeselectAll },
+    );
+  }
+
+  function handleDelete() {
+    const ids = ownedSelected.map((c) => c.id);
+    if (ids.length === 0) return;
+    setConfirmDeleteOpen(false);
+    bulkDelete.mutate({ ids }, { onSuccess: onDeselectAll });
+  }
+
+  return (
+    <>
+      <div className="relative mb-4 flex flex-col gap-1.5 rounded-md border bg-muted/50 p-2">
+        <div className="relative flex min-h-8 items-center gap-1.5 pr-9">
+          <span className="shrink-0 whitespace-nowrap text-sm text-muted-foreground">
+            {count === 0 ? "None selected" : `${count} selected`}
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-6 px-1.5 text-sm"
+            onClick={allSelected ? onDeselectAll : onSelectAll}
+          >
+            {allSelected ? "Deselect all" : "Select all"}
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="icon-sm"
+            className="-translate-y-1/2 absolute top-1/2 right-1 shrink-0 rounded-full"
+            aria-label="Exit selection mode"
+            data-testid="archived-exit-selection"
+            onClick={onExit}
+          >
+            <XIcon className="size-3.5" />
+          </Button>
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 gap-1.5 text-xs"
+            disabled={isBusy || ownedSelected.length === 0}
+            onClick={handleUnarchive}
+            data-testid="archived-bulk-unarchive"
+          >
+            {bulkArchive.isPending ? (
+              <Loader2Icon className="size-3 animate-spin" />
+            ) : (
+              <ArchiveRestoreIcon className="size-3" />
+            )}
+            Unarchive {ownedSelected.length > 0 ? ownedSelected.length : ""}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className={cn("h-7 gap-1.5 text-xs", ownedSelected.length > 0 && "text-destructive")}
+            disabled={isBusy || ownedSelected.length === 0}
+            onClick={() => setConfirmDeleteOpen(true)}
+            data-testid="archived-bulk-delete"
+          >
+            {bulkDelete.isPending ? (
+              <Loader2Icon className="size-3 animate-spin" />
+            ) : (
+              <Trash2Icon className="size-3" />
+            )}
+            Delete {ownedSelected.length > 0 ? ownedSelected.length : ""}
+          </Button>
+        </div>
+
+        {(bulkArchive.isError || bulkDelete.isError) && (
+          <p className="text-xs text-destructive" role="alert">
+            Some actions failed. Retry or dismiss.
+          </p>
+        )}
+      </div>
+
+      <Dialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete {ownedSelected.length} session(s)?</DialogTitle>
+            <DialogDescription>
+              This will permanently delete the selected sessions and all their history. This cannot
+              be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setConfirmDeleteOpen(false)}
+              disabled={bulkDelete.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={bulkDelete.isPending}
+            >
+              Delete {ownedSelected.length} session(s)
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+/**
  * One archived-session row. Not clickable (archived sessions aren't a
  * navigation target here); the title + timestamp read as a record, and the
  * Delete / Unarchive controls reveal on hover (always visible on touch).
+ * In selection mode, clicking the row toggles its checkbox.
  * Unarchive navigates to the restored session once the PATCH lands.
  */
-function ArchivedRow({ conversation }: { conversation: Conversation }) {
+function ArchivedRow({
+  conversation,
+  selectionMode,
+  isSelected,
+  onToggleSelected,
+}: {
+  conversation: Conversation;
+  selectionMode: boolean;
+  isSelected: boolean;
+  onToggleSelected: (id: string) => void;
+}) {
   const navigate = useNavigate();
   const archive = useArchiveConversation();
   const del = useStopAndDeleteConversation();
@@ -2015,8 +2250,22 @@ function ArchivedRow({ conversation }: { conversation: Conversation }) {
   return (
     <li
       data-testid="archived-row"
-      className="group relative flex items-center gap-2 rounded-md px-3 py-2 hover:bg-muted"
+      className={cn(
+        "group relative flex items-center gap-2 rounded-md px-3 py-2 hover:bg-muted",
+        selectionMode && "cursor-pointer",
+        isSelected && "bg-muted",
+      )}
+      onClick={selectionMode ? () => onToggleSelected(conversation.id) : undefined}
     >
+      {selectionMode && (
+        <span className="flex shrink-0 items-center">
+          {isSelected ? (
+            <SquareCheckIcon className="size-4 text-primary" />
+          ) : (
+            <SquareIcon className="size-4 text-muted-foreground" />
+          )}
+        </span>
+      )}
       <div className="min-w-0 flex-1">
         <div className="truncate text-ui font-medium" title={label}>
           {label}
@@ -2025,42 +2274,43 @@ function ArchivedRow({ conversation }: { conversation: Conversation }) {
           {absoluteTime(conversation.updated_at * 1000)}
         </div>
       </div>
-      {/* Actions reveal on hover (desktop) / always shown on touch. */}
-      <div className="flex shrink-0 items-center gap-1 transition-opacity md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100">
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          aria-label="Delete session"
-          data-testid="delete-archived"
-          disabled={busy}
-          onClick={() => setDeleteOpen(true)}
-        >
-          <Trash2Icon className="size-4 text-destructive" />
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          // No background in light mode (ghost). Dark mode needs a fill so the
-          // button reads against the dark row — borrow the secondary tokens
-          // there only, without touching the text color.
-          className="gap-1.5 dark:bg-secondary dark:hover:bg-secondary/80"
-          data-testid="unarchive-conversation"
-          disabled={busy}
-          onClick={() =>
-            archive.mutate(
-              { id: conversation.id, archived: false },
-              // Unarchiving is how a user brings a session back into play, so
-              // land them in it — the row leaves this list either way.
-              { onSuccess: () => navigate(`/c/${conversation.id}`) },
-            )
-          }
-        >
-          <ArchiveRestoreIcon className="size-3.5" />
-          Unarchive
-        </Button>
-      </div>
+      {/* Actions reveal on hover (desktop) / always shown on touch.
+          Hidden in selection mode — bulk bar owns the actions. */}
+      {!selectionMode && (
+        <div className="flex shrink-0 items-center gap-1 transition-opacity md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Delete session"
+            data-testid="delete-archived"
+            disabled={busy}
+            onClick={() => setDeleteOpen(true)}
+          >
+            <Trash2Icon className="size-4 text-destructive" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            // No background in light mode (ghost). Dark mode needs a fill so the
+            // button reads against the dark row — borrow the secondary tokens
+            // there only, without touching the text color.
+            className="gap-1.5 dark:bg-secondary dark:hover:bg-secondary/80"
+            data-testid="unarchive-conversation"
+            disabled={busy}
+            onClick={() =>
+              archive.mutate(
+                { id: conversation.id, archived: false },
+                { onSuccess: () => navigate(`/c/${conversation.id}`) },
+              )
+            }
+          >
+            <ArchiveRestoreIcon className="size-3.5" />
+            Unarchive
+          </Button>
+        </div>
+      )}
 
       <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <DialogContent>
@@ -2079,8 +2329,6 @@ function ArchivedRow({ conversation }: { conversation: Conversation }) {
               variant="destructive"
               disabled={del.isPending}
               onClick={() => {
-                // Fire-and-forget: the row drops out once the conversations
-                // cache refreshes after the delete settles.
                 del.mutate({ id: conversation.id });
                 setDeleteOpen(false);
               }}


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add selection mode to the archived sessions settings page (`/settings/archived`), enabling users to select multiple sessions and bulk-delete or bulk-unarchive them.
- Reuses existing `useBulkDeleteConversations` and `useBulkArchiveConversations` hooks already used by the sidebar's bulk action bar.
- Includes ownership filtering so only sessions owned by the viewer can be acted on, stale selection pruning when the archived list changes, and a confirmation dialog before bulk deletion.

## Test Plan

1. Navigate to Settings > Archived sessions.
2. Click "Select" to enter selection mode — checkboxes appear on each row, per-row actions hide.
3. Click rows to toggle selection; verify the selected count updates.
4. Click "Select all" / "Deselect all" and verify behavior.
5. Click "Delete N" — confirm the dialog appears, then confirm deletion.
6. Click "Unarchive N" — verify sessions are restored to the sidebar.
7. Click the X button to exit selection mode — verify selection clears and per-row actions reappear.
8. Verify the "Select" button is hidden when there are no archived sessions.

## Demo

<!-- UI change — attach a screenshot or recording before merging. -->

[Kooha-2026-07-30-21-27-04.webm](https://github.com/user-attachments/assets/d979340e-aeb4-45a5-9716-ea0e28628f48)


## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added 6 unit tests covering: entering/exiting selection mode, row selection toggling, bulk delete with confirmation dialog, bulk unarchive, select all/deselect all, and hiding the Select button when empty.

## Changelog

Archived sessions in Settings now support bulk selection for deleting or unarchiving multiple sessions at once.