### PR TITLE
refactor(tracing): type tracer boundary

### DIFF
--- a/omnigent/inner/tracing.py
+++ b/omnigent/inner/tracing.py
@@ -42,7 +42,7 @@ import logging
 from typing import TYPE_CHECKING, Any, TypeAlias
 
 if TYPE_CHECKING:
-    from opentelemetry.trace import Span
+    from opentelemetry.trace import Span, Tracer
 
 from omnigent.runtime.telemetry import (
     parse_provider_name,
@@ -106,7 +106,7 @@ def is_tracing_enabled() -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _tracer() -> Any:
+def _tracer() -> Tracer:
     from opentelemetry import trace
 
     return trace.get_tracer("omnigent")


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Type the OpenTelemetry tracer factory as `Tracer` instead of `Any`.
- Let the typed SDK return propagate through agent, tool, and policy span creation, removing four mypy errors without runtime changes.

## Test Plan

- `uv run --no-sync pytest -q tests/inner/test_tracing_genai_semconv.py` (9 passed)
- `pre-commit run --files omnigent/inner/tracing.py`
- `uv run --no-sync mypy omnigent` (branch baseline is 1,081 errors versus 1,085 on its `main` base; no errors remain in the touched file)

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing tracing tests cover agent, tool, and policy spans plus content-capture behavior.

## Changelog

N/A — internal type cleanup with no user-facing behavior change.
