### PR TITLE
refactor(runner): type session init payloads

### DIFF
--- a/omnigent/runner/session_init_protocol.py
+++ b/omnigent/runner/session_init_protocol.py
@@ -2,17 +2,18 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Literal, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from omnigent.entities import Conversation
 
-SESSION_INIT_PROTOCOL_VERSION = 2
+SessionInitProtocolVersion: TypeAlias = Literal[2]
+SESSION_INIT_PROTOCOL_VERSION: SessionInitProtocolVersion = 2
 SESSION_INIT_PAYLOAD_KEY = "session_init"
 
 
-class RunnerSessionInitSnapshot(BaseModel):
+class RunnerSessionInitSnapshot(BaseModel):  # type: ignore[explicit-any]  # Pydantic uses Any
     """Server-owned session state needed while starting a runner session."""
 
     model_config = ConfigDict(extra="ignore")
@@ -31,12 +32,12 @@ class RunnerSessionInitSnapshot(BaseModel):
     root_session_id: str | None = None
 
 
-class RunnerSessionInitEnvelope(BaseModel):
+class RunnerSessionInitEnvelope(BaseModel):  # type: ignore[explicit-any]  # Pydantic uses Any
     """Metadata a current server can send instead of runner callback reads."""
 
     model_config = ConfigDict(extra="ignore")
 
-    protocol_version: Literal[SESSION_INIT_PROTOCOL_VERSION]
+    protocol_version: SessionInitProtocolVersion
     server_version: str
     session_id: str
     agent_id: str
@@ -55,7 +56,7 @@ def build_runner_session_init_payload(
     *,
     server_version: str,
     suppress_recovery_turn: bool = False,
-) -> dict[str, Any]:
+) -> dict[str, object]:
     """Build the versioned initialization fields appended to the legacy body."""
     if conversation.agent_id is None:
         raise ValueError("runner session initialization requires an agent_id")
@@ -90,7 +91,7 @@ def build_runner_session_init_payload(
 
 
 def parse_runner_session_init_envelope(
-    body: dict[str, Any],
+    body: dict[str, object],
 ) -> RunnerSessionInitEnvelope | None:
     """Return a supported envelope, or ``None`` for the removable legacy path."""
     raw = body.get(SESSION_INIT_PAYLOAD_KEY)


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Replace open-ended `Any` annotations on the versioned runner session-init payload with an object-valued JSON boundary.
- Give protocol version 2 a literal type and contain Pydantic's dynamic constructor typing at the two model declarations, removing five mypy errors without changing validation behavior.

## Test Plan

- `uv run --no-sync pytest -q tests/server/test_runner_session_init.py tests/runner/test_suppress_recovery_turn.py` (7 passed)
- `pre-commit run --files omnigent/runner/session_init_protocol.py`
- `uv run --no-sync mypy omnigent` (branch baseline is 1,065 errors versus 1,070 on its `main` base; no errors remain in the touched file)

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing session initialization and recovery tests cover payload construction, envelope parsing, and the recovery-suppression flag.

## Changelog

N/A — internal type cleanup with no user-facing behavior change.
