### PR TITLE
refactor(auth): narrow cookie claims

### DIFF
--- a/omnigent/server/auth.py
+++ b/omnigent/server/auth.py
@@ -518,6 +518,8 @@ class UnifiedAuthProvider(AuthProvider):
         # share `cookie_secret` and `session_cookie_name` properties
         # by construction (see AccountsConfig docstring).
         cookie_config = self._oidc_config if self._source == "oidc" else self._accounts_config
+        if cookie_config is None:
+            return None
         cookie_name = cookie_config.session_cookie_name
         token = request.cookies.get(cookie_name)
         if not token:
@@ -543,7 +545,7 @@ class UnifiedAuthProvider(AuthProvider):
             return None
 
         user_id = payload.get("sub")
-        if not user_id or user_id in _RESERVED_USERS:
+        if not isinstance(user_id, str) or not user_id or user_id in _RESERVED_USERS:
             return None
 
         # Delegated (device-grant) tokens carry a ``grant_id`` claim.
@@ -552,6 +554,8 @@ class UnifiedAuthProvider(AuthProvider):
         # served from the plain user-id cache (which would skip both).
         grant_id = payload.get("grant_id")
         if grant_id is not None:
+            if not isinstance(grant_id, str):
+                return None
             if not delegated_path_allowed(request.url.path):
                 return None
             if self._grant_revoked is not None and self._grant_revoked(grant_id):

--- a/tests/server/test_oidc.py
+++ b/tests/server/test_oidc.py
@@ -523,6 +523,12 @@ def test_oidc_source_returns_none_for_missing_cookie() -> None:
     assert provider.get_user_id(request) is None
 
 
+def test_oidc_source_returns_none_for_missing_cookie_config() -> None:
+    provider = UnifiedAuthProvider(source="oidc")
+
+    assert provider.get_user_id(_mock_request()) is None
+
+
 def test_oidc_source_returns_none_for_tampered_cookie() -> None:
     """OIDC source rejects a cookie signed with a different secret.
 
@@ -582,6 +588,43 @@ def test_oidc_source_rejects_reserved_sub_claims(reserved: str) -> None:
         ttl_hours=8,
         provider="google",
     )
+    request = _mock_request(cookies={config.session_cookie_name: token})
+    assert provider.get_user_id(request) is None
+
+
+def test_oidc_source_rejects_non_string_sub_claim() -> None:
+    config = _make_oidc_config()
+    provider = UnifiedAuthProvider(source="oidc", oidc_config=config)
+    token = jwt.encode(
+        {
+            "sub": 123,
+            "iat": int(time.time()),
+            "exp": int(time.time()) + 3600,
+            "provider": "google",
+        },
+        _TEST_SECRET,
+        algorithm="HS256",
+    )
+
+    request = _mock_request(cookies={config.session_cookie_name: token})
+    assert provider.get_user_id(request) is None
+
+
+def test_oidc_source_rejects_non_string_grant_id_claim() -> None:
+    config = _make_oidc_config()
+    provider = UnifiedAuthProvider(source="oidc", oidc_config=config)
+    token = jwt.encode(
+        {
+            "sub": "alice@example.com",
+            "grant_id": 123,
+            "iat": int(time.time()),
+            "exp": int(time.time()) + 3600,
+            "provider": "google",
+        },
+        _TEST_SECRET,
+        algorithm="HS256",
+    )
+
     request = _mock_request(cookies={config.session_cookie_name: token})
     assert provider.get_user_id(request) is None
 


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Fail closed when OIDC/accounts cookie authentication has no active cookie configuration.
- Require string JWT `sub` and delegated `grant_id` claims before using them as identities or revocation keys.
- Remove all 5 server-auth mypy diagnostics and add regressions for malformed/missing auth inputs.

## Test Plan

- `.venv/bin/pytest -q tests/server/test_oidc.py tests/server/test_accounts.py` (137 passed)
- `.venv/bin/mypy --no-incremental omnigent` (1,160 → 1,155 errors; no server-auth diagnostics)
- `SKIP=normalize-uv-lock-registry .venv/bin/pre-commit run --all-files`

## Demo

N/A — non-visual authentication hardening.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New tests cover missing cookie configuration and non-string `sub`/`grant_id` claims; existing suites cover valid, expired, tampered, reserved, OIDC, and accounts cookies.