### PR TITLE
refactor: type Kimi bridge payloads

### DIFF
--- a/omnigent/kimi_native_bridge.py
+++ b/omnigent/kimi_native_bridge.py
@@ -19,9 +19,11 @@ import subprocess
 import tempfile
 import time
 from pathlib import Path
-from typing import Any
+from typing import TypeAlias
 
 from omnigent._platform import stable_user_id
+
+_JsonObject: TypeAlias = dict[str, object]
 
 #: Env var carrying the bridge dir into the harness executor process.
 BRIDGE_DIR_ENV_VAR = "HARNESS_KIMI_NATIVE_BRIDGE_DIR"
@@ -116,7 +118,7 @@ def write_hook_config(
     os.replace(tmp, bridge_dir / _HOOK_CONFIG_FILE)
 
 
-def read_hook_config(bridge_dir: Path) -> dict[str, Any]:
+def read_hook_config(bridge_dir: Path) -> _JsonObject:
     """Read Omnigent routing details for the kimi hook subprocess.
 
     :param bridge_dir: The kimi-native bridge dir.
@@ -153,7 +155,7 @@ def write_tmux_target(
 ) -> None:
     """Advertise the tmux socket + target for the running Kimi terminal."""
     _ensure_dir(bridge_dir)
-    payload: dict[str, Any] = {
+    payload: _JsonObject = {
         "socket_path": str(socket_path),
         "tmux_target": tmux_target,
         "updated_at": time.time(),


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Replace broad `Any` annotations on Kimi-native hook-config reads and tmux-state writes with an explicit `dict[str, object]` JSON boundary.
- Preserve malformed-file fallback and emitted bridge JSON while removing both mypy diagnostics from `omnigent/kimi_native_bridge.py`.

**ELI5:** Kimi's bridge files are JSON objects, so their Python type now says exactly that.

```text
hook/tmux JSON -> typed object map -> Kimi bridge consumers
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/mypy --no-incremental omnigent` (two target diagnostics removed; no errors remain in `omnigent/kimi_native_bridge.py`)
- `TMPDIR=/tmp .venv/bin/pytest -q tests/test_kimi_native_bridge_hook_config.py tests/inner/test_kimi_native_executor.py` (26 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing Kimi bridge/executor tests cover hook-config round trips and malformed files, tmux interaction, content extraction, and approval keystrokes.
