### PR TITLE
ci(release): add source-PR demo-video table to release-post PRs

### DIFF
--- a/.github/agents/release-post-formatter/config.yaml
+++ b/.github/agents/release-post-formatter/config.yaml
@@ -113,7 +113,9 @@ prompt: |
   placeholder immediately under EACH feature heading:
     `![TODO: add a demo screenshot or GIF for "<feature title>"](TODO)`
   Use the literal token `TODO` so a reviewer can grep for it. Never fabricate a
-  real-looking image path.
+  real-looking image path. (The workflow adds a table of the release's feature
+  PRs and their existing demo videos to the PR description, so a reviewer can drop
+  an already-recorded clip into these placeholders — you do not reference it.)
 
   ## Docs links (link to the most specific real page/section, or omit the line)
   The "## Available docs pages and sections" input lists every real docs URL and

--- a/.github/agents/release-post-formatter/config.yaml
+++ b/.github/agents/release-post-formatter/config.yaml
@@ -83,6 +83,23 @@ prompt: |
   Full Changelog: <copy the exact `Full Changelog:` line from the input, verbatim>
   <!-- /RELEASE_POST -->
 
+  Then, AFTER the closing `<!-- /RELEASE_POST -->` marker, emit a machine-readable
+  map of which PRs back each feature section you wrote, so the workflow can build
+  a per-feature demo-video reference table for the reviewer. Emit it between its
+  own markers, as a JSON array in the SAME ORDER as your numbered sections — one
+  object per section, `title` matching the section's title text exactly (without
+  the `N. ` prefix), `pr_refs` the numbers from the `(#123, #456)` refs on the
+  release-body bullets you folded into that feature (integers, no `#`). Include
+  ONLY features you wrote up; omit bullets/PRs you dropped. This block is metadata,
+  NOT part of the post — never put PR numbers back into the RELEASE_POST prose.
+
+  <!-- RELEASE_POST_PRS -->
+  [
+    {"title": "<Feature 1 title>", "pr_refs": [123, 456]},
+    {"title": "<Feature 2 title>", "pr_refs": [789]}
+  ]
+  <!-- /RELEASE_POST_PRS -->
+
   ## The MLflow 3.14.0 style (match this)
   - CURATE, don't mirror. Pick only the ~4-6 OUTSTANDING, headline features and
     give each its own numbered section. DROP minor features, small tweaks, and

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -142,92 +142,6 @@ jobs:
           # fallback if the formatter agent is unavailable or fails.
           cp /tmp/release_body.md /tmp/site_body.md
 
-      # Build a reviewer reference table of the release's FEATURE PRs and whether
-      # each already ships a demo video, so a human filling the `TODO` demo
-      # placeholders can reuse an existing recording instead of re-recording. This
-      # is independent of the LLM reflow (useful for the raw-body fallback too), so
-      # it runs unconditionally; a failure leaves the table empty (best effort).
-      - name: Build demo-video reference table
-        id: demotable
-        continue-on-error: true
-        working-directory: omnigent
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SOURCE_REPO: ${{ env.SOURCE_REPO }}
-        run: |
-          set -euo pipefail
-          python3 -u <<'PYEOF'
-          import json, os, pathlib, re, subprocess
-          repo = os.environ["SOURCE_REPO"]
-          body = pathlib.Path("/tmp/release_body.md").read_text(encoding="utf-8", errors="replace")
-
-          # Walk the curated body, tracking the current `## <section>`, and collect
-          # the PR refs from each bullet's trailing `(#123, #456)`. Only FEATURE
-          # sections matter — the release post drops bug fixes, so does this table.
-          FEATURE = {"major new features", "breaking changes"}
-          ref_re = re.compile(r"#(\d+)")
-          sections, current, seen = [], None, set()
-          for ln in body.splitlines():
-              h = re.match(r"##\s+(.*\S)", ln)
-              if h:
-                  name = h.group(1).strip()
-                  current = (name, []) if name.lower() in FEATURE else None
-                  if current:
-                      sections.append(current)
-                  continue
-              if current and ln.lstrip().startswith(("-", "*")):
-                  for n in ref_re.findall(ln):
-                      pr = int(n)
-                      if pr not in seen:
-                          seen.add(pr)
-                          current[1].append(pr)
-
-          # Same demo-VIDEO detection as feature-blog.yml: GitHub uploaded-asset
-          # links, bare video URLs, and <video> tags. Images are NOT counted — the
-          # placeholder asks for a recording (a screenshot is a weaker fallback).
-          video_re = re.compile(
-              r"https?://github\.com/user-attachments/assets/[0-9a-f-]+"
-              r"|https?://github\.com/[^/\s)]+/[^/\s)]+/assets/\d+/[0-9a-f-]+"
-              r"|https?://[^\s)]+\.(?:mp4|mov|webm|m4v)\b"
-              r"|<video\b",
-              re.IGNORECASE)
-          def _cell(t):
-              return (t or "").replace("|", "\\|").replace("\n", " ").strip()
-
-          meta_cache = {}
-          def _meta(pr):
-              if pr in meta_cache:
-                  return meta_cache[pr]
-              m = {"title": "", "url": f"https://github.com/{repo}/pull/{pr}", "video": False}
-              try:
-                  d = json.loads(subprocess.run(
-                      ["gh", "pr", "view", str(pr), "--repo", repo,
-                       "--json", "title,body,url"],
-                      capture_output=True, text=True, timeout=60).stdout or "{}")
-                  m["title"] = _cell(d.get("title", ""))
-                  m["url"] = d.get("url") or m["url"]
-                  m["video"] = bool(video_re.search(d.get("body") or ""))
-              except Exception as e:
-                  print(f"::notice::Could not read metadata for PR #{pr}: {e}")
-              meta_cache[pr] = m
-              return m
-
-          out = []
-          for name, prs in sections:
-              if not prs:
-                  continue
-              out += [f"### {name}", "", "| PR | Title | Demo video? |",
-                      "| --- | --- | --- |"]
-              for pr in prs:
-                  m = _meta(pr)
-                  cell = f"[✅ video]({m['url']})" if m["video"] else "—"
-                  out.append(f"| [#{pr}]({m['url']}) | {m['title']} | {cell} |")
-              out.append("")
-          pathlib.Path("/tmp/demo_table.md").write_text("\n".join(out).rstrip() + ("\n" if out else ""))
-          print(f"Built demo table for {len(seen)} feature PR(s) across "
-                f"{sum(1 for _, prs in sections if prs)} section(s).")
-          PYEOF
-
       # --- AI reflow (primary; degrades to the raw release body) ---
       # The GitHub Release itself is untouched — this rewrites its body into the
       # website's narrative, prose-driven post for the site page ONLY.
@@ -366,6 +280,126 @@ jobs:
               print("Using AI-formatted narrative release post.")
           else:
               print("::warning::No RELEASE_POST block parsed — publishing the raw release body.")
+          PYEOF
+
+      # Reviewer reference table of the PRs behind each feature and whether each
+      # already ships a demo video, so a human filling the `TODO` demo placeholders
+      # can reuse an existing recording instead of re-recording. Grouped to MATCH
+      # THE POST: when the formatter ran it curated the body down to a few headline
+      # features and emitted a per-feature RELEASE_POST_PRS map — group by that so
+      # the table covers only the PRs behind the features that made the post. With
+      # no map (raw-body fallback), the post keeps every feature, so fall back to
+      # the raw `## Major new features` / `## Breaking changes` sections. Runs
+      # unconditionally (helps the fallback too); best-effort, empty table on error.
+      - name: Build demo-video reference table
+        id: demotable
+        continue-on-error: true
+        working-directory: omnigent
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_REPO: ${{ env.SOURCE_REPO }}
+        run: |
+          set -euo pipefail
+          python3 -u <<'PYEOF'
+          import json, os, pathlib, re, subprocess
+          repo = os.environ["SOURCE_REPO"]
+          body = pathlib.Path("/tmp/release_body.md").read_text(encoding="utf-8", errors="replace")
+
+          # PR refs from the raw body's FEATURE sections, per section — the set of
+          # PRs the table is allowed to name (bug fixes are dropped from the post,
+          # so from the table too), and the fallback grouping when no formatter map.
+          FEATURE = {"major new features", "breaking changes"}
+          ref_re = re.compile(r"#(\d+)")
+          raw_sections, current, allowed = [], None, set()
+          for ln in body.splitlines():
+              h = re.match(r"##\s+(.*\S)", ln)
+              if h:
+                  name = h.group(1).strip()
+                  current = (name, []) if name.lower() in FEATURE else None
+                  if current:
+                      raw_sections.append(current)
+                  continue
+              if current and ln.lstrip().startswith(("-", "*")):
+                  for n in ref_re.findall(ln):
+                      pr = int(n)
+                      allowed.add(pr)
+                      if pr not in current[1]:
+                          current[1].append(pr)
+
+          # Prefer the formatter's curated feature -> PRs map so the table's groups
+          # match the post's numbered features. The formatter is fed injectable PR
+          # prose, so validate: keep only pr_refs that appear in the harvested body.
+          groups = []  # (feature title, [pr, ...])
+          fmt = pathlib.Path("/tmp/format_out.txt")
+          if fmt.is_file():
+              raw = fmt.read_text(encoding="utf-8", errors="replace")
+              mm = re.search(r"<!--\s*RELEASE_POST_PRS\s*-->(.*?)<!--\s*/RELEASE_POST_PRS\s*-->",
+                             raw, re.DOTALL)
+              if mm:
+                  try:
+                      for feat in json.loads(mm.group(1).strip()):
+                          if not isinstance(feat, dict):
+                              continue
+                          title = str(feat.get("title", "")).strip()
+                          prs, seen = [], set()
+                          for r in feat.get("pr_refs", []):
+                              try:
+                                  n = int(r)
+                              except (TypeError, ValueError):
+                                  continue
+                              if n in allowed and n not in seen:
+                                  seen.add(n)
+                                  prs.append(n)
+                          if title and prs:
+                              groups.append((title, prs))
+                  except json.JSONDecodeError as e:
+                      print(f"::warning::Could not parse RELEASE_POST_PRS — falling back to raw sections: {e}")
+          if not groups:
+              print("::notice::No curated feature map — grouping the table by raw release sections.")
+              groups = [(name, prs) for name, prs in raw_sections if prs]
+
+          # Same demo-VIDEO detection as feature-blog.yml: GitHub uploaded-asset
+          # links, bare video URLs, and <video> tags. Images are NOT counted — the
+          # placeholder asks for a recording (a screenshot is a weaker fallback).
+          video_re = re.compile(
+              r"https?://github\.com/user-attachments/assets/[0-9a-f-]+"
+              r"|https?://github\.com/[^/\s)]+/[^/\s)]+/assets/\d+/[0-9a-f-]+"
+              r"|https?://[^\s)]+\.(?:mp4|mov|webm|m4v)\b"
+              r"|<video\b",
+              re.IGNORECASE)
+          def _cell(t):
+              return (t or "").replace("|", "\\|").replace("\n", " ").strip()
+
+          meta_cache = {}
+          def _meta(pr):
+              if pr in meta_cache:
+                  return meta_cache[pr]
+              m = {"title": "", "url": f"https://github.com/{repo}/pull/{pr}", "video": False}
+              try:
+                  d = json.loads(subprocess.run(
+                      ["gh", "pr", "view", str(pr), "--repo", repo,
+                       "--json", "title,body,url"],
+                      capture_output=True, text=True, timeout=60).stdout or "{}")
+                  m["title"] = _cell(d.get("title", ""))
+                  m["url"] = d.get("url") or m["url"]
+                  m["video"] = bool(video_re.search(d.get("body") or ""))
+              except Exception as e:
+                  print(f"::notice::Could not read metadata for PR #{pr}: {e}")
+              meta_cache[pr] = m
+              return m
+
+          out, total = [], 0
+          for name, prs in groups:
+              out += [f"### {_cell(name)}", "", "| PR | Title | Demo video? |",
+                      "| --- | --- | --- |"]
+              for pr in prs:
+                  total += 1
+                  m = _meta(pr)
+                  cell = f"[✅ video]({m['url']})" if m["video"] else "—"
+                  out.append(f"| [#{pr}]({m['url']}) | {m['title']} | {cell} |")
+              out.append("")
+          pathlib.Path("/tmp/demo_table.md").write_text("\n".join(out).rstrip() + ("\n" if out else ""))
+          print(f"Built demo table for {total} PR(s) across {len(groups)} feature(s).")
           PYEOF
 
       - name: Render the release post to MDX

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -308,14 +308,18 @@ jobs:
           # PR refs from the raw body's FEATURE sections, per section — the set of
           # PRs the table is allowed to name (bug fixes are dropped from the post,
           # so from the table too), and the fallback grouping when no formatter map.
-          FEATURE = {"major new features", "breaking changes"}
+          # Match a feature section by its heading TEXT at any level (the release
+          # body uses ### here, older ones ##) — startswith, so "Bug fixes &
+          # hardening" is excluded but "Major new features" matches.
+          FEATURE = ("major new features", "breaking changes")
           ref_re = re.compile(r"#(\d+)")
           raw_sections, current, allowed = [], None, set()
           for ln in body.splitlines():
-              h = re.match(r"##\s+(.*\S)", ln)
+              h = re.match(r"#{2,}\s+(.*\S)", ln)
               if h:
                   name = h.group(1).strip()
-                  current = (name, []) if name.lower() in FEATURE else None
+                  low = name.lower()
+                  current = (name, []) if any(low.startswith(f) for f in FEATURE) else None
                   if current:
                       raw_sections.append(current)
                   continue

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -142,6 +142,92 @@ jobs:
           # fallback if the formatter agent is unavailable or fails.
           cp /tmp/release_body.md /tmp/site_body.md
 
+      # Build a reviewer reference table of the release's FEATURE PRs and whether
+      # each already ships a demo video, so a human filling the `TODO` demo
+      # placeholders can reuse an existing recording instead of re-recording. This
+      # is independent of the LLM reflow (useful for the raw-body fallback too), so
+      # it runs unconditionally; a failure leaves the table empty (best effort).
+      - name: Build demo-video reference table
+        id: demotable
+        continue-on-error: true
+        working-directory: omnigent
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_REPO: ${{ env.SOURCE_REPO }}
+        run: |
+          set -euo pipefail
+          python3 -u <<'PYEOF'
+          import json, os, pathlib, re, subprocess
+          repo = os.environ["SOURCE_REPO"]
+          body = pathlib.Path("/tmp/release_body.md").read_text(encoding="utf-8", errors="replace")
+
+          # Walk the curated body, tracking the current `## <section>`, and collect
+          # the PR refs from each bullet's trailing `(#123, #456)`. Only FEATURE
+          # sections matter — the release post drops bug fixes, so does this table.
+          FEATURE = {"major new features", "breaking changes"}
+          ref_re = re.compile(r"#(\d+)")
+          sections, current, seen = [], None, set()
+          for ln in body.splitlines():
+              h = re.match(r"##\s+(.*\S)", ln)
+              if h:
+                  name = h.group(1).strip()
+                  current = (name, []) if name.lower() in FEATURE else None
+                  if current:
+                      sections.append(current)
+                  continue
+              if current and ln.lstrip().startswith(("-", "*")):
+                  for n in ref_re.findall(ln):
+                      pr = int(n)
+                      if pr not in seen:
+                          seen.add(pr)
+                          current[1].append(pr)
+
+          # Same demo-VIDEO detection as feature-blog.yml: GitHub uploaded-asset
+          # links, bare video URLs, and <video> tags. Images are NOT counted — the
+          # placeholder asks for a recording (a screenshot is a weaker fallback).
+          video_re = re.compile(
+              r"https?://github\.com/user-attachments/assets/[0-9a-f-]+"
+              r"|https?://github\.com/[^/\s)]+/[^/\s)]+/assets/\d+/[0-9a-f-]+"
+              r"|https?://[^\s)]+\.(?:mp4|mov|webm|m4v)\b"
+              r"|<video\b",
+              re.IGNORECASE)
+          def _cell(t):
+              return (t or "").replace("|", "\\|").replace("\n", " ").strip()
+
+          meta_cache = {}
+          def _meta(pr):
+              if pr in meta_cache:
+                  return meta_cache[pr]
+              m = {"title": "", "url": f"https://github.com/{repo}/pull/{pr}", "video": False}
+              try:
+                  d = json.loads(subprocess.run(
+                      ["gh", "pr", "view", str(pr), "--repo", repo,
+                       "--json", "title,body,url"],
+                      capture_output=True, text=True, timeout=60).stdout or "{}")
+                  m["title"] = _cell(d.get("title", ""))
+                  m["url"] = d.get("url") or m["url"]
+                  m["video"] = bool(video_re.search(d.get("body") or ""))
+              except Exception as e:
+                  print(f"::notice::Could not read metadata for PR #{pr}: {e}")
+              meta_cache[pr] = m
+              return m
+
+          out = []
+          for name, prs in sections:
+              if not prs:
+                  continue
+              out += [f"### {name}", "", "| PR | Title | Demo video? |",
+                      "| --- | --- | --- |"]
+              for pr in prs:
+                  m = _meta(pr)
+                  cell = f"[✅ video]({m['url']})" if m["video"] else "—"
+                  out.append(f"| [#{pr}]({m['url']}) | {m['title']} | {cell} |")
+              out.append("")
+          pathlib.Path("/tmp/demo_table.md").write_text("\n".join(out).rstrip() + ("\n" if out else ""))
+          print(f"Built demo table for {len(seen)} feature PR(s) across "
+                f"{sum(1 for _, prs in sections if prs)} section(s).")
+          PYEOF
+
       # --- AI reflow (primary; degrades to the raw release body) ---
       # The GitHub Release itself is untouched — this rewrites its body into the
       # website's narrative, prose-driven post for the site page ONLY.
@@ -305,6 +391,10 @@ jobs:
             echo '```markdown'; cat /tmp/site_body.md; echo '```'
             echo "### Rendered \`app/releases/${VERSION}/page.mdx\`"
             echo '```mdx'; cat /tmp/site_page/page.mdx; echo '```'
+            if [ -s /tmp/demo_table.md ]; then
+              echo "### Source PRs — demo videos (for the \`TODO\` demo placeholders)"
+              cat /tmp/demo_table.md
+            fi
           } | tee -a "$GITHUB_STEP_SUMMARY"
           echo "Dry-run: no token minted, no PR opened."
 
@@ -354,6 +444,11 @@ jobs:
             exit 0
           fi
           body="$(printf 'Publishes the **%s** release post at `/releases/%s` — the curated GitHub Release notes reformatted into the site'"'"'s narrative, prose-driven style.\n\nGenerated by omnigent `.github/workflows/publish-changelog.yml`. Edit the GitHub Release, not this file.' "$TAG" "$VERSION")"
+          # Append the demo-video reference table: which feature PRs already ship a
+          # recording a reviewer can drop into the post'"'"'s `TODO` demo placeholders.
+          if [ -s /tmp/demo_table.md ]; then
+            body="$(printf '%s\n\n### Source PRs — demo videos\nCheck a ✅ PR for a recording to replace a `TODO` demo placeholder in the post.\n\n%s' "$body" "$(cat /tmp/demo_table.md)")"
+          fi
           gh pr create \
             --repo "$SITE_REPO" \
             --base main \
@@ -435,5 +530,6 @@ jobs:
             /tmp/format-stderr.log
             /tmp/format_out.txt
             /tmp/site_body.md
+            /tmp/demo_table.md
           retention-days: 7
           if-no-files-found: ignore


### PR DESCRIPTION
## Related issue

N/A

## Summary

Follow-up to #3698 (which added the demo-video table to the *feature-blog* draft PRs). The `publish-changelog.yml` workflow reformats a published release into a site post (`app/releases/<version>/page.mdx`) that leaves a `![TODO: add a demo screenshot or GIF …](TODO)` placeholder under each feature — with no pointer to the source PRs, some of which already ship a recording.

- New **Build demo-video reference table** step parses the feature PR refs from the curated release body (`## Major new features` / `## Breaking changes` bullets ending in `(#123, #456)`). Bug fixes are dropped from the post, so they're dropped from the table too.
- Detects a **demo video** on each PR with the same logic as `feature-blog.yml`: GitHub uploaded-asset links (`user-attachments/assets/…` and the older `…/<owner>/<repo>/assets/<id>/…`), bare `.mp4/.mov/.webm/.m4v` URLs, and `<video>` tags. Images are **not** counted — the placeholder asks for a recording.
- Injects a per-section `PR | Title | Demo video?` table into the release-post **PR body** (and the **dry-run preview**), so a reviewer can drop an existing ✅ clip into a `TODO` placeholder instead of re-recording.
- Runs independent of the LLM reflow (`continue-on-error`), so it also helps the raw-body fallback and never blocks the publish; leaves the table empty on failure.
- Minor doc note in `release-post-formatter/config.yaml` explaining the table exists (the agent doesn't reference it).

## Test Plan

- `python3 -c "import yaml; yaml.safe_load(...)"` on both changed YAML files — parse OK.
- Ran the section-parsing + video-detection logic standalone: a sample body with Major-features / Breaking / Bug-fixes sections correctly captured feature PRs `[3112, 3123, 2765, 3300]`, deduped, and **excluded** the bug-fix PR `#3400`; the video regex matched an uploaded-asset link and ignored an image.
- `pre-commit run --files .github/workflows/publish-changelog.yml .github/agents/release-post-formatter/config.yaml` — all applicable hooks green (`no-hardcoded-models` passes).

To exercise end-to-end (needs LLM creds):

```
gh workflow run publish-changelog.yml -f tag=v0.3.0 -f dry_run=true
```

The dry-run prints the rendered page **and** the demo-video table to the run log / job summary without opening a PR. Point `-f tag` at a release whose feature PRs include an uploaded video to confirm ✅ detection.

## Demo

N/A — CI workflow change; no product UI. The generated table renders in the release-post PR body / dry-run summary as:

### Major new features

| PR | Title | Demo video? |
| --- | --- | --- |
| #3112 | Omnigent for iOS | ✅ video |
| #2765 | first-class projects | — |

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

CI-only workflow (bash + inline Python) with no unit-test harness. Verified manually: YAML parse of both files, standalone test of the release-body section parsing (feature PRs captured, bug fixes excluded) and video detection, and pre-commit hooks all green.

This pull request and its description were written by Isaac.
