### PR TITLE
refactor(config): narrow dynamic helper returns

### DIFF
--- a/omnigent/cli_auth.py
+++ b/omnigent/cli_auth.py
@@ -40,7 +40,7 @@ def _token_file_path() -> Path:
     """
     from omnigent_ui_sdk.terminal._config import state_dir
 
-    return state_dir() / _TOKEN_FILE_NAME
+    return Path(state_dir()) / _TOKEN_FILE_NAME
 
 
 def _normalize_server_url(server_url: str) -> str:

--- a/omnigent/onboarding/databricks_config.py
+++ b/omnigent/onboarding/databricks_config.py
@@ -142,5 +142,7 @@ def get_workspace_url_for_profile(profile: str) -> str | None:
 
     for spec in DEFAULT_PROFILES:
         if spec.name == profile:
-            return spec.host.rstrip("/")
+            host = spec.host
+            if isinstance(host, str):
+                return host.rstrip("/")
     return None

--- a/omnigent/onboarding/setup.py
+++ b/omnigent/onboarding/setup.py
@@ -509,7 +509,9 @@ def _derive_workspace_profile_name(workspace_url: str, existing: dict[str, str])
 
     for spec in DEFAULT_PROFILES:
         if _host_matches(spec.host, workspace_url):
-            return spec.name
+            name = spec.name
+            if isinstance(name, str):
+                return name
     netloc = urlparse(workspace_url).netloc
     # The first DNS label is the most human-recognizable handle; fall back
     # to the full netloc, then a constant, so we never return an empty name.

--- a/omnigent/update_check.py
+++ b/omnigent/update_check.py
@@ -409,13 +409,14 @@ def _index_from_uv_config() -> str:
         indexes = data.get("index")
         if isinstance(indexes, list):
             for entry in indexes:
+                url = entry.get("url") if isinstance(entry, dict) else None
                 if (
                     isinstance(entry, dict)
                     and entry.get("default") is True
-                    and isinstance(entry.get("url"), str)
-                    and entry["url"].strip()
+                    and isinstance(url, str)
+                    and url.strip()
                 ):
-                    return entry["url"].strip().rstrip("/")
+                    return url.strip().rstrip("/")
     return ""
 
 


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Normalize the UI SDK state-directory result through `Path` before building the token-file path.
- Runtime-narrow optional internal-beta profile host/name values before returning public string contracts.
- Reuse the narrowed uv index URL instead of indexing an untyped TOML mapping.
- Remove 4 mypy Any-return errors without suppressions.

## Test Plan

- `TMPDIR=/tmp uv run --no-sync pytest -q tests/cli/test_cli_auth.py tests/test_cli_auth_token_file_mode.py tests/cli/test_update_check.py tests/onboarding/test_databricks_config.py tests/onboarding/test_setup.py -k 'not test_find_repo_root_finds_git_dir'` (145 passed, 1 worktree-only assertion deselected)
- `TMPDIR=/tmp uv run --no-sync mypy omnigent` (922 -> 918 errors; no targeted errors remain)
- `TMPDIR=/tmp pre-commit run --all-files`

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing CLI, update-check, and onboarding tests cover the narrowed dynamic boundaries. The deselected repository-root test assumes `.git` is a directory and fails in every linked git worktree, independent of this diff.
