### PR TITLE
refactor(egress): type proxy transports

### DIFF
--- a/omnigent/inner/egress/proxy.py
+++ b/omnigent/inner/egress/proxy.py
@@ -37,6 +37,7 @@ from dataclasses import dataclass
 from email.message import Message
 from email.parser import BytesParser
 from pathlib import Path
+from typing import cast
 from urllib.parse import urlparse
 
 from omnigent.inner.credential_proxy import (
@@ -260,6 +261,7 @@ class EgressProxy:
         # the base64 round-trip on every connection. Stored as bytes
         # so we can ``hmac.compare_digest`` against the raw header
         # value lifted from the request without re-encoding.
+        self._expected_auth_value: bytes | None
         if auth_token is not None:
             self._expected_auth_value = b"Basic " + base64.b64encode(
                 f"omnigent:{auth_token}".encode()
@@ -501,7 +503,7 @@ class EgressProxy:
             await self._send_forbidden(writer, str(exc))
             return
 
-        writer.transport.pause_reading()
+        cast(asyncio.ReadTransport, writer.transport).pause_reading()
 
         writer.write(_CONNECT_RESPONSE)
         await writer.drain()
@@ -540,8 +542,9 @@ class EgressProxy:
         transport = writer.transport
         loop = asyncio.get_event_loop()
         try:
-            tls_transport = await loop.start_tls(
-                transport, tls_protocol, ssl_ctx, server_side=True
+            tls_transport = cast(
+                asyncio.WriteTransport,
+                await loop.start_tls(transport, tls_protocol, ssl_ctx, server_side=True),
             )
         except (ssl.SSLError, ConnectionResetError, OSError) as exc:
             # WARNING (was DEBUG) so a client that drops mid-handshake


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Declare the proxy's precomputed auth header as nullable bytes.
- Narrow the accepted client transport to its read side before pausing it and the TLS-upgraded transport to its write side before constructing `StreamWriter`.
- Remove 3 mypy errors, reducing the measured branch baseline from 817 to 814 errors with cast-only runtime behavior.

ELI5: asyncio exposes the same socket through separate read/write interfaces; this PR tells mypy which side the proxy uses at each step.

```text
client stream -> read transport pause -> TLS upgrade -> write transport stream
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest -q tests/inner/egress/test_proxy.py` (70 passed)
- `TMPDIR=/tmp .venv/bin/pre-commit run --all-files`
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (814 remaining baseline errors; none in `omnigent/inner/egress/proxy.py`)

## Demo

N/A — non-visual typing cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The full egress proxy suite covers HTTP/TLS transport setup, CONNECT handling, auth, credential rewrites, destination blocking, request validation, and shutdown behavior.
