### PR TITLE
feat(ui): show line additions from new files, and total line changes (additions and deletions) across all files

### DIFF
--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -50,6 +50,10 @@ _logger = logging.getLogger(__name__)
 # git so the panel surfaces a failure rather than blocking forever.
 _DEFAULT_GIT_TIMEOUT_SECONDS = 30.0
 
+# Avoid reading arbitrarily large untracked files just to render a line-count
+# badge. This matches the file-content read cap used by the runner and host.
+_MAX_LINE_COUNT_BYTES = 10 * 1024 * 1024
+
 
 def _git_timeout_seconds() -> float:
     """Return the git-subprocess timeout, honoring the env override.
@@ -979,9 +983,7 @@ class GitFilesystemRegistry(FilesystemRegistry):
             first_component = Path(rel_path).parts[0] if Path(rel_path).parts else ""
             if first_component in _SKIP_DIRS:
                 continue
-            # Counts come only from `git diff HEAD` (via numstat). Files git
-            # doesn't diff — untracked new files, binaries — get no counter.
-            counts = numstat.get(rel_path, (None, None))
+            counts = self._line_counts(rel_path, operation, numstat)
             records.append(self._make_record(rel_path, operation, counts))
 
         records.sort(key=lambda r: (r["modified_at"] or 0, r["path"]), reverse=True)
@@ -1169,6 +1171,36 @@ class GitFilesystemRegistry(FilesystemRegistry):
             "lines_added": added,
             "lines_removed": removed,
         }
+
+    def _line_counts(
+        self,
+        rel_path: str,
+        operation: str,
+        numstat: dict[str, tuple[int | None, int | None]],
+    ) -> tuple[int | None, int | None]:
+        """Return independent added and removed line counts for a changed file.
+
+        Tracked changes come from git numstat. Untracked text files are absent
+        from numstat, so count their lines from disk as additions. Binary,
+        oversized, and unreadable files keep unknown counts.
+        """
+        if rel_path in numstat:
+            return numstat[rel_path]
+        if operation != "created":
+            return (None, None)
+
+        abs_path = self._cwd / rel_path
+        try:
+            if abs_path.stat().st_size > _MAX_LINE_COUNT_BYTES:
+                return (None, None)
+            data = abs_path.read_bytes()
+        except OSError:
+            return (None, None)
+        if b"\x00" in data:
+            return (None, None)
+
+        added = data.count(b"\n") + (1 if data and not data.endswith(b"\n") else 0)
+        return (added, 0)
 
     def _run_git_numstat(self) -> dict[str, tuple[int | None, int | None]]:
         """Return per-file line counts from ``git diff --numstat HEAD``.

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -1280,17 +1280,40 @@ def test_git_line_counts_modified(tmp_path: Path) -> None:
     assert rec["lines_removed"] == 1, rec
 
 
-def test_git_line_counts_untracked_is_none(tmp_path: Path) -> None:
-    """An untracked new file (absent from `git diff HEAD`) reports no counts.
-
-    Counts come only from numstat; git doesn't diff untracked files, so the UI
-    omits the counter for them — matching VS Code / Cursor's source-control view.
-    """
+def test_git_line_counts_untracked_are_additions(tmp_path: Path) -> None:
+    """An untracked text file reports every line as an addition."""
     _init_git_with_commit(tmp_path, "committed.py", "x\n")
-    (tmp_path / "new.py").write_text("one\ntwo\nthree\n")
+    (tmp_path / "new.py").write_text("one\ntwo\nthree")
 
     reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
     rec = next(r for r in reg.list_changed_files("any-conv", limit=100) if r["path"] == "new.py")
+    assert rec["status"] == "created"
+    assert rec["lines_added"] == 3, rec
+    assert rec["lines_removed"] == 0, rec
+
+
+def test_git_line_counts_untracked_binary_are_unknown(tmp_path: Path) -> None:
+    """An untracked binary file does not get a misleading added-line count."""
+    _init_git_with_commit(tmp_path, "committed.py", "x\n")
+    (tmp_path / "new.bin").write_bytes(b"text\n\x00binary\n")
+
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    rec = next(r for r in reg.list_changed_files("any-conv", limit=100) if r["path"] == "new.bin")
+    assert rec["status"] == "created"
+    assert rec["lines_added"] is None, rec
+    assert rec["lines_removed"] is None, rec
+
+
+def test_git_line_counts_untracked_large_file_are_unknown(tmp_path: Path, monkeypatch) -> None:
+    """An untracked file over the read cap is not loaded for its badge."""
+    monkeypatch.setattr("omnigent.runtime.filesystem_registry._MAX_LINE_COUNT_BYTES", 16)
+    _init_git_with_commit(tmp_path, "committed.py", "x\n")
+    (tmp_path / "large.txt").write_text("line\n" * 100)
+
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    rec = next(
+        r for r in reg.list_changed_files("any-conv", limit=100) if r["path"] == "large.txt"
+    )
     assert rec["status"] == "created"
     assert rec["lines_added"] is None, rec
     assert rec["lines_removed"] is None, rec

--- a/tests/test_workspace_fs.py
+++ b/tests/test_workspace_fs.py
@@ -293,13 +293,12 @@ def test_changes_lists_git_working_tree_modifications(tmp_path: Path) -> None:
     by_path = {e["path"]: e for e in result["data"]}
     assert by_path["committed.txt"]["status"] == "modified"
     assert by_path["new.txt"]["status"] == "created"
-    # Line counts come from numstat (git diff HEAD), so the host-served
-    # list surfaces them just like the runner endpoint. The tracked edit
-    # rewrote one line; the untracked file isn't in numstat → no counts.
+    # Tracked counts come from numstat; untracked text files are counted from
+    # disk so the desktop can show them as positive additions too.
     assert by_path["committed.txt"]["lines_added"] == 1
     assert by_path["committed.txt"]["lines_removed"] == 1
-    assert by_path["new.txt"]["lines_added"] is None
-    assert by_path["new.txt"]["lines_removed"] is None
+    assert by_path["new.txt"]["lines_added"] == 1
+    assert by_path["new.txt"]["lines_removed"] == 0
 
 
 def test_diff_returns_before_and_after_for_modified_file(tmp_path: Path) -> None:

--- a/web/src/shell/FilesPanel.test.tsx
+++ b/web/src/shell/FilesPanel.test.tsx
@@ -387,25 +387,55 @@ describe("FilesPanel scope switch (Changed | All) visibility", () => {
   });
 });
 
-describe("FilesPanel Changed pill", () => {
-  // The Changed pill shows the file count only — no +/− line totals.
+describe("FilesPanel Changed pill line totals", () => {
   function changedPill() {
     return screen.getByRole("radio", { name: /^changed$/i });
   }
 
-  it("shows the file count but no +/− line totals", () => {
+  it("sums additions and deletions independently", () => {
     renderPanel({
-      conversationId: "conv_pill_count",
+      conversationId: "conv_totals_no_netting",
       flatView: true,
       files: [],
       changedFiles: [
-        changedFile("src/a.ts", "modified", 10, 2),
-        changedFile("src/b.ts", "modified", 5, 1),
+        changedFile("src/a.ts", "modified", 10, 8),
+        changedFile("src/b.ts", "modified", 2, 7),
       ],
     });
 
     const pill = changedPill();
-    expect(within(pill).getByText("2")).toBeInTheDocument(); // file count
+    expect(within(pill).getByText("2")).toBeInTheDocument();
+    expect(within(pill).getByText("+12")).toBeInTheDocument();
+    expect(within(pill).getByText("−15")).toBeInTheDocument();
+    expect(within(pill).queryByText("−3")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["addition-only", changedFile("src/new.ts", "created", 12, 0), "+12", "−0"],
+    ["deletion-only", changedFile("src/gone.ts", "deleted", 0, 7), "+0", "−7"],
+  ])("keeps separate counters for %s files", (_, changed, additions, deletions) => {
+    renderPanel({
+      conversationId: "conv_totals_zero_side",
+      flatView: true,
+      files: [],
+      changedFiles: [changed],
+    });
+
+    const pill = changedPill();
+    expect(within(pill).getByText(additions)).toBeInTheDocument();
+    expect(within(pill).getByText(deletions)).toBeInTheDocument();
+  });
+
+  it("omits totals when all line counts are unavailable", () => {
+    renderPanel({
+      conversationId: "conv_totals_unknown",
+      flatView: true,
+      files: [],
+      changedFiles: [changedFile("a.bin"), changedFile("b.bin")],
+    });
+
+    const pill = changedPill();
+    expect(within(pill).getByText("2")).toBeInTheDocument();
     expect(within(pill).queryByText(/^\+/)).not.toBeInTheDocument();
     expect(within(pill).queryByText(/^−/)).not.toBeInTheDocument();
   });

--- a/web/src/shell/FilesPanel.test.tsx
+++ b/web/src/shell/FilesPanel.test.tsx
@@ -387,9 +387,13 @@ describe("FilesPanel scope switch (Changed | All) visibility", () => {
   });
 });
 
-describe("FilesPanel Changed pill line totals", () => {
+describe("FilesPanel Changed view line totals", () => {
   function changedPill() {
     return screen.getByRole("radio", { name: /^changed$/i });
+  }
+
+  function changedTotals() {
+    return screen.getByLabelText("Changed line totals");
   }
 
   it("sums additions and deletions independently", () => {
@@ -405,9 +409,15 @@ describe("FilesPanel Changed pill line totals", () => {
 
     const pill = changedPill();
     expect(within(pill).getByText("2")).toBeInTheDocument();
-    expect(within(pill).getByText("+12")).toBeInTheDocument();
-    expect(within(pill).getByText("−15")).toBeInTheDocument();
-    expect(within(pill).queryByText("−3")).not.toBeInTheDocument();
+    expect(within(pill).queryByText(/^\+/)).not.toBeInTheDocument();
+    expect(within(pill).queryByText(/^−/)).not.toBeInTheDocument();
+
+    const totals = changedTotals();
+    expect(totals).toHaveClass("justify-start", "text-sm", "md:text-xs");
+    expect(within(totals).getByText("Total:")).toHaveClass("text-foreground");
+    expect(within(totals).getByText("+12")).toHaveClass("text-green-600");
+    expect(within(totals).getByText("−15")).toHaveClass("text-destructive");
+    expect(within(totals).queryByText("−3")).not.toBeInTheDocument();
   });
 
   it.each([
@@ -421,9 +431,9 @@ describe("FilesPanel Changed pill line totals", () => {
       changedFiles: [changed],
     });
 
-    const pill = changedPill();
-    expect(within(pill).getByText(additions)).toBeInTheDocument();
-    expect(within(pill).getByText(deletions)).toBeInTheDocument();
+    const totals = changedTotals();
+    expect(within(totals).getByText(additions)).toBeInTheDocument();
+    expect(within(totals).getByText(deletions)).toBeInTheDocument();
   });
 
   it("omits totals when all line counts are unavailable", () => {
@@ -434,10 +444,19 @@ describe("FilesPanel Changed pill line totals", () => {
       changedFiles: [changedFile("a.bin"), changedFile("b.bin")],
     });
 
-    const pill = changedPill();
-    expect(within(pill).getByText("2")).toBeInTheDocument();
-    expect(within(pill).queryByText(/^\+/)).not.toBeInTheDocument();
-    expect(within(pill).queryByText(/^−/)).not.toBeInTheDocument();
+    expect(within(changedPill()).getByText("2")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Changed line totals")).not.toBeInTheDocument();
+  });
+
+  it("hides totals until the Changed view is selected", () => {
+    renderPanel({
+      conversationId: "conv_totals_all_view",
+      flatView: false,
+      files: [],
+      changedFiles: [changedFile("src/app.ts", "modified", 5, 2)],
+    });
+
+    expect(screen.queryByLabelText("Changed line totals")).not.toBeInTheDocument();
   });
 });
 

--- a/web/src/shell/FilesPanel.tsx
+++ b/web/src/shell/FilesPanel.tsx
@@ -171,14 +171,10 @@ function FileScopeSwitch({
   flatView,
   onChange,
   count,
-  additions,
-  deletions,
 }: {
   flatView: boolean;
   onChange: (flatView: boolean) => void;
   count: number;
-  additions: number;
-  deletions: number;
 }) {
   const changedSelected = flatView;
   const allSelected = !flatView;
@@ -202,12 +198,6 @@ function FileScopeSwitch({
         {count > 0 && (
           <span className="shrink-0 font-normal text-[11px] text-muted-foreground tabular-nums">
             {count}
-          </span>
-        )}
-        {(additions > 0 || deletions > 0) && (
-          <span className="flex shrink-0 gap-1 font-mono text-[10px]">
-            <span className="text-green-600 dark:text-green-400">+{additions}</span>
-            <span className="text-destructive">&minus;{deletions}</span>
           </span>
         )}
       </button>
@@ -449,13 +439,7 @@ export function FilesPanel({
           className="shrink-0 flex items-center gap-2 px-2 py-1.5 @max-[400px]/filespanel:flex-col @max-[400px]/filespanel:items-stretch"
           onClick={(e) => e.stopPropagation()}
         >
-          <FileScopeSwitch
-            flatView={flatView}
-            onChange={onFlatViewChange}
-            count={changedCount}
-            additions={lineTotals.additions}
-            deletions={lineTotals.deletions}
-          />
+          <FileScopeSwitch flatView={flatView} onChange={onFlatViewChange} count={changedCount} />
           <div className="flex min-w-0 flex-1 items-center gap-2">
             <div className="flex min-w-0 flex-1 items-center gap-[6px] rounded-full border border-border px-[10px] py-[4px] transition-colors focus-within:border-border-strong">
               <SearchIcon className="size-4 shrink-0 text-muted-foreground" />
@@ -472,16 +456,20 @@ export function FilesPanel({
           </div>
         </div>
       )}
+      {flatView && (lineTotals.additions > 0 || lineTotals.deletions > 0) && (
+        <div
+          className="flex shrink-0 justify-start gap-1.5 px-4 pb-1 font-mono text-sm md:text-xs"
+          aria-label="Changed line totals"
+        >
+          <span className="text-foreground">Total:</span>
+          <span className="text-green-600 dark:text-green-400">+{lineTotals.additions}</span>
+          <span className="text-destructive">&minus;{lineTotals.deletions}</span>
+        </div>
+      )}
       {!flatView && (
         <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
           <div className="flex items-center gap-2 px-2 py-1.5 @max-[400px]/filespanel:flex-col @max-[400px]/filespanel:items-stretch">
-            <FileScopeSwitch
-              flatView={flatView}
-              onChange={onFlatViewChange}
-              count={changedCount}
-              additions={lineTotals.additions}
-              deletions={lineTotals.deletions}
-            />
+            <FileScopeSwitch flatView={flatView} onChange={onFlatViewChange} count={changedCount} />
             <div className="flex min-w-0 flex-1 items-center gap-2">
               <div className="flex min-w-0 flex-1 items-center gap-[6px] rounded-full border border-border px-[10px] py-[4px] transition-colors focus-within:border-border-strong">
                 <SearchIcon className="size-4 shrink-0 text-muted-foreground" />

--- a/web/src/shell/FilesPanel.tsx
+++ b/web/src/shell/FilesPanel.tsx
@@ -171,10 +171,14 @@ function FileScopeSwitch({
   flatView,
   onChange,
   count,
+  additions,
+  deletions,
 }: {
   flatView: boolean;
   onChange: (flatView: boolean) => void;
   count: number;
+  additions: number;
+  deletions: number;
 }) {
   const changedSelected = flatView;
   const allSelected = !flatView;
@@ -198,6 +202,12 @@ function FileScopeSwitch({
         {count > 0 && (
           <span className="shrink-0 font-normal text-[11px] text-muted-foreground tabular-nums">
             {count}
+          </span>
+        )}
+        {(additions > 0 || deletions > 0) && (
+          <span className="flex shrink-0 gap-1 font-mono text-[10px]">
+            <span className="text-green-600 dark:text-green-400">+{additions}</span>
+            <span className="text-destructive">&minus;{deletions}</span>
           </span>
         )}
       </button>
@@ -322,6 +332,13 @@ export function FilesPanel({
   const workingDir = envQuery.data?.root ?? null;
   const changedFiles = changedQuery.data?.data ?? [];
   const changedCount = changedFiles.length;
+  const lineTotals = changedFiles.reduce(
+    (totals, file) => ({
+      additions: totals.additions + (file.lines_added ?? 0),
+      deletions: totals.deletions + (file.lines_removed ?? 0),
+    }),
+    { additions: 0, deletions: 0 },
+  );
   const hiddenFilesCount = changedFiles.filter((f) =>
     f.path.split("/").some((seg) => seg.startsWith(".")),
   ).length;
@@ -432,7 +449,13 @@ export function FilesPanel({
           className="shrink-0 flex items-center gap-2 px-2 py-1.5 @max-[400px]/filespanel:flex-col @max-[400px]/filespanel:items-stretch"
           onClick={(e) => e.stopPropagation()}
         >
-          <FileScopeSwitch flatView={flatView} onChange={onFlatViewChange} count={changedCount} />
+          <FileScopeSwitch
+            flatView={flatView}
+            onChange={onFlatViewChange}
+            count={changedCount}
+            additions={lineTotals.additions}
+            deletions={lineTotals.deletions}
+          />
           <div className="flex min-w-0 flex-1 items-center gap-2">
             <div className="flex min-w-0 flex-1 items-center gap-[6px] rounded-full border border-border px-[10px] py-[4px] transition-colors focus-within:border-border-strong">
               <SearchIcon className="size-4 shrink-0 text-muted-foreground" />
@@ -452,7 +475,13 @@ export function FilesPanel({
       {!flatView && (
         <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
           <div className="flex items-center gap-2 px-2 py-1.5 @max-[400px]/filespanel:flex-col @max-[400px]/filespanel:items-stretch">
-            <FileScopeSwitch flatView={flatView} onChange={onFlatViewChange} count={changedCount} />
+            <FileScopeSwitch
+              flatView={flatView}
+              onChange={onFlatViewChange}
+              count={changedCount}
+              additions={lineTotals.additions}
+              deletions={lineTotals.deletions}
+            />
             <div className="flex min-w-0 flex-1 items-center gap-2">
               <div className="flex min-w-0 flex-1 items-center gap-[6px] rounded-full border border-border px-[10px] py-[4px] transition-colors focus-within:border-border-strong">
                 <SearchIcon className="size-4 shrink-0 text-muted-foreground" />


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Count untracked text files as additions so newly created files show accurate `+N` values; binary, unreadable, and oversized files remain unknown.
- Show a compact `Total: +N −M` summary only inside the active Changed view, keeping the `Changed N` tab uncluttered.
- ELI5: new files count all their lines as green additions, red deletions stay separate, and the totals appear only after opening Changed files.

```text
tracked files ── git numstat ──┐
                               ├─ additions total (+N)
untracked text ─ line count ───┘
tracked files ── git numstat ───── deletions total (−M)
```

## Test Plan

- `.venv/bin/pytest tests/runtime/test_filesystem_registry.py tests/test_workspace_fs.py -k 'git_line_counts or changes_lists_git_working_tree_modifications'` — 9 passed.
- `pnpm --dir web exec vitest run src/shell/FilesPanel.test.tsx src/shell/FlatFileList.test.tsx` — 52 passed.
- `pnpm --dir web type-check`.
- `.venv/bin/pre-commit run --all-files`.
- `pnpm --dir web build`.
- Manually verified created, modified, and temporarily deleted files in the desktop Changed panel.

## Demo

### Before Change
<img width="735" height="480" alt="Screenshot 2026-08-01 at 10 26 52" src="https://github.com/user-attachments/assets/8f0aa8bf-1264-4277-bac7-3004dd7168d5" />

### After Change
<img width="693" height="497" alt="Screenshot 2026-08-01 at 10 26 46" src="https://github.com/user-attachments/assets/2201e576-bf10-4bcc-b7c1-d9bf7f4dbaa6" />


## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified that new text files contribute only additions, deleted files contribute separate deletions, and the Changed summary never nets deletions against additions. The summary is visible only in the Changed view. Binary and oversized untracked files continue to omit line counts.

## Changelog

Show accurate, separate addition and deletion counts for changed workspace files.
