### PR TITLE
refactor: narrow session metadata state

### DIFF
--- a/omnigent/server/background_session_titles.py
+++ b/omnigent/server/background_session_titles.py
@@ -289,6 +289,8 @@ def prepare_background_session_title(
         return None
 
     expected_seed_title = synthesize_conversation_title([{"type": "input_text", "text": prompt}])
+    if expected_seed_title is None:
+        return None
     return PendingBackgroundSessionTitle(
         coordinator=coordinator,
         request=BackgroundTitleRequest(

--- a/omnigent/server/presence.py
+++ b/omnigent/server/presence.py
@@ -311,7 +311,9 @@ def _expire_leave(root_id: str, user_id: str) -> None:
     with _lock:
         _pending_leaves.pop((root_id, user_id), None)
         users = _viewers.get(root_id)
-        entry = users.get(user_id) if users is not None else None
+        if users is None:
+            return
+        entry = users.get(user_id)
         if entry is None or entry.connections:
             return
         del users[user_id]


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Eliminate the absent presence-viewer map before expiring a leave timer.
- Skip background-title scheduling when deterministic title synthesis cannot produce a seed.
- Remove 2 mypy errors while preserving reconnect and title-race behavior.

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest -q tests/server/test_presence.py tests/server/test_background_session_titles.py` (32 passed)
- `TMPDIR=/tmp .venv/bin/mypy omnigent` (781 expected baseline errors, down from 783)
- `TMPDIR=/tmp pre-commit run --all-files`

## Demo

N/A — non-visual typing cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing presence and background-title suites cover reconnect races, leave expiry, deterministic seeds, unsupported harnesses, and rename races.
