### PR TITLE
fix: reject malformed install ledgers

### DIFF
--- a/omnigent/install_ledger.py
+++ b/omnigent/install_ledger.py
@@ -198,7 +198,13 @@ class InstallLedger:
 
     @classmethod
     def from_dict(cls, data: _JsonObject) -> InstallLedger:
-        entries_data = cast(_JsonObject, data.get("entries") or {})
+        entries_value = data.get("entries")
+        if entries_value is None:
+            entries_data: _JsonObject = {}
+        elif isinstance(entries_value, dict):
+            entries_data = entries_value
+        else:
+            raise ValueError("install ledger entries must be an object")
         entries = LedgerEntries(
             profiles=[
                 ProfileEntry(**item)
@@ -241,8 +247,10 @@ class InstallLedger:
             ),
         )
         schema_version = data.get("schema_version", SCHEMA_VERSION)
-        if not isinstance(schema_version, int | str | bytes | bytearray):
-            schema_version = SCHEMA_VERSION
+        if isinstance(schema_version, bool) or not isinstance(
+            schema_version, int | str | bytes | bytearray
+        ):
+            raise ValueError("install ledger schema_version must be an integer")
         return cls(
             schema_version=int(schema_version),
             ledger_source=str(data.get("ledger_source", "backfill")),
@@ -280,9 +288,15 @@ def load_ledger(path: Path) -> InstallLedger | None:
         return None
     except json.JSONDecodeError:
         return None
-    if not isinstance(data, dict) or data.get("schema_version") != SCHEMA_VERSION:
+    if not isinstance(data, dict):
         return None
-    return InstallLedger.from_dict(data)
+    schema_version = data.get("schema_version")
+    if isinstance(schema_version, bool) or schema_version != SCHEMA_VERSION:
+        return None
+    try:
+        return InstallLedger.from_dict(data)
+    except (AttributeError, TypeError, ValueError):
+        return None
 
 
 def write_ledger(ledger: InstallLedger, *, path: Path | None = None) -> None:

--- a/tests/test_install_ledger.py
+++ b/tests/test_install_ledger.py
@@ -36,6 +36,18 @@ def test_load_ledger_rejects_non_object_json(tmp_path: Path) -> None:
     assert install_ledger.load_ledger(path) is None
 
 
+def test_load_ledger_rejects_malformed_nested_shapes(tmp_path: Path) -> None:
+    path = tmp_path / "install_ledger.json"
+    malformed_payloads = [
+        {"schema_version": True},
+        {"schema_version": install_ledger.SCHEMA_VERSION, "entries": []},
+    ]
+
+    for payload in malformed_payloads:
+        path.write_text(json.dumps(payload))
+        assert install_ledger.load_ledger(path) is None
+
+
 def test_backfill_requires_anchor_signal(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path / ".omnigent"))


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Reject boolean schema versions and non-object `entries` values when loading an install ledger.
- Treat malformed nested ledger structures as unreadable instead of allowing parser exceptions to escape; this follows up on code-quality review after #3817 merged.

**ELI5:** A broken ledger file now gets ignored safely rather than crashing the loader.

```text
ledger JSON -> root/schema/entries validation -> typed ledger or None
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/pytest -q tests/test_install_ledger.py` (9 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Regression coverage includes boolean schema versions, non-object ledger roots, and non-object nested `entries` payloads alongside the existing round-trip cases.
