### PR TITLE
refactor: type native wrapper JSON boundaries

### DIFF
--- a/omnigent/goose_native.py
+++ b/omnigent/goose_native.py
@@ -25,7 +25,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any
+from typing import TypeAlias
 
 import click
 import httpx
@@ -59,6 +59,8 @@ from omnigent.native_terminal import (
     normalize_extra_args as _normalize_extra_args,
 )
 from omnigent.native_terminal import url_component
+
+_JsonObject: TypeAlias = dict[str, object]
 
 _DEFAULT_GOOSE_COMMAND = "goose"
 _GOOSE_PATH_ENV = "OMNIGENT_GOOSE_PATH"
@@ -202,7 +204,7 @@ def _materialize_goose_agent_spec(tmpdir: Path) -> Path:
     :returns: Path to the generated YAML spec.
     """
     yaml_path = tmpdir / "goose-native-ui.yaml"
-    raw: dict[str, Any] = {
+    raw: _JsonObject = {
         "name": _AGENT_NAME,
         "prompt": (
             "Goose is running in the session terminal. The user drives the "
@@ -406,7 +408,7 @@ async def _create_goose_session(
     terminal_launch_args: list[str] | None = None,
 ) -> str:
     """Create a bundled terminal-first goose-native session."""
-    metadata: dict[str, Any] = {"labels": dict(_SESSION_LABELS)}
+    metadata: _JsonObject = {"labels": dict(_SESSION_LABELS)}
     if terminal_launch_args:
         metadata["terminal_launch_args"] = terminal_launch_args
     resp = await client.post(
@@ -426,7 +428,7 @@ async def _create_goose_session(
     return new_session_id
 
 
-async def _fetch_goose_session(client: httpx.AsyncClient, session_id: str) -> dict[str, Any]:
+async def _fetch_goose_session(client: httpx.AsyncClient, session_id: str) -> _JsonObject:
     """Fetch an existing Omnigent session."""
     resp = await client.get(f"/v1/sessions/{url_component(session_id)}")
     if resp.status_code == 404:

--- a/omnigent/hermes_native.py
+++ b/omnigent/hermes_native.py
@@ -24,7 +24,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any
+from typing import TypeAlias
 
 import click
 import httpx
@@ -58,6 +58,8 @@ from omnigent.native_terminal import (
     normalize_extra_args as _normalize_extra_args,
 )
 from omnigent.native_terminal import url_component
+
+_JsonObject: TypeAlias = dict[str, object]
 
 _DEFAULT_HERMES_COMMAND = "hermes"
 _HERMES_PATH_ENV = "OMNIGENT_HERMES_PATH"
@@ -201,7 +203,7 @@ def _materialize_hermes_agent_spec(tmpdir: Path) -> Path:
     :returns: Path to the generated YAML spec.
     """
     yaml_path = tmpdir / "hermes-native-ui.yaml"
-    raw: dict[str, Any] = {
+    raw: _JsonObject = {
         "name": _AGENT_NAME,
         "prompt": (
             "Hermes is running in the session terminal. The user drives the hermes TUI directly."
@@ -404,7 +406,7 @@ async def _create_hermes_session(
     terminal_launch_args: list[str] | None = None,
 ) -> str:
     """Create a bundled terminal-first hermes-native session."""
-    metadata: dict[str, Any] = {"labels": dict(_SESSION_LABELS)}
+    metadata: _JsonObject = {"labels": dict(_SESSION_LABELS)}
     if terminal_launch_args:
         metadata["terminal_launch_args"] = terminal_launch_args
     resp = await client.post(
@@ -424,7 +426,7 @@ async def _create_hermes_session(
     return new_session_id
 
 
-async def _fetch_hermes_session(client: httpx.AsyncClient, session_id: str) -> dict[str, Any]:
+async def _fetch_hermes_session(client: httpx.AsyncClient, session_id: str) -> _JsonObject:
     """Fetch an existing Omnigent session."""
     resp = await client.get(f"/v1/sessions/{url_component(session_id)}")
     if resp.status_code == 404:

--- a/omnigent/kimi_native.py
+++ b/omnigent/kimi_native.py
@@ -22,7 +22,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any
+from typing import TypeAlias
 
 import click
 import httpx
@@ -56,6 +56,8 @@ from omnigent.native_terminal import (
     normalize_extra_args as _normalize_extra_args,
 )
 from omnigent.native_terminal import url_component
+
+_JsonObject: TypeAlias = dict[str, object]
 
 _DEFAULT_KIMI_COMMAND = "kimi"
 _KIMI_PATH_ENV = "OMNIGENT_KIMI_PATH"
@@ -206,7 +208,7 @@ def _materialize_kimi_agent_spec(tmpdir: Path) -> Path:
     :returns: Path to the generated YAML spec.
     """
     yaml_path = tmpdir / "kimi-native-ui.yaml"
-    raw: dict[str, Any] = {
+    raw: _JsonObject = {
         "name": _AGENT_NAME,
         "prompt": (
             "Kimi is running in the session terminal. The user drives the kimi TUI directly."
@@ -419,7 +421,7 @@ async def _create_kimi_session(
     terminal_launch_args: list[str] | None = None,
 ) -> str:
     """Create a bundled terminal-first kimi-native session."""
-    metadata: dict[str, Any] = {"labels": dict(_SESSION_LABELS)}
+    metadata: _JsonObject = {"labels": dict(_SESSION_LABELS)}
     if terminal_launch_args:
         metadata["terminal_launch_args"] = terminal_launch_args
     resp = await client.post(
@@ -439,7 +441,7 @@ async def _create_kimi_session(
     return new_session_id
 
 
-async def _fetch_kimi_session(client: httpx.AsyncClient, session_id: str) -> dict[str, Any]:
+async def _fetch_kimi_session(client: httpx.AsyncClient, session_id: str) -> _JsonObject:
     """Fetch an existing Omnigent session."""
     resp = await client.get(f"/v1/sessions/{url_component(session_id)}")
     if resp.status_code == 404:

--- a/omnigent/pi_native.py
+++ b/omnigent/pi_native.py
@@ -11,7 +11,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any
+from typing import TypeAlias
 
 import click
 import httpx
@@ -48,6 +48,8 @@ from omnigent.native_terminal import url_component
 from omnigent.pi_native_bridge import bridge_dir_for_session_id
 
 _logger = logging.getLogger(__name__)
+
+_JsonObject: TypeAlias = dict[str, object]
 
 _DEFAULT_PI_COMMAND = "pi"
 _PI_PATH_ENV = "OMNIGENT_PI_PATH"
@@ -247,7 +249,7 @@ def _materialize_pi_agent_spec(tmpdir: Path) -> Path:
     :returns: Path to the generated YAML spec.
     """
     yaml_path = tmpdir / "pi-native-ui.yaml"
-    raw: dict[str, Any] = {
+    raw: _JsonObject = {
         "name": _AGENT_NAME,
         "prompt": (
             "Pi is running in the session terminal. Web UI messages are "
@@ -460,7 +462,7 @@ async def _create_pi_session(
     :param terminal_launch_args: Pass-through Pi CLI args to persist.
     :returns: New Omnigent session id.
     """
-    metadata: dict[str, Any] = {"labels": dict(_SESSION_LABELS)}
+    metadata: _JsonObject = {"labels": dict(_SESSION_LABELS)}
     if terminal_launch_args:
         metadata["terminal_launch_args"] = terminal_launch_args
     resp = await client.post(
@@ -480,7 +482,7 @@ async def _create_pi_session(
     return new_session_id
 
 
-async def _fetch_pi_session(client: httpx.AsyncClient, session_id: str) -> dict[str, Any]:
+async def _fetch_pi_session(client: httpx.AsyncClient, session_id: str) -> _JsonObject:
     """Fetch an existing Omnigent session."""
     resp = await client.get(f"/v1/sessions/{url_component(session_id)}")
     if resp.status_code == 404:

--- a/omnigent/qwen_native.py
+++ b/omnigent/qwen_native.py
@@ -25,7 +25,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any
+from typing import TypeAlias
 
 import click
 import httpx
@@ -59,6 +59,8 @@ from omnigent.native_terminal import (
     normalize_extra_args as _normalize_extra_args,
 )
 from omnigent.native_terminal import url_component
+
+_JsonObject: TypeAlias = dict[str, object]
 
 _DEFAULT_QWEN_COMMAND = "qwen"
 _QWEN_PATH_ENV = "OMNIGENT_QWEN_PATH"
@@ -201,7 +203,7 @@ def _materialize_qwen_agent_spec(tmpdir: Path) -> Path:
     :returns: Path to the generated YAML spec.
     """
     yaml_path = tmpdir / "qwen-native-ui.yaml"
-    raw: dict[str, Any] = {
+    raw: _JsonObject = {
         "name": _AGENT_NAME,
         "prompt": (
             "qwen is running in the session terminal. The user drives the qwen TUI directly."
@@ -404,7 +406,7 @@ async def _create_qwen_session(
     terminal_launch_args: list[str] | None = None,
 ) -> str:
     """Create a bundled terminal-first qwen-native session."""
-    metadata: dict[str, Any] = {"labels": dict(_SESSION_LABELS)}
+    metadata: _JsonObject = {"labels": dict(_SESSION_LABELS)}
     if terminal_launch_args:
         metadata["terminal_launch_args"] = terminal_launch_args
     resp = await client.post(
@@ -424,7 +426,7 @@ async def _create_qwen_session(
     return new_session_id
 
 
-async def _fetch_qwen_session(client: httpx.AsyncClient, session_id: str) -> dict[str, Any]:
+async def _fetch_qwen_session(client: httpx.AsyncClient, session_id: str) -> _JsonObject:
     """Fetch an existing Omnigent session."""
     resp = await client.get(f"/v1/sessions/{url_component(session_id)}")
     if resp.status_code == 404:


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Give the Goose, Hermes, Kimi, Pi, and Qwen wrappers the same typed JSON-object boundary already used by the OpenCode wrapper.
- Replace broad `Any` annotations for generated specs, session metadata, and fetched session objects with `dict[str, object]` aliases.
- Remove 15 mypy errors, reducing the measured branch baseline from 863 to 848 errors without changing runtime behavior.

ELI5: these wrappers all pass JSON-shaped dictionaries around; this PR tells mypy that their keys are strings while requiring callers to narrow each value before use.

```text
five broad Any dictionaries -> typed JSON object boundaries -> existing behavior
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest -q tests/test_goose_native.py tests/test_hermes_native.py tests/test_qwen_native.py tests/test_pi_native_credentials.py tests/test_pi_native_extension.py tests/test_pi_native_resume.py tests/test_kimi_native_hook.py tests/test_kimi_native_forwarder.py tests/test_kimi_native_bridge_hook_config.py tests/test_kimi_native_credentials.py -k 'not test_resolve_hermes_executable_missing_raises_with_hint and not test_resolve_qwen_executable_missing_raises_with_hint'` (204 passed, 2 deselected because both CLIs are installed locally)
- `TMPDIR=/tmp .venv/bin/pre-commit run --all-files`
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (848 remaining baseline errors; none in the five changed files)

## Demo

N/A — non-visual typing cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing native-wrapper tests cover agent-spec materialization, session payload handling, terminal setup, resume behavior, credentials, hooks, and forwarders.
