### PR TITLE
refactor(runner): type resource registry contracts

### DIFF
--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -20,7 +20,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
 
 from cachetools import TTLCache
 
@@ -37,7 +37,10 @@ from omnigent.entities.session_resources import (
 )
 
 if TYPE_CHECKING:
+    from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
     from omnigent.inner.os_env import OSEnvironment
+    from omnigent.inner.terminal import TerminalInstance
+    from omnigent.spec.types import AgentSpec
     from omnigent.terminals.registry import TerminalRegistry
 
 _logger = logging.getLogger(__name__)
@@ -172,7 +175,7 @@ def _trim_terminal_exit_output(text: str | None) -> str | None:
 
 
 def _terminal_exit_diagnostics(
-    instance: Any | None,
+    instance: TerminalInstance | None,
 ) -> tuple[str | None, int | None, str | None, str | None]:
     """Extract generic launch/output diagnostics from a terminal instance."""
     if instance is None:
@@ -447,7 +450,7 @@ class SessionResourceRegistry:
         session_id: str,
         *,
         resource_type: Literal["environment", "terminal", "file"] | None = None,
-        agent_spec: Any | None = None,
+        agent_spec: AgentSpec | None = None,
     ) -> PagedList[SessionResourceView]:
         """List all resources for a session.
 
@@ -550,7 +553,7 @@ class SessionResourceRegistry:
         self,
         session_id: str,
         environment_id: str,
-        agent_spec: Any | None = None,
+        agent_spec: AgentSpec | None = None,
     ) -> OSEnvironment:
         """Resolve an environment id to a live OSEnvironment.
 
@@ -586,7 +589,7 @@ class SessionResourceRegistry:
     def _resolve_primary(
         self,
         session_id: str,
-        agent_spec: Any | None,
+        agent_spec: AgentSpec | None,
     ) -> OSEnvironment:
         """Get or create the primary OSEnvironment for a session.
 
@@ -606,7 +609,7 @@ class SessionResourceRegistry:
     def _create_primary_env(
         self,
         session_id: str,
-        agent_spec: Any | None,
+        agent_spec: AgentSpec | None,
     ) -> OSEnvironment:
         """Create a new primary OSEnvironment.
 
@@ -694,7 +697,7 @@ class SessionResourceRegistry:
     def compute_default_env_root(
         self,
         session_id: str,
-        agent_spec: Any | None,
+        agent_spec: AgentSpec | None,
     ) -> str | None:
         """Compute the resolved filesystem root for the default environment.
 
@@ -760,11 +763,11 @@ class SessionResourceRegistry:
         session_id: str,
         terminal_name: str,
         session_key: str,
-        spec: Any,
+        spec: TerminalEnvSpec,
         *,
         cwd_override: str | None = None,
         sandbox_override: str | None = None,
-        parent_os_env: Any | None = None,
+        parent_os_env: OSEnvSpec | None = None,
         resource_role: str | None = None,
     ) -> SessionResourceView:
         """Launch a terminal required for the owning session to execute.
@@ -793,11 +796,11 @@ class SessionResourceRegistry:
         session_id: str,
         terminal_name: str,
         session_key: str,
-        spec: Any,
+        spec: TerminalEnvSpec,
         *,
         cwd_override: str | None = None,
         sandbox_override: str | None = None,
-        parent_os_env: Any | None = None,
+        parent_os_env: OSEnvSpec | None = None,
         resource_role: str | None = None,
     ) -> SessionResourceView:
         """Launch a terminal resource attached to the owning session.
@@ -828,10 +831,10 @@ class SessionResourceRegistry:
         session_id: str,
         terminal_name: str,
         session_key: str,
-        spec: Any,
+        spec: TerminalEnvSpec,
         cwd_override: str | None = None,
         sandbox_override: str | None = None,
-        parent_os_env: Any | None = None,
+        parent_os_env: OSEnvSpec | None = None,
         resource_role: str | None = None,
     ) -> SessionResourceView:
         """Launch a terminal, then observe it with the requested lifecycle."""
@@ -861,7 +864,7 @@ class SessionResourceRegistry:
         session_id: str,
         terminal_name: str,
         session_key: str,
-        instance: Any,
+        instance: TerminalInstance,
         *,
         resource_role: str | None = None,
     ) -> SessionResourceView:
@@ -884,7 +887,7 @@ class SessionResourceRegistry:
         session_id: str,
         terminal_name: str,
         session_key: str,
-        instance: Any,
+        instance: TerminalInstance,
         *,
         resource_role: str | None = None,
     ) -> SessionResourceView:
@@ -909,7 +912,7 @@ class SessionResourceRegistry:
         session_id: str,
         terminal_name: str,
         session_key: str,
-        instance: Any,
+        instance: TerminalInstance,
         resource_role: str | None = None,
     ) -> SessionResourceView:
         """Project and observe an already-launched terminal instance."""
@@ -957,7 +960,7 @@ class SessionResourceRegistry:
         session_id: str,
         terminal_name: str,
         session_key: str,
-        instance: Any,
+        instance: TerminalInstance,
         resource_role: str | None,
         lifecycle: TerminalLifecycle,
         *,
@@ -1150,7 +1153,7 @@ class SessionResourceRegistry:
         terminal_name: str,
         session_key: str,
         lifecycle: TerminalLifecycle,
-        instance: Any | None = None,
+        instance: TerminalInstance | None = None,
     ) -> None:
         """Clean up and publish lifecycle events for an unexpected terminal exit."""
         terminal_id = terminal_resource_id(terminal_name, session_key)


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Replace broad dynamic annotations in the session resource registry with the existing concrete `AgentSpec`, `TerminalEnvSpec`, `OSEnvSpec`, and `TerminalInstance` contracts.
- Type default-environment resolution and required/auxiliary terminal lifecycle paths end to end without runtime behavior changes.
- Remove all **14 mypy errors** from `runner/resource_registry.py`, reducing its clean full-tree branch baseline from **1,639 to 1,625** with no new diagnostics.

ELI5: the resource registry now states exactly which environment, terminal specification, and live terminal objects it accepts instead of treating them as arbitrary values.

```text
agent / terminal / environment objects
                  |
        concrete existing contracts
                  |
       session resource lifecycle
```

## Test Plan

- `env -u OPENAI_API_KEY uv run --no-sync pytest -q tests/runner/test_resource_registry.py tests/runner/test_session_resources.py tests/runner/test_environment_filesystem.py` — 138 passed.
- `uv run --no-sync mypy --no-incremental omnigent/runner/resource_registry.py` — no target-module diagnostics; only 14 pre-existing generated protobuf stub diagnostics remain.
- `.venv/bin/mypy --no-incremental omnigent` in equivalent base/branch environments — 14 fewer errors with zero newly introduced diagnostics.
- `pre-commit run --all-files` — passed.

## Demo

N/A — non-visual type-safety refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing registry, session resource API, and environment filesystem suites exercise the typed environment resolution, terminal launch/observation, lifecycle watcher, and cleanup paths.

## Changelog

N/A — internal type-safety refactor.
