### PR TITLE
feat(web): expose agy's permission bypass in the new-chat config modal

### DIFF
--- a/web/src/lib/nativeCodingAgents.test.ts
+++ b/web/src/lib/nativeCodingAgents.test.ts
@@ -4,6 +4,7 @@ import {
   UI_MODE_TERMINAL_VALUE,
   WRAPPER_LABEL_KEY,
   isNativeTerminalSession,
+  nativeAgentHasCapability,
   nativeCodingAgentForHarness,
   nativeWrapperLabelsForAgent,
 } from "./nativeCodingAgents";
@@ -63,6 +64,20 @@ describe("nativeCodingAgentForHarness", () => {
     expect(nativeCodingAgentForHarness("native-antigravity")).toBe(
       nativeCodingAgentForHarness("antigravity-native"),
     );
+  });
+
+  // agy's only pre-emptive control is the all-or-nothing bypass, so it must
+  // declare `skipPermissions` and NOT Claude's graded `permissionMode` — the
+  // latter would emit `--permission-mode <mode>`, a flag agy does not accept.
+  it("gives antigravity-native the skipPermissions capability, not permissionMode", () => {
+    const agy = nativeCodingAgentForHarness("antigravity-native");
+    expect(agy?.capabilities).toEqual(["skipPermissions"]);
+    expect(
+      nativeAgentHasCapability({ name: "antigravity-native-ui", harness: null }, "skipPermissions"),
+    ).toBe(true);
+    expect(
+      nativeAgentHasCapability({ name: "antigravity-native-ui", harness: null }, "permissionMode"),
+    ).toBe(false);
   });
 
   it("leaves unknown / non-native harnesses unresolved", () => {

--- a/web/src/lib/nativeCodingAgents.ts
+++ b/web/src/lib/nativeCodingAgents.ts
@@ -16,7 +16,8 @@ export type NativeCodingAgentIconKind =
   | "antigravity"
   | "kimi"
   | "hermes";
-export type NativeCodingAgentCapability = "permissionMode" | "approvalMode" | "cursorMode";
+export type NativeCodingAgentCapability =
+  "permissionMode" | "approvalMode" | "cursorMode" | "skipPermissions";
 
 export interface NativeCodingAgentSpec {
   key: NativeCodingAgentIconKind;
@@ -110,6 +111,10 @@ export const NATIVE_CODING_AGENTS = [
     displayName: "Antigravity",
     iconKind: "antigravity",
     sortRank: 45,
+    // agy's only pre-emptive control is the all-or-nothing
+    // `--dangerously-skip-permissions`, so it gets a two-value toggle rather
+    // than Claude's graded permissionMode selector.
+    capabilities: ["skipPermissions"],
   },
   {
     key: "goose",

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -784,6 +784,69 @@ describe("NewChatLandingScreen create flow", () => {
     expect(body.terminal_launch_args).toBeUndefined();
   });
 
+  it("posts --dangerously-skip-permissions when the bypass is picked for antigravity-native", async () => {
+    setAgents([
+      agent({ id: "ag_agy", name: "antigravity-native-ui", display_name: "Antigravity" }),
+    ]);
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_agy" }),
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    openAgentConfig("ag_agy");
+    pickSelectOption("new-chat-landing-config-agy-skip", "Skip permissions");
+    saveConfig();
+    typeMessage("go");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
+    const [, init] = vi.mocked(authenticatedFetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    // agy's ONLY pre-emptive control, as a bare single token. Claude's
+    // `["--permission-mode", ...]` pair would be rejected by agy, which has no
+    // such flag — so assert the exact spelling, not merely "some args".
+    expect(body.terminal_launch_args).toEqual(["--dangerously-skip-permissions"]);
+  });
+
+  it("omits terminal_launch_args when antigravity-native permissions are left at default", async () => {
+    setAgents([
+      agent({ id: "ag_agy", name: "antigravity-native-ui", display_name: "Antigravity" }),
+    ]);
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_agy" }),
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    typeMessage("go");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
+    const [, init] = vi.mocked(authenticatedFetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    // Anchor so the absence check is not vacuous against a malformed body.
+    expect(body.labels?.["omnigent.wrapper"]).toBe("antigravity-native-ui");
+    // Untouched → agy keeps its own request-review prompt.
+    expect(body.terminal_launch_args).toBeUndefined();
+  });
+
+  it("shows a danger banner while the antigravity-native bypass is selected", async () => {
+    setAgents([
+      agent({ id: "ag_agy", name: "antigravity-native-ui", display_name: "Antigravity" }),
+    ]);
+    renderLanding();
+    await waitForWorkspaceSeed();
+    openAgentConfig("ag_agy");
+    // agy exposes no firing pre-tool hook, so Omnigent cannot re-gate tools
+    // once this is armed — the banner is the only guardrail the user gets.
+    expect(screen.queryByTestId("new-chat-landing-agy-skip-banner")).toBeNull();
+    pickSelectOption("new-chat-landing-config-agy-skip", "Skip permissions");
+    expect(screen.getByTestId("new-chat-landing-agy-skip-banner")).toBeTruthy();
+  });
+
   it("omits model + effort on create when the picker is untouched for claude-native", async () => {
     setAgents([agent({ id: "ag_native", name: "claude-native-ui", display_name: "Claude Code" })]);
     vi.mocked(authenticatedFetch).mockResolvedValueOnce({

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -209,6 +209,33 @@ const CLAUDE_NATIVE_PERMISSION_MODES: { value: string; label: string; descriptio
   },
 ];
 
+// Antigravity (agy) permission control. agy exposes exactly ONE pre-emptive
+// knob — `--dangerously-skip-permissions`, an all-or-nothing bypass — with no
+// per-tool equivalent of acceptEdits/plan, so this is a two-value toggle rather
+// than Claude's graded selector. "default" sends no flags and leaves agy's own
+// request-review prompt in place. Keep in sync with `agy --help`.
+const AGY_NATIVE_DEFAULT_SKIP_MODE = "default";
+const AGY_NATIVE_SKIP_VALUE = "skip";
+const AGY_NATIVE_SKIP_MODES: {
+  value: string;
+  label: string;
+  description: string;
+  args: string[];
+}[] = [
+  {
+    value: AGY_NATIVE_DEFAULT_SKIP_MODE,
+    label: "Ask every time",
+    description: "Prompts before each tool runs",
+    args: [],
+  },
+  {
+    value: AGY_NATIVE_SKIP_VALUE,
+    label: "Skip permissions",
+    description: "Runs everything; no prompts or safety checks",
+    args: ["--dangerously-skip-permissions"],
+  },
+];
+
 // Cursor execution modes. "default" sends no flags; other values map to CLI
 // args passed via terminal_launch_args. Keep in sync with `cursor-agent --help`.
 const CURSOR_NATIVE_DEFAULT_EXEC_MODE = "default";
@@ -1237,6 +1264,7 @@ function HarnessConfigModal({
   permissionMode,
   approvalMode,
   cursorExecMode,
+  agySkipMode,
   bypassSandbox,
   pickedModel,
   claudeModelOptions,
@@ -1249,6 +1277,7 @@ function HarnessConfigModal({
   setPermissionMode,
   setApprovalMode,
   setCursorExecMode,
+  setAgySkipMode,
   setBypassSandbox,
   setPickedModel,
   setPickedEffort,
@@ -1265,6 +1294,7 @@ function HarnessConfigModal({
   permissionMode: string;
   approvalMode: string;
   cursorExecMode: string;
+  agySkipMode: string;
   bypassSandbox: boolean;
   pickedModel: string;
   claudeModelOptions: readonly Pick<NativeModelOption, "id" | "displayName" | "isDefault">[];
@@ -1277,6 +1307,7 @@ function HarnessConfigModal({
   setPermissionMode: (mode: string) => void;
   setApprovalMode: (mode: string) => void;
   setCursorExecMode: (mode: string) => void;
+  setAgySkipMode: (mode: string) => void;
   setBypassSandbox: (enabled: boolean) => void;
   setPickedModel: (model: string) => void;
   setPickedEffort: (effort: string) => void;
@@ -1290,6 +1321,7 @@ function HarnessConfigModal({
   const hasPermission = nativeAgentHasCapability(agent, "permissionMode");
   const hasApproval = nativeAgentHasCapability(agent, "approvalMode");
   const hasCursor = nativeAgentHasCapability(agent, "cursorMode");
+  const hasAgySkip = nativeAgentHasCapability(agent, "skipPermissions");
   const isCodex = entryHarness === "codex-native";
   const modelOptions = isCodex ? codexModelOptions : claudeModelOptions;
   const modelsLoading = isCodex ? codexModelsLoading : claudeModelsLoading;
@@ -1304,6 +1336,7 @@ function HarnessConfigModal({
   const [draftPermission, setDraftPermission] = useState(permissionMode);
   const [draftApproval, setDraftApproval] = useState(approvalMode);
   const [draftCursor, setDraftCursor] = useState(cursorExecMode);
+  const [draftAgySkip, setDraftAgySkip] = useState(agySkipMode);
   const [draftBypass, setDraftBypass] = useState(bypassSandbox);
   const [draftHarness, setDraftHarness] = useState<string | null>(pickedHarness);
   const [draftRouting, setDraftRouting] = useState<CostControlMode>(costControlMode);
@@ -1315,6 +1348,7 @@ function HarnessConfigModal({
     setDraftPermission(permissionMode);
     setDraftApproval(approvalMode);
     setDraftCursor(cursorExecMode);
+    setDraftAgySkip(agySkipMode);
     setDraftBypass(bypassSandbox);
     setDraftHarness(pickedHarness);
     setDraftRouting(costControlMode);
@@ -1372,6 +1406,9 @@ function HarnessConfigModal({
     } else if (hasCursor) {
       setCursorExecMode(draftCursor);
       if (entryHarness) writeHarnessOption(entryHarness, { mode: draftCursor });
+    } else if (hasAgySkip) {
+      setAgySkipMode(draftAgySkip);
+      if (entryHarness) writeHarnessOption(entryHarness, { mode: draftAgySkip });
     } else if (brainDefault) {
       // Picking the spec default clears the override so the session tracks it.
       setPickedHarness(draftHarness === brainDefault ? null : draftHarness, agent.id);
@@ -1591,7 +1628,37 @@ function HarnessConfigModal({
             </ConfigRow>
           )}
 
-          {!hasPermission && !hasApproval && !hasCursor && brainDefault && (
+          {hasAgySkip && (
+            <>
+              <ConfigRow label="Permissions" description="What the agent can do without asking">
+                <DescribedSelect
+                  value={draftAgySkip}
+                  onValueChange={setDraftAgySkip}
+                  options={AGY_NATIVE_SKIP_MODES}
+                  testId="new-chat-landing-config-agy-skip"
+                  ariaLabel="Permissions"
+                />
+              </ConfigRow>
+              {/* Persistent danger banner while the bypass is selected. agy has
+                  no firing pre-tool hook, so Omnigent cannot re-gate individual
+                  tools once this is on — the warning is the only guardrail. */}
+              {draftAgySkip === AGY_NATIVE_SKIP_VALUE && (
+                <div
+                  role="alert"
+                  data-testid="new-chat-landing-agy-skip-banner"
+                  className="flex items-start gap-1.5 rounded-md border border-destructive bg-destructive/10 px-2 py-1.5 text-xs font-medium leading-relaxed text-destructive"
+                >
+                  <TriangleAlertIcon className="mt-0.5 size-3.5 shrink-0" />
+                  <span>
+                    Danger: this session runs Antigravity with all tool permission prompts disabled.
+                    It can edit any file and run any command without asking.
+                  </span>
+                </div>
+              )}
+            </>
+          )}
+
+          {!hasPermission && !hasApproval && !hasCursor && !hasAgySkip && brainDefault && (
             <ConfigRow label="Agent Harness" description="Underlying coding harness">
               <Select value={draftHarness ?? brainDefault} onValueChange={setDraftHarness}>
                 <SelectTrigger
@@ -1668,6 +1735,7 @@ interface LandingDraft {
   approvalMode: string;
   bypassSandbox: boolean;
   cursorExecMode: string;
+  agySkipMode: string;
   pickedHarness: string | null;
   pickedModel: string;
   pickedEffort: string;
@@ -1925,6 +1993,11 @@ export function NewChatLandingScreen() {
   const [cursorExecMode, setCursorExecMode] = useState<string>(
     () => landingDraft?.cursorExecMode ?? CURSOR_NATIVE_DEFAULT_EXEC_MODE,
   );
+  // agy's all-or-nothing `--dangerously-skip-permissions` toggle. Only
+  // meaningful for the antigravity-native wrapper; ignored otherwise.
+  const [agySkipMode, setAgySkipMode] = useState<string>(
+    () => landingDraft?.agySkipMode ?? AGY_NATIVE_DEFAULT_SKIP_MODE,
+  );
   // Per-session brain-harness override for bundle agents (polly / debby).
   // null = the agent spec's declared harness (no override sent). On agent
   // switch, seeded from the user's last stored pick for that agent.
@@ -1996,6 +2069,7 @@ export function NewChatLandingScreen() {
     approvalMode,
     bypassSandbox,
     cursorExecMode,
+    agySkipMode,
     pickedHarness,
     pickedModel,
     pickedEffort,
@@ -2233,6 +2307,7 @@ export function NewChatLandingScreen() {
   const supportsPermissionMode = nativeAgentHasCapability(selectedAgent, "permissionMode");
   const supportsApprovalMode = nativeAgentHasCapability(selectedAgent, "approvalMode");
   const supportsCursorMode = nativeAgentHasCapability(selectedAgent, "cursorMode");
+  const supportsAgySkipPermissions = nativeAgentHasCapability(selectedAgent, "skipPermissions");
   const hideUnconfiguredHarnesses = useMemo(() => readHideUnconfiguredHarnesses(), []);
   // Smart Routing (per-session model selection) is superseded by the Auto
   // harness which handles both harness + model. Hide it entirely for now.
@@ -2246,6 +2321,7 @@ export function NewChatLandingScreen() {
     supportsPermissionMode ||
     supportsApprovalMode ||
     supportsCursorMode ||
+    supportsAgySkipPermissions ||
     smartRoutingEligible ||
     (selectedAgent?.harness != null && selectedAgent.harness in brainHarnessLabels);
   // Label/value pairs summarizing the selected agent's current run-config, for
@@ -2308,6 +2384,11 @@ export function NewChatLandingScreen() {
         CURSOR_NATIVE_EXEC_MODES.find((m) => m.value === cursorExecMode)?.label ?? cursorExecMode;
       return [{ label: "Mode", value: modeValue }, ...routingRow];
     }
+    if (supportsAgySkipPermissions) {
+      const skipValue =
+        AGY_NATIVE_SKIP_MODES.find((m) => m.value === agySkipMode)?.label ?? agySkipMode;
+      return [{ label: "Permissions", value: skipValue }, ...routingRow];
+    }
     if (selectedAgent?.harness != null && selectedAgent.harness in brainHarnessLabels) {
       const active = pickedHarness ?? selectedAgent.harness;
       return [
@@ -2320,6 +2401,7 @@ export function NewChatLandingScreen() {
     supportsPermissionMode,
     supportsApprovalMode,
     supportsCursorMode,
+    supportsAgySkipPermissions,
     smartRoutingEligible,
     selectedAgent,
     brainHarnessLabels,
@@ -2332,6 +2414,7 @@ export function NewChatLandingScreen() {
     approvalMode,
     bypassSandbox,
     cursorExecMode,
+    agySkipMode,
     pickedHarness,
   ]);
   // Reset per-agent-instance run-config that must not carry across an agent
@@ -2402,6 +2485,8 @@ export function NewChatLandingScreen() {
       );
     } else if (supportsCursorMode) {
       setCursorExecMode(resolve(CURSOR_NATIVE_EXEC_MODES, CURSOR_NATIVE_DEFAULT_EXEC_MODE));
+    } else if (supportsAgySkipPermissions) {
+      setAgySkipMode(resolve(AGY_NATIVE_SKIP_MODES, AGY_NATIVE_DEFAULT_SKIP_MODE));
     }
     // Reseed on harness changes and when the selected host's catalog resolves;
     // capability flags are derived from the same harness and stay omitted.
@@ -2901,6 +2986,7 @@ export function NewChatLandingScreen() {
       const agentSupportsPermissionMode = nativeAgentHasCapability(agent, "permissionMode");
       const agentSupportsApprovalMode = nativeAgentHasCapability(agent, "approvalMode");
       const agentSupportsCursorMode = nativeAgentHasCapability(agent, "cursorMode");
+      const agentSupportsAgySkip = nativeAgentHasCapability(agent, "skipPermissions");
 
       let data: { id: string };
 
@@ -2979,7 +3065,9 @@ export function NewChatLandingScreen() {
                   ? (CODEX_NATIVE_APPROVAL_MODES.find((m) => m.value === approvalMode)?.args ?? [])
                   : agentSupportsCursorMode && cursorExecMode !== CURSOR_NATIVE_DEFAULT_EXEC_MODE
                     ? (CURSOR_NATIVE_EXEC_MODES.find((m) => m.value === cursorExecMode)?.args ?? [])
-                    : undefined,
+                    : agentSupportsAgySkip && agySkipMode !== AGY_NATIVE_DEFAULT_SKIP_MODE
+                      ? (AGY_NATIVE_SKIP_MODES.find((m) => m.value === agySkipMode)?.args ?? [])
+                      : undefined,
             // Model + reasoning effort, persisted on the session row before
             // the runner launches. Claude and Codex read model_override at
             // terminal launch; an unselected ("") knob is omitted so the
@@ -3461,6 +3549,7 @@ export function NewChatLandingScreen() {
                     permissionMode={permissionMode}
                     approvalMode={approvalMode}
                     cursorExecMode={cursorExecMode}
+                    agySkipMode={agySkipMode}
                     bypassSandbox={bypassSandbox}
                     pickedModel={pickedModel}
                     claudeModelOptions={claudeModelOptions}
@@ -3477,6 +3566,7 @@ export function NewChatLandingScreen() {
                     setPermissionMode={setPermissionMode}
                     setApprovalMode={setApprovalMode}
                     setCursorExecMode={setCursorExecMode}
+                    setAgySkipMode={setAgySkipMode}
                     setBypassSandbox={setBypassSandbox}
                     setPickedModel={setPickedModel}
                     setPickedEffort={setPickedEffort}


### PR DESCRIPTION
## Related issue

N/A — found while using the harness; no existing issue filed. Happy to open one if
maintainers prefer an issue on record.

## Summary

`antigravity-native` is the only native harness whose new-chat config modal shows **no
permission control at all**. The gear's contents are gated by a frontend capability
registry (`web/src/lib/nativeCodingAgents.ts`), and the antigravity row declared no
`capabilities`, so `nativeAgentHasCapability` returned `false` and the whole block was
hidden. Reaching agy's bypass meant the CLI pass-through
(`omnigent antigravity -- --dangerously-skip-permissions`) or a manual
`terminal_launch_args` PATCH.

Adding Claude's `permissionMode` to that row would have been wrong. It emits
`["--permission-mode", <mode>]` (`NewChatDialog.tsx`), which the runner forwards
verbatim into `build_agy_launch` — and `agy` has no such flag (verified against `agy
--help`, 1.1.9). agy exposes exactly one pre-emptive control, the all-or-nothing
`--dangerously-skip-permissions`, with no per-tool equivalent of `acceptEdits` / `plan`.

So this adds a **`skipPermissions` capability** carrying its own `args` array — the same
shape `codex-native` and `cursor-native` already use — rendered as a two-value toggle:

| Choice | args emitted |
| --- | --- |
| Ask every time (default) | *none* — `terminal_launch_args` omitted |
| Skip permissions | `["--dangerously-skip-permissions"]` |

Selecting the bypass shows the same persistent red danger banner Codex's full-bypass
gets. That is deliberate rather than decorative: agy exposes **no firing pre-tool hook**,
so Omnigent cannot re-gate individual tools once this is armed (its policy gate for this
harness is post-hoc/audit-only, per `antigravity_native_launch.py`). Bypass here is a
bigger step than on claude-native, so it should not be a quiet dropdown entry.

**No backend change.** The runner already reads `terminal_launch_args` and passes them as
`extra_args` into `build_agy_launch`, which de-dupes the flag if a user also passed it
manually.

## Test Plan

**Unit** — 4 tests added:

- `NewChatDialog.flow.test.tsx` — picking the bypass posts exactly
  `["--dangerously-skip-permissions"]`; leaving the default omits `terminal_launch_args`
  entirely; the danger banner appears only once the bypass is selected. The first test
  asserts the exact flag spelling, so a regression to Claude's `--permission-mode` pair
  fails loudly rather than silently launching agy with an unknown flag.
- `nativeCodingAgents.test.ts` — antigravity declares `skipPermissions` and **not**
  `permissionMode`.

**Suites run** (all affected): `nativeCodingAgents.test.ts`, `NewChatDialog.test.tsx`,
`NewChatDialog.flow.test.tsx`, `CreateScheduledTaskDialog.test.tsx` → **272 passed**.
`tsc -b` clean; `pre-commit` (prettier + oxlint) clean.

**Flag verified against the real binary** — `agy --help` (1.1.9) lists
`--dangerously-skip-permissions` and no `--permission-mode`, which is what makes the
capability split necessary rather than cosmetic.

## Demo

⚠️ **Screenshot pending — I'll attach it to this PR.** The new control is the
"Permissions" row in the gear config modal when Antigravity is the selected agent, plus
the red danger banner that appears under it when "Skip permissions" is chosen.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The three flow tests drive the real modal through the create call, so the UI →
`terminal_launch_args` path is covered end-to-end in jsdom. What they do not cover is agy
actually consuming the flag — that side is already covered by `build_agy_launch`'s
existing tests and was confirmed against `agy --help`.

One design note for reviewers: the picked value persists per-harness via
`writeHarnessOption`, matching how claude-native persists `bypassPermissions` and cursor
persists `yolo`. Codex's full-bypass deliberately does *not* persist (it re-opts-in per
context) because it also drops the OS sandbox. agy's flag doesn't touch a sandbox, so it
follows the claude/cursor precedent — but happy to make it re-opt-in per session if
maintainers consider the risk closer to Codex's.

## Changelog

Antigravity sessions can now skip tool permission prompts from the new-chat config modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
