### PR TITLE
refactor(pi): type executor JSON boundaries

### DIFF
--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -45,7 +45,7 @@ import tempfile
 from asyncio import Queue, Task
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, TypeAlias
+from typing import Any, NotRequired, TypeAlias, TypedDict, cast
 from urllib.parse import urlparse as _urlparse
 
 from omnigent import model_catalog
@@ -130,6 +130,34 @@ NativePolicyGate: TypeAlias = Callable[  # type: ignore[explicit-any]
 # Plain JSON value — recursive union used by ``_check_blocked`` to walk
 # parsed Pi tool-result payloads.
 JsonValue: TypeAlias = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
+_JsonObject: TypeAlias = dict[str, object]
+
+
+class _PiProviderConfig(TypedDict):
+    baseUrl: str
+    apiKey: str
+    api: str
+    models: list[_JsonObject]
+    authHeader: NotRequired[bool]
+    compat: NotRequired[_JsonObject]
+
+
+class _PiModelsConfig(TypedDict):
+    providers: dict[str, _PiProviderConfig]
+
+
+class _PiMessageUsage(TypedDict):
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    cache_read_input_tokens: int
+    cache_creation_input_tokens: int
+    model: str | None
+
+
+class _PiTurnUsage(_PiMessageUsage):
+    context_tokens: int
+
 
 # ---------------------------------------------------------------------------
 # TCP tool server — serves Omnigent tools to the Pi extension
@@ -570,7 +598,7 @@ def _find_pi_cli() -> str | None:
 # a static id — in which case _build_models_json's append is skipped, so the
 # capability has to be declared here too or attached images are silently
 # dropped (#515/#516).
-_DATABRICKS_OPENAI_MODELS = [
+_DATABRICKS_OPENAI_MODELS: list[_JsonObject] = [
     {
         "id": "databricks-gpt-5-4-mini",
         "name": "GPT-5.4 Mini",
@@ -603,7 +631,7 @@ _DATABRICKS_OPENAI_MODELS = [
     },
 ]
 
-_DATABRICKS_ANTHROPIC_MODELS = [
+_DATABRICKS_ANTHROPIC_MODELS: list[_JsonObject] = [
     {
         "id": "databricks-claude-opus-4-8",
         "name": "Claude Opus 4.8",
@@ -631,7 +659,7 @@ _DATABRICKS_ANTHROPIC_MODELS = [
 
 # Empty: the only listed endpoint (meta-llama-3.3-70b) no longer exists on
 # the gateway. The provider stays so non-Claude/GPT ids keep a routing home.
-_DATABRICKS_COMPLETIONS_MODELS: list[dict[str, str | int]] = []
+_DATABRICKS_COMPLETIONS_MODELS: list[_JsonObject] = []
 
 # Prefix-matched env var names allowed into the Pi subprocess. Only
 # known-safe categories pass: Pi's own config knobs, proxy settings,
@@ -719,10 +747,10 @@ def _build_models_json(
     model: str | None = None,
     model_wire_apis: Mapping[str, frozenset[ModelWireAPI]] | None = None,
     openai_wire_api: str | None = None,
-) -> dict[str, Any]:  # type: ignore[explicit-any]
+) -> _PiModelsConfig:
     # Pi's models.json mixes str/int/bool/list/dict across provider configs;
-    # see _DATABRICKS_*_MODELS and the compat/authHeader shapes below. The
-    # schema is owned by the Pi CLI and not worth a TypedDict tree here.
+    # keep provider fields explicit while treating Pi-owned model entries as
+    # opaque JSON objects.
     """Build a Pi ``models.json`` with three gateway providers.
 
     Each provider targets a different API gateway path and wire format so
@@ -780,13 +808,13 @@ def _build_models_json(
         codex_gateway_url = openai_base_url
         mlflow_gateway_url = openai_base_url
     claude_base_url = (base_urls or {}).get("claude") or f"{h}/serving-endpoints/anthropic"
-    _openai_responses_compat: dict[str, Any] = {  # type: ignore[explicit-any]
+    _openai_responses_compat: _JsonObject = {
         "supportsDeveloperRole": False,
         "supportsStore": False,
         "supportsStrictMode": False,
         "supportsReasoningEffort": False,
     }
-    config: dict[str, Any] = {  # type: ignore[explicit-any]  # Pi-owned schema, see note above
+    config: _PiModelsConfig = {
         "providers": {
             # Newer GPT models (gpt-5-5, gpt-5-6-*, gpt-5-3-codex) → OpenAI
             # Responses API at the AI Gateway. These models reject function
@@ -888,7 +916,7 @@ def _build_models_json(
             # provider-side 400 on image turns — a deliberate trade (loud error
             # over silent loss), since most current gateway models are
             # multimodal and text-only turns are unaffected.
-            entry: dict[str, Any] = {"id": model, "input": ["text", "image"]}  # type: ignore[explicit-any]
+            entry: _JsonObject = {"id": model, "input": ["text", "image"]}
             if _pi_model_is_reasoning(model):
                 entry["reasoning"] = True
             provider["models"] = [*provider["models"], entry]
@@ -1263,7 +1291,7 @@ def _extract_text(msg: Message) -> str:
 
 def _extract_latest_user_content(
     messages: list[Message],
-) -> str | list[dict[str, Any]]:
+) -> str | list[_JsonObject]:
     """
     Extract the latest user message content.
 
@@ -1282,12 +1310,12 @@ def _extract_latest_user_content(
             if isinstance(content, str):
                 return content
             if isinstance(content, list):
-                return content
+                return cast(list[_JsonObject], content)
             return str(content)
     return ""
 
 
-def _split_pi_prompt(blocks: list[dict[str, Any]]) -> tuple[str, list[dict[str, str]]]:
+def _split_pi_prompt(blocks: list[_JsonObject]) -> tuple[str, list[dict[str, str]]]:
     """Split content blocks into Pi's prompt ``message`` text and ``images``.
 
     Pi's RPC ``prompt`` command carries text in ``message`` and images in a
@@ -1365,9 +1393,7 @@ def _split_pi_prompt(blocks: list[dict[str, Any]]) -> tuple[str, list[dict[str, 
     return "\n".join(text_parts), images
 
 
-def _build_pi_prompt(
-    messages: list[Message], *, is_first_turn: bool
-) -> str | list[dict[str, Any]]:
+def _build_pi_prompt(messages: list[Message], *, is_first_turn: bool) -> str | list[_JsonObject]:
     """
     Build the prompt to send to Pi.
 
@@ -1546,7 +1572,7 @@ def _resolve_pi_skill_args(
 def _extract_pi_turn_usage(
     message: object,
     fallback_model: str | None,
-) -> dict[str, Any] | None:  # type: ignore[explicit-any]
+) -> _PiMessageUsage | None:
     """Map a Pi assistant message's ``usage`` object onto the wire shape
     that :class:`TurnComplete` consumes, so pi sub-agent cost is priced
     the same way as ``claude-sdk`` and ``codex`` turns.
@@ -1586,9 +1612,9 @@ def _extract_pi_turn_usage(
 
 
 def _aggregate_pi_turn_usage(
-    message_usages: list[dict[str, Any]],  # type: ignore[explicit-any]
+    message_usages: list[_PiMessageUsage],
     fallback_model: str | None,
-) -> dict[str, Any] | None:  # type: ignore[explicit-any]
+) -> _PiTurnUsage | None:
     """Aggregate per-message Pi usage into one turn-level usage dict.
 
     A single Omnigent turn drives Pi's full agent loop, which may make
@@ -1958,7 +1984,10 @@ class PiExecutor(Executor):
                 "databricks",
                 family="claude",
             )
-            return resolution.model_id
+            model_id = resolution.model_id
+            if not isinstance(model_id, str):
+                raise TypeError("Databricks model resolution returned a non-string model id")
+            return model_id
         return model
 
     def _generic_openai_wire_api(self) -> str | None:
@@ -2300,7 +2329,7 @@ class PiExecutor(Executor):
         else:
             message = prompt
         cmd_id = f"turn_{id(messages)}"
-        command: dict[str, Any] = {"type": "prompt", "message": message, "id": cmd_id}
+        command: CodexEvent = {"type": "prompt", "message": message, "id": cmd_id}
         if images:
             command["images"] = images
         try:
@@ -2317,7 +2346,7 @@ class PiExecutor(Executor):
         # fallback). Summed into a turn-level usage dict at completion so a
         # multi-step (tool-loop) turn bills for every call, not just the
         # last. Empty when pi reports no usage — cost tracking is skipped.
-        message_usages: list[dict[str, Any]] = []  # type: ignore[explicit-any]
+        message_usages: list[_PiMessageUsage] = []
         # Error reported by a ``message_end`` (stopReason=error); surfaced at
         # ``agent_end`` so the terminal event is consumed off the RPC stream.
         pending_error: str | None = None
@@ -2338,7 +2367,10 @@ class PiExecutor(Executor):
                 else:
                     turn_usage = _aggregate_pi_turn_usage(message_usages, model)
                     _notify_usage_from_dict(model=model, usage=turn_usage)
-                    yield TurnComplete(response=response_text, usage=turn_usage)
+                    yield TurnComplete(
+                        response=response_text,
+                        usage=dict(turn_usage) if turn_usage is not None else None,
+                    )
                 return
 
             try:
@@ -2494,7 +2526,10 @@ class PiExecutor(Executor):
                             break
                 turn_usage = _aggregate_pi_turn_usage(message_usages, model)
                 _notify_usage_from_dict(model=model, usage=turn_usage)
-                yield TurnComplete(response=response_text, usage=turn_usage)
+                yield TurnComplete(
+                    response=response_text,
+                    usage=dict(turn_usage) if turn_usage is not None else None,
+                )
                 return
 
             # message_end carries one completed assistant message, whose


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Replace open-ended Pi model configuration, multimodal prompt, usage, and RPC command annotations with focused JSON aliases and `TypedDict` contracts.
- Narrow the catalog-resolved model id before returning it from the async provider boundary.
- Remove all 14 mypy findings from `omnigent/inner/pi_executor.py`, reducing a clean current-`main` run from 1,544 to 1,530 errors.

**ELI5:** Pi's flexible JSON messages now pass through named, checked shapes instead of being treated as anything at all.

```text
models + prompts -> typed Pi JSON boundaries -> RPC session
Pi usage events -> typed usage records -> TurnComplete
```

## Test Plan

- `uv run --no-sync pytest -q tests/inner/test_pi_executor.py tests/inner/test_pi_native_executor.py` (157 passed)
- `uv run --no-sync mypy --no-incremental omnigent` (1,530 existing errors; none in `pi_executor.py`)
- `pre-commit run --all-files`
- Confirmed `uv.lock` is unchanged.

## Demo

N/A — non-visual type-safety refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing focused suites cover model configuration generation, multimodal prompt conversion, catalog model resolution, RPC command submission, and turn usage aggregation.

## Changelog

N/A — internal type-safety cleanup.