### PR TITLE
refactor(stores): type collection and blob boundaries

### DIFF
--- a/omnigent/stores/agent_store/__init__.py
+++ b/omnigent/stores/agent_store/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 from abc import ABC, abstractmethod
 
 from omnigent.entities import Agent, PagedList
@@ -100,7 +101,7 @@ class AgentStore(ABC):
         ...
 
     @abstractmethod
-    def get_names(self, agent_ids: list[str]) -> dict[str, str]:
+    def get_names(self, agent_ids: builtins.list[str]) -> dict[str, str]:
         """
         Batch-fetch agent names for a list of IDs.
 

--- a/omnigent/stores/agent_store/sqlalchemy_store.py
+++ b/omnigent/stores/agent_store/sqlalchemy_store.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import builtins
+
 from sqlalchemy import and_, asc, desc, or_, select
 from sqlalchemy.exc import IntegrityError
 
@@ -231,7 +233,7 @@ class SqlAlchemyAgentStore(AgentStore):
                 has_more=has_more,
             )
 
-    def get_names(self, agent_ids: list[str]) -> dict[str, str]:
+    def get_names(self, agent_ids: builtins.list[str]) -> dict[str, str]:
         """
         Batch-fetch agent names for a list of IDs.
 

--- a/omnigent/stores/artifact_store/s3.py
+++ b/omnigent/stores/artifact_store/s3.py
@@ -193,7 +193,10 @@ class S3ArtifactStore(ArtifactStore):
 
         try:
             resp = self._client.get_object(Bucket=self._bucket, Key=self._resolve(key))
-            return resp["Body"].read()
+            data = resp["Body"].read()
+            if not isinstance(data, bytes):
+                raise TypeError(f"S3 object body returned {type(data).__name__}, expected bytes")
+            return data
         except ClientError as exc:
             if _is_not_found(exc):
                 raise KeyError(key) from None

--- a/omnigent/stores/file_store/__init__.py
+++ b/omnigent/stores/file_store/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 from abc import ABC, abstractmethod
 
 from omnigent.entities import PagedList, StoredFile
@@ -122,7 +123,7 @@ class FileStore(ABC):
         ...
 
     @abstractmethod
-    def delete_all_for_session(self, session_id: str) -> list[str]:
+    def delete_all_for_session(self, session_id: str) -> builtins.list[str]:
         """
         Delete all file metadata for a session.
 

--- a/omnigent/stores/file_store/sqlalchemy_store.py
+++ b/omnigent/stores/file_store/sqlalchemy_store.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import builtins
+
 from sqlalchemy import and_, asc, desc, or_, select
 
 from omnigent.db.db_models import SqlFile, current_workspace_id, normalize_uuid
@@ -202,7 +204,7 @@ class SqlAlchemyFileStore(FileStore):
             session.delete(row)
             return True
 
-    def delete_all_for_session(self, session_id: str) -> list[str]:
+    def delete_all_for_session(self, session_id: str) -> builtins.list[str]:
         """
         Delete all file metadata for a session.
 


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Qualify collection return/argument types where store methods named `list` shadow the builtin.
- Validate the dynamically typed S3 streaming-body result before returning the store's `bytes` contract.
- Remove 5 mypy errors across agent, file, and artifact stores without suppressions.

## Test Plan

- `TMPDIR=/tmp uv run --no-sync pytest -q tests/stores/test_agent_store.py tests/stores/test_file_store.py tests/stores/test_s3_artifact_store.py` (58 passed)
- `TMPDIR=/tmp uv run --no-sync mypy omnigent` (975 -> 970 errors; no errors remain in changed files)
- `TMPDIR=/tmp pre-commit run --all-files`

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing store tests cover the affected collection methods and S3 put/get behavior.
