### PR TITLE
fix: file forked sessions into the source's project

### DIFF
--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -2014,6 +2014,18 @@ def register_core_routes(
             else None
         )
 
+        # Keep the fork filed in the source's first-class project, but only
+        # when the forker owns that project — projects are owner-private, so
+        # a fork of a shared session filed in someone else's project stays
+        # unfiled (a foreign project id would show in no folder view).
+        fork_project_id = None
+        if source.project_id is not None and project_store is not None:
+            owned = await asyncio.to_thread(
+                project_store.get, source.project_id, owner_user_id=user_id
+            )
+            if owned is not None:
+                fork_project_id = source.project_id
+
         try:
             new_conv = await asyncio.to_thread(
                 conversation_store.fork_conversation,
@@ -2034,6 +2046,7 @@ def register_core_routes(
                 resume_source_native_session=resume_source_native_session,
                 presentation_labels=presentation_labels,
                 up_to_response_id=body.up_to_response_id,
+                project_id=fork_project_id,
             )
         except LookupError as exc:
             raise OmnigentError(

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1460,6 +1460,7 @@ class ConversationStore(ABC):
         resume_source_native_session: bool = True,
         presentation_labels: dict[str, str] | None = None,
         up_to_response_id: str | None = None,
+        project_id: str | None = None,
     ) -> Conversation:
         """
         Deep-copy a conversation and its items into a new conversation.
@@ -1534,6 +1535,11 @@ class ConversationStore(ABC):
             transcript; when the response is the source's last one, the
             copy is equivalent to a full fork and the directive is kept.
             ``None`` (default) copies the full history.
+        :param project_id: First-class project to file the fork into
+            (``metadata.project_id``), or ``None`` (default) to leave it
+            unfiled. The caller resolves whether the fork keeps the
+            source's project — projects are owner-private, so the route
+            passes the source's id only when the forker owns it.
         :returns: The newly created :class:`Conversation`.
         :raises LookupError: If no conversation with
             *source_conversation_id* exists.

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -3264,6 +3264,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         resume_source_native_session: bool = True,
         presentation_labels: dict[str, str] | None = None,
         up_to_response_id: str | None = None,
+        project_id: str | None = None,
     ) -> Conversation:
         """
         Deep-copy a conversation and its items into a new conversation.
@@ -3345,6 +3346,11 @@ class SqlAlchemyConversationStore(ConversationStore):
             response is the source's last one the copy is equivalent to a
             full fork, so the directive is kept. ``None`` (default)
             copies the full history.
+        :param project_id: First-class project to file the fork into
+            (``metadata.project_id``), or ``None`` (default) to leave it
+            unfiled. The caller resolves whether the fork keeps the
+            source's project — projects are owner-private, so the route
+            passes the source's id only when the forker owns it.
         :returns: The newly created :class:`Conversation`.
         :raises LookupError: If no conversation with
             *source_conversation_id* exists.
@@ -3365,6 +3371,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             resume_source_native_session=resume_source_native_session,
             presentation_labels=presentation_labels,
             up_to_response_id=up_to_response_id,
+            project_id=project_id,
         )
 
     def _fork_conversation_with_id(
@@ -3383,6 +3390,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         resume_source_native_session: bool = True,
         presentation_labels: dict[str, str] | None = None,
         up_to_response_id: str | None = None,
+        project_id: str | None = None,
     ) -> Conversation:
         """Body of :meth:`fork_conversation` under a caller-supplied
         ``conversation_id``. The public method generates a fresh id; this seam
@@ -3604,6 +3612,9 @@ class SqlAlchemyConversationStore(ConversationStore):
                 kind=encode_conversation_kind("default"),
                 # Copy terminal args from source so the fork launches with same native args.
                 terminal_launch_args=source_terminal_args,
+                # First-class project membership, resolved by the caller
+                # (None = unfiled).
+                project_id=project_id,
             )
 
         # Write fork metadata (and cloned agent if any) to the Omnigent DB.

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -559,6 +559,64 @@ def reset_mock_llm(mock_url: str) -> None:
     resp.raise_for_status()
 
 
+def seed_committed_turn(
+    session_id: str,
+    *,
+    prompt: str,
+    reply: str,
+    response_id: str = "resp_seeded",
+) -> None:
+    """Write one committed user+assistant exchange straight into the store.
+
+    For tests that need a settled transcript to act on (per-message actions
+    anchor on a committed assistant response) but not the model's behaviour.
+    Skips the runner and the LLM entirely, so the test neither waits on a turn
+    nor inherits the mock-LLM harness's flakiness. Seed BEFORE navigating —
+    the chat hydrates its history on load.
+
+    Items are appended through the same store the server writes with, so they
+    are indistinguishable from a real turn's (same shape, ids, FTS rows).
+
+    :param session_id: Session to append to, e.g. ``"conv_abc123"``.
+    :param prompt: User message text, e.g. ``"ping"``.
+    :param reply: Assistant message text, e.g. ``"pong"``.
+    :param response_id: Response id shared by both items — per-message
+        actions pass it as the turn anchor (e.g. a fork's truncation point).
+    :raises RuntimeError: If the server under test isn't one we spawned
+        (``--ui-base-url``), so its database isn't reachable from here.
+    """
+    from omnigent.entities import MessageData, NewConversationItem
+    from omnigent.stores.conversation_store.sqlalchemy_store import (
+        SqlAlchemyConversationStore,
+    )
+
+    database_uri = _server_state.get("database_uri")
+    if not database_uri:
+        raise RuntimeError(
+            "seed_committed_turn needs the spawned server's database; it is "
+            "unavailable when running against --ui-base-url."
+        )
+    SqlAlchemyConversationStore(str(database_uri)).append(
+        session_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id=response_id,
+                data=MessageData(role="user", content=[{"type": "input_text", "text": prompt}]),
+            ),
+            NewConversationItem(
+                type="message",
+                response_id=response_id,
+                data=MessageData(
+                    role="assistant",
+                    content=[{"type": "output_text", "text": reply}],
+                    agent="hello_world",
+                ),
+            ),
+        ],
+    )
+
+
 def set_fallback_mock_llm(
     mock_url: str,
     key: str,
@@ -1009,6 +1067,9 @@ def live_server(
     _server_state["binding_token"] = binding_token
     _server_state["server_url"] = base_url
     _server_state["mock_llm_url"] = mock_url
+    # Exposed so a test can seed a committed transcript straight into the
+    # store (see :func:`seed_committed_turn`) instead of driving the LLM.
+    _server_state["database_uri"] = f"sqlite:///{db_path}"
 
     # Set a non-resettable fallback for the policy-classifier LLM queue so
     # every per-test reset leaves the server's guardrails path functional.

--- a/tests/e2e_ui/sessions/test_sidebar_projects.py
+++ b/tests/e2e_ui/sessions/test_sidebar_projects.py
@@ -28,6 +28,8 @@ import uuid
 import httpx
 from playwright.sync_api import Locator, Page, expect
 
+from tests.e2e_ui.conftest import seed_committed_turn
+
 
 def _set_title(base_url: str, session_id: str, title: str) -> None:
     """Give a session a unique title via ``PATCH /v1/sessions/{id}`` so its row
@@ -108,6 +110,72 @@ def test_move_session_into_new_project(
 
     expect(_section(page, project).locator(f'a[href="/c/{session_id}"]')).to_be_visible()
     expect(_section(page, "Sessions").locator(f'a[href="/c/{session_id}"]')).to_have_count(0)
+
+
+def test_fork_of_filed_session_joins_the_folder_without_reload(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Forking a filed session shows the clone in the same folder, live.
+
+    Two halves, both needed for the clone to land where the user is looking:
+    the server files the fork into the source's project, and the client
+    refreshes that folder's own ``["project-sessions", <name>]`` list. A folder
+    list has no poll — it converges only on an explicit invalidation — and the
+    push stream can't cover this one either (it skips the active session, which
+    the fork becomes on navigate). So a fork-time invalidation is the only thing
+    that puts the row there before a reload.
+
+    Failure modes this catches:
+
+    - The fork route drops the source's ``project_id``, so the clone is
+      unfiled and surfaces under "Sessions" instead of the folder.
+    - The fork dialog refreshes only the flat session list, leaving the folder
+      stale until the user reloads or navigates away and back.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound ``hello_world`` session.
+    """
+    base_url, session_id = seeded_session
+    title = f"e2e-proj-fork-{uuid.uuid4().hex[:8]}"
+    _set_title(base_url, session_id, title)
+    project = f"Project {uuid.uuid4().hex[:6]}"
+
+    # "Fork from here" is the only fork entry point and it anchors on a
+    # COMMITTED assistant response. What's under test is the sidebar, not the
+    # model, so seed the exchange instead of driving a turn.
+    seed_committed_turn(session_id, prompt="ping", reply="pong")
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    assistant = page.locator('[data-testid="message-bubble"][data-role="assistant"]')
+    expect(assistant).to_have_count(1, timeout=30_000)
+
+    _move_to_new_project(page, _row(page, session_id), project)
+    expect(_section(page, project).locator(f'a[href="/c/{session_id}"]')).to_be_visible()
+
+    reply = assistant.nth(0)
+    reply.hover()
+    reply.get_by_test_id("fork-from-response").click()
+    dialog = page.get_by_test_id("fork-session-dialog")
+    expect(dialog).to_be_visible()
+    page.get_by_test_id("fork-session-submit").click()
+
+    # Land in the clone — a URL still on the source means the fork never
+    # happened, so the folder assertion below would pass vacuously.
+    expect(page).to_have_url(
+        re.compile(rf"/c/(?!{re.escape(session_id)})[0-9a-f]{{32}}"),
+        timeout=30_000,
+    )
+    fork_id = page.url.rsplit("/c/", 1)[1].split("?", 1)[0]
+
+    # The whole point: the clone's row is under the SAME folder, and no reload
+    # or re-navigation happens between the fork and this assertion.
+    expect(_section(page, project).locator(f'a[href="/c/{fork_id}"]')).to_be_visible(
+        timeout=20_000
+    )
+    expect(_section(page, "Sessions").locator(f'a[href="/c/{fork_id}"]')).to_have_count(0)
 
 
 def test_remove_session_from_project(

--- a/tests/server/routes/test_sessions_fork.py
+++ b/tests/server/routes/test_sessions_fork.py
@@ -135,6 +135,7 @@ class _ConversationStore:
         resume_source_native_session: bool = True,
         presentation_labels: dict[str, str] | None = None,
         up_to_response_id: str | None = None,
+        project_id: str | None = None,
     ) -> Conversation:
         """
         Record the fork call and return a fixed new conversation.
@@ -166,6 +167,9 @@ class _ConversationStore:
         :param up_to_response_id: Truncation point, e.g. ``"resp_a"``.
             Mirrors the real store: ``None`` copies everything; a value
             matching no item's ``response_id`` raises ValueError.
+        :param project_id: First-class project the fork is filed into
+            (route passes the source's project only when the forker
+            owns it), or ``None`` for unfiled.
         :returns: A new Conversation with a deterministic ID.
         :raises LookupError: If source is not in our map.
         :raises ValueError: If *up_to_response_id* matches no item.
@@ -184,6 +188,7 @@ class _ConversationStore:
                 "resume_source_native_session": resume_source_native_session,
                 "presentation_labels": presentation_labels,
                 "up_to_response_id": up_to_response_id,
+                "project_id": project_id,
             }
         )
         src = self._convs.get(source_conversation_id)

--- a/tests/server/routes/test_sessions_project_membership.py
+++ b/tests/server/routes/test_sessions_project_membership.py
@@ -161,6 +161,35 @@ def test_unfile_unknown_session_404(db_uri: str) -> None:
     assert resp.status_code == 404
 
 
+def test_fork_inherits_source_project(db_uri: str) -> None:
+    """A fork of a filed session lands in the same project as its source."""
+    _ensure_agent(db_uri)
+    conv = SqlAlchemyConversationStore(db_uri).create_conversation(title="s", agent_id=AGENT_ID)
+    client = TestClient(_single_user_app(db_uri))
+    project = client.post("/v1/projects", json={"name": "Work"}).json()
+    client.patch(f"/v1/sessions/{conv.id}", json={"project_id": project["id"]})
+
+    resp = client.post(f"/v1/sessions/{conv.id}/fork", json={})
+    assert resp.status_code == 201
+    fork = resp.json()
+    assert fork["project_id"] == project["id"]
+
+    # The project folder lists both the source and the fork.
+    listed = client.get("/v1/sessions?project=Work")
+    assert {s["id"] for s in listed.json()["data"]} == {conv.id, fork["id"]}
+
+
+def test_fork_of_unfiled_session_stays_unfiled(db_uri: str) -> None:
+    """Forking a session outside any project must not invent a filing."""
+    _ensure_agent(db_uri)
+    conv = SqlAlchemyConversationStore(db_uri).create_conversation(title="s", agent_id=AGENT_ID)
+    client = TestClient(_single_user_app(db_uri))
+
+    resp = client.post(f"/v1/sessions/{conv.id}/fork", json={})
+    assert resp.status_code == 201
+    assert resp.json()["project_id"] is None
+
+
 def test_project_filter_excludes_other_projects(db_uri: str) -> None:
     """?project=<name> returns only that project's members, not another's."""
     _ensure_agent(db_uri)
@@ -275,6 +304,47 @@ def test_cannot_file_into_another_owners_project(db_uri: str) -> None:
     # Still unfiled — the rejected filing had no side effect.
     snap = client.get(f"/v1/sessions/{conv_id}", headers=_hdr(ALICE))
     assert snap.json()["project_id"] is None
+
+
+def test_fork_of_shared_session_in_foreign_project_stays_unfiled(db_uri: str) -> None:
+    """Alice forks Bob's shared session filed in Bob's project. Projects are
+    owner-private, so her fork must not carry Bob's project id — a foreign id
+    would surface in no folder view of hers."""
+    _ensure_agent(db_uri)
+    conv_id = _seed_owned_session(db_uri, BOB)
+    perms = SqlAlchemyPermissionStore(db_uri)
+    perms.ensure_user(ALICE)
+    perms.grant(ALICE, conv_id, LEVEL_EDIT)
+    client = TestClient(_multi_user_app(db_uri))
+    bob_project = client.post("/v1/projects", json={"name": "Bob"}, headers=_hdr(BOB)).json()
+    filed = client.patch(
+        f"/v1/sessions/{conv_id}",
+        json={"project_id": bob_project["id"]},
+        headers=_hdr(BOB),
+    )
+    assert filed.status_code == 200
+
+    resp = client.post(f"/v1/sessions/{conv_id}/fork", json={}, headers=_hdr(ALICE))
+    assert resp.status_code == 201
+    assert resp.json()["project_id"] is None
+
+
+def test_fork_keeps_own_project_multi_user(db_uri: str) -> None:
+    """Under header auth, Bob's fork of his own filed session stays in his
+    project (the ownership check resolves against the forker's id)."""
+    _ensure_agent(db_uri)
+    conv_id = _seed_owned_session(db_uri, BOB)
+    client = TestClient(_multi_user_app(db_uri))
+    bob_project = client.post("/v1/projects", json={"name": "Bob"}, headers=_hdr(BOB)).json()
+    client.patch(
+        f"/v1/sessions/{conv_id}",
+        json={"project_id": bob_project["id"]},
+        headers=_hdr(BOB),
+    )
+
+    resp = client.post(f"/v1/sessions/{conv_id}/fork", json={}, headers=_hdr(BOB))
+    assert resp.status_code == 201
+    assert resp.json()["project_id"] == bob_project["id"]
 
 
 def test_editor_cannot_file_shared_session(db_uri: str) -> None:

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -3256,6 +3256,23 @@ def test_fork_conversation_copies_items(
         assert fork_item.data == src_item.data
 
 
+def test_fork_conversation_files_into_project(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """``project_id=`` files the fork; the default leaves it unfiled even
+    when the source itself is filed (the route resolves ownership)."""
+    project_id = "b" * 32
+    source = conversation_store.create_conversation(title="src")
+    conversation_store.set_conversation_project(source.id, project_id)
+
+    filed_fork = conversation_store.fork_conversation(source.id, project_id=project_id)
+    assert filed_fork.project_id == project_id
+    assert conversation_store.get_conversation(filed_fork.id).project_id == project_id
+
+    unfiled_fork = conversation_store.fork_conversation(source.id)
+    assert unfiled_fork.project_id is None
+
+
 def test_fork_copies_terminal_launch_args_by_default(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:

--- a/web/src/shell/ForkSessionDialog.test.tsx
+++ b/web/src/shell/ForkSessionDialog.test.tsx
@@ -226,6 +226,9 @@ describe("ForkSessionDialog", () => {
     expect(forkSessionMock).toHaveBeenCalledWith("conv_src", "My clone", undefined, undefined);
     // Session list refreshed so the fork shows in the sidebar, then navigated.
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
+    // A fork inherits the source's project, so the project-folder lists must
+    // refetch too — otherwise a filed fork stays missing from its folder.
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["project-sessions"] });
     await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_fork"));
   });
 

--- a/web/src/shell/ForkSessionDialog.tsx
+++ b/web/src/shell/ForkSessionDialog.tsx
@@ -504,6 +504,11 @@ export function ForkSessionForm({
       }
       // Fire-and-forget: the sidebar refresh must not gate navigation.
       void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+      // The fork inherits the source's project, and each folder renders its
+      // own ["project-sessions", <name>] list. The WS fallback can't converge
+      // it either: it skips the active session, and the navigate below makes
+      // the fork active.
+      void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });
       onClose();
       navigate(`/c/${fork.id}`);
     } catch (e) {


### PR DESCRIPTION
## Related issue

N/A

## Summary

Forking a session that lives in a project didn't put the clone in that project. Two independent breaks, one per side:

**Server — the fork was never filed.** Session→project membership is `omnigent_conversation_metadata.project_id`, and `fork_conversation` built the fork's metadata row with only `kind` and `terminal_launch_args`, silently dropping it. (Legacy `omni_project` label-projects were unaffected — labels are copied on fork.) `fork_conversation` now takes an optional `project_id` (appended last, back-compat) and stamps it, and the fork route passes the source's — gated on the forker **owning** that project, the same check `PATCH` filing uses. Projects are owner-private, so a fork of a shared session filed in someone else's project stays unfiled rather than carrying a foreign id that would surface in none of the forker's folder views.

**Web — the folder never refreshed.** With the server fixed the clone was filed but still invisible: the dialog invalidated only the flat session list, while each folder renders its own `["project-sessions", <name>]` query. That query has no poll, so it converges only on an explicit invalidation, and the push stream can't cover this case either — it skips the active session, which the fork becomes on navigate. The clone stayed missing from its folder until a reload or a re-navigation, which is what a user hits in practice.

## Test Plan

- **Store** — `test_fork_conversation_files_into_project`: `project_id=` files the fork; the default leaves it unfiled even when the source is filed.
- **Routes** (`test_sessions_project_membership.py`) — fork inherits the source's project and shows under `?project=`; fork of an unfiled session stays unfiled; multi-user: your own filed session's fork keeps your project, a shared session filed in the owner's project forks unfiled.
- **Web unit** — `ForkSessionDialog.test.tsx` asserts the fork invalidates `["project-sessions"]` alongside `["conversations"]`.
- **Browser e2e** — `test_fork_of_filed_session_joins_the_folder_without_reload` drives the real chain (file into a project → "Fork from here" → submit) and asserts the clone's row is under the same folder with no reload in between. Verified as a genuine regression test: it fails on the pre-fix bundle and passes after. It seeds the committed turn the fork action anchors on straight into the store (new `seed_committed_turn` helper) rather than driving a model turn, so it runs in ~2s and doesn't inherit the mock-LLM harness's flakiness.
- Suites run locally, all green: conversation-store fork/project (40), split-db (27), project-membership routes (15), shared projects (3), fork routes + fork integration (34), `tests/e2e_ui/sessions/test_sidebar_projects.py` (4) plus neighboring project e2e files, and the web suites for the fork dialog / session-updates / conversations hooks (107). `pre-commit` clean on every changed file.
- **Manual** — against a live `omnigent server` with a built UI: filed a session into a project, forked it from the message action, and watched the clone appear inside the same folder without touching reload. Also confirmed the unfiled case still lands in the flat list.

## Demo

N/A — the visible change is a sidebar row appearing where it already should have; covered by the e2e test above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The e2e test covers the full user path end to end. Manual verification additionally confirmed the two cases the automated tests don't assert together: an unfiled fork still landing in the flat list, and the folder updating live in a real browser against a real server rather than the test harness.

## Changelog

Forking a session in a project now files the clone into the same project, and it appears in that folder immediately
