### PR TITLE
refactor(codex): type goal request boundaries

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     # Type-only import: the runner keeps codex deps out of its runtime import
     # graph (they are imported lazily inside the codex-native helpers).
     from omnigent.claude_native import ClaudeNativeUcodeConfig
+    from omnigent.codex_native_bridge import CodexNativeBridgeState
     from omnigent.terminals.registry import TerminalListEntry
 
 import click
@@ -3662,7 +3663,7 @@ def create_runner_app(
         *,
         action: str,
         missing_state_log_level: int = logging.WARNING,
-    ) -> Any | None:
+    ) -> CodexNativeBridgeState | None:
         from omnigent.codex_native_bridge import (
             CODEX_NATIVE_BRIDGE_ID_LABEL_KEY,
             bridge_dir_for_bridge_id,

--- a/omnigent/runner/codex/goal.py
+++ b/omnigent/runner/codex/goal.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 import contextlib
 import logging
 from collections.abc import Callable
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from omnigent.codex_native_bridge import CodexNativeBridgeState
 
 from fastapi.responses import JSONResponse, Response
 
@@ -27,7 +30,7 @@ class BridgeStateForSession(Protocol):
         *,
         action: str,
         missing_state_log_level: int = logging.WARNING,
-    ) -> Any | None: ...
+    ) -> CodexNativeBridgeState | None: ...
 
 
 class ClientSafeErrorDetail(Protocol):
@@ -51,7 +54,7 @@ class CodexGoalRunner:
         self._logger = logger
 
     @staticmethod
-    def _goal_to_api(goal: dict[str, Any]) -> dict[str, Any]:
+    def _goal_to_api(goal: dict[str, object]) -> dict[str, object]:
         """
         Convert a Codex app-server goal object to Omnigent API field names.
 
@@ -100,7 +103,7 @@ class CodexGoalRunner:
         }
 
     @staticmethod
-    def _goal_result(response: dict[str, Any], *, action: str) -> dict[str, Any]:
+    def _goal_result(response: dict[str, object], *, action: str) -> dict[str, object]:
         """Extract a JSON-RPC ``result`` object from a Codex goal response."""
         result = response.get("result")
         if not isinstance(result, dict):
@@ -135,8 +138,8 @@ class CodexGoalRunner:
         *,
         action: str,
         method: str,
-        params: dict[str, Any],
-    ) -> dict[str, Any] | JSONResponse:
+        params: dict[str, object],
+    ) -> dict[str, object] | JSONResponse:
         """Execute one Codex app-server goal JSON-RPC request."""
         from omnigent.codex_native_app_server import client_for_transport
 
@@ -205,7 +208,7 @@ class CodexGoalRunner:
         status: str | None,
     ) -> Response:
         """Create or replace the current Codex app-server goal for a thread."""
-        params: dict[str, Any] = {
+        params: dict[str, object] = {
             "objective": objective,
         }
         if token_budget_provided:
@@ -276,7 +279,7 @@ class CodexGoalRunner:
         self,
         conv_id: str,
         body_type: str | None,
-        body: Any,
+        body: object,
         *,
         session_harness_name: Callable[[str], str | None],
     ) -> Response | None:
@@ -302,7 +305,8 @@ class CodexGoalRunner:
         if body_type == "goal_set":
             # The AP route validates this too, but direct runner callers should
             # get a clear 400 instead of an app-server validation error.
-            objective = body.get("objective") if isinstance(body, dict) else None
+            body_payload = body if isinstance(body, dict) else {}
+            objective = body_payload.get("objective")
             if not isinstance(objective, str) or not objective.strip():
                 return JSONResponse(
                     status_code=400,
@@ -319,8 +323,8 @@ class CodexGoalRunner:
                         "detail": "Body 'objective' must be at most 4000 characters",
                     },
                 )
-            token_budget_provided = isinstance(body, dict) and "token_budget" in body
-            token_budget = body.get("token_budget") if token_budget_provided else None
+            token_budget_provided = "token_budget" in body_payload
+            token_budget = body_payload.get("token_budget") if token_budget_provided else None
             if token_budget is not None and (
                 isinstance(token_budget, bool)
                 or not isinstance(token_budget, int)
@@ -333,7 +337,7 @@ class CodexGoalRunner:
                         "detail": "Body 'token_budget' must be a positive integer or null",
                     },
                 )
-            status = body.get("status") if isinstance(body, dict) else None
+            status = body_payload.get("status")
             if status is not None and status not in ("active", "paused"):
                 return JSONResponse(
                     status_code=400,


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Type Codex goal bridge resolution with the existing `CodexNativeBridgeState` contract.
- Replace broad `Any` goal/request payloads with object-valued JSON dictionaries and narrow direct event bodies before access.
- Remove all 6 diagnostics from `runner/codex/goal.py` plus the adjacent bridge callback diagnostic in `runner/app.py`.

## Test Plan

- `.venv/bin/python -c "import omnigent.runner.app; import omnigent.runner.codex.goal"`
- `.venv/bin/pytest -q -rs tests/codex_parity/test_codex_goal.py` (17 skipped; suite requires `--codex-parity` and runs in CI)
- `.venv/bin/mypy --no-incremental omnigent` (1,183 → 1,176 errors; no changed-boundary diagnostics)
- `SKIP=normalize-uv-lock-registry .venv/bin/pre-commit run --all-files`

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing Codex parity suite covers goal set/get/status/clear and malformed payload handling; it is opt-in locally and runs in the repository parity job.