### PR TITLE
refactor(stores): type conversation SQLAlchemy boundaries

### DIFF
--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
+from typing import Any, Protocol, cast
 
 from sqlalchemy import (
     ColumnElement,
@@ -94,6 +94,11 @@ from omnigent.stores.conversation_store import (
 )
 
 _logger = logging.getLogger(__name__)
+
+
+class _RowCountResult(Protocol):
+    rowcount: int
+
 
 # Per-session config overrides packed into the ``conversations.session_overrides``
 # JSON blob. Order is fixed so the encoded object is stable across writes.
@@ -478,12 +483,16 @@ def _fetch_labels(
     :returns: Mapping from label key to value (string-typed).
         Empty dict when no rows match.
     """
-    rows = session.execute(
-        select(SqlConversationLabel.key, SqlConversationLabel.value).where(
-            SqlConversationLabel.workspace_id == current_workspace_id(),
-            SqlConversationLabel.conversation_id == conversation_id,
+    rows = (
+        session.execute(
+            select(SqlConversationLabel.key, SqlConversationLabel.value).where(
+                SqlConversationLabel.workspace_id == current_workspace_id(),
+                SqlConversationLabel.conversation_id == conversation_id,
+            )
         )
-    ).all()
+        .tuples()
+        .all()
+    )
     return dict(rows)
 
 
@@ -737,10 +746,10 @@ class SqlAlchemyConversationStore(ConversationStore):
         # same-timestamp collisions in practice. Other dialects fall back to
         # the string id column (non-deterministic for ties; proper fix: add a
         # BIGSERIAL seq col).
-        self._tiebreaker_col = (
+        self._tiebreaker_col: ColumnElement[Any] = (
             literal_column("conversations.rowid")
             if self._conv_engine.dialect.name == "sqlite"
-            else SqlConversation.id
+            else cast(ColumnElement[Any], SqlConversation.id)
         )
         ensure_fts_table(self._conv_engine)
 
@@ -1151,11 +1160,11 @@ class SqlAlchemyConversationStore(ConversationStore):
             # too — _to_conversation reads ORM columns, which would raise
             # DetachedInstanceError once the session closes.
             labels_by_conv = _fetch_labels_bulk(session, [row.id for row in rows])
-        meta_rows = []
+        meta_rows: list[SqlConversationMetadata] = []
         if rows:
             row_ids = [r.id for r in rows]
             with self._session() as meta_sess:
-                meta_rows = (
+                meta_rows = list(
                     meta_sess.execute(
                         select(SqlConversationMetadata).where(
                             SqlConversationMetadata.workspace_id == current_workspace_id(),
@@ -1325,13 +1334,16 @@ class SqlAlchemyConversationStore(ConversationStore):
             conversation has no metadata row.
         """
         with self._session() as session:
-            result = session.execute(
-                update(SqlConversationMetadata)
-                .where(
-                    SqlConversationMetadata.workspace_id == current_workspace_id(),
-                    SqlConversationMetadata.id == conversation_id,
-                )
-                .values(project_id=project_id)
+            result = cast(
+                _RowCountResult,
+                session.execute(
+                    update(SqlConversationMetadata)
+                    .where(
+                        SqlConversationMetadata.workspace_id == current_workspace_id(),
+                        SqlConversationMetadata.id == conversation_id,
+                    )
+                    .values(project_id=project_id)
+                ),
             )
             return result.rowcount > 0
 
@@ -1427,10 +1439,8 @@ class SqlAlchemyConversationStore(ConversationStore):
                     )
                 )
             else:
-                # mypy sees the Mapped[...] descriptor types; at runtime
-                # these are plain attributes accepting the Python value.
-                existing.cost_usd = existing.cost_usd + delta_usd  # type: ignore[assignment]
-                existing.updated_at = now  # type: ignore[assignment]
+                existing.cost_usd = existing.cost_usd + delta_usd
+                existing.updated_at = now
 
     def _upsert_daily_cost_dialect(
         self,
@@ -1602,8 +1612,8 @@ class SqlAlchemyConversationStore(ConversationStore):
                     )
                 )
             else:
-                existing.ask_approved_usd = ask_approved_usd  # type: ignore[assignment]
-                existing.updated_at = now  # type: ignore[assignment]
+                existing.ask_approved_usd = ask_approved_usd
+                existing.updated_at = now
 
     def get_session_owner(self, conversation_id: str) -> str | None:
         """
@@ -2721,17 +2731,20 @@ class SqlAlchemyConversationStore(ConversationStore):
     ) -> Conversation | None:
         """Rename a conversation with an atomic title compare-and-swap."""
         with self._conv_session() as session:
-            result = session.execute(
-                update(SqlConversation)
-                .where(
-                    SqlConversation.workspace_id == current_workspace_id(),
-                    SqlConversation.id == conversation_id,
-                    SqlConversation.title == expected_title,
-                )
-                .values(
-                    title=title,
-                    updated_at=now_epoch(),
-                )
+            result = cast(
+                _RowCountResult,
+                session.execute(
+                    update(SqlConversation)
+                    .where(
+                        SqlConversation.workspace_id == current_workspace_id(),
+                        SqlConversation.id == conversation_id,
+                        SqlConversation.title == expected_title,
+                    )
+                    .values(
+                        title=title,
+                        updated_at=now_epoch(),
+                    )
+                ),
             )
             if result.rowcount != 1:
                 return None
@@ -2771,7 +2784,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 .where(SqlConversationMetadata.runner_id.is_(None))
                 .values(runner_id=runner_id)
             )
-            result = session.execute(stmt)
+            result = cast(_RowCountResult, session.execute(stmt))
             return result.rowcount == 1
 
     def touch_runner_liveness(self, runner_ids: list[str], now: int) -> None:


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Type SQLAlchemy tuple results, metadata collections, cursor columns, and row-count results at their actual runtime boundaries.
- Remove stale ORM assignment suppressions that current SQLAlchemy typing no longer needs.
- Preserve database behavior while removing all 14 mypy diagnostics from the conversation-store implementation.

**ELI5:** database operations still return the same values, but mypy now knows whether each result is a tuple, ORM row, cursor count, or SQL expression instead of treating those boundaries ambiguously.

    SQLAlchemy result -> typed tuple / ORM collection -> store entity
    UPDATE result     -> row-count protocol          -> bool / compare-and-swap

## Test Plan

- .venv/bin/pytest -q tests/stores/test_conversation_store.py tests/stores/test_conversation_store_split_db.py tests/stores/test_conversation_labels.py (221 passed)
- .venv/bin/mypy --no-incremental omnigent/stores/conversation_store/sqlalchemy_store.py (zero target-module diagnostics; generated protobuf baseline only)
- Clean base-vs-branch .venv/bin/mypy --no-incremental omnigent comparison (1,414 -> 1,400; zero new non-target diagnostics)
- .venv/bin/pre-commit run --all-files (all hooks passed)
- Confirmed uv.lock is unchanged.

## Demo

N/A — non-visual type-safety refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing conversation-store suites cover labels, metadata lookup, project updates, daily-cost writes, cursor pagination, compare-and-swap renames, runner binding, and split-database behavior.
