### PR TITLE
fix(managed-sandbox): install a missing harness CLI before failing the launch

### DIFF
--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import os
 import secrets
 import time
 import urllib.parse
@@ -4166,6 +4167,90 @@ async def _launch_runner_on_host_impl(
             error=result.get("error"),
         )
     return _HostLaunchAttempt(runner_id=new_runner_id)
+
+
+async def _launch_runner_with_install_fallback(
+    conv: Conversation,
+    conversation_store: ConversationStore,
+    host_registry: HostRegistry,
+    host_conn: HostConnection,
+) -> _HostLaunchAttempt:
+    """
+    Launch a runner on a managed-sandbox host, installing a missing harness
+    CLI onto it first if the host refuses.
+
+    The New Chat dialog's pre-launch "Install" action
+    (``POST /hosts/{host_id}/harnesses/{harness}/install``, see
+    ``routes/hosts.py``) only ever sees an already-connected host, so a user
+    can install a missing CLI before launching. A managed sandbox host has no
+    such window: it is provisioned and used in the same launch call, so
+    :func:`_launch_runner_on_host` refusing with
+    :data:`~omnigent.host.frames.HARNESS_NOT_CONFIGURED_ERROR_CODE` would
+    otherwise always be terminal for a harness the image doesn't bake in.
+
+    Closes that gap for the harnesses the install route already supports
+    (``claude``, ``codex``, ``pi``, ``opencode``, ``qwen``): behind the same
+    ``OMNIGENT_HARNESS_INSTALL_ENABLED`` opt-in, install the CLI onto the
+    just-provisioned host and retry the launch once before giving up.
+
+    :param conv: The conversation that needs a runner.
+    :param conversation_store: Store for updating ``runner_id``.
+    :param host_registry: In-memory ``HostRegistry``.
+    :param host_conn: The live ``HostConnection`` for the host.
+    :returns: The original attempt when it succeeded, wasn't a
+        harness-not-configured refusal, the feature is off, the harness isn't
+        UI-installable, or the install itself failed; otherwise the result of
+        retrying the launch after a successful install.
+    """
+    from omnigent.host.frames import HARNESS_NOT_CONFIGURED_ERROR_CODE
+
+    attempt = await _launch_runner_on_host(conv, conversation_store, host_registry, host_conn)
+    if attempt.error_code != HARNESS_NOT_CONFIGURED_ERROR_CODE:
+        return attempt
+
+    from omnigent.onboarding.harness_install import ui_install_key
+    from omnigent.process_logging import env_truthy
+
+    # Local imports: keeps routes.hosts out of this module's import graph,
+    # matching the existing _proxy_model_options reuse below.
+    from omnigent.server.routes.hosts import HARNESS_INSTALL_ENABLED_ENV, _proxy_install_harness
+
+    if not env_truthy(os.environ.get(HARNESS_INSTALL_ENABLED_ENV)):
+        return attempt
+    harness = _resolve_harness(conv)
+    if harness is None or ui_install_key(harness) is None:
+        return attempt
+
+    try:
+        result = await _proxy_install_harness(
+            host_registry=host_registry, host_conn=host_conn, harness=harness
+        )
+    except HTTPException as exc:
+        _logger.warning(
+            "Auto-install of harness %s onto managed host %s failed for session %s: %s",
+            harness,
+            host_conn.host_id,
+            conv.id,
+            exc.detail,
+        )
+        return attempt
+    if result.get("status") != "ok":
+        _logger.warning(
+            "Auto-install of harness %s onto managed host %s failed for session %s: %s",
+            harness,
+            host_conn.host_id,
+            conv.id,
+            result.get("error"),
+        )
+        return attempt
+
+    _logger.info(
+        "Installed harness %s onto managed host %s for session %s; retrying launch",
+        harness,
+        host_conn.host_id,
+        conv.id,
+    )
+    return await _launch_runner_on_host(conv, conversation_store, host_registry, host_conn)
 
 
 async def cancel_managed_launch_tasks() -> None:
@@ -8686,6 +8771,7 @@ __all__ = [
     "_latest_assistant_text_from_store",
     "_latest_message_preview",
     "_launch_runner_on_host",
+    "_launch_runner_with_install_fallback",
     "_load_agent_spec_for_session",
     "_load_model_options",
     "_load_model_options_from_host",

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -2361,17 +2361,20 @@ async def _bind_and_launch_managed_runner(
     if host_registry is not None:
         host_conn = host_registry.get(managed.host_id)
         if host_conn is not None:
-            launch_attempt = await _launch_runner_on_host(
+            launch_attempt = await _launch_runner_with_install_fallback(
                 conv,
                 conversation_store,
                 host_registry,
                 host_conn,
             )
             if launch_attempt.error_code == _HARNESS_NOT_CONFIGURED_ERROR_CODE:
-                # The sandbox image should bake in the harness, but if the
-                # host refuses, fail the launch loudly (mirroring the
-                # delete-during-provisioning path) rather than waiting out
-                # the connect timeout for a runner that will never appear.
+                # The sandbox image should bake in the harness, and
+                # _launch_runner_with_install_fallback already tried
+                # installing it onto this host when that opt-in is enabled —
+                # a refusal here is terminal, so fail the launch loudly
+                # (mirroring the delete-during-provisioning path) rather than
+                # waiting out the connect timeout for a runner that will
+                # never appear.
                 reason = launch_attempt.error or "harness not configured on the sandbox host"
                 tracker.fail(session_id, reason)
                 _publish_sandbox_status(session_id, "failed", reason)
@@ -2798,7 +2801,11 @@ async def _run_managed_wake(
                 )
                 return
         if host_conn is not None:
-            launch_attempt = await _launch_runner_on_host(
+            # host_conn is only ever non-None here because host_registry was
+            # non-None above (it's how host_conn got set) — narrow explicitly
+            # since that fact spans two variables mypy can't connect on its own.
+            assert host_registry is not None
+            launch_attempt = await _launch_runner_with_install_fallback(
                 refreshed,
                 conversation_store,
                 host_registry,

--- a/tests/server/integration/test_host_session_binding.py
+++ b/tests/server/integration/test_host_session_binding.py
@@ -1331,6 +1331,181 @@ async def test_managed_launch_fails_when_runner_never_connects(
     assert stages[-1] == ("failed", "managed runner did not connect after launch")
 
 
+async def test_managed_launch_installs_missing_harness_and_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A managed sandbox host that refuses for a missing, UI-installable harness
+    gets the CLI installed onto it and the launch retried, instead of failing
+    outright — closing the gap where the New Chat dialog's pre-launch
+    "Install" action never gets a chance to run against a host that doesn't
+    exist until this same launch call provisions it.
+    """
+    from omnigent.host.frames import HARNESS_NOT_CONFIGURED_ERROR_CODE
+    from omnigent.server.routes import sessions as sessions_module
+
+    monkeypatch.setenv("OMNIGENT_HARNESS_INSTALL_ENABLED", "1")
+
+    session_id = "2b6c1c1e6b394e6c9f5f6f0b6c9a1b2c"
+    conv = SimpleNamespace(id=session_id)
+    tracker = ManagedLaunchTracker()
+    tracker.begin(session_id)
+    launch = tracker.get(session_id)
+    assert launch is not None
+    stages: list[tuple[str, str | None]] = []
+    launch_calls = 0
+    install_calls: list[str] = []
+
+    async def _launch_runner(*_args: object, **_kwargs: object) -> object:
+        nonlocal launch_calls
+        launch_calls += 1
+        if launch_calls == 1:
+            return sessions_module._HostLaunchAttempt(
+                runner_id="runner_before_install",
+                error_code=HARNESS_NOT_CONFIGURED_ERROR_CODE,
+                error="harness 'opencode-native' is not configured on host 'managed-test'",
+            )
+        return sessions_module._HostLaunchAttempt(runner_id="runner_after_install")
+
+    async def _proxy_install_harness(
+        *, host_registry: object, host_conn: object, harness: str
+    ) -> dict[str, object]:
+        del host_registry, host_conn
+        install_calls.append(harness)
+        return {"status": "ok", "configured_harnesses": {}}
+
+    class _HostRegistry:
+        def get(self, _host_id: str) -> object:
+            return SimpleNamespace(host_id=_host_id)
+
+    class _TunnelRegistry:
+        async def wait_for_runner(self, _runner_id: str, *, timeout_s: float) -> object:
+            del timeout_s
+            return object()
+
+    monkeypatch.setattr(sessions_module, "_launch_runner_on_host", _launch_runner)
+    monkeypatch.setattr(sessions_module, "_resolve_harness", lambda _conv: "opencode-native")
+    monkeypatch.setattr(
+        "omnigent.server.routes.hosts._proxy_install_harness", _proxy_install_harness
+    )
+    monkeypatch.setattr(
+        sessions_module,
+        "_publish_sandbox_status",
+        lambda _sid, stage, error=None: stages.append((stage, error)),
+    )
+
+    await sessions_module._bind_and_launch_managed_runner(
+        session_id=session_id,
+        managed=ManagedHostLaunch(
+            host_id="3c8cdcdb61903904849174c864620a5c",
+            workspace="/root/workspace",
+        ),
+        sandbox_config=ManagedSandboxConfig(
+            server_url="https://managed-test.example.com",
+            launcher_factory=lambda: FakeSandboxLauncher(),
+            token_ttl_s=3600,
+        ),
+        tracker=tracker,
+        conversation_store=SimpleNamespace(
+            set_host_id=lambda _sid, _host_id, _workspace: conv,
+        ),
+        host_store=SimpleNamespace(),
+        host_registry=_HostRegistry(),  # type: ignore[arg-type]
+        tunnel_registry=_TunnelRegistry(),  # type: ignore[arg-type]
+    )
+
+    assert install_calls == ["opencode-native"]
+    assert launch_calls == 2
+    # finish() pops the entry once settled — the reference captured before
+    # the call is the only way to observe the settled state.
+    assert tracker.get(session_id) is None
+    assert launch.settled.is_set()
+    assert launch.error is None
+    assert stages[-1] == ("ready", None)
+
+
+async def test_managed_launch_skips_install_when_feature_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``OMNIGENT_HARNESS_INSTALL_ENABLED`` defaults off, so a managed sandbox
+    host refusing an unconfigured harness still fails the launch outright —
+    unchanged behavior for deployments that haven't opted in.
+    """
+    from omnigent.host.frames import HARNESS_NOT_CONFIGURED_ERROR_CODE
+    from omnigent.server.routes import sessions as sessions_module
+
+    monkeypatch.delenv("OMNIGENT_HARNESS_INSTALL_ENABLED", raising=False)
+
+    session_id = "9f1e2d3c4b5a69788796a5b4c3d2e1f0"
+    conv = SimpleNamespace(id=session_id)
+    tracker = ManagedLaunchTracker()
+    tracker.begin(session_id)
+    stages: list[tuple[str, str | None]] = []
+    install_calls: list[str] = []
+
+    async def _launch_runner(*_args: object, **_kwargs: object) -> object:
+        return sessions_module._HostLaunchAttempt(
+            runner_id="runner_before_install",
+            error_code=HARNESS_NOT_CONFIGURED_ERROR_CODE,
+            error="harness 'opencode-native' is not configured on host 'managed-test'",
+        )
+
+    async def _proxy_install_harness(
+        *, host_registry: object, host_conn: object, harness: str
+    ) -> dict[str, object]:
+        del host_registry, host_conn
+        install_calls.append(harness)
+        return {"status": "ok", "configured_harnesses": {}}
+
+    class _HostRegistry:
+        def get(self, _host_id: str) -> object:
+            return SimpleNamespace(host_id=_host_id)
+
+    class _TunnelRegistry:
+        async def wait_for_runner(self, _runner_id: str, *, timeout_s: float) -> object:
+            del timeout_s
+            return object()
+
+    monkeypatch.setattr(sessions_module, "_launch_runner_on_host", _launch_runner)
+    monkeypatch.setattr(sessions_module, "_resolve_harness", lambda _conv: "opencode-native")
+    monkeypatch.setattr(
+        "omnigent.server.routes.hosts._proxy_install_harness", _proxy_install_harness
+    )
+    monkeypatch.setattr(
+        sessions_module,
+        "_publish_sandbox_status",
+        lambda _sid, stage, error=None: stages.append((stage, error)),
+    )
+
+    await sessions_module._bind_and_launch_managed_runner(
+        session_id=session_id,
+        managed=ManagedHostLaunch(
+            host_id="3c8cdcdb61903904849174c864620a5c",
+            workspace="/root/workspace",
+        ),
+        sandbox_config=ManagedSandboxConfig(
+            server_url="https://managed-test.example.com",
+            launcher_factory=lambda: FakeSandboxLauncher(),
+            token_ttl_s=3600,
+        ),
+        tracker=tracker,
+        conversation_store=SimpleNamespace(
+            set_host_id=lambda _sid, _host_id, _workspace: conv,
+        ),
+        host_store=SimpleNamespace(),
+        host_registry=_HostRegistry(),  # type: ignore[arg-type]
+        tunnel_registry=_TunnelRegistry(),  # type: ignore[arg-type]
+    )
+
+    assert install_calls == []
+    launch = tracker.get(session_id)
+    assert launch is not None
+    assert launch.settled.is_set()
+    assert launch.error == "harness 'opencode-native' is not configured on host 'managed-test'"
+    assert stages[-1][0] == "failed"
+
+
 async def test_cancel_managed_launch_tasks_returns_while_provision_parked(
     managed_session_env: ManagedSessionEnv,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Related issue

Closes #3720

## Summary

- `OMNIGENT_HARNESS_INSTALL_ENABLED` (from #2912/#2987) only ever helps an
  already-connected host — a managed sandbox host is provisioned and used in
  the same launch call, so it never gets a chance to hit that route before
  `harness_not_configured` fails the launch outright.
- Adds `_launch_runner_with_install_fallback`: when a managed-sandbox launch
  refuses because the harness isn't configured and the install feature is
  enabled, install the CLI onto the just-provisioned host (reusing the same
  `_proxy_install_harness` / `host.install_harness` frame the UI route
  already sends) and retry the launch once before giving up.
- Wired into both managed-launch call sites: initial provisioning
  (`_bind_and_launch_managed_runner`) and wake-from-sleep (`_run_managed_wake`).
- No behavior change when the flag is off (the default) or the harness isn't
  in the UI-installable set (`claude`, `codex`, `pi`, `opencode`, `qwen`) —
  falls straight back to the original immediate failure.

## Test Plan

- Added `test_managed_launch_installs_missing_harness_and_retries` and
  `test_managed_launch_skips_install_when_feature_disabled` to
  `tests/server/integration/test_host_session_binding.py`, alongside the
  existing managed-launch tests they're modeled on.
- `uv run --extra dev pytest tests/server/integration/test_host_session_binding.py tests/server/integration/test_session_host_launch.py tests/server/integration/test_hosts_api.py tests/server/integration/test_hosts_install_harness.py tests/server/integration/test_hosts_store_credential.py -q` → 96 passed.
- `uv run ruff check` / `ruff format --check` on the touched files → clean.
- `uv run --extra dev mypy` on the two touched source files → same pre-existing error count as the unmodified files (0 new errors); added an explicit `assert host_registry is not None` at the wake-path call site to keep the newly-typed helper's signature honest there (the untyped `*args: Any` proxy it replaces was silently swallowing that gap).

## Demo

N/A — backend fix, no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by the new integration tests.

## Changelog

Managed sandbox sessions now install a missing, UI-installable harness CLI onto the host instead of failing outright, when `OMNIGENT_HARNESS_INSTALL_ENABLED` is set