### PR TITLE
refactor(native): type pending approvals

### DIFF
--- a/omnigent/goose_native_permissions.py
+++ b/omnigent/goose_native_permissions.py
@@ -34,12 +34,19 @@ import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TypedDict
 
 import httpx
 
 from omnigent.goose_native_bridge import capture_goose_pane, send_goose_pane_keys
 
 _logger = logging.getLogger(__name__)
+
+
+class _PendingApproval(TypedDict):
+    elicitation_id: str
+    task: asyncio.Task[None]
+
 
 _POLL_INTERVAL_S = 0.3
 _POST_TIMEOUT_S = 86400.0
@@ -160,7 +167,7 @@ async def supervise_goose_approval_mirror(
     :param auth: Optional httpx auth for the runner's requests.
     :param poll_interval_s: Pane poll cadence in seconds.
     """
-    active: dict[str, object] | None = None
+    active: _PendingApproval | None = None
     episode = 0
     timeout = httpx.Timeout(_POST_TIMEOUT_S, connect=10.0)
     async with httpx.AsyncClient(

--- a/omnigent/hermes_native_permissions.py
+++ b/omnigent/hermes_native_permissions.py
@@ -36,10 +36,17 @@ import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TypedDict
 
 import httpx
 
 from omnigent.hermes_native_bridge import capture_hermes_pane, send_hermes_pane_keys
+
+
+class _PendingApproval(TypedDict):
+    elicitation_id: str
+    task: asyncio.Task[None]
+
 
 _logger = logging.getLogger(__name__)
 
@@ -169,7 +176,7 @@ async def supervise_hermes_approval_mirror(
     :param auth: Optional httpx auth for the runner's requests.
     :param poll_interval_s: Pane poll cadence in seconds.
     """
-    active: dict[str, object] | None = None
+    active: _PendingApproval | None = None
     episode = 0
     timeout = httpx.Timeout(_POST_TIMEOUT_S, connect=10.0)
     async with httpx.AsyncClient(

--- a/omnigent/qwen_native_permissions.py
+++ b/omnigent/qwen_native_permissions.py
@@ -41,12 +41,19 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TypedDict
 
 import httpx
 
 from omnigent.qwen_native_bridge import events_file_path, submit_confirmation
 
 _logger = logging.getLogger(__name__)
+
+
+class _PendingApproval(TypedDict):
+    elicitation_id: str
+    task: asyncio.Task[None]
+
 
 #: Event-file poll cadence. Matches the transcript forwarder so a pending
 #: approval surfaces in the web UI within a step of the terminal prompt.
@@ -251,7 +258,7 @@ async def supervise_qwen_approval_mirror(
     except OSError:
         offset = 0
     # request_id -> {"elicitation_id": str, "task": asyncio.Task}
-    pending: dict[str, dict[str, object]] = {}
+    pending: dict[str, _PendingApproval] = {}
     timeout = httpx.Timeout(_POST_TIMEOUT_S, connect=10.0)
     async with httpx.AsyncClient(
         base_url=base_url, headers=headers, auth=auth, timeout=timeout


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Give Goose, Hermes, and Qwen pending approval records explicit typed-dictionary contracts.
- Preserve each mirror's task lifecycle and elicitation correlation behavior.
- Remove 3 mypy assignment errors caused by opaque object-valued state.

## Test Plan

- `TMPDIR=/tmp uv run --no-sync pytest -q tests/test_goose_native_permissions.py tests/test_hermes_native_permissions.py tests/test_qwen_native_permissions.py` (40 passed)
- `TMPDIR=/tmp uv run --no-sync mypy omnigent` (1,010 -> 1,007 errors; no errors remain in changed files)
- `TMPDIR=/tmp pre-commit run --all-files`

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing native permission-mirror tests cover task creation, pending-state transitions, terminal resolution, and web verdict handling.
