### PR TITLE
fix(antigravity-native): load agy user plugins and surface agy's own skills

### DIFF
--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -340,6 +340,15 @@ _AGY_SEED_FILES = (
 )
 
 
+# agy resolves imported plugins (skills + hooks) relative to its Gemini dir, so a
+# bridge-owned ``--gemini_dir`` starts with none of the user's plugins unless they
+# are seeded. ``plugins/`` is symlinked rather than copied: the payload is a git
+# checkout per plugin, and a link keeps a mid-session ``/plugin install`` or update
+# visible instead of pinning a stale copy.
+_AGY_PLUGINS_DIR = "plugins"
+_AGY_IMPORT_MANIFEST = "import_manifest.json"
+
+
 def agy_home_dir(bridge_dir: Path) -> Path:
     """Return the parent directory for this session's isolated agy state.
 
@@ -535,10 +544,46 @@ def seed_isolated_agy_home(
     with contextlib.suppress(OSError):
         (iso_gemini / _MCP_CONFIG_DIR / ".migrated").touch()
 
+    _seed_isolated_agy_plugins(real_home, iso_gemini)
+
     if trusted_workspace is not None:
         _seed_isolated_agy_workspace_trust(iso_gemini, Path(trusted_workspace))
 
     return {}
+
+
+def _seed_isolated_agy_plugins(real_home: Path, iso_gemini: Path) -> None:
+    """Expose the user's imported agy plugins under the isolated Gemini dir.
+
+    Links ``config/plugins`` to the real tree and copies ``import_manifest.json``
+    (agy needs both: the manifest declares which plugins are imported, the
+    directory holds their skills and hooks). Without this an omnigent-spawned
+    session lists zero plugin skills while a direct ``agy`` run lists them all.
+
+    Best-effort: a user with no plugins, or a platform that refuses symlinks,
+    simply gets a session without them rather than a failed launch.
+
+    :param real_home: The user's real home directory.
+    :param iso_gemini: The bridge-owned ``--gemini_dir`` being seeded.
+    """
+    real_config = real_home / ".gemini" / _MCP_CONFIG_DIR
+    iso_config = iso_gemini / _MCP_CONFIG_DIR
+
+    real_plugins = real_config / _AGY_PLUGINS_DIR
+    if real_plugins.is_dir():
+        link = iso_config / _AGY_PLUGINS_DIR
+        with contextlib.suppress(OSError):
+            # Re-seeding an existing bridge dir must not fail on the prior link;
+            # drop a stale or broken one so the target is always current.
+            if link.is_symlink() or link.is_file():
+                link.unlink()
+            if not link.exists():
+                link.symlink_to(real_plugins.resolve(), target_is_directory=True)
+
+    real_manifest = real_config / _AGY_IMPORT_MANIFEST
+    if real_manifest.is_file():
+        with contextlib.suppress(OSError):
+            (iso_config / _AGY_IMPORT_MANIFEST).write_bytes(real_manifest.read_bytes())
 
 
 # agy's periodic engagement survey ("How's the CLI experience so far?") is gated by

--- a/omnigent/spec/skill_sources.py
+++ b/omnigent/spec/skill_sources.py
@@ -25,7 +25,12 @@ from omnigent.spec.types import SkillSpec
 
 _log = logging.getLogger(__name__)
 
-_SKILL_FAMILIES = frozenset({"claude", "codex", "cursor", "pi"})
+_SKILL_FAMILIES = frozenset({"claude", "codex", "cursor", "pi", "antigravity"})
+
+# The bare ``antigravity`` harness is the in-process Gemini SDK executor, NOT the
+# agy CLI. It never launches agy, so ~/.gemini plugin/builtin skills are not its
+# skills — it keeps the generic walk, whose skills omnigent resolves+injects.
+_ANTIGRAVITY_SDK_HARNESS = "antigravity"
 
 
 def _harness_family(harness: str | None) -> str | None:
@@ -49,9 +54,16 @@ def _harness_family(harness: str | None) -> str | None:
     # SDK harness flows in as ``claude_sdk`` (canonicalize_harness leaves it
     # unchanged), and without this it would miss the ``claude`` family and
     # silently lose plugin slash-commands.
-    parts = harness.replace("_", "-").split("-")
+    normalized = harness.replace("_", "-")
+    parts = normalized.split("-")
     base = parts[1] if parts[0] == "native" and len(parts) > 1 else parts[0]
-    return base if base in _SKILL_FAMILIES else None
+    if base not in _SKILL_FAMILIES:
+        return None
+    # Unlike claude (where SDK and native share ~/.claude), antigravity's two
+    # harnesses are different runtimes: only the agy CLI reads ~/.gemini.
+    if base == _ANTIGRAVITY_SDK_HARNESS and normalized == _ANTIGRAVITY_SDK_HARNESS:
+        return None
+    return base
 
 
 @dataclass(frozen=True)
@@ -373,6 +385,115 @@ def cursor_host_skills(ctx: SkillSourceContext) -> list[SkillSpec]:
     return out
 
 
+def _agy_skill_dirs(ctx: SkillSourceContext) -> list[tuple[Path, str | None]]:
+    """
+    agy's skill directories with their namespace, in discovery order.
+
+    The five sources agy's own ``/skills`` panel lists (live-verified, agy
+    1.1.9 — the panel prints these paths verbatim)::
+
+        <workspace>/.agents/skills/<skill>/SKILL.md          "Workspace"
+        ~/.gemini/antigravity-cli/skills/<skill>/SKILL.md    "Global"
+        ~/.gemini/skills/<skill>/SKILL.md                    "Shared"
+        ~/.gemini/config/plugins/<plugin>/skills/<skill>/…   imported plugins
+        ~/.gemini/antigravity-cli/builtin/skills/<skill>/…   shipped builtins
+
+    Only plugin skills are namespaced — agy registers them as
+    ``<plugin>:<skill>`` and its TUI accepts only that spelling; every other
+    source is bare. The workspace source is ``.agents/skills`` (vendor-neutral),
+    NOT ``.claude/skills``: that is the one directory the old generic fallback
+    got right for agy.
+
+    A plugin is ENABLED iff it still carries ``plugin.json``: ``agy plugin
+    disable`` renames that file to ``plugin.json.disabled`` and changes nothing
+    else — ``config/import_manifest.json`` keeps listing the plugin (so does
+    ``agy plugin list``) and the ``skills/`` tree stays on disk. The manifest is
+    therefore NOT a usable enabled-signal; the manifest file's name is.
+
+    :param ctx: Session discovery context. ``home`` is the real user home: agy
+        runs under a bridge-owned ``--gemini_dir`` whose plugins are linked back
+        to the real tree, so the real home is the truthful source either way.
+    :returns: ``(directory, namespace)`` pairs; ``namespace`` is ``None`` for
+        every source except plugins.
+    """
+    gemini = ctx.home / ".gemini"
+    dirs: list[tuple[Path, str | None]] = []
+    for root in ctx.roots:
+        workspace_skills = root / ".agents" / "skills"
+        if workspace_skills.is_dir():
+            dirs.append((workspace_skills, None))
+    for bare in (
+        gemini / "antigravity-cli" / "skills",
+        gemini / "skills",
+    ):
+        if bare.is_dir():
+            dirs.append((bare, None))
+    plugins_root = gemini / "config" / "plugins"
+    try:
+        plugins = sorted(plugins_root.iterdir()) if plugins_root.is_dir() else []
+    except OSError as exc:
+        # An unreadable plugins dir must not 500 the /skills endpoint.
+        _log.warning("Skipping unreadable agy plugins dir %s: %s", plugins_root, exc)
+        plugins = []
+    for plugin in plugins:
+        if not (plugin / "plugin.json").is_file():
+            continue  # absent or renamed to plugin.json.disabled
+        skills_dir = plugin / "skills"
+        if skills_dir.is_dir():
+            dirs.append((skills_dir, plugin.name))
+    builtin = gemini / "antigravity-cli" / "builtin" / "skills"
+    if builtin.is_dir():
+        dirs.append((builtin, None))
+    return dirs
+
+
+def antigravity_host_skills(ctx: SkillSourceContext) -> list[SkillSpec]:
+    """
+    agy's own skills: enabled ``~/.gemini`` plugins plus shipped builtins.
+
+    agy owns a host-skill mechanism (a ``/skills`` TUI listing backed by
+    :func:`_agy_skill_dirs`), and unlike Pi's that mechanism is enumerable — so
+    agy gets a real provider rather than a no-op. It deliberately does NOT
+    compose with :func:`_generic_host_skills` (the way ``claude`` does): the
+    generic walk sources ``~/.claude/skills``, which are Claude's, not agy's.
+    The menu lists what this agent actually has, matching codex/cursor.
+
+    Honors ``skills_filter`` (``"none"`` hermetic, ``"all"`` everything, a list
+    selecting by the surfaced name). Names match what agy's TUI accepts —
+    ``<plugin>:<skill>`` for plugin skills, bare elsewhere — because a native
+    session's ``/name`` is sent to the vendor CLI as plaintext for it to expand
+    (there is no server-side resolve+inject on this path), so a label agy does
+    not recognise would simply fail.
+
+    :param ctx: Session discovery context.
+    :returns: Parsed skills; unparseable ones are skipped (best-effort).
+    """
+    if ctx.skills_filter == "none":
+        return []
+    filter_names: set[str] | None = (
+        set(ctx.skills_filter) if isinstance(ctx.skills_filter, list) else None
+    )
+    out: list[SkillSpec] = []
+    for skills_dir, namespace in _agy_skill_dirs(ctx):
+        try:
+            children = sorted(skills_dir.iterdir())
+        except OSError as exc:
+            _log.warning("Skipping unreadable agy skills dir %s: %s", skills_dir, exc)
+            continue
+        for child in children:
+            if not child.is_dir() or not (child / "SKILL.md").is_file():
+                continue
+            try:
+                spec = _parse_skill(child / "SKILL.md")
+            except (OmnigentError, OSError):  # best-effort discovery
+                continue
+            name = spec.name if namespace is None else f"{namespace}:{spec.name}"
+            if filter_names is not None and name not in filter_names:
+                continue
+            out.append(spec if namespace is None else replace(spec, name=name))
+    return out
+
+
 def pi_host_skills(ctx: SkillSourceContext) -> list[SkillSpec]:
     """
     Pi exposes no *extra* discoverable skills to the menu.
@@ -402,14 +523,25 @@ def pi_host_skills(ctx: SkillSourceContext) -> list[SkillSpec]:
 
 
 # Keyed by harness family (see _harness_family). A harness with no entry
-# (antigravity, qwen, openai-agents, …) falls through to _generic_host_skills
-# in resolve_harness_skills — the unchanged pre-existing ~/.claude/skills walk,
-# whose skills omnigent resolves+injects regardless of vendor. Pi is the one
-# harness that needs an explicit no-op (see pi_host_skills) because it owns a
-# host-skill mechanism omnigent can't enumerate.
+# (qwen, openai-agents, the in-process antigravity SDK, …) falls through to
+# _generic_host_skills in resolve_harness_skills — the ~/.claude/skills walk,
+# whose skills omnigent resolves+injects regardless of vendor.
+#
+# The dividing line is whether the harness owns a host-skill mechanism, and if
+# so whether omnigent can enumerate it:
+#
+#   no mechanism            -> generic walk (omnigent injects the skill text)
+#   mechanism, enumerable   -> dedicated provider listing what the agent has
+#                              (claude, codex, cursor, antigravity/agy)
+#   mechanism, unenumerable -> explicit no-op (pi) — listing anything would
+#                              risk surfacing a command the harness can't run
+#
+# agy moved from the first row to the second when it gained plugin + builtin
+# skills; it is enumerable (see antigravity_host_skills), so it lists its own.
 _SKILL_SOURCES: dict[str | None, SkillSource] = {
     "claude": claude_host_skills,
     "codex": codex_host_skills,
     "cursor": cursor_host_skills,
     "pi": pi_host_skills,
+    "antigravity": antigravity_host_skills,
 }

--- a/tests/spec/test_skill_sources.py
+++ b/tests/spec/test_skill_sources.py
@@ -50,7 +50,11 @@ def _ctx(root: Path, home: Path, skills_filter: str | list[str] = "all") -> Skil
         ("pi-native", "pi"),
         ("native-pi", "pi"),
         ("openai-agents", None),
+        # Only the agy CLI reads ~/.gemini plugins; the in-process Gemini SDK
+        # harness (bare "antigravity") does not, so it stays unmapped.
         ("antigravity", None),
+        ("antigravity-native", "antigravity"),
+        ("native-antigravity", "antigravity"),
         ("qwen", None),
         (None, None),
         ("", None),
@@ -638,3 +642,204 @@ def test_cursor_provider_tolerates_unreadable_skills_dir(
     # Must not raise.
     out = resolve_harness_skills(_ctx(tmp_path / "ws", home), "cursor-native")
     assert out == []
+
+
+# ---------------------------------------------------------------------------
+# antigravity (agy CLI) provider
+# ---------------------------------------------------------------------------
+#
+# Layout live-verified against agy 1.1.9:
+#   ~/.gemini/config/plugins/<name>/skills/<skill>/SKILL.md   (imported plugins)
+#   ~/.gemini/antigravity-cli/builtin/skills/<skill>/SKILL.md (shipped builtins)
+# A plugin is DISABLED by renaming its manifest to ``plugin.json.disabled``
+# (``agy plugin disable`` performs exactly that rename; the import manifest and
+# config.json are left untouched, and ``agy plugin list`` still lists it).
+
+
+def _write_agy_plugin(home: Path, plugin: str, *skills: str, enabled: bool = True) -> None:
+    """Write an agy plugin with *skills*, enabled or disabled via its manifest name."""
+    root = home / ".gemini" / "config" / "plugins" / plugin
+    root.mkdir(parents=True, exist_ok=True)
+    (root / ("plugin.json" if enabled else "plugin.json.disabled")).write_text('{"name":"x"}')
+    for skill in skills:
+        _write_skill(root / "skills", skill)
+
+
+def test_antigravity_provider_surfaces_plugin_and_builtin_skills(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """agy's own skills — imported plugins plus shipped builtins — reach the menu."""
+    home = tmp_path / "home"
+    _write_agy_plugin(home, "superpowers", "brainstorming", "writing-plans")
+    _write_skill(home / ".gemini" / "antigravity-cli" / "builtin" / "skills", "antigravity-guide")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+
+    names = [
+        s.name for s in resolve_harness_skills(_ctx(tmp_path / "ws", home), "antigravity-native")
+    ]
+    # Plugin skills are namespaced <plugin>:<skill> (agy's own /skills panel
+    # lists them that way and the TUI only accepts that spelling); builtins are
+    # bare. Live-verified against agy 1.1.9.
+    assert sorted(names) == [
+        "antigravity-guide",
+        "superpowers:brainstorming",
+        "superpowers:writing-plans",
+    ]
+
+
+def test_antigravity_provider_skips_disabled_plugin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A plugin disabled via the plugin.json -> plugin.json.disabled rename is hidden.
+
+    The skills stay on disk and the import manifest still lists the plugin, so the
+    manifest is NOT a usable enabled-signal — the manifest name is.
+    """
+    home = tmp_path / "home"
+    _write_agy_plugin(home, "superpowers", "brainstorming", enabled=False)
+    _write_agy_plugin(home, "othertools", "still-on", enabled=True)
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+
+    names = [
+        s.name for s in resolve_harness_skills(_ctx(tmp_path / "ws", home), "antigravity-native")
+    ]
+    assert "superpowers:brainstorming" not in names
+    assert "othertools:still-on" in names
+
+
+def test_antigravity_session_does_not_inherit_generic_claude_host_walk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An agy session must not surface ~/.claude/skills (those belong to Claude).
+
+    agy owns an enumerable host-skill mechanism, so it lists exactly what agy has
+    rather than falling through to the generic walk.
+    """
+    home = tmp_path / "home"
+    _write_skill(home / ".claude" / "skills", "claude-only-skill")
+    _write_agy_plugin(home, "superpowers", "brainstorming")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+
+    names = [
+        s.name for s in resolve_harness_skills(_ctx(tmp_path / "ws", home), "antigravity-native")
+    ]
+    assert "claude-only-skill" not in names
+    assert "superpowers:brainstorming" in names
+
+
+def test_antigravity_sdk_harness_keeps_the_generic_walk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The in-process Gemini SDK harness is NOT agy and keeps the generic fallback.
+
+    It never launches the agy CLI, so ~/.gemini plugins are not its skills; its
+    skills are the omnigent-injected generic ones.
+    """
+    home = tmp_path / "home"
+    _write_skill(home / ".claude" / "skills", "claude-only-skill")
+    _write_agy_plugin(home, "superpowers", "brainstorming")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+
+    names = [s.name for s in resolve_harness_skills(_ctx(tmp_path / "ws", home), "antigravity")]
+    assert "claude-only-skill" in names
+    assert "superpowers:brainstorming" not in names
+
+
+def test_antigravity_provider_filters_user_invocable_false(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A user-invocable:false agy skill is dropped (consistent across harnesses)."""
+    home = tmp_path / "home"
+    _write_agy_plugin(home, "superpowers")
+    _write_skill(home / ".gemini" / "config" / "plugins" / "superpowers" / "skills", "shown")
+    _write_skill(
+        home / ".gemini" / "config" / "plugins" / "superpowers" / "skills",
+        "internal",
+        user_invocable=False,
+    )
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+
+    names = [
+        s.name for s in resolve_harness_skills(_ctx(tmp_path / "ws", home), "antigravity-native")
+    ]
+    assert names == ["superpowers:shown"]
+
+
+def test_antigravity_provider_respects_none_filter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``skills: none`` in the agent spec suppresses agy's host skills."""
+    home = tmp_path / "home"
+    _write_agy_plugin(home, "superpowers", "brainstorming")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+
+    out = resolve_harness_skills(_ctx(tmp_path / "ws", home, "none"), "antigravity-native")
+    assert out == []
+
+
+def test_antigravity_provider_tolerates_missing_and_unreadable_dirs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No ~/.gemini at all (or an unreadable tree) yields [] rather than raising."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    assert resolve_harness_skills(_ctx(tmp_path / "ws", home), "antigravity-native") == []
+
+    _write_agy_plugin(home, "superpowers", "brainstorming")
+    real_iterdir = Path.iterdir
+
+    def _boom(self: Path):
+        if self.name == "plugins":
+            raise PermissionError("permission denied")
+        return real_iterdir(self)
+
+    monkeypatch.setattr("pathlib.Path.iterdir", _boom)
+    # Must not raise.
+    assert resolve_harness_skills(_ctx(tmp_path / "ws", home), "antigravity-native") == []
+
+
+def test_antigravity_provider_surfaces_all_five_agy_sources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every source agy's own /skills panel lists is surfaced.
+
+    Live-verified against agy 1.1.9, whose panel names them: Workspace
+    (``<ws>/.agents/skills``), Global (``antigravity-cli/skills``), Shared
+    (``.gemini/skills``), plus imported plugins and shipped builtins.
+    """
+    home = tmp_path / "home"
+    ws = tmp_path / "ws"
+    _write_skill(ws / ".agents" / "skills", "ws-skill")
+    _write_skill(home / ".gemini" / "antigravity-cli" / "skills", "global-skill")
+    _write_skill(home / ".gemini" / "skills", "shared-skill")
+    _write_agy_plugin(home, "superpowers", "brainstorming")
+    _write_skill(home / ".gemini" / "antigravity-cli" / "builtin" / "skills", "antigravity-guide")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+
+    names = sorted(s.name for s in resolve_harness_skills(_ctx(ws, home), "antigravity-native"))
+    assert names == [
+        "antigravity-guide",
+        "global-skill",
+        "shared-skill",
+        "superpowers:brainstorming",
+        "ws-skill",
+    ]
+
+
+def test_antigravity_provider_reads_agents_skills_not_claude_skills(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``.agents/skills`` in the workspace is agy's; ``.claude/skills`` is not.
+
+    The generic walk scans both, which is why agy previously saw Claude's. agy
+    genuinely reads the vendor-neutral ``.agents/skills``, so that one stays.
+    """
+    home = tmp_path / "home"
+    ws = tmp_path / "ws"
+    _write_skill(ws / ".agents" / "skills", "neutral-skill")
+    _write_skill(ws / ".claude" / "skills", "claude-ws-skill")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+
+    names = [s.name for s in resolve_harness_skills(_ctx(ws, home), "antigravity-native")]
+    assert names == ["neutral-skill"]

--- a/tests/test_antigravity_native_bridge.py
+++ b/tests/test_antigravity_native_bridge.py
@@ -1583,6 +1583,93 @@ def test_seed_isolated_agy_home_tolerates_missing_credential(
     assert (iso_gemini / "antigravity-cli" / "cache" / "onboarding.json").is_file()
 
 
+def test_seed_isolated_agy_home_exposes_user_plugins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The user's imported plugins (skills + hooks) are visible under --gemini_dir."""
+    fake_home = tmp_path / "real-home"
+    real_config = fake_home / ".gemini" / "config"
+    (real_config / "plugins" / "superpowers" / "skills").mkdir(parents=True)
+    (real_config / "plugins" / "superpowers" / "skills" / "brainstorming.md").write_text(
+        "# brainstorming", encoding="utf-8"
+    )
+    manifest = json.dumps(
+        {"imports": [{"name": "superpowers", "components": ["skills", "hooks"]}]}
+    )
+    (real_config / "import_manifest.json").write_text(manifest, encoding="utf-8")
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    seed_isolated_agy_home(bridge_dir)
+
+    iso_config = agy_gemini_dir(bridge_dir) / "config"
+    # agy resolves plugins relative to --gemini_dir, so both the manifest and the
+    # plugin payload must be reachable there or the session lists zero skills.
+    assert json.loads((iso_config / "import_manifest.json").read_text(encoding="utf-8")) == (
+        json.loads(manifest)
+    )
+    seeded_skill = iso_config / "plugins" / "superpowers" / "skills" / "brainstorming.md"
+    assert seeded_skill.read_text(encoding="utf-8") == "# brainstorming"
+
+
+def test_seed_isolated_agy_home_does_not_copy_plugin_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Plugins are linked, not copied, so plugin updates are picked up live."""
+    fake_home = tmp_path / "real-home"
+    real_plugins = fake_home / ".gemini" / "config" / "plugins"
+    (real_plugins / "superpowers").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    seed_isolated_agy_home(bridge_dir)
+
+    iso_plugins = agy_gemini_dir(bridge_dir) / "config" / "plugins"
+    assert iso_plugins.is_symlink()
+    assert iso_plugins.resolve() == real_plugins.resolve()
+    # A plugin installed/updated after the session started is still visible.
+    (real_plugins / "later").mkdir()
+    assert (iso_plugins / "later").is_dir()
+
+
+def test_seed_isolated_agy_home_plugin_seed_is_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Re-seeding an existing bridge dir does not fail on the existing link."""
+    fake_home = tmp_path / "real-home"
+    (fake_home / ".gemini" / "config" / "plugins").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    seed_isolated_agy_home(bridge_dir)
+    seed_isolated_agy_home(bridge_dir)
+
+    iso_plugins = agy_gemini_dir(bridge_dir) / "config" / "plugins"
+    assert iso_plugins.is_symlink()
+
+
+def test_seed_isolated_agy_home_tolerates_absent_plugins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A user with no imported plugins seeds cleanly — no link, no manifest."""
+    fake_home = tmp_path / "real-home"
+    (fake_home / ".gemini").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: fake_home))
+
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    seed_isolated_agy_home(bridge_dir)
+
+    iso_config = agy_gemini_dir(bridge_dir) / "config"
+    assert not (iso_config / "plugins").exists()
+    assert not (iso_config / "import_manifest.json").exists()
+    # The rest of the seed still landed.
+    assert (iso_config / ".migrated").is_file()
+
+
 def test_agy_home_dir_is_under_bridge_dir(tmp_path: Path) -> None:
     """The isolated state parent is a child of the per-session bridge dir."""
     bridge_dir = tmp_path / "bridge"


### PR DESCRIPTION
## Related issue

N/A — found while using the harness; no existing issue filed. Happy to open one if
maintainers prefer an issue on record.

## Summary

Two bugs in the same area — agy's user plugins are invisible to Omnigent. Both are
live-verified against agy 1.1.9.

**1. Plugins are missing from the session's agy entirely.** The native bridge runs agy
under a per-session `--gemini_dir` so the MCP relay config stays out of the user's real
`~/.gemini` (the config-scoping footgun documented at `antigravity_native_bridge.py`),
but `seed_isolated_agy_home` seeded only OAuth markers and onboarding state. agy resolves
imported plugins relative to its Gemini dir, so the isolated tree had no
`config/plugins/` and no `config/import_manifest.json` — dropping every plugin skill
*and* hook. `agy plugin list` proves it: `superpowers` against the real `~/.gemini`,
`No imported plugins.` against the isolated one.

Fix: symlink `config/plugins` at the real tree and copy the manifest. Linking rather than
copying because the payload is a git checkout per plugin (3.2 MB for `superpowers`,
mostly `.git`) and a link keeps a mid-session install or update visible.

**2. The web UI's skill menu shows Claude's skills, not agy's.** `_harness_family` maps
only claude/codex/cursor/pi, so `antigravity-native` fell through to
`_generic_host_skills` — a walk over `.claude/skills`, `.agents/skills` and
`~/.claude/skills`. Result: an agy session listed the user's *Claude* skills and none of
its own, so superpowers never appeared.

That fallback was a deliberate choice for harnesses with **no** host-skill mechanism,
whose skills omnigent resolves and injects itself. agy no longer fits the premise: it
owns a `/skills` mechanism, and unlike Pi's it is **enumerable** — so it gets a real
provider rather than the fallback or a no-op. The `_SKILL_SOURCES` comment (which named
antigravity as an example of the no-mechanism case) is updated to state the rule:

```
no mechanism            -> generic walk (omnigent injects the skill text)
mechanism, enumerable   -> dedicated provider (claude, codex, cursor, antigravity)
mechanism, unenumerable -> explicit no-op (pi)
```

Sources, read off agy's own `/skills` panel, which prints these paths verbatim:

| source | naming |
| --- | --- |
| `<workspace>/.agents/skills/` | bare |
| `~/.gemini/antigravity-cli/skills/` | bare |
| `~/.gemini/skills/` | bare |
| `~/.gemini/config/plugins/<plugin>/skills/` | **`<plugin>:<skill>`** |
| `~/.gemini/antigravity-cli/builtin/skills/` | bare |

Three details that panel settled, each of which would have been a bug if guessed:

- **Plugin skills are namespaced** `<plugin>:<skill>`, and agy's TUI accepts only that
  spelling. This is load-bearing: a native session sends `/name` to the vendor CLI as
  **plaintext for it to expand** (`ChatPage.tsx` — there is no server-side
  resolve+inject on that path), so a label agy doesn't recognise simply fails.
- **Names come from frontmatter, not the directory** — `antigravity_guide/` surfaces as
  `antigravity-guide`.
- **A plugin is enabled iff it still carries `plugin.json`.** `agy plugin disable`
  renames it to `plugin.json.disabled` and changes nothing else — `import_manifest.json`
  keeps listing the plugin, and so does `agy plugin list`. The manifest is therefore
  **not** a usable enabled-signal, which is the natural thing to reach for.

Note `.agents/skills` (vendor-neutral) is kept — that one directory the generic fallback
got right for agy — while `.claude/skills` is dropped.

The bare `antigravity` harness is the in-process Gemini SDK executor, not agy; it never
reads `~/.gemini`, so it keeps the generic walk.

## Test Plan

**Unit** — 4 tests for the seeding (plugins + manifest reachable under `--gemini_dir`;
linked not copied; re-seed idempotency; clean handling with no plugins) and 12 for the
provider (all five sources; namespacing; disabled-plugin rename; no `.claude/skills`
leak; `.agents/skills` kept; SDK harness keeps the fallback; `user-invocable:false`;
`skills: none`; missing/unreadable dirs).

`test_skill_sources.py` → **60 passed**; `tests/spec/` + `test_antigravity_native_bridge.py`
→ **649 passed**. `pre-commit` clean.

**Live verification against agy 1.1.9**

`agy plugin list` for the seeding fix:

| `--gemini_dir` | result |
| --- | --- |
| real `~/.gemini` (direct run) | `superpowers` — skills + hooks |
| isolated dir, **before** | `No imported plugins.` |
| isolated dir, **after** | `superpowers` — skills + hooks |

For the provider, output was diffed against agy's own `/skills` panel on the same host:

```
provider count: 17
plugin skills match agy panel : True     (14 superpowers:*)
builtin skills match agy panel: True
claude-only leak (caveman)    : False
```

The disable semantics were established by running `agy plugin disable/enable` against a
throwaway `--gemini_dir` and diffing the tree (the rename, and nothing else; enable
restored it byte-identically).

## Demo

N/A — non-visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the `agy plugin list` A/B and the `/skills`-panel diff above —
both need an installed agy with a real imported plugin, so they aren't automated; the
unit tests pin the seeding contract and the provider against fixtures taken from those
captures.

Two things for reviewers:

- **Known 1-entry over-report.** The `permissioned-github` builtin is gated behind agy's
  `enable_permissioned_github` feature flag; with the flag off agy does not register it
  as a slash command, but it is present on disk and indistinguishable from the other
  builtins by frontmatter. omnigent can't evaluate agy's flags, so it may appear in the
  menu. Excluding it by name would be brittle for users who have the flag on, so I
  documented it instead — happy to hardcode an exclusion if preferred.
- **Symlink write-through.** Because `config/plugins` is linked to the real tree, a
  `/plugin disable` inside an omnigent session renames `plugin.json` in the user's real
  `~/.gemini`, disabling the plugin for every agy session, not just that one. I still
  think the link is right (a copy would make each session's install/disable invisible and
  confusing), but the tradeoff should be chosen knowingly rather than inherited.

## Changelog

Antigravity sessions now load your agy plugins and list agy's own skills in the skill menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)
