### PR TITLE
refactor: type policy hook requests

### DIFF
--- a/omnigent/antigravity_native_audit.py
+++ b/omnigent/antigravity_native_audit.py
@@ -55,7 +55,10 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
-from omnigent.native_policy_hook import hook_payload_to_evaluation_request
+from omnigent.native_policy_hook import (
+    PolicyHookEvaluationRequest,
+    hook_payload_to_evaluation_request,
+)
 
 # Harness label stamped onto the audit ``EvaluationRequest`` context so server
 # policies can recognize antigravity-native as the originating surface.
@@ -136,7 +139,7 @@ def build_audit_evaluation_request(
     tool_name: str,
     tool_input: Mapping[str, object],
     model: str | None,
-) -> dict[str, object] | None:
+) -> PolicyHookEvaluationRequest | None:
     """
     Build the proto ``EvaluationRequest`` for a post-hoc tool-call audit.
 

--- a/omnigent/native_policy_hook.py
+++ b/omnigent/native_policy_hook.py
@@ -26,7 +26,8 @@ import secrets
 import shlex
 import sys
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
+from typing import NotRequired, TypedDict
 
 import httpx
 
@@ -79,6 +80,18 @@ _RELAY_URL_ENV = "_OMNIGENT_RELAY_URL"
 _RELAY_TOKEN_ENV = "_OMNIGENT_RELAY_TOKEN"
 
 _TOOL_RELAY_FILE = "tool_relay.json"
+
+
+class _EvaluationEvent(TypedDict):
+    type: str
+    target: str
+    data: dict[str, object]
+    context: dict[str, object]
+    request_data: NotRequired[dict[str, object]]
+
+
+class PolicyHookEvaluationRequest(TypedDict):
+    event: _EvaluationEvent
 
 
 def read_relay_policy_config(
@@ -260,7 +273,7 @@ def _is_login_redirect_or_unauthorized(response: httpx.Response) -> bool:
 def hook_payload_to_evaluation_request(
     hook_event: str,
     payload: dict[str, object],
-) -> dict[str, object] | None:
+) -> PolicyHookEvaluationRequest | None:
     """
     Convert a native-harness tool-hook payload into a proto ``EvaluationRequest``.
 
@@ -510,7 +523,7 @@ def fail_closed_hook_output(
 def post_evaluate_with_retry(
     url: str,
     headers: dict[str, str],
-    eval_request: dict[str, object],
+    eval_request: Mapping[str, object],
     read_timeout: float,
     hook_label: str,
     reauth: Callable[[], dict[str, str] | None] | None = None,


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Define the shared native policy-hook evaluation request shape with `TypedDict` instead of an unstructured dictionary.
- Accept request mappings in the retrying POST helper and preserve that precise type through the dormant Antigravity audit adapter.
- Remove 3 mypy errors shared by the Claude, Codex, and Kimi policy hooks, reducing the verified branch baseline from 799 to 796 errors.

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest tests/test_native_policy_hook.py tests/test_antigravity_native_audit.py tests/test_codex_native_hook.py tests/test_kimi_native_hook.py tests/test_claude_native_hook.py -q` (136 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (796 remaining errors; all 3 target hook errors removed)

## Demo

N/A — non-visual type-safety cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing shared converter and per-harness policy-hook suites exercise every affected request path.
