### PR TITLE
refactor(python): type remaining call boundaries

### DIFF
--- a/omnigent/onboarding/harness_auth.py
+++ b/omnigent/onboarding/harness_auth.py
@@ -23,7 +23,8 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Literal, NamedTuple
+from collections.abc import Callable
+from typing import Literal, NamedTuple, Protocol
 
 from omnigent.onboarding.configure_models import (
     build_gateway_provider_entry,
@@ -62,7 +63,16 @@ class StoreCredentialResult(NamedTuple):
     reason: str | None
 
 
-def _config_writer():  # type: ignore[no-untyped-def]
+class _ConfigSaver(Protocol):
+    def __call__(
+        self,
+        settings: dict[str, object],
+        *,
+        deep_merge_providers: bool,
+    ) -> None: ...
+
+
+def _config_writer() -> tuple[Callable[[], dict[str, object]], _ConfigSaver]:
     """Return a ``(load, save)`` pair for the global config on this host.
 
     Isolated so the daemon writes to the same ``~/.omnigent/config.yaml`` the
@@ -95,7 +105,12 @@ def _config_writer():  # type: ignore[no-untyped-def]
     return _load, _save
 
 
-def _pin_defaults_after_write(name: str, family: str, load, save) -> None:  # type: ignore[no-untyped-def]
+def _pin_defaults_after_write(
+    name: str,
+    family: str,
+    load: Callable[[], dict[str, object]],
+    save: _ConfigSaver,
+) -> None:
     """Point the right defaults at a just-written provider entry *name*.
 
     Two pins, each only when nothing already claims the slot (so we never
@@ -124,7 +139,7 @@ def _pin_defaults_after_write(name: str, family: str, load, save) -> None:  # ty
         set_default_provider,
     )
 
-    def _pin(scope: str, resolved) -> None:  # type: ignore[no-untyped-def]
+    def _pin(scope: str, resolved: object | None) -> None:
         if resolved is not None:
             return
         block = load().get("providers")

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -2309,7 +2309,7 @@ class _SessionsChatReplAdapter:
                 self._pending_local_skill_slash_commands.remove(command_key)
             self._is_streaming = False
 
-    async def cancel(self):
+    async def cancel(self) -> None:
         """
         Interrupt the running turn (if any).
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5412,7 +5412,7 @@ def create_runner_app(
                 return resolved, None
             return None, None
 
-        async def proxy_stream():
+        async def proxy_stream() -> AsyncIterator[bytes]:
             import asyncio as _asyncio
             import json as _json
 

--- a/omnigent/server/routes/device_auth.py
+++ b/omnigent/server/routes/device_auth.py
@@ -730,7 +730,10 @@ def _consent_html(
     self-contained (no JS framework) so it works regardless of the
     server's front-end build.
     """
-    esc = lambda s: html.escape(str(s or ""))  # noqa: E731
+
+    def esc(value: object) -> str:
+        return html.escape(str(value or ""))
+
     # Requesting client's identifier, defaulting to a neutral label when it
     # didn't identify itself.
     app_name = esc(client_id) if client_id else "An application"


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Type the remaining callable boundaries reported by mypy: the harness-auth config callbacks, device-auth HTML escaper, REPL cancel method, and runner byte stream.
- Replace the untyped HTML lambda with a named typed helper and describe the config writer's callback contract with a protocol.
- Remove **12 mypy errors** (`2119` → `2107`) with no added diagnostics, including all **11 remaining `no-untyped-call` errors** on current `main`.

Follow-up to #3633; this PR is independent and can merge in either order.

**ELI5:** these functions already had stable input/output shapes; this change records those shapes so mypy can safely follow calls through them.

```text
untyped callback / coroutine / stream -> explicit callable contract -> typed caller
```

## Test Plan

- Same-environment full-tree mypy comparison: `2119` → `2107`; `no-untyped-call` `110` → `99`; no added diagnostics
- `uv run --no-sync ruff check omnigent/onboarding/harness_auth.py omnigent/server/routes/device_auth.py omnigent/repl/_repl.py omnigent/runner/app.py`
- `uv run --no-sync pytest -q tests/onboarding/test_harness_auth.py tests/server/test_device_auth.py tests/repl/test_sessions_chat_adapter.py tests/runner/test_app_sessions_native_events_lifecycle.py tests/runner/test_app_sessions_native_workflow_messages.py` (132 passed)
- `uv run --no-sync pre-commit run --all-files`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing tests exercise credential writes, device consent rendering, REPL sessions, and runner event streaming.
