### PR TITLE
refactor(server): narrow optional app config

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -887,6 +887,8 @@ def create_app(
             from omnigent.server.accounts_bootstrap import bootstrap_admin
 
             _accounts_cfg = auth_provider._accounts_config
+            if _accounts_cfg is None:
+                raise ValueError("accounts auth provider requires accounts_config")
             _bootstrap_result = bootstrap_admin(
                 account_store,
                 init_admin_password=_accounts_cfg.init_admin_password,
@@ -1747,16 +1749,17 @@ def create_app(
         # config is wired AND its provider can actually serve a managed
         # launch (staged providers parse but reject at launch — they
         # must not advertise the option).
-        managed_sandboxes_enabled = (
-            sandbox_config is not None and sandbox_config.managed_launch_supported
-        )
         # sandbox_provider names the backing provider (e.g. "modal",
         # "islo") so the web UI can label the option per provider
         # ("Modal Sandbox" / "Islo Sandbox") instead of the
         # generic "New Sandbox". Only surfaced when the option is
         # actually offered; None when no provider is named (embedding
         # configs may leave it unset) so the UI keeps the generic label.
-        sandbox_provider = sandbox_config.provider if managed_sandboxes_enabled else None
+        managed_sandboxes_enabled = False
+        sandbox_provider = None
+        if sandbox_config is not None and sandbox_config.managed_launch_supported:
+            managed_sandboxes_enabled = True
+            sandbox_provider = sandbox_config.provider
         # sharing_mode is the server's session-sharing policy
         # (on/read_only/off), surfaced so the web app can hide the Share
         # control (off) or restrict it to read-only (read_only) in lockstep


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Validate the accounts-auth configuration before first-admin bootstrap.
- Narrow managed-sandbox configuration in the same branch that derives its advertised provider, removing five nullable-config diagnostics while preserving valid configuration behavior.

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest -q tests/server/test_accounts.py::test_info_endpoint_advertises_accounts_enabled tests/server/test_accounts.py::test_info_endpoint_reports_disabled_in_header_mode tests/server/test_managed_hosts.py::test_info_reports_managed_sandboxes_capability tests/server/test_managed_hosts.py::test_info_reports_enabled_for_injected_custom_launcher` (8 passed)
- `TMPDIR=/tmp pre-commit run --all-files`
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (902 remaining baseline errors, down from 907 on this branch's base)

## Demo

N/A — non-visual type-checking cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused account and managed-sandbox info tests cover valid configurations; full lint and mypy scans verify the narrowing.
