### PR TITLE
feat(harness): emit native-agent rows on /v1/harnesses (PR 2.2)

### DIFF
--- a/designs/harness-modular-registry-proposal.md
+++ b/designs/harness-modular-registry-proposal.md
@@ -470,6 +470,8 @@ signature.
 | 1.7 Server seeding loop | landed | #3599 | 07-31 |
 | 1.7 follow-up: opencode e2e onto shared agent-name constant | landed | #3656 | 07-31 |
 | 1.8 Derive enumerations + fork_history/shell-tool capability axes | landed | #3648 | 07-31 |
+| 2.1 Validator flip (accept community native harnesses) | in review | #3670 | — |
+| 2.2 `/v1/harnesses` native-agent rows | in review | (this PR) | — |
 
 **1.4 descoped.** The CLI-subcommand collapse (`cli_native.py` → a loop over
 `native_agents()`) is orthogonal to making native harnesses community-pluggable:

--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -1133,6 +1133,48 @@ def harness_catalog() -> list[dict[str, Any]]:
     return rows
 
 
+def native_agent_catalog() -> list[dict[str, Any]]:
+    """Return JSON-serializable native-agent rows for ``GET /v1/harnesses``.
+
+    Built-in *and* community native agents (after PR 2.1 accepts them). Each row
+    is the native agent's stable identity (``key`` / ``agent_name`` / ``harness``
+    / ``wrapper_label`` / ``terminal_name`` / ``display_name`` /
+    ``subagent_wrapper_label``) plus its harness ``capabilities`` and the
+    ``fork_history`` axis, so the web can drive native-agent recognition,
+    fork-history gating, and capability gating off the server instead of the
+    hardcoded ``web/src/lib/nativeCodingAgents.ts`` literals (PR 2.3).
+
+    Only fields with an unambiguous server source are emitted. The web literal
+    additionally carries UI-presentation fields (``iconKind``, ``sortRank``, a
+    marketing ``displayName`` like "Claude Code" vs the row's "Claude", and a
+    picker-capability list) that have no clean registry source today; whether to
+    add those to ``NativeCodingAgent`` is deferred to the PR 2.3 review (see the
+    workstream doc) rather than expanding the frozen wire shape here.
+
+    :returns: One row per native coding agent, ordered by ``key`` for stability.
+    """
+    capabilities = harness_capabilities()
+    rows: list[dict[str, Any]] = []
+    for agent in sorted(native_agents(), key=lambda a: a.key):
+        capability = capabilities.get(agent.harness)
+        rows.append(
+            {
+                "key": agent.key,
+                "agent_name": agent.agent_name,
+                "harness": agent.harness,
+                "wrapper_label": agent.wrapper_label,
+                "terminal_name": agent.terminal_name,
+                "display_name": agent.display_name,
+                "subagent_wrapper_label": agent.subagent_wrapper_label,
+                "fork_history": (
+                    capability.fork_history.value if capability is not None else None
+                ),
+                "capabilities": capability.as_dict() if capability is not None else None,
+            }
+        )
+    return rows
+
+
 def harness_setup_steps_by_spelling() -> dict[str, list[dict[str, Any]]]:
     """Map every harness spelling to its ordered UI setup steps.
 

--- a/omnigent/server/routes/harnesses.py
+++ b/omnigent/server/routes/harnesses.py
@@ -6,7 +6,11 @@ from typing import Any
 
 from fastapi import APIRouter, Request
 
-from omnigent.harness_plugins import harness_catalog, harness_setup_steps_by_spelling
+from omnigent.harness_plugins import (
+    harness_catalog,
+    harness_setup_steps_by_spelling,
+    native_agent_catalog,
+)
 from omnigent.server.auth import AuthProvider
 from omnigent.server.routes._auth_helpers import require_user
 
@@ -23,10 +27,14 @@ def create_harnesses_router(*, auth_provider: AuthProvider | None = None) -> API
         # declare — native wrappers (``codex-native``) and installable ids that
         # aren't picker rows (``opencode``/``qwen``) — so the setup dialog can
         # resolve steps by the harness it actually holds without the picker
-        # list gaining non-pickable rows.
+        # list gaining non-pickable rows. ``native_agents`` carries the native
+        # coding-agent identity + capability rows (built-in and community) so
+        # the web can drive native recognition / fork-history / capability
+        # gating off the server instead of hardcoded literals (PR 2.2 → 2.3).
         return {
             "data": harness_catalog(),
             "setup_steps": harness_setup_steps_by_spelling(),
+            "native_agents": native_agent_catalog(),
         }
 
     return router

--- a/tests/test_harness_plugins.py
+++ b/tests/test_harness_plugins.py
@@ -269,6 +269,37 @@ def test_native_provider_for_key_lookup() -> None:
     assert hp.native_provider_for_key("does-not-exist") is None
 
 
+def test_native_agent_catalog_covers_every_native_agent() -> None:
+    """One JSON-serializable row per native agent, keyed 1:1 with the registry."""
+    import json
+
+    rows = hp.native_agent_catalog()
+    assert sorted(r["key"] for r in rows) == sorted(a.key for a in hp.native_agents())
+    # Fully JSON-serializable (values are primitives / dicts, no enums).
+    json.dumps(rows)
+
+
+def test_native_agent_catalog_row_shape_and_capabilities() -> None:
+    """Each row carries identity + fork_history + capabilities from the registry."""
+    rows = {r["key"]: r for r in hp.native_agent_catalog()}
+    claude = rows["claude"]
+    # Identity fields come straight off NativeCodingAgent.
+    assert claude["agent_name"] == "claude-native-ui"
+    assert claude["harness"] == "claude-native"
+    assert claude["wrapper_label"] == "claude-code-native-ui"
+    assert claude["terminal_name"] == "claude"
+    # fork_history + capabilities are pulled from harness_capabilities().
+    assert claude["fork_history"] == "rebuild"
+    assert claude["capabilities"]["integration_mode"] == "native-tui"
+    # cursor uses the preamble fork axis (verifies the axis is per-harness).
+    assert rows["cursor"]["fork_history"] == "preamble"
+    # A native agent whose harness has no capability record still emits a row
+    # with null fork_history/capabilities (defensive — every built-in declares
+    # one, but community natives may not).
+    for row in rows.values():
+        assert "fork_history" in row and "capabilities" in row
+
+
 def test_builtin_native_providers_have_required_hooks() -> None:
     """run_native, auto_create_terminal, and spawn_env_builder are mandatory."""
     for provider in hp.native_providers():


### PR DESCRIPTION
## Related issue

N/A — Phase 2 of the modular native-harness registry workstream (`designs/harness-modular-registry-proposal.md`).

## Summary

PR **2.2** makes the server the source of truth for native coding-agent metadata: `GET /v1/harnesses` gains a new `native_agents` array so the web can drive native-agent recognition, fork-history gating, and capability gating off the endpoint instead of the hardcoded `web/src/lib/nativeCodingAgents.ts` literals (that web swap is **2.3**).

- New `native_agent_catalog()` in `harness_plugins.py`: one JSON row per `native_agents()` entry — built-in today, and community natives automatically once **2.1** (#3670) lands, since it just iterates the registry.
- Each row carries the fields with an unambiguous registry source: `key`, `agent_name`, `harness`, `wrapper_label`, `terminal_name`, `display_name`, `subagent_wrapper_label`, the `fork_history` axis, and the full harness `capabilities` dict.
- Wired into the route as a new `native_agents` key alongside the existing `data` (picker catalog) and `setup_steps`.

### ⚠️ Open question for review — deliberately NOT emitted

The web literal (`nativeCodingAgents.ts`) also carries **UI-presentation** fields that have **no clean registry source today**:
- `iconKind` (currently always `== key`, but that's coincidence, not contract),
- `sortRank` (picker ordering),
- a *marketing* `displayName` — the literal says **"Claude Code"** where the registry row's `display_name` is **"Claude"**,
- a picker-capability list (`permissionMode` / `approvalMode` / `cursorMode`) that is **not cleanly derivable** from the capability axes — kiro/goose/hermes/qwen all share `elicitation=APPROVAL_MIRROR` yet only some expose a picker.

Adding these to the frozen `NativeCodingAgent` wire shape is exactly the identity-field scope-creep deferred in 1.8, so I **did not** decide it unilaterally. **This is the main thing to weigh in the 2.3 review:** either (a) add these as new `NativeCodingAgent` fields (contributors declare icon/sort/picker-caps), or (b) keep them web-side as a small presentation layer keyed by `key`. I lean (b) for icon/sortRank (pure presentation) and (a) only for the picker-capability list if we want community natives to expose permission pickers. Happy to go either way — flagging it before 2.3 hardcodes an assumption.

### ELI5

The web currently keeps its own copy of "here are the native agents and what they can do." This publishes that list from the server so the web can stop maintaining a duplicate — except a few purely-cosmetic bits (icon, sort order, the fancy display name) that the server has no opinion on yet; those are called out for us to decide.

## Test Plan

```bash
uv run pytest tests/test_harness_plugins.py -q
uv run pytest tests/server/ -q
uv run pre-commit run --all-files
```

- `native_agent_catalog` covers every native agent 1:1, is JSON-serializable, and each row carries identity + per-harness `fork_history` (claude=`rebuild`, cursor=`preamble`) + `capabilities`.
- Route handler imports and returns the new key; adjacent suites (`test_schemas`, `test_harness_capabilities`, `test_native_dispatch`) pass. The one failing capabilities test (`test_catalog_rows_carry_setup_steps`) is the **pre-existing** `acp:qwen-openclaw-test` local-plugin pollution, confirmed on clean `main`.

## Demo

N/A — server endpoint addition; the visible change lands in 2.3 (web).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Additive, read-only endpoint field. Verified `native_agent_catalog()` output shape + JSON-serializability and the route returns the new `native_agents` key. Manual: printed the claude/cursor rows and confirmed `wrapper_label` matches the web literal (`claude-code-native-ui`) and `fork_history` matches the 1.8 axis.

---

**Workstream progress**: Phase 1 complete (1.1–1.8). **Phase 2: 2.1 (#3670), 2.2 this PR.** Remaining — 2.3 (web off the endpoint), 2.4 (docs + benchable example plugin). Independent of 2.1 (branched off main); the ledger row will de-conflict at rebase like the 1.7/1.8 churn did.
