### PR TITLE
refactor: tighten host process typing

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -18,6 +18,7 @@ import sys
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal, Protocol, SupportsIndex, SupportsInt, cast
 
 import websockets.asyncio.client
 from websockets.exceptions import InvalidStatus, InvalidURI
@@ -117,6 +118,16 @@ from omnigent.tls import client_ssl_context
 from omnigent.version import VERSION
 
 _logger = logging.getLogger(__name__)
+
+
+class _WaitidInfo(Protocol):
+    si_pid: int
+
+
+def _coerce_int(value: object) -> int:
+    """Convert a validated JSON scalar with the standard ``int`` semantics."""
+    return int(cast(str | bytes | bytearray | SupportsInt | SupportsIndex, value))
+
 
 # Binary appearance is cheap to probe, so new CLI installs surface quickly.
 HARNESS_READINESS_REFRESH_INTERVAL_S = 5.0
@@ -856,9 +867,14 @@ class HostProcess:
         """
         reaped = 0
         tracked = self._tracked_runner_pids()
+        waitid = cast(
+            "Callable[[object, int, int], _WaitidInfo | None]",
+            vars(os)["waitid"],
+        )
+        p_all = vars(os)["P_ALL"]
         while True:
             try:
-                info = os.waitid(os.P_ALL, 0, os.WEXITED | os.WNOHANG | os.WNOWAIT)
+                info = waitid(p_all, 0, os.WEXITED | os.WNOHANG | os.WNOWAIT)
             except (ChildProcessError, OSError):
                 break
             if info is None:
@@ -1707,7 +1723,7 @@ class HostProcess:
         elif frame.kind in ("key", "gateway"):
             result = store_harness_credential(
                 family=family,
-                kind=frame.kind,
+                kind=cast(Literal["key", "gateway"], frame.kind),
                 secret=frame.secret_value or "",
                 base_url=frame.base_url,
                 default_model=frame.default_model,
@@ -1999,7 +2015,7 @@ class HostProcess:
         if op == "list_or_read":
             return r.list_or_read(
                 str(params.get("path", "")),
-                limit=int(params.get("limit", 20)),
+                limit=_coerce_int(params.get("limit", 20)),
                 after=cast("str | None", params.get("after")),
                 before=cast("str | None", params.get("before")),
                 order=str(params.get("order", "desc")),
@@ -2013,7 +2029,7 @@ class HostProcess:
                 str(params.get("q", "")),
                 include=cast("str | None", params.get("include")),
                 exclude=cast("str | None", params.get("exclude")),
-                limit=int(params.get("limit", 500)),
+                limit=_coerce_int(params.get("limit", 500)),
             )
         raise ValueError(f"unknown fs op: {op!r}")
 
@@ -2553,18 +2569,18 @@ class HostProcess:
         elif isinstance(frame, HostInstallHarnessFrame):
             # The installer shells out (npm) and can run for minutes, so run
             # it off the event loop and reply when it completes.
-            result = await asyncio.to_thread(self._handle_install_harness, frame)
-            await ws.send(encode_host_frame(result))
+            install_result = await asyncio.to_thread(self._handle_install_harness, frame)
+            await ws.send(encode_host_frame(install_result))
         elif isinstance(frame, HostStoreSecretFrame):
             # The credential write touches the OS keychain / config file, so run
             # it off the event loop and reply when it completes.
-            result = await asyncio.to_thread(self._handle_store_secret, frame)
-            await ws.send(encode_host_frame(result))
+            secret_result = await asyncio.to_thread(self._handle_store_secret, frame)
+            await ws.send(encode_host_frame(secret_result))
         elif isinstance(frame, HostDetectCredentialsFrame):
             # Ambient detection may probe files / a localhost socket, so run it
             # off the event loop.
-            result = await asyncio.to_thread(self._handle_detect_credentials, frame)
-            await ws.send(encode_host_frame(result))
+            credentials_result = await asyncio.to_thread(self._handle_detect_credentials, frame)
+            await ws.send(encode_host_frame(credentials_result))
         elif isinstance(frame, HostCreateWorktreeFrame):
             await ws.send(encode_host_frame(await self._handle_create_worktree(frame)))
         elif isinstance(frame, HostRemoveWorktreeFrame):
@@ -2574,8 +2590,8 @@ class HostProcess:
         elif isinstance(frame, HostFsRequestFrame):
             # Git status and directory walks can block, so run the read
             # off the event loop and reply when it completes.
-            result = await asyncio.to_thread(self._handle_fs_request, frame)
-            await ws.send(encode_host_frame(result))
+            fs_result = await asyncio.to_thread(self._handle_fs_request, frame)
+            await ws.send(encode_host_frame(fs_result))
         elif isinstance(frame, HostModelOptionsFrame):
             await ws.send(encode_host_frame(await self._handle_model_options(frame)))
 

--- a/omnigent/process_logging.py
+++ b/omnigent/process_logging.py
@@ -10,7 +10,7 @@ from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import BinaryIO, TextIO
+from typing import BinaryIO, TextIO, TypedDict
 
 from omnigent._platform import IS_POSIX
 
@@ -20,6 +20,21 @@ LOG_TO_STDERR_ENV_VAR = "OMNIGENT_LOG_TO_STDERR"
 LOG_FORCE_COLOR_ENV_VAR = "OMNIGENT_LOG_FORCE_COLOR"
 PROCESS_LOG_FILE_ENV_VAR = "OMNIGENT_PROCESS_LOG_FILE"
 LOG_TTY_FD_ENV_VAR = "OMNIGENT_LOG_TTY_FD"
+
+
+class ChildLoggingPopenKwargs(TypedDict, total=False):
+    """Keyword arguments forwarded to :class:`subprocess.Popen`."""
+
+    pass_fds: tuple[int, ...]
+
+
+class _ProcessLogStreamHandler(logging.StreamHandler[TextIO]):
+    _omnigent_process_log_stderr: bool
+
+
+class _ProcessLogFileHandler(logging.FileHandler):
+    _omnigent_process_log_path: str
+
 
 DEFAULT_LOG_SOURCE_WIDTH = 32
 DEFAULT_LOG_FUNC_WIDTH = 18
@@ -254,7 +269,7 @@ def terminal_stream_handler() -> logging.Handler:
     stream = _terminal_stream()
     if stream is None:
         return logging.NullHandler()
-    handler = logging.StreamHandler(stream)
+    handler = _ProcessLogStreamHandler(stream)
     handler._omnigent_process_log_stderr = True
     return handler
 
@@ -288,7 +303,7 @@ def configure_process_logging(
     formatter = TerminalLogFormatter(use_colors=False)
     handlers: list[logging.Handler] = []
 
-    file_handler = logging.FileHandler(path, encoding="utf-8")
+    file_handler = _ProcessLogFileHandler(path, encoding="utf-8")
     file_handler.setLevel(resolved_level)
     file_handler.setFormatter(formatter)
     file_handler._omnigent_process_log_path = str(path)
@@ -343,7 +358,7 @@ def _add_handler_once(logger: logging.Logger, handler: logging.Handler) -> None:
 
 
 @contextmanager
-def child_logging_popen_kwargs(env: dict[str, str]) -> Iterator[dict[str, object]]:
+def child_logging_popen_kwargs(env: dict[str, str]) -> Iterator[ChildLoggingPopenKwargs]:
     """Prepare inherited terminal-fd kwargs for a child process.
 
     Mutates *env* only when ``--log-to-stderr`` requested a mirror and the


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Model child-process logging kwargs and handler metadata with explicit types.
- Narrow platform-specific `waitid`, credential kinds, JSON integer inputs, and host frame results at their boundaries without changing runtime behavior.
- Remove 13 mypy errors from `omnigent/host/connect.py` and `omnigent/process_logging.py`, reducing the measured baseline from 873 to 860 errors.

ELI5: these host-process boundaries already validate or constrain their values at runtime; this PR gives mypy the same information.

```text
untyped host/process boundaries -> focused narrowing -> existing runtime behavior
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest -q tests/test_process_logging.py tests/host/test_connect.py` (105 passed)
- `TMPDIR=/tmp .venv/bin/pre-commit run --all-files`
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (860 remaining baseline errors; none in the two changed files)

## Demo

N/A — non-visual typing cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing host connection, orphan reaper, credential storage, filesystem request, and process logging tests cover the narrowed paths.
