### PR TITLE
refactor(server): type runner tunnel route

### DIFF
--- a/omnigent/server/routes/runner_tunnel.py
+++ b/omnigent/server/routes/runner_tunnel.py
@@ -26,6 +26,7 @@ from fastapi import APIRouter, Request, WebSocket, WebSocketDisconnect
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.runner.identity import RUNNER_TUNNEL_TOKEN_HEADER, token_bound_runner_id
 from omnigent.runner.transports.ws_tunnel.frames import (
+    HelloFrame,
     PingFrame,
     PongFrame,
     WSCloseFrame,
@@ -266,7 +267,7 @@ def create_runner_tunnel_router(
         online = session is not None
         # Hide runners owned by other users.
         if (
-            online
+            session is not None
             and user_id is not None
             and session.owner is not None
             and session.owner != user_id
@@ -443,7 +444,7 @@ def create_runner_tunnel_router(
             # 3. Receive hello frame.
             raw = await ws.receive_text()
             frame = decode_frame(raw)
-            if not hasattr(frame, "frame_protocol_version"):
+            if not isinstance(frame, HelloFrame):
                 await ws.close(code=4001, reason="expected hello frame")
                 return
 
@@ -528,31 +529,35 @@ def create_runner_tunnel_router(
                             task_name,
                         )
                         continue
-                    exc = task.exception()
-                    if exc is None:
+                    task_error = task.exception()
+                    if task_error is None:
                         _logger.warning(
                             "Tunnel helper task ended for runner %s: %s",
                             runner_id,
                             task_name,
                         )
                         continue
-                    if isinstance(exc, WebSocketDisconnect):
+                    if isinstance(task_error, WebSocketDisconnect):
                         _logger.warning(
                             "Tunnel helper task disconnected for runner %s: %s "
                             "(code=%s, reason=%r)",
                             runner_id,
                             task_name,
-                            getattr(exc, "code", None),
-                            getattr(exc, "reason", None),
+                            getattr(task_error, "code", None),
+                            getattr(task_error, "reason", None),
                         )
                     else:
                         _logger.warning(
                             "Tunnel helper task failed for runner %s: %s",
                             runner_id,
                             task_name,
-                            exc_info=(type(exc), exc, exc.__traceback__),
+                            exc_info=(
+                                type(task_error),
+                                task_error,
+                                task_error.__traceback__,
+                            ),
                         )
-                    raise exc
+                    raise task_error
             finally:
                 for task in (sender_task, ping_task, receive_task):
                     task.cancel()

--- a/tests/server/integration/test_runner_tunnel_route.py
+++ b/tests/server/integration/test_runner_tunnel_route.py
@@ -20,6 +20,7 @@ from omnigent.runner import create_runner_app
 from omnigent.runner.identity import RUNNER_TUNNEL_TOKEN_HEADER, token_bound_runner_id
 from omnigent.runner.transports.ws_tunnel.frames import (
     HelloFrame,
+    PingFrame,
     RequestFrame,
     decode_frame,
     encode_frame,
@@ -735,6 +736,25 @@ async def test_ws_tunnel_route_survives_malformed_frame(
         await communicator.send_input({"type": "websocket.disconnect", "code": 1000})
         with contextlib.suppress(asyncio.TimeoutError):
             await communicator.wait(timeout=1.0)
+
+
+async def test_ws_tunnel_rejects_non_hello_first_frame(app: FastAPI) -> None:
+    registry = app.state.tunnel_registry
+    communicator = await _connect_route(app, _TUNNEL_PATH)
+
+    await communicator.send_input(
+        {"type": "websocket.receive", "text": encode_frame(PingFrame(ts=1))}
+    )
+    close = await communicator.receive_output(timeout=1.0)
+
+    assert close == {
+        "type": "websocket.close",
+        "code": 4001,
+        "reason": "expected hello frame",
+    }
+    assert registry.get(_RUNNER_ID) is None
+    with contextlib.suppress(asyncio.TimeoutError):
+        await communicator.wait(timeout=1.0)
 
 
 async def test_ws_tunnel_route_is_not_double_prefixed(app: FastAPI) -> None:


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Narrow optional runner sessions directly before owner access, so status visibility checks operate on a concrete registered session.
- Require the tunnel's first decoded frame to be an actual `HelloFrame` rather than accepting any object with a similarly named attribute.
- Remove all 24 mypy findings from `omnigent/server/routes/runner_tunnel.py`, including the helper-task exception-name collision, reducing a clean current-`main` run from 1,640 to 1,616 errors.

**ELI5:** A connecting runner must show the exact hello badge before the server registers it, and the server only reads owner details after proving the runner exists.

```text
WebSocket connect -> exact HelloFrame -> registered RunnerSession -> tunnel tasks
```

## Test Plan

- `uv run --no-sync pytest -q tests/server/integration/test_runner_tunnel_route.py` (30 passed)
- `uv run --no-sync mypy --no-incremental omnigent` (1,616 existing errors; none in `omnigent/server/routes/runner_tunnel.py`)
- `pre-commit run --all-files`
- Confirmed `uv.lock` is unchanged.

## Demo

N/A — non-visual type-safety refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The runner tunnel integration suite now explicitly verifies that a non-hello first frame closes with protocol code 4001 and never registers the runner, alongside existing ownership, routing, and malformed-frame coverage.

## Changelog

N/A — internal type-safety cleanup.
