### PR TITLE
refactor(sessions): type policy hook boundaries

### DIFF
--- a/omnigent/server/routes/sessions/__init__.py
+++ b/omnigent/server/routes/sessions/__init__.py
@@ -87,8 +87,12 @@ from omnigent.runner.identity import (
 )
 from omnigent.runner.routing import RunnerRouter
 from omnigent.runtime import (
-    get_agent_cache,
-    get_caps,
+    get_agent_cache as _runtime_get_agent_cache,
+)
+from omnigent.runtime import (
+    get_caps as _runtime_get_caps,
+)
+from omnigent.runtime import (
     get_policy_store,
     pending_elicitations,
     pending_inputs,
@@ -144,7 +148,7 @@ from omnigent.server.routes._auth_helpers import (
     get_session_owner_id as _get_session_owner_id,
 )
 from omnigent.server.routes._auth_helpers import (
-    get_user_id as _get_user_id,
+    get_user_id as _auth_get_user_id,
 )
 from omnigent.server.routes._auth_helpers import (
     require_access as _require_access,
@@ -317,6 +321,10 @@ from omnigent.telemetry.events import SessionDeletedEvent as _TelSessionDeletedE
 from omnigent.telemetry.events import SessionStoppedEvent as _TelSessionStoppedEvent
 from omnigent.telemetry.installation_id import get_installation_id as _get_installation_id
 from omnigent.tools.client_specified import parse_client_side_tool_specs
+
+get_agent_cache = _runtime_get_agent_cache
+get_caps = _runtime_get_caps
+_get_user_id = _auth_get_user_id
 
 # ── Module-level constants (rule 34) ──────────────────────────────
 

--- a/omnigent/server/routes/sessions/routes_hooks.py
+++ b/omnigent/server/routes/sessions/routes_hooks.py
@@ -774,7 +774,9 @@ def register_hooks_routes(
                 # an ALLOW (or now-hard DENY) collapses the ASK and falls through
                 # without a second prompt. Held across the human wait by design;
                 # a declined ASK records nothing, so siblings legitimately re-ask.
-                async with _native_ask_gate_lock(session_id, result.deciding_policy):
+                deciding_policy = result.deciding_policy
+                assert deciding_policy is not None
+                async with _native_ask_gate_lock(session_id, deciding_policy):
                     engine = _build_engine()
                     result = await engine.evaluate(ctx, read_only=is_read_only)
                     if result.action == PolicyAction.ASK and phase in (
@@ -805,15 +807,15 @@ def register_hooks_routes(
                                 get_server_runner_router(),
                                 {"type": "interrupt"},
                             )
-                            verdict_body = {
+                            decline_body = {
                                 "result": "POLICY_ACTION_DENY",
                                 "reason": exc.args[0] or "Approval was declined.",
                             }
                             return Response(
-                                content=json.dumps(verdict_body),
+                                content=json.dumps(decline_body),
                                 media_type="application/json",
                             )
-                        verdict_body: dict[str, Any] = (
+                        approval_body: dict[str, Any] = (
                             {"result": "POLICY_ACTION_ALLOW"}
                             if approved
                             else {
@@ -822,7 +824,7 @@ def register_hooks_routes(
                             }
                         )
                         return Response(
-                            content=json.dumps(verdict_body),
+                            content=json.dumps(approval_body),
                             media_type="application/json",
                         )
                 # Re-evaluation collapsed the ASK (a sibling's approval recorded


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Make the session-route facade's patched auth/runtime accessors explicit exports while preserving their existing monkeypatch seam.
- Narrow ASK results to their required deciding-policy name before acquiring the per-policy lock.
- Give decline and approval response bodies distinct locals.
- Remove 6 mypy errors across policy hooks and a facade consumer, reducing the measured branch baseline from 817 to 811 errors.

ELI5: session policy hooks already know which facade functions tests may replace and that an ASK must name its policy; this PR records those contracts for mypy.

```text
facade accessors + ASK result -> explicit contracts -> existing hook responses
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest -q tests/server/routes/test_sessions_policy.py tests/server/integration/test_sessions_policy_evaluate.py tests/server/integration/test_sessions_policy_evaluate_read_only.py` (45 passed)
- `TMPDIR=/tmp .venv/bin/pre-commit run --all-files`
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (811 remaining baseline errors; none in the changed files)

## Demo

N/A — non-visual typing cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing policy-route tests cover facade monkeypatching, ACLs, all policy phases, ASK approval/decline, read-only behavior, and concurrent ASK serialization.
