### PR TITLE
refactor(claude): type local HTTP addresses

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -48,7 +48,7 @@ from datetime import datetime
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from urllib import error, request
 
 from omnigent._platform import stable_user_id
@@ -610,6 +610,11 @@ def _message_delta_from_jsonl_text(text: str | None) -> ClaudeMessageDelta | Non
     )
 
 
+def _http_server_host_port(httpd: ThreadingHTTPServer) -> tuple[str, int]:
+    """Return the IPv4 address shape requested by local bridge servers."""
+    return cast(tuple[str, int], httpd.server_address)
+
+
 class ClaudeNativeToolRelay:
     """
     HTTP relay for Claude MCP tool calls, scoped to its caller's lifetime.
@@ -659,7 +664,7 @@ class ClaudeNativeToolRelay:
         :returns: None.
         """
         relay_file = self._bridge_dir / _TOOL_RELAY_FILE
-        host, port = self._httpd.server_address
+        host, port = _http_server_host_port(self._httpd)
         # A newer relay that overwrote the file advertises a different url
         # (this relay's socket is still bound, so its port is unique), so the
         # file is left for that relay to own.
@@ -3328,7 +3333,7 @@ def start_tool_relay(
         session_id=session_id,
     )
     httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
-    host, port = httpd.server_address
+    host, port = _http_server_host_port(httpd)
     relay_info: dict[str, Any] = {
         "url": f"http://{host}:{port}",
         "token": token,
@@ -3433,7 +3438,7 @@ def _start_http_ingress(
     """
     handler_cls = _handler_factory(token, notification_queue)
     httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
-    host, port = httpd.server_address
+    host, port = _http_server_host_port(httpd)
     server_info = {
         "url": f"http://{host}:{port}",
         "token": token,


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Name the IPv4 `(host, port)` invariant shared by Claude's local bridge and tool-relay HTTP servers.
- Narrow `ThreadingHTTPServer.server_address` once at that constructor boundary instead of unpacking the broader IPv4/IPv6 socket type at three call sites, removing six mypy errors.

## Test Plan

- `TMPDIR=/tmp uv run --no-sync pytest -q tests/test_claude_native_bridge.py` (182 passed)
- `pre-commit run --files omnigent/claude_native_bridge.py`
- `uv run --no-sync mypy omnigent` (branch baseline is 1,032 errors versus 1,038 on its `main` base; the six address-shape errors are removed)

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing Claude bridge tests cover relay startup, advertisement ownership, HTTP ingress, and all supported native bridge roots.

## Changelog

N/A — internal type cleanup with no user-facing behavior change.
