### PR TITLE
refactor(accounts): type SQLAlchemy write results

### DIFF
--- a/omnigent/server/accounts_store.py
+++ b/omnigent/server/accounts_store.py
@@ -29,8 +29,10 @@ Schema:
 from __future__ import annotations
 
 import time
+from typing import cast
 
 from sqlalchemy import and_, delete, exists, select, update
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -392,18 +394,21 @@ class SqlAlchemyAccountStore:
         opaque-to-bruteforce-guessing).
         """
         with self._session() as session:
-            result = session.execute(
-                update(SqlAccountToken)
-                .where(
-                    and_(
-                        SqlAccountToken.workspace_id == current_workspace_id(),
-                        SqlAccountToken.id == token_id,
-                        SqlAccountToken.kind == encode_account_token_kind(kind),
-                        SqlAccountToken.redeemed_at.is_(None),
-                        SqlAccountToken.expires_at > now_epoch_seconds,
+            result = cast(
+                CursorResult[tuple[object]],
+                session.execute(
+                    update(SqlAccountToken)
+                    .where(
+                        and_(
+                            SqlAccountToken.workspace_id == current_workspace_id(),
+                            SqlAccountToken.id == token_id,
+                            SqlAccountToken.kind == encode_account_token_kind(kind),
+                            SqlAccountToken.redeemed_at.is_(None),
+                            SqlAccountToken.expires_at > now_epoch_seconds,
+                        )
                     )
-                )
-                .values(redeemed_at=now_epoch_seconds)
+                    .values(redeemed_at=now_epoch_seconds)
+                ),
             )
             if result.rowcount == 0:
                 return None
@@ -421,11 +426,14 @@ class SqlAlchemyAccountStore:
         :returns: The number of rows deleted.
         """
         with self._session() as session:
-            result = session.execute(
-                delete(SqlAccountToken).where(
-                    SqlAccountToken.workspace_id == current_workspace_id(),
-                    SqlAccountToken.expires_at <= now_epoch_seconds,
-                )
+            result = cast(
+                CursorResult[tuple[object]],
+                session.execute(
+                    delete(SqlAccountToken).where(
+                        SqlAccountToken.workspace_id == current_workspace_id(),
+                        SqlAccountToken.expires_at <= now_epoch_seconds,
+                    )
+                ),
             )
             return result.rowcount
 
@@ -457,18 +465,21 @@ class SqlAlchemyAccountStore:
             it was missing / wrong-kind / already-redeemed / expired.
         """
         with self._session() as session:
-            result = session.execute(
-                update(SqlAccountToken)
-                .where(
-                    and_(
-                        SqlAccountToken.workspace_id == current_workspace_id(),
-                        SqlAccountToken.id == token_id,
-                        SqlAccountToken.kind == encode_account_token_kind("invite"),
-                        SqlAccountToken.redeemed_at.is_(None),
-                        SqlAccountToken.expires_at > now_epoch_seconds,
+            result = cast(
+                CursorResult[tuple[object]],
+                session.execute(
+                    update(SqlAccountToken)
+                    .where(
+                        and_(
+                            SqlAccountToken.workspace_id == current_workspace_id(),
+                            SqlAccountToken.id == token_id,
+                            SqlAccountToken.kind == encode_account_token_kind("invite"),
+                            SqlAccountToken.redeemed_at.is_(None),
+                            SqlAccountToken.expires_at > now_epoch_seconds,
+                        )
                     )
-                )
-                .values(redeemed_at=now_epoch_seconds, user_id=email)
+                    .values(redeemed_at=now_epoch_seconds, user_id=email)
+                ),
             )
             return result.rowcount == 1
 


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Type SQLAlchemy `UPDATE` and `DELETE` results as `CursorResult` before reading `rowcount`.
- Remove all 5 mypy errors from `omnigent/server/accounts_store.py`, lowering the full-tree baseline from 1,153 to 1,148 errors.

## Test Plan

- `pytest tests/server/test_accounts.py -q` (84 passed)
- `mypy omnigent --no-error-summary` (1,148 expected existing errors; none in `accounts_store.py`)
- `SKIP=normalize-uv-lock-registry pre-commit run --all-files`

## Demo

N/A — non-visual typing cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing account-store suite covers token redemption and expired-token deletion behavior; this PR changes only static result typing.
