### PR TITLE
refactor(policies): type cache lookups

### DIFF
--- a/omnigent/runtime/policies/builder.py
+++ b/omnigent/runtime/policies/builder.py
@@ -194,7 +194,7 @@ def _resolve_session_owner_cached(
     :returns: The owner user id, or ``None`` when the session has no
         owner grant (single-user mode).
     """
-    owner = _SESSION_OWNER_CACHE.get(conversation_id)
+    owner: str | None = _SESSION_OWNER_CACHE.get(conversation_id)
     if owner is not None:
         return owner
     owner = conversation_store.get_session_owner(conversation_id)
@@ -1064,7 +1064,7 @@ def _load_default_policy_specs(
     from omnigent.db.db_models import current_workspace_id
 
     workspace_id = current_workspace_id()
-    cached = _DEFAULT_POLICY_SPECS_CACHE.get(workspace_id)
+    cached: list[PolicySpec] | None = _DEFAULT_POLICY_SPECS_CACHE.get(workspace_id)
     if cached is not None:
         return cached
     specs: list[PolicySpec] = []
@@ -1154,7 +1154,7 @@ def _load_session_policy_specs(
     from omnigent.db.db_models import current_workspace_id
 
     key = (current_workspace_id(), conversation_id)
-    cached = _SESSION_POLICY_SPECS_CACHE.get(key)
+    cached: list[PolicySpec] | None = _SESSION_POLICY_SPECS_CACHE.get(key)
     if cached is not None:
         return cached
     stored = policy_store.list_for_session(conversation_id)


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Annotate session-owner and policy-spec cache lookups with the value types already declared on their caches.
- Prevent untyped `cachetools.get()` results from leaking through typed policy-builder returns.
- Remove 3 mypy errors, reducing the measured branch baseline from 863 to 860 errors without changing cache behavior.

ELI5: the caches already promise to hold owners and policy lists; this PR repeats those contracts at the untyped library boundary so mypy can verify the return paths.

```text
untyped cachetools result -> declared cache value type -> typed policy return
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest -q tests/runtime/policies/test_builder.py tests/runtime/policies/test_builder_session_policies.py tests/runtime/policies/test_user_daily_cost_routing.py` (47 passed)
- `TMPDIR=/tmp .venv/bin/pre-commit run --all-files`
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (860 remaining baseline errors; none in `omnigent/runtime/policies/builder.py`)

## Demo

N/A — non-visual typing cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing policy-builder tests cover owner routing, session/default policy cache hits, invalidation, policy ordering, and engine construction.
