### PR TITLE
refactor: tighten built-in policy types

### DIFF
--- a/omnigent/policies/builtins/github.py
+++ b/omnigent/policies/builtins/github.py
@@ -798,7 +798,7 @@ def _classify_gh(tokens: list[str]) -> _ShellOp | None:
         return _ShellOp(
             kind="write",
             repo=repo,
-            branches=branches,
+            branches=frozenset(branches),
             branch_targeted=False,
             detail=detail,
             destructive=is_destructive,

--- a/omnigent/policies/builtins/working_dir.py
+++ b/omnigent/policies/builtins/working_dir.py
@@ -50,7 +50,7 @@ import re
 import shlex
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 from omnigent.policies.builtins._shell import (
     MAX_SHELL_NESTING,
@@ -291,7 +291,7 @@ def block_working_dir_changes(
     shell_tool_names = (
         frozenset(shell_tools) if shell_tools is not None else frozenset(_DEFAULT_SHELL_TOOLS)
     )
-    result_kind = "DENY" if action == "deny" else "ASK"
+    result_kind: Literal["DENY", "ASK"] = "DENY" if action == "deny" else "ASK"
 
     def _violation(reason: str) -> PolicyResponse:
         """


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Preserve `_ShellOp.branches` as an immutable `frozenset` when classifying `gh` writes.
- Keep the validated working-directory policy result narrowed to `DENY | ASK`.
- Remove 2 mypy errors without changing policy behavior.

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest -q tests/policies/builtins/test_github.py tests/policies/builtins/test_working_dir.py` (191 passed)
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (790 expected baseline errors, down from 792)
- `TMPDIR=/tmp pre-commit run --all-files`

## Demo

N/A — non-visual typing cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing GitHub and working-directory policy suites exercise both narrowed paths.
