### PR TITLE
ci(web): enforce high-signal lint baseline

### DIFF
--- a/web/.oxlintrc.json
+++ b/web/.oxlintrc.json
@@ -9,6 +9,13 @@
   "rules": {
     "react/react-in-jsx-scope": "off",
     "import/no-unassigned-import": "off",
+    "import/newline-after-import": "error",
+    "import/no-cycle": "error",
+    "import/no-duplicates": "error",
+    "no-empty": "error",
+    "no-fallthrough": "error",
+    "no-multi-assign": "error",
+    "no-param-reassign": "error",
     "no-promise-executor-return": "error",
     "no-restricted-globals": [
       "error",
@@ -17,10 +24,23 @@
         "message": "Don't call the bare global fetch(). Use hostFetch (@/lib/host) or authenticatedFetch (@/lib/identity) so requests route through the embed host transport. The only allowed bare fetch() is the choke point in src/lib/host.ts."
       }
     ],
+    "no-throw-literal": "error",
     "no-unreachable-loop": "error",
     "no-useless-assignment": "error",
+    "prefer-object-has-own": "error",
+    "react/button-has-type": "error",
     "react/jsx-no-useless-fragment": "error",
+    "react/no-react-children": "error",
     "react-hooks/rules-of-hooks": "error",
+    "typescript/array-type": "error",
+    "typescript/consistent-generic-constructors": "error",
+    "typescript/consistent-type-definitions": "error",
+    "typescript/consistent-type-imports": "error",
+    "typescript/method-signature-style": "error",
+    "typescript/no-dynamic-delete": "error",
+    "typescript/no-explicit-any": "error",
+    "typescript/no-import-type-side-effects": "error",
+    "typescript/no-inferrable-types": "error",
     "no-restricted-imports": [
       "error",
       {

--- a/web/src/components/PermissionsModal.test.tsx
+++ b/web/src/components/PermissionsModal.test.tsx
@@ -1,5 +1,3 @@
-import type * as HostModule from "@/lib/host";
-
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -26,7 +24,7 @@ vi.mock("qrcode.react", () => ({
 // Host config is read-once at render to decide plain-input vs combobox and to
 // transform the share link. Mock both getters so we can drive each branch.
 vi.mock("@/lib/host", async (importOriginal) => {
-  const actual = await importOriginal<typeof HostModule>();
+  const actual = await importOriginal<typeof host>();
   return {
     ...actual,
     getOmnigentUserSearch: vi.fn(() => undefined),

--- a/web/src/pages/InboxPage.test.tsx
+++ b/web/src/pages/InboxPage.test.tsx
@@ -11,8 +11,6 @@
 // component that just exposes an Accept button wired to its `onSubmit`, which
 // lets us drive the approve/rollback path without the real card's internals.
 
-import type * as UseConversationsModule from "@/hooks/useConversations";
-
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -49,7 +47,7 @@ vi.mock("@/components/blocks/ApprovalCard", () => ({
 }));
 
 vi.mock("@/hooks/useConversations", async (importActual) => ({
-  ...(await importActual<typeof UseConversationsModule>()),
+  ...(await importActual<typeof conversationsHook>()),
   useConversations: vi.fn(),
 }));
 vi.mock("@/hooks/useCommentInbox", () => ({ useCommentInbox: vi.fn() }));


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Enable 20 previously cleaned, high-signal Oxlint rules covering TypeScript safety, imports, React correctness, and control flow.
- Reuse the existing `web-oxlint` pre-commit hook, so the same zero-warning baseline is enforced locally and in CI.
- Consolidate two duplicate imports exposed by the final combined rule set.

**ELI5:** The cleanup removed existing warnings; this PR locks the doors so those warning patterns cannot return.

```text
developer change
      |
      v
pre-commit web-oxlint ----> CI web-oxlint
      |                          |
      +---- same 20-rule gate ---+
```

## Cleanup series

- Foundation: [#3504](https://github.com/omnigent-ai/omnigent/pull/3504), [#3542](https://github.com/omnigent-ai/omnigent/pull/3542), [#3600](https://github.com/omnigent-ai/omnigent/pull/3600)
- Safety and control flow: [#3573](https://github.com/omnigent-ai/omnigent/pull/3573), [#3601](https://github.com/omnigent-ai/omnigent/pull/3601), [#3602](https://github.com/omnigent-ai/omnigent/pull/3602), [#3603](https://github.com/omnigent-ai/omnigent/pull/3603), [#3604](https://github.com/omnigent-ai/omnigent/pull/3604), [#3605](https://github.com/omnigent-ai/omnigent/pull/3605), [#3606](https://github.com/omnigent-ai/omnigent/pull/3606), [#3607](https://github.com/omnigent-ai/omnigent/pull/3607), [#3608](https://github.com/omnigent-ai/omnigent/pull/3608), [#3609](https://github.com/omnigent-ai/omnigent/pull/3609)
- Type and import consistency: [#3610](https://github.com/omnigent-ai/omnigent/pull/3610), [#3611](https://github.com/omnigent-ai/omnigent/pull/3611), [#3612](https://github.com/omnigent-ai/omnigent/pull/3612), [#3613](https://github.com/omnigent-ai/omnigent/pull/3613), [#3614](https://github.com/omnigent-ai/omnigent/pull/3614), [#3615](https://github.com/omnigent-ai/omnigent/pull/3615), [#3616](https://github.com/omnigent-ai/omnigent/pull/3616), [#3617](https://github.com/omnigent-ai/omnigent/pull/3617), [#3618](https://github.com/omnigent-ai/omnigent/pull/3618), [#3619](https://github.com/omnigent-ai/omnigent/pull/3619), [#3621](https://github.com/omnigent-ai/omnigent/pull/3621), [#3623](https://github.com/omnigent-ai/omnigent/pull/3623)

## Test Plan

- `pnpm --filter web run lint`
- `pnpm --filter web run type-check`
- `pnpm --filter web exec vitest run` (4,786 passed, 3 expected failures, 1 skipped)
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The complete web unit suite and repository-wide pre-commit suite pass with the enforced rule set.