### PR TITLE
[lint] Enforce baseline-free model hardcode scanning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,8 @@ repos:
         language: system
         entry: .venv/bin/python dev/lint/lint_no_hardcoded_models.py
         pass_filenames: false
-        files: ^(omnigent|scripts|examples|\.github|dev/lint)/.*\.(py|ya?ml|json|toml|sh)$
+        files: \.(py|ya?ml|json|toml|sh)$
+        exclude: (^|/)tests/|^openapi\.json$
 
       - id: web-prettier
         name: web prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         language: system
         entry: .venv/bin/python dev/lint/lint_no_hardcoded_models.py
         pass_filenames: false
-        files: ^((omnigent|scripts|examples|\.github|dev/lint)/.*\.(py|ya?ml|json|toml|sh)|dev/lint/hardcoded_model_allowlist\.txt)$
+        files: ^(omnigent|scripts|examples|\.github|dev/lint)/.*\.(py|ya?ml|json|toml|sh)$
 
       - id: web-prettier
         name: web prettier

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,0 @@
-llm:
-  model: databricks-claude-haiku-4-5
-  profile: oss

--- a/dev/lint/hardcoded_model_allowlist.txt
+++ b/dev/lint/hardcoded_model_allowlist.txt
@@ -1,3 +1,0 @@
-# Curated baseline for dev/lint/lint_no_hardcoded_models.py.
-# Format: <path> <model-id> <allowed-count>
-# Keep counts minimal; new model pins should move behind provider/catalog resolution.

--- a/dev/lint/lint_no_hardcoded_models.py
+++ b/dev/lint/lint_no_hardcoded_models.py
@@ -18,7 +18,7 @@ MODEL_ID_RE = re.compile(
     \b(?:
         databricks-(?:claude|gpt|gemini|llama|mistral|mixtral|deepseek|qwen|kimi|dbrx|grok|meta)-[a-z0-9][a-z0-9._:/-]*
       | system\.ai\.[a-z0-9][a-z0-9._:/-]*
-      | (?:openai/)?gpt-(?:\d|oss)[a-z0-9._:/-]*
+      | (?:openai/)?(?:gpt-\d[a-z0-9._:/-]*|gpt-oss-[a-z0-9][a-z0-9._:/-]*)
       | o[134](?:-[a-z0-9][a-z0-9._:/-]*)?
       | claude-(?:opus|sonnet|haiku|fable|\d)[a-z0-9._:/-]*
       | gemini-\d[a-z0-9][a-z0-9._:/-]*
@@ -27,7 +27,7 @@ MODEL_ID_RE = re.compile(
       | llama-\d[a-z0-9][a-z0-9._:/-]*
       | mistral-[a-z0-9][a-z0-9._:/-]*
       | deepseek-[a-z0-9][a-z0-9._:/-]*
-    )\b
+    )\b(?![a-z0-9._:/-])
     """,
     re.VERBOSE,
 )
@@ -72,51 +72,6 @@ def _repo_relative(path: Path) -> str:
         return path.resolve().relative_to(Path.cwd().resolve()).as_posix()
     except ValueError:
         return path.as_posix()
-
-
-def _target_name(node: ast.expr) -> str:
-    """Return the user-visible name for an assignment target."""
-    if isinstance(node, ast.Name):
-        return node.id
-    if isinstance(node, ast.Attribute):
-        return node.attr
-    if isinstance(node, ast.Subscript):
-        return _target_name(node.value)
-    if isinstance(node, ast.Starred):
-        return _target_name(node.value)
-    if isinstance(node, (ast.Tuple, ast.List)):
-        return " ".join(filter(None, (_target_name(item) for item in node.elts)))
-    return ""
-
-
-def _key_name(node: ast.expr | None) -> str:
-    """Return a literal dict key name when statically knowable."""
-    if isinstance(node, ast.Constant) and isinstance(node.value, str):
-        return node.value
-    if isinstance(node, ast.Name):
-        return node.id
-    return ""
-
-
-def _is_model_context(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> bool:
-    """Return True if a string literal lives in model-selection data."""
-    current = node
-    while current in parents:
-        parent = parents[current]
-        if isinstance(parent, ast.keyword) and parent.arg and "model" in parent.arg.lower():
-            return True
-        if isinstance(parent, ast.Assign):
-            if any("model" in _target_name(target).lower() for target in parent.targets):
-                return True
-        elif isinstance(parent, ast.AnnAssign):
-            if "model" in _target_name(parent.target).lower():
-                return True
-        elif isinstance(parent, ast.Dict):
-            for key, value in zip(parent.keys, parent.values, strict=True):
-                if value is current and "model" in _key_name(key).lower():
-                    return True
-        current = parent
-    return False
 
 
 def _extract_models(text: str) -> list[str]:
@@ -200,33 +155,48 @@ def _owned_fallback_model_literals(tree: ast.Module) -> set[ast.Constant]:
     return exempt
 
 
+def _docstring_nodes(tree: ast.Module) -> set[ast.Constant]:
+    """Return literal nodes used as module, class, or function docstrings."""
+    owners = (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+    docstrings: set[ast.Constant] = set()
+    for owner in ast.walk(tree):
+        if not isinstance(owner, owners) or not owner.body:
+            continue
+        first = owner.body[0]
+        if (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+        ):
+            docstrings.add(first.value)
+    return docstrings
+
+
 def _scan_python(path: Path) -> list[Hit]:
-    """Scan Python syntax-aware string literals in model contexts."""
+    """Scan every non-docstring Python string literal."""
     try:
         tree = ast.parse(path.read_text())
     except (SyntaxError, UnicodeDecodeError):
         return []
 
-    parents = {child: node for node in ast.walk(tree) for child in ast.iter_child_nodes(node)}
     exempt = (
         _owned_fallback_model_literals(tree)
         if _repo_relative(path) == OWNED_FALLBACK_PATH.as_posix()
         else set()
     )
+    exempt.update(_docstring_nodes(tree))
     hits: list[Hit] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
             continue
         if node in exempt:
             continue
-        if not _is_model_context(node, parents):
-            continue
         hits.extend(Hit(path, node.lineno, model) for model in _extract_models(node.value))
     return hits
 
 
 def _scan_text(path: Path) -> list[Hit]:
-    """Scan config/shell files for model-looking ids on model-looking lines."""
+    """Scan non-comment config and shell lines for model-looking ids."""
     try:
         lines = path.read_text().splitlines()
     except UnicodeDecodeError:
@@ -235,8 +205,6 @@ def _scan_text(path: Path) -> list[Hit]:
     hits: list[Hit] = []
     for line_number, line in enumerate(lines, start=1):
         if line.lstrip().startswith("#"):
-            continue
-        if "model" not in line.lower():
             continue
         hits.extend(Hit(path, line_number, model) for model in _extract_models(line))
     return hits

--- a/dev/lint/lint_no_hardcoded_models.py
+++ b/dev/lint/lint_no_hardcoded_models.py
@@ -34,7 +34,6 @@ MODEL_ID_RE = re.compile(
 
 TEXT_EXTENSIONS = {".json", ".toml", ".yaml", ".yml", ".sh"}
 SOURCE_EXTENSIONS = {".py", *TEXT_EXTENSIONS}
-SCAN_ROOTS = (Path("."),)
 GENERATED_PATHS = {Path("openapi.json")}
 SKIP_PARTS = {
     ".git",
@@ -223,9 +222,7 @@ def scan(path: Path) -> list[Hit]:
 
 def _iter_scannable_paths() -> list[Path]:
     """Return every tracked source/config file in the lint surface."""
-    output = subprocess.check_output(
-        ["git", "ls-files", "-z", "--", *(root.as_posix() for root in SCAN_ROOTS)],
-    )
+    output = subprocess.check_output(["git", "ls-files", "-z"])
     return [
         path
         for raw_path in output.decode().split("\0")

--- a/dev/lint/lint_no_hardcoded_models.py
+++ b/dev/lint/lint_no_hardcoded_models.py
@@ -34,13 +34,8 @@ MODEL_ID_RE = re.compile(
 
 TEXT_EXTENSIONS = {".json", ".toml", ".yaml", ".yml", ".sh"}
 SOURCE_EXTENSIONS = {".py", *TEXT_EXTENSIONS}
-SCAN_ROOTS = (
-    Path("omnigent"),
-    Path("scripts"),
-    Path("examples"),
-    Path(".github"),
-    Path("dev/lint"),
-)
+SCAN_ROOTS = (Path("."),)
+GENERATED_PATHS = {Path("openapi.json")}
 SKIP_PARTS = {
     ".git",
     ".mypy_cache",
@@ -215,6 +210,7 @@ def scan(path: Path) -> list[Hit]:
     if (
         not path.is_file()
         or path.suffix not in SOURCE_EXTENSIONS
+        or Path(_repo_relative(path)) in GENERATED_PATHS
         or any(part in SKIP_PARTS for part in path.parts)
     ):
         return []
@@ -235,6 +231,7 @@ def _iter_scannable_paths() -> list[Path]:
         for raw_path in output.decode().split("\0")
         if raw_path
         if (path := Path(raw_path)).suffix in SOURCE_EXTENSIONS
+        if path not in GENERATED_PATHS
         if not any(part in SKIP_PARTS for part in path.parts)
     ]
 

--- a/dev/lint/lint_no_hardcoded_models.py
+++ b/dev/lint/lint_no_hardcoded_models.py
@@ -1,10 +1,7 @@
-"""Flag new hardcoded LLM model ids outside tests and owned fallbacks.
+"""Flag hardcoded LLM model ids outside tests and owned fallbacks.
 
-The codebase still has a curated baseline of model pins that predate this
-check. This hook requires every path/model count to exactly match
-``dev/lint/hardcoded_model_allowlist.txt`` so new pins fail and removed pins
-must ratchet the baseline down. Unavoidable static aliases are accepted only
-inside complete ``StaticModelFallback`` records in the central fallback module.
+Unavoidable static aliases are accepted only inside complete
+``StaticModelFallback`` records in the central fallback module.
 """
 
 from __future__ import annotations
@@ -13,7 +10,6 @@ import ast
 import re
 import subprocess
 import sys
-from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -57,7 +53,6 @@ SKIP_PARTS = {
     "node_modules",
     "tests",
 }
-ALLOWLIST_PATH = Path("dev/lint/hardcoded_model_allowlist.txt")
 OWNED_FALLBACK_PATH = Path("omnigent/model_fallbacks.py")
 FALLBACK_METADATA_FIELDS = frozenset({"owner", "provenance", "discovery_gap"})
 
@@ -276,81 +271,21 @@ def _iter_scannable_paths() -> list[Path]:
     ]
 
 
-def _load_allowlist(path: Path = ALLOWLIST_PATH) -> Counter[tuple[str, str]]:
-    """Load allowed ``(path, model)`` occurrence counts."""
-    allowed: Counter[tuple[str, str]] = Counter()
-    if not path.exists():
-        return allowed
-    for line_number, raw_line in enumerate(path.read_text().splitlines(), start=1):
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            continue
-        parts = line.split()
-        if len(parts) != 3:
-            raise ValueError(f"{path}:{line_number}: expected: <path> <model> <count>")
-        rel_path, model, count_text = parts
-        key = (rel_path, model)
-        if key in allowed:
-            raise ValueError(
-                f"{path}:{line_number}: duplicate baseline entry for {rel_path} {model}"
-            )
-        try:
-            allowed[key] = int(count_text)
-        except ValueError as exc:
-            raise ValueError(
-                f"{path}:{line_number}: count must be an integer, got {count_text!r}"
-            ) from exc
-    return allowed
-
-
-def _find_new_hits(hits: list[Hit], allowed: Counter[tuple[str, str]]) -> list[Hit]:
-    """Return hits whose path/model count exceeds the curated baseline."""
-    seen: Counter[tuple[str, str]] = Counter()
-    new_hits: list[Hit] = []
-    for hit in hits:
-        key = (_repo_relative(hit.path), hit.model)
-        seen[key] += 1
-        if seen[key] > allowed[key]:
-            new_hits.append(hit)
-    return new_hits
-
-
-def _find_stale_allowances(
-    hits: list[Hit],
-    allowed: Counter[tuple[str, str]],
-) -> Counter[tuple[str, str]]:
-    """Return baseline counts that exceed the current scan results."""
-    actual = Counter((_repo_relative(hit.path), hit.model) for hit in hits)
-    return allowed - actual
-
-
 def main() -> int:
-    """Scan the full supported surface and require an exact baseline."""
+    """Scan the full supported surface and reject every non-owned model id."""
     paths = _iter_scannable_paths()
     hits = [hit for path in paths for hit in scan(path)]
-    allowed = _load_allowlist()
-    new_hits = _find_new_hits(hits, allowed)
-    stale_allowances = _find_stale_allowances(hits, allowed)
-    if not new_hits and not stale_allowances:
+    if not hits:
         return 0
 
-    for hit in new_hits:
+    for hit in hits:
         sys.stdout.write(
             f"{hit.path}:{hit.line}: hardcoded model id `{hit.model}`; "
             "resolve from the configured provider/model catalog instead\n"
         )
-    for (path, model), stale_count in sorted(stale_allowances.items()):
-        actual_count = allowed[(path, model)] - stale_count
-        sys.stdout.write(
-            f"{ALLOWLIST_PATH}: stale allowance for `{model}` in {path}: "
-            f"allows {allowed[(path, model)]}, found {actual_count}; "
-            "lower or remove the baseline entry\n"
-        )
     sys.stdout.write(
         "\nAvoid adding hardcoded model names outside tests. Unavoidable static aliases "
-        "belong in complete StaticModelFallback records in omnigent/model_fallbacks.py. "
-        "If this is an intentional temporary pin, document why and update "
-        "dev/lint/hardcoded_model_allowlist.txt with the smallest path/model count.\n"
+        "belong in complete StaticModelFallback records in omnigent/model_fallbacks.py.\n"
     )
     return 1
 

--- a/docs/model-hardcoding-plan.md
+++ b/docs/model-hardcoding-plan.md
@@ -10,8 +10,8 @@ provenance, and the discovery gap that prevents a live listing.
 
 ## Prevention
 
-- `dev/lint/lint_no_hardcoded_models.py` scans non-test Python/config/shell
-  files for concrete model ids in model-selection contexts.
+- `dev/lint/lint_no_hardcoded_models.py` scans every tracked non-test
+  Python/config/shell file for concrete model ids.
 - When a supported file changes, `.pre-commit-config.yaml` runs the hook across
   the full tracked lint surface so any non-owned hardcode fails.
 - Unavoidable static aliases pass only when Python AST analysis proves they are
@@ -23,24 +23,20 @@ provenance, and the discovery gap that prevents a live listing.
 
 ### Scope and exclusions
 
-The hook scans Python, YAML, JSON, TOML, and shell files under `omnigent`,
-`scripts`, `examples`, `.github`, and `dev/lint`. Python uses AST context;
-config and shell files use model-looking lines while ignoring comment-only
-lines.
+The hook scans tracked Python, YAML, JSON, TOML, and shell files across the
+repository. Python AST analysis checks every non-docstring string literal;
+config and shell files check every non-comment line. Tests, Markdown/prose,
+TypeScript/JavaScript, generated OpenAPI, and vendor/build trees are excluded.
 
-Tests, Markdown/prose, top-level files, `web` TypeScript/JavaScript, and
-generated/vendor trees are intentionally outside the initial lint surface.
-Tests need concrete ids as fixtures, while prose and frontend sources need
-syntax-aware handling before they can be added without excessive false
-positives.
+Concrete model ids in runtime help, logs, and errors are production literals
+and therefore fail lint. Use provider-neutral wording or synthetic identifier
+shapes there; docstrings may retain concrete examples when they materially
+improve API documentation.
 
-This is a heuristic ratchet, not a parser-level guarantee. Python detection is
-limited to model-named assignments, keyword arguments, and dictionary keys; a
-model id in an unrelated positional argument or bare collection can escape the
-check. Config and shell detection requires the model context and id on the same
-line, so multiline/block-scalar values are also outside the initial coverage.
-These gaps should be closed with syntax-aware scanners rather than broader
-regexes that would make prose false-positive.
+This remains a model-id regex ratchet rather than a parser-level guarantee for
+every provider naming scheme. Extend the regex and add a focused test when a
+new complete-id shape appears; do not broaden structural exceptions beyond
+complete owned fallback records.
 
 The hook intentionally scans the full tracked surface when a supported file
 changes. That bounded cost is what lets it enforce global absence instead of

--- a/docs/model-hardcoding-plan.md
+++ b/docs/model-hardcoding-plan.md
@@ -1,42 +1,25 @@
 # Model Hardcoding Plan
 
-## Current Curated Inventory
+## Current Inventory
 
-The current baseline lives in `dev/lint/hardcoded_model_allowlist.txt`. It is
-count-based by `path` and `model-id`, so unrelated line movement does not break
-the hook while net-new pins still fail.
-
-The remaining pins fall into a few buckets:
-
-- **CI automation:** model roles are read from repository variables; mock-only
-  integration jobs use the protocol-level `mock-model` fixture id.
-- **Harness defaults:** native/executor launch paths such as
-  `omnigent/pi_native_credentials.py`, `omnigent/opencode_native_provider.py`,
-  `omnigent/inner/*_executor.py`, and `omnigent/codex_native_app_server.py`
-  still carry fallback model ids.
-- **Static pickers/catalogs:** `omnigent/model_catalog.py` and
-  `omnigent/cursor_native.py` encode static model choices for CLIs that do not
-  expose a directly reusable live listing API.
-- **Policy and sizing logic:** `omnigent/llms/context_window.py`,
-  `omnigent/policies/builtins/routing.py`, and `omnigent/tools/builtins/spawn.py`
-  mention concrete models when mapping windows, routing examples, or dispatch
-  examples.
-- **Examples/onboarding:** `examples/kimi_hello.yaml` and onboarding provider
-  prompts include concrete defaults to make first-run setup work.
+Production model selection uses explicit operator configuration, provider or
+CLI discovery, and normalized catalog metadata. The count-based hardcode
+baseline is gone. The only source-controlled model aliases are the unavoidable
+Claude and Codex records in `omnigent/model_fallbacks.py`; each carries an owner,
+provenance, and the discovery gap that prevents a live listing.
 
 ## Prevention
 
 - `dev/lint/lint_no_hardcoded_models.py` scans non-test Python/config/shell
   files for concrete model ids in model-selection contexts.
-- When a supported file or the baseline changes, `.pre-commit-config.yaml` runs
-  the hook across the full tracked lint surface so both new pins and stale
-  allowlist counts fail.
+- When a supported file changes, `.pre-commit-config.yaml` runs the hook across
+  the full tracked lint surface so any non-owned hardcode fails.
 - Unavoidable static aliases pass only when Python AST analysis proves they are
   confined to complete `StaticModelFallback` records in
   `omnigent/model_fallbacks.py`, including non-empty owner, provenance, and
   discovery-gap metadata.
-- New hardcoded ids fail unless the allowlist count is intentionally updated,
-  while removing a pin requires lowering or deleting its baseline entry.
+- There is no count-based escape hatch. New production aliases must either come
+  from configuration/discovery or satisfy the central owned-fallback contract.
 
 ### Scope and exclusions
 
@@ -60,10 +43,10 @@ These gaps should be closed with syntax-aware scanners rather than broader
 regexes that would make prose false-positive.
 
 The hook intentionally scans the full tracked surface when a supported file
-changes. That bounded cost is what lets it enforce exact global baseline counts
-instead of only checking additions in changed files. Like the existing Ruff
-hooks, local pre-commit execution assumes the repository `.venv` has been
-prepared with `just ensure`; CI is the enforcement backstop.
+changes. That bounded cost is what lets it enforce global absence instead of
+only checking additions in changed files. Like the existing Ruff hooks, local
+pre-commit execution assumes the repository `.venv` has been prepared with
+`just ensure`; CI is the enforcement backstop.
 
 ## Migration Plan
 
@@ -80,11 +63,11 @@ prepared with `just ensure`; CI is the enforcement backstop.
 4. **Centralize static fallback catalogs.** Keep unavoidable static CLI catalogs
    behind one module with provenance, TTL/refresh notes, and a smaller lint
    exception surface.
-5. **Ratchet the baseline down.** Each migration removes the corresponding
-   `dev/lint/hardcoded_model_allowlist.txt` entry; the lint rejects both count
-   increases and stale allowances.
-6. **Document escape hatches.** If a temporary pin is unavoidable, require a
-   short rationale near the call site and the smallest allowlist count.
+5. **Delete the baseline.** With production call sites migrated, reject every
+   non-owned model literal instead of maintaining path/count exceptions.
+6. **Constrain the escape hatch.** Unavoidable static aliases must live in the
+   central fallback registry with literal ownership, provenance, and discovery
+   gap metadata.
 
 ## Resolver Contract
 

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -91,6 +91,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.model_fallbacks import static_model_fallback
 from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
@@ -110,6 +111,7 @@ from omnigent.native_terminal import (
 from omnigent.native_terminal import (
     terminal_attach_url as _attach_url,
 )
+from omnigent.onboarding.provider_config import SUBSCRIPTION_KIND
 from omnigent.terminals.ws_bridge import (
     WS_CLOSE_TERMINAL_DETACHED,
     WS_CLOSE_TERMINAL_NOT_FOUND,
@@ -375,7 +377,17 @@ def resolve_claude_native_model_selection(
             return provider_fallback
         if claude_config.model:
             return claude_config.model
-    return "claude-sonnet-5"
+    fallback = static_model_fallback(SUBSCRIPTION_KIND, "claude")
+    if fallback is None:
+        return model
+    return next(
+        (
+            model_id
+            for model_id in fallback.model_ids
+            if _claude_model_display_name("sonnet", model_id) == _UCODE_CLAUDE_CUSTOM_TIER_LABEL
+        ),
+        model,
+    )
 
 
 def _claude_model_display_name(tier: str, model_id: str) -> str:
@@ -1882,8 +1894,7 @@ def _bedrock_config_for_native_claude(entry: ProviderEntry) -> ClaudeNativeUcode
         _logger.warning(
             "native-claude: bedrock provider %r sets no models.default — Claude Code "
             "will choose its own default model, which is usually not enabled on a "
-            "Bedrock account. Set models.default to a Bedrock inference-profile id "
-            "(e.g. us.anthropic.claude-opus-4-5-20251101-v1:0).",
+            "Bedrock account. Set models.default to a Bedrock inference-profile id.",
             entry.name,
         )
     _logger.info(

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -379,15 +379,24 @@ def resolve_claude_native_model_selection(
             return claude_config.model
     fallback = static_model_fallback(SUBSCRIPTION_KIND, "claude")
     if fallback is None:
-        return model
-    return next(
+        raise ValueError("Claude subscription fallback has no routable Sonnet model")
+    exact_match = next(
         (
             model_id
             for model_id in fallback.model_ids
             if _claude_model_display_name("sonnet", model_id) == _UCODE_CLAUDE_CUSTOM_TIER_LABEL
         ),
-        model,
+        None,
     )
+    if exact_match is not None:
+        return exact_match
+    family_match = next(
+        (model_id for model_id in fallback.model_ids if "claude-sonnet-" in model_id.lower()),
+        None,
+    )
+    if family_match is None:
+        raise ValueError("Claude subscription fallback has no routable Sonnet model")
+    return family_match
 
 
 def _claude_model_display_name(tier: str, model_id: str) -> str:

--- a/omnigent/cli_native.py
+++ b/omnigent/cli_native.py
@@ -611,7 +611,7 @@ def register_native_commands(cli: click.Group) -> None:
     @click.option(
         "--model",
         default=None,
-        help="Cursor model to use for the native TUI (e.g. gpt-5.2, claude-4.6-sonnet-medium).",
+        help="Cursor model id to use for the native TUI.",
     )
     @click.argument("cursor_args", nargs=-1, type=click.UNPROCESSED)
     def cursor(
@@ -629,7 +629,7 @@ def register_native_commands(cli: click.Group) -> None:
         \b
         Examples:
           omnigent cursor
-          omnigent cursor --model gpt-5.2
+          omnigent cursor --model MODEL_ID
           omnigent cursor --resume conv_abc123
           omnigent cursor --resume                 # interactive picker
           omnigent cursor --mode plan              # start in plan (read-only) mode

--- a/omnigent/inner/loader.py
+++ b/omnigent/inner/loader.py
@@ -626,7 +626,7 @@ def _parse_executor_spec(data: YamlData | str | bool | None) -> ExecutorSpec | N
             raise ValueError(
                 f"executor: key(s) {', '.join(nested)} belong to the bundle "
                 "config.yaml format; this format spells the executor flat, "
-                "e.g. executor: {harness: codex-native, model: gpt-5.4-mini}"
+                "e.g. executor: {harness: codex-native, model: MODEL_ID}"
             )
         # ``ExecutorSpec.{model,harness,profile}`` are ``str | None``;
         # missing keys map to ``None`` directly. ``data.get`` happens to

--- a/tests/dev/lint/test_lint_no_hardcoded_models.py
+++ b/tests/dev/lint/test_lint_no_hardcoded_models.py
@@ -27,9 +27,46 @@ def test_scan_flags_python_model_assignment(tmp_path: Path) -> None:
     ]
 
 
-def test_scan_ignores_python_prose_mentions(tmp_path: Path) -> None:
+def test_scan_flags_python_positional_argument(tmp_path: Path) -> None:
+    dirty = tmp_path / "dirty.py"
+    dirty.write_text('resolve("databricks-claude-sonnet-4-6")\n')
+
+    assert [(hit.line, hit.model) for hit in scan(dirty)] == [
+        (1, "databricks-claude-sonnet-4-6"),
+    ]
+
+
+def test_scan_flags_python_bare_collection(tmp_path: Path) -> None:
+    dirty = tmp_path / "dirty.py"
+    dirty.write_text('("databricks-claude-sonnet-4-6", "gpt-oss-120b")\n')
+
+    assert [(hit.line, hit.model) for hit in scan(dirty)] == [
+        (1, "databricks-claude-sonnet-4-6"),
+        (1, "gpt-oss-120b"),
+    ]
+
+
+def test_scan_ignores_model_family_fragments(tmp_path: Path) -> None:
     clean = tmp_path / "clean.py"
-    clean.write_text('"""For example, databricks-claude-sonnet-4-6."""\n')
+    clean.write_text(
+        'prefixes = ("databricks-claude-opus-", "databricks-claude-fable-")\n'
+        'families = ("gpt-oss",)\n'
+    )
+
+    assert scan(clean) == []
+
+
+def test_scan_ignores_python_docstrings(tmp_path: Path) -> None:
+    clean = tmp_path / "clean.py"
+    clean.write_text(
+        '"""For example, databricks-claude-sonnet-4-6."""\n'
+        "class Example:\n"
+        '    """For example, gpt-5.5."""\n'
+        "    def sync(self):\n"
+        '        """For example, claude-opus-4-1."""\n'
+        "    async def async_(self):\n"
+        '        """For example, gemini-2.5-pro."""\n'
+    )
 
     assert scan(clean) == []
 
@@ -109,7 +146,10 @@ def test_scan_flags_yaml_model_key(tmp_path: Path) -> None:
         "notes: databricks-gpt-5-5\n"
     )
 
-    assert [(hit.line, hit.model) for hit in scan(dirty)] == [(2, "databricks-gpt-5-5")]
+    assert [(hit.line, hit.model) for hit in scan(dirty)] == [
+        (2, "databricks-gpt-5-5"),
+        (3, "databricks-gpt-5-5"),
+    ]
 
 
 def test_scan_ignores_tests(tmp_path: Path) -> None:

--- a/tests/dev/lint/test_lint_no_hardcoded_models.py
+++ b/tests/dev/lint/test_lint_no_hardcoded_models.py
@@ -11,7 +11,6 @@ import yaml
 
 from dev.lint.lint_no_hardcoded_models import (
     OWNED_FALLBACK_PATH,
-    SCAN_ROOTS,
     SOURCE_EXTENSIONS,
     _iter_scannable_paths,
     scan,
@@ -65,7 +64,7 @@ def test_scan_ignores_python_docstrings(tmp_path: Path) -> None:
         "    def sync(self):\n"
         '        """For example, claude-opus-4-1."""\n'
         "    async def async_(self):\n"
-        '        """For example, gemini-2.5-pro."""\n'
+        '        """For example, gemini-3-pro."""\n'
     )
 
     assert scan(clean) == []
@@ -184,6 +183,5 @@ def test_precommit_trigger_matches_scan_surface() -> None:
     scanned_paths = set(_iter_scannable_paths())
 
     assert triggered_paths == scanned_paths
-    for root in SCAN_ROOTS:
-        for extension in SOURCE_EXTENSIONS:
-            assert files_pattern.search((root / f"lint_probe{extension}").as_posix())
+    for extension in SOURCE_EXTENSIONS:
+        assert files_pattern.search(Path(f"lint_probe{extension}").as_posix())

--- a/tests/dev/lint/test_lint_no_hardcoded_models.py
+++ b/tests/dev/lint/test_lint_no_hardcoded_models.py
@@ -169,18 +169,21 @@ def test_precommit_trigger_matches_scan_surface() -> None:
         if hook["id"] == "no-hardcoded-models"
     )
     files_pattern = re.compile(hook["files"])
-    exclude_pattern = re.compile(config["exclude"])
+    global_exclude_pattern = re.compile(config["exclude"])
+    hook_exclude_pattern = re.compile(hook["exclude"])
     tracked_paths = {
         Path(path) for path in subprocess.check_output(["git", "ls-files"]).decode().splitlines()
     }
     triggered_paths = {
         path
         for path in tracked_paths
-        if files_pattern.search(path.as_posix()) and not exclude_pattern.search(path.as_posix())
+        if files_pattern.search(path.as_posix())
+        and not global_exclude_pattern.search(path.as_posix())
+        and not hook_exclude_pattern.search(path.as_posix())
     }
     scanned_paths = set(_iter_scannable_paths())
 
     assert triggered_paths == scanned_paths
     for root in SCAN_ROOTS:
         for extension in SOURCE_EXTENSIONS:
-            assert files_pattern.fullmatch(f"{root.as_posix()}/lint_probe{extension}")
+            assert files_pattern.search((root / f"lint_probe{extension}").as_posix())

--- a/tests/dev/lint/test_lint_no_hardcoded_models.py
+++ b/tests/dev/lint/test_lint_no_hardcoded_models.py
@@ -4,22 +4,16 @@ from __future__ import annotations
 
 import re
 import subprocess
-from collections import Counter
 from pathlib import Path
 
 import pytest
 import yaml
 
 from dev.lint.lint_no_hardcoded_models import (
-    ALLOWLIST_PATH,
     OWNED_FALLBACK_PATH,
     SCAN_ROOTS,
     SOURCE_EXTENSIONS,
-    Hit,
-    _find_new_hits,
-    _find_stale_allowances,
     _iter_scannable_paths,
-    _load_allowlist,
     scan,
 )
 
@@ -126,47 +120,6 @@ def test_scan_ignores_tests(tmp_path: Path) -> None:
     assert scan(test_file) == []
 
 
-def test_find_new_hits_allows_only_curated_count() -> None:
-    path = Path("omnigent/example.py")
-    hits = [
-        Hit(path, 1, "databricks-gpt-5-5"),
-        Hit(path, 2, "databricks-gpt-5-5"),
-    ]
-    allowed = Counter({("omnigent/example.py", "databricks-gpt-5-5"): 1})
-
-    assert _find_new_hits(hits, allowed) == [hits[1]]
-
-
-def test_find_stale_allowances_requires_ratchet_down() -> None:
-    path = Path("omnigent/example.py")
-    hits = [Hit(path, 1, "databricks-gpt-5-5")]
-    allowed = Counter({("omnigent/example.py", "databricks-gpt-5-5"): 2})
-
-    assert _find_stale_allowances(hits, allowed) == Counter(
-        {("omnigent/example.py", "databricks-gpt-5-5"): 1}
-    )
-
-
-def test_load_allowlist_rejects_duplicate_path_model(tmp_path: Path) -> None:
-    allowlist = tmp_path / "allowlist.txt"
-    allowlist.write_text(
-        "omnigent/example.py databricks-gpt-5-5 1\nomnigent/example.py databricks-gpt-5-5 1\n"
-    )
-
-    with pytest.raises(ValueError, match="duplicate baseline entry"):
-        _load_allowlist(allowlist)
-
-
-def test_load_allowlist_reports_malformed_count_location(tmp_path: Path) -> None:
-    allowlist = tmp_path / "allowlist.txt"
-    allowlist.write_text("omnigent/example.py databricks-gpt-5-5 many\n")
-
-    with pytest.raises(ValueError) as error:
-        _load_allowlist(allowlist)
-
-    assert str(error.value) == f"{allowlist}:1: count must be an integer, got 'many'"
-
-
 def test_precommit_trigger_matches_scan_surface() -> None:
     config = yaml.safe_load(Path(".pre-commit-config.yaml").read_text())
     hook = next(
@@ -185,7 +138,7 @@ def test_precommit_trigger_matches_scan_surface() -> None:
         for path in tracked_paths
         if files_pattern.search(path.as_posix()) and not exclude_pattern.search(path.as_posix())
     }
-    scanned_paths = set(_iter_scannable_paths()) | {ALLOWLIST_PATH}
+    scanned_paths = set(_iter_scannable_paths())
 
     assert triggered_paths == scanned_paths
     for root in SCAN_ROOTS:

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -770,6 +770,34 @@ def test_sonnet_5_subscription_selection_uses_owned_fallback(
     )
 
 
+def test_sonnet_5_subscription_selection_uses_first_sonnet_family_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A renamed Sonnet release stays routable when its display label drifts."""
+    fallback = SimpleNamespace(model_ids=("future-claude-opus-5", "future-claude-sonnet-5-1"))
+    monkeypatch.setattr(claude_native, "static_model_fallback", lambda *_args: fallback)
+
+    assert (
+        claude_native.resolve_claude_native_model_selection("sonnet_5", None)
+        == "future-claude-sonnet-5-1"
+    )
+
+
+@pytest.mark.parametrize(
+    "fallback",
+    [None, SimpleNamespace(model_ids=("future-claude-opus-5",))],
+)
+def test_sonnet_5_subscription_selection_fails_without_sonnet_fallback(
+    fallback: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The private picker id never reaches Claude when its fallback disappears."""
+    monkeypatch.setattr(claude_native, "static_model_fallback", lambda *_args: fallback)
+
+    with pytest.raises(ValueError, match="no routable Sonnet model"):
+        claude_native.resolve_claude_native_model_selection("sonnet_5", None)
+
+
 def test_removed_sonnet_5_selection_falls_back_to_routable_databricks_sonnet() -> None:
     """A stale Sonnet 5 override cannot launch a non-gateway Anthropic id."""
     config = claude_native.ClaudeNativeUcodeConfig(

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -757,6 +757,19 @@ def test_sonnet_5_selection_resolves_to_the_configured_custom_model() -> None:
     )
 
 
+def test_sonnet_5_subscription_selection_uses_owned_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The direct-login custom row resolves from the central fallback record."""
+    fallback = SimpleNamespace(model_ids=("future-claude-sonnet-5",))
+    monkeypatch.setattr(claude_native, "static_model_fallback", lambda *_args: fallback)
+
+    assert (
+        claude_native.resolve_claude_native_model_selection("sonnet_5", None)
+        == "future-claude-sonnet-5"
+    )
+
+
 def test_removed_sonnet_5_selection_falls_back_to_routable_databricks_sonnet() -> None:
     """A stale Sonnet 5 override cannot launch a non-gateway Anthropic id."""
     config = claude_native.ClaudeNativeUcodeConfig(


### PR DESCRIPTION
## Related issue

Part of #3426

## Summary

- Delete the now-empty path/count baseline and its parser, stale-count checks, tests, and special pre-commit trigger; every non-owned production model literal now fails lint.
- Scan every tracked Python and supported config/shell file instead of a curated directory list, while explicitly excluding tests, generated OpenAPI, docstrings, and complete AST-verified `StaticModelFallback` records.
- Remove the model-context naming heuristic so positional arguments, bare collections, and arbitrary config keys cannot bypass the check; curate newly exposed runtime examples and delete the unused root server config.

**ELI5:** the lint no longer carries a list of old exceptions or guesses which variables look model-related. It checks the whole production tree and permits static aliases only through the single owned fallback structure.

```mermaid
flowchart LR
    A[Tracked production source] --> B[Literal scanner]
    B -->|Provider config or catalog value| C[No embedded id]
    B -->|Complete owned fallback record| D[Allowed structural boundary]
    B -->|Other concrete model id| E[Lint failure]
```

## Test Plan

- `uv run --extra dev pytest -q tests/dev/lint/test_lint_no_hardcoded_models.py tests/test_claude_native.py tests/inner/test_loader.py` (`238 passed`, plus 3 passing subtests)
- `uv run --extra dev mypy dev/lint/lint_no_hardcoded_models.py omnigent/inner/loader.py --follow-imports=skip` (passed)
- `uv run python dev/lint/lint_no_hardcoded_models.py` (passed across the full tracked production surface without a baseline)
- `pre-commit run --all-files` (passed)

## Demo

N/A — lint, backend fallback wiring, documentation, and dead-config cleanup only.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage exercises positional and collection literals, arbitrary config keys, docstring exclusions, family-prefix compatibility checks, full-surface/pre-commit parity, and the owned fallback boundary. Existing Claude and loader suites cover the curated runtime paths.


