### PR TITLE
refactor(openai): type response replay boundaries

### DIFF
--- a/omnigent/inner/open_responses_sdk.py
+++ b/omnigent/inner/open_responses_sdk.py
@@ -187,10 +187,10 @@ def _convert_tools_to_responses(tools: list[ToolSpec]) -> list[ResponsesItem]:
 
 
 def _normalize_message_content(
-    content: Any,
+    content: object,
     *,
     empty_placeholder: str,
-) -> str | list[dict[str, Any]]:
+) -> str | list[dict[str, object]]:
     """
     Normalize a message ``content`` field for the Responses API.
 
@@ -367,13 +367,13 @@ def _normalize_response_output_items(items: list[ResponseOutputItem]) -> list[Re
 
         item_type = plain.get("type")
         if item_type == "message":
-            replay_item = {
+            message_item: ResponsesItem = {
                 "type": "message",
                 "role": plain.get("role", "assistant"),
             }
             if "content" in plain:
-                replay_item["content"] = plain["content"]
-            result.append(replay_item)
+                message_item["content"] = plain["content"]
+            result.append(message_item)
             continue
 
         if item_type == "function_call":
@@ -387,13 +387,13 @@ def _normalize_response_output_items(items: list[ResponseOutputItem]) -> list[Re
                 continue
             raw_args = plain.get("arguments")
             arg_str: str = raw_args if isinstance(raw_args, str) else ""
-            replay_item = {
+            function_call_item: ResponsesItem = {
                 "type": "function_call",
                 "call_id": raw_call_id,
                 "name": raw_name,
                 "arguments": arg_str,
             }
-            result.append(replay_item)
+            result.append(function_call_item)
             continue
 
         if item_type == "reasoning":
@@ -402,13 +402,13 @@ def _normalize_response_output_items(items: list[ResponseOutputItem]) -> list[Re
             # summary parts, otherwise the next turn 400s with
             # "Missing required parameter: 'input[N].summary'".
             raw_summary = plain.get("summary")
-            replay_item: ResponsesItem = {
+            reasoning_item: ResponsesItem = {
                 "type": "reasoning",
                 "summary": raw_summary if isinstance(raw_summary, list) else [],
             }
             if plain.get("encrypted_content"):
-                replay_item["encrypted_content"] = plain["encrypted_content"]
-            result.append(replay_item)
+                reasoning_item["encrypted_content"] = plain["encrypted_content"]
+            result.append(reasoning_item)
             continue
 
     return result
@@ -603,7 +603,7 @@ class OpenResponsesExecutor(Executor):
                         ]
                         _last_user_msg = " ".join(_parts)[:500]
                     break
-            _req_data: dict[str, Any] = {
+            _req_data: dict[str, object] = {
                 "model": model,
                 "messages_count": len(request_input),
                 "tools_count": len(tools),
@@ -827,7 +827,7 @@ class OpenResponsesExecutor(Executor):
             if not _resp_text_preview:
                 _resp_text_preview = _extract_response_text(response) or ""
             _fc_count = sum(1 for item in response.output if item.type == "function_call")
-            _resp_data: dict[str, Any] = {
+            _resp_data: dict[str, object] = {
                 "model": model,
                 "text_preview": _resp_text_preview[:500],
                 "tool_calls_count": _fc_count,


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Treat raw message content as an unknown object and expose a concrete structured-content return type.
- Give each replay-item branch its own typed dictionary variable instead of redefining one inferred shape.
- Type policy request/response metadata as object-valued records.
- Remove 4 explicit-Any/redefinition mypy errors without suppressions.

## Test Plan

- `TMPDIR=/tmp uv run --no-sync pytest -q tests/inner/test_open_responses_sdk.py` (28 passed)
- `TMPDIR=/tmp uv run --no-sync mypy omnigent` (919 -> 915 errors; no errors remain in the changed file)
- `TMPDIR=/tmp pre-commit run --all-files`

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing OpenAI Responses executor tests cover structured content, replay items, policy metadata, and stateful follow-up turns.
