### PR TITLE
refactor: type native interrupt dependencies

### DIFF
--- a/omnigent/runner/native/interrupt.py
+++ b/omnigent/runner/native/interrupt.py
@@ -34,8 +34,9 @@ import importlib
 import logging
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Protocol
 
+import httpx
 from fastapi.responses import JSONResponse, Response
 
 from omnigent.native_coding_agents import native_coding_agent_for_harness
@@ -44,12 +45,31 @@ from omnigent.runner.native.orchestration import (
     _claude_native_bridge_id_for_session,
     _session_labels_for_runner_spawn,
 )
+from omnigent.runner.resource_registry import SessionResourceRegistry
+
+if TYPE_CHECKING:
+    from omnigent.codex_native_bridge import CodexNativeBridgeState
+
+
+class SubagentDeliveryAck(Protocol):
+    """Result of attempting to deliver a terminal sub-agent payload."""
+
+    @property
+    def delivered(self) -> bool: ...
+
+    @property
+    def entry(self) -> object | None: ...
+
+    @property
+    def reason(self) -> str: ...
 
 
 class MarkSubagentTerminalAndWake(Protocol):
     """Mark a sub-agent work entry terminal and wake its parent."""
 
-    def __call__(self, child_session_id: str, *, status: str, output: str | None) -> Any: ...
+    def __call__(
+        self, child_session_id: str, *, status: str, output: str | None
+    ) -> SubagentDeliveryAck: ...
 
 
 class ClientSafeErrorDetail(Protocol):
@@ -67,7 +87,7 @@ class CodexBridgeStateForSession(Protocol):
         *,
         action: str,
         missing_state_log_level: int = logging.WARNING,
-    ) -> Any | None: ...
+    ) -> CodexNativeBridgeState | None: ...
 
 
 @dataclass(frozen=True)
@@ -224,9 +244,9 @@ class NativeInterruptRunner:
     def __init__(
         self,
         *,
-        server_client: Any,
-        resource_registry: Any,
-        publish_event: Callable[[str, dict[str, Any]], None],
+        server_client: httpx.AsyncClient,
+        resource_registry: SessionResourceRegistry,
+        publish_event: Callable[[str, dict[str, object]], None],
         mark_subagent_terminal_and_wake: MarkSubagentTerminalAndWake,
         session_sub_agent_names: Mapping[str, str],
         codex_bridge_state_for_session: CodexBridgeStateForSession,

--- a/omnigent/runner/native/interrupt.py
+++ b/omnigent/runner/native/interrupt.py
@@ -55,13 +55,16 @@ class SubagentDeliveryAck(Protocol):
     """Result of attempting to deliver a terminal sub-agent payload."""
 
     @property
-    def delivered(self) -> bool: ...
+    def delivered(self) -> bool:
+        raise NotImplementedError
 
     @property
-    def entry(self) -> object | None: ...
+    def entry(self) -> object | None:
+        raise NotImplementedError
 
     @property
-    def reason(self) -> str: ...
+    def reason(self) -> str:
+        raise NotImplementedError
 
 
 class MarkSubagentTerminalAndWake(Protocol):
@@ -69,13 +72,15 @@ class MarkSubagentTerminalAndWake(Protocol):
 
     def __call__(
         self, child_session_id: str, *, status: str, output: str | None
-    ) -> SubagentDeliveryAck: ...
+    ) -> SubagentDeliveryAck:
+        raise NotImplementedError
 
 
 class ClientSafeErrorDetail(Protocol):
     """Log an exception and return safe client-facing detail."""
 
-    def __call__(self, exc: BaseException, *, context: str) -> str: ...
+    def __call__(self, exc: BaseException, *, context: str) -> str:
+        raise NotImplementedError
 
 
 class CodexBridgeStateForSession(Protocol):
@@ -87,7 +92,8 @@ class CodexBridgeStateForSession(Protocol):
         *,
         action: str,
         missing_state_log_level: int = logging.WARNING,
-    ) -> CodexNativeBridgeState | None: ...
+    ) -> CodexNativeBridgeState | None:
+        raise NotImplementedError
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Replace broad interrupt-runner dependency annotations with concrete `httpx.AsyncClient`, `SessionResourceRegistry`, Codex bridge-state, delivery-ack, and event-publisher contracts.
- Keep the app-local delivery result decoupled through a small structural protocol and remove all three mypy diagnostics from `omnigent/runner/native/interrupt.py`.

**ELI5:** The interrupt runner now states exactly what each injected helper must provide instead of accepting anything.

```text
runner app dependencies -> typed interrupt runner -> native bridge control
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/mypy --no-incremental omnigent` (three target diagnostics removed; no errors remain in `omnigent/runner/native/interrupt.py`)
- `TMPDIR=/tmp .venv/bin/pytest -q tests/runner/test_native_interrupt_runner.py` (12 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing direct runner tests cover uniform and special-case interrupt/stop dispatch, bridge failures, teardown, parent wake-up, and no-handler fallthrough.
