### PR TITLE
docs(harness): reference native plugin (echo-native) + native checklist (PR 2.4) [draft, stacked on #3670+#3672]

### DIFF
--- a/designs/harness-modular-registry-proposal.md
+++ b/designs/harness-modular-registry-proposal.md
@@ -470,6 +470,7 @@ signature.
 | 1.7 Server seeding loop | landed | #3599 | 07-31 |
 | 1.7 follow-up: opencode e2e onto shared agent-name constant | landed | #3656 | 07-31 |
 | 1.8 Derive enumerations + fork_history/shell-tool capability axes | landed | #3648 | 07-31 |
+| 2.1 Validator flip (accept community native harnesses) | in review | (this PR) | — |
 
 **1.4 descoped.** The CLI-subcommand collapse (`cli_native.py` → a loop over
 `native_agents()`) is orthogonal to making native harnesses community-pluggable:

--- a/designs/harness-modular-registry-proposal.md
+++ b/designs/harness-modular-registry-proposal.md
@@ -470,7 +470,10 @@ signature.
 | 1.7 Server seeding loop | landed | #3599 | 07-31 |
 | 1.7 follow-up: opencode e2e onto shared agent-name constant | landed | #3656 | 07-31 |
 | 1.8 Derive enumerations + fork_history/shell-tool capability axes | landed | #3648 | 07-31 |
-| 2.1 Validator flip (accept community native harnesses) | in review | (this PR) | — |
+| 2.1 Validator flip (accept community native harnesses) | in review | #3670 | — |
+| 2.2 `/v1/harnesses` native-agent rows | in review | #3672 | — |
+| 2.3a Web: native identity + fork_history off the endpoint | in review | #3690 | — |
+| 2.4 Docs + example native plugin (echo-native) | in review | (this PR, stacked on 2.1+2.2) | — |
 
 **1.4 descoped.** The CLI-subcommand collapse (`cli_native.py` → a loop over
 `native_agents()`) is orthogonal to making native harnesses community-pluggable:

--- a/designs/harness-plugin-interface.md
+++ b/designs/harness-plugin-interface.md
@@ -166,11 +166,18 @@ For a non-native harness:
 
 ## Native TUI Harnesses
 
-Community native terminal harnesses are not supported by this interface yet.
-Core native harnesses still use internal registry metadata, but the runner,
-chat-resume, CLI-command, interrupt/stop, and built-in agent seeding paths are
-not pluggable. Community plugins that set `native_harnesses` or `native_agents`
-are rejected at load time until those lifecycle hooks are wired end to end.
+Community native terminal harnesses **are** supported: the runner, chat-resume,
+interrupt/stop, spawn-env, and built-in agent-seeding paths all dispatch through
+the `NativeHarnessProvider` seam, so a plugin that ships `native_agents` +
+`native_providers` is accepted at load time (validated for internal consistency
+and identity collisions — see `_validate_native_contribution`). A contribution
+must pair each `NativeCodingAgent` with a `NativeHarnessProvider` keyed by the
+same `key`, declare the agent's harness id in `valid_harnesses`, supply the
+required provider hooks (`run_native`, `auto_create_terminal`), and keep every
+provider import path under `COMMUNITY_MODULE_PREFIX`.
+
+A full step-by-step native-plugin checklist and a benchable example plugin ship
+with the plugin-interface docs update (workstream PR 2.4).
 
 ## Import Rules
 

--- a/designs/harness-plugin-interface.md
+++ b/designs/harness-plugin-interface.md
@@ -176,8 +176,61 @@ same `key`, declare the agent's harness id in `valid_harnesses`, supply the
 required provider hooks (`run_native`, `auto_create_terminal`), and keep every
 provider import path under `COMMUNITY_MODULE_PREFIX`.
 
-A full step-by-step native-plugin checklist and a benchable example plugin ship
-with the plugin-interface docs update (workstream PR 2.4).
+### Native provider hooks
+
+`NativeHarnessProvider` (keyed by the same `key` as its `NativeCodingAgent`)
+carries dotted import-path strings for the lifecycle hooks the runner resolves
+lazily at dispatch time:
+
+`run_native` (required)
+: CLI + resume launch entry point, `run_<key>_native(*, server, session_id,
+extra_args=..., resume_picker=..., auto_open_conversation=...)`. Called by the
+resume dispatch.
+
+`auto_create_terminal` (required)
+: Runner terminal builder `async (NativeLaunchContext) -> SessionResourceView`.
+Runs on the runner (may import the runner stack — it is imported at dispatch
+time, not during entry-point discovery).
+
+`spawn_env_builder` (optional)
+: `(agent_spec) -> dict[str, str]` env vars injected into the harness spawn.
+
+`materialize_agent_spec` (optional)
+: `(tmpdir: Path) -> Path` writing the built-in `<key>-native-ui` wrapper spec,
+so the server's seeding loop registers a picker-ready agent.
+
+`interrupt_handler` / `stop_handler` (optional)
+: Currently runner-internal; leave unset — a native harness without them falls
+through to the in-process turn cancel.
+
+### Minimal Native Harness Checklist
+
+- Create the package under the reserved `omnigent.community.harness.<key>.*`
+  namespace and add the `omnigent.community.harness` entry point.
+- `get_contribution()` returns `native_agents=(NativeCodingAgent(...),)` +
+  `native_providers=(NativeHarnessProvider(...),)`, both keyed `<key>`, plus
+  `valid_harnesses={"<key>-native"}`, `harness_modules`, and (optionally) an
+  `aliases={"native-<key>": "<key>-native"}` reversed spelling.
+- Declare `capabilities[<key>-native]` including the `fork_history` axis (drives
+  fork/switch history gating) and, if the harness bench should probe it,
+  `shell_tool_name` / `shell_tool_prompt`.
+- Keep every provider import path under `omnigent.community.harness.<key>.*`.
+- Implement the hook modules (the runner imports them lazily): `run_<key>_native`,
+  the `auto_create_terminal` adapter, and the `create_app()` subprocess harness.
+
+### Example plugin
+
+`examples/omnigent-echo-native/` is the reference native contribution —
+`echo-native`. It is a real, installable, registry-loadable package: its
+`get_contribution()` passes the community validator, its hooks resolve, and it
+surfaces on `GET /v1/harnesses`. The vendor-integration internals (live TUI
+bridge, transcript forwarder) are documented stubs marked `TODO(real-harness)`
+that point at the built-in `pi_native` / `claude_native` implementations; the
+package proves the *contract wiring* end to end (see
+`tests/test_example_echo_native_plugin.py`). Making the example fully
+`--live` benchable (`python -m tests.harness_bench --harness echo-native
+--live`) requires implementing those stubs against a real vendor CLI and is the
+remaining follow-up.
 
 ## Import Rules
 

--- a/examples/omnigent-echo-native/README.md
+++ b/examples/omnigent-echo-native/README.md
@@ -1,0 +1,52 @@
+# omnigent-echo-native — example native harness plugin
+
+The **reference community native-harness contribution** for Omnigent. It shows
+the minimum a package must ship to register a native (terminal/TUI) harness
+through the `NativeHarnessProvider` seam — the contract that landed in Phase 1
+(runner/resume/interrupt/seeding behind the seam) and Phase 2.1/2.2 (validator
+accepts native contributions; `/v1/harnesses` publishes them).
+
+## What it demonstrates
+
+- A `get_contribution()` entry point (`omnigent.community.harness` group) that
+  pairs a `NativeCodingAgent` (identity) with a `NativeHarnessProvider`
+  (behavior hook paths), both keyed `echo`, under the reserved
+  `omnigent.community.harness.echo.*` namespace.
+- The provider hooks core resolves lazily: `run_native`, `auto_create_terminal`,
+  `spawn_env_builder`, `materialize_agent_spec`.
+- A `capabilities` record incl. the `fork_history` axis and bench shell-tool
+  fields.
+
+## What is real vs. stubbed
+
+| Piece | State |
+|---|---|
+| `get_contribution()` / registry rows | **real** — passes the community validator, merges into the accessors |
+| `materialize_echo_agent_spec` | **real** — writes a loadable `echo-native-ui` spec |
+| `build_echo_native_spawn_env` | **real** — pure env mapping |
+| `run_echo_native`, `launch_echo`, `create_app` | **stub** — `NotImplementedError` with a pointer to the built-in `pi_native` / `claude_native` real implementation |
+
+The stubs are marked `TODO(real-harness)`. A production native plugin fills them
+in against a live vendor CLI (spawn the TUI in a runner terminal, tail its
+transcript, mirror output). That is what makes it fully `--live` benchable.
+
+## Try it
+
+```bash
+# From an omnigent checkout, install the example against it (sibling source).
+uv pip install -e examples/omnigent-echo-native
+
+# It now registers through the real entry-point loader:
+uv run python -c "from omnigent.harness_plugins import valid_harnesses; print('echo-native' in valid_harnesses())"
+uv run python -c "from omnigent.harness_plugins import native_provider_for_key; print(native_provider_for_key('echo'))"
+```
+
+The end-to-end registry behavior is covered (without an install step) by
+`tests/test_example_echo_native_plugin.py` in the core repo.
+
+## See also
+
+- `designs/harness-plugin-interface.md` § "Native TUI Harnesses" — the checklist
+  this package implements.
+- `omnigent/pi_native.py`, `omnigent/runner/native/orchestration.py` — the real
+  built-in native harness the stubs point at.

--- a/examples/omnigent-echo-native/omnigent/community/harness/echo/__init__.py
+++ b/examples/omnigent-echo-native/omnigent/community/harness/echo/__init__.py
@@ -1,0 +1,1 @@
+"""The echo-native example harness package."""

--- a/examples/omnigent-echo-native/omnigent/community/harness/echo/echo_native.py
+++ b/examples/omnigent-echo-native/omnigent/community/harness/echo/echo_native.py
@@ -1,0 +1,74 @@
+"""Launch + agent-seeding hooks for the echo-native example harness.
+
+STUB SCOPE. A real native harness wraps a live vendor CLI in a tmux/PTY
+session, tails its transcript, and mirrors output back into Omnigent (see
+``omnigent.pi_native`` / ``omnigent.claude_native`` for the full pattern —
+each is 1–2k lines of bridge + forwarder + executor). The example keeps these
+hooks deliberately minimal so the *contract* is legible and the plugin is
+registry-loadable and unit-testable end to end, without shipping a second real
+vendor integration. Points where a real harness does substantive work are
+marked ``TODO(real-harness)``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_AGENT_NAME = "echo-native-ui"
+
+
+def run_echo_native(
+    *,
+    server: str | None,
+    session_id: str | None,
+    extra_args: tuple[str, ...] | None = None,
+    resume_picker: bool = False,
+    auto_open_conversation: bool = False,
+) -> None:
+    """CLI + resume launch entry point (``run_native`` hook).
+
+    Signature mirrors the built-in ``run_<x>_native`` launchers so the resume
+    dispatch (``resume_dispatch._dispatch_wrapper``) can call it uniformly.
+
+    :param server: Resolved Omnigent server URL, or ``None`` for local.
+    :param session_id: Existing session to resume, or ``None`` for a fresh run.
+    :param extra_args: Pass-through vendor CLI args.
+    :param resume_picker: Whether to show the vendor's resume picker.
+    :param auto_open_conversation: Whether to auto-open the conversation.
+    """
+    # TODO(real-harness): resolve the vendor CLI, spawn it in an Omnigent
+    # terminal, and run the transcript forwarder. The stub only documents the
+    # entry shape a real launcher implements.
+    raise NotImplementedError(
+        "echo-native is an example harness stub; run_echo_native has no live vendor CLI. "
+        "See omnigent.pi_native.run_pi_native for a real implementation."
+    )
+
+
+def materialize_echo_agent_spec(tmpdir: Path) -> Path:
+    """Write the terminal-first wrapper agent spec (``materialize_agent_spec`` hook).
+
+    Produces the ``echo-native-ui`` built-in agent's spec YAML. This IS fully
+    functional — it is what the server's seeding loop
+    (``_ensure_default_native_agents``) tars into a bundle and registers, so the
+    example agent shows up in the picker like any built-in native.
+
+    :param tmpdir: Temporary directory for the generated YAML file.
+    :returns: Path to the generated spec.
+    """
+    yaml_path = tmpdir / "echo-native-ui.yaml"
+    raw: dict[str, Any] = {
+        "name": _AGENT_NAME,
+        "prompt": (
+            "Echo is an example native harness. In a real harness the vendor CLI "
+            "runs in the session terminal and web messages are forwarded into it."
+        ),
+        "executor": {"harness": "echo-native"},
+        "spawn": True,
+        "os_env": {"type": "caller_process", "cwd": ".", "sandbox": {"type": "none"}},
+    }
+    yaml_path.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+    return yaml_path

--- a/examples/omnigent-echo-native/omnigent/community/harness/echo/echo_native_bridge.py
+++ b/examples/omnigent-echo-native/omnigent/community/harness/echo/echo_native_bridge.py
@@ -1,0 +1,28 @@
+"""Spawn-env builder hook for the echo-native example harness.
+
+``build_echo_native_spawn_env`` is the ``spawn_env_builder`` hook: the runner
+calls it to derive per-spawn environment variables from the agent spec before
+launching the harness subprocess. Unlike the launch adapter this is a pure,
+side-effect-free mapping, so the example implements it for real.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_echo_native_spawn_env(agent_spec: Any) -> dict[str, str]:
+    """Return env vars to inject into the echo-native spawn (``spawn_env_builder``).
+
+    A real builder reads vendor config off ``agent_spec`` (model override, auth
+    passthrough, sandbox hints). The example emits a single marker var so the
+    hook is observable end to end without needing a live vendor.
+
+    :param agent_spec: The session's resolved agent spec (may be ``None``).
+    :returns: Environment variables for the harness subprocess.
+    """
+    env = {"OMNIGENT_ECHO_NATIVE_EXAMPLE": "1"}
+    model = getattr(agent_spec, "model", None)
+    if isinstance(model, str) and model:
+        env["OMNIGENT_ECHO_MODEL"] = model
+    return env

--- a/examples/omnigent-echo-native/omnigent/community/harness/echo/inner/echo_native_harness.py
+++ b/examples/omnigent-echo-native/omnigent/community/harness/echo/inner/echo_native_harness.py
@@ -1,0 +1,25 @@
+"""Subprocess harness module for echo-native (``harness_modules`` target).
+
+``omnigent.runtime.harnesses`` maps ``echo-native`` → this module; the runner
+imports it and calls ``create_app()`` to serve the harness over a Unix socket.
+A real native harness returns a FastAPI app that bridges the vendor process
+(see ``omnigent.inner.pi_native_harness``). The example keeps a minimal factory
+so the module contract is legible.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def create_app() -> Any:
+    """Return the harness ASGI app the runner serves (``create_app`` contract).
+
+    :returns: A FastAPI (ASGI) application.
+    """
+    # TODO(real-harness): build and return the harness FastAPI app that proxies
+    # the vendor process. See omnigent.inner.pi_native_harness.create_app.
+    raise NotImplementedError(
+        "echo-native is an example harness stub; create_app has no live harness app. "
+        "See omnigent.inner.pi_native_harness for a real implementation."
+    )

--- a/examples/omnigent-echo-native/omnigent/community/harness/echo/plugin.py
+++ b/examples/omnigent-echo-native/omnigent/community/harness/echo/plugin.py
@@ -1,0 +1,102 @@
+"""Entry point for the ``echo-native`` example community harness.
+
+``get_contribution()`` is what core's entry-point loader calls. Per the plugin
+import rules it must stay import-light: it constructs pure-data registry rows
+and dotted import-path *strings* only — it never imports the runner / CLI /
+provider stack (those modules are imported lazily by the resolver at dispatch
+time, from the paths named here).
+
+This is the reference native contribution: it pairs one ``NativeCodingAgent``
+(identity) with one ``NativeHarnessProvider`` (behavior hook paths), both keyed
+``"echo"``, and declares the ``echo-native`` harness id + a reversed
+``native-echo`` alias. Every hook path lives under
+``omnigent.community.harness.echo.*`` so core's community-prefix validation
+accepts it (see ``_validate_native_contribution``).
+"""
+
+from __future__ import annotations
+
+from omnigent.harness_capabilities import (
+    AuthModel,
+    EffortFamily,
+    Elicitation,
+    ForkHistory,
+    HarnessCapabilities,
+    IntegrationMode,
+    ModelFamily,
+    Resume,
+)
+from omnigent.harness_install_spec import HarnessInstallSpec
+from omnigent.harness_plugins import (
+    HarnessContribution,
+    NativeCodingAgent,
+    NativeHarnessProvider,
+)
+
+_MODULE = "omnigent.community.harness.echo"
+
+
+def get_contribution() -> HarnessContribution:
+    """Return the ``echo-native`` harness contribution.
+
+    Kept import-light: only registry types + capability enums, no runtime
+    modules. The behavior hooks are dotted strings resolved lazily by core.
+    """
+    agent = NativeCodingAgent(
+        key="echo",
+        display_name="Echo",
+        agent_name="echo-native-ui",
+        harness="echo-native",
+        wrapper_label="echo-native-ui",
+        terminal_name="echo",
+    )
+    provider = NativeHarnessProvider(
+        key="echo",
+        # CLI + resume launch entry point (`omnigent echo` would call this once
+        # the CLI loop is registry-driven; today it's exercised via resume).
+        run_native=f"{_MODULE}.echo_native:run_echo_native",
+        # Runner terminal builder — the adapter the launch/attach seam resolves
+        # and calls with a NativeLaunchContext.
+        auto_create_terminal=f"{_MODULE}.runner:launch_echo",
+        # Per-spawn env vars derived from the agent spec.
+        spawn_env_builder=f"{_MODULE}.echo_native_bridge:build_echo_native_spawn_env",
+        # Built-in agent seeding: materialize the wrapper agent's spec YAML.
+        materialize_agent_spec=f"{_MODULE}.echo_native:materialize_echo_agent_spec",
+    )
+    return HarnessContribution(
+        name="omnigent-echo-native",
+        valid_harnesses=frozenset({"echo-native"}),
+        harness_modules={"echo-native": f"{_MODULE}.inner.echo_native_harness"},
+        aliases={"native-echo": "echo-native"},
+        native_harnesses=frozenset({"echo-native"}),
+        native_agents=(agent,),
+        native_providers=(provider,),
+        harness_labels={"echo-native": "Echo"},
+        install_specs={
+            "echo-native": HarnessInstallSpec(
+                "Echo",
+                "echo",
+                package=None,
+                install_hint="the echo example ships a stub CLI; no install needed",
+            )
+        },
+        harness_install_keys={"echo-native": "echo-native", "native-echo": "echo-native"},
+        capabilities={
+            "echo-native": HarnessCapabilities(
+                IntegrationMode.NATIVE_TUI,
+                Elicitation.APPROVAL_MIRROR,
+                Resume.WARM_REATTACH,
+                EffortFamily.NONE,
+                ModelFamily.MULTI,
+                AuthModel.OWN_AUTH,
+                subagents=False,
+                interrupt=True,
+                streaming=True,
+                fork_history=ForkHistory.NONE,
+                shell_tool_name="bash",
+                shell_tool_prompt=(
+                    "Use your shell tool to run this exact command: echo omnigent-bench-ok"
+                ),
+            )
+        },
+    )

--- a/examples/omnigent-echo-native/omnigent/community/harness/echo/runner.py
+++ b/examples/omnigent-echo-native/omnigent/community/harness/echo/runner.py
@@ -1,0 +1,38 @@
+"""Runner terminal-builder hook for the echo-native example harness.
+
+``launch_echo`` is the ``auto_create_terminal`` hook the launch/attach seam
+resolves and calls with a :class:`~omnigent.runner.native.NativeLaunchContext`.
+It runs on the RUNNER, so (unlike ``plugin.py``) it may import the runner stack
+— the resolver only imports this module at dispatch time, never during
+entry-point discovery.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from omnigent.entities.session_resources import SessionResourceView
+    from omnigent.runner.native import NativeLaunchContext
+
+
+async def launch_echo(ctx: NativeLaunchContext) -> SessionResourceView:
+    """Build the echo-native terminal from a launch context (``auto_create_terminal``).
+
+    A real adapter launches the vendor CLI as a runner-owned terminal resource
+    and returns its :class:`SessionResourceView` (see
+    ``omnigent.runner.native.orchestration._launch_pi`` →
+    ``_auto_create_pi_terminal`` for the full pattern: spawn the TUI, register
+    the streamable terminal, start the transcript forwarder).
+
+    :param ctx: Launch inputs (session id, resource registry, event publisher,
+        server client, resolved agent spec, …).
+    :returns: The created terminal resource view.
+    """
+    # TODO(real-harness): call ctx.resource_registry.launch_required_terminal(...)
+    # with the vendor command, register the native terminal role, and start the
+    # forwarder. The stub documents the adapter's return contract.
+    raise NotImplementedError(
+        "echo-native is an example harness stub; launch_echo has no live vendor terminal. "
+        "See omnigent.runner.native.orchestration._auto_create_pi_terminal for a real one."
+    )

--- a/examples/omnigent-echo-native/pyproject.toml
+++ b/examples/omnigent-echo-native/pyproject.toml
@@ -1,0 +1,31 @@
+[project]
+name = "omnigent-echo-native"
+version = "0.1.0"
+description = "Example community native-harness plugin for Omnigent (the reference native contribution)."
+requires-python = ">=3.12"
+# A real plugin pins the core it was built against, e.g. "omnigent==0.3.0.dev0".
+# The example keeps the dependency loose so it installs against a sibling
+# checkout via [tool.uv.sources] below.
+dependencies = ["omnigent"]
+
+# The entry point that makes core discover this plugin. `omni`/the server call
+# `omnigent.harness_plugins.plugin_state()`, which loads every entry point in
+# this group and merges the returned HarnessContribution.
+[project.entry-points."omnigent.community.harness"]
+echo = "omnigent.community.harness.echo.plugin:get_contribution"
+
+# Local sibling-checkout wiring so `uv pip install -e .` builds against the
+# in-repo core rather than a published wheel. A standalone plugin repo points
+# this at wherever its omnigent checkout lives.
+[tool.uv.sources]
+omnigent = { path = "../..", editable = true }
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+# The implementation modules live under the reserved namespace
+# `omnigent.community.harness.*` (core rejects flat packages / builtin-name
+# overrides). Declare the namespaced package explicitly for the build backend.
+[tool.hatch.build.targets.wheel]
+packages = ["omnigent"]

--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -1240,6 +1240,48 @@ def harness_catalog() -> list[dict[str, Any]]:
     return rows
 
 
+def native_agent_catalog() -> list[dict[str, Any]]:
+    """Return JSON-serializable native-agent rows for ``GET /v1/harnesses``.
+
+    Built-in *and* community native agents (after PR 2.1 accepts them). Each row
+    is the native agent's stable identity (``key`` / ``agent_name`` / ``harness``
+    / ``wrapper_label`` / ``terminal_name`` / ``display_name`` /
+    ``subagent_wrapper_label``) plus its harness ``capabilities`` and the
+    ``fork_history`` axis, so the web can drive native-agent recognition,
+    fork-history gating, and capability gating off the server instead of the
+    hardcoded ``web/src/lib/nativeCodingAgents.ts`` literals (PR 2.3).
+
+    Only fields with an unambiguous server source are emitted. The web literal
+    additionally carries UI-presentation fields (``iconKind``, ``sortRank``, a
+    marketing ``displayName`` like "Claude Code" vs the row's "Claude", and a
+    picker-capability list) that have no clean registry source today; whether to
+    add those to ``NativeCodingAgent`` is deferred to the PR 2.3 review (see the
+    workstream doc) rather than expanding the frozen wire shape here.
+
+    :returns: One row per native coding agent, ordered by ``key`` for stability.
+    """
+    capabilities = harness_capabilities()
+    rows: list[dict[str, Any]] = []
+    for agent in sorted(native_agents(), key=lambda a: a.key):
+        capability = capabilities.get(agent.harness)
+        rows.append(
+            {
+                "key": agent.key,
+                "agent_name": agent.agent_name,
+                "harness": agent.harness,
+                "wrapper_label": agent.wrapper_label,
+                "terminal_name": agent.terminal_name,
+                "display_name": agent.display_name,
+                "subagent_wrapper_label": agent.subagent_wrapper_label,
+                "fork_history": (
+                    capability.fork_history.value if capability is not None else None
+                ),
+                "capabilities": capability.as_dict() if capability is not None else None,
+            }
+        )
+    return rows
+
+
 def harness_setup_steps_by_spelling() -> dict[str, list[dict[str, Any]]]:
     """Map every harness spelling to its ordered UI setup steps.
 

--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -811,11 +811,38 @@ def _module_part(import_path: str) -> str:
     return import_path.split(":", 1)[0]
 
 
+# NativeHarnessProvider fields that carry a dotted import path the resolver
+# imports at dispatch time (so they must live under COMMUNITY_MODULE_PREFIX for a
+# community plugin). ``key`` is an identifier and ``bridge_id_label_key`` is a
+# session-label key, not code — both are excluded.
+_NATIVE_PROVIDER_IMPORT_PATH_FIELDS: tuple[str, ...] = (
+    "run_native",
+    "auto_create_terminal",
+    "spawn_env_builder",
+    "interrupt_handler",
+    "stop_handler",
+    "materialize_agent_spec",
+    "bridge_dir",
+)
+
+
+def _native_provider_import_paths(contribution: HarnessContribution) -> list[str]:
+    """Return every dotted import path a contribution's native providers resolve."""
+    paths: list[str] = []
+    for provider in contribution.native_providers:
+        for field_name in _NATIVE_PROVIDER_IMPORT_PATH_FIELDS:
+            value = getattr(provider, field_name)
+            if value:
+                paths.append(value)
+    return paths
+
+
 def _community_paths(contribution: HarnessContribution) -> list[str]:
     paths: list[str] = []
     paths.extend(contribution.harness_modules.values())
     paths.extend(contribution.spawn_env_builders.values())
     paths.extend(spec.generator for spec in contribution.background_title_generators.values())
+    paths.extend(_native_provider_import_paths(contribution))
     return paths
 
 
@@ -852,6 +879,88 @@ def _native_agent_identity_values(contribution: HarnessContribution) -> set[str]
     return values
 
 
+# Native-provider hooks a community plugin MUST supply — the launch/route path
+# cannot run without them. The remaining hooks are optional (interrupt/stop fall
+# through to the in-process cancel; materialize_agent_spec only gates built-in
+# seeding; bridge_dir only feeds the cost-popup lookup).
+_REQUIRED_NATIVE_PROVIDER_HOOKS: tuple[str, ...] = ("run_native", "auto_create_terminal")
+
+
+def _validate_native_contribution(
+    contribution: HarnessContribution,
+    *,
+    entry_point_name: str,
+) -> str | None:
+    """Validate a community plugin's native-terminal contribution.
+
+    Native terminal harnesses ARE supported (the runner runs every native
+    harness through the ``NativeHarnessProvider`` seam). A contribution that
+    ships native metadata must be internally consistent: each declared agent
+    needs a provider row (and vice versa) keyed by the same ``key``, and each
+    provider must supply the hooks the launch path requires. Import-path prefix
+    and identity-collision checks are enforced by the shared community-validator
+    (native provider hook paths are included via ``_community_paths``, and agent
+    identity values via ``_native_agent_identity_values``).
+
+    :param contribution: The plugin's contribution.
+    :param entry_point_name: The entry-point name, for error messages.
+    :returns: An error string when the native metadata is inconsistent, else
+        ``None`` (including when the plugin ships no native metadata).
+    """
+    if not (contribution.native_agents or contribution.native_providers):
+        return None
+
+    agent_keys = [agent.key for agent in contribution.native_agents]
+    provider_keys = [provider.key for provider in contribution.native_providers]
+    agent_key_set = set(agent_keys)
+    provider_key_set = set(provider_keys)
+
+    if len(agent_key_set) != len(agent_keys):
+        dupes = sorted({k for k in agent_keys if agent_keys.count(k) > 1})
+        return (
+            f"community harness plugin {entry_point_name!r} declares duplicate native "
+            f"agent keys: {dupes}"
+        )
+    if len(provider_key_set) != len(provider_keys):
+        dupes = sorted({k for k in provider_keys if provider_keys.count(k) > 1})
+        return (
+            f"community harness plugin {entry_point_name!r} declares duplicate native "
+            f"provider keys: {dupes}"
+        )
+
+    agents_without_provider = sorted(agent_key_set - provider_key_set)
+    if agents_without_provider:
+        return (
+            f"community harness plugin {entry_point_name!r} declares native agents without a "
+            f"matching provider row: {agents_without_provider}"
+        )
+    providers_without_agent = sorted(provider_key_set - agent_key_set)
+    if providers_without_agent:
+        return (
+            f"community harness plugin {entry_point_name!r} declares native providers without a "
+            f"matching agent row: {providers_without_agent}"
+        )
+
+    # Every declared native agent's harness id must be in valid_harnesses, or the
+    # runner/spec layer can never route to it.
+    for agent in contribution.native_agents:
+        if agent.harness not in contribution.valid_harnesses:
+            return (
+                f"community harness plugin {entry_point_name!r} native agent {agent.key!r} "
+                f"declares harness {agent.harness!r}, which is not in valid_harnesses"
+            )
+
+    for provider in contribution.native_providers:
+        for hook in _REQUIRED_NATIVE_PROVIDER_HOOKS:
+            if not getattr(provider, hook):
+                return (
+                    f"community harness plugin {entry_point_name!r} native provider "
+                    f"{provider.key!r} is missing required hook {hook!r}"
+                )
+
+    return None
+
+
 def _validate_community_contribution(
     contribution: HarnessContribution,
     *,
@@ -868,11 +977,9 @@ def _validate_community_contribution(
                 f"{path!r}; expected {COMMUNITY_MODULE_PREFIX}*"
             )
 
-    if contribution.native_harnesses or contribution.native_agents:
-        return (
-            f"community harness plugin {entry_point_name!r} registers native terminal "
-            "metadata, but community native terminal harnesses are not supported yet"
-        )
+    native_error = _validate_native_contribution(contribution, entry_point_name=entry_point_name)
+    if native_error is not None:
+        return native_error
 
     existing_harness_spellings: set[str] = set()
     existing_install_keys: set[str] = set()

--- a/omnigent/server/routes/harnesses.py
+++ b/omnigent/server/routes/harnesses.py
@@ -6,7 +6,11 @@ from typing import Any
 
 from fastapi import APIRouter, Request
 
-from omnigent.harness_plugins import harness_catalog, harness_setup_steps_by_spelling
+from omnigent.harness_plugins import (
+    harness_catalog,
+    harness_setup_steps_by_spelling,
+    native_agent_catalog,
+)
 from omnigent.server.auth import AuthProvider
 from omnigent.server.routes._auth_helpers import require_user
 
@@ -23,10 +27,14 @@ def create_harnesses_router(*, auth_provider: AuthProvider | None = None) -> API
         # declare — native wrappers (``codex-native``) and installable ids that
         # aren't picker rows (``opencode``/``qwen``) — so the setup dialog can
         # resolve steps by the harness it actually holds without the picker
-        # list gaining non-pickable rows.
+        # list gaining non-pickable rows. ``native_agents`` carries the native
+        # coding-agent identity + capability rows (built-in and community) so
+        # the web can drive native recognition / fork-history / capability
+        # gating off the server instead of hardcoded literals (PR 2.2 → 2.3).
         return {
             "data": harness_catalog(),
             "setup_steps": harness_setup_steps_by_spelling(),
+            "native_agents": native_agent_catalog(),
         }
 
     return router

--- a/tests/test_example_echo_native_plugin.py
+++ b/tests/test_example_echo_native_plugin.py
@@ -1,0 +1,147 @@
+"""End-to-end registry test for the echo-native EXAMPLE plugin (PR 2.4).
+
+Proves the reference community native harness in
+``examples/omnigent-echo-native`` loads through the real registry: its
+``get_contribution()`` is accepted by the 2.1 validator, its harness/agent/
+provider merge into the accessors, its hooks resolve to importable objects, and
+it surfaces on the 2.2 ``/v1/harnesses`` native-agent catalog.
+
+The example's implementation dir is added to ``sys.path`` here (the namespace
+package ``omnigent.community.harness`` already extends onto it), so the test
+runs without a separate ``pip install`` step — the same contract a real
+installed plugin satisfies via its entry point.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+import pytest
+
+import omnigent.harness_plugins as hp
+from omnigent import native_dispatch
+
+_EXAMPLE_ROOT = Path(__file__).resolve().parents[1] / "examples" / "omnigent-echo-native"
+
+
+class _EntryPoint:
+    def __init__(self, name: str, loader: Callable[[], hp.HarnessContribution]) -> None:
+        self.name = name
+        self._loader = loader
+
+    def load(self) -> Callable[[], hp.HarnessContribution]:
+        return self._loader
+
+
+@pytest.fixture(autouse=True)
+def _reset_plugin_state() -> Iterator[None]:
+    hp.reset_plugin_state_for_tests()
+    yield
+    hp.reset_plugin_state_for_tests()
+
+
+@pytest.fixture
+def echo_plugin(monkeypatch: pytest.MonkeyPatch) -> Callable[[], hp.HarnessContribution]:
+    """Put the example impl dir on sys.path and install its entry point."""
+    monkeypatch.syspath_prepend(str(_EXAMPLE_ROOT))
+    # The namespace package caches __path__ at import; refresh so it discovers
+    # the example dir we just prepended.
+    import omnigent.community.harness as harness_ns
+
+    importlib.reload(harness_ns)
+    from omnigent.community.harness.echo.plugin import get_contribution
+
+    monkeypatch.setattr(
+        hp.importlib.metadata,
+        "entry_points",
+        lambda: {hp.COMMUNITY_ENTRY_POINT_GROUP: (_EntryPoint("echo", get_contribution),)},
+    )
+    return get_contribution
+
+
+def test_example_plugin_loads_without_error(
+    echo_plugin: Callable[[], hp.HarnessContribution],
+) -> None:
+    """The example contribution passes the community validator (no load error)."""
+    state = hp.plugin_state()
+    assert "echo" not in state.load_errors, state.load_errors
+    assert "echo-native" in hp.valid_harnesses()
+    # The reversed alias folds to the canonical harness.
+    assert hp.harness_aliases()["native-echo"] == "echo-native"
+
+
+def test_example_plugin_registers_agent_and_provider(
+    echo_plugin: Callable[[], hp.HarnessContribution],
+) -> None:
+    """The example's native agent + provider merge in, keyed by the same key."""
+    assert any(a.key == "echo" for a in hp.native_agents())
+    provider = hp.native_provider_for_key("echo")
+    assert provider is not None
+    assert provider.run_native.startswith("omnigent.community.harness.echo.")
+
+
+def test_example_plugin_hooks_resolve(
+    echo_plugin: Callable[[], hp.HarnessContribution],
+) -> None:
+    """Every declared provider hook resolves to an importable object.
+
+    This is the payoff of the seam: core resolves the plugin's dotted hook
+    paths with no per-harness ``import`` branch. A typo or renamed symbol in the
+    example fails HERE, not at dispatch time.
+    """
+    provider = hp.native_provider_for_key("echo")
+    assert provider is not None
+    for hook in (
+        "run_native",
+        "auto_create_terminal",
+        "spawn_env_builder",
+        "materialize_agent_spec",
+    ):
+        resolved = native_dispatch.resolve_hook(provider, hook)
+        assert callable(resolved), hook
+
+
+def test_example_plugin_surfaces_on_native_agent_catalog(
+    echo_plugin: Callable[[], hp.HarnessContribution],
+) -> None:
+    """The example appears on the 2.2 native-agent catalog with identity + caps."""
+    rows = {r["key"]: r for r in hp.native_agent_catalog()}
+    assert "echo" in rows
+    echo = rows["echo"]
+    assert echo["agent_name"] == "echo-native-ui"
+    assert echo["harness"] == "echo-native"
+    assert echo["wrapper_label"] == "echo-native-ui"
+    assert echo["fork_history"] == "none"
+    assert echo["capabilities"]["integration_mode"] == "native-tui"
+
+
+def test_example_materialize_spec_produces_valid_bundle_spec(
+    echo_plugin: Callable[[], hp.HarnessContribution],
+    tmp_path: Path,
+) -> None:
+    """The materialize hook writes a loadable echo-native-ui spec.
+
+    Mirrors what the server's seeding loop does with the hook, so the example
+    agent would seed like any built-in native.
+    """
+    from omnigent.community.harness.echo.echo_native import materialize_echo_agent_spec
+
+    spec_path = materialize_echo_agent_spec(tmp_path)
+    assert spec_path.exists()
+    import yaml
+
+    raw = yaml.safe_load(spec_path.read_text())
+    assert raw["name"] == "echo-native-ui"
+    assert raw["executor"]["harness"] == "echo-native"
+
+
+def test_example_spawn_env_builder_emits_marker(
+    echo_plugin: Callable[[], hp.HarnessContribution],
+) -> None:
+    """The spawn-env hook is a real, side-effect-free mapping."""
+    from omnigent.community.harness.echo.echo_native_bridge import build_echo_native_spawn_env
+
+    env = build_echo_native_spawn_env(None)
+    assert env["OMNIGENT_ECHO_NATIVE_EXAMPLE"] == "1"

--- a/tests/test_harness_plugins.py
+++ b/tests/test_harness_plugins.py
@@ -144,22 +144,143 @@ def test_community_harness_rejects_community_collision(
     assert hp.harness_modules()["foo"] == "omnigent.community.harness.foo.inner.foo_harness"
 
 
-def test_community_harness_rejects_native_terminal_metadata(
+_FOO_NATIVE_MODULE = "omnigent.community.harness.foo"
+
+
+def _foo_native_agent() -> hp.NativeCodingAgent:
+    return hp.NativeCodingAgent(
+        key="foo",
+        display_name="Foo",
+        agent_name="foo-native-ui",
+        harness="foo-native",
+        wrapper_label="foo-native-ui",
+        terminal_name="foo",
+    )
+
+
+def _foo_native_provider(**overrides: object) -> hp.NativeHarnessProvider:
+    fields: dict[str, object] = {
+        "key": "foo",
+        "run_native": f"{_FOO_NATIVE_MODULE}.foo_native:run_foo_native",
+        "auto_create_terminal": f"{_FOO_NATIVE_MODULE}.runner:_launch_foo",
+        "spawn_env_builder": f"{_FOO_NATIVE_MODULE}.foo_native_bridge:build_foo_native_spawn_env",
+    }
+    fields.update(overrides)
+    return hp.NativeHarnessProvider(**fields)  # type: ignore[arg-type]
+
+
+def _foo_native_contribution(
+    *,
+    agents: tuple[hp.NativeCodingAgent, ...] | None = None,
+    providers: tuple[hp.NativeHarnessProvider, ...] | None = None,
+) -> hp.HarnessContribution:
+    return hp.HarnessContribution(
+        name="omnigent-foo",
+        valid_harnesses=frozenset({"foo-native"}),
+        harness_modules={"foo-native": f"{_FOO_NATIVE_MODULE}.inner.foo_native_harness"},
+        native_harnesses=frozenset({"foo-native"}),
+        native_agents=(_foo_native_agent(),) if agents is None else agents,
+        native_providers=(_foo_native_provider(),) if providers is None else providers,
+    )
+
+
+def test_community_harness_accepts_native_terminal_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def _contribution() -> hp.HarnessContribution:
-        return hp.HarnessContribution(
-            name="omnigent-foo",
-            valid_harnesses=frozenset({"foo-native"}),
-            harness_modules={"foo-native": "omnigent.community.harness.foo.inner.foo_harness"},
-            native_harnesses=frozenset({"foo-native"}),
-        )
+    """A consistent community native harness is accepted and merged (PR 2.1 flip).
 
-    _install_entry_points(monkeypatch, _EntryPoint("foo", _contribution))
+    Native terminal harnesses ARE supported now that the runner runs every
+    native harness through the provider seam; a plugin whose agent/provider rows
+    are internally consistent and community-prefixed must load, not be rejected.
+    """
+    _install_entry_points(monkeypatch, _EntryPoint("foo", _foo_native_contribution))
+
+    state = hp.plugin_state()
+    assert "foo" not in state.load_errors, state.load_errors
+    assert "foo-native" in hp.valid_harnesses()
+    # The native agent + provider are both visible through the registry.
+    assert any(a.key == "foo" for a in hp.native_agents())
+    provider = hp.native_provider_for_key("foo")
+    assert provider is not None
+    assert provider.run_native == f"{_FOO_NATIVE_MODULE}.foo_native:run_foo_native"
+
+
+def test_community_native_rejects_non_community_provider_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A native provider hook outside the community prefix is rejected."""
+    contribution = _foo_native_contribution(
+        providers=(_foo_native_provider(run_native="omnigent.claude_native:run_claude_native"),),
+    )
+    _install_entry_points(monkeypatch, _EntryPoint("foo", lambda: contribution))
 
     state = hp.plugin_state()
     assert "foo" in state.load_errors
+    assert hp.native_provider_for_key("foo") is None
+
+
+def test_community_native_rejects_agent_without_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A native agent with no matching provider row is rejected."""
+    contribution = _foo_native_contribution(providers=())
+    _install_entry_points(monkeypatch, _EntryPoint("foo", lambda: contribution))
+
+    state = hp.plugin_state()
+    assert "foo" in state.load_errors
+    assert "matching provider row" in state.load_errors["foo"]
     assert "foo-native" not in hp.valid_harnesses()
+
+
+def test_community_native_rejects_provider_without_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A native provider with no matching agent row is rejected."""
+    contribution = _foo_native_contribution(agents=())
+    _install_entry_points(monkeypatch, _EntryPoint("foo", lambda: contribution))
+
+    state = hp.plugin_state()
+    assert "foo" in state.load_errors
+    assert "matching agent row" in state.load_errors["foo"]
+
+
+def test_community_native_rejects_missing_required_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A native provider missing a required launch hook is rejected."""
+    contribution = _foo_native_contribution(
+        providers=(_foo_native_provider(auto_create_terminal=""),),
+    )
+    _install_entry_points(monkeypatch, _EntryPoint("foo", lambda: contribution))
+
+    state = hp.plugin_state()
+    assert "foo" in state.load_errors
+    assert "auto_create_terminal" in state.load_errors["foo"]
+
+
+def test_community_native_rejects_agent_identity_collision_with_builtin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A native agent whose identity collides with a built-in is rejected.
+
+    The shared identity-collision guard (`_native_agent_identity_values`) must
+    still fire for native contributions after the accept flip — a plugin can't
+    claim ``claude``'s key / agent_name / wrapper_label / terminal_name.
+    """
+    colliding_agent = hp.NativeCodingAgent(
+        key="foo",
+        display_name="Foo",
+        agent_name="claude-native-ui",  # collides with the built-in claude agent
+        harness="foo-native",
+        wrapper_label="foo-native-ui",
+        terminal_name="foo",
+    )
+    contribution = _foo_native_contribution(agents=(colliding_agent,))
+    _install_entry_points(monkeypatch, _EntryPoint("foo", lambda: contribution))
+
+    state = hp.plugin_state()
+    assert "foo" in state.load_errors
+    assert "native-agent keys" in state.load_errors["foo"]
 
 
 def test_community_harness_readiness_uses_install_metadata(

--- a/tests/test_harness_plugins.py
+++ b/tests/test_harness_plugins.py
@@ -390,6 +390,37 @@ def test_native_provider_for_key_lookup() -> None:
     assert hp.native_provider_for_key("does-not-exist") is None
 
 
+def test_native_agent_catalog_covers_every_native_agent() -> None:
+    """One JSON-serializable row per native agent, keyed 1:1 with the registry."""
+    import json
+
+    rows = hp.native_agent_catalog()
+    assert sorted(r["key"] for r in rows) == sorted(a.key for a in hp.native_agents())
+    # Fully JSON-serializable (values are primitives / dicts, no enums).
+    json.dumps(rows)
+
+
+def test_native_agent_catalog_row_shape_and_capabilities() -> None:
+    """Each row carries identity + fork_history + capabilities from the registry."""
+    rows = {r["key"]: r for r in hp.native_agent_catalog()}
+    claude = rows["claude"]
+    # Identity fields come straight off NativeCodingAgent.
+    assert claude["agent_name"] == "claude-native-ui"
+    assert claude["harness"] == "claude-native"
+    assert claude["wrapper_label"] == "claude-code-native-ui"
+    assert claude["terminal_name"] == "claude"
+    # fork_history + capabilities are pulled from harness_capabilities().
+    assert claude["fork_history"] == "rebuild"
+    assert claude["capabilities"]["integration_mode"] == "native-tui"
+    # cursor uses the preamble fork axis (verifies the axis is per-harness).
+    assert rows["cursor"]["fork_history"] == "preamble"
+    # A native agent whose harness has no capability record still emits a row
+    # with null fork_history/capabilities (defensive — every built-in declares
+    # one, but community natives may not).
+    for row in rows.values():
+        assert "fork_history" in row and "capabilities" in row
+
+
 def test_builtin_native_providers_have_required_hooks() -> None:
     """run_native, auto_create_terminal, and spawn_env_builder are mandatory."""
     for provider in hp.native_providers():


### PR DESCRIPTION
> **Draft, stacked on #3670 (2.1) + #3672 (2.2).** This branch cherry-picks both so the example test is verifiable in isolation; review/merge 2.1 and 2.2 first, then this rebases to just its own commit. The example's live-vendor internals are documented stubs — see "What's real vs. stubbed".

## Related issue

N/A — final PR of Phase 2 of the modular native-harness registry workstream (`designs/harness-modular-registry-proposal.md`).

## Summary

PR **2.4** ships the **reference community native-harness plugin** and documents the contract, closing the Phase-2 loop: a third party can now build a native harness against a stable, tested example instead of reverse-engineering core.

- **`examples/omnigent-echo-native/`** — a real, installable, registry-loadable package under the reserved `omnigent.community.harness.echo.*` namespace. `get_contribution()` pairs a `NativeCodingAgent` with a `NativeHarnessProvider` (both keyed `echo`), declares `echo-native` + a `native-echo` alias, and a `capabilities` record including the `fork_history` axis + bench shell-tool fields.
- **`tests/test_example_echo_native_plugin.py`** — proves the whole chain end to end: the example passes the 2.1 validator, merges into the registry accessors, **every provider hook resolves to an importable object**, and it surfaces on the 2.2 `/v1/harnesses` native-agent catalog. 6 tests.
- **`designs/harness-plugin-interface.md` § "Native TUI Harnesses"** — native provider-hook reference, a Minimal Native Harness Checklist, and an example-plugin pointer.

### What's real vs. stubbed (honest scope)

This is a **PoC of the deliverable shape**, not a second full vendor integration. A real native harness is 1–2k lines of live TUI bridge + transcript forwarder (see `pi_native`/`claude_native`).

| Piece | State |
|---|---|
| `get_contribution()` / registry rows | **real** — passes the community validator, merges into the accessors |
| `materialize_echo_agent_spec` | **real** — writes a loadable `echo-native-ui` spec |
| `build_echo_native_spawn_env` | **real** — pure env mapping |
| `run_echo_native`, `launch_echo`, `create_app` | **stub** — `NotImplementedError` + `TODO(real-harness)` pointing at the built-in real impl |

The package proves the **contract wiring** end to end. Full `--live` bench (`python -m tests.harness_bench --harness echo-native --live`) requires implementing the stubs against a real vendor CLI — the acceptance criterion the design doc names, and the remaining follow-up. I flagged this rather than fake a live run.

### ELI5

"Here's the smallest real example of a plugin that adds a new terminal agent, plus a test proving core actually loads and wires it, plus a checklist so someone can copy it." The parts that need a real vendor CLI are left as clearly-marked stubs.

## Test Plan

```bash
uv run pytest tests/test_example_echo_native_plugin.py tests/test_harness_plugins.py \
  tests/test_native_dispatch.py -q
uv run pre-commit run --all-files
```

- 34 passed across the stacked 2.1+2.2+2.4 surface. The example loads through the *real* entry-point loader (namespace package + `sys.path`), no `pip install` needed for the test.
- ruff check/format clean on the new package + test.

## Demo

N/A — no UI surface (a registry/example/docs change). The web already renders community natives via 2.3a (generic icon).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The example plugin's registry wiring is fully covered (load / validator-accept / hook-resolve / catalog-surface / materialize / spawn-env). The three live-vendor hooks are intentionally uncovered stubs (they `raise NotImplementedError` with a pointer to the real implementation) — covering them requires a real vendor CLI + a `--live` bench run, which is the documented follow-up, not part of this PoC.

---

**Workstream progress**: Phase 1 complete. Phase 2 — 2.1 (#3670), 2.2 (#3672), 2.3a (#3690 draft), **2.4 this PR (draft, stacked on 2.1+2.2)**. Remaining after review: 2.3b (presentation overlay + demo) and making the example fully `--live` benchable.
