### PR TITLE
refactor(native): type read-only SQLite connects

### DIFF
--- a/omnigent/goose_native_forwarder.py
+++ b/omnigent/goose_native_forwarder.py
@@ -168,9 +168,11 @@ def _connect_ro(db_path: Path) -> sqlite3.Connection | None:
     read via the ``-shm``; a plain connection is the fallback for the rare window
     where ``-shm`` is momentarily absent. Only SELECTs are issued.
     """
-    for uri, kw in ((f"file:{db_path}?mode=ro", {"uri": True}), (str(db_path), {})):
+    for uri, use_uri in ((f"file:{db_path}?mode=ro", True), (str(db_path), False)):
         try:
-            return sqlite3.connect(uri, timeout=5.0, **kw)
+            if use_uri:
+                return sqlite3.connect(uri, timeout=5.0, uri=True)
+            return sqlite3.connect(uri, timeout=5.0)
         except sqlite3.Error:
             continue
     return None

--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -366,9 +366,11 @@ def _connect_ro(db_path: Path) -> sqlite3.Connection | None:
     via the ``-shm``; a plain connection is the fallback for the rare window where
     ``-shm`` is momentarily absent. Only SELECTs are issued.
     """
-    for uri, kw in ((f"file:{db_path}?mode=ro", {"uri": True}), (str(db_path), {})):
+    for uri, use_uri in ((f"file:{db_path}?mode=ro", True), (str(db_path), False)):
         try:
-            return sqlite3.connect(uri, timeout=5.0, **kw)
+            if use_uri:
+                return sqlite3.connect(uri, timeout=5.0, uri=True)
+            return sqlite3.connect(uri, timeout=5.0)
         except sqlite3.Error:
             continue
     return None


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Replace dynamically expanded SQLite keyword dictionaries with explicit URI and fallback connect calls.
- Preserve the live-WAL read-only path and plain-path fallback behavior.
- Remove 4 mypy overload/Any-return errors across the Goose and Hermes forwarders without suppressions.

## Test Plan

- `TMPDIR=/tmp uv run --no-sync pytest -q tests/test_goose_native_forwarder.py tests/test_hermes_native_forwarder.py` (79 passed)
- `TMPDIR=/tmp uv run --no-sync mypy omnigent` (1,010 -> 1,006 errors; no errors remain in changed files)
- `TMPDIR=/tmp pre-commit run --all-files`

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing Goose and Hermes forwarder tests cover database discovery, reads, polling, and fallback behavior.
