### PR TITLE
refactor: type accounts auth boundaries

### DIFF
--- a/omnigent/server/routes/accounts_auth.py
+++ b/omnigent/server/routes/accounts_auth.py
@@ -233,6 +233,8 @@ def create_accounts_auth_router(
     if auth_provider._source != "accounts":
         raise RuntimeError("create_accounts_auth_router called with non-accounts provider")
     config = auth_provider._accounts_config
+    if config is None:
+        raise RuntimeError("accounts auth provider has no accounts configuration")
     router = APIRouter()
 
     _secure = config.secure_cookies

--- a/omnigent/stores/permission_store/__init__.py
+++ b/omnigent/stores/permission_store/__init__.py
@@ -81,6 +81,19 @@ class PermissionStore(ABC):
         ...
 
     @abstractmethod
+    def reassign_user_grants(self, from_user_id: str, to_user_id: str) -> int:
+        """Move one user's grants to another user.
+
+        Existing destination grants win when both users have access to the
+        same session, and the duplicate source grant is removed.
+
+        :param from_user_id: Source grantee whose grants move.
+        :param to_user_id: Destination grantee that receives them.
+        :returns: Number of grants moved to *to_user_id*.
+        """
+        ...
+
+    @abstractmethod
     def list_for_session(
         self,
         conversation_id: str,

--- a/omnigent/stores/permission_store/sqlalchemy_store.py
+++ b/omnigent/stores/permission_store/sqlalchemy_store.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 from sqlalchemy import delete, exists, literal, select, update
 from sqlalchemy.dialects.mysql import insert as mysql_insert
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.engine import CursorResult
+from sqlalchemy.sql.dml import Insert
 
 from omnigent.db.db_models import SqlSessionPermission, SqlUser, current_workspace_id
 from omnigent.db.utils import get_or_create_engine, make_managed_session_maker
@@ -90,6 +94,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
                 "level": level,
                 "can_approve": can_approve,
             }
+            stmt: Insert
             if dialect == "sqlite":
                 stmt = (
                     sqlite_insert(SqlSessionPermission)
@@ -126,12 +131,15 @@ class SqlAlchemyPermissionStore(PermissionStore):
     def revoke(self, user_id: str, conversation_id: str) -> bool:
         """Remove a permission grant. See base class for contract."""
         with self._session() as session:
-            result = session.execute(
-                delete(SqlSessionPermission).where(
-                    SqlSessionPermission.workspace_id == current_workspace_id(),
-                    SqlSessionPermission.user_id == user_id,
-                    SqlSessionPermission.conversation_id == conversation_id,
-                )
+            result = cast(
+                CursorResult[tuple[object]],
+                session.execute(
+                    delete(SqlSessionPermission).where(
+                        SqlSessionPermission.workspace_id == current_workspace_id(),
+                        SqlSessionPermission.user_id == user_id,
+                        SqlSessionPermission.conversation_id == conversation_id,
+                    )
+                ),
             )
             return result.rowcount > 0
 
@@ -293,6 +301,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
         with self._session() as session:
             dialect = self._engine.dialect.name
             values = {"id": user_id, "is_admin": is_admin}
+            stmt: Insert
             if dialect == "sqlite":
                 stmt = (
                     sqlite_insert(SqlUser)


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Enforces the accounts router's documented non-null configuration invariant at construction time.
- Adds the existing grant-reassignment operation to the `PermissionStore` contract.
- Types SQLAlchemy dialect-specific inserts and DML results without changing persistence behavior.

**ELI5:** Accounts routes need configuration before they can exist, and the permission store already knows how to move a user's grants. This makes those facts explicit so callers and mypy see the same contract runtime uses.

```text
accounts provider -> require AccountsConfig -> auth routes
permission contract -> SQLAlchemy implementation -> typed DML
```

Full-tree mypy baseline: **1,958 → 1,930 errors**.

## Test Plan

- `uv run --no-sync pytest -q tests/server/test_accounts.py tests/stores/test_permission_store.py tests/server/integration/test_accounts_auth_e2e.py` (160 passed)
- `uv run --no-sync mypy omnigent` (expected nonzero baseline; 1,930 errors, no findings in changed files)
- `uv run --no-sync ruff check omnigent/server/routes/accounts_auth.py omnigent/stores/permission_store/__init__.py omnigent/stores/permission_store/sqlalchemy_store.py`
- `uv run --no-sync ruff format --check omnigent/server/routes/accounts_auth.py omnigent/stores/permission_store/__init__.py omnigent/stores/permission_store/sqlalchemy_store.py`
- `uv run --no-sync pre-commit run --all-files`

## Demo

N/A — type and invariant cleanup with no visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing accounts, permission-store, and accounts-auth E2E suites cover router construction, auth flows, grant migration, and all supported SQLAlchemy persistence paths.

## Changelog

N/A — internal type cleanup only.
