### PR TITLE
refactor(codex): type native input boundaries

### DIFF
--- a/omnigent/inner/codex_native_executor.py
+++ b/omnigent/inner/codex_native_executor.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import binascii
 import json
 import logging
 import os
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from pathlib import Path
-from typing import Any
+from typing import cast
 
 from omnigent.codex_native_app_server import client_for_transport
 from omnigent.codex_native_bridge import (
@@ -24,6 +25,7 @@ from omnigent.codex_native_bridge import (
 )
 from omnigent.inner.codex_goal_command import goal_objective_from_content
 from omnigent.inner.executor import (
+    EnqueuedContent,
     Executor,
     ExecutorConfig,
     ExecutorError,
@@ -73,7 +75,7 @@ class CodexNativeExecutor(Executor):
         """:returns: ``True`` because active turns accept ``turn/steer``."""
         return True
 
-    async def enqueue_session_message(self, session_key: str, content: Any) -> bool:
+    async def enqueue_session_message(self, session_key: str, content: EnqueuedContent) -> bool:
         """
         Steer an active native Codex turn.
 
@@ -115,7 +117,8 @@ class CodexNativeExecutor(Executor):
                 return False
             finally:
                 await client.close()
-            turn_id = response.get("result", {}).get("turnId")
+            result = _json_object(response.get("result"))
+            turn_id = result.get("turnId") if result is not None else None
             if isinstance(turn_id, str) and turn_id:
                 update_active_turn_id(self._bridge_dir, turn_id)
                 _logger.info("Codex native steered active turn: turn_id=%s", turn_id)
@@ -206,7 +209,7 @@ class CodexNativeExecutor(Executor):
         settings_overrides = _model_effort_overrides(config)
         latest_user_content = _latest_user_content(messages)
         goal_objective = goal_objective_from_content(latest_user_content)
-        input_items = (
+        input_items: list[dict[str, object]] = (
             [{"type": "text", "text": goal_objective}]
             if goal_objective is not None
             else _content_to_input_items(latest_user_content, self._bridge_dir)
@@ -277,7 +280,8 @@ class CodexNativeExecutor(Executor):
                                 "input": input_items,
                             },
                         )
-                        turn_id = response.get("result", {}).get("turnId")
+                        result = _json_object(response.get("result"))
+                        turn_id = result.get("turnId") if result is not None else None
                         if isinstance(turn_id, str) and turn_id:
                             update_active_turn_id(self._bridge_dir, turn_id)
                             _logger.info("Codex native steered active turn: turn_id=%s", turn_id)
@@ -297,12 +301,14 @@ class CodexNativeExecutor(Executor):
                                     **settings_overrides,
                                 },
                             )
-                        turn_params: dict[str, Any] = {
+                        turn_params: dict[str, object] = {
                             "threadId": state.thread_id,
                             "input": input_items,
                         }
                         response = await client.request("turn/start", turn_params)
-                        turn_id = response.get("result", {}).get("turn", {}).get("id")
+                        result = _json_object(response.get("result"))
+                        turn = _json_object(result.get("turn")) if result is not None else None
+                        turn_id = turn.get("id") if turn is not None else None
                         if isinstance(turn_id, str) and turn_id:
                             update_active_turn_id(self._bridge_dir, turn_id)
                             _logger.info("Codex native started turn: turn_id=%s", turn_id)
@@ -322,7 +328,7 @@ class CodexNativeExecutor(Executor):
             yield TurnComplete(response=None)
 
 
-def _model_effort_overrides(config: ExecutorConfig | None) -> dict[str, Any]:
+def _model_effort_overrides(config: ExecutorConfig | None) -> dict[str, object]:
     """
     Build Codex ``thread/settings/update`` model / reasoning-effort overrides.
 
@@ -346,7 +352,7 @@ def _model_effort_overrides(config: ExecutorConfig | None) -> dict[str, Any]:
     """
     if config is None:
         return {}
-    overrides: dict[str, Any] = {}
+    overrides: dict[str, object] = {}
     model = config.model
     if isinstance(model, str) and model:
         overrides["model"] = model
@@ -397,7 +403,7 @@ def _session_is_active(session_id: str, request_session_id: str | None) -> bool:
     return request_session_id is None or request_session_id == session_id
 
 
-def _latest_user_content(messages: list[Message]) -> Any:
+def _latest_user_content(messages: list[Message]) -> object:
     """
     Return the latest user message content.
 
@@ -410,7 +416,7 @@ def _latest_user_content(messages: list[Message]) -> Any:
     return None
 
 
-def _content_to_input_items(content: Any, bridge_dir: Path) -> list[dict[str, Any]]:
+def _content_to_input_items(content: object, bridge_dir: Path) -> list[dict[str, object]]:
     """
     Normalize executor content into Codex app-server input items.
 
@@ -431,9 +437,10 @@ def _content_to_input_items(content: Any, bridge_dir: Path) -> list[dict[str, An
     if isinstance(content, str):
         return [{"type": "text", "text": content}] if content else []
     if isinstance(content, list):
-        items: list[dict[str, Any]] = []
-        for block in content:
-            if not isinstance(block, dict):
+        items: list[dict[str, object]] = []
+        for raw_block in content:
+            block = _json_object(raw_block)
+            if block is None:
                 continue
             block_type = block.get("type")
             if block_type in {"input_text", "text"}:
@@ -456,7 +463,10 @@ def _content_to_input_items(content: Any, bridge_dir: Path) -> list[dict[str, An
     return [{"type": "text", "text": json.dumps(content, ensure_ascii=True)}]
 
 
-def _file_block_to_input_item(block: dict[str, Any], bridge_dir: Path) -> dict[str, Any] | None:
+def _file_block_to_input_item(
+    block: Mapping[str, object],
+    bridge_dir: Path,
+) -> dict[str, object] | None:
     """
     Convert an ``input_file`` block into a Codex input item.
 
@@ -481,7 +491,7 @@ def _file_block_to_input_item(block: dict[str, Any], bridge_dir: Path) -> dict[s
             if parsed.mime_type.startswith("text/"):
                 text = base64.b64decode(parsed.base64_payload).decode("utf-8", errors="replace")
                 return {"type": "text", "text": text} if text else None
-        except (ValueError, base64.binascii.Error):
+        except (ValueError, binascii.Error):
             _logger.warning("Failed to decode input_file data URI", exc_info=True)
     path = materialize_attachment(block, bridge_dir)
     if path is not None:
@@ -491,3 +501,10 @@ def _file_block_to_input_item(block: dict[str, Any], bridge_dir: Path) -> dict[s
         # omnigent/entities/conversation.py. Keep in sync.
         return {"type": "text", "text": f"[Attached file: {path}]"}
     return {"type": "text", "text": unresolved_attachment_marker(block)}
+
+
+def _json_object(value: object) -> dict[str, object] | None:
+    """Return a string-keyed JSON object, or ``None`` for other shapes."""
+    if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
+        return None
+    return cast("dict[str, object]", value)

--- a/omnigent/inner/native_attachments.py
+++ b/omnigent/inner/native_attachments.py
@@ -14,14 +14,15 @@ that shared decode-and-write step.
 from __future__ import annotations
 
 import base64
+import binascii
 import hashlib
 import logging
 import re
 import urllib.parse
 import uuid
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 import httpx
 
@@ -78,7 +79,7 @@ def parse_data_uri(uri: str) -> DataUri:
     return DataUri(mime_type=mime_part, base64_payload=payload)
 
 
-def materialize_attachment(block: dict[str, Any], bridge_dir: Path) -> Path | None:
+def materialize_attachment(block: Mapping[str, object], bridge_dir: Path) -> Path | None:
     """
     Decode a base64 data URI from a content block and write it to disk.
 
@@ -106,13 +107,13 @@ def materialize_attachment(block: dict[str, Any], bridge_dir: Path) -> Path | No
     try:
         parsed = parse_data_uri(data_uri)
         raw_bytes = base64.b64decode(parsed.base64_payload)
-    except (ValueError, base64.binascii.Error):
+    except (ValueError, binascii.Error):
         _logger.warning("Failed to decode data URI for attachment", exc_info=True)
         return None
 
     ext = MIME_TO_EXT.get(parsed.mime_type, "")
     filename = block.get("filename")
-    if not filename:
+    if not isinstance(filename, str) or not filename:
         filename = f"attachment_{uuid.uuid4().hex[:8]}{ext}"
     else:
         filename = Path(filename).name or f"attachment_{uuid.uuid4().hex[:8]}{ext}"
@@ -157,7 +158,7 @@ UNRESOLVED_ATTACHMENT_MARKER_PATTERN = r"\[Attachment [^\]]+ could not be loaded
 ATTACHMENT_MARKER_STRIP_PATTERN = rf"\[Attached:[^\]]*\]|{UNRESOLVED_ATTACHMENT_MARKER_PATTERN}"
 
 
-def unresolved_attachment_marker(block: dict[str, Any]) -> str:
+def unresolved_attachment_marker(block: Mapping[str, object]) -> str:
     """
     Visible placeholder for an attachment that could not be loaded.
 
@@ -177,7 +178,7 @@ def unresolved_attachment_marker(block: dict[str, Any]) -> str:
     return f"[Attachment {_MARKER_UNSAFE.sub('_', name)} could not be loaded]"
 
 
-def attachment_reference_line(block: dict[str, Any], bridge_dir: Path) -> str:
+def attachment_reference_line(block: Mapping[str, object], bridge_dir: Path) -> str:
     """
     Materialize *block* and return the transcript line referencing it.
 
@@ -197,7 +198,7 @@ def attachment_reference_line(block: dict[str, Any], bridge_dir: Path) -> str:
     return unresolved_attachment_marker(block)
 
 
-def has_unresolved_file_id(block: dict[str, Any]) -> bool:
+def has_unresolved_file_id(block: Mapping[str, object]) -> bool:
     """
     True if *block* carries a ``file_id`` no resolver has inlined yet.
 
@@ -212,11 +213,11 @@ def has_unresolved_file_id(block: dict[str, Any]) -> bool:
 
 
 async def resolve_file_id_block(
-    block: dict[str, Any],
+    block: Mapping[str, object],
     *,
     session_id: str,
     client: httpx.AsyncClient,
-) -> dict[str, Any] | None:
+) -> dict[str, object] | None:
     """
     Fetch a ``file_id`` attachment's bytes and inline them as a data URI.
 

--- a/tests/inner/test_native_attachments.py
+++ b/tests/inner/test_native_attachments.py
@@ -93,6 +93,20 @@ def test_materialize_attachment_uses_block_filename(tmp_path: Path) -> None:
     assert path.parent == tmp_path / "uploads"
 
 
+def test_materialize_attachment_ignores_non_string_filename(tmp_path: Path) -> None:
+    block = {
+        "type": "input_image",
+        "image_url": _PNG_DATA_URI,
+        "filename": 42,
+    }
+
+    path = materialize_attachment(block, tmp_path)
+
+    assert path is not None
+    assert path.name.startswith("attachment_")
+    assert path.suffix == ".png"
+
+
 def test_materialize_attachment_returns_none_without_data_uri(tmp_path: Path) -> None:
     """
     A block whose data URI is missing yields ``None`` and writes nothing.


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Replace broad `Any` annotations in the native Codex executor with the existing `EnqueuedContent` contract, string-keyed JSON objects, and runtime narrowing for app-server response envelopes.
- Type the shared native-attachment helpers as read-only JSON mappings, handle non-string filenames safely, and catch `binascii.Error` from the actual module rather than the nonexistent `base64.binascii` attribute.
- Remove all 18 mypy findings across `omnigent/inner/codex_native_executor.py` and `omnigent/inner/native_attachments.py`, reducing a clean current-`main` run from 1,573 to 1,555 errors.

**ELI5:** User content and Codex responses now pass through checked JSON-shaped doors before the executor reads fields or writes attachments.

```text
user content -> typed attachment/input normalization -> Codex app-server
Codex response -> object-shape checks -> active turn state
```

## Test Plan

- `uv run --no-sync pytest -q tests/inner/test_native_attachments.py tests/inner/test_codex_native_executor.py` (31 passed)
- `uv run --no-sync mypy --no-incremental omnigent` (1,555 existing errors; none in the two changed modules)
- `pre-commit run --all-files`
- Confirmed `uv.lock` is unchanged.

## Demo

N/A — non-visual type-safety refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused suites cover Codex turn start/steer response handling, text/image/file normalization, attachment materialization, and the new non-string filename fallback.

## Changelog

N/A — internal type-safety cleanup.
