### PR TITLE
refactor: export session stream explicitly

### DIFF
--- a/omnigent/server/routes/sessions/__init__.py
+++ b/omnigent/server/routes/sessions/__init__.py
@@ -96,8 +96,10 @@ from omnigent.runtime import (
     get_policy_store,
     pending_elicitations,
     pending_inputs,
-    session_stream,
     user_session_stream,
+)
+from omnigent.runtime import (
+    session_stream as session_stream,
 )
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.runtime.policies.approval import _ELICITATION_MODE


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Explicitly re-export `session_stream` from the sessions route facade, where sibling route modules access the monkeypatchable shared stream.
- Satisfy strict `no_implicit_reexport` checking without changing runtime behavior.
- Remove 3 mypy errors across browser, event, and agent-switch routes, reducing the verified branch baseline from 799 to 796 errors and from 88 to 87 files.

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest tests/server/integration/test_browser_action_bridge.py tests/server/routes/test_sessions_policy.py tests/server/routes/test_sessions_switch_agent.py -q` (46 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (796 remaining errors; all 3 session-stream export errors removed)

## Demo

N/A — non-visual type-safety cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing browser-action, policy-route, and agent-switch suites exercise each facade access path.
