### PR TITLE
fix(antigravity): delegate default model to SDK

### DIFF
--- a/dev/lint/lint_no_hardcoded_models.py
+++ b/dev/lint/lint_no_hardcoded_models.py
@@ -21,7 +21,11 @@ MODEL_ID_RE = re.compile(
       | (?:openai/)?(?:gpt-\d[a-z0-9._:/-]*|gpt-oss-[a-z0-9][a-z0-9._:/-]*)
       | o[134](?:-[a-z0-9][a-z0-9._:/-]*)?
       | claude-(?:opus|sonnet|haiku|fable|\d)[a-z0-9._:/-]*
-      | gemini-\d[a-z0-9][a-z0-9._:/-]*
+      | gemini-(?:
+            \d[a-z0-9][a-z0-9._:/-]*
+          | \d+(?:\.\d+)+(?:-[a-z0-9][a-z0-9._:/-]*)?
+          | \d+(?:-\d+)*-[a-z][a-z0-9._:/-]*
+        )
       | kimi-k\d[a-z0-9._:/-]*
       | qwen\d[a-z0-9][a-z0-9._:/-]*
       | llama-\d[a-z0-9][a-z0-9._:/-]*

--- a/omnigent/inner/antigravity_executor.py
+++ b/omnigent/inner/antigravity_executor.py
@@ -13,7 +13,7 @@ agent reuse, and a streaming :meth:`run_turn` mapping SDK events onto Omnigent
    harness only runs on hosts with glibc ≳ 2.36; older hosts surface an
    :class:`ExecutorError`.
 
-Default model is Gemini 3.5 Flash; the SDK can also drive Claude / GPT-OSS.
+Model selection defaults to the SDK when no explicit override is configured.
 
 Streaming model:
 
@@ -72,9 +72,6 @@ from .executor import (
 )
 
 logger = logging.getLogger(__name__)
-
-# Default model when neither spec nor provider pins one.
-_ANTIGRAVITY_DEFAULT_MODEL = "gemini-3.5-flash"
 
 # Sentinel the producer pushes when the step stream is exhausted, so the
 # consumer can distinguish "turn finished" from a queued event.
@@ -313,7 +310,7 @@ class _AntigravitySessionState:
 
     agent: SDKAgent = None
     conversation: SDKConversation = None
-    agent_signature: tuple[str, str, str] | None = field(default=None)
+    agent_signature: tuple[str | None, str, str] | None = field(default=None)
     pending_tools: dict[str, _PendingTool] = field(default_factory=dict)
     active_queue: _EventQueue | None = field(default=None)
     last_usage: SDKUsage = None
@@ -336,9 +333,8 @@ class AntigravityExecutor(Executor):
         """Create an AntigravityExecutor.
 
         :param model: Default model when per-turn :attr:`ExecutorConfig.model`
-            is unset, e.g. ``"gemini-3.5-flash"`` (from
-            ``HARNESS_ANTIGRAVITY_MODEL``). ``None`` falls back to
-            :data:`_ANTIGRAVITY_DEFAULT_MODEL`.
+            is unset, typically from ``HARNESS_ANTIGRAVITY_MODEL``. ``None``
+            delegates model selection to the installed SDK.
         :param api_key: Direct Antigravity / Gemini API key (from
             ``HARNESS_ANTIGRAVITY_API_KEY``). ``None`` lets the SDK read its
             ambient ``GEMINI_API_KEY`` / ``ANTIGRAVITY_API_KEY``.
@@ -490,11 +486,7 @@ class AntigravityExecutor(Executor):
             terminal :class:`TurnComplete` / :class:`TurnCancelled` /
             :class:`ExecutorError`.
         """
-        model = (
-            (config.model if config and config.model else None)
-            or self._model_override
-            or (_ANTIGRAVITY_DEFAULT_MODEL)
-        )
+        model = (config.model if config and config.model else None) or self._model_override
         session_key = self._session_key(messages)
         prompt = _latest_user_text(messages)
 
@@ -776,7 +768,7 @@ class AntigravityExecutor(Executor):
         self,
         session_key: str,
         *,
-        model: str,
+        model: str | None,
         system_prompt: str,
         tools: list[ToolSpec],
     ) -> tuple[_AntigravitySessionState, bool]:
@@ -788,7 +780,8 @@ class AntigravityExecutor(Executor):
         closes over it) stays valid.
 
         :param session_key: The Omnigent session id.
-        :param model: The resolved model id to pin, e.g. ``"gemini-3.5-flash"``.
+        :param model: The resolved model id to pin, or ``None`` to use the SDK
+            default.
         :param system_prompt: The agent's system instructions.
         :param tools: Omnigent tool specs to expose to the agent.
         :returns: ``(state, created)`` — the session's
@@ -844,7 +837,7 @@ class AntigravityExecutor(Executor):
         self,
         state: _AntigravitySessionState,
         *,
-        model: str,
+        model: str | None,
         system_prompt: str,
         tools: list[ToolSpec],
     ) -> SDKAgent:
@@ -858,7 +851,8 @@ class AntigravityExecutor(Executor):
         :class:`ToolCallComplete` for every tool the agent runs.
 
         :param state: The session state the tool-completion hook closes over.
-        :param model: The resolved model id to pin.
+        :param model: The resolved model id to pin, or ``None`` to use the SDK
+            default.
         :param system_prompt: The agent's system instructions.
         :param tools: Omnigent tool specs to expose as callables.
         :returns: The opened SDK ``Agent``.
@@ -996,7 +990,7 @@ class AntigravityExecutor(Executor):
         self,
         antigravity: ModuleType,
         *,
-        model: str,
+        model: str | None,
         kwargs: _StrAnyDict,
     ) -> SDKConfig:
         """Build a ``LocalAgentConfig``, passing only supported optional fields.
@@ -1005,14 +999,16 @@ class AntigravityExecutor(Executor):
         field the installed SDK doesn't accept, rather than crashing on drift.
 
         :param antigravity: The imported ``google.antigravity`` module.
-        :param model: The resolved model id to pin.
+        :param model: The resolved model id to pin, or ``None`` to use the SDK
+            default.
         :param kwargs: Base config kwargs (system instructions, tools, hooks).
         :returns: A ``LocalAgentConfig`` instance.
         """
         local_config_cls = antigravity.LocalAgentConfig
         supported = self._config_field_names(local_config_cls)
         candidate: _StrAnyDict = dict(kwargs)
-        candidate["model"] = model
+        if model is not None:
+            candidate["model"] = model
         if self._api_key:
             candidate["api_key"] = self._api_key
         if self._vertex:

--- a/omnigent/inner/antigravity_harness.py
+++ b/omnigent/inner/antigravity_harness.py
@@ -15,9 +15,9 @@ Vertex AI), so there are no ``*_GATEWAY_*`` env vars.
 
 Env vars read at startup:
 
-- ``HARNESS_ANTIGRAVITY_MODEL``: model the executor pins for every turn, e.g.
-  ``"gemini-3.5-flash"``. Wins over per-turn ``request.model`` (which carries
-  the agent NAME, not an LLM id). ``None`` falls back to the built-in default.
+- ``HARNESS_ANTIGRAVITY_MODEL``: model the executor pins for every turn. Wins
+  over per-turn ``request.model`` (which carries the agent NAME, not an LLM
+  id). When absent, the installed SDK chooses its default.
 - ``HARNESS_ANTIGRAVITY_API_KEY``: direct Antigravity / Gemini API key. Set
   when the spec declares ``executor.auth: {type: api_key, …}`` or a global
   API-key auth resolves. Takes precedence over ambient credential lookup.

--- a/omnigent/model_override.py
+++ b/omnigent/model_override.py
@@ -152,8 +152,7 @@ def model_family_mismatch(harness: str, model: str) -> str | None:
         return (
             f"harness {canon!r} is Gemini-native and cannot run Claude/GPT or "
             f"Databricks-gateway models; got {model!r}. Use a Gemini id "
-            "(e.g. 'gemini-3.5-flash'), or the claude_code / codex / pi worker "
-            "for those families."
+            "or the claude_code / codex / pi worker for those families."
         )
     return None
 

--- a/tests/dev/lint/test_lint_no_hardcoded_models.py
+++ b/tests/dev/lint/test_lint_no_hardcoded_models.py
@@ -35,6 +35,17 @@ def test_scan_flags_python_positional_argument(tmp_path: Path) -> None:
     ]
 
 
+@pytest.mark.parametrize(
+    "model",
+    ["gemini-3.5-flash", "gemini-2.0", "gemini-3-pro", "gemini-2-5-pro"],
+)
+def test_scan_flags_gemini_release_ids(tmp_path: Path, model: str) -> None:
+    dirty = tmp_path / "dirty.py"
+    dirty.write_text(f'MODEL = "{model}"\n')
+
+    assert [(hit.line, hit.model) for hit in scan(dirty)] == [(1, model)]
+
+
 def test_scan_flags_python_bare_collection(tmp_path: Path) -> None:
     dirty = tmp_path / "dirty.py"
     dirty.write_text('("databricks-claude-sonnet-4-6", "gpt-oss-120b")\n')
@@ -49,7 +60,7 @@ def test_scan_ignores_model_family_fragments(tmp_path: Path) -> None:
     clean = tmp_path / "clean.py"
     clean.write_text(
         'prefixes = ("databricks-claude-opus-", "databricks-claude-fable-")\n'
-        'families = ("gpt-oss",)\n'
+        'families = ("gpt-oss", "gemini-2-5")\n'
     )
 
     assert scan(clean) == []

--- a/tests/inner/test_antigravity_executor.py
+++ b/tests/inner/test_antigravity_executor.py
@@ -211,6 +211,9 @@ class _FakeAgent:
         self.closed = True
 
 
+_MODEL_NOT_PROVIDED = object()
+
+
 class _FakeLocalAgentConfig:
     """Mirror of ``LocalAgentConfig`` — accepts exactly the fields the executor sets."""
 
@@ -218,7 +221,7 @@ class _FakeLocalAgentConfig:
         self,
         *,
         system_instructions: str | None = None,
-        model: str | None = None,
+        model: str | None | object = _MODEL_NOT_PROVIDED,
         api_key: str | None = None,
         vertex: bool | None = None,
         project: str | None = None,
@@ -227,7 +230,8 @@ class _FakeLocalAgentConfig:
         hooks: Any = None,
     ) -> None:
         self.system_instructions = system_instructions
-        self.model = model
+        self.model = model if isinstance(model, str) else None
+        self.model_provided = model is not _MODEL_NOT_PROVIDED
         self.api_key = api_key
         self.vertex = vertex
         self.project = project
@@ -989,18 +993,19 @@ async def test_model_switch_rebuilds_agent(monkeypatch: pytest.MonkeyPatch) -> N
     assert len(captured["agents"]) == 2
     assert captured["configs"][0].model == "gemini-3-pro"
     assert captured["configs"][1].model == "gemini-3-flash"
+    assert all(config.model_provided for config in captured["configs"])
 
 
 @pytest.mark.asyncio
-async def test_default_model_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
-    """With no model on the executor or per-turn config, the built-in default is pinned."""
+async def test_sdk_default_model_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no explicit model, model selection remains owned by the SDK."""
     captured = _install_fake_sdk(monkeypatch, scripts=[[_text_step("ok")]])
     executor = AntigravityExecutor()  # no model anywhere
 
     await _drain(executor, [{"role": "user", "content": "hi", "session_id": "s1"}])
 
-    # Pins _ANTIGRAVITY_DEFAULT_MODEL; changing the default must update this.
-    assert captured["configs"][0].model == "gemini-3.5-flash"
+    assert captured["configs"][0].model is None
+    assert captured["configs"][0].model_provided is False
 
 
 @pytest.mark.asyncio
@@ -1030,6 +1035,8 @@ async def test_api_key_and_vertex_threaded_to_config(monkeypatch: pytest.MonkeyP
     await _drain(key_exec, [{"role": "user", "content": "hi", "session_id": "s1"}])
     cfg = captured["configs"][0]
     assert cfg.api_key == "gem-key"
+    assert cfg.model is None
+    assert cfg.model_provided is False
     # Vertex left unset on the API-key path.
     assert cfg.vertex is None
 
@@ -1039,6 +1046,8 @@ async def test_api_key_and_vertex_threaded_to_config(monkeypatch: pytest.MonkeyP
     assert vcfg.vertex is True
     assert vcfg.project == "my-proj"
     assert vcfg.location == "us-central1"
+    assert vcfg.model is None
+    assert vcfg.model_provided is False
     # The SDK config has no base_url field — the executor must never set one.
     assert not hasattr(vcfg, "base_url")
 


### PR DESCRIPTION
## Related issue

Closes #3749

## Summary

- Stop embedding a release-specific Gemini default in the Antigravity SDK executor; explicit per-turn and `HARNESS_ANTIGRAVITY_MODEL` choices still win, while an absent model now delegates to `google-antigravity` for both API-key and Vertex sessions.
- Extend the hardcoded-model lint to recognize dotted, canonical, and normalized Gemini release ids, while retaining version-family fragments used for compatibility checks.
- Remove the stale Gemini release example from runtime error text and cover both omitted and explicit SDK model fields.

ELI5: if the user does not choose a model, Omnigent no longer guesses a Gemini release. It lets the installed Antigravity SDK choose its maintained default.

```text
per-turn override -> harness/spec override -> SDK-owned default
```

## Test Plan

- `uv run pytest -q tests/dev/lint/test_lint_no_hardcoded_models.py tests/inner/test_antigravity_executor.py tests/inner/test_antigravity_harness.py tests/test_model_override.py` (`173 passed`)
- `.venv/bin/python dev/lint/lint_no_hardcoded_models.py`
- `pre-commit run --all-files`
- Verified `google-antigravity` 0.1.0, 0.1.1, and 0.1.2 all accept an omitted model and provide their own `GeminiConfig` default.

## Demo

N/A — no visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated tests cover explicit model precedence, SDK-default omission, API-key and Vertex configuration, scanner detection, and the full production-tree baseline.

## Changelog

Antigravity sessions without an explicit model now follow the installed SDK's current default.
