### PR TITLE
refactor(kiro): type JSON boundaries

### DIFF
--- a/omnigent/kiro_native.py
+++ b/omnigent/kiro_native.py
@@ -11,7 +11,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any
+from typing import TypeAlias
 
 import click
 import httpx
@@ -45,6 +45,8 @@ from omnigent.native_terminal import (
     normalize_extra_args as _normalize_extra_args,
 )
 from omnigent.native_terminal import url_component
+
+_JsonObject: TypeAlias = dict[str, object]
 
 _DEFAULT_KIRO_COMMAND = "kiro-cli"
 _KIRO_PATH_ENV = "OMNIGENT_KIRO_PATH"
@@ -129,7 +131,7 @@ def list_kiro_cli_model_options(
     *,
     env: Mapping[str, str] | None = None,
     timeout_s: float = 10.0,
-) -> list[dict[str, Any]]:
+) -> list[_JsonObject]:
     """Discover Kiro picker options from the installed CLI."""
     executable = resolve_kiro_executable(env=env)
     completed = subprocess.run(
@@ -146,7 +148,7 @@ def list_kiro_cli_model_options(
         raise ValueError("Kiro model list must contain a models array")
     default_model = payload.get("default_model")
     default_id = default_model.strip() if isinstance(default_model, str) else None
-    options: list[dict[str, Any]] = []
+    options: list[_JsonObject] = []
     for raw_model in raw_models:
         if not isinstance(raw_model, dict):
             continue
@@ -158,7 +160,7 @@ def list_kiro_cli_model_options(
         display_name = (
             raw_name.strip() if isinstance(raw_name, str) and raw_name.strip() else model_id
         )
-        option: dict[str, Any] = {
+        option: _JsonObject = {
             "id": model_id,
             "displayName": display_name,
             "isDefault": model_id == default_id,
@@ -244,7 +246,7 @@ def _materialize_kiro_agent_spec(tmpdir: Path, *, model: str | None = None) -> P
     executor: dict[str, str] = {"harness": "kiro-native"}
     if model:
         executor["model"] = model
-    raw: dict[str, Any] = {
+    raw: _JsonObject = {
         "name": _AGENT_NAME,
         "prompt": (
             "Kiro is running in the session terminal. The user drives the kiro-cli TUI directly."
@@ -443,7 +445,7 @@ async def _create_kiro_session(
     terminal_launch_args: list[str] | None = None,
 ) -> str:
     """Create a bundled terminal-first kiro-native session."""
-    metadata: dict[str, Any] = {"labels": dict(_SESSION_LABELS)}
+    metadata: _JsonObject = {"labels": dict(_SESSION_LABELS)}
     if terminal_launch_args:
         metadata["terminal_launch_args"] = terminal_launch_args
     resp = await client.post(
@@ -463,7 +465,7 @@ async def _create_kiro_session(
     return new_session_id
 
 
-async def _fetch_kiro_session(client: httpx.AsyncClient, session_id: str) -> dict[str, Any]:
+async def _fetch_kiro_session(client: httpx.AsyncClient, session_id: str) -> _JsonObject:
     """Fetch an existing Omnigent session."""
     resp = await client.get(f"/v1/sessions/{url_component(session_id)}")
     if resp.status_code == 404:


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Introduce a shared `_JsonObject` alias for Kiro model metadata, generated agent specs, session metadata, and fetched session payloads.
- Replace six broad `dict[str, Any]` boundaries while preserving the existing runtime structures.
- Remove all 6 mypy errors from `omnigent/kiro_native.py`, lowering the full-tree branch baseline from 1,136 to 1,130 errors.

## Test Plan

- `pytest tests/test_kiro_native.py -q -k 'not test_resolve_kiro_executable_errors_when_missing'` (43 passed)
- The excluded test fails unchanged on this workstation because `kiro-cli` is installed in a fallback directory while the test assumes it is absent.
- `mypy omnigent --no-error-summary` (1,130 expected existing errors; none in `kiro_native.py`)
- `SKIP=normalize-uv-lock-registry pre-commit run --all-files`

## Demo

N/A — non-visual typing cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing Kiro suite covers model discovery, agent-spec generation, session metadata, and response parsing; this PR changes static boundary annotations only.
