### PR TITLE
refactor(migrations): type batch recreation mode

### DIFF
--- a/omnigent/db/migrations/versions/b3c1a2d4e5f6_unify_user_id_columns.py
+++ b/omnigent/db/migrations/versions/b3c1a2d4e5f6_unify_user_id_columns.py
@@ -34,6 +34,7 @@ p1a2b3c4d5e6.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Literal
 
 import sqlalchemy as sa
 from alembic import op
@@ -57,7 +58,7 @@ def upgrade() -> None:
     not-yet-renamed column). So drop the dependent object first, rename in its
     own batch, then create the renamed object.
     """
-    recreate = "always" if _is_sqlite() else "auto"
+    recreate: Literal["always", "auto"] = "always" if _is_sqlite() else "auto"
 
     # hosts.owner → user_id, VARCHAR(256) → VARCHAR(128). The unique constraint
     # sits on the renamed column, and SQLite can only drop a constraint via a
@@ -95,7 +96,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Restore owner / owner_user_id column names (and hosts width to 256)."""
-    recreate = "always" if _is_sqlite() else "auto"
+    recreate: Literal["always", "auto"] = "always" if _is_sqlite() else "auto"
 
     op.drop_index("ix_scheduled_tasks_user_id", table_name="scheduled_tasks")
     with op.batch_alter_table("scheduled_tasks", recreate=recreate) as batch_op:


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Type the user-id migration's Alembic `recreate` mode as the exact `Literal["always", "auto"]` union selected by its SQLite dialect check.
- Apply the same typed mode to upgrade and downgrade so all eight `batch_alter_table` calls satisfy Alembic's contract without casts or suppressions.
- Eliminate 8 full-tree mypy findings, reducing the current `main` baseline from 1,354 to 1,346 errors.

**ELI5:** The migration still chooses the same two strings at runtime; mypy now knows they are Alembic's supported modes rather than arbitrary text.

```text
SQLite     -> "always" -> Alembic batch table rebuild
other SQL  -> "auto"   -> native ALTER TABLE when supported
```

## Test Plan

- `uv run --no-sync pytest -q tests/db/test_migration_unify_user_id.py tests/db/test_migrations_sqlite_safe.py` (7 passed)
- `uv run --no-sync mypy --no-incremental omnigent` (1,346 existing errors; no findings in the migration)
- `SKIP=normalize-uv-lock-registry pre-commit run --all-files` (all applicable hooks passed)
- Confirmed `uv.lock` is unchanged; lockfile maintenance remains in its separate workstream.

## Demo

N/A — non-visual type-safety refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The dedicated migration suite verifies both renamed tables, constraints, indexes, downgrade restoration, the full SQLite migration round trip, and absence of SQLite-unsafe raw DDL.

## Changelog

N/A — internal type-safety cleanup.
