### PR TITLE
refactor(runner): type transport wire payloads

### DIFF
--- a/omnigent/runner/proxy_mcp_manager.py
+++ b/omnigent/runner/proxy_mcp_manager.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Callable
-from typing import Any
+from typing import cast
 
 import httpx
 
@@ -37,6 +37,32 @@ from omnigent.runner.tool_dispatch import MCP_PROXY_CALL_TIMEOUT_S
 from omnigent.spec.types import AgentSpec
 
 _logger = logging.getLogger(__name__)
+
+_JsonObject = dict[str, object]
+_EventPublisher = Callable[[str, _JsonObject], None]
+
+
+def _json_object(value: object) -> _JsonObject | None:
+    """Return a string-keyed object mapping when the value has that shape."""
+    if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
+        return None
+    return cast("_JsonObject", value)
+
+
+def _response_json_object(response: httpx.Response) -> _JsonObject:
+    """Decode one JSON-RPC response object."""
+    value: object = response.json()
+    result = _json_object(value)
+    if result is None:
+        raise ValueError("MCP proxy response must be a JSON object")
+    return result
+
+
+def _json_object_list(value: object) -> list[_JsonObject]:
+    """Return only object entries from a JSON array."""
+    if not isinstance(value, list):
+        return []
+    return [item for raw in value if (item := _json_object(raw)) is not None]
 
 
 class ProxyMcpManager:
@@ -59,7 +85,7 @@ class ProxyMcpManager:
         self,
         session_id: str,
         ap_client: httpx.AsyncClient,
-        publish_event: Callable[[str, dict[str, Any]], None] | None = None,
+        publish_event: _EventPublisher | None = None,
     ) -> None:
         """Create a proxy manager bound to one session.
 
@@ -105,7 +131,7 @@ class ProxyMcpManager:
         if not spec.mcp_servers:
             return McpSchemasResult(schemas=[], tool_names=set(), failures={})
 
-        payload: dict[str, Any] = {
+        payload: _JsonObject = {
             "jsonrpc": "2.0",
             "id": 1,
             "method": "tools/list",
@@ -118,7 +144,7 @@ class ProxyMcpManager:
                 timeout=30.0,
             )
             resp.raise_for_status()
-            data: dict[str, Any] = resp.json()
+            data = _response_json_object(resp)
         except Exception as exc:  # noqa: BLE001 — network + HTTP errors all surface as failures
             _logger.warning(
                 "ProxyMcpManager tools/list failed for session %r: %s",
@@ -132,8 +158,12 @@ class ProxyMcpManager:
             )
 
         if "error" in data:
-            err: dict[str, Any] = data["error"]
-            msg = f"MCP proxy error {err.get('code')}: {err.get('message')}"
+            err = _json_object(data.get("error"))
+            msg = (
+                f"MCP proxy error {err.get('code')}: {err.get('message')}"
+                if err is not None
+                else "MCP proxy returned a non-object RPC error"
+            )
             _logger.warning(
                 "ProxyMcpManager tools/list returned RPC error for session %r: %s",
                 self._session_id,
@@ -145,29 +175,42 @@ class ProxyMcpManager:
                 failures={"proxy": msg},
             )
 
-        tools_list: list[dict[str, Any]] = data.get("result", {}).get("tools", [])
-        schemas: list[dict[str, Any]] = []
+        result = _json_object(data.get("result"))
+        if result is None:
+            msg = "MCP proxy returned a non-object tools/list result"
+            _logger.warning(
+                "ProxyMcpManager tools/list returned malformed result for session %r",
+                self._session_id,
+            )
+            return McpSchemasResult(
+                schemas=[],
+                tool_names=set(),
+                failures={"proxy": msg},
+            )
+        tools_list = _json_object_list(result.get("tools"))
+        schemas: list[_JsonObject] = []
         tool_names: set[str] = set()
         for tool in tools_list:
-            name = tool.get("name", "")
-            if not name:
+            name = tool.get("name")
+            if not isinstance(name, str) or not name:
                 continue
             # The Omnigent server returns ``inputSchema`` (JSON Schema from MCP).
             # Convert to the ``parameters`` key expected by LLM providers,
             # normalizing the same way RunnerMcpManager does via
             # _normalize_input_schema (ensure ``properties`` key is present).
-            raw_schema: dict[str, Any] | None = tool.get("inputSchema")
-            parameters: dict[str, Any]
+            raw_schema = _json_object(tool.get("inputSchema"))
+            parameters: _JsonObject
             if raw_schema is None:
                 parameters = {"type": "object", "properties": {}}
             elif raw_schema.get("type") == "object" and "properties" not in raw_schema:
                 parameters = {**raw_schema, "properties": {}}
             else:
                 parameters = raw_schema
-            schema: dict[str, Any] = {
+            description = tool.get("description")
+            schema: _JsonObject = {
                 "type": "function",
                 "name": name,
-                "description": tool.get("description", ""),
+                "description": description if isinstance(description, str) else "",
                 "parameters": parameters,
             }
             schemas.append(schema)
@@ -179,9 +222,7 @@ class ProxyMcpManager:
         self,
         spec: AgentSpec | None,
         tool_name: str,
-        # Values are Any because MCP tool arguments are JSON objects with
-        # heterogeneous value types (str, int, bool, nested dicts, etc.).
-        arguments: dict[str, Any],  # type: ignore[explicit-any]
+        arguments: _JsonObject,
     ) -> str:
         """Dispatch a tool call via the Omnigent server MCP proxy (``tools/call``).
 
@@ -207,7 +248,7 @@ class ProxyMcpManager:
         """
         del spec  # Omnigent server resolves spec from session context
 
-        payload: dict[str, Any] = {
+        payload: _JsonObject = {
             "jsonrpc": "2.0",
             "id": 1,
             "method": "tools/call",
@@ -232,7 +273,7 @@ class ProxyMcpManager:
                     ),
                 )
                 resp.raise_for_status()
-                data: dict[str, Any] = resp.json()
+                data = _response_json_object(resp)
             except Exception as exc:
                 raise RuntimeError(
                     f"MCP proxy call failed for tool {tool_name!r} in session "
@@ -240,7 +281,11 @@ class ProxyMcpManager:
                 ) from exc
 
             if "error" in data:
-                err: dict[str, Any] = data["error"]
+                err = _json_object(data.get("error"))
+                if err is None:
+                    raise RuntimeError(
+                        f"MCP proxy returned a non-object RPC error for tool {tool_name!r}"
+                    )
                 code = err.get("code")
                 msg = err.get("message", "")
                 # -32000 is the MCP convention for server-defined errors (tool
@@ -252,7 +297,11 @@ class ProxyMcpManager:
                     f"MCP proxy protocol error {code} for tool {tool_name!r}: {msg}"
                 )
 
-            result: dict[str, Any] = data.get("result", {})
+            result = _json_object(data.get("result"))
+            if result is None:
+                raise RuntimeError(
+                    f"MCP proxy returned a non-object result for tool {tool_name!r}"
+                )
 
             # ── ASK: Omnigent server returned InputRequiredResult ───────────────
             # Park for user approval and retry with inputResponses per the
@@ -262,8 +311,11 @@ class ProxyMcpManager:
                     # Guard against unexpected re-elicitation after one retry.
                     return json.dumps({"error": "Approval loop exceeded"})
 
-                input_requests: dict[str, Any] = result.get("inputRequests") or {}
-                request_state: str = result.get("requestState", "")
+                input_requests = _json_object(result.get("inputRequests"))
+                if input_requests is None:
+                    input_requests = {}
+                request_state_value = result.get("requestState")
+                request_state = request_state_value if isinstance(request_state_value, str) else ""
                 # The Omnigent server uses the elicitation_id as the key in
                 # inputRequests (MRTR spec: keys are server-assigned and the
                 # client CAN read them — only requestState is opaque).
@@ -273,7 +325,7 @@ class ProxyMcpManager:
                         {"error": "Approval required but no elicitation in inputRequests"}
                     )
 
-                _pub: Callable[[str, dict[str, Any]], None] = (
+                publisher: _EventPublisher = (
                     self._publish_event
                     if self._publish_event is not None
                     else (lambda _s, _e: None)
@@ -281,7 +333,7 @@ class ProxyMcpManager:
                 approved = await pending_approvals.wait_for_user_approval(
                     elicitation_id=elicitation_id,
                     conversation_id=self._session_id,
-                    publish_event=_pub,
+                    publish_event=publisher,
                 )
 
                 payload = {
@@ -303,11 +355,14 @@ class ProxyMcpManager:
             content = result.get("content", [])
             is_error = result.get("isError", False)
             if isinstance(content, list):
-                parts = [
-                    block.get("text", "")
-                    for block in content
-                    if isinstance(block, dict) and block.get("type") == "text"
-                ]
+                parts: list[str] = []
+                for raw_block in content:
+                    block = _json_object(raw_block)
+                    if block is None or block.get("type") != "text":
+                        continue
+                    block_text = block.get("text")
+                    if isinstance(block_text, str):
+                        parts.append(block_text)
                 text = "\n".join(p for p in parts if p)
                 if is_error:
                     return json.dumps({"error": text})

--- a/omnigent/runner/transports/ws_tunnel/frames.py
+++ b/omnigent/runner/transports/ws_tunnel/frames.py
@@ -23,7 +23,9 @@ import base64
 import json
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+from typing import cast
+
+_JsonObject = dict[str, object]
 
 
 class FrameKind(str, Enum):
@@ -296,7 +298,7 @@ def decode_frame(text: str) -> Frame:
     return _decode_known_frame(kind, msg)
 
 
-def _parse_frame_object(text: str) -> dict[str, Any]:
+def _parse_frame_object(text: str) -> _JsonObject:
     """Parse a JSON frame object.
 
     :param text: Raw JSON frame text.
@@ -304,15 +306,17 @@ def _parse_frame_object(text: str) -> dict[str, Any]:
     :raises ValueError: If the payload is not a JSON object.
     """
     try:
-        msg = json.loads(text)
+        value: object = json.loads(text)
     except json.JSONDecodeError as exc:
         raise ValueError(f"frame is not valid JSON: {exc}") from exc
-    if not isinstance(msg, dict):
-        raise ValueError(f"frame must be a JSON object, got {type(msg).__name__}")
-    return msg
+    if not isinstance(value, dict):
+        raise ValueError(f"frame must be a JSON object, got {type(value).__name__}")
+    if not all(isinstance(key, str) for key in value):
+        raise ValueError("frame object keys must be strings")
+    return cast("_JsonObject", value)
 
 
-def _parse_frame_kind(msg: dict[str, Any]) -> FrameKind:
+def _parse_frame_kind(msg: _JsonObject) -> FrameKind:
     """Parse the frame kind discriminator.
 
     :param msg: Decoded frame object.
@@ -328,7 +332,7 @@ def _parse_frame_kind(msg: dict[str, Any]) -> FrameKind:
         raise ValueError(f"unknown frame kind: {kind!r}") from exc
 
 
-def _decode_known_frame(kind: FrameKind, msg: dict[str, Any]) -> Frame:
+def _decode_known_frame(kind: FrameKind, msg: _JsonObject) -> Frame:
     """Decode a frame with a validated kind.
 
     :param kind: Parsed frame kind.
@@ -363,7 +367,7 @@ def _decode_known_frame(kind: FrameKind, msg: dict[str, Any]) -> Frame:
     raise ValueError(f"unhandled frame kind: {kind.value!r}")  # pragma: no cover
 
 
-def _decode_hello(msg: dict[str, Any]) -> HelloFrame:
+def _decode_hello(msg: _JsonObject) -> HelloFrame:
     """Decode a hello frame.
 
     :param msg: Decoded frame object.
@@ -378,7 +382,7 @@ def _decode_hello(msg: dict[str, Any]) -> HelloFrame:
     )
 
 
-def _decode_request(msg: dict[str, Any]) -> RequestFrame:
+def _decode_request(msg: _JsonObject) -> RequestFrame:
     """Decode a request frame.
 
     :param msg: Decoded frame object.
@@ -396,7 +400,7 @@ def _decode_request(msg: dict[str, Any]) -> RequestFrame:
     )
 
 
-def _decode_response_head(msg: dict[str, Any]) -> ResponseHeadFrame:
+def _decode_response_head(msg: _JsonObject) -> ResponseHeadFrame:
     """Decode a response-head frame.
 
     :param msg: Decoded frame object.
@@ -409,7 +413,7 @@ def _decode_response_head(msg: dict[str, Any]) -> ResponseHeadFrame:
     )
 
 
-def _decode_response_body(msg: dict[str, Any]) -> ResponseBodyFrame:
+def _decode_response_body(msg: _JsonObject) -> ResponseBodyFrame:
     """Decode a response-body frame.
 
     :param msg: Decoded frame object.
@@ -422,7 +426,7 @@ def _decode_response_body(msg: dict[str, Any]) -> ResponseBodyFrame:
     )
 
 
-def _decode_request_cancel(msg: dict[str, Any]) -> RequestCancelFrame:
+def _decode_request_cancel(msg: _JsonObject) -> RequestCancelFrame:
     """Decode a request-cancel frame.
 
     :param msg: Decoded frame object.
@@ -434,7 +438,7 @@ def _decode_request_cancel(msg: dict[str, Any]) -> RequestCancelFrame:
     )
 
 
-def _decode_ws_open(msg: dict[str, Any]) -> WSOpenFrame:
+def _decode_ws_open(msg: _JsonObject) -> WSOpenFrame:
     """Decode a WebSocket-open frame.
 
     :param msg: Decoded frame object.
@@ -447,7 +451,7 @@ def _decode_ws_open(msg: dict[str, Any]) -> WSOpenFrame:
     )
 
 
-def _decode_ws_frame(msg: dict[str, Any]) -> WSFrame:
+def _decode_ws_frame(msg: _JsonObject) -> WSFrame:
     """Decode a WebSocket data frame.
 
     :param msg: Decoded frame object.
@@ -460,7 +464,7 @@ def _decode_ws_frame(msg: dict[str, Any]) -> WSFrame:
     )
 
 
-def _decode_ws_close(msg: dict[str, Any]) -> WSCloseFrame:
+def _decode_ws_close(msg: _JsonObject) -> WSCloseFrame:
     """Decode a WebSocket-close frame.
 
     :param msg: Decoded frame object.
@@ -473,21 +477,21 @@ def _decode_ws_close(msg: dict[str, Any]) -> WSCloseFrame:
     )
 
 
-def _required_str(msg: dict[str, Any], key: str) -> str:
+def _required_str(msg: _JsonObject, key: str) -> str:
     val = msg.get(key)
     if not isinstance(val, str):
         raise ValueError(f"frame missing required string field: {key!r}")
     return val
 
 
-def _required_int(msg: dict[str, Any], key: str) -> int:
+def _required_int(msg: _JsonObject, key: str) -> int:
     val = msg.get(key)
     if not isinstance(val, int) or isinstance(val, bool):
         raise ValueError(f"frame missing required int field: {key!r}")
     return val
 
 
-def _optional_str(msg: dict[str, Any], key: str, default: str) -> str:
+def _optional_str(msg: _JsonObject, key: str, default: str) -> str:
     """Return an optional string field.
 
     :param msg: Decoded frame object.
@@ -502,7 +506,7 @@ def _optional_str(msg: dict[str, Any], key: str, default: str) -> str:
     return val
 
 
-def _optional_bool(msg: dict[str, Any], key: str, default: bool) -> bool:
+def _optional_bool(msg: _JsonObject, key: str, default: bool) -> bool:
     """Return an optional boolean field.
 
     :param msg: Decoded frame object.
@@ -517,7 +521,7 @@ def _optional_bool(msg: dict[str, Any], key: str, default: bool) -> bool:
     return val
 
 
-def _optional_int(msg: dict[str, Any], key: str, default: int) -> int:
+def _optional_int(msg: _JsonObject, key: str, default: int) -> int:
     """Return an optional integer field.
 
     :param msg: Decoded frame object.
@@ -532,7 +536,7 @@ def _optional_int(msg: dict[str, Any], key: str, default: int) -> int:
     return val
 
 
-def _optional_body(msg: dict[str, Any]) -> str | None:
+def _optional_body(msg: _JsonObject) -> str | None:
     """Return an optional request body field.
 
     :param msg: Decoded request frame object.
@@ -545,7 +549,7 @@ def _optional_body(msg: dict[str, Any]) -> str | None:
     return val
 
 
-def _optional_str_list(msg: dict[str, Any], key: str) -> list[str]:
+def _optional_str_list(msg: _JsonObject, key: str) -> list[str]:
     """Return an optional list of strings.
 
     :param msg: Decoded frame object.
@@ -559,7 +563,7 @@ def _optional_str_list(msg: dict[str, Any], key: str) -> list[str]:
     return list(val)
 
 
-def _optional_headers(msg: dict[str, Any]) -> list[list[str]]:
+def _optional_headers(msg: _JsonObject) -> list[list[str]]:
     """Return optional HTTP headers.
 
     :param msg: Decoded request or response-head frame object.

--- a/tests/runner/test_proxy_mcp_manager.py
+++ b/tests/runner/test_proxy_mcp_manager.py
@@ -301,6 +301,29 @@ async def test_schemas_for_rpc_error_body_returns_failure() -> None:
     assert "Method not found" in result.failures["proxy"]
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("rpc_body", "expected_message"),
+    [
+        ({"jsonrpc": "2.0", "id": 1, "error": []}, "non-object RPC error"),
+        ({"jsonrpc": "2.0", "id": 1, "result": []}, "non-object tools/list result"),
+    ],
+)
+async def test_schemas_for_malformed_rpc_objects_return_failure(
+    rpc_body: dict[str, Any],
+    expected_message: str,
+) -> None:
+    """Malformed JSON-RPC objects surface as schema failures rather than empty success."""
+    transport = _StubTransport([_json_resp(rpc_body)])
+    manager = _make_manager(transport)
+
+    result = await manager.schemas_for(_make_spec("github"))
+
+    assert result.schemas == []
+    assert result.tool_names == set()
+    assert expected_message in result.failures["proxy"]
+
+
 # ── call_tool ──────────────────────────────────────────────────────────────
 
 
@@ -411,6 +434,16 @@ async def test_call_tool_non_32000_rpc_error_raises() -> None:
     manager = _make_manager(transport)
 
     with pytest.raises(RuntimeError, match="-32600"):
+        await manager.call_tool(_make_spec("github"), "github__search", {})
+
+
+@pytest.mark.asyncio
+async def test_call_tool_non_object_rpc_error_raises_precise_error() -> None:
+    """A malformed JSON-RPC error remains fail-closed with a precise diagnostic."""
+    transport = _StubTransport([_json_resp({"jsonrpc": "2.0", "id": 1, "error": []})])
+    manager = _make_manager(transport)
+
+    with pytest.raises(RuntimeError, match="non-object RPC error"):
         await manager.call_tool(_make_spec("github"), "github__search", {})
 
 


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Replace broad `Any` dictionaries in WebSocket tunnel frame decoding with validated string-keyed JSON objects.
- Validate MCP proxy JSON-RPC envelopes, schema records, approval payloads, and content blocks before typed use; malformed schema responses now fail closed with regression coverage.
- Remove all **36 mypy errors** from the two target modules, reducing the clean full-tree baseline from **1,639 to 1,603** with no new diagnostics.

ELI5: verify runner transport data at the wire boundary so downstream code receives known shapes instead of arbitrary dictionaries.

```text
WebSocket frames / MCP JSON-RPC
              |
      runtime shape validation
              |
       typed runner payloads
```

## Test Plan

- `env -u OPENAI_API_KEY uv run --no-sync pytest -q tests/runner/test_proxy_mcp_manager.py` — 16 passed.
- `env -u OPENAI_API_KEY uv run --no-sync pytest -q tests/runner/transports/ws_tunnel` — 166 passed.
- `uv run --no-sync mypy --no-incremental omnigent/runner/transports/ws_tunnel/frames.py omnigent/runner/proxy_mcp_manager.py` — no target-module diagnostics; only 14 pre-existing generated protobuf stub diagnostics remain.
- `.venv/bin/mypy --no-incremental omnigent` in clean worktrees — **1,639 → 1,603 errors**, with zero newly introduced diagnostics.
- `pre-commit run --all-files` — passed.

## Demo

N/A — non-visual type-safety refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new regression case verifies malformed JSON-RPC objects fail closed; existing MCP proxy and WebSocket tunnel suites cover successful, error, malformed, streaming, and concurrent transport paths.

## Changelog

N/A — internal type-safety refactor.