### PR TITLE
refactor(types): document optional import boundaries

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -8429,7 +8429,7 @@ def setup(internal_beta: bool) -> None:
         # build. Fail loud with a clear message instead of an ImportError deep
         # in the onboarding flow when someone passes --internal-beta there.
         try:
-            import omnigent.onboarding.internal_beta  # noqa: F401
+            import omnigent.onboarding.internal_beta  # type: ignore[import-not-found]  # noqa: F401
         except ImportError:
             raise click.ClickException(
                 "Databricks internal-beta setup is not available in this build. "
@@ -8453,7 +8453,9 @@ def setup(internal_beta: bool) -> None:
         # bootstrap so a fresh machine sees every gap at once.
         _warn_missing_harness_dependencies()
         from omnigent.onboarding.internal_beta import _INTERNAL_BETA_DEFAULT_SERVER
-        from omnigent.onboarding.sandboxes.lakebox import install_demo_databricks_cli
+        from omnigent.onboarding.sandboxes.lakebox import (  # type: ignore[import-not-found]
+            install_demo_databricks_cli,
+        )
         from omnigent.onboarding.setup import run_onboarding
 
         # Install the demo `databricks` CLI (with the `lakebox`

--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -177,7 +177,7 @@ def _isolated_databricks_cfg() -> collections.abc.Generator[None, None, None]:
     import signal
     import tempfile
 
-    from omnigent.onboarding.internal_beta import DEFAULT_PROFILES
+    import omnigent.onboarding.internal_beta as internal_beta  # type: ignore[import-not-found]
     from omnigent.onboarding.setup import CONFLICTING_ENV_VARS
 
     original_cfg = Path.home() / ".databrickscfg"
@@ -203,7 +203,7 @@ def _isolated_databricks_cfg() -> collections.abc.Generator[None, None, None]:
     if original_cfg.exists():
         orig_cfg.read(original_cfg)
     cfg = configparser.ConfigParser()
-    for spec in DEFAULT_PROFILES:
+    for spec in internal_beta.DEFAULT_PROFILES:
         if orig_cfg.has_section(spec.name):
             cfg[spec.name] = dict(orig_cfg[spec.name])
 
@@ -245,7 +245,7 @@ def _isolated_databricks_cfg() -> collections.abc.Generator[None, None, None]:
         orig_cfg = configparser.ConfigParser()
         if original_cfg.exists():
             orig_cfg.read(original_cfg)
-        for spec in DEFAULT_PROFILES:
+        for spec in internal_beta.DEFAULT_PROFILES:
             if tmp_cfg.has_section(spec.name):
                 orig_cfg[spec.name] = dict(tmp_cfg[spec.name])
         write_tmp = original_cfg.with_suffix(".tmp")

--- a/omnigent/onboarding/databricks_config.py
+++ b/omnigent/onboarding/databricks_config.py
@@ -134,13 +134,13 @@ def get_workspace_url_for_profile(profile: str) -> str | None:
                 return host.rstrip("/")
 
     try:
-        from omnigent.onboarding.internal_beta import DEFAULT_PROFILES
+        import omnigent.onboarding.internal_beta as internal_beta  # type: ignore[import-not-found]
     except ModuleNotFoundError:
         # The internal-beta catalog is intentionally absent from the OSS
         # build; without it there are no bundled-profile fallbacks.
         return None
 
-    for spec in DEFAULT_PROFILES:
+    for spec in internal_beta.DEFAULT_PROFILES:
         if spec.name == profile:
             return spec.host.rstrip("/")
     return None

--- a/omnigent/onboarding/sandboxes/__init__.py
+++ b/omnigent/onboarding/sandboxes/__init__.py
@@ -157,9 +157,9 @@ def get_launcher(provider: str, *, workspace_host: str | None = None) -> Sandbox
         # Imported here (not at module top) because the lakebox module
         # may be absent from a distribution; the availability check above
         # guarantees it exists in this one.
-        from omnigent.onboarding.sandboxes.lakebox import LakeboxLauncher
+        import omnigent.onboarding.sandboxes.lakebox as lakebox  # type: ignore[import-not-found]
 
-        return LakeboxLauncher(workspace_host=workspace_host)
+        return lakebox.LakeboxLauncher(workspace_host=workspace_host)
     module_name, _, class_name = target.partition(":")
     module = importlib.import_module(module_name)
     launcher_cls: type[SandboxLauncher] = getattr(module, class_name)

--- a/omnigent/onboarding/setup.py
+++ b/omnigent/onboarding/setup.py
@@ -268,13 +268,13 @@ def _compute_actions(existing: dict[str, str]) -> _Actions:
     """
     # Lazy import: the internal-beta workspace list is excluded from the OSS
     # build. This function is only reached via ``setup --internal-beta``.
-    from omnigent.onboarding.internal_beta import DEFAULT_PROFILES
+    import omnigent.onboarding.internal_beta as internal_beta  # type: ignore[import-not-found]
 
     ready: list[ProfileSpec] = []
     aliasable: list[tuple[str, ProfileSpec]] = []
     oauth: list[ProfileSpec] = []
     wrong_host: list[tuple[ProfileSpec, str]] = []
-    for spec in DEFAULT_PROFILES:
+    for spec in internal_beta.DEFAULT_PROFILES:
         host = existing.get(spec.name)
         if host is not None and _host_matches(host, spec.host):
             ready.append(spec)

--- a/omnigent/onboarding/ucode_setup.py
+++ b/omnigent/onboarding/ucode_setup.py
@@ -34,9 +34,11 @@ def model_gateway_workspace_urls() -> list[str]:
     :returns: Gateway workspace URLs, each stripped of a trailing slash.
     """
     # Lazy import: internal-beta workspace list, excluded from the OSS build.
-    from omnigent.onboarding.internal_beta import DEFAULT_PROFILES
+    import omnigent.onboarding.internal_beta as internal_beta  # type: ignore[import-not-found]
 
-    return [spec.host.rstrip("/") for spec in DEFAULT_PROFILES if spec.is_model_gateway]
+    return [
+        spec.host.rstrip("/") for spec in internal_beta.DEFAULT_PROFILES if spec.is_model_gateway
+    ]
 
 
 def build_ucode_configure_command(

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -1293,7 +1293,7 @@ def _classify_anthropic_exception(exception: BaseException) -> str | None:
         recognize.
     """
     try:
-        import anthropic
+        import anthropic  # type: ignore[import-not-found]
     except ImportError:
         return None
 

--- a/omnigent/server/dictation.py
+++ b/omnigent/server/dictation.py
@@ -345,7 +345,7 @@ class SherpaDictationEngine:
             model; silently skipped when absent or incomplete.
         :raises RuntimeError: If the ASR file set is incomplete.
         """
-        import sherpa_onnx
+        import sherpa_onnx  # type: ignore[import-not-found]
 
         files = _asr_files(asr_dir)
         if files is None:
@@ -423,7 +423,7 @@ class _SherpaStream:
 
     def feed_pcm16(self, data: bytes) -> DictationUpdate:
         """Decode one PCM chunk; fold an endpoint into ``finalized``."""
-        import numpy as np
+        import numpy as np  # type: ignore[import-not-found]
 
         # Drop a trailing odd byte rather than crash the take; the next
         # frame realigns (client frames are always whole samples).


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Mark intentional optional and proprietary Python imports with narrow `import-not-found` suppressions.
- Keep runtime import behavior unchanged while removing 10 actionable mypy diagnostics from the cleanup baseline.

## Test Plan

- `TMPDIR=/tmp pre-commit run --all-files`
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (909 remaining baseline errors, down from 919 on this branch's base)

## Demo

N/A — non-visual type-checking cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

No runtime behavior changes; repository pre-commit checks cover formatting and linting, and the full application mypy scan verifies the intended diagnostic reduction.
