### PR TITLE
refactor(runner): type direct MCP manager

### DIFF
--- a/omnigent/runner/mcp_manager.py
+++ b/omnigent/runner/mcp_manager.py
@@ -10,16 +10,18 @@ import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
 
+import httpx
 from mcp.types import ElicitRequestParams, ElicitResult
 from mcp.types import Tool as McpToolDef
 
-from omnigent.spec.types import AgentSpec, MCPServerConfig
+from omnigent.spec.types import AgentSpec, MCPServerConfig, RetryPolicy
 from omnigent.tools.base import is_valid_tool_name
 from omnigent.tools.mcp import McpServerConnection
 
 _logger = logging.getLogger(__name__)
+
+_JsonObject = dict[str, object]
 
 
 def _build_accept_content(
@@ -79,7 +81,7 @@ class _SpecEntry:
 class McpSchemasResult:
     """Output of :meth:`RunnerMcpManager.schemas_for`."""
 
-    schemas: list[dict[str, Any]]
+    schemas: list[_JsonObject]
     tool_names: set[str]
     failures: dict[str, str]  # server_name → error message
 
@@ -112,13 +114,14 @@ def compute_spec_hash(configs: list[MCPServerConfig], cwd: Path | None = None) -
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
 
 
-def _retry_payload(retry: Any | None) -> Any:
+def _retry_payload(retry: RetryPolicy | None) -> object:
     """Return a stable JSON payload for a retry policy-like object."""
     if retry is None:
         return None
     to_json = getattr(retry, "to_json", None)
     if callable(to_json):
-        return json.loads(to_json())
+        payload: object = json.loads(to_json())
+        return payload
     return repr(retry)
 
 
@@ -152,7 +155,7 @@ def _mcp_tool_schema(
     server_name: str,
     tool_def: McpToolDef,
     allowed: set[str] | None,
-) -> dict[str, Any] | None:
+) -> _JsonObject | None:
     """Translate an MCP tool def to an OpenAI function-tool schema with a
     namespaced name; honor *allowed*.
 
@@ -213,7 +216,7 @@ class RunnerMcpManager:
     def __init__(
         self,
         stdio_cwd: Path | None = None,
-        server_client: Any | None = None,
+        server_client: httpx.AsyncClient | None = None,
     ) -> None:
         """
         :param stdio_cwd: Working directory for spawned stdio MCP
@@ -277,12 +280,13 @@ class RunnerMcpManager:
 
             message = getattr(params, "message", "")
             requested_schema = getattr(params, "requestedSchema", None)
-            body: dict[str, Any] = {
+            event_data: _JsonObject = {"message": message}
+            body: _JsonObject = {
                 "type": "mcp_elicitation",
-                "data": {"message": message},
+                "data": event_data,
             }
             if requested_schema is not None:
-                body["data"]["requestedSchema"] = requested_schema
+                event_data["requestedSchema"] = requested_schema
 
             try:
                 resp = await server_client.post(
@@ -291,7 +295,7 @@ class RunnerMcpManager:
                     timeout=30.0,
                 )
                 resp.raise_for_status()
-                data = resp.json()
+                data: object = resp.json()
             except Exception as exc:  # noqa: BLE001
                 _logger.warning(
                     "MCP elicitation callback: Omnigent server POST failed (%s) — declining",
@@ -299,8 +303,8 @@ class RunnerMcpManager:
                 )
                 return ElicitResult(action="decline")
 
-            elicitation_id = data.get("elicitation_id", "")
-            if not elicitation_id:
+            elicitation_id = data.get("elicitation_id") if isinstance(data, dict) else None
+            if not isinstance(elicitation_id, str) or not elicitation_id:
                 _logger.warning(
                     "MCP elicitation callback: Omnigent server returned no "
                     "elicitation_id — declining",
@@ -369,7 +373,7 @@ class RunnerMcpManager:
                 except Exception:
                     _logger.exception("runner mcp connect task raised; surfacing partial results")
 
-            schemas: list[dict[str, Any]] = []
+            schemas: list[_JsonObject] = []
             tool_names: set[str] = set()
             failures: dict[str, str] = {}
             for ref in refs:
@@ -383,7 +387,9 @@ class RunnerMcpManager:
                     if schema is None:
                         continue
                     schemas.append(schema)
-                    tool_names.add(schema["name"])
+                    schema_name = schema["name"]
+                    if isinstance(schema_name, str):
+                        tool_names.add(schema_name)
             return McpSchemasResult(schemas=schemas, tool_names=tool_names, failures=failures)
         finally:
             async with self._lock:
@@ -394,7 +400,7 @@ class RunnerMcpManager:
         self,
         spec: AgentSpec,
         tool_name: str,
-        arguments: dict[str, Any],
+        arguments: _JsonObject,
         session_id: str | None = None,
     ) -> str:
         """
@@ -445,11 +451,11 @@ class RunnerMcpManager:
             else:
                 await self.schemas_for(spec)
                 async with self._lock:
-                    entry = self._specs.get(spec_hash)
+                    existing_entry = self._specs.get(spec_hash)
                     route = (
                         None
-                        if entry is None
-                        else self._resolve_tool_route_from_entry(entry, tool_name)
+                        if existing_entry is None
+                        else self._resolve_tool_route_from_entry(existing_entry, tool_name)
                     )
                     if route is not None:
                         self._retain_server_ref(route[0])
@@ -784,9 +790,9 @@ class RunnerMcpManager:
         if close_after_connect is not None:
             await self._safe_close(close_after_connect, spec_hash, server.config.name)
 
-    def status_snapshot(self) -> dict[str, Any]:
+    def status_snapshot(self) -> _JsonObject:
         """JSON-able view of pool state for introspection."""
-        out_specs: list[dict[str, Any]] = []
+        out_specs: list[_JsonObject] = []
         for spec_hash in self._lru:
             entry = self._specs.get(spec_hash)
             if entry is None:


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Replace broad dynamic annotations in the direct runner MCP manager with concrete retry-policy, HTTP client, and JSON-object contracts.
- Validate elicitation response payloads before reading their IDs and keep schema/status snapshots typed end to end.
- Remove all **11 mypy errors** from `runner/mcp_manager.py`, reducing the clean full-tree branch baseline from **1,639 to 1,628** with no new diagnostics.

ELI5: the runner now labels MCP configuration and JSON payloads precisely instead of treating them as arbitrary values.

```text
MCP config + server JSON
          |
  concrete typed boundaries
          |
 schemas, tool calls, status
```

## Test Plan

- `uv run --no-sync pytest -q tests/runner/test_mcp_manager.py` — 18 passed.
- `uv run --no-sync mypy --no-incremental omnigent/runner/mcp_manager.py` — no target-module diagnostics; only 14 pre-existing generated protobuf stub diagnostics remain.
- `.venv/bin/mypy --no-incremental omnigent` in equivalent base/branch environments — 11 fewer errors with zero newly introduced diagnostics.
- `pre-commit run --all-files` — passed.

## Demo

N/A — non-visual type-safety refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing runner MCP manager tests exercise schema generation, tool dispatch, pool lifecycle, status snapshots, and configuration hashing.

## Changelog

N/A — internal type-safety refactor.
