### PR TITLE
refactor(auth): type device grant write results

### DIFF
--- a/omnigent/server/device_grant_store.py
+++ b/omnigent/server/device_grant_store.py
@@ -25,8 +25,10 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+from typing import cast
 
 from sqlalchemy import and_, delete, or_, update
+from sqlalchemy.engine import CursorResult
 
 from omnigent.db.db_models import SqlDeviceGrant, current_workspace_id
 from omnigent.db.enum_codecs import decode_device_grant_status, encode_device_grant_status
@@ -196,21 +198,24 @@ class DeviceGrantStore:
         (unknown, already decided, or expired).
         """
         with self._session() as session:
-            result = session.execute(
-                update(SqlDeviceGrant)
-                .where(
-                    and_(
-                        SqlDeviceGrant.workspace_id == current_workspace_id(),
-                        SqlDeviceGrant.id == grant_id,
-                        SqlDeviceGrant.status == encode_device_grant_status("pending"),
-                        SqlDeviceGrant.expires_at > now_epoch_seconds,
+            result = cast(
+                CursorResult[tuple[object]],
+                session.execute(
+                    update(SqlDeviceGrant)
+                    .where(
+                        and_(
+                            SqlDeviceGrant.workspace_id == current_workspace_id(),
+                            SqlDeviceGrant.id == grant_id,
+                            SqlDeviceGrant.status == encode_device_grant_status("pending"),
+                            SqlDeviceGrant.expires_at > now_epoch_seconds,
+                        )
                     )
-                )
-                .values(
-                    status=encode_device_grant_status("approved"),
-                    user_id=user_id,
-                    approved_at=now_epoch_seconds,
-                )
+                    .values(
+                        status=encode_device_grant_status("approved"),
+                        user_id=user_id,
+                        approved_at=now_epoch_seconds,
+                    )
+                ),
             )
             if result.rowcount == 0:
                 return None
@@ -220,16 +225,19 @@ class DeviceGrantStore:
     def deny(self, grant_id: str) -> bool:
         """Mark a ``pending`` grant ``denied``. Returns True if it flipped."""
         with self._session() as session:
-            result = session.execute(
-                update(SqlDeviceGrant)
-                .where(
-                    and_(
-                        SqlDeviceGrant.workspace_id == current_workspace_id(),
-                        SqlDeviceGrant.id == grant_id,
-                        SqlDeviceGrant.status == encode_device_grant_status("pending"),
+            result = cast(
+                CursorResult[tuple[object]],
+                session.execute(
+                    update(SqlDeviceGrant)
+                    .where(
+                        and_(
+                            SqlDeviceGrant.workspace_id == current_workspace_id(),
+                            SqlDeviceGrant.id == grant_id,
+                            SqlDeviceGrant.status == encode_device_grant_status("pending"),
+                        )
                     )
-                )
-                .values(status=encode_device_grant_status("denied"))
+                    .values(status=encode_device_grant_status("denied"))
+                ),
             )
             return result.rowcount == 1
 
@@ -302,20 +310,23 @@ class DeviceGrantStore:
         ``approved`` state (already redeemed, expired, revoked, …).
         """
         with self._session() as session:
-            result = session.execute(
-                update(SqlDeviceGrant)
-                .where(
-                    and_(
-                        SqlDeviceGrant.workspace_id == current_workspace_id(),
-                        SqlDeviceGrant.id == grant_id,
-                        SqlDeviceGrant.status == encode_device_grant_status("approved"),
-                        SqlDeviceGrant.expires_at > now_epoch_seconds,
+            result = cast(
+                CursorResult[tuple[object]],
+                session.execute(
+                    update(SqlDeviceGrant)
+                    .where(
+                        and_(
+                            SqlDeviceGrant.workspace_id == current_workspace_id(),
+                            SqlDeviceGrant.id == grant_id,
+                            SqlDeviceGrant.status == encode_device_grant_status("approved"),
+                            SqlDeviceGrant.expires_at > now_epoch_seconds,
+                        )
                     )
-                )
-                .values(
-                    status=encode_device_grant_status("redeemed"),
-                    refresh_token_hash=refresh_token_hash,
-                )
+                    .values(
+                        status=encode_device_grant_status("redeemed"),
+                        refresh_token_hash=refresh_token_hash,
+                    )
+                ),
             )
             if result.rowcount == 0:
                 return None
@@ -358,18 +369,21 @@ class DeviceGrantStore:
         """
         min_approved_at = now_epoch_seconds - max_lifetime_seconds
         with self._session() as session:
-            result = session.execute(
-                update(SqlDeviceGrant)
-                .where(
-                    and_(
-                        SqlDeviceGrant.workspace_id == current_workspace_id(),
-                        SqlDeviceGrant.id == grant_id,
-                        SqlDeviceGrant.status == encode_device_grant_status("redeemed"),
-                        SqlDeviceGrant.refresh_token_hash == expected_hash,
-                        SqlDeviceGrant.approved_at > min_approved_at,
+            result = cast(
+                CursorResult[tuple[object]],
+                session.execute(
+                    update(SqlDeviceGrant)
+                    .where(
+                        and_(
+                            SqlDeviceGrant.workspace_id == current_workspace_id(),
+                            SqlDeviceGrant.id == grant_id,
+                            SqlDeviceGrant.status == encode_device_grant_status("redeemed"),
+                            SqlDeviceGrant.refresh_token_hash == expected_hash,
+                            SqlDeviceGrant.approved_at > min_approved_at,
+                        )
                     )
-                )
-                .values(refresh_token_hash=new_hash, prev_refresh_token_hash=expected_hash)
+                    .values(refresh_token_hash=new_hash, prev_refresh_token_hash=expected_hash)
+                ),
             )
             if result.rowcount == 0:
                 return None
@@ -406,20 +420,23 @@ class DeviceGrantStore:
         this ``grant_id`` are rejected via the revocation denylist.
         """
         with self._session() as session:
-            result = session.execute(
-                update(SqlDeviceGrant)
-                .where(
-                    and_(
-                        SqlDeviceGrant.workspace_id == current_workspace_id(),
-                        SqlDeviceGrant.id == grant_id,
-                        SqlDeviceGrant.status != encode_device_grant_status("revoked"),
+            result = cast(
+                CursorResult[tuple[object]],
+                session.execute(
+                    update(SqlDeviceGrant)
+                    .where(
+                        and_(
+                            SqlDeviceGrant.workspace_id == current_workspace_id(),
+                            SqlDeviceGrant.id == grant_id,
+                            SqlDeviceGrant.status != encode_device_grant_status("revoked"),
+                        )
                     )
-                )
-                .values(
-                    status=encode_device_grant_status("revoked"),
-                    refresh_token_hash=None,
-                    prev_refresh_token_hash=None,
-                )
+                    .values(
+                        status=encode_device_grant_status("revoked"),
+                        refresh_token_hash=None,
+                        prev_refresh_token_hash=None,
+                    )
+                ),
             )
             return result.rowcount == 1
 
@@ -480,12 +497,15 @@ class DeviceGrantStore:
                 )
             )
         with self._session() as session:
-            result = session.execute(
-                delete(SqlDeviceGrant).where(
-                    and_(
-                        SqlDeviceGrant.workspace_id == current_workspace_id(),
-                        or_(*conds),
+            result = cast(
+                CursorResult[tuple[object]],
+                session.execute(
+                    delete(SqlDeviceGrant).where(
+                        and_(
+                            SqlDeviceGrant.workspace_id == current_workspace_id(),
+                            or_(*conds),
+                        )
                     )
-                )
+                ),
             )
             return result.rowcount


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Narrow SQLAlchemy `UPDATE` and `DELETE` execution results to `CursorResult[tuple[object]]`, matching the established permission-store pattern.
- Preserve the atomic `rowcount` checks used for approval, denial, redemption, refresh rotation, revocation, and purge operations while making their boolean/integer return types explicit.
- Remove all 9 mypy findings from `omnigent/server/device_grant_store.py`, reducing the full-tree baseline from 1,498 to 1,489 errors.

**ELI5:** SQLAlchemy already returns a result with a changed-row count for these writes; this tells the type checker that exact result type before the store reads it.

```text
UPDATE / DELETE -> CursorResult -> typed rowcount -> grant state decision
```

## Test Plan

- `uv run --no-sync pytest -q tests/server/test_device_auth.py` (23 passed)
- `uv run --no-sync mypy --no-incremental omnigent` (1,489 existing errors; none in `device_grant_store.py`)
- `pre-commit run --all-files`
- Confirmed `uv.lock` is unchanged.

## Demo

N/A — non-visual type-safety refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing device-auth suite covers grant approval and denial, atomic single-use redemption, refresh rotation and replay detection, revocation, purge counts, and the full HTTP flow.

## Changelog

N/A — internal type-safety cleanup.