### PR TITLE
refactor(types): remove stale mypy ignores

### DIFF
--- a/omnigent/__init__.py
+++ b/omnigent/__init__.py
@@ -20,7 +20,7 @@ def _fips_safe_md5(*args, **kwargs):  # type: ignore[no-untyped-def]
     return _fips_safe_orig_md5(*args, **kwargs)
 
 
-_fips_safe_hashlib.md5 = _fips_safe_md5  # type: ignore[assignment]
+_fips_safe_hashlib.md5 = _fips_safe_md5
 
 # Mirror legacy ``OMNIAGENTS_*`` env vars onto their new ``OMNIGENT_*`` names
 # before any submodule below reads the environment, so the dual-read

--- a/omnigent/cursor_native_usage.py
+++ b/omnigent/cursor_native_usage.py
@@ -71,7 +71,7 @@ _SUPERVISOR_HEALTHY_UPTIME_S = 60.0
 def _coerce_int(value: object) -> int:
     """Coerce a hook token field to a non-negative int (0 on anything odd)."""
     try:
-        out = int(value)  # type: ignore[arg-type]
+        out = int(value)
     except (TypeError, ValueError):
         return 0
     return out if out >= 0 else 0

--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -340,7 +340,7 @@ class _DatabricksBearerAuth(httpx.Auth):
 
     def __init__(
         self,
-        config: Any,  # type: ignore[explicit-any]
+        config: Any,
         profile_name: str | None = None,
         failure_message: str | None = None,
     ) -> None:

--- a/omnigent/inner/kimi_executor.py
+++ b/omnigent/inner/kimi_executor.py
@@ -595,8 +595,8 @@ class KimiExecutor(Executor):
 
 
 async def _create_subprocess_exec(
-    *args: Any,  # type: ignore[explicit-any]
-    **kwargs: Any,  # type: ignore[explicit-any]
+    *args: Any,
+    **kwargs: Any,
 ) -> asyncio.subprocess.Process:
     """Indirection point so tests can stub subprocess creation.
 

--- a/omnigent/inner/open_responses_sdk.py
+++ b/omnigent/inner/open_responses_sdk.py
@@ -187,7 +187,7 @@ def _convert_tools_to_responses(tools: list[ToolSpec]) -> list[ResponsesItem]:
 
 
 def _normalize_message_content(
-    content: Any,  # type: ignore[explicit-any]
+    content: Any,
     *,
     empty_placeholder: str,
 ) -> str | list[dict[str, Any]]:

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -298,21 +298,21 @@ class ExecutorAdapter(HarnessApp):
         # attribute set is best-effort — executors that don't
         # read it ignore the value, executors that DO read it
         # (Claude SDK) honor the round-trip protocol.
-        if getattr(executor, "_tool_executor", None) is None:  # type: ignore[attr-defined]
+        if getattr(executor, "_tool_executor", None) is None:
             executor._tool_executor = self._stable_tool_executor  # type: ignore[attr-defined]
         # Install the elicitation handler once on first use, same
         # stable-reference pattern as ``_tool_executor``. The SDK's
         # ``can_use_tool`` callback is constructed per-turn inside
         # ClaudeSDKExecutor.run_turn() from this attribute, so the
         # closure always reads ``_current_ctx`` at call time.
-        if getattr(executor, "_elicitation_handler", None) is None:  # type: ignore[attr-defined]
+        if getattr(executor, "_elicitation_handler", None) is None:
             executor._elicitation_handler = self._stable_elicitation_handler  # type: ignore[attr-defined]
         # Install the policy evaluator bridge once on first use, same
         # stable-reference pattern as ``_tool_executor``. The inner
         # executor calls this before/after each LLM call to evaluate
         # LLM_REQUEST / LLM_RESPONSE policies via a round-trip to the
         # Omnigent server (routed through the runner).
-        if getattr(executor, "_policy_evaluator", None) is None:  # type: ignore[attr-defined]
+        if getattr(executor, "_policy_evaluator", None) is None:
             executor._policy_evaluator = self._stable_policy_evaluator  # type: ignore[attr-defined]
         self._current_ctx = ctx
         self._current_agent = request.model

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2506,7 +2506,7 @@ class _SPAStaticFiles(StaticFiles):
             return
         await super().__call__(scope, receive, send)
 
-    async def get_response(self, path: str, scope: Scope) -> Response:  # type: ignore[override]
+    async def get_response(self, path: str, scope: Scope) -> Response:
         served_path = path
         try:
             response = await super().get_response(path, scope)

--- a/omnigent/stores/project_store/sqlalchemy_store.py
+++ b/omnigent/stores/project_store/sqlalchemy_store.py
@@ -121,7 +121,7 @@ class SqlAlchemyProjectStore(ProjectStore):
 
     def _name_taken(
         self,
-        session,  # type: ignore[no-untyped-def]
+        session,
         *,
         owner_user_id: str | None,
         name: str,

--- a/omnigent/tools/mcp.py
+++ b/omnigent/tools/mcp.py
@@ -111,7 +111,7 @@ def _resolve_databricks_token(profile: str) -> str:
         result = client.config.authenticate()
         # SDK returns either a dict (newer versions) or a callable
         # that produces headers (older versions).
-        headers: dict[str, str] = result if isinstance(result, dict) else result(None)  # type: ignore[assignment]
+        headers: dict[str, str] = result if isinstance(result, dict) else result(None)
         auth_header = headers.get("Authorization", "")
         if auth_header.startswith("Bearer "):
             return auth_header[len("Bearer ") :]


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Remove 12 stale, code-specific `type: ignore` comments that mypy reports as unused.
- Keep the underlying real diagnostics visible for subsequent focused fixes.
- Limit this batch to non-CLI and non-REPL modules so those larger areas can be cleaned independently.

## Test Plan

- `TMPDIR=/tmp uv run --no-sync mypy omnigent` (1,015 -> 1,003 errors; no new diagnostics)
- `TMPDIR=/tmp pre-commit run --all-files`

## Demo

N/A — comment-only type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Only stale type-check suppression comments change; runtime code is unchanged. Full pre-commit and the repository mypy command verify the cleanup.
