### PR TITLE
refactor(scheduled): type local task ownership

### DIFF
--- a/omnigent/server/routes/scheduled_tasks.py
+++ b/omnigent/server/routes/scheduled_tasks.py
@@ -272,7 +272,7 @@ def create_scheduled_tasks_router(
         )
         return canonical_workspace, validated_model, validated_effort
 
-    def _require_owned(scheduled_task_id: str, owner: str) -> ScheduledTask:
+    def _require_owned(scheduled_task_id: str, owner: str | None) -> ScheduledTask:
         """Load a task the caller owns, or raise 404.
 
         A task owned by someone else 404s (not 403) so tasks aren't


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Widen the scheduled-task ownership helper to accept `str | None`, matching the store contract where local single-user tasks have a null owner.
- Remove the same false-positive argument error from all five get/run/update/delete route call sites.
- Preserve the existing owner comparison and 404 behavior with no runtime changes.

## Test Plan

- `.venv/bin/pytest -q tests/server/integration/test_scheduled_tasks_routes.py` (44 passed)
- `.venv/bin/mypy --no-incremental omnigent` (1,160 → 1,155 errors; no scheduled-task-route diagnostics)
- `SKIP=normalize-uv-lock-registry .venv/bin/pre-commit run --all-files`

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The integration suite covers local and authenticated ownership, cross-user 404s, task CRUD, run history, scheduler synchronization, and validation failures.