### PR TITLE
refactor(sessions): narrow resource replay events

### DIFF
--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -31,6 +31,7 @@ from omnigent.entities import (
     ErrorData,
     MessageData,
     NewConversationItem,
+    ResourceEventData,
 )
 from omnigent.entities.conversation import (
     FunctionCallData,
@@ -4427,6 +4428,7 @@ async def _relay_runner_stream(
                     # clients.
                     resource_item = _resource_event_item_from_sse(session_id, event)
                     if resource_item is not None:
+                        resource_data = resource_item.data
                         await _relay_persist(
                             conversation_store,
                             session_id,
@@ -4439,8 +4441,9 @@ async def _relay_runner_stream(
                         # between launch and clear). Only fire on a real
                         # state change to avoid redundant stream traffic.
                         if (
-                            resource_item.data.event_type == "session.resource.created"
-                            and resource_item.data.resource_type == "terminal"
+                            isinstance(resource_data, ResourceEventData)
+                            and resource_data.event_type == "session.resource.created"
+                            and resource_data.resource_type == "terminal"
                             and _session_terminal_pending_cache.get(session_id, False)
                         ):
                             _publish_terminal_pending(session_id, False)


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Narrow persisted session resource replay payloads to `ResourceEventData` before inspecting lifecycle fields.
- Preserve the runtime guard while removing 20 cascading union-attribute mypy diagnostics from session orchestration.

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest -q tests/server/routes/test_session_resources.py -k 'relay_persists_terminal_resource or relay_skips_malformed_resource or relay_skips_empty_resource'` (7 passed)
- `TMPDIR=/tmp pre-commit run --all-files`
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (899 remaining baseline errors, down from 919 on this branch's base)

## Demo

N/A — non-visual type-checking cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing resource relay tests cover created, deleted, and malformed lifecycle events; the full mypy scan verifies the intended diagnostic reduction.
