### PR TITLE
refactor(opencode): type runtime boundaries

### DIFF
--- a/omnigent/inner/opencode_native_executor.py
+++ b/omnigent/inner/opencode_native_executor.py
@@ -17,7 +17,6 @@ import json
 import os
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
 
 from omnigent.native_server_harness import NativeServerHarness
 from omnigent.native_server_transport import NativePrompt
@@ -54,7 +53,7 @@ class OpenCodeNativeExecutor(NativeServerHarness):
             build_prompt=self._build_prompt_with_model_override,
         )
 
-    def _build_prompt_with_model_override(self, content: Any) -> NativePrompt | None:
+    def _build_prompt_with_model_override(self, content: object) -> NativePrompt | None:
         """
         Build a prompt, pinning the resolved model so it governs from turn one.
 
@@ -131,7 +130,7 @@ def _session_is_active(session_id: str, request_session_id: str | None) -> bool:
     return request_session_id is None or request_session_id == session_id
 
 
-def _content_to_native_prompt(content: Any) -> NativePrompt | None:
+def _content_to_native_prompt(content: object) -> NativePrompt | None:
     """
     Normalize executor message content into a :class:`NativePrompt`.
 
@@ -148,7 +147,7 @@ def _content_to_native_prompt(content: Any) -> NativePrompt | None:
         return NativePrompt(text=content) if content else None
     if isinstance(content, list):
         texts: list[str] = []
-        attachments: list[Mapping[str, Any]] = []
+        attachments: list[Mapping[str, object]] = []
         for block in content:
             if not isinstance(block, dict):
                 continue

--- a/omnigent/opencode_http_transport.py
+++ b/omnigent/opencode_http_transport.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 from collections.abc import AsyncIterator, Callable, Mapping
 from pathlib import Path
-from typing import Any
+from typing import TypeAlias
 
 from omnigent.native_server_transport import (
     NativeEvent,
@@ -37,6 +37,9 @@ _logger = logging.getLogger(__name__)
 
 ClientFactory = Callable[[], OpenCodeClient]
 
+_JsonObject: TypeAlias = dict[str, object]
+_JsonMapping: TypeAlias = Mapping[str, object]
+
 # Public surface of this transport module. ``ClientFactory`` is the documented
 # annotation for ``OpenCodeHttpTransport(client_factory=...)``; export it so the
 # alias reads as intended public API (its only other use is a PEP 563 stringified
@@ -44,7 +47,7 @@ ClientFactory = Callable[[], OpenCodeClient]
 __all__ = ["ClientFactory", "OpenCodeHttpTransport", "build_prompt_payload"]
 
 
-def build_prompt_payload(prompt: NativePrompt) -> dict[str, Any]:
+def build_prompt_payload(prompt: NativePrompt) -> _JsonObject:
     """
     Build an OpenCode prompt request body from a :class:`NativePrompt`.
 
@@ -52,14 +55,14 @@ def build_prompt_payload(prompt: NativePrompt) -> dict[str, Any]:
     :returns: A ``{"parts": [...], ...}`` body for ``POST
         /session/{id}/message`` or ``/prompt_async``.
     """
-    parts: list[dict[str, Any]] = []
+    parts: list[_JsonObject] = []
     if prompt.text:
         parts.append({"type": "text", "text": prompt.text})
     for attachment in prompt.attachments:
         part = _attachment_to_part(attachment)
         if part is not None:
             parts.append(part)
-    payload: dict[str, Any] = {"parts": parts}
+    payload: _JsonObject = {"parts": parts}
     if prompt.system_prompt:
         payload["system"] = prompt.system_prompt
     model = _split_model(prompt.model)
@@ -68,7 +71,7 @@ def build_prompt_payload(prompt: NativePrompt) -> dict[str, Any]:
     return payload
 
 
-def _attachment_to_part(attachment: Mapping[str, Any]) -> dict[str, Any] | None:
+def _attachment_to_part(attachment: _JsonMapping) -> _JsonObject | None:
     """
     Convert an Omnigent attachment block into an OpenCode file part.
 
@@ -85,7 +88,7 @@ def _attachment_to_part(attachment: Mapping[str, Any]) -> dict[str, Any] | None:
         url = attachment.get("file_data") or attachment.get("url")
         if isinstance(url, str) and url:
             mime = _mime_from_data_uri(url) or "application/octet-stream"
-            part: dict[str, Any] = {"type": "file", "mime": mime, "url": url}
+            part: _JsonObject = {"type": "file", "mime": mime, "url": url}
             filename = attachment.get("filename")
             if isinstance(filename, str) and filename:
                 part["filename"] = filename
@@ -206,7 +209,7 @@ class OpenCodeHttpTransport:
         finally:
             await client.aclose()
 
-    async def send_prompt(self, session_id: str, prompt: NativePrompt) -> Mapping[str, Any]:
+    async def send_prompt(self, session_id: str, prompt: NativePrompt) -> _JsonMapping:
         """Inject a prompt via ``POST /session/{id}/prompt_async``."""
         client = self._client()
         try:
@@ -237,7 +240,7 @@ class OpenCodeHttpTransport:
         finally:
             await client.aclose()
 
-    async def list_history(self, session_id: str) -> list[Mapping[str, Any]]:
+    async def list_history(self, session_id: str) -> list[_JsonMapping]:
         """Return the session's message history."""
         client = self._client()
         try:

--- a/omnigent/opencode_native.py
+++ b/omnigent/opencode_native.py
@@ -26,7 +26,7 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any
+from typing import TypeAlias
 
 import click
 import httpx
@@ -67,6 +67,8 @@ _logger = logging.getLogger(__name__)
 # ``wrapper_agent_name`` and the web native registry).
 _AGENT_NAME = "opencode-native-ui"
 
+_JsonObject: TypeAlias = dict[str, object]
+
 
 def _materialize_opencode_agent_spec(
     tmpdir: Path,
@@ -84,7 +86,7 @@ def _materialize_opencode_agent_spec(
     executor: dict[str, str] = {"harness": "opencode-native"}
     if model is not None:
         executor["model"] = model
-    raw: dict[str, Any] = {
+    raw: _JsonObject = {
         "name": _AGENT_NAME,
         "prompt": (
             "OpenCode is running in the session terminal. Web UI messages are "
@@ -365,7 +367,7 @@ async def _create_opencode_session(
     terminal_launch_args: list[str] | None = None,
 ) -> str:
     """Create a bundled terminal-first opencode-native session."""
-    metadata: dict[str, Any] = {"labels": dict(_SESSION_LABELS)}
+    metadata: _JsonObject = {"labels": dict(_SESSION_LABELS)}
     if terminal_launch_args:
         metadata["terminal_launch_args"] = terminal_launch_args
     resp = await client.post(
@@ -387,7 +389,7 @@ async def _create_opencode_session(
     return new_session_id
 
 
-async def _fetch_opencode_session(client: httpx.AsyncClient, session_id: str) -> dict[str, Any]:
+async def _fetch_opencode_session(client: httpx.AsyncClient, session_id: str) -> _JsonObject:
     """Fetch an existing Omnigent session."""
     resp = await client.get(f"/v1/sessions/{url_component(session_id)}")
     if resp.status_code == 404:
@@ -521,13 +523,16 @@ def _prompt_opencode_resume_workspace_action(
         f"  {_RESUME_ACTION_SWITCH:<6} - Switch working directory to {recorded_path}", err=True
     )
     click.echo(f"  {_RESUME_ACTION_CANCEL:<6} - Cancel resume", err=True)
-    return click.prompt(
+    action = click.prompt(
         "Resume action",
         type=click.Choice([_RESUME_ACTION_SWITCH, _RESUME_ACTION_CANCEL]),
         default=_RESUME_ACTION_SWITCH,
         show_choices=True,
         err=True,
     )
+    if not isinstance(action, str):
+        raise click.ClickException("Resume action must be a string.")
+    return action
 
 
 async def _find_running_opencode_terminal(

--- a/omnigent/opencode_native_bridge.py
+++ b/omnigent/opencode_native_bridge.py
@@ -624,8 +624,11 @@ def read_bridge_state(bridge_dir: Path) -> OpenCodeNativeBridgeState | None:
     session_id = raw.get("session_id")
     server_base_url = raw.get("server_base_url")
     opencode_session_id = raw.get("opencode_session_id")
-    required = (session_id, server_base_url, opencode_session_id)
-    if not all(isinstance(value, str) and value for value in required):
+    if not isinstance(session_id, str) or not session_id:
+        return None
+    if not isinstance(server_base_url, str) or not server_base_url:
+        return None
+    if not isinstance(opencode_session_id, str) or not opencode_session_id:
         return None
 
     def _opt_str(key: str) -> str | None:


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Replace remaining broad `Any` annotations across the OpenCode transport, launcher, and executor with object-valued JSON boundaries.
- Validate each required bridge-state string independently so mypy and runtime share the same narrowing invariant.
- Runtime-check Click's dynamically typed resume prompt result before returning it as an action.
- Remove all 17 remaining mypy findings across the OpenCode-native runtime modules (`1,958 → 1,941`) without touching `uv.lock`.

**ELI5:** the last OpenCode launch paths now treat dynamic data as unknown values to validate, while bridge state and prompt choices prove their required string fields before use.

```text
executor content -> object narrowing -> NativePrompt -> typed HTTP transport
state.json       -> required string checks -> OpenCodeNativeBridgeState
```

## Test Plan

- `uv run --no-sync pytest -q tests/test_opencode_http_transport.py tests/test_opencode_native.py tests/test_opencode_native_bridge.py tests/inner/test_opencode_native_executor.py` (90 passed)
- `uv run --no-sync mypy omnigent` (expected repository baseline: 1,941 errors; zero in all four changed modules)
- `uv run --no-sync pre-commit run --all-files`

## Demo

N/A — typing-only runtime-boundary refactor with unchanged launch behavior.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing suites cover prompt rendering, session creation/resume, terminal attachment, malformed bridge state, model overrides, executor message normalization, aborts, and harness app construction.

## Changelog

N/A — internal typing cleanup only.
