### PR TITLE
feat(web): drive native identity + fork_history off /v1/harnesses (PR 2.3a) [draft, on #3672]

### DIFF
--- a/designs/harness-modular-registry-proposal.md
+++ b/designs/harness-modular-registry-proposal.md
@@ -470,6 +470,9 @@ signature.
 | 1.7 Server seeding loop | landed | #3599 | 07-31 |
 | 1.7 follow-up: opencode e2e onto shared agent-name constant | landed | #3656 | 07-31 |
 | 1.8 Derive enumerations + fork_history/shell-tool capability axes | landed | #3648 | 07-31 |
+| 2.1 Validator flip (accept community native harnesses) | in review | #3670 | — |
+| 2.2 `/v1/harnesses` native-agent rows | in review | #3672 | — |
+| 2.3a Web: native identity + fork_history off the endpoint | in review | (this PR) | — |
 
 **1.4 descoped.** The CLI-subcommand collapse (`cli_native.py` → a loop over
 `native_agents()`) is orthogonal to making native harnesses community-pluggable:

--- a/designs/harness-web-mirror-options.md
+++ b/designs/harness-web-mirror-options.md
@@ -1,0 +1,162 @@
+# PR 2.3 design options — driving the web off `/v1/harnesses`
+
+Status: **Option 1 chosen** (user, 2026-08). 2.3a (data plumb) implemented; 2.3b
+(presentation) pending. Community-provided icon resources deferred to a
+follow-up (default generic icon for now). Feeds PR 2.3 of the modular
+native-harness registry workstream.
+
+## The question
+
+`web/src/lib/nativeCodingAgents.ts` hardcodes an 11-row table of native coding
+agents. PR 2.2 (#3672) now publishes native rows on `GET /v1/harnesses`
+(`native_agents[]`) carrying `key`, `agent_name`, `harness`, `wrapper_label`,
+`terminal_name`, `display_name`, `subagent_wrapper_label`, `fork_history`, and
+the full `capabilities` dict. **2.3 replaces the literal with the endpoint —**
+but four fields the web literal carries have *no clean server source today*, and
+how we resolve each decides whether a community native harness can appear in the
+UI at all. This doc grounds that decision in how the web actually consumes each
+field.
+
+## What the ~20 consumers actually need
+
+I traced every importer of `nativeCodingAgents.ts`. The public API splits into
+**four field groups** with very different portability:
+
+### Group A — identity (already on the endpoint, trivially portable)
+`key`, `agent_name`, `harness`, `wrapper_label`, `terminal_name`,
+`display_name`, `subagent_wrapper_label`.
+- Consumed by: `nativeCodingAgentForHarness/AgentName/Wrapper`,
+  `isNativeTerminalSession`, `nativeWrapperLabelsForAgent`, plus the reversed
+  `HARNESS_ALIASES` map (which mirrors `harness_aliases.NATIVE_HARNESSES`).
+- **2.2 already emits all of these.** A community harness Just Works for
+  recognition, wrapper-label stamping, and native-session detection.
+
+### Group B — `fork_history` (already on the endpoint, replaces `forkHarness.ts` sets)
+- `forkHarness.ts` hardcodes `NATIVE_REBUILD_HARNESSES` / `PREAMBLE_FORK_HARNESSES`
+  (a `switch` over `claude-native` / `native-claude` / …). This is a *pure
+  duplicate* of the server's `_FORK_HISTORY_NATIVE_HARNESSES` /
+  `_CURSOR_FORK_HISTORY_HARNESSES`, which 1.8 already derives from the
+  `fork_history` capability axis.
+- **2.2 emits `fork_history` per row**, so the web `switch` becomes a lookup.
+  Fully portable, no new decision.
+
+### Group C — `sortRank` + marketing `displayName` (presentation, no server source)
+- `sortRank`: picker ordering only (`agentGrouping.ts` sorts by it). Arbitrary
+  10/20/25/… integers a human chose.
+- `displayName`: the literal says **"Claude Code"** / **"Qwen Code"**; the
+  registry `display_name` is **"Claude"** / **"Qwen"**. Marketing label vs
+  identity label — genuinely different strings, used in the picker card title
+  (`nativeDisplayNameForAgent`).
+- Neither has a server source. Both are **pure presentation**.
+
+### Group D — the capability picker list (`permissionMode`/`approvalMode`/`cursorMode`)
+This is the one that looks like it should be a capability axis but **is not**:
+- `NewChatDialog.tsx` gates three *distinct, vendor-specific* pickers on these
+  flags. Each picker has a **hardcoded option list with vendor-specific launch
+  args**: claude → `default`/`acceptEdits`/`plan`/`bypassPermissions`; codex →
+  `--sandbox read-only --ask-for-approval on-request` etc.; cursor → its own
+  mode set.
+- These are **not derivable from `capabilities`** — kiro/goose/hermes/qwen all
+  share `elicitation=APPROVAL_MIRROR` yet expose *no* picker; the flag marks
+  "this specific vendor has a launch-time mode UI the web knows how to render,"
+  which is inherently client knowledge (the option lists + args live in the web).
+- **Critically:** even if the server emitted "supports a permission picker," the
+  web still couldn't render one for an *unknown* community vendor — it has no
+  option list or args for it. So this flag is only ever meaningful for vendors
+  the web already ships bespoke UI for.
+
+### Group E — `iconKind` (the hard blocker, must stay client-side)
+- `iconKind` maps to a **bundled SVG React component** imported at build time
+  (`AgentCard.tsx`: `if (iconKind === "claude") return ClaudeIcon` over 10
+  imported glyphs; `SubagentsPanel.tsx` duplicates it).
+- A community plugin's icon **cannot** be a server string — the web bundle has
+  no `FooIcon` to import for an unknown plugin. Unknown `iconKind` already falls
+  through to a generic bot glyph (qwen/hermes do this today, on purpose).
+- **This field is fundamentally client-side** and can't move to the registry in
+  any meaningful way. The most the server could say is "here's a URL to an SVG,"
+  which is a much bigger lift (remote asset loading, sanitization) and out of
+  scope.
+
+## The insight
+
+Only **A + B** (identity + fork_history) are genuinely server-portable, and 2.2
+**already ships them**. **C, D, E are irreducibly client-side presentation** —
+not because we haven't done the work, but because they *are* client concerns:
+a bundled icon, a human-chosen sort order, a marketing name, and bespoke per-
+vendor launch-arg UIs the web alone knows how to render.
+
+So the real design question is narrower than "expand `NativeCodingAgent` or
+not." It's: **how should the web hold the C/D/E presentation bits for the
+built-in vendors, once the identity/behavior data comes from the server?**
+
+## Options
+
+### Option 1 — Server = data, web = presentation overlay (RECOMMENDED)
+- **2.3a:** Drive Groups A + B off `/v1/harnesses`. `nativeCodingAgents.ts`
+  stops being the source of identity/fork data; it fetches native rows from the
+  endpoint (via the existing `useAvailableAgents`/harness-catalog query layer).
+- Keep a **small client-side presentation map keyed by `key`** for C/D/E:
+  `{ claude: { iconKind, sortRank, displayName, pickerCaps }, … }`. A row whose
+  `key` isn't in the map renders with sensible defaults (generic bot icon,
+  `sortRank=∞` → sorts last, `display_name` from the server, no picker). This is
+  **exactly today's fallback behavior** for qwen/hermes icons.
+- **Community harness result:** appears in the picker with correct name/behavior
+  and a generic icon — the honest, working outcome. A vendor that wants brand
+  polish upstreams an icon + presentation entry (a tiny, reviewable web PR).
+- **Pros:** no `NativeCodingAgent` wire-shape churn; server owns identity/behavior;
+  the web keeps only what is truly client knowledge; matches the 1.8 principle of
+  not putting presentation on the identity dataclass. Smallest, safest diff.
+- **Cons:** two sources (server data + web presentation map) — but they're
+  cleanly split by *concern* (behavior vs. bundled presentation), not duplicated.
+
+### Option 2 — Expand `NativeCodingAgent` with presentation fields
+- Add `icon_kind`, `sort_rank`, `ui_display_name`, `picker_capabilities` to the
+  frozen dataclass; 2.2 emits them; web reads everything from the server.
+- **Pros:** one source of truth; a community harness *could* declare `sort_rank`
+  and a picker-cap.
+- **Cons:** (a) `iconKind` **still** can't work for community plugins (no bundled
+  asset) — so the headline benefit is illusory for the field that matters most;
+  (b) puts marketing/presentation on the identity wire shape — the exact
+  scope-creep deferred in 1.8, and it bloats every native row for all API
+  consumers; (c) `picker_capabilities` is a lie unless the web also ships the
+  vendor's option list + args, so a community value renders nothing. High churn,
+  low real payoff.
+
+### Option 3 — Hybrid: server owns `sort_rank` only; web keeps icon/displayName/caps
+- Add just `sort_rank` to the dataclass (it's arguably legit ordering metadata a
+  contributor might want), leave icon/displayName/picker-caps client-side.
+- **Pros:** lets a community harness place itself in the picker order.
+- **Cons:** marginal — sort order is the least important of the three, and mixing
+  "some presentation on the server, some on the web" is muddier than Option 1's
+  clean behavior/presentation split. Not worth the dataclass change.
+
+## Recommendation
+
+**Option 1.** The research shows the web literal conflates *behavior/identity*
+(portable, already on the endpoint) with *bundled presentation* (icon, sort,
+marketing name, bespoke pickers — irreducibly client-side). 2.3 should split
+those: server drives A+B, a small `key`-keyed web presentation map holds C/D/E
+with graceful defaults for unknown keys. That gives community native harnesses a
+correct, working picker entry today (generic icon), lets vendors upstream brand
+polish as a trivial follow-up, and avoids bloating the identity wire shape or
+shipping a picker-capability flag the web can't honor for unknown vendors.
+
+### If Option 1 is chosen, 2.3 splits cleanly
+- **2.3a (data plumb, testable):** point identity + fork_history lookups at the
+  endpoint; delete the `forkHarness.ts` rebuild/preamble sets and the identity
+  half of `nativeCodingAgents.ts`. Unit-testable (mock the query), no visual risk.
+- **2.3b (presentation, demo-gated):** reduce `nativeCodingAgents.ts` to the
+  `key`-keyed presentation map (icon/sort/displayName/pickerCaps) with the
+  unknown-key defaults; wire `AgentCard`/`SubagentsPanel`/`NewChatDialog`. This
+  is the piece that needs the screenshot/recording demo.
+
+## Open sub-questions for the reviewer
+1. **Marketing `display_name`:** keep "Claude Code"/"Qwen Code" as web
+   presentation, or standardize the picker on the server's "Claude"/"Qwen"? (If
+   the latter, Group C's `displayName` disappears entirely and the web map only
+   holds icon/sort/pickerCaps.)
+2. **Community icon story:** ship with generic-bot fallback now (recommended), or
+   is a server-provided icon URL wanted later (separate design)?
+3. **`picker_capabilities`:** confirm these stay web-side keyed by `key` — a
+   community native gets no launch-time mode picker until the web ships bespoke
+   UI for it, which is the honest constraint.

--- a/web/src/lib/agentLabels.ts
+++ b/web/src/lib/agentLabels.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
+import { primeNativeAgentCatalog, type NativeAgentServerRow } from "@/lib/nativeCodingAgents";
 
 /**
  * Shared display-name helpers for agents and brain harnesses, used by
@@ -47,6 +48,10 @@ interface HarnessCatalogWire {
   // Setup steps keyed by EVERY harness spelling a session may declare (native
   // wrappers + installable non-picker ids), not just the picker rows in `data`.
   setup_steps?: Record<string, SetupStepWire[]>;
+  // Native coding-agent identity + capability rows (built-in and community),
+  // published by the server (PR 2.2). Drives native-agent recognition and
+  // fork-history gating; see `primeNativeAgentCatalog` in nativeCodingAgents.ts.
+  native_agents?: NativeAgentServerRow[];
 }
 
 interface HarnessCatalog {
@@ -54,6 +59,24 @@ interface HarnessCatalog {
   labels: Record<string, string>;
   /** harness spelling → ordered setup steps (install/auth) the server describes. */
   setupSteps: Record<string, SetupStepWire[]>;
+  /** Native coding-agent rows straight from the server (identity + fork_history). */
+  nativeAgents: NativeAgentServerRow[];
+}
+
+function parseNativeAgentRows(raw: unknown): NativeAgentServerRow[] {
+  if (!Array.isArray(raw)) return [];
+  const rows: NativeAgentServerRow[] = [];
+  for (const item of raw) {
+    if (
+      item != null &&
+      typeof item === "object" &&
+      typeof (item as { key?: unknown }).key === "string" &&
+      typeof (item as { harness?: unknown }).harness === "string"
+    ) {
+      rows.push(item as NativeAgentServerRow);
+    }
+  }
+  return rows;
 }
 
 async function fetchHarnessCatalog(): Promise<HarnessCatalog> {
@@ -70,7 +93,13 @@ async function fetchHarnessCatalog(): Promise<HarnessCatalog> {
   // so the dialog resolves whatever harness the session declares.
   const setupSteps =
     body.setup_steps && typeof body.setup_steps === "object" ? body.setup_steps : {};
-  return { labels, setupSteps };
+  const nativeAgents = parseNativeAgentRows(body.native_agents);
+  // Prime the synchronous module cache so the many non-React consumers of
+  // nativeCodingAgents.ts (composerMentions, agentGrouping, chatStore) see the
+  // server rows — including community native harnesses absent from the built-in
+  // literal — without threading this async data through every call site.
+  primeNativeAgentCatalog(nativeAgents);
+  return { labels, setupSteps, nativeAgents };
 }
 
 // Both hooks share one request + cache entry, each selecting its own slice.

--- a/web/src/lib/forkHarness.ts
+++ b/web/src/lib/forkHarness.ts
@@ -1,3 +1,5 @@
+import { serverForkHistoryForHarness } from "@/lib/nativeCodingAgents";
+
 // Pure helpers for the "fork / switch agent" flows: decide which target
 // harnesses preserve the source's conversation history (and so should appear
 // in each picker). Three carry mechanisms, all keyed off the TARGET harness —
@@ -134,6 +136,10 @@ const PREAMBLE_FORK_HARNESSES: ReadonlySet<string> = new Set([
  */
 export function forkTargetCarriesHistory(targetHarness: string | null | undefined): boolean {
   if (!targetHarness) return false;
+  // Prefer the server's fork_history axis (PR 2.2) so community native harnesses
+  // classify correctly; fall back to the built-in sets before the catalog loads.
+  const fork = serverForkHistoryForHarness(targetHarness);
+  if (fork === "rebuild" || fork === "preamble") return true;
   return (
     NATIVE_REBUILD_HARNESSES.has(targetHarness) ||
     PREAMBLE_FORK_HARNESSES.has(targetHarness) ||
@@ -155,6 +161,13 @@ export function forkTargetCarriesHistory(targetHarness: string | null | undefine
  */
 export function switchTargetCarriesHistory(targetHarness: string | null | undefined): boolean {
   if (!targetHarness) return false;
+  // Switch-agent carries history for rebuild only — NOT preamble, which is
+  // fork-only (a switch has no first-message injection point). Prefer the
+  // server axis; a `preamble` verdict means switch does NOT carry (preamble
+  // natives have no SDK family). Fall back to the built-in set pre-fetch.
+  const fork = serverForkHistoryForHarness(targetHarness);
+  if (fork === "rebuild") return true;
+  if (fork === "preamble") return false;
   return NATIVE_REBUILD_HARNESSES.has(targetHarness) || harnessFamily(targetHarness) !== null;
 }
 

--- a/web/src/lib/nativeCodingAgents.test.ts
+++ b/web/src/lib/nativeCodingAgents.test.ts
@@ -1,12 +1,32 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect } from "vitest";
 import {
   UI_MODE_LABEL_KEY,
   UI_MODE_TERMINAL_VALUE,
   WRAPPER_LABEL_KEY,
+  type NativeAgentServerRow,
   isNativeTerminalSession,
+  nativeCodingAgentForAgentName,
   nativeCodingAgentForHarness,
   nativeWrapperLabelsForAgent,
+  primeNativeAgentCatalog,
+  resetNativeAgentCatalogForTests,
+  serverForkHistoryForHarness,
 } from "./nativeCodingAgents";
+
+function serverRow(overrides: Partial<NativeAgentServerRow> = {}): NativeAgentServerRow {
+  return {
+    key: "foo",
+    agent_name: "foo-native-ui",
+    harness: "foo-native",
+    wrapper_label: "foo-native-ui",
+    terminal_name: "foo",
+    display_name: "Foo",
+    subagent_wrapper_label: null,
+    fork_history: "none",
+    capabilities: null,
+    ...overrides,
+  };
+}
 
 describe("nativeCodingAgentForHarness", () => {
   it("resolves the canonical pi-native harness", () => {
@@ -123,5 +143,85 @@ describe("isNativeTerminalSession", () => {
     expect(isNativeTerminalSession(null)).toBe(false);
     expect(isNativeTerminalSession(undefined)).toBe(false);
     expect(isNativeTerminalSession({})).toBe(false);
+  });
+});
+
+describe("primeNativeAgentCatalog (server-driven native rows, PR 2.3a)", () => {
+  afterEach(() => {
+    // Reset the module cache so these tests don't leak into the built-in-only
+    // suites above/below.
+    resetNativeAgentCatalogForTests();
+  });
+
+  it("makes a community native harness resolvable by harness + agent name", () => {
+    // Before priming, an unknown community harness is not recognized.
+    expect(nativeCodingAgentForHarness("foo-native")).toBeUndefined();
+
+    primeNativeAgentCatalog([serverRow()]);
+
+    expect(nativeCodingAgentForHarness("foo-native")?.key).toBe("foo");
+    expect(nativeCodingAgentForAgentName("foo-native-ui")?.harness).toBe("foo-native");
+  });
+
+  it("defaults presentation for an unknown community harness (generic icon, sort last)", () => {
+    primeNativeAgentCatalog([serverRow()]);
+    const spec = nativeCodingAgentForHarness("foo-native");
+    // Unknown key → generic-bot fallback (iconKind matches no icon branch) and
+    // sorts last; displayName falls back to the server's display_name.
+    expect(spec?.iconKind).toBe("foo");
+    expect(spec?.sortRank).toBe(Number.POSITIVE_INFINITY);
+    expect(spec?.displayName).toBe("Foo");
+    expect(spec?.capabilities).toBeUndefined();
+  });
+
+  it("keeps built-in presentation (icon/sortRank/marketing name) when the server row overrides identity", () => {
+    // The server reports claude with its identity display_name "Claude", but the
+    // web presentation keeps the marketing "Claude Code" + brand icon + sortRank.
+    primeNativeAgentCatalog([
+      serverRow({
+        key: "claude",
+        agent_name: "claude-native-ui",
+        harness: "claude-native",
+        wrapper_label: "claude-code-native-ui",
+        display_name: "Claude",
+        fork_history: "rebuild",
+      }),
+    ]);
+    const spec = nativeCodingAgentForHarness("claude-native");
+    expect(spec?.iconKind).toBe("claude");
+    expect(spec?.sortRank).toBe(10);
+    expect(spec?.displayName).toBe("Claude Code");
+  });
+
+  it("exposes the server fork_history axis (and omits 'none')", () => {
+    primeNativeAgentCatalog([
+      serverRow({ key: "foo", harness: "foo-native", fork_history: "rebuild" }),
+      serverRow({
+        key: "bar",
+        agent_name: "bar-native-ui",
+        harness: "bar-native",
+        wrapper_label: "bar-native-ui",
+        fork_history: "preamble",
+      }),
+      serverRow({
+        key: "baz",
+        agent_name: "baz-native-ui",
+        harness: "baz-native",
+        wrapper_label: "baz-native-ui",
+        fork_history: "none",
+      }),
+    ]);
+    expect(serverForkHistoryForHarness("foo-native")).toBe("rebuild");
+    expect(serverForkHistoryForHarness("bar-native")).toBe("preamble");
+    // "none" is not indexed — a harness with no carry path is undefined.
+    expect(serverForkHistoryForHarness("baz-native")).toBeUndefined();
+    expect(serverForkHistoryForHarness("unknown-native")).toBeUndefined();
+  });
+
+  it("built-in harnesses still resolve before any server priming (fallback)", () => {
+    // No prime call: the built-in literal is the source, so built-ins work
+    // pre-fetch with no regression.
+    expect(nativeCodingAgentForHarness("claude-native")?.key).toBe("claude");
+    expect(nativeCodingAgentForHarness("codex-native")?.key).toBe("codex");
   });
 });

--- a/web/src/lib/nativeCodingAgents.ts
+++ b/web/src/lib/nativeCodingAgents.ts
@@ -157,15 +157,117 @@ export const NATIVE_CODING_AGENTS = [
   },
 ] as const satisfies readonly NativeCodingAgentSpec[];
 
-const BY_AGENT_NAME = new Map<string, NativeCodingAgentSpec>(
-  NATIVE_CODING_AGENTS.map((agent) => [agent.agentName, agent]),
+/**
+ * A native-agent row as published by the server on `GET /v1/harnesses`
+ * (`native_agents[]`, PR 2.2). Carries identity + the fork-history axis; the
+ * capabilities object is passed through opaquely (consumers that need a
+ * specific axis read it by name). Presentation fields (iconKind / sortRank /
+ * marketing displayName / picker capabilities) are NOT server-sourced — they
+ * stay in the built-in literal above and default gracefully for unknown keys.
+ */
+export interface NativeAgentServerRow {
+  key: string;
+  agent_name: string;
+  harness: string;
+  wrapper_label: string;
+  terminal_name: string;
+  display_name: string;
+  subagent_wrapper_label: string | null;
+  fork_history: string | null;
+  capabilities: Record<string, unknown> | null;
+}
+
+// Synchronous module cache of the server's native-agent rows, primed by the
+// /v1/harnesses query (see primeNativeAgentCatalog). The many non-React
+// consumers of this module read the merged view built-in-literal ∪ server-rows,
+// so a community native harness resolves once the catalog has loaded, and the
+// built-ins still work before the first fetch (they're in the literal).
+let SERVER_ROWS: readonly NativeAgentServerRow[] = [];
+
+/**
+ * Turn a server row into the `NativeCodingAgentSpec` shape the module's lookups
+ * return, borrowing presentation fields (iconKind / sortRank / displayName /
+ * capabilities) from the same-`key` built-in literal when present, else safe
+ * defaults: generic-bot icon (`iconKind` matching no branch), sort-last, the
+ * server's `display_name`, and no picker capabilities. Plugin-provided icon
+ * resources are a planned follow-up; today an unknown harness renders with the
+ * generic glyph (same fallback qwen/hermes already use).
+ */
+function specFromServerRow(row: NativeAgentServerRow): NativeCodingAgentSpec {
+  const builtin = BUILTIN_BY_KEY.get(row.key);
+  return {
+    key: (builtin?.key ?? row.key) as NativeCodingAgentIconKind,
+    agentName: row.agent_name,
+    harness: row.harness,
+    wrapperLabel: row.wrapper_label,
+    displayName: builtin?.displayName ?? row.display_name,
+    iconKind: (builtin?.iconKind ?? row.key) as NativeCodingAgentIconKind,
+    sortRank: builtin?.sortRank ?? Number.POSITIVE_INFINITY,
+    capabilities: builtin?.capabilities,
+  };
+}
+
+const BUILTIN_BY_KEY = new Map<string, NativeCodingAgentSpec>(
+  NATIVE_CODING_AGENTS.map((agent) => [agent.key, agent]),
 );
-const BY_HARNESS = new Map<string, NativeCodingAgentSpec>(
-  NATIVE_CODING_AGENTS.map((agent) => [agent.harness, agent]),
-);
-const BY_WRAPPER = new Map<string, NativeCodingAgentSpec>(
-  NATIVE_CODING_AGENTS.map((agent) => [agent.wrapperLabel, agent]),
-);
+
+/**
+ * Prime the module cache with the server's native-agent rows. Called by the
+ * `/v1/harnesses` query (`agentLabels.ts`) whenever the catalog loads/refreshes.
+ * A native harness the server reports but the built-in literal lacks (a
+ * community plugin) becomes resolvable; built-ins are refreshed from the server
+ * for identity/fork data while keeping their client-side presentation.
+ */
+export function primeNativeAgentCatalog(rows: readonly NativeAgentServerRow[]): void {
+  SERVER_ROWS = rows;
+  rebuildIndexes();
+}
+
+// Test-only: reset the cache to the built-in literal (no server rows).
+export function resetNativeAgentCatalogForTests(): void {
+  SERVER_ROWS = [];
+  rebuildIndexes();
+}
+
+let BY_AGENT_NAME = new Map<string, NativeCodingAgentSpec>();
+let BY_HARNESS = new Map<string, NativeCodingAgentSpec>();
+let BY_WRAPPER = new Map<string, NativeCodingAgentSpec>();
+// harness id (canonical) → fork_history axis value, server-sourced. Empty until
+// the catalog primes; forkHarness.ts falls back to its built-in sets meanwhile.
+let FORK_HISTORY_BY_HARNESS = new Map<string, string>();
+
+function rebuildIndexes(): void {
+  // Built-in literal first, then server rows override by the same key — so the
+  // server is authoritative for identity/fork on built-ins, and community rows
+  // are additive. Presentation still comes from the literal via specFromServerRow.
+  const merged = new Map<string, NativeCodingAgentSpec>();
+  for (const agent of NATIVE_CODING_AGENTS) merged.set(agent.key, agent);
+  const forkByHarness = new Map<string, string>();
+  for (const row of SERVER_ROWS) {
+    merged.set(row.key, specFromServerRow(row));
+    if (typeof row.fork_history === "string" && row.fork_history !== "none") {
+      forkByHarness.set(row.harness, row.fork_history);
+    }
+  }
+  const specs = [...merged.values()];
+  BY_AGENT_NAME = new Map(specs.map((a) => [a.agentName, a]));
+  BY_HARNESS = new Map(specs.map((a) => [a.harness, a]));
+  BY_WRAPPER = new Map(specs.map((a) => [a.wrapperLabel, a]));
+  FORK_HISTORY_BY_HARNESS = forkByHarness;
+}
+
+rebuildIndexes();
+
+/**
+ * Server-sourced fork-history axis for a canonical harness id, or `undefined`
+ * before the catalog loads / for a harness the server doesn't classify.
+ * `forkHarness.ts` consults this first and falls back to its built-in sets.
+ */
+export function serverForkHistoryForHarness(
+  harness: string | null | undefined,
+): string | undefined {
+  return harness == null ? undefined : FORK_HISTORY_BY_HARNESS.get(harness);
+}
 
 // Reversed harness spellings that fold to a canonical native `harness`.
 // Mirrors omnigent.harness_aliases.NATIVE_HARNESSES on the server, which


### PR DESCRIPTION
> **Draft** — depends on the `native_agents` field added by PR 2.2 (#3672), which is unreviewed. Opened for early visibility; mark ready once 2.2 lands (or is reviewed).

## Related issue

N/A — Phase 2 of the modular native-harness registry workstream (`designs/harness-modular-registry-proposal.md`).

## Summary

PR **2.3a** — the **data-plumb half** of driving the web off `/v1/harnesses`. Chosen approach is **Option 1** from `designs/harness-web-mirror-options.md` (server = data, web = presentation overlay), which I wrote up after researching all ~20 consumers of `nativeCodingAgents.ts`. The web stops owning native-agent identity/behavior and reads it from the server's `native_agents` rows (2.2), so a community native harness is recognized without editing the web literal.

- **`agentLabels.ts`**: parse `native_agents` off `/v1/harnesses` and **prime a synchronous module cache** on every catalog load. The existing `useHarnessCatalog` query is already mounted (`NewChatDialog`/`ChatPage`/…), so the cache primes on app use — this lets the ~20 **non-React** consumers (`composerMentions`, `agentGrouping`, `chatStore`) see server data without threading a hook through every call site.
- **`nativeCodingAgents.ts`**: identity lookups now read **built-in-literal ∪ server-rows**, rebuilt when primed. The literal stays as the pre-fetch fallback (built-ins work before first fetch — no regression) *and* as the client-side presentation source. Community rows are additive; unknown keys default to generic icon + sort-last + the server's `display_name`.
- **`forkHarness.ts`**: `forkTargetCarriesHistory` / `switchTargetCarriesHistory` consult the server `fork_history` axis first, falling back to the built-in REBUILD/PREAMBLE sets pre-fetch — so community natives gate fork/switch history correctly.

### Why this splits from 2.3b

This is the **non-visual, fully unit-tested** half. The presentation-overlay *reduction* (shrinking the literal to icon/sort/displayName/picker-caps and wiring `AgentCard`/`SubagentsPanel`/`NewChatDialog`) is **2.3b**, which needs the screenshot/recording demo. Splitting keeps the risky visual work isolated from this verifiable data change.

### Decisions captured (from the options doc)
- **Option 1** (not expanding `NativeCodingAgent` with presentation fields).
- **Community icon**: generic-bot default now; **plugin-provided icon resource (svg/URL) is a deferred follow-up** — the code leaves a clean seam (`specFromServerRow`) for a future server-provided icon field.

## Test Plan

```bash
cd web && npx tsc -b && npx vitest run && npx oxlint --deny-warnings . && npx prettier --check .
```

- Full web suite green: **4792 passed**.
- New coverage in `nativeCodingAgents.test.ts`: community-harness resolution after priming, presentation defaults for unknown keys, built-in presentation preserved over server identity ("Claude Code" + brand icon kept when the server reports "Claude"), and the `fork_history` axis (rebuild/preamble, `none` omitted). Existing 105 tests still pass (built-in fallback preserves current behavior).

## Demo

N/A for 2.3a — no visual change (data plumbing only). The visible picker/icon/fork behavior is unchanged for built-ins; **2.3b carries the demo**.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

UI / frontend change, but 2.3a is intentionally non-visual (data plumbing); built-in native agents render identically. Verified via the full vitest suite + tsc + oxlint + prettier. Known limitation noted for review: the module cache primes only when a component using the `/v1/harnesses` query is mounted; a community harness resolves once the picker/catalog has loaded (built-ins always resolve via the literal fallback). Priming at app root is a small 2.3b follow-up.

---

**Workstream progress**: Phase 1 complete. Phase 2 — 2.1 (#3670), 2.2 (#3672), **2.3a this PR (draft, on 2.2)**. Remaining: 2.3b (presentation overlay + demo), 2.4 (docs + benchable example plugin). Ledger row de-conflicts at rebase, as in Phase 1.
