### PR TITLE
feat(projects): add per-project monthly LLM spend budgets

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3437,6 +3437,7 @@ def server(
         artifact_store=artifact_store,
         comment_store=comment_store,
         policy_store=policy_store,
+        project_store=project_store,
         caps=caps,
     )
 

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -706,6 +706,12 @@ class SqlProject(OmnigentBase):
     # change. Stored values are hints the new-chat dialog pre-fills and the user
     # can always override.
     config: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Optional monthly spend budget as a compact JSON object
+    # (``{"limit_usd": ..., "ask_thresholds_usd": [...]}) ``), or NULL for "no
+    # budget configured" (unlimited). Same opaque, whole-row JSON blob
+    # convention as ``config``. Read by the project monthly cost-budget
+    # policy; spend itself is tracked separately in ``project_monthly_cost``.
+    budget_config: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     __table_args__ = (
         # "list my projects" — prefix scan on (workspace_id, owner_user_id) with
@@ -1351,6 +1357,56 @@ class SqlUserDailyCost(OmnigentBase):
     )
     user_id: Mapped[str] = mapped_column(String(128), primary_key=True)
     day_utc: Mapped[str] = mapped_column(String(10), primary_key=True)
+    cost_usd: Mapped[float] = mapped_column(Float, nullable=False)
+    ask_approved_usd: Mapped[float] = mapped_column(Float, nullable=False, server_default="0")
+    updated_at: Mapped[int] = mapped_column(Integer)
+
+
+class SqlProjectMonthlyCost(OmnigentBase):
+    """
+    SQLAlchemy model for the ``project_monthly_cost`` table.
+
+    A running per-project, per-UTC-calendar-month rollup of LLM spend, used
+    by the project monthly cost-budget policy (see ``PLAN.md``, closes #1662)
+    to read a project's accumulated month-to-date cost as a single O(1) point
+    lookup, mirroring :class:`SqlUserDailyCost`.
+
+    One row per ``(workspace_id, project_id, month_utc)``. Incremented
+    (UPSERT ``cost_usd = cost_usd + delta``) at each turn boundary from the
+    same cost write sites as ``user_daily_cost`` — but only when the turn's
+    session resolves a ``project_id`` (directly, or via the spawn-tree root
+    for sub-agent sessions, which never carry ``project_id`` themselves) —
+    so the table is never touched for sessions unfiled from a project.
+
+    :param project_id: The project the cost is attributed to
+        (``SqlProject.id``, no DB foreign key — see ``SqlProject``'s
+        docstring on the no-FK convention for project membership).
+    :param month_utc: The UTC calendar month the spend occurred, as
+        ``"YYYY-MM"``, e.g. ``"2026-07"``. Bucketed by the turn's wall-clock
+        time, so a session spanning a month boundary splits its cost across
+        both months correctly.
+    :param cost_usd: Cumulative USD spend for this project in this month.
+    :param ask_approved_usd: Highest soft warning checkpoint (USD) the
+        project owner has already approved continuing past this month —
+        read and written by the project monthly cost-budget policy so an
+        approved checkpoint prompts at most once per month across all the
+        project's sessions. ``0.0`` (the server default) means no
+        checkpoint approved yet.
+    :param updated_at: Unix epoch seconds of the last increment.
+    """
+
+    __tablename__ = "project_monthly_cost"
+
+    # Tenant partition key: Databricks workspace id owning this row (0 = default). Part of the PK.
+    workspace_id: Mapped[int] = mapped_column(
+        BigInteger,
+        primary_key=True,
+        nullable=False,
+        server_default="0",
+        default=current_workspace_id,
+    )
+    project_id: Mapped[str] = mapped_column(String(32), primary_key=True)
+    month_utc: Mapped[str] = mapped_column(String(7), primary_key=True)
     cost_usd: Mapped[float] = mapped_column(Float, nullable=False)
     ask_approved_usd: Mapped[float] = mapped_column(Float, nullable=False, server_default="0")
     updated_at: Mapped[int] = mapped_column(Integer)

--- a/omnigent/db/migrations/versions/e5f6a7b8c9d0_add_budget_config_to_projects.py
+++ b/omnigent/db/migrations/versions/e5f6a7b8c9d0_add_budget_config_to_projects.py
@@ -1,0 +1,45 @@
+"""add budget_config to projects
+
+Revision ID: e5f6a7b8c9d0
+Revises: b3c4d5e6f7a8
+Create Date: 2026-07-30 00:00:00.000000
+
+Adds a nullable ``budget_config`` text column to ``projects`` holding a
+compact JSON object (``{"limit_usd": ..., "ask_thresholds_usd": [...]}``) for
+the project's optional monthly spend budget (see ``PLAN.md``, closes #1662).
+``NULL`` means "no budget configured" (unlimited) — this is an opt-in field,
+so every pre-existing project is unaffected until its owner sets a limit.
+
+Mirrors the existing ``config`` column added in
+``b3c4d5e6f7a8_add_config_to_projects.py``: an opaque, client/policy-owned
+JSON blob that the backend persists and reflects back whole, never filtered
+in SQL.
+
+Additive: a nullable column with no default, so an older server binary
+reading the migrated DB simply ignores it. Rollback is a clean
+``downgrade()`` (drops the column) since no existing data is rewritten.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e5f6a7b8c9d0"
+down_revision: str | None = "b3c4d5e6f7a8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the nullable ``budget_config`` column to ``projects``."""
+    with op.batch_alter_table("projects") as batch_op:
+        batch_op.add_column(sa.Column("budget_config", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop the ``budget_config`` column."""
+    with op.batch_alter_table("projects") as batch_op:
+        batch_op.drop_column("budget_config")

--- a/omnigent/db/migrations/versions/f6a7b8c9d0e1_add_project_monthly_cost_table.py
+++ b/omnigent/db/migrations/versions/f6a7b8c9d0e1_add_project_monthly_cost_table.py
@@ -1,0 +1,60 @@
+"""add project_monthly_cost table
+
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-07-30 00:00:00.000001
+
+Adds the ``project_monthly_cost`` table: a per-project, per-UTC-calendar-month
+rollup of LLM spend used by the project monthly cost-budget policy to read a
+project's accumulated month-to-date cost in O(1) (see ``PLAN.md``, closes
+#1662). One row per ``(workspace_id, project_id, month_utc)``, incremented at
+each turn boundary alongside ``user_daily_cost``.
+
+Mirrors ``user_daily_cost`` (``cad9b3e1f7a2_add_user_daily_cost_table.py`` +
+``d4f1a9c2b8e3_add_ask_approved_to_user_daily_cost.py``) in shape, including
+``ask_approved_usd`` from the start (unlike ``user_daily_cost``, which grew it
+in a follow-up migration) and the ``workspace_id`` tenant-partition column
+that ``user_daily_cost`` only gained via the later
+``r1a2b3c4d5e6_add_workspace_id_to_all_tables.py`` retrofit — this table is
+created after that retrofit landed, so it carries the column from creation.
+
+This is a brand-new table, so it does not affect deployments whose database
+lacks it: the server only ever reads or writes it from policy-gated code
+paths, which are inert when no project has a budget configured.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f6a7b8c9d0e1"
+down_revision: str | None = "e5f6a7b8c9d0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the ``project_monthly_cost`` table."""
+    op.create_table(
+        "project_monthly_cost",
+        sa.Column(
+            "workspace_id",
+            sa.BigInteger(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column("project_id", sa.String(32), nullable=False),
+        sa.Column("month_utc", sa.String(7), nullable=False),
+        sa.Column("cost_usd", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("ask_approved_usd", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("updated_at", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("workspace_id", "project_id", "month_utc"),
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``project_monthly_cost`` table."""
+    op.drop_table("project_monthly_cost")

--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -1047,3 +1047,18 @@ def utc_day(epoch_seconds: int) -> str:
     :returns: The UTC date as ``"YYYY-MM-DD"``, e.g. ``"2026-06-05"``.
     """
     return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).date().isoformat()
+
+
+def utc_month(epoch_seconds: int) -> str:
+    """
+    Return the UTC calendar month for a Unix epoch timestamp.
+
+    The month key used to bucket per-project monthly cost, mirroring
+    :func:`utc_day` one level up: a session spanning a month boundary
+    (UTC) splits its spend across both months. Always UTC so the bucket
+    is unambiguous across deployments.
+
+    :param epoch_seconds: Unix epoch seconds, e.g. ``1749081600``.
+    :returns: The UTC month as ``"YYYY-MM"``, e.g. ``"2026-06"``.
+    """
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).strftime("%Y-%m")

--- a/omnigent/entities/project.py
+++ b/omnigent/entities/project.py
@@ -32,6 +32,10 @@ class Project:
         empty dict when none are stored. The key vocabulary is owned by the
         client; the store persists and returns it whole. These are hints the
         new-chat dialog pre-fills, not enforced requirements.
+    :param budget_config: Optional monthly spend budget as an opaque JSON
+        object (``{"limit_usd": ..., "ask_thresholds_usd": [...]}``), or an
+        empty dict when no budget is configured (unlimited). Read by the
+        project monthly cost-budget policy (see ``PLAN.md``, closes #1662).
     """
 
     id: str
@@ -40,3 +44,4 @@ class Project:
     created_at: int
     updated_at: int | None = None
     config: dict[str, Any] = field(default_factory=dict)
+    budget_config: dict[str, Any] = field(default_factory=dict)

--- a/omnigent/policies/builtins/cost.py
+++ b/omnigent/policies/builtins/cost.py
@@ -72,6 +72,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from omnigent.policies.schema import (
+    PROJECT_MONTHLY_ASK_APPROVED_STATE_KEY,
     SESSION_COST_ASK_APPROVED_STATE_KEY,
     SESSION_COST_UNPRICED_APPROVED_KEY,
     USER_DAILY_ASK_APPROVED_STATE_KEY,
@@ -730,6 +731,192 @@ def user_daily_cost_budget(
                         "state_updates": [
                             {
                                 "key": USER_DAILY_ASK_APPROVED_STATE_KEY,
+                                "action": "set",
+                                "value": crossed,
+                            },
+                        ],
+                    }
+        return _ALLOW
+
+    return evaluate  # type: ignore[return-value]
+
+
+def _project_monthly_cost_usd(event: PolicyEvent) -> float:
+    """Read the session's project's accumulated cost this UTC month (USD).
+
+    Mirrors :func:`_user_daily_cost_usd` one level up.
+
+    :param event: Policy event dict.
+    :returns: ``event["context"]["project_monthly_cost"]["cost_usd"]`` as a
+        float, or ``0.0`` when absent (engine didn't inject it — e.g. no
+        project / not priced), so the gate never trips on missing data.
+    """
+    context = event.get("context") or {}
+    monthly = context.get("project_monthly_cost") or {}
+    raw = monthly.get("cost_usd", 0.0)
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _project_monthly_ask_approved_usd(event: PolicyEvent) -> float:
+    """Read the highest soft checkpoint the project approved this month (USD).
+
+    Mirrors :func:`_user_daily_ask_approved_usd` one level up.
+
+    :param event: Policy event dict.
+    :returns: ``event["context"]["project_monthly_cost"]["ask_approved_usd"]``
+        as a float, or ``0.0`` when absent / none approved yet.
+    """
+    context = event.get("context") or {}
+    monthly = context.get("project_monthly_cost") or {}
+    raw = monthly.get("ask_approved_usd", 0.0)
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def project_monthly_cost_budget(
+    max_cost_usd: float,
+    ask_thresholds_usd: list[float] | None = None,
+    expensive_models: list[str] | None = None,
+) -> PolicyCallable:
+    """Factory: gate on the session's PROJECT's per-UTC-month LLM spend (USD).
+
+    Identical gating logic to :func:`user_daily_cost_budget`, but scoped to
+    the session's **project** (the whole project's cumulative spend this
+    UTC calendar month) instead of its owning user's day. It reads
+    ``event["context"]["project_monthly_cost"]`` (``cost_usd`` /
+    ``ask_approved_usd``), which the policy engine injects — at
+    engine-build time — only when this policy is configured (from the
+    ``project_monthly_cost`` store, attributed to the session's project;
+    a sub-agent session falls back to its spawn-tree root's project). The
+    hard limit and the soft warning checkpoints both gate the ``request``
+    phase (before the LLM turn) and the ``tool_call`` phase (see
+    :func:`cost_budget`).
+
+    Unlike the other budgets in this module, this policy is not normally
+    hand-declared in an agent's YAML: :func:`~omnigent.runtime.policies.builder.build_policy_engine`
+    synthesizes it automatically for any session filed into a project
+    whose ``budget_config`` has a positive ``limit_usd`` (see
+    ``_load_project_budget_policy_specs`` there) — closing #1662. It can
+    still be declared explicitly, the same as any other function policy.
+
+    - **Soft (`ask_thresholds_usd`)**: the first time the project's
+      month-to-date spend crosses a checkpoint, the turn (request phase) or
+      tool call (tool-call phase) is parked for approval (ASK). The approval
+      is recorded **per project+month** (in
+      ``project_monthly_cost.ask_approved_usd`` via a reserved
+      ``state_updates`` key the engine routes to that store), so an approved
+      checkpoint won't re-prompt again this month — including from a
+      different session filed into the same project. A decline blocks that
+      one turn / tool call and re-asks next time.
+    - **Hard (`max_cost_usd`)**: once the project's month-to-date spend
+      reaches the limit, DENY every tool call while the session is on an
+      ``expensive_models`` model (a ``/model`` downgrade gate, not a stop);
+      ALLOW once on a cheaper model. The limit is re-checked live against
+      the project's *current* ``budget_config.limit_usd`` on every turn
+      (the synthesized spec is rebuilt fresh each time the engine is
+      constructed), so a project owner raising the limit unblocks the very
+      next turn — no separate "retry" mechanism is needed.
+
+    Abstains (ALLOW) on every other phase, and whenever the monthly cost
+    is ``0.0`` (no spend recorded, no project, or pricing unavailable).
+
+    :param max_cost_usd: Hard monthly limit in USD. Must be ``> 0``.
+    :param ask_thresholds_usd: Optional soft monthly warning checkpoints
+        in USD, e.g. ``[10.0, 40.0]``. Each value must be ``> 0`` and
+        ``< max_cost_usd``. ``None`` / ``[]`` disables the soft gate.
+    :param expensive_models: Optional case-insensitive substring tokens
+        for the model tiers blocked once over the monthly limit. ``None``
+        (the default) or ``[]`` makes the hard cap a true hard stop —
+        all models are blocked once the limit is reached. Pass an
+        explicit non-empty list for a downgrade gate that only blocks the
+        named tiers.
+    :returns: A policy callable implementing the project monthly budget.
+    :raises ValueError: Same validation as :func:`cost_budget`.
+    """
+    if max_cost_usd <= 0:
+        raise ValueError(f"max_cost_usd must be > 0, got {max_cost_usd!r}")
+    thresholds = sorted({float(t) for t in (ask_thresholds_usd or [])})
+    for t in thresholds:
+        if not (0 < t < max_cost_usd):
+            raise ValueError(
+                f"each ask_thresholds_usd value must be in "
+                f"(0, max_cost_usd={max_cost_usd}), got {t!r}"
+            )
+    cfg = _resolve_expensive_models(expensive_models)
+
+    def evaluate(event: PolicyEvent) -> PolicyResponse:
+        """Evaluate the project monthly cost budget for a request or tool call.
+
+        Mirrors :func:`user_daily_cost_budget`'s ``evaluate`` exactly,
+        reading the project's monthly spend / approval instead of the
+        owner's daily spend, and recording an approved checkpoint to the
+        project+month store (reserved ``state_updates`` key) rather than
+        the user+day store.
+
+        :param event: Policy event dict.
+        :returns: DENY when over the monthly budget on an expensive model;
+            ASK when a new monthly soft checkpoint is newly crossed; ALLOW
+            otherwise.
+        """
+        phase = event.get("type")
+        if phase not in _GATED_PHASES:
+            return _ALLOW
+        context = event.get("context") or {}
+        if _usage_is_unpriced(context.get("usage") or {}):
+            if not (event.get("session_state") or {}).get(_UNPRICED_APPROVED_KEY):
+                return _UNPRICED_ASK
+            return _ALLOW
+        cost = _project_monthly_cost_usd(event)
+        if cfg.hard_cap_enabled and cost >= max_cost_usd:
+            if _model_blocked_over_budget(
+                _current_model(event),
+                cfg.expensive_tokens,
+                cfg.exclude_tokens,
+                block_all=cfg.block_all_models,
+            ):
+                return {
+                    "result": "DENY",
+                    "reason": _over_budget_deny_reason(
+                        cost,
+                        max_cost_usd,
+                        cfg.expensive_tokens,
+                        _current_harness(event),
+                        phase=phase,
+                        policy_label="project monthly cost-budget",
+                        budget_label="project's monthly cost budget",
+                        subject_user="This project",
+                        block_all=cfg.block_all_models,
+                    ),
+                }
+            return _ALLOW
+        # Soft ASK fires on both gated phases — each has a server-side
+        # approval round-trip that persists the checkpoint on accept (see
+        # cost_budget.evaluate).
+        if thresholds:
+            crossed = max((t for t in thresholds if cost >= t), default=None)
+            if crossed is not None:
+                approved_up_to = _project_monthly_ask_approved_usd(event)
+                if crossed > approved_up_to:
+                    return {
+                        "result": "ASK",
+                        "reason": (
+                            f"This project's spend this month ${cost:.2f} passed the "
+                            f"${crossed:.2f} monthly warning threshold (monthly limit "
+                            f"${max_cost_usd:.2f}). Continue?"
+                        ),
+                        # Reserved key — the engine routes this to
+                        # project_monthly_cost.ask_approved_usd (per
+                        # project+month), applied only on approve, so it
+                        # won't re-prompt this month across the project's
+                        # sessions.
+                        "state_updates": [
+                            {
+                                "key": PROJECT_MONTHLY_ASK_APPROVED_STATE_KEY,
                                 "action": "set",
                                 "value": crossed,
                             },

--- a/omnigent/policies/function.py
+++ b/omnigent/policies/function.py
@@ -226,6 +226,14 @@ def _build_event(ctx: EvaluationContext) -> dict[str, Any]:
             # only when the per-user daily cost-budget policy is present;
             # empty dict otherwise (that policy treats it as $0 → never trips).
             "user_daily_cost": dict(ctx.user_daily_cost) if ctx.user_daily_cost else {},
+            # The session's project's per-UTC-month cost rollup
+            # ({"cost_usd", "ask_approved_usd", "project_id"}), injected by
+            # the engine only when the project monthly cost-budget policy is
+            # present; empty dict otherwise (that policy treats it as $0 →
+            # never trips). Mirrors user_daily_cost one level up.
+            "project_monthly_cost": (
+                dict(ctx.project_monthly_cost) if ctx.project_monthly_cost else {}
+            ),
             # The session's current model (model_override or spec llm.model),
             # injected by the engine. ``None`` when undeterminable — cost
             # policies treat that as "cannot confirm a cheaper model".

--- a/omnigent/policies/schema.py
+++ b/omnigent/policies/schema.py
@@ -87,6 +87,14 @@ class UsageContext(TypedDict, total=False):
 # sessions, not just the one conversation.
 USER_DAILY_ASK_APPROVED_STATE_KEY = "_policy_user_daily_ask_approved_usd"
 
+# Reserved ``state_updates`` key the project monthly cost-budget policy
+# emits on an ASK so the engine routes the approved checkpoint to the
+# ``project_monthly_cost.ask_approved_usd`` store column (per project+month)
+# instead of the per-conversation ``session_state``. Mirrors
+# USER_DAILY_ASK_APPROVED_STATE_KEY exactly, one level up (project instead
+# of user). See PLAN.md, closes #1662.
+PROJECT_MONTHLY_ASK_APPROVED_STATE_KEY = "_policy_project_monthly_ask_approved_usd"
+
 # Reserved ``state_updates`` key the per-session cost-budget policy emits on
 # an ASK to record the highest soft checkpoint approved. The cost budget is
 # per-SESSION (the whole spawn tree), but a sub-agent runs as its own
@@ -131,6 +139,33 @@ class UserDailyCostContext(TypedDict, total=False):
     user_id: str
 
 
+class ProjectMonthlyCostContext(TypedDict, total=False):
+    """The session's project's per-UTC-calendar-month LLM cost rollup.
+
+    Injected into the event context only when a policy needs it (the
+    project monthly cost-budget policy is configured); absent / empty
+    otherwise. Read via ``event["context"]["project_monthly_cost"]``.
+    Mirrors :class:`UserDailyCostContext`, one level up (project instead
+    of user, month instead of day). See PLAN.md, closes #1662.
+
+    :param cost_usd: The project's accumulated LLM spend (USD) for the
+        current UTC month, as of this turn's start, e.g. ``12.40``.
+        ``0.0`` when nothing recorded yet / pricing unavailable.
+    :param ask_approved_usd: Highest soft warning checkpoint (USD) the
+        project owner has already approved continuing past this month,
+        so an approved checkpoint does not re-prompt across the
+        project's sessions. ``0.0`` when none approved.
+    :param project_id: The project the rollup belongs to, e.g. a
+        32-char hex id — surfaced so the budget policy can name which
+        project tripped the gate. Absent when the session (and its
+        spawn-tree root) isn't filed into a project.
+    """
+
+    cost_usd: float
+    ask_approved_usd: float
+    project_id: str
+
+
 class EventContext(TypedDict, total=False):
     """Context metadata attached to every policy event.
 
@@ -140,6 +175,11 @@ class EventContext(TypedDict, total=False):
         rollup (``cost_usd`` / ``ask_approved_usd``). Present only when
         the per-user daily cost-budget policy is configured; read via
         ``event["context"]["user_daily_cost"]``.
+    :param project_monthly_cost: The session's project's per-UTC-month
+        cost rollup (``cost_usd`` / ``ask_approved_usd`` /
+        ``project_id``). Present only when the project monthly
+        cost-budget policy is configured; read via
+        ``event["context"]["project_monthly_cost"]``.
     :param model: The model the session is currently using —
         the conversation's ``model_override`` when set (e.g. via a
         mid-session ``/model`` change), else the agent spec's
@@ -163,6 +203,7 @@ class EventContext(TypedDict, total=False):
     actor: ActorContext
     usage: UsageContext
     user_daily_cost: UserDailyCostContext
+    project_monthly_cost: ProjectMonthlyCostContext
     # ``str | None`` (not ``str``): the value is ``ctx.model``, which is
     # ``None`` when the engine could not determine a model — the dict carries
     # ``None``, it is not merely absent. Cost policies treat ``None`` as an
@@ -392,6 +433,7 @@ def request_attachments(data: Any) -> list[dict[str, Any]]:
 
 
 __all__ = [
+    "PROJECT_MONTHLY_ASK_APPROVED_STATE_KEY",
     "USER_DAILY_ASK_APPROVED_STATE_KEY",
     "ActorContext",
     "EventContext",
@@ -399,6 +441,7 @@ __all__ = [
     "PolicyCallableWithConfig",
     "PolicyEvent",
     "PolicyResponse",
+    "ProjectMonthlyCostContext",
     "StateUpdateEntry",
     "UsageContext",
     "UserDailyCostContext",

--- a/omnigent/policies/types.py
+++ b/omnigent/policies/types.py
@@ -151,6 +151,15 @@ class EvaluationContext:
         cost-budget policy is configured) — ``None`` otherwise, so
         sessions without that policy pay no owner/daily-cost lookup.
         Surfaced as ``event["context"]["user_daily_cost"]``.
+    :param project_monthly_cost: The session's project's per-UTC-month
+        cost rollup, shape
+        ``{"cost_usd": <float>, "ask_approved_usd": <float>,
+        "project_id": <str>}``, read from the ``project_monthly_cost``
+        store at engine-build time. Injected ONLY when a policy needs
+        it (the project monthly cost-budget policy is configured) —
+        ``None`` otherwise, so sessions without that policy pay no
+        project-cost lookup. Surfaced as
+        ``event["context"]["project_monthly_cost"]``.
     :param model: The model the session is currently using —
         the conversation's ``model_override`` when set (e.g. via
         a mid-session ``/model`` change), else the agent spec's
@@ -193,6 +202,7 @@ class EvaluationContext:
     usage: dict[str, float] | None = None
     subtree_usage: dict[str, float] | None = None
     user_daily_cost: dict[str, float | str] | None = None
+    project_monthly_cost: dict[str, float | str] | None = None
     model: str | None = None
     harness: str | None = None
     labels: dict[str, str] | None = None

--- a/omnigent/runtime/__init__.py
+++ b/omnigent/runtime/__init__.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     )
     from omnigent.stores.comment_store import CommentStore
     from omnigent.stores.policy_store import PolicyStore
+    from omnigent.stores.project_store import ProjectStore
     from omnigent.terminals import TerminalRegistry
     from omnigent.tools import ToolManager
 
@@ -37,6 +38,7 @@ def init(
     artifact_store: ArtifactStore | None = None,
     comment_store: CommentStore | None = None,
     policy_store: PolicyStore | None = None,
+    project_store: ProjectStore | None = None,
     caps: RuntimeCaps | None = None,
 ) -> None:
     """
@@ -61,6 +63,9 @@ def init(
     :param policy_store: The PolicyStore instance for
         session-scoped policies managed via the CRUD API.
         ``None`` when session policies are not configured.
+    :param project_store: The ProjectStore instance used to resolve a
+        project's ``budget_config`` when building a policy engine.
+        ``None`` when projects are not configured for this deployment.
     :param caps: Operator-configured execution ceiling.
         ``None`` uses :class:`RuntimeCaps` defaults.
     """
@@ -72,6 +77,7 @@ def init(
         artifact_store=artifact_store,
         comment_store=comment_store,
         policy_store=policy_store,
+        project_store=project_store,
         caps=caps,
     )
 
@@ -154,6 +160,19 @@ def get_policy_store() -> PolicyStore | None:
     :returns: The PolicyStore set during :func:`init`, or ``None``.
     """
     return _globals._policy_store
+
+
+def get_project_store() -> ProjectStore | None:
+    """
+    Return the ProjectStore instance, or ``None`` if not configured.
+
+    Returns ``None`` (rather than raising) because project_store is
+    optional — the policy builder simply skips synthesizing a project
+    monthly cost-budget policy when no store is available.
+
+    :returns: The ProjectStore set during :func:`init`, or ``None``.
+    """
+    return _globals._project_store
 
 
 def get_agent_cache() -> AgentCache:

--- a/omnigent/runtime/_globals.py
+++ b/omnigent/runtime/_globals.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     )
     from omnigent.stores.comment_store import CommentStore
     from omnigent.stores.policy_store import PolicyStore
+    from omnigent.stores.project_store import ProjectStore
     from omnigent.terminals import TerminalRegistry
     from omnigent.tools import ToolManager
     from omnigent.tools.base import ToolContext
@@ -36,6 +37,7 @@ _file_store: FileStore | None = None
 _artifact_store: ArtifactStore | None = None
 _comment_store: CommentStore | None = None
 _policy_store: PolicyStore | None = None
+_project_store: ProjectStore | None = None
 _caps: RuntimeCaps = RuntimeCaps()
 
 # Server-resident tmux terminal registry. Initialized in
@@ -169,6 +171,7 @@ def init(
     artifact_store: ArtifactStore | None = None,
     comment_store: CommentStore | None = None,
     policy_store: PolicyStore | None = None,
+    project_store: ProjectStore | None = None,
     caps: RuntimeCaps | None = None,
 ) -> None:
     """
@@ -198,6 +201,12 @@ def init(
         ``None`` when session policies are not configured;
         the policy engine will only use spec-declared
         policies.
+    :param project_store: The ProjectStore instance used to resolve a
+        project's ``budget_config`` when building a policy engine, so a
+        project's monthly cost budget applies automatically to sessions
+        filed into it (see ``PLAN.md``, closes #1662). ``None`` when
+        projects are not configured for this deployment; the policy
+        engine will not synthesize a project budget policy.
     :param caps: Operator-configured execution ceiling.
         ``None`` uses :class:`RuntimeCaps` defaults.
     """
@@ -205,7 +214,7 @@ def init(
 
     global _conversation_store, _agent_store
     global _agent_cache, _file_store, _artifact_store, _caps
-    global _terminal_registry, _comment_store, _policy_store
+    global _terminal_registry, _comment_store, _policy_store, _project_store
     _conversation_store = conversation_store
     _agent_store = agent_store
     _agent_cache = agent_cache
@@ -213,6 +222,7 @@ def init(
     _artifact_store = artifact_store
     _comment_store = comment_store
     _policy_store = policy_store
+    _project_store = project_store
     _caps = caps if caps is not None else RuntimeCaps()
     # Tmux terminal registry: server-resident, conversation-scoped
     # ``inner.terminal.TerminalInstance`` map. See

--- a/omnigent/runtime/policies/builder.py
+++ b/omnigent/runtime/policies/builder.py
@@ -47,6 +47,7 @@ from omnigent.spec.types import (
 )
 from omnigent.stores.conversation_store import ConversationStore
 from omnigent.stores.policy_store import PolicyStore
+from omnigent.stores.project_store import ProjectStore
 
 _logger = logging.getLogger(__name__)
 
@@ -61,6 +62,17 @@ _USER_DAILY_COST_POLICY_PATH = "omnigent.policies.builtins.cost.user_daily_cost_
 # seeded with the subtree-scoped usage ONLY when a policy set includes
 # this handler — otherwise the subtree usage lookup is skipped.
 _SUBAGENT_COST_POLICY_PATH = "omnigent.policies.builtins.cost.subagent_cost_budget"
+
+# Dotted path of the project monthly cost-budget factory. The engine is
+# seeded with the project's monthly-cost rollup ONLY when a policy set
+# includes this handler — mirrors _USER_DAILY_COST_POLICY_PATH one level
+# up. See PLAN.md, closes #1662.
+_PROJECT_MONTHLY_COST_POLICY_PATH = "omnigent.policies.builtins.cost.project_monthly_cost_budget"
+
+# Synthesized policy name for the project-configured monthly budget (see
+# _load_project_budget_policy_specs). A fixed, reserved name — a project
+# has at most one budget, so there's never a naming collision to avoid.
+_PROJECT_MONTHLY_COST_POLICY_NAME = "__project_monthly_cost_budget"
 
 # Hardcoded policy that always ASKs before sys_add_policy executes.
 # Injected unconditionally into every engine so agents cannot add
@@ -118,6 +130,31 @@ def _needs_user_daily_cost(specs: list[PolicySpec]) -> bool:
         isinstance(s, FunctionPolicySpec)
         and s.function is not None
         and s.function.path == _USER_DAILY_COST_POLICY_PATH
+        for s in specs
+    )
+
+
+def _needs_project_monthly_cost(specs: list[PolicySpec]) -> bool:
+    """
+    Return whether any policy in *specs* is the project monthly cost-budget.
+
+    Mirrors :func:`_needs_user_daily_cost` one level up. Drives the
+    conditional injection: only when this returns ``True`` does
+    :func:`build_policy_engine` resolve the session's project and read
+    its monthly-cost rollup. By the time this runs, *specs* already
+    includes any policy synthesized by
+    :func:`_load_project_budget_policy_specs`, so a project with a
+    configured budget always makes this ``True`` without the caller
+    having to declare the policy explicitly in the agent spec.
+
+    :param specs: The merged policy specs for the engine.
+    :returns: ``True`` when a :class:`FunctionPolicySpec` references the
+        ``project_monthly_cost_budget`` factory.
+    """
+    return any(
+        isinstance(s, FunctionPolicySpec)
+        and s.function is not None
+        and s.function.path == _PROJECT_MONTHLY_COST_POLICY_PATH
         for s in specs
     )
 
@@ -234,12 +271,146 @@ def _load_user_daily_cost(
     return state
 
 
+def _resolve_project_id_for_policy(
+    conversation_id: str,
+    conversation_store: ConversationStore,
+) -> str | None:
+    """
+    Resolve the project a session's turn should be attributed/gated to.
+
+    Mirrors ``_resolve_project_id`` in
+    ``omnigent.server.routes._sessions.helpers`` (the turn-boundary cost
+    write path — see ``PLAN.md``, closes #1662): a session's own
+    ``project_id`` wins; a sub-agent conversation never carries one
+    itself, so it falls back to its spawn-tree root's ``project_id``.
+    Duplicated locally (rather than imported) because ``omnigent.runtime``
+    is a lower layer than ``omnigent.server.routes`` and must not depend
+    on it.
+
+    :param conversation_id: The session to resolve, e.g. ``"conv_abc123"``.
+    :param conversation_store: Store for the conversation lookup(s).
+    :returns: The project id to attribute/gate this turn to, or ``None``
+        when the session (and its root, if a sub-agent) is unfiled.
+    """
+    conv = conversation_store.get_conversation(conversation_id)
+    if conv is None:
+        return None
+    if conv.project_id is not None:
+        return conv.project_id
+    if conv.root_conversation_id == conv.id:
+        return None
+    root = conversation_store.get_conversation(conv.root_conversation_id)
+    return root.project_id if root is not None else None
+
+
+def _load_project_monthly_cost(
+    conversation_id: str,
+    conversation_store: ConversationStore,
+) -> dict[str, float | str]:
+    """
+    Read the session's project's per-UTC-month cost rollup as the engine seed.
+
+    Resolves the project (with sub-agent root fallback — see
+    :func:`_resolve_project_id_for_policy`) and reads
+    ``{cost_usd, ask_approved_usd}`` for the current UTC month, tagged
+    with ``project_id`` so the budget policy can name which project
+    tripped the gate and so a later ASK approval
+    (:meth:`PolicyEngine._record_project_monthly_ask_approved`) writes
+    back to the same row this seed read from. Mirrors
+    :func:`_load_user_daily_cost` one level up. When the session (and
+    its root) isn't filed into a project, returns zeros with no
+    ``project_id`` so the budget never trips — consistent with the
+    write path, which also no-ops without a resolvable project.
+
+    :param conversation_id: The session, e.g. ``"conv_abc123"``.
+    :param conversation_store: Store for the project + monthly-cost
+        lookups.
+    :returns: ``{"cost_usd": <float>, "ask_approved_usd": <float>,
+        "project_id": <id>}``; ``project_id`` omitted when unfiled.
+    """
+    from omnigent.db.utils import now_epoch, utc_month
+
+    project_id = _resolve_project_id_for_policy(conversation_id, conversation_store)
+    if project_id is None:
+        return {"cost_usd": 0.0, "ask_approved_usd": 0.0}
+    state: dict[str, float | str] = dict(
+        conversation_store.get_project_monthly_cost_state(project_id, utc_month(now_epoch()))
+    )
+    state["project_id"] = project_id
+    return state
+
+
+def _load_project_budget_policy_specs(
+    conversation_id: str,
+    conversation_store: ConversationStore,
+    project_store: ProjectStore | None,
+) -> list[PolicySpec]:
+    """
+    Synthesize a ``project_monthly_cost_budget`` policy spec, when applicable.
+
+    A project's monthly budget (``Project.budget_config``) is configured
+    through the projects API, not declared in any agent's YAML — so
+    unlike every other policy source merged in :func:`build_policy_engine`,
+    there is nothing in ``spec.guardrails.policies`` /
+    ``policy_store`` / *default_policies* for a budgeted project to
+    attach through. This is that attachment point: when the session (or
+    its spawn-tree root, for a sub-agent) is filed into a project that
+    has a positive ``budget_config["limit_usd"]``, this synthesizes the
+    equivalent of a hand-written
+    ``FunctionPolicySpec(function=FunctionRef(path=".project_monthly_cost_budget", ...))``
+    on the fly, using the project's stored ``limit_usd`` /
+    ``ask_thresholds_usd`` as its arguments. Every session filed into
+    that project — including ones a different, non-owner member creates,
+    if/when project sharing ships (see ``PLAN-2.md``) — picks this up
+    automatically, with no per-session configuration.
+
+    :param conversation_id: The session this workflow is running on.
+    :param conversation_store: Store for resolving the session's project
+        (with sub-agent root fallback).
+    :param project_store: Store for reading the resolved project's
+        ``budget_config``. ``None`` (not every deployment/call site
+        wires one — see ``PLAN.md``'s dependency on PR #3102 for the
+        Docker/Kubernetes entrypoint) skips this entirely: no project
+        lookup, no synthesized policy, existing behavior unchanged.
+    :returns: A single-element list with the synthesized spec, or ``[]``
+        when there's no project, no store, or no positive budget
+        configured.
+    """
+    if project_store is None:
+        return []
+    project_id = _resolve_project_id_for_policy(conversation_id, conversation_store)
+    if project_id is None:
+        return []
+    project = project_store.get_by_id(project_id)
+    if project is None:
+        return []
+    limit_usd = project.budget_config.get("limit_usd")
+    if not isinstance(limit_usd, int | float) or isinstance(limit_usd, bool) or limit_usd <= 0:
+        return []
+    arguments: dict[str, Any] = {"max_cost_usd": float(limit_usd)}
+    thresholds = project.budget_config.get("ask_thresholds_usd")
+    if isinstance(thresholds, list) and thresholds:
+        arguments["ask_thresholds_usd"] = thresholds
+    return [
+        FunctionPolicySpec(
+            name=_PROJECT_MONTHLY_COST_POLICY_NAME,
+            on=None,
+            function=FunctionRef(
+                path=_PROJECT_MONTHLY_COST_POLICY_PATH,
+                arguments=arguments,
+            ),
+        )
+    ]
+
+
 def any_policies_apply(
     *,
     spec: AgentSpec,
     conversation_id: str,
     default_policies: list[PolicySpec] | None,
     policy_store: PolicyStore | None,
+    conversation_store: ConversationStore | None = None,
+    project_store: ProjectStore | None = None,
     phase: Phase | None = None,
     tool_name: str | None = None,
 ) -> bool:
@@ -258,6 +429,20 @@ def any_policies_apply(
     :param default_policies: Server-wide policies from ``RuntimeCaps``.
     :param policy_store: Session-scoped policy store; ``None`` means no DB
         policies are configured.
+    :param conversation_store: Store for resolving the session's project
+        (with sub-agent root fallback), needed only to check for a
+        project-synthesized budget policy. ``None`` skips that check
+        (matching *project_store* ``None``) — callers that don't pass a
+        conversation_store just don't get the project-budget fast path,
+        they still see it once the full engine is built.
+    :param project_store: Project store; when both this and
+        *conversation_store* are given, checks whether the session's
+        project has a configured monthly budget (see
+        :func:`_load_project_budget_policy_specs`) — a project's budget
+        has no entry in *spec* / *policy_store* / *default_policies* to
+        be found by the other checks below, so without this a budgeted
+        project with no other policies would be wrongly fast-pathed past
+        the engine build and never enforced.
     :param phase: The evaluation phase, if known.
     :param tool_name: The tool being called (for ``PHASE_TOOL_CALL`` events).
     :returns: ``False`` when the engine would have an empty policy list and
@@ -278,6 +463,10 @@ def any_policies_apply(
     # this is a cache hit on any call after the first for this session.
     if _load_session_policy_specs(conversation_id, policy_store):
         return True
+    if conversation_store is not None and _load_project_budget_policy_specs(
+        conversation_id, conversation_store, project_store
+    ):
+        return True
     return False
 
 
@@ -289,6 +478,7 @@ def build_policy_engine(
     connection_override: dict[str, str] | None = None,
     default_policies: list[PolicySpec] | None = None,
     policy_store: PolicyStore | None = None,
+    project_store: ProjectStore | None = None,
     server_llm: LLMConfig | None = None,
     host_connection: dict[str, str] | None = None,
 ) -> PolicyEngine:
@@ -341,6 +531,12 @@ def build_policy_engine(
         provided, enabled policies for ``conversation_id`` are
         loaded and inserted between agent and admin policies in
         the evaluation order.
+    :param project_store: Project store used to resolve the session's
+        project (with sub-agent root fallback) and, when that project
+        has a configured monthly budget, synthesize a
+        ``project_monthly_cost_budget`` policy spec automatically — see
+        :func:`_load_project_budget_policy_specs`. ``None`` (the
+        default) skips this: no project lookup, no synthesized policy.
     :param server_llm: Server-level LLM configuration from
         ``RuntimeCaps.llm``. When provided, a
         :class:`~omnigent.policies.types.PolicyLLMClient` is
@@ -376,7 +572,18 @@ def build_policy_engine(
         root_policy_specs = [p for p in root_policy_specs if p.name not in child_names]
         session_policy_specs = root_policy_specs + session_policy_specs
     db_default_policy_specs = _load_default_policy_specs(policy_store)
-    admin_policy_specs: list[PolicySpec] = db_default_policy_specs + list(default_policies or [])
+    # A project's monthly budget is configured through the projects API, not
+    # declared anywhere in the agent spec / policy stores above — this is its
+    # attachment point (see _load_project_budget_policy_specs). Treated like
+    # an admin-controlled default: it runs after session/agent policies and
+    # applies automatically to every session filed into the budgeted project,
+    # with no per-session configuration.
+    project_budget_policy_specs = _load_project_budget_policy_specs(
+        conversation_id, conversation_store, project_store
+    )
+    admin_policy_specs: list[PolicySpec] = (
+        db_default_policy_specs + list(default_policies or []) + project_budget_policy_specs
+    )
     all_policy_specs = session_policy_specs + agent_policy_specs + admin_policy_specs
 
     # Always require user approval before sys_add_policy executes.
@@ -427,6 +634,15 @@ def build_policy_engine(
         if _needs_user_daily_cost(all_policy_specs)
         else None
     )
+    # Conditional injection: only pay the project + monthly-cost lookups
+    # when a project monthly cost-budget policy is actually present (either
+    # declared explicitly, or synthesized above from the project's
+    # budget_config).
+    initial_project_monthly_cost = (
+        _load_project_monthly_cost(conversation_id, conversation_store)
+        if _needs_project_monthly_cost(all_policy_specs)
+        else None
+    )
     initial_model = _resolve_session_model(conversation_id, conversation_store, spec)
     # Pass the full ModelPricing so the engine can price cache-read and
     # cache-write tokens at their own rates via compute_llm_cost().
@@ -458,6 +674,7 @@ def build_policy_engine(
         initial_usage=initial_usage,
         initial_subtree_usage=initial_subtree_usage,
         initial_user_daily_cost=initial_user_daily_cost,
+        initial_project_monthly_cost=initial_project_monthly_cost,
         token_pricing=token_pricing,
         initial_model=initial_model,
         conversation_store=conversation_store,

--- a/omnigent/runtime/policies/engine.py
+++ b/omnigent/runtime/policies/engine.py
@@ -113,6 +113,7 @@ class PolicyEngine:
         initial_usage: dict[str, float] | None = None,
         initial_subtree_usage: dict[str, float] | None = None,
         initial_user_daily_cost: dict[str, float | str] | None = None,
+        initial_project_monthly_cost: dict[str, float | str] | None = None,
         token_pricing: ModelPricing | None = None,
         initial_model: str | None = None,
         conversation_store: ConversationStore,
@@ -158,6 +159,12 @@ class PolicyEngine:
         # ``None`` → not needed → never injected, so no owner/daily lookup
         # cost for sessions that don't use the daily policy.
         self._user_daily_cost = initial_user_daily_cost
+        # The session's project's per-UTC-month cost rollup
+        # ({"cost_usd", "ask_approved_usd", "project_id"}), seeded at build
+        # time ONLY when a policy needs it (project monthly cost-budget
+        # configured). ``None`` → not needed → never injected, mirroring
+        # ``_user_daily_cost`` one level up (project instead of user).
+        self._project_monthly_cost = initial_project_monthly_cost
         self._token_pricing = token_pricing
         self._model = initial_model
         self._store = conversation_store
@@ -344,6 +351,7 @@ class PolicyEngine:
         ctx = self._inject_usage(ctx)
         ctx = self._inject_subtree_usage(ctx)
         ctx = self._inject_user_daily_cost(ctx)
+        ctx = self._inject_project_monthly_cost(ctx)
         ctx = self._inject_model(ctx)
         ctx = self._inject_labels(ctx)
         ctx = self._inject_llm_client(ctx)
@@ -533,22 +541,26 @@ class PolicyEngine:
         if not updates:
             return
         from omnigent.policies.schema import (
+            PROJECT_MONTHLY_ASK_APPROVED_STATE_KEY,
             SESSION_COST_ASK_APPROVED_STATE_KEY,
             SESSION_COST_UNPRICED_APPROVED_KEY,
             USER_DAILY_ASK_APPROVED_STATE_KEY,
         )
 
-        # Two reserved keys are routed off this conversation's session_state:
-        # the per-user daily approval goes to the user+day store column (so it
-        # persists across the user's sessions), and the per-SESSION cost
-        # approval goes to the ROOT conversation (so approving once covers the
-        # whole spawn tree — a sub-agent runs as its own conversation, and
+        # Reserved keys routed off this conversation's session_state: the
+        # per-user daily approval goes to the user+day store column, the
+        # project monthly approval goes to the project+month store column
+        # (mirrors the daily one), and the per-SESSION cost approval goes to
+        # the ROOT conversation (so approving once covers the whole spawn
+        # tree — a sub-agent runs as its own conversation, and
         # build_policy_engine seeds the approval from the root). Every other
         # update lands in this conversation's session_state as usual.
         session_ops = []
         for op in updates:
             if op.key == USER_DAILY_ASK_APPROVED_STATE_KEY:
                 self._record_user_daily_ask_approved(op.value)
+            elif op.key == PROJECT_MONTHLY_ASK_APPROVED_STATE_KEY:
+                self._record_project_monthly_ask_approved(op.value)
             elif (
                 op.key in (SESSION_COST_ASK_APPROVED_STATE_KEY, SESSION_COST_UNPRICED_APPROVED_KEY)
                 and self._root_conversation_id != self._conversation_id
@@ -617,6 +629,43 @@ class PolicyEngine:
         # approval stays current via _apply_one(self._session_state, ...).
         if self._user_daily_cost is not None:
             self._user_daily_cost["ask_approved_usd"] = approved
+
+    def _record_project_monthly_ask_approved(self, value: Any) -> None:
+        """
+        Persist a project monthly cost-budget ASK approval.
+
+        Writes the approved soft-checkpoint value to the project's
+        ``project_monthly_cost.ask_approved_usd`` for the current UTC
+        month, so the same checkpoint won't re-prompt for that project
+        again this month (including from other sessions filed into it).
+        Mirrors :meth:`_record_user_daily_ask_approved`, but resolves the
+        target project from ``self._project_monthly_cost["project_id"]``
+        (set at build time by ``_load_project_monthly_cost``, which
+        already applied the sub-agent root-conversation fallback) rather
+        than re-resolving here — so a sub-agent's approval lands on the
+        same project row its threshold check read from. A no-op when the
+        engine wasn't seeded with a project (unfiled session) or *value*
+        is not numeric.
+
+        :param value: The crossed checkpoint value (USD) the project
+            owner approved, e.g. ``50.0``.
+        """
+        if value is None or self._project_monthly_cost is None:
+            return
+        project_id = self._project_monthly_cost.get("project_id")
+        if not isinstance(project_id, str) or not project_id:
+            return
+        try:
+            approved = float(value)
+        except (TypeError, ValueError):
+            return
+        from omnigent.db.utils import now_epoch, utc_month
+
+        self._store.set_project_monthly_ask_approved(project_id, utc_month(now_epoch()), approved)
+        # Keep the in-memory snapshot current so any later evaluate() on
+        # this engine sees the approval and doesn't re-ASK the checkpoint
+        # just approved — mirroring the daily-cost counterpart above.
+        self._project_monthly_cost["ask_approved_usd"] = approved
 
     def record_usage(
         self,
@@ -735,6 +784,26 @@ class PolicyEngine:
         if self._user_daily_cost is None:
             return ctx
         return replace(ctx, user_daily_cost=dict(self._user_daily_cost))
+
+    def _inject_project_monthly_cost(self, ctx: EvaluationContext) -> EvaluationContext:
+        """
+        Return a copy of *ctx* with ``project_monthly_cost`` populated, when seeded.
+
+        Injects the session's project's per-UTC-month cost rollup (read once
+        at engine-build time) so the project monthly cost-budget policy can
+        read it via ``event["context"]["project_monthly_cost"]`` without
+        re-querying the store. Mirrors :meth:`_inject_user_daily_cost` one
+        level up. When the engine was built without it (``None`` — no
+        policy needs it, or the session isn't filed into a project), *ctx*
+        is returned unchanged.
+
+        :param ctx: Original :class:`EvaluationContext` from the caller.
+        :returns: *ctx* unchanged when no project monthly cost was seeded,
+            else a copy with ``project_monthly_cost`` set to a defensive copy.
+        """
+        if self._project_monthly_cost is None:
+            return ctx
+        return replace(ctx, project_monthly_cost=dict(self._project_monthly_cost))
 
     def _inject_model(self, ctx: EvaluationContext) -> EvaluationContext:
         """

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2425,6 +2425,7 @@ def create_app(
         app.include_router(
             create_projects_router(
                 project_store=project_store,
+                conversation_store=conversation_store,
                 auth_provider=auth_provider,
             ),
             prefix="/v1",

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -72,6 +72,7 @@ from omnigent.runner.routing import RunnerRouter
 from omnigent.runner.transports.ws_tunnel.registry import TunnelRegistry
 from omnigent.runtime import (
     get_policy_store,
+    get_project_store,
     inflight_text,
     pending_elicitations,
     pending_inputs,
@@ -1705,13 +1706,52 @@ def _utc_day(epoch_seconds: int) -> str:
     return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).date().isoformat()
 
 
+def _utc_month(epoch_seconds: int) -> str:
+    """
+    Convert a Unix epoch timestamp to its UTC calendar month.
+
+    :param epoch_seconds: Unix epoch seconds, e.g. ``1749081600``.
+    :returns: The UTC month as ``"YYYY-MM"``, e.g. ``"2026-06"``.
+    """
+    from datetime import datetime, timezone
+
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).strftime("%Y-%m")
+
+
+def _resolve_project_id(conv: Conversation, conversation_store: ConversationStore) -> str | None:
+    """
+    Resolve the project a turn's cost should be attributed to, if any.
+
+    Sub-agent conversations never carry ``project_id`` themselves — only
+    the top-level session a user explicitly files into a project does —
+    so a spawned child falls back to its spawn-tree root's
+    ``project_id``, mirroring the owner fallback in
+    :func:`_record_daily_cost`. This keeps sub-agent spend inside the
+    project monthly rollup instead of silently escaping it whenever the
+    parent session is filed into a budgeted project.
+
+    :param conv: The conversation row for the session that incurred the
+        cost.
+    :param conversation_store: Store for the root-session lookup.
+    :returns: The project id to attribute the cost to, or ``None`` when
+        the session (and its root, if a sub-agent) is unfiled.
+    """
+    if conv.project_id is not None:
+        return conv.project_id
+    if conv.root_conversation_id == conv.id:
+        return None
+    root = conversation_store.get_conversation(conv.root_conversation_id)
+    return root.project_id if root is not None else None
+
+
 def _record_daily_cost(
     conv: Conversation | None,
     delta_usd: float,
     conversation_store: ConversationStore,
 ) -> None:
     """
-    Add a turn's LLM cost to the session owner's daily rollup.
+    Add a turn's LLM cost to the session owner's daily rollup, and to its
+    project's monthly rollup when the session is filed into one.
 
     A no-op when *delta_usd* is not positive or the session has no
     resolvable owner. Attributes the cost to the session creator
@@ -1736,11 +1776,16 @@ def _record_daily_cost(
     is attributed to the same user as the parent rather than silently
     dropped from the daily rollup.
 
+    The project monthly rollup (see :func:`_resolve_project_id`) uses the
+    same root-fallback idea for ``project_id`` and is skipped entirely
+    (no row ever created) when neither the session nor its root is filed
+    into a project.
+
     :param conv: The conversation row for the session, or ``None``
         (a no-op — no owner to attribute to).
     :param delta_usd: The turn's cost in USD; ``<= 0`` is a no-op.
-    :param conversation_store: Store for the owner lookup and the
-        daily-cost UPSERT.
+    :param conversation_store: Store for the owner/project lookups and
+        the daily-cost / monthly-cost UPSERTs.
     """
     if conv is None or delta_usd <= 0:
         return
@@ -1749,11 +1794,14 @@ def _record_daily_cost(
         # Sub-agent: no direct owner grant — fall back to the root session's
         # owner so sub-agent spend is attributed rather than silently dropped.
         owner = conversation_store.get_session_owner(conv.root_conversation_id)
-    if owner is None:
-        return
     from omnigent.db.utils import now_epoch
 
-    conversation_store.add_daily_cost(owner, _utc_day(now_epoch()), delta_usd)
+    now = now_epoch()
+    if owner is not None:
+        conversation_store.add_daily_cost(owner, _utc_day(now), delta_usd)
+    project_id = _resolve_project_id(conv, conversation_store)
+    if project_id is not None:
+        conversation_store.add_project_monthly_cost(project_id, _utc_month(now), delta_usd)
 
 
 def _priced_cost_for_display(usage: dict[str, Any]) -> float | None:
@@ -6317,6 +6365,7 @@ def _build_policy_engine_from_spec_impl(
         conversation_store=conversation_store,
         default_policies=caps.default_policies,
         policy_store=get_policy_store(),
+        project_store=get_project_store(),
         server_llm=caps.llm,
         host_connection=host_connection,
     )
@@ -6771,7 +6820,12 @@ async def _evaluate_output_policy(
     spec = await asyncio.to_thread(_load_agent_spec_for_session, conv, agent_store)
     if spec is None:
         return None
-    if not spec.guardrails and not get_caps().default_policies and get_policy_store() is None:
+    if (
+        not spec.guardrails
+        and not get_caps().default_policies
+        and get_policy_store() is None
+        and get_project_store() is None
+    ):
         return None
 
     engine = await asyncio.to_thread(

--- a/omnigent/server/routes/projects.py
+++ b/omnigent/server/routes/projects.py
@@ -28,6 +28,7 @@ from omnigent.server.schemas import (
     CreateProjectRequest,
     UpdateProjectRequest,
 )
+from omnigent.stores.conversation_store import ConversationStore
 from omnigent.stores.project_store import ProjectStore
 
 
@@ -44,16 +45,22 @@ def _to_response(project: Project) -> dict[str, Any]:
         "created_at": project.created_at,
         "updated_at": project.updated_at,
         "config": project.config,
+        "budget_config": project.budget_config,
     }
 
 
 def create_projects_router(
     project_store: ProjectStore,
+    conversation_store: ConversationStore,
     auth_provider: AuthProvider | None = None,
 ) -> APIRouter:
     """Build the projects router (``/v1/projects``).
 
     :param project_store: The store backing project persistence.
+    :param conversation_store: The store backing the project monthly
+        cost-budget rollup (``project_monthly_cost``), read by
+        ``GET /projects/{project_id}/budget``. See ``PLAN.md``, closes
+        #1662.
     :param auth_provider: Auth provider used to identify the requesting user.
         ``None`` in single-user mode (owner scope is ``None``).
     :returns: A configured :class:`APIRouter`.
@@ -80,6 +87,7 @@ def create_projects_router(
             body.name,
             user_id,
             body.config,
+            body.budget_config,
         )
         return _to_response(project)
 
@@ -134,10 +142,47 @@ def create_projects_router(
             owner_user_id=user_id,
             name=body.name,
             config=body.config,
+            budget_config=body.budget_config,
         )
         if project is None:
             raise OmnigentError("Project not found", code=ErrorCode.NOT_FOUND)
         return _to_response(project)
+
+    @router.get("/projects/{project_id}/budget")
+    async def get_project_budget(request: Request, project_id: str) -> dict[str, Any]:
+        """Return the caller's project's budget config and current spend.
+
+        Reports the project's month-to-date spend against its configured
+        monthly limit (see ``PLAN.md``, closes #1662). A project with no
+        ``budget_config`` reports ``limit_usd: None`` (unlimited); spend is
+        still reported so the owner can see month-to-date cost even without
+        a configured cap.
+
+        :param request: The incoming request, used to identify the user.
+        :param project_id: The project to report on.
+        :returns: ``{"object": "project.budget", "limit_usd": <float|None>,
+            "ask_thresholds_usd": [...], "spend_usd": <float>,
+            "month_utc": "YYYY-MM"}``.
+        :raises OmnigentError: 401 if unauthenticated, 404 if not found / not
+            owned by the caller.
+        """
+        from omnigent.db.utils import now_epoch, utc_month
+
+        user_id = require_user(request, auth_provider)
+        project = await asyncio.to_thread(project_store.get, project_id, owner_user_id=user_id)
+        if project is None:
+            raise OmnigentError("Project not found", code=ErrorCode.NOT_FOUND)
+        month_utc = utc_month(now_epoch())
+        state = await asyncio.to_thread(
+            conversation_store.get_project_monthly_cost_state, project_id, month_utc
+        )
+        return {
+            "object": "project.budget",
+            "limit_usd": project.budget_config.get("limit_usd"),
+            "ask_thresholds_usd": project.budget_config.get("ask_thresholds_usd") or [],
+            "spend_usd": state["cost_usd"],
+            "month_utc": month_utc,
+        }
 
     @router.delete("/projects/{project_id}")
     async def delete_project(request: Request, project_id: str) -> dict[str, Any]:

--- a/omnigent/server/routes/sessions/routes_hooks.py
+++ b/omnigent/server/routes/sessions/routes_hooks.py
@@ -23,6 +23,7 @@ from omnigent.runtime import (
     get_agent_cache,
     get_caps,
     get_policy_store,
+    get_project_store,
     pending_inputs,
 )
 from omnigent.runtime.agent_cache import AgentCache
@@ -558,6 +559,8 @@ def register_hooks_routes(
             conversation_id=session_id,
             default_policies=_caps.default_policies,
             policy_store=get_policy_store(),
+            conversation_store=conversation_store,
+            project_store=get_project_store(),
             phase=phase,
             tool_name=data.get("name") if isinstance(data, dict) else None,
         ):
@@ -588,6 +591,7 @@ def register_hooks_routes(
                 conversation_store=conversation_store,
                 default_policies=_caps.default_policies,
                 policy_store=get_policy_store(),
+                project_store=get_project_store(),
                 server_llm=_caps.llm,
                 host_connection=_host_conn,
             )

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -4286,6 +4286,45 @@ class SessionProjectSummary(BaseModel):
     name: str
 
 
+def _validate_project_budget_config(value: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Validate a project's ``budget_config`` shape, shared by create/update.
+
+    Mirrors the validation
+    :func:`omnigent.policies.builtins.cost.project_monthly_cost_budget`
+    itself applies at policy-build time, but at the API boundary so a
+    malformed budget is rejected immediately (422) rather than silently
+    never taking effect (the policy builder skips synthesis rather than
+    raising on a bad stored value — see
+    ``_load_project_budget_policy_specs`` — since a background workflow
+    build is the wrong place to surface a validation error to the user).
+
+    :param value: The raw ``budget_config`` from the request, or ``None`` /
+        ``{}`` (no budget / leave-unchanged / clear — callers distinguish
+        those, this only validates shape when a limit is present).
+    :returns: *value* unchanged, once validated.
+    :raises ValueError: If ``limit_usd`` is present but not a positive
+        number, or any ``ask_thresholds_usd`` entry is not in
+        ``(0, limit_usd)``.
+    """
+    if not value:
+        return value
+    limit_usd = value.get("limit_usd")
+    if limit_usd is None:
+        return value
+    if not isinstance(limit_usd, int | float) or isinstance(limit_usd, bool) or limit_usd <= 0:
+        raise ValueError(f"budget_config.limit_usd must be a positive number, got {limit_usd!r}")
+    thresholds = value.get("ask_thresholds_usd") or []
+    if not isinstance(thresholds, list):
+        raise ValueError("budget_config.ask_thresholds_usd must be a list of numbers")
+    for t in thresholds:
+        if not isinstance(t, int | float) or isinstance(t, bool) or not (0 < t < limit_usd):
+            raise ValueError(
+                "each budget_config.ask_thresholds_usd value must be a number in "
+                f"(0, limit_usd={limit_usd}), got {t!r}"
+            )
+    return value
+
+
 class CreateProjectRequest(BaseModel):
     """
     Request body for ``POST /v1/projects``.
@@ -4294,12 +4333,23 @@ class CreateProjectRequest(BaseModel):
         at most 100 characters; unique among the caller's projects.
     :param config: Optional default session settings (opaque JSON object).
         Omitted / empty stores no defaults.
+    :param budget_config: Optional monthly spend budget,
+        ``{"limit_usd": <float>, "ask_thresholds_usd": [<float>, ...]}``.
+        Omitted / empty means no budget (unlimited). See ``PLAN.md``,
+        closes #1662.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     name: str
     config: dict[str, Any] = Field(default_factory=dict)
+    budget_config: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("budget_config")
+    @classmethod
+    def _validate_budget_config(cls, value: dict[str, Any]) -> dict[str, Any]:
+        """Validate ``budget_config`` shape; see :func:`_validate_project_budget_config`."""
+        return _validate_project_budget_config(value) or {}
 
     @field_validator("name")
     @classmethod
@@ -4328,12 +4378,23 @@ class UpdateProjectRequest(BaseModel):
         trimmed, non-empty, at most 100 characters.
     :param config: New config object to replace the stored one. ``None`` leaves
         it unchanged; an empty object ``{}`` clears the stored defaults.
+    :param budget_config: New monthly budget object to replace the stored
+        one, ``{"limit_usd": <float>, "ask_thresholds_usd": [<float>, ...]}``.
+        ``None`` leaves it unchanged; an empty object ``{}`` clears the
+        budget (unlimited). See ``PLAN.md``, closes #1662.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     name: str | None = None
     config: dict[str, Any] | None = None
+    budget_config: dict[str, Any] | None = None
+
+    @field_validator("budget_config")
+    @classmethod
+    def _validate_budget_config(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Validate ``budget_config`` shape; see :func:`_validate_project_budget_config`."""
+        return _validate_project_budget_config(value)
 
     @field_validator("name")
     @classmethod

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1125,6 +1125,70 @@ class ConversationStore(ABC):
         ...
 
     @abstractmethod
+    def add_project_monthly_cost(self, project_id: str, month_utc: str, delta_usd: float) -> None:
+        """
+        Atomically add *delta_usd* to a project's spend for one UTC month.
+
+        UPSERTs the ``project_monthly_cost`` row keyed by
+        ``(project_id, month_utc)``: inserts ``delta_usd`` when no row
+        exists, otherwise increments the existing ``cost_usd`` by
+        ``delta_usd`` in a single atomic statement — mirrors
+        :meth:`add_daily_cost`. Powers the project monthly cost-budget
+        policy's project spend reads. Callers gate this on the turn's
+        session resolving a ``project_id`` (directly, or via the
+        spawn-tree root for sub-agent sessions), so the table is
+        untouched for sessions unfiled from a project.
+
+        :param project_id: The project the cost is attributed to,
+            e.g. ``"a1b2c3d4e5f6..."``.
+        :param month_utc: UTC calendar month as ``"YYYY-MM"``, e.g.
+            ``"2026-07"``.
+        :param delta_usd: USD amount to add. A no-op when ``<= 0`` so a
+            zero-cost turn never creates a row.
+        """
+        ...
+
+    @abstractmethod
+    def get_project_monthly_cost_state(self, project_id: str, month_utc: str) -> dict[str, float]:
+        """
+        Return a project's monthly cost rollup state for one UTC month.
+
+        Reads both the accumulated spend and the highest soft
+        checkpoint already approved that month, in one lookup — what
+        the project monthly cost-budget policy needs. Mirrors
+        :meth:`get_daily_cost_state`.
+
+        :param project_id: The project to read.
+        :param month_utc: UTC calendar month as ``"YYYY-MM"``, e.g.
+            ``"2026-07"``.
+        :returns: ``{"cost_usd": <float>, "ask_approved_usd": <float>}``;
+            both ``0.0`` when no row exists for ``(project_id, month_utc)``.
+        """
+        ...
+
+    @abstractmethod
+    def set_project_monthly_ask_approved(
+        self, project_id: str, month_utc: str, ask_approved_usd: float
+    ) -> None:
+        """
+        Record the highest approved soft checkpoint for a project+month.
+
+        Sets ``ask_approved_usd`` without altering ``cost_usd`` (insert
+        with ``cost_usd = 0`` when no row exists, else update only the
+        approval field). Called when a project monthly cost-budget ASK
+        is approved, so an approved checkpoint does not re-prompt for
+        that project again the same month — including from other
+        sessions filed into it. Mirrors :meth:`set_daily_ask_approved`.
+
+        :param project_id: The project the approval is for.
+        :param month_utc: UTC calendar month as ``"YYYY-MM"``, e.g.
+            ``"2026-07"``.
+        :param ask_approved_usd: The crossed checkpoint value (USD) the
+            project owner approved continuing past, e.g. ``50.0``.
+        """
+        ...
+
+    @abstractmethod
     def get_session_owner(self, conversation_id: str) -> str | None:
         """
         Return the user id that owns a session (its creator).

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -35,6 +35,7 @@ from omnigent.db.db_models import (
     SqlConversationMetadata,
     SqlPolicy,
     SqlProject,
+    SqlProjectMonthlyCost,
     SqlSessionPermission,
     SqlUserDailyCost,
     current_workspace_id,
@@ -1596,6 +1597,149 @@ class SqlAlchemyConversationStore(ConversationStore):
                     SqlUserDailyCost(
                         user_id=user_id,
                         day_utc=day_utc,
+                        cost_usd=0.0,
+                        ask_approved_usd=ask_approved_usd,
+                        updated_at=now,
+                    )
+                )
+            else:
+                existing.ask_approved_usd = ask_approved_usd  # type: ignore[assignment]
+                existing.updated_at = now  # type: ignore[assignment]
+
+    def add_project_monthly_cost(self, project_id: str, month_utc: str, delta_usd: float) -> None:
+        """
+        Atomically add *delta_usd* to a project's spend for one UTC month.
+
+        Mirrors :meth:`add_daily_cost`, keyed by
+        ``(workspace_id, project_id, month_utc)`` instead of
+        ``(workspace_id, user_id, day_utc)``.
+
+        :param project_id: The project the cost is attributed to.
+        :param month_utc: UTC month as ``"YYYY-MM"``, e.g. ``"2026-07"``.
+        :param delta_usd: USD amount to add; ``<= 0`` is a no-op.
+        """
+        if delta_usd <= 0:
+            return
+        now = now_epoch()
+        with self._session() as session:
+            dialect = session.bind.dialect.name if session.bind is not None else ""
+            if dialect in ("sqlite", "postgresql"):
+                stmt: Any
+                if dialect == "sqlite":
+                    from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+                    stmt = sqlite_insert(SqlProjectMonthlyCost)
+                else:
+                    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+                    stmt = pg_insert(SqlProjectMonthlyCost)
+                stmt = stmt.values(
+                    project_id=project_id,
+                    month_utc=month_utc,
+                    cost_usd=delta_usd,
+                    updated_at=now,
+                )
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["workspace_id", "project_id", "month_utc"],
+                    set_={
+                        "cost_usd": SqlProjectMonthlyCost.cost_usd + stmt.excluded.cost_usd,
+                        "updated_at": stmt.excluded.updated_at,
+                    },
+                )
+                session.execute(stmt)
+                return
+            # Generic dialect fallback — SELECT-then-INSERT/UPDATE in one
+            # transaction.
+            existing = session.get(
+                SqlProjectMonthlyCost, (current_workspace_id(), project_id, month_utc)
+            )
+            if existing is None:
+                session.add(
+                    SqlProjectMonthlyCost(
+                        project_id=project_id,
+                        month_utc=month_utc,
+                        cost_usd=delta_usd,
+                        updated_at=now,
+                    )
+                )
+            else:
+                existing.cost_usd = existing.cost_usd + delta_usd  # type: ignore[assignment]
+                existing.updated_at = now  # type: ignore[assignment]
+
+    def get_project_monthly_cost_state(self, project_id: str, month_utc: str) -> dict[str, float]:
+        """
+        Return a project's monthly cost rollup state for one UTC month.
+
+        Mirrors :meth:`get_daily_cost_state`.
+
+        :param project_id: The project to read.
+        :param month_utc: UTC month as ``"YYYY-MM"``, e.g. ``"2026-07"``.
+        :returns: ``{"cost_usd": <float>, "ask_approved_usd": <float>}``;
+            both ``0.0`` when no row exists for ``(project_id, month_utc)``.
+        """
+        with self._session() as session:
+            row = session.get(
+                SqlProjectMonthlyCost, (current_workspace_id(), project_id, month_utc)
+            )
+            if row is None:
+                return {"cost_usd": 0.0, "ask_approved_usd": 0.0}
+            return {
+                "cost_usd": float(row.cost_usd),
+                "ask_approved_usd": float(row.ask_approved_usd or 0.0),
+            }
+
+    def set_project_monthly_ask_approved(
+        self, project_id: str, month_utc: str, ask_approved_usd: float
+    ) -> None:
+        """
+        Record the highest approved soft checkpoint for a project+month.
+
+        Mirrors :meth:`set_daily_ask_approved`: UPSERT that sets
+        ``ask_approved_usd`` without touching ``cost_usd``.
+
+        :param project_id: The project the approval is for.
+        :param month_utc: UTC month as ``"YYYY-MM"``, e.g. ``"2026-07"``.
+        :param ask_approved_usd: The crossed checkpoint value (USD) the
+            project owner approved continuing past.
+        """
+        now = now_epoch()
+        with self._session() as session:
+            dialect = session.bind.dialect.name if session.bind is not None else ""
+            if dialect in ("sqlite", "postgresql"):
+                stmt: Any
+                if dialect == "sqlite":
+                    from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+                    stmt = sqlite_insert(SqlProjectMonthlyCost)
+                else:
+                    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+                    stmt = pg_insert(SqlProjectMonthlyCost)
+                stmt = stmt.values(
+                    project_id=project_id,
+                    month_utc=month_utc,
+                    cost_usd=0.0,
+                    ask_approved_usd=ask_approved_usd,
+                    updated_at=now,
+                )
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["workspace_id", "project_id", "month_utc"],
+                    set_={
+                        "ask_approved_usd": stmt.excluded.ask_approved_usd,
+                        "updated_at": stmt.excluded.updated_at,
+                    },
+                )
+                session.execute(stmt)
+                return
+            # Generic dialect fallback — SELECT-then-INSERT/UPDATE.
+            existing = session.get(
+                SqlProjectMonthlyCost, (current_workspace_id(), project_id, month_utc)
+            )
+            if existing is None:
+                session.add(
+                    SqlProjectMonthlyCost(
+                        project_id=project_id,
+                        month_utc=month_utc,
                         cost_usd=0.0,
                         ask_approved_usd=ask_approved_usd,
                         updated_at=now,

--- a/omnigent/stores/project_store/__init__.py
+++ b/omnigent/stores/project_store/__init__.py
@@ -42,6 +42,7 @@ class ProjectStore(ABC):
         name: str,
         owner_user_id: str | None,
         config: dict[str, Any] | None = None,
+        budget_config: dict[str, Any] | None = None,
     ) -> Project:
         """
         Insert a new, empty project.
@@ -52,6 +53,8 @@ class ProjectStore(ABC):
         :param owner_user_id: Owning user, or ``None`` in single-user mode.
         :param config: Optional default session settings (opaque JSON object);
             ``None`` or empty stores no defaults.
+        :param budget_config: Optional monthly spend budget (opaque JSON
+            object); ``None`` or empty means no budget configured (unlimited).
         :returns: The newly created :class:`Project`.
         :raises OmnigentError: ``ALREADY_EXISTS`` if the owner already has a
             project with this name.
@@ -67,6 +70,26 @@ class ProjectStore(ABC):
         :param owner_user_id: The requesting owner; a project owned by someone
             else is treated as not found.
         :returns: The :class:`Project` if found and owned, else ``None``.
+        """
+        ...
+
+    @abstractmethod
+    def get_by_id(self, project_id: str) -> Project | None:
+        """
+        Return a project by id with no owner check, or ``None`` if not found.
+
+        Internal/system lookup for code paths that don't run in a
+        request-scoped user context — currently the policy engine builder,
+        which resolves a session's project (via ``conversation.project_id``)
+        to read its ``budget_config`` and has no authenticated caller to
+        scope the read to. Unlike :meth:`get`, this is **not** an
+        authorization boundary — callers on a user-facing path must keep
+        using :meth:`get`/:meth:`list`, never this method, since it returns
+        another user's project data with no ownership check.
+
+        :param project_id: Opaque project identifier.
+        :returns: The :class:`Project` if found, else ``None`` — regardless
+            of who owns it.
         """
         ...
 
@@ -88,6 +111,7 @@ class ProjectStore(ABC):
         owner_user_id: str | None,
         name: str | None = None,
         config: dict[str, Any] | None = None,
+        budget_config: dict[str, Any] | None = None,
     ) -> Project | None:
         """
         Update mutable fields of an owned project.
@@ -101,6 +125,9 @@ class ProjectStore(ABC):
             non-empty, unique among the owner's projects.
         :param config: New config object to replace the stored one, or ``None``
             to leave it unchanged. An empty dict clears the stored defaults.
+        :param budget_config: New budget config to replace the stored one, or
+            ``None`` to leave it unchanged. An empty dict clears the budget
+            (unlimited).
         :returns: The updated :class:`Project`, or ``None`` if not found.
         :raises OmnigentError: ``ALREADY_EXISTS`` if the new name collides with
             another of the owner's projects.

--- a/omnigent/stores/project_store/sqlalchemy_store.py
+++ b/omnigent/stores/project_store/sqlalchemy_store.py
@@ -93,6 +93,7 @@ def _to_entity(row: SqlProject) -> Project:
         created_at=row.created_at,
         updated_at=row.updated_at,
         config=_decode_config(row.config),
+        budget_config=_decode_config(row.budget_config),
     )
 
 
@@ -154,6 +155,7 @@ class SqlAlchemyProjectStore(ProjectStore):
         name: str,
         owner_user_id: str | None,
         config: dict[str, Any] | None = None,
+        budget_config: dict[str, Any] | None = None,
     ) -> Project:
         """Insert a new, empty project.
 
@@ -178,6 +180,7 @@ class SqlAlchemyProjectStore(ProjectStore):
                 created_at=now_epoch(),
                 updated_at=None,
                 config=_encode_config(config),
+                budget_config=_encode_config(budget_config),
             )
             session.add(row)
             try:
@@ -199,6 +202,12 @@ class SqlAlchemyProjectStore(ProjectStore):
                 return None
             return _to_entity(row)
 
+    def get_by_id(self, project_id: str) -> Project | None:
+        """Return a project by id with no owner check, or ``None`` if not found."""
+        with self._session() as session:
+            row = session.get(SqlProject, (current_workspace_id(), project_id))
+            return _to_entity(row) if row is not None else None
+
     def list(self, *, owner_user_id: str | None) -> list[Project]:
         """List the owner's projects ordered by ``created_at ASC, id ASC``."""
         with self._session() as session:
@@ -218,12 +227,14 @@ class SqlAlchemyProjectStore(ProjectStore):
         owner_user_id: str | None,
         name: str | None = None,
         config: dict[str, Any] | None = None,
+        budget_config: dict[str, Any] | None = None,
     ) -> Project | None:
         """Update mutable fields of an owned project.
 
         ``None`` leaves a field unchanged. Returns ``None`` if the project does
-        not exist or is not owned by ``owner_user_id``. A ``config`` of ``{}``
-        clears the stored defaults (distinct from ``None`` = leave unchanged).
+        not exist or is not owned by ``owner_user_id``. A ``config``/
+        ``budget_config`` of ``{}`` clears the stored value (distinct from
+        ``None`` = leave unchanged).
         """
         with self._session() as session:
             row = session.get(SqlProject, (current_workspace_id(), project_id))
@@ -244,6 +255,11 @@ class SqlAlchemyProjectStore(ProjectStore):
                 encoded = _encode_config(config)
                 if row.config != encoded:
                     row.config = encoded
+                    changed = True
+            if budget_config is not None:
+                encoded_budget = _encode_config(budget_config)
+                if row.budget_config != encoded_budget:
+                    row.budget_config = encoded_budget
                     changed = True
             if changed:
                 row.updated_at = now_epoch()

--- a/tests/policies/builtins/test_project_monthly_cost.py
+++ b/tests/policies/builtins/test_project_monthly_cost.py
@@ -1,0 +1,287 @@
+"""Tests for the project monthly cost-budget policy.
+
+``project_monthly_cost_budget`` gates the ``request`` and ``tool_call``
+phases on the session's PROJECT's cumulative spend for the current UTC
+calendar month, read from ``event["context"]["project_monthly_cost"]``
+(injected by the engine). Same ASK/DENY/downgrade logic as
+``user_daily_cost_budget`` (see ``PLAN.md``, closes #1662), but:
+
+- the budget is the project's monthly spend, not a user's daily spend;
+- an approved soft checkpoint is read from / recorded to the monthly
+  store (``ask_approved_usd``) rather than ``session_state``, via the
+  reserved ``PROJECT_MONTHLY_ASK_APPROVED_STATE_KEY`` state-update the
+  engine routes to that store.
+
+These exercise the policy callable directly with synthetic events — the
+engine wiring (injection + state-update routing) and the automatic
+synthesis of this policy from a project's ``budget_config`` are covered
+by ``tests/runtime/policies/test_project_budget_wiring.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from omnigent.policies.builtins.cost import project_monthly_cost_budget
+from omnigent.policies.schema import PROJECT_MONTHLY_ASK_APPROVED_STATE_KEY, PolicyEvent
+
+
+def _tool(
+    cost: float | None,
+    *,
+    ask_approved: float = 0.0,
+    model: str | None = "databricks-claude-opus-4-8",
+    harness: str | None = None,
+    project_id: str | None = None,
+) -> PolicyEvent:
+    """
+    Build a ``tool_call`` event carrying the project's monthly cost rollup.
+
+    :param cost: ``cost_usd`` under ``context.project_monthly_cost``, e.g.
+        ``12.5``. ``None`` omits the field (unpriced / no-project case).
+    :param ask_approved: ``ask_approved_usd`` under
+        ``context.project_monthly_cost`` — the highest checkpoint the
+        project owner already approved this month, e.g. ``10.0``.
+    :param model: Active model under ``context.model``; defaults to an
+        expensive (Opus) model. ``None`` is the undeterminable case.
+    :param harness: ``context.harness``, e.g. ``"codex-native"``;
+        ``None`` is the web / API / unstamped case.
+    :param project_id: ``project_id`` under ``context.project_monthly_cost``
+        — the project the rollup belongs to. ``None`` omits it (unfiled
+        session).
+    :returns: A ``tool_call`` event dict.
+    """
+    monthly: dict[str, Any] = (
+        {} if cost is None else {"cost_usd": cost, "ask_approved_usd": ask_approved}
+    )
+    if project_id is not None:
+        monthly["project_id"] = project_id
+    return {
+        "type": "tool_call",
+        "target": "sys_os_shell",
+        "data": {"name": "sys_os_shell", "arguments": {}},
+        "context": {
+            "actor": {},
+            "project_monthly_cost": monthly,
+            "model": model,
+            "harness": harness,
+        },
+        "session_state": {},
+    }
+
+
+def test_below_ask_threshold_allows() -> None:
+    """Monthly spend under the lowest checkpoint abstains (ALLOW)."""
+    policy = project_monthly_cost_budget(max_cost_usd=50.0, ask_thresholds_usd=[25.0])
+    assert policy(_tool(10.0)) == {"result": "ALLOW"}
+
+
+@pytest.mark.parametrize("phase", ["response", "tool_result", "llm_request", "llm_response"])
+def test_non_gated_phase_allows(phase: str) -> None:
+    """Non-gated phases abstain even over budget (request/tool_call ARE gated)."""
+    policy = project_monthly_cost_budget(max_cost_usd=50.0)
+    event: PolicyEvent = {
+        "type": phase,
+        "target": None,
+        "data": "x",
+        "context": {"project_monthly_cost": {"cost_usd": 99.99}, "model": "opus"},
+        "session_state": {},
+    }
+    assert policy(event) == {"result": "ALLOW"}
+
+
+def test_request_phase_over_budget_on_expensive_model_denies() -> None:
+    """Over the hard monthly limit on an expensive model DENYs at the request phase.
+
+    The monthly gate fires before the LLM turn too, so a text-only turn
+    counts against the monthly budget. The reason must be the user-facing
+    variant (no tool-call directive), since a request-phase DENY is shown
+    straight to the user.
+    """
+    policy = project_monthly_cost_budget(max_cost_usd=50.0)
+    event: PolicyEvent = {
+        "type": "request",
+        "target": None,
+        "data": "please run the build",
+        "context": {
+            "actor": {},
+            "project_monthly_cost": {"cost_usd": 60.0, "ask_approved_usd": 0.0},
+            "model": "databricks-claude-opus-4-8",
+        },
+        "session_state": {},
+    }
+    result = policy(event)
+    assert result["result"] == "DENY"
+    assert "60.00" in result["reason"]
+    assert "monthly" in result["reason"].lower()
+    # User-facing phrasing only — no tool-call directive leaks through.
+    assert "re-issue the tool call" not in result["reason"]
+
+
+def test_request_phase_soft_checkpoint_asks_and_records_monthly_key() -> None:
+    """Crossing a monthly checkpoint ASKs at the request phase → ASK + monthly key."""
+    policy = project_monthly_cost_budget(max_cost_usd=50.0, ask_thresholds_usd=[25.0])
+    event: PolicyEvent = {
+        "type": "request",
+        "target": None,
+        "data": "please run the build",
+        "context": {
+            "actor": {},
+            "project_monthly_cost": {"cost_usd": 25.0, "ask_approved_usd": 0.0},
+            "model": "databricks-claude-opus-4-8",
+        },
+        "session_state": {},
+    }
+    result = policy(event)
+    assert result["result"] == "ASK"
+    assert result["state_updates"] == [
+        {"key": PROJECT_MONTHLY_ASK_APPROVED_STATE_KEY, "action": "set", "value": 25.0},
+    ]
+
+
+def test_zero_or_missing_monthly_cost_allows() -> None:
+    """No monthly cost recorded (no project / unpriced) → never trips."""
+    policy = project_monthly_cost_budget(max_cost_usd=50.0, ask_thresholds_usd=[10.0])
+    # cost=None omits the field entirely → reads as 0.0.
+    assert policy(_tool(None)) == {"result": "ALLOW"}
+
+
+def test_crossing_a_checkpoint_asks_and_records_monthly_key() -> None:
+    """Crossing a monthly checkpoint (unapproved) → ASK + reserved monthly state key.
+
+    The ASK must carry a ``state_updates`` SET on
+    ``PROJECT_MONTHLY_ASK_APPROVED_STATE_KEY`` (NOT the session key) so
+    the engine routes the approval to the per-project+month store — that's
+    what makes an approval persist across the project's other sessions
+    this month. A missing / wrong key would re-prompt every session.
+    """
+    policy = project_monthly_cost_budget(max_cost_usd=50.0, ask_thresholds_usd=[20.0, 40.0])
+    result = policy(_tool(20.0))  # exactly at the first checkpoint — `>=`
+    assert result["result"] == "ASK"
+    assert result["state_updates"] == [
+        {"key": PROJECT_MONTHLY_ASK_APPROVED_STATE_KEY, "action": "set", "value": 20.0},
+    ]
+
+
+def test_approved_checkpoint_from_monthly_store_does_not_reprompt() -> None:
+    """Approval read from context.project_monthly_cost.ask_approved_usd suppresses re-ask.
+
+    With ask_approved=20.0, a $30 monthly-spend tool call is silent;
+    reaching the next checkpoint ($40) ASKs again.
+    """
+    policy = project_monthly_cost_budget(max_cost_usd=50.0, ask_thresholds_usd=[20.0, 40.0])
+    # Already approved past $20 this month (possibly from a different session) → silent.
+    assert policy(_tool(30.0, ask_approved=20.0)) == {"result": "ALLOW"}
+    # Crossing the next checkpoint prompts again.
+    result = policy(_tool(40.0, ask_approved=20.0))
+    assert result["result"] == "ASK"
+    assert result["state_updates"] == [
+        {"key": PROJECT_MONTHLY_ASK_APPROVED_STATE_KEY, "action": "set", "value": 40.0},
+    ]
+
+
+def test_over_monthly_budget_denies_any_model() -> None:
+    """Over the hard monthly limit → DENY for any model (default hard stop).
+
+    The default is a true hard stop — all models are blocked (a
+    *downgrade* gate, not a session-terminating block: see the module
+    docstring). The reason must surface the spend, say all calls are
+    blocked, and frame it as the project's MONTHLY budget.
+    """
+    policy = project_monthly_cost_budget(max_cost_usd=50.0, ask_thresholds_usd=[20.0])
+    for model in ("databricks-claude-opus-4-8", "databricks-claude-sonnet-4-6"):
+        result = policy(_tool(60.0, model=model))
+        assert result["result"] == "DENY", f"expected DENY for {model}"
+        assert "60.00" in result["reason"]
+        assert "All model calls are blocked" in result["reason"]
+        assert "monthly" in result["reason"].lower()
+
+
+def test_ask_message_names_the_project_scope() -> None:
+    """The ASK reason is phrased as the project's spend (not a user's)."""
+    policy = project_monthly_cost_budget(max_cost_usd=50.0, ask_thresholds_usd=[20.0])
+    result = policy(_tool(20.0, project_id="a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"))
+    assert result["result"] == "ASK"
+    assert result["reason"].startswith("This project's spend this month $20.00 passed")
+
+
+def test_deny_message_names_the_project_scope() -> None:
+    """The over-limit DENY reason also frames the spend as the project's."""
+    policy = project_monthly_cost_budget(max_cost_usd=50.0, ask_thresholds_usd=[20.0])
+    result = policy(_tool(60.0, model="databricks-claude-opus-4-8"))
+    assert result["result"] == "DENY"
+    assert "This project's spend $60.00 reached" in result["reason"]
+
+
+def test_over_monthly_budget_on_cheaper_model_allows_with_explicit_list() -> None:
+    """Over the monthly limit on a cheaper model → ALLOW when using an explicit expensive list.
+
+    With explicit expensive_models (downgrade-gate mode), Sonnet is not in
+    the list, so a downgraded session proceeds even over the monthly limit.
+    """
+    policy = project_monthly_cost_budget(max_cost_usd=50.0, expensive_models=["opus"])
+    assert policy(_tool(60.0, model="databricks-claude-sonnet-4-6")) == {"result": "ALLOW"}
+
+
+@pytest.mark.parametrize(
+    "bad_kwargs",
+    [
+        {"max_cost_usd": 0.0},
+        {"max_cost_usd": 50.0, "ask_thresholds_usd": [50.0]},  # threshold == limit
+        {"max_cost_usd": 50.0, "ask_thresholds_usd": [0.0]},  # threshold not > 0
+        {"max_cost_usd": 50.0, "expensive_models": [""]},  # empty model token
+    ],
+)
+def test_invalid_config_raises(bad_kwargs: dict[str, Any]) -> None:
+    """Same validation as user_daily_cost_budget — bad config fails loud at build."""
+    with pytest.raises(ValueError):
+        project_monthly_cost_budget(**bad_kwargs)
+
+
+def test_declined_monthly_checkpoint_reasks_until_approved() -> None:
+    """An un-approved monthly checkpoint re-asks on every tool call.
+
+    The monthly policy reads the approved highwater from the injected
+    monthly rollup (``ask_approved_usd``), not session_state. With it at
+    0.0, the same over-threshold monthly spend must ASK every time — a
+    decline never records the approval (the engine withholds an ASK's
+    state_updates on decline), so the gate keeps prompting until
+    approved. Both calls must ASK.
+    """
+    policy = project_monthly_cost_budget(max_cost_usd=50.0, ask_thresholds_usd=[20.0])
+    first = policy(_tool(30.0, ask_approved=0.0))
+    second = policy(_tool(30.0, ask_approved=0.0))
+    assert first["result"] == "ASK"
+    assert second["result"] == "ASK"  # not recorded → re-asks
+
+
+def test_over_monthly_budget_unknown_model_denies_fail_closed() -> None:
+    """Over the monthly limit with an undeterminable model → DENY (fail closed)."""
+    policy = project_monthly_cost_budget(max_cost_usd=50.0)
+    result = policy(_tool(60.0, model=None))
+    assert result["result"] == "DENY"
+
+
+def test_monthly_deny_reason_for_codex_points_to_terminal() -> None:
+    """The monthly DENY reason is harness-aware: codex-native → terminal /model."""
+    policy = project_monthly_cost_budget(max_cost_usd=50.0, expensive_models=["opus"])
+    result = policy(_tool(60.0, model="opus", harness="codex-native"))
+    assert result["result"] == "DENY"
+    assert "in the terminal" in result["reason"]
+    assert "/model" in result["reason"]
+
+
+def test_over_owner_raised_limit_clears_immediately() -> None:
+    """A fresh call built with a higher max_cost_usd is no longer DENY.
+
+    Mirrors the real recovery path: the owner raises `budget_config.limit_usd`,
+    the next `build_policy_engine` call synthesizes the policy with the new
+    limit (see `_load_project_budget_policy_specs`), and this same $60 spend
+    is re-evaluated against it — with no separate "retry" mechanism needed.
+    """
+    over_limit = project_monthly_cost_budget(max_cost_usd=50.0)
+    assert over_limit(_tool(60.0))["result"] == "DENY"
+    raised_limit = project_monthly_cost_budget(max_cost_usd=100.0)
+    assert raised_limit(_tool(60.0)) == {"result": "ALLOW"}

--- a/tests/runtime/policies/test_project_budget_wiring.py
+++ b/tests/runtime/policies/test_project_budget_wiring.py
@@ -1,0 +1,346 @@
+"""Tests for automatic project monthly budget policy synthesis and wiring.
+
+A project's monthly budget (``Project.budget_config``) has no entry in any
+agent's YAML, session policy store, or server-wide ``default_policies`` — so
+unlike every other policy source ``build_policy_engine`` merges,
+:func:`_load_project_budget_policy_specs` synthesizes the
+``project_monthly_cost_budget`` spec on the fly from the project's stored
+config (see ``PLAN.md``, closes #1662). These tests exercise that synthesis,
+the context injection it depends on, and the ``any_policies_apply`` fast-path
+gap it closes — through the real ``build_policy_engine`` → ``PolicyEngine``
+pipeline, not the callable in isolation (that's
+``tests/policies/builtins/test_project_monthly_cost.py``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.policies.types import EvaluationContext
+from omnigent.runtime.policies.builder import any_policies_apply, build_policy_engine
+from omnigent.spec.types import AgentSpec, LLMConfig, Phase, PolicyAction
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+from omnigent.stores.project_store.sqlalchemy_store import SqlAlchemyProjectStore
+
+_PROJECT_POLICY_NAME = "__project_monthly_cost_budget"
+_SPEC = AgentSpec(spec_version=1, name="test-agent", llm=LLMConfig(model="gpt-4"))
+
+
+@pytest.fixture()
+def project_store(db_uri: str) -> SqlAlchemyProjectStore:
+    """A :class:`SqlAlchemyProjectStore` backed by the same per-test SQLite DB
+    as the ``conversation_store`` fixture (see ``tests/runtime/policies/conftest.py``)."""
+    return SqlAlchemyProjectStore(db_uri)
+
+
+def _request_ctx() -> EvaluationContext:
+    return EvaluationContext(phase=Phase.REQUEST, content="hello", tool_name=None)
+
+
+# ── Synthesis: does a budgeted project get the policy at all? ──────────────
+
+
+def test_project_with_budget_synthesizes_policy(
+    conversation_store: SqlAlchemyConversationStore,
+    project_store: SqlAlchemyProjectStore,
+) -> None:
+    """A project with a positive ``limit_usd`` gets the policy automatically —
+    no agent-spec / session-policy / default_policies declaration needed."""
+    project = project_store.create(
+        "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+        "budgeted",
+        "alice@example.com",
+        budget_config={"limit_usd": 10.0},
+    )
+    conv = conversation_store.create_conversation()
+    assert conversation_store.set_conversation_project(conv.id, project.id)
+
+    engine = build_policy_engine(
+        spec=_SPEC,
+        conversation_id=conv.id,
+        conversation_store=conversation_store,
+        project_store=project_store,
+    )
+    assert _PROJECT_POLICY_NAME in [p.spec.name for p in engine.policies]
+
+
+def test_project_without_budget_synthesizes_nothing(
+    conversation_store: SqlAlchemyConversationStore,
+    project_store: SqlAlchemyProjectStore,
+) -> None:
+    """A project with no configured budget never gets the policy."""
+    project = project_store.create(
+        "b1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4", "unbudgeted", "alice@example.com"
+    )
+    conv = conversation_store.create_conversation()
+    assert conversation_store.set_conversation_project(conv.id, project.id)
+
+    engine = build_policy_engine(
+        spec=_SPEC,
+        conversation_id=conv.id,
+        conversation_store=conversation_store,
+        project_store=project_store,
+    )
+    assert _PROJECT_POLICY_NAME not in [p.spec.name for p in engine.policies]
+
+
+def test_unfiled_session_synthesizes_nothing(
+    conversation_store: SqlAlchemyConversationStore,
+    project_store: SqlAlchemyProjectStore,
+) -> None:
+    """A session with no ``project_id`` gets no project budget policy, even
+    when *some* project somewhere has one configured."""
+    project_store.create(
+        "c1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+        "someone else's budget",
+        "alice@example.com",
+        budget_config={"limit_usd": 10.0},
+    )
+    conv = conversation_store.create_conversation()  # never filed
+
+    engine = build_policy_engine(
+        spec=_SPEC,
+        conversation_id=conv.id,
+        conversation_store=conversation_store,
+        project_store=project_store,
+    )
+    assert _PROJECT_POLICY_NAME not in [p.spec.name for p in engine.policies]
+
+
+def test_no_project_store_synthesizes_nothing(
+    conversation_store: SqlAlchemyConversationStore,
+    project_store: SqlAlchemyProjectStore,
+) -> None:
+    """``project_store=None`` (the default) skips synthesis entirely, even
+    for a session filed into a budgeted project — deployments that don't wire
+    a project store see no behavior change."""
+    project = project_store.create(
+        "d1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+        "budgeted",
+        "alice@example.com",
+        budget_config={"limit_usd": 10.0},
+    )
+    conv = conversation_store.create_conversation()
+    assert conversation_store.set_conversation_project(conv.id, project.id)
+
+    engine = build_policy_engine(
+        spec=_SPEC,
+        conversation_id=conv.id,
+        conversation_store=conversation_store,
+        # project_store omitted.
+    )
+    assert _PROJECT_POLICY_NAME not in [p.spec.name for p in engine.policies]
+
+
+def test_subagent_synthesizes_from_root_project(
+    conversation_store: SqlAlchemyConversationStore,
+    project_store: SqlAlchemyProjectStore,
+) -> None:
+    """A sub-agent conversation (no ``project_id`` of its own) still gets the
+    root session's project budget policy via the root fallback."""
+    project = project_store.create(
+        "e1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+        "budgeted",
+        "alice@example.com",
+        budget_config={"limit_usd": 10.0},
+    )
+    parent = conversation_store.create_conversation()
+    assert conversation_store.set_conversation_project(parent.id, project.id)
+    child = conversation_store.create_conversation(
+        kind="sub_agent", parent_conversation_id=parent.id
+    )
+    assert conversation_store.get_conversation(child.id).project_id is None  # sanity
+
+    engine = build_policy_engine(
+        spec=_SPEC,
+        conversation_id=child.id,
+        conversation_store=conversation_store,
+        project_store=project_store,
+    )
+    assert _PROJECT_POLICY_NAME in [p.spec.name for p in engine.policies]
+
+
+# ── End-to-end enforcement through the real engine ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_under_budget_allows(
+    conversation_store: SqlAlchemyConversationStore,
+    project_store: SqlAlchemyProjectStore,
+) -> None:
+    project = project_store.create(
+        "f1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+        "p",
+        "alice@example.com",
+        budget_config={"limit_usd": 10.0, "ask_thresholds_usd": [5.0]},
+    )
+    conv = conversation_store.create_conversation()
+    assert conversation_store.set_conversation_project(conv.id, project.id)
+    conversation_store.add_project_monthly_cost(project.id, _this_month(), 2.0)
+
+    engine = build_policy_engine(
+        spec=_SPEC,
+        conversation_id=conv.id,
+        conversation_store=conversation_store,
+        project_store=project_store,
+    )
+    result = await engine.evaluate(_request_ctx())
+    assert result.action == PolicyAction.ALLOW
+
+
+@pytest.mark.asyncio
+async def test_crossing_threshold_asks(
+    conversation_store: SqlAlchemyConversationStore,
+    project_store: SqlAlchemyProjectStore,
+) -> None:
+    project = project_store.create(
+        "01b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+        "p",
+        "alice@example.com",
+        budget_config={"limit_usd": 10.0, "ask_thresholds_usd": [5.0]},
+    )
+    conv = conversation_store.create_conversation()
+    assert conversation_store.set_conversation_project(conv.id, project.id)
+    conversation_store.add_project_monthly_cost(project.id, _this_month(), 6.0)
+
+    engine = build_policy_engine(
+        spec=_SPEC,
+        conversation_id=conv.id,
+        conversation_store=conversation_store,
+        project_store=project_store,
+    )
+    result = await engine.evaluate(_request_ctx())
+    assert result.action == PolicyAction.ASK
+
+
+@pytest.mark.asyncio
+async def test_over_limit_denies(
+    conversation_store: SqlAlchemyConversationStore,
+    project_store: SqlAlchemyProjectStore,
+) -> None:
+    project = project_store.create(
+        "11b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+        "p",
+        "alice@example.com",
+        budget_config={"limit_usd": 10.0},
+    )
+    conv = conversation_store.create_conversation()
+    assert conversation_store.set_conversation_project(conv.id, project.id)
+    conversation_store.add_project_monthly_cost(project.id, _this_month(), 12.0)
+
+    engine = build_policy_engine(
+        spec=_SPEC,
+        conversation_id=conv.id,
+        conversation_store=conversation_store,
+        project_store=project_store,
+    )
+    result = await engine.evaluate(_request_ctx())
+    assert result.action == PolicyAction.DENY
+
+
+@pytest.mark.asyncio
+async def test_owner_raising_limit_clears_deny_on_next_build(
+    conversation_store: SqlAlchemyConversationStore,
+    project_store: SqlAlchemyProjectStore,
+) -> None:
+    """The synthesized policy re-reads ``budget_config`` on every
+    ``build_policy_engine`` call — no separate "retry" mechanism is needed
+    for a limit raise to take effect; the very next engine build sees it."""
+    project = project_store.create(
+        "21b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+        "p",
+        "alice@example.com",
+        budget_config={"limit_usd": 10.0},
+    )
+    conv = conversation_store.create_conversation()
+    assert conversation_store.set_conversation_project(conv.id, project.id)
+    conversation_store.add_project_monthly_cost(project.id, _this_month(), 12.0)
+
+    engine = build_policy_engine(
+        spec=_SPEC,
+        conversation_id=conv.id,
+        conversation_store=conversation_store,
+        project_store=project_store,
+    )
+    assert (await engine.evaluate(_request_ctx())).action == PolicyAction.DENY
+
+    project_store.update(
+        project.id, owner_user_id="alice@example.com", budget_config={"limit_usd": 20.0}
+    )
+    rebuilt = build_policy_engine(
+        spec=_SPEC,
+        conversation_id=conv.id,
+        conversation_store=conversation_store,
+        project_store=project_store,
+    )
+    assert (await rebuilt.evaluate(_request_ctx())).action == PolicyAction.ALLOW
+
+
+# ── any_policies_apply fast-path (the gap this feature closed) ─────────────
+
+
+def test_any_policies_apply_true_for_budgeted_project_with_no_other_policies(
+    conversation_store: SqlAlchemyConversationStore,
+    project_store: SqlAlchemyProjectStore,
+) -> None:
+    """A session with NO agent guardrails / session policies / server
+    defaults, filed into a budgeted project, must still report
+    ``any_policies_apply() == True`` — otherwise the native-hook fast path
+    (``routes_hooks.py``) would skip the engine build and the project's
+    budget would silently never be enforced for that session.
+    """
+    project = project_store.create(
+        "31b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+        "p",
+        "alice@example.com",
+        budget_config={"limit_usd": 10.0},
+    )
+    conv = conversation_store.create_conversation()
+    assert conversation_store.set_conversation_project(conv.id, project.id)
+
+    assert (
+        any_policies_apply(
+            spec=_SPEC,
+            conversation_id=conv.id,
+            default_policies=None,
+            policy_store=None,
+            conversation_store=conversation_store,
+            project_store=project_store,
+        )
+        is True
+    )
+
+
+def test_any_policies_apply_false_without_conversation_store(
+    conversation_store: SqlAlchemyConversationStore,
+    project_store: SqlAlchemyProjectStore,
+) -> None:
+    """Omitting ``conversation_store`` (a caller that can't check project
+    budgets) falls back to the pre-existing checks only — no crash, just no
+    project-budget fast path (the full engine build still catches it later)."""
+    project = project_store.create(
+        "41b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+        "p",
+        "alice@example.com",
+        budget_config={"limit_usd": 10.0},
+    )
+    conv = conversation_store.create_conversation()
+    assert conversation_store.set_conversation_project(conv.id, project.id)
+
+    assert (
+        any_policies_apply(
+            spec=_SPEC,
+            conversation_id=conv.id,
+            default_policies=None,
+            policy_store=None,
+        )
+        is False
+    )
+
+
+def _this_month() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).strftime("%Y-%m")

--- a/tests/server/routes/test_projects_crud.py
+++ b/tests/server/routes/test_projects_crud.py
@@ -193,6 +193,126 @@ async def test_patch_empty_config_clears_it(project_client: httpx.AsyncClient) -
     assert resp.json()["config"] == {}
 
 
+async def test_create_defaults_to_empty_budget_config(project_client: httpx.AsyncClient) -> None:
+    """A project created without a budget_config field reports an empty one."""
+    body = (await project_client.post("/v1/projects", json={"name": "P"})).json()
+    assert body["budget_config"] == {}
+
+
+async def test_create_and_get_roundtrips_budget_config(project_client: httpx.AsyncClient) -> None:
+    """A budget_config passed on create round-trips through create + get."""
+    budget = {"limit_usd": 50.0, "ask_thresholds_usd": [25.0]}
+    created = (
+        await project_client.post(
+            "/v1/projects", json={"name": "Budgeted", "budget_config": budget}
+        )
+    ).json()
+    assert created["budget_config"] == budget
+    fetched = (await project_client.get(f"/v1/projects/{created['id']}")).json()
+    assert fetched["budget_config"] == budget
+
+
+async def test_create_budget_config_invalid_limit_rejected(
+    project_client: httpx.AsyncClient,
+) -> None:
+    """A non-positive limit_usd is rejected with 422, not silently stored."""
+    resp = await project_client.post(
+        "/v1/projects", json={"name": "Bad", "budget_config": {"limit_usd": -5.0}}
+    )
+    assert resp.status_code == 422
+
+    resp_zero = await project_client.post(
+        "/v1/projects", json={"name": "BadZero", "budget_config": {"limit_usd": 0}}
+    )
+    assert resp_zero.status_code == 422
+
+
+async def test_create_budget_config_threshold_out_of_range_rejected(
+    project_client: httpx.AsyncClient,
+) -> None:
+    """A threshold not in ``(0, limit_usd)`` is rejected with 422."""
+    resp = await project_client.post(
+        "/v1/projects",
+        json={"name": "Bad", "budget_config": {"limit_usd": 10.0, "ask_thresholds_usd": [10.0]}},
+    )
+    assert resp.status_code == 422
+
+
+async def test_patch_replaces_budget_config(project_client: httpx.AsyncClient) -> None:
+    """PATCH with a new budget_config replaces the stored one and stamps updated_at."""
+    created = (
+        await project_client.post(
+            "/v1/projects", json={"name": "P", "budget_config": {"limit_usd": 10.0}}
+        )
+    ).json()
+    resp = await project_client.patch(
+        f"/v1/projects/{created['id']}", json={"budget_config": {"limit_usd": 20.0}}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["budget_config"] == {"limit_usd": 20.0}
+    assert body["updated_at"] is not None
+
+
+async def test_patch_without_budget_config_preserves_it(project_client: httpx.AsyncClient) -> None:
+    """A PATCH that omits budget_config (e.g. a rename) leaves it intact."""
+    created = (
+        await project_client.post(
+            "/v1/projects", json={"name": "P", "budget_config": {"limit_usd": 10.0}}
+        )
+    ).json()
+    renamed = await project_client.patch(f"/v1/projects/{created['id']}", json={"name": "P2"})
+    assert renamed.json()["budget_config"] == {"limit_usd": 10.0}
+
+
+async def test_patch_empty_budget_config_clears_it(project_client: httpx.AsyncClient) -> None:
+    """PATCH with budget_config={} clears the budget (distinct from omitting)."""
+    created = (
+        await project_client.post(
+            "/v1/projects", json={"name": "P", "budget_config": {"limit_usd": 10.0}}
+        )
+    ).json()
+    resp = await project_client.patch(f"/v1/projects/{created['id']}", json={"budget_config": {}})
+    assert resp.json()["budget_config"] == {}
+
+
+async def test_get_budget_report_unlimited_project(project_client: httpx.AsyncClient) -> None:
+    """A project with no budget_config reports limit_usd: None but still reports spend."""
+    created = (await project_client.post("/v1/projects", json={"name": "Unlimited"})).json()
+    resp = await project_client.get(f"/v1/projects/{created['id']}/budget")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["object"] == "project.budget"
+    assert body["limit_usd"] is None
+    assert body["ask_thresholds_usd"] == []
+    assert body["spend_usd"] == 0.0
+    assert len(body["month_utc"]) == 7  # "YYYY-MM"
+
+
+async def test_get_budget_report_configured_project(project_client: httpx.AsyncClient) -> None:
+    """A project's budget report surfaces its configured limit and thresholds."""
+    created = (
+        await project_client.post(
+            "/v1/projects",
+            json={
+                "name": "Budgeted",
+                "budget_config": {"limit_usd": 50.0, "ask_thresholds_usd": [25.0]},
+            },
+        )
+    ).json()
+    resp = await project_client.get(f"/v1/projects/{created['id']}/budget")
+    body = resp.json()
+    assert body["limit_usd"] == 50.0
+    assert body["ask_thresholds_usd"] == [25.0]
+    assert body["spend_usd"] == 0.0
+
+
+async def test_get_budget_missing_project_404(project_client: httpx.AsyncClient) -> None:
+    """The budget report 404s for an unknown/unowned project, like the other routes."""
+    resp = await project_client.get(f"/v1/projects/{'0' * 32}/budget")
+    assert resp.status_code == 404
+
+
 async def test_delete_project(project_client: httpx.AsyncClient) -> None:
     """DELETE removes the project; a second delete 404s."""
     created = (await project_client.post("/v1/projects", json={"name": "Doomed"})).json()
@@ -304,6 +424,29 @@ async def test_cannot_get_another_users_project(
     # The owner still sees it.
     assert (
         await multi_user_client.get(f"/v1/projects/{created['id']}", headers=_as_user(BOB))
+    ).status_code == 200
+
+
+async def test_cannot_get_another_users_project_budget(
+    multi_user_client: httpx.AsyncClient,
+) -> None:
+    """Bob's budget report is 404 (not found), never readable, for Alice."""
+    created = (
+        await multi_user_client.post(
+            "/v1/projects",
+            json={"name": "Bob only", "budget_config": {"limit_usd": 10.0}},
+            headers=_as_user(BOB),
+        )
+    ).json()
+    resp = await multi_user_client.get(
+        f"/v1/projects/{created['id']}/budget", headers=_as_user(ALICE)
+    )
+    assert resp.status_code == 404
+    # The owner still sees it.
+    assert (
+        await multi_user_client.get(
+            f"/v1/projects/{created['id']}/budget", headers=_as_user(BOB)
+        )
     ).status_code == 200
 
 

--- a/tests/server/routes/test_session_updates_ws.py
+++ b/tests/server/routes/test_session_updates_ws.py
@@ -861,3 +861,86 @@ def test_daily_cost_attributed_via_root_for_sub_agent_without_owner_grant(
 
     # Sub-agent spend must appear in Alice's daily rollup via the root fallback.
     assert conversation_store.get_daily_cost(ALICE, today) == pytest.approx(0.75)
+
+
+# ── Project monthly cost rollup (PLAN.md, closes #1662) ──────────────────
+
+
+def test_project_monthly_cost_recorded_for_filed_session(app: FastAPI, stores) -> None:
+    """A turn on a session filed into a project rolls up into that project's
+    ``project_monthly_cost``, alongside (not instead of) the owner's daily cost."""
+    conversation_store, _agent_store, _permission_store = stores
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    month = datetime.now(timezone.utc).strftime("%Y-%m")
+
+    sid = _seed_session(stores, owner=ALICE, title="filed session")
+    project_id = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"
+    assert conversation_store.set_conversation_project(sid, project_id)
+
+    resp = TestClient(app).post(
+        f"/v1/sessions/{sid}/events",
+        json={"type": "external_session_usage", "data": {"cumulative_cost_usd": 1.5}},
+        headers={"X-Forwarded-Email": ALICE},
+    )
+    assert resp.status_code == 202, resp.text
+
+    assert conversation_store.get_project_monthly_cost_state(project_id, month)[
+        "cost_usd"
+    ] == pytest.approx(1.5)
+    # The existing per-user daily rollup still fires too — the two are independent.
+    assert conversation_store.get_daily_cost(ALICE, today) == pytest.approx(1.5)
+
+
+def test_project_monthly_cost_not_recorded_for_unfiled_session(app: FastAPI, stores) -> None:
+    """A session with no ``project_id`` never creates a project_monthly_cost row."""
+    conversation_store, _agent_store, _permission_store = stores
+    month = datetime.now(timezone.utc).strftime("%Y-%m")
+    sid = _seed_session(stores, owner=ALICE, title="unfiled session")
+
+    resp = TestClient(app).post(
+        f"/v1/sessions/{sid}/events",
+        json={"type": "external_session_usage", "data": {"cumulative_cost_usd": 3.0}},
+        headers={"X-Forwarded-Email": ALICE},
+    )
+    assert resp.status_code == 202, resp.text
+
+    # No project was ever filed — some_other_project must read as untouched zeros.
+    assert conversation_store.get_project_monthly_cost_state("some_other_project", month)[
+        "cost_usd"
+    ] == 0.0
+
+
+def test_project_monthly_cost_attributed_via_root_for_sub_agent(app: FastAPI, stores) -> None:
+    """Sub-agent spend rolls up into the ROOT session's project.
+
+    A sub-agent conversation never carries ``project_id`` itself (only a
+    user explicitly files a top-level session into a project) — this
+    mirrors ``test_daily_cost_attributed_via_root_for_sub_agent_without_owner_grant``
+    for the project rollup: the fix falls back to the spawn-tree root's
+    ``project_id`` when the child's own is unset, so sub-agent spend under a
+    budgeted project isn't silently dropped from the monthly total.
+    """
+    conversation_store, _agent_store, _permission_store = stores
+    month = datetime.now(timezone.utc).strftime("%Y-%m")
+
+    parent_id = _seed_session(stores, owner=ALICE, title="parent session")
+    project_id = "f6a5b4c3d2e1f6a5b4c3d2e1f6a5b4c3"
+    assert conversation_store.set_conversation_project(parent_id, project_id)
+
+    child = conversation_store.create_conversation(
+        title="sub-agent",
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
+        parent_conversation_id=parent_id,
+    )
+    # Sanity: the child itself carries no project_id (the gap being covered).
+    assert conversation_store.get_conversation(child.id).project_id is None
+
+    resp = TestClient(app).post(
+        f"/v1/sessions/{child.id}/events",
+        json={"type": "external_session_usage", "data": {"cumulative_cost_usd": 0.4}},
+    )
+    assert resp.status_code == 202, resp.text
+
+    assert conversation_store.get_project_monthly_cost_state(project_id, month)[
+        "cost_usd"
+    ] == pytest.approx(0.4)

--- a/tests/server/routes/test_sessions_project_membership.py
+++ b/tests/server/routes/test_sessions_project_membership.py
@@ -71,15 +71,19 @@ def _single_user_app(db_uri: str) -> FastAPI:
         )
 
     project_store = SqlAlchemyProjectStore(db_uri)
+    conversation_store = SqlAlchemyConversationStore(db_uri)
     app.include_router(
         create_sessions_router(
-            conversation_store=SqlAlchemyConversationStore(db_uri),
+            conversation_store=conversation_store,
             agent_store=SqlAlchemyAgentStore(db_uri),
             project_store=project_store,
         ),
         prefix="/v1",
     )
-    app.include_router(create_projects_router(project_store=project_store), prefix="/v1")
+    app.include_router(
+        create_projects_router(project_store=project_store, conversation_store=conversation_store),
+        prefix="/v1",
+    )
     return app
 
 
@@ -212,9 +216,10 @@ def _multi_user_app(db_uri: str) -> FastAPI:
 
     auth = UnifiedAuthProvider(source="header")
     project_store = SqlAlchemyProjectStore(db_uri)
+    conversation_store = SqlAlchemyConversationStore(db_uri)
     app.include_router(
         create_sessions_router(
-            conversation_store=SqlAlchemyConversationStore(db_uri),
+            conversation_store=conversation_store,
             agent_store=SqlAlchemyAgentStore(db_uri),
             auth_provider=auth,
             permission_store=SqlAlchemyPermissionStore(db_uri),
@@ -223,7 +228,11 @@ def _multi_user_app(db_uri: str) -> FastAPI:
         prefix="/v1",
     )
     app.include_router(
-        create_projects_router(project_store=project_store, auth_provider=auth),
+        create_projects_router(
+            project_store=project_store,
+            conversation_store=conversation_store,
+            auth_provider=auth,
+        ),
         prefix="/v1",
     )
     return app

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -4405,6 +4405,120 @@ def test_add_daily_cost_stacks_after_ask_approved(
     assert state["ask_approved_usd"] == pytest.approx(2.0)
 
 
+# ── Project monthly cost (PLAN.md, closes #1662) ───────────
+
+
+def test_get_project_monthly_cost_state_missing_returns_zeros(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A (project, month) with no row reads as zeros for both fields."""
+    state = conversation_store.get_project_monthly_cost_state("proj_1", "2026-06")
+    assert state == {"cost_usd": 0.0, "ask_approved_usd": 0.0}
+
+
+def test_add_project_monthly_cost_accumulates(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Repeated adds for the same (project, month) sum into one total."""
+    conversation_store.add_project_monthly_cost("proj_1", "2026-06", 5.0)
+    conversation_store.add_project_monthly_cost("proj_1", "2026-06", 3.0)
+    conversation_store.add_project_monthly_cost("proj_1", "2026-06", 8.0)
+
+    state = conversation_store.get_project_monthly_cost_state("proj_1", "2026-06")
+    # 5.0 + 3.0 + 8.0 = 16.0 proves each delta was added, not overwritten.
+    assert state["cost_usd"] == pytest.approx(16.0)
+
+
+def test_add_project_monthly_cost_isolated_by_project_and_month(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Spend is partitioned by both project and UTC month; no cross-bleed."""
+    conversation_store.add_project_monthly_cost("proj_1", "2026-06", 10.0)
+    conversation_store.add_project_monthly_cost("proj_1", "2026-07", 4.0)
+    conversation_store.add_project_monthly_cost("proj_2", "2026-06", 20.0)
+
+    # Same project, different month: only that month's delta.
+    assert conversation_store.get_project_monthly_cost_state("proj_1", "2026-06")[
+        "cost_usd"
+    ] == pytest.approx(10.0)
+    assert conversation_store.get_project_monthly_cost_state("proj_1", "2026-07")[
+        "cost_usd"
+    ] == pytest.approx(4.0)
+    # Different project, same month: isolated from proj_1.
+    assert conversation_store.get_project_monthly_cost_state("proj_2", "2026-06")[
+        "cost_usd"
+    ] == pytest.approx(20.0)
+
+
+def test_add_project_monthly_cost_nonpositive_is_noop(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """``delta <= 0`` never creates or mutates a row."""
+    conversation_store.add_project_monthly_cost("proj_1", "2026-06", 0.0)
+    conversation_store.add_project_monthly_cost("proj_1", "2026-06", -1.0)
+    assert conversation_store.get_project_monthly_cost_state("proj_1", "2026-06")[
+        "cost_usd"
+    ] == 0.0
+
+    # A subsequent positive add still works and isn't polluted by the no-ops.
+    conversation_store.add_project_monthly_cost("proj_1", "2026-06", 2.5)
+    assert conversation_store.get_project_monthly_cost_state("proj_1", "2026-06")[
+        "cost_usd"
+    ] == pytest.approx(2.5)
+
+
+def test_set_project_monthly_ask_approved_does_not_clobber_cost(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Recording an approved checkpoint leaves accumulated cost intact."""
+    conversation_store.add_project_monthly_cost("proj_1", "2026-06", 30.0)
+    conversation_store.set_project_monthly_ask_approved("proj_1", "2026-06", 20.0)
+
+    state = conversation_store.get_project_monthly_cost_state("proj_1", "2026-06")
+    # cost must survive the approval write (set touches only ask_approved_usd);
+    # if it dropped to 0 the UPSERT wrongly overwrote cost_usd.
+    assert state["cost_usd"] == pytest.approx(30.0)
+    assert state["ask_approved_usd"] == pytest.approx(20.0)
+
+
+def test_add_project_monthly_cost_does_not_clobber_ask_approved(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Accumulating cost after an approval leaves the approval intact."""
+    conversation_store.set_project_monthly_ask_approved("proj_1", "2026-06", 20.0)
+    conversation_store.add_project_monthly_cost("proj_1", "2026-06", 15.0)
+
+    state = conversation_store.get_project_monthly_cost_state("proj_1", "2026-06")
+    # The increment UPSERT must only touch cost_usd; ask_approved survives.
+    assert state["cost_usd"] == pytest.approx(15.0)
+    assert state["ask_approved_usd"] == pytest.approx(20.0)
+
+
+def test_set_project_monthly_ask_approved_creates_row_when_absent(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Approving with no prior row inserts a cost=0 row carrying the approval."""
+    conversation_store.set_project_monthly_ask_approved("proj_1", "2026-06", 5.0)
+    state = conversation_store.get_project_monthly_cost_state("proj_1", "2026-06")
+    assert state["cost_usd"] == 0.0
+    assert state["ask_approved_usd"] == pytest.approx(5.0)
+
+
+def test_add_project_monthly_cost_stacks_after_ask_approved(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Cost increments stack (not overwrite) even after an approval is set."""
+    conversation_store.set_project_monthly_ask_approved("proj_1", "2026-06", 20.0)
+    conversation_store.add_project_monthly_cost("proj_1", "2026-06", 15.0)
+    conversation_store.add_project_monthly_cost("proj_1", "2026-06", 10.0)
+
+    state = conversation_store.get_project_monthly_cost_state("proj_1", "2026-06")
+    # 15.0 + 10.0 proves the second add incremented rather than overwrote;
+    # ask_approved untouched throughout.
+    assert state["cost_usd"] == pytest.approx(25.0)
+    assert state["ask_approved_usd"] == pytest.approx(20.0)
+
+
 # ── set_session_state ─────────────────────────────────────────────────────
 
 

--- a/tests/stores/test_project_store.py
+++ b/tests/stores/test_project_store.py
@@ -290,6 +290,117 @@ def test_decode_coerces_non_object_blob_to_empty(store: SqlAlchemyProjectStore) 
     assert got.config == {}
 
 
+# ── budget_config (monthly spend budget, PLAN.md, closes #1662) ─────────────
+
+
+def test_create_defaults_to_empty_budget_config(store: SqlAlchemyProjectStore) -> None:
+    """A project created without a budget reads back an empty dict (no limit)."""
+    project = store.create(_uid("p1"), "No Budget", "alice@example.com")
+    assert project.budget_config == {}
+    assert store.get(_uid("p1"), owner_user_id="alice@example.com").budget_config == {}
+
+
+def test_create_persists_budget_config(store: SqlAlchemyProjectStore) -> None:
+    """A budget_config passed to ``create`` round-trips through ``get``/``list``."""
+    budget = {"limit_usd": 50.0, "ask_thresholds_usd": [25.0]}
+    store.create(_uid("p1"), "Budgeted", "alice@example.com", budget_config=budget)
+    assert store.get(_uid("p1"), owner_user_id="alice@example.com").budget_config == budget
+    assert store.list(owner_user_id="alice@example.com")[0].budget_config == budget
+
+
+def test_config_and_budget_config_are_independent(store: SqlAlchemyProjectStore) -> None:
+    """Setting one of config/budget_config at create time never touches the other."""
+    project = store.create(
+        _uid("p1"),
+        "Both",
+        "alice@example.com",
+        config={"host_id": "h1"},
+        budget_config={"limit_usd": 10.0},
+    )
+    assert project.config == {"host_id": "h1"}
+    assert project.budget_config == {"limit_usd": 10.0}
+
+
+def test_update_replaces_budget_config_and_stamps_updated_at(
+    store: SqlAlchemyProjectStore,
+) -> None:
+    """Passing a new ``budget_config`` replaces the stored one and stamps updated_at."""
+    store.create(_uid("p1"), "P", "alice@example.com", budget_config={"limit_usd": 10.0})
+    updated = store.update(
+        _uid("p1"), owner_user_id="alice@example.com", budget_config={"limit_usd": 20.0}
+    )
+    assert updated is not None
+    assert updated.budget_config == {"limit_usd": 20.0}
+    assert updated.updated_at is not None
+
+
+def test_update_budget_config_none_leaves_it_unchanged(store: SqlAlchemyProjectStore) -> None:
+    """``budget_config=None`` (the default) leaves the stored budget untouched."""
+    store.create(_uid("p1"), "P", "alice@example.com", budget_config={"limit_usd": 10.0})
+    # Rename only — budget_config omitted — must not wipe the stored budget.
+    updated = store.update(_uid("p1"), owner_user_id="alice@example.com", name="Renamed")
+    assert updated is not None
+    assert updated.budget_config == {"limit_usd": 10.0}
+
+
+def test_update_config_does_not_touch_budget_config(store: SqlAlchemyProjectStore) -> None:
+    """Updating ``config`` alone leaves an already-set ``budget_config`` intact."""
+    store.create(
+        _uid("p1"),
+        "P",
+        "alice@example.com",
+        config={"host_id": "old"},
+        budget_config={"limit_usd": 10.0},
+    )
+    updated = store.update(
+        _uid("p1"), owner_user_id="alice@example.com", config={"host_id": "new"}
+    )
+    assert updated is not None
+    assert updated.config == {"host_id": "new"}
+    assert updated.budget_config == {"limit_usd": 10.0}
+
+
+def test_update_empty_budget_config_clears_budget(store: SqlAlchemyProjectStore) -> None:
+    """An explicit ``budget_config={}`` clears the stored budget (unlimited)."""
+    store.create(_uid("p1"), "P", "alice@example.com", budget_config={"limit_usd": 10.0})
+    updated = store.update(_uid("p1"), owner_user_id="alice@example.com", budget_config={})
+    assert updated is not None
+    assert updated.budget_config == {}
+    assert updated.updated_at is not None
+
+
+def test_update_same_budget_config_is_noop(store: SqlAlchemyProjectStore) -> None:
+    """Re-setting the identical budget_config changes nothing, leaving updated_at None."""
+    store.create(_uid("p1"), "P", "alice@example.com", budget_config={"limit_usd": 10.0})
+    updated = store.update(
+        _uid("p1"), owner_user_id="alice@example.com", budget_config={"limit_usd": 10.0}
+    )
+    assert updated is not None
+    assert updated.updated_at is None
+
+
+# ── get_by_id (internal, unscoped — PLAN.md, closes #1662) ──────────────────
+
+
+def test_get_by_id_returns_project_for_any_owner(store: SqlAlchemyProjectStore) -> None:
+    """Unlike ``get``, ``get_by_id`` needs no owner match to return the row.
+
+    This is the policy-builder's read path (build_policy_engine has no
+    authenticated caller to scope a request-shaped ``get`` to) — it must
+    resolve regardless of who owns the project.
+    """
+    store.create(_uid("p1"), "Alice's", "alice@example.com", budget_config={"limit_usd": 5.0})
+    got = store.get_by_id(_uid("p1"))
+    assert got is not None
+    assert got.owner_user_id == "alice@example.com"
+    assert got.budget_config == {"limit_usd": 5.0}
+
+
+def test_get_by_id_missing_returns_none(store: SqlAlchemyProjectStore) -> None:
+    """An unknown id returns ``None``, same as ``get``."""
+    assert store.get_by_id(_uid("nope")) is None
+
+
 # ── update ─────────────────────────────────────────────────────────────────
 
 

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -34,9 +34,13 @@ import {
   createProject as apiCreateProject,
   deleteProject as apiDeleteProject,
   getProject as apiGetProject,
+  getProjectBudget as apiGetProjectBudget,
   listProjects as apiListProjects,
+  type ProjectBudgetConfig,
+  type ProjectBudgetReport,
   type ProjectConfig,
   renameProject as apiRenameProject,
+  updateProjectBudget as apiUpdateProjectBudget,
   updateProjectConfig as apiUpdateProjectConfig,
 } from "@/lib/projectsApi";
 import { useChatStore } from "@/store/chatStore";
@@ -1492,6 +1496,59 @@ export function useUpdateProjectConfig() {
           : [...prev, summary];
       });
       void queryClient.invalidateQueries({ queryKey: ["project-config"] });
+      void queryClient.invalidateQueries({ queryKey: ["projects"] });
+    },
+  });
+}
+
+/**
+ * Fetch a project's monthly budget config + current month-to-date spend
+ * (`GET /v1/projects/{id}/budget`). See `ProjectSettingsDialog`'s budget
+ * section and `PLAN.md`, closes #1662.
+ */
+export function useProjectBudget(id: string | null) {
+  return useQuery<ProjectBudgetReport>({
+    queryKey: ["project-budget", id],
+    queryFn: async () => apiGetProjectBudget(id as string),
+    enabled: id !== null,
+    staleTime: 30_000,
+  });
+}
+
+/**
+ * Replace a project's stored `budget_config` (`PATCH /v1/projects/{id}`). A
+ * label-only folder (`id === null`) is promoted on demand, mirroring
+ * `useUpdateProjectConfig`. Passing `budget_config: {}` clears the budget
+ * (unlimited).
+ */
+export function useUpdateProjectBudget() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      name,
+      budgetConfig,
+    }: {
+      id: string | null;
+      name: string;
+      budgetConfig: ProjectBudgetConfig;
+    }) => {
+      const projectId = id ?? (await apiCreateProject(name)).id;
+      return apiUpdateProjectBudget(projectId, budgetConfig);
+    },
+    onSuccess: (project) => {
+      // Invalidate rather than seed: unlike config (a pure client-side
+      // prefill), the budget report also carries server-computed spend_usd,
+      // which this mutation response doesn't include — a stale seed would
+      // show the pre-edit spend until the next 30s refetch.
+      void queryClient.invalidateQueries({ queryKey: ["project-budget", project.id] });
+      queryClient.setQueryData<ProjectSummary[]>(["projects"], (prev) => {
+        if (!prev) return prev;
+        const summary = { id: project.id, name: project.name };
+        return prev.some((p) => p.name === project.name)
+          ? prev.map((p) => (p.name === project.name ? summary : p))
+          : [...prev, summary];
+      });
       void queryClient.invalidateQueries({ queryKey: ["projects"] });
     },
   });

--- a/web/src/lib/projectsApi.ts
+++ b/web/src/lib/projectsApi.ts
@@ -36,6 +36,22 @@ export interface ProjectConfig {
   use_worktree?: boolean;
 }
 
+/**
+ * A project's optional monthly spend budget. Enforced by the
+ * `project_monthly_cost_budget` policy, synthesized automatically for any
+ * session filed into a project with a positive `limit_usd` — see
+ * `omnigent/policies/builtins/cost.py`, closes #1662. `{}` (both fields
+ * unset) means "no budget configured" (unlimited).
+ */
+export interface ProjectBudgetConfig {
+  /** Hard monthly limit in USD. Once month-to-date spend reaches this, the
+   *  project's sessions are gated onto cheaper models (not blocked outright)
+   *  until the owner raises the limit or the UTC month rolls over. */
+  limit_usd?: number;
+  /** Optional soft warning checkpoints in USD, each in `(0, limit_usd)`. */
+  ask_thresholds_usd?: number[];
+}
+
 /** A first-class project. Mirrors the `ProjectObject` response shape. */
 export interface Project {
   id: string;
@@ -46,6 +62,19 @@ export interface Project {
   updated_at?: number | null;
   /** Stored default session settings; `{}` when the project has none. */
   config?: ProjectConfig;
+  /** Stored monthly budget; `{}` when the project has none configured. */
+  budget_config?: ProjectBudgetConfig;
+}
+
+/** `GET /v1/projects/{id}/budget` response — config plus live spend. */
+export interface ProjectBudgetReport {
+  /** The configured monthly limit, or `null` when unlimited. */
+  limit_usd: number | null;
+  ask_thresholds_usd: number[];
+  /** Month-to-date spend in USD, reported even when unlimited. */
+  spend_usd: number;
+  /** The UTC calendar month this report covers, e.g. `"2026-07"`. */
+  month_utc: string;
 }
 
 interface ProjectListResponse {
@@ -112,6 +141,34 @@ export async function updateProjectConfig(id: string, config: ProjectConfig): Pr
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ config }),
+  });
+  if (!res.ok) throw new Error(await readError(res));
+  return (await res.json()) as Project;
+}
+
+/** Fetch a project's budget config + current month-to-date spend. 404s if not owned. */
+export async function getProjectBudget(id: string): Promise<ProjectBudgetReport> {
+  const res = await authenticatedFetch(`/v1/projects/${encodeURIComponent(id)}/budget`);
+  if (!res.ok) throw new Error(await readError(res));
+  return (await res.json()) as ProjectBudgetReport;
+}
+
+/**
+ * Replace a project's stored `budget_config`. Passing `{}` clears it (the
+ * server treats `{}` as "no budget configured" / unlimited, distinct from
+ * omitting the field, which leaves it unchanged). Only `budget_config` is
+ * sent, so the name and `config` are untouched. A `limit_usd` <= 0, or an
+ * `ask_thresholds_usd` entry outside `(0, limit_usd)`, is rejected with the
+ * server's 422 message.
+ */
+export async function updateProjectBudget(
+  id: string,
+  budgetConfig: ProjectBudgetConfig,
+): Promise<Project> {
+  const res = await authenticatedFetch(`/v1/projects/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ budget_config: budgetConfig }),
   });
   if (!res.ok) throw new Error(await readError(res));
   return (await res.json()) as Project;

--- a/web/src/shell/ProjectSettingsDialog.test.tsx
+++ b/web/src/shell/ProjectSettingsDialog.test.tsx
@@ -3,11 +3,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { ProjectSettingsDialog } from "./ProjectSettingsDialog";
-import { getProject, updateProjectConfig, createProject } from "@/lib/projectsApi";
+import {
+  getProject,
+  getProjectBudget,
+  updateProjectConfig,
+  updateProjectBudget,
+  createProject,
+} from "@/lib/projectsApi";
 
 vi.mock("@/lib/projectsApi", () => ({
   getProject: vi.fn(),
+  getProjectBudget: vi.fn(),
   updateProjectConfig: vi.fn(),
+  updateProjectBudget: vi.fn(),
   createProject: vi.fn(),
 }));
 vi.mock("@/hooks/useHosts", () => ({
@@ -47,23 +55,46 @@ vi.mock("./WorkspacePicker", () => ({
 }));
 
 const getProjectMock = vi.mocked(getProject);
+const getBudgetMock = vi.mocked(getProjectBudget);
 const updateMock = vi.mocked(updateProjectConfig);
+const updateBudgetMock = vi.mocked(updateProjectBudget);
 const createMock = vi.mocked(createProject);
 
 function renderDialog(projectId: string | null = "p_1") {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(
-    <QueryClientProvider client={client}>
-      <ProjectSettingsDialog open onOpenChange={vi.fn()} projectId={projectId} projectName="Work" />
-    </QueryClientProvider>,
-  );
+  const onOpenChange = vi.fn();
+  return {
+    ...render(
+      <QueryClientProvider client={client}>
+        <ProjectSettingsDialog
+          open
+          onOpenChange={onOpenChange}
+          projectId={projectId}
+          projectName="Work"
+        />
+      </QueryClientProvider>,
+    ),
+    onOpenChange,
+  };
 }
 
 beforeEach(() => {
   getProjectMock.mockReset();
+  getBudgetMock.mockReset();
   updateMock.mockReset();
+  updateBudgetMock.mockReset();
   createMock.mockReset();
   updateMock.mockResolvedValue({ id: "p_1", name: "Work", config: {} });
+  // Default: no budget configured, nothing spent — matches an unconfigured
+  // project so pre-existing config-only tests don't need to know about
+  // budget at all.
+  getBudgetMock.mockResolvedValue({
+    limit_usd: null,
+    ask_thresholds_usd: [],
+    spend_usd: 0,
+    month_utc: "2026-07",
+  });
+  updateBudgetMock.mockResolvedValue({ id: "p_1", name: "Work", config: {}, budget_config: {} });
 });
 
 afterEach(cleanup);
@@ -212,5 +243,173 @@ describe("ProjectSettingsDialog", () => {
     // Even if a submit is forced, onSubmit bails — no clearing PATCH is sent.
     fireEvent.submit(screen.getByTestId("project-settings-save").closest("form")!);
     expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  describe("budget (PLAN.md, closes #1662)", () => {
+    it("seeds the limit and warning fields from the stored budget", async () => {
+      getProjectMock.mockResolvedValue({ id: "p_1", name: "Work", config: {} });
+      getBudgetMock.mockResolvedValue({
+        limit_usd: 50,
+        ask_thresholds_usd: [25],
+        spend_usd: 12.5,
+        month_utc: "2026-07",
+      });
+      renderDialog();
+      await waitFor(() =>
+        expect(screen.getByTestId("project-settings-budget-limit")).toHaveValue(50),
+      );
+      expect(screen.getByTestId("project-settings-budget-threshold")).toHaveValue(25);
+    });
+
+    it("shows month-to-date spend against the limit as a progress bar", async () => {
+      getProjectMock.mockResolvedValue({ id: "p_1", name: "Work", config: {} });
+      getBudgetMock.mockResolvedValue({
+        limit_usd: 50,
+        ask_thresholds_usd: [],
+        spend_usd: 12.5,
+        month_utc: "2026-07",
+      });
+      renderDialog();
+      const report = await screen.findByTestId("project-settings-budget-report");
+      expect(report).toHaveTextContent("$12.50 / $50.00");
+    });
+
+    it("reports spend even when unlimited, with no progress bar", async () => {
+      getProjectMock.mockResolvedValue({ id: "p_1", name: "Work", config: {} });
+      getBudgetMock.mockResolvedValue({
+        limit_usd: null,
+        ask_thresholds_usd: [],
+        spend_usd: 3.0,
+        month_utc: "2026-07",
+      });
+      renderDialog();
+      const report = await screen.findByTestId("project-settings-budget-report");
+      expect(report).toHaveTextContent("$3.00");
+      expect(report).not.toHaveTextContent("/");
+    });
+
+    it("hides the warning-threshold field until a limit is entered", async () => {
+      getProjectMock.mockResolvedValue({ id: "p_1", name: "Work", config: {} });
+      renderDialog();
+      await waitFor(() =>
+        expect((screen.getByTestId("project-settings-save") as HTMLButtonElement).disabled).toBe(
+          false,
+        ),
+      );
+      expect(screen.queryByTestId("project-settings-budget-threshold")).not.toBeInTheDocument();
+
+      fireEvent.change(screen.getByTestId("project-settings-budget-limit"), {
+        target: { value: "50" },
+      });
+      expect(screen.getByTestId("project-settings-budget-threshold")).toBeInTheDocument();
+    });
+
+    it("saves the entered limit and threshold, after the config save resolves", async () => {
+      getProjectMock.mockResolvedValue({ id: "p_1", name: "Work", config: {} });
+      renderDialog();
+      await waitFor(() =>
+        expect((screen.getByTestId("project-settings-save") as HTMLButtonElement).disabled).toBe(
+          false,
+        ),
+      );
+
+      fireEvent.change(screen.getByTestId("project-settings-budget-limit"), {
+        target: { value: "50" },
+      });
+      fireEvent.change(screen.getByTestId("project-settings-budget-threshold"), {
+        target: { value: "25" },
+      });
+      fireEvent.click(screen.getByTestId("project-settings-save"));
+
+      await waitFor(() =>
+        expect(updateBudgetMock).toHaveBeenCalledWith("p_1", {
+          limit_usd: 50,
+          ask_thresholds_usd: [25],
+        }),
+      );
+      // Sequenced, not parallel — config must have resolved before budget saves
+      // (both independently promote a label-only folder; see ProjectSettingsDialog's
+      // onSubmit comment on why parallel mutations would race two creates).
+      expect(updateMock).toHaveBeenCalled();
+    });
+
+    it("clears the budget when the limit field is emptied", async () => {
+      getProjectMock.mockResolvedValue({ id: "p_1", name: "Work", config: {} });
+      getBudgetMock.mockResolvedValue({
+        limit_usd: 50,
+        ask_thresholds_usd: [25],
+        spend_usd: 0,
+        month_utc: "2026-07",
+      });
+      const { onOpenChange } = renderDialog();
+      await waitFor(() =>
+        expect(screen.getByTestId("project-settings-budget-limit")).toHaveValue(50),
+      );
+
+      fireEvent.change(screen.getByTestId("project-settings-budget-limit"), {
+        target: { value: "" },
+      });
+      fireEvent.click(screen.getByTestId("project-settings-save"));
+
+      // Wait for the full mutation chain — config, then budget, then the
+      // dialog-close callback — to settle before the test ends, so its
+      // pending promises can't resolve mid-flight during a LATER test.
+      await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+      expect(updateBudgetMock).toHaveBeenCalledWith("p_1", {});
+    });
+
+    it("rejects a non-positive limit client-side without calling the API", async () => {
+      getProjectMock.mockResolvedValue({ id: "p_1", name: "Work", config: {} });
+      renderDialog();
+      await waitFor(() =>
+        expect((screen.getByTestId("project-settings-save") as HTMLButtonElement).disabled).toBe(
+          false,
+        ),
+      );
+
+      fireEvent.change(screen.getByTestId("project-settings-budget-limit"), {
+        target: { value: "-5" },
+      });
+      fireEvent.click(screen.getByTestId("project-settings-save"));
+
+      await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/positive number/i));
+      expect(updateMock).not.toHaveBeenCalled();
+      expect(updateBudgetMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects a warning threshold at or above the limit client-side", async () => {
+      getProjectMock.mockResolvedValue({ id: "p_1", name: "Work", config: {} });
+      renderDialog();
+      await waitFor(() =>
+        expect((screen.getByTestId("project-settings-save") as HTMLButtonElement).disabled).toBe(
+          false,
+        ),
+      );
+
+      fireEvent.change(screen.getByTestId("project-settings-budget-limit"), {
+        target: { value: "50" },
+      });
+      fireEvent.change(screen.getByTestId("project-settings-budget-threshold"), {
+        target: { value: "50" },
+      });
+      fireEvent.click(screen.getByTestId("project-settings-save"));
+
+      await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/below the limit/i));
+      expect(updateMock).not.toHaveBeenCalled();
+      expect(updateBudgetMock).not.toHaveBeenCalled();
+    });
+
+    it("blocks Save when the budget report fails to load", async () => {
+      getProjectMock.mockResolvedValue({ id: "p_1", name: "Work", config: {} });
+      getBudgetMock.mockRejectedValue(new Error("500 Server Error"));
+      renderDialog();
+
+      await waitFor(() =>
+        expect(screen.getByTestId("project-settings-budget-load-error")).toBeInTheDocument(),
+      );
+      expect((screen.getByTestId("project-settings-save") as HTMLButtonElement).disabled).toBe(
+        true,
+      );
+    });
   });
 });

--- a/web/src/shell/ProjectSettingsDialog.tsx
+++ b/web/src/shell/ProjectSettingsDialog.tsx
@@ -30,8 +30,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Progress } from "@/components/ui/progress";
 import { Switch } from "@/components/ui/switch";
-import { useProjectConfig, useUpdateProjectConfig } from "@/hooks/useConversations";
+import {
+  useProjectBudget,
+  useProjectConfig,
+  useUpdateProjectBudget,
+  useUpdateProjectConfig,
+} from "@/hooks/useConversations";
 import { useAvailableAgents } from "@/hooks/useAvailableAgents";
 import { useHosts } from "@/hooks/useHosts";
 import { sortAgentsForDisplay } from "@/lib/agentGrouping";
@@ -39,7 +46,7 @@ import { sandboxOptionLabel } from "@/lib/capabilities";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { SANDBOX_HOST_CHOICE } from "@/lib/hostPreferences";
 import { isNativeCodingAgent } from "@/lib/nativeCodingAgents";
-import type { ProjectConfig } from "@/lib/projectsApi";
+import type { ProjectBudgetConfig, ProjectConfig } from "@/lib/projectsApi";
 import { shouldGuardDialogDismiss } from "@/lib/dialogDismissGuard";
 import { AgentHarnessPicker } from "./NewChatDialog";
 import { isNavigablePath, WorkspacePicker } from "./WorkspacePicker";
@@ -100,6 +107,15 @@ export function ProjectSettingsDialog({
   // never in this state.
   const loadFailed = projectId !== null && isError;
   const updateConfig = useUpdateProjectConfig();
+  // Budget: a label-only folder has no row, so no spend to report either —
+  // same "fetch only for a first-class project" gate as config above.
+  const {
+    data: budgetReport,
+    isLoading: isBudgetLoading,
+    isError: isBudgetError,
+  } = useProjectBudget(open ? projectId : null);
+  const budgetLoadFailed = projectId !== null && isBudgetError;
+  const updateBudget = useUpdateProjectBudget();
   const hosts = useHosts();
   const { data: agents } = useAvailableAgents();
   const info = useServerInfo();
@@ -119,6 +135,12 @@ export function ProjectSettingsDialog({
   const [useWorktree, setUseWorktree] = useState(false);
   const [agentId, setAgentId] = useState<string | null>(null);
   const [workspaceOpen, setWorkspaceOpen] = useState(false);
+  // Budget draft: text inputs so an empty field unambiguously means "no
+  // limit / no warning" rather than coercing to 0, which the policy factory
+  // (and the update endpoint's own validation) would reject as <= 0.
+  const [limitUsd, setLimitUsd] = useState("");
+  const [askThresholdUsd, setAskThresholdUsd] = useState("");
+  const [budgetValidationError, setBudgetValidationError] = useState<string | null>(null);
 
   // The agent picker and the host Select portal their dropdowns OUTSIDE
   // DialogContent, so their dismiss (pick an option / click the body while
@@ -165,11 +187,48 @@ export function ProjectSettingsDialog({
     setWorkspaceOpen(false);
   }, [open, stored, loadFailed]);
 
+  useEffect(() => {
+    if (!open || budgetLoadFailed) return;
+    setLimitUsd(budgetReport?.limit_usd != null ? String(budgetReport.limit_usd) : "");
+    // Only a single warning checkpoint is editable here (v1 of the budget
+    // UI); a budget saved with multiple thresholds (e.g. via the API
+    // directly) shows its lowest one and a save from this dialog collapses
+    // back to that single value.
+    const thresholds = budgetReport?.ask_thresholds_usd ?? [];
+    setAskThresholdUsd(thresholds.length > 0 ? String(Math.min(...thresholds)) : "");
+  }, [open, budgetReport, budgetLoadFailed]);
+
   const onSubmit = (e: FormEvent) => {
     e.preventDefault();
     // Guard against submitting a blank draft seeded from a failed load, which
     // the server would read as "clear the stored defaults".
-    if (loadFailed) return;
+    if (loadFailed || budgetLoadFailed) return;
+    setBudgetValidationError(null);
+
+    // Build budget_config from the two text inputs. An empty limit means "no
+    // budget" (`{}`), matching how an all-default config dialog clears to
+    // `{}` — validated client-side first so a typo doesn't round-trip to the
+    // server just to bounce back as a 422.
+    const trimmedLimit = limitUsd.trim();
+    let budgetConfig: ProjectBudgetConfig = {};
+    if (trimmedLimit !== "") {
+      const limit = Number(trimmedLimit);
+      if (!Number.isFinite(limit) || limit <= 0) {
+        setBudgetValidationError("Monthly limit must be a positive number.");
+        return;
+      }
+      budgetConfig = { limit_usd: limit };
+      const trimmedThreshold = askThresholdUsd.trim();
+      if (trimmedThreshold !== "") {
+        const threshold = Number(trimmedThreshold);
+        if (!Number.isFinite(threshold) || threshold <= 0 || threshold >= limit) {
+          setBudgetValidationError("Warning threshold must be a positive number below the limit.");
+          return;
+        }
+        budgetConfig.ask_thresholds_usd = [threshold];
+      }
+    }
+
     // Build the config from set fields only — an unset slot is an absent key,
     // so the whole object is `{}` when nothing is configured (the server treats
     // that as "clear the stored defaults").
@@ -186,9 +245,23 @@ export function ProjectSettingsDialog({
     // leaving it OFF stores nothing, so an all-default dialog still clears to {}.
     if (useWorktree) config.use_worktree = true;
 
+    // Sequenced, not parallel: both mutations independently promote a
+    // label-only folder (create a row when `projectId === null`) the same
+    // way `useUpdateProjectConfig` does. Firing them in parallel would race
+    // two `createProject` calls for the same name — the second loses to a
+    // 409. Saving config first and reusing ITS resolved id for the budget
+    // save (rather than the stale `projectId` closure) guarantees exactly
+    // one row is created either way.
     updateConfig.mutate(
       { id: projectId, name: projectName, config },
-      { onSuccess: () => onOpenChange(false) },
+      {
+        onSuccess: (project) => {
+          updateBudget.mutate(
+            { id: project.id, name: projectName, budgetConfig },
+            { onSuccess: () => onOpenChange(false) },
+          );
+        },
+      },
     );
   };
 
@@ -416,6 +489,69 @@ export function ProjectSettingsDialog({
             </div>
           </Field>
 
+          <div className="flex flex-col gap-4 border-t pt-4">
+            <Field
+              label="Monthly budget"
+              hint="Cap this project's LLM spend for the calendar month (UTC)"
+              htmlFor="project-settings-budget-limit"
+            >
+              <div className="flex items-center gap-1.5">
+                <span className="text-muted-foreground text-sm">$</span>
+                <Input
+                  id="project-settings-budget-limit"
+                  data-testid="project-settings-budget-limit"
+                  type="number"
+                  step="any"
+                  inputMode="decimal"
+                  placeholder="No limit"
+                  value={limitUsd}
+                  onChange={(e) => setLimitUsd(e.target.value)}
+                  disabled={isBudgetLoading}
+                />
+              </div>
+            </Field>
+
+            {limitUsd.trim() !== "" && (
+              <Field
+                label="Warning at"
+                hint="Ask for confirmation once month-to-date spend crosses this — optional"
+                htmlFor="project-settings-budget-threshold"
+              >
+                <div className="flex items-center gap-1.5">
+                  <span className="text-muted-foreground text-sm">$</span>
+                  <Input
+                    id="project-settings-budget-threshold"
+                    data-testid="project-settings-budget-threshold"
+                    type="number"
+                    step="any"
+                    inputMode="decimal"
+                    placeholder="No warning"
+                    value={askThresholdUsd}
+                    onChange={(e) => setAskThresholdUsd(e.target.value)}
+                    disabled={isBudgetLoading}
+                  />
+                </div>
+              </Field>
+            )}
+
+            {!budgetLoadFailed && budgetReport && (
+              <div className="flex flex-col gap-1.5" data-testid="project-settings-budget-report">
+                <div className="flex items-center justify-between text-muted-foreground text-xs">
+                  <span>Spent this month</span>
+                  <span>
+                    ${budgetReport.spend_usd.toFixed(2)}
+                    {budgetReport.limit_usd != null && ` / $${budgetReport.limit_usd.toFixed(2)}`}
+                  </span>
+                </div>
+                {budgetReport.limit_usd != null && budgetReport.limit_usd > 0 && (
+                  <Progress
+                    value={Math.min(100, (budgetReport.spend_usd / budgetReport.limit_usd) * 100)}
+                  />
+                )}
+              </div>
+            )}
+          </div>
+
           {loadFailed && (
             <p
               className="text-destructive text-sm"
@@ -426,9 +562,29 @@ export function ProjectSettingsDialog({
               disabled so your existing defaults aren't overwritten.
             </p>
           )}
+          {budgetLoadFailed && (
+            <p
+              className="text-destructive text-sm"
+              role="alert"
+              data-testid="project-settings-budget-load-error"
+            >
+              Couldn't load this project's budget. Close and reopen to try again — saving is
+              disabled so the existing budget isn't overwritten.
+            </p>
+          )}
+          {budgetValidationError && (
+            <p className="text-destructive text-sm" role="alert">
+              {budgetValidationError}
+            </p>
+          )}
           {updateConfig.isError && (
             <p className="text-destructive text-sm" role="alert">
               {(updateConfig.error as Error).message}
+            </p>
+          )}
+          {updateBudget.isError && (
+            <p className="text-destructive text-sm" role="alert">
+              {(updateBudget.error as Error).message}
             </p>
           )}
 
@@ -437,16 +593,23 @@ export function ProjectSettingsDialog({
               type="button"
               variant="ghost"
               onClick={() => onOpenChange(false)}
-              disabled={updateConfig.isPending}
+              disabled={updateConfig.isPending || updateBudget.isPending}
             >
               Cancel
             </Button>
             <Button
               type="submit"
               data-testid="project-settings-save"
-              disabled={updateConfig.isPending || isLoading || loadFailed}
+              disabled={
+                updateConfig.isPending ||
+                updateBudget.isPending ||
+                isLoading ||
+                isBudgetLoading ||
+                loadFailed ||
+                budgetLoadFailed
+              }
             >
-              {updateConfig.isPending ? "Saving…" : "Save"}
+              {updateConfig.isPending || updateBudget.isPending ? "Saving…" : "Save"}
             </Button>
           </DialogFooter>
         </form>

--- a/web/src/shell/Sidebar.archive.test.tsx
+++ b/web/src/shell/Sidebar.archive.test.tsx
@@ -52,6 +52,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useProjectConfig: () => ({ data: undefined, isLoading: false }),
   useUpdateProjectConfig: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useProjectBudget: () => ({ data: undefined, isLoading: false, isError: false }),
+  useUpdateProjectBudget: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.bulkActionLayout.test.tsx
+++ b/web/src/shell/Sidebar.bulkActionLayout.test.tsx
@@ -58,6 +58,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useProjectConfig: () => ({ data: undefined, isLoading: false }),
   useUpdateProjectConfig: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useProjectBudget: () => ({ data: undefined, isLoading: false, isError: false }),
+  useUpdateProjectBudget: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.delete.test.tsx
+++ b/web/src/shell/Sidebar.delete.test.tsx
@@ -50,6 +50,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useProjectConfig: () => ({ data: undefined, isLoading: false }),
   useUpdateProjectConfig: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useProjectBudget: () => ({ data: undefined, isLoading: false, isError: false }),
+  useUpdateProjectBudget: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.pinnedAutoExpand.test.tsx
+++ b/web/src/shell/Sidebar.pinnedAutoExpand.test.tsx
@@ -40,6 +40,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useProjectConfig: () => ({ data: undefined, isLoading: false }),
   useUpdateProjectConfig: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useProjectBudget: () => ({ data: undefined, isLoading: false, isError: false }),
+  useUpdateProjectBudget: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.projectHeaderChevron.test.tsx
+++ b/web/src/shell/Sidebar.projectHeaderChevron.test.tsx
@@ -56,6 +56,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useProjectConfig: () => ({ data: undefined, isLoading: false }),
   useUpdateProjectConfig: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useProjectBudget: () => ({ data: undefined, isLoading: false, isError: false }),
+  useUpdateProjectBudget: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -116,6 +116,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useProjectConfig: () => ({ data: undefined, isLoading: false }),
   useUpdateProjectConfig: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useProjectBudget: () => ({ data: undefined, isLoading: false, isError: false }),
+  useUpdateProjectBudget: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.shiftSelect.test.tsx
+++ b/web/src/shell/Sidebar.shiftSelect.test.tsx
@@ -98,6 +98,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useProjectConfig: () => ({ data: undefined, isLoading: false }),
   useUpdateProjectConfig: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useProjectBudget: () => ({ data: undefined, isLoading: false, isError: false }),
+  useUpdateProjectBudget: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: vi.fn(() => Promise.resolve([] as string[])),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.stop.test.tsx
+++ b/web/src/shell/Sidebar.stop.test.tsx
@@ -49,6 +49,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useProjectConfig: () => ({ data: undefined, isLoading: false }),
   useUpdateProjectConfig: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useProjectBudget: () => ({ data: undefined, isLoading: false, isError: false }),
+  useUpdateProjectBudget: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.subagentHighlight.test.tsx
+++ b/web/src/shell/Sidebar.subagentHighlight.test.tsx
@@ -47,6 +47,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   useProjectConfig: () => ({ data: undefined, isLoading: false }),
   useUpdateProjectConfig: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useProjectBudget: () => ({ data: undefined, isLoading: false, isError: false }),
+  useUpdateProjectBudget: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: () => Promise.resolve([]),
   PROJECT_LABEL_KEY: "omni_project",
 }));

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -134,6 +134,8 @@ vi.mock("@/hooks/useConversations", () => ({
   useCreateProject: () => ({ mutate: createProjectSpy, isPending: false, isError: false }),
   useProjectConfig: () => ({ data: undefined, isLoading: false }),
   useUpdateProjectConfig: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useProjectBudget: () => ({ data: undefined, isLoading: false, isError: false }),
+  useUpdateProjectBudget: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
   fetchProjectSessionIds: fetchProjectSessionIdsMock,
   PROJECT_LABEL_KEY: "omni_project",
 }));


### PR DESCRIPTION
## Related issue

Closes #1662

## Summary

- Let a project owner cap the project's month-to-date LLM spend: a new
  `budget_config` column on `projects` (`limit_usd` +
  `ask_thresholds_usd`) and a `project_monthly_cost` rollup table
  (mirrors the existing `user_daily_cost` shape), added via Alembic
  migration.
- Extend the turn-boundary cost write path to also record spend into
  the project's monthly rollup, attributing sub-agent spend to the
  spawn-tree root's `project_id` (sub-agents never carry their own).
- Add a `project_monthly_cost_budget` policy factory
  (`omnigent/policies/builtins/cost.py`), synthesized automatically by
  `build_policy_engine` for any session filed into a budgeted project —
  no per-agent YAML declaration needed. Same staged-ASK /
  model-downgrade-on-DENY semantics as the existing
  `user_daily_cost_budget`, so a project owner raising the limit
  unblocks the very next turn with no separate retry mechanism.
- Fix a related gap in `any_policies_apply`'s fast path: it previously
  had no way to know about a project's budget, so a session with no
  other policies filed into a budgeted project would skip the policy
  engine build entirely and the budget would never be enforced.
- Add `budget_config` CRUD to the projects API plus
  `GET /v1/projects/{id}/budget` (limit, thresholds, month-to-date
  spend), and a "Monthly budget" section in the project settings
  dialog with a live spend-vs-limit progress bar.

## Test Plan

- `uv run pytest tests/policies/builtins/test_project_monthly_cost.py tests/stores/test_conversation_store.py tests/stores/test_project_store.py tests/server/routes/test_session_updates_ws.py tests/server/routes/test_projects_crud.py tests/runtime/policies/test_project_budget_wiring.py -q` (313 passed)
- `uv run pytest tests/policies/ tests/runtime/policies/ -q` (872 passed, no regressions in the existing cost-budget policies)
- `pnpm --dir web exec vitest run` (4703 passed — 1 pre-existing, unrelated failure in `AgentInfo.test.tsx`)
- `pnpm --dir web run type-check` (71 pre-existing errors, unchanged before/after — no new type errors)
- Manual verification: ran the server + web UI locally, created a
  project, set a $10 monthly limit with a $5 warning threshold from
  the settings dialog, confirmed the PATCH round-trips through
  `GET /v1/projects/{id}/budget`, and confirmed the dialog re-seeds
  correctly (limit/threshold inputs + spend progress bar) on reopen.

## Demo

Project settings dialog showing the new "Monthly budget" section —
limit and warning threshold set, with the live "$0.00 / $10.00" spend
progress bar underneath.

<img width="458" height="541" alt="image" src="https://github.com/user-attachments/assets/4cb6fd91-af70-439f-bdb1-d9a78958aa53" />


## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New coverage spans every layer touched: the policy factory
(`tests/policies/builtins/test_project_monthly_cost.py`), the
automatic-synthesis wiring and `any_policies_apply` fast-path fix
(`tests/runtime/policies/test_project_budget_wiring.py`), the store
rollup (`tests/stores/test_conversation_store.py`,
`tests/stores/test_project_store.py`), the turn-boundary write path
including the sub-agent root-fallback
(`tests/server/routes/test_session_updates_ws.py`), the projects API
(`tests/server/routes/test_projects_crud.py`), and the settings-dialog
UI (`web/src/shell/ProjectSettingsDialog.test.tsx`).
