### PR TITLE
refactor(runtime): type harness server config

### DIFF
--- a/omnigent/runtime/harnesses/_runner.py
+++ b/omnigent/runtime/harnesses/_runner.py
@@ -46,6 +46,7 @@ import sys
 import threading
 import time
 from types import FrameType
+from typing import cast
 
 import uvicorn
 from fastapi import FastAPI
@@ -345,6 +346,33 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _create_uvicorn_config(
+    app: FastAPI,
+    socket_path: str | None,
+    bind: str | None,
+) -> uvicorn.Config:
+    """Build the Uvicorn config for a Unix socket or TCP endpoint."""
+    # Uvicorn accepts fractional seconds despite its integer annotation.
+    graceful_timeout = cast("int", _GRACEFUL_SHUTDOWN_TIMEOUT_S)
+    if socket_path:
+        return uvicorn.Config(
+            app,
+            uds=socket_path,
+            log_level=_UVICORN_LOG_LEVEL,
+            timeout_graceful_shutdown=graceful_timeout,
+        )
+    if bind:
+        host, _, port = bind.rpartition(":")
+        return uvicorn.Config(
+            app,
+            host=host,
+            port=int(port),
+            log_level=_UVICORN_LOG_LEVEL,
+            timeout_graceful_shutdown=graceful_timeout,
+        )
+    sys.exit("runner: exactly one of --socket or --bind is required")
+
+
 def main(argv: list[str] | None = None) -> None:
     """
     Runner entrypoint.
@@ -373,19 +401,7 @@ def main(argv: list[str] | None = None) -> None:
     # Windows). ``log_level`` keeps per-process noise low — see
     # ``_UVICORN_LOG_LEVEL``. ``timeout_graceful_shutdown`` bounds how long
     # uvicorn waits for active connections after SIGTERM before force-exiting.
-    if args.socket:
-        bind_kwargs: dict[str, object] = {"uds": args.socket}
-    elif args.bind:
-        host, _, port = args.bind.rpartition(":")
-        bind_kwargs = {"host": host, "port": int(port)}
-    else:
-        sys.exit("runner: exactly one of --socket or --bind is required")
-    config = uvicorn.Config(
-        app,
-        log_level=_UVICORN_LOG_LEVEL,
-        timeout_graceful_shutdown=_GRACEFUL_SHUTDOWN_TIMEOUT_S,
-        **bind_kwargs,
-    )
+    config = _create_uvicorn_config(app, args.socket, args.bind)
     _HardExitServer(config).run()
 
 

--- a/omnigent/runtime/harnesses/_runner.py
+++ b/omnigent/runtime/harnesses/_runner.py
@@ -351,7 +351,11 @@ def _create_uvicorn_config(
     socket_path: str | None,
     bind: str | None,
 ) -> uvicorn.Config:
-    """Build the Uvicorn config for a Unix socket or TCP endpoint."""
+    """Build the Uvicorn config for the allocated runner endpoint.
+
+    Uses a Unix socket on POSIX or loopback TCP on Windows, keeps
+    per-process logging quiet, and bounds graceful connection draining.
+    """
     # Uvicorn accepts fractional seconds despite its integer annotation.
     graceful_timeout = cast("int", _GRACEFUL_SHUTDOWN_TIMEOUT_S)
     if socket_path:
@@ -396,11 +400,6 @@ def main(argv: list[str] | None = None) -> None:
     if args.parent_pid is not None:
         _set_pdeathsig()
         _start_parent_watchdog(args.parent_pid)
-    # Bind the endpoint Omnigent allocated for this conversation: a Unix socket
-    # path (``--socket``, POSIX) or a TCP loopback host:port (``--bind``,
-    # Windows). ``log_level`` keeps per-process noise low — see
-    # ``_UVICORN_LOG_LEVEL``. ``timeout_graceful_shutdown`` bounds how long
-    # uvicorn waits for active connections after SIGTERM before force-exiting.
     config = _create_uvicorn_config(app, args.socket, args.bind)
     _HardExitServer(config).run()
 

--- a/tests/runtime/harnesses/test_runner.py
+++ b/tests/runtime/harnesses/test_runner.py
@@ -10,6 +10,7 @@ ground here would just duplicate.
 from __future__ import annotations
 
 import pytest
+from fastapi import FastAPI
 
 from omnigent.runtime.harnesses import _runner
 
@@ -148,3 +149,25 @@ def test_load_harness_app_loads_test_fixture() -> None:
     # The harness name is also stashed for introspection /
     # logging — verifies the second app.state plumbing.
     assert app.state.harness == "test"
+
+
+def test_create_uvicorn_config_for_unix_socket() -> None:
+    config = _runner._create_uvicorn_config(FastAPI(), "/tmp/runner.sock", None)
+
+    assert config.uds == "/tmp/runner.sock"
+    assert config.timeout_graceful_shutdown == _runner._GRACEFUL_SHUTDOWN_TIMEOUT_S
+    assert config.log_level == _runner._UVICORN_LOG_LEVEL
+
+
+def test_create_uvicorn_config_for_tcp_bind() -> None:
+    config = _runner._create_uvicorn_config(FastAPI(), None, "127.0.0.1:8765")
+
+    assert config.host == "127.0.0.1"
+    assert config.port == 8765
+    assert config.timeout_graceful_shutdown == _runner._GRACEFUL_SHUTDOWN_TIMEOUT_S
+    assert config.log_level == _runner._UVICORN_LOG_LEVEL
+
+
+def test_create_uvicorn_config_requires_endpoint() -> None:
+    with pytest.raises(SystemExit, match="exactly one of --socket or --bind"):
+        _runner._create_uvicorn_config(FastAPI(), None, None)


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Replace the harness runner's `dict[str, object]` Uvicorn kwargs bag with explicit, typed Unix-socket and TCP config paths.
- Preserve fractional graceful-shutdown values used by subprocess tests while isolating Uvicorn's overly narrow integer annotation at the library boundary.
- Remove all 20 mypy findings from `omnigent/runtime/harnesses/_runner.py`, reducing a clean current-`main` run from 1,640 to 1,620 errors.

**ELI5:** Instead of putting unrelated server settings in one mystery bag, the runner now builds the exact configuration for the endpoint it is using.

```text
allocated endpoint -> UDS config | TCP config -> Uvicorn server
```

## Test Plan

- `uv run --no-sync pytest -q tests/runtime/harnesses/test_runner.py tests/runtime/harnesses/test_process_manager.py::test_runner_subprocess_hard_exits_when_sigterm_shutdown_wedges` (11 passed)
- `uv run --no-sync mypy --no-incremental omnigent` (1,620 existing errors; none in `omnigent/runtime/harnesses/_runner.py`)
- `pre-commit run --all-files`
- Confirmed `uv.lock` is unchanged.

## Demo

N/A — non-visual type-safety refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage verifies Unix-socket and TCP config construction, missing-endpoint rejection, and the existing fractional-timeout hard-exit subprocess path.

## Changelog

N/A — internal type-safety cleanup.
