### PR TITLE
refactor(openai-agents): type SDK executor boundaries

### DIFF
--- a/omnigent/inner/openai_agents_sdk_executor.py
+++ b/omnigent/inner/openai_agents_sdk_executor.py
@@ -19,7 +19,7 @@ import logging
 import os
 import subprocess
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable, Generator
+from collections.abc import AsyncIterator, Awaitable, Callable, Generator, Sequence
 from dataclasses import dataclass
 from types import ModuleType
 from typing import Any, Literal, Protocol, TypeAlias, cast
@@ -72,6 +72,8 @@ _EMPTY_TURN_MAX_ATTEMPTS = 2
 # retried.
 _NON_OUTPUT_ITEM_TYPES: frozenset[str] = frozenset({"reasoning_item", "compaction_item"})
 
+_JsonObject: TypeAlias = dict[str, object]
+
 # Replay items persisted to the SDK Session — heterogeneous Responses-API
 # input items (function_call / function_call_output / message / etc.).
 # The SDK declares this as ``TResponseInputItem``, which is a TypedDict
@@ -110,8 +112,8 @@ ToolArgs: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
 
 
 def _normalize_responses_items_for_chat(
-    items: list[dict[str, Any]],
-) -> list[dict[str, Any]]:
+    items: list[_JsonObject],
+) -> list[_JsonObject]:
     """Apply :func:`_normalize_content_blocks_for_chat` to every message item.
 
     Walks the full Responses-API item list produced by
@@ -124,7 +126,7 @@ def _normalize_responses_items_for_chat(
     :returns: New list with normalised ``input_file`` blocks in message
         content.  Items without ``input_file`` blocks are returned as-is.
     """
-    result: list[dict[str, Any]] = []
+    result: list[_JsonObject] = []
     for item in items:
         if item.get("type") == "message":
             raw_content = item.get("content")
@@ -137,8 +139,8 @@ def _normalize_responses_items_for_chat(
 
 
 def _normalize_content_blocks_for_chat(
-    content: list[dict[str, Any]],
-) -> list[dict[str, Any]]:
+    content: list[_JsonObject],
+) -> list[_JsonObject]:
     """Normalize content blocks before handing them to the openai-agents Runner.
 
     Converts ``input_file`` blocks whose ``file_data`` is a ``data:`` URI into
@@ -170,13 +172,14 @@ def _normalize_content_blocks_for_chat(
         (non-``text/*``) file blocks, undecodable, or empty file blocks are
         silently dropped.  Unknown block types pass through unchanged.
     """
-    result: list[dict[str, Any]] = []
+    result: list[_JsonObject] = []
     changed = False
     for block in content:
         block_type = block.get("type")
         if block_type == "input_file":
             changed = True
-            file_data: str = block.get("file_data", "")
+            raw_file_data = block.get("file_data", "")
+            file_data = raw_file_data if isinstance(raw_file_data, str) else ""
             if file_data.startswith("data:"):
                 try:
                     meta, b64 = file_data.split(",", 1)
@@ -207,7 +210,7 @@ def _normalize_content_blocks_for_chat(
     return result if changed else content
 
 
-def _copy_known_keys(block: dict[str, Any], keys: tuple[str, ...]) -> dict[str, Any]:
+def _copy_known_keys(block: _JsonObject, keys: tuple[str, ...]) -> _JsonObject:
     """Return *block* with only keys accepted by provider content schemas.
 
     Omnigent content blocks can carry UI/history metadata such as
@@ -370,7 +373,7 @@ def _patch_openai_sse_keepalive_tolerance() -> None:
 
     _orig_decode = decoder.decode
 
-    def decode(self: Any, line: str) -> Any:  # type: ignore[explicit-any]
+    def decode(self: object, line: str) -> object:
         sse = _orig_decode(self, line)
         if sse is not None and not (getattr(sse, "data", None) or "").strip():
             # Empty-data keepalive frame: drop it so the client never calls
@@ -378,8 +381,8 @@ def _patch_openai_sse_keepalive_tolerance() -> None:
             return None
         return sse
 
-    decoder.decode = decode  # type: ignore[method-assign]
-    decoder._omnigent_keepalive_patch = True  # type: ignore[attr-defined]
+    decoder.decode = decode
+    decoder._omnigent_keepalive_patch = True
 
 
 def _ensure_agents_sdk() -> ModuleType:
@@ -666,11 +669,11 @@ class _AgentsSessionState:
         before starting. Set by :meth:`interrupt_session`.
     """
 
-    sdk_session: Any  # type: ignore[explicit-any]  # _SanitizingSession or OpenAIResponsesCompactionSession
+    sdk_session: _SDKSession
     started: bool = False
     # agents.Agent[Any] instance; cached for reuse across turns.
     agent: SDKAgent = None
-    agent_signature: tuple[str, str, str, str, str] | None = None
+    agent_signature: tuple[str, str, str, str, str, str] | None = None
     resume_state: _RunState | None = None
     active_result: _RunResult | None = None
     interrupt_requested: bool = False
@@ -938,7 +941,7 @@ def _wrap_client_for_reasoning_models(client: AsyncOpenAIClient) -> AsyncOpenAIC
     return client
 
 
-def _count_output_items(new_items: list[Any]) -> int:  # type: ignore[explicit-any]
+def _count_output_items(new_items: Sequence[object]) -> int:
     """Count run items that represent user-visible output.
 
     Excludes bookkeeping items (reasoning, compaction) per
@@ -954,7 +957,7 @@ def _count_output_items(new_items: list[Any]) -> int:  # type: ignore[explicit-a
     )
 
 
-def _sum_output_tokens(raw_responses: list[Any] | None) -> int:  # type: ignore[explicit-any]
+def _sum_output_tokens(raw_responses: Sequence[object] | None) -> int:
     """Sum ``output_tokens`` across a run's raw model responses.
 
     :param raw_responses: ``RunResult.raw_responses``; each element has a
@@ -963,13 +966,16 @@ def _sum_output_tokens(raw_responses: list[Any] | None) -> int:  # type: ignore[
     """
     if not raw_responses:
         return 0
-    return sum(getattr(r.usage, "output_tokens", 0) or 0 for r in raw_responses)
+    return sum(
+        getattr(getattr(response, "usage", None), "output_tokens", 0) or 0
+        for response in raw_responses
+    )
 
 
 def _is_empty_turn(
     final_text: str,
     saw_tool_activity: bool,
-    new_items: list[Any],  # type: ignore[explicit-any]
+    new_items: Sequence[object],
 ) -> bool:
     """Whether a completed run produced literally nothing worth surfacing.
 
@@ -1115,14 +1121,17 @@ class OpenAIAgentsSDKExecutor(Executor):
             return state
 
         underlying = _SanitizingSession(agents_sdk.SQLiteSession(session_key))
-        sdk_session: Any = underlying  # type: ignore[explicit-any]
+        sdk_session: _SDKSession = underlying
         # Wrap with compaction session when the client targets a real
         # HTTP endpoint. Skip for bare object() clients in unit tests
         # that lack base_url.
         _base = str(getattr(self._client, "base_url", ""))
         if _base.startswith("http"):
             try:
-                from agents.memory import OpenAIResponsesCompactionSession
+                from agents.memory import (
+                    OpenAIResponsesCompactionArgs,
+                    OpenAIResponsesCompactionSession,
+                )
 
                 class _SafeCompactionSession(OpenAIResponsesCompactionSession):
                     """Compaction session that treats compaction failures as non-fatal.
@@ -1133,7 +1142,10 @@ class OpenAIAgentsSDKExecutor(Executor):
                     without compaction.
                     """
 
-                    async def run_compaction(self, args=None):  # type: ignore[override]
+                    async def run_compaction(
+                        self,
+                        args: OpenAIResponsesCompactionArgs | None = None,
+                    ) -> None:
                         try:
                             await super().run_compaction(args)
                         except Exception:  # noqa: BLE001
@@ -1143,10 +1155,13 @@ class OpenAIAgentsSDKExecutor(Executor):
                                 exc_info=True,
                             )
 
-                sdk_session = _SafeCompactionSession(
-                    session_id=session_key,
-                    underlying_session=underlying,  # type: ignore[arg-type]
-                    client=self._client,
+                sdk_session = cast(
+                    _SDKSession,
+                    _SafeCompactionSession(
+                        session_id=session_key,
+                        underlying_session=underlying,  # type: ignore[arg-type]
+                        client=self._client,
+                    ),
                 )
             except (ImportError, AttributeError, ValueError) as exc:
                 logger.debug(
@@ -1520,7 +1535,7 @@ class OpenAIAgentsSDKExecutor(Executor):
                         ]
                         _last_user_msg = " ".join(_parts)[:500]
                     break
-            _req_data: dict[str, Any] = {
+            _req_data: _JsonObject = {
                 "model": model,
                 "messages_count": len(messages),
                 "tools_count": len(tools),
@@ -1796,7 +1811,7 @@ class OpenAIAgentsSDKExecutor(Executor):
         # re-sends the full history); the last sub-turn's total is
         # stable. Always set so the REPL and compaction don't fall
         # back to total_tokens (which sums across ALL sub-turns).
-        turn_usage: dict[str, Any] | None = None
+        turn_usage: _JsonObject | None = None
         raw_responses = getattr(result, "raw_responses", None)
         if raw_responses:
             in_tok = sum(getattr(r.usage, "input_tokens", 0) or 0 for r in raw_responses)
@@ -1843,8 +1858,10 @@ class OpenAIAgentsSDKExecutor(Executor):
 
                     _compaction_tokens = 0
                     if turn_usage is not None:
-                        _compaction_tokens = turn_usage.get("context_tokens", 0) or 0
-                    _compacted: list[dict[str, Any]] | None = None
+                        context_tokens = turn_usage.get("context_tokens")
+                        if isinstance(context_tokens, int):
+                            _compaction_tokens = context_tokens
+                    _compacted: list[ReplayItem] | None = None
                     try:
                         _compacted = await state.sdk_session.get_items()
                     except Exception:  # noqa: BLE001


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Replace untyped OpenAI Responses payload collections with object-valued JSON boundaries and runtime narrowing.
- Model SDK sessions, output sequences, compaction arguments, and the six-field agent cache signature with their concrete contracts.
- Remove all 17 mypy diagnostics from the OpenAI Agents SDK executor without changing provider behavior.

**ELI5:** flexible SDK payloads stay flexible, but the executor now checks values before treating them as strings, token counts, session records, or cache keys.

    provider payload -> object-valued boundary -> runtime narrowing
    SDK session      -> local protocol        -> replay/compaction
    agent settings   -> six-field signature   -> cache reuse

## Test Plan

- uv run --no-sync pytest -q tests/inner/test_openai_agents_sdk_executor.py tests/inner/test_openai_agents_sdk_harness.py (95 passed)
- uv run --no-sync mypy --no-incremental omnigent/inner/openai_agents_sdk_executor.py (zero target-module diagnostics; generated protobuf baseline only)
- Clean base-vs-branch uv run --no-sync mypy --no-incremental omnigent comparison (1,354 -> 1,337; zero new non-target diagnostics)
- pre-commit run --all-files (all hooks passed)
- Confirmed uv.lock is unchanged.

## Demo

N/A — non-visual type-safety refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing executor and harness suites cover Responses and Chat Completions payload normalization, SDK replay sessions, compaction fallback, streaming events, tool calls, policy evaluation, usage accounting, retries, interruption, authentication, and model settings.
