### PR TITLE
refactor(qwen): type ACP wire boundaries

### DIFF
--- a/omnigent/inner/qwen_executor.py
+++ b/omnigent/inner/qwen_executor.py
@@ -28,9 +28,9 @@ import json
 import logging
 import os
 import secrets
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol, TypeAlias
 
 from omnigent.inner._acp_omnigent_mcp import OmnigentAcpMcp
 from omnigent.inner.agent_env import clean_agent_env, declared_passthrough
@@ -42,12 +42,26 @@ from omnigent.inner.executor import (
     ExecutorEvent,
     Message,
     TextChunk,
+    ToolSpec,
     TurnComplete,
 )
 from omnigent.inner.os_env import OSEnvironment, create_os_environment
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 
 logger = logging.getLogger(__name__)
+
+# Qwen speaks the extensible ACP JSON-RPC schema; consumers narrow fields
+# before use.
+_AcpJsonObject: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
+
+
+class _PolicyVerdict(Protocol):
+    action: str
+
+
+_PolicyEvaluator: TypeAlias = Callable[[str, _AcpJsonObject], Awaitable[_PolicyVerdict]]
+_ElicitationHandler: TypeAlias = Callable[[str, _AcpJsonObject], Awaitable[bool]]
+_ToolExecutor: TypeAlias = Callable[[str, _AcpJsonObject], Awaitable[_AcpJsonObject]]
 
 # ACP error code qwen maps to a filesystem "not found" (ENOENT) when a
 # delegated ``fs/read_text_file`` fails — qwen's AcpFileSystemService special-
@@ -110,7 +124,7 @@ _INIT_TIMEOUT_SECONDS = 30.0
 _PROTOCOL_VERSION = 1
 
 
-def _inline_text_file_data(file_data: Any) -> str:  # type: ignore[explicit-any]
+def _inline_text_file_data(file_data: object) -> str:
     """Decode a text ``input_file`` ``file_data`` data URI into inline text.
 
     Mirrors the codex executor: ``input_file`` blocks may carry a
@@ -138,7 +152,7 @@ def _inline_text_file_data(file_data: Any) -> str:  # type: ignore[explicit-any]
         return ""
 
 
-def _parse_image_data_uri(data_uri: Any) -> tuple[str, str] | None:  # type: ignore[explicit-any]
+def _parse_image_data_uri(data_uri: object) -> tuple[str, str] | None:
     """Split an ``image/*`` ``data:`` URI into ``(mime_type, base64_payload)``.
 
     ACP's ``image`` content block carries the raw base64 payload plus its media
@@ -222,10 +236,10 @@ class QwenExecutor(Executor):
         self._gateway_auth_command = gateway_auth_command
 
         # Asyncio subprocess (created on first run_turn call).
-        self._proc: asyncio.subprocess.Process | None = None  # type: ignore[name-defined]
+        self._proc: asyncio.subprocess.Process | None = None
 
         # Queue fed by the stdout-reader coroutine.
-        self._queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()  # type: ignore[explicit-any]
+        self._queue: asyncio.Queue[_AcpJsonObject] = asyncio.Queue()
         self._reader_task: asyncio.Task[None] | None = None
         # Drains qwen stderr so a chatty CLI can't fill the pipe buffer
         # (~64 KiB) and wedge the subprocess mid-turn — see _read_stderr.
@@ -237,7 +251,7 @@ class QwenExecutor(Executor):
         # Pending RPC responses keyed by request id.
         # When _reader_task receives a response (has "id" + "result"/"error"),
         # it places it here for the awaiting coroutine.
-        self._pending: dict[int, asyncio.Future[dict[str, Any]]] = {}  # type: ignore[explicit-any]
+        self._pending: dict[int, asyncio.Future[_AcpJsonObject]] = {}
 
         # ACP session id assigned by qwen (returned in session/new response).
         self._session_id: str | None = None
@@ -266,14 +280,14 @@ class QwenExecutor(Executor):
         # them and the intent is explicit. ``None`` means "no bridge wired"
         # (standalone use / unit tests), in which case permission falls back
         # to allow. See _decide_permission.
-        self._policy_evaluator: Any | None = None  # type: ignore[explicit-any]
-        self._elicitation_handler: Any | None = None  # type: ignore[explicit-any]
+        self._policy_evaluator: _PolicyEvaluator | None = None
+        self._elicitation_handler: _ElicitationHandler | None = None
         # Adapter-injected tool bridge + the Omnigent-tool MCP relay it backs.
         # Exposes Omnigent builtin tools to qwen via session/new.mcpServers (the
         # shared serve-mcp relay); qwen keeps its own built-in tool registry.
-        self._tool_executor: Any | None = None  # type: ignore[explicit-any]
+        self._tool_executor: _ToolExecutor | None = None
         self._mcp = OmnigentAcpMcp(label="qwen")
-        self._omnigent_tools: list[Any] = []  # type: ignore[explicit-any]
+        self._omnigent_tools: list[ToolSpec] = []
 
     # ------------------------------------------------------------------
     # Low-level ACP helpers
@@ -480,7 +494,7 @@ class QwenExecutor(Executor):
                 if not line:
                     continue
                 try:
-                    msg: dict[str, Any] = json.loads(line)  # type: ignore[explicit-any]
+                    msg: _AcpJsonObject = json.loads(line)
                 except json.JSONDecodeError:
                     logger.debug("qwen: non-JSON stdout line: %r", line[:200])
                     continue
@@ -512,7 +526,7 @@ class QwenExecutor(Executor):
                     fut.set_exception(exc)
             await self._queue.put({"type": "error", "message": str(exc)})
 
-    async def _send(self, msg: dict[str, Any]) -> None:  # type: ignore[explicit-any]
+    async def _send(self, msg: _AcpJsonObject) -> None:
         """Write one newline-terminated JSON message to qwen stdin."""
         assert self._proc and self._proc.stdin
         encoded = (json.dumps(msg) + "\n").encode("utf-8")
@@ -522,9 +536,9 @@ class QwenExecutor(Executor):
     async def _rpc(
         self,
         method: str,
-        params: dict[str, Any],  # type: ignore[explicit-any]
+        params: _AcpJsonObject,
         timeout: float = _INIT_TIMEOUT_SECONDS,
-    ) -> dict[str, Any]:  # type: ignore[explicit-any]
+    ) -> _AcpJsonObject:
         """Send a JSON-RPC 2.0 request and await its response.
 
         :param method: RPC method name, e.g. ``"initialize"``.
@@ -538,10 +552,10 @@ class QwenExecutor(Executor):
         self._rpc_id += 1
         req_id = self._rpc_id
         loop = asyncio.get_event_loop()
-        fut: asyncio.Future[dict[str, Any]] = loop.create_future()  # type: ignore[explicit-any]
+        fut: asyncio.Future[_AcpJsonObject] = loop.create_future()
         self._pending[req_id] = fut
 
-        request: dict[str, Any] = {  # type: ignore[explicit-any]
+        request: _AcpJsonObject = {
             "jsonrpc": "2.0",
             "id": req_id,
             "method": method,
@@ -554,9 +568,9 @@ class QwenExecutor(Executor):
             self._pending.pop(req_id, None)
             raise
 
-    async def _notify(self, method: str, params: dict[str, Any]) -> None:  # type: ignore[explicit-any]
+    async def _notify(self, method: str, params: _AcpJsonObject) -> None:
         """Send a JSON-RPC 2.0 notification (no response expected)."""
-        notification: dict[str, Any] = {  # type: ignore[explicit-any]
+        notification: _AcpJsonObject = {
             "jsonrpc": "2.0",
             "method": method,
             "params": params,
@@ -613,7 +627,7 @@ class QwenExecutor(Executor):
             tool_executor=getattr(self, "_tool_executor", None),
             loop=asyncio.get_event_loop(),
         )
-        params: dict[str, Any] = {  # type: ignore[explicit-any]
+        params: _AcpJsonObject = {
             "sessionId": secrets.token_urlsafe(16),
             "cwd": self._cwd,
             "mcpServers": mcp_servers,
@@ -646,7 +660,7 @@ class QwenExecutor(Executor):
     # Server-initiated requests (agent → client)
     # ------------------------------------------------------------------
 
-    async def _respond_to_agent_request(self, request: dict[str, Any]) -> None:  # type: ignore[explicit-any]
+    async def _respond_to_agent_request(self, request: _AcpJsonObject) -> None:
         """Answer a server-initiated ACP request from qwen.
 
         qwen can drive the client mid-turn (e.g. permission prompts). A blanket
@@ -676,8 +690,8 @@ class QwenExecutor(Executor):
         # actually delegates permissions/fs to us (vs handling them itself).
         logger.debug("qwen agent request: method=%s id=%s", method, req_id)
 
-        result: dict[str, Any] | None = None  # type: ignore[explicit-any]
-        error: dict[str, Any] | None = None  # type: ignore[explicit-any]
+        result: _AcpJsonObject | None = None
+        error: _AcpJsonObject | None = None
 
         try:
             if method == "session/request_permission":
@@ -700,7 +714,7 @@ class QwenExecutor(Executor):
             logger.debug("qwen agent request %s failed: %s", method, exc)
             error = {"code": -32603, "message": f"{method} failed: {exc}"}
 
-        reply: dict[str, Any] = {"jsonrpc": "2.0", "id": req_id}  # type: ignore[explicit-any]
+        reply: _AcpJsonObject = {"jsonrpc": "2.0", "id": req_id}
         if error is not None:
             reply["error"] = error
         else:
@@ -728,7 +742,7 @@ class QwenExecutor(Executor):
             self._os_environment = env
         return self._os_environment
 
-    async def _handle_fs_read(self, params: dict[str, Any]) -> dict[str, Any]:  # type: ignore[explicit-any]
+    async def _handle_fs_read(self, params: _AcpJsonObject) -> _AcpJsonObject:
         """Serve an ACP ``fs/read_text_file`` by reading through the OSEnvironment.
 
         ACP params: ``{path, line?, limit?}`` where ``line`` is a 1-based start
@@ -761,7 +775,7 @@ class QwenExecutor(Executor):
             raise _AcpRequestError(-32603, f"{path}: not a UTF-8 text file")
         return {"content": result.get("content", "")}
 
-    async def _handle_fs_write(self, params: dict[str, Any]) -> dict[str, Any]:  # type: ignore[explicit-any]
+    async def _handle_fs_write(self, params: _AcpJsonObject) -> _AcpJsonObject:
         """Serve an ACP ``fs/write_text_file`` by writing through the OSEnvironment.
 
         ACP params: ``{path, content}``. The write goes through the helper, so
@@ -785,7 +799,7 @@ class QwenExecutor(Executor):
         return {}
 
     @staticmethod
-    def _extract_tool_call(params: dict[str, Any]) -> tuple[str, dict[str, Any]]:  # type: ignore[explicit-any]
+    def _extract_tool_call(params: _AcpJsonObject) -> tuple[str, _AcpJsonObject]:
         """Pull ``(tool_name, tool_input)`` from a ``session/request_permission``.
 
         Qwen's payload carries a ``toolCall`` with ``_meta.toolName`` (e.g.
@@ -801,7 +815,7 @@ class QwenExecutor(Executor):
             args = {}
         return str(name), args
 
-    async def _decide_permission(self, params: dict[str, Any]) -> bool:  # type: ignore[explicit-any]
+    async def _decide_permission(self, params: _AcpJsonObject) -> bool:
         """Decide allow/deny for a permission request — policy then elicitation.
 
         Mirrors ``ClaudeSDKExecutor``'s ``can_use_tool`` gate, composed of two
@@ -869,9 +883,7 @@ class QwenExecutor(Executor):
         return True
 
     @staticmethod
-    def _permission_outcome(  # type: ignore[explicit-any]
-        params: dict[str, Any], *, allow: bool
-    ) -> dict[str, Any]:
+    def _permission_outcome(params: _AcpJsonObject, *, allow: bool) -> _AcpJsonObject:
         """Map an allow/deny decision to an ACP permission ``outcome``.
 
         On allow, prefer a once-scoped grant (``allow_once``) over
@@ -880,7 +892,7 @@ class QwenExecutor(Executor):
         """
         options = [o for o in (params.get("options") or []) if isinstance(o, dict)]
 
-        def _pick(*kinds: str) -> dict[str, Any] | None:  # type: ignore[explicit-any]
+        def _pick(*kinds: str) -> _AcpJsonObject | None:
             for kind in kinds:  # exact-kind preference order
                 for opt in options:
                     if opt.get("kind") == kind:
@@ -902,9 +914,7 @@ class QwenExecutor(Executor):
         return {"outcome": "selected", "optionId": chosen.get("optionId")}
 
     @staticmethod
-    def _accumulate_usage(  # type: ignore[explicit-any]
-        acc: dict[str, int], update: dict[str, Any]
-    ) -> None:
+    def _accumulate_usage(acc: dict[str, int], update: _AcpJsonObject) -> None:
         """Fold a ``session/update``'s ``_meta.usage`` into the turn accumulator.
 
         qwen reports token usage out-of-band on an ``agent_message_chunk`` update
@@ -933,7 +943,7 @@ class QwenExecutor(Executor):
         if not isinstance(usage, dict):
             return
 
-        def _int(value: Any) -> int:  # type: ignore[explicit-any]
+        def _int(value: object) -> int:
             return int(value) if isinstance(value, (int, float)) else 0
 
         cached = _int(usage.get("cachedReadTokens"))
@@ -947,7 +957,7 @@ class QwenExecutor(Executor):
             acc["cache_read_input_tokens"] = acc.get("cache_read_input_tokens", 0) + cached
 
     @staticmethod
-    def _image_blocks_from_content(content: Any) -> list[dict[str, Any]]:  # type: ignore[explicit-any]
+    def _image_blocks_from_content(content: object) -> list[_AcpJsonObject]:
         """Build ACP ``image`` prompt blocks from a message's ``input_image`` blocks.
 
         The runner resolves a ``file_id`` into an inline ``image_url`` (or
@@ -959,7 +969,7 @@ class QwenExecutor(Executor):
         :param content: A message's ``content`` (block list, or non-list → none).
         :returns: A list of ACP image content blocks (possibly empty).
         """
-        out: list[dict[str, Any]] = []  # type: ignore[explicit-any]
+        out: list[_AcpJsonObject] = []
         if not isinstance(content, list):
             return out
         for block in content:
@@ -973,9 +983,9 @@ class QwenExecutor(Executor):
 
     @staticmethod
     def _text_from_blocks(
-        blocks: list[Any],
+        blocks: list[object],
         *,
-        emit_image_marker: bool = False,  # type: ignore[explicit-any]
+        emit_image_marker: bool = False,
     ) -> str:
         """Extract prompt text from a Responses-API content-block list.
 
@@ -1046,7 +1056,7 @@ class QwenExecutor(Executor):
         return "\n".join(parts)
 
     @classmethod
-    def _history_prefix(cls, prior: list[Any]) -> str:  # type: ignore[explicit-any]
+    def _history_prefix(cls, prior: Sequence[object]) -> str:
         """Serialize prior conversation turns into a text prefix.
 
         On a *fresh* ACP session (the first turn of a newly spawned/respawned
@@ -1095,7 +1105,7 @@ class QwenExecutor(Executor):
     async def run_turn(
         self,
         messages: list[Message],
-        tools: list[Any],  # type: ignore[explicit-any]  # qwen runs its own tools; used for the Omnigent MCP relay
+        tools: list[ToolSpec],
         system_prompt: str,
         config: ExecutorConfig | None = None,  # noqa: ARG002 — unused; required by the Executor interface
     ) -> AsyncIterator[ExecutorEvent]:
@@ -1132,7 +1142,7 @@ class QwenExecutor(Executor):
 
         # Build the prompt payload from the most recent user message.
         user_text = ""
-        image_blocks: list[dict[str, Any]] = []  # type: ignore[explicit-any]
+        image_blocks: list[_AcpJsonObject] = []
         latest_user_idx: int | None = None
         for idx in range(len(messages) - 1, -1, -1):
             msg = messages[idx]
@@ -1173,7 +1183,7 @@ class QwenExecutor(Executor):
             self._system_prompt_sent = True
 
         # Text first, then any image blocks (ACP prompt is an ordered array).
-        prompt_blocks: list[dict[str, Any]] = []  # type: ignore[explicit-any]
+        prompt_blocks: list[_AcpJsonObject] = []
         if user_text or not image_blocks:
             prompt_blocks.append({"type": "text", "text": user_text})
         prompt_blocks.extend(image_blocks)
@@ -1195,10 +1205,10 @@ class QwenExecutor(Executor):
         self._rpc_id += 1
         req_id = self._rpc_id
         loop = asyncio.get_event_loop()
-        fut: asyncio.Future[dict[str, Any]] = loop.create_future()  # type: ignore[explicit-any]
+        fut: asyncio.Future[_AcpJsonObject] = loop.create_future()
         self._pending[req_id] = fut
 
-        prompt_request: dict[str, Any] = {  # type: ignore[explicit-any]
+        prompt_request: _AcpJsonObject = {
             "jsonrpc": "2.0",
             "id": req_id,
             "method": _AGENT_METHOD_SESSION_PROMPT,


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Consolidate Qwen's extensible ACP JSON-RPC payloads behind one documented wire-boundary alias instead of repeating broad annotations and suppressions.
- Type prompt content, usage accumulation, history, Omnigent tools, and policy/elicitation/tool callbacks with focused contracts matching the generic ACP and Goose executors.
- Remove all 8 mypy findings from `omnigent/inner/qwen_executor.py`, reducing the full-tree baseline from 1,482 to 1,474 errors.

**ELI5:** Qwen's external protocol remains flexible JSON, while every value the executor uses internally now passes through a specific typed contract.

```text
Qwen JSON-RPC -> documented ACP boundary -> narrowed executor fields
Omnigent tools -> ToolSpec + typed bridges -> ACP MCP relay
```

## Test Plan

- `uv run --no-sync pytest -q tests/inner/test_qwen_executor.py` (75 passed)
- `uv run --no-sync mypy --no-incremental omnigent` (1,474 existing errors; none in `qwen_executor.py`)
- `pre-commit run --all-files`
- Confirmed `uv.lock` is unchanged.

## Demo

N/A — non-visual type-safety refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing suite covers JSON-RPC handling, prompt text and image conversion, usage accumulation, policy and elicitation callbacks, MCP relay setup, session lifecycle, sandboxing, and runner integration.

## Changelog

N/A — internal type-safety cleanup.