### PR TITLE
refactor(cli): type late-bound helper proxies

### DIFF
--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -53,22 +53,26 @@ if TYPE_CHECKING:
 _CLI_LOGIN_BRAND: dict[str, str] = {"claude": "Claude", "codex": "ChatGPT"}
 
 
-def _load_global_config(*a, **k):  # type: ignore[no-untyped-def]
+def _load_global_config() -> dict[str, Any]:  # type: ignore[explicit-any]
     import omnigent.cli as _cli
 
-    return _cli._load_global_config(*a, **k)
+    return _cli._load_global_config()
 
 
-def _save_global_config(*a, **k):  # type: ignore[no-untyped-def]
+def _save_global_config(  # type: ignore[explicit-any]
+    settings: collections.abc.Mapping[str, Any],
+    unset_keys: tuple[str, ...] = (),
+    deep_merge_keys: tuple[str, ...] = (),
+) -> None:
     import omnigent.cli as _cli
 
-    return _cli._save_global_config(*a, **k)
+    _cli._save_global_config(settings, unset_keys, deep_merge_keys)
 
 
-def _load_effective_config(*a, **k):  # type: ignore[no-untyped-def]
+def _load_effective_config() -> dict[str, Any]:  # type: ignore[explicit-any]
     import omnigent.cli as _cli
 
-    return _cli._load_effective_config(*a, **k)
+    return _cli._load_effective_config()
 
 
 # Node version hint shared by the preflight problem messages and surfaced

--- a/omnigent/cli_native.py
+++ b/omnigent/cli_native.py
@@ -20,6 +20,8 @@ scope, from the leaf :mod:`omnigent.cli_common`.
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
+from typing import ParamSpec, TypeVar
 
 import click
 
@@ -33,6 +35,18 @@ from omnigent.cli_common import (
 from omnigent.cli_common import (
     reject_native_on_windows as _reject_native_on_windows,
 )
+
+_Args = ParamSpec("_Args")
+_Return = TypeVar("_Return")
+
+
+def _late_bound(
+    getter: Callable[[], Callable[_Args, _Return]],
+) -> Callable[_Args, _Return]:
+    def proxy(*args: _Args.args, **kwargs: _Args.kwargs) -> _Return:
+        return getter()(*args, **kwargs)
+
+    return proxy
 
 
 def register_native_commands(cli: click.Group) -> None:
@@ -51,26 +65,15 @@ def register_native_commands(cli: click.Group) -> None:
     # Resolve each shared helper on the live module per call so a test's
     # monkeypatch of ``omnigent.cli.<helper>`` is honored. Binding the function
     # objects once here would capture the pre-patch originals.
-    def _build_kiro_launch_args(*a, **k):  # type: ignore[no-untyped-def]
-        return _cli._build_kiro_launch_args(*a, **k)
-
-    def _ensure_backend(*a, **k):  # type: ignore[no-untyped-def]
-        return _cli._ensure_backend(*a, **k)
-
-    def _load_effective_config(*a, **k):  # type: ignore[no-untyped-def]
-        return _cli._load_effective_config(*a, **k)
-
-    def _reject_reserved_kiro_resume_args(*a, **k):  # type: ignore[no-untyped-def]
-        return _cli._reject_reserved_kiro_resume_args(*a, **k)
-
-    def _resolve_auto_open_conversation_from_config(*a, **k):  # type: ignore[no-untyped-def]
-        return _cli._resolve_auto_open_conversation_from_config(*a, **k)
-
-    def _resolve_harness_startup_args(*a, **k):  # type: ignore[no-untyped-def]
-        return _cli._resolve_harness_startup_args(*a, **k)
-
-    def _split_resume_value(*a, **k):  # type: ignore[no-untyped-def]
-        return _cli._split_resume_value(*a, **k)
+    _build_kiro_launch_args = _late_bound(lambda: _cli._build_kiro_launch_args)
+    _ensure_backend = _late_bound(lambda: _cli._ensure_backend)
+    _load_effective_config = _late_bound(lambda: _cli._load_effective_config)
+    _reject_reserved_kiro_resume_args = _late_bound(lambda: _cli._reject_reserved_kiro_resume_args)
+    _resolve_auto_open_conversation_from_config = _late_bound(
+        lambda: _cli._resolve_auto_open_conversation_from_config
+    )
+    _resolve_harness_startup_args = _late_bound(lambda: _cli._resolve_harness_startup_args)
+    _split_resume_value = _late_bound(lambda: _cli._split_resume_value)
 
     @cli.command(
         context_settings={


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add a typed `ParamSpec` late-bound forwarder for native CLI helpers, preserving arbitrary positional/keyword forwarding and call-time lookup for monkeypatching.
- Type the config proxies with the same callable contracts as the helpers they forward to.
- Reduce full-tree mypy output by **99 errors** (`2119` → `2020`) and `no-untyped-call` errors by **99** (`110` → `11`) in the same environment.

**ELI5:** these proxies still pass every argument through unchanged; mypy now learns the contract from the real helper instead of treating the proxy as untyped.

```text
CLI command -> typed late-bound proxy(*args, **kwargs) -> live omnigent.cli helper
```

## Test Plan

- `uv run --no-sync ruff check omnigent/cli_native.py omnigent/cli_config.py`
- `uv run --no-sync mypy omnigent/cli_native.py omnigent/cli_config.py --no-pretty --show-error-codes` (no `cli_native.py` errors; only four unrelated existing `cli_config.py` errors)
- Full-tree same-environment comparison: `2119` → `2020` mypy errors; `110` → `11` `no-untyped-call` errors
- `uv run --no-sync pytest -q tests/cli/test_cli.py tests/cli/test_configure_models.py tests/test_harness_startup_config.py --deselect tests/cli/test_configure_models.py::test_overview_lists_kiro_row` (391 passed; deselected test also fails unchanged on `main` due the locally installed Kiro version)
- `uv run --no-sync pre-commit run --all-files`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing CLI/config tests exercise passthrough arguments, proxy call paths, and monkeypatch behavior.
