### PR TITLE
refactor(databricks): type auth and stream boundaries

### DIFF
--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -20,7 +20,7 @@ import logging
 import os
 from collections.abc import AsyncIterator, Generator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
 
 import httpx
 
@@ -320,6 +320,10 @@ class DatabricksAuthError(OSError):
     """
 
 
+class _DatabricksAuthConfig(Protocol):
+    def authenticate(self) -> dict[str, str]: ...
+
+
 class _DatabricksBearerAuth(httpx.Auth):
     """httpx Auth that calls ``Config.authenticate()`` on every HTTP request.
 
@@ -340,7 +344,7 @@ class _DatabricksBearerAuth(httpx.Auth):
 
     def __init__(
         self,
-        config: Any,
+        config: _DatabricksAuthConfig,
         profile_name: str | None = None,
         failure_message: str | None = None,
     ) -> None:
@@ -785,7 +789,7 @@ def _convert_messages(
     return result
 
 
-def _extract_stream_text_delta(content: Any) -> str:
+def _extract_stream_text_delta(content: object) -> str:
     """
     Extract assistant-visible text from a Chat Completions stream delta.
 

--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -321,7 +321,8 @@ class DatabricksAuthError(OSError):
 
 
 class _DatabricksAuthConfig(Protocol):
-    def authenticate(self) -> dict[str, str]: ...
+    def authenticate(self) -> dict[str, str]:
+        raise NotImplementedError
 
 
 class _DatabricksBearerAuth(httpx.Auth):


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Define the minimal Databricks authentication config protocol used by the bearer auth adapter.
- Treat raw OpenAI-compatible stream delta content as an unknown object and narrow supported shapes at runtime.
- Remove 3 explicit-Any/Any-return mypy errors without suppressions.

## Test Plan

- `TMPDIR=/tmp uv run --no-sync pytest -q tests/inner/test_databricks_executor.py` (59 passed)
- `TMPDIR=/tmp uv run --no-sync mypy omnigent` (919 -> 916 errors; no errors remain in the changed file)
- `TMPDIR=/tmp pre-commit run --all-files`

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing Databricks executor tests cover bearer token refresh, malformed auth schemes, and string/list stream delta shapes.
