### PR TITLE
refactor(pi): type native bridge JSON payloads

### DIFF
--- a/omnigent/pi_native_bridge.py
+++ b/omnigent/pi_native_bridge.py
@@ -12,7 +12,9 @@ import time
 import uuid
 from importlib.resources import files
 from pathlib import Path
-from typing import Any
+from typing import TypeAlias
+
+_JsonObject: TypeAlias = dict[str, object]
 
 # Per-process tiebreaker for inbox ordering. The extension delivers inbox
 # files in lexicographic filename order, so a high-resolution timestamp alone
@@ -179,7 +181,7 @@ def enqueue_compact(bridge_dir: Path, custom_instructions: str | None = None) ->
     :returns: Opaque compact id.
     """
     compact_id = f"compact_{uuid.uuid4().hex}"
-    payload: dict[str, Any] = {
+    payload: _JsonObject = {
         "id": compact_id,
         "type": "compact",
         "created_at": time.time(),
@@ -217,7 +219,7 @@ def enqueue_model_change(bridge_dir: Path, model: str) -> str:
     return model_change_id
 
 
-def _enqueue_payload(bridge_dir: Path, item_id: str, payload: dict[str, Any]) -> None:
+def _enqueue_payload(bridge_dir: Path, item_id: str, payload: _JsonObject) -> None:
     inbox = bridge_dir / _INBOX_DIR
     inbox.mkdir(mode=0o700, parents=True, exist_ok=True)
     # Order-preserving filename. The extension polls ``inbox/*.json`` and
@@ -248,7 +250,7 @@ def write_extension_files(
     server_url: str,
     conversation_url: str,
     auth_headers: dict[str, str] | None = None,
-    tools: list[dict[str, Any]] | None = None,
+    tools: list[_JsonObject] | None = None,
 ) -> tuple[Path, Path]:
     """
     Write the Pi extension and config used by a native Pi terminal.
@@ -269,7 +271,7 @@ def write_extension_files(
     :returns: ``(extension_path, config_path)``.
     """
     bridge_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
-    payload: dict[str, Any] = {
+    payload: _JsonObject = {
         "sessionId": session_id,
         "serverUrl": server_url.rstrip("/"),
         "conversationUrl": conversation_url,
@@ -360,7 +362,7 @@ def _extension_source() -> str:
     return resource.read_text(encoding="utf-8")
 
 
-def _atomic_json(path: Path, payload: dict[str, Any]) -> None:
+def _atomic_json(path: Path, payload: _JsonObject) -> None:
     fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Introduce a shared JSON-object alias for Pi inbox commands, extension configuration, tool schemas, and atomic JSON writes.
- Replace five broad `dict[str, Any]` boundaries while keeping parsed payload values explicitly heterogeneous.
- Remove all 5 mypy errors from `omnigent/pi_native_bridge.py`, lowering the full-tree branch baseline from 1,136 to 1,131 errors.

## Test Plan

- `pytest tests/test_pi_native_bridge.py -q` (16 passed)
- `mypy omnigent --no-error-summary` (1,131 expected existing errors; none in `pi_native_bridge.py`)
- `SKIP=normalize-uv-lock-registry pre-commit run --all-files`

## Demo

N/A — non-visual typing cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing Pi bridge suite covers inbox ordering, extension config generation, embedded tools, auth refresh, and relay credentials; this PR changes static payload typing only.
