### PR TITLE
refactor(egress): type proxy lifecycle state

### DIFF
--- a/omnigent/inner/egress/controller.py
+++ b/omnigent/inner/egress/controller.py
@@ -40,7 +40,6 @@ import threading
 from collections.abc import MutableMapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
 
 from omnigent._platform import IS_WINDOWS
 from omnigent.inner.credential_proxy import CredentialRewriteRule
@@ -92,8 +91,8 @@ class EgressProxyHandle:
     socket_path: Path
     ca_bundle_path: Path
     auth_token: str | None
-    _proxy: Any = field(repr=False)
-    _loop: Any = field(repr=False)
+    _proxy: EgressProxy = field(repr=False)
+    _loop: asyncio.AbstractEventLoop = field(repr=False)
     _thread: threading.Thread = field(repr=False)
     _stopped: bool = field(default=False, repr=False)
 

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -17,7 +17,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict, cast
 from urllib.parse import urlparse, urlunparse
 
 from omnigent._platform import IS_WINDOWS, WINDOWS_ENV_PASSTHROUGH
@@ -45,6 +45,12 @@ from .sandbox import (
     set_temp_env,
     with_additional_write_roots,
 )
+
+if TYPE_CHECKING:
+    import asyncio
+
+    from .egress import EgressProxyHandle
+    from .egress.proxy import EgressProxy
 from .sandbox import (
     run_launcher as _run_launcher,
 )
@@ -70,6 +76,10 @@ OpRequest: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
 
 # A single ``edit`` list entry — an {oldText, newText} pair of strings.
 EditEntry: TypeAlias = dict[str, str]
+
+
+class _PopenKwargs(TypedDict, total=False):
+    pass_fds: tuple[int, ...]
 
 
 # Environment variables every helper subprocess inherits unconditionally.
@@ -374,15 +384,15 @@ class _HelperProcessClient:
         # ``_stop_locked`` to tear down the helper's process tree.
         self._sandbox_handle: ContainmentHandle | None = None
         self._tmpdir: Path | None = None
-        self._egress_proxy: Any | None = None  # EgressProxy when active
-        self._egress_loop: Any | None = None  # asyncio event loop for proxy
+        self._egress_proxy: EgressProxy | None = None
+        self._egress_loop: asyncio.AbstractEventLoop | None = None
         self._egress_thread: threading.Thread | None = None
         # Controller handle for unified start/stop. The legacy
         # ``_egress_proxy`` / ``_egress_loop`` / ``_egress_thread``
         # mirrors are kept for back-compat with any tooling that
         # introspects them, but the lifecycle is driven through
         # the handle when present.
-        self._egress_handle: Any | None = None  # EgressProxyHandle
+        self._egress_handle: EgressProxyHandle | None = None
         self._lock = threading.Lock()
         self._closed = False
         atexit.register(self.close)
@@ -573,7 +583,7 @@ class _HelperProcessClient:
         # in the child, which is why we can pass it as a plain ``--config-fd``
         # argv arg. On Windows the config came via ``--config-file`` instead,
         # so there is no fd to inherit.
-        popen_kwargs: dict[str, Any] = {}
+        popen_kwargs: _PopenKwargs = {}
         if r_fd is not None:
             popen_kwargs["pass_fds"] = (r_fd,)
         try:


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Replace opaque egress proxy, event-loop, and controller state with their concrete lifecycle types in both the shared controller and OS environment client.
- Type the platform-specific `pass_fds` subprocess expansion with a narrow `TypedDict`, removing seven mypy errors without changing startup or shutdown behavior.

## Test Plan

- `TMPDIR=/tmp uv run --no-sync pytest -q tests/inner/test_os_env.py tests/inner/egress/test_proxy.py -k 'not stop_cancels_in_flight_connection_handlers'` (84 passed, 1 deselected because that existing test cancels the pytest task itself)
- `pre-commit run --files omnigent/inner/egress/controller.py omnigent/inner/os_env.py`
- `uv run --no-sync mypy omnigent` (branch baseline is 1,031 errors versus 1,038 on its `main` base; no errors remain in the touched lifecycle state)

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing OS environment and egress proxy tests cover subprocess startup, TCP/Unix listeners, request filtering, credentials, and lifecycle shutdown paths.

## Changelog

N/A — internal type cleanup with no user-facing behavior change.
