### PR TITLE
refactor(codex): narrow bridge state

### DIFF
--- a/omnigent/codex_native_bridge.py
+++ b/omnigent/codex_native_bridge.py
@@ -618,8 +618,16 @@ def read_bridge_state(bridge_dir: Path) -> CodexNativeBridgeState | None:
     thread_id = raw.get("thread_id")
     codex_home = raw.get("codex_home")
     active_turn_id = raw.get("active_turn_id")
-    required = (session_id, socket_path, thread_id, codex_home)
-    if not all(isinstance(value, str) and value for value in required):
+    if (
+        not isinstance(session_id, str)
+        or not session_id
+        or not isinstance(socket_path, str)
+        or not socket_path
+        or not isinstance(thread_id, str)
+        or not thread_id
+        or not isinstance(codex_home, str)
+        or not codex_home
+    ):
         return None
     parsed_active_turn_id = (
         active_turn_id if isinstance(active_turn_id, str) and active_turn_id else None


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Narrow each required Codex bridge-state field independently after JSON decoding.
- Preserve the existing non-empty-string validation while allowing mypy to prove all constructor arguments are strings, removing four errors.

## Test Plan

- `uv run --no-sync pytest -q tests/test_codex_native_bridge.py` (18 passed)
- `pre-commit run --files omnigent/codex_native_bridge.py`
- `uv run --no-sync mypy omnigent` (branch baseline is 1,071 errors versus 1,075 on its `main` base; no errors remain in the touched file)

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing bridge tests cover valid, missing, and malformed persisted state plus active-turn updates.

## Changelog

N/A — internal type cleanup with no user-facing behavior change.
