### PR TITLE
fix: require model for fresh harness turns

### DIFF
--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -1248,6 +1248,13 @@ class HarnessApp:
                     code=ErrorCode.CONFLICT,
                 )
 
+            model = request.model
+            if model is None:
+                raise OmnigentError(
+                    "model is required when starting a new turn",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+
             response_id = f"resp_{uuid.uuid4().hex[:24]}"
             event_queue: asyncio.Queue[HarnessStreamEvent | None] = asyncio.Queue()
             cancelled = asyncio.Event()
@@ -1260,12 +1267,12 @@ class HarnessApp:
             self._active_turn_ctx = ctx
 
         return StreamingResponse(
-            self._stream_turn(request, ctx),
+            self._stream_turn(request, ctx, model),
             media_type="text/event-stream",
         )
 
     async def _stream_turn(
-        self, request: CreateResponseRequest, ctx: TurnContext
+        self, request: CreateResponseRequest, ctx: TurnContext, model: str
     ) -> AsyncIterator[bytes]:
         """
         Drive ``run_turn`` and yield SSE-formatted events.
@@ -1288,9 +1295,7 @@ class HarnessApp:
             HTTP response.
         """
         sequence = 0
-        for initial_event in self._initial_envelope_events(
-            ctx, model=request.model, start_seq=sequence
-        ):
+        for initial_event in self._initial_envelope_events(ctx, model=model, start_seq=sequence):
             yield _format_sse_event(initial_event)
             sequence += 1
 
@@ -1334,7 +1339,7 @@ class HarnessApp:
                 sequence += 1
                 yield _format_sse_event(event)
             terminal = await self._build_terminal_event(
-                ctx, model=request.model, run_task=run_task, sequence=sequence
+                ctx, model=model, run_task=run_task, sequence=sequence
             )
             # Clear before yielding the terminal event so the next
             # request (continuation turn) sees _active_turn_ctx as

--- a/tests/runtime/harnesses/test_scaffold.py
+++ b/tests/runtime/harnesses/test_scaffold.py
@@ -38,11 +38,12 @@ from typing import Any
 import httpx
 import pytest
 
-from omnigent.errors import ErrorCode
+from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.runtime.harnesses import _HARNESS_MODULES
 from omnigent.runtime.harnesses._scaffold import HarnessApp, TurnContext
 from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
 from omnigent.runtime.tool_output import MAX_TOOL_OUTPUT_BYTES
+from omnigent.server.schemas import CreateResponseRequest
 
 _TEST_HARNESS_NAME = "scaffold_fixture"
 _TEST_HARNESS_MODULE = "tests.runtime.harnesses._test_scaffold_harnesses"
@@ -123,6 +124,17 @@ def _make_side_client(socket_path: str) -> httpx.AsyncClient:
         transport=httpx.AsyncHTTPTransport(uds=socket_path),
         base_url="http://harness.local",
     )
+
+
+@pytest.mark.asyncio
+async def test_stale_continuation_without_model_is_rejected() -> None:
+    request = CreateResponseRequest(
+        input="continue",
+        previous_response_id="resp_stale",
+    )
+
+    with pytest.raises(OmnigentError, match="model is required"):
+        await HarnessApp()._start_or_inject_turn(request)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Reject a continuation request with no model when its `previous_response_id` does not match an active turn, instead of starting a model-less stream.
- Pass the validated model explicitly through initial and terminal response-envelope construction.
- Remove 2 mypy errors, reducing the verified branch baseline from 799 to 797 errors and from 88 to 87 files.

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest tests/runtime/harnesses/test_scaffold.py -q` (31 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (797 remaining errors; no errors in the scaffold module)

## Demo

N/A — non-visual harness correctness and type-safety fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added a regression test for an unmatched continuation request with no model; the existing scaffold suite covers streaming, injections, cancellation, and terminal envelopes.

## Changelog

Reject stale harness continuation requests that cannot resolve an agent model.
