### PR TITLE
refactor: narrow residual Python boundaries

### DIFF
--- a/omnigent/inner/codex_goal_command.py
+++ b/omnigent/inner/codex_goal_command.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
 
-
-def goal_objective_from_content(content: Any) -> str | None:
+def goal_objective_from_content(content: object) -> str | None:
     """Return the objective from a standalone, text-only ``/goal`` command."""
     if isinstance(content, list):
         text_parts: list[str] = []

--- a/omnigent/integration_daemon.py
+++ b/omnigent/integration_daemon.py
@@ -171,10 +171,7 @@ class IntegrationDaemon:
         # stdout+stderr to the log file. Mirrors the host daemon spawn.
         try:
             with child_logging_popen_kwargs(env) as logging_kwargs:
-                # spawn_kwargs()/logging_kwargs are dict[str, object] splats, so
-                # mypy can't resolve a Popen overload; the runtime kwargs are
-                # valid (matches the host-daemon spawn).
-                proc = subprocess.Popen(  # type: ignore[call-overload]
+                proc = subprocess.Popen(
                     argv,
                     env=env,
                     cwd=str(cwd) if cwd is not None else None,

--- a/omnigent/onboarding/ucode_state.py
+++ b/omnigent/onboarding/ucode_state.py
@@ -166,14 +166,16 @@ def read_ucode_state(workspace_url: str) -> UcodeWorkspaceState | None:
 
     normalized = workspace_url.rstrip("/")
     ws_key: str | None = None
-    ws_data: dict | None = None
+    ws_data: dict[str, object] | None = None
     for key, value in workspaces.items():
+        if not isinstance(key, str) or not isinstance(value, dict):
+            continue
         if key.rstrip("/") == normalized:
             ws_key = key.rstrip("/")
             ws_data = value
             break
 
-    if ws_key is None or ws_data is None or not isinstance(ws_data, dict):
+    if ws_key is None or ws_data is None:
         return None
 
     claude_models_raw = ws_data.get("claude_models", {})


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Replace broad `Any` and unparameterized-dictionary annotations at the Codex goal and uCode state boundaries with concrete object types.
- Skip malformed uCode workspace records safely and remove a now-stale `Popen` suppression, eliminating three mypy diagnostics without changing valid runtime behavior.

**ELI5:** These helpers now describe unknown input as generic objects and check it before use instead of opting out of type checking.

```text
untrusted input -> runtime shape checks -> typed goal/state/process use
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/mypy --no-incremental omnigent` (three target diagnostics removed; no errors remain in the touched files)
- `.venv/bin/pytest tests/inner/test_codex_executor.py -k goal_objective` (1 passed)
- `.venv/bin/pytest tests/onboarding/test_ucode_state.py tests/cli/test_integration_slack.py` (27 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing Codex goal parsing, uCode state parsing, and integration-daemon tests cover the affected paths, including malformed state and process lifecycle behavior.
