### PR TITLE
refactor(runner): type filesystem boundaries

### DIFF
--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -300,6 +300,7 @@ class OSEnvironment(ABC):
         path: str,
         offset: int = 1,
         limit: int | None = None,
+        max_binary_bytes: int | None = None,
     ) -> OpResult:
         raise NotImplementedError
 

--- a/omnigent/runner/environment_filesystem.py
+++ b/omnigent/runner/environment_filesystem.py
@@ -15,8 +15,9 @@ import base64
 import os
 import re
 import stat
+from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Literal, ParamSpec
 
 from omnigent.entities.environment_filesystem import (
     DeleteFilesystemResult,
@@ -33,9 +34,10 @@ from omnigent.entities.pagination import PagedList
 from omnigent.inner.os_env import _DEFAULT_READ_LIMIT
 
 if TYPE_CHECKING:
-    from omnigent.inner.os_env import OSEnvironment
+    from omnigent.inner.os_env import OpResult, OSEnvironment
 
 _MAX_READ_BYTES = 10 * 1024 * 1024  # 10 MiB
+_Params = ParamSpec("_Params")
 
 
 def _shell_quote(s: str) -> str:
@@ -157,10 +159,10 @@ def split_glob_list(raw: str | None) -> list[str]:
 
 
 async def _run_os_env_async(
-    method: Any,
-    *args: Any,
-    **kwargs: Any,
-) -> dict[str, Any]:
+    method: Callable[_Params, Awaitable[OpResult]],
+    *args: _Params.args,
+    **kwargs: _Params.kwargs,
+) -> OpResult:
     """Call an OSEnvironment async method.
 
     The OSEnvironment protocol uses ``OpResult = dict[str, Any]``
@@ -173,7 +175,7 @@ async def _run_os_env_async(
     :param kwargs: Keyword arguments.
     :returns: The OpResult dict.
     """
-    return await method(*args, **kwargs)  # type: ignore[no-any-return]
+    return await method(*args, **kwargs)
 
 
 def _validate_path(relative_path: str) -> str:
@@ -220,7 +222,7 @@ def _entry_from_stat(
         )
 
     if stat.S_ISDIR(st.st_mode):
-        entry_type = "directory"
+        entry_type: Literal["file", "directory", "symlink", "other"] = "directory"
         size = None
     elif stat.S_ISLNK(st.st_mode):
         entry_type = "symlink"
@@ -349,7 +351,7 @@ class CallerProcessFilesystem:
         for item in raw:
             name = item["n"]
             rel = os.path.join(validated, name) if validated else name
-            entry_type = "directory" if item["t"] == "d" else "file"
+            entry_type: Literal["file", "directory"] = "directory" if item["t"] == "d" else "file"
             entries.append(
                 FilesystemEntry(
                     id=rel,
@@ -658,7 +660,7 @@ class CallerProcessFilesystem:
         except _json.JSONDecodeError as exc:
             raise FilesystemPathNotFound(f"Path {path!r} not found") from exc
         name = os.path.basename(validated) if validated else ""
-        entry_type = "file"
+        entry_type: Literal["file", "directory", "symlink"] = "file"
         if info.get("d"):
             entry_type = "directory"
         elif info.get("l"):


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Type the dynamic async OS-environment adapter with `ParamSpec` and its existing `OpResult` contract instead of broad `Any`.
- Add the supported binary-read limit to the base environment contract and annotate filesystem entry discriminators as literals, removing four mypy errors.

## Test Plan

- `uv run --no-sync pytest -q tests/runner/test_environment_filesystem.py` (61 passed)
- `pre-commit run --files omnigent/runner/environment_filesystem.py omnigent/inner/os_env.py`
- `uv run --no-sync mypy omnigent` (branch baseline is 1,071 errors versus 1,075 on its `main` base; no errors remain in the runner filesystem service)

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing filesystem tests cover local and sandboxed reads, binary limits, listings, search, edits, deletes, diffs, and error paths.

## Changelog

N/A — internal type cleanup with no user-facing behavior change.
