### PR TITLE
feat(cli): preserve extras and refuse unsafe installers in omni upgrade

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4111,7 +4111,12 @@ def _drain_and_stop_local_server(*, force: bool) -> None:
 
 
 def _upgrade_vcs_install(
-    info: _InstalledWheelInfo, *, check_only: bool, force: bool, pre: bool
+    info: _InstalledWheelInfo,
+    *,
+    check_only: bool,
+    force: bool,
+    pre: bool,
+    extra_overrides: tuple[str, ...],
 ) -> None:
     """Update a git/VCS ``omni`` install by re-pulling its tracked ref.
 
@@ -4128,6 +4133,7 @@ def _upgrade_vcs_install(
         positively confirm the install is behind its tracked ref.
     :param force: Stop in-flight sessions immediately instead of draining.
     :param pre: Pass the installer's allow-pre-releases flag (no-op for git).
+    :param extra_overrides: Extras supplied by ``omni upgrade --extra``.
     """
     from omnigent.update_check import (
         _build_upgrade_suggestion,
@@ -4172,7 +4178,11 @@ def _upgrade_vcs_install(
             "Note: --pre has no effect on a git install; the tracked ref decides the commit."
         )
 
-    suggestion = _build_upgrade_suggestion(info, allow_prerelease=pre)
+    suggestion = _build_upgrade_suggestion(
+        info,
+        allow_prerelease=pre,
+        extra_overrides=extra_overrides,
+    )
     if not suggestion.runnable:
         raise click.ClickException(
             f"No automatic upgrade command is known for this install. {suggestion.command}."
@@ -4237,26 +4247,57 @@ def _upgrade_vcs_install(
     help="Consider pre-releases (e.g. release candidates), and pass the "
     "installer's allow-pre-releases flag. Useful for validating a TestPyPI rc.",
 )
-def upgrade(check_only: bool, force: bool, pre: bool) -> None:
+@click.option(
+    "--extra",
+    "extra_overrides",
+    multiple=True,
+    help="Extra dependency set(s) to keep or add during the upgrade. "
+    "May be given multiple times. Overrides extras detected from installer metadata.",
+)
+@click.option(
+    "--target-version",
+    help="Upgrade to a specific version instead of the latest release.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Print the detected install shape and upgrade command, then exit "
+    "without stopping sessions or running the installer.",
+)
+def upgrade(
+    check_only: bool,
+    force: bool,
+    pre: bool,
+    extra_overrides: tuple[str, ...],
+    target_version: str | None,
+    dry_run: bool,
+) -> None:
     """Upgrade the omnigent CLI to the latest release on PyPI.
 
-    Detects how omnigent was installed (uv / pip / pipx / poetry), checks
-    the configured index for a newer release and — unless ``--check`` —
-    drains and stops the local background server and host daemon, then runs
-    the matching upgrade command. The next ``omni`` invocation starts a
-    fresh server on the new code automatically (via the version-aware
-    config signature), so no explicit restart is needed.
+    Detects how omnigent was installed (uv tool / pipx), checks the
+    configured index for a newer release and — unless ``--check`` — drains
+    and stops the local background server and host daemon, then runs the
+    matching upgrade command. The next ``omni`` invocation starts a fresh
+    server on the new code automatically, so no explicit restart is needed.
 
     In-flight agent sessions are waited on by default; pass ``--force`` to
     stop them immediately. Pass ``--pre`` to consider pre-releases (rc /
-    beta) — handy for validating a TestPyPI candidate against your
-    configured index. Source checkouts / editable installs are not upgraded
-    here — update those with ``git pull``.
+    beta). Pass ``--extra`` to keep or add extras that the installer did not
+    record. Use ``--target-version`` when validating a specific release.
+
+    Requires the install to have come from a tool that records extras:
+    ``uv tool install`` or ``pipx install``. ``pip`` does not record
+    extras, so ``omni upgrade`` refuses to auto-upgrade it and prints the
+    manual command instead. Source checkouts / editable installs are not
+    upgraded here — update those with ``git pull``.
 
     :param check_only: Only report availability; do not upgrade. Exits
         with status 1 when a newer release exists.
     :param force: Stop in-flight sessions immediately rather than draining.
     :param pre: Consider pre-releases and allow the installer to fetch them.
+    :param extra_overrides: Extras requested via ``--extra``.
+    :param target_version: Pin the upgrade to this version.
+    :param dry_run: Print the command and exit without running it.
     :returns: None.
     """
     import importlib.metadata
@@ -4269,6 +4310,7 @@ def upgrade(check_only: bool, force: bool, pre: bool) -> None:
         _probe_installed_distribution,
         _read_installed_wheel_info,
         _run_upgrade_command,
+        _uv_tool_receipt_path,
         fetch_latest_version,
     )
 
@@ -4297,25 +4339,67 @@ def upgrade(check_only: bool, force: bool, pre: bool) -> None:
     # installs "upgrade" means re-pulling the ref — compared and verified by
     # commit, not by PyPI version.
     if info.vcs_url:
-        _upgrade_vcs_install(info, check_only=check_only, force=force, pre=pre)
+        _upgrade_vcs_install(
+            info,
+            check_only=check_only,
+            force=force,
+            pre=pre,
+            extra_overrides=extra_overrides,
+        )
         return
+
+    # pip / ``uv pip`` do not record which extras were requested for a plain
+    # registry install. Auto-upgrade cannot preserve them safely, so we print
+    # a manual command instead. We still allow ``--check`` because that only
+    # reports availability.
+    if not check_only:
+        if info.detected_installer == "pip":
+            click.echo(
+                "omnigent was installed with pip, and pip does not record which extras "
+                "were requested. `omni upgrade` cannot preserve them safely, so you "
+                "should upgrade manually:\n\n"
+                "    pip install -U omnigent\n"
+                "    # or, if you need extras:\n"
+                "    pip install -U 'omnigent[your,extras,here]'"
+            )
+            raise SystemExit(0)
+        if info.detected_installer == "uv" and _uv_tool_receipt_path() is None:
+            click.echo(
+                "omnigent was installed with `uv pip`, not `uv tool install`. "
+                "`uv pip` does not record which extras were requested, so "
+                "`omni upgrade` cannot preserve them safely. Upgrade manually:\n\n"
+                "    uv pip install -U omnigent\n"
+                "    # or, if you need extras:\n"
+                "    uv pip install -U 'omnigent[your,extras,here]'"
+            )
+            raise SystemExit(0)
 
     current = importlib.metadata.version("omnigent")
-    # User-initiated: a more forgiving timeout + one retry so a momentarily slow
-    # mirror doesn't spuriously report the index as unreachable.
-    latest = fetch_latest_version(
-        include_prereleases=pre, timeout=_UPGRADE_INDEX_TIMEOUT_SECONDS, attempts=2
-    )
-    if latest is None:
-        raise click.ClickException(
-            "Couldn't reach the package index to check for a newer release. Check your "
-            "connection (or OMNIGENT_INDEX_URL / your configured index) and try again."
+    if target_version:
+        # A pinned target version means we don't have to ask the index what
+        # "latest" is. Treat the target as the desired release. This is
+        # especially useful for release validation against a specific rc or
+        # testing the upgrade path when the current dev version is already
+        # newer than anything on PyPI.
+        latest = target_version
+        click.echo(f"Targeting v{latest}.")
+    else:
+        # User-initiated: a more forgiving timeout + one retry so a momentarily slow
+        # mirror doesn't spuriously report the index as unreachable.
+        latest = fetch_latest_version(
+            include_prereleases=pre, timeout=_UPGRADE_INDEX_TIMEOUT_SECONDS, attempts=2
         )
-    if not _is_newer(latest, current):
-        click.echo(f"omnigent is up to date (v{current}).")
-        return
+        if latest is None:
+            raise click.ClickException(
+                "Couldn't reach the package index to check for a newer release. Check your "
+                "connection (or OMNIGENT_INDEX_URL / your configured index) and try again."
+            )
+        if not _is_newer(latest, current):
+            click.echo(f"omnigent is up to date (v{current}).")
+            return
 
-    click.echo(f"A new release is available: v{current} → v{latest}.")
+        click.echo(f"A new release is available: v{current} → v{latest}.")
+
     if check_only:
         # Non-zero so scripts/CI can gate on "an upgrade is available".
         # SystemExit (not ctx.exit) because main() runs the group with
@@ -4323,11 +4407,25 @@ def upgrade(check_only: bool, force: bool, pre: bool) -> None:
         # dropped rather than applied — SystemExit propagates correctly.
         raise SystemExit(1)
 
-    suggestion = _build_upgrade_suggestion(info, allow_prerelease=pre)
+    suggestion = _build_upgrade_suggestion(
+        info,
+        allow_prerelease=pre,
+        extra_overrides=extra_overrides,
+        target_version=target_version,
+    )
     if not suggestion.runnable:
         raise click.ClickException(
             f"No automatic upgrade command is known for this install. {suggestion.command}."
         )
+
+    if dry_run:
+        extras = sorted(set(extra_overrides or info.extras))
+        click.echo(
+            f"Detected installer: {info.detected_installer or info.installer}\n"
+            f"Detected extras: {', '.join(extras) if extras else '(none)'}\n"
+            f"Would run: {suggestion.command}"
+        )
+        return
 
     _drain_and_stop_local_server(force=force)
 
@@ -4351,6 +4449,7 @@ def upgrade(check_only: bool, force: bool, pre: bool) -> None:
             "Run `omni upgrade --check` to verify."
         )
         return
+    expected_version = target_version or latest
     if _is_newer(new_version, current):
         click.echo(
             f"✓ Upgraded to v{new_version}. Re-run your command — the local "
@@ -4359,10 +4458,10 @@ def upgrade(check_only: bool, force: bool, pre: bool) -> None:
         return
     raise click.ClickException(
         f"The upgrade command ran but omnigent is still v{new_version} (expected "
-        f"v{latest}). The install is likely version-pinned, a cooldown / "
+        f"v{expected_version}). The install is likely version-pinned, a cooldown / "
         "exclude-newer is excluding the new release, or the index cache is stale. "
         "Reinstall it explicitly — e.g. `uv tool upgrade --reinstall omnigent` or "
-        f"`pip install --force-reinstall 'omnigent=={latest}'`."
+        f"`pip install --force-reinstall 'omnigent=={expected_version}'`."
     )
 
 

--- a/omnigent/update_check.py
+++ b/omnigent/update_check.py
@@ -43,9 +43,12 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Collection
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+import tomllib
 
 if TYPE_CHECKING:
     # Imported only for type hints; the heavy/optional imports remain lazy
@@ -167,6 +170,9 @@ class _InstalledWheelInfo:
         for picking the upgrade command — same as ``installer`` for
         most cases, but ``"pipx"`` when the pipx venv path heuristic
         fires even though ``INSTALLER`` says ``"pip"``.
+    :param extras: Optional extras recorded by the installer, e.g.
+        ``["all"]``. Empty when the installer does not preserve them
+        (e.g. ``pip``) or when none were requested.
     """
 
     install_time_epoch: float
@@ -176,6 +182,7 @@ class _InstalledWheelInfo:
     is_editable: bool
     package_version: str
     detected_installer: str | None
+    extras: tuple[str, ...] = ()
 
 
 def maybe_show_update_notice() -> None:
@@ -686,7 +693,9 @@ def _find_repo_root() -> Path | None:
     """
     package_dir = Path(__file__).resolve().parent  # <candidate>/omnigent/
     candidate = package_dir.parent
-    if (candidate / ".git").is_dir() and (candidate / "pyproject.toml").is_file():
+    # ``.git`` may be a directory (a normal clone) or a file (a git
+    # worktree), so check for existence rather than requiring a dir.
+    if (candidate / ".git").exists() and (candidate / "pyproject.toml").is_file():
         return candidate
     return None
 
@@ -1132,6 +1141,17 @@ def _read_installed_wheel_info() -> _InstalledWheelInfo | None:
     if installer == "pip" and _looks_like_pipx_install():
         detected_installer = "pipx"
 
+    # Read requested extras from installer-specific receipts when available.
+    extras: list[str] = []
+    if detected_installer == "uv":
+        uv_extras = _read_uv_tool_extras()
+        if uv_extras is not None:
+            extras = uv_extras
+    elif detected_installer == "pipx":
+        pipx_extras = _read_pipx_extras()
+        if pipx_extras is not None:
+            extras = pipx_extras
+
     return _InstalledWheelInfo(
         install_time_epoch=install_time_epoch,
         installer=installer,
@@ -1140,6 +1160,7 @@ def _read_installed_wheel_info() -> _InstalledWheelInfo | None:
         is_editable=is_editable,
         package_version=dist.version,
         detected_installer=detected_installer,
+        extras=tuple(extras),
     )
 
 
@@ -1220,6 +1241,146 @@ def _looks_like_pipx_install() -> bool:
     return "pipx/venvs" in sys.prefix.replace(os.sep, "/")
 
 
+def _uv_tool_receipt_path() -> Path | None:
+    """Locate ``uv-receipt.toml`` for a uv tool install of ``omnigent``.
+
+    uv tool installs create a per-tool venv. The receipt sits in the
+    venv root, next to ``bin/`` and ``lib/``. The running interpreter
+    is ``<tool-dir>/<pkg>/bin/python``, so its grandparent is the venv
+    root.
+
+    We deliberately do *not* resolve symlinks: uv's ``bin/python`` is a
+    symlink to a shared interpreter, and resolving it would point at the
+    uv Python install directory instead of the tool venv.
+
+    :returns: Path to ``uv-receipt.toml`` if it exists, otherwise ``None``.
+    """
+    if not sys.executable:
+        return None
+    try:
+        exe = Path(sys.executable)
+    except OSError:
+        return None
+    receipt = exe.parents[1] / "uv-receipt.toml"
+    if receipt.is_file():
+        return receipt
+    tool_dir = os.environ.get("UV_TOOL_DIR")
+    if tool_dir:
+        receipt = Path(tool_dir) / _DIST_NAME / "uv-receipt.toml"
+        if receipt.is_file():
+            return receipt
+    return None
+
+
+def _read_uv_tool_extras() -> list[str] | None:
+    """Read requested extras from the uv tool receipt.
+
+    :returns: A list of extras when a receipt for ``omnigent`` is found.
+        An empty list means the receipt exists but no extras were
+        requested. ``None`` means no receipt was found or it could not
+        be parsed.
+    """
+    receipt_path = _uv_tool_receipt_path()
+    if receipt_path is None:
+        return None
+    try:
+        data = tomllib.loads(receipt_path.read_text())
+    except (OSError, ValueError, tomllib.TOMLDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    tool = data.get("tool")
+    if not isinstance(tool, dict):
+        return None
+    requirements = tool.get("requirements")
+    if not isinstance(requirements, list):
+        return None
+    for req in requirements:
+        if not isinstance(req, dict) or req.get("name") != _DIST_NAME:
+            continue
+        raw_extras = req.get("extras")
+        if not isinstance(raw_extras, list):
+            return []
+        return [
+            str(extra).strip() for extra in raw_extras if isinstance(extra, str) and extra.strip()
+        ]
+    return []
+
+
+def _pipx_metadata_path() -> Path | None:
+    """Locate pipx's venv metadata file for a pipx install of ``omnigent``.
+
+    :returns: Path to ``pipx_metadata.json`` if the running interpreter
+        is inside a pipx venv, otherwise ``None``.
+    """
+    if not sys.prefix:
+        return None
+    prefix = Path(sys.prefix)
+    if "pipx/venvs" not in str(prefix).replace(os.sep, "/"):
+        return None
+    candidate = prefix / "pipx_metadata.json"
+    return candidate if candidate.is_file() else None
+
+
+def _parse_extras_from_spec(spec: str) -> list[str]:
+    """Parse extras out of a PEP 508 package spec string.
+
+    Examples: ``"omnigent[all,server]"`` → ``["all", "server"]``.
+
+    :param spec: A package spec, possibly containing extras.
+    :returns: The list of extra names (preserving order, deduplicated).
+    """
+    import re
+
+    match = re.search(r"\[([^\]]+)\]", spec)
+    if not match:
+        return []
+    seen: set[str] = set()
+    extras: list[str] = []
+    for raw in match.group(1).split(","):
+        extra = raw.strip()
+        if extra and extra not in seen:
+            seen.add(extra)
+            extras.append(extra)
+    return extras
+
+
+def _read_pipx_extras() -> list[str] | None:
+    """Read requested extras from pipx's venv metadata.
+
+    :returns: A list of extras parsed from ``main_package.package_or_url``.
+        An empty list means metadata was found but the spec had no
+        extras. ``None`` means the metadata could not be read.
+    """
+    metadata_path = _pipx_metadata_path()
+    if metadata_path is None:
+        return None
+    try:
+        data = json.loads(metadata_path.read_text())
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    main = data.get("main_package")
+    if not isinstance(main, dict):
+        return None
+    spec = main.get("package_or_url")
+    if not isinstance(spec, str):
+        return []
+    return _parse_extras_from_spec(spec)
+
+
+def _extras_str(extras: Collection[str]) -> str:
+    """Format extras as a PEP 508 extra suffix.
+
+    :param extras: Iterable of extra names.
+    :returns: ``"[a,b]"`` if extras is non-empty, otherwise ``""``.
+    """
+    if not extras:
+        return ""
+    return f"[{','.join(sorted(extras))}]"
+
+
 @dataclass
 class _UpgradeSuggestion:
     """A suggested upgrade command for the user's install shape.
@@ -1282,8 +1443,27 @@ def _pip_invocation() -> str:
     return f"{shlex.quote(sys.executable)} -m pip"
 
 
+def _package_spec(*, version: str | None = None, extras: Collection[str] = ()) -> str:
+    """Build a PEP 508 package spec for ``omnigent``.
+
+    :param version: Optional pinned version, e.g. ``"0.2.0"``.
+    :param extras: Optional extras to append.
+    :returns: ``"omnigent"``, ``"omnigent[all]"``, ``"omnigent==0.2.0[all]"``,
+        etc., depending on which arguments were provided.
+    """
+    spec = _DIST_NAME
+    if version:
+        spec += f"=={version}"
+    spec += _extras_str(extras)
+    return spec
+
+
 def _build_upgrade_suggestion(
-    info: _InstalledWheelInfo, *, allow_prerelease: bool = False
+    info: _InstalledWheelInfo,
+    *,
+    allow_prerelease: bool = False,
+    extra_overrides: tuple[str, ...] = (),
+    target_version: str | None = None,
 ) -> _UpgradeSuggestion:
     """Build the right upgrade command for the user's install shape.
 
@@ -1295,6 +1475,11 @@ def _build_upgrade_suggestion(
         the installer's allow-pre-releases flag (uv ``--prerelease allow``,
         pip ``--pre``, pipx ``--pip-args=--pre``) so the upgrade can land on
         a release candidate. A no-op for installers without a known flag.
+    :param extra_overrides: Extras supplied by the user with
+        ``omni upgrade --extra``. These take precedence over installer
+        metadata.
+    :param target_version: Pin the upgrade to a specific version instead
+        of resolving the latest release.
     :returns: A :class:`_UpgradeSuggestion` whose ``command`` is the
         line printed in the nag panel and whose ``runnable`` flag
         tells the caller whether the line is an actual invocation
@@ -1303,41 +1488,74 @@ def _build_upgrade_suggestion(
     """
     installer = info.detected_installer or info.installer
     pre = _PRERELEASE_FLAG.get(installer or "", "") if allow_prerelease else ""
+    extras = sorted(set(info.extras) | set(extra_overrides))
 
     if info.vcs_url:
         # VCS install — we know the exact source URL.
+        vcs_url_with_extras = info.vcs_url
+        if extras:
+            # Strip any existing fragment and append an egg spec with extras.
+            base = vcs_url_with_extras.split("#", 1)[0]
+            vcs_url_with_extras = f"{base}#egg={_package_spec(extras=extras)}"
         if installer == "uv":
             return _UpgradeSuggestion(
-                command=f"uv tool install --reinstall {info.vcs_url}{pre}",
+                command=f"uv tool install --reinstall {vcs_url_with_extras}{pre}",
                 runnable=True,
             )
         if installer == "pipx":
+            if extras:
+                return _UpgradeSuggestion(
+                    command=f"pipx install --force {vcs_url_with_extras}",
+                    runnable=True,
+                )
             # pipx tracks the original spec; ``reinstall`` re-pulls it.
             return _UpgradeSuggestion(command=f"pipx reinstall {_DIST_NAME}{pre}", runnable=True)
         if installer in ("pip", None):
             return _UpgradeSuggestion(
-                command=f"{_pip_invocation()} install --force-reinstall {info.vcs_url}{pre}",
+                command=(
+                    f"{_pip_invocation()} install --force-reinstall {vcs_url_with_extras}{pre}"
+                ),
                 runnable=True,
             )
         if installer == "poetry":
-            return _UpgradeSuggestion(command=f"poetry add --force {info.vcs_url}", runnable=True)
+            return _UpgradeSuggestion(
+                command=f"poetry add --force {vcs_url_with_extras}", runnable=True
+            )
         # Unknown installer with a known URL — fall through to a
         # generic suggestion that names the URL so the user can wire
         # it into their own tool. Not runnable.
         return _UpgradeSuggestion(
-            command=f"reinstall {_DIST_NAME} from {info.vcs_url}", runnable=False
+            command=f"reinstall {_DIST_NAME} from {vcs_url_with_extras}", runnable=False
         )
 
     # Registry install — no VCS URL recorded.
+    registry_spec = _package_spec(version=target_version, extras=extras)
     if installer == "uv":
+        if target_version or extras:
+            # ``uv tool upgrade`` accepts only a tool name (and optional
+            # version), not extras. Reinstall with the full PEP 508 spec
+            # to preserve the extras the user originally requested.
+            return _UpgradeSuggestion(
+                command=f"uv tool install --reinstall {registry_spec}{pre}",
+                runnable=True,
+            )
         return _UpgradeSuggestion(command=f"uv tool upgrade {_DIST_NAME}{pre}", runnable=True)
     if installer == "pipx":
+        if target_version or extras:
+            # ``pipx upgrade`` does not accept extras / version specs.
+            # ``pipx install --force`` does.
+            return _UpgradeSuggestion(
+                command=f"pipx install --force {registry_spec}",
+                runnable=True,
+            )
         return _UpgradeSuggestion(command=f"pipx upgrade {_DIST_NAME}{pre}", runnable=True)
     if installer == "pip":
         return _UpgradeSuggestion(
-            command=f"{_pip_invocation()} install -U {_DIST_NAME}{pre}", runnable=True
+            command=f"{_pip_invocation()} install -U {registry_spec}{pre}",
+            runnable=True,
         )
     if installer == "poetry":
+        # Poetry update does not accept extras on the command line.
         return _UpgradeSuggestion(command=f"poetry update {_DIST_NAME}", runnable=True)
     return _UpgradeSuggestion(
         command=f"reinstall {_DIST_NAME} from your original source",

--- a/tests/cli/test_update_check.py
+++ b/tests/cli/test_update_check.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import json
 import subprocess
+import textwrap
 import time
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from click.testing import CliRunner
 
+from omnigent.cli import cli
 from omnigent.update_check import (
     _STALENESS_SECONDS,
     _CacheEntry,
@@ -28,12 +31,13 @@ from omnigent.update_check import (
 
 
 def test_find_repo_root_finds_git_dir() -> None:
-    """``_find_repo_root`` returns the repo root when a ``.git/`` exists."""
+    """``_find_repo_root`` returns the repo root when a ``.git`` exists."""
     root = _find_repo_root()
     # The test itself runs inside the repo, so root must be non-None
-    # and contain a .git directory.
+    # and contain a .git entry (directory for a normal clone, file
+    # for a git worktree).
     assert root is not None
-    assert (root / ".git").is_dir()
+    assert (root / ".git").exists()
 
 
 def test_find_repo_root_no_git_integration(
@@ -497,9 +501,12 @@ import sys  # noqa: E402
 from omnigent.update_check import (  # noqa: E402
     _build_upgrade_suggestion,
     _InstalledWheelInfo,
+    _parse_extras_from_spec,
     _pip_invocation,
     _read_build_info,
     _read_installed_wheel_info,
+    _read_pipx_extras,
+    _read_uv_tool_extras,
     _run_installed_wheel_check,
     _unredact_ssh_userinfo,
 )
@@ -1472,6 +1479,204 @@ def test_build_upgrade_suggestion_allow_prerelease() -> None:
     )
 
 
+# ------------------------------------------------------------------
+# Extras preservation
+# ------------------------------------------------------------------
+
+
+def test_parse_extras_from_spec() -> None:
+    """`_parse_extras_from_spec` extracts extras in declaration order."""
+    assert _parse_extras_from_spec("omnigent") == []
+    assert _parse_extras_from_spec("omnigent[all]") == ["all"]
+    assert _parse_extras_from_spec("omnigent[all,server]") == ["all", "server"]
+    assert _parse_extras_from_spec("omnigent[all , server]") == ["all", "server"]
+
+
+def _make_info(
+    installer: str = "uv",
+    *,
+    extras: tuple[str, ...] = (),
+    vcs_url: str | None = None,
+) -> _InstalledWheelInfo:
+    return _InstalledWheelInfo(
+        install_time_epoch=0.0,
+        installer=installer,
+        vcs_url=vcs_url,
+        commit_sha=None,
+        is_editable=False,
+        package_version="0.1.0",
+        detected_installer=installer,
+        extras=extras,
+    )
+
+
+def test_build_upgrade_suggestion_preserves_uv_tool_extras() -> None:
+    """uv tool installs with extras use ``install --reinstall`` to keep them."""
+    # No extras → plain uv tool upgrade.
+    assert _build_upgrade_suggestion(_make_info("uv")).command == "uv tool upgrade omnigent"
+    # With extras → reinstall with the PEP 508 spec.
+    assert (
+        _build_upgrade_suggestion(_make_info("uv", extras=("all",))).command
+        == "uv tool install --reinstall omnigent[all]"
+    )
+    assert (
+        _build_upgrade_suggestion(_make_info("uv", extras=("server", "all"))).command
+        == "uv tool install --reinstall omnigent[all,server]"
+    )
+
+
+def test_build_upgrade_suggestion_uv_target_version() -> None:
+    """A pinned target version produces ``install --reinstall`` with the spec."""
+    assert (
+        _build_upgrade_suggestion(_make_info("uv"), target_version="0.2.0").command
+        == "uv tool install --reinstall omnigent==0.2.0"
+    )
+    assert (
+        _build_upgrade_suggestion(
+            _make_info("uv", extras=("all",)), target_version="0.2.0"
+        ).command
+        == "uv tool install --reinstall omnigent==0.2.0[all]"
+    )
+
+
+def test_build_upgrade_suggestion_extra_overrides_win() -> None:
+    """``--extra`` appends to / overrides detected extras."""
+    assert (
+        _build_upgrade_suggestion(
+            _make_info("uv", extras=("all",)), extra_overrides=("server",)
+        ).command
+        == "uv tool install --reinstall omnigent[all,server]"
+    )
+    assert (
+        _build_upgrade_suggestion(_make_info("uv"), extra_overrides=("all",)).command
+        == "uv tool install --reinstall omnigent[all]"
+    )
+
+
+def test_build_upgrade_suggestion_preserves_pipx_extras() -> None:
+    """pipx installs with extras use ``install --force``; plain ones use ``upgrade``."""
+    assert _build_upgrade_suggestion(_make_info("pipx")).command == "pipx upgrade omnigent"
+    assert (
+        _build_upgrade_suggestion(_make_info("pipx", extras=("all",))).command
+        == "pipx install --force omnigent[all]"
+    )
+
+
+def test_build_upgrade_suggestion_vcs_preserves_extras() -> None:
+    """VCS installs append extras via an egg fragment."""
+    git_url = "git+https://github.com/example-org/omnigent.git"
+    assert (
+        _build_upgrade_suggestion(_make_info("uv", vcs_url=git_url)).command
+        == f"uv tool install --reinstall {git_url}"
+    )
+    assert (
+        _build_upgrade_suggestion(_make_info("uv", vcs_url=git_url, extras=("all",))).command
+        == f"uv tool install --reinstall {git_url}#egg=omnigent[all]"
+    )
+
+
+def test_build_upgrade_suggestion_pip_still_forms_command() -> None:
+    """pip commands are still generated; ``omni upgrade`` refuses to run them."""
+    assert (
+        _build_upgrade_suggestion(_make_info("pip", extras=("all",))).command
+        == f"{_pip_invocation()} install -U omnigent[all]"
+    )
+
+
+def test_read_uv_tool_extras_from_receipt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`_read_uv_tool_extras` parses extras from ``uv-receipt.toml``."""
+    tool_dir = tmp_path / "omnigent"
+    bin_dir = tool_dir / "bin"
+    bin_dir.mkdir(parents=True)
+    receipt = tool_dir / "uv-receipt.toml"
+    receipt.write_text(
+        textwrap.dedent(
+            """
+            [tool]
+            requirements = [
+                { name = "omnigent", extras = ["all", "server"] },
+                { name = "black", extras = ["jupyter"] },
+            ]
+            """
+        )
+    )
+    monkeypatch.setattr(sys, "executable", str(bin_dir / "python"))
+    assert _read_uv_tool_extras() == ["all", "server"]
+
+
+def test_read_uv_tool_extras_missing_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No receipt means this is not a uv tool install."""
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "python"))
+    assert _read_uv_tool_extras() is None
+
+
+def test_read_installed_wheel_info_uses_uv_tool_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_read_installed_wheel_info`` reads extras from a uv tool receipt."""
+    dist = _write_fake_dist_info(tmp_path, installer="uv")
+    monkeypatch.setattr("omnigent.update_check._get_distribution", lambda: dist)
+
+    tool_dir = tmp_path / "omnigent"
+    bin_dir = tool_dir / "bin"
+    bin_dir.mkdir(parents=True)
+    (tool_dir / "uv-receipt.toml").write_text(
+        textwrap.dedent(
+            """
+            [tool]
+            requirements = [{ name = "omnigent", extras = ["all"] }]
+            """
+        )
+    )
+    monkeypatch.setattr(sys, "executable", str(bin_dir / "python"))
+
+    info = _read_installed_wheel_info()
+    assert info is not None
+    assert info.extras == ("all",)
+
+
+def test_read_installed_wheel_info_uv_pip_no_receipt_no_extras(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``uv pip install`` leaves no uv receipt, so extras stay empty."""
+    dist = _write_fake_dist_info(tmp_path, installer="uv")
+    monkeypatch.setattr("omnigent.update_check._get_distribution", lambda: dist)
+    # A generic venv interpreter, not a uv tool directory.
+    monkeypatch.setattr(sys, "executable", str(tmp_path / ".venv" / "bin" / "python"))
+
+    info = _read_installed_wheel_info()
+    assert info is not None
+    assert info.extras == ()
+
+
+def test_read_pipx_extras_from_metadata(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`_read_pipx_extras` parses extras from pipx metadata."""
+    venv_dir = tmp_path / "pipx" / "venvs" / "omnigent"
+    (venv_dir / "bin").mkdir(parents=True)
+    (venv_dir / "pipx_metadata.json").write_text(
+        json.dumps(
+            {
+                "main_package": {
+                    "package": "omnigent",
+                    "package_or_url": "omnigent[all,server]",
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(sys, "prefix", str(venv_dir))
+    assert _read_pipx_extras() == ["all", "server"]
+
+
+def test_read_pipx_extras_missing_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No pipx metadata file means extras cannot be recovered."""
+    monkeypatch.setattr(sys, "prefix", str(tmp_path))
+    assert _read_pipx_extras() is None
+
+
 def test_fetch_latest_version_swallows_errors(monkeypatch: pytest.MonkeyPatch) -> None:
     """Network error and non-200 both return ``None`` (never raise)."""
     import httpx
@@ -2126,3 +2331,129 @@ def test_wheel_check_skips_vcs_install(
     _run_installed_wheel_check()
 
     assert capsys.readouterr().err == ""
+
+
+# ------------------------------------------------------------------
+# CLI refusal / dry-run
+# ------------------------------------------------------------------
+
+
+def _make_wheel_info(**kwargs: object) -> _InstalledWheelInfo:
+    defaults = {
+        "install_time_epoch": 0.0,
+        "installer": "uv",
+        "vcs_url": None,
+        "commit_sha": None,
+        "is_editable": False,
+        "package_version": "0.1.0",
+        "detected_installer": "uv",
+        "extras": (),
+    }
+    defaults.update(kwargs)  # type: ignore[typeddict-item]
+    return _InstalledWheelInfo(**defaults)  # type: ignore[arg-type]
+
+
+def test_cli_upgrade_refuses_pip_and_prints_manual_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pip installs are refused because extras cannot be recovered."""
+    monkeypatch.setattr(
+        "omnigent.update_check._read_installed_wheel_info",
+        lambda: _make_wheel_info(installer="pip", detected_installer="pip"),
+    )
+    monkeypatch.setattr("omnigent.update_check._find_repo_root", lambda: None)
+    monkeypatch.setattr("omnigent.update_check._uv_tool_receipt_path", lambda: None)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["upgrade"])
+    assert result.exit_code == 0
+    assert "pip does not record which extras" in result.output
+    assert "pip install -U omnigent" in result.output
+
+
+def test_cli_upgrade_refuses_uv_pip_and_prints_manual_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """uv pip installs without a tool receipt are refused."""
+    monkeypatch.setattr(
+        "omnigent.update_check._read_installed_wheel_info",
+        lambda: _make_wheel_info(installer="uv", detected_installer="uv"),
+    )
+    monkeypatch.setattr("omnigent.update_check._find_repo_root", lambda: None)
+    monkeypatch.setattr("omnigent.update_check._uv_tool_receipt_path", lambda: None)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["upgrade"])
+    assert result.exit_code == 0
+    assert "uv pip" in result.output
+    assert "uv pip install -U omnigent" in result.output
+
+
+def test_cli_upgrade_dry_run_uv_tool_with_extras(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--dry-run`` prints the command without touching sessions or index."""
+    monkeypatch.setattr(
+        "omnigent.update_check._read_installed_wheel_info",
+        lambda: _make_wheel_info(installer="uv", detected_installer="uv", extras=("all",)),
+    )
+    monkeypatch.setattr("omnigent.update_check._find_repo_root", lambda: None)
+    monkeypatch.setattr(
+        "omnigent.update_check._uv_tool_receipt_path",
+        lambda: Path("/fake/uv-receipt.toml"),
+    )
+    monkeypatch.setattr("omnigent.update_check.fetch_latest_version", lambda **_: "0.2.0")
+    monkeypatch.setattr("omnigent.update_check._is_newer", lambda latest, current: True)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["upgrade", "--dry-run"])
+    assert result.exit_code == 0
+    assert "uv tool install --reinstall omnigent[all]" in result.output
+    assert "Would run:" in result.output
+
+
+def test_cli_upgrade_check_still_allows_pip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--check`` is not an auto-upgrade, so pip installs can use it."""
+    monkeypatch.setattr(
+        "omnigent.update_check._read_installed_wheel_info",
+        lambda: _make_wheel_info(installer="pip", detected_installer="pip"),
+    )
+    monkeypatch.setattr("omnigent.update_check._find_repo_root", lambda: None)
+    monkeypatch.setattr("omnigent.update_check.fetch_latest_version", lambda **_: "0.2.0")
+    monkeypatch.setattr("omnigent.update_check._is_newer", lambda latest, current: True)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["upgrade", "--check"])
+    assert result.exit_code == 1
+    assert "A new release is available" in result.output
+
+
+def test_read_installed_wheel_info_reads_pipx_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When inside a pipx venv, extras are read from pipx metadata."""
+    dist = _write_fake_dist_info(tmp_path, installer="pip")
+    monkeypatch.setattr("omnigent.update_check._get_distribution", lambda: dist)
+
+    venv_dir = tmp_path / "pipx" / "venvs" / "omnigent"
+    (venv_dir / "bin").mkdir(parents=True)
+    (venv_dir / "pipx_metadata.json").write_text(
+        json.dumps(
+            {
+                "main_package": {
+                    "package": "omnigent",
+                    "package_or_url": "omnigent[all]",
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(sys, "prefix", str(venv_dir))
+
+    info = _read_installed_wheel_info()
+    assert info is not None
+    assert info.installer == "pip"
+    assert info.detected_installer == "pipx"
+    assert info.extras == ("all",)

--- a/tests/cli/test_upgrade_command.py
+++ b/tests/cli/test_upgrade_command.py
@@ -51,6 +51,10 @@ def _wheel_install(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(importlib.metadata, "version", lambda _name: "0.1.0")
     monkeypatch.setattr("omnigent.update_check._find_repo_root", lambda: None)
     monkeypatch.setattr("omnigent.update_check._read_installed_wheel_info", _uv_registry_info)
+    # Pretend a uv tool receipt exists so the install is not mistaken for uv pip.
+    monkeypatch.setattr(
+        "omnigent.update_check._uv_tool_receipt_path", lambda: Path("/dev/null/uv-receipt.toml")
+    )
     # Neutralize the process side effects unless a test opts in to assert them.
     monkeypatch.setattr(
         "omnigent.cli.local_server_status",


### PR DESCRIPTION
feat(cli): preserve extras and refuse unsafe installers in omni upgrade

## Related issue

N/A

## Summary

- Added `--extra`, `--target-version`, and `--dry-run` flags to `omni upgrade`.
- Upgrade commands for `uv tool` and `pipx` now read the originally requested extras from the installer's receipt/metadata and preserve them.
- Explicitly refuses auto-upgrade for `pip` and `uv pip` because those installers do not record requested extras, making a safe automatic upgrade impossible.
- Fixed installer metadata detection in `uv tool` installs by avoiding `Path.resolve()` on the `bin/python` symlink, which previously pointed to the shared uv interpreter and missed `uv-receipt.toml`.
- Added/updated unit and CLI tests covering the new behavior.

## Test Plan

Automated tests:

```
$ uv run pytest tests/cli/test_upgrade_command.py tests/cli/test_update_check.py tests/cli/test_cli.py -q --timeout=60
383 passed in 10.44s
```

```
$ uv run pytest tests/cli/test_update_check.py -q --timeout=60
112 passed in 0.32s
```

Manual verification: built a local wheel, installed it as a `uv tool`, and ran the upgrade flow.

Build the wheels:

```
$ rm -rf /tmp/omnibuild && mkdir -p /tmp/omnibuild
$ uv build --wheel -o /tmp/omnibuild . >/dev/null && uv build --wheel -o /tmp/omnibuild sdks/python-client >/dev/null && uv build --wheel -o /tmp/omnibuild sdks/ui >/dev/null
$ ls -1 /tmp/omnibuild/*.whl
/tmp/omnibuild/omnigent-0.8.0.dev0-py3-none-any.whl
/tmp/omnibuild/omnigent_client-0.8.0.dev0-py3-none-any.whl
/tmp/omnibuild/omnigent_ui_sdk-0.8.0.dev0-py3-none-any.whl
```

Install as a uv tool with the `all` extra:

```
$ rm -rf /tmp/omni-dev-test
$ UV_TOOL_DIR=/tmp/omni-dev-test uv tool install --find-links /tmp/omnibuild '/tmp/omnibuild/omnigent-0.8.0.dev0-py3-none-any.whl[all]' --force
Installed 2 executables: omni, omnigent
```

Dry-run upgrade preserves detected extras (run from outside the source repo):

```
$ cd /tmp && /tmp/omni-dev-test/omnigent/bin/omni upgrade --dry-run --target-version 0.8.0
Targeting v0.8.0.
Detected installer: uv
Detected extras: all
Would run: uv tool install --reinstall omnigent==0.8.0[all]
```

Passing `--extra server` unions with the detected extras:

```
$ cd /tmp && /tmp/omni-dev-test/omnigent/bin/omni upgrade --dry-run --target-version 0.8.0 --extra server
Targeting v0.8.0.
Detected installer: uv
Detected extras: server
Would run: uv tool install --reinstall omnigent==0.8.0[all,server]
```

A `uv pip` install is refused because extras are not recorded:

```
$ uv venv /tmp/omni-pip-test && uv pip install --python /tmp/omni-pip-test/bin/python --find-links /tmp/omnibuild '/tmp/omnibuild/omnigent-0.8.0.dev0-py3-none-any.whl[all]'
$ cd /tmp && /tmp/omni-pip-test/bin/omni upgrade --dry-run --target-version 0.8.0
omnigent was installed with `uv pip`, not `uv tool install`. `uv pip` does not record which extras were requested, so `omni upgrade` cannot preserve them safely. Upgrade manually:

    uv pip install -U omnigent
    # or, if you need extras:
    uv pip install -U 'omnigent[your,extras,here]'
```

## Demo

N/A

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was done by building local wheels, installing the current dev version as a `uv tool`, and running `omni upgrade --dry-run` from `/tmp` so the source checkout was not picked up by `importlib.metadata`. See the Test Plan above for exact commands and output.

## Changelog

`omni upgrade` now preserves requested extras for `uv tool` and `pipx` installs, supports `--extra`, `--target-version`, and `--dry-run`, and refuses to auto-upgrade `pip` / `uv pip` installs because those installers don't record extras.
