### PR TITLE
refactor(repl): type session log boundaries

### DIFF
--- a/omnigent/repl/_session_log.py
+++ b/omnigent/repl/_session_log.py
@@ -59,10 +59,14 @@ import time
 import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
 from omnigent_client import OmnigentClient
 from omnigent_ui_sdk import state_dir
+
+from omnigent.stores.conversation_store import (
+    ConversationNotFoundError,
+    ConversationStore,
+)
 
 # Schema version — bump only on breaking shape changes. Readers MAY
 # accept earlier versions; writers SHOULD always emit the current
@@ -282,7 +286,7 @@ async def write_session_log(
         visited,
     )
 
-    payload: dict[str, Any] = {
+    payload: dict[str, object] = {
         "version": _LOG_SCHEMA_VERSION,
         "written_at": datetime.now(timezone.utc).isoformat(),
         "format": _LOG_FORMAT,
@@ -297,7 +301,7 @@ async def _build_node_async(
     client: OmnigentClient,
     conversation_id: str,
     visited: set[str],
-) -> dict[str, Any]:
+) -> dict[str, object]:
     """
     Build one node of the session tree (id + items + children)
     via the SDK, recursing into sub-agent children.
@@ -410,7 +414,7 @@ def _extract_child_conversation_ids(items: list[dict[str, object]]) -> list[str]
 
 
 def write_session_log_from_store(
-    conv_store: Any,
+    conv_store: ConversationStore,
     conversation_id: str,
     *,
     agent_name: str,
@@ -444,7 +448,7 @@ def write_session_log_from_store(
     visited: set[str] = set()
     root_node = _build_node_sync(conv_store, conversation_id, visited)
 
-    payload: dict[str, Any] = {
+    payload: dict[str, object] = {
         "version": _LOG_SCHEMA_VERSION,
         "written_at": datetime.now(timezone.utc).isoformat(),
         "format": _LOG_FORMAT,
@@ -456,10 +460,10 @@ def write_session_log_from_store(
 
 
 def _build_node_sync(
-    conv_store: Any,
+    conv_store: ConversationStore,
     conversation_id: str,
     visited: set[str],
-) -> dict[str, Any]:
+) -> dict[str, object]:
     """
     Sync sibling of :func:`_build_node_async`. Same recursion +
     cycle handling, just driven by direct store calls.
@@ -479,6 +483,8 @@ def _build_node_sync(
     visited.add(conversation_id)
 
     conversation = conv_store.get_conversation(conversation_id)
+    if conversation is None:
+        raise ConversationNotFoundError(f"conversation {conversation_id!r} does not exist")
     items = _fetch_all_items_sync(conv_store, conversation_id)
     children = []
     for child_id in _extract_child_conversation_ids(items):
@@ -495,7 +501,10 @@ def _build_node_sync(
     }
 
 
-def _fetch_all_items_sync(conv_store: Any, conversation_id: str) -> list[dict[str, object]]:
+def _fetch_all_items_sync(
+    conv_store: ConversationStore,
+    conversation_id: str,
+) -> list[dict[str, object]]:
     """
     Sync sibling of :func:`_fetch_all_items` that pages through a
     :class:`ConversationStore` directly. See that function's
@@ -561,7 +570,7 @@ async def _fetch_all_items_via_sessions(
             after=cursor,
             order="asc",
         )
-        if not page:
+        if page is None or not page:
             return collected
         collected.extend(page)
         last_id = page[-1].get("id")

--- a/tests/repl/test_session_log.py
+++ b/tests/repl/test_session_log.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from omnigent.entities import (
     FunctionCallOutputData,
     MessageData,
@@ -35,6 +37,7 @@ from omnigent.repl._session_log import (
     default_log_path,
     write_session_log_from_store,
 )
+from omnigent.stores.conversation_store import ConversationNotFoundError
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
@@ -160,6 +163,22 @@ def test_write_session_log_from_store_dumps_basic_conversation(
     user_item, assistant_item = payload["conversation"]["items"]
     assert user_item["data"]["role"] == "user"
     assert assistant_item["data"]["role"] == "assistant"
+
+
+def test_write_session_log_from_store_rejects_missing_conversation(
+    db_uri: str,
+    tmp_path: Path,
+) -> None:
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    missing_id = "0" * 32
+
+    with pytest.raises(ConversationNotFoundError, match=missing_id):
+        write_session_log_from_store(
+            conv_store,
+            missing_id,
+            agent_name="missing_agent",
+            log_dir=tmp_path,
+        )
 
 
 def test_write_session_log_from_store_pages_long_conversations(


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Replace broad session-log `Any` boundaries with concrete JSON object and `ConversationStore` contracts.
- Narrow missing conversations and optional SDK item pages before access, removing all 7 mypy diagnostics from `omnigent/repl/_session_log.py`.
- Preserve the existing dump shape while raising the store's typed not-found exception for absent conversations.

## Test Plan

- `.venv/bin/pytest -q tests/repl/test_session_log.py` (8 passed)
- `.venv/bin/mypy --no-incremental omnigent` (1,203 → 1,196 errors; no target-file diagnostics)
- `SKIP=normalize-uv-lock-registry .venv/bin/pre-commit run --all-files`

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused suite covers basic dumps, pagination, child recursion, deduplication, and the newly explicit missing-conversation path.