### PR TITLE
refactor(policies): type dynamic policy boundaries

### DIFF
--- a/omnigent/policies/builtins/context.py
+++ b/omnigent/policies/builtins/context.py
@@ -183,7 +183,12 @@ def detect_task_switch(
             return None
 
         state = event.get("session_state") or {}
-        history: list[str] = state.get(_TASK_SWITCH_HISTORY_KEY) or []
+        raw_history = state.get(_TASK_SWITCH_HISTORY_KEY)
+        history = (
+            [item for item in raw_history if isinstance(item, str)]
+            if isinstance(raw_history, list)
+            else []
+        )
 
         # Slide the window: append new message, keep last history_window entries.
         updated_history = [*history, new_message[:500]][-history_window:]

--- a/omnigent/policies/builtins/cost.py
+++ b/omnigent/policies/builtins/cost.py
@@ -533,7 +533,10 @@ def cost_budget(
             crossed = max((t for t in thresholds if cost >= t), default=None)
             if crossed is not None:
                 state = event.get("session_state") or {}
-                approved_up_to = float(state.get(_ASK_APPROVED_KEY, 0.0) or 0.0)
+                approved_value = state.get(_ASK_APPROVED_KEY, 0.0)
+                approved_up_to = (
+                    float(approved_value) if isinstance(approved_value, int | float | str) else 0.0
+                )
                 if crossed > approved_up_to:
                     limit_str = f" (limit ${max_cost_usd:.2f})" if max_cost_usd is not None else ""
                     return {
@@ -855,7 +858,10 @@ def subagent_cost_budget(
             crossed = max((t for t in thresholds if cost >= t), default=None)
             if crossed is not None:
                 state = event.get("session_state") or {}
-                approved_up_to = float(state.get(_SUBAGENT_ASK_APPROVED_KEY, 0.0) or 0.0)
+                approved_value = state.get(_SUBAGENT_ASK_APPROVED_KEY, 0.0)
+                approved_up_to = (
+                    float(approved_value) if isinstance(approved_value, int | float | str) else 0.0
+                )
                 if crossed > approved_up_to:
                     limit_str = f" (limit ${max_cost_usd:.2f})" if max_cost_usd else ""
                     return {

--- a/omnigent/policies/builtins/risk_score.py
+++ b/omnigent/policies/builtins/risk_score.py
@@ -235,9 +235,11 @@ def _current_score(event: PolicyEvent, cfg: _RiskCfg) -> int:
     :returns: The effective integer score (≥ the actor's offset).
     """
     state = event.get("session_state") or {}
-    accumulated = int(state.get(cfg.state_key, 0))
-    actor = (event.get("context") or {}).get("actor") or {}
-    run_as = actor.get("run_as") or ""
+    accumulated_value = state.get(cfg.state_key, 0)
+    accumulated = int(accumulated_value) if isinstance(accumulated_value, int | float | str) else 0
+    context = event.get("context")
+    actor = context.get("actor") if context is not None else None
+    run_as = actor.get("run_as", "") if actor is not None else ""
     actor_offset = cfg.initial_scores_by_actor.get(run_as, 0)
     return actor_offset + accumulated
 

--- a/omnigent/policies/builtins/routing.py
+++ b/omnigent/policies/builtins/routing.py
@@ -379,7 +379,8 @@ def intent_based_authorization() -> PolicyCallable:
             return None
 
         state = event.get("session_state") or {}
-        intent: str = state.get(_INTENT_KEY, "")
+        intent_value = state.get(_INTENT_KEY, "")
+        intent = intent_value if isinstance(intent_value, str) else ""
         if not intent:
             return None  # no intent captured yet — fail open
 

--- a/omnigent/policies/builtins/safety.py
+++ b/omnigent/policies/builtins/safety.py
@@ -103,7 +103,8 @@ def max_tool_calls_per_session(limit: int = 100) -> PolicyCallable:
         if event.get("type") != "tool_call":
             return _ALLOW
         state = event.get("session_state") or {}
-        count = int(state.get("_policy_tool_call_count", 0))
+        count_value = state.get("_policy_tool_call_count", 0)
+        count = int(count_value) if isinstance(count_value, int | float | str) else 0
         if count >= limit:
             return {
                 "result": "DENY",
@@ -175,7 +176,12 @@ def detect_loop(window: int = 10, threshold: int = 3) -> PolicyCallable:
         h = _args_hash(tool_name, arguments)
 
         state = event.get("session_state") or {}
-        recent: list[str] = list(state.get(_LOOP_STATE_KEY) or [])
+        recent_value = state.get(_LOOP_STATE_KEY)
+        recent = (
+            [item for item in recent_value if isinstance(item, str)]
+            if isinstance(recent_value, list)
+            else []
+        )
 
         recent.append(h)
         # Trim to sliding window.

--- a/omnigent/policies/function.py
+++ b/omnigent/policies/function.py
@@ -41,10 +41,11 @@ from __future__ import annotations
 import asyncio
 import importlib
 import inspect
-from collections.abc import Callable
-from typing import Any
+from collections.abc import Awaitable, Callable
+from typing import Protocol, cast
 
 from omnigent.policies.base import Policy
+from omnigent.policies.schema import PolicyEvent
 from omnigent.policies.types import EvaluationContext, PolicyResult
 from omnigent.spec.types import (
     FunctionPolicySpec,
@@ -54,10 +55,9 @@ from omnigent.spec.types import (
     StateUpdateAction,
 )
 
-# Type alias for what a resolved FunctionPolicy callable can be.
-# Distinguishing form handled at call time — the adapter wraps
-# each variant into a uniform async call.
-_PolicyCallable = Callable[..., Any]
+
+class _DynamicCallable(Protocol):
+    def __call__(self, *args: object, **kwargs: object) -> object: ...
 
 
 def _phase_to_event_type(phase: Phase) -> str:
@@ -96,7 +96,7 @@ class FunctionPolicy(Policy):
     def __init__(
         self,
         spec: FunctionPolicySpec,
-        callable_obj: _PolicyCallable,
+        callable_obj: object,
     ) -> None:
         """
         Wrap a resolved callable in the Policy contract.
@@ -106,15 +106,15 @@ class FunctionPolicy(Policy):
             unwrapped from any factory).
         """
         self.spec = spec
-        self._callable = callable_obj
-        self._is_async = inspect.iscoroutinefunction(callable_obj)
+        self._callable = cast(_DynamicCallable, callable_obj)
+        self._is_async = inspect.iscoroutinefunction(self._callable)
         self._arity = _callable_arity(callable_obj)
-        self._config: dict[str, Any] = dict(spec.config) if spec.config else {}
+        self._config: dict[str, str] = dict(spec.config) if spec.config else {}
 
     async def evaluate(
         self,
         ctx: EvaluationContext,
-        context: dict[str, Any],  # noqa: ARG002 — engine contract; callable uses event.context instead
+        context: dict[str, object],  # noqa: ARG002 — engine contract; callable uses event.context instead
     ) -> PolicyResult:
         """
         Build an event dict and invoke the underlying callable.
@@ -170,7 +170,7 @@ class FunctionPolicy(Policy):
     async def _call(
         self,
         ctx: EvaluationContext,
-    ) -> Any:
+    ) -> object:
         """
         Build an event dict and dispatch the callable.
 
@@ -179,17 +179,17 @@ class FunctionPolicy(Policy):
             ``{"result": ..., "reason": ...}`` dict).
         """
         event = _build_event(ctx)
-        args: tuple[Any, ...]
+        args: tuple[object, ...]
         if self._arity >= 2:
             args = (event, self._config)
         else:
             args = (event,)
         if self._is_async:
-            return await self._callable(*args)
+            return await cast(Awaitable[object], self._callable(*args))
         return await asyncio.to_thread(self._callable, *args)
 
 
-def _build_event(ctx: EvaluationContext) -> dict[str, Any]:
+def _build_event(ctx: EvaluationContext) -> PolicyEvent:
     """
     Build an ``event`` dict from an :class:`EvaluationContext`.
 
@@ -214,7 +214,7 @@ def _build_event(ctx: EvaluationContext) -> dict[str, Any]:
     :param ctx: The evaluation context populated by the caller.
     :returns: Event dict ready for the callable.
     """
-    event: dict[str, Any] = {
+    event: dict[str, object] = {
         "type": _phase_to_event_type(ctx.phase),
         "target": ctx.tool_name,
         "data": ctx.content,
@@ -252,7 +252,7 @@ def _build_event(ctx: EvaluationContext) -> dict[str, Any]:
     }
     if ctx.request_data is not None:
         event["request_data"] = ctx.request_data
-    return event
+    return cast(PolicyEvent, event)
 
 
 def resolve_function_policy(spec: FunctionPolicySpec) -> FunctionPolicy:
@@ -281,7 +281,7 @@ def resolve_function_policy(spec: FunctionPolicySpec) -> FunctionPolicy:
             f"FunctionPolicy {spec.name!r} has no function reference; "
             f"parser should have rejected this at spec load.",
         )
-    target = _resolve_dotted_path(func_ref.path)
+    target = cast(_DynamicCallable, _resolve_dotted_path(func_ref.path))
     # ``arguments is not None`` distinguishes factory form (dict,
     # possibly empty ``{}``) from direct-callable form (``None``).
     # Using truthiness (``if func_ref.arguments``) would treat
@@ -319,7 +319,7 @@ def resolve_function_policy(spec: FunctionPolicySpec) -> FunctionPolicy:
     return FunctionPolicy(spec, callable_obj)
 
 
-def _resolve_dotted_path(path: str) -> Any:
+def _resolve_dotted_path(path: str) -> object:
     """
     Resolve a ``module.sub.attr`` style path to its attribute.
 
@@ -342,10 +342,10 @@ def _resolve_dotted_path(path: str) -> Any:
         )
     module_path, attr = path.rsplit(".", 1)
     module = importlib.import_module(module_path)
-    return getattr(module, attr)
+    return cast(object, getattr(module, attr))
 
 
-def _callable_arity(fn: _PolicyCallable) -> int:
+def _callable_arity(fn: object) -> int:
     """
     Count the positional parameters a callable accepts.
 
@@ -364,7 +364,7 @@ def _callable_arity(fn: _PolicyCallable) -> int:
         + ``POSITIONAL_OR_KEYWORD``).
     """
     try:
-        sig = inspect.signature(fn)
+        sig = inspect.signature(cast(_DynamicCallable, fn))
     except (TypeError, ValueError):
         return 1
     positional_kinds = (
@@ -374,7 +374,7 @@ def _callable_arity(fn: _PolicyCallable) -> int:
     return sum(1 for p in sig.parameters.values() if p.kind in positional_kinds)
 
 
-def _has_no_required_params(fn: _PolicyCallable) -> bool:
+def _has_no_required_params(fn: object) -> bool:
     """
     Check whether a callable has zero required positional params.
 
@@ -393,7 +393,7 @@ def _has_no_required_params(fn: _PolicyCallable) -> bool:
         default value.
     """
     try:
-        sig = inspect.signature(fn)
+        sig = inspect.signature(cast(_DynamicCallable, fn))
     except (TypeError, ValueError):
         return False
     positional_kinds = (
@@ -414,7 +414,7 @@ def make_fixed_action_callable(
     set_labels: dict[str, str] | None = None,
     on_phases: list[str] | None = None,
     on_tools: list[str] | None = None,
-) -> _PolicyCallable:
+) -> Callable[[PolicyEvent], dict[str, object] | None]:
     """
     Factory that returns a policy callable emitting a fixed decision.
 
@@ -449,7 +449,7 @@ def make_fixed_action_callable(
     frozen_phases = set(on_phases) if on_phases else None
     frozen_tools = set(on_tools) if on_tools else None
 
-    def _fixed(event: dict[str, Any]) -> dict[str, Any] | None:
+    def _fixed(event: PolicyEvent) -> dict[str, object] | None:
         """Return the fixed decision, or None to abstain."""
         # Phase gate: abstain if the event type is not in the
         # declared phases.
@@ -460,7 +460,7 @@ def make_fixed_action_callable(
         if frozen_tools is not None:
             if event.get("target") not in frozen_tools:
                 return None
-        result: dict[str, Any] = {"result": action, "reason": reason}
+        result: dict[str, object] = {"result": action, "reason": reason}
         if frozen_labels:
             result["set_labels"] = frozen_labels
         return result
@@ -468,7 +468,7 @@ def make_fixed_action_callable(
     return _fixed
 
 
-def _coerce_to_policy_result(raw: Any, *, spec_name: str) -> PolicyResult:
+def _coerce_to_policy_result(raw: object, *, spec_name: str) -> PolicyResult:
     """
     Normalize a FunctionPolicy callable's return value.
 
@@ -538,7 +538,7 @@ def _coerce_to_policy_result(raw: Any, *, spec_name: str) -> PolicyResult:
 
 
 def _policy_result_from_dict(
-    raw: dict[str, Any],
+    raw: dict[str, object],
     *,
     spec_name: str,
 ) -> PolicyResult:
@@ -578,9 +578,10 @@ def _policy_result_from_dict(
         ) from exc
     raw_state_updates = raw.get("state_updates")
     raw_set_labels = raw.get("set_labels")
+    reason = raw.get("reason")
     return PolicyResult(
         action=action,
-        reason=raw.get("reason"),
+        reason=cast("str | None", reason),
         data=raw.get("data"),
         state_updates=_coerce_state_updates(raw_state_updates, spec_name=spec_name),
         set_labels=dict(raw_set_labels) if isinstance(raw_set_labels, dict) else None,
@@ -588,7 +589,7 @@ def _policy_result_from_dict(
 
 
 def _coerce_state_updates(
-    raw: Any,
+    raw: object,
     *,
     spec_name: str,
 ) -> list[StateUpdate] | None:

--- a/omnigent/policies/schema.py
+++ b/omnigent/policies/schema.py
@@ -35,7 +35,7 @@ Factory form (with ``factory_params``)::
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Protocol, TypedDict
+from typing import TYPE_CHECKING, Literal, Protocol, TypedDict, cast
 
 if TYPE_CHECKING:
     from omnigent.policies.types import PolicyLLMClient
@@ -136,6 +136,8 @@ class EventContext(TypedDict, total=False):
 
     :param actor: The identity of the user driving the session.
     :param usage: Cumulative LLM token usage for the session.
+    :param subtree_usage: Cumulative LLM usage for this conversation and
+        its descendants. Present when subagent cost enforcement is enabled.
     :param user_daily_cost: The session owner's per-UTC-day cost
         rollup (``cost_usd`` / ``ask_approved_usd``). Present only when
         the per-user daily cost-budget policy is configured; read via
@@ -162,6 +164,7 @@ class EventContext(TypedDict, total=False):
 
     actor: ActorContext
     usage: UsageContext
+    subtree_usage: UsageContext
     user_daily_cost: UserDailyCostContext
     # ``str | None`` (not ``str``): the value is ``ctx.model``, which is
     # ``None`` when the engine could not determine a model — the dict carries
@@ -231,11 +234,11 @@ class PolicyEvent(TypedDict, total=False):
         "llm_response",
     ]
     target: str | None
-    data: Any
+    data: object
     context: EventContext
-    session_state: dict[str, Any]
+    session_state: dict[str, object]
     llm_client: PolicyLLMClient | None
-    request_data: Any
+    request_data: object
 
 
 # ── Response (output from callable) ──────────────────────────────────────────
@@ -254,7 +257,7 @@ class StateUpdateEntry(TypedDict, total=False):
 
     key: str
     action: Literal["set", "increment", "delete", "append"]
-    value: Any
+    value: object
 
 
 class PolicyResponse(TypedDict, total=False):
@@ -299,7 +302,7 @@ class PolicyResponse(TypedDict, total=False):
 
     result: Literal["ALLOW", "DENY", "ASK"]
     reason: str
-    data: Any
+    data: object
     state_updates: list[StateUpdateEntry]
     set_labels: dict[str, str]
 
@@ -347,7 +350,7 @@ class PolicyCallableWithConfig(Protocol):
 # ── REQUEST-phase data helpers ───────────────────────────────────────────────
 
 
-def request_user_text(data: Any) -> str:
+def request_user_text(data: object) -> str:
     """Extract the user's typed text from a REQUEST-phase ``event["data"]``.
 
     Request ``data`` is a dict ``{"user_content", "attachments"}`` from the
@@ -374,7 +377,7 @@ def request_user_text(data: Any) -> str:
     return ""
 
 
-def request_attachments(data: Any) -> list[dict[str, Any]]:
+def request_attachments(data: object) -> list[dict[str, object]]:
     """Return the text attachments on a REQUEST-phase ``event["data"]``.
 
     Each entry is ``{"filename", "content_type", "text"}`` — the decoded text of
@@ -387,7 +390,11 @@ def request_attachments(data: Any) -> list[dict[str, Any]]:
     if isinstance(data, dict):
         attachments = data.get("attachments")
         if isinstance(attachments, list):
-            return [att for att in attachments if isinstance(att, dict)]
+            return [
+                cast("dict[str, object]", attachment)
+                for attachment in attachments
+                if isinstance(attachment, dict)
+            ]
     return []
 
 

--- a/omnigent/policies/types.py
+++ b/omnigent/policies/types.py
@@ -29,10 +29,29 @@ and :class:`PolicyResult` from here (or from the
 from __future__ import annotations
 
 import logging
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Protocol, cast
 
 from omnigent.spec.types import Phase, PolicyAction, StateUpdate
+
+if TYPE_CHECKING:
+    from omnigent.llms.client import Client
+    from omnigent.llms.types import Response, ResponseStreamEvent
+
+
+class _CreateResponse(Protocol):
+    async def __call__(
+        self,
+        *,
+        input: list[dict[str, object]],
+        model: str,
+        connection_params: dict[str, str] | None,
+        timeout: int | None,
+        instructions: str | None,
+        **kwargs: object,
+    ) -> Response | AsyncIterator[ResponseStreamEvent]: ...
+
 
 _log = logging.getLogger(__name__)
 
@@ -185,18 +204,18 @@ class EvaluationContext:
     """
 
     phase: Phase
-    content: Any
+    content: object
     tool_name: str | None = None
     actor: dict[str, str] | None = None
-    request_data: Any = None
-    session_state: dict[str, Any] | None = None
+    request_data: object | None = None
+    session_state: dict[str, object] | None = None
     usage: dict[str, float] | None = None
     subtree_usage: dict[str, float] | None = None
     user_daily_cost: dict[str, float | str] | None = None
     model: str | None = None
     harness: str | None = None
     labels: dict[str, str] | None = None
-    llm_client: Any = None  # PolicyLLMClient | None — Any to avoid import cycle
+    llm_client: PolicyLLMClient | None = None
 
 
 @dataclass(frozen=True)
@@ -259,7 +278,7 @@ class PolicyResult:
     reason: str | None = None
     set_labels: dict[str, str] | None = None
     deciding_policies: list[str] | None = None
-    data: Any = None
+    data: object | None = None
     state_updates: list[StateUpdate] | None = None
 
     @property
@@ -315,7 +334,7 @@ class ElicitationRequest:
     phase: str
     policy_names: list[str]
     content_preview: str
-    requested_schema: dict[str, Any] = field(default_factory=dict)
+    requested_schema: dict[str, object] = field(default_factory=dict)
 
     @property
     def policy_name(self) -> str:
@@ -362,7 +381,7 @@ class PolicyLLMClient:
         ``_connection`` is ``None``).
     """
 
-    _client: Any  # omnigent.llms.client.Client — Any to avoid import cycle
+    _client: Client
     _model: str
     _connection: dict[str, str] | None
     _request_timeout: int
@@ -371,10 +390,10 @@ class PolicyLLMClient:
     async def create(
         self,
         *,
-        input: list[dict[str, Any]],
+        input: list[dict[str, object]],
         instructions: str | None = None,
-        **kwargs: Any,
-    ) -> Any:
+        **kwargs: object,
+    ) -> Response | AsyncIterator[ResponseStreamEvent]:
         """
         Call the server-level LLM with pre-bound model and credentials.
 
@@ -406,15 +425,19 @@ class PolicyLLMClient:
             candidate model fails. Propagates the primary model's
             exception when no fallbacks are configured.
         """
-        connection_params = kwargs.pop("connection_params", self._connection)
-        timeout = kwargs.pop("timeout", self._request_timeout)
+        create_response = cast(_CreateResponse, self._client.responses.create)
+        connection_params = cast(
+            "dict[str, str] | None",
+            kwargs.pop("connection_params", self._connection),
+        )
+        timeout = cast(int | None, kwargs.pop("timeout", self._request_timeout))
 
         # An explicit model override opts out of the fallback chain —
         # honour exactly what the caller asked for.
         if "model" in kwargs:
-            return await self._client.responses.create(
+            return await create_response(
                 input=input,
-                model=kwargs.pop("model"),
+                model=cast(str, kwargs.pop("model")),
                 connection_params=connection_params,
                 timeout=timeout,
                 instructions=instructions,
@@ -425,7 +448,7 @@ class PolicyLLMClient:
         last_exc: Exception | None = None
         for index, model in enumerate(candidates):
             try:
-                response = await self._client.responses.create(
+                response = await create_response(
                     input=input,
                     model=model,
                     connection_params=connection_params,

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -6099,7 +6099,7 @@ async def _handle_mcp_tools_call(
         # If the policy returned transformed arguments (e.g.
         # PII-redacted args), use them instead of the originals.
         if call_result.data is not None:
-            arguments = call_result.data
+            arguments = cast("dict[str, object]", call_result.data)
 
     # ── Server-side sys_advise_models intercept ──────────────────────────
     # After policy evaluation (DENY/ASK handled above); arguments may have


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Replace opaque `Any` annotations in the core policy runtime contracts with `object`, `TypedDict` shapes, and explicit narrowing at dynamic boundaries.
- Type `PolicyLLMClient` against the real LLM client and response types while preserving provider-specific keyword forwarding.
- Reduce full-tree mypy output by **33 errors** (`1998` → `1965`) without changing policy behavior or touching `uv.lock`.

**ELI5:** policy payloads can still contain arbitrary Python values, but callers must now inspect those values before using them instead of silently opting out of type checking.

```text
runtime payload (object) -> validate/narrow -> typed policy event/result
```

## Test Plan

- `uv run --no-sync pytest -q tests/policies tests/runtime/policies` (922 passed)
- `uv run --no-sync mypy omnigent --no-pretty --show-error-codes` (same-environment baseline: `1998` → `1965`)
- `uv run --no-sync ruff check` on all changed Python files
- `uv run --no-sync ruff format --check` on all changed Python files
- `uv run --no-sync pre-commit run --all-files`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing policy and runtime-policy suites cover callable dispatch, state payloads, LLM policy clients, transformations, and approval flows.

## Changelog

N/A

