### PR TITLE
refactor(loader): type sandbox defaults

### DIFF
--- a/omnigent/inner/loader.py
+++ b/omnigent/inner/loader.py
@@ -6,7 +6,7 @@ import importlib
 import re
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, TypeAlias
+from typing import Any, TypeAlias, cast
 
 import yaml
 
@@ -842,17 +842,17 @@ def _parse_os_env_sandbox_spec(data: YamlData | str | bool | None) -> OSEnvSandb
         cwd_hidden_scan_max_entries=(
             int(max_entries_raw)
             if max_entries_raw is not None
-            else fields["cwd_hidden_scan_max_entries"].default
+            else cast(int, fields["cwd_hidden_scan_max_entries"].default)
         ),
         cwd_hidden_scan_overflow=(
             str(overflow_raw)
             if overflow_raw is not None
-            else fields["cwd_hidden_scan_overflow"].default
+            else cast(str, fields["cwd_hidden_scan_overflow"].default)
         ),
         cwd_hidden_scan_recursive=(
             bool(recursive_raw)
             if recursive_raw is not None
-            else fields["cwd_hidden_scan_recursive"].default
+            else cast(bool, fields["cwd_hidden_scan_recursive"].default)
         ),
         mask_paths=list(mask_paths_raw) if mask_paths_raw is not None else None,
         env_passthrough=data.get("env_passthrough"),


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Narrow the three `OSEnvSandboxSpec` dataclass defaults read dynamically by the inner YAML loader to their declared field types.
- Keep the dataclass as the single source of truth for hidden-scan defaults while excluding the impossible `MISSING` sentinel from constructor arguments.
- Remove 3 mypy errors, reducing the measured branch baseline from 858 to 855 errors without changing parsed values.

ELI5: the loader intentionally reads defaults from the dataclass instead of copying literals; this PR tells mypy which type each known field contains.

```text
dynamic dataclass default -> declared field type -> typed sandbox constructor
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest -q tests/inner/test_loader.py tests/spec/test_parser.py -k 'loader or cwd_hidden_scan'` (77 passed, 210 deselected, 3 subtests passed)
- `TMPDIR=/tmp .venv/bin/pre-commit run --all-files`
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (855 remaining baseline errors; none in `omnigent/inner/loader.py`)

## Demo

N/A — non-visual typing cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing loader and parser tests cover sandbox defaults, explicit hidden-scan values, validation, and inner-loader sandbox behavior.
