### PR TITLE
fix(sessions): reject undeclared sub_agent_name at create (#3526)

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -148,6 +148,32 @@ from omnigent.tools.builtins.load_skill import (
 _logger = logging.getLogger(__name__)
 
 
+def _warn_unresolved_sub_agent(session_id: str | None, sub_agent_name: str) -> None:
+    """
+    Log that a sub-agent name did not resolve to a declared child spec.
+
+    Every spec-swap site is guarded by ``if sub_spec is not None`` with no
+    ``else`` and falls back to the already-resolved PARENT spec — so a
+    renamed/removed sub-agent or stale session metadata silently boots the
+    child as a parent clone (parent prompt, tools, harness, workdir). The
+    create route now rejects an undeclared name up front, but stale rows
+    and post-create bundle edits can still reach these sites; a loud log
+    makes the fallback diagnosable instead of invisible.
+
+    :param session_id: The session whose turn is resolving the spec.
+    :param sub_agent_name: The name that failed to resolve in the parent
+        spec tree.
+    """
+    _logger.warning(
+        "Sub-agent %r for session %s did not resolve in the parent spec; "
+        "falling back to the parent spec (child runs with the parent's "
+        "prompt, tools and harness). Likely a renamed/removed sub-agent or "
+        "stale session metadata.",
+        sub_agent_name,
+        session_id,
+    )
+
+
 def __getattr__(name: str) -> Any:
     """Preserve private native-helper imports during the package move."""
     return getattr(_native, name)
@@ -2542,6 +2568,8 @@ def create_runner_app(
                         if _resolved_spec_workdir(spec_entry) is not None
                         else spec
                     )
+                else:
+                    _warn_unresolved_sub_agent(session_id, _sa_name_assign)
             harness_name = spec.executor.config.get("harness") or spec.executor.type
             harness_name = canonicalize_harness(harness_name) or harness_name
 
@@ -5792,6 +5820,8 @@ def create_runner_app(
                     if cached_spec_workdir is not None
                     else cached_spec
                 )
+            else:
+                _warn_unresolved_sub_agent(conv, _sa_name)
 
         cached_spec = _spec_with_workdir_paths(cached_spec, cached_spec_workdir)
         if cached_spec is not None:
@@ -8595,6 +8625,8 @@ def create_runner_app(
                             if workdir is not None
                             else sub_spec
                         )
+                    else:
+                        _warn_unresolved_sub_agent(session_id, sub_agent_name)
             _session_spec_cache[session_id] = spec_entry
             return spec_entry
 
@@ -9701,6 +9733,8 @@ async def _resolve_harness_config(
                 sub_spec = _find_spec_by_name(spec, sub_agent_name)
                 if sub_spec is not None:
                     spec = sub_spec
+                else:
+                    _warn_unresolved_sub_agent(session_id, sub_agent_name)
             harness = harness_override or spec.executor.config.get("harness") or spec.executor.type
             harness = canonicalize_harness(harness) or harness
             spawn_env = _build_spawn_env_from_spec(

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -7245,6 +7245,58 @@ def _resolve_subagent_spec(
     return _find_spec_by_name(parent_spec, sub_agent_name)
 
 
+def _require_declared_subagent(
+    *,
+    agent: Agent,
+    sub_agent_name: str,
+    agent_cache: AgentCache | None,
+) -> None:
+    """
+    Reject a ``sub_agent_name`` the parent's spec does not declare.
+
+    ``POST /v1/sessions`` persists ``sub_agent_name`` verbatim, and every
+    downstream site that swaps in the resolved child spec is guarded by
+    ``if ... is not None`` with no ``else`` — so a name that resolves to
+    nothing leaves the parent's spec, workdir, harness and instructions in
+    place and the child silently boots as a full clone of the parent
+    (runaway recursion for an orchestrator). This gate fails the create
+    loud instead, mirroring normal dispatch (``tool_dispatch`` rejects an
+    undeclared ``agent``) and the ``AGENTSPEC.md`` contract that unlisted
+    names are rejected.
+
+    Only rejects when the bundle loads AND the name is positively absent:
+    a load failure or absent cache cannot prove the negative, so it is
+    left to fail-loud downstream rather than blocking a create we cannot
+    adjudicate here.
+
+    :param agent: The parent agent row whose bundle declares the
+        sub-agents.
+    :param sub_agent_name: The requested sub-agent name to validate.
+    :param agent_cache: Cache for loading the parsed parent bundle.
+        ``None`` skips the check (cannot resolve the tree).
+    :raises OmnigentError: 404 ``NOT_FOUND`` when the bundle loads and
+        declares no sub-agent named ``sub_agent_name``.
+    """
+    if agent_cache is None:
+        return
+    from omnigent.runtime.workflow import _find_spec_by_name
+
+    try:
+        parent_spec = agent_cache.load(
+            agent.id, agent.bundle_location, expand_env=agent.session_id is None
+        ).spec
+    except Exception:  # noqa: BLE001
+        # Can't load the bundle -> can't prove the name is undeclared.
+        # Leave it to the runner's fail-loud resolution rather than
+        # rejecting a create we cannot adjudicate.
+        return
+    if _find_spec_by_name(parent_spec, sub_agent_name) is None:
+        raise OmnigentError(
+            f"Sub-agent not declared in parent spec: {sub_agent_name!r}",
+            code=ErrorCode.NOT_FOUND,
+        )
+
+
 def _spec_harness(spec: AgentSpec) -> str:
     """
     Return the canonical harness identifier for a resolved spec.
@@ -8607,6 +8659,7 @@ __all__ = [
     "_replace_text_in_message_body",
     "_require_collaboration_mode_forward",
     "_require_cost_control_label_authority",
+    "_require_declared_subagent",
     "_require_external_status_forward",
     "_require_host_conn_for_worktree",
     "_reset_runner_resources_after_switch",

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -5299,6 +5299,19 @@ async def _create_session_from_existing_agent(
             conversation_store,
         )
 
+    # Reject an undeclared sub-agent before persisting the row. Downstream
+    # spec swaps are all guarded by ``if ... is not None`` with no
+    # ``else``, so a name the parent's spec never declares would leave the
+    # parent spec/workdir/harness/instructions in place and boot the child
+    # as a parent clone. Fail loud here instead.
+    if body.sub_agent_name:
+        await asyncio.to_thread(
+            _require_declared_subagent,
+            agent=agent,
+            sub_agent_name=body.sub_agent_name,
+            agent_cache=agent_cache,
+        )
+
     # The persisted override reaches a native CLI as a ``--model`` argv
     # element at terminal launch, so reject shell-/flag-shaped values
     # before any row or worktree exists.

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -135,6 +135,17 @@ executor:
   model: gpt-4o-mini
   harness: openai-agents
 
+# ``researcher`` sub-agent declared inline so the sub-agent create tests
+# (mobile workflow, subagent tab title) can spawn a child named
+# "researcher"; the create route rejects an undeclared sub_agent_name.
+tools:
+  researcher:
+    type: agent
+    prompt: You research questions and report findings.
+    executor:
+      model: gpt-4o-mini
+      harness: openai-agents
+
 # Required for PUT /filesystem/{path} seeding in UI tests (e.g. markdown
 # editor comments) — the runner returns 404 when os_env is absent.
 os_env:

--- a/tests/server/helpers.py
+++ b/tests/server/helpers.py
@@ -737,6 +737,12 @@ def build_agent_bundle(
                     "model": sa["name"],
                     "connection": {"api_key": "test-key"},
                 },
+                # A ``config.yaml`` sub-agent goes through the strict
+                # spec_version:1 parser, which requires an explicit
+                # harness for an omnigent executor. Default to the same
+                # harness the parent uses; callers may override via
+                # ``sa["executor"]``.
+                "executor": sa.get("executor", {"config": {"harness": "claude-sdk"}}),
             }
             if "description" in sa:
                 sa_config["description"] = sa["description"]
@@ -778,6 +784,7 @@ async def create_test_agent(
     user: str | None = None,
     guardrails: dict[str, Any] | None = None,
     include_llm: bool = True,
+    sub_agents: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """
     Create an agent via multipart session create and return the agent JSON.
@@ -805,6 +812,11 @@ async def create_test_agent(
         :func:`build_agent_bundle`. ``None`` omits guardrails.
     :param include_llm: Whether to include the default ``llm:`` block.
         Set ``False`` for model-less harness tests.
+    :param sub_agents: Optional sub-agent config dicts declared in the
+        bundle, each with at least a ``"name"`` key, e.g.
+        ``[{"name": "worker"}]``. Required for tests that create a child
+        session with a ``sub_agent_name`` — the create route rejects an
+        undeclared name.
     :returns: Parsed agent response body from the session agent
         endpoint, with an extra ``_session_id`` key for the owning
         session.
@@ -817,6 +829,7 @@ async def create_test_agent(
         skills=skills,
         guardrails=guardrails,
         include_llm=include_llm,
+        sub_agents=sub_agents,
     )
     metadata: dict[str, Any] = {}
     headers: dict[str, str] = {}

--- a/tests/server/integration/test_sessions_child_sessions.py
+++ b/tests/server/integration/test_sessions_child_sessions.py
@@ -1357,6 +1357,41 @@ async def test_native_subagent_yolo_args_reject_overlong_spec_value(
     assert "invalid terminal_launch_args in sub-agent spec" in error["message"]
 
 
+async def test_subagent_create_rejects_undeclared_name(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    A ``sub_agent_name`` the parent's spec does not declare fails the create.
+
+    The downstream spec-swap sites are all guarded by ``if ... is not None``
+    with no ``else``: a name that resolves to nothing would leave the
+    parent's spec, workdir, harness and instructions in place and boot the
+    child as a full clone of the parent — silently escalating a worker to
+    the orchestrator's capability and instruction surface. The create route
+    must reject the undeclared name up front (404) so nothing is persisted,
+    mirroring normal ``sys_session_send`` dispatch and the AGENTSPEC.md
+    contract that unlisted names are rejected.
+    """
+    parent = await _create_parent_with_subagents(
+        client,
+        name="orch-undeclared-subagent",
+        sub_agents=[{"name": "impl", "harness": "claude-native"}],
+    )
+    resp = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": parent["agent_id"],
+            "parent_session_id": parent["session_id"],
+            "title": "ghost:task",
+            "sub_agent_name": "does-not-exist",
+        },
+    )
+    assert resp.status_code == 404, resp.text
+    error = resp.json()["error"]
+    assert error["code"] == "not_found"
+    assert "does-not-exist" in error["message"]
+
+
 @pytest.mark.parametrize(
     "sub_config,expected_persisted",
     [

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -3509,7 +3509,7 @@ async def test_post_external_session_status_idle_forwards_persisted_assistant_ou
 
     monkeypatch.setattr(sessions_module, "_get_runner_client", _fake_get_runner_client)
     try:
-        agent = await create_test_agent(client)
+        agent = await create_test_agent(client, sub_agents=[{"name": "worker"}])
         parent = await _create_session(client, agent["id"])
         child_resp = await client.post(
             "/v1/sessions",
@@ -3621,7 +3621,7 @@ async def test_post_external_session_status_propagates_runner_delivery_failure(
 
     monkeypatch.setattr(sessions_module, "_get_runner_client", _fake_get_runner_client)
     try:
-        agent = await create_test_agent(client)
+        agent = await create_test_agent(client, sub_agents=[{"name": "worker"}])
         parent = await _create_session(client, agent["id"])
         child_resp = await client.post(
             "/v1/sessions",


### PR DESCRIPTION
## Related issue

Closes #3526

## Summary

`POST /v1/sessions` accepted and persisted an arbitrary `sub_agent_name`
with no check that the parent's spec declares it. Because every
downstream spec-swap site is guarded by `if ... is not None` with no
`else`, a name that resolves to nothing left the **parent's** spec,
workdir, harness and instructions in place — silently booting the child
as a full clone of the parent (a worker of an orchestrator runs *as* the
orchestrator, able to dispatch its own sub-agents). Nothing logged, nothing
failed.

- **Fail loud at the create route.** `_require_declared_subagent` loads
  the trusted, server-loaded parent bundle and rejects a `sub_agent_name`
  the spec does not declare with **404**, before any conversation row is
  persisted — closing the issue's documented live reproduction. This
  mirrors normal `sys_session_send` dispatch (`tool_dispatch` rejects an
  undeclared `agent`) and the `AGENTSPEC.md` contract that unlisted names
  are rejected. It only fires when the bundle loads and the name is
  positively absent; a load failure or absent cache can't prove the
  negative, so it's left to fail-loud downstream rather than blocking a
  create we can't adjudicate.
- **Defense-in-depth logging** at the four runner spec-swap miss sites
  (`_warn_unresolved_sub_agent`): stale session rows or post-create bundle
  edits that still reach the parent-spec fallback now emit a warning
  instead of being invisible.

Note: #3525 (a declared child paired with the parent's bundle dir) is a
separate defect on the resolve-*hit* path and is untouched here.

## Test Plan

- New `test_subagent_create_rejects_undeclared_name` asserts the create
  route returns **404 `not_found`** for a `sub_agent_name` absent from the
  parent spec.
- `pytest tests/server/integration/test_sessions_child_sessions.py` (55) —
  all pass, confirming legitimate declared-sub-agent creates, YOLO
  arg derivation, and caller-supplied-arg rejection are unaffected.
- `pytest tests/runtime/test_workflow_subagent_resolution.py` and
  `tests/runner/test_native_subagent_harness_resolution.py` — pass; the
  new `else` warning branches don't change control flow.
- `pre-commit run --files <changed>` — clean.

## Demo

N/A — server/runner behavior; no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: reproduced the miss path in the integration harness —
a create with a valid parent `agent_id` + `parent_session_id` and a
`sub_agent_name` the parent spec doesn't declare now returns 404 instead
of 201, so the escalated child row is never persisted.

## Changelog

An undeclared sub-agent name on session create is now rejected instead of silently running the child as the parent agent