### PR TITLE
refactor(scheduled): type recurrence boundaries

### DIFF
--- a/omnigent/server/scheduled/fire.py
+++ b/omnigent/server/scheduled/fire.py
@@ -531,7 +531,7 @@ async def _resolve_owner_host(deps: FireDeps, task: ScheduledTask) -> str:
     hosts = await asyncio.to_thread(deps.host_store.list_hosts, owner)
     for host in hosts:
         if deps.host_registry.get(host.host_id) is not None:
-            return host.host_id
+            return str(host.host_id)
     raise _CannotLaunchScheduledFire(
         "no online host is available for the scheduled task owner",
         error_code="no_online_host",
@@ -588,7 +588,7 @@ async def _create_session(deps: FireDeps, task: ScheduledTask) -> Conversation:
     # Connected-host, existing-workspace runs create the conversation directly.
     # Future execution modes such as managed sandbox, branch selection, and
     # replay/backfill must use shared session-create orchestration.
-    conv = await asyncio.to_thread(
+    conv: Conversation = await asyncio.to_thread(
         deps.conversation_store.create_conversation,
         agent_id=task.agent_id,
         title=task.name,
@@ -596,7 +596,7 @@ async def _create_session(deps: FireDeps, task: ScheduledTask) -> Conversation:
         workspace=task.workspace,
     )
     if task.model_override is not None or task.reasoning_effort is not None:
-        updated = await asyncio.to_thread(
+        updated: Conversation | None = await asyncio.to_thread(
             deps.conversation_store.update_conversation,
             conv.id,
             model_override=task.model_override,

--- a/omnigent/server/scheduled/rrule.py
+++ b/omnigent/server/scheduled/rrule.py
@@ -56,9 +56,11 @@ class RRuleValidationError(ValueError):
 
 
 class _ParsedRRule(Protocol):
-    def after(self, dt: datetime, inc: bool = False) -> datetime | None: ...
+    def after(self, dt: datetime, inc: bool = False) -> datetime | None:
+        raise NotImplementedError
 
-    def __iter__(self) -> Iterator[datetime]: ...
+    def __iter__(self) -> Iterator[datetime]:
+        raise NotImplementedError
 
 
 def _anchor_dtstart(after: datetime, tz: ZoneInfo) -> datetime:

--- a/omnigent/server/scheduled/rrule.py
+++ b/omnigent/server/scheduled/rrule.py
@@ -16,11 +16,13 @@ fire spawns a real agent session, so a runaway cadence is expensive.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import Protocol, cast
 from zoneinfo import ZoneInfo
 
-from dateutil.rrule import rrulestr
+from dateutil.rrule import rrulestr  # type: ignore[import-untyped]
 
 # Reject anything more frequent than this. Each fire spawns a real agent
 # session, so a tight cadence gets expensive fast. One hour is the tightest
@@ -51,6 +53,12 @@ _MAX_SAMPLE_OCCURRENCES = 2000
 
 class RRuleValidationError(ValueError):
     """Raised when an RRULE string is malformed or violates a scheduler rule."""
+
+
+class _ParsedRRule(Protocol):
+    def after(self, dt: datetime, inc: bool = False) -> datetime | None: ...
+
+    def __iter__(self) -> Iterator[datetime]: ...
 
 
 def _anchor_dtstart(after: datetime, tz: ZoneInfo) -> datetime:
@@ -118,13 +126,13 @@ class RRuleTrigger:
         return get_next_fire_time(self.rule, after, tz)
 
 
-def _parse(rule_str: str, dtstart: datetime):
+def _parse(rule_str: str, dtstart: datetime) -> _ParsedRRule:
     """Parse an RRULE string anchored at ``dtstart``, normalizing errors.
 
     :raises RRuleValidationError: On any malformed input ``dateutil`` rejects.
     """
     try:
-        return rrulestr(rule_str, dtstart=dtstart)
+        return cast(_ParsedRRule, rrulestr(rule_str, dtstart=dtstart))
     except (ValueError, TypeError) as exc:
         raise RRuleValidationError(f"Invalid RRULE {rule_str!r}: {exc}") from exc
 
@@ -165,6 +173,7 @@ def validate_rrule(rule_str: str, tz: ZoneInfo | None = None) -> RRuleTrigger:  
             continue
         min_gap = min(min_gap, (occ - prev).total_seconds())
         prev = occ
+        assert window_end is not None
         if occ >= window_end or count >= _MAX_SAMPLE_OCCURRENCES:
             break
 


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Add a narrow protocol around untyped `python-dateutil` recurrence objects instead of letting `Any` flow through scheduler logic.
- Type dynamic scheduled-fire store results at their owning boundaries, removing five mypy errors without changing scheduling behavior.

## Test Plan

- `uv run --no-sync pytest -q tests/server/scheduled/test_rrule.py tests/server/scheduled/test_fire.py` (51 passed)
- `pre-commit run --files omnigent/server/scheduled/rrule.py omnigent/server/scheduled/fire.py`
- `uv run --no-sync mypy omnigent` (branch baseline is 1,095 errors versus 1,100 on its `main` base; no errors remain in the touched files)

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing recurrence and scheduled-fire tests cover parsing, interval validation, host resolution, session creation, and failure paths.

## Changelog

N/A — internal type cleanup with no user-facing behavior change.
