### PR TITLE
refactor(migrations): type compressed text decoding

### DIFF
--- a/omnigent/db/migrations/versions/z4a2b3c4d5e6_compress_opaque_text_columns.py
+++ b/omnigent/db/migrations/versions/z4a2b3c4d5e6_compress_opaque_text_columns.py
@@ -93,13 +93,19 @@ def _decode(value: object) -> str:
     if isinstance(value, str):
         return value
     if isinstance(value, memoryview):
-        value = value.tobytes()
-    data = bytes(value)
+        data = value.tobytes()
+    elif isinstance(value, bytes):
+        data = value
+    elif isinstance(value, bytearray):
+        data = bytes(value)
+    else:
+        raise TypeError(f"expected binary compressed text, got {type(value).__name__}")
     if not data or data[0] != 0x00:
         return data.decode("utf-8")  # legacy unframed text
     codec, payload = data[1], data[2:]
     if codec == 0x01:  # zstd
-        return zstandard.ZstdDecompressor().decompress(payload).decode("utf-8")
+        decompressed: bytes = zstandard.ZstdDecompressor().decompress(payload)
+        return decompressed.decode("utf-8")
     return payload.decode("utf-8")  # framed, uncompressed
 
 

--- a/omnigent/db/migrations/versions/z9a2b3c4d5e6_compress_policy_host_text_columns.py
+++ b/omnigent/db/migrations/versions/z9a2b3c4d5e6_compress_policy_host_text_columns.py
@@ -91,13 +91,19 @@ def _decode(value: object) -> str:
     if isinstance(value, str):
         return value
     if isinstance(value, memoryview):
-        value = value.tobytes()
-    data = bytes(value)
+        data = value.tobytes()
+    elif isinstance(value, bytes):
+        data = value
+    elif isinstance(value, bytearray):
+        data = bytes(value)
+    else:
+        raise TypeError(f"expected binary compressed text, got {type(value).__name__}")
     if not data or data[0] != 0x00:
         return data.decode("utf-8")  # legacy unframed text
     codec, payload = data[1], data[2:]
     if codec == 0x01:  # zstd
-        return zstandard.ZstdDecompressor().decompress(payload).decode("utf-8")
+        decompressed: bytes = zstandard.ZstdDecompressor().decompress(payload)
+        return decompressed.decode("utf-8")
     return payload.decode("utf-8")  # framed, uncompressed
 
 


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Narrow compressed-text downgrade values to the concrete driver shapes the migrations support: `str`, `bytes`, `bytearray`, and `memoryview`.
- Materialize zstd output as `bytes` before decoding and fail explicitly if a database driver returns an unsupported value type.
- Remove all 6 mypy diagnostics across the two compressed-text migrations, reducing this branch's full-tree baseline from 1,248 to 1,242.

**ELI5:** Migration downgrades now verify that database values are actually text or bytes before decoding them, instead of asking `bytes()` to guess.

```text
DB value -> supported text/binary shape -> optional zstd decode -> plaintext
```

## Test Plan

- `uv run --no-sync mypy --no-incremental omnigent` (1,242 errors; 6 fewer than `main`)
- `pytest -q tests/db/test_migrations_sqlite_safe.py` (2 passed; full migration chain round-trip)
- `SKIP=normalize-uv-lock-registry pre-commit run --all-files` (all non-lockfile hooks pass)

## Demo

N/A — non-visual migration type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The SQLite migration safety suite upgrades and downgrades the complete Alembic chain, exercising both compressed-text migrations in both directions.

## Changelog

N/A — internal migration decoding hardening with no supported-input behavior change.
