### PR TITLE
fix: require builtin session context

### DIFF
--- a/omnigent/tools/builtins/list_files.py
+++ b/omnigent/tools/builtins/list_files.py
@@ -112,6 +112,10 @@ class ListFilesTool(Tool):
         if after is not None and not isinstance(after, str):
             return json.dumps({"error": "'after' must be a string"})
 
+        conversation_id = ctx.conversation_id
+        if conversation_id is None:
+            return json.dumps({"error": "list_files requires a conversation_id"})
+
         from omnigent.runtime import get_file_store
 
         file_store = get_file_store()
@@ -125,7 +129,7 @@ class ListFilesTool(Tool):
             after=after,
             before=None,
             order="desc",
-            session_id=ctx.conversation_id,
+            session_id=conversation_id,
             include_unscoped=True,
         )
 

--- a/omnigent/tools/builtins/sys_terminal.py
+++ b/omnigent/tools/builtins/sys_terminal.py
@@ -1046,7 +1046,8 @@ class SysTerminalCloseTool(Tool):
         :returns: JSON-encoded result. Success: ``{"terminal",
             "session", "status": "closed" | "not_found"}``.
         """
-        if ctx.conversation_id is None:
+        conversation_id = ctx.conversation_id
+        if conversation_id is None:
             return json.dumps({"error": "sys_terminal_close requires a conversation_id"})
 
         parsed = _parse_arguments(arguments)
@@ -1065,12 +1066,12 @@ class SysTerminalCloseTool(Tool):
         # never races with a tmux op already in progress. ``None``
         # means the instance was already closed (or never launched);
         # registry.close() returns False in that case anyway.
-        lock = self._registry.get_instance_lock(ctx.conversation_id, terminal_name, session_key)
+        lock = self._registry.get_instance_lock(conversation_id, terminal_name, session_key)
 
         def _do_close() -> bool:
             try:
                 return asyncio.run(
-                    self._registry.close(ctx.conversation_id, terminal_name, session_key)
+                    self._registry.close(conversation_id, terminal_name, session_key)
                 )
             except (RuntimeError, OSError) as exc:
                 # tmux teardown can raise when the server is already

--- a/tests/tools/builtins/test_file_tools.py
+++ b/tests/tools/builtins/test_file_tools.py
@@ -331,6 +331,15 @@ def test_list_files_rejects_non_string_after(tool_ctx: ToolContext) -> None:
     assert result == {"error": "'after' must be a string"}
 
 
+def test_list_files_requires_conversation_id() -> None:
+    tool = ListFilesTool()
+    ctx = ToolContext(task_id="task_test", agent_id="agent_test")
+
+    result = json.loads(tool.invoke("{}", ctx))
+
+    assert result == {"error": "list_files requires a conversation_id"}
+
+
 def test_list_files_excludes_other_sessions(
     monkeypatch: pytest.MonkeyPatch,
     tool_ctx: ToolContext,


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Reject `list_files` calls without a conversation ID instead of issuing an unscoped query, so the tool fails closed and matches the file-store contract.
- Preserve the existing `sys_terminal_close` conversation guard through its nested close operation with a stable local ID.
- Remove 2 mypy errors, reducing the verified branch baseline from 799 to 797 errors and from 88 to 86 files.

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest tests/tools/builtins/test_file_tools.py tests/tools/builtins/test_sys_terminal.py -q` (47 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (797 remaining errors; both built-in session-context errors removed)

## Demo

N/A — non-visual backend correctness and type-safety cleanup.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added a regression test for pathless file-list calls; the existing terminal suite covers guarded close behavior and registry isolation.

## Changelog

Prevent `list_files` from running without a conversation scope.

