### PR TITLE
refactor: narrow local tool paths

### DIFF
--- a/omnigent/tools/local.py
+++ b/omnigent/tools/local.py
@@ -50,7 +50,7 @@ from typing import Any
 from omnigent_client.tools import ToolMetadata, get_tool_metadata
 
 from omnigent.runner.identity import strip_runner_auth_secrets
-from omnigent.spec.types import LocalToolInfo, SandboxConfig
+from omnigent.spec.types import LocalToolInfo, SandboxConfig, ToolRuntime
 from omnigent.tools._pep723 import parse_inline_metadata
 from omnigent.tools._srt import wrap_with_srt
 from omnigent.tools.base import Tool, ToolContext
@@ -458,6 +458,7 @@ class LocalPythonTool(Tool):
             "``self._sandbox_config.container_image is not None``"
         )
         runtime = self._sandbox_config.container_runtime
+        assert runtime is not None, "SandboxConfig must resolve container_runtime"
         return [
             runtime,
             "run",
@@ -662,9 +663,14 @@ def load_local_python_tools(
     discovered: dict[str, _DiscoveredTool] = {}
 
     for info in local_tools:
-        if info.language != "python":
+        if info.language != "python" or info.runtime != ToolRuntime.SERVER:
             continue
-        tool_path = Path(info.path)
+        path = info.path
+        if path is None:
+            raise LocalToolLoadError(
+                f"Agent {effective_agent_name!r}: server tool {info.name!r} has no source path."
+            )
+        tool_path = Path(path)
         if not tool_path.is_absolute():
             tool_path = workdir / tool_path
         if not tool_path.is_file():

--- a/omnigent/tools/local_callable.py
+++ b/omnigent/tools/local_callable.py
@@ -44,7 +44,7 @@ import json
 import logging
 from typing import Any
 
-from omnigent.spec.types import LocalToolInfo
+from omnigent.spec.types import LocalToolInfo, ToolRuntime
 from omnigent.tools.base import Tool, ToolContext
 
 _logger = logging.getLogger(__name__)
@@ -73,8 +73,11 @@ class LocalCallableTool(Tool):
     """
 
     def __init__(self, info: LocalToolInfo) -> None:
+        if info.path is None:
+            raise ValueError(f"local-callable tool {info.name!r} has no server-side path")
         self._info = info
         self._name = info.name
+        self._path = info.path
         self._callable: Any = None
         self._description: str = ""
         self._parameters: dict[str, Any] = info.parameters or {
@@ -101,7 +104,7 @@ class LocalCallableTool(Tool):
         :returns: Dotted import path, e.g.
             ``"examples._shared.tool_functions.calculate"``.
         """
-        return self._info.path
+        return self._path
 
     @classmethod
     def description(cls) -> str:
@@ -193,7 +196,7 @@ class LocalCallableTool(Tool):
         """
         if self._callable is not None:
             return
-        path = self._info.path
+        path = self._path
         module_name, _, attr_name = path.rpartition(".")
         if not module_name or not attr_name:
             raise ImportError(
@@ -241,16 +244,11 @@ def load_local_callable_tools(
         entry. Empty list when none are present (which is the
         case for native Omnigent specs).
     """
-    from omnigent.spec.types import ToolRuntime
-
     result: list[LocalCallableTool] = []
     for info in local_tools:
         if info.language != _OMNIGENT_CALLABLE_LANGUAGE:
             continue
-        # UC function tools have path=None and are dispatched by
-        # the runner via the SQL Statement Execution API — they
-        # are not in-process callables and must not be wrapped.
-        if info.runtime == ToolRuntime.UC_FUNCTION:
+        if info.runtime != ToolRuntime.SERVER:
             continue
         result.append(LocalCallableTool(info))
     return result

--- a/tests/tools/test_local.py
+++ b/tests/tools/test_local.py
@@ -14,7 +14,7 @@ from typing import Any
 import pytest
 
 from omnigent.runner.identity import RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR
-from omnigent.spec.types import LocalToolInfo, SandboxConfig
+from omnigent.spec.types import LocalToolInfo, SandboxConfig, ToolRuntime
 from omnigent.tools.base import ToolContext
 from omnigent.tools.local import (
     LocalPythonTool,
@@ -330,6 +330,29 @@ def test_load_skips_typescript(tmp_path: Path) -> None:
     info = LocalToolInfo(name="ts_tool", path="tools/typescript/ts_tool.ts", language="typescript")
     tools = load_local_python_tools([info], tmp_path)
     assert tools == []
+
+
+def test_load_skips_client_runtime_tool(tmp_path: Path) -> None:
+    info = LocalToolInfo(
+        name="client_tool",
+        path=None,
+        language="python",
+        runtime=ToolRuntime.CLIENT,
+    )
+
+    assert load_local_python_tools([info], tmp_path) == []
+
+
+def test_load_server_tool_without_path_fails_loud(tmp_path: Path) -> None:
+    info = LocalToolInfo(
+        name="pathless",
+        path=None,
+        language="python",
+        runtime=ToolRuntime.SERVER,
+    )
+
+    with pytest.raises(LocalToolLoadError, match="no source path"):
+        load_local_python_tools([info], tmp_path, agent_name="testagent")
 
 
 def test_load_missing_file_fails_loud(tmp_path: Path) -> None:

--- a/tests/tools/test_local_callable.py
+++ b/tests/tools/test_local_callable.py
@@ -193,6 +193,11 @@ def test_resolution_failures_are_explicit(
         tool.get_schema()
 
 
+def test_pathless_callable_fails_at_construction() -> None:
+    with pytest.raises(ValueError, match="no server-side path"):
+        LocalCallableTool(_info("pathless", None))
+
+
 def test_load_local_callable_tools_filters_to_omnigent_server_callables() -> None:
     loaded = load_local_callable_tools(
         [
@@ -202,6 +207,11 @@ def test_load_local_callable_tools_filters_to_omnigent_server_callables() -> Non
                 "uc_function",
                 None,
                 runtime=ToolRuntime.UC_FUNCTION,
+            ),
+            _info(
+                "client_tool",
+                None,
+                runtime=ToolRuntime.CLIENT,
             ),
             _info("unimportable", "does.not.exist"),
         ]


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Separate server-backed local tools from pathless client and Unity Catalog tools at loader boundaries.
- Fail clearly when a server tool is missing its required path, and preserve the resolved container-runtime invariant.
- Remove 4 mypy errors, reducing the verified baseline from 799 to 795 errors and from 88 to 86 files.

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest tests/tools/test_local.py tests/tools/test_local_callable.py -q` (54 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (795 remaining errors; none in the touched modules)

## Demo

N/A — non-visual type-safety cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added boundary tests for client-runtime filtering and invalid pathless server tools; the existing local-tool suites cover command construction and callable resolution.
