### PR TITLE
refactor: narrow runner policy payloads

### DIFF
--- a/omnigent/runner/policy.py
+++ b/omnigent/runner/policy.py
@@ -38,8 +38,8 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
-from typing import Literal, cast
+from dataclasses import dataclass, replace
+from typing import Literal
 
 from omnigent.policies import FunctionPolicy, resolve_function_policy
 from omnigent.policies.types import EvaluationContext, PolicyResult
@@ -243,8 +243,11 @@ class RunnerToolPolicyGate:
         )
         verdict = await self._evaluate_policies(ctx, Phase.TOOL_RESULT)
         if verdict.action == "allow":
-            # If the policy returned transformed output, use it instead.
-            return cast(str, verdict.data) if verdict.data is not None else output
+            if verdict.data is None:
+                return output
+            if not isinstance(verdict.data, str):
+                raise TypeError("TOOL_RESULT policy replacement data must be a string")
+            return verdict.data
         if verdict.action == "deny":
             assert verdict.deny_text is not None
             return verdict.deny_text
@@ -285,8 +288,8 @@ class RunnerToolPolicyGate:
             denied.
         """
         pending_ask: PolicyVerdict | None = None
-        # Last non-None data from any ALLOW-or-ASK result. Last write
-        # wins — callers that need chained transforms compose in one callable.
+        # Sequentially accumulated data. Each transformed payload becomes the
+        # next policy's input, matching the server-side policy engine.
         composed_data: object | None = None
         for gated in self._policies:
             if phase not in gated.phases:
@@ -319,6 +322,7 @@ class RunnerToolPolicyGate:
                 )
             if result.data is not None:
                 composed_data = result.data
+                ctx = replace(ctx, content=composed_data)
             if result.action == PolicyAction.ASK and pending_ask is None:
                 pending_ask = PolicyVerdict(
                     action="ask",

--- a/omnigent/runner/policy.py
+++ b/omnigent/runner/policy.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Literal, cast
 
 from omnigent.policies import FunctionPolicy, resolve_function_policy
 from omnigent.policies.types import EvaluationContext, PolicyResult
@@ -98,7 +98,7 @@ class PolicyVerdict:
     deny_text: str | None = None
     policy_name: str | None = None
     reason: str | None = None
-    data: Any = None
+    data: object | None = None
 
 
 # Singleton ALLOW verdict — frozen dataclass, no state, allocate
@@ -129,7 +129,7 @@ def _unresolved_policy_sentinel(
     """Fail-closed stand-in for a configured policy that failed to resolve."""
     reason = _resolve_failure_diagnostic(ps, exc)
 
-    def _always_deny(_event: Any) -> dict[str, str]:
+    def _always_deny(_event: object) -> dict[str, object]:
         return {"result": "DENY", "reason": reason}
 
     return FunctionPolicy(ps, _always_deny)
@@ -192,7 +192,7 @@ class RunnerToolPolicyGate:
     async def evaluate_tool_call(
         self,
         tool_name: str,
-        arguments: dict[str, Any],
+        arguments: dict[str, object],
     ) -> PolicyVerdict:
         """
         Run TOOL_CALL policies; return the first non-ALLOW verdict.
@@ -244,7 +244,7 @@ class RunnerToolPolicyGate:
         verdict = await self._evaluate_policies(ctx, Phase.TOOL_RESULT)
         if verdict.action == "allow":
             # If the policy returned transformed output, use it instead.
-            return verdict.data if verdict.data is not None else output
+            return cast(str, verdict.data) if verdict.data is not None else output
         if verdict.action == "deny":
             assert verdict.deny_text is not None
             return verdict.deny_text
@@ -287,7 +287,7 @@ class RunnerToolPolicyGate:
         pending_ask: PolicyVerdict | None = None
         # Last non-None data from any ALLOW-or-ASK result. Last write
         # wins — callers that need chained transforms compose in one callable.
-        composed_data: Any = None
+        composed_data: object | None = None
         for gated in self._policies:
             if phase not in gated.phases:
                 continue

--- a/tests/runner/test_runner_tool_policy_gate.py
+++ b/tests/runner/test_runner_tool_policy_gate.py
@@ -140,6 +140,58 @@ async def test_valid_allow_policy_unchanged() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tool_result_policy_transformations_are_chained() -> None:
+    gate = RunnerToolPolicyGate.from_spec(
+        _agent_with_policies(
+            _tool_policy("first", _FIXED_ALLOW),
+            _tool_policy("second", _FIXED_ALLOW),
+        ),
+    )
+    first_policy, second_policy = gate._policies
+    first_original = first_policy.policy._callable
+    second_original = second_policy.policy._callable
+    seen: list[object] = []
+
+    def _first(_event: object) -> dict[str, object]:
+        return {"result": "allow", "data": "first transform"}
+
+    def _second(event: object) -> dict[str, object]:
+        assert isinstance(event, dict)
+        seen.append(event.get("data"))
+        return {"result": "allow", "data": "second transform"}
+
+    first_policy.policy._callable = _first  # type: ignore[method-assign]
+    second_policy.policy._callable = _second  # type: ignore[method-assign]
+    try:
+        output = await gate.evaluate_tool_result("web_search", "raw output")
+    finally:
+        first_policy.policy._callable = first_original
+        second_policy.policy._callable = second_original
+
+    assert seen == ["first transform"]
+    assert output == "second transform"
+
+
+@pytest.mark.asyncio
+async def test_tool_result_policy_rejects_non_string_replacement() -> None:
+    gate = RunnerToolPolicyGate.from_spec(
+        _agent_with_policies(_tool_policy("invalid_transform", _FIXED_ALLOW)),
+    )
+    gated = gate._policies[0]
+    original = gated.policy._callable
+
+    def _invalid(_event: object) -> dict[str, object]:
+        return {"result": "allow", "data": {"redacted": True}}
+
+    gated.policy._callable = _invalid  # type: ignore[method-assign]
+    try:
+        with pytest.raises(TypeError, match="replacement data must be a string"):
+            await gate.evaluate_tool_result("web_search", "raw output")
+    finally:
+        gated.policy._callable = original
+
+
+@pytest.mark.asyncio
 async def test_valid_deny_policy_unchanged() -> None:
     """Successfully resolved DENY policies keep their reason and denial shape."""
     gate = RunnerToolPolicyGate.from_spec(


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Align the runner policy gate with the shared `PolicyResult.data: object | None` contract instead of carrying explicit `Any` through verdicts, tool arguments, and composed data.
- Runtime-validate TOOL_RESULT replacement strings and feed each transformed payload into the next policy, matching server-side sequential composition while removing all five mypy diagnostics from `omnigent/runner/policy.py`.

**ELI5:** Policy payloads can still contain different shapes, but the gate now treats them as unknown objects until the exact phase determines their shape.

```text
policy result object -> composed verdict -> phase-specific caller boundary
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/mypy --no-incremental omnigent` (five target diagnostics removed; no errors remain in `omnigent/runner/policy.py`)
- `TMPDIR=/tmp .venv/bin/pytest -q tests/runner/test_runner_tool_policy_gate.py` (13 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing runner policy-gate suite covers ALLOW, DENY, ASK-adjacent fail-closed behavior, tool-call arguments, and tool-result forwarding.

