### PR TITLE
refactor: preserve UI environment type

### DIFF
--- a/omnigent/inner/ui.py
+++ b/omnigent/inner/ui.py
@@ -79,8 +79,8 @@ def show_banner(*, isatty: bool | None = None, env: dict[str, str] | None = None
         isatty = sys.stderr.isatty()
     if not isatty:
         return False
-    env = os.environ if env is None else env
-    raw = str(env.get(NO_BANNER_ENV_VAR, "")).strip().lower()
+    effective_env = os.environ if env is None else env
+    raw = str(effective_env.get(NO_BANNER_ENV_VAR, "")).strip().lower()
     return raw not in {"1", "true", "yes", "on"}
 
 

--- a/omnigent/inner/ui.py
+++ b/omnigent/inner/ui.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import os
 import sys
+from collections.abc import Mapping
 
 from rich.console import Console
 from rich.panel import Panel
@@ -61,7 +62,7 @@ console = Console(theme=OMNIGENT_THEME, highlight=False)
 err_console = Console(stderr=True, theme=OMNIGENT_THEME, highlight=False)
 
 
-def show_banner(*, isatty: bool | None = None, env: dict[str, str] | None = None) -> bool:
+def show_banner(*, isatty: bool | None = None, env: Mapping[str, str] | None = None) -> bool:
     """
     Decide whether the brand banner / brandmark should be drawn.
 


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Keep the optional test environment parameter separate from the effective process environment used by banner rendering.
- Preserve support for both plain dictionaries and `os.environ` without rebinding the narrower parameter type.
- Remove 2 mypy errors, reducing the verified branch baseline from 799 to 797 errors and from 88 to 87 files.

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest tests/inner/test_ui.py -q` (10 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (797 remaining errors; no errors in `omnigent/inner/ui.py`)

## Demo

N/A — non-visual type-safety cleanup with unchanged CLI output.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing UI tests cover default process-environment handling and explicit environment overrides.
