### PR TITLE
refactor(runner): type transport helpers

### DIFF
--- a/omnigent/runner/transports/tcp.py
+++ b/omnigent/runner/transports/tcp.py
@@ -47,6 +47,8 @@ def _pick_free_port() -> int:
     s.bind(("127.0.0.1", 0))
     port = s.getsockname()[1]
     s.close()
+    if not isinstance(port, int):
+        raise RuntimeError(f"expected an integer TCP port, got {port!r}")
     return port
 
 

--- a/omnigent/runner/transports/uds.py
+++ b/omnigent/runner/transports/uds.py
@@ -86,7 +86,7 @@ class RunnerSubprocess:
     startup_timeout_s: float = 30.0
     extra_env: dict[str, str] | None = None
     _process: subprocess.Popen[bytes] | None = None
-    _tmp_dir: tempfile.TemporaryDirectory | None = None
+    _tmp_dir: tempfile.TemporaryDirectory[str] | None = None
 
     def __enter__(self) -> RunnerSubprocess:
         if self.socket_path is None:

--- a/omnigent/runner/transports/ws_tunnel/registry.py
+++ b/omnigent/runner/transports/ws_tunnel/registry.py
@@ -37,6 +37,7 @@ import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from functools import partial
 from typing import Protocol
 
 from omnigent.runner.transports.ws_tunnel.frames import (
@@ -341,12 +342,10 @@ class TunnelRegistry:
     @staticmethod
     def _abort_session_inflight(session: RunnerSession, error: BaseException) -> None:
         for state in list(session.in_flight.values()):
-            _call_soon_threadsafe(state, lambda state=state: _abort_request_state(state, error))
+            _call_soon_threadsafe(state, partial(_abort_request_state, state, error))
         session.in_flight.clear()
         for channel in list(session.ws_channels.values()):
-            _call_channel_soon_threadsafe(
-                channel, lambda ch=channel: ch.inbound_queue.put_nowait(None)
-            )
+            _call_channel_soon_threadsafe(channel, partial(channel.inbound_queue.put_nowait, None))
         session.ws_channels.clear()
 
     def get(self, runner_id: str) -> RunnerSession | None:

--- a/omnigent/server/_runner_ws_tunnel.py
+++ b/omnigent/server/_runner_ws_tunnel.py
@@ -38,6 +38,7 @@ import contextlib
 import logging
 import re
 import secrets
+from collections.abc import Callable
 from types import TracebackType
 from typing import TYPE_CHECKING
 
@@ -75,7 +76,7 @@ _RUNNER_PATH_RE = re.compile(r"^/v1/sessions/(?P<conv>[^/?]+)/resources/terminal
 def make_tunnel_ws_factory(
     router: RunnerRouter,
     registry: TunnelRegistry,
-):
+) -> Callable[[str], _TunneledWSConn]:
     """Build a ``ws_factory`` callable that opens tunneled WS channels.
 
     Install via :func:`omnigent.runtime.set_runner_ws_factory`. The


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Give the TCP port probe and UDS temporary directory concrete runtime types.
- Replace default-argument cleanup lambdas with typed partial callbacks.
- Declare the tunneled WebSocket factory's callable contract.
- Remove 5 mypy errors without suppressions or behavior changes.

## Test Plan

- `TMPDIR=/tmp uv run --no-sync pytest -q tests/runner/transports/test_tcp_unit.py tests/runner/transports/test_uds_unit.py tests/runner/transports/ws_tunnel` (188 passed)
- `TMPDIR=/tmp uv run --no-sync mypy omnigent` (1,015 -> 1,010 errors; no errors remain in changed files)
- `TMPDIR=/tmp pre-commit run --all-files`

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing transport unit and tunnel tests exercise all changed runtime paths.
