### PR TITLE
Filter Codex picker to compatible OpenAI models

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import shlex
+import socket
 import sys
 import tempfile
 import uuid
@@ -19,6 +20,7 @@ from typing import TYPE_CHECKING, TypeAlias, cast
 
 import tomlkit
 import websockets
+from cachetools import TTLCache
 from websockets.asyncio.client import ClientConnection
 
 from omnigent import model_catalog
@@ -57,6 +59,7 @@ CodexParams: TypeAlias = _JsonObject
 
 _CONNECT_RETRY_DELAY_SECONDS = 0.05
 _CONNECT_TIMEOUT_SECONDS = 10.0
+_MODEL_DISCOVERY_CACHE_SECONDS = 300.0
 _STDERR_CHUNK_LIMIT = 65536
 _UDS_WEBSOCKET_HANDSHAKE_URI = "ws://localhost/rpc"
 _MAX_WEBSOCKET_MESSAGE_SIZE_BYTES = 128 << 20
@@ -557,6 +560,159 @@ class CodexAppServerClient:
                     future.set_result(message)
                 continue
             await self._events.put(message)
+
+
+async def list_codex_model_options(client: CodexAppServerClient) -> list[_JsonObject]:
+    """Read every visible model from an initialized Codex app-server client.
+
+    :param client: Connected Codex app-server client.
+    :returns: Raw ``model/list`` rows in Codex preference order.
+    :raises ValueError: When Codex returns a malformed response.
+    """
+    options: list[_JsonObject] = []
+    cursor: str | None = None
+    while True:
+        params: CodexParams = {"includeHidden": False}
+        if cursor is not None:
+            params["cursor"] = cursor
+        response = await client.request("model/list", params)
+        result = response.get("result")
+        if not isinstance(result, dict):
+            raise ValueError("Codex model/list result must be an object")
+        data = result.get("data")
+        if not isinstance(data, list):
+            raise ValueError("Codex model/list data must be a list")
+        for raw_model in data:
+            if not isinstance(raw_model, dict):
+                raise ValueError("Codex model/list item must be an object")
+            options.append(raw_model)
+        next_cursor = result.get("nextCursor")
+        if next_cursor is None:
+            return options
+        if not isinstance(next_cursor, str) or not next_cursor:
+            raise ValueError("Codex model/list nextCursor must be a string or null")
+        cursor = next_cursor
+
+
+_model_discovery_cache: TTLCache[str, tuple[_JsonObject, ...]] = TTLCache(
+    maxsize=8,
+    ttl=_MODEL_DISCOVERY_CACHE_SECONDS,
+)
+
+
+async def discover_codex_model_options(*, codex_path: str | None = None) -> list[_JsonObject]:
+    """Query the installed Codex CLI's credential-free compatibility catalog.
+
+    Starts a short-lived app-server with an empty private ``CODEX_HOME`` and
+    no provider overrides. The resulting ``model/list`` is Codex's own curated
+    compatibility set; callers can intersect it with a provider's live
+    availability without exposing provider credentials to the subprocess.
+
+    :param codex_path: Optional Codex executable override.
+    :returns: Raw visible ``model/list`` rows in Codex preference order.
+    :raises ImportError: When the Codex CLI is unavailable.
+    :raises RuntimeError: When the discovery app-server exits before connecting.
+    :raises TimeoutError: When the discovery app-server does not become ready.
+    """
+    resolved_codex = codex_path or _find_codex_cli()
+    if not resolved_codex:
+        raise ImportError("Native Codex model discovery requires the 'codex' CLI on PATH.")
+    cached = _model_discovery_cache.get(resolved_codex)
+    if cached is not None:
+        return [dict(option) for option in cached]
+
+    with tempfile.TemporaryDirectory(prefix="omnigent-codex-model-discovery-") as raw_dir:
+        root = Path(raw_dir)
+        codex_home = root / "codex-home"
+        codex_home.mkdir(mode=0o700)
+        port = _allocate_loopback_port()
+        listen_url = f"ws://127.0.0.1:{port}"
+        env = _clean_codex_env()
+        for name in tuple(env):
+            if name.startswith("OPENAI_") or name in {
+                "DATABRICKS_BEARER",
+                "DATABRICKS_CODEX_TOKEN",
+            }:
+                env.pop(name)
+        env["CODEX_HOME"] = str(codex_home)
+        process = await _start_codex_model_discovery_process(
+            codex_path=resolved_codex,
+            listen_url=listen_url,
+            env=env,
+            cwd=root,
+        )
+        client: CodexAppServerClient | None = None
+        try:
+            await _wait_for_discovery_listener(process, port)
+            client = CodexAppServerClient(
+                ws_url=listen_url,
+                client_name="omnigent-codex-model-discovery",
+            )
+            await client.connect()
+            options = await list_codex_model_options(client)
+        finally:
+            if client is not None:
+                with contextlib.suppress(Exception):
+                    await client.close()
+            _proc.terminate_tree(process)
+            try:
+                await asyncio.wait_for(process.wait(), timeout=5.0)
+            except TimeoutError:
+                _proc.kill_tree(process)
+                await process.wait()
+
+    _model_discovery_cache[resolved_codex] = tuple(dict(option) for option in options)
+    return options
+
+
+async def _start_codex_model_discovery_process(
+    *,
+    codex_path: str,
+    listen_url: str,
+    env: dict[str, str],
+    cwd: Path,
+) -> asyncio.subprocess.Process:
+    """Start the isolated Codex process used only for model discovery."""
+    return await asyncio.create_subprocess_exec(
+        codex_path,
+        "app-server",
+        "--listen",
+        listen_url,
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+        env=env,
+        cwd=str(cwd),
+        **_proc.spawn_kwargs(),
+    )
+
+
+def _allocate_loopback_port() -> int:
+    """Return an ephemeral TCP port on loopback for model discovery."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+async def _wait_for_discovery_listener(
+    process: asyncio.subprocess.Process,
+    port: int,
+) -> None:
+    """Wait until a discovery app-server accepts loopback connections."""
+    deadline = asyncio.get_running_loop().time() + _CONNECT_TIMEOUT_SECONDS
+    while asyncio.get_running_loop().time() < deadline:
+        if process.returncode is not None:
+            raise RuntimeError(f"Codex model discovery exited early ({process.returncode})")
+        try:
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        except OSError:
+            await asyncio.sleep(_CONNECT_RETRY_DELAY_SECONDS)
+            continue
+        writer.close()
+        await writer.wait_closed()
+        del reader
+        return
+    raise TimeoutError("Timed out waiting for Codex model discovery app-server")
 
 
 @dataclass

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1893,7 +1893,13 @@ class HostProcess:
                     available_ids = {model.id for model in listing.models}
                     models = []
                     seen: set[str] = set()
-                    for option in await discover_codex_model_options():
+                    selected_default = False
+                    try:
+                        codex_options = await discover_codex_model_options()
+                    except Exception:
+                        _logger.exception("Failed to discover Codex-compatible pre-launch models")
+                        codex_options = []
+                    for option in codex_options:
                         raw_id = option.get("model") or option.get("id")
                         if (
                             not isinstance(raw_id, str)
@@ -1904,8 +1910,11 @@ class HostProcess:
                         seen.add(raw_id)
                         display_name = option.get("displayName")
                         is_default = raw_id == default_id or (
-                            default_model is None and option.get("isDefault") is True
+                            default_model is None
+                            and not selected_default
+                            and option.get("isDefault") is True
                         )
+                        selected_default = selected_default or is_default
                         models.append(
                             {
                                 "id": raw_id,

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1847,8 +1847,16 @@ class HostProcess:
         harness = canonicalize_harness(frame.harness) or frame.harness
         if harness == "codex-native":
             try:
-                from omnigent.codex_native_app_server import resolve_native_codex_launch
-                from omnigent.model_catalog import list_models_for_worker, resolve_catalog_model
+                from omnigent.codex_native_app_server import (
+                    discover_codex_model_options,
+                    resolve_native_codex_launch,
+                )
+                from omnigent.model_catalog import (
+                    is_direct_openai_provider,
+                    list_models_for_worker,
+                    resolve_catalog_model,
+                    resolve_model_provider,
+                )
                 from omnigent.spec.types import AgentSpec, ExecutorSpec
 
                 launch = await asyncio.to_thread(resolve_native_codex_launch, model=None)
@@ -1876,14 +1884,48 @@ class HostProcess:
                 default_id = (
                     default_model if default_model in {m.id for m in listing.models} else None
                 )
-                models = [
-                    {
-                        "id": model.id,
-                        "displayName": model.id,
-                        **({"isDefault": True} if model.id == default_id else {}),
-                    }
-                    for model in listing.models
-                ]
+                provider = (
+                    resolve_model_provider(spec, "codex-native")
+                    if listing.source == "openai-compatible"
+                    else None
+                )
+                if provider is not None and is_direct_openai_provider(provider):
+                    available_ids = {model.id for model in listing.models}
+                    models = []
+                    seen: set[str] = set()
+                    for option in await discover_codex_model_options():
+                        raw_id = option.get("model") or option.get("id")
+                        if (
+                            not isinstance(raw_id, str)
+                            or raw_id not in available_ids
+                            or raw_id in seen
+                        ):
+                            continue
+                        seen.add(raw_id)
+                        display_name = option.get("displayName")
+                        is_default = raw_id == default_id or (
+                            default_model is None and option.get("isDefault") is True
+                        )
+                        models.append(
+                            {
+                                "id": raw_id,
+                                "displayName": (
+                                    display_name
+                                    if isinstance(display_name, str) and display_name
+                                    else raw_id
+                                ),
+                                **({"isDefault": True} if is_default else {}),
+                            }
+                        )
+                else:
+                    models = [
+                        {
+                            "id": model.id,
+                            "displayName": model.id,
+                            **({"isDefault": True} if model.id == default_id else {}),
+                        }
+                        for model in listing.models
+                    ]
             except Exception:
                 _logger.exception("Failed to resolve pre-launch Codex model options")
                 return HostModelOptionsResultFrame(

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -242,6 +242,16 @@ class ResolvedModelProvider:
     detail: str = ""
 
 
+def is_direct_openai_provider(provider: ResolvedModelProvider) -> bool:
+    """Return whether *provider* targets OpenAI's canonical models API."""
+    if provider.family != OPENAI_FAMILY or not provider.base_url:
+        return False
+    from omnigent.onboarding.configure_models import default_base_url_for_family
+
+    canonical = default_base_url_for_family(OPENAI_FAMILY)
+    return _models_url(provider.base_url).lower() == _models_url(canonical).lower()
+
+
 # Unfiltered listings keyed by provider identity. TTLCache is not thread-safe
 # and enumeration runs via asyncio.to_thread, so accesses lock; the HTTP fetch
 # stays outside it (duplicate fetches are benign, corruption is not).

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -3777,7 +3777,10 @@ def create_runner_app(
         )
 
     async def _codex_native_model_options(conv_id: str) -> list[dict[str, Any]]:
-        from omnigent.codex_native_app_server import client_for_transport
+        from omnigent.codex_native_app_server import (
+            client_for_transport,
+            list_codex_model_options,
+        )
 
         state = await _codex_native_bridge_state_for_session(
             conv_id,
@@ -3791,35 +3794,12 @@ def create_runner_app(
             state.socket_path,
             client_name="omnigent-codex-native-runner",
         )
-        options: list[dict[str, Any]] = []
         try:
             await codex_client.connect()
-            cursor: str | None = None
-            while True:
-                params: dict[str, Any] = {"includeHidden": False}
-                if cursor is not None:
-                    params["cursor"] = cursor
-                response = await codex_client.request("model/list", params)
-                result = response.get("result")
-                if not isinstance(result, dict):
-                    raise ValueError("Codex model/list result must be an object")
-                data = result.get("data")
-                if not isinstance(data, list):
-                    raise ValueError("Codex model/list data must be a list")
-                for raw_model in data:
-                    if not isinstance(raw_model, dict):
-                        raise ValueError("Codex model/list item must be an object")
-                    options.append(raw_model)
-                next_cursor = result.get("nextCursor")
-                if next_cursor is None:
-                    break
-                if not isinstance(next_cursor, str) or not next_cursor:
-                    raise ValueError("Codex model/list nextCursor must be a string or null")
-                cursor = next_cursor
+            return await list_codex_model_options(codex_client)
         finally:
             with contextlib.suppress(Exception):
                 await codex_client.close()
-        return options
 
     async def _handle_pi_native_model_change(
         conv_id: str,

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -237,6 +237,145 @@ async def test_handle_model_options_uses_databricks_catalog_default(
     ]
 
 
+async def test_handle_model_options_filters_direct_openai_through_codex_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct OpenAI availability is intersected with Codex compatibility."""
+    from omnigent import codex_native_app_server
+    from omnigent.model_catalog import ModelEntry, ModelListing, ResolvedModelProvider
+
+    monkeypatch.setattr(
+        "omnigent.model_catalog.list_models_for_worker",
+        lambda spec, harness: ModelListing(
+            source="openai-compatible",
+            verified=True,
+            models=tuple(
+                ModelEntry(id=model_id, family="openai")
+                for model_id in (
+                    "coding-compatible",
+                    "audio-preview",
+                    "realtime-preview",
+                    "image-preview",
+                    "embedding-preview",
+                    "moderation-preview",
+                )
+            ),
+            note="test OpenAI catalog",
+        ),
+    )
+    monkeypatch.setattr(
+        "omnigent.model_catalog.resolve_model_provider",
+        lambda spec, harness: ResolvedModelProvider(
+            kind="key",
+            family="openai",
+            base_url="https://api.openai.com",
+            detail="test OpenAI key",
+        ),
+    )
+    monkeypatch.setattr(
+        codex_native_app_server,
+        "resolve_native_codex_launch",
+        lambda *, model: codex_native_app_server.NativeCodexLaunch(
+            config_overrides=[],
+            model=None,
+            profile=None,
+        ),
+    )
+
+    async def _fake_codex_options() -> list[dict[str, object]]:
+        return [
+            {
+                "id": "coding-compatible",
+                "model": "coding-compatible",
+                "displayName": "Coding Compatible",
+                "isDefault": True,
+            },
+            {
+                "id": "coding-unavailable",
+                "model": "coding-unavailable",
+                "displayName": "Coding Unavailable",
+                "isDefault": False,
+            },
+        ]
+
+    monkeypatch.setattr(
+        codex_native_app_server,
+        "discover_codex_model_options",
+        _fake_codex_options,
+    )
+    host = _make_host_process()
+
+    result = await host._handle_model_options(
+        HostModelOptionsFrame(request_id="req_models", harness="codex-native"),
+    )
+
+    assert result.models == [
+        {
+            "id": "coding-compatible",
+            "displayName": "Coding Compatible",
+            "isDefault": True,
+        }
+    ]
+
+
+async def test_handle_model_options_keeps_custom_gateway_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Custom gateway ids remain selectable without Codex alias filtering."""
+    from omnigent import codex_native_app_server
+    from omnigent.model_catalog import ModelEntry, ModelListing, ResolvedModelProvider
+
+    monkeypatch.setattr(
+        "omnigent.model_catalog.list_models_for_worker",
+        lambda spec, harness: ModelListing(
+            source="openai-compatible",
+            verified=True,
+            models=(ModelEntry(id="gateway-coding-model", family="openai"),),
+            note="test gateway catalog",
+        ),
+    )
+    monkeypatch.setattr(
+        "omnigent.model_catalog.resolve_model_provider",
+        lambda spec, harness: ResolvedModelProvider(
+            kind="gateway",
+            family="openai",
+            base_url="https://gateway.example/v1",
+            detail="test gateway",
+        ),
+    )
+    monkeypatch.setattr(
+        codex_native_app_server,
+        "resolve_native_codex_launch",
+        lambda *, model: codex_native_app_server.NativeCodexLaunch(
+            config_overrides=[],
+            model="gateway-coding-model",
+            profile=None,
+        ),
+    )
+
+    async def _unexpected_codex_options() -> list[dict[str, object]]:
+        raise AssertionError("custom gateways must not use the OpenAI compatibility filter")
+
+    monkeypatch.setattr(
+        codex_native_app_server,
+        "discover_codex_model_options",
+        _unexpected_codex_options,
+    )
+    host = _make_host_process()
+
+    result = await host._handle_model_options(
+        HostModelOptionsFrame(request_id="req_models", harness="codex-native"),
+    )
+
+    assert result.models == [
+        {
+            "id": "gateway-coding-model",
+            "displayName": "gateway-coding-model",
+            "isDefault": True,
+        }
+    ]
+
+
 async def test_handle_model_options_rejects_unsupported_harness() -> None:
     """Only launch paths with host-resolved model catalogs are accepted."""
     host = _make_host_process()

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -318,6 +318,121 @@ async def test_handle_model_options_filters_direct_openai_through_codex_catalog(
     ]
 
 
+async def test_handle_model_options_tolerates_codex_discovery_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Discovery failures keep the implicit default without unsafe model rows."""
+    from omnigent import codex_native_app_server
+    from omnigent.model_catalog import ModelEntry, ModelListing, ResolvedModelProvider
+
+    monkeypatch.setattr(
+        "omnigent.model_catalog.list_models_for_worker",
+        lambda spec, harness: ModelListing(
+            source="openai-compatible",
+            verified=True,
+            models=(ModelEntry(id="unverified-model", family="openai"),),
+            note="test OpenAI catalog",
+        ),
+    )
+    monkeypatch.setattr(
+        "omnigent.model_catalog.resolve_model_provider",
+        lambda spec, harness: ResolvedModelProvider(
+            kind="key",
+            family="openai",
+            base_url="https://api.openai.com",
+            detail="test OpenAI key",
+        ),
+    )
+    monkeypatch.setattr(
+        codex_native_app_server,
+        "resolve_native_codex_launch",
+        lambda *, model: codex_native_app_server.NativeCodexLaunch(
+            config_overrides=[],
+            model=None,
+            profile=None,
+        ),
+    )
+
+    async def _failed_codex_options() -> list[dict[str, object]]:
+        raise TimeoutError("test discovery timeout")
+
+    monkeypatch.setattr(
+        codex_native_app_server,
+        "discover_codex_model_options",
+        _failed_codex_options,
+    )
+    host = _make_host_process()
+
+    result = await host._handle_model_options(
+        HostModelOptionsFrame(request_id="req_models", harness="codex-native"),
+    )
+
+    assert result == HostModelOptionsResultFrame(
+        request_id="req_models",
+        status="ok",
+        models=[],
+    )
+
+
+async def test_handle_model_options_marks_only_first_codex_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed Codex catalogs cannot mark multiple picker rows as default."""
+    from omnigent import codex_native_app_server
+    from omnigent.model_catalog import ModelEntry, ModelListing, ResolvedModelProvider
+
+    model_ids = ("coding-first", "coding-second")
+    monkeypatch.setattr(
+        "omnigent.model_catalog.list_models_for_worker",
+        lambda spec, harness: ModelListing(
+            source="openai-compatible",
+            verified=True,
+            models=tuple(ModelEntry(id=model_id, family="openai") for model_id in model_ids),
+            note="test OpenAI catalog",
+        ),
+    )
+    monkeypatch.setattr(
+        "omnigent.model_catalog.resolve_model_provider",
+        lambda spec, harness: ResolvedModelProvider(
+            kind="key",
+            family="openai",
+            base_url="https://api.openai.com",
+            detail="test OpenAI key",
+        ),
+    )
+    monkeypatch.setattr(
+        codex_native_app_server,
+        "resolve_native_codex_launch",
+        lambda *, model: codex_native_app_server.NativeCodexLaunch(
+            config_overrides=[],
+            model=None,
+            profile=None,
+        ),
+    )
+
+    async def _multiple_codex_defaults() -> list[dict[str, object]]:
+        return [
+            {"model": model_id, "displayName": model_id, "isDefault": True}
+            for model_id in model_ids
+        ]
+
+    monkeypatch.setattr(
+        codex_native_app_server,
+        "discover_codex_model_options",
+        _multiple_codex_defaults,
+    )
+    host = _make_host_process()
+
+    result = await host._handle_model_options(
+        HostModelOptionsFrame(request_id="req_models", harness="codex-native"),
+    )
+
+    assert result.models == [
+        {"id": "coding-first", "displayName": "coding-first", "isDefault": True},
+        {"id": "coding-second", "displayName": "coding-second"},
+    ]
+
+
 async def test_handle_model_options_keeps_custom_gateway_catalog(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -20,13 +20,118 @@ from omnigent.codex_native_app_server import (
     CodexNativeAppServer,
     _codex_policy_hooks_settings,
     _hooks_list_diagnostics,
+    _model_discovery_cache,
     _our_policy_hooks_from_list,
     _sync_codex_developer_instructions,
     build_codex_native_server,
+    discover_codex_model_options,
     trust_native_policy_hooks,
 )
 from omnigent.codex_native_hook import _EVALUATE_POLICY_TIMEOUT_S
 from omnigent.inner.codex_executor import _populate_codex_home_config
+
+
+async def test_discover_codex_model_options_strips_secrets_and_stops_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pre-launch discovery uses an empty home, no credentials, and clean teardown."""
+    from omnigent import codex_native_app_server
+
+    captured_env: dict[str, str] = {}
+
+    class _FakeProcess:
+        pid = None
+        returncode: int | None = None
+        terminated = False
+
+        def terminate(self) -> None:
+            self.terminated = True
+            self.returncode = 0
+
+        def kill(self) -> None:
+            self.returncode = -1
+
+        async def wait(self) -> int:
+            self.returncode = 0 if self.returncode is None else self.returncode
+            return self.returncode
+
+    process = _FakeProcess()
+
+    async def _fake_start(
+        *,
+        codex_path: str,
+        listen_url: str,
+        env: dict[str, str],
+        cwd: Path,
+    ) -> _FakeProcess:
+        assert codex_path == "/test/codex"
+        assert listen_url.startswith("ws://127.0.0.1:")
+        assert cwd.is_dir()
+        assert Path(env["CODEX_HOME"]).is_dir()
+        captured_env.update(env)
+        return process
+
+    async def _fake_wait(process: _FakeProcess, port: int) -> None:
+        assert process is not None
+        assert port > 0
+
+    class _FakeClient:
+        def __init__(self, *, ws_url: str, client_name: str) -> None:
+            assert ws_url.startswith("ws://127.0.0.1:")
+            assert client_name == "omnigent-codex-model-discovery"
+
+        async def connect(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+        async def request(
+            self,
+            method: str,
+            params: dict[str, object],
+        ) -> dict[str, object]:
+            assert method == "model/list"
+            assert params == {"includeHidden": False}
+            return {
+                "result": {
+                    "data": [
+                        {
+                            "id": "coding-model",
+                            "model": "coding-model",
+                            "isDefault": True,
+                        }
+                    ],
+                    "nextCursor": None,
+                }
+            }
+
+    monkeypatch.setattr(
+        codex_native_app_server,
+        "_clean_codex_env",
+        lambda: {
+            "PATH": "/bin",
+            "OPENAI_API_KEY": "openai-secret",
+            "OPENAI_BASE_URL": "https://example.invalid/v1",
+            "DATABRICKS_BEARER": "databricks-secret",
+            "DATABRICKS_CODEX_TOKEN": "databricks-secret",
+        },
+    )
+    monkeypatch.setattr(
+        codex_native_app_server,
+        "_start_codex_model_discovery_process",
+        _fake_start,
+    )
+    monkeypatch.setattr(codex_native_app_server, "_wait_for_discovery_listener", _fake_wait)
+    monkeypatch.setattr(codex_native_app_server, "CodexAppServerClient", _FakeClient)
+    _model_discovery_cache.clear()
+
+    options = await discover_codex_model_options(codex_path="/test/codex")
+
+    assert options == [{"id": "coding-model", "model": "coding-model", "isDefault": True}]
+    assert captured_env == {"PATH": "/bin", "CODEX_HOME": captured_env["CODEX_HOME"]}
+    assert process.terminated is True
+    _model_discovery_cache.clear()
 
 
 def test_sync_developer_instructions_preserves_and_restores_user_config(tmp_path: Path) -> None:


### PR DESCRIPTION
## Related issue

Closes #3654

## Summary

- Intersects direct OpenAI `/v1/models` availability with the installed Codex CLI's authoritative `model/list`, so specialty and incompatible models no longer appear in the launch picker.
- Runs compatibility discovery in a credential-free temporary Codex home, caches it for five minutes, and always tears down the transient app-server.
- If compatibility discovery fails, keeps the implicit Default launch available without exposing unverified provider rows; malformed catalogs can mark at most one default.
- Reuses the same paginated `model/list` reader for pre-launch and in-session discovery while leaving Databricks and custom gateway catalogs provider-authoritative.

ELI5: OpenAI says what the key can access; Codex says what it can run. The picker now shows only models present in both lists.

```text
OpenAI /v1/models ─┐
                   ├─ intersection ─> Codex launch picker
Codex model/list ──┘
```

## Test Plan

- `uv run pytest tests/host/test_connect.py tests/test_codex_native_app_server.py tests/runner/test_app_sessions_native_events_lifecycle.py::test_codex_native_model_options_query_model_list -q` — 133 passed.
- `uv run pre-commit run --all-files` — passed.
- Queried a real OpenAI account: the provider returned 125 models; the Codex-compatible intersection retained 5.
- Manually queried an isolated installed Codex app-server twice: first discovery completed in 0.28s, the cached call was immediate, and no discovery process remained.

## Demo

Real OpenAI `/v1/models` verification:

- **Before:** 125 models, including embeddings, audio, realtime, image, moderation, search, transcription, TTS, Sora, legacy chat/completions, and dated aliases.
- **After:** 5 models — `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, and `gpt-5.2`.

A deterministic picker screenshot is not reproducible in CI because both sides of the intersection depend on a live OpenAI account and the locally installed Codex CLI. The real endpoint counts above and focused unit coverage document the observable before/after instead.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage verifies mixed compatible/incompatible OpenAI responses, graceful discovery failure, single-default handling, custom-gateway passthrough, credential stripping, and subprocess teardown. The existing runner endpoint test verifies paginated in-session `model/list` behavior through the shared reader. Manual verification used both a real OpenAI account and an empty temporary Codex home, confirming the 125-to-5 filter, real CLI output, caching, and cleanup.

## Changelog

The Codex model picker now hides OpenAI models that the installed Codex CLI cannot run.
