### PR TITLE
refactor: narrow update metadata parsing

### DIFF
--- a/omnigent/update_check.py
+++ b/omnigent/update_check.py
@@ -948,7 +948,7 @@ def _read_build_info() -> tuple[float, str] | None:
         without ``git``); the caller treats that as "no commit info".
     """
     try:
-        from omnigent import _build_info  # type: ignore[attr-defined]
+        from omnigent import _build_info
     except ImportError:
         return None
     try:
@@ -1112,9 +1112,9 @@ def _read_installed_wheel_info() -> _InstalledWheelInfo | None:
             uv_data = None
         if isinstance(uv_data, dict):
             if install_time_epoch is None:
-                ts = uv_data.get("timestamp")
-                if isinstance(ts, dict):
-                    secs = ts.get("secs_since_epoch")
+                timestamp_data = uv_data.get("timestamp")
+                if isinstance(timestamp_data, dict):
+                    secs = timestamp_data.get("secs_since_epoch")
                     if isinstance(secs, (int, float)):
                         install_time_epoch = float(secs)
             if commit_sha is None:


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Remove the obsolete generated-module suppression now that `_build_info` is explicitly exported.
- Keep build-info and `uv_cache.json` timestamps in distinct locals so each retains its actual type.
- Remove 2 mypy errors without changing update-check behavior.

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest -q tests/cli/test_update_check.py` (112 passed)
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (785 expected baseline errors, down from 787)
- `TMPDIR=/tmp pre-commit run --all-files`

## Demo

N/A — non-visual typing cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The full update-check suite covers generated build metadata, uv cache parsing, distribution fallbacks, caching, notices, and index lookup.
