### PR TITLE
refactor(onboarding): type sandbox SDK returns

### DIFF
--- a/omnigent/onboarding/sandboxes/bootstrap.py
+++ b/omnigent/onboarding/sandboxes/bootstrap.py
@@ -379,7 +379,8 @@ def _workspace_org_id(workspace_host: str) -> str | None:
         response = httpx.get(f"{workspace_host}/login.html", timeout=10.0)
     except httpx.HTTPError:
         return None
-    return response.headers.get("x-databricks-org-id")
+    workspace_id = response.headers.get("x-databricks-org-id")
+    return str(workspace_id) if workspace_id is not None else None
 
 
 def derive_workspace(server_url: str) -> DerivedWorkspace | None:

--- a/omnigent/onboarding/sandboxes/cwsandbox.py
+++ b/omnigent/onboarding/sandboxes/cwsandbox.py
@@ -115,7 +115,7 @@ class _CWRemoteProcess(RemoteProcess):
         return self._lines
 
     def wait(self) -> int:
-        return self._process.wait()
+        return int(self._process.wait())
 
     def close(self) -> None:
         # DEVIATION from the base contract: the SDK's process.cancel() only
@@ -228,9 +228,10 @@ class CWSandboxLauncher(SandboxLauncher):
             sandbox.wait()
         except CWSandboxError as exc:
             raise click.ClickException(f"CW Sandbox creation failed: {exc}") from exc
-        sandbox_id = sandbox.sandbox_id
-        if not sandbox_id:
+        raw_sandbox_id = sandbox.sandbox_id
+        if not raw_sandbox_id:
             raise click.ClickException("CW Sandbox creation returned no sandbox id")
+        sandbox_id = str(raw_sandbox_id)
         self._sandboxes[sandbox_id] = sandbox
         click.echo(f"  → created {sandbox_id}")
         return sandbox_id
@@ -317,7 +318,7 @@ class CWSandboxLauncher(SandboxLauncher):
         # /tmp. The interrupt path already cleans up via
         # :func:`foreground_kill_command`.
         handle.exec(["bash", "-c", f"rm -rf {run_dir} 2>/dev/null"]).wait()
-        return rc
+        return int(rc)
 
     def wheel_install_command(self, remote_tgz_path: str) -> str:
         """Overlay shipped wheels onto the prebaked host image."""

--- a/omnigent/onboarding/sandboxes/daytona.py
+++ b/omnigent/onboarding/sandboxes/daytona.py
@@ -169,7 +169,7 @@ def _drive_foreground_pty(pty: PtyHandle, sandbox_id: str, command: str) -> int:
             f"The PTY session on sandbox '{sandbox_id}' ended without "
             f"an exit code{f': {result.error}' if result.error else ''}."
         )
-    return result.exit_code
+    return int(result.exit_code)
 
 
 class DaytonaSandboxLauncher(SandboxLauncher):
@@ -366,9 +366,10 @@ class DaytonaSandboxLauncher(SandboxLauncher):
             # 502 — and a waiting message POST — carries it verbatim
             # instead of a generic "internal error".
             raise click.ClickException(f"Daytona sandbox creation failed: {exc}") from exc
-        self._sandboxes[handle.id] = handle
-        click.echo(f"  → created {handle.id}")
-        return handle.id
+        sandbox_id = str(handle.id)
+        self._sandboxes[sandbox_id] = handle
+        click.echo(f"  → created {sandbox_id}")
+        return sandbox_id
 
     def attach(self, sandbox_id: str) -> None:
         """

--- a/omnigent/onboarding/sandboxes/e2b.py
+++ b/omnigent/onboarding/sandboxes/e2b.py
@@ -506,7 +506,7 @@ class E2BSandboxLauncher(SandboxLauncher):
         env_vars = self._resolve_sandbox_env()
         click.echo(f"▸ Creating E2B sandbox '{name}' from template '{template}'")
         sandbox = self._create_sandbox(template, resolve_max_lifetime_s(), name, env_vars)
-        sandbox_id = sandbox.sandbox_id
+        sandbox_id = str(sandbox.sandbox_id)
         self._sandboxes[sandbox_id] = sandbox
         click.echo(f"  → created {sandbox_id}")
         return sandbox_id

--- a/omnigent/onboarding/sandboxes/modal.py
+++ b/omnigent/onboarding/sandboxes/modal.py
@@ -249,7 +249,7 @@ class _ModalRemoteProcess(RemoteProcess):
 
         :returns: The process's exit code.
         """
-        return self._process.wait()
+        return int(self._process.wait())
 
     def close(self) -> None:
         """
@@ -393,9 +393,10 @@ class ModalSandboxLauncher(SandboxLauncher):
             secrets=secrets or None,
         )
         handle.set_tags({"omnigent-name": name})
-        self._sandboxes[handle.object_id] = handle
-        click.echo(f"  → created {handle.object_id}")
-        return handle.object_id
+        sandbox_id = str(handle.object_id)
+        self._sandboxes[sandbox_id] = handle
+        click.echo(f"  → created {sandbox_id}")
+        return sandbox_id
 
     def attach(self, sandbox_id: str) -> None:
         """
@@ -554,7 +555,7 @@ class ModalSandboxLauncher(SandboxLauncher):
         # dir in /tmp. The interrupt path already cleans up via
         # :func:`foreground_kill_command`.
         handle.exec("bash", "-c", f"rm -rf {run_dir} 2>/dev/null").wait()
-        return rc
+        return int(rc)
 
     def wheel_install_command(self, remote_tgz_path: str) -> str:
         """


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Normalize dynamically typed sandbox SDK identifiers and exit codes at provider boundaries.
- Preserve provider-specific missing-ID handling while removing 10 `no-any-return` mypy errors across Modal, E2B, Daytona, CoreWeave, and workspace detection.

## Test Plan

- `uv run --no-sync pytest -q tests/onboarding/sandboxes/test_bootstrap.py tests/onboarding/sandboxes/test_cwsandbox.py tests/onboarding/sandboxes/test_daytona.py tests/onboarding/sandboxes/test_e2b.py tests/onboarding/sandboxes/test_modal.py` (144 passed)
- `pre-commit run --files omnigent/onboarding/sandboxes/bootstrap.py omnigent/onboarding/sandboxes/modal.py omnigent/onboarding/sandboxes/e2b.py omnigent/onboarding/sandboxes/daytona.py omnigent/onboarding/sandboxes/cwsandbox.py`
- `uv run --no-sync mypy omnigent` (baseline drops from 1,105 to 1,095 errors; no errors remain in the touched files)

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing sandbox-provider tests exercise the normalized identifiers, process exit codes, foreground execution, and workspace-header handling.

## Changelog

N/A — internal type cleanup with no user-facing behavior change.
