### PR TITLE
feat(cli): group and colorize `omnigent --help` output

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1345,6 +1345,67 @@ def _print_version_callback(ctx: click.Context, _param: click.Parameter, value: 
     ctx.exit()
 
 
+# Visible top-level subcommands that launch an agent harness (or a
+# bundled agent). Grouped under their own "Harnesses" heading in
+# ``omnigent --help`` so the long harness roster doesn't drown out the
+# management commands. Keep in sync with the harness launch commands
+# decorated below.
+_HARNESS_COMMANDS: frozenset[str] = frozenset(
+    {
+        "antigravity",
+        "claude",
+        "codex",
+        "cursor",
+        "debby",
+        "goose",
+        "hermes",
+        "kimi",
+        "kiro",
+        "opencode",
+        "pi",
+        "polly",
+        "qwen",
+    }
+)
+
+
+# Brand accent (Otto's magenta-pink, ``ui.ACCENT`` / ``#F43BA6``) as an
+# RGB triple for :func:`click.style` truecolor. Kept as a literal so
+# help formatting stays import-light (no pull of the rich-backed ui
+# module just to draw ``--help``).
+_ACCENT_RGB = (244, 59, 166)
+
+
+def _harness_extra_checks() -> dict[str, Callable[[], bool]]:
+    """Map extras-gated harness commands to their SDK-installed predicate.
+
+    Harnesses that ride an optional pip extra (lazily imported on first
+    turn) are hidden from ``omnigent --help`` until the extra is
+    importable, so the listing only advertises harnesses ready to launch.
+    The predicates use ``importlib.util.find_spec`` (no heavy import).
+    Commands absent from this map are always listed.
+    """
+    from omnigent.onboarding.antigravity_auth import antigravity_sdk_installed
+    from omnigent.onboarding.cursor_auth import cursor_sdk_installed
+
+    return {
+        "cursor": cursor_sdk_installed,
+        "antigravity": antigravity_sdk_installed,
+    }
+
+
+def _help_style(text: str, **style: object) -> str:
+    """Colorize *text* for help output, honoring ``NO_COLOR``.
+
+    Click's ``echo`` already strips ANSI when the sink is not a TTY, so
+    this only needs to guard the explicit ``NO_COLOR`` opt-out; on an
+    interactive terminal the styled string is emitted as-is.
+    """
+    if os.environ.get("NO_COLOR"):
+        return text
+    return click.style(text, **style)  # type: ignore[arg-type]
+
+
 class _OmnigentCLI(click.Group):
     """Top-level group that prints the brand lockup above its help.
 
@@ -1354,6 +1415,83 @@ class _OmnigentCLI(click.Group):
     clean. Only the top-level group overrides help; subcommand help
     (``omnigent run --help``) is untouched.
     """
+
+    def format_usage(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        """Render the usage line with an accent-colored ``Usage:`` prefix."""
+        pieces = self.collect_usage_pieces(ctx)
+        prefix = f"{_help_style('Usage:', fg=_ACCENT_RGB, bold=True)} "
+        formatter.write_usage(ctx.command_path, " ".join(pieces), prefix=prefix)
+
+    def format_options(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        """Color the ``Options`` heading + flag names, then the commands."""
+        opts = []
+        for param in self.get_params(ctx):
+            rv = param.get_help_record(ctx)
+            if rv is not None:
+                opts.append((_help_style(rv[0], fg="green"), rv[1]))
+        if opts:
+            with formatter.section(_help_style("Options", fg=_ACCENT_RGB, bold=True)):
+                formatter.write_dl(opts)
+        self.format_commands(ctx, formatter)
+
+    def format_commands(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        """List commands under two headings: Harnesses and Commands.
+
+        Mirrors Click's default ``format_commands`` (skipping hidden
+        commands, sharing one column width) but splits the visible
+        subcommands into the harness launchers and everything else, and
+        tints each section: harness names in the brand accent, the rest
+        in cyan.
+        """
+        harness_rows: list[tuple[str, click.Command]] = []
+        other_rows: list[tuple[str, click.Command]] = []
+        any_hidden = False
+        extra_checks = _harness_extra_checks()
+        for subcommand in self.list_commands(ctx):
+            cmd = self.get_command(ctx, subcommand)
+            if cmd is None or cmd.hidden:
+                continue
+            if subcommand in _HARNESS_COMMANDS:
+                # Hide extras-gated harnesses whose SDK isn't installed;
+                # they remain runnable (running them offers the install).
+                check = extra_checks.get(subcommand)
+                if check is not None and not check():
+                    any_hidden = True
+                    continue
+                harness_rows.append((subcommand, cmd))
+            else:
+                other_rows.append((subcommand, cmd))
+
+        all_names = [name for name, _ in (*harness_rows, *other_rows)]
+        if not all_names:
+            return
+        # Share one help column across both sections so their
+        # descriptions line up. Width is measured on the plain names —
+        # ANSI styling is added afterward and is stripped by Click's
+        # ``term_len`` when it computes alignment.
+        limit = formatter.width - 6 - max(len(name) for name in all_names)
+
+        def _emit(title: str, rows: list[tuple[str, click.Command]], name_fg: object) -> None:
+            if not rows:
+                return
+            with formatter.section(_help_style(title, fg=_ACCENT_RGB, bold=True)):
+                formatter.write_dl(
+                    [
+                        (_help_style(name, fg=name_fg), cmd.get_short_help_str(limit))
+                        for name, cmd in rows
+                    ]
+                )
+
+        _emit("Harnesses", harness_rows, _ACCENT_RGB)
+        if any_hidden:
+            formatter.write_paragraph()
+            formatter.write_text(
+                _help_style(
+                    "Some harnesses need an optional extra — run `omnigent setup` to enable them.",
+                    dim=True,
+                )
+            )
+        _emit("Commands", other_rows, "cyan")
 
     def format_help(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         from omnigent.inner import ui

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -952,6 +952,59 @@ def test_kiro_command_is_registered_in_click_help() -> None:
     assert "kiro" in result.output
 
 
+def test_help_groups_harnesses_and_other_commands() -> None:
+    """``--help`` lists a ``Harnesses`` section separate from ``Commands``."""
+    result = CliRunner().invoke(cli, ["--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "Harnesses:" in result.output
+    assert "Commands:" in result.output
+    # A harness launcher lands under Harnesses; a management command
+    # lands under Commands (both after their respective headings).
+    harnesses_at = result.output.index("Harnesses:")
+    commands_at = result.output.index("Commands:", harnesses_at)
+    assert harnesses_at < result.output.index("claude") < commands_at
+    assert commands_at < result.output.index("server")
+
+
+def test_help_hides_extras_gated_harness_when_sdk_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """cursor/antigravity drop out of the harness list; a notice replaces them."""
+    monkeypatch.setattr(
+        "omnigent.cli._harness_extra_checks",
+        lambda: {"cursor": lambda: False, "antigravity": lambda: False},
+    )
+
+    result = CliRunner().invoke(cli, ["--help"])
+
+    assert result.exit_code == 0, result.output
+    # Not listed as launchable harnesses...
+    assert "Launch the Cursor TUI" not in result.output
+    assert "Launch the Antigravity" not in result.output
+    # ...but a generic notice points at setup instead.
+    assert "Some harnesses need an optional extra" in result.output
+    # Still a real, registered command — only the listing is suppressed.
+    assert "cursor" in _CLICK_SUBCOMMANDS
+
+
+def test_help_shows_extras_gated_harness_when_sdk_installed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """cursor/antigravity appear in --help once their extra is importable."""
+    monkeypatch.setattr(
+        "omnigent.cli._harness_extra_checks",
+        lambda: {"cursor": lambda: True, "antigravity": lambda: True},
+    )
+
+    result = CliRunner().invoke(cli, ["--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "cursor" in result.output
+    assert "antigravity" in result.output
+    assert "Some harnesses need an optional extra" not in result.output
+
+
 def test_kiro_command_parses_native_options_and_prompt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Splits the top-level `omnigent --help` command list into two sections — **Harnesses** (agent/harness launch commands: `claude`, `codex`, `pi`, `polly`, …) and **Commands** (session, server, config, maintenance, …) — so the long harness roster no longer drowns out the management commands.
- Adds brand-accent color to the help output: headings (`Usage:`, `Options`, `Harnesses`, `Commands`) and harness names in the accent magenta (`#F43BA6`), other command names in cyan, and option flags in green.
- **Hides extras-gated harnesses (`cursor`, `antigravity`) from the listing when their optional SDK isn't installed**, and shows a small generic notice instead: `Some harnesses need an optional extra — run \`omnigent setup\` to enable them.` The commands stay runnable (running one still offers to install the extra); only the launch-list entry is suppressed. Detection uses lightweight `importlib.util.find_spec` predicates (`_harness_extra_checks`). The notice deliberately doesn't enumerate harnesses/extras (that set changes) — and `omnigent setup` genuinely lists those harnesses and offers to install the missing extra.
- **Hides the `update` alias** (the same Click object as `upgrade`) from the listing so it no longer shows as a duplicate line; it stays registered and runnable.
- **Tidies the short-help copy:** harness one-liners → `Launch <Name> with Omnigent.` (was an inconsistent mix of `Launch the … TUI in an Omnigent terminal`); `upgrade` → `Upgrade Omnigent to the latest release.`; and drops the parenthetical on the `debug` group.
- Color is gated on `NO_COLOR` and Click strips ANSI on non-TTY sinks, so piped / CI help stays plain. Alignment is ANSI-safe (Click's `term_len` strips escapes before measuring columns).

Implemented via `format_usage` / `format_options` / `format_commands` overrides on `_OmnigentCLI` plus `_help_style` / `_harness_extra_checks` helpers; `_HARNESS_COMMANDS` / `_ALIAS_COMMANDS` sets drive the partition. Subcommand help (`omnigent run --help`) is untouched.

## Test Plan

- `uv run omnigent --help` in a terminal — shows the two colored sections.
- `uv run omnigent --help | cat` — plain text, **0** escape sequences.
- `NO_COLOR=1` on a forced TTY — plain text, **0** escape sequences.
- With `cursor-sdk` / `google-antigravity` absent: `cursor` / `antigravity` are omitted from the harness list and replaced by the notice, but `omnigent cursor --help` still works (command remains registered).
- With the extras present (simulated): both reappear under **Harnesses** and the notice disappears.
- `omnigent update --help` still works while `update` is omitted from the listing.
- `uv run pytest tests/cli/test_cli.py tests/cli/test_upgrade_command.py` — **275 passed**.
- `pre-commit run` — all hooks pass.

## Demo

`omnigent --help` when the cursor / antigravity extras are **not** installed (color not visible in text capture):

```
Usage: omnigent [OPTIONS] COMMAND [ARGS]...

  Omnigent CLI.

Options:
  --debug          Enable verbose DEBUG logging for Omnigent processes.
  --log-to-stderr  Mirror process logs to the terminal when stderr is interactive.
  --version        Show the version and exit.
  --help           Show this message and exit.

Harnesses:
  claude    Launch Claude Code with Omnigent.
  codex     Launch Codex with Omnigent.
  debby     Launch debby, the bundled two-headed brainstorming agent.
  goose     Launch Goose with Omnigent.
  hermes    Launch Hermes with Omnigent.
  kimi      Launch Kimi Code with Omnigent.
  kiro      Launch Kiro with Omnigent.
  opencode  Launch OpenCode with Omnigent.
  pi        Launch Pi with Omnigent.
  polly     Launch polly, the bundled multi-agent coding orchestrator.
  qwen      Launch Qwen Code with Omnigent.

Some harnesses need an optional extra — run `omnigent setup` to enable them.

Commands:
  attach       Attach the REPL to a LIVE session — never starts anything.
  config       Get, set, and view Omnigent defaults and credentials.
  debug        Internal maintenance commands — advanced, not needed for...
  ... (server, session, host, integration, doctor, upgrade, usage, …)
```

Once the cursor / antigravity extra is installed, those harnesses reappear under **Harnesses** and the notice drops away. Colors (in a real terminal): headings + harness names in accent magenta, other command names in cyan, option flags in green, the notice dimmed.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added unit tests in `tests/cli/test_cli.py`: the Harnesses/Commands grouping; the extras-gated hide (asserting the harness launch line is gone, the setup notice is shown, and the command stays registered); the show path once the extra is present (notice absent); and the hidden `update` alias (omitted from the listing but still resolving to the `upgrade` command). Manual verification: ran `omnigent --help` in a TTY (colored, grouped, notice dimmed), piped (`| cat`, 0 escape codes), and with `NO_COLOR=1` on a forced TTY (0 escape codes); confirmed `omnigent cursor --help` / `omnigent update --help` still work while those names are omitted from the listing, and confirmed `omnigent setup` lists cursor/antigravity and offers to install their extra. Existing assertions on `"Usage:"` / `"Commands:"` and the command roster continue to pass (275 tests).

## Changelog

`omnigent --help` now groups launch commands under a **Harnesses** section, colorizes the output, hides harnesses whose optional extra isn't installed (with a notice pointing at `omnigent setup`), drops the duplicate `update` alias line, and tidies the command descriptions
