### PR TITLE
refactor: type identity migration updates

### DIFF
--- a/omnigent/server/identity_migration.py
+++ b/omnigent/server/identity_migration.py
@@ -35,8 +35,10 @@ grants we still need).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import cast
 
 from sqlalchemy import Engine, select, update
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.orm import Session
 
 from omnigent.db.db_models import (
@@ -211,23 +213,29 @@ def remap_identities(
                 (SqlComment, SqlComment.created_by),
                 (SqlPolicy, SqlPolicy.created_by),
             ):
-                result = session.execute(
-                    update(model)
-                    .where(model.workspace_id == current_workspace_id(), column == old_id)
-                    .values(created_by=new_id)
+                result = cast(
+                    CursorResult[tuple[object]],
+                    session.execute(
+                        update(model)
+                        .where(model.workspace_id == current_workspace_id(), column == old_id)
+                        .values(created_by=new_id)
+                    ),
                 )
                 report._bump(model.__tablename__, result.rowcount or 0)
 
             # account_tokens has two id columns to repoint.
             for column_name in ("user_id", "created_by"):
                 column = getattr(SqlAccountToken, column_name)
-                result = session.execute(
-                    update(SqlAccountToken)
-                    .where(
-                        SqlAccountToken.workspace_id == current_workspace_id(),
-                        column == old_id,
-                    )
-                    .values(**{column_name: new_id})
+                result = cast(
+                    CursorResult[tuple[object]],
+                    session.execute(
+                        update(SqlAccountToken)
+                        .where(
+                            SqlAccountToken.workspace_id == current_workspace_id(),
+                            column == old_id,
+                        )
+                        .values(**{column_name: new_id})
+                    ),
                 )
                 report._bump(SqlAccountToken.__tablename__, result.rowcount or 0)
 


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Narrow bulk identity-remap `UPDATE` results to SQLAlchemy `CursorResult` before reading `rowcount`.
- Match the typed pattern already used by the account, device-grant, and permission stores.
- Remove 2 mypy errors without changing migration behavior.

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest -q tests/server/test_identity_migration.py` (15 passed)
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (783 expected baseline errors, down from 785)
- `TMPDIR=/tmp pre-commit run --all-files`

## Demo

N/A — non-visual typing cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The identity-migration suite covers row remapping, collision handling, dry runs, missing identities, and CLI commit behavior.
