### PR TITLE
refactor(opencode): type client wire payloads

### DIFF
--- a/omnigent/opencode_native_client.py
+++ b/omnigent/opencode_native_client.py
@@ -21,7 +21,7 @@ import json
 import logging
 from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TypeAlias
 
 import httpx
 
@@ -33,6 +33,9 @@ OPENCODE_MIN_VERSION = "1.17.7"
 OPENCODE_MAX_VERSION_EXCLUSIVE = "1.18.0"
 
 _DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+
+_JsonObject: TypeAlias = dict[str, object]
+_JsonMapping: TypeAlias = Mapping[str, object]
 
 
 @dataclass(frozen=True)
@@ -51,10 +54,10 @@ class OpenCodeSession:
     title: str | None = None
     parent_id: str | None = None
     directory: str | None = None
-    raw: dict[str, Any] = field(default_factory=dict)
+    raw: _JsonObject = field(default_factory=dict)
 
     @classmethod
-    def from_payload(cls, payload: Mapping[str, Any]) -> OpenCodeSession:
+    def from_payload(cls, payload: _JsonMapping) -> OpenCodeSession:
         """
         Build an :class:`OpenCodeSession` from a raw server payload.
 
@@ -91,12 +94,12 @@ class OpenCodeEvent:
 
     id: str | None
     type: str
-    properties: dict[str, Any]
-    raw: dict[str, Any]
+    properties: _JsonObject
+    raw: _JsonObject
 
     @classmethod
     def from_envelope(
-        cls, envelope: Mapping[str, Any], *, event_id: str | None = None
+        cls, envelope: _JsonMapping, *, event_id: str | None = None
     ) -> OpenCodeEvent:
         """
         Build an :class:`OpenCodeEvent` from a decoded SSE data object.
@@ -108,8 +111,9 @@ class OpenCodeEvent:
         """
         type_value = envelope.get("type")
         props = envelope.get("properties")
+        envelope_id = envelope.get("id")
         return cls(
-            id=envelope.get("id") if isinstance(envelope.get("id"), str) else event_id,
+            id=envelope_id if isinstance(envelope_id, str) else event_id,
             type=type_value if isinstance(type_value, str) else "",
             properties=props if isinstance(props, dict) else {},
             raw=dict(envelope),
@@ -176,7 +180,13 @@ class OpenCodeClient:
 
     # --- helpers ---------------------------------------------------------
 
-    async def _request_json(self, method: str, path: str, **kwargs: Any) -> Any:
+    async def _request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: _JsonMapping | None = None,
+    ) -> object:
         """
         Issue a request and return decoded JSON, raising on HTTP errors.
 
@@ -186,7 +196,10 @@ class OpenCodeClient:
             empty body.
         :raises OpenCodeClientError: On a non-2xx status.
         """
-        response = await self._client.request(method, path, **kwargs)
+        if json_body is None:
+            response = await self._client.request(method, path)
+        else:
+            response = await self._client.request(method, path, json=dict(json_body))
         if response.status_code >= 400:
             raise OpenCodeClientError(
                 f"OpenCode {method} {path} failed: {response.status_code} {response.text[:500]}"
@@ -194,13 +207,14 @@ class OpenCodeClient:
         if not response.content:
             return None
         try:
-            return response.json()
+            decoded: object = response.json()
+            return decoded
         except json.JSONDecodeError:
             return None
 
     # --- sessions --------------------------------------------------------
 
-    async def create_session(self, payload: Mapping[str, Any] | None = None) -> OpenCodeSession:
+    async def create_session(self, payload: _JsonMapping | None = None) -> OpenCodeSession:
         """
         Create an OpenCode session (``POST /session``).
 
@@ -211,7 +225,7 @@ class OpenCodeClient:
             :func:`omnigent.opencode_http_transport.build_prompt_payload`.
         :returns: The created session.
         """
-        data = await self._request_json("POST", "/session", json=dict(payload or {}))
+        data = await self._request_json("POST", "/session", json_body=payload or {})
         if not isinstance(data, Mapping):
             raise OpenCodeClientError("OpenCode create_session returned a non-object body")
         return OpenCodeSession.from_payload(data)
@@ -235,7 +249,7 @@ class OpenCodeClient:
             return None
         return OpenCodeSession.from_payload(data)
 
-    async def list_messages(self, session_id: str) -> list[dict[str, Any]]:
+    async def list_messages(self, session_id: str) -> list[_JsonObject]:
         """
         List a session's messages (``GET /session/{id}/message``).
 
@@ -248,7 +262,7 @@ class OpenCodeClient:
             return [item for item in data if isinstance(item, dict)]
         return []
 
-    async def get_message(self, session_id: str, message_id: str) -> dict[str, Any]:
+    async def get_message(self, session_id: str, message_id: str) -> _JsonObject:
         """
         Fetch one message (``GET /session/{id}/message/{messageID}``).
 
@@ -259,7 +273,7 @@ class OpenCodeClient:
         data = await self._request_json("GET", f"/session/{session_id}/message/{message_id}")
         return data if isinstance(data, dict) else {}
 
-    async def list_models(self) -> list[dict[str, Any]]:
+    async def list_models(self) -> list[_JsonObject]:
         """
         List available models (``GET /api/model``).
 
@@ -273,7 +287,7 @@ class OpenCodeClient:
                 return [m for m in models if isinstance(m, dict)]
         return []
 
-    async def prompt(self, session_id: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+    async def prompt(self, session_id: str, payload: _JsonMapping) -> _JsonObject:
         """
         Send a (blocking) prompt (``POST /session/{id}/message``).
 
@@ -282,11 +296,11 @@ class OpenCodeClient:
         :returns: The server response object (often the assistant message).
         """
         data = await self._request_json(
-            "POST", f"/session/{session_id}/message", json=dict(payload)
+            "POST", f"/session/{session_id}/message", json_body=payload
         )
         return data if isinstance(data, dict) else {}
 
-    async def prompt_async(self, session_id: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+    async def prompt_async(self, session_id: str, payload: _JsonMapping) -> _JsonObject:
         """
         Admit a prompt without blocking (``POST /session/{id}/prompt_async``).
 
@@ -298,7 +312,7 @@ class OpenCodeClient:
         :returns: The server response object (may be empty).
         """
         data = await self._request_json(
-            "POST", f"/session/{session_id}/prompt_async", json=dict(payload)
+            "POST", f"/session/{session_id}/prompt_async", json_body=payload
         )
         return data if isinstance(data, dict) else {}
 
@@ -334,7 +348,7 @@ class OpenCodeClient:
         await self._request_json(
             "POST",
             f"/session/{session_id}/summarize",
-            json={"providerID": provider_id, "modelID": model_id},
+            json_body={"providerID": provider_id, "modelID": model_id},
         )
         return True
 
@@ -361,10 +375,10 @@ class OpenCodeClient:
         :returns: ``True`` once opencode has accepted the message.
         :raises OpenCodeClientError: On a non-2xx status.
         """
-        body: dict[str, Any] = {"parts": [{"type": "text", "text": text}], "noReply": True}
+        body: _JsonObject = {"parts": [{"type": "text", "text": text}], "noReply": True}
         if provider_id and model_id:
             body["model"] = {"providerID": provider_id, "modelID": model_id}
-        await self._request_json("POST", f"/session/{session_id}/message", json=body)
+        await self._request_json("POST", f"/session/{session_id}/message", json_body=body)
         return True
 
     async def reply_question(self, request_id: str, answers: list[list[str]]) -> bool:
@@ -384,7 +398,7 @@ class OpenCodeClient:
         :raises OpenCodeClientError: On a non-2xx status.
         """
         await self._request_json(
-            "POST", f"/question/{request_id}/reply", json={"answers": answers}
+            "POST", f"/question/{request_id}/reply", json_body={"answers": answers}
         )
         return True
 
@@ -402,9 +416,7 @@ class OpenCodeClient:
         await self._request_json("POST", f"/question/{request_id}/reject")
         return True
 
-    async def fork(
-        self, session_id: str, payload: Mapping[str, Any] | None = None
-    ) -> OpenCodeSession:
+    async def fork(self, session_id: str, payload: _JsonMapping | None = None) -> OpenCodeSession:
         """
         Fork a session (``POST /session/{id}/fork``).
 
@@ -413,7 +425,7 @@ class OpenCodeClient:
         :returns: The new forked session.
         """
         data = await self._request_json(
-            "POST", f"/session/{session_id}/fork", json=dict(payload or {})
+            "POST", f"/session/{session_id}/fork", json_body=payload or {}
         )
         if not isinstance(data, Mapping):
             raise OpenCodeClientError("OpenCode fork returned a non-object body")
@@ -421,7 +433,7 @@ class OpenCodeClient:
 
     # --- permissions -----------------------------------------------------
 
-    async def list_permissions(self) -> list[dict[str, Any]]:
+    async def list_permissions(self) -> list[_JsonObject]:
         """
         List pending permission requests (``GET /permission``).
 
@@ -432,7 +444,7 @@ class OpenCodeClient:
             return [item for item in data if isinstance(item, dict)]
         return []
 
-    async def reply_permission(self, request_id: str, reply: Mapping[str, Any]) -> bool:
+    async def reply_permission(self, request_id: str, reply: _JsonMapping) -> bool:
         """
         Reply to a permission request (``POST /permission/{id}/reply``).
 

--- a/omnigent/opencode_native_permissions.py
+++ b/omnigent/opencode_native_permissions.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Literal, TypeAlias
 
 OPENCODE_NATIVE_HARNESS = "opencode-native"
 
@@ -26,6 +26,9 @@ OpenCodeReply = Literal["once", "always", "reject"]
 
 # Omnigent-side normalized decisions used by the forwarder.
 PolicyDecision = Literal["allow_once", "allow_always", "reject", "ask"]
+
+_JsonObject: TypeAlias = dict[str, object]
+_JsonMapping: TypeAlias = Mapping[str, object]
 
 
 @dataclass(frozen=True)
@@ -46,13 +49,13 @@ class OpenCodePermissionRequest:
     request_id: str
     session_id: str | None
     action: str | None
-    resources: list[Any] = field(default_factory=list)
-    metadata: dict[str, Any] = field(default_factory=dict)
+    resources: list[object] = field(default_factory=list)
+    metadata: _JsonObject = field(default_factory=dict)
     source: str | None = None
-    raw: dict[str, Any] = field(default_factory=dict)
+    raw: _JsonObject = field(default_factory=dict)
 
 
-def parse_permission_request(payload: Mapping[str, Any]) -> OpenCodePermissionRequest | None:
+def parse_permission_request(payload: _JsonMapping) -> OpenCodePermissionRequest | None:
     """
     Parse a raw permission payload into :class:`OpenCodePermissionRequest`.
 
@@ -91,7 +94,9 @@ def parse_permission_request(payload: Mapping[str, Any]) -> OpenCodePermissionRe
         session_id=session_id if isinstance(session_id, str) else None,
         action=action if isinstance(action, str) else None,
         resources=list(resources) if isinstance(resources, list) else [],
-        metadata=dict(metadata) if isinstance(metadata, Mapping) else {},
+        metadata={key: value for key, value in metadata.items() if isinstance(key, str)}
+        if isinstance(metadata, Mapping)
+        else {},
         source=source if isinstance(source, str) else None,
         raw=dict(payload),
     )
@@ -102,7 +107,7 @@ def normalize_for_policy(
     *,
     omnigent_session_id: str,
     workspace: str | None,
-) -> dict[str, Any]:
+) -> _JsonObject:
     """
     Build an Omnigent policy-evaluation input from a permission request.
 
@@ -143,9 +148,7 @@ def _extract_resource_fields(
     command: str | None = None
     path: str | None = None
     url: str | None = None
-    candidates: list[Mapping[str, Any]] = []
-    if isinstance(request.metadata, Mapping):
-        candidates.append(request.metadata)
+    candidates: list[_JsonMapping] = [request.metadata]
     for resource in request.resources:
         if isinstance(resource, Mapping):
             candidates.append(resource)
@@ -162,7 +165,7 @@ def _extract_resource_fields(
     return command, path, url
 
 
-def map_verdict_to_decision(verdict: Mapping[str, Any] | None) -> PolicyDecision:
+def map_verdict_to_decision(verdict: _JsonMapping | None) -> PolicyDecision:
     """
     Map an Omnigent policy verdict onto a normalized decision.
 
@@ -214,7 +217,7 @@ def decision_to_reply(decision: PolicyDecision) -> OpenCodeReply | None:
     return None
 
 
-def reply_body(reply: OpenCodeReply, *, message: str | None = None) -> dict[str, Any]:
+def reply_body(reply: OpenCodeReply, *, message: str | None = None) -> _JsonObject:
     """
     Build the JSON body for ``POST /permission/{requestID}/reply``.
 
@@ -222,7 +225,7 @@ def reply_body(reply: OpenCodeReply, *, message: str | None = None) -> dict[str,
     :param message: Optional human-readable note attached to the reply.
     :returns: The reply request body.
     """
-    body: dict[str, Any] = {"reply": reply}
+    body: _JsonObject = {"reply": reply}
     if message is not None:
         body["message"] = message
     return body


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Replace broad `Any` annotations in the OpenCode HTTP/SSE client and permission normalizer with explicit object-valued JSON mappings.
- Narrow the private request helper from arbitrary `**kwargs` to its actual contract: an optional JSON body.
- Preserve raw event/session payloads while requiring runtime checks before consuming dynamic values, and type normalized permission resources, metadata, verdicts, and reply bodies.
- Remove all 28 mypy findings across both modules (`1,958 → 1,930`) without touching `uv.lock`.

**ELI5:** these APIs still accept and preserve dynamic JSON, but the client now says “this is a JSON value that must be checked” instead of letting `Any` disable checking throughout the call chain.

```text
HTTP/SSE bytes -> object-valued JSON -> validated session/event records
permission JSON -> normalized request -> typed policy input/reply
```

## Test Plan

- `uv run --no-sync pytest -q tests/test_opencode_native_client.py tests/test_opencode_native_permissions.py` (39 passed)
- `uv run --no-sync mypy omnigent` (expected repository baseline: 1,930 errors; zero in both changed modules)
- `uv run --no-sync pre-commit run --all-files`

## Demo

N/A — typing-only wire-contract refactor with unchanged HTTP/SSE behavior.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing client suite covers REST success/error paths, request bodies, session/message/model endpoints, and SSE parsing; the permission suite covers v1/v2 request normalization, resource extraction, fail-closed verdict mapping, and reply bodies.

## Changelog

N/A — internal typing cleanup only.
