### PR TITLE
refactor: type cursor bridge payloads

### DIFF
--- a/omnigent/cursor_native_bridge.py
+++ b/omnigent/cursor_native_bridge.py
@@ -21,7 +21,7 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, TypeAlias
 
 import click
 
@@ -29,6 +29,8 @@ from omnigent._platform import stable_user_id
 
 if TYPE_CHECKING:
     from omnigent.cursor_native import CursorModelOption
+
+_JsonObject: TypeAlias = dict[str, object]
 
 #: Env var carrying the bridge dir into the harness executor process.
 BRIDGE_DIR_ENV_VAR = "HARNESS_CURSOR_NATIVE_BRIDGE_DIR"
@@ -252,7 +254,7 @@ def build_mcp_config(
     bridge_dir: Path,
     *,
     python_executable: str | None = None,
-) -> dict[str, Any]:
+) -> _JsonObject:
     """Build Cursor's ``.cursor/mcp.json`` for the Omnigent relay server.
 
     Cursor prompts for MCP tool approval before it sends ``tools/call`` to the
@@ -316,9 +318,7 @@ def write_mcp_config(
     return path
 
 
-def build_hooks_config(
-    bridge_dir: Path, *, python_executable: str | None = None
-) -> dict[str, Any]:
+def build_hooks_config(bridge_dir: Path, *, python_executable: str | None = None) -> _JsonObject:
     """Build Cursor's ``.cursor/hooks.json`` registering the usage ``stop`` hook.
 
     cursor-agent fires the ``stop`` hook once per completed turn with a JSON
@@ -453,7 +453,7 @@ def write_tmux_target(
 ) -> None:
     """Advertise the tmux socket + target for the running Cursor terminal."""
     _ensure_dir(bridge_dir)
-    payload: dict[str, Any] = {
+    payload: _JsonObject = {
         "socket_path": str(socket_path),
         "tmux_target": tmux_target,
         "updated_at": time.time(),


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Replace three broad `Any` annotations in Cursor-native MCP, hook, and tmux JSON payloads with one explicit `dict[str, object]` boundary.
- Preserve the emitted configuration and bridge-state JSON while removing every mypy diagnostic from `omnigent/cursor_native_bridge.py`.

**ELI5:** These values are JSON objects, so the bridge now says that directly instead of allowing arbitrary untyped values.

```text
Cursor bridge values -> typed JSON object -> mcp/hooks/tmux files
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/mypy --no-incremental omnigent` (three target diagnostics removed; no errors remain in `omnigent/cursor_native_bridge.py`)
- `TMPDIR=/tmp .venv/bin/pytest -q tests/test_cursor_native_bridge.py tests/test_cursor_native_permissions.py` (73 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing Cursor bridge and permission tests cover MCP/hook configuration, tmux state, message/model injection, and permission supervision.
