### PR TITLE
refactor(workspace): type filesystem payloads

### DIFF
--- a/omnigent/workspace_fs.py
+++ b/omnigent/workspace_fs.py
@@ -37,7 +37,7 @@ import mimetypes
 import os
 import re
 from pathlib import Path
-from typing import Any
+from typing import TypeAlias, cast
 
 from omnigent.entities.environment_filesystem import InvalidPath
 from omnigent.entities.pagination import paginate_in_memory
@@ -54,6 +54,8 @@ from omnigent.runtime.filesystem_registry import (
 
 # Match the runner's caps so a host-served read is truncated identically.
 _MAX_READ_BYTES = 10 * 1024 * 1024  # 10 MiB
+
+_WorkspacePayload: TypeAlias = dict[str, object]
 
 
 class WorkspaceReaderError(Exception):
@@ -125,7 +127,7 @@ class WorkspaceReader:
         after: str | None = None,
         before: str | None = None,
         order: str = "desc",
-    ) -> dict[str, Any]:
+    ) -> _WorkspacePayload:
         """List a directory or read a file, mirroring ``_fs_list_or_read``.
 
         :param path: Relative path (``""`` for the workspace root).
@@ -149,7 +151,7 @@ class WorkspaceReader:
         after: str | None,
         before: str | None,
         order: str,
-    ) -> dict[str, Any]:
+    ) -> _WorkspacePayload:
         """Build the directory-listing payload for a resolved directory.
 
         Classifies entries by target type (follows symlinks) and skips
@@ -157,7 +159,7 @@ class WorkspaceReader:
         does not fail the listing — matching the runner's ``list_dir``.
         """
         validated = _validate_path(rel) if rel else ""
-        entries: list[dict[str, Any]] = []
+        entries: list[_WorkspacePayload] = []
         try:
             names = sorted(os.listdir(resolved))
         except OSError as exc:
@@ -197,7 +199,7 @@ class WorkspaceReader:
             )
         page = paginate_in_memory(
             entries,
-            id_fn=lambda e: e["id"],
+            id_fn=lambda entry: cast(str, entry["id"]),
             limit=limit,
             after=after,
             before=before,
@@ -217,7 +219,7 @@ class WorkspaceReader:
         resolved: Path,
         *,
         limit: int | None = _DEFAULT_READ_LIMIT,
-    ) -> dict[str, Any]:
+    ) -> _WorkspacePayload:
         """Build the file-content payload for a resolved file.
 
         Text files are UTF-8 decoded and line-capped at ``limit``; binary
@@ -245,7 +247,7 @@ class WorkspaceReader:
         raw: bytes,
         *,
         limit: int | None,
-    ) -> dict[str, Any]:
+    ) -> _WorkspacePayload:
         """Assemble the file-content dict from raw bytes."""
         content_type_guess, _ = mimetypes.guess_type(rel)
         truncated = False
@@ -273,7 +275,7 @@ class WorkspaceReader:
             else:
                 is_text = False
 
-        payload: dict[str, Any] = {
+        payload: _WorkspacePayload = {
             "object": "session.environment.filesystem.file_content",
             "path": rel,
             "content_type": content_type_guess,
@@ -305,7 +307,7 @@ class WorkspaceReader:
         include: str | None = None,
         exclude: str | None = None,
         limit: int = 500,
-    ) -> dict[str, Any]:
+    ) -> _WorkspacePayload:
         """Search files by substring + glob filters, like the runner.
 
         :param query: Case-insensitive substring matched against name and
@@ -323,7 +325,7 @@ class WorkspaceReader:
         inc = [re.compile(_glob_to_regex(p), re.IGNORECASE) for p in split_glob_list(include)]
         exc = [re.compile(_glob_to_regex(p), re.IGNORECASE) for p in split_glob_list(exclude)]
 
-        results: list[dict[str, Any]] = []
+        results: list[_WorkspacePayload] = []
         for dirpath, dirnames, filenames in os.walk(self._root):
             rel_dir = os.path.relpath(dirpath, self._root)
             # Prune excluded subtrees so a "**/node_modules" pattern
@@ -365,12 +367,12 @@ class WorkspaceReader:
                     break
             if len(results) >= limit:
                 break
-        results.sort(key=lambda e: e["path"])
+        results.sort(key=lambda entry: cast(str, entry["path"]))
         return {"object": "list", "data": results, "has_more": len(results) >= limit}
 
     # ── Changed files / diff ───────────────────────────────────────
 
-    def changes(self, session_id: str) -> dict[str, Any]:
+    def changes(self, session_id: str) -> _WorkspacePayload:
         """List changed files, mirroring ``list_filesystem_changes``.
 
         Git workspaces report the working-tree diff (``git status``);
@@ -401,7 +403,7 @@ class WorkspaceReader:
         ]
         return {"object": "list", "data": data, "has_more": False}
 
-    def diff(self, session_id: str, relative_path: str) -> dict[str, Any]:
+    def diff(self, session_id: str, relative_path: str) -> _WorkspacePayload:
         """Return before/after content, mirroring the runner diff endpoint.
 
         :param session_id: Session id (git mode ignores it).


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Replace the workspace reader's heterogeneous `dict[str, Any]` response annotations with a shared opaque payload type.
- Narrow entry IDs and paths to strings only where pagination and sorting require them.
- Reduce full-tree mypy output by **10 errors** (`1998` → `1988`) without changing filesystem behavior or touching `uv.lock`.

**ELI5:** workspace responses can still contain mixed JSON-like values, but they no longer disable type checking for every value that passes through them.

```text
workspace files -> typed payload map -> host/server response
```

## Test Plan

- `uv run --no-sync pytest -q tests/test_workspace_fs.py` (18 passed)
- `uv run --no-sync mypy omnigent --no-pretty --show-error-codes` (same-environment baseline: `1998` → `1988`)
- `uv run --no-sync ruff check omnigent/workspace_fs.py`
- `uv run --no-sync ruff format --check omnigent/workspace_fs.py`
- `uv run --no-sync pre-commit run --all-files`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing workspace filesystem suite covers directory listing, text and binary reads, truncation, search, path confinement, git changes, and diffs.

## Changelog

N/A

