### PR TITLE
refactor: narrow native dispatch hooks

### DIFF
--- a/omnigent/native_dispatch.py
+++ b/omnigent/native_dispatch.py
@@ -13,7 +13,8 @@ module at most once.
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Callable
+from typing import Any, TypeAlias, cast
 
 from omnigent.harness_plugins import (
     NativeHarnessProvider,
@@ -21,8 +22,11 @@ from omnigent.harness_plugins import (
     native_provider_for_key,
 )
 
+# Provider hooks intentionally have unrelated sync and async signatures.
+_NativeHook: TypeAlias = Callable[..., Any]  # type: ignore[explicit-any]
 
-def resolve(import_path: str) -> Any:
+
+def resolve(import_path: str) -> object:
     """Resolve a ``module:attr`` / ``module.attr`` path to its object.
 
     Thin wrapper over :func:`omnigent.harness_plugins.load_object`. Deliberately
@@ -35,7 +39,7 @@ def resolve(import_path: str) -> Any:
     return load_object(import_path)
 
 
-def resolve_hook(provider: NativeHarnessProvider, hook: str) -> Any | None:
+def resolve_hook(provider: NativeHarnessProvider, hook: str) -> _NativeHook | None:
     """Resolve one named hook on a provider, or ``None`` if it is unset.
 
     ``hook`` is a field name on :class:`NativeHarnessProvider` (e.g.
@@ -46,10 +50,13 @@ def resolve_hook(provider: NativeHarnessProvider, hook: str) -> Any | None:
     import_path = getattr(provider, hook)
     if import_path is None:
         return None
-    return resolve(import_path)
+    resolved = resolve(import_path)
+    if not callable(resolved):
+        raise TypeError(f"native provider hook {import_path!r} is not callable")
+    return cast(_NativeHook, resolved)
 
 
-def resolve_hook_for_key(key: str, hook: str) -> Any | None:
+def resolve_hook_for_key(key: str, hook: str) -> _NativeHook | None:
     """Resolve a hook by native-agent ``key``, or ``None`` if unknown/unset."""
     provider = native_provider_for_key(key)
     if provider is None:

--- a/tests/test_native_dispatch.py
+++ b/tests/test_native_dispatch.py
@@ -50,6 +50,15 @@ def test_resolve_hook_resolves_populated_hook() -> None:
     assert run_native.__name__ == "run_pi_native"
 
 
+def test_resolve_hook_rejects_non_callable_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = hp.native_provider_for_key("pi")
+    assert provider is not None
+    monkeypatch.setattr("omnigent.pi_native.run_pi_native", object())
+
+    with pytest.raises(TypeError, match="is not callable"):
+        native_dispatch.resolve_hook(provider, "run_native")
+
+
 def test_resolve_hook_for_key() -> None:
     run_native = native_dispatch.resolve_hook_for_key("codex", "run_native")
     assert callable(run_native)


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Return plain `object` from arbitrary import-path resolution and isolate heterogeneous native hook signatures behind one documented callable boundary.
- Validate that populated provider hooks actually resolve to callables, failing clearly on bad registrations and removing all three mypy diagnostics from `omnigent/native_dispatch.py`.

**ELI5:** Importing any symbol may produce anything, but importing a registered hook must produce a function.

```text
import path -> object -> callable check -> native hook dispatch
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/mypy --no-incremental omnigent` (three target diagnostics removed; no errors remain in `omnigent/native_dispatch.py`)
- `TMPDIR=/tmp .venv/bin/pytest -q tests/test_native_dispatch.py tests/test_harness_plugins.py` (22 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new regression test covers a non-callable hook registration; existing dispatch and plugin tests cover populated, optional, unknown, and built-in hook resolution.
