### PR TITLE
refactor(policies): type cost usage contracts

### DIFF
--- a/omnigent/policies/builtins/cost.py
+++ b/omnigent/policies/builtins/cost.py
@@ -68,8 +68,8 @@ a non-empty ``arguments`` block (the registry declares it
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
 
 from omnigent.policies.schema import (
     SESSION_COST_ASK_APPROVED_STATE_KEY,
@@ -111,7 +111,7 @@ _UNPRICED_ASK: PolicyResponse = {
 }
 
 
-def _usage_is_unpriced(usage: dict[str, Any]) -> bool:
+def _usage_is_unpriced(usage: Mapping[str, object]) -> bool:
     """Return ``True`` when token usage is present but cost is unpriced.
 
     The session has had at least one turn (token counters are non-zero) yet
@@ -555,7 +555,7 @@ def cost_budget(
                     }
         return _ALLOW
 
-    return evaluate  # type: ignore[return-value]
+    return evaluate
 
 
 def _user_daily_cost_usd(event: PolicyEvent) -> float:
@@ -740,7 +740,7 @@ def user_daily_cost_budget(
                     }
         return _ALLOW
 
-    return evaluate  # type: ignore[return-value]
+    return evaluate
 
 
 # session_state key recording the highest ``ask_thresholds_usd`` checkpoint
@@ -880,12 +880,12 @@ def subagent_cost_budget(
                     }
         return _ALLOW
 
-    return evaluate  # type: ignore[return-value]
+    return evaluate
 
 
 # ── Registry ─────────────────────────────────────────────────────────────────
 
-POLICY_REGISTRY: list[dict[str, Any]] = [
+POLICY_REGISTRY: list[dict[str, object]] = [
     {
         "handler": "omnigent.policies.builtins.cost.cost_budget",
         "kind": "factory",


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Accept read-only object-valued usage mappings in the unpriced-session check, matching the shared `UsageContext` typed dictionary passed by all three budget evaluators.
- Remove stale return-value suppressions now that the nested evaluators satisfy `PolicyCallable`, and type the policy registry as object-valued metadata.
- Remove all 8 mypy findings from `omnigent/policies/builtins/cost.py`, reducing the current full-tree baseline from 1,470 to 1,462 errors.

**ELI5:** The cost policy only reads usage counters, so it now accepts the shared read-only usage shape instead of demanding a mutable dictionary containing anything.

```text
UsageContext -> read-only usage check -> session/daily/subagent budgets
```

## Test Plan

- `uv run --no-sync pytest -q tests/policies/builtins/test_cost.py` (57 passed)
- `uv run --no-sync mypy --no-incremental omnigent` (1,462 existing errors; none in `cost.py`)
- `pre-commit run --all-files`
- Confirmed `uv.lock` is unchanged.

## Demo

N/A — non-visual type-safety refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing suite covers priced and unpriced usage, session/daily/subagent hard caps, warning approvals, model downgrade gates, factory validation, registry discovery, and policy-engine integration.

## Changelog

N/A — internal type-safety cleanup.