### PR TITLE
feat(harness): accept community native harnesses (PR 2.1 validator flip)

### DIFF
--- a/designs/harness-modular-registry-proposal.md
+++ b/designs/harness-modular-registry-proposal.md
@@ -470,6 +470,7 @@ signature.
 | 1.7 Server seeding loop | landed | #3599 | 07-31 |
 | 1.7 follow-up: opencode e2e onto shared agent-name constant | landed | #3656 | 07-31 |
 | 1.8 Derive enumerations + fork_history/shell-tool capability axes | landed | #3648 | 07-31 |
+| 2.1 Validator flip (accept community native harnesses) | in review | (this PR) | — |
 
 **1.4 descoped.** The CLI-subcommand collapse (`cli_native.py` → a loop over
 `native_agents()`) is orthogonal to making native harnesses community-pluggable:

--- a/designs/harness-plugin-interface.md
+++ b/designs/harness-plugin-interface.md
@@ -166,11 +166,18 @@ For a non-native harness:
 
 ## Native TUI Harnesses
 
-Community native terminal harnesses are not supported by this interface yet.
-Core native harnesses still use internal registry metadata, but the runner,
-chat-resume, CLI-command, interrupt/stop, and built-in agent seeding paths are
-not pluggable. Community plugins that set `native_harnesses` or `native_agents`
-are rejected at load time until those lifecycle hooks are wired end to end.
+Community native terminal harnesses **are** supported: the runner, chat-resume,
+interrupt/stop, spawn-env, and built-in agent-seeding paths all dispatch through
+the `NativeHarnessProvider` seam, so a plugin that ships `native_agents` +
+`native_providers` is accepted at load time (validated for internal consistency
+and identity collisions — see `_validate_native_contribution`). A contribution
+must pair each `NativeCodingAgent` with a `NativeHarnessProvider` keyed by the
+same `key`, declare the agent's harness id in `valid_harnesses`, supply the
+required provider hooks (`run_native`, `auto_create_terminal`), and keep every
+provider import path under `COMMUNITY_MODULE_PREFIX`.
+
+A full step-by-step native-plugin checklist and a benchable example plugin ship
+with the plugin-interface docs update (workstream PR 2.4).
 
 ## Import Rules
 

--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -811,11 +811,38 @@ def _module_part(import_path: str) -> str:
     return import_path.split(":", 1)[0]
 
 
+# NativeHarnessProvider fields that carry a dotted import path the resolver
+# imports at dispatch time (so they must live under COMMUNITY_MODULE_PREFIX for a
+# community plugin). ``key`` is an identifier and ``bridge_id_label_key`` is a
+# session-label key, not code — both are excluded.
+_NATIVE_PROVIDER_IMPORT_PATH_FIELDS: tuple[str, ...] = (
+    "run_native",
+    "auto_create_terminal",
+    "spawn_env_builder",
+    "interrupt_handler",
+    "stop_handler",
+    "materialize_agent_spec",
+    "bridge_dir",
+)
+
+
+def _native_provider_import_paths(contribution: HarnessContribution) -> list[str]:
+    """Return every dotted import path a contribution's native providers resolve."""
+    paths: list[str] = []
+    for provider in contribution.native_providers:
+        for field_name in _NATIVE_PROVIDER_IMPORT_PATH_FIELDS:
+            value = getattr(provider, field_name)
+            if value:
+                paths.append(value)
+    return paths
+
+
 def _community_paths(contribution: HarnessContribution) -> list[str]:
     paths: list[str] = []
     paths.extend(contribution.harness_modules.values())
     paths.extend(contribution.spawn_env_builders.values())
     paths.extend(spec.generator for spec in contribution.background_title_generators.values())
+    paths.extend(_native_provider_import_paths(contribution))
     return paths
 
 
@@ -852,6 +879,88 @@ def _native_agent_identity_values(contribution: HarnessContribution) -> set[str]
     return values
 
 
+# Native-provider hooks a community plugin MUST supply — the launch/route path
+# cannot run without them. The remaining hooks are optional (interrupt/stop fall
+# through to the in-process cancel; materialize_agent_spec only gates built-in
+# seeding; bridge_dir only feeds the cost-popup lookup).
+_REQUIRED_NATIVE_PROVIDER_HOOKS: tuple[str, ...] = ("run_native", "auto_create_terminal")
+
+
+def _validate_native_contribution(
+    contribution: HarnessContribution,
+    *,
+    entry_point_name: str,
+) -> str | None:
+    """Validate a community plugin's native-terminal contribution.
+
+    Native terminal harnesses ARE supported (the runner runs every native
+    harness through the ``NativeHarnessProvider`` seam). A contribution that
+    ships native metadata must be internally consistent: each declared agent
+    needs a provider row (and vice versa) keyed by the same ``key``, and each
+    provider must supply the hooks the launch path requires. Import-path prefix
+    and identity-collision checks are enforced by the shared community-validator
+    (native provider hook paths are included via ``_community_paths``, and agent
+    identity values via ``_native_agent_identity_values``).
+
+    :param contribution: The plugin's contribution.
+    :param entry_point_name: The entry-point name, for error messages.
+    :returns: An error string when the native metadata is inconsistent, else
+        ``None`` (including when the plugin ships no native metadata).
+    """
+    if not (contribution.native_agents or contribution.native_providers):
+        return None
+
+    agent_keys = [agent.key for agent in contribution.native_agents]
+    provider_keys = [provider.key for provider in contribution.native_providers]
+    agent_key_set = set(agent_keys)
+    provider_key_set = set(provider_keys)
+
+    if len(agent_key_set) != len(agent_keys):
+        dupes = sorted({k for k in agent_keys if agent_keys.count(k) > 1})
+        return (
+            f"community harness plugin {entry_point_name!r} declares duplicate native "
+            f"agent keys: {dupes}"
+        )
+    if len(provider_key_set) != len(provider_keys):
+        dupes = sorted({k for k in provider_keys if provider_keys.count(k) > 1})
+        return (
+            f"community harness plugin {entry_point_name!r} declares duplicate native "
+            f"provider keys: {dupes}"
+        )
+
+    agents_without_provider = sorted(agent_key_set - provider_key_set)
+    if agents_without_provider:
+        return (
+            f"community harness plugin {entry_point_name!r} declares native agents without a "
+            f"matching provider row: {agents_without_provider}"
+        )
+    providers_without_agent = sorted(provider_key_set - agent_key_set)
+    if providers_without_agent:
+        return (
+            f"community harness plugin {entry_point_name!r} declares native providers without a "
+            f"matching agent row: {providers_without_agent}"
+        )
+
+    # Every declared native agent's harness id must be in valid_harnesses, or the
+    # runner/spec layer can never route to it.
+    for agent in contribution.native_agents:
+        if agent.harness not in contribution.valid_harnesses:
+            return (
+                f"community harness plugin {entry_point_name!r} native agent {agent.key!r} "
+                f"declares harness {agent.harness!r}, which is not in valid_harnesses"
+            )
+
+    for provider in contribution.native_providers:
+        for hook in _REQUIRED_NATIVE_PROVIDER_HOOKS:
+            if not getattr(provider, hook):
+                return (
+                    f"community harness plugin {entry_point_name!r} native provider "
+                    f"{provider.key!r} is missing required hook {hook!r}"
+                )
+
+    return None
+
+
 def _validate_community_contribution(
     contribution: HarnessContribution,
     *,
@@ -868,11 +977,9 @@ def _validate_community_contribution(
                 f"{path!r}; expected {COMMUNITY_MODULE_PREFIX}*"
             )
 
-    if contribution.native_harnesses or contribution.native_agents:
-        return (
-            f"community harness plugin {entry_point_name!r} registers native terminal "
-            "metadata, but community native terminal harnesses are not supported yet"
-        )
+    native_error = _validate_native_contribution(contribution, entry_point_name=entry_point_name)
+    if native_error is not None:
+        return native_error
 
     existing_harness_spellings: set[str] = set()
     existing_install_keys: set[str] = set()

--- a/tests/test_harness_plugins.py
+++ b/tests/test_harness_plugins.py
@@ -144,22 +144,143 @@ def test_community_harness_rejects_community_collision(
     assert hp.harness_modules()["foo"] == "omnigent.community.harness.foo.inner.foo_harness"
 
 
-def test_community_harness_rejects_native_terminal_metadata(
+_FOO_NATIVE_MODULE = "omnigent.community.harness.foo"
+
+
+def _foo_native_agent() -> hp.NativeCodingAgent:
+    return hp.NativeCodingAgent(
+        key="foo",
+        display_name="Foo",
+        agent_name="foo-native-ui",
+        harness="foo-native",
+        wrapper_label="foo-native-ui",
+        terminal_name="foo",
+    )
+
+
+def _foo_native_provider(**overrides: object) -> hp.NativeHarnessProvider:
+    fields: dict[str, object] = {
+        "key": "foo",
+        "run_native": f"{_FOO_NATIVE_MODULE}.foo_native:run_foo_native",
+        "auto_create_terminal": f"{_FOO_NATIVE_MODULE}.runner:_launch_foo",
+        "spawn_env_builder": f"{_FOO_NATIVE_MODULE}.foo_native_bridge:build_foo_native_spawn_env",
+    }
+    fields.update(overrides)
+    return hp.NativeHarnessProvider(**fields)  # type: ignore[arg-type]
+
+
+def _foo_native_contribution(
+    *,
+    agents: tuple[hp.NativeCodingAgent, ...] | None = None,
+    providers: tuple[hp.NativeHarnessProvider, ...] | None = None,
+) -> hp.HarnessContribution:
+    return hp.HarnessContribution(
+        name="omnigent-foo",
+        valid_harnesses=frozenset({"foo-native"}),
+        harness_modules={"foo-native": f"{_FOO_NATIVE_MODULE}.inner.foo_native_harness"},
+        native_harnesses=frozenset({"foo-native"}),
+        native_agents=(_foo_native_agent(),) if agents is None else agents,
+        native_providers=(_foo_native_provider(),) if providers is None else providers,
+    )
+
+
+def test_community_harness_accepts_native_terminal_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def _contribution() -> hp.HarnessContribution:
-        return hp.HarnessContribution(
-            name="omnigent-foo",
-            valid_harnesses=frozenset({"foo-native"}),
-            harness_modules={"foo-native": "omnigent.community.harness.foo.inner.foo_harness"},
-            native_harnesses=frozenset({"foo-native"}),
-        )
+    """A consistent community native harness is accepted and merged (PR 2.1 flip).
 
-    _install_entry_points(monkeypatch, _EntryPoint("foo", _contribution))
+    Native terminal harnesses ARE supported now that the runner runs every
+    native harness through the provider seam; a plugin whose agent/provider rows
+    are internally consistent and community-prefixed must load, not be rejected.
+    """
+    _install_entry_points(monkeypatch, _EntryPoint("foo", _foo_native_contribution))
+
+    state = hp.plugin_state()
+    assert "foo" not in state.load_errors, state.load_errors
+    assert "foo-native" in hp.valid_harnesses()
+    # The native agent + provider are both visible through the registry.
+    assert any(a.key == "foo" for a in hp.native_agents())
+    provider = hp.native_provider_for_key("foo")
+    assert provider is not None
+    assert provider.run_native == f"{_FOO_NATIVE_MODULE}.foo_native:run_foo_native"
+
+
+def test_community_native_rejects_non_community_provider_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A native provider hook outside the community prefix is rejected."""
+    contribution = _foo_native_contribution(
+        providers=(_foo_native_provider(run_native="omnigent.claude_native:run_claude_native"),),
+    )
+    _install_entry_points(monkeypatch, _EntryPoint("foo", lambda: contribution))
 
     state = hp.plugin_state()
     assert "foo" in state.load_errors
+    assert hp.native_provider_for_key("foo") is None
+
+
+def test_community_native_rejects_agent_without_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A native agent with no matching provider row is rejected."""
+    contribution = _foo_native_contribution(providers=())
+    _install_entry_points(monkeypatch, _EntryPoint("foo", lambda: contribution))
+
+    state = hp.plugin_state()
+    assert "foo" in state.load_errors
+    assert "matching provider row" in state.load_errors["foo"]
     assert "foo-native" not in hp.valid_harnesses()
+
+
+def test_community_native_rejects_provider_without_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A native provider with no matching agent row is rejected."""
+    contribution = _foo_native_contribution(agents=())
+    _install_entry_points(monkeypatch, _EntryPoint("foo", lambda: contribution))
+
+    state = hp.plugin_state()
+    assert "foo" in state.load_errors
+    assert "matching agent row" in state.load_errors["foo"]
+
+
+def test_community_native_rejects_missing_required_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A native provider missing a required launch hook is rejected."""
+    contribution = _foo_native_contribution(
+        providers=(_foo_native_provider(auto_create_terminal=""),),
+    )
+    _install_entry_points(monkeypatch, _EntryPoint("foo", lambda: contribution))
+
+    state = hp.plugin_state()
+    assert "foo" in state.load_errors
+    assert "auto_create_terminal" in state.load_errors["foo"]
+
+
+def test_community_native_rejects_agent_identity_collision_with_builtin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A native agent whose identity collides with a built-in is rejected.
+
+    The shared identity-collision guard (`_native_agent_identity_values`) must
+    still fire for native contributions after the accept flip — a plugin can't
+    claim ``claude``'s key / agent_name / wrapper_label / terminal_name.
+    """
+    colliding_agent = hp.NativeCodingAgent(
+        key="foo",
+        display_name="Foo",
+        agent_name="claude-native-ui",  # collides with the built-in claude agent
+        harness="foo-native",
+        wrapper_label="foo-native-ui",
+        terminal_name="foo",
+    )
+    contribution = _foo_native_contribution(agents=(colliding_agent,))
+    _install_entry_points(monkeypatch, _EntryPoint("foo", lambda: contribution))
+
+    state = hp.plugin_state()
+    assert "foo" in state.load_errors
+    assert "native-agent keys" in state.load_errors["foo"]
 
 
 def test_community_harness_readiness_uses_install_metadata(


### PR DESCRIPTION
## Related issue

N/A — first PR of Phase 2 of the modular native-harness registry workstream (`designs/harness-modular-registry-proposal.md`).

## Summary

PR **2.1** — the keystone that makes the Phase 1 seam *mean* something: **community pip packages can now contribute native terminal harnesses.** Phase 1 routed every native path (launch, terminal-route, interrupt/stop, spawn-env, resume, built-in seeding) through the `NativeHarnessProvider` seam; this flips the validator that used to reject native contributions at load time.

- `_validate_community_contribution` no longer hard-rejects `native_harnesses` / `native_agents`. A new `_validate_native_contribution` accepts a native contribution when it's internally consistent:
  - each `NativeCodingAgent` pairs with a `NativeHarnessProvider` keyed by the same `key` (and vice versa — no dangling agent or provider);
  - no duplicate agent/provider keys;
  - each agent's `harness` id is in `valid_harnesses`;
  - each provider supplies the required launch hooks (`run_native`, `auto_create_terminal`).
- The existing shared guards keep applying to native contributions: native **provider hook import paths** are now included in `_community_paths`, so they must live under `COMMUNITY_MODULE_PREFIX`; and agent **identity values** must not collide with an accepted contribution (`_native_agent_identity_values`).

### What this unlocks

After this merges, a third-party `omnigent-foo-native` package works end-to-end on the non-web paths **immediately**: `omnigent foo` CLI, spec `harness: foo-native`, resume, sub-agents, interrupt/stop. It won't show in the **web** picker until 2.2 (`/v1/harnesses` rows) + 2.3 (web off the endpoint).

### ELI5

The seam was built in Phase 1 but the front door was still bolted shut — any plugin that declared a native harness was rejected on load. This unbolts the door and adds a bouncer: a native plugin gets in if its agent and provider rows match up, its harness id is declared, its launch hooks are present, and it isn't impersonating a built-in.

## Test Plan

```bash
uv run pytest tests/test_harness_plugins.py tests/test_native_dispatch.py \
  tests/test_harness_capabilities.py -q
uv run pre-commit run --all-files
```

- Flipped `test_community_harness_rejects_native_terminal_metadata` → `test_community_harness_accepts_native_terminal_metadata` (a consistent native plugin loads, and its agent + provider are visible through the registry).
- Added rejection coverage for each new failure path: non-community provider import path, agent-without-provider, provider-without-agent, missing required hook, and identity collision with a built-in.
- `tests/test_harness_plugins.py`: 20 passed. The one failing test in the capabilities suite (`test_catalog_rows_carry_setup_steps`) is a **pre-existing** local-plugin pollution (`acp:qwen-openclaw-test`), confirmed failing identically on clean `main`; unrelated to this change.

## Demo

N/A — validator + registry change, no UI surface yet (the web story lands in 2.2/2.3).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Security-relevant boundary change (what community plugins may register), so each accept/reject rule is pinned by a dedicated test. Manual verification: constructed a consistent `foo-native` contribution via a fake entry point and confirmed it merges into `valid_harnesses()` / `native_agents()` / `native_provider_for_key("foo")`; confirmed each malformed variant lands in `plugin_state().load_errors` (a broken plugin never breaks core startup). Also corrected the now-stale "native harnesses are not supported" paragraph in `designs/harness-plugin-interface.md`; the full contributor checklist + a benchable example plugin land in **PR 2.4**.

---

**Workstream progress** (`designs/harness-modular-registry-proposal.md`): Phase 1 complete (1.1–1.8, 10 PRs). **Phase 2: 2.1 is this PR.** Remaining — 2.2 (`/v1/harnesses` native rows), 2.3 (web off the endpoint), 2.4 (docs + benchable example plugin).
