### PR TITLE
refactor(auth): type OIDC route boundaries

### DIFF
--- a/omnigent/server/routes/auth.py
+++ b/omnigent/server/routes/auth.py
@@ -16,6 +16,7 @@ import logging
 import secrets
 import time
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, cast
 from urllib.parse import urlencode
 
 import httpx
@@ -49,6 +50,9 @@ _CLI_TICKET_TTL_SECONDS = 300  # 5 minutes
 # provider's default invite window (72h) — long enough to share
 # out-of-band, short enough to bound exposure of an unused link.
 _OIDC_INVITE_TTL_SECONDS = 72 * 3600
+
+if TYPE_CHECKING:
+    from omnigent.server.oidc import OIDCConfig
 
 
 @dataclass
@@ -101,9 +105,12 @@ def create_auth_router(
     """
     router = APIRouter()
     config = auth_provider._oidc_config
+    if config is None:
+        raise ValueError("OIDC auth router requires an OIDC-configured auth provider")
 
     # Invites are opt-in AND require the token store. Both must hold.
-    _invites_enabled = config.allow_invites and account_store is not None
+    invite_store = account_store if config.allow_invites else None
+    _invites_enabled = invite_store is not None
 
     # Admission policy: domain allowlist (env ∪ runtime-editable file)
     # with admin-list and (when enabled) invite bypasses. One place
@@ -112,7 +119,7 @@ def create_auth_router(
         env_allowed_domains=config.allowed_domains,
         domains_file_path=resolve_allowed_domains_path(),
         admin_list=admin_list,
-        invited_lookup=account_store if _invites_enabled else None,
+        invited_lookup=invite_store,
         config_allowed_domains=allowed_domains,
     )
 
@@ -279,11 +286,21 @@ def create_auth_router(
                     content={"error": "Token exchange failed"},
                 )
 
-            token_json = token_resp.json()
+            token_json = _json_object(_response_json(token_resp))
+            if token_json is None:
+                _logger.error("Token exchange returned a non-object JSON response")
+                return JSONResponse(
+                    status_code=400,
+                    content={"error": "Token exchange returned an invalid response"},
+                )
 
             # Extract user email.
             if config.provider_type == "github":
-                email = await _resolve_github_email(client, token_json.get("access_token", ""))
+                access_token = token_json.get("access_token")
+                email = await _resolve_github_email(
+                    client,
+                    access_token if isinstance(access_token, str) else "",
+                )
             else:
                 email = _resolve_oidc_email(token_json, config)
 
@@ -303,10 +320,10 @@ def create_auth_router(
         # account_tokens row, which doubles as the durable pre-auth that
         # admits the email on subsequent logins. Reserved-name emails are
         # rejected below regardless, so binding one here is harmless.
-        if _invites_enabled:
+        if invite_store is not None:
             invite_token = state_payload.get("invite")
             if invite_token:
-                account_store.redeem_oidc_invite(
+                invite_store.redeem_oidc_invite(
                     str(invite_token), email, now_epoch_seconds=int(time.time())
                 )
 
@@ -407,7 +424,7 @@ def create_auth_router(
         )
         return response
 
-    if _invites_enabled:
+    if invite_store is not None:
 
         @router.post("/invite")
         async def oidc_invite(request: Request) -> Response:
@@ -440,7 +457,7 @@ def create_auth_router(
 
             token_id = secrets.token_urlsafe(32)
             now = int(time.time())
-            account_store.create_token(
+            invite_store.create_token(
                 token_id,
                 kind="invite",
                 user_id=None,
@@ -711,9 +728,17 @@ async def _resolve_github_email(
         timeout=10.0,
     )
     if emails_resp.status_code == 200:
-        for entry in emails_resp.json():
+        payload = _response_json(emails_resp)
+        if not isinstance(payload, list):
+            return None
+        for raw_entry in payload:
+            entry = _json_object(raw_entry)
+            if entry is None:
+                continue
             if entry.get("primary") and entry.get("verified"):
-                return entry.get("email")
+                email = entry.get("email")
+                if isinstance(email, str) and email:
+                    return email
 
     # No primary, verified address. Deliberately do NOT fall back to the
     # ``/user.email`` profile field: it is unverified and attacker-settable,
@@ -743,7 +768,7 @@ def _claim_is_verified_true(value: object) -> bool:
 
 
 def _resolve_oidc_email(
-    token_json: dict,
+    token_json: dict[str, object],
     config: OIDCConfig,
 ) -> str | None:
     """Extract the verified email from the OIDC ``id_token``.
@@ -781,7 +806,10 @@ def _resolve_oidc_email(
         skipped via config).
     """
     id_token = token_json.get("id_token")
-    if not id_token:
+    if not isinstance(id_token, str) or not id_token:
+        return None
+    if config.jwks_uri is None:
+        _logger.warning("Rejecting id_token: OIDC configuration has no JWKS URI")
         return None
 
     try:
@@ -856,6 +884,17 @@ def _resolve_oidc_email(
     return email
 
 
-# Forward ref for type annotation.
-if False:  # TYPE_CHECKING
-    from omnigent.server.oidc import OIDCConfig
+def _json_object(value: object) -> dict[str, object] | None:
+    """Return a string-keyed JSON object, or ``None`` for other shapes."""
+    if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
+        return None
+    return cast("dict[str, object]", value)
+
+
+def _response_json(response: httpx.Response) -> object | None:
+    """Decode a JSON response, returning ``None`` when decoding fails."""
+    try:
+        value: object = response.json()
+    except ValueError:
+        return None
+    return value

--- a/tests/server/integration/test_oidc_auth_e2e.py
+++ b/tests/server/integration/test_oidc_auth_e2e.py
@@ -96,7 +96,7 @@ def _mint_state_cookie(
 
 def _mock_httpx_client_for_github(
     token_status: int = 200,
-    token_json: dict | None = None,
+    token_json: object | None = None,
     emails_json: list | None = None,
 ) -> AsyncMock:
     """Build a mock httpx.AsyncClient context manager for GitHub endpoints.
@@ -286,6 +286,24 @@ async def test_callback_returns_400_on_token_exchange_failure() -> None:
 
     assert resp.status_code == 400
     assert "Token exchange failed" in resp.json()["error"]
+
+
+async def test_callback_returns_400_on_non_object_token_response() -> None:
+    mock_cm = _mock_httpx_client_for_github(token_json=["invalid"])
+    transport = _build_oidc_app()
+    state = "test-state"
+    state_cookie = _mint_state_cookie(state)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        with patch("omnigent.server.routes.auth.httpx.AsyncClient", return_value=mock_cm):
+            resp = await client.get(
+                "/auth/callback",
+                params={"code": "bad-response", "state": state},
+                cookies={"ap_auth_state": state_cookie},
+            )
+
+    assert resp.status_code == 400
+    assert resp.json() == {"error": "Token exchange returned an invalid response"}
 
 
 # ── 5. Logout ──────────────────────────────────────────────────────

--- a/tests/server/routes/test_auth_routes.py
+++ b/tests/server/routes/test_auth_routes.py
@@ -7,10 +7,13 @@ pure-function helpers directly instead of via HTTP.
 from __future__ import annotations
 
 import time
+from pathlib import Path
 
 import httpx
 import pytest
 
+from omnigent.server.admin_list import AdminList
+from omnigent.server.auth import UnifiedAuthProvider
 from omnigent.server.routes.auth import (
     _GITHUB_EMAILS_ENDPOINT,
     _claim_is_verified_true,
@@ -18,6 +21,7 @@ from omnigent.server.routes.auth import (
     _evict_expired_tickets,
     _resolve_github_email,
     _sanitize_return_to,
+    create_auth_router,
 )
 
 # ── _sanitize_return_to ──────────────────────────────────────────────
@@ -196,6 +200,33 @@ class TestResolveGithubEmail:
 
         assert email is None
 
+    @pytest.mark.asyncio
+    async def test_malformed_email_entries_are_ignored(self) -> None:
+        async with _github_client(
+            emails=httpx.Response(
+                200,
+                json=[
+                    "not-an-object",
+                    {"email": 42, "primary": True, "verified": True},
+                ],
+            ),
+            profile=httpx.Response(200, json={"email": "profile@example.com"}),
+        ) as client:
+            email = await _resolve_github_email(client, "tok")
+
+        assert email is None
+
     def test_emails_endpoint_constant_is_user_emails(self) -> None:
         """Guard: the resolver queries the verified-email list endpoint."""
         assert _GITHUB_EMAILS_ENDPOINT.endswith("/user/emails")
+
+
+def test_create_auth_router_requires_oidc_config(tmp_path: Path) -> None:
+    provider = UnifiedAuthProvider(source="header")
+
+    with pytest.raises(ValueError, match="OIDC-configured auth provider"):
+        create_auth_router(
+            provider,
+            permission_store=None,
+            admin_list=AdminList(tmp_path / "admins"),
+        )


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Enforce the OIDC router's required configuration once at construction and preserve the optional invite store as a narrowed concrete dependency.
- Validate token-endpoint and GitHub email JSON shapes before typed use, and fail closed when a generic OIDC configuration has no JWKS URI.
- Remove all 31 mypy findings from `omnigent/server/routes/auth.py`, reducing a clean current-`main` run from 1,640 to 1,609 errors.

**ELI5:** External identity providers return untyped data. This change checks that data at the door so the rest of the OIDC flow only handles known shapes.

```text
IdP response -> JSON/config validation -> typed OIDC login flow
```

## Test Plan

- `uv run --no-sync pytest -q tests/server/test_oidc.py tests/server/test_oidc_access.py tests/server/test_oidc_admin_users.py tests/server/test_oidc_callback.py tests/server/test_oidc_invites.py tests/server/test_oidc_open_redirect.py tests/server/routes/test_auth_routes.py tests/server/integration/test_oidc_auth_e2e.py tests/server/integration/test_oidc_default_policies.py` (152 passed)
- `uv run --no-sync mypy --no-incremental omnigent` (1,609 existing errors; none in `omnigent/server/routes/auth.py`)
- `pre-commit run --all-files`
- Confirmed `uv.lock` is unchanged.

## Demo

N/A — non-visual type-safety refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage exercises the missing-config invariant, malformed GitHub email records, malformed token responses, and the existing OIDC login, callback, invite, admin, and policy flows.

## Changelog

N/A — internal type-safety cleanup.
