### PR TITLE
fix(host): guard orphan reaper against missing os.WNOHANG on Windows

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -819,6 +819,10 @@ class HostProcess:
             # acceptable, since the leak this guards against accrues over hours,
             # not a two-minute worst case.
             return 0
+        if not hasattr(os, "WNOHANG"):
+            # Windows: no child reparenting to a subreaper and no ``WNOHANG`` /
+            # ``waitpid(-1, ...)`` — nothing to reap and the calls would raise.
+            return 0
         if hasattr(os, "waitid") and hasattr(os, "P_ALL"):
             return self._reap_orphans_waitid()
         return self._reap_orphans_waitpid()

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -1227,6 +1227,25 @@ def test_host_subprocess_op_guard_is_reentrant_and_balanced(tmp_path: Path) -> N
     assert host._owned_subprocess_ops == 0, "guard leaked a ref on exception — reaper wedged"
 
 
+def test_reap_orphans_is_noop_without_wnohang(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On Windows (no ``os.WNOHANG``) the reaper is a clean no-op, not a crash.
+
+    Windows has no child reparenting to a subreaper and no
+    ``waitpid(-1, WNOHANG)``; touching ``os.WNOHANG`` there raises
+    ``AttributeError``. The final drain runs unguarded in ``run``'s
+    ``finally``, so an unguarded sweep would crash shutdown. Simulate the
+    platform by deleting ``os.WNOHANG`` and assert a quiet ``0``.
+    """
+    import os
+
+    monkeypatch.delattr(os, "WNOHANG", raising=False)
+
+    host = _make_host_process()
+    assert host._reap_orphans_once() == 0
+
+
 def test_install_child_subreaper_is_safe_to_call() -> None:
     """``_install_child_subreaper`` never raises and reports a bool.
 


### PR DESCRIPTION
## Related issue

Closes #1930

## Summary

Issue #1930 has two parts. The primary crash — unguarded `os.getuid()` at module scope in the four `*_native_bridge.py` files that made `omni host` crash-loop forever on native Windows — was **already fixed on `main`** by #2343 (all four now use the guarded `_platform.stable_user_id()` helper). Verified: `python -c "import omnigent.onboarding.harness_readiness as hr; hr.configured_harness_map()"` now imports cleanly.

This PR fixes the **secondary Windows crash the reporter documented in the same issue**: the host orphan reaper (`host/connect.py`) uses `os.WNOHANG` and `os.waitpid(-1, ...)` in its `waitpid` fallback, neither of which exists / is supported on native Windows.

- The periodic reaper loop swallows the resulting `AttributeError` (so it silently no-ops every sweep), but the **final drain in `run()`'s `finally` block runs unguarded** and would raise on shutdown.
- Windows also has no child reparenting to a subreaper, so there is genuinely nothing to reap. We now return early with `0` when `os.WNOHANG` is absent, matching the reaper's own documented "non-Linux is a no-op" contract.

## Test Plan

- `uv run pytest tests/host/test_connect.py -k "reap or subreaper"` → 5 passed.
- New `test_reap_orphans_is_noop_without_wnohang` deletes `os.WNOHANG` via monkeypatch to simulate Windows and asserts `_reap_orphans_once()` returns `0` instead of raising.
- `pre-commit run --files omnigent/host/connect.py tests/host/test_connect.py` → all hooks pass.

## Demo

N/A — non-visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — unit test added.

This pull request and its description were written by Isaac.