### PR TITLE
refactor: narrow migration driver values

### DIFF
--- a/omnigent/db/migrations/versions/b7e4d2c9a1f3_merge_agent_configuration_into_conversations.py
+++ b/omnigent/db/migrations/versions/b7e4d2c9a1f3_merge_agent_configuration_into_conversations.py
@@ -38,6 +38,7 @@ NULL/short blobs cost only their bytes).
 from __future__ import annotations
 
 import json
+import uuid
 from collections.abc import Sequence
 
 import sqlalchemy as sa
@@ -78,7 +79,9 @@ def _as_uuid_bytes(value: object) -> bytes | None:
             return raw
         # A varchar id surfaced as bytes (e.g. hex text) — decode then normalise.
         return uuid_to_bytes(raw.decode("ascii"))
-    return uuid_to_bytes(value)  # str / uuid.UUID
+    if isinstance(value, (str, uuid.UUID)):
+        return uuid_to_bytes(value)
+    raise TypeError(f"Unsupported UUID value: {type(value).__name__}")
 
 
 def _encode_overrides(values: dict[str, str | None]) -> str | None:

--- a/omnigent/db/migrations/versions/b7e4d2c9a1f3_merge_agent_configuration_into_conversations.py
+++ b/omnigent/db/migrations/versions/b7e4d2c9a1f3_merge_agent_configuration_into_conversations.py
@@ -67,9 +67,10 @@ def _as_uuid_bytes(value: object) -> bytes | None:
 
     Accepts whatever the driver returns for the source column, regardless of
     its declared type: ``None``; 16 raw bytes / ``memoryview`` (binary column);
-    or a 32-char hex string, optionally dashed / legacy-prefixed, possibly
-    delivered as ``bytes`` (varchar column). This lets the copy target a binary
-    column on every dialect without relying on implicit type coercion.
+    a ``uuid.UUID``; or a 32-char hex string, optionally dashed /
+    legacy-prefixed, possibly delivered as ``bytes`` (varchar column). This
+    lets the copy target a binary column on every dialect without relying on
+    implicit type coercion.
     """
     if value is None:
         return None

--- a/omnigent/db/migrations/versions/u1a2b3c4d5e6_enums_varchar_to_smallint.py
+++ b/omnigent/db/migrations/versions/u1a2b3c4d5e6_enums_varchar_to_smallint.py
@@ -30,6 +30,8 @@ migrations/env.py) rebuilds the SQLite table so the constraint swap lands.
 
 from __future__ import annotations
 
+from typing import Literal
+
 import sqlalchemy as sa
 from alembic import op
 
@@ -113,7 +115,7 @@ def _swap_to_int(
     tmp = f"{column}_int"
     op.add_column(table, sa.Column(tmp, sa.SmallInteger(), nullable=True))
     op.execute(f"UPDATE {table} SET {tmp} = {_case_sql(column, mapping)}")
-    recreate = "always" if _is_sqlite() else "auto"
+    recreate: Literal["always", "auto"] = "always" if _is_sqlite() else "auto"
     with op.batch_alter_table(table, recreate=recreate) as batch_op:
         if check_name is not None:
             batch_op.drop_constraint(check_name, type_="check")
@@ -141,7 +143,7 @@ def _swap_to_string(
     tmp = f"{column}_str"
     op.add_column(table, sa.Column(tmp, sa.String(length=length), nullable=True))
     op.execute(f"UPDATE {table} SET {tmp} = {_case_sql_reverse(column, mapping)}")
-    recreate = "always" if _is_sqlite() else "auto"
+    recreate: Literal["always", "auto"] = "always" if _is_sqlite() else "auto"
     with op.batch_alter_table(table, recreate=recreate) as batch_op:
         batch_op.drop_constraint(check_name or f"ck_{table}_{column}", type_="check")
         batch_op.drop_column(column)

--- a/omnigent/db/migrations/versions/z7a2b3c4d5e6_convert_ids_to_binary_uuid.py
+++ b/omnigent/db/migrations/versions/z7a2b3c4d5e6_convert_ids_to_binary_uuid.py
@@ -55,7 +55,6 @@ from __future__ import annotations
 import hashlib
 import re
 from collections.abc import Sequence
-from typing import cast
 
 import sqlalchemy as sa
 from alembic import op
@@ -123,7 +122,9 @@ def _bytes_to_id(value: object) -> str:
     """Return the bare 32-char hex form of a stored 16-byte id (downgrade)."""
     if isinstance(value, str):  # already hex (idempotent)
         return value.replace("-", "")[-32:]
-    return bytes(cast(bytes | bytearray | memoryview[int], value)).hex()
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return bytes(value).hex()
+    raise TypeError(f"Unsupported binary UUID value: {type(value).__name__}")
 
 
 def _nullability(bind: sa.Connection) -> dict[tuple[str, str], bool]:

--- a/omnigent/db/migrations/versions/z7a2b3c4d5e6_convert_ids_to_binary_uuid.py
+++ b/omnigent/db/migrations/versions/z7a2b3c4d5e6_convert_ids_to_binary_uuid.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 import hashlib
 import re
 from collections.abc import Sequence
+from typing import cast
 
 import sqlalchemy as sa
 from alembic import op
@@ -122,7 +123,7 @@ def _bytes_to_id(value: object) -> str:
     """Return the bare 32-char hex form of a stored 16-byte id (downgrade)."""
     if isinstance(value, str):  # already hex (idempotent)
         return value.replace("-", "")[-32:]
-    return bytes(value).hex()
+    return bytes(cast(bytes | bytearray | memoryview[int], value)).hex()
 
 
 def _nullability(bind: sa.Connection) -> dict[tuple[str, str], bool]:


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Narrow UUID migration values to the string, UUID, and bytes-like forms database drivers return.
- Preserve the binary-ID downgrade conversion while exposing its bytes-like invariant to mypy.
- Keep Alembic batch recreation modes narrowed to its accepted literals.
- Remove 5 mypy errors without changing valid migration data paths.

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest -q tests/db/test_migration_enums_to_smallint.py tests/db/test_migration_merge_agent_configuration.py tests/db/test_migration_conversation_items_created_at_pk.py` (10 passed)
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (782 expected baseline errors, down from 787)
- `TMPDIR=/tmp pre-commit run --all-files`

## Demo

N/A — non-visual typing cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing migration tests cover enum upgrade/downgrade, agent-configuration UUID copying, and binary-ID downgrade paths.
