### PR TITLE
feat(web): redesign sidebar bulk-selection bar and scope it per section

### DIFF
--- a/tests/e2e_ui/sessions/test_sidebar_bulk_actions.py
+++ b/tests/e2e_ui/sessions/test_sidebar_bulk_actions.py
@@ -1,11 +1,16 @@
 """Browser e2e for bulk session actions in the sidebar.
 
-Selection mode is toggled via the ``data-testid="toggle-selection-mode"``
-button next to the search box. Once active, each conversation row renders
-a checkbox (``SquareCheckBigIcon`` / ``SquareIcon``); clicking the row
-toggles selection instead of navigating. A ``BulkActionBar`` appears at
-the bottom of the sidebar with Archive, Unarchive, Stop, Delete, Select
-all / Deselect all, and Clear (deselect) controls.
+Selection is scoped: the ``data-testid="toggle-selection-mode"`` icon on the
+**Sessions** header selects the flat session list, while the Projects header
+kebab's "Select sessions" item (``data-testid="projects-select-sessions"``)
+selects the sessions nested inside project folders. Once active, each row in
+the targeted scope renders a leading checkbox (``SquareCheckIcon`` /
+``SquareIcon``) and clicking the row toggles selection instead of navigating.
+
+A single-pill ``BulkActionBar`` renders directly under the header of the
+targeted section: an Exit (X) button, an "N selected" count, and icon-only
+Archive + Delete actions (Archive shows by default but is disabled until an
+archivable session is selected; Delete likewise).
 
 These tests drive the full round-trip: enter selection mode → select
 sessions → perform a bulk action → verify the server-side effect is
@@ -19,6 +24,12 @@ import uuid
 
 import httpx
 from playwright.sync_api import Locator, Page, expect
+
+from tests.e2e_ui.conftest import _build_hello_world_bundle
+
+# Reserved label key that stores project membership (see
+# ``sqlalchemy_store.list_projects`` and ``web/src/lib/sessionListCache.ts``).
+_PROJECT_LABEL_KEY = "omni_project"
 
 
 def _row_link(page: Page, title: str) -> Locator:
@@ -48,19 +59,62 @@ def _set_title(base_url: str, session_id: str, title: str) -> None:
     resp.raise_for_status()
 
 
+def _seed_project_session(base_url: str, *, title: str, project: str) -> str:
+    """Create a session, title it, and file it under *project*.
+
+    Goes through the same multipart ``POST /v1/sessions`` path as the
+    ``seeded_session`` fixture, then a single ``PATCH`` sets the title and the
+    ``omni_project`` label (folder membership). No runner binding — the session
+    only needs to *list* under its folder and be bulk-archived, neither of which
+    dispatches to a runner (mirrors ``test_archived_project_filter``).
+
+    :param base_url: The live server base URL.
+    :param title: Unique title so the row is easy to spot on the shared server.
+    :param project: Project name to file the session under.
+    :returns: The new session id.
+    """
+    import json as _json
+
+    create_resp = httpx.post(
+        f"{base_url}/v1/sessions",
+        data={"metadata": _json.dumps({})},
+        files={"bundle": ("agent.tar.gz", _build_hello_world_bundle(), "application/gzip")},
+        timeout=30.0,
+    )
+    create_resp.raise_for_status()
+    session_id = create_resp.json()["session_id"]
+
+    patch_resp = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"title": title, "labels": {_PROJECT_LABEL_KEY: project}},
+        timeout=10.0,
+    )
+    patch_resp.raise_for_status()
+    return session_id
+
+
+def _delete_sessions(base_url: str, session_ids: list[str]) -> None:
+    """Best-effort cleanup so seeded sessions don't leak into other tests."""
+    import contextlib
+
+    for session_id in session_ids:
+        with contextlib.suppress(httpx.HTTPError):
+            httpx.delete(f"{base_url}/v1/sessions/{session_id}", timeout=10.0)
+
+
 def test_selection_mode_toggle(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """Entering selection mode shows checkboxes; exiting hides them and clears selection.
+    """Entering selection mode shows a leading checkbox; exiting hides it and clears selection.
 
     Verifies:
-    - The toggle button enters selection mode (aria-label flips).
-    - Rows show checkbox icons in selection mode.
+    - The Sessions-header trigger enters selection mode (aria-label flips onto
+      the bar's Exit button).
+    - Rows show a leading (left-edge) checkbox icon in selection mode.
     - Clicking a row in selection mode toggles its selection (no navigation).
-    - The BulkActionBar shows the selection count.
-    - Clicking Clear deselects all but stays in selection mode.
-    - Exiting selection mode (toggle button) hides the bar and checkboxes.
+    - The BulkActionBar shows the selection count ("0 selected" → "1 selected").
+    - Exiting selection mode (the bar's Exit button) hides the bar and checkboxes.
 
     :param page: Playwright page fixture (fresh context per test).
     :param seeded_session: ``(base_url, session_id)`` for a pre-created
@@ -78,11 +132,13 @@ def test_selection_mode_toggle(
     toggle = page.get_by_test_id("toggle-selection-mode")
     expect(toggle).to_have_attribute("aria-label", "Select sessions")
 
-    # Enter selection mode.
+    # Enter selection mode — the trigger is replaced by the bar's Exit button.
     toggle.click()
-    expect(toggle).to_have_attribute("aria-label", "Exit selection mode")
+    exit_btn = page.get_by_role("button", name="Exit selection mode")
+    expect(exit_btn).to_be_visible()
+    expect(page.get_by_text("0 selected")).to_be_visible()
 
-    # The row's parent <li> should now show a checkbox icon (unchecked square).
+    # The row's parent <li> shows a checkbox icon (unchecked square).
     row_item = row.locator("..")
     expect(row_item.locator("svg.lucide-square")).to_be_visible()
 
@@ -90,27 +146,59 @@ def test_selection_mode_toggle(
     row.click()
     # The checked icon appears instead of the unchecked one.
     expect(row_item.locator("svg.lucide-square-check")).to_be_visible()
-
-    # BulkActionBar shows "1 selected".
     expect(page.get_by_text("1 selected")).to_be_visible()
 
-    # Click Clear to deselect all (stays in selection mode).
-    page.get_by_role("button", name="Clear").click()
-    expect(page.get_by_text("None selected")).to_be_visible()
+    # Exit selection mode via the bar's Exit button.
+    exit_btn.click()
+    expect(page.get_by_test_id("toggle-selection-mode")).to_have_attribute(
+        "aria-label", "Select sessions"
+    )
 
-    # Still in selection mode — checkbox icons remain visible (unchecked).
-    expect(row_item.locator("svg.lucide-square")).to_be_visible()
-
-    # Exit selection mode via the toggle button.
-    toggle.click()
-    expect(toggle).to_have_attribute("aria-label", "Select sessions")
-
-    # Checkbox icons should be gone.
+    # Checkbox icons and the bar are gone.
     expect(row_item.locator("svg.lucide-square")).to_have_count(0)
     expect(row_item.locator("svg.lucide-square-check")).to_have_count(0)
+    expect(page.get_by_text("0 selected")).to_have_count(0)
 
-    # BulkActionBar text should be gone.
-    expect(page.get_by_text("None selected")).to_have_count(0)
+
+def test_archive_action_disabled_until_selection(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Archive and Delete render up front but stay disabled until a row is selected.
+
+    Verifies the "show the action by default, enable on selection" contract:
+    - On entering selection mode with nothing selected, Archive and Delete are
+      present but disabled.
+    - Selecting a session enables both.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound session.
+    """
+    base_url, session_id = seeded_session
+    title = f"e2e-bulk-disabled-{uuid.uuid4().hex[:8]}"
+    _set_title(base_url, session_id, title)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    row = _row_link(page, title)
+    expect(row).to_be_visible()
+
+    page.get_by_test_id("toggle-selection-mode").click()
+    expect(page.get_by_text("0 selected")).to_be_visible()
+
+    archive_btn = page.get_by_test_id("bulk-archive")
+    delete_btn = page.get_by_test_id("bulk-delete")
+    expect(archive_btn).to_be_visible()
+    expect(archive_btn).to_be_disabled()
+    expect(delete_btn).to_be_visible()
+    expect(delete_btn).to_be_disabled()
+
+    # Selecting a row enables both.
+    row.click()
+    expect(page.get_by_text("1 selected")).to_be_visible()
+    expect(archive_btn).to_be_enabled()
+    expect(delete_btn).to_be_enabled()
 
 
 def test_bulk_archive_moves_session_to_archived(
@@ -143,12 +231,9 @@ def test_bulk_archive_moves_session_to_archived(
 
     # Click Archive.
     archive_btn = page.get_by_test_id("bulk-archive")
-    expect(archive_btn).to_be_visible()
+    expect(archive_btn).to_be_enabled()
     archive_btn.click()
 
-    # The selection clears on success (the bar shows "None selected" or
-    # exits selection mode). The row may still be visible if "Show archived"
-    # is toggled, but the server flag must be set.
     # Poll the server to verify the archived flag is durably true.
     deadline = time.monotonic() + 15.0
     archived = False
@@ -200,7 +285,7 @@ def test_bulk_delete_removes_sessions(
 
     # Click Delete — should open confirmation dialog.
     delete_btn = page.get_by_test_id("bulk-delete")
-    expect(delete_btn).to_be_visible()
+    expect(delete_btn).to_be_enabled()
     delete_btn.click()
 
     dialog = page.get_by_role("dialog")
@@ -226,43 +311,76 @@ def test_bulk_delete_removes_sessions(
     )
 
 
-def test_select_all_and_deselect_all(
+def test_projects_scope_selects_project_sessions(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """Select all / Deselect all buttons toggle all visible sessions.
+    """The Projects kebab selects sessions inside a folder, not the flat list.
 
-    Verifies:
-    - "Select all" checks every visible row (selection count matches).
-    - "Deselect all" unchecks everything (count drops to "None selected").
+    Seeds a project session, opens the Projects header kebab, and picks
+    "Select sessions" (project scope). Verifies:
+    - The project row becomes selectable (leading checkbox) and selecting it
+      updates the count.
+    - The flat seeded session is NOT selectable in this scope (no checkbox),
+      so clicking it navigates instead of toggling — the count stays at 1.
+    - Bulk-archiving the selected project session durably flips its flag.
 
     :param page: Playwright page fixture (fresh context per test).
     :param seeded_session: ``(base_url, session_id)`` for a pre-created
-        runner-bound session.
+        runner-bound session (used as the flat-list control row).
     """
-    base_url, session_id = seeded_session
-    title = f"e2e-bulk-selectall-{uuid.uuid4().hex[:8]}"
-    _set_title(base_url, session_id, title)
+    base_url, flat_id = seeded_session
+    # The flat control session needs a stable title so it's addressable.
+    flat_title = f"e2e-proj-flat-{uuid.uuid4().hex[:8]}"
+    _set_title(base_url, flat_id, flat_title)
 
-    page.goto(f"{base_url}/c/{session_id}")
+    uniq = uuid.uuid4().hex[:6]
+    project = f"E2E BulkProj {uniq}"
+    proj_title = f"e2e-proj-member-{uniq}"
+    proj_id = _seed_project_session(base_url, title=proj_title, project=project)
 
-    row = _row_link(page, title)
-    expect(row).to_be_visible()
+    try:
+        page.goto(f"{base_url}/c/{flat_id}")
 
-    # Enter selection mode.
-    page.get_by_test_id("toggle-selection-mode").click()
+        # Expand the project folder so its session is visible, then enter
+        # project-scope selection from the header kebab. Match the folder toggle
+        # by its EXACT name — the per-folder kebab's aria-label ("Project actions
+        # for <name>") also contains the project name, so a substring match is
+        # ambiguous (strict-mode violation).
+        folder = page.get_by_role("button", name=project, exact=True)
+        expect(folder).to_be_visible()
+        if folder.get_attribute("aria-expanded") == "false":
+            folder.click()
+        proj_row = _row_link(page, proj_title)
+        expect(proj_row).to_be_visible()
 
-    # Initially none selected.
-    expect(page.get_by_text("None selected")).to_be_visible()
+        page.get_by_test_id("project-list-actions").click()
+        page.get_by_test_id("projects-select-sessions").click()
 
-    # Click "Select all".
-    page.get_by_role("button", name="Select all").click()
-    # At least 1 session should be selected (the seeded one).
-    expect(page.get_by_text("None selected")).to_have_count(0)
-    # The button text flips to "Deselect all" when all are selected.
-    deselect_btn = page.get_by_role("button", name="Deselect all")
-    expect(deselect_btn).to_be_visible()
+        # The project row is selectable; selecting it updates the count.
+        expect(page.get_by_text("0 selected")).to_be_visible()
+        proj_row.click()
+        expect(proj_row.locator("..").locator("svg.lucide-square-check")).to_be_visible()
+        expect(page.get_by_text("1 selected")).to_be_visible()
 
-    # Click "Deselect all".
-    deselect_btn.click()
-    expect(page.get_by_text("None selected")).to_be_visible()
+        # The flat session is NOT in project scope — no checkbox, so clicking
+        # it navigates rather than toggling; the count is unchanged.
+        flat_marker = _row_link(page, flat_title).locator("..").locator("svg.lucide-square")
+        expect(flat_marker).to_have_count(0)
+
+        # Bulk-archive the selected project session; verify durability.
+        archive_btn = page.get_by_test_id("bulk-archive")
+        expect(archive_btn).to_be_enabled()
+        archive_btn.click()
+
+        deadline = time.monotonic() + 15.0
+        archived = False
+        while time.monotonic() < deadline:
+            resp = httpx.get(f"{base_url}/v1/sessions/{proj_id}", timeout=10.0)
+            if resp.status_code == 200 and resp.json().get("archived") is True:
+                archived = True
+                break
+            time.sleep(0.5)
+        assert archived, "project session should be archived on the server after bulk archive"
+    finally:
+        _delete_sessions(base_url, [proj_id])

--- a/web/src/shell/Sidebar.bulkActionLayout.test.tsx
+++ b/web/src/shell/Sidebar.bulkActionLayout.test.tsx
@@ -173,8 +173,9 @@ describe("bulk-action bar layout", () => {
 
     // The actions are icon-only buttons labelled for assistive tech; there
     // must be a single instance of each (no breakpoint-duplicated copies).
+    // With a single owned selection the Delete label carries no count ("Delete").
     expect(screen.getAllByRole("button", { name: "Archive selected" })).toHaveLength(1);
-    expect(screen.getAllByRole("button", { name: "Delete selected" })).toHaveLength(1);
+    expect(screen.getAllByRole("button", { name: "Delete" })).toHaveLength(1);
   });
 
   it("shows Archive and Delete disabled at zero selection, enabling them once a row is picked", () => {

--- a/web/src/shell/Sidebar.bulkActionLayout.test.tsx
+++ b/web/src/shell/Sidebar.bulkActionLayout.test.tsx
@@ -1,17 +1,14 @@
 // Layout regression tests for the sidebar's bulk-action bar (selection
-// mode). The reported bug: on mobile the Archive/Delete buttons floated
-// *over* other controls. The cause was that the mobile copy of those
-// buttons lived inline in the same flex row as the "Exit selection"
-// button, which is absolutely positioned (`absolute right-0`) — so the
-// inline buttons overflowed underneath it. The fix removes the duplicated
-// mobile-only inline copy and renders the Archive/Delete buttons once, on
-// their own row below the count/select-all row, visible at every
-// breakpoint. These tests lock that structure in:
-//   1. The action buttons sit on a row that does NOT contain the
-//      absolutely-positioned Exit button (no overlap).
-//   2. That row is not breakpoint-gated (no `hidden`/`md:hidden`) and is
-//      in normal flow (not `absolute`), so it shows on mobile.
-//   3. The actions render exactly once (no mobile/desktop duplication).
+// mode). The bar is a single bordered pill rendered under the Sessions
+// header: an inline Exit (X) button, the "N selected" count, and the
+// icon-only Archive/Delete actions grouped at the trailing edge. It lives
+// entirely in normal flow (no absolutely-positioned control, no
+// breakpoint-gated duplicate), which is what kept an earlier mobile-overflow
+// bug from recurring. These tests lock that structure in:
+//   1. The whole bar is in normal flow (no `absolute`), so nothing floats
+//      over its neighbours at any breakpoint.
+//   2. The actions render exactly once (no mobile/desktop duplication).
+//   3. Exit / count / actions share the one pill row.
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
@@ -134,46 +131,82 @@ afterEach(() => {
 });
 
 describe("bulk-action bar layout", () => {
-  it("renders Archive/Delete on a row separate from the absolutely-positioned Exit button", () => {
+  it("groups Exit, count, and the Archive/Delete actions in one pill, no floating control", () => {
     renderSidebar();
     enterSelectionModeAndSelect();
 
     const exitBtn = screen.getByRole("button", { name: "Exit selection mode" });
-    // The exit button is the absolutely-positioned control that the action
-    // buttons used to overflow under.
-    expect(exitBtn.className).toContain("absolute");
-
     const deleteBtn = screen.getByTestId("bulk-delete");
-    const actionRow = deleteBtn.parentElement as HTMLElement;
+    const archiveBtn = screen.getByTestId("bulk-archive");
 
-    // The fix: the action buttons live on their own row, NOT inside the
-    // row that holds the floating Exit button. If they shared a row again,
-    // the overlap would return.
-    expect(actionRow).not.toContainElement(exitBtn);
-    expect(screen.getByTestId("bulk-archive").parentElement).toBe(actionRow);
+    // Archive and Delete share the trailing action group.
+    const actionGroup = deleteBtn.parentElement as HTMLElement;
+    expect(archiveBtn.parentElement).toBe(actionGroup);
+
+    // Exit, count, and the action group all live in the single pill row —
+    // and nothing is absolutely positioned, so nothing can float over its
+    // neighbours (the mobile-overflow bug this guards against).
+    const pill = actionGroup.parentElement as HTMLElement;
+    expect(pill).toContainElement(exitBtn);
+    for (const el of [exitBtn, deleteBtn, archiveBtn, actionGroup, pill]) {
+      expect(el.className).not.toMatch(/\babsolute\b/);
+    }
   });
 
-  it("keeps the action row visible at every breakpoint and in normal flow", () => {
+  it("keeps the bar visible at every breakpoint and in normal flow", () => {
     renderSidebar();
     enterSelectionModeAndSelect();
 
-    const actionRow = screen.getByTestId("bulk-delete").parentElement as HTMLElement;
+    const pill = (screen.getByTestId("bulk-delete").parentElement as HTMLElement)
+      .parentElement as HTMLElement;
 
-    // Must not be breakpoint-gated — the old desktop copy was `md:flex`
-    // (hidden on mobile) and the mobile copy was the overlapping inline one.
-    expect(actionRow.className).not.toMatch(/\bhidden\b/);
-    expect(actionRow.className).not.toMatch(/\bmd:hidden\b/);
-    // Must stay in normal flow so it can't float over neighbours.
-    expect(actionRow.className).not.toMatch(/\babsolute\b/);
+    // Not breakpoint-gated and not floated, so it renders identically on
+    // mobile and desktop without overlapping neighbours.
+    expect(pill.className).not.toMatch(/\bhidden\b/);
+    expect(pill.className).not.toMatch(/\bmd:hidden\b/);
+    expect(pill.className).not.toMatch(/\babsolute\b/);
   });
 
   it("renders the Archive and Delete actions exactly once (no mobile/desktop duplication)", () => {
     renderSidebar();
     enterSelectionModeAndSelect();
 
-    // The pre-fix layout shipped two copies (mobile inline + desktop row);
-    // there must now be a single instance of each action.
-    expect(screen.getAllByRole("button", { name: /^Archive$/ })).toHaveLength(1);
-    expect(screen.getAllByRole("button", { name: /^Delete/ })).toHaveLength(1);
+    // The actions are icon-only buttons labelled for assistive tech; there
+    // must be a single instance of each (no breakpoint-duplicated copies).
+    expect(screen.getAllByRole("button", { name: "Archive selected" })).toHaveLength(1);
+    expect(screen.getAllByRole("button", { name: "Delete selected" })).toHaveLength(1);
+  });
+
+  it("shows Archive and Delete disabled at zero selection, enabling them once a row is picked", () => {
+    renderSidebar();
+    // Enter selection mode WITHOUT selecting anything yet.
+    fireEvent.click(screen.getByRole("button", { name: "Select sessions" }));
+
+    // Both actions are present up front (not conditionally hidden) but
+    // disabled while nothing is selected.
+    const archiveBtn = screen.getByTestId("bulk-archive");
+    const deleteBtn = screen.getByTestId("bulk-delete");
+    expect(archiveBtn).toBeDisabled();
+    expect(deleteBtn).toBeDisabled();
+    expect(screen.getByText("0 selected")).toBeInTheDocument();
+
+    // Selecting a row enables both.
+    fireEvent.click(screen.getByRole("link", { name: /My Session/ }));
+    expect(archiveBtn).toBeEnabled();
+    expect(deleteBtn).toBeEnabled();
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+  });
+
+  it("renders the row checkbox to the LEFT of the session title", () => {
+    renderSidebar();
+    fireEvent.click(screen.getByRole("button", { name: "Select sessions" }));
+
+    // The checkbox marker sits at the row's leading edge (left-2), not the
+    // trailing edge — so the title indents to make room after it.
+    const row = screen.getByRole("link", { name: /My Session/ });
+    const li = row.closest("li") as HTMLElement;
+    const marker = li.querySelector("svg.lucide-square")?.parentElement as HTMLElement;
+    expect(marker.className).toMatch(/\bleft-2\b/);
+    expect(marker.className).not.toMatch(/\bright-/);
   });
 });

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -303,16 +303,17 @@ describe("quick pin/unpin hover button", () => {
   });
 
   it("sizes the Projects group-header controls to the same compact icon", () => {
-    // The "New project" / "Expand all" controls share the right-edge column
-    // with the folder + session kebabs, so they use the same compact `icon-xs`
+    // The "New project" button and the list-actions kebab (expand-all /
+    // select-sessions live inside it) share the right-edge column with the
+    // folder + session kebabs, so they use the same compact `icon-xs`
     // (size-6), not the larger `icon-sm` (size-7).
     mocks.projects = ["Sprint 42"];
     renderSidebar();
 
     expect(screen.getByTestId("new-project")).toHaveClass("size-6");
     expect(screen.getByTestId("new-project")).not.toHaveClass("size-7");
-    expect(screen.getByTestId("expand-all-projects")).toHaveClass("size-6");
-    expect(screen.getByTestId("expand-all-projects")).not.toHaveClass("size-7");
+    expect(screen.getByTestId("project-list-actions")).toHaveClass("size-6");
+    expect(screen.getByTestId("project-list-actions")).not.toHaveClass("size-7");
   });
 
   it("toggles the pin without opening the kebab menu, moving the row under Pinned", () => {

--- a/web/src/shell/Sidebar.shiftSelect.test.tsx
+++ b/web/src/shell/Sidebar.shiftSelect.test.tsx
@@ -7,6 +7,7 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Conversation } from "@/hooks/useConversations";
+import type * as IdentityModule from "@/lib/identity";
 
 // ── Pure unit tests ─────────────────────────────────────────────────────────
 import { computeShiftSelectRange, Sidebar } from "./Sidebar";
@@ -110,6 +111,14 @@ vi.mock("@/hooks/useConversations", () => ({
 }));
 
 vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));
+
+// Resolve the viewer to a fixed id so a conversation whose `owner` differs
+// reads as "not owned" (drives the mixed-ownership Delete-count assertion).
+vi.mock("@/lib/identity", async (importOriginal) => ({
+  ...(await importOriginal<typeof IdentityModule>()),
+  getCurrentUserId: () => "viewer",
+  resolveIdentity: () => Promise.resolve("viewer"),
+}));
 
 import { useConversations } from "@/hooks/useConversations";
 
@@ -316,6 +325,35 @@ describe("Sidebar shift-click selection", () => {
     const [{ ids, archived }] = bulkArchiveMock.mutate.mock.calls[0];
     expect(archived).toBe(true);
     expect([...ids].sort()).toEqual(["p1", "p2", "p3"]);
+  });
+
+  it("labels Delete with the owned count when the selection is mixed-ownership", async () => {
+    // A project folder can hold sessions owned by other users (the folder query
+    // isn't ownership-filtered). Delete acts only on owned rows, so its label
+    // must reflect the owned count — not the raw "N selected" — when they differ.
+    projectsMock.push("Alpha");
+    const mine = conv("mine", { owner: "viewer", labels: { omni_project: "Alpha" } });
+    const theirs = conv("theirs", { owner: "someone_else", labels: { omni_project: "Alpha" } });
+    mockConversations([mine, theirs]);
+    localStorage.setItem("omnigent:expanded-project-sections", JSON.stringify(["Alpha"]));
+    renderSidebar();
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Project list actions" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByTestId("projects-select-sessions"));
+
+    // Select both rows — "2 selected", but only the owned one is deletable.
+    fireEvent.click(await screen.findByRole("link", { name: "mine" }));
+    fireEvent.click(screen.getByRole("link", { name: "theirs" }));
+    await waitFor(() => {
+      expect(screen.getByText("2 selected")).toBeInTheDocument();
+    });
+
+    // Delete label carries the owned count (1), diverging from the "2 selected".
+    expect(screen.getByRole("button", { name: "Delete 1" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Delete" })).toBeNull();
   });
 
   it("normal click after shift-select sets a new anchor", async () => {

--- a/web/src/shell/Sidebar.shiftSelect.test.tsx
+++ b/web/src/shell/Sidebar.shiftSelect.test.tsx
@@ -45,18 +45,23 @@ describe("computeShiftSelectRange", () => {
 
 // ── Integration tests ───────────────────────────────────────────────────────
 
-const { projectsMock, conversationsRef, projectSessionsMock } = vi.hoisted(() => ({
+const { projectsMock, conversationsRef, projectSessionsMock, bulkArchiveMock } = vi.hoisted(() => ({
   projectsMock: [] as string[],
   conversationsRef: {
     current: [] as { id: string; labels?: Record<string, string>; archived?: boolean }[],
   },
   projectSessionsMock: { current: {} as Record<string, unknown[]> },
+  bulkArchiveMock: { mutate: vi.fn() },
 }));
 
 vi.mock("@/hooks/useConversations", () => ({
   useConversations: vi.fn(),
   useArchiveConversation: () => ({ mutate: vi.fn() }),
-  useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkArchiveConversations: () => ({
+    mutate: bulkArchiveMock.mutate,
+    isPending: false,
+    isError: false,
+  }),
   useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useConnectedConversations: () => [],
@@ -165,6 +170,7 @@ function renderSidebar() {
 
 beforeEach(() => {
   useConvMock.mockReset();
+  bulkArchiveMock.mutate.mockReset();
   localStorage.clear();
   projectsMock.length = 0;
   projectSessionsMock.current = {};
@@ -264,6 +270,52 @@ describe("Sidebar shift-click selection", () => {
     // grow the selection (it has no checkbox and its link stays a navigation).
     fireEvent.click(screen.getByRole("link", { name: "c1" }), { shiftKey: true });
     expect(screen.getByText("3 selected")).toBeInTheDocument();
+  });
+
+  it("resolves a folder session outside the global window for shift-select AND bulk archive", async () => {
+    // Regression: the folder paginates independently of the global list, so it
+    // can render a member (p3) the global window hasn't loaded. Projects-scope
+    // selection must resolve rows against the folder's own query, not the global
+    // list — otherwise p3 would toggle a count but silently drop from the range
+    // and from the bulk action.
+    projectsMock.push("Alpha");
+    // Global window: only p1, p2 (p3 is beyond it).
+    mockConversations([
+      conv("p1", { labels: { omni_project: "Alpha" } }),
+      conv("p2", { labels: { omni_project: "Alpha" } }),
+    ]);
+    // The folder's OWN query returns p1, p2, p3 — p3 is out-of-window.
+    projectSessionsMock.current["Alpha"] = [
+      conv("p1", { labels: { omni_project: "Alpha" } }),
+      conv("p2", { labels: { omni_project: "Alpha" } }),
+      conv("p3", { labels: { omni_project: "Alpha" } }),
+    ];
+    localStorage.setItem("omnigent:expanded-project-sections", JSON.stringify(["Alpha"]));
+    renderSidebar();
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Project list actions" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByTestId("projects-select-sessions"));
+
+    // Shift-select p1 → p3: the range must span all three (including the
+    // out-of-window p3), not collapse to a single toggle.
+    fireEvent.click(await screen.findByRole("link", { name: "p1" }));
+    fireEvent.click(screen.getByRole("link", { name: "p3" }), { shiftKey: true });
+    await waitFor(() => {
+      expect(screen.getByText("3 selected")).toBeInTheDocument();
+    });
+
+    // Bulk-archive must fire with ALL three ids — p3 must not be silently
+    // dropped because the global window didn't resolve it.
+    fireEvent.click(screen.getByTestId("bulk-archive"));
+    await waitFor(() => {
+      expect(bulkArchiveMock.mutate).toHaveBeenCalledTimes(1);
+    });
+    const [{ ids, archived }] = bulkArchiveMock.mutate.mock.calls[0];
+    expect(archived).toBe(true);
+    expect([...ids].sort()).toEqual(["p1", "p2", "p3"]);
   });
 
   it("normal click after shift-select sets a new anchor", async () => {

--- a/web/src/shell/Sidebar.shiftSelect.test.tsx
+++ b/web/src/shell/Sidebar.shiftSelect.test.tsx
@@ -230,6 +230,42 @@ describe("Sidebar shift-click selection", () => {
     });
   });
 
+  it("selects sessions within projects (not the flat list) from the Projects kebab", async () => {
+    // Project "Alpha" has 3 sessions; the flat list has 2 unfiled chats.
+    projectsMock.push("Alpha");
+    const sessions = [
+      conv("p1", { labels: { omni_project: "Alpha" } }),
+      conv("p2", { labels: { omni_project: "Alpha" } }),
+      conv("p3", { labels: { omni_project: "Alpha" } }),
+      conv("c1"),
+      conv("c2"),
+    ];
+    mockConversations(sessions);
+    // Selection mode preserves the current expansion; seed Alpha expanded so
+    // its sessions are visible (the kebab no longer auto-expands folders).
+    localStorage.setItem("omnigent:expanded-project-sections", JSON.stringify(["Alpha"]));
+    renderSidebar();
+
+    // Enter selection mode via the Projects header kebab → project scope.
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Project list actions" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByTestId("projects-select-sessions"));
+
+    // Shift-select across the project sessions: p1 anchor → p3 selects p1..p3.
+    fireEvent.click(await screen.findByRole("link", { name: "p1" }));
+    fireEvent.click(screen.getByRole("link", { name: "p3" }), { shiftKey: true });
+    await waitFor(() => {
+      expect(screen.getByText("3 selected")).toBeInTheDocument();
+    });
+
+    // A flat-list chat is NOT selectable in project scope: clicking it does not
+    // grow the selection (it has no checkbox and its link stays a navigation).
+    fireEvent.click(screen.getByRole("link", { name: "c1" }), { shiftKey: true });
+    expect(screen.getByText("3 selected")).toBeInTheDocument();
+  });
+
   it("normal click after shift-select sets a new anchor", async () => {
     const sessions = [conv("s1"), conv("s2"), conv("s3"), conv("s4")];
     mockConversations(sessions);
@@ -248,41 +284,6 @@ describe("Sidebar shift-click selection", () => {
 
     // Normal click on s4 (sets new anchor, toggles s4 on)
     fireEvent.click(screen.getByRole("link", { name: "s4" }));
-
-    await waitFor(() => {
-      expect(screen.getByText("3 selected")).toBeInTheDocument();
-    });
-  });
-
-  it("shift-select within a project uses the folder's own rendered IDs, not the global list", async () => {
-    // Seed a project with sessions that differ from the global list:
-    // the global list has p1,p2 but the folder's own query returns p1,p2,p3.
-    projectsMock.push("Alpha");
-    const sessions = [
-      conv("p1", { labels: { omni_project: "Alpha" } }),
-      conv("p2", { labels: { omni_project: "Alpha" } }),
-      conv("c1"),
-    ];
-    mockConversations(sessions);
-    // The folder's useProjectSessions returns an extra session (p3)
-    // that isn't in the global paginated window.
-    projectSessionsMock.current["Alpha"] = [
-      conv("p1", { labels: { omni_project: "Alpha" } }),
-      conv("p2", { labels: { omni_project: "Alpha" } }),
-      conv("p3", { labels: { omni_project: "Alpha" } }),
-    ];
-    localStorage.setItem("omnigent:expanded-project-sections", JSON.stringify(["Alpha"]));
-
-    renderSidebar();
-
-    const selectBtn = screen.getByRole("button", { name: /select/i });
-    fireEvent.click(selectBtn);
-
-    // Click p1 (anchor) then shift-click p3 — the range should include
-    // p1, p2, p3 (all from the folder's own query, including p3 which
-    // isn't in the global list).
-    fireEvent.click(screen.getByRole("link", { name: "p1" }));
-    fireEvent.click(screen.getByRole("link", { name: "p3" }), { shiftKey: true });
 
     await waitFor(() => {
       expect(screen.getByText("3 selected")).toBeInTheDocument();

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -229,6 +229,20 @@ function showSharedTab() {
   fireEvent.mouseDown(screen.getByTestId("sidebar-tab-shared"), { button: 0 });
 }
 
+/** Open the Projects header kebab (expand-all / revert / select sessions). */
+function openProjectsMenu() {
+  fireEvent.pointerDown(screen.getByRole("button", { name: "Project list actions" }), {
+    button: 0,
+    ctrlKey: false,
+  });
+}
+
+/** Close an open dropdown menu (Radix marks the rest of the tree aria-hidden
+    while open, so folder buttons aren't queryable until it closes). */
+function closeProjectsMenu() {
+  fireEvent.keyDown(document.activeElement ?? document.body, { key: "Escape" });
+}
+
 beforeEach(() => {
   useConvMock.mockReset();
   useHostsMock.mockReset();
@@ -1143,11 +1157,14 @@ describe("Sidebar project sections", () => {
     expect(screen.getByRole("button", { name: /^Beta/ })).toHaveAttribute("aria-expanded", "false");
 
     // Open just one folder, then expand all → every folder opens and the
-    // control flips to "revert".
+    // control flips to "revert". Expand-all / revert live in the Projects
+    // header kebab, so open it before clicking the menu item.
     fireEvent.click(screen.getByRole("button", { name: /^Alpha/ }));
+    openProjectsMenu();
     fireEvent.click(screen.getByTestId("expand-all-projects"));
     expect(screen.getByRole("button", { name: /^Alpha/ })).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByRole("button", { name: /^Beta/ })).toHaveAttribute("aria-expanded", "true");
+    openProjectsMenu();
     expect(screen.queryByTestId("expand-all-projects")).toBeNull();
 
     // Revert to last state → restores exactly the set that was open before
@@ -1169,8 +1186,10 @@ describe("Sidebar project sections", () => {
     renderSidebar();
 
     // Open every folder by hand → the control is revert (not expand-all).
+    // Expand-all / revert live in the Projects header kebab; open it to check.
     fireEvent.click(screen.getByRole("button", { name: /^Alpha/ }));
     fireEvent.click(screen.getByRole("button", { name: /^Beta/ }));
+    openProjectsMenu();
     expect(screen.queryByTestId("expand-all-projects")).toBeNull();
     expect(screen.getByTestId("revert-projects")).toBeInTheDocument();
 
@@ -1181,14 +1200,18 @@ describe("Sidebar project sections", () => {
       "false",
     );
     expect(screen.getByRole("button", { name: /^Beta/ })).toHaveAttribute("aria-expanded", "false");
+    openProjectsMenu();
     expect(screen.getByTestId("expand-all-projects")).toBeInTheDocument();
+    closeProjectsMenu();
 
     // After expand-all, a manual collapse of one folder retires the snapshot, so
     // the next full manual expansion reverts to collapse-all (not the stale set).
     fireEvent.click(screen.getByRole("button", { name: /^Alpha/ }));
+    openProjectsMenu();
     fireEvent.click(screen.getByTestId("expand-all-projects")); // snapshot = [Alpha]
     fireEvent.click(screen.getByRole("button", { name: /^Beta/ })); // manual toggle clears it
     fireEvent.click(screen.getByRole("button", { name: /^Beta/ })); // back to all open by hand
+    openProjectsMenu();
     fireEvent.click(screen.getByTestId("revert-projects"));
     expect(screen.getByRole("button", { name: /^Alpha/ })).toHaveAttribute(
       "aria-expanded",
@@ -1207,17 +1230,40 @@ describe("Sidebar project sections", () => {
     ]);
     renderSidebar();
 
-    // Offered while the group is expanded (default).
+    // Offered (in the header kebab) while the group is expanded (default).
+    openProjectsMenu();
     expect(screen.getByTestId("expand-all-projects")).toBeInTheDocument();
+    closeProjectsMenu();
 
-    // Collapse the "Projects" group → control disappears.
+    // Collapse the "Projects" group → control disappears from the kebab.
     fireEvent.click(screen.getByRole("button", { name: "Projects" }));
+    openProjectsMenu();
     expect(screen.queryByTestId("expand-all-projects")).toBeNull();
     expect(screen.queryByTestId("revert-projects")).toBeNull();
+    closeProjectsMenu();
 
     // Re-expanding the group brings it back.
     fireEvent.click(screen.getByRole("button", { name: "Projects" }));
+    openProjectsMenu();
     expect(screen.getByTestId("expand-all-projects")).toBeInTheDocument();
+  });
+
+  it("enters session-selection mode from the Projects header kebab", () => {
+    projectsMock.push("Alpha");
+    mockConversations([
+      conv("conv_a", "Claude Code", { labels: { omni_project: "Alpha" } }),
+      conv("conv_loose", "Claude Code"),
+    ]);
+    renderSidebar();
+
+    // Not selecting yet: the bulk-action bar's exit control is absent.
+    expect(screen.queryByRole("button", { name: "Exit selection mode" })).toBeNull();
+
+    // "Select sessions" in the Projects kebab flips the whole sidebar into
+    // selection mode (same mode the Sessions-header trigger opens).
+    openProjectsMenu();
+    fireEvent.click(screen.getByTestId("projects-select-sessions"));
+    expect(screen.getByRole("button", { name: "Exit selection mode" })).toBeInTheDocument();
   });
 
   it("deletes a project (and all its sessions) from the folder kebab after confirming", async () => {

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -1570,9 +1570,11 @@ function ConversationList({
   // The bulk-action bar lives under the header of the section it targets, so it
   // unmounts when that section empties (e.g. every selected session
   // archived/deleted). Exit selection mode in that case so the user isn't
-  // stranded without its controls.
+  // stranded without its controls. Suppressed while the list is refetching: a
+  // background refetch can briefly yield an empty page, and exiting on that
+  // transient would kick the user out of selection mode mid-task.
   useEffect(() => {
-    if (!selectionMode) return;
+    if (!selectionMode || conversationsQuery.isFetching) return;
     const pool =
       selectionScope === "projects" ? projectSessionPool.length : sections.sessions.length;
     if (pool === 0) onExitSelectionMode();
@@ -1581,6 +1583,7 @@ function ConversationList({
     selectionScope,
     sections.sessions.length,
     projectSessionPool.length,
+    conversationsQuery.isFetching,
     onExitSelectionMode,
   ]);
 
@@ -4110,6 +4113,18 @@ function BulkActionBar({
   const count = selectedIds.size;
   const isBusy = bulkArchive.isPending || bulkDelete.isPending;
 
+  // Delete acts only on owned rows, so surface that count on the control when it
+  // differs from "N selected" — otherwise a mixed-ownership selection (reachable
+  // in projects scope, where a folder can hold others' sessions) reads
+  // "3 selected" while Delete hits fewer. Used for both the tooltip (visual) and
+  // the aria-label (assistive tech). Archive needs no such hint: its gate
+  // (`allSelectedSameArchiveGroup`) only enables it when every owned row shares
+  // one archive state, and archived rows never appear in a selectable section.
+  const deleteLabel =
+    ownedSelected.length > 0 && ownedSelected.length !== count
+      ? `Delete ${ownedSelected.length}`
+      : "Delete";
+
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
   function handleArchive() {
@@ -4237,7 +4252,7 @@ function BulkActionBar({
                   className={cn("shrink-0", ownedSelected.length > 0 && "text-destructive")}
                   disabled={isBusy || ownedSelected.length === 0}
                   onClick={() => setConfirmDeleteOpen(true)}
-                  aria-label="Delete selected"
+                  aria-label={deleteLabel}
                   data-testid="bulk-delete"
                 >
                   {bulkDelete.isPending ? (
@@ -4247,7 +4262,7 @@ function BulkActionBar({
                   )}
                 </Button>
               </TooltipTrigger>
-              <TooltipContent side="bottom">Delete</TooltipContent>
+              <TooltipContent side="bottom">{deleteLabel}</TooltipContent>
             </Tooltip>
           </div>
         </div>

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -1572,7 +1572,10 @@ function ConversationList({
   // archived/deleted). Exit selection mode in that case so the user isn't
   // stranded without its controls. Suppressed while the list is refetching: a
   // background refetch can briefly yield an empty page, and exiting on that
-  // transient would kick the user out of selection mode mid-task.
+  // transient would kick the user out of selection mode mid-task. The projects
+  // pool unions global-derived membership with the folder queries, so a single
+  // folder's transient-empty refetch can't zero it while any member is still in
+  // the global window (only a genuinely empty pool exits).
   useEffect(() => {
     if (!selectionMode || conversationsQuery.isFetching) return;
     const pool =

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -225,6 +225,11 @@ function SidebarRowDataProvider({
  */
 type SidebarTab = "mine" | "shared";
 
+// Bulk-selection targets either the flat "Sessions" list or the sessions
+// nested inside project folders; the active scope decides which rows show
+// checkboxes and where the bulk-action bar renders.
+type SelectionScope = "sessions" | "projects";
+
 interface SidebarProps {
   open: boolean;
   onClose: () => void;
@@ -420,6 +425,10 @@ export function useMigrateLocalPinsToServer(
 
 export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: SidebarProps) {
   const [selectionMode, setSelectionMode] = useState(false);
+  // Which rows the current selection targets: the flat "Sessions" list, or the
+  // sessions nested inside project folders. Set when selection mode is entered
+  // (from the Sessions header or the Projects header kebab, respectively).
+  const [selectionScope, setSelectionScope] = useState<SelectionScope>("sessions");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   // Which session tab is shown. "mine" (default) keeps the full Pinned /
   // Projects / Chats structure; "shared" is a flat list of sessions others
@@ -434,8 +443,6 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
 
   const lastSelectedIdRef = useRef<string | null>(null);
   const getVisibleIdsRef = useRef<() => string[]>(() => []);
-  const getVisibleConversationsRef = useRef<() => Conversation[]>(() => []);
-  const [visibleConversationCount, setVisibleConversationCount] = useState(0);
 
   const toggleSelected = useCallback((id: string, shiftKey?: boolean) => {
     setSelectedIds((prev) => {
@@ -458,18 +465,24 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
     });
   }, []);
 
-  const selectAll = useCallback((conversations: Conversation[]) => {
-    setSelectedIds(new Set(conversations.map((c) => c.id)));
-  }, []);
-
   const deselectAll = useCallback(() => {
     setSelectedIds(new Set());
   }, []);
 
   const exitSelectionMode = useCallback(() => {
     setSelectionMode(false);
+    setSelectionScope("sessions");
     setSelectedIds(new Set());
     lastSelectedIdRef.current = null;
+  }, []);
+
+  // Enter selection mode targeting a given scope; clear any prior selection so
+  // rows from the previous scope don't linger.
+  const enterSelectionMode = useCallback((scope: SelectionScope) => {
+    setSelectionScope(scope);
+    setSelectedIds(new Set());
+    lastSelectedIdRef.current = null;
+    setSelectionMode(true);
   }, []);
 
   // One paginated session list — sessions are no longer split by
@@ -791,52 +804,40 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
                 Automations
               </Link>
             </Button>
-            {selectionMode ? (
-              <BulkActionBar
-                selectedIds={selectedIds}
-                allConversations={loadedRows}
-                visibleCount={visibleConversationCount}
-                onSelectAll={() => selectAll(getVisibleConversationsRef.current())}
-                onDeselectAll={deselectAll}
-                onClear={deselectAll}
-                onExit={exitSelectionMode}
-              />
-            ) : (
-              <Button
-                asChild
-                variant="ghost"
-                className={cn(
-                  "sidebar-compact-text h-7 w-full justify-start gap-2 rounded-[var(--radius-otto-button)] border-0 px-2 font-normal",
-                  SIDEBAR_HOVER_HIGHLIGHT,
-                  isInboxPage && SIDEBAR_ACTIVE_HIGHLIGHT,
+            <Button
+              asChild
+              variant="ghost"
+              className={cn(
+                "sidebar-compact-text h-7 w-full justify-start gap-2 rounded-[var(--radius-otto-button)] border-0 px-2 font-normal",
+                SIDEBAR_HOVER_HIGHLIGHT,
+                isInboxPage && SIDEBAR_ACTIVE_HIGHLIGHT,
+              )}
+              data-testid="inbox-button"
+            >
+              <Link to="/inbox" onClick={onNavClick}>
+                <InboxIcon className="size-3.5 text-muted-foreground" />
+                Inbox
+                {inboxCount > 0 && (
+                  <span
+                    aria-label={
+                      inboxCount === 1
+                        ? "1 inbox item waiting"
+                        : `${inboxCount} inbox items waiting`
+                    }
+                    className="ml-auto inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-warning/15 px-1 text-10 font-medium text-warning tabular-nums"
+                  >
+                    {inboxCount}
+                  </span>
                 )}
-                data-testid="inbox-button"
-              >
-                <Link to="/inbox" onClick={onNavClick}>
-                  <InboxIcon className="size-3.5 text-muted-foreground" />
-                  Inbox
-                  {inboxCount > 0 && (
-                    <span
-                      aria-label={
-                        inboxCount === 1
-                          ? "1 inbox item waiting"
-                          : `${inboxCount} inbox items waiting`
-                      }
-                      className="ml-auto inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-warning/15 px-1 text-10 font-medium text-warning tabular-nums"
-                    >
-                      {inboxCount}
-                    </span>
-                  )}
-                </Link>
-              </Button>
-            )}
+              </Link>
+            </Button>
           </div>
 
           {/* Session-scope tabs: split the viewer's own sessions ("My
           sessions") from ones shared with them ("Shared with me"). Sits above
           the scrolling list (non-scrolling) so it stays put while the list
-          scrolls. Hidden during selection mode, where the bulk-action bar owns
-          this strip. */}
+          scrolls. Hidden during selection mode to keep the strip quiet while
+          the bulk-action bar sits under the Sessions header. */}
           {multiUser && !selectionMode && (
             <div className="px-2 pb-2">
               <Tabs
@@ -879,13 +880,14 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
               pinnedConversationIds={pinnedConversationIds}
               pinnedConversations={pinnedConversations}
               onTogglePinned={togglePinnedConversation}
-              onEnterSelectionMode={() => setSelectionMode(true)}
+              onEnterSelectionMode={enterSelectionMode}
               selectionMode={selectionMode}
+              selectionScope={selectionScope}
               selectedIds={selectedIds}
               onToggleSelected={toggleSelected}
+              onDeselectAll={deselectAll}
+              onExitSelectionMode={exitSelectionMode}
               getVisibleIdsRef={getVisibleIdsRef}
-              getVisibleConversationsRef={getVisibleConversationsRef}
-              onVisibleCountChange={setVisibleConversationCount}
             />
           </nav>
         </>
@@ -978,7 +980,6 @@ function ProjectFolder({
   selectedIds,
   onToggleSelected,
   onProjectAssigned,
-  projectRenderedIdsRef,
 }: {
   name: string;
   /** First-class project id, or null for a label-only folder. */
@@ -998,7 +999,6 @@ function ProjectFolder({
   selectedIds: Set<string>;
   onToggleSelected: (conversationId: string, shiftKey?: boolean) => void;
   onProjectAssigned?: (projectName: string) => void;
-  projectRenderedIdsRef?: RefObject<Map<string, string[]>>;
 }) {
   const query = useProjectSessions(name, expanded);
   const pinnedSet = useMemo(() => new Set(pinnedConversationIds), [pinnedConversationIds]);
@@ -1011,16 +1011,6 @@ function ProjectFolder({
       frozenSortKeys,
     );
   }, [query.data, pinnedSet, activeOverride, frozenSortKeys]);
-
-  // Register this folder's rendered IDs synchronously during render so the
-  // shift-select range uses the real per-project data, not the global list.
-  const renderedIds = useMemo(
-    () => (expanded ? conversations.map((c) => c.id) : []),
-    [expanded, conversations],
-  );
-  if (projectRenderedIdsRef) {
-    projectRenderedIdsRef.current.set(name, renderedIds);
-  }
 
   // While the first page loads, show a "Loading…" footer instead of the "No
   // chats" empty state (which would otherwise flash before rows arrive).
@@ -1100,13 +1090,14 @@ interface ConversationListProps {
   // outside the loaded pagination window still renders in the Pinned section.
   pinnedConversations: Conversation[];
   onTogglePinned: (conversationId: string) => void;
-  onEnterSelectionMode: () => void;
+  onEnterSelectionMode: (scope: SelectionScope) => void;
   selectionMode: boolean;
+  selectionScope: SelectionScope;
   selectedIds: Set<string>;
   onToggleSelected: (conversationId: string, shiftKey?: boolean) => void;
+  onDeselectAll: () => void;
+  onExitSelectionMode: () => void;
   getVisibleIdsRef: RefObject<() => string[]>;
-  getVisibleConversationsRef: RefObject<() => Conversation[]>;
-  onVisibleCountChange: (count: number) => void;
 }
 
 // Ownership drives the My-vs-Shared split and every owner-only row action.
@@ -1164,11 +1155,12 @@ function ConversationList({
   onTogglePinned,
   onEnterSelectionMode,
   selectionMode,
+  selectionScope,
   selectedIds,
   onToggleSelected,
+  onDeselectAll,
+  onExitSelectionMode,
   getVisibleIdsRef,
-  getVisibleConversationsRef,
-  onVisibleCountChange,
 }: ConversationListProps) {
   // Viewer id for the owner-based My/Shared split below.
   const viewerId = useViewerId();
@@ -1200,11 +1192,6 @@ function ConversationList({
     return map;
   }, [projects]);
 
-  // Each ProjectFolder registers its actually-rendered conversation IDs here
-  // (synchronously during render) so shift-select ranges use the real rendered
-  // order, not the global paginated list which can diverge.
-  const projectRenderedIdsRef = useRef<Map<string, string[]>>(new Map());
-
   // Freeze the active chat's sort key while you're inside it so an
   // updated_at bump from sending a message doesn't reorder the row
   // out from under you. Snapshot is dropped on navigate-away so the
@@ -1222,8 +1209,8 @@ function ConversationList({
   // triggers, hitting a session the user never aimed at; a reorder during an
   // edit can move (and blur) the input, committing a half-typed title. The
   // map accumulates keys lazily inside sortByUpdatedAtDesc (a render-time ref
-  // write, like projectRenderedIdsRef) and is cleared once neither hold is
-  // active, when the order snaps back to reality.
+  // write) and is cleared once neither hold is active, when the order snaps
+  // back to reality.
   const frozenKeysRef = useRef<Map<string, number>>(new Map());
   const [pointerInside, setPointerInside] = useState(false);
   const [editingIds, setEditingIds] = useState<ReadonlySet<string>>(() => new Set());
@@ -1324,6 +1311,11 @@ function ConversationList({
     activeTab,
     viewerId,
   ]);
+
+  // Scope-active flags: which section owns the current selection UI (checkboxes
+  // + bulk-action bar). Only one is ever true at a time.
+  const sessionsSelecting = selectionMode && selectionScope === "sessions";
+  const projectsSelecting = selectionMode && selectionScope === "projects";
 
   // Collapsed section titles — persisted like pins so the preference
   // survives reloads. Lifted here (not per-section state) because the
@@ -1515,6 +1507,32 @@ function ConversationList({
     });
   }, [expandedViaButton, revertSnapshot]);
 
+  // Total sessions filed across all project folders (regardless of whether a
+  // folder is expanded) — the pool the "projects" selection scope targets. The
+  // guard below watches it so the bar doesn't strand once none remain, while
+  // collapsed folders (which merely hide selectable rows) don't trip it.
+  const totalProjectSessionCount = useMemo(
+    () => sections.projectGroups.reduce((sum, g) => sum + g.conversations.length, 0),
+    [sections.projectGroups],
+  );
+
+  // The bulk-action bar lives under the header of the section it targets, so it
+  // unmounts when that section empties (e.g. every selected session
+  // archived/deleted). Exit selection mode in that case so the user isn't
+  // stranded without its controls.
+  useEffect(() => {
+    if (!selectionMode) return;
+    const pool =
+      selectionScope === "projects" ? totalProjectSessionCount : sections.sessions.length;
+    if (pool === 0) onExitSelectionMode();
+  }, [
+    selectionMode,
+    selectionScope,
+    sections.sessions.length,
+    totalProjectSessionCount,
+    onExitSelectionMode,
+  ]);
+
   // The project the currently-selected session is filed under, if any. Derived
   // as a primitive so the auto-expand effect below only fires when the
   // selection (or its project) changes — not on every background list refetch,
@@ -1554,37 +1572,18 @@ function ConversationList({
       ...visible("Chats", sections.sessions),
     ].map((c) => c.id);
   }, [sections, effectiveCollapsedSections, expandedProjects]);
-  useEffect(() => {
-    onVisibleCountChange(orderedConversationIds.length);
-  }, [orderedConversationIds.length, onVisibleCountChange]);
-  getVisibleConversationsRef.current = () => {
-    const visible = (title: string, list: readonly Conversation[]) =>
-      effectiveCollapsedSections.includes(title) ? [] : [...list];
-    const projectsCollapsed = effectiveCollapsedSections.includes("Projects");
-    const projectVisible = (name: string, list: readonly Conversation[]) =>
-      !projectsCollapsed && expandedProjects.includes(name) ? [...list] : [];
-    return [
-      ...visible("Pinned", sections.pinned),
-      ...sections.projectGroups.flatMap((g) => projectVisible(g.name, g.conversations)),
-      ...visible("Chats", sections.sessions),
-    ];
-  };
-  // Getter that builds the shift-select visible order on demand (at click
-  // time). Reading projectRenderedIdsRef lazily — rather than snapshotting it
-  // during render — guarantees the project segment is always fresh even when a
-  // ProjectFolder re-renders independently (async query resolve, session
-  // re-sort) without triggering a parent re-render.
+  // Getter for the shift-select range, built on demand (at click time). Scopes
+  // to whichever section is selectable: the flat Sessions list, or the sessions
+  // across expanded project folders (in render order). Rows outside the active
+  // scope have no checkboxes, so they never enter a range.
   getVisibleIdsRef.current = () => {
-    const vis = (title: string, list: readonly Conversation[]) =>
-      effectiveCollapsedSections.includes(title) ? [] : list.map((c) => c.id);
-    const projCollapsed = effectiveCollapsedSections.includes("Projects");
-    return [
-      ...vis("Pinned", sections.pinned),
-      ...(projCollapsed
-        ? []
-        : sections.projectGroups.flatMap((g) => projectRenderedIdsRef.current.get(g.name) ?? [])),
-      ...vis("Chats", sections.sessions),
-    ];
+    if (selectionScope === "projects") {
+      if (effectiveCollapsedSections.includes("Projects")) return [];
+      return sections.projectGroups.flatMap((g) =>
+        expandedProjects.includes(g.name) ? g.conversations.map((c) => c.id) : [],
+      );
+    }
+    return effectiveCollapsedSections.includes("Chats") ? [] : sections.sessions.map((c) => c.id);
   };
   useSessionSwitchHotkey(orderedConversationIds, activeId);
 
@@ -1698,7 +1697,7 @@ function ConversationList({
                       onToggleCollapsed={() => effectiveToggleSectionCollapsed("Pinned")}
                       onRowClick={onRowClick}
                       onTogglePinned={onTogglePinned}
-                      selectionMode={selectionMode}
+                      selectionMode={false}
                       selectedIds={selectedIds}
                       onToggleSelected={onToggleSelected}
                       onProjectAssigned={expandProject}
@@ -1716,15 +1715,31 @@ function ConversationList({
                     title="Projects"
                     collapsed={effectiveCollapsedSections.includes("Projects")}
                     onToggleCollapsed={() => effectiveToggleSectionCollapsed("Projects")}
+                    afterHeader={
+                      projectsSelecting ? (
+                        <BulkActionBar
+                          selectedIds={selectedIds}
+                          allConversations={sections.projectGroups.flatMap((g) => g.conversations)}
+                          onDeselectAll={onDeselectAll}
+                          onExit={onExitSelectionMode}
+                        />
+                      ) : undefined
+                    }
                     headerAction={
-                      <ProjectHeaderActions
-                        projectNames={sections.projectGroups.map((group) => group.name)}
-                        collapsed={effectiveCollapsedSections.includes("Projects")}
-                        expandedProjects={expandedProjects}
-                        onExpandAll={expandAllProjects}
-                        onRevert={revertProjects}
-                        onProjectCreated={expandProject}
-                      />
+                      !selectionMode ? (
+                        <ProjectHeaderActions
+                          projectNames={sections.projectGroups.map((group) => group.name)}
+                          collapsed={effectiveCollapsedSections.includes("Projects")}
+                          expandedProjects={expandedProjects}
+                          hasProjectSessions={sections.projectGroups.some(
+                            (group) => group.conversations.length > 0,
+                          )}
+                          onExpandAll={expandAllProjects}
+                          onRevert={revertProjects}
+                          onProjectCreated={expandProject}
+                          onEnterSelectionMode={() => onEnterSelectionMode("projects")}
+                        />
+                      ) : undefined
                     }
                   >
                     {sections.projectGroups.map((group) => (
@@ -1743,11 +1758,10 @@ function ConversationList({
                         scrollRoot={scrollContainerRef}
                         onRowClick={onRowClick}
                         onTogglePinned={onTogglePinned}
-                        selectionMode={selectionMode}
+                        selectionMode={projectsSelecting}
                         selectedIds={selectedIds}
                         onToggleSelected={onToggleSelected}
                         onProjectAssigned={expandProject}
-                        projectRenderedIdsRef={projectRenderedIdsRef}
                       />
                     ))}
                     {sections.projectGroups.length === 0 &&
@@ -1776,10 +1790,20 @@ function ConversationList({
                       onToggleCollapsed={() => effectiveToggleSectionCollapsed("Chats")}
                       onRowClick={onRowClick}
                       onTogglePinned={onTogglePinned}
-                      selectionMode={selectionMode}
+                      selectionMode={sessionsSelecting}
                       selectedIds={selectedIds}
                       onToggleSelected={onToggleSelected}
                       onProjectAssigned={expandProject}
+                      afterHeader={
+                        sessionsSelecting ? (
+                          <BulkActionBar
+                            selectedIds={selectedIds}
+                            allConversations={sections.sessions}
+                            onDeselectAll={onDeselectAll}
+                            onExit={onExitSelectionMode}
+                          />
+                        ) : undefined
+                      }
                       headerAction={
                         !selectionMode ? (
                           <Tooltip>
@@ -1792,7 +1816,7 @@ function ConversationList({
                                 data-testid="toggle-selection-mode"
                                 onClick={(event) => {
                                   event.stopPropagation();
-                                  onEnterSelectionMode();
+                                  onEnterSelectionMode("sessions");
                                 }}
                               >
                                 <ListChecksIcon className="size-3.5" />
@@ -2033,16 +2057,22 @@ function ProjectHeaderActions({
   projectNames,
   collapsed,
   expandedProjects,
+  hasProjectSessions,
   onExpandAll,
   onRevert,
   onProjectCreated,
+  onEnterSelectionMode,
 }: {
   projectNames: string[];
   collapsed: boolean;
   expandedProjects: string[];
+  /** Whether any project holds sessions — gates the "Select sessions" item, so
+      it isn't offered when there's nothing under any folder to select. */
+  hasProjectSessions: boolean;
   onExpandAll: (projectNames: string[]) => void;
   onRevert: () => void;
   onProjectCreated: (projectName: string) => void;
+  onEnterSelectionMode: () => void;
 }) {
   const showExpandControls = !collapsed && projectNames.length > 0;
   const allExpanded =
@@ -2050,47 +2080,47 @@ function ProjectHeaderActions({
 
   return (
     <div className="flex items-center gap-0.5">
-      {showExpandControls &&
-        (allExpanded ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-xs"
-                aria-label="Collapse to previous"
-                data-testid="revert-projects"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onRevert();
-                }}
-              >
+      <NewProjectButton onCreated={onProjectCreated} />
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Project list actions"
+            data-testid="project-list-actions"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <MoreHorizontalIcon className="size-3.5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="min-w-40 [&_[role=menuitem]]:text-xs">
+          {showExpandControls &&
+            (allExpanded ? (
+              <DropdownMenuItem data-testid="revert-projects" onSelect={() => onRevert()}>
                 <Minimize2Icon className="size-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">Collapse to previous</TooltipContent>
-          </Tooltip>
-        ) : (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-xs"
-                aria-label="Expand all"
+                Collapse to previous
+              </DropdownMenuItem>
+            ) : (
+              <DropdownMenuItem
                 data-testid="expand-all-projects"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onExpandAll(projectNames);
-                }}
+                onSelect={() => onExpandAll(projectNames)}
               >
                 <Maximize2Icon className="size-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">Expand all</TooltipContent>
-          </Tooltip>
-        ))}
-      <NewProjectButton onCreated={onProjectCreated} />
+                Expand all
+              </DropdownMenuItem>
+            ))}
+          {hasProjectSessions && (
+            <DropdownMenuItem
+              data-testid="projects-select-sessions"
+              onSelect={() => onEnterSelectionMode()}
+            >
+              <ListChecksIcon className="size-3.5" />
+              Select sessions
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 }
@@ -2103,6 +2133,7 @@ function SectionGroup({
   collapsed,
   onToggleCollapsed,
   headerAction,
+  afterHeader,
   children,
 }: {
   title: string;
@@ -2111,6 +2142,9 @@ function SectionGroup({
   /** Optional control overlaid at the group header's right edge (e.g. the
       "collapse all projects" toggle). Hover/focus-revealed on desktop. */
   headerAction?: ReactNode;
+  /** Optional content rendered directly under the header, above the children
+      (and shown even when collapsed) — e.g. the bulk-selection action bar. */
+  afterHeader?: ReactNode;
   children: ReactNode;
 }) {
   return (
@@ -2130,11 +2164,12 @@ function SectionGroup({
           // — NOT :focus-within — so clicking the button with the mouse doesn't
           // leave it stuck visible: React reuses the same node when it swaps
           // expand↔revert, so the clicked button keeps focus afterward.
-          <div className="-translate-y-1/2 absolute top-1/2 right-1 hidden items-center transition-opacity md:flex md:opacity-0 md:has-[:focus-visible]:opacity-100 md:group-hover/header:opacity-100">
+          <div className="-translate-y-1/2 absolute top-1/2 right-1 hidden items-center transition-opacity md:flex md:opacity-0 md:has-[:focus-visible]:opacity-100 md:group-has-[[data-state=open]]/header:opacity-100 md:group-hover/header:opacity-100">
             {headerAction}
           </div>
         )}
       </div>
+      {afterHeader}
       {!collapsed && <div className="flex flex-col gap-0.5">{children}</div>}
     </section>
   );
@@ -2156,6 +2191,7 @@ function ConversationSection({
   emptyMessage,
   indentRows,
   headerAction,
+  afterHeader,
   footer,
   onProjectAssigned,
 }: {
@@ -2181,6 +2217,9 @@ function ConversationSection({
   /** Optional control overlaid at the header's right edge (e.g. a project's
       kebab). Hover/focus-revealed on desktop, always shown on mobile. */
   headerAction?: ReactNode;
+  /** Optional content rendered directly under the header, above the rows (and
+      shown even when collapsed) — e.g. the bulk-selection action bar. */
+  afterHeader?: ReactNode;
   /** Optional content rendered after the rows inside the expanded body (e.g. a
       project folder's own infinite-scroll sentinel / loading row). */
   footer?: ReactNode;
@@ -2212,6 +2251,7 @@ function ConversationSection({
           )}
         </div>
       )}
+      {afterHeader}
       {!isCollapsed && (
         <>
           {conversations.length === 0 && emptyMessage ? (
@@ -3044,7 +3084,7 @@ function ConversationRow({
               : "pr-28 md:pr-2"),
         !selectionMode && "md:group-hover:pr-14 md:group-focus-within:pr-14",
         !selectionMode && menuOpen && "md:pr-14",
-        selectionMode && "pr-10",
+        selectionMode && "pr-2 pl-8",
         isActive && SIDEBAR_ACTIVE_HIGHLIGHT,
         selectionMode && isSelected && SIDEBAR_ACTIVE_HIGHLIGHT,
       )}
@@ -3180,7 +3220,7 @@ function ConversationRow({
         </Tooltip>
       )}
       {selectionMode ? (
-        <span className="-translate-y-1/2 pointer-events-none absolute top-1/2 right-2.5 flex items-center">
+        <span className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-2 flex items-center">
           {isSelected ? (
             <SquareCheckIcon className="size-4 text-primary" />
           ) : (
@@ -3974,18 +4014,12 @@ function ConversationEditRow({ initialTitle, onCommit, onCancel }: ConversationE
 function BulkActionBar({
   selectedIds,
   allConversations,
-  visibleCount,
-  onSelectAll,
   onDeselectAll,
-  onClear,
   onExit,
 }: {
   selectedIds: Set<string>;
   allConversations: Conversation[];
-  visibleCount: number;
-  onSelectAll: () => void;
   onDeselectAll: () => void;
-  onClear: () => void;
   onExit: () => void;
 }) {
   const navigate = useNavigate();
@@ -4018,7 +4052,6 @@ function BulkActionBar({
     ownedSelected.length > 0 && (archivedSelected.length === 0 || nonArchivedSelected.length === 0);
 
   const count = selectedIds.size;
-  const allSelected = count > 0 && count === visibleCount;
   const isBusy = bulkArchive.isPending || bulkDelete.isPending;
 
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
@@ -4070,37 +4103,15 @@ function BulkActionBar({
 
   return (
     <>
-      <div className="relative mt-3 flex flex-col gap-1.5">
-        <div className="relative flex min-h-8 items-center gap-1.5 px-2 pr-9">
-          <span className="shrink-0 whitespace-nowrap text-sm text-muted-foreground">
-            {count === 0 ? "None selected" : `${count} selected`}
-          </span>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-6 px-1.5 text-sm"
-            onClick={allSelected ? onDeselectAll : onSelectAll}
-          >
-            {allSelected ? "Deselect all" : "Select all"}
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-6 px-1.5 text-sm"
-            disabled={count === 0}
-            onClick={onClear}
-          >
-            Clear
-          </Button>
+      <div className="mt-1 mb-1 flex flex-col gap-1.5">
+        <div className="flex h-7 items-center gap-2 rounded-lg border border-border bg-background px-2">
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
                 type="button"
-                variant="secondary"
-                size="icon-sm"
-                className="-translate-y-1/2 absolute top-1/2 right-0 shrink-0 rounded-full"
+                variant="ghost"
+                size="icon-xs"
+                className="shrink-0"
                 aria-label="Exit selection mode"
                 data-testid="toggle-selection-mode"
                 onClick={onExit}
@@ -4110,61 +4121,79 @@ function BulkActionBar({
             </TooltipTrigger>
             <TooltipContent side="bottom">Exit selection</TooltipContent>
           </Tooltip>
-        </div>
+          <span className="sidebar-compact-text shrink-0 whitespace-nowrap font-medium">
+            {count} selected
+          </span>
 
-        <div className="flex items-center gap-1.5 px-2">
-          {allSelectedSameArchiveGroup && nonArchivedSelected.length > 0 && (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="h-7 gap-1.5 text-xs"
-              disabled={isBusy}
-              onClick={handleArchive}
-              data-testid="bulk-archive"
-            >
-              {bulkArchive.isPending ? (
-                <Loader2Icon className="size-3 animate-spin" />
-              ) : (
-                <ArchiveIcon className="size-3" />
-              )}
-              Archive
-            </Button>
-          )}
-          {allSelectedSameArchiveGroup && archivedSelected.length > 0 && (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="h-7 gap-1.5 text-xs"
-              disabled={isBusy}
-              onClick={handleUnarchive}
-              data-testid="bulk-unarchive"
-            >
-              {bulkArchive.isPending ? (
-                <Loader2Icon className="size-3 animate-spin" />
-              ) : (
-                <ArchiveRestoreIcon className="size-3" />
-              )}
-              Unarchive
-            </Button>
-          )}
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className={cn("h-7 gap-1.5 text-xs", ownedSelected.length > 0 && "text-destructive")}
-            disabled={isBusy || ownedSelected.length === 0}
-            onClick={() => setConfirmDeleteOpen(true)}
-            data-testid="bulk-delete"
-          >
-            {bulkDelete.isPending ? (
-              <Loader2Icon className="size-3 animate-spin" />
-            ) : (
-              <Trash2Icon className="size-3" />
+          <div className="ml-auto flex items-center gap-0.5">
+            {!(allSelectedSameArchiveGroup && archivedSelected.length > 0) && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="shrink-0"
+                    disabled={isBusy || nonArchivedSelected.length === 0}
+                    onClick={handleArchive}
+                    aria-label="Archive selected"
+                    data-testid="bulk-archive"
+                  >
+                    {bulkArchive.isPending ? (
+                      <Loader2Icon className="size-3.5 animate-spin" />
+                    ) : (
+                      <ArchiveIcon className="size-3.5" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Archive</TooltipContent>
+              </Tooltip>
             )}
-            Delete {ownedSelected.length > 0 ? ownedSelected.length : ""}
-          </Button>
+            {allSelectedSameArchiveGroup && archivedSelected.length > 0 && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="shrink-0"
+                    disabled={isBusy}
+                    onClick={handleUnarchive}
+                    aria-label="Unarchive selected"
+                    data-testid="bulk-unarchive"
+                  >
+                    {bulkArchive.isPending ? (
+                      <Loader2Icon className="size-3.5 animate-spin" />
+                    ) : (
+                      <ArchiveRestoreIcon className="size-3.5" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Unarchive</TooltipContent>
+              </Tooltip>
+            )}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  className={cn("shrink-0", ownedSelected.length > 0 && "text-destructive")}
+                  disabled={isBusy || ownedSelected.length === 0}
+                  onClick={() => setConfirmDeleteOpen(true)}
+                  aria-label="Delete selected"
+                  data-testid="bulk-delete"
+                >
+                  {bulkDelete.isPending ? (
+                    <Loader2Icon className="size-3.5 animate-spin" />
+                  ) : (
+                    <Trash2Icon className="size-3.5" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Delete</TooltipContent>
+            </Tooltip>
+          </div>
         </div>
 
         {(bulkArchive.isError || bulkDelete.isError) && (

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -980,6 +980,7 @@ function ProjectFolder({
   selectedIds,
   onToggleSelected,
   onProjectAssigned,
+  onConversationsLoaded,
 }: {
   name: string;
   /** First-class project id, or null for a label-only folder. */
@@ -999,6 +1000,12 @@ function ProjectFolder({
   selectedIds: Set<string>;
   onToggleSelected: (conversationId: string, shiftKey?: boolean) => void;
   onProjectAssigned?: (projectName: string) => void;
+  /** Report this folder's own loaded (rendered) sessions to the parent. The
+      folder paginates independently of the global window, so bulk-selection in
+      the projects scope must resolve selected rows against these — not the
+      global list — or an out-of-window member would silently drop from the
+      action. */
+  onConversationsLoaded?: (name: string, conversations: Conversation[]) => void;
 }) {
   const query = useProjectSessions(name, expanded);
   const pinnedSet = useMemo(() => new Set(pinnedConversationIds), [pinnedConversationIds]);
@@ -1011,6 +1018,13 @@ function ProjectFolder({
       frozenSortKeys,
     );
   }, [query.data, pinnedSet, activeOverride, frozenSortKeys]);
+
+  // Publish the folder's rendered rows upward so projects-scope bulk selection
+  // resolves them (the parent sources its action set from these, not the global
+  // paginated window).
+  useEffect(() => {
+    onConversationsLoaded?.(name, conversations);
+  }, [name, conversations, onConversationsLoaded]);
 
   // While the first page loads, show a "Loading…" footer instead of the "No
   // chats" empty state (which would otherwise flash before rows arrive).
@@ -1507,14 +1521,51 @@ function ConversationList({
     });
   }, [expandedViaButton, revertSnapshot]);
 
-  // Total sessions filed across all project folders (regardless of whether a
-  // folder is expanded) — the pool the "projects" selection scope targets. The
-  // guard below watches it so the bar doesn't strand once none remain, while
-  // collapsed folders (which merely hide selectable rows) don't trip it.
-  const totalProjectSessionCount = useMemo(
-    () => sections.projectGroups.reduce((sum, g) => sum + g.conversations.length, 0),
-    [sections.projectGroups],
+  // Sessions each expanded ProjectFolder has actually rendered, keyed by
+  // project name. A folder paginates independently of the global window, so its
+  // rows can include members the global list hasn't loaded; projects-scope
+  // selection must resolve against these to avoid silently dropping an
+  // out-of-window row from a bulk action. Folders report via
+  // `onConversationsLoaded`; collapsed folders report `[]`.
+  const [folderConversations, setFolderConversations] = useState<Map<string, Conversation[]>>(
+    () => new Map(),
   );
+  const handleFolderConversationsLoaded = useCallback(
+    (name: string, conversations: Conversation[]) => {
+      setFolderConversations((prev) => {
+        const existing = prev.get(name);
+        // Skip the update when the id set is unchanged, so a background refetch
+        // that returns the same rows doesn't churn state (and re-render).
+        if (
+          existing &&
+          existing.length === conversations.length &&
+          existing.every((c, i) => c.id === conversations[i]?.id)
+        ) {
+          return prev;
+        }
+        const next = new Map(prev);
+        next.set(name, conversations);
+        return next;
+      });
+    },
+    [],
+  );
+
+  // The projects-scope selection pool: the folders' own rendered rows (the
+  // authoritative, possibly-out-of-window set) unioned with the global-derived
+  // membership as a fallback for folders that haven't reported yet. Deduped by
+  // id. This backs the bulk-action bar, the shift-select range, and the
+  // stranding guard so all three agree on what's selectable.
+  const projectSessionPool = useMemo(() => {
+    const byId = new Map<string, Conversation>();
+    for (const group of sections.projectGroups) {
+      for (const c of group.conversations) byId.set(c.id, c);
+    }
+    for (const rows of folderConversations.values()) {
+      for (const c of rows) byId.set(c.id, c);
+    }
+    return [...byId.values()];
+  }, [sections.projectGroups, folderConversations]);
 
   // The bulk-action bar lives under the header of the section it targets, so it
   // unmounts when that section empties (e.g. every selected session
@@ -1523,13 +1574,13 @@ function ConversationList({
   useEffect(() => {
     if (!selectionMode) return;
     const pool =
-      selectionScope === "projects" ? totalProjectSessionCount : sections.sessions.length;
+      selectionScope === "projects" ? projectSessionPool.length : sections.sessions.length;
     if (pool === 0) onExitSelectionMode();
   }, [
     selectionMode,
     selectionScope,
     sections.sessions.length,
-    totalProjectSessionCount,
+    projectSessionPool.length,
     onExitSelectionMode,
   ]);
 
@@ -1574,14 +1625,18 @@ function ConversationList({
   }, [sections, effectiveCollapsedSections, expandedProjects]);
   // Getter for the shift-select range, built on demand (at click time). Scopes
   // to whichever section is selectable: the flat Sessions list, or the sessions
-  // across expanded project folders (in render order). Rows outside the active
-  // scope have no checkboxes, so they never enter a range.
+  // across expanded project folders (in render order). For projects scope the
+  // range uses each folder's own reported rows — the same source the folder
+  // renders — so a shift target the global window hasn't loaded still resolves.
+  // Rows outside the active scope have no checkboxes, so they never enter a range.
   getVisibleIdsRef.current = () => {
     if (selectionScope === "projects") {
       if (effectiveCollapsedSections.includes("Projects")) return [];
-      return sections.projectGroups.flatMap((g) =>
-        expandedProjects.includes(g.name) ? g.conversations.map((c) => c.id) : [],
-      );
+      return sections.projectGroups.flatMap((g) => {
+        if (!expandedProjects.includes(g.name)) return [];
+        const rows = folderConversations.get(g.name) ?? g.conversations;
+        return rows.map((c) => c.id);
+      });
     }
     return effectiveCollapsedSections.includes("Chats") ? [] : sections.sessions.map((c) => c.id);
   };
@@ -1719,7 +1774,7 @@ function ConversationList({
                       projectsSelecting ? (
                         <BulkActionBar
                           selectedIds={selectedIds}
-                          allConversations={sections.projectGroups.flatMap((g) => g.conversations)}
+                          allConversations={projectSessionPool}
                           onDeselectAll={onDeselectAll}
                           onExit={onExitSelectionMode}
                         />
@@ -1762,6 +1817,7 @@ function ConversationList({
                         selectedIds={selectedIds}
                         onToggleSelected={onToggleSelected}
                         onProjectAssigned={expandProject}
+                        onConversationsLoaded={handleFolderConversationsLoaded}
                       />
                     ))}
                     {sections.projectGroups.length === 0 &&


### PR DESCRIPTION
## Related issue

N/A

## Summary

Reworks the sidebar's bulk-selection UI and scopes it per section so it acts on the right rows.

- **Bar redesign** — one bordered "pill" rendered directly under the header of the section it targets: an Exit (X) button, an "N selected" count (at the session-title font size), and icon-only **Archive** + **Delete** actions. Archive now shows by default and is disabled until an archivable session is selected (Delete likewise). Unarchive replaces Archive only when the selection is entirely archived.
- **Row checkbox moved to the left** of the session title.
- **Selection scope** — the Sessions-header trigger selects the flat session list; the **Projects**-header kebab's "Select sessions" selects the sessions nested inside project folders (bar renders under the Projects header). Entering a scope preserves the current folder expansion. The shift-select range and a stranding guard follow the active scope.
- **Projects header kebab** — folded the expand-all / collapse-to-previous controls and the new "Select sessions" item into a kebab placed to the right of the New-project (+) button.

## Test Plan

- `cd web && npm test` — 4789 passing (incl. updated `Sidebar.*` unit specs: bulkActionLayout, shiftSelect projects-scope, Sidebar projects-kebab).
- `cd web && npm run build` — clean (`tsc -b && vite build`).
- `rtk proxy python -m pytest tests/e2e_ui/sessions/test_sidebar_bulk_actions.py -o addopts=""` — **5 passing**, incl. a projects-scope round-trip (select project sessions → durable bulk-archive) and an "Archive disabled until selection" check.
- `oxlint`, `ruff check`, `ruff format` — clean. Pre-commit hooks green.

## Demo

https://github.com/user-attachments/assets/287bb9e9-89d9-493d-b274-5d6a02faa5c4

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified in the running app: entering selection from the Sessions header shows left-edge checkboxes with the pill under "Sessions"; the Projects kebab selects folder sessions with the bar under "Projects" and preserves folder expansion; Archive/Delete stay disabled at "0 selected" and enable on selection.

## Changelog

Redesigned the sidebar's bulk-select bar and added per-section selection: pick sessions from the flat list or from within project folders
