### PR TITLE
refactor(policies): narrow JSON boundaries

### DIFF
--- a/omnigent/inner/nessie/policies.py
+++ b/omnigent/inner/nessie/policies.py
@@ -10,7 +10,13 @@ from omnigent.policies.builtins.orchestration import POLICY_REGISTRY as _new_reg
 # bundles that were deployed before the module was renamed.
 _OLD = "omnigent.inner.nessie.policies."
 _NEW = "omnigent.policies.builtins.orchestration."
-POLICY_REGISTRY = [
-    {**entry, "handler": entry["handler"].replace(_NEW, _OLD), "internal_only": True}
-    for entry in _new_registry
-]
+
+
+def _legacy_entry(entry: dict[str, object]) -> dict[str, object]:
+    handler = entry.get("handler")
+    if not isinstance(handler, str):
+        raise TypeError("policy registry handler must be a string")
+    return {**entry, "handler": handler.replace(_NEW, _OLD), "internal_only": True}
+
+
+POLICY_REGISTRY = [_legacy_entry(entry) for entry in _new_registry]

--- a/omnigent/policies/base.py
+++ b/omnigent/policies/base.py
@@ -23,7 +23,6 @@ write-through store) and the composition loop live in
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any
 
 from omnigent.policies.types import EvaluationContext, PolicyResult
 from omnigent.spec.types import PolicySpec
@@ -50,7 +49,7 @@ class Policy(ABC):
     async def evaluate(
         self,
         ctx: EvaluationContext,
-        context: dict[str, Any],
+        context: dict[str, object],
     ) -> PolicyResult:
         """
         Return this policy's decision for one evaluation.

--- a/omnigent/policies/builtins/orchestration.py
+++ b/omnigent/policies/builtins/orchestration.py
@@ -644,7 +644,7 @@ def read_only_os(
 
 # ── Registry ─────────────────────────────────────────────────────────────────
 
-POLICY_REGISTRY: list[dict[str, Any]] = [
+POLICY_REGISTRY: list[dict[str, object]] = [
     {
         "handler": "omnigent.policies.builtins.orchestration.blast_radius",
         "kind": "factory",

--- a/omnigent/policies/builtins/prompt.py
+++ b/omnigent/policies/builtins/prompt.py
@@ -174,6 +174,7 @@ def prompt_policy(
                         ],
                     },
                 ],
+                text=_CLASSIFIER_SCHEMA,
             )
             raw_text = _extract_response_text(response)
             if not raw_text:

--- a/omnigent/policies/builtins/prompt.py
+++ b/omnigent/policies/builtins/prompt.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 import json
 import logging
 import secrets
-from typing import Any
 
 from omnigent.policies.schema import PolicyCallable, PolicyEvent, PolicyResponse
 
@@ -71,7 +70,7 @@ the agent should do instead. Leave reason empty for ALLOW.
 """
 
 # Structured output schema for the classifier response.
-_CLASSIFIER_SCHEMA: dict[str, Any] = {
+_CLASSIFIER_SCHEMA: dict[str, object] = {
     "format": {
         "type": "json_schema",
         "name": "policy_verdict",
@@ -254,7 +253,7 @@ def _strip_code_fences(text: str) -> str:
     return stripped
 
 
-def _serialize_content(content: Any) -> str:
+def _serialize_content(content: object) -> str:
     """
     Render content for the classifier prompt.
 
@@ -271,7 +270,7 @@ def _serialize_content(content: Any) -> str:
     return repr(content)
 
 
-def _extract_response_text(response: Any) -> str:
+def _extract_response_text(response: object) -> str:
     """
     Extract text from an LLM response.
 
@@ -288,12 +287,13 @@ def _extract_response_text(response: Any) -> str:
     content = getattr(first, "content", None)
     if not isinstance(content, list) or not content:
         return ""
-    return getattr(content[0], "text", "") or ""
+    content_text = getattr(content[0], "text", "")
+    return content_text if isinstance(content_text, str) else ""
 
 
 # ── Registry ─────────────────────────────────────────────────────────────────
 
-POLICY_REGISTRY: list[dict[str, Any]] = [
+POLICY_REGISTRY: list[dict[str, object]] = [
     {
         "handler": "omnigent.policies.builtins.prompt.prompt_policy",
         "kind": "factory",

--- a/omnigent/policies/builtins/routing.py
+++ b/omnigent/policies/builtins/routing.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from typing import Any
 
 from omnigent.policies.schema import (
     PolicyCallable,
@@ -49,7 +48,7 @@ _DEFAULT_CLASSIFICATION_PROMPT = (
 # Responses API structured output schema for the classifier.
 # Forces the model to return ``{"difficulty": "TRIVIAL"}`` or
 # ``{"difficulty": "COMPLEX"}`` — no free-text parsing needed.
-_CLASSIFICATION_SCHEMA: dict[str, Any] = {
+_CLASSIFICATION_SCHEMA: dict[str, object] = {
     "format": {
         "type": "json_schema",
         "name": "difficulty_classification",
@@ -69,7 +68,7 @@ _CLASSIFICATION_SCHEMA: dict[str, Any] = {
 }
 
 
-def _extract_response_text(response: Any) -> str:
+def _extract_response_text(response: object) -> str:
     """
     Extract the text content from an LLM response.
 
@@ -96,7 +95,8 @@ def _extract_response_text(response: Any) -> str:
     content = getattr(first, "content", None)
     if not isinstance(content, list) or not content:
         return ""
-    return getattr(content[0], "text", "") or ""
+    content_text = getattr(content[0], "text", "")
+    return content_text if isinstance(content_text, str) else ""
 
 
 def deny_trivial_to_expensive_model(
@@ -275,7 +275,7 @@ Return strict JSON only:
 {"verdict": "ON_TASK" | "OFF_TASK"}
 """
 
-_INTENT_CHECK_SCHEMA: dict[str, Any] = {
+_INTENT_CHECK_SCHEMA: dict[str, object] = {
     "format": {
         "type": "json_schema",
         "name": "intent_check_verdict",
@@ -469,7 +469,7 @@ def intent_based_authorization() -> PolicyCallable:
 
 # ── Registry ─────────────────────────────────────────────────────────────────
 
-POLICY_REGISTRY: list[dict[str, Any]] = [
+POLICY_REGISTRY: list[dict[str, object]] = [
     {
         "handler": "omnigent.policies.builtins.routing.deny_trivial_to_expensive_model",
         "kind": "factory",


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Replace broad `Any` annotations in built-in policy schemas, registries, response readers, and the base context contract with `object` plus runtime narrowing.
- Validate the legacy Nessie registry handler before rewriting it, preserving the compatibility shim while removing 10 mypy errors.
- Pass the existing structured-output schema to prompt-policy LLM calls, addressing Code Quality feedback and matching the documented behavior.

## Test Plan

- `uv run --no-sync pytest -q tests/policies/builtins/test_prompt.py tests/policies/builtins/test_routing.py tests/inner/nessie/test_policies.py tests/runtime/policies/test_function_policy.py tests/policies/test_registry.py` (194 passed)
- `uv run --no-sync pytest -q tests/policies/builtins/test_prompt.py` (15 passed after the review fix)
- `pre-commit run --files omnigent/policies/base.py omnigent/policies/builtins/routing.py omnigent/policies/builtins/prompt.py omnigent/policies/builtins/orchestration.py omnigent/inner/nessie/policies.py`
- `uv run --no-sync mypy omnigent` (branch baseline is 1,086 errors versus 1,096 on its `main` base; no errors remain in the touched files)

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing policy tests cover structured LLM responses, routing decisions, registry discovery, legacy handler rewriting, and function-policy context handling.

## Changelog

N/A — internal type cleanup with no user-facing behavior change.

