### PR TITLE
build(web): emit source maps from the embed build

### DIFF
--- a/web/vite.embed.config.ts
+++ b/web/vite.embed.config.ts
@@ -265,7 +265,11 @@ export default defineConfig({
     outDir: path.resolve(__dirname, "./dist-embed"),
     emptyOutDir: true,
     cssCodeSplit: false,
-    sourcemap: false,
+    // Emit source maps so downstream bundlers embedding this build (e.g. the
+    // Databricks monolith's rspack/webpack) can chain through to the original
+    // src/** — without them, host-side error stack frames bottom out at
+    // omnigent-embed.js:<line>. Consumed at the host build via source-map-loader.
+    sourcemap: true,
     lib: {
       entry: path.resolve(__dirname, "./src/embed.tsx"),
       formats: ["es"],


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

N/A

## Summary

The embed build had `sourcemap: false`, so downstream bundlers that embed this output (e.g. the Databricks monolith's rspack/webpack) had no input map to chain through — host-side error stacks bottomed out at `omnigent-embed.js:<line>` instead of the original `src/**`.

Flip `sourcemap` to `true` in `vite.embed.config.ts` so hosts can compose maps via `source-map-loader`. `dist-embed` is gitignored, so this ships nothing new to the repo; it only enriches the maps consumers already pull from the build artifact.

## Test Plan

1. From `web/`, run the embed build (e.g. `pnpm build:embed` or the package script that produces `dist-embed`).
2. Confirm `.js.map` (or equivalent) files are emitted next to the embed bundle under `dist-embed/`.
3. In a host that embeds the build with `source-map-loader` (or equivalent), trigger an error in embed code and confirm the stack resolves to `src/**` instead of only `omnigent-embed.js:<line>`.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Build-config only — no runtime behavior change in the app itself. Automated tests don't assert embed sourcemap emission; verification is confirming maps appear in `dist-embed` and that a host with map chaining can resolve stacks to source.