### PR TITLE
refactor(opencode): type forwarder events

### DIFF
--- a/omnigent/opencode_native_forwarder.py
+++ b/omnigent/opencode_native_forwarder.py
@@ -24,7 +24,7 @@ from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TypeAlias, TypedDict
 from urllib.parse import quote
 
 import httpx
@@ -32,6 +32,7 @@ import httpx
 from omnigent.opencode_native_bridge import update_active_message_id, update_last_event_id
 from omnigent.opencode_native_client import OpenCodeClient, OpenCodeEvent
 from omnigent.opencode_native_permissions import (
+    OpenCodePermissionRequest,
     PolicyDecision,
     decision_to_reply,
     map_verdict_to_decision,
@@ -76,9 +77,20 @@ _OPENCODE_REAUTH_HINT = (
 # Bound the dedupe set so a long-lived session can't grow it without limit.
 _MAX_DEDUPE_KEYS = 8192
 
+_JsonObject: TypeAlias = dict[str, object]
+_JsonMapping: TypeAlias = Mapping[str, object]
+
+
+class _AssistantUsage(TypedDict):
+    cost: float
+    tokens: _JsonObject
+    model: str | None
+    model_id: str | None
+
+
 # Policy verdict resolver: receives a normalized policy input and returns a
 # verdict mapping (or None when no policy is configured / reachable).
-PolicyEvaluator = Callable[[Mapping[str, Any]], Awaitable[Mapping[str, Any] | None]]
+PolicyEvaluator = Callable[[_JsonMapping], Awaitable[_JsonMapping | None]]
 
 
 @dataclass
@@ -108,7 +120,7 @@ class OpenCodeForwarderState:
         return True
 
 
-def _int_or_zero(value: Any) -> int:
+def _int_or_zero(value: object) -> int:
     """Coerce an opencode token-count field to a non-negative int (0 otherwise)."""
     return value if isinstance(value, int) and value >= 0 else 0
 
@@ -173,8 +185,8 @@ class OpenCodeNativeForwarder:
         # messageID -> latest {cost, tokens, model, model_id} for assistant
         # messages (opencode reports cost/tokens per message). Summed into the
         # cumulative usage posted as ``external_session_usage``.
-        self._usage_by_message: dict[str, dict[str, Any]] = {}
-        self._last_usage_signature: tuple[tuple[str, Any], ...] | None = None
+        self._usage_by_message: dict[str, _AssistantUsage] = {}
+        self._last_usage_signature: tuple[tuple[str, object], ...] | None = None
         # Last model mirrored to Omnigent (provider/id), to dedupe switches.
         self._last_model: str | None = None
         # reasoning part id -> chars already streamed as a delta. opencode sends
@@ -327,7 +339,7 @@ class OpenCodeNativeForwarder:
 
     # --- posting helpers -------------------------------------------------
 
-    async def _post_event(self, event_type: str, data: dict[str, Any]) -> httpx.Response | None:
+    async def _post_event(self, event_type: str, data: _JsonObject) -> httpx.Response | None:
         """
         POST one Omnigent session event with a single retry.
 
@@ -349,7 +361,7 @@ class OpenCodeNativeForwarder:
             )
             return None
 
-    async def _post_status(self, status: str, *, extra: Mapping[str, Any] | None = None) -> None:
+    async def _post_status(self, status: str, *, extra: _JsonMapping | None = None) -> None:
         """Publish a coarse session status edge.
 
         :param extra: Extra fields merged into the edge payload. On the
@@ -361,7 +373,7 @@ class OpenCodeNativeForwarder:
             a mid-turn reconnect stays live. A ``failed`` edge instead carries
             ``output`` / ``reauth_required``.
         """
-        data: dict[str, Any] = {"status": status}
+        data: _JsonObject = {"status": status}
         if extra:
             data.update(extra)
         await self._post_event(_EXTERNAL_STATUS, data)
@@ -407,7 +419,7 @@ class OpenCodeNativeForwarder:
         )
 
     async def _post_tool_call(
-        self, call_id: str, tool: str, arguments: dict[str, Any], *, message_id: str | None
+        self, call_id: str, tool: str, arguments: _JsonObject, *, message_id: str | None
     ) -> None:
         """Mirror a tool invocation as a function_call item."""
         await self._post_event(
@@ -456,7 +468,7 @@ class OpenCodeNativeForwarder:
             )
 
     async def _end_turn(
-        self, *, status: str = _STATUS_IDLE, extra: Mapping[str, Any] | None = None
+        self, *, status: str = _STATUS_IDLE, extra: _JsonMapping | None = None
     ) -> None:
         """Post the terminal status (idle by default), stamped with the turn's id.
 
@@ -478,7 +490,7 @@ class OpenCodeNativeForwarder:
         # that were rendered live. Fall back to the latest assistant id (then the
         # session id) when no running edge fired.
         terminal_id = self._running_response_id or self._active_message_id
-        merged_extra: dict[str, Any] = {"response_id": self._response_id(terminal_id)}
+        merged_extra: _JsonObject = {"response_id": self._response_id(terminal_id)}
         if extra:
             merged_extra.update(extra)
         if self._bridge_dir is not None:
@@ -544,7 +556,7 @@ class OpenCodeNativeForwarder:
             # it so text and tool items land in the chat in step order.
             await self._flush_pending_text()
 
-    def _accumulate_text_part(self, part: Mapping[str, Any]) -> None:
+    def _accumulate_text_part(self, part: _JsonMapping) -> None:
         """Record the latest full-text snapshot for an assistant text part.
 
         ``message.part.updated`` carries the cumulative text each time, so we
@@ -566,7 +578,7 @@ class OpenCodeNativeForwarder:
             text,
         )
 
-    async def _post_user_text_part(self, part: Mapping[str, Any]) -> None:
+    async def _post_user_text_part(self, part: _JsonMapping) -> None:
         """Post a user message immediately so it precedes its assistant reply.
 
         Unlike assistant text (accumulated + flushed on step end), a user part
@@ -594,7 +606,7 @@ class OpenCodeNativeForwarder:
                 continue
             await self._post_assistant_text(text, message_id=message_id)
 
-    async def _handle_tool_part(self, part: Mapping[str, Any]) -> None:
+    async def _handle_tool_part(self, part: _JsonMapping) -> None:
         """Mirror an opencode tool part (call + result) as chat items.
 
         opencode reports a tool as a single part whose ``state`` advances
@@ -629,7 +641,7 @@ class OpenCodeNativeForwarder:
                 call_id, f"[error] {error}" if error else "[error]", message_id=response_message_id
             )
 
-    async def _handle_reasoning_part(self, part: Mapping[str, Any]) -> None:
+    async def _handle_reasoning_part(self, part: _JsonMapping) -> None:
         """Forward an opencode ``reasoning`` part as transient reasoning deltas.
 
         opencode carries the cumulative chain-of-thought text on each
@@ -658,7 +670,7 @@ class OpenCodeNativeForwarder:
         )
         self._reasoning_posted[part_id] = len(text)
 
-    async def _handle_file_part(self, part: Mapping[str, Any]) -> None:
+    async def _handle_file_part(self, part: _JsonMapping) -> None:
         """Mirror an opencode ``file`` part — images as image blocks, else a note.
 
         opencode emits ``{type:"file", mime, url, filename}`` parts for images
@@ -696,10 +708,10 @@ class OpenCodeNativeForwarder:
         )
 
     async def _post_message_content(
-        self, role: str, content: list[dict[str, Any]], *, message_id: str | None
+        self, role: str, content: list[_JsonObject], *, message_id: str | None
     ) -> None:
         """Persist a message item with arbitrary content blocks (image / note)."""
-        item_data: dict[str, Any] = {"role": role, "content": content}
+        item_data: _JsonObject = {"role": role, "content": content}
         if role == "assistant":
             item_data["agent"] = _AGENT_NAME
         await self._post_event(
@@ -725,7 +737,7 @@ class OpenCodeNativeForwarder:
         await self._post_session_usage()
         await self._end_turn()
 
-    def _record_assistant_usage(self, message_id: str, info: Mapping[str, Any]) -> None:
+    def _record_assistant_usage(self, message_id: str, info: _JsonMapping) -> None:
         """Cache the latest cost/tokens/model for an assistant message.
 
         opencode reports ``cost`` (USD) + ``tokens`` per assistant message, so
@@ -745,7 +757,9 @@ class OpenCodeNativeForwarder:
         )
         self._usage_by_message[message_id] = {
             "cost": float(cost) if isinstance(cost, (int, float)) else 0.0,
-            "tokens": dict(tokens) if isinstance(tokens, Mapping) else {},
+            "tokens": {key: value for key, value in tokens.items() if isinstance(key, str)}
+            if isinstance(tokens, Mapping)
+            else {},
             "model": model,
             "model_id": model_id if isinstance(model_id, str) else None,
         }
@@ -762,7 +776,7 @@ class OpenCodeNativeForwarder:
             return
         cum_cost = 0.0
         cum_in = cum_out = cum_cache = 0
-        latest: dict[str, Any] | None = None
+        latest: _AssistantUsage | None = None
         for entry in self._usage_by_message.values():
             cum_cost += entry["cost"]
             tokens = entry["tokens"]
@@ -772,31 +786,34 @@ class OpenCodeNativeForwarder:
             if isinstance(cache, Mapping):
                 cum_cache += _int_or_zero(cache.get("read"))
             latest = entry
-        data: dict[str, Any] = {
+        data: _JsonObject = {
             "cumulative_cost_usd": round(cum_cost, 6),
             "cumulative_input_tokens": cum_in,
             "cumulative_output_tokens": cum_out,
             "cumulative_cache_read_input_tokens": cum_cache,
         }
         if latest is not None:
-            lt = latest["tokens"]
-            lcache = lt.get("cache") if isinstance(lt.get("cache"), Mapping) else {}
+            latest_tokens = latest["tokens"]
+            raw_cache = latest_tokens.get("cache")
+            latest_cache = raw_cache if isinstance(raw_cache, Mapping) else {}
             ctx = (
-                _int_or_zero(lt.get("input"))
-                + _int_or_zero(lcache.get("read"))
-                + _int_or_zero(lcache.get("write"))
+                _int_or_zero(latest_tokens.get("input"))
+                + _int_or_zero(latest_cache.get("read"))
+                + _int_or_zero(latest_cache.get("write"))
             )
             if ctx > 0:
                 data["context_tokens"] = ctx
-            if latest.get("model_id"):
+            model_id = latest["model_id"]
+            if model_id:
                 try:
                     from omnigent.llms.context_window import get_model_context_window
 
-                    data["context_window"] = get_model_context_window(latest["model_id"])
+                    data["context_window"] = get_model_context_window(model_id)
                 except Exception:  # noqa: BLE001 - context window is best effort.
                     pass
-            if latest.get("model"):
-                data["model"] = latest["model"]
+            model = latest["model"]
+            if model:
+                data["model"] = model
         signature = tuple(sorted(data.items()))
         if signature == self._last_usage_signature:
             return
@@ -825,7 +842,7 @@ class OpenCodeNativeForwarder:
             message = "OpenCode session ended with an error."
         status_code = data.get("statusCode") if isinstance(data, Mapping) else None
         is_auth = name == "ProviderAuthError" or (name == "APIError" and status_code in (401, 403))
-        extra: dict[str, Any] = {"output": message.strip()}
+        extra: _JsonObject = {"output": message.strip()}
         if is_auth:
             extra["output"] = f"{message.strip()}\n\n{_OPENCODE_REAUTH_HINT}"
             extra["reauth_required"] = True
@@ -901,7 +918,9 @@ class OpenCodeNativeForwarder:
                 exc_info=True,
             )
 
-    async def _resolve_permission(self, *, request_dict: Any) -> PolicyDecision:
+    async def _resolve_permission(
+        self, *, request_dict: OpenCodePermissionRequest
+    ) -> PolicyDecision:
         """
         Resolve a permission request to a normalized decision.
 
@@ -927,7 +946,7 @@ class OpenCodeNativeForwarder:
         return map_verdict_to_decision(verdict)
 
 
-def opencode_tool_output_text(state: Mapping[str, Any]) -> str:
+def opencode_tool_output_text(state: _JsonMapping) -> str:
     """
     Extract shared durable output from a completed OpenCode tool state.
 


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Replace broad `Any` annotations across OpenCode SSE event handling and event-post payloads with opaque object mappings that require runtime narrowing.
- Model accumulated assistant usage with a concrete `TypedDict`, including typed token, model, and cost fields.
- Type the policy evaluator and permission resolution seam against `OpenCodePermissionRequest` rather than an unconstrained value.
- Remove all 23 mypy findings from `omnigent/opencode_native_forwarder.py` (`1,958 → 1,935`) without changing forwarding behavior or touching `uv.lock`.

**ELI5:** OpenCode events remain dynamic JSON, but known usage and permission records now have explicit contracts while unknown values must be checked before use.

```text
OpenCode SSE JSON -> object-valued event map -> validated fields -> Omnigent events
assistant info    -> typed usage record      -> cumulative usage
permission event  -> OpenCodePermissionRequest -> policy evaluator
```

## Test Plan

- `uv run --no-sync pytest -q tests/test_opencode_native_forwarder.py tests/test_opencode_native_permissions.py` (51 passed)
- `uv run --no-sync mypy omnigent` (expected repository baseline: 1,935 errors; zero in `omnigent/opencode_native_forwarder.py`)
- `uv run --no-sync pre-commit run --all-files`

## Demo

N/A — typing-only refactor with unchanged forwarding behavior.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing suites cover SSE filtering and dedupe, message/tool/reasoning forwarding, cumulative usage, reconnect behavior, provider errors, and fail-closed permission mapping.

## Changelog

N/A — internal typing cleanup only.
