### PR TITLE
refactor(llms): close package typing gaps

### DIFF
--- a/omnigent/llms/_usage_observer.py
+++ b/omnigent/llms/_usage_observer.py
@@ -48,9 +48,9 @@ import json
 import logging
 import os
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Protocol, TypedDict
 
 logger = logging.getLogger(__name__)
 
@@ -68,8 +68,20 @@ class UsageObserver(Protocol):
     ) -> None: ...
 
 
+class _ModelUsage(TypedDict):
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    calls: int
+
+
+class _UsageBucket(_ModelUsage):
+    models: list[str]
+    by_model: dict[str, _ModelUsage]
+
+
 _OBSERVERS: list[UsageObserver] = []
-_RECORDS: dict[str, dict[str, Any]] = {}  # type: ignore[explicit-any]
+_RECORDS: dict[str, _UsageBucket] = {}
 _CURRENT_NODEID: str | None = None
 # Serializes mutations of ``_RECORDS`` so notify() calls from concurrent
 # threads (or asyncio executors backed by threads) don't lose updates on
@@ -129,7 +141,7 @@ def add_observer(callback: UsageObserver) -> Callable[[], None]:
 def notify_from_dict(
     *,
     model: str | None,
-    usage: dict[str, Any] | None,  # type: ignore[explicit-any]
+    usage: Mapping[str, object] | None,
 ) -> None:
     """Convenience wrapper for callers that already have a ``usage`` dict.
 
@@ -138,14 +150,20 @@ def notify_from_dict(
     standard keys and calls :func:`notify`. ``None`` and empty dicts are
     no-ops.
     """
-    if not isinstance(usage, dict):
+    if not isinstance(usage, Mapping):
         return
     notify(
         model=model,
-        input_tokens=int(usage.get("input_tokens") or 0),
-        output_tokens=int(usage.get("output_tokens") or 0),
-        total_tokens=int(usage.get("total_tokens") or 0),
+        input_tokens=_usage_int(usage.get("input_tokens")),
+        output_tokens=_usage_int(usage.get("output_tokens")),
+        total_tokens=_usage_int(usage.get("total_tokens")),
     )
+
+
+def _usage_int(value: object) -> int:
+    if isinstance(value, (int, float, str)):
+        return int(value or 0)
+    return 0
 
 
 def notify(
@@ -290,13 +308,15 @@ def _write_records() -> None:
             totals["output_tokens"] += bucket["output_tokens"]
             totals["total_tokens"] += bucket["total_tokens"]
             totals["calls"] += bucket["calls"]
-            for model, per_model in bucket.get("by_model", {}).items():
+            for model, per_model in bucket["by_model"].items():
                 model_totals = totals_by_model.setdefault(
                     model,
                     {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0, "calls": 0},
                 )
-                for k in model_totals:
-                    model_totals[k] += per_model[k]
+                model_totals["input_tokens"] += per_model["input_tokens"]
+                model_totals["output_tokens"] += per_model["output_tokens"]
+                model_totals["total_tokens"] += per_model["total_tokens"]
+                model_totals["calls"] += per_model["calls"]
         payload = json.dumps(
             {"totals": totals, "totals_by_model": totals_by_model, "by_test": _RECORDS},
             indent=2,

--- a/omnigent/llms/adapters/_content.py
+++ b/omnigent/llms/adapters/_content.py
@@ -11,12 +11,14 @@ from __future__ import annotations
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import TypeVar, cast
 
 _INLINE_BASE64_DATA_URI = re.compile(
     r"data:([^;,\s]*)(?:;[^;,\r\n]*)*;base64,[ \t]?([A-Za-z0-9+/=_-]+)",
     re.IGNORECASE,
 )
+
+_Value = TypeVar("_Value")
 
 
 @dataclass
@@ -62,9 +64,9 @@ def parse_data_uri(uri: str) -> DataUriParts | None:
 
 
 def redact_inline_data_uris(
-    value: Any,  # type: ignore[explicit-any]
+    value: _Value,
     marker: Callable[[str, int], str],
-) -> Any:  # type: ignore[explicit-any]
+) -> _Value:
     """Recursively replace inline base64 data URIs with compact markers.
 
     Dict keys and all non-data-URI values are preserved. String values may
@@ -77,12 +79,18 @@ def redact_inline_data_uris(
     :returns: A copy with inline base64 payloads redacted.
     """
     if isinstance(value, str):
-        return _INLINE_BASE64_DATA_URI.sub(
-            lambda match: marker(match.group(1), len(match.group(2))),
-            value,
+        return cast(
+            _Value,
+            _INLINE_BASE64_DATA_URI.sub(
+                lambda match: marker(match.group(1), len(match.group(2))),
+                value,
+            ),
         )
     if isinstance(value, list):
-        return [redact_inline_data_uris(item, marker) for item in value]
+        return cast(_Value, [redact_inline_data_uris(item, marker) for item in value])
     if isinstance(value, dict):
-        return {key: redact_inline_data_uris(item, marker) for key, item in value.items()}
+        return cast(
+            _Value,
+            {key: redact_inline_data_uris(item, marker) for key, item in value.items()},
+        )
     return value

--- a/omnigent/llms/adapters/anthropic.py
+++ b/omnigent/llms/adapters/anthropic.py
@@ -239,7 +239,8 @@ async def _get_anthropic_model_metadata(
     cache_key = (base_url, model, credential_partition)
     with _MODEL_METADATA_CACHE_LOCK:
         if cache_key in _MODEL_METADATA_CACHE:
-            return _MODEL_METADATA_CACHE[cache_key]
+            cached: ModelMetadata = _MODEL_METADATA_CACHE[cache_key]
+            return cached
         task = _MODEL_METADATA_IN_FLIGHT.get(cache_key)
         if task is None:
             task = asyncio.create_task(

--- a/omnigent/llms/adapters/openai.py
+++ b/omnigent/llms/adapters/openai.py
@@ -155,9 +155,15 @@ class OpenAICompatibleAdapter(BaseAdapter):
         # headers threaded through connection_params. MAS routes CP serving-endpoint
         # calls through the Barnacle forward proxy for CP→CP mTLS, which needs a
         # `host` header + s2s auth headers rather than a bearer token.
-        extra_headers = params.get("extra_headers")
-        if extra_headers:
-            headers = {**headers, **extra_headers}
+        extra_headers: object = params.get("extra_headers")
+        if isinstance(extra_headers, dict):
+            headers.update(
+                {
+                    key: value
+                    for key, value in extra_headers.items()
+                    if isinstance(key, str) and isinstance(value, str)
+                }
+            )
 
         if stream:
             effective_timeout = timeout if timeout is not None else _STREAM_TIMEOUT

--- a/omnigent/llms/context_window.py
+++ b/omnigent/llms/context_window.py
@@ -8,9 +8,11 @@ conservative 128K fallback.
 
 from __future__ import annotations
 
+import importlib
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol, cast
 
 from omnigent.onboarding.providers import ModelInfo, find_catalog_models
 
@@ -18,6 +20,10 @@ _DEFAULT_CONTEXT_WINDOW: int = 128_000
 
 _ANTHROPIC_1M_BETA_SUFFIX = "[1m]"
 _ANTHROPIC_1M_BETA_WINDOW = 1_000_000
+
+
+class _LiteLLM(Protocol):
+    def get_model_info(self, model: str) -> Mapping[str, object]: ...
 
 
 def _encoded_context_window(model: str) -> int | None:
@@ -84,14 +90,14 @@ def get_model_context_window(model: str) -> int:
     if catalog_window is not None:
         return catalog_window
     try:
-        import litellm
+        litellm = cast(_LiteLLM, importlib.import_module("litellm"))
     except ImportError:
         return _DEFAULT_CONTEXT_WINDOW
     try:
         info = litellm.get_model_info(model)
         if info:
             limit = info.get("max_input_tokens")
-            if limit:
+            if isinstance(limit, (int, float, str)) and limit:
                 return int(limit)
     except Exception:
         pass
@@ -100,7 +106,7 @@ def get_model_context_window(model: str) -> int:
             info = litellm.get_model_info(f"databricks/{model}")
             if info:
                 limit = info.get("max_input_tokens")
-                if limit:
+                if isinstance(limit, (int, float, str)) and limit:
                     return int(limit)
         except Exception:
             pass


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Make `omnigent.llms` fully mypy-clean under its current package policy.
- Type recursive content redaction and token-usage buckets, load optional LiteLLM metadata through a typed module protocol, validate forwarded OpenAI headers, and pin the Anthropic metadata cache return type.
- Remove all **7 LLM package errors** (`2119` → `2112` full-tree) with no added diagnostics.

Python typing cleanup series: #3633, #3634, #3635.

**ELI5:** several dynamic boundaries had known shapes but mypy could not see them. This records those shapes and validates optional/dynamic values before use.

```text
nested content / usage JSON / optional module / cache -> typed boundary -> adapter logic
```

## Test Plan

- `uv run --no-sync mypy omnigent/llms --no-pretty --show-error-codes` (zero LLM diagnostics; only unrelated imported generated-protobuf diagnostics remain)
- Same-environment full-tree mypy comparison: `2119` → `2112`; no added diagnostics
- `uv run --no-sync pytest -q tests/llms/test_context_window.py tests/llms/test_content_helpers.py tests/llms/test_anthropic_adapter.py tests/llms/test_usage_observer.py tests/llms/test_openai_adapter.py` (135 passed)
- `uv run --no-sync pre-commit run --all-files`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing tests cover content redaction, usage recording, context-window fallback, Anthropic metadata caching, and OpenAI request handling.
