### PR TITLE
refactor(policies): type evaluator boundaries

### DIFF
--- a/omnigent/inner/policies.py
+++ b/omnigent/inner/policies.py
@@ -60,15 +60,18 @@ PolicyResponsePayload: TypeAlias = dict[str, object]
 
 class _LabelRule(Protocol):
     @property
-    def values(self) -> Sequence[str]: ...
+    def values(self) -> Sequence[str]:
+        raise NotImplementedError
 
 
 class _PolicySession(Protocol):
     @property
-    def labels(self) -> Mapping[str, str]: ...
+    def labels(self) -> Mapping[str, str]:
+        raise NotImplementedError
 
     @property
-    def _root_label_schema(self) -> Mapping[str, _LabelRule]: ...
+    def _root_label_schema(self) -> Mapping[str, _LabelRule]:
+        raise NotImplementedError
 
 
 _POLICY_SYSTEM_PROMPT = (

--- a/omnigent/inner/policies.py
+++ b/omnigent/inner/policies.py
@@ -12,9 +12,9 @@ import inspect
 import json
 import re
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Literal, TypeAlias
+from typing import Any, Literal, Protocol, TypeAlias
 
 from .datamodel import AgentDef, ExecutorSpec
 from .executor import (
@@ -31,12 +31,12 @@ from .executor import (
 # a tool result (str or dict) for "tool_result". Policies branch on
 # type internally; pinning a union here would force every inspection
 # site to narrow before reading.
-PolicyContent: TypeAlias = Any  # type: ignore[explicit-any]
+PolicyContent: TypeAlias = object
 
 # Ambient context handed to policies: ``{"labels": {...}, "configured_phases":
 # [...], plus caller-supplied extras}``. Policy authors may add arbitrary
 # keys for their evaluators.
-PolicyContext: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
+PolicyContext: TypeAlias = dict[str, object]
 
 # Dynamically-supplied Python callable acting as a policy evaluator.
 # Signatures vary (``(content, phase)`` or ``(content, phase, context)``),
@@ -45,17 +45,31 @@ PolicyContext: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
 PolicyCallable: TypeAlias = Callable[..., Any]  # type: ignore[explicit-any]
 
 # Arbitrary kwargs passed to a policy factory function.
-FactoryParams: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
+FactoryParams: TypeAlias = dict[str, object]
 
 # Raw return value from a policy callable — either a ``PolicyResult``, a
 # dict-shaped version of one, or any other value (the caller coerces
 # everything else into ``PolicyAction.ALLOW``).
-PolicyCallableResult: TypeAlias = Any  # type: ignore[explicit-any]
+PolicyCallableResult: TypeAlias = object
 
 # Parsed JSON dict from a PromptPolicy LLM response — shape is
 # ``{"action": str, "reason": str|None, "set_labels": dict}`` but values
 # arrive from LLM output, so we keep them open and narrow field-by-field.
-PolicyResponsePayload: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
+PolicyResponsePayload: TypeAlias = dict[str, object]
+
+
+class _LabelRule(Protocol):
+    @property
+    def values(self) -> Sequence[str]: ...
+
+
+class _PolicySession(Protocol):
+    @property
+    def labels(self) -> Mapping[str, str]: ...
+
+    @property
+    def _root_label_schema(self) -> Mapping[str, _LabelRule]: ...
+
 
 _POLICY_SYSTEM_PROMPT = (
     "You are an Omnigent policy evaluator. Return exactly one JSON object and nothing else."
@@ -112,7 +126,7 @@ class Policy:
         init=False,
         repr=False,
     )
-    _session: Any | None = field(default=None, init=False, repr=False)
+    _session: _PolicySession | None = field(default=None, init=False, repr=False)
 
     def bind_runtime(self, runtime_context: PolicyRuntimeContext) -> None:
         self._runtime_context = runtime_context
@@ -182,7 +196,7 @@ def _build_inner_event(
     content: PolicyContent,
     phase: str,
     context: PolicyContext,
-) -> dict[str, Any]:
+) -> PolicyContext:
     """
     Build an ``event`` dict from inner-system args.
 
@@ -205,7 +219,7 @@ def _build_inner_event(
             tool_name = raw_tool_name
 
     labels = context.get("labels")
-    event: dict[str, Any] = {
+    event: PolicyContext = {
         "type": phase,
         "target": tool_name,
         "data": content,
@@ -222,7 +236,7 @@ def _call_policy_callable(
     content: PolicyContent,
     phase: str,
     context: PolicyContext,
-    config: dict[str, Any] | None = None,
+    config: PolicyContext | None = None,
 ) -> PolicyCallableResult:
     """
     Build an event dict and invoke a sync policy callable.
@@ -251,7 +265,7 @@ async def _async_call_policy_callable(
     content: PolicyContent,
     phase: str,
     context: PolicyContext,
-    config: dict[str, Any] | None = None,
+    config: PolicyContext | None = None,
 ) -> PolicyCallableResult:
     """
     Async sibling of :func:`_call_policy_callable`. Builds an
@@ -288,8 +302,8 @@ class FunctionPolicy(Policy):
     callable: PolicyCallable | None = None
     factory_params: FactoryParams = field(default_factory=dict)
     factory: PolicyCallable | None = field(default=None, repr=False)
-    # Any: opaque user-supplied configuration values.
-    config: dict[str, Any] | None = None  # type: ignore[explicit-any]
+    # Opaque user-supplied configuration values.
+    config: PolicyContext | None = None
 
     def __post_init__(self) -> None:
         if self.factory_params and self.factory is None:
@@ -331,7 +345,7 @@ class FunctionPolicy(Policy):
         if self.callable is None:
             return PolicyResult(action=PolicyAction.ALLOW)
 
-        phase_context = {"configured_phases": list(self.on)}
+        phase_context: PolicyContext = {"configured_phases": list(self.on)}
         if context:
             phase_context.update(context)
         merged_context = self._get_context(phase_context)
@@ -359,7 +373,7 @@ class FunctionPolicy(Policy):
         return PolicyResult(action=PolicyAction.ALLOW)
 
 
-def _coerce_v0_dict_to_result(raw: dict[str, Any]) -> PolicyResult:
+def _coerce_v0_dict_to_result(raw: PolicyResponsePayload) -> PolicyResult:
     """
     Parse a ``{"result": ..., "reason": ..., "data": ...}`` dict into
     a :class:`PolicyResult`.
@@ -374,9 +388,10 @@ def _coerce_v0_dict_to_result(raw: dict[str, Any]) -> PolicyResult:
             f"FunctionPolicy dict return missing 'result' key; got {raw!r}",
         )
     action = PolicyAction(str(result_raw).lower())
+    raw_reason = raw.get("reason")
     return PolicyResult(
         action=action,
-        reason=raw.get("reason"),
+        reason=str(raw_reason) if raw_reason is not None else None,
     )
 
 
@@ -652,6 +667,6 @@ def _extract_json_object(text: str) -> PolicyResponsePayload:
     raise ValueError(f"policy response is not valid JSON: {text!r}")
 
 
-def _bind_session_recursive(policy: Policy, session: Any) -> None:
+def _bind_session_recursive(policy: Policy, session: _PolicySession) -> None:
     """Bind a session to a policy."""
     policy._session = session


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Replace open-ended policy content, context, factory parameter, callable result, and LLM response annotations with `object`-valued contracts that consumers narrow at runtime.
- Describe the session label surface with small read-only protocols instead of storing an untyped session object.
- Remove all 10 mypy findings from `omnigent/inner/policies.py`, reducing a clean current-`main` run from 1,518 to 1,508 errors.

**ELI5:** Policy inputs remain flexible, but the engine now checks what each value is before treating it like a label, result, or response field.

```text
request/tool data -> object-valued policy envelope -> user evaluator
session labels    -> read-only protocol           -> prompt policy
```

## Test Plan

- `uv run --no-sync pytest -q tests/inner/test_policies.py tests/inner/test_loader.py` (84 passed, 3 subtests passed)
- `uv run --no-sync mypy --no-incremental omnigent` (1,508 existing errors; none in `inner/policies.py`)
- `pre-commit run --all-files`
- Confirmed `uv.lock` is unchanged.

## Demo

N/A — non-visual type-safety refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing focused suites cover sync and async function policies, factory parameters, policy configuration, prompt-policy parsing, session-label prompt envelopes, and loader integration.

## Changelog

N/A — internal type-safety cleanup.