### PR TITLE
refactor: narrow server request boundaries

### DIFF
--- a/omnigent/server/routes/device_auth.py
+++ b/omnigent/server/routes/device_auth.py
@@ -101,14 +101,15 @@ def _generate_user_code() -> str:
     return f"{chars[:4]}-{chars[4:]}"
 
 
-def _client_id(body: dict) -> str | None:
+def _client_id(body: dict[str, object]) -> str | None:
     """Extract the RFC 8628 ``client_id`` from an authorize body.
 
     A public string naming the requesting application (e.g. Slack passes
     ``"slack"``), the same for every grant that application initiates.
     Display + audit only — never an authorization key.
     """
-    return (body.get("client_id") or "").strip() or None
+    value = body.get("client_id")
+    return value.strip() or None if isinstance(value, str) else None
 
 
 def _mint_refresh_token() -> str:

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -175,14 +175,15 @@ def create_host_tunnel_router(
                 return
             tunnel_owner = managed.user_id
         elif auth_provider is not None:
-            tunnel_owner = auth_provider.get_user_id(ws)
-            if tunnel_owner is None:
+            authenticated_owner = auth_provider.get_user_id(ws)
+            if authenticated_owner is None:
                 # Auth is enabled but this peer didn't authenticate. Fail
                 # closed — never fall back to RESERVED_USER_LOCAL, which is
                 # admin-equivalent under the multi-user header scheme
                 # Closing before accept() refuses the handshake.
                 await ws.close(code=4004, reason="unauthenticated")
                 return
+            tunnel_owner = authenticated_owner
         else:
             # No auth provider configured = explicit single-user / local
             # deployment; RESERVED_USER_LOCAL is the accepted local owner

--- a/omnigent/server/routes/session_mcp_servers.py
+++ b/omnigent/server/routes/session_mcp_servers.py
@@ -386,9 +386,9 @@ def _find_mcp_location(root: Path, name: str) -> _McpLocation | None:
         config = _read_yaml_mapping(config_path)
         tools = config.get("tools")
         if isinstance(tools, dict):
-            raw = tools.get(name)
-            if isinstance(raw, dict) and str(raw.get("type", "")) == "mcp":
-                return _McpLocation(source="inline", path=config_path, raw=dict(raw))
+            inline_raw = tools.get(name)
+            if isinstance(inline_raw, dict) and str(inline_raw.get("type", "")) == "mcp":
+                return _McpLocation(source="inline", path=config_path, raw=dict(inline_raw))
     return None
 
 

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -252,8 +252,14 @@ def register_resources_routes(
                 detail="runner resource endpoint unavailable",
             ) from exc
         if resp.status_code == 404:
+            payload = resp.json()
+            message = "Resource not found"
+            if isinstance(payload, dict):
+                error = payload.get("error")
+                if isinstance(error, dict) and isinstance(error.get("message"), str):
+                    message = error["message"]
             raise OmnigentError(
-                resp.json().get("error", {}).get("message", "Resource not found"),
+                message,
                 code=ErrorCode.NOT_FOUND,
             )
         if resp.status_code != 200:
@@ -264,12 +270,12 @@ def register_resources_routes(
             except Exception:
                 msg = "runner resource endpoint failed"
             raise HTTPException(status_code=502, detail=msg)
-        payload = resp.json()
-        if not isinstance(payload, dict):
+        response_payload = resp.json()
+        if not isinstance(response_payload, dict):
             raise HTTPException(
                 status_code=502, detail="runner resource endpoint returned invalid JSON"
             )
-        return cast(dict[str, Any], payload)
+        return cast(dict[str, Any], response_payload)
 
     async def _fs_get_with_host_fallback(
         session_id: str,

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -251,11 +251,16 @@ def register_resources_routes(
                 status_code=502,
                 detail="runner resource endpoint unavailable",
             ) from exc
+        try:
+            response_payload = resp.json()
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=502, detail="runner resource endpoint returned invalid JSON"
+            ) from exc
         if resp.status_code == 404:
-            payload = resp.json()
             message = "Resource not found"
-            if isinstance(payload, dict):
-                error = payload.get("error")
+            if isinstance(response_payload, dict):
+                error = response_payload.get("error")
                 if isinstance(error, dict) and isinstance(error.get("message"), str):
                     message = error["message"]
             raise OmnigentError(
@@ -263,17 +268,15 @@ def register_resources_routes(
                 code=ErrorCode.NOT_FOUND,
             )
         if resp.status_code != 200:
-            try:
-                body = resp.json()
-                error = body.get("error", {})
+            if isinstance(response_payload, dict):
+                error = response_payload.get("error", {})
                 msg = error.get("message") or "runner resource endpoint failed"
-            except Exception:
+            else:
                 msg = "runner resource endpoint failed"
             raise HTTPException(status_code=502, detail=msg)
-        response_payload = resp.json()
         if not isinstance(response_payload, dict):
             raise HTTPException(
-                status_code=502, detail="runner resource endpoint returned invalid JSON"
+                status_code=502, detail="runner resource endpoint returned non-object JSON"
             )
         return cast(dict[str, Any], response_payload)
 

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import mimetypes
 import urllib.parse
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 import httpx
 from fastapi import (
@@ -264,7 +264,12 @@ def register_resources_routes(
             except Exception:
                 msg = "runner resource endpoint failed"
             raise HTTPException(status_code=502, detail=msg)
-        return resp.json()
+        payload = resp.json()
+        if not isinstance(payload, dict):
+            raise HTTPException(
+                status_code=502, detail="runner resource endpoint returned invalid JSON"
+            )
+        return cast(dict[str, Any], payload)
 
     async def _fs_get_with_host_fallback(
         session_id: str,

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -1113,6 +1113,37 @@ async def test_get_resource_by_id_404_with_non_mapping_body(
     assert resp.json()["error"]["message"] == "Resource not found"
 
 
+@pytest.mark.asyncio
+async def test_get_resource_by_id_rejects_invalid_runner_json(
+    client: httpx.AsyncClient,
+) -> None:
+    """Malformed runner JSON becomes a controlled 502."""
+    path = "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/bad-json"
+    fake_runner = _FakeRunnerClient(
+        text_responses={path: (200, "not-json", {"content-type": "application/json"})}
+    )
+    set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
+
+    resp = await client.get(path)
+
+    assert resp.status_code == 502
+    assert resp.json()["detail"] == "runner resource endpoint returned invalid JSON"
+
+
+@pytest.mark.asyncio
+async def test_get_resource_by_id_rejects_non_mapping_runner_json(
+    client: httpx.AsyncClient,
+) -> None:
+    """Valid non-object runner JSON becomes a distinct controlled 502."""
+    fake_runner = _FakeRunnerClient(payload=["not", "an", "object"])
+    set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
+
+    resp = await client.get("/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/non-object")
+
+    assert resp.status_code == 502
+    assert resp.json()["detail"] == "runner resource endpoint returned non-object JSON"
+
+
 @pytest.fixture
 def bash_terminal_spec(monkeypatch: pytest.MonkeyPatch) -> None:
     """Resolve the session's agent spec to one declaring a ``bash`` terminal.

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -1099,6 +1099,20 @@ async def test_get_resource_by_id_404_from_runner(
     assert resp.json()["error"]["code"] == "not_found"
 
 
+@pytest.mark.asyncio
+async def test_get_resource_by_id_404_with_non_mapping_body(
+    client: httpx.AsyncClient,
+) -> None:
+    """A malformed runner 404 uses the default not-found message."""
+    fake_runner = _FakeRunnerClient(payload=["not", "an", "object"], status_code=404)
+    set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
+
+    resp = await client.get("/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/nonexistent")
+
+    assert resp.status_code == 404
+    assert resp.json()["error"]["message"] == "Resource not found"
+
+
 @pytest.fixture
 def bash_terminal_spec(monkeypatch: pytest.MonkeyPatch) -> None:
     """Resolve the session's agent spec to one declaring a ``bash`` terminal.


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Validate device-auth client ids before string normalization and keep authenticated host owners non-null after the handshake guard.
- Separate inline MCP payloads from file-level YAML mappings so their types do not bleed across branches.
- Require runner resource responses to decode as JSON objects, distinguish malformed JSON from non-object JSON, and safely fall back when a 404 has no usable message.
- Remove 4 mypy errors while making malformed external inputs fail safely.

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest -q tests/server/test_device_auth.py tests/server/integration/test_host_tunnel_route.py tests/server/integration/test_session_mcp_servers.py tests/server/routes/test_session_resources.py` (161 passed)
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (781 expected baseline errors, down from 785)
- `TMPDIR=/tmp pre-commit run --all-files`

## Demo

N/A — non-visual typing cleanup.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing device-auth, host-tunnel, MCP-management, and session-resource suites cover the narrowed request and response boundaries; added tests cover malformed JSON, non-object JSON, and malformed 404 payloads.
