### PR TITLE
refactor(sandbox): type Win32 job APIs

### DIFF
--- a/omnigent/inner/windows_jobobject_sandbox.py
+++ b/omnigent/inner/windows_jobobject_sandbox.py
@@ -33,8 +33,10 @@ import ctypes
 import ctypes.wintypes as wintypes
 import functools
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from types import TracebackType
+from typing import Protocol, cast
 
 from .datamodel import OSEnvSandboxSpec, OSEnvSpec
 from .sandbox import (
@@ -106,6 +108,35 @@ _PROCESS_SET_QUOTA = 0x0100
 _PROCESS_TERMINATE = 0x0001
 
 
+class _WinFunction(Protocol):
+    restype: object
+    argtypes: list[object]
+
+    def __call__(self, *args: object) -> int | None:
+        raise NotImplementedError
+
+
+class _Kernel32(Protocol):
+    CreateJobObjectW: _WinFunction
+    SetInformationJobObject: _WinFunction
+    OpenProcess: _WinFunction
+    AssignProcessToJobObject: _WinFunction
+    CloseHandle: _WinFunction
+
+
+class _WinLibraries(Protocol):
+    kernel32: _Kernel32
+
+
+def _kernel32() -> _Kernel32:
+    return cast(_WinLibraries, vars(ctypes)["windll"]).kernel32
+
+
+def _get_last_error() -> int:
+    get_last_error = cast(Callable[[], int], vars(ctypes)["get_last_error"])
+    return get_last_error()
+
+
 class _JobHandle:
     """Owns a Windows Job Object handle; closing it kills the contained tree.
 
@@ -121,7 +152,7 @@ class _JobHandle:
         if self._handle is None:
             return
         handle, self._handle = self._handle, None
-        if not ctypes.windll.kernel32.CloseHandle(wintypes.HANDLE(handle)):
+        if not _kernel32().CloseHandle(wintypes.HANDLE(handle)):
             _LOGGER.debug("windows_jobobject: CloseHandle failed for job handle")
 
     def __enter__(self) -> _JobHandle:
@@ -219,14 +250,14 @@ class WindowsJobObjectSandboxBackend(SandboxBackend):
             not be established.
         """
         del policy
-        kernel32 = ctypes.windll.kernel32
+        kernel32 = _kernel32()
 
         job = kernel32.CreateJobObjectW(None, None)
         if not job:
             _LOGGER.warning(
                 "windows_jobobject: CreateJobObject failed (err=%d); helper pid "
                 "%d runs without Job Object containment.",
-                ctypes.get_last_error(),
+                _get_last_error(),
                 pid,
             )
             return None
@@ -242,7 +273,7 @@ class WindowsJobObjectSandboxBackend(SandboxBackend):
             _LOGGER.warning(
                 "windows_jobobject: SetInformationJobObject failed (err=%d); "
                 "closing job and continuing uncontained.",
-                ctypes.get_last_error(),
+                _get_last_error(),
             )
             kernel32.CloseHandle(wintypes.HANDLE(job))
             return None
@@ -254,7 +285,7 @@ class WindowsJobObjectSandboxBackend(SandboxBackend):
             _LOGGER.warning(
                 "windows_jobobject: OpenProcess(pid=%d) failed (err=%d); continuing uncontained.",
                 pid,
-                ctypes.get_last_error(),
+                _get_last_error(),
             )
             kernel32.CloseHandle(wintypes.HANDLE(job))
             return None
@@ -268,7 +299,7 @@ class WindowsJobObjectSandboxBackend(SandboxBackend):
                     "(err=%d) — process may already be in a non-nestable job. "
                     "Continuing without Job Object containment.",
                     pid,
-                    ctypes.get_last_error(),
+                    _get_last_error(),
                 )
                 kernel32.CloseHandle(wintypes.HANDLE(job))
                 return None
@@ -290,7 +321,7 @@ def os_name() -> str:
 # HANDLE/DWORD widths correct on 64-bit Python (pointers must not be truncated
 # to 32-bit ints).
 def _configure_prototypes() -> None:
-    k = ctypes.windll.kernel32
+    k = _kernel32()
     k.CreateJobObjectW.restype = wintypes.HANDLE
     k.CreateJobObjectW.argtypes = [wintypes.LPVOID, wintypes.LPCWSTR]
     k.SetInformationJobObject.restype = wintypes.BOOL


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Model the five Win32 Job Object functions used by the Windows sandbox behind narrow callable and library protocols.
- Centralize access to platform-only `ctypes.windll` and `ctypes.get_last_error` attributes, removing seven non-Windows mypy errors while preserving the configured prototypes and calls.

## Test Plan

- `uv run --no-sync pytest -q tests/inner/test_proc_and_platform.py` (24 passed, 8 skipped)
- `pre-commit run --files omnigent/inner/windows_jobobject_sandbox.py`
- `uv run --no-sync mypy omnigent` (branch baseline is 1,049 errors versus 1,056 on its `main` base; no errors remain in the touched file)

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing platform tests cover backend selection and import behavior on POSIX; Windows CI exercises the Job Object process-containment path.

## Changelog

N/A — internal type cleanup with no user-facing behavior change.
