### PR TITLE
refactor(codex): narrow elicitation request types

### DIFF
--- a/omnigent/codex_native_elicitation.py
+++ b/omnigent/codex_native_elicitation.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import hashlib
 import json
-from typing import Any
+from typing import TypeGuard
 
 _CODEX_ELICITATION_ID_DIGEST_LENGTH = 32
 
 
-def is_codex_request_id(value: Any) -> bool:
+def is_codex_request_id(value: object) -> TypeGuard[int | str]:
     """
     Return whether *value* is a supported Codex JSON-RPC request id.
 

--- a/omnigent/server/routes/_codex_elicitation.py
+++ b/omnigent/server/routes/_codex_elicitation.py
@@ -367,6 +367,7 @@ def _codex_command_approval_response(
         decisions, e.g. ``{"availableDecisions": [...]}``.
     :returns: Codex command approval response payload.
     """
+    decision: str | dict[str, dict[str, list[str]]]
     if method == _CODEX_COMMAND_EXECUTION_REQUEST_APPROVAL_METHOD:
         amendment = _result_execpolicy_amendment(result.content)
         if result.action == "accept" and amendment is not None:


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Make Codex JSON-RPC request-id validation a type guard over unknown objects.
- Declare the command-approval decision union before protocol-specific branching.
- Remove 6 mypy errors across the shared elicitation helper, server adapter, and native forwarder without suppressions.

## Test Plan

- `TMPDIR=/tmp uv run --no-sync pytest -q tests/server/routes/test_codex_elicitation.py` (24 passed)
- `TMPDIR=/tmp uv run --no-sync pytest -q tests/test_codex_native_forwarder.py` (76 passed)
- `TMPDIR=/tmp uv run --no-sync mypy omnigent` (1,015 -> 1,009 errors; no errors remain in changed files)
- `TMPDIR=/tmp pre-commit run --all-files`

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing Codex elicitation and forwarder tests cover the narrowed request and response paths.
