### PR TITLE
refactor(policies): type CEL adapter boundary

### DIFF
--- a/omnigent/policies/builtins/cel.py
+++ b/omnigent/policies/builtins/cel.py
@@ -58,11 +58,13 @@ CEL reference: https://cel.dev/overview/cel-overview
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 try:
     import celpy
     import celpy.celtypes
+    from celpy.adapter import json_to_cel
+    from celpy.celparser import CELParseError
+    from celpy.evaluation import CELEvalError
 except ImportError:
     celpy = None  # type: ignore[assignment]
 
@@ -113,7 +115,7 @@ def cel_policy(
     env = celpy.Environment()
     try:
         ast = env.compile(expression)
-    except celpy.CELParseError as exc:
+    except CELParseError as exc:
         _log.warning("CEL compile error: %s", exc)
         raise ValueError(f"CEL policy: compile error in expression: {exc}") from exc
 
@@ -136,8 +138,8 @@ def cel_policy(
         if event.get("type") == "request":
             cel_event["data"] = request_user_text(event.get("data"))
         try:
-            result = prog.evaluate({"event": celpy.json_to_cel(cel_event)})
-        except (celpy.CELEvalError, ValueError, TypeError):
+            result = prog.evaluate({"event": json_to_cel(cel_event)})
+        except (CELEvalError, ValueError, TypeError):
             _log.debug(
                 "CEL policy eval error on event type %r, abstaining",
                 event.get("type"),
@@ -160,12 +162,12 @@ def cel_policy(
             out["reason"] = reason
         return out
 
-    return evaluate  # type: ignore[return-value]
+    return evaluate
 
 
 # ── Registry ─────────────────────────────────────────────────────────────────
 
-POLICY_REGISTRY: list[dict[str, Any]] = (
+POLICY_REGISTRY: list[dict[str, object]] = (
     []
     if celpy is None
     else [


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Import CEL parser, evaluator, and JSON adapter symbols from their typed owning modules instead of relying on unexported `celpy` package attributes.
- Remove an obsolete return suppression and type the registry as heterogeneous objects, eliminating five mypy errors at the CEL adapter boundary.

## Test Plan

- `uv run --no-sync pytest -q tests/policies/builtins/test_cel.py` (15 passed)
- `pre-commit run --files omnigent/policies/builtins/cel.py`
- `uv run --no-sync mypy omnigent` (branch baseline is 1,080 errors versus 1,085 on its `main` base; no errors remain in the touched file)

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing CEL policy tests cover compilation, evaluation, custom reasons, map validation, and list expressions.

## Changelog

N/A — internal type cleanup with no user-facing behavior change.
