### PR TITLE
fix(codex-native): auto-trust workspace when using desktop UI and headless session

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -567,6 +567,10 @@ class CodexNativeAppServer:
         per-session ``config.toml`` at start, or ``None``. Keeps the
         forwarder's config.toml model mirror (and the cost gate's hook
         read) consistent with what the session was launched to run.
+    :param trust_project: Whether to trust :attr:`cwd` in the private
+        session config before startup. Runner-owned headless sessions set
+        this because nobody can answer Codex's project-trust TUI prompt.
+        Interactive CLI sessions leave it disabled.
     :param policy_notice_pending: One-shot flag: ``True`` once a degrade
         reason is recorded, until the runner's terminal-ensure handler
         surfaces it to Omnigent (which posts a single durable banner). Prevents
@@ -595,6 +599,7 @@ class CodexNativeAppServer:
     process_registry_tag: str | None = None
     process_owner_lock: CodexNativeProcessOwnerLock | None = None
     codex_cli_version: tuple[int, int, int] | None = None
+    trust_project: bool = False
 
     async def start(self) -> None:
         """
@@ -611,6 +616,8 @@ class CodexNativeAppServer:
             self.codex_home,
             _codex_home_config_source_from_env(),
         )
+        if self.trust_project:
+            _trust_codex_project(self.codex_home, self.cwd)
         # Write the MCP server config into config.toml so the app-server
         # discovers it at config load. The -c overrides may not be honored
         # by `codex app-server`, so we write directly to the file.
@@ -1191,6 +1198,35 @@ async def trust_native_policy_hooks(client: CodexAppServerClient, *, cwd: str) -
         )
 
 
+def _trust_codex_project(codex_home: Path, cwd: Path) -> None:
+    """
+    Trust a runner-selected workspace in the private Codex config.
+
+    Codex 0.146 introduced a project-trust screen before the remote TUI
+    creates its thread. Headless sessions cannot answer it, so startup waits
+    until Omnigent reports a timeout. The config is already a private copy;
+    this never modifies the user's shared ``~/.codex/config.toml``.
+
+    :param codex_home: Private per-session ``CODEX_HOME`` directory.
+    :param cwd: Workspace selected for this runner-owned session.
+    :returns: None.
+    """
+    config_path = codex_home / "config.toml"
+    existing = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
+    document = tomlkit.parse(existing) if existing else tomlkit.document()
+    projects = document.get("projects")
+    if projects is None:
+        projects = tomlkit.table()
+        document["projects"] = projects
+    project_key = str(cwd.resolve())
+    project = projects.get(project_key)
+    if project is None:
+        project = tomlkit.table()
+        projects[project_key] = project
+    project["trust_level"] = "trusted"
+    config_path.write_text(tomlkit.dumps(document), encoding="utf-8")
+
+
 def build_codex_native_server(
     *,
     socket_path: Path,
@@ -1206,6 +1242,7 @@ def build_codex_native_server(
     extra_config_overrides: list[str] | None = None,
     developer_instructions: str | None = None,
     bypass_sandbox: bool = False,
+    trust_project: bool = False,
 ) -> CodexNativeAppServer:
     """
     Build a configured native Codex app-server process wrapper.
@@ -1240,6 +1277,9 @@ def build_codex_native_server(
         disables both approval prompts and the command sandbox; gated
         behind an explicit, typed-confirmation opt-in in the web UI.
         Default ``False``. See issue #657.
+    :param trust_project: Whether to trust ``cwd`` in the private session
+        config before app-server startup. Intended for runner-owned headless
+        sessions whose hidden TUI cannot answer Codex's project-trust prompt.
     :returns: Configured app-server process wrapper.
     :raises ImportError: If no Codex CLI is available.
     :raises OSError: If Databricks routing was requested but no
@@ -1301,6 +1341,7 @@ def build_codex_native_server(
         ap_auth_headers=ap_auth_headers,
         python_executable=python_executable,
         pinned_model=model,
+        trust_project=trust_project,
     )
 
 

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3658,6 +3658,10 @@ async def _auto_create_codex_terminal(
         ap_server_url=launch_config.policy_server_url,
         ap_auth_headers=policy_headers,
         bypass_sandbox=launch_config.bypass_sandbox,
+        # Codex 0.146 prompts for project trust before creating a thread.
+        # This TUI runs detached for the web UI, so trust the runner-selected
+        # workspace in the session-private config instead of blocking forever.
+        trust_project=True,
     )
     app_server.listen_url = codex_ws_url
     await app_server.start()

--- a/tests/runner/test_app_sessions_native_terminals_runtime.py
+++ b/tests/runner/test_app_sessions_native_terminals_runtime.py
@@ -585,6 +585,7 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
     assert app_server.codex_home == expected_codex_home
     assert build_calls[0]["model"] == "gpt-5.4-mini"
     assert build_calls[0]["cwd"] == tmp_path / "workspace"
+    assert build_calls[0]["trust_project"] is True
     assert "developer_instructions" not in build_calls[0]
     assert len(launched_specs) == 1
     launched = launched_specs[0]

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -14,6 +14,7 @@ from typing import Any
 import click
 import httpx
 import pytest
+import tomllib
 import yaml
 
 from omnigent import codex_native, codex_native_app_server, codex_native_forwarder
@@ -1097,6 +1098,43 @@ def test_build_codex_remote_args_bypass_hook_trust_default_false() -> None:
         remote_url="ws://127.0.0.1:9876",
     )
     assert "--dangerously-bypass-hook-trust" not in args
+
+
+def test_trust_codex_project_updates_private_config_only(tmp_path: Path) -> None:
+    """Headless startup trusts the workspace without changing shared config."""
+    source_config = tmp_path / "shared-config.toml"
+    source_text = '[projects."/existing"]\ntrust_level = "untrusted"\n'
+    source_config.write_text(source_text, encoding="utf-8")
+    codex_home = tmp_path / "private-home"
+    codex_home.mkdir()
+    private_config = codex_home / "config.toml"
+    private_config.write_text(source_text, encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    codex_native_app_server._trust_codex_project(codex_home, workspace)
+
+    parsed = tomllib.loads(private_config.read_text(encoding="utf-8"))
+    assert parsed["projects"][str(workspace.resolve())]["trust_level"] == "trusted"
+    assert parsed["projects"]["/existing"]["trust_level"] == "untrusted"
+    assert source_config.read_text(encoding="utf-8") == source_text
+
+
+def test_build_codex_native_server_does_not_trust_project_by_default(
+    tmp_path: Path,
+) -> None:
+    """Interactive Codex launches retain the normal project trust prompt."""
+    app_server = codex_native_app_server.build_codex_native_server(
+        socket_path=tmp_path / "app.sock",
+        codex_home=tmp_path / "codex-home",
+        cwd=tmp_path / "workspace",
+        model=None,
+        profile=None,
+        bridge_dir=tmp_path / "bridge",
+        codex_path="/opt/codex/bin/codex",
+    )
+
+    assert app_server.trust_project is False
 
 
 def test_codex_app_server_client_uses_codex_remote_handshake(


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Trust the runner-selected workspace in the session-private Codex config for desktop/web-owned native sessions.
- Prevent Codex's project-trust prompt from blocking the hidden TUI before it emits `thread/started`.
- Keep interactive `omnigent codex` behavior unchanged and never modify the user's shared `~/.codex/config.toml`.

**ELI5:** Desktop Codex runs in a terminal the user cannot see. When Codex asks that hidden terminal whether the selected folder is trusted, nobody can answer and startup times out. Omnigent now records trust only in that session's private Codex settings before starting the terminal.

```mermaid
flowchart LR
    A[Desktop selects workspace] --> B[Runner creates private CODEX_HOME]
    B --> C[Mark selected workspace trusted]
    C --> D[Start Codex app-server and hidden TUI]
    D --> E[Codex emits thread/started]
    E --> F[Omnigent chat responds]
```

## Test Plan

- `pre-commit run --all-files`
- `.venv/bin/pytest -q tests/test_codex_native.py -k 'trust_codex_project or build_codex_native_server_does_not_trust_project or build_codex_remote_args_bypass_hook_trust'`
- `.venv/bin/pytest -q tests/runner/test_app_sessions_native_terminals_runtime.py -k 'auto_create_codex_terminal_uses_persisted_resume_launch_config'`
- Manually launched Codex CLI 0.146.0 with a session-private config and untrusted workspace; verified it reached the main TUI without the project or hook review screens.

## Demo

N/A — backend startup behavior only; no desktop UI changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage verifies that trust is written only to the private config and interactive launches remain opt-in. Runner coverage verifies desktop/web-owned sessions request project trust. Manual verification used Codex CLI 0.146.0 against an otherwise untrusted workspace.

## Changelog

Codex sessions opened from the desktop no longer time out while waiting for a hidden project-trust prompt.
