### PR TITLE
[POC] Store Omnigent skills/knowledge packs in UC OSS (store-only)

### DIFF
--- a/examples/uc-oss-skillpack/.gitignore
+++ b/examples/uc-oss-skillpack/.gitignore
@@ -1,0 +1,2 @@
+# Volume storage created at runtime by the Docker server / bootstrap.
+data/

--- a/examples/uc-oss-skillpack/Makefile
+++ b/examples/uc-oss-skillpack/Makefile
@@ -1,0 +1,24 @@
+# Convenience targets for the UC OSS skillpack POC. Thin wrappers over run.sh
+# so `make up` / `make down` work as expected.
+#
+# POC / not for production.
+
+.PHONY: up down clean logs status demo
+
+up:            ## Start the UC OSS server + bootstrap catalog/schema/volume
+	./run.sh up
+
+down:          ## Stop and remove the server (keeps ./data)
+	./run.sh down
+
+clean:         ## down + wipe ./data (deletes all stored packs)
+	./run.sh clean
+
+logs:          ## Tail the server logs
+	./run.sh logs
+
+status:        ## Show whether the REST API is reachable
+	./run.sh status
+
+demo:          ## Run the end-to-end demo (assumes `make up` already ran)
+	./demo.sh

--- a/examples/uc-oss-skillpack/README.md
+++ b/examples/uc-oss-skillpack/README.md
@@ -1,0 +1,219 @@
+# UC OSS Skillpack POC (store-only)
+
+Store Omnigent **skills / knowledge packs** in a Dockerized
+[Unity Catalog OSS](https://github.com/unitycatalog/unitycatalog) server, then
+**list** and **pull** them back.
+
+**Scope A — STORE-ONLY.** No AI-gateway or policy wiring. This is a
+proof-of-concept for using UC OSS as a blob + metadata registry for skill
+packs. **POC / not for production.**
+
+---
+
+## What it does
+
+- Stands up the open-source Unity Catalog server locally in Docker (REST API on
+  `http://localhost:8080`).
+- Creates a catalog `unity`, schema `omnigent`, and an EXTERNAL volume
+  `unity.omnigent.skillpacks` backed by a local directory.
+- `skillpack push <skill_dir>` — tar.gz's a skill directory (reusing the
+  project's `SKILL.md` frontmatter parser for name/description), stores the
+  blob in the volume, and upserts a metadata row for the `unity.omnigent.skills`
+  table.
+- `skillpack list` — reads the metadata and prints name / version / updated /
+  description.
+- `skillpack pull <name> [dest]` — fetches the blob and extracts it.
+
+### How bytes are stored (important POC honesty note)
+
+The managed-Databricks backend (`omnigent/stores/artifact_store/databricks_volumes.py`)
+uploads file bytes through the `/files` REST API; the S3 backend
+(`omnigent/stores/artifact_store/s3.py`) uses `boto3`. **UC OSS has neither** —
+its REST surface is *metadata* (catalogs, schemas, volumes, tables) plus
+temporary storage-credential vending for cloud volumes. The bytes live at the
+volume's `storage_location`.
+
+So this POC store (`UnityCatalogOSSArtifactStore`):
+
+1. Calls the UC REST API to **resolve the volume's `storage_location`** (a
+   `file://` path for a local server — the local analogue of credential
+   vending).
+2. Reads/writes blob bytes **directly on that filesystem path**, which is made
+   host-visible via a Docker **bind mount** (`./data`).
+
+Likewise, UC OSS has **no row-level DML over REST**, so the skill metadata
+"rows" are kept as a JSON manifest blob inside the volume
+(`_manifest/skills.json`), and the CLI *registers* `unity.omnigent.skills` as an
+EXTERNAL table pointing at that manifest so the three-level name exists and is
+inspectable (`GET /tables/unity.omnigent.skills`). A deliberate store-only
+shortcut.
+
+### `list()` and the ArtifactStore ABC
+
+The live `ArtifactStore` ABC defines only `put/get/delete/exists`. This POC adds
+`list(prefix)` **only on the concrete `UnityCatalogOSSArtifactStore`** — the
+`skillpack` CLI needs to enumerate packs, and a local UC OSS volume is cheap to
+walk on the filesystem. Keeping `list` off the ABC is the least-invasive choice:
+the `local` / `s3` / `databricks_volumes` backends are untouched.
+
+---
+
+## Prerequisites
+
+- Docker (with `docker compose` v2, or `docker-compose` v1).
+- Python 3.12 with this repo installed (the CLI imports `omnigent`). Run the CLI
+  from the repo root, or with `PYTHONPATH` set to the repo root (the `demo.sh`
+  script does this for you).
+
+---
+
+## 1. Start the server
+
+```bash
+cd examples/uc-oss-skillpack
+make up            # or: ./run.sh up
+```
+
+`make up` will:
+1. `docker compose up -d` the pinned `unitycatalog/unitycatalog:v0.5.1` image
+   (REST API on `:8080`).
+2. Wait for the REST API to answer.
+3. Run `./bootstrap.sh` to create the catalog / schema / volume (idempotent).
+
+Check it:
+
+```bash
+make status
+curl -s localhost:8080/api/2.1/unity-catalog/volumes/unity.omnigent.skillpacks | python3 -m json.tool
+```
+
+### Fallback: build the image from source
+
+If `unitycatalog/unitycatalog:v0.5.1` can't be pulled, build it locally and
+retag (the compose file references that exact tag):
+
+```bash
+git clone --depth 1 --branch v0.5.1 https://github.com/unitycatalog/unitycatalog
+cd unitycatalog
+docker build -t unitycatalog/unitycatalog:v0.5.1 .
+```
+
+Then `make up` as above.
+
+---
+
+## 2. Point the CLI at the server
+
+The bootstrap prints these; export them in your shell:
+
+```bash
+export UC_OSS_URI=http://localhost:8080
+export UC_OSS_VOLUME=unity.omnigent.skillpacks
+# Host path of the bind-mounted volume storage (so the host-side CLI can
+# read/write the same bytes the container's file:// volume points at):
+export UC_OSS_VOLUME_LOCAL_PATH="$(pwd)/data/skillpacks"
+```
+
+| Env var | Meaning | Default |
+|---|---|---|
+| `UC_OSS_URI` | UC OSS server base URI | `http://localhost:8080` |
+| `UC_OSS_VOLUME` | three-level volume name | `unity.omnigent.skillpacks` |
+| `UC_OSS_TOKEN` | bearer token (local UC OSS needs none) | unset |
+| `UC_OSS_VOLUME_LOCAL_PATH` | host mount of the volume storage | resolve from REST `storage_location` |
+
+> **Why `UC_OSS_VOLUME_LOCAL_PATH`?** The volume's `storage_location`
+> (`file:///home/unitycatalog/etc/data/skillpacks`) is only valid *inside* the
+> container. On the host, those bytes live at `./data/skillpacks` via the bind
+> mount, so the CLI needs the host path. Omit it only if you run a
+> non-containerized UC server on this same host.
+
+---
+
+## 3. End-to-end walkthrough
+
+Push one of Denny's real skills, list it, and pull it back:
+
+```bash
+# from repo root (so `omnigent` imports), or set PYTHONPATH=$(pwd)
+PY=examples/uc-oss-skillpack/skillpack.py
+
+# pack only (no server needed) — shows parsed frontmatter + blob size
+python "$PY" pack ~/.claude/skills/startup-score-sheet
+
+# push a skill pack (blob + metadata)
+python "$PY" push ~/.claude/skills/startup-score-sheet
+
+# push a bundled repo skill too
+python "$PY" push examples/polly/skills/investigate
+
+# list what's stored
+python "$PY" list
+# NAME                         VER  UPDATED              DESCRIPTION
+# investigate                    1  2026-08-01 00:22:10  Delegate read-only investigation ...
+# startup-score-sheet            1  2026-08-01 00:22:03  Evaluate a startup using ...
+
+# pull one back into a temp dir
+python "$PY" pull startup-score-sheet /tmp/pulled-skill
+ls /tmp/pulled-skill/startup-score-sheet/SKILL.md
+```
+
+The CLI works against Denny's real skill libraries — his personal
+`~/.claude/skills/*` and this repo's bundled `examples/polly/skills/*` — so a
+`push <dir>` against either works out of the box.
+
+---
+
+## One-command demo
+
+With the server already up (`make up`):
+
+```bash
+./demo.sh          # or: make demo
+```
+
+`demo.sh` pushes a real skill (prefers `~/.claude/skills/startup-score-sheet`,
+falls back to the bundled `examples/polly/skills/investigate`), lists it, pulls
+it into a fresh temp dir, and diffs the pulled tree against the source to prove
+the round-trip.
+
+---
+
+## Teardown
+
+```bash
+make down          # stop + remove the container (keeps ./data)
+make clean         # also delete ./data (wipes stored packs)
+```
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `docker-compose.yml` | UC OSS server (pinned `v0.5.1`), `:8080`, `./data` bind mount |
+| `run.sh` | `up` / `down` / `clean` / `logs` / `status` |
+| `Makefile` | `make up/down/clean/logs/status/demo` wrappers |
+| `bootstrap.sh` | Create catalog / schema / volume over REST (idempotent) |
+| `skillpack.py` | The `pack` / `push` / `list` / `pull` CLI |
+| `demo.sh` | One-command end-to-end round-trip demo |
+
+The store backend lives at `omnigent/stores/artifact_store/unitycatalog_oss.py`
+(`UnityCatalogOSSArtifactStore`), alongside the local, S3, and Databricks
+backends.
+
+## What was assumed / stubbed (for reviewers)
+
+- **Image tag**: pinned to `unitycatalog/unitycatalog:v0.5.1` (a published tag
+  on Docker Hub at time of writing). Fallback build instructions above.
+- **Credential vending**: for a local `file://` volume there are no cloud
+  credentials to vend, so the store resolves the storage location and
+  reads/writes the bind-mounted filesystem directly.
+  `generate_temporary_volume_credentials` is implemented for parity but not on
+  the happy path. A cloud (`s3://`) volume is explicitly rejected unless
+  `local_root` is set.
+- **Metadata table**: registered as an EXTERNAL JSON table for inspectability;
+  the actual rows live in the `_manifest/skills.json` blob because UC OSS has no
+  row-level DML over REST.
+- The Docker path is exercised manually via this README / `demo.sh`; the unit
+  tests mock the REST API and do **not** require Docker.

--- a/examples/uc-oss-skillpack/README.md
+++ b/examples/uc-oss-skillpack/README.md
@@ -75,7 +75,7 @@ make up            # or: ./run.sh up
 ```
 
 `make up` will:
-1. `docker compose up -d` the pinned `unitycatalog/unitycatalog:v0.5.1` image
+1. `docker compose up -d` the pinned `unitycatalog/unitycatalog:v0.5.0` image
    (REST API on `:8080`).
 2. Wait for the REST API to answer.
 3. Run `./bootstrap.sh` to create the catalog / schema / volume (idempotent).
@@ -89,13 +89,13 @@ curl -s localhost:8080/api/2.1/unity-catalog/volumes/unity.omnigent.skillpacks |
 
 ### Fallback: build the image from source
 
-If `unitycatalog/unitycatalog:v0.5.1` can't be pulled, build it locally and
+If `unitycatalog/unitycatalog:v0.5.0` can't be pulled, build it locally and
 retag (the compose file references that exact tag):
 
 ```bash
-git clone --depth 1 --branch v0.5.1 https://github.com/unitycatalog/unitycatalog
+git clone --depth 1 --branch v0.5.0 https://github.com/unitycatalog/unitycatalog
 cd unitycatalog
-docker build -t unitycatalog/unitycatalog:v0.5.1 .
+docker build -t unitycatalog/unitycatalog:v0.5.0 .
 ```
 
 Then `make up` as above.
@@ -191,7 +191,7 @@ make clean         # also delete ./data (wipes stored packs)
 
 | File | Purpose |
 |---|---|
-| `docker-compose.yml` | UC OSS server (pinned `v0.5.1`), `:8080`, `./data` bind mount |
+| `docker-compose.yml` | UC OSS server (pinned `v0.5.0`), `:8080`, `./data` bind mount |
 | `run.sh` | `up` / `down` / `clean` / `logs` / `status` |
 | `Makefile` | `make up/down/clean/logs/status/demo` wrappers |
 | `bootstrap.sh` | Create catalog / schema / volume over REST (idempotent) |
@@ -204,7 +204,7 @@ backends.
 
 ## What was assumed / stubbed (for reviewers)
 
-- **Image tag**: pinned to `unitycatalog/unitycatalog:v0.5.1` (a published tag
+- **Image tag**: pinned to `unitycatalog/unitycatalog:v0.5.0` (a published tag
   on Docker Hub at time of writing). Fallback build instructions above.
 - **Credential vending**: for a local `file://` volume there are no cloud
   credentials to vend, so the store resolves the storage location and

--- a/examples/uc-oss-skillpack/bootstrap.sh
+++ b/examples/uc-oss-skillpack/bootstrap.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # Create the catalog / schema / volume the skillpack POC needs.
 #
-# Idempotent: re-running is safe (existing objects return HTTP 409, which this
-# script treats as success). Talks to the UC OSS REST API directly with curl
-# so it has no Python dependency.
+# Idempotent: re-running is safe, and it succeeds whether the server is bare or
+# already has unity/omnigent/skillpacks. The v0.5.0 image ships with the `unity`
+# catalog pre-created, so "already exists" must be a success — UC signals it as
+# either HTTP 409 or HTTP 400 with an *_ALREADY_EXISTS error_code body. Talks to
+# the UC OSS REST API directly with curl so it has no Python dependency.
 #
 # POC / not for production.
 set -euo pipefail
@@ -19,19 +21,24 @@ VOLUME="${SKILLPACK_VOLUME:-skillpacks}"
 # bytes under ./data/${VOLUME}.
 VOLUME_STORAGE="file:///home/unitycatalog/etc/data/${VOLUME}"
 
-# POST helper: succeeds on 2xx AND on 409 (already exists).
+# POST helper: succeeds on 2xx AND on an already-exists signal — either HTTP 409
+# or HTTP 400 with an *_ALREADY_EXISTS error_code body (what UC OSS v0.5.0
+# returns for a pre-existing catalog/schema/volume).
 post() {
-  local path="$1" body="$2" code
+  local path="$1" body="$2" code out
   code="$(curl -sS -o /tmp/skillpack_boot.out -w '%{http_code}' \
     -X POST "${API}${path}" \
     -H 'Content-Type: application/json' \
     -d "${body}")"
+  out="$(cat /tmp/skillpack_boot.out)"
   if [[ "${code}" == 2* ]]; then
     echo "  ok (${code})"
   elif [[ "${code}" == "409" ]]; then
     echo "  already exists (409)"
+  elif [[ "${code}" == "400" && "${out}" == *ALREADY_EXISTS* ]]; then
+    echo "  already exists (400 ALREADY_EXISTS)"
   else
-    echo "  FAILED (${code}): $(cat /tmp/skillpack_boot.out)" >&2
+    echo "  FAILED (${code}): ${out}" >&2
     return 1
   fi
 }

--- a/examples/uc-oss-skillpack/bootstrap.sh
+++ b/examples/uc-oss-skillpack/bootstrap.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Create the catalog / schema / volume the skillpack POC needs.
+#
+# Idempotent: re-running is safe (existing objects return HTTP 409, which this
+# script treats as success). Talks to the UC OSS REST API directly with curl
+# so it has no Python dependency.
+#
+# POC / not for production.
+set -euo pipefail
+
+UC_OSS_URI="${UC_OSS_URI:-http://localhost:8080}"
+API="${UC_OSS_URI}/api/2.1/unity-catalog"
+
+CATALOG="${SKILLPACK_CATALOG:-unity}"
+SCHEMA="${SKILLPACK_SCHEMA:-omnigent}"
+VOLUME="${SKILLPACK_VOLUME:-skillpacks}"
+# Storage location INSIDE the container. ./data on the host is bind-mounted to
+# /home/unitycatalog/etc/data (see docker-compose.yml), so the host sees these
+# bytes under ./data/${VOLUME}.
+VOLUME_STORAGE="file:///home/unitycatalog/etc/data/${VOLUME}"
+
+# POST helper: succeeds on 2xx AND on 409 (already exists).
+post() {
+  local path="$1" body="$2" code
+  code="$(curl -sS -o /tmp/skillpack_boot.out -w '%{http_code}' \
+    -X POST "${API}${path}" \
+    -H 'Content-Type: application/json' \
+    -d "${body}")"
+  if [[ "${code}" == 2* ]]; then
+    echo "  ok (${code})"
+  elif [[ "${code}" == "409" ]]; then
+    echo "  already exists (409)"
+  else
+    echo "  FAILED (${code}): $(cat /tmp/skillpack_boot.out)" >&2
+    return 1
+  fi
+}
+
+echo "UC OSS server: ${UC_OSS_URI}"
+
+echo "catalog: ${CATALOG}"
+post "/catalogs" "{\"name\":\"${CATALOG}\",\"comment\":\"Omnigent skillpack POC\"}"
+
+echo "schema: ${CATALOG}.${SCHEMA}"
+post "/schemas" "{\"name\":\"${SCHEMA}\",\"catalog_name\":\"${CATALOG}\",\"comment\":\"Omnigent skillpack POC\"}"
+
+echo "volume: ${CATALOG}.${SCHEMA}.${VOLUME} -> ${VOLUME_STORAGE}"
+post "/volumes" "{\"catalog_name\":\"${CATALOG}\",\"schema_name\":\"${SCHEMA}\",\"name\":\"${VOLUME}\",\"volume_type\":\"EXTERNAL\",\"storage_location\":\"${VOLUME_STORAGE}\",\"comment\":\"Skill/knowledge pack blobs (POC)\"}"
+
+echo
+echo "Bootstrap complete."
+echo "  volume       : ${CATALOG}.${SCHEMA}.${VOLUME}"
+echo "  host storage : ./data/${VOLUME}"
+echo
+echo "Point the CLI at it with:"
+echo "  export UC_OSS_URI=${UC_OSS_URI}"
+echo "  export UC_OSS_VOLUME=${CATALOG}.${SCHEMA}.${VOLUME}"
+echo "  export UC_OSS_VOLUME_LOCAL_PATH=\$(pwd)/data/${VOLUME}"

--- a/examples/uc-oss-skillpack/demo.sh
+++ b/examples/uc-oss-skillpack/demo.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# End-to-end demo: push one of Denny's real skills into UC OSS, list it, and
+# pull it back into a temp dir to prove the round-trip.
+#
+# Assumes the Docker UC OSS server is already up (run `./run.sh up` or
+# `make up` first). Run from this directory.
+#
+# POC / not for production.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+
+# ── config (override via env) ────────────────────────────────
+export UC_OSS_URI="${UC_OSS_URI:-http://localhost:8080}"
+export UC_OSS_VOLUME="${UC_OSS_VOLUME:-unity.omnigent.skillpacks}"
+export UC_OSS_VOLUME_LOCAL_PATH="${UC_OSS_VOLUME_LOCAL_PATH:-$(pwd)/data/skillpacks}"
+
+# Pick a real skill to demo. Prefer one of Denny's ~/.claude/skills; fall back
+# to the bundled polly investigate skill so the demo works anywhere.
+SKILL_DIR="${SKILL_DIR:-}"
+SKILL_NAME="${SKILL_NAME:-}"
+if [[ -z "${SKILL_DIR}" ]]; then
+  if [[ -d "${HOME}/.claude/skills/startup-score-sheet" ]]; then
+    SKILL_DIR="${HOME}/.claude/skills/startup-score-sheet"
+    SKILL_NAME="startup-score-sheet"
+  else
+    SKILL_DIR="${REPO_ROOT}/examples/polly/skills/investigate"
+    SKILL_NAME="investigate"
+  fi
+fi
+
+PY="${PYTHON:-python3}"
+CLI=("${PY}" "${REPO_ROOT}/examples/uc-oss-skillpack/skillpack.py")
+export PYTHONPATH="${REPO_ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
+
+echo "== 1. push: ${SKILL_DIR}"
+"${CLI[@]}" push "${SKILL_DIR}"
+echo
+
+echo "== 2. list"
+"${CLI[@]}" list
+echo
+
+DEST="$(mktemp -d)/pulled"
+echo "== 3. pull ${SKILL_NAME} -> ${DEST}"
+"${CLI[@]}" pull "${SKILL_NAME}" "${DEST}"
+echo
+
+echo "== 4. round-trip check"
+echo "extracted tree:"
+find "${DEST}" -type f | sed "s#${DEST}#  .#"
+if diff -r "${SKILL_DIR}" "${DEST}/${SKILL_NAME}" >/dev/null 2>&1; then
+  echo "OK: pulled contents match the source skill directory byte-for-byte."
+else
+  echo "NOTE: pulled tree differs from source (expected if source has"
+  echo "      non-file entries); SKILL.md is present:"
+  ls -1 "${DEST}/${SKILL_NAME}/SKILL.md"
+fi

--- a/examples/uc-oss-skillpack/docker-compose.yml
+++ b/examples/uc-oss-skillpack/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   uc:
     # Pinned to a specific published tag for reproducibility. If this image
     # cannot be pulled, build from source instead (see README "Fallback").
-    image: unitycatalog/unitycatalog:v0.5.1
+    image: unitycatalog/unitycatalog:v0.5.0
     container_name: uc-oss-skillpack
     ports:
       - "8080:8080"

--- a/examples/uc-oss-skillpack/docker-compose.yml
+++ b/examples/uc-oss-skillpack/docker-compose.yml
@@ -1,0 +1,40 @@
+# Dockerized Unity Catalog OSS server for the skillpack POC.
+#
+# Stands up the open-source Unity Catalog server (the Apache-licensed
+# unitycatalog/unitycatalog project) and exposes its REST API on
+# localhost:8080. Blob + manifest bytes live under ./data on the host,
+# bind-mounted into the container so the skillpack CLI (running on the host)
+# can read/write the same files the EXTERNAL volume points at.
+#
+# POC / not for production.
+name: uc-oss-skillpack
+
+services:
+  uc:
+    # Pinned to a specific published tag for reproducibility. If this image
+    # cannot be pulled, build from source instead (see README "Fallback").
+    image: unitycatalog/unitycatalog:v0.5.1
+    container_name: uc-oss-skillpack
+    ports:
+      - "8080:8080"
+    volumes:
+      # Host ./data  ↔  container /home/unitycatalog/etc/data
+      # (etc/ is the writable tree in the UC image). The EXTERNAL volume +
+      # metadata table are created with storage_location
+      # file:///home/unitycatalog/etc/data/... (see bootstrap.sh), so the host
+      # sees the same bytes under ./data.
+      - type: bind
+        source: ./data
+        target: /home/unitycatalog/etc/data
+    healthcheck:
+      # The runtime image is bare alpine (no curl); busybox wget is present.
+      # The list-catalogs endpoint returns 200 once the server is ready.
+      test:
+        - CMD-SHELL
+        - >-
+          wget -q -O /dev/null
+          http://localhost:8080/api/2.1/unity-catalog/catalogs
+          || exit 1
+      interval: 3s
+      timeout: 5s
+      retries: 20

--- a/examples/uc-oss-skillpack/run.sh
+++ b/examples/uc-oss-skillpack/run.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Convenience wrapper for the Dockerized UC OSS skillpack POC.
+#
+#   ./run.sh up      start the UC OSS server and bootstrap catalog/schema/volume
+#   ./run.sh down    stop and remove the server (keeps ./data)
+#   ./run.sh clean   down + delete ./data (wipes all stored packs)
+#   ./run.sh logs    tail the server logs
+#   ./run.sh status  show whether the REST API is up
+#
+# POC / not for production.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+UC_OSS_URI="${UC_OSS_URI:-http://localhost:8080}"
+
+# Prefer `docker compose` (v2); fall back to `docker-compose` (v1).
+if docker compose version >/dev/null 2>&1; then
+  DC=(docker compose)
+else
+  DC=(docker-compose)
+fi
+
+wait_for_server() {
+  echo "waiting for UC OSS REST API at ${UC_OSS_URI} ..."
+  for _ in $(seq 1 40); do
+    if curl -fsS "${UC_OSS_URI}/api/2.1/unity-catalog/catalogs" >/dev/null 2>&1; then
+      echo "server is up."
+      return 0
+    fi
+    sleep 2
+  done
+  echo "server did not become ready in time" >&2
+  return 1
+}
+
+case "${1:-}" in
+  up)
+    mkdir -p data
+    "${DC[@]}" up -d
+    wait_for_server
+    ./bootstrap.sh
+    ;;
+  down)
+    "${DC[@]}" down
+    ;;
+  clean)
+    "${DC[@]}" down
+    rm -rf data
+    echo "removed ./data"
+    ;;
+  logs)
+    "${DC[@]}" logs -f
+    ;;
+  status)
+    if curl -fsS "${UC_OSS_URI}/api/2.1/unity-catalog/catalogs" >/dev/null 2>&1; then
+      echo "UC OSS REST API is up at ${UC_OSS_URI}"
+    else
+      echo "UC OSS REST API is NOT reachable at ${UC_OSS_URI}"
+      exit 1
+    fi
+    ;;
+  *)
+    echo "usage: $0 {up|down|clean|logs|status}" >&2
+    exit 2
+    ;;
+esac

--- a/examples/uc-oss-skillpack/skillpack.py
+++ b/examples/uc-oss-skillpack/skillpack.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+"""``skillpack`` — store Omnigent skill/knowledge packs in a UC OSS volume.
+
+A small standalone CLI for the Unity Catalog OSS store-only POC. It is
+intentionally NOT wired into the main ``omni`` CLI — run it directly::
+
+    python examples/uc-oss-skillpack/skillpack.py push ~/.claude/skills/foo
+    python examples/uc-oss-skillpack/skillpack.py list
+
+Subcommands
+-----------
+- ``pack <skill_dir>``  — tar.gz a skill directory and print the name /
+  description parsed from its ``SKILL.md`` frontmatter (no server needed).
+- ``push <skill_dir>``  — pack, store the blob in the UC OSS volume, and
+  upsert a metadata row (name, description, version, blob key, updated_at)
+  into the metadata manifest for the ``unity.omnigent.skills`` table.
+- ``list``              — read the metadata manifest and print each pack's
+  name / description / updated time.
+- ``pull <name> [dest]``— fetch a pack's blob and extract it to *dest*.
+
+Metadata storage — a POC honesty note
+--------------------------------------
+Managed Databricks can INSERT rows into a UC table over its SQL API.
+**UC OSS has no row-level DML over REST** — its REST surface is metadata-only
+(create/list/get catalogs, schemas, volumes, tables). So this CLI keeps the
+skill metadata "rows" as a JSON manifest blob inside the same volume (key
+``_manifest/skills.json``) and *registers* the UC table
+``unity.omnigent.skills`` as an EXTERNAL table pointing at that manifest
+location, so the three-level name exists and is inspectable via the REST API
+(``GET /tables/unity.omnigent.skills``). ``list`` reads the manifest. This is
+a deliberate store-only shortcut, not a production metastore design.
+
+POC / not for production.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import sys
+import tarfile
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from omnigent.spec.parser import _parse_skill
+from omnigent.spec.types import SkillSpec
+from omnigent.stores.artifact_store.unitycatalog_oss import (
+    UnityCatalogOSSArtifactStore,
+    UnityCatalogRestClient,
+    _parse_volume_full_name,
+)
+
+# Key of the JSON manifest that holds the skill metadata "rows" inside the
+# volume. See the module docstring for why rows live in a blob.
+_MANIFEST_KEY = "_manifest/skills.json"
+# Default three-level names for the POC. Overridable via UC_OSS_VOLUME /
+# --volume and --table.
+_DEFAULT_VOLUME = "unity.omnigent.skillpacks"
+_DEFAULT_TABLE = "unity.omnigent.skills"
+
+
+@dataclass
+class SkillPackRecord:
+    """
+    One metadata row for a stored skill/knowledge pack.
+
+    :param name: The skill's ``name`` from its ``SKILL.md`` frontmatter, e.g.
+        ``"code-review"``.
+    :param description: The skill's ``description`` from frontmatter.
+    :param blob_key: The artifact-store key of the pack's tar.gz, e.g.
+        ``"skills/code-review/code-review.tar.gz"``.
+    :param version: Monotonic push counter for this name (1 on first push,
+        incremented on each re-push), e.g. ``2``.
+    :param updated_at: Epoch-millisecond timestamp of the last push.
+    :param source: Absolute path of the skill directory that was packed, e.g.
+        ``"/Users/denny.lee/.claude/skills/code-review"``. Recorded for
+        provenance so a reviewer can see where the pack came from.
+    """
+
+    name: str
+    description: str
+    blob_key: str
+    version: int
+    updated_at: int
+    source: str
+
+
+@dataclass
+class PackedSkill:
+    """
+    The result of packing a skill directory.
+
+    :param spec: The parsed :class:`SkillSpec` (name, description, etc.) read
+        from the directory's ``SKILL.md``.
+    :param blob: The gzip-compressed tar bytes of the skill directory.
+    """
+
+    spec: SkillSpec
+    blob: bytes
+
+
+def _blob_key(name: str) -> str:
+    """
+    Compute the artifact-store key for a pack's tar.gz blob.
+
+    :param name: The skill name, e.g. ``"code-review"``.
+    :returns: The forward-slash key, e.g.
+        ``"skills/code-review/code-review.tar.gz"``.
+    """
+    return f"skills/{name}/{name}.tar.gz"
+
+
+def pack_skill(skill_dir: Path) -> PackedSkill:
+    """
+    Read a skill's frontmatter and produce a deterministic tar.gz.
+
+    Reuses the project's ``SKILL.md`` frontmatter parser
+    (:func:`omnigent.spec.parser._parse_skill`) rather than duplicating the
+    YAML-frontmatter logic. The archive is reproducible: entries are sorted
+    and their mtimes zeroed, so packing the same directory twice yields
+    identical bytes.
+
+    :param skill_dir: Path to the skill directory containing a ``SKILL.md``,
+        e.g. ``Path("~/.claude/skills/code-review")``.
+    :returns: A :class:`PackedSkill` with the parsed spec and the
+        gzip-compressed tar bytes of the directory.
+    :raises FileNotFoundError: If *skill_dir* is not a directory or has no
+        ``SKILL.md``.
+    """
+    skill_dir = skill_dir.expanduser()
+    if not skill_dir.is_dir():
+        raise FileNotFoundError(f"not a directory: {skill_dir}")
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file():
+        raise FileNotFoundError(f"no SKILL.md in {skill_dir}")
+
+    spec = _parse_skill(skill_md)
+
+    buf = io.BytesIO()
+    # mtime=0 + sorted entries → reproducible archive bytes.
+    with tarfile.open(fileobj=buf, mode="w:gz", format=tarfile.PAX_FORMAT) as tar:
+        for path in sorted(skill_dir.rglob("*")):
+            if not path.is_file():
+                continue
+            arcname = f"{spec.name}/{path.relative_to(skill_dir).as_posix()}"
+            info = tar.gettarinfo(str(path), arcname=arcname)
+            info.mtime = 0
+            info.uid = info.gid = 0
+            info.uname = info.gname = ""
+            with path.open("rb") as fh:
+                tar.addfile(info, fh)
+    return PackedSkill(spec=spec, blob=buf.getvalue())
+
+
+def _load_manifest(store: UnityCatalogOSSArtifactStore) -> dict[str, SkillPackRecord]:
+    """
+    Load the skill metadata manifest from the volume.
+
+    :param store: The UC OSS artifact store backing the volume.
+    :returns: Mapping of skill name → :class:`SkillPackRecord`. Empty when no
+        manifest has been written yet.
+    """
+    try:
+        raw = store.get(_MANIFEST_KEY)
+    except KeyError:
+        return {}
+    rows = json.loads(raw.decode("utf-8"))
+    return {r["name"]: SkillPackRecord(**r) for r in rows}
+
+
+def _save_manifest(
+    store: UnityCatalogOSSArtifactStore, manifest: dict[str, SkillPackRecord]
+) -> None:
+    """
+    Persist the skill metadata manifest to the volume.
+
+    :param store: The UC OSS artifact store backing the volume.
+    :param manifest: Mapping of skill name → :class:`SkillPackRecord`.
+    """
+    rows = [asdict(manifest[name]) for name in sorted(manifest)]
+    store.put(_MANIFEST_KEY, json.dumps(rows, indent=2).encode("utf-8"))
+
+
+def _ensure_table_registered(
+    client: UnityCatalogRestClient,
+    table: str,
+    storage_location: str,
+) -> None:
+    """
+    Register the metadata table in UC if it is not already present.
+
+    Creates ``unity.omnigent.skills`` as an EXTERNAL table pointing at the
+    manifest's storage location so the three-level name exists and is
+    inspectable over REST. Row data itself lives in the manifest blob (see the
+    module docstring) — this is registration only.
+
+    :param client: The UC REST client.
+    :param table: Three-level table name, e.g. ``"unity.omnigent.skills"``.
+    :param storage_location: The manifest's backing ``file://`` location.
+    """
+    import httpx
+
+    catalog, schema, name = _parse_volume_full_name(table)
+    columns = [
+        {
+            "name": "name",
+            "type_text": "string",
+            "type_name": "STRING",
+            "position": 0,
+            "nullable": False,
+        },
+        {
+            "name": "description",
+            "type_text": "string",
+            "type_name": "STRING",
+            "position": 1,
+            "nullable": True,
+        },
+        {
+            "name": "blob_key",
+            "type_text": "string",
+            "type_name": "STRING",
+            "position": 2,
+            "nullable": False,
+        },
+        {
+            "name": "version",
+            "type_text": "int",
+            "type_name": "INT",
+            "position": 3,
+            "nullable": False,
+        },
+        {
+            "name": "updated_at",
+            "type_text": "long",
+            "type_name": "LONG",
+            "position": 4,
+            "nullable": False,
+        },
+    ]
+    body: dict[str, Any] = {
+        "name": name,
+        "catalog_name": catalog,
+        "schema_name": schema,
+        "table_type": "EXTERNAL",
+        "data_source_format": "JSON",
+        "columns": columns,
+        "storage_location": storage_location,
+        "comment": "Omnigent skill/knowledge pack registry (POC, store-only).",
+    }
+    resp = client._client.post("/tables", json=body)
+    if resp.status_code == httpx.codes.CONFLICT:
+        return
+    resp.raise_for_status()
+
+
+def _make_store(args: argparse.Namespace) -> UnityCatalogOSSArtifactStore:
+    """
+    Build a UC OSS artifact store from parsed CLI args / env vars.
+
+    :param args: Parsed argparse namespace carrying ``volume``, ``uri``,
+        ``token``, and ``local_root`` (each may be ``None`` to fall back to the
+        corresponding ``UC_OSS_*`` env var).
+    :returns: A configured :class:`UnityCatalogOSSArtifactStore`.
+    """
+    # Precedence: --volume flag → UC_OSS_VOLUME env → literal default.
+    volume = args.volume or os.environ.get("UC_OSS_VOLUME") or _DEFAULT_VOLUME
+    # Keep the namespace in sync so command handlers print the real volume.
+    args.volume = volume
+    return UnityCatalogOSSArtifactStore(
+        storage_location=volume,
+        uri=args.uri,
+        token=args.token,
+        local_root=args.local_root,
+    )
+
+
+def cmd_pack(args: argparse.Namespace) -> int:
+    """
+    Handle ``skillpack pack`` — tar.gz a skill dir and show metadata.
+
+    :param args: Parsed args carrying ``skill_dir``.
+    :returns: Process exit code (0 on success).
+    """
+    packed = pack_skill(Path(args.skill_dir))
+    print(f"name:        {packed.spec.name}")
+    print(f"description: {packed.spec.description}")
+    print(f"blob_key:    {_blob_key(packed.spec.name)}")
+    print(f"size:        {len(packed.blob)} bytes (tar.gz)")
+    if args.out:
+        Path(args.out).write_bytes(packed.blob)
+        print(f"written:     {args.out}")
+    return 0
+
+
+def cmd_push(args: argparse.Namespace) -> int:
+    """
+    Handle ``skillpack push`` — store a pack blob + upsert metadata.
+
+    :param args: Parsed args carrying ``skill_dir`` (+ store config).
+    :returns: Process exit code (0 on success).
+    """
+    packed = pack_skill(Path(args.skill_dir))
+    spec = packed.spec
+    store = _make_store(args)
+    key = _blob_key(spec.name)
+    store.put(key, packed.blob)
+
+    manifest = _load_manifest(store)
+    prev = manifest.get(spec.name)
+    record = SkillPackRecord(
+        name=spec.name,
+        description=spec.description,
+        blob_key=key,
+        version=(prev.version + 1) if prev else 1,
+        updated_at=int(time.time() * 1000),
+        source=str(Path(args.skill_dir).expanduser().resolve()),
+    )
+    manifest[spec.name] = record
+    _save_manifest(store, manifest)
+
+    # Register the UC metadata table (idempotent). The manifest's backing
+    # file:// location is the store's resolved storage dir + manifest key.
+    manifest_location = (store._resolve_storage_dir() / _MANIFEST_KEY).as_uri()
+    _ensure_table_registered(store._client, args.table, manifest_location)
+
+    verb = "updated" if prev else "stored"
+    print(f"{verb} {spec.name} v{record.version} → {args.volume} ({len(packed.blob)} bytes)")
+    print(f"  blob_key: {key}")
+    print(f"  table:    {args.table}")
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    """
+    Handle ``skillpack list`` — print the metadata manifest.
+
+    :param args: Parsed args (store config).
+    :returns: Process exit code (0 on success).
+    """
+    store = _make_store(args)
+    manifest = _load_manifest(store)
+    if not manifest:
+        print(f"(no skill packs in {args.volume})")
+        return 0
+    print(f"{'NAME':<28} {'VER':>3}  {'UPDATED':<20} DESCRIPTION")
+    for name in sorted(manifest):
+        r = manifest[name]
+        updated = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(r.updated_at / 1000))
+        desc = r.description if len(r.description) <= 60 else r.description[:57] + "..."
+        print(f"{r.name:<28} {r.version:>3}  {updated:<20} {desc}")
+    return 0
+
+
+def cmd_pull(args: argparse.Namespace) -> int:
+    """
+    Handle ``skillpack pull`` — fetch a pack blob and extract it.
+
+    :param args: Parsed args carrying ``name`` and optional ``dest``.
+    :returns: Process exit code (0 on success, 1 if the pack is absent).
+    """
+    store = _make_store(args)
+    manifest = _load_manifest(store)
+    record = manifest.get(args.name)
+    if record is None:
+        print(f"error: no skill pack named {args.name!r} in {args.volume}", file=sys.stderr)
+        return 1
+    blob = store.get(record.blob_key)
+    dest = Path(args.dest or f"./{args.name}").expanduser()
+    dest.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tar:
+        _safe_extract(tar, dest)
+    print(f"pulled {args.name} v{record.version} → {dest}")
+    return 0
+
+
+def _safe_extract(tar: tarfile.TarFile, dest: Path) -> None:
+    """
+    Extract *tar* into *dest*, rejecting entries that escape *dest*.
+
+    Guards against path-traversal in archive member names (``..`` or absolute
+    paths) so a malicious pack cannot write outside the extraction directory.
+
+    :param tar: An open :class:`tarfile.TarFile` in read mode.
+    :param dest: The destination directory (already created).
+    :raises ValueError: If any member would extract outside *dest*.
+    """
+    dest_resolved = dest.resolve()
+    for member in tar.getmembers():
+        target = (dest / member.name).resolve()
+        if not target.is_relative_to(dest_resolved):
+            raise ValueError(f"unsafe path in archive: {member.name!r}")
+    # filter="data" applies the stdlib safe-extraction filter (strips setuid
+    # bits, rejects absolute/traversal paths) on top of the containment check.
+    tar.extractall(dest, filter="data")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """
+    Build the ``skillpack`` argument parser.
+
+    :returns: The configured :class:`argparse.ArgumentParser`.
+    """
+    parser = argparse.ArgumentParser(
+        prog="skillpack",
+        description="Store Omnigent skill/knowledge packs in a UC OSS volume (POC).",
+    )
+
+    def add_store_args(sp: argparse.ArgumentParser) -> None:
+        """Attach shared store-config flags to a subparser."""
+        sp.add_argument(
+            "--volume",
+            default=None,
+            help=f"three-level volume name (env UC_OSS_VOLUME; default {_DEFAULT_VOLUME})",
+        )
+        sp.add_argument(
+            "--table",
+            default=_DEFAULT_TABLE,
+            help=f"three-level metadata table name (default {_DEFAULT_TABLE})",
+        )
+        sp.add_argument(
+            "--uri",
+            default=None,
+            help="UC OSS server URI (env UC_OSS_URI; default http://localhost:8080)",
+        )
+        sp.add_argument(
+            "--token",
+            default=None,
+            help="bearer token (env UC_OSS_TOKEN; local UC OSS needs none)",
+        )
+        sp.add_argument(
+            "--local-root",
+            dest="local_root",
+            default=None,
+            help="host path to the volume storage (env UC_OSS_VOLUME_LOCAL_PATH)",
+        )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_pack = sub.add_parser("pack", help="tar.gz a skill dir and show its metadata")
+    p_pack.add_argument("skill_dir", help="path to a skill directory containing SKILL.md")
+    p_pack.add_argument("--out", default=None, help="also write the tar.gz to this path")
+    p_pack.set_defaults(func=cmd_pack)
+
+    p_push = sub.add_parser("push", help="pack + store a skill pack and upsert its metadata")
+    p_push.add_argument("skill_dir", help="path to a skill directory containing SKILL.md")
+    add_store_args(p_push)
+    p_push.set_defaults(func=cmd_push)
+
+    p_list = sub.add_parser("list", help="list stored skill packs")
+    add_store_args(p_list)
+    p_list.set_defaults(func=cmd_list)
+
+    p_pull = sub.add_parser("pull", help="fetch a skill pack and extract it")
+    p_pull.add_argument("name", help="skill name to pull")
+    p_pull.add_argument(
+        "dest", nargs="?", default=None, help="destination directory (default ./<name>)"
+    )
+    add_store_args(p_pull)
+    p_pull.set_defaults(func=cmd_pull)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """
+    CLI entry point.
+
+    :param argv: Argument vector (defaults to ``sys.argv[1:]``).
+    :returns: Process exit code.
+    """
+    args = build_parser().parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/uc-oss-skillpack/skillpack.py
+++ b/examples/uc-oss-skillpack/skillpack.py
@@ -241,12 +241,21 @@ def _ensure_table_registered(
     storage_location: str,
 ) -> None:
     """
-    Register the metadata table in UC if it is not already present.
+    Best-effort register the metadata table in UC.
 
     Creates ``unity.omnigent.skills`` as an EXTERNAL table pointing at the
     manifest's storage location so the three-level name exists and is
     inspectable over REST. Row data itself lives in the manifest blob (see the
     module docstring) — this is registration only.
+
+    Registration is **best-effort**: the blob + manifest are the source of
+    truth and were already written before this runs. A real UC OSS server
+    rejects an EXTERNAL table whose ``storage_location`` isn't under a
+    registered external location (HTTP 400), so on any non-2xx (other than a
+    409, treated as idempotent success) this logs a concise note to stderr and
+    returns rather than raising — a failed table registration must not abort an
+    otherwise-successful push. The round-trip (push → list → pull) reads the
+    manifest, not this table, so it is unaffected.
 
     :param client: The UC REST client.
     :param table: Three-level table name, e.g. ``"unity.omnigent.skills"``.
@@ -303,9 +312,17 @@ def _ensure_table_registered(
         "comment": "Omnigent skill/knowledge pack registry (POC, store-only).",
     }
     resp = client._client.post("/tables", json=body)
-    if resp.status_code == httpx.codes.CONFLICT:
+    if resp.is_success or resp.status_code == httpx.codes.CONFLICT:
         return
-    resp.raise_for_status()
+    # Non-2xx (e.g. 400 when storage_location isn't under a registered external
+    # location): keep the push successful — table registration is inspectability
+    # only. Surface a one-line note without the full body.
+    reason = resp.reason_phrase or "error"
+    print(
+        f"note: skill metadata table registration skipped: {resp.status_code} "
+        f"{reason}; blob+manifest stored, round-trip unaffected",
+        file=sys.stderr,
+    )
 
 
 def _make_store(args: argparse.Namespace) -> UnityCatalogOSSArtifactStore:

--- a/examples/uc-oss-skillpack/skillpack.py
+++ b/examples/uc-oss-skillpack/skillpack.py
@@ -36,6 +36,7 @@ POC / not for production.
 from __future__ import annotations
 
 import argparse
+import gzip
 import io
 import json
 import os
@@ -43,8 +44,7 @@ import sys
 import tarfile
 import time
 from dataclasses import asdict, dataclass
-from pathlib import Path
-from typing import Any
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 from omnigent.spec.parser import _parse_skill
 from omnigent.spec.types import SkillSpec
@@ -103,26 +103,68 @@ class PackedSkill:
     blob: bytes
 
 
+def _validate_skill_name(name: str) -> str:
+    """
+    Validate a skill's ``name`` before it becomes path material.
+
+    A skill's ``name`` (from its ``SKILL.md`` frontmatter) is used both as a
+    store-key path component (:func:`_blob_key`) and as the tar member prefix
+    (the arcname in :func:`pack_skill`). A malformed/malicious name like
+    ``/escape``, ``../escape``, ``a/b``, ``C:\\evil``, or ``\\\\unc\\share``
+    could otherwise emit an absolute/traversing tar member or a corrupt store
+    key (e.g. ``skills//escape//escape.tar.gz``) that stores but won't pull.
+    Require a single safe path component: reject empties, ``.``/``..``, forward
+    and back slashes, and Windows drive/UNC forms.
+
+    :param name: The ``name`` field parsed from ``SKILL.md``.
+    :returns: *name* unchanged when valid (for convenient inline use).
+    :raises ValueError: If *name* is not a single safe path component.
+    """
+    if (
+        not name
+        or name in (".", "..")
+        or "/" in name
+        or "\\" in name
+        or PurePosixPath(name).is_absolute()
+        or PureWindowsPath(name).is_absolute()
+        or PureWindowsPath(name).drive
+    ):
+        raise ValueError(
+            f"invalid skill name {name!r}: must be a single path component "
+            "(no '/', '\\\\', '..', absolute paths, or Windows drive/UNC forms)"
+        )
+    return name
+
+
 def _blob_key(name: str) -> str:
     """
     Compute the artifact-store key for a pack's tar.gz blob.
 
-    :param name: The skill name, e.g. ``"code-review"``.
+    :param name: The skill name, e.g. ``"code-review"``. Validated as a single
+        safe path component via :func:`_validate_skill_name`.
     :returns: The forward-slash key, e.g.
         ``"skills/code-review/code-review.tar.gz"``.
+    :raises ValueError: If *name* is not a single safe path component.
     """
+    _validate_skill_name(name)
     return f"skills/{name}/{name}.tar.gz"
 
 
 def pack_skill(skill_dir: Path) -> PackedSkill:
     """
-    Read a skill's frontmatter and produce a deterministic tar.gz.
+    Read a skill's frontmatter and produce a byte-stable tar.gz.
 
     Reuses the project's ``SKILL.md`` frontmatter parser
     (:func:`omnigent.spec.parser._parse_skill`) rather than duplicating the
-    YAML-frontmatter logic. The archive is reproducible: entries are sorted
-    and their mtimes zeroed, so packing the same directory twice yields
-    identical bytes.
+    YAML-frontmatter logic. The skill ``name`` is validated as a single safe
+    path component (:func:`_validate_skill_name`) before it becomes the tar
+    member prefix, so a malicious ``name:`` can't emit a traversing arcname.
+
+    The archive is reproducible across time: the gzip layer is written with a
+    fixed ``mtime=0`` header (via :class:`gzip.GzipFile`), entries are sorted,
+    and each member's mtime / uid / gid / uname / gname are normalized — so
+    packing the same directory twice yields byte-identical output regardless of
+    wall-clock time.
 
     :param skill_dir: Path to the skill directory containing a ``SKILL.md``,
         e.g. ``Path("~/.claude/skills/code-review")``.
@@ -130,6 +172,8 @@ def pack_skill(skill_dir: Path) -> PackedSkill:
         gzip-compressed tar bytes of the directory.
     :raises FileNotFoundError: If *skill_dir* is not a directory or has no
         ``SKILL.md``.
+    :raises ValueError: If the parsed skill ``name`` is not a single safe path
+        component.
     """
     skill_dir = skill_dir.expanduser()
     if not skill_dir.is_dir():
@@ -139,14 +183,20 @@ def pack_skill(skill_dir: Path) -> PackedSkill:
         raise FileNotFoundError(f"no SKILL.md in {skill_dir}")
 
     spec = _parse_skill(skill_md)
+    name = _validate_skill_name(spec.name)
 
     buf = io.BytesIO()
-    # mtime=0 + sorted entries → reproducible archive bytes.
-    with tarfile.open(fileobj=buf, mode="w:gz", format=tarfile.PAX_FORMAT) as tar:
+    # gzip header mtime=0 + sorted entries + normalized member metadata →
+    # byte-stable archive across wall-clock time (mode="w:gz" would stamp a
+    # live mtime into the gzip header, breaking determinism).
+    with (
+        gzip.GzipFile(fileobj=buf, mode="wb", mtime=0) as gz,
+        tarfile.open(fileobj=gz, mode="w", format=tarfile.PAX_FORMAT) as tar,
+    ):
         for path in sorted(skill_dir.rglob("*")):
             if not path.is_file():
                 continue
-            arcname = f"{spec.name}/{path.relative_to(skill_dir).as_posix()}"
+            arcname = f"{name}/{path.relative_to(skill_dir).as_posix()}"
             info = tar.gettarinfo(str(path), arcname=arcname)
             info.mtime = 0
             info.uid = info.gid = 0
@@ -242,7 +292,7 @@ def _ensure_table_registered(
             "nullable": False,
         },
     ]
-    body: dict[str, Any] = {
+    body: dict[str, object] = {
         "name": name,
         "catalog_name": catalog,
         "schema_name": schema,
@@ -427,10 +477,13 @@ def build_parser() -> argparse.ArgumentParser:
             default=None,
             help="UC OSS server URI (env UC_OSS_URI; default http://localhost:8080)",
         )
+        # Prefer the env var: a --token on the command line can leak via shell
+        # history / the process list. Local UC OSS needs no token at all.
         sp.add_argument(
             "--token",
             default=None,
-            help="bearer token (env UC_OSS_TOKEN; local UC OSS needs none)",
+            help="bearer token (prefer env UC_OSS_TOKEN to avoid shell/process leaks; "
+            "local UC OSS needs none)",
         )
         sp.add_argument(
             "--local-root",

--- a/omnigent/stores/artifact_store/unitycatalog_oss.py
+++ b/omnigent/stores/artifact_store/unitycatalog_oss.py
@@ -1,0 +1,563 @@
+"""Unity Catalog OSS implementation of ArtifactStore.
+
+Stores artifact blobs in a volume managed by an **open-source** Unity
+Catalog server (github.com/unitycatalog/unitycatalog), NOT managed
+Databricks. It mirrors the shape of the sibling ``s3.py`` and
+``databricks_volumes.py`` backends but talks to the UC OSS REST API over
+plain HTTP (via ``httpx``, already a core dependency) — no boto3, no
+Databricks SDK.
+
+How bytes are stored
+--------------------
+The managed-Databricks backend uploads file bytes through the
+``WorkspaceClient.files`` REST API; the S3 backend uses ``boto3``.
+**UC OSS has neither** — its REST surface manages *metadata* (catalogs,
+schemas, volumes, tables) plus, for cloud volumes, temporary
+storage-credential vending. The bytes themselves live at the volume's
+``storage_location``.
+
+For a **local** UC OSS deployment a volume's ``storage_location`` is a
+``file://`` URI (e.g. ``file:///home/unitycatalog/etc/data/skillpacks``).
+There are no cloud credentials to vend for a ``file://`` volume, so this
+store resolves the volume's ``storage_location`` from the REST API (the
+local analogue of credential vending) and then reads/writes the blob
+bytes directly on that filesystem. When the UC server runs in Docker,
+that path is made host-visible with a bind mount and supplied as
+``local_root`` (see ``examples/uc-oss-skillpack``).
+
+Storage location format::
+
+    <catalog>.<schema>.<volume>
+
+i.e. the three-level volume name the UC REST API keys on, e.g.
+``unity.omnigent.skillpacks`` — unlike the ``dbfs:/Volumes/...`` /
+``s3://...`` URIs the sibling backends use.
+
+POC / not for production. See ``examples/uc-oss-skillpack/README.md``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import TYPE_CHECKING, Any
+from urllib.parse import unquote, urlparse
+
+from omnigent.stores.artifact_store import ArtifactStore
+
+if TYPE_CHECKING:
+    import httpx
+
+# REST API root for a UC OSS server. The ``/api/2.1/unity-catalog`` prefix
+# is fixed by the OSS OpenAPI spec (api/all.yaml ``servers:`` in the
+# unitycatalog repo).
+_UC_API_PREFIX = "/api/2.1/unity-catalog"
+_DEFAULT_URI = "http://localhost:8080"
+
+
+def _ensure_httpx() -> None:
+    """
+    Verify that ``httpx`` is importable.
+
+    ``httpx`` is a core dependency, so this should never fail in a
+    correctly-installed environment. Mirrors the ``_ensure_boto3`` pattern
+    in ``s3.py`` — turns a confusing ``ModuleNotFoundError`` deep in the
+    stack into a clear message.
+
+    :raises ImportError: If ``httpx`` is not available.
+    """
+    try:
+        import httpx  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - httpx is a core dep
+        raise ImportError(
+            "UnityCatalogOSSArtifactStore requires 'httpx'. Install with: pip install httpx"
+        ) from exc
+
+
+def _parse_volume_full_name(storage_location: str) -> tuple[str, str, str]:
+    """
+    Split a three-level volume name into ``(catalog, schema, volume)``.
+
+    :param storage_location: The fully-qualified volume name, e.g.
+        ``"unity.omnigent.skillpacks"``.
+    :returns: ``(catalog, schema, volume)``, e.g.
+        ``("unity", "omnigent", "skillpacks")``.
+    :raises ValueError: If it is not exactly three dot-separated, non-empty
+        parts.
+    """
+    parts = storage_location.split(".")
+    if len(parts) != 3 or not all(parts):
+        raise ValueError(
+            "storage_location must be a three-level volume name "
+            f"'<catalog>.<schema>.<volume>', got: {storage_location!r}"
+        )
+    return parts[0], parts[1], parts[2]
+
+
+def _validate_key(key: str) -> None:
+    """
+    Validate an artifact key against traversal attacks.
+
+    Same validation as ``LocalArtifactStore`` / ``S3ArtifactStore`` — reject
+    empty keys, ``..`` sequences, backslashes, and absolute paths — so a
+    crafted key can't escape the volume storage directory.
+
+    :param key: Forward-slash-separated artifact key, e.g.
+        ``"skills/code-review/code-review.tar.gz"``.
+    :raises ValueError: If the key is invalid.
+    """
+    parts = PurePosixPath(key).parts
+    if (
+        not parts
+        or ".." in parts
+        or "\\" in key
+        or PurePosixPath(key).is_absolute()
+        or PureWindowsPath(key).is_absolute()
+    ):
+        raise ValueError(f"invalid artifact key: {key!r}")
+
+
+def _json_object(resp: httpx.Response) -> dict[str, Any]:
+    """
+    Decode an HTTP response body as a JSON object, narrowing its type.
+
+    ``httpx.Response.json()`` is typed ``Any``; returning it directly from
+    a function annotated ``-> dict[str, ...]`` trips mypy's strict
+    ``no-any-return``. This helper does the JSON decode and a runtime
+    ``isinstance`` narrowing at the boundary, which both satisfies the type
+    checker and hardens against a malformed non-object body from the server.
+
+    :param resp: A 2xx :class:`httpx.Response` whose body is expected to be a
+        JSON object (UC returns ``VolumeInfo`` / ``CatalogInfo`` / etc.).
+    :returns: The decoded body as a ``dict``.
+    :raises ValueError: If the body is not a JSON object (list, string,
+        number) — a sign the server contract changed or the wrong endpoint
+        was hit.
+    """
+    data = resp.json()
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"expected a JSON object from {resp.request.method} {resp.request.url}, "
+            f"got {type(data).__name__}"
+        )
+    return data
+
+
+class UnityCatalogRestClient:
+    """
+    Thin HTTP client for the Unity Catalog OSS REST API.
+
+    Wraps an :class:`httpx.Client` and exposes just the operations this POC
+    needs: resolving a volume, vending temporary volume credentials, and
+    creating/reading catalogs, schemas, volumes, and tables. Kept separate
+    from the store so the ``skillpack`` CLI can reuse it for the metadata
+    table without importing ``ArtifactStore``.
+
+    :param uri: Base server URI (scheme + host + port, no API path), e.g.
+        ``"http://localhost:8080"``.
+    :param token: Optional bearer token. Local UC OSS runs with auth disabled
+        by default, so this is usually ``None``.
+    :param client: Optional pre-built :class:`httpx.Client` — used by tests to
+        inject an :class:`httpx.MockTransport`. When omitted, a client is
+        constructed from *uri* and *token*.
+    """
+
+    def __init__(
+        self,
+        uri: str = _DEFAULT_URI,
+        token: str | None = None,
+        client: httpx.Client | None = None,
+    ) -> None:
+        """
+        Build the REST client.
+
+        :param uri: Base server URI, e.g. ``"http://localhost:8080"``.
+        :param token: Optional bearer token, or ``None`` for the auth-disabled
+            local default.
+        :param client: Optional injected :class:`httpx.Client` (tests).
+        """
+        _ensure_httpx()
+        import httpx
+
+        self._uri = uri.rstrip("/")
+        if client is not None:
+            self._client = client
+        else:
+            headers = {"Authorization": f"Bearer {token}"} if token else {}
+            self._client = httpx.Client(
+                base_url=f"{self._uri}{_UC_API_PREFIX}",
+                headers=headers,
+                timeout=30.0,
+            )
+
+    def close(self) -> None:
+        """Close the underlying HTTP client."""
+        self._client.close()
+
+    def __enter__(self) -> UnityCatalogRestClient:
+        """Enter a context manager, returning ``self``."""
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        """Exit the context manager, closing the HTTP client."""
+        self.close()
+
+    # ── volumes ──────────────────────────────────────────────
+
+    def get_volume(self, full_name: str) -> dict[str, Any]:
+        """
+        Fetch a volume's metadata by three-level name.
+
+        :param full_name: Fully-qualified volume name, e.g.
+            ``"unity.omnigent.skillpacks"``.
+        :returns: The ``VolumeInfo`` JSON — includes ``storage_location``,
+            ``volume_id``, ``volume_type``, etc.
+        :raises KeyError: If the volume does not exist (HTTP 404).
+        :raises httpx.HTTPStatusError: On other non-2xx responses.
+        """
+        import httpx
+
+        resp = self._client.get(f"/volumes/{full_name}")
+        if resp.status_code == httpx.codes.NOT_FOUND:
+            raise KeyError(f"volume not found: {full_name}")
+        resp.raise_for_status()
+        return _json_object(resp)
+
+    def create_volume(
+        self,
+        catalog: str,
+        schema: str,
+        name: str,
+        storage_location: str,
+        comment: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Create an EXTERNAL volume backed by an explicit storage path.
+
+        EXTERNAL (rather than MANAGED) is used so the POC controls the exact
+        ``storage_location`` and can bind-mount it into the container.
+
+        :param catalog: Parent catalog name, e.g. ``"unity"``.
+        :param schema: Parent schema name, e.g. ``"omnigent"``.
+        :param name: Volume name, e.g. ``"skillpacks"``.
+        :param storage_location: Backing storage URI. For local UC OSS a
+            ``file://`` path, e.g. ``"file:///home/unitycatalog/etc/data/skillpacks"``.
+        :param comment: Optional free-form description.
+        :returns: The created ``VolumeInfo`` JSON.
+        :raises httpx.HTTPStatusError: On a non-2xx response.
+        """
+        body: dict[str, Any] = {
+            "catalog_name": catalog,
+            "schema_name": schema,
+            "name": name,
+            "volume_type": "EXTERNAL",
+            "storage_location": storage_location,
+        }
+        if comment is not None:
+            body["comment"] = comment
+        resp = self._client.post("/volumes", json=body)
+        resp.raise_for_status()
+        return _json_object(resp)
+
+    def generate_temporary_volume_credentials(
+        self,
+        volume_id: str,
+        operation: str = "READ_VOLUME",
+    ) -> dict[str, Any]:
+        """
+        Vend temporary credentials for a volume's backing storage.
+
+        The UC OSS equivalent of the cloud credential-vending flow. For
+        **cloud** volumes the response carries ``aws_temp_credentials`` /
+        ``azure_user_delegation_sas`` / ``gcp_oauth_token``. For a **local**
+        ``file://`` volume there are no cloud credentials to hand out; UC
+        returns the normalized storage ``url`` and this store reads/writes
+        that path on the (bind-mounted) filesystem directly. Exposed for
+        parity/completeness — the store's happy path resolves the storage
+        location via :meth:`get_volume`.
+
+        :param volume_id: The volume's ``volume_id`` (from :meth:`get_volume`).
+        :param operation: ``"READ_VOLUME"`` or ``"WRITE_VOLUME"``.
+        :returns: The ``TemporaryCredentials`` JSON.
+        :raises httpx.HTTPStatusError: On a non-2xx response.
+        """
+        resp = self._client.post(
+            "/temporary-volume-credentials",
+            json={"volume_id": volume_id, "operation": operation},
+        )
+        resp.raise_for_status()
+        return _json_object(resp)
+
+    # ── catalogs / schemas ───────────────────────────────────
+
+    def create_catalog(self, name: str, comment: str | None = None) -> dict[str, Any]:
+        """
+        Create a catalog, tolerating one that already exists.
+
+        :param name: Catalog name, e.g. ``"unity"``.
+        :param comment: Optional free-form description.
+        :returns: The ``CatalogInfo`` JSON.
+        :raises httpx.HTTPStatusError: On a non-2xx response other than a 409.
+        """
+        return self._create_tolerating_conflict(
+            "/catalogs",
+            {"name": name, **({"comment": comment} if comment else {})},
+            f"/catalogs/{name}",
+        )
+
+    def create_schema(self, catalog: str, name: str, comment: str | None = None) -> dict[str, Any]:
+        """
+        Create a schema, tolerating one that already exists.
+
+        :param catalog: Parent catalog name, e.g. ``"unity"``.
+        :param name: Schema name, e.g. ``"omnigent"``.
+        :param comment: Optional free-form description.
+        :returns: The ``SchemaInfo`` JSON.
+        :raises httpx.HTTPStatusError: On a non-2xx response other than a 409.
+        """
+        return self._create_tolerating_conflict(
+            "/schemas",
+            {"name": name, "catalog_name": catalog, **({"comment": comment} if comment else {})},
+            f"/schemas/{catalog}.{name}",
+        )
+
+    def _create_tolerating_conflict(
+        self,
+        create_path: str,
+        body: dict[str, Any],
+        get_path: str,
+    ) -> dict[str, Any]:
+        """
+        POST to *create_path*; on 409 conflict, GET the existing object.
+
+        UC OSS returns 409 when a securable already exists. For an idempotent
+        bootstrap ("create the catalog if absent") that is a success, so this
+        swallows the conflict and returns the existing object's metadata.
+
+        :param create_path: The create endpoint, e.g. ``"/catalogs"``.
+        :param body: The JSON request body for creation.
+        :param get_path: The endpoint to GET on a 409, e.g. ``"/catalogs/unity"``.
+        :returns: The created (or pre-existing) object JSON.
+        :raises httpx.HTTPStatusError: On a non-2xx response other than 409.
+        """
+        import httpx
+
+        resp = self._client.post(create_path, json=body)
+        if resp.status_code == httpx.codes.CONFLICT:
+            existing = self._client.get(get_path)
+            existing.raise_for_status()
+            return _json_object(existing)
+        resp.raise_for_status()
+        return _json_object(resp)
+
+
+class UnityCatalogOSSArtifactStore(ArtifactStore):
+    """
+    Stores binary blobs in a Unity Catalog OSS volume.
+
+    Resolves the volume's ``storage_location`` from the UC OSS REST API, then
+    reads/writes blob bytes on the filesystem at that location (see the module
+    docstring for why bytes don't travel over REST in OSS). Keys are
+    forward-slash-separated and joined onto the resolved storage directory::
+
+        <storage_dir>/
+            skills/code-review/code-review.tar.gz
+            skills/triage/triage.tar.gz
+
+    :param storage_location: Three-level volume name
+        ``<catalog>.<schema>.<volume>``, e.g. ``"unity.omnigent.skillpacks"``.
+        Read from ``UC_OSS_VOLUME`` when omitted.
+    :param uri: UC OSS server base URI, e.g. ``"http://localhost:8080"``.
+        Read from ``UC_OSS_URI`` when omitted.
+    :param token: Optional bearer token. Read from ``UC_OSS_TOKEN`` when
+        omitted (local UC OSS defaults to auth disabled).
+    :param local_root: Host filesystem path where the volume's
+        ``storage_location`` is accessible — required when the UC server runs
+        in a container and the ``file://`` path is only reachable via a bind
+        mount. Read from ``UC_OSS_VOLUME_LOCAL_PATH`` when omitted. When
+        neither is set, the ``file://`` ``storage_location`` from the REST API
+        is used directly (valid when the store runs on the same host as a
+        non-containerized UC server).
+    :param client: Optional injected :class:`UnityCatalogRestClient` (tests
+        inject one backed by an :class:`httpx.MockTransport`).
+    """
+
+    def __init__(
+        self,
+        storage_location: str | None = None,
+        uri: str | None = None,
+        token: str | None = None,
+        local_root: str | None = None,
+        client: UnityCatalogRestClient | None = None,
+    ) -> None:
+        """
+        Initialize the UC OSS artifact store.
+
+        Configuration precedence is explicit argument, then environment
+        variable, then default — matching how ``s3.py`` reads ambient config.
+
+        :param storage_location: Three-level volume name, or ``None`` to read
+            ``UC_OSS_VOLUME``.
+        :param uri: Server base URI, or ``None`` to read ``UC_OSS_URI``
+            (default ``"http://localhost:8080"``).
+        :param token: Bearer token, or ``None`` to read ``UC_OSS_TOKEN``.
+        :param local_root: Host path to the volume storage, or ``None`` to read
+            ``UC_OSS_VOLUME_LOCAL_PATH``.
+        :param client: Optional injected REST client.
+        :raises ImportError: If ``httpx`` is not installed.
+        :raises ValueError: If no volume name is provided or resolvable, or the
+            name is not a valid three-level name.
+        """
+        _ensure_httpx()
+        resolved = storage_location or os.environ.get("UC_OSS_VOLUME")
+        if not resolved:
+            raise ValueError(
+                "storage_location is required: pass it or set UC_OSS_VOLUME to a "
+                "three-level name like 'unity.omnigent.skillpacks'"
+            )
+        _parse_volume_full_name(resolved)  # validate shape early
+        super().__init__(resolved)
+
+        self._uri = uri or os.environ.get("UC_OSS_URI") or _DEFAULT_URI
+        self._token = token if token is not None else os.environ.get("UC_OSS_TOKEN")
+        self._local_root = local_root or os.environ.get("UC_OSS_VOLUME_LOCAL_PATH")
+        self._client = (
+            client
+            if client is not None
+            else UnityCatalogRestClient(uri=self._uri, token=self._token)
+        )
+        # Resolved lazily on first I/O so construction never requires a live
+        # server (keeps unit tests and __init__ side-effect-free).
+        self._storage_dir: Path | None = None
+
+    def _resolve_storage_dir(self) -> Path:
+        """
+        Resolve (and cache) the local directory backing the volume.
+
+        Queries the UC OSS REST API for the volume's ``storage_location`` —
+        the metadata step that couples the store to a live UC server (the
+        local analogue of cloud credential vending). The path is then:
+
+        - ``local_root`` (if configured): used directly as the base directory
+          — the host-visible bind mount of the container's ``file://`` path.
+        - otherwise: the ``file://`` ``storage_location`` is parsed and its
+          filesystem path used directly (non-containerized server, same host).
+
+        :returns: The resolved base :class:`Path`, created if absent.
+        :raises KeyError: If the volume does not exist on the server.
+        :raises ValueError: If no ``local_root`` is set and the volume's
+            ``storage_location`` is not a ``file://`` URI (e.g. a cloud
+            ``s3://`` volume, which this filesystem-backed store cannot serve
+            without vended cloud credentials).
+        """
+        if self._storage_dir is not None:
+            return self._storage_dir
+
+        info = self._client.get_volume(self._storage_location)
+        if self._local_root:
+            base = Path(self._local_root)
+        else:
+            raw = info.get("storage_location")
+            if not isinstance(raw, str):
+                raise ValueError(f"volume {self._storage_location!r} has no storage_location")
+            parsed = urlparse(raw)
+            if parsed.scheme not in ("file", ""):
+                raise ValueError(
+                    f"volume storage_location {raw!r} is not a file:// path; set "
+                    "local_root / UC_OSS_VOLUME_LOCAL_PATH to the host mount of the "
+                    "volume storage (cloud volumes need vended credentials, which "
+                    "this filesystem-backed POC store does not implement)"
+                )
+            base = Path(unquote(parsed.path))
+
+        base.mkdir(parents=True, exist_ok=True)
+        self._storage_dir = base
+        return base
+
+    def _resolve(self, key: str) -> Path:
+        """
+        Map *key* to an absolute filesystem path under the volume root.
+
+        :param key: Forward-slash-separated artifact key.
+        :returns: The resolved absolute :class:`Path`.
+        :raises ValueError: If the key is invalid or resolves outside the
+            volume storage directory.
+        """
+        _validate_key(key)
+        base = self._resolve_storage_dir()
+        resolved = (base / Path(*PurePosixPath(key).parts)).resolve()
+        if not resolved.is_relative_to(base.resolve()):
+            raise ValueError(f"artifact key escapes volume storage: {key!r}")
+        return resolved
+
+    # ── ArtifactStore interface ──────────────────────────────
+
+    def put(self, key: str, data: bytes) -> None:
+        """
+        Write bytes to the volume storage under *key*. Overwrites if present.
+
+        :param key: Forward-slash-separated artifact key.
+        :param data: Raw bytes to store.
+        """
+        path = self._resolve(key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+
+    def get(self, key: str) -> bytes:
+        """
+        Read bytes from the volume storage.
+
+        :param key: Forward-slash-separated artifact key.
+        :returns: The raw bytes of the stored blob.
+        :raises KeyError: If no blob exists for the key.
+        """
+        path = self._resolve(key)
+        if not path.exists():
+            raise KeyError(key)
+        return path.read_bytes()
+
+    def delete(self, key: str) -> None:
+        """
+        Remove a blob from the volume storage. No-op if absent.
+
+        :param key: Forward-slash-separated artifact key.
+        """
+        path = self._resolve(key)
+        if path.exists():
+            path.unlink()
+
+    def exists(self, key: str) -> bool:
+        """
+        Check whether a blob exists for *key*.
+
+        :param key: Forward-slash-separated artifact key.
+        :returns: ``True`` if the blob exists, ``False`` otherwise.
+        """
+        return self._resolve(key).exists()
+
+    # ── beyond the ABC ───────────────────────────────────────
+
+    def list(self, prefix: str = "") -> list[str]:
+        """
+        List keys of all blobs whose key starts with *prefix*.
+
+        Not part of the :class:`ArtifactStore` ABC (which is
+        put/get/delete/exists only) — this backend adds it because the
+        ``skillpack`` CLI needs to enumerate stored packs, and a local UC OSS
+        volume can be walked cheaply on the filesystem. Kept concrete-only to
+        avoid forcing a ``list`` implementation onto the other backends.
+
+        :param prefix: Key prefix to filter by, e.g. ``"skills/"``. The
+            empty-string default returns every key.
+        :returns: Sorted list of matching forward-slash keys, e.g.
+            ``["skills/code-review/code-review.tar.gz"]``.
+        """
+        base = self._resolve_storage_dir()
+        keys: list[str] = []
+        for path in base.rglob("*"):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(base).as_posix()
+            if rel.startswith(prefix):
+                keys.append(rel)
+        return sorted(keys)

--- a/omnigent/stores/artifact_store/unitycatalog_oss.py
+++ b/omnigent/stores/artifact_store/unitycatalog_oss.py
@@ -507,12 +507,17 @@ class UnityCatalogOSSArtifactStore(ArtifactStore):
         """
         Read bytes from the volume storage.
 
+        Only regular files are artifacts: a key that resolves to a directory
+        (e.g. a prefix like ``"skills"``) raises :class:`KeyError`, not an
+        ``IsADirectoryError`` — matching object-store semantics where a prefix
+        is not itself a retrievable object.
+
         :param key: Forward-slash-separated artifact key.
         :returns: The raw bytes of the stored blob.
-        :raises KeyError: If no blob exists for the key.
+        :raises KeyError: If no regular file exists for the key.
         """
         path = self._resolve(key)
-        if not path.exists():
+        if not path.is_file():
             raise KeyError(key)
         return path.read_bytes()
 
@@ -520,20 +525,26 @@ class UnityCatalogOSSArtifactStore(ArtifactStore):
         """
         Remove a blob from the volume storage. No-op if absent.
 
+        Only a regular file is unlinked; a key resolving to a directory (a
+        prefix) is a no-op, never a recursive delete.
+
         :param key: Forward-slash-separated artifact key.
         """
         path = self._resolve(key)
-        if path.exists():
+        if path.is_file():
             path.unlink()
 
     def exists(self, key: str) -> bool:
         """
         Check whether a blob exists for *key*.
 
+        Returns ``True`` only for a regular file; a directory key (a prefix)
+        is ``False``, so ``exists`` and ``get`` agree on what is an artifact.
+
         :param key: Forward-slash-separated artifact key.
-        :returns: ``True`` if the blob exists, ``False`` otherwise.
+        :returns: ``True`` if a regular file exists for the key, else ``False``.
         """
-        return self._resolve(key).exists()
+        return self._resolve(key).is_file()
 
     # ── beyond the ABC ───────────────────────────────────────
 

--- a/tests/examples/test_uc_oss_skillpack_cli.py
+++ b/tests/examples/test_uc_oss_skillpack_cli.py
@@ -84,11 +84,25 @@ def test_pack_skill_archive_contains_files_under_name_prefix(tmp_path):
     assert names == ["triage/SKILL.md", "triage/reference.md"]
 
 
-def test_pack_skill_is_deterministic(tmp_path):
-    """Packing the same directory twice yields identical bytes (mtimes/order
-    don't leak in), so re-pushing an unchanged skill is stable."""
+def test_pack_skill_is_deterministic(tmp_path, monkeypatch):
+    """Packing the same directory twice yields byte-identical output even when
+    wall-clock time advances between the two packs. This is meaningful only
+    because the gzip layer is written with a fixed mtime=0 header (mode="w:gz"
+    stamps a live mtime and would fail this)."""
     skill_dir = _write_skill(tmp_path, "same", "Deterministic pack.")
-    assert skillpack.pack_skill(skill_dir).blob == skillpack.pack_skill(skill_dir).blob
+
+    # First pack at t=1000, second at t=2000 — a different second, so a live
+    # gzip-header mtime would differ between the two blobs.
+    monkeypatch.setattr("time.time", lambda: 1000.0)
+    blob1 = skillpack.pack_skill(skill_dir).blob
+    monkeypatch.setattr("time.time", lambda: 2000.0)
+    blob2 = skillpack.pack_skill(skill_dir).blob
+
+    assert blob1 == blob2
+    # gzip header stores mtime little-endian in bytes 4..8; assert it's zeroed
+    # so the determinism doesn't merely rely on both calls landing in the same
+    # second.
+    assert blob1[4:8] == b"\x00\x00\x00\x00"
 
 
 def test_pack_skill_missing_skill_md(tmp_path):
@@ -98,6 +112,35 @@ def test_pack_skill_missing_skill_md(tmp_path):
     empty.mkdir()
     with pytest.raises(FileNotFoundError, match=r"SKILL\.md"):
         skillpack.pack_skill(empty)
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    ["/escape", "../escape", "a/b", "C:\\evil", "\\\\unc\\share", "..", ""],
+)
+def test_pack_skill_rejects_unsafe_names(tmp_path, bad_name):
+    """A malicious/malformed SKILL.md `name:` is rejected at pack time, before
+    it can become a traversing tar member or a corrupt store key. Proves the
+    PACKER (not just _safe_extract) refuses unsafe names."""
+    # The directory name is safe; only the frontmatter `name:` is hostile.
+    skill_dir = tmp_path / "src"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {bad_name!r}\ndescription: hostile.\n---\n\nBody.\n"
+    )
+    with pytest.raises(ValueError, match="invalid skill name"):
+        skillpack.pack_skill(skill_dir)
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    ["/escape", "../escape", "a/b", "C:\\evil", "\\\\unc\\share"],
+)
+def test_blob_key_rejects_unsafe_names(bad_name):
+    """_blob_key validates the name too, so the store key and the tar arcname
+    can't diverge on an unsafe name."""
+    with pytest.raises(ValueError, match="invalid skill name"):
+        skillpack._blob_key(bad_name)
 
 
 # ── push / list / pull round-trip ───────────────────────────

--- a/tests/examples/test_uc_oss_skillpack_cli.py
+++ b/tests/examples/test_uc_oss_skillpack_cli.py
@@ -1,0 +1,230 @@
+"""Tests for the ``skillpack`` CLI (examples/uc-oss-skillpack).
+
+Covers the two pieces worth pinning without Docker:
+
+1. ``pack_skill`` — SKILL.md frontmatter parsing (delegated to the project
+   parser) + a deterministic tar.gz.
+2. ``push`` → ``list`` → ``pull`` round-trip through a real
+   :class:`UnityCatalogOSSArtifactStore` whose REST volume lookup is mocked
+   with :class:`httpx.MockTransport` and whose bytes live on a temp filesystem.
+
+The CLI module lives at a hyphenated path (``examples/uc-oss-skillpack/
+skillpack.py``) that isn't a normal importable package, so it's loaded by file
+path via importlib.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import tarfile
+import types
+from pathlib import Path
+
+import httpx
+import pytest
+
+from omnigent.stores.artifact_store.unitycatalog_oss import (
+    UnityCatalogOSSArtifactStore,
+    UnityCatalogRestClient,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CLI_PATH = _REPO_ROOT / "examples" / "uc-oss-skillpack" / "skillpack.py"
+_VOLUME = "unity.omnigent.skillpacks"
+
+
+def _load_cli() -> types.ModuleType:
+    """Load the skillpack CLI module from its hyphenated file path."""
+    spec = importlib.util.spec_from_file_location("skillpack_cli", _CLI_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so @dataclass can resolve the module by name
+    # (dataclasses looks up cls.__module__ in sys.modules during build).
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+skillpack = _load_cli()
+
+
+def _write_skill(root: Path, name: str, description: str, body: str = "Body.") -> Path:
+    """Create a minimal skill directory with a valid SKILL.md."""
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\n{body}\n"
+    )
+    (skill_dir / "reference.md").write_text("Extra resource.\n")
+    return skill_dir
+
+
+# ── pack_skill ──────────────────────────────────────────────
+
+
+def test_pack_skill_reads_frontmatter(tmp_path):
+    """pack_skill returns the name/description parsed from SKILL.md, so pushed
+    packs and the metadata table report what's actually stored."""
+    skill_dir = _write_skill(tmp_path, "code-review", "Reviews code changes.")
+    packed = skillpack.pack_skill(skill_dir)
+    assert packed.spec.name == "code-review"
+    assert packed.spec.description == "Reviews code changes."
+    assert isinstance(packed.blob, bytes) and len(packed.blob) > 0
+
+
+def test_pack_skill_archive_contains_files_under_name_prefix(tmp_path):
+    """The tar.gz holds the skill's files under a <name>/ prefix, so pull
+    reproduces the directory tree."""
+    skill_dir = _write_skill(tmp_path, "triage", "Triages inbound requests.")
+    packed = skillpack.pack_skill(skill_dir)
+    with tarfile.open(fileobj=io.BytesIO(packed.blob), mode="r:gz") as tar:
+        names = sorted(tar.getnames())
+    assert names == ["triage/SKILL.md", "triage/reference.md"]
+
+
+def test_pack_skill_is_deterministic(tmp_path):
+    """Packing the same directory twice yields identical bytes (mtimes/order
+    don't leak in), so re-pushing an unchanged skill is stable."""
+    skill_dir = _write_skill(tmp_path, "same", "Deterministic pack.")
+    assert skillpack.pack_skill(skill_dir).blob == skillpack.pack_skill(skill_dir).blob
+
+
+def test_pack_skill_missing_skill_md(tmp_path):
+    """A directory without SKILL.md fails loud rather than packing a nameless
+    blob."""
+    empty = tmp_path / "not-a-skill"
+    empty.mkdir()
+    with pytest.raises(FileNotFoundError, match=r"SKILL\.md"):
+        skillpack.pack_skill(empty)
+
+
+# ── push / list / pull round-trip ───────────────────────────
+
+
+@pytest.fixture()
+def store_factory(tmp_path):
+    """Factory returning a store backed by a mocked REST volume + temp FS.
+
+    The volume storage_location is reported as file://{tmp_path}/vol and the
+    table-registration POST is accepted.
+    """
+    storage = (tmp_path / "vol").as_uri()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if request.method == "GET" and path.endswith(f"/volumes/{_VOLUME}"):
+            return httpx.Response(
+                200,
+                json={
+                    "catalog_name": "unity",
+                    "schema_name": "omnigent",
+                    "name": "skillpacks",
+                    "volume_id": "vol-1",
+                    "volume_type": "EXTERNAL",
+                    "storage_location": storage,
+                    "full_name": _VOLUME,
+                },
+            )
+        if request.method == "POST" and path.endswith("/tables"):
+            return httpx.Response(200, json={"name": "skills"})
+        raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+    def _factory() -> UnityCatalogOSSArtifactStore:
+        client = httpx.Client(
+            base_url="http://uc.test/api/2.1/unity-catalog",
+            transport=httpx.MockTransport(handler),
+        )
+        rest = UnityCatalogRestClient(uri="http://uc.test", client=client)
+        return UnityCatalogOSSArtifactStore(storage_location=_VOLUME, client=rest)
+
+    return _factory
+
+
+def test_push_stores_blob_and_manifest(tmp_path, store_factory):
+    """A push writes the pack blob AND a manifest row for it, so list/pull can
+    find the pack afterward."""
+    skill_dir = _write_skill(tmp_path / "src", "alpha", "First skill.")
+    store = store_factory()
+
+    packed = skillpack.pack_skill(skill_dir)
+    store.put(skillpack._blob_key("alpha"), packed.blob)
+    manifest = skillpack._load_manifest(store)
+    manifest["alpha"] = skillpack.SkillPackRecord(
+        name="alpha",
+        description="First skill.",
+        blob_key=skillpack._blob_key("alpha"),
+        version=1,
+        updated_at=1,
+        source=str(skill_dir),
+    )
+    skillpack._save_manifest(store, manifest)
+
+    assert store.get(skillpack._blob_key("alpha")) == packed.blob
+    reloaded = skillpack._load_manifest(store)
+    assert reloaded["alpha"].description == "First skill."
+    assert reloaded["alpha"].blob_key == "skills/alpha/alpha.tar.gz"
+
+
+def test_push_list_pull_round_trip_via_cli(tmp_path, monkeypatch, store_factory, capsys):
+    """End-to-end through the real cmd_push/cmd_list/cmd_pull handlers, with
+    _make_store pinned to the mocked store. Guards the CLI arg wiring and the
+    manifest version/upsert logic."""
+    skill_dir = _write_skill(tmp_path / "src", "beta", "Second skill.")
+    store = store_factory()
+    monkeypatch.setattr(skillpack, "_make_store", lambda args: store)
+
+    parser = skillpack.build_parser()
+
+    rc = skillpack.cmd_push(parser.parse_args(["push", str(skill_dir)]))
+    assert rc == 0
+    assert "beta v1" in capsys.readouterr().out
+
+    # push again → version increments to 2 (upsert, not duplicate)
+    rc = skillpack.cmd_push(parser.parse_args(["push", str(skill_dir)]))
+    assert rc == 0
+    assert "beta v2" in capsys.readouterr().out
+    manifest = skillpack._load_manifest(store)
+    assert list(manifest) == ["beta"]
+    assert manifest["beta"].version == 2
+
+    rc = skillpack.cmd_list(parser.parse_args(["list"]))
+    assert rc == 0
+    list_out = capsys.readouterr().out
+    assert "beta" in list_out and "Second skill." in list_out
+
+    dest = tmp_path / "pulled"
+    rc = skillpack.cmd_pull(parser.parse_args(["pull", "beta", str(dest)]))
+    assert rc == 0
+    pulled = dest / "beta" / "SKILL.md"
+    assert pulled.read_text() == (skill_dir / "SKILL.md").read_text()
+
+
+def test_pull_unknown_name_errors(tmp_path, monkeypatch, store_factory, capsys):
+    """pull of an unknown pack name returns exit code 1 with a clear message."""
+    store = store_factory()
+    monkeypatch.setattr(skillpack, "_make_store", lambda args: store)
+    parser = skillpack.build_parser()
+    rc = skillpack.cmd_pull(parser.parse_args(["pull", "ghost", str(tmp_path / "d")]))
+    assert rc == 1
+    assert "no skill pack named 'ghost'" in capsys.readouterr().err
+
+
+def test_safe_extract_rejects_traversal(tmp_path):
+    """_safe_extract refuses archive members that escape the dest, blocking
+    path-traversal via a malicious pack."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        data = b"evil"
+        info = tarfile.TarInfo(name="../escape.txt")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    buf.seek(0)
+    dest = tmp_path / "out"
+    dest.mkdir()
+    with (
+        tarfile.open(fileobj=buf, mode="r:gz") as tar,
+        pytest.raises(ValueError, match="unsafe path"),
+    ):
+        skillpack._safe_extract(tar, dest)

--- a/tests/examples/test_uc_oss_skillpack_cli.py
+++ b/tests/examples/test_uc_oss_skillpack_cli.py
@@ -244,6 +244,59 @@ def test_push_list_pull_round_trip_via_cli(tmp_path, monkeypatch, store_factory,
     assert pulled.read_text() == (skill_dir / "SKILL.md").read_text()
 
 
+def test_push_survives_table_registration_failure(tmp_path, monkeypatch, capsys):
+    """A non-409 error from the /tables endpoint (a real UC OSS server rejects
+    the EXTERNAL JSON table with 400) must NOT abort push: the blob + manifest
+    are the source of truth and are already written, and table registration is
+    inspectability-only. Guards demo.sh against a non-atomic push abort."""
+    storage = (tmp_path / "vol").as_uri()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if request.method == "GET" and path.endswith(f"/volumes/{_VOLUME}"):
+            return httpx.Response(
+                200,
+                json={
+                    "catalog_name": "unity",
+                    "schema_name": "omnigent",
+                    "name": "skillpacks",
+                    "volume_id": "vol-1",
+                    "volume_type": "EXTERNAL",
+                    "storage_location": storage,
+                    "full_name": _VOLUME,
+                },
+            )
+        if request.method == "POST" and path.endswith("/tables"):
+            # What real UC OSS returns: storage_location not under a registered
+            # external location.
+            return httpx.Response(400, json={"error_code": "INVALID_PARAMETER_VALUE"})
+        raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+    client = httpx.Client(
+        base_url="http://uc.test/api/2.1/unity-catalog",
+        transport=httpx.MockTransport(handler),
+    )
+    rest = UnityCatalogRestClient(uri="http://uc.test", client=client)
+    store = UnityCatalogOSSArtifactStore(storage_location=_VOLUME, client=rest)
+    monkeypatch.setattr(skillpack, "_make_store", lambda args: store)
+
+    skill_dir = _write_skill(tmp_path / "src", "gamma", "Registration-failure skill.")
+    parser = skillpack.build_parser()
+
+    # push must succeed (exit 0) despite the 400 from /tables ...
+    rc = skillpack.cmd_push(parser.parse_args(["push", str(skill_dir)]))
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "gamma v1" in captured.out
+    # ... and it must warn (best-effort) rather than raise.
+    assert "table registration skipped" in captured.err
+    assert "400" in captured.err
+
+    # The blob + manifest are still stored, so the round-trip is intact.
+    assert store.get(skillpack._blob_key("gamma")) == skillpack.pack_skill(skill_dir).blob
+    assert skillpack._load_manifest(store)["gamma"].blob_key == "skills/gamma/gamma.tar.gz"
+
+
 def test_pull_unknown_name_errors(tmp_path, monkeypatch, store_factory, capsys):
     """pull of an unknown pack name returns exit code 1 with a clear message."""
     store = store_factory()

--- a/tests/stores/test_unitycatalog_oss_artifact_store.py
+++ b/tests/stores/test_unitycatalog_oss_artifact_store.py
@@ -1,0 +1,343 @@
+"""Tests for UnityCatalogOSSArtifactStore against a mocked UC OSS REST API.
+
+The REST API is mocked with a real :class:`httpx.MockTransport` (not a
+MagicMock) so the store's actual HTTP request shapes are exercised; blob bytes
+round-trip through a real temp-filesystem volume storage directory. No Docker
+or live server is required — the Docker path is exercised manually via the
+POC README / demo.sh.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from omnigent.stores.artifact_store import ArtifactStore
+from omnigent.stores.artifact_store.unitycatalog_oss import (
+    UnityCatalogOSSArtifactStore,
+    UnityCatalogRestClient,
+    _json_object,
+    _parse_volume_full_name,
+    _validate_key,
+)
+
+_VOLUME = "unity.omnigent.skillpacks"
+
+
+# ── _parse_volume_full_name ─────────────────────────────────
+
+
+def test_parse_volume_full_name_basic():
+    """A three-level name splits into (catalog, schema, volume)."""
+    assert _parse_volume_full_name("unity.omnigent.skillpacks") == (
+        "unity",
+        "omnigent",
+        "skillpacks",
+    )
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["", "unity", "unity.omnigent", "unity.omnigent.skillpacks.extra", "unity..vol", ".a.b"],
+)
+def test_parse_volume_full_name_rejects_bad_shapes(bad):
+    """Names without exactly three non-empty parts fail fast at construction,
+    not with a confusing downstream 404."""
+    with pytest.raises(ValueError, match="three-level"):
+        _parse_volume_full_name(bad)
+
+
+# ── _validate_key (same contract as s3/local) ───────────────
+
+
+@pytest.mark.parametrize(
+    "bad_key",
+    ["", "..", "../etc/passwd", "foo\\bar", "a/../b", "/absolute/path", "C:/windows"],
+)
+def test_validate_key_rejects_traversal(bad_key):
+    """Traversal-style keys are rejected so a crafted key can't escape the
+    volume storage directory."""
+    with pytest.raises(ValueError, match="invalid artifact key"):
+        _validate_key(bad_key)
+
+
+def test_validate_key_accepts_valid_keys():
+    """Normal forward-slash keys pass validation."""
+    _validate_key("skills/code-review/code-review.tar.gz")
+    _validate_key("_manifest/skills.json")
+    _validate_key("simple")
+
+
+# ── REST mock plumbing ──────────────────────────────────────
+
+
+def _make_store(
+    tmp_path: Path,
+    *,
+    volume: str = _VOLUME,
+    storage_location: str | None = None,
+    local_root: str | None = None,
+    volume_present: bool = True,
+) -> UnityCatalogOSSArtifactStore:
+    """Build a store whose REST client is backed by an httpx.MockTransport.
+
+    The mock answers ``GET /volumes/<full_name>`` with a VolumeInfo whose
+    ``storage_location`` is *storage_location* (defaulting to a ``file://`` URI
+    under *tmp_path*), or 404 when *volume_present* is False.
+    """
+    if storage_location is None:
+        storage_location = (tmp_path / "vol").as_uri()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        expected = f"/api/2.1/unity-catalog/volumes/{volume}"
+        if request.method == "GET" and request.url.path == expected:
+            if not volume_present:
+                return httpx.Response(404, json={"message": "not found"})
+            return httpx.Response(
+                200,
+                json={
+                    "catalog_name": volume.split(".")[0],
+                    "schema_name": volume.split(".")[1],
+                    "name": volume.split(".")[2],
+                    "volume_id": "vol-test-123",
+                    "volume_type": "EXTERNAL",
+                    "storage_location": storage_location,
+                    "full_name": volume,
+                },
+            )
+        raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+    client = httpx.Client(
+        base_url="http://uc.test/api/2.1/unity-catalog",
+        transport=httpx.MockTransport(handler),
+    )
+    rest = UnityCatalogRestClient(uri="http://uc.test", client=client)
+    return UnityCatalogOSSArtifactStore(
+        storage_location=volume, local_root=local_root, client=rest
+    )
+
+
+@pytest.fixture()
+def store(tmp_path):
+    """A store whose volume storage lives at ``tmp_path/vol`` (file:// URI)."""
+    return _make_store(tmp_path)
+
+
+# ── construction / config ───────────────────────────────────
+
+
+def test_requires_volume(monkeypatch):
+    """Construction fails loud when no volume is given and none in env, rather
+    than failing confusingly on first I/O."""
+    monkeypatch.delenv("UC_OSS_VOLUME", raising=False)
+    with pytest.raises(ValueError, match="storage_location is required"):
+        UnityCatalogOSSArtifactStore()
+
+
+def test_volume_from_env(monkeypatch, tmp_path):
+    """UC_OSS_VOLUME supplies the volume when the arg is omitted (the config
+    path the CLI/demo use)."""
+    monkeypatch.setenv("UC_OSS_VOLUME", _VOLUME)
+    monkeypatch.setenv("UC_OSS_VOLUME_LOCAL_PATH", str(tmp_path / "vol"))
+    store = UnityCatalogOSSArtifactStore()
+    assert store.storage_location == _VOLUME
+
+
+def test_is_artifact_store(store):
+    """The store is a proper ArtifactStore subclass so it drops in wherever an
+    ArtifactStore is expected."""
+    assert isinstance(store, ArtifactStore)
+    assert store.storage_location == _VOLUME
+
+
+# ── put / get / delete / exists ─────────────────────────────
+
+
+def test_put_and_get_round_trip(store):
+    """Bytes written under a key read back identically."""
+    store.put("skills/foo/foo.tar.gz", b"hello world")
+    assert store.get("skills/foo/foo.tar.gz") == b"hello world"
+
+
+def test_put_writes_to_resolved_storage_location(store, tmp_path):
+    """The blob lands at the file:// storage_location the REST API vends —
+    proving the store honors the volume's real location rather than writing
+    somewhere else."""
+    store.put("skills/foo/foo.tar.gz", b"payload")
+    on_disk = tmp_path / "vol" / "skills" / "foo" / "foo.tar.gz"
+    assert on_disk.read_bytes() == b"payload"
+
+
+def test_get_missing_raises_key_error(store):
+    """A missing key raises KeyError (interface contract) so callers can catch
+    a stable exception type."""
+    with pytest.raises(KeyError, match="missing"):
+        store.get("missing")
+
+
+def test_delete_existing_and_missing(store):
+    """delete removes an existing blob and is a no-op for an absent one."""
+    store.put("k", b"data")
+    store.delete("k")
+    assert not store.exists("k")
+    store.delete("k")  # no-op, must not raise
+
+
+def test_exists_true_false(store):
+    """exists reflects presence."""
+    assert not store.exists("absent")
+    store.put("present", b"x")
+    assert store.exists("present")
+
+
+def test_put_overwrites(store):
+    """Re-pushing the same key overwrites the prior blob."""
+    store.put("k", b"first")
+    store.put("k", b"second")
+    assert store.get("k") == b"second"
+
+
+# ── list (concrete-only, not on the ABC) ────────────────────
+
+
+def test_list_empty(store):
+    """Listing an empty volume returns []."""
+    assert store.list() == []
+
+
+def test_list_returns_all_keys_sorted(store):
+    """list() returns every blob key, sorted, as forward-slash paths."""
+    store.put("skills/b/b.tar.gz", b"1")
+    store.put("skills/a/a.tar.gz", b"2")
+    store.put("_manifest/skills.json", b"[]")
+    assert store.list() == [
+        "_manifest/skills.json",
+        "skills/a/a.tar.gz",
+        "skills/b/b.tar.gz",
+    ]
+
+
+def test_list_prefix_filters(store):
+    """list(prefix) returns only keys starting with prefix, so the manifest
+    blob doesn't leak into skill listings."""
+    store.put("skills/a/a.tar.gz", b"1")
+    store.put("_manifest/skills.json", b"[]")
+    assert store.list("skills/") == ["skills/a/a.tar.gz"]
+
+
+def test_list_not_on_abc():
+    """list is deliberately NOT on the ArtifactStore ABC — it's a concrete-only
+    extension so the sibling backends aren't forced to implement it."""
+    assert not hasattr(ArtifactStore, "list")
+
+
+# ── storage-location resolution ─────────────────────────────
+
+
+def test_local_root_overrides_reported_storage_location(tmp_path):
+    """local_root is used verbatim, ignoring the REST storage_location — the
+    containerized case where the file:// path is only valid inside the
+    container and the host reaches the bytes via a bind mount."""
+    host_mount = tmp_path / "host_mount"
+    store = _make_store(
+        tmp_path,
+        storage_location="file:///home/unitycatalog/etc/data/skillpacks",
+        local_root=str(host_mount),
+    )
+    store.put("skills/x/x.tar.gz", b"bytes")
+    assert (host_mount / "skills" / "x" / "x.tar.gz").read_bytes() == b"bytes"
+
+
+def test_missing_volume_raises_key_error(tmp_path):
+    """A first I/O against a non-existent volume surfaces KeyError, not an
+    opaque HTTP error."""
+    store = _make_store(tmp_path, volume_present=False)
+    with pytest.raises(KeyError, match="volume not found"):
+        store.put("skills/x/x.tar.gz", b"bytes")
+
+
+def test_non_file_storage_location_requires_local_root(tmp_path):
+    """A cloud (non-file://) volume without local_root fails loud rather than
+    silently accepting an s3:// volume this filesystem-backed store can't
+    serve."""
+    store = _make_store(tmp_path, storage_location="s3://bucket/skillpacks")
+    with pytest.raises(ValueError, match="not a file:// path"):
+        store.exists("anything")
+
+
+def test_key_escaping_storage_dir_rejected(store):
+    """A key that resolves outside the storage dir is rejected (belt and
+    suspenders on top of _validate_key)."""
+    with pytest.raises(ValueError, match=r"invalid artifact key|escapes volume"):
+        store.put("../outside.tar.gz", b"x")
+
+
+# ── REST client bootstrap helpers ───────────────────────────
+
+
+def test_create_catalog_tolerates_conflict():
+    """create_catalog swallows a 409 and returns the existing object, so
+    re-running bootstrap (or a second push) stays idempotent."""
+    requests_seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests_seen.append(f"{request.method} {request.url.path}")
+        if request.method == "POST" and request.url.path.endswith("/catalogs"):
+            return httpx.Response(409, json={"message": "already exists"})
+        if request.method == "GET" and request.url.path.endswith("/catalogs/unity"):
+            return httpx.Response(200, json={"name": "unity", "comment": "existing"})
+        raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+    client = httpx.Client(
+        base_url="http://uc.test/api/2.1/unity-catalog",
+        transport=httpx.MockTransport(handler),
+    )
+    rest = UnityCatalogRestClient(uri="http://uc.test", client=client)
+    result = rest.create_catalog("unity")
+    assert result["comment"] == "existing"
+    assert "POST /api/2.1/unity-catalog/catalogs" in requests_seen
+    assert "GET /api/2.1/unity-catalog/catalogs/unity" in requests_seen
+
+
+def test_get_volume_404_raises_key_error():
+    """get_volume maps a 404 to KeyError so absent-volume detection doesn't
+    leak the raw HTTPStatusError."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"message": "not found"})
+
+    client = httpx.Client(
+        base_url="http://uc.test/api/2.1/unity-catalog",
+        transport=httpx.MockTransport(handler),
+    )
+    rest = UnityCatalogRestClient(uri="http://uc.test", client=client)
+    with pytest.raises(KeyError, match="volume not found"):
+        rest.get_volume("unity.omnigent.nope")
+
+
+# ── _json_object boundary narrowing ─────────────────────────
+
+
+def test_json_object_returns_dict_body():
+    """_json_object returns a JSON object body as a plain dict."""
+    resp = httpx.Response(
+        200,
+        json={"name": "unity", "volume_id": "v1"},
+        request=httpx.Request("GET", "http://uc.test/volumes/unity.omnigent.x"),
+    )
+    assert _json_object(resp) == {"name": "unity", "volume_id": "v1"}
+
+
+def test_json_object_rejects_non_object_body():
+    """_json_object raises ValueError on a non-object body — the runtime
+    narrowing that keeps the REST helpers' `-> dict` return honest under mypy
+    strict and fails loud on a malformed server response."""
+    resp = httpx.Response(
+        200,
+        json=["not", "an", "object"],
+        request=httpx.Request("GET", "http://uc.test/volumes/unity.omnigent.x"),
+    )
+    with pytest.raises(ValueError, match="expected a JSON object"):
+        _json_object(resp)

--- a/tests/stores/test_unitycatalog_oss_artifact_store.py
+++ b/tests/stores/test_unitycatalog_oss_artifact_store.py
@@ -199,6 +199,23 @@ def test_put_overwrites(store):
     assert store.get("k") == b"second"
 
 
+def test_directory_prefix_is_not_an_artifact(store):
+    """A key that resolves to a directory (a prefix) is not an artifact:
+    exists() is False and get() raises KeyError, not IsADirectoryError —
+    matching object-store semantics."""
+    store.put("skills/foo/foo.tar.gz", b"x")
+    # "skills" and "skills/foo" are directories on disk, not stored blobs.
+    assert store.exists("skills") is False
+    assert store.exists("skills/foo") is False
+    with pytest.raises(KeyError):
+        store.get("skills")
+    with pytest.raises(KeyError):
+        store.get("skills/foo")
+    # delete on a directory key is a no-op (never a recursive delete).
+    store.delete("skills")
+    assert store.exists("skills/foo/foo.tar.gz") is True
+
+
 # ── list (concrete-only, not on the ABC) ────────────────────
 
 


### PR DESCRIPTION
> **POC / not for production — do NOT merge.** Store-only slice (Scope A): no
> AI-gateway or policy wiring. Opened for review of the approach.

## Related issue

N/A — exploratory POC.

## Summary

Local proof-of-concept for storing Omnigent **skill / knowledge packs** in a
Dockerized **Unity Catalog OSS** server, then listing and pulling them back.

- **`UnityCatalogOSSArtifactStore`** (`omnigent/stores/artifact_store/unitycatalog_oss.py`) —
  mirrors the `s3.py` backend's shape (module-level `_ensure_*` / `_parse_*` /
  `_validate_key`, injectable `client`, lazy import). Implements
  `put/get/delete/exists`. **UC OSS has no file-bytes REST endpoint** (unlike
  managed Databricks' `/files` or S3's boto3), so the store resolves the
  volume's `file://` `storage_location` via the UC REST API and reads/writes
  bytes on that filesystem — made host-visible via a Docker bind mount.
- **`list(prefix)` is a concrete-only extension, NOT added to the
  `ArtifactStore` ABC.** The live ABC is `put/get/delete/exists` only; the
  `skillpack` CLI is the sole `list` caller and a local UC volume is cheap to
  walk. Keeping it off the ABC leaves `local` / `s3` / `databricks_volumes`
  untouched (least-invasive choice).
- **`examples/uc-oss-skillpack/`** — `docker-compose.yml` (pinned
  `unitycatalog/unitycatalog:v0.5.0`), `run.sh` / `Makefile` / `bootstrap.sh`,
  a standalone `skillpack` CLI (`pack`/`push`/`list`/`pull`) reusing the
  `SKILL.md` frontmatter parser and pointed at `~/.claude/skills/*` and
  `examples/polly/skills/*`, plus `README.md` and a one-command `demo.sh`.
- **Metadata**: UC OSS has no row-level DML over REST, so skill "rows" live in
  a `_manifest/skills.json` blob in the volume and the CLI *registers*
  `unity.omnigent.skills` as an EXTERNAL table for inspectability. Deliberate
  store-only shortcut.

### How to run the Docker server + demo

```bash
cd examples/uc-oss-skillpack
make up            # docker compose up v0.5.0 on :8080 + bootstrap catalog/schema/volume
export UC_OSS_URI=http://localhost:8080
export UC_OSS_VOLUME=unity.omnigent.skillpacks
export UC_OSS_VOLUME_LOCAL_PATH="$(pwd)/data/skillpacks"
./demo.sh          # push a real skill -> list -> pull into temp dir -> diff round-trip
make down          # or: make clean
```

## Test Plan

```bash
uv run --extra dev pre-commit run --files \
  omnigent/stores/artifact_store/unitycatalog_oss.py \
  examples/uc-oss-skillpack/skillpack.py \
  tests/examples/test_uc_oss_skillpack_cli.py tests/examples/__init__.py \
  tests/stores/test_unitycatalog_oss_artifact_store.py
# → ruff-format, ruff-check, no-skipped-tests, no-hardcoded-models: all Passed

uv run --extra dev python -m pytest \
  tests/stores/test_unitycatalog_oss_artifact_store.py \
  tests/examples/test_uc_oss_skillpack_cli.py -q
# → 58 passed
```

Unit tests mock the UC OSS REST API with `httpx.MockTransport` (real transport,
not MagicMock) and round-trip bytes through a temp filesystem — **no Docker or
network required**. The Docker path is exercised manually via the README /
`demo.sh`. Existing `tests/stores/test_artifact_store.py` and
`test_s3_artifact_store.py` still pass (44) — the ABC is unchanged.

## Demo

<img width="960" alt="uc-oss-skillpack-demo" src="https://github.com/user-attachments/assets/66e7d2b0-22fb-4420-ac09-72584263d07d" />

`make up` → `./demo.sh` → `make down` against a real UC OSS server: pack a skill → list → pull → byte-for-byte round-trip. Full transcript in the PR comment below.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the store (key validation, volume-name parsing, storage
resolution, put/get/delete/exists/list, REST 404/409 handling, JSON boundary
narrowing) and the CLI (frontmatter pack, deterministic tar.gz, push/list/pull
round-trip, traversal guard) without Docker. Manual verification = the Docker
`make up` + `demo.sh` round-trip described above; not automated because it
requires pulling and running the UC OSS container.

This pull request and its description were written by Isaac.
