### PR TITLE
refactor: type crash UI tracebacks

### DIFF
--- a/omnigent/crash_ui.py
+++ b/omnigent/crash_ui.py
@@ -23,6 +23,7 @@ import shutil
 import sys
 import traceback as _tb
 from pathlib import Path
+from types import TracebackType
 from typing import TextIO
 
 # --------------------------------------------------------------------------- #
@@ -220,7 +221,7 @@ def _full_traceback_env() -> bool:
 
 def format_traceback(
     exc: BaseException,
-    tb,
+    tb: TracebackType | None,
     *,
     colored: bool,
     unicode_ok: bool,
@@ -328,7 +329,7 @@ def render_crash_screen(
     app_name: str,
     report_path: str,
     exc: BaseException,
-    tb=None,
+    tb: TracebackType | None = None,
     stream: TextIO | None = None,
     first_party_prefixes: tuple[str, ...] = _DEFAULT_FIRST_PARTY_PREFIXES,
 ) -> None:
@@ -370,7 +371,7 @@ def render_crash_screen(
     if not on_tty:
         # Piped / CI / log file: plain text, no box, no emoji, no color.
         # Path at the top here since there's no interactive prompt after.
-        lines = [
+        plain_lines = [
             "",
             f"{display} ran into an issue.",
             "",
@@ -381,7 +382,7 @@ def render_crash_screen(
             tb_text,
             "",
         ]
-        stream.write("\n".join(lines) + "\n")
+        stream.write("\n".join(plain_lines) + "\n")
         stream.flush()
         return
 


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Type crash-screen traceback inputs as `TracebackType | None`.
- Give the non-TTY and TTY output buffers distinct local names so mypy does not merge their branch assignments.
- Remove 3 mypy errors, reducing the measured branch baseline from 835 to 832 errors without changing rendered output.

ELI5: the crash UI already receives Python traceback objects; this PR records that fact and keeps two independent output lists unambiguous.

```text
exception + traceback -> typed formatter -> unchanged terminal/plain output
```

## Test Plan

- `env -u NO_COLOR TMPDIR=/tmp .venv/bin/pytest -q tests/cli/test_crash_handler.py` (22 passed; `NO_COLOR` is unset because the TTY test asserts ANSI output)
- `TMPDIR=/tmp .venv/bin/pre-commit run --all-files`
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (832 remaining baseline errors; none in `omnigent/crash_ui.py`)

## Demo

N/A — non-visual typing cleanup with unchanged output.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing crash-handler tests cover TTY and non-TTY rendering, traceback formatting, first-party frame handling, report persistence, and interactive actions.
