### PR TITLE
test(e2e): fold opencode host e2e onto shared agent-name constant

### DIFF
--- a/tests/e2e/test_host_opencode_native_e2e.py
+++ b/tests/e2e/test_host_opencode_native_e2e.py
@@ -34,10 +34,9 @@ import httpx
 import pytest
 
 from omnigent.entities.session_resources import terminal_resource_id
+from omnigent.native_coding_agents import OPENCODE_NATIVE_AGENT_NAME
 from tests._helpers.compat import apply_runner_env, compat_runner_cwd, runner_executable
 from tests.e2e.helpers import POLL_INTERVAL_S
-
-_OPENCODE_NATIVE_AGENT_NAME = "opencode-native-ui"
 
 pytestmark = pytest.mark.skipif(
     os.environ.get("OMNIGENT_E2E_OPENCODE_NATIVE") != "1" or shutil.which("opencode") is None,
@@ -112,7 +111,7 @@ def test_opencode_native_multiturn_item_order(
     resp = http_client.get("/v1/agents")
     resp.raise_for_status()
     agent_id = next(
-        (a["id"] for a in resp.json()["data"] if a["name"] == _OPENCODE_NATIVE_AGENT_NAME), None
+        (a["id"] for a in resp.json()["data"] if a["name"] == OPENCODE_NATIVE_AGENT_NAME), None
     )
     assert agent_id is not None
     workspace = tmp_path / "ws"
@@ -211,9 +210,9 @@ def test_opencode_native_builtin_registered_at_startup(http_client: httpx.Client
     resp = http_client.get("/v1/agents")
     resp.raise_for_status()
     names = {a["name"] for a in resp.json()["data"]}
-    assert _OPENCODE_NATIVE_AGENT_NAME in names, (
-        f"Expected {_OPENCODE_NATIVE_AGENT_NAME!r} in built-ins {names}; "
-        "_ensure_default_opencode_agent did not run."
+    assert OPENCODE_NATIVE_AGENT_NAME in names, (
+        f"Expected {OPENCODE_NATIVE_AGENT_NAME!r} in built-ins {names}; "
+        "_ensure_default_native_agents did not run."
     )
 
 
@@ -239,7 +238,7 @@ def test_opencode_native_host_session_auto_creates_terminal(
     resp = http_client.get("/v1/agents")
     resp.raise_for_status()
     agent_id = next(
-        (a["id"] for a in resp.json()["data"] if a["name"] == _OPENCODE_NATIVE_AGENT_NAME), None
+        (a["id"] for a in resp.json()["data"] if a["name"] == OPENCODE_NATIVE_AGENT_NAME), None
     )
     assert agent_id is not None, "opencode-native-ui agent not seeded"
 


### PR DESCRIPTION
## Related issue

N/A — follow-up cleanup to #3599 (PR 1.7 of the modular native-harness registry workstream).

## Summary

#3599 moved the built-in native agent-name constants into a shared public block in
`omnigent/native_coding_agents.py` (`CLAUDE_NATIVE_AGENT_NAME` … `KIMI_NATIVE_AGENT_NAME`) and
migrated the claude/codex host e2e tests onto them — but missed the opencode sibling. This
completes the sweep:

- `tests/e2e/test_host_opencode_native_e2e.py` now imports the shared
  `OPENCODE_NATIVE_AGENT_NAME` constant instead of its own local
  `_OPENCODE_NATIVE_AGENT_NAME = "opencode-native-ui"` literal.
- Its assertion message referenced the deleted per-harness seeder
  (`_ensure_default_opencode_agent`); updated to the collapsed loop
  `_ensure_default_native_agents`.

All three host e2e tests (claude/codex/opencode) are now consistent. Caught by Polly's review
on #3599, but only after that PR had merged — hence this small standalone follow-up.

## Test Plan

Test-only, and opt-in: `test_host_opencode_native_e2e.py` is skipped unless
`OMNIGENT_E2E_OPENCODE_NATIVE=1` (needs a pinned `opencode` binary + LLM creds). Verified the
file parses, imports the shared constant, and passes `ruff check`. The referenced symbol
`OPENCODE_NATIVE_AGENT_NAME` exists on `main` (landed in #3599).

## Demo

N/A — test-only, no user-facing change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Behavior-preserving test cleanup: swaps a hardcoded literal for the equivalent shared constant
(same value, `"opencode-native-ui"`) and fixes a stale assertion message string. No assertion
logic changes. The opt-in e2e is unchanged in what it exercises.
