### PR TITLE
feat(cli): tidy `omnigent --help` command copy and hide the update alias

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1375,6 +1375,12 @@ _HARNESS_COMMANDS: frozenset[str] = frozenset(
 # module just to draw ``--help``).
 _ACCENT_RGB = (244, 59, 166)
 
+# Command names that are pure aliases of another command (the same Click
+# object registered under a second name, e.g. ``update`` -> ``upgrade``).
+# Kept runnable/registered but omitted from the ``--help`` listing so the
+# alias isn't shown as a duplicate line.
+_ALIAS_COMMANDS: frozenset[str] = frozenset({"update"})
+
 
 def _harness_extra_checks() -> dict[str, Callable[[], bool]]:
     """Map extras-gated harness commands to their SDK-installed predicate.
@@ -1450,6 +1456,10 @@ class _OmnigentCLI(click.Group):
         for subcommand in self.list_commands(ctx):
             cmd = self.get_command(ctx, subcommand)
             if cmd is None or cmd.hidden:
+                continue
+            # Skip pure aliases (e.g. ``update`` -> ``upgrade``) so the
+            # listing doesn't show a duplicate line; still runnable.
+            if subcommand in _ALIAS_COMMANDS:
                 continue
             if subcommand in _HARNESS_COMMANDS:
                 # Hide extras-gated harnesses whose SDK isn't installed;
@@ -4101,7 +4111,7 @@ def uninstall(
     no_backup: bool,
     assume_inferred: bool,
 ) -> None:
-    """Uninstall Omnigent while preserving user data unless --purge is set."""
+    """Uninstall Omnigent from this machine."""
     from omnigent.install_ledger import resolve_uninstall_ledger
 
     ledger = resolve_uninstall_ledger()
@@ -4410,7 +4420,7 @@ def upgrade(
     target_version: str | None,
     dry_run: bool,
 ) -> None:
-    """Upgrade the omnigent CLI to the latest release on PyPI.
+    """Upgrade Omnigent to the latest release.
 
     Detects how omnigent was installed (uv tool / pipx), checks the
     configured index for a newer release and — unless ``--check`` — drains
@@ -5326,7 +5336,7 @@ def _render_usage(report: dict[str, Any], limit: int) -> None:  # type: ignore[e
     help="Emit the raw usage report as JSON instead of the table.",
 )
 def usage(limit: int, server: str | None, as_json: bool) -> None:
-    """Show your Omnigent LLM cost for today / the last 7 / 30 days.
+    """Show your Omnigent usage and costs.
 
     The summary is sourced from the per-user daily cost rollup, which
     attributes spend to the UTC calendar day it occurred on — so the
@@ -6618,7 +6628,7 @@ def attach(
     tools: str | None,
     debug_events: bool,
 ) -> None:
-    """Attach the REPL to a LIVE session — never starts anything.
+    """Attach the REPL to a live session.
 
     ``attach`` is a thin client: it joins an already-running conversation
     on a server and streams its I/O. It never spawns a server, runner, or
@@ -8757,7 +8767,7 @@ if _sandbox_providers():
 
 @cli.group("debug")
 def debug() -> None:
-    """Internal maintenance commands (advanced — not needed for normal use).
+    """Internal maintenance commands.
 
     Houses operator-only database and accounts maintenance: tracking-DB
     schema upgrades (``db-upgrade``) and the accounts→OIDC identity remap

--- a/omnigent/cli_native.py
+++ b/omnigent/cli_native.py
@@ -174,7 +174,7 @@ def register_native_commands(cli: click.Group) -> None:
         #     existing Claude config.
         # :param profile_startup: When True, print startup timing marks.
         # :param claude_args: Pass-through args for ``claude``.
-        """Launch Claude Code in an Omnigent terminal.
+        """Launch Claude Code with Omnigent.
 
         \b
         Examples:
@@ -314,7 +314,7 @@ def register_native_commands(cli: click.Group) -> None:
         # :param model: Codex model id.
         # :param prompt: Optional first prompt.
         # :param codex_args: Pass-through args for ``codex`` before ``resume``.
-        """Launch Codex TUI in an Omnigent terminal.
+        """Launch Codex with Omnigent.
 
         \b
         Examples:
@@ -424,7 +424,7 @@ def register_native_commands(cli: click.Group) -> None:
         # (opencode-native resolves its binary on the runner side; if a spec/env
         # path to thread a client override through is added later, this stays
         # consistent with the other native commands' env/config override model.)
-        """Launch OpenCode TUI in an Omnigent terminal.
+        """Launch OpenCode with Omnigent.
 
         \b
         Examples:
@@ -515,7 +515,7 @@ def register_native_commands(cli: click.Group) -> None:
         session_id: str | None,
         pi_args: tuple[str, ...],
     ) -> None:
-        """Launch Pi TUI in an Omnigent terminal.
+        """Launch Pi with Omnigent.
 
         \b
         Examples:
@@ -624,7 +624,7 @@ def register_native_commands(cli: click.Group) -> None:
     ) -> None:
         # Param docs live in comments — Click uses the docstring for --help.
         # :param model: Cursor model id passed to cursor-agent as ``--model``.
-        """Launch the Cursor TUI in an Omnigent terminal.
+        """Launch Cursor with Omnigent.
 
         \b
         Examples:
@@ -751,7 +751,7 @@ def register_native_commands(cli: click.Group) -> None:
         prompt: str | None,
         kiro_args: tuple[str, ...],
     ) -> None:
-        """Launch the Kiro TUI in an Omnigent terminal.
+        """Launch Kiro with Omnigent.
 
         \b
         Examples:
@@ -851,7 +851,7 @@ def register_native_commands(cli: click.Group) -> None:
         session_id: str | None,
         goose_args: tuple[str, ...],
     ) -> None:
-        """Launch the Goose TUI in an Omnigent terminal.
+        """Launch Goose with Omnigent.
 
         \b
         Examples:
@@ -938,7 +938,7 @@ def register_native_commands(cli: click.Group) -> None:
         session_id: str | None,
         hermes_args: tuple[str, ...],
     ) -> None:
-        """Launch the Hermes TUI in an Omnigent terminal.
+        """Launch Hermes with Omnigent.
 
         \b
         Examples:
@@ -1027,7 +1027,7 @@ def register_native_commands(cli: click.Group) -> None:
         model: str | None,
         antigravity_args: tuple[str, ...],
     ) -> None:
-        """Launch the Antigravity (agy) TUI in an Omnigent terminal.
+        """Launch Antigravity (agy) with Omnigent.
 
         \b
         Examples:
@@ -1126,7 +1126,7 @@ def register_native_commands(cli: click.Group) -> None:
         session_id: str | None,
         qwen_args: tuple[str, ...],
     ) -> None:
-        """Launch the qwen (Qwen Code) TUI in an Omnigent terminal.
+        """Launch Qwen Code with Omnigent.
 
         \b
         Examples:
@@ -1213,7 +1213,7 @@ def register_native_commands(cli: click.Group) -> None:
         session_id: str | None,
         kimi_args: tuple[str, ...],
     ) -> None:
-        """Launch the Kimi Code TUI in an Omnigent terminal.
+        """Launch Kimi Code with Omnigent.
 
         Boots Moonshot AI's interactive ``kimi`` TUI
         (https://github.com/MoonshotAI/Kimi-Code) in a runner-owned terminal and

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -135,7 +135,7 @@ def test_python_module_entrypoint_uses_unified_click_cli() -> None:
 
     assert "Usage: python -m omnigent [OPTIONS] COMMAND [ARGS]..." in result.stdout
     assert "Commands:" in result.stdout
-    assert "run" in result.stdout and "Attach the REPL to a LIVE session" in result.stdout
+    assert "run" in result.stdout and "Attach the REPL to a live session" in result.stdout
     assert "Omnigent quick chat" not in result.stdout
 
 
@@ -967,6 +967,18 @@ def test_help_groups_harnesses_and_other_commands() -> None:
     assert commands_at < result.output.index("server")
 
 
+def test_help_hides_update_alias_but_keeps_it_runnable() -> None:
+    """The ``update`` alias is omitted from --help but stays registered."""
+    result = CliRunner().invoke(cli, ["--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "upgrade" in result.output
+    # The alias line is suppressed so it doesn't duplicate ``upgrade``...
+    assert "\n  update " not in result.output
+    # ...but it's still a real, invokable command.
+    assert cli.commands["update"] is cli.commands["upgrade"]
+
+
 def test_help_hides_extras_gated_harness_when_sdk_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -980,8 +992,8 @@ def test_help_hides_extras_gated_harness_when_sdk_missing(
 
     assert result.exit_code == 0, result.output
     # Not listed as launchable harnesses...
-    assert "Launch the Cursor TUI" not in result.output
-    assert "Launch the Antigravity" not in result.output
+    assert "Launch Cursor with Omnigent" not in result.output
+    assert "Launch Antigravity" not in result.output
     # ...but a generic notice points at setup instead.
     assert "Some harnesses need an optional extra" in result.output
     # Still a real, registered command — only the listing is suppressed.


### PR DESCRIPTION
## Related issue

N/A

## Summary

Follow-up copy polish on the grouped/colored `omnigent --help` (landed in #3795). Wording only + one duplicate-listing fix — no behavior change.

- **Normalize harness one-liners** to `Launch <Name> with Omnigent.` — previously an inconsistent mix of `Launch the <Name> TUI in an Omnigent terminal`, `Launch <Name> TUI …`, `Launch <Name Code> …`; "in an Omnigent terminal" was noisy.
- **Trim over-long / over-specific one-liners:**
  - `attach` — drop the trailing "— never starts anything" clause (the `attach --help` body still explains it's a pure client that never spawns a server/runner/harness).
  - `uninstall` — `Uninstall Omnigent from this machine.` (was a long "…while preserving user data unless --purge is set." that got truncated in the listing).
  - `usage` — `Show your Omnigent usage and costs.` (was pinned to "today / the last 7 / 30 days").
  - `upgrade` — `Upgrade Omnigent to the latest release.`
  - `debug` — `Internal maintenance commands.`
- **Hide the `update` alias** (the same Click object as `upgrade`) from the listing via `_ALIAS_COMMANDS`, so it no longer shows as a duplicate line. It stays registered and runnable (`omnigent update` still works).

## Test Plan

- `uv run omnigent --help` — harness rows read `Launch <Name> with Omnigent.`; `update` no longer appears; `attach` / `uninstall` / `usage` / `upgrade` / `debug` show the trimmed copy.
- `omnigent update --help` still works (alias hidden from listing, not removed).
- `uv run pytest tests/cli/test_cli.py tests/cli/test_upgrade_command.py` — **275 passed**.
- `pre-commit run` — all hooks pass.

## Demo

```
Harnesses:
  claude    Launch Claude Code with Omnigent.
  codex     Launch Codex with Omnigent.
  debby     Launch debby, the bundled two-headed brainstorming agent.
  goose     Launch Goose with Omnigent.
  hermes    Launch Hermes with Omnigent.
  kimi      Launch Kimi Code with Omnigent.
  kiro      Launch Kiro with Omnigent.
  opencode  Launch OpenCode with Omnigent.
  pi        Launch Pi with Omnigent.
  polly     Launch polly, the bundled multi-agent coding orchestrator.
  qwen      Launch Qwen Code with Omnigent.

Some harnesses need an optional extra — run `omnigent setup` to enable them.

Commands:
  attach       Attach the REPL to a live session.
  config       Get, set, and view Omnigent defaults and credentials.
  debug        Internal maintenance commands.
  doctor       Run maintenance checks and one-off migrations.
  host         Register this machine as a host with a server.
  import       Import chats from supported local coding harnesses.
  integration  Run and manage Omnigent chat integrations.
  login        Authenticate with a remote Omnigent server.
  resume       Resume an Omnigent conversation, auto-dispatching by runtime.
  run          Start a session with an Omnigent agent.
  sandbox      Run an Omnigent host inside a remote sandbox.
  server       Start the Omnigent server, or manage the background server.
  session      Manage Omnigent sessions.
  setup        Launch the Omnigent first-time setup flow.
  stop         Stop everything Omnigent is running on this machine.
  uninstall    Uninstall Omnigent from this machine.
  upgrade      Upgrade Omnigent to the latest release.
  usage        Show your Omnigent usage and costs.
```

(`update` alias no longer listed; colors unchanged from #3795.)

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Updated the existing help assertions to the new `attach` / harness copy, and added a test that the `update` alias is omitted from `--help` yet still resolves to the same command object as `upgrade`. Manually ran `omnigent --help` (trimmed copy, no `update` line) and `omnigent update --help` (still works). Existing CLI tests pass (275).

## Changelog

`omnigent --help` command descriptions are tidied (harness rows read "Launch <Name> with Omnigent"), and the duplicate `update` alias line is hidden from the listing
