### PR TITLE
refactor: type Cursor executor boundaries

### DIFF
--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -47,10 +47,10 @@ import json
 import logging
 import os
 import sys
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, TypeAlias
+from typing import Protocol, TypeAlias, TypedDict
 
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 
@@ -77,7 +77,42 @@ logger = logging.getLogger(__name__)
 # Omnigent's bridged-tool callback: (tool_name, args) -> awaitable result.
 # Installed by the runtime adapter (see ``_executor_adapter``); mirrors the
 # claude-sdk executor's ``ToolExecutor``.
-ToolExecutor: TypeAlias = Callable[[str, dict[str, Any]], Awaitable[Any]]  # type: ignore[explicit-any]
+_JsonObject: TypeAlias = dict[str, object]
+ToolExecutor: TypeAlias = Callable[[str, _JsonObject], Awaitable[object]]
+PolicyEvaluator: TypeAlias = Callable[[str, _JsonObject], Awaitable[object]]
+ElicitationHandler: TypeAlias = Callable[[str, _JsonObject], Awaitable[bool]]
+
+
+class _PolicyGate(TypedDict):
+    block: bool
+    reason: str
+
+
+class _CursorStreamEvent(Protocol):
+    @property
+    def sdk_message(self) -> object | None:
+        raise NotImplementedError
+
+    @property
+    def interaction_update(self) -> object | None:
+        raise NotImplementedError
+
+
+class _CursorRun(Protocol):
+    def events(self) -> AsyncIterator[_CursorStreamEvent]:
+        raise NotImplementedError
+
+    async def wait(self) -> object:
+        raise NotImplementedError
+
+    async def cancel(self) -> object:
+        raise NotImplementedError
+
+
+class _CursorAgent(Protocol):
+    async def send(self, prompt: str, *, options: object) -> _CursorRun:
+        raise NotImplementedError
+
 
 # Cursor's auto model-select, used when a spec pins no cursor model (the SDK
 # requires a model for local agents, so unlike the old ACP path we can't pass
@@ -123,21 +158,21 @@ def _resolve_model(model: str | None) -> str:
     return model
 
 
-def _first_of(d: dict[str, Any], *keys: str, default: int = 0) -> int:
-    """Return the value of the first key present (and not None) in *d*."""
-    for k in keys:
-        v = d.get(k)
-        if v is not None:
-            return int(v)
+def _first_of(data: Mapping[str, object], *keys: str, default: int = 0) -> int:
+    """Return the value of the first numeric key present in *data*."""
+    for key in keys:
+        value = data.get(key)
+        if isinstance(value, (int, float, str)):
+            return int(value)
     return default
 
 
-def _normalize_cursor_usage(raw: dict[str, Any], model: str) -> dict[str, Any]:
+def _normalize_cursor_usage(raw: Mapping[str, object], model: str) -> _JsonObject:
     """Map Cursor SDK usage fields to the standard Omnigent usage dict."""
     in_tok = _first_of(raw, "inputTokens", "input_tokens")
     out_tok = _first_of(raw, "outputTokens", "output_tokens")
     total = _first_of(raw, "totalTokens", "total_tokens", default=in_tok + out_tok)
-    usage: dict[str, Any] = {
+    usage: _JsonObject = {
         "input_tokens": in_tok,
         "output_tokens": out_tok,
         "total_tokens": total,
@@ -162,9 +197,9 @@ def _normalize_cursor_usage(raw: dict[str, Any], model: str) -> dict[str, Any]:
         ),
     ):
         for src in sources:
-            val = raw.get(src)
-            if val is not None:
-                usage[dst] = val
+            value = raw.get(src)
+            if isinstance(value, (int, float, str)):
+                usage[dst] = int(value)
                 break
     # cursor's inputTokens is INCLUSIVE of cache read + write. compute_llm_cost
     # expects input_tokens to be the NON-cached portion and prices the cache
@@ -172,8 +207,8 @@ def _normalize_cursor_usage(raw: dict[str, Any], model: str) -> dict[str, Any]:
     # are billed twice (once at the full input rate, once at their cache rate).
     # Mirrors the qwen / antigravity executors. Clamp so a malformed cached >
     # input never goes negative. total_tokens keeps the reported inclusive total.
-    cached = (usage.get("cache_read_input_tokens") or 0) + (
-        usage.get("cache_creation_input_tokens") or 0
+    cached = _first_of(usage, "cache_read_input_tokens") + _first_of(
+        usage, "cache_creation_input_tokens"
     )
     usage["input_tokens"] = max(0, in_tok - cached)
     return usage
@@ -267,7 +302,7 @@ def _build_cursor_prompt(
 # ---------------------------------------------------------------------------
 
 
-def _sdk_message_to_events(message: Any) -> list[ExecutorEvent]:  # type: ignore[explicit-any]
+def _sdk_message_to_events(message: object) -> list[ExecutorEvent]:
     """Map one ``cursor_sdk`` ``SDKMessage`` to zero or more ExecutorEvents.
 
     Handles the message types the harness surfaces; everything else (status,
@@ -295,7 +330,7 @@ def _sdk_message_to_events(message: Any) -> list[ExecutorEvent]:  # type: ignore
         status = getattr(message, "status", "")
         name = str(getattr(message, "name", "") or "tool")
         raw_args = getattr(message, "args", None)
-        args: dict[str, Any] = raw_args if isinstance(raw_args, dict) else {}
+        args: _JsonObject = raw_args if isinstance(raw_args, dict) else {}
         # Cursor surfaces host custom tools under an envelope: name == "mcp",
         # args == {providerIdentifier, toolName, args}. Unwrap to the real
         # Omnigent tool name + args so the observed events (and any name-keyed
@@ -341,7 +376,7 @@ def _sdk_message_to_events(message: Any) -> list[ExecutorEvent]:  # type: ignore
 # ---------------------------------------------------------------------------
 
 
-def _tool_error_payload(text: str) -> dict[str, Any]:  # type: ignore[explicit-any]
+def _tool_error_payload(text: str) -> _JsonObject:
     """An SDK custom-tool *error* result.
 
     A mapping with a ``content`` list and ``isError`` is passed through unchanged
@@ -351,7 +386,7 @@ def _tool_error_payload(text: str) -> dict[str, Any]:  # type: ignore[explicit-a
     return {"content": [{"type": "text", "text": text}], "isError": True}
 
 
-def _encode_tool_result(result: Any) -> Any:  # type: ignore[explicit-any]
+def _encode_tool_result(result: object) -> object:
     """Encode a bridged-tool result for the SDK custom-tool return.
 
     A result that :func:`classify_tool_result` flags as anything other than
@@ -485,8 +520,8 @@ async def _bridge_spawn_in_cwd(cwd: str) -> AsyncIterator[None]:
 class _CursorSessionState:
     """Per-Omnigent-conversation SDK session state."""
 
-    client: Any = None  # cursor_sdk.AsyncClient
-    agent: Any = None  # cursor_sdk.AsyncAgent
+    client: object | None = None  # cursor_sdk.AsyncClient
+    agent: _CursorAgent | None = None  # cursor_sdk.AsyncAgent
     system_prompt: str | None = None
     model: str | None = None
     tools_fingerprint: str | None = None
@@ -544,11 +579,11 @@ class CursorExecutor(Executor):
         # PHASE_LLM_RESPONSE, and PHASE_TOOL_CALL policies (the same round-trip
         # pi / claude-sdk use). ``None`` on single-process / pre-turn paths
         # (then policy is a no-op).
-        self._policy_evaluator: Callable[[str, dict[str, Any]], Awaitable[Any]] | None = None
+        self._policy_evaluator: PolicyEvaluator | None = None
         # Installed by the runtime adapter; surfaces ASK verdicts to the
         # user via the elicitation UI (approval prompt). ``None`` when no
         # handler is wired (single-process / test paths → fail closed).
-        self._elicitation_handler: Callable[[str, dict[str, Any]], Awaitable[bool]] | None = None
+        self._elicitation_handler: ElicitationHandler | None = None
 
     def supports_streaming(self) -> bool:
         return True
@@ -579,9 +614,7 @@ class CursorExecutor(Executor):
 
     # -- native-tool policy gate --------------------------------------------
 
-    async def _evaluate_native_tool_policy(
-        self, name: str, args: dict[str, Any]
-    ) -> dict[str, Any]:
+    async def _evaluate_native_tool_policy(self, name: str, args: _JsonObject) -> _PolicyGate:
         """Gate a Cursor native tool call via policy check + user elicitation.
 
         Returns ``{"block": bool, "reason": str}``.
@@ -636,16 +669,17 @@ class CursorExecutor(Executor):
 
     def _make_custom_tools(
         self, tools: list[ToolSpec], loop: asyncio.AbstractEventLoop
-    ) -> dict[str, Any]:  # type: ignore[explicit-any]
+    ) -> dict[str, object]:
         """Build the SDK ``custom_tools`` mapping from Omnigent ToolSpecs.
 
         Each tool's ``execute`` runs on the SDK callback server's daemon thread,
         so it hops back to *loop* (the main event loop) to await
         ``_tool_executor`` — the bridge into Omnigent's tool dispatch.
         """
-        from cursor_sdk import CustomTool  # lazy: optional dependency
+        # cursor-sdk is an optional dependency imported only by this harness.
+        from cursor_sdk import CustomTool  # type: ignore[import-not-found]
 
-        custom: dict[str, Any] = {}  # type: ignore[explicit-any]
+        custom: dict[str, object] = {}
         for spec in tools:
             name = spec.get("name")
             if not isinstance(name, str) or not name:
@@ -662,7 +696,7 @@ class CursorExecutor(Executor):
 
     def _make_execute(
         self, tool_name: str, loop: asyncio.AbstractEventLoop
-    ) -> Callable[[dict[str, Any], Any], Any]:  # type: ignore[explicit-any]
+    ) -> Callable[[_JsonObject, object], object]:
         """Build a sync ``execute`` that bridges a cursor tool call to Omnigent.
 
         Runs on the SDK callback server's daemon thread and blocks it on the
@@ -674,12 +708,15 @@ class CursorExecutor(Executor):
         than propagating raw onto the daemon thread.
         """
 
-        def execute(args: dict[str, Any], _ctx: Any) -> Any:  # type: ignore[explicit-any]
+        async def await_result(result: Awaitable[object]) -> object:
+            return await result
+
+        def execute(args: _JsonObject, _ctx: object) -> object:
             if self._tool_executor is None:
                 return _tool_error_payload(
                     f"Tool {tool_name!r} is unavailable: no tool executor wired."
                 )
-            coro = self._tool_executor(tool_name, dict(args or {}))
+            coro = await_result(self._tool_executor(tool_name, dict(args or {})))
             future = asyncio.run_coroutine_threadsafe(coro, loop)
             try:
                 result = future.result(timeout=_TOOL_CALL_TIMEOUT_S)
@@ -753,7 +790,7 @@ class CursorExecutor(Executor):
         async with _bridge_spawn_in_cwd(cwd):
             client = await AsyncClient.launch_bridge(workspace=cwd)
         try:
-            local_kwargs: dict[str, Any] = {
+            local_kwargs: _JsonObject = {
                 "cwd": cwd,
                 "custom_tools": self._make_custom_tools(tools, loop) or None,
                 # Bypass cursor's own TUI approval prompts so native tool calls
@@ -850,21 +887,23 @@ class CursorExecutor(Executor):
         # Streamed deltas of a single response (no tool between) still
         # concatenate seamlessly, so this never splits one sentence.
         separate_next_text = False
-        turn_usage: dict[str, Any] | None = None
+        turn_usage: _JsonObject | None = None
         try:
             # Pass SendOptions with on_delta so the backend sends
             # interaction updates (including TurnEndedUpdate with usage).
             # Without enableDeltas the backend omits them entirely.
             from cursor_sdk import SendOptions as _SendOptions  # lazy: optional dep
 
-            def _capture_delta(update: Any) -> None:  # type: ignore[explicit-any]
+            def _capture_delta(update: object) -> None:
                 nonlocal turn_usage
                 if getattr(update, "type", None) == "turn-ended":
                     raw = getattr(update, "usage", None)
                     if isinstance(raw, dict) and raw:
                         turn_usage = _normalize_cursor_usage(raw, model)
 
-            run = await state.agent.send(prompt, options=_SendOptions(on_delta=_capture_delta))
+            agent = state.agent
+            assert agent is not None
+            run = await agent.send(prompt, options=_SendOptions(on_delta=_capture_delta))
             async for stream_event in run.events():
                 if stream_event.sdk_message is not None:
                     for event in _sdk_message_to_events(stream_event.sdk_message):
@@ -1019,7 +1058,7 @@ class CursorExecutor(Executor):
             await self.close_session(key)
 
 
-async def _safe_close(obj: Any) -> None:  # type: ignore[explicit-any]
+async def _safe_close(obj: object) -> None:
     """Best-effort async close of a ``cursor_sdk`` object, preferring ``aclose()``.
 
     The SDK's :class:`cursor_sdk.AsyncClient` exposes only ``aclose()`` — and


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Replace explicit `Any` annotations at Cursor SDK and JSON boundaries with narrow aliases, protocols, and typed policy results.
- Preserve the optional SDK import boundary while making session lifecycle, tool callbacks, usage payloads, and event streams statically checkable.
- Remove all 19 mypy diagnostics from `omnigent/inner/cursor_executor.py`, reducing the clean-base total from 1,469 to 1,450 with no new diagnostics elsewhere.

**ELI5:** Cursor still sends and receives the same data; this change gives mypy a precise description of those shapes instead of opting out with `Any`.

```text
Cursor SDK objects -> narrow protocols -> CursorExecutor
JSON payloads       -> object mappings -> policies/tools/usage
```

## Test Plan

- `.venv/bin/mypy --no-incremental omnigent/inner/cursor_executor.py` (zero Cursor executor diagnostics; generated protobuf baseline only)
- `.venv/bin/pytest -q tests/inner/test_cursor_executor.py tests/inner/test_cursor_harness.py` (81 passed)
- Clean base-vs-branch `.venv/bin/mypy --no-incremental omnigent` comparison (`1,469 -> 1,450`; zero new non-target diagnostics)
- `.venv/bin/pre-commit run --all-files` (all hooks passed)

## Demo

N/A — non-visual typing cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing Cursor executor and harness tests cover event conversion, tool bridging, policies, usage normalization, and session lifecycle behavior.
