### PR TITLE
refactor(native-server): type transport payloads

### DIFF
--- a/omnigent/native_server_transport.py
+++ b/omnigent/native_server_transport.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal, Protocol, runtime_checkable
+from typing import Literal, Protocol, runtime_checkable
 
 
 @dataclass(frozen=True)
@@ -71,10 +71,10 @@ class NativePrompt:
     """
 
     text: str
-    attachments: tuple[Mapping[str, Any], ...] = ()
+    attachments: tuple[Mapping[str, object], ...] = ()
     system_prompt: str | None = None
     model: str | None = None
-    metadata: Mapping[str, Any] = field(default_factory=dict)
+    metadata: Mapping[str, object] = field(default_factory=dict)
 
     def is_empty(self) -> bool:
         """:returns: ``True`` when there is nothing to send."""
@@ -94,8 +94,8 @@ class NativeEvent:
 
     id: str | None
     type: str
-    payload: Mapping[str, Any]
-    raw: Mapping[str, Any]
+    payload: Mapping[str, object]
+    raw: Mapping[str, object]
 
 
 @dataclass(frozen=True)
@@ -139,7 +139,7 @@ class NativeServerTransport(Protocol):
         """Resume ``launch.external_session_id`` or create a new session id."""
         raise NotImplementedError
 
-    async def send_prompt(self, session_id: str, prompt: NativePrompt) -> Mapping[str, Any]:
+    async def send_prompt(self, session_id: str, prompt: NativePrompt) -> Mapping[str, object]:
         """Inject a prompt into the native session."""
         raise NotImplementedError
 
@@ -151,7 +151,7 @@ class NativeServerTransport(Protocol):
         """Stream native events for *session_id*."""
         raise NotImplementedError
 
-    async def list_history(self, session_id: str) -> list[Mapping[str, Any]]:
+    async def list_history(self, session_id: str) -> list[Mapping[str, object]]:
         """Return the native session's message history."""
         raise NotImplementedError
 


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Replace open-ended `Any` values in native prompts, events, metadata, prompt responses, and history records with `Mapping[str, object]` contracts.
- Align the shared `NativeServerTransport` protocol with the object-valued JSON mappings already implemented by `OpenCodeHttpTransport`.
- Eliminate 8 full-tree mypy findings, reducing the current `main` baseline from 1,404 to 1,396 errors.

**ELI5:** Native-server payloads remain flexible JSON dictionaries, but their values are now explicitly opaque objects that consumers must inspect before using.

```text
prompt attachments -> object-valued mapping -> native transport
server events      -> object-valued mapping -> shared harness
history/response   -> object-valued mapping -> caller narrowing
```

## Test Plan

- `uv run --no-sync pytest -q tests/test_native_server_harness.py tests/test_opencode_http_transport.py` (29 passed)
- `uv run --no-sync mypy --no-incremental omnigent` (1,396 existing errors; no findings in `native_server_transport.py`)
- `SKIP=normalize-uv-lock-registry pre-commit run --all-files` (all applicable hooks passed)
- Confirmed `uv.lock` is unchanged; lockfile maintenance remains in its separate workstream.

## Demo

N/A — non-visual type-safety refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing native-server harness and OpenCode HTTP transport suites cover prompt normalization, attachments, server lifecycle, event mapping, history, permission replies, interruption, steering, and TUI attach behavior.

## Changelog

N/A — internal type-safety cleanup.
