### PR TITLE
refactor(policies): type async callable contracts

### DIFF
--- a/omnigent/policies/builtins/context.py
+++ b/omnigent/policies/builtins/context.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Any
+from typing import Literal
 
 from omnigent.policies.schema import (
     PolicyCallable,
@@ -24,6 +24,22 @@ from omnigent.policies.schema import (
 )
 
 _log = logging.getLogger(__name__)
+
+_ContextAction = Literal["ASK", "DENY"]
+
+
+def _normalise_action(action: object, *, policy_name: str) -> _ContextAction:
+    candidate = action.upper() if isinstance(action, str) else "ASK"
+    if candidate == "DENY":
+        return "DENY"
+    if candidate != "ASK":
+        _log.warning(
+            "%s: unknown action %r — defaulting to ASK",
+            policy_name,
+            action,
+        )
+    return "ASK"
+
 
 # ── detect_task_switch ────────────────────────────────────────────────────────
 
@@ -49,7 +65,7 @@ Return strict JSON only:
 {"verdict": "CONTINUATION" | "TASK_SWITCH"}
 """
 
-_TASK_SWITCH_SCHEMA: dict[str, Any] = {
+_TASK_SWITCH_SCHEMA: dict[str, object] = {
     "format": {
         "type": "json_schema",
         "name": "task_switch_verdict",
@@ -89,7 +105,7 @@ def _strip_code_fences(text: str) -> str:
     return stripped
 
 
-def _extract_text(response: Any) -> str:
+def _extract_text(response: object) -> str:
     """Pull plain text out of a PolicyLLMClient response."""
     text = getattr(response, "output_text", None)
     if isinstance(text, str) and text.strip():
@@ -156,13 +172,7 @@ def detect_task_switch(
         enforced via structured output regardless.
     :returns: An async policy callable that fires on ``request`` events.
     """
-    normalised_action = action.upper() if isinstance(action, str) else "ASK"
-    if normalised_action not in {"DENY", "ASK"}:
-        _log.warning(
-            "detect_task_switch: unknown action %r — defaulting to ASK",
-            action,
-        )
-        normalised_action = "ASK"
+    normalised_action = _normalise_action(action, policy_name="detect_task_switch")
 
     async def evaluate(event: PolicyEvent) -> PolicyResponse | None:
         """Classify the new user message and flag task switches.
@@ -285,7 +295,7 @@ def detect_task_switch(
         # Unrecognised verdict — fail open.
         return None
 
-    return evaluate  # type: ignore[return-value]
+    return evaluate
 
 
 # ── detect_thrashing ─────────────────────────────────────────────────────────
@@ -373,13 +383,7 @@ def detect_thrashing(
         (default) or ``"DENY"``.
     :returns: A policy callable that fires on ``tool_result`` events.
     """
-    normalised_action = action.upper() if isinstance(action, str) else "ASK"
-    if normalised_action not in {"DENY", "ASK"}:
-        _log.warning(
-            "detect_thrashing: unknown action %r — defaulting to ASK",
-            action,
-        )
-        normalised_action = "ASK"
+    normalised_action = _normalise_action(action, policy_name="detect_thrashing")
 
     def evaluate(event: PolicyEvent) -> PolicyResponse | None:
         """Track tool-result outcomes and flag sustained failure runs.
@@ -460,12 +464,12 @@ def detect_thrashing(
 
         return state_update
 
-    return evaluate  # type: ignore[return-value]
+    return evaluate
 
 
 # ── Registry ──────────────────────────────────────────────────────────────────
 
-POLICY_REGISTRY: list[dict[str, Any]] = [
+POLICY_REGISTRY: list[dict[str, object]] = [
     {
         "handler": "omnigent.policies.builtins.context.detect_task_switch",
         "kind": "factory",

--- a/omnigent/policies/builtins/prompt.py
+++ b/omnigent/policies/builtins/prompt.py
@@ -203,7 +203,7 @@ def prompt_policy(
             "reason": fixed_reason or llm_reason or "Denied by prompt policy.",
         }
 
-    return evaluate  # type: ignore[return-value]
+    return evaluate
 
 
 def _make_nonce() -> str:

--- a/omnigent/policies/builtins/routing.py
+++ b/omnigent/policies/builtins/routing.py
@@ -238,7 +238,7 @@ def deny_trivial_to_expensive_model(
 
         return None
 
-    return evaluate  # type: ignore[return-value]
+    return evaluate
 
 
 # ── intent_based_authorization ───────────────────────────────────────────────────────────────
@@ -464,7 +464,7 @@ def intent_based_authorization() -> PolicyCallable:
 
         return None  # unrecognised verdict — fail open
 
-    return evaluate  # type: ignore[return-value]
+    return evaluate
 
 
 # ── Registry ─────────────────────────────────────────────────────────────────

--- a/omnigent/policies/schema.py
+++ b/omnigent/policies/schema.py
@@ -35,7 +35,8 @@ Factory form (with ``factory_params``)::
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, Protocol, TypedDict, cast
+from collections.abc import Awaitable
+from typing import TYPE_CHECKING, Literal, Protocol, TypeAlias, TypedDict, cast
 
 if TYPE_CHECKING:
     from omnigent.policies.types import PolicyLLMClient
@@ -309,6 +310,8 @@ class PolicyResponse(TypedDict, total=False):
 
 # ── Callable protocol ────────────────────────────────────────────────────────
 
+_PolicyCallableReturn: TypeAlias = PolicyResponse | Awaitable[PolicyResponse | None] | None
+
 
 class PolicyCallable(Protocol):
     """Protocol for a one-argument policy callable.
@@ -325,7 +328,7 @@ class PolicyCallable(Protocol):
             return {"result": "ALLOW"}
     """
 
-    def __call__(self, event: PolicyEvent) -> PolicyResponse | None: ...
+    def __call__(self, event: PolicyEvent) -> _PolicyCallableReturn: ...
 
 
 class PolicyCallableWithConfig(Protocol):
@@ -344,7 +347,7 @@ class PolicyCallableWithConfig(Protocol):
             ...
     """
 
-    def __call__(self, event: PolicyEvent, config: dict[str, str]) -> PolicyResponse | None: ...
+    def __call__(self, event: PolicyEvent, config: dict[str, str]) -> _PolicyCallableReturn: ...
 
 
 # ── REQUEST-phase data helpers ───────────────────────────────────────────────

--- a/omnigent/policies/schema.py
+++ b/omnigent/policies/schema.py
@@ -328,7 +328,8 @@ class PolicyCallable(Protocol):
             return {"result": "ALLOW"}
     """
 
-    def __call__(self, event: PolicyEvent) -> _PolicyCallableReturn: ...
+    def __call__(self, event: PolicyEvent) -> _PolicyCallableReturn:
+        raise NotImplementedError
 
 
 class PolicyCallableWithConfig(Protocol):
@@ -347,7 +348,8 @@ class PolicyCallableWithConfig(Protocol):
             ...
     """
 
-    def __call__(self, event: PolicyEvent, config: dict[str, str]) -> _PolicyCallableReturn: ...
+    def __call__(self, event: PolicyEvent, config: dict[str, str]) -> _PolicyCallableReturn:
+        raise NotImplementedError
 
 
 # ── REQUEST-phase data helpers ───────────────────────────────────────────────


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Correct the shared `PolicyCallable` protocols to model their documented synchronous-or-asynchronous return contract.
- Narrow context-policy actions to the supported `ASK`/`DENY` literals and replace open-ended classifier/registry annotations with object-valued boundaries.
- Remove newly obsolete async-return suppressions from the prompt and routing policies, eliminating 7 net full-tree mypy findings and reducing the baseline from 1,470 to 1,463 errors.

**ELI5:** Async policies were already supported at runtime and documented as valid; the shared type contract now agrees, while context-policy actions are checked before being returned.

```text
sync evaluator  ─┐
                 ├─> PolicyCallable -> PolicyResponse
async evaluator ─┘
```

## Test Plan

- `uv run --no-sync pytest -q tests/policies/builtins/test_context.py tests/policies/builtins/test_prompt.py tests/policies/builtins/test_routing.py` (90 passed)
- `uv run --no-sync mypy --no-incremental omnigent` (1,463 existing errors; no findings in `schema.py` or `context.py`)
- `pre-commit run --all-files`
- Confirmed `uv.lock` is unchanged.

## Demo

N/A — non-visual type-safety refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing suites cover async task-switch classification, synchronous thrashing detection, prompt-policy evaluation, both async routing classifiers, action fallback behavior, state updates, and fail-open/fail-closed paths.

## Changelog

N/A — internal type-safety cleanup.