### PR TITLE
refactor(runtime): narrow dynamic helper returns

### DIFF
--- a/omnigent/host/local_server.py
+++ b/omnigent/host/local_server.py
@@ -146,7 +146,7 @@ def _pid_alive(pid: int) -> bool:
     :returns: ``True`` if the process exists and is not a zombie.
     """
     try:
-        return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
+        return bool(psutil.Process(pid).status() != psutil.STATUS_ZOMBIE)
     except psutil.NoSuchProcess:
         # Includes psutil.ZombieProcess (a NoSuchProcess subclass), raised
         # on platforms where a zombie's status cannot be queried at all.

--- a/omnigent/inner/credential_proxy.py
+++ b/omnigent/inner/credential_proxy.py
@@ -413,7 +413,7 @@ def _databricks_authenticate(config: object) -> str:
             code=ErrorCode.INVALID_INPUT,
         ) from exc
     auth = (headers or {}).get("Authorization", "")
-    if not auth.startswith("Bearer "):
+    if not isinstance(auth, str) or not auth.startswith("Bearer "):
         raise OmnigentError(
             "Databricks authentication returned a non-Bearer scheme; only "
             "Bearer tokens (PAT / OAuth) are supported by the credential proxy.",

--- a/omnigent/server/dictation.py
+++ b/omnigent/server/dictation.py
@@ -404,7 +404,8 @@ class SherpaDictationEngine:
         cleaned = _PUNCT_STRIP_RE.sub("", text.lower())
         try:
             with self._lock:
-                return self._punct.add_punctuation_with_case(cleaned)
+                result = self._punct.add_punctuation_with_case(cleaned)
+            return result if isinstance(result, str) else text
         except Exception:  # noqa: BLE001 - never fail a take over cosmetics
             return text
 


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Fall back to the original dictation text if the optional punctuation model returns a non-string value.
- Runtime-narrow Databricks authorization headers before returning a bearer token.
- Materialize psutil's dynamically typed status comparison as a concrete boolean.
- Remove 3 mypy Any-return errors without suppressions.

## Test Plan

- `TMPDIR=/tmp uv run --no-sync pytest -q tests/server/test_dictation_engine.py tests/inner/test_credential_proxy.py tests/host/test_local_server.py` (52 passed, 2 skipped)
- `TMPDIR=/tmp uv run --no-sync mypy omnigent` (919 -> 916 errors; no targeted errors remain)
- `TMPDIR=/tmp pre-commit run --all-files`

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing dictation, credential-proxy, and local-server tests cover the narrowed runtime boundaries.
