### PR TITLE
perf(conversation-store): speed up list_items DB query

### DIFF
--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -20,7 +20,7 @@ from sqlalchemy import (
     text,
     update,
 )
-from sqlalchemy.orm import QueryableAttribute, Session, aliased
+from sqlalchemy.orm import QueryableAttribute, Session, aliased, load_only
 from sqlalchemy.sql.selectable import Subquery
 
 from omnigent._wrapper_labels import UI_MODE_LABEL_KEY, WRAPPER_LABEL_KEY
@@ -1768,17 +1768,40 @@ class SqlAlchemyConversationStore(ConversationStore):
         with self._conv_session() as session:
             is_asc = order == "asc"
             sort_fn = asc if is_asc else desc
-            stmt = select(SqlConversationItem).where(
-                SqlConversationItem.workspace_id == current_workspace_id(),
-                SqlConversationItem.conversation_id == conversation_id,
+            # Load only the columns _to_item reads. search_text is a wide Text
+            # column (roughly mirrors the message body) that this read path never
+            # touches; on Postgres it is TOAST-ed, so omitting it skips a detoast
+            # and roughly halves the bytes pulled per row on a chatty conversation.
+            stmt = (
+                select(SqlConversationItem)
+                .options(
+                    load_only(
+                        SqlConversationItem.id,
+                        SqlConversationItem.type,
+                        SqlConversationItem.status,
+                        SqlConversationItem.response_id,
+                        SqlConversationItem.created_at,
+                        SqlConversationItem.data,
+                        SqlConversationItem.created_by,
+                    )
+                )
+                .where(
+                    SqlConversationItem.workspace_id == current_workspace_id(),
+                    SqlConversationItem.conversation_id == conversation_id,
+                )
             )
             if type is not None:
                 stmt = stmt.where(SqlConversationItem.type == encode_item_type(type))
             if after:
+                # Scope the cursor lookup to conversation_id so it lands on the
+                # (workspace_id, conversation_id, id) primary key as a point
+                # lookup. Without it, (workspace_id, id) leads no index and the
+                # subquery degrades to a workspace-wide scan every paginated page.
                 sub = (
                     select(SqlConversationItem.position)
                     .where(
                         SqlConversationItem.workspace_id == current_workspace_id(),
+                        SqlConversationItem.conversation_id == conversation_id,
                         SqlConversationItem.id == after,
                     )
                     .scalar_subquery()
@@ -1794,6 +1817,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     select(SqlConversationItem.position)
                     .where(
                         SqlConversationItem.workspace_id == current_workspace_id(),
+                        SqlConversationItem.conversation_id == conversation_id,
                         SqlConversationItem.id == before,
                     )
                     .scalar_subquery()

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -1092,6 +1092,28 @@ def test_list_items_before_cursor(
     assert [it.id for it in page.data] == [items[i].id for i in range(3)]
 
 
+def test_list_items_cursor_scoped_to_conversation(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A cursor id from another conversation resolves to no position.
+
+    The cursor subquery is scoped to conversation_id so it stays a
+    primary-key point lookup. A foreign cursor id therefore matches no
+    row, the scalar subquery is NULL, and the position comparison yields
+    an empty page rather than silently using the other conversation's
+    position as a cutoff.
+    """
+    conv = conversation_store.create_conversation()
+    other = conversation_store.create_conversation()
+    _make_5_items(conversation_store, conv.id)
+    other_items = _make_5_items(conversation_store, other.id)
+
+    after_page = conversation_store.list_items(conv.id, after=other_items[1].id)
+    assert after_page.data == []
+    before_page = conversation_store.list_items(conv.id, before=other_items[1].id)
+    assert before_page.data == []
+
+
 # ── Conversation ID / response ID lookups ────────────
 
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

`GET /v1/sessions/{id}/items` — the web chat transcript read — delegates to `SqlAlchemyConversationStore.list_items`. Two localized optimizations to that query:

- **Cursor subqueries are now index-aligned.** The `after`/`before` position lookups now scope to `conversation_id`, so they land on the `(workspace_id, conversation_id, id)` primary key as point lookups. Previously they filtered on `(workspace_id, id)` — which leads no index — so every paginated page degraded to a workspace-wide scan.
- **`search_text` is no longer loaded.** The base `select` uses `load_only(...)` restricted to the seven columns `_to_item` actually reads. The wide `search_text` `Text` column (roughly the message body) is skipped; on Postgres it's TOAST-ed, so omitting it drops a detoast and roughly halves the bytes pulled per row on a chatty conversation.

Scoping the cursor to the conversation also fixes a latent correctness edge: a cursor id belonging to a *different* conversation previously resolved its position workspace-wide and applied it as a nonsensical cutoff. It now resolves to `NULL` and correctly returns an empty page.

## Test Plan

```bash
~/omnigent/.venv/bin/python -m pytest \
  tests/stores/test_conversation_store.py \
  tests/stores/test_conversation_store_split_db.py \
  tests/server/integration/test_sessions_endpoints.py -q
```

- `test_conversation_store.py` + `test_conversation_store_split_db.py`: 205 passed (incl. the new `test_list_items_cursor_scoped_to_conversation`).
- `test_sessions_endpoints.py` items/pagination cases: 11 passed.
- `ruff format --check` and `ruff check` clean on both files.

## Demo

N/A — non-visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new `test_list_items_cursor_scoped_to_conversation` guards the cursor-scoping behavior (foreign cursor id → empty page). Existing pagination/order/type-filter tests cover the unchanged read paths; existing session-endpoint tests cover the HTTP handler.

This pull request and its description were written by Isaac.