### PR TITLE
refactor(sessions): narrow elicitation params

### DIFF
--- a/omnigent/server/routes/sessions/routes_elicitations.py
+++ b/omnigent/server/routes/sessions/routes_elicitations.py
@@ -188,7 +188,8 @@ def register_elicitations_routes(
             return {"status": "resolved"}
 
         _conv_id, event = found
-        params = event.get("params") if isinstance(event.get("params"), dict) else {}
+        params_value = event.get("params")
+        params = params_value if isinstance(params_value, dict) else {}
         return {
             "status": "pending",
             "can_approve": access.can_approve,


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Read an elicitation event's `params` value once, then reuse the existing dictionary shape check.
- Preserve pending/resolved response behavior while allowing mypy to narrow all four parameter lookups.
- Remove 4 mypy errors, reducing the measured branch baseline from 811 to 807 errors.

ELI5: checking one value and then using that same value lets the type checker remember the check.

```text
event params value -> dictionary check -> approval-page response
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest -q tests/server/integration/test_sessions_elicitation_api.py` (8 passed)
- `TMPDIR=/tmp .venv/bin/pre-commit run --all-files`
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (807 remaining baseline errors; none in the changed file)

## Demo

N/A — non-visual typing cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The dedicated elicitation API suite covers pending and resolved payloads, missing sessions/elicitations, resolve actions, and idempotency.
