### PR TITLE
fix(web): bump postcss + linkify-it overrides to patched versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ overrides:
   '@tailwindcss/postcss': 4.3.1
   jiti: 2.7.0
   lightningcss: 1.32.0
-  postcss: 8.5.15
-  linkify-it: 5.0.1
+  postcss: 8.5.18
+  linkify-it: 5.0.2
   shiki: 4.2.0
   react: ^18.2.0
   react-dom: ^18.2.0
@@ -381,8 +381,8 @@ importers:
         specifier: ^1.62.0
         version: 1.74.0
       postcss:
-        specifier: 8.5.15
-        version: 8.5.15
+        specifier: 8.5.18
+        version: 8.5.18
       prettier:
         specifier: ^3.8.3
         version: 3.9.5
@@ -6134,8 +6134,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  linkify-it@5.0.1:
-    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   linkifyjs@4.3.3:
     resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
@@ -7074,8 +7074,8 @@ packages:
     resolution: {integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==}
     engines: {node: '>=4'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postject@1.0.0-alpha.6:
@@ -13094,7 +13094,7 @@ snapshots:
     dependencies:
       anser: 2.3.5
       escape-carriage: 1.3.1
-      linkify-it: 5.0.1
+      linkify-it: 5.0.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
@@ -15308,7 +15308,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkify-it@5.0.1:
+  linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
 
@@ -15428,7 +15428,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.1
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
@@ -16542,7 +16542,7 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.15:
+  postcss@8.5.18:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -17535,7 +17535,7 @@ snapshots:
       node-fetch: 3.3.2
       open: 11.0.0
       ora: 8.2.0
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-selector-parser: 7.1.4
       prompts: 2.4.2
       recast: 0.23.12
@@ -18230,7 +18230,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.15
+      postcss: 8.5.18
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -18244,7 +18244,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.15
+      postcss: 8.5.18
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,8 +38,8 @@ overrides:
   '@tailwindcss/postcss': 4.3.1
   jiti: 2.7.0
   lightningcss: 1.32.0
-  postcss: 8.5.15
-  linkify-it: 5.0.1
+  postcss: 8.5.18
+  linkify-it: 5.0.2
   shiki: "catalog:"
   react: "catalog:"
   react-dom: "catalog:"


### PR DESCRIPTION
## Related issue

N/A — resolves two open Dependabot security advisories directly.

## Summary

- `pnpm-workspace.yaml`'s `overrides:` block force-pinned **postcss to 8.5.15** and **linkify-it to 5.0.1**, both flagged by open **high-severity** advisories: postcss [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) (source-map loading) and linkify-it [GHSA-v245-v573-v5vm](https://github.com/advisories/GHSA-v245-v573-v5vm) (quadratic-complexity DoS in the `mailto:` validator).
- Because the override sits **above** `package.json`, the earlier Dependabot bump of postcss to `^8.5.18` (#3385) was **inert** — the lock kept resolving 8.5.15, so the CVE was never actually fixed and the `--frozen-lockfile` gate saw no drift. This is the root cause we traced from that PR.
- Bump both override pins to the patched releases and regenerate the lock: **postcss 8.5.18**, **linkify-it 5.0.2**. This also lets #3037 (the linkify-it PR, which targeted the wrong manifest) be closed.

## Test Plan

- `pnpm install --lockfile-only` regenerated the lock cleanly; the diff is confined to the two override lines, the `web` importer's postcss entry, and the postcss/linkify-it package + snapshot entries (integrity hashes updated to the published 8.5.18 / 5.0.2 tarballs).
- Verified no vulnerable versions remain: `grep -cE '^  postcss@8\.5\.15:|^  linkify-it@5\.0\.1:' pnpm-lock.yaml` → 0.
- Verified no proxy/registry URL introduced into the lock.
- `pre-commit run --files pnpm-workspace.yaml pnpm-lock.yaml` passes (oxlint + yaml/hygiene).
- **Bundle safety (relies on CI):** unlike the vite/tailwind/lightningcss pins in the same override block, postcss and linkify-it are not the bundler — postcss is a same-minor patch of the CSS transform engine, linkify-it is a transitive markdown util (via `markdown-it` / `ansi-to-react`), not imported directly in `web/src`. Neither affects chunk splitting or the Shiki/PDF-worker asset emission the override comment warns about. The Docker build + web test on this PR are the final confirmation.

## Demo

N/A — dependency/security bump, no UI behavior change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified the lockfile diff is scoped and the vulnerable versions are gone; existing web build + E2E UI coverage exercises the CSS pipeline (postcss) and markdown rendering (linkify-it via markdown-it), so a regression from the patch bumps would surface in CI's Docker build / web test / E2E UI.

<!-- Changelog: DELETE — internal dependency security bump, not user-facing. -->
