### PR TITLE
refactor: narrow cursor usage inputs

### DIFF
--- a/omnigent/cursor_native_usage.py
+++ b/omnigent/cursor_native_usage.py
@@ -37,6 +37,12 @@ import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from httpx import Auth as HttpxAuth
+else:
+    HttpxAuth = object
 
 _logger = logging.getLogger(__name__)
 
@@ -70,6 +76,8 @@ _SUPERVISOR_HEALTHY_UPTIME_S = 60.0
 
 def _coerce_int(value: object) -> int:
     """Coerce a hook token field to a non-negative int (0 on anything odd)."""
+    if not isinstance(value, (str, bytes, bytearray, int, float)):
+        return 0
     try:
         out = int(value)
     except (TypeError, ValueError):
@@ -276,7 +284,7 @@ async def forward_cursor_usage_to_session(
     session_id: str,
     bridge_dir: Path,
     poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
-    auth: object | None = None,
+    auth: HttpxAuth | None = None,
 ) -> None:
     """Tail ``cursor_usage.jsonl`` and POST cumulative usage to the AP session.
 
@@ -349,7 +357,7 @@ async def supervise_cursor_usage_forwarder(
     session_id: str,
     bridge_dir: Path,
     poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
-    auth: object | None = None,
+    auth: HttpxAuth | None = None,
 ) -> None:
     """Run :func:`forward_cursor_usage_to_session` under a restart supervisor.
 


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Restrict Cursor hook token coercion to the scalar values a decoded JSON payload can contain.
- Type the usage forwarder's auth boundary as `httpx.Auth` while preserving the hook module's stdlib-only runtime import path.
- Remove 2 mypy errors without changing valid hook payload or runner-auth behavior.

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest -q tests/test_cursor_native_usage.py` (31 passed)
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (785 expected baseline errors, down from 787)
- `TMPDIR=/tmp pre-commit run --all-files`

## Demo

N/A — non-visual typing cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing Cursor usage suite covers hook payload normalization, token coercion, persistence, forwarding, retries, and supervisor behavior.
