### PR TITLE
refactor(executor): name event payload types

### DIFF
--- a/omnigent/inner/executor.py
+++ b/omnigent/inner/executor.py
@@ -36,6 +36,8 @@ ToolArgs: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
 ToolResult: TypeAlias = Any  # type: ignore[explicit-any]
 ToolCallMetadata: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
 ExecutorExtra: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
+ExecutorUsage: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
+CompactedMessages: TypeAlias = list[Message]
 
 # ``enqueue_session_message`` content — arbitrary user-supplied payload
 # (string text or a structured JSON value).
@@ -172,7 +174,7 @@ class TurnComplete(ExecutorEvent):
     response: str | None = None
     modified_by_policy: bool = False
     continue_turn: bool = False
-    usage: dict[str, Any] | None = None
+    usage: ExecutorUsage | None = None
 
 
 class ToolCallStatus(str, enum.Enum):
@@ -230,7 +232,7 @@ class CompactionComplete(ExecutorEvent):
     summary: str
     token_count: int
     model: str | None = None
-    compacted_messages: list[dict[str, Any]] | None = None
+    compacted_messages: CompactedMessages | None = None
 
 
 @dataclass


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Name the provider-opaque usage payload and compacted-message collection alongside the executor module's existing boundary aliases.
- Reuse those aliases in event dataclasses, containing dynamic provider data at the declared boundary and removing four mypy errors.

## Test Plan

- `uv run --no-sync pytest -q tests/inner/test_executor.py` (12 passed)
- `pre-commit run --files omnigent/inner/executor.py`
- `uv run --no-sync mypy omnigent` (branch baseline is 1,071 errors versus 1,075 on its `main` base; no errors remain in the touched file)

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing executor tests cover event construction, scripted turns, tool calls, continuation, and provider stream cleanup.

## Changelog

N/A — internal type cleanup with no user-facing behavior change.
