### PR TITLE
refactor: align native executor content types

### DIFF
--- a/omnigent/inner/claude_native_executor.py
+++ b/omnigent/inner/claude_native_executor.py
@@ -7,7 +7,6 @@ import logging
 import os
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any
 
 from omnigent.claude_native_bridge import (
     BRIDGE_DIR_ENV_VAR,
@@ -18,6 +17,7 @@ from omnigent.claude_native_bridge import (
     read_launch_model,
 )
 from omnigent.inner.executor import (
+    EnqueuedContent,
     Executor,
     ExecutorConfig,
     ExecutorError,
@@ -75,7 +75,7 @@ class ClaudeNativeExecutor(Executor):
         """:returns: ``True`` because messages can be injected mid-turn."""
         return True
 
-    async def enqueue_session_message(self, session_key: str, content: Any) -> bool:
+    async def enqueue_session_message(self, session_key: str, content: EnqueuedContent) -> bool:
         """
         Inject a live steering message into the Claude terminal.
 
@@ -272,7 +272,7 @@ def _latest_user_text(messages: list[Message], bridge_dir: Path) -> str:
     return ""
 
 
-def _content_to_text(content: Any, bridge_dir: Path) -> str:
+def _content_to_text(content: EnqueuedContent, bridge_dir: Path) -> str:
     """
     Normalize executor content into plain text.
 

--- a/omnigent/inner/cursor_native_executor.py
+++ b/omnigent/inner/cursor_native_executor.py
@@ -15,7 +15,6 @@ import logging
 import os
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any
 
 from omnigent.cursor_native_bridge import (
     BRIDGE_DIR_ENV_VAR,
@@ -25,6 +24,7 @@ from omnigent.cursor_native_bridge import (
     wrap_fork_preamble,
 )
 from omnigent.inner.executor import (
+    EnqueuedContent,
     Executor,
     ExecutorConfig,
     ExecutorError,
@@ -63,7 +63,7 @@ class CursorNativeExecutor(Executor):
         """:returns: ``True`` — messages can be injected mid-turn (steering)."""
         return True
 
-    async def enqueue_session_message(self, session_key: str, content: Any) -> bool:
+    async def enqueue_session_message(self, session_key: str, content: EnqueuedContent) -> bool:
         """Inject a live steering message into the Cursor terminal."""
         del session_key
         text = _content_to_text(content, self._bridge_dir)
@@ -130,7 +130,7 @@ def _latest_user_text(messages: list[Message], bridge_dir: Path) -> str:
     return ""
 
 
-def _content_to_text(content: Any, bridge_dir: Path) -> str:
+def _content_to_text(content: EnqueuedContent, bridge_dir: Path) -> str:
     """Normalize executor content into text the Cursor TUI receives.
 
     Text blocks are extracted directly. Image/file blocks carrying a base64

--- a/omnigent/inner/goose_native_executor.py
+++ b/omnigent/inner/goose_native_executor.py
@@ -15,10 +15,10 @@ import logging
 import os
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any
 
 from omnigent.goose_native_bridge import BRIDGE_DIR_ENV_VAR, inject_user_message
 from omnigent.inner.executor import (
+    EnqueuedContent,
     Executor,
     ExecutorConfig,
     ExecutorError,
@@ -57,7 +57,7 @@ class GooseNativeExecutor(Executor):
         """:returns: ``True`` — messages can be injected mid-turn (steering)."""
         return True
 
-    async def enqueue_session_message(self, session_key: str, content: Any) -> bool:
+    async def enqueue_session_message(self, session_key: str, content: EnqueuedContent) -> bool:
         """Inject a live steering message into the Goose terminal."""
         del session_key
         text = _content_to_text(content, self._bridge_dir)
@@ -108,7 +108,7 @@ def _latest_user_text(messages: list[Message], bridge_dir: Path) -> str:
     return ""
 
 
-def _content_to_text(content: Any, bridge_dir: Path) -> str:
+def _content_to_text(content: EnqueuedContent, bridge_dir: Path) -> str:
     """Normalize executor content into text the Goose TUI receives.
 
     Text blocks are extracted directly. Image/file blocks carrying a base64 data

--- a/omnigent/inner/hermes_native_executor.py
+++ b/omnigent/inner/hermes_native_executor.py
@@ -16,10 +16,10 @@ import logging
 import os
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any
 
 from omnigent.hermes_native_bridge import BRIDGE_DIR_ENV_VAR, inject_interrupt, inject_user_message
 from omnigent.inner.executor import (
+    EnqueuedContent,
     Executor,
     ExecutorConfig,
     ExecutorError,
@@ -58,7 +58,7 @@ class HermesNativeExecutor(Executor):
         """:returns: ``True`` — messages can be injected mid-turn (steering)."""
         return True
 
-    async def enqueue_session_message(self, session_key: str, content: Any) -> bool:
+    async def enqueue_session_message(self, session_key: str, content: EnqueuedContent) -> bool:
         """Inject a live steering message into the Hermes terminal."""
         del session_key
         text = _content_to_text(content, self._bridge_dir)
@@ -122,7 +122,7 @@ def _latest_user_text(messages: list[Message], bridge_dir: Path) -> str:
     return ""
 
 
-def _content_to_text(content: Any, bridge_dir: Path) -> str:
+def _content_to_text(content: EnqueuedContent, bridge_dir: Path) -> str:
     """Normalize executor content into text the Hermes TUI receives.
 
     Text blocks are extracted directly. Image/file blocks carrying a base64 data

--- a/omnigent/inner/kimi_native_executor.py
+++ b/omnigent/inner/kimi_native_executor.py
@@ -19,9 +19,9 @@ import logging
 import os
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any
 
 from omnigent.inner.executor import (
+    EnqueuedContent,
     Executor,
     ExecutorConfig,
     ExecutorError,
@@ -61,7 +61,7 @@ class KimiNativeExecutor(Executor):
         """:returns: ``True`` — messages can be injected mid-turn (steering)."""
         return True
 
-    async def enqueue_session_message(self, session_key: str, content: Any) -> bool:
+    async def enqueue_session_message(self, session_key: str, content: EnqueuedContent) -> bool:
         """Inject a live steering message into the Kimi terminal."""
         del session_key
         text = _content_to_text(content, self._bridge_dir)
@@ -112,7 +112,7 @@ def _latest_user_text(messages: list[Message], bridge_dir: Path) -> str:
     return ""
 
 
-def _content_to_text(content: Any, bridge_dir: Path) -> str:
+def _content_to_text(content: EnqueuedContent, bridge_dir: Path) -> str:
     """Normalize executor content into text the Kimi TUI receives.
 
     Text blocks are extracted directly. Image/file blocks carrying a base64

--- a/omnigent/inner/kiro_native_executor.py
+++ b/omnigent/inner/kiro_native_executor.py
@@ -6,9 +6,9 @@ import asyncio
 import os
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any
 
 from omnigent.inner.executor import (
+    EnqueuedContent,
     Executor,
     ExecutorConfig,
     ExecutorError,
@@ -35,7 +35,7 @@ class KiroNativeExecutor(Executor):
         """:returns: ``True`` — messages can be injected mid-turn."""
         return True
 
-    async def enqueue_session_message(self, session_key: str, content: Any) -> bool:
+    async def enqueue_session_message(self, session_key: str, content: EnqueuedContent) -> bool:
         """Inject a live steering message into the Kiro terminal."""
         del session_key
         text = _content_to_text(content, self._bridge_dir)
@@ -88,7 +88,7 @@ def _latest_user_text(messages: list[Message], bridge_dir: Path) -> str:
     return ""
 
 
-def _content_to_text(content: Any, bridge_dir: Path) -> str:
+def _content_to_text(content: EnqueuedContent, bridge_dir: Path) -> str:
     """Normalize executor content into text the Kiro TUI receives."""
     if isinstance(content, str):
         return content

--- a/omnigent/inner/pi_native_executor.py
+++ b/omnigent/inner/pi_native_executor.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import os
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any
 
 from omnigent.inner.executor import (
+    EnqueuedContent,
     Executor,
     ExecutorConfig,
     ExecutorError,
@@ -56,7 +56,7 @@ class PiNativeExecutor(Executor):
         """:returns: ``True`` because messages can be queued for the extension."""
         return True
 
-    async def enqueue_session_message(self, session_key: str, content: Any) -> bool:
+    async def enqueue_session_message(self, session_key: str, content: EnqueuedContent) -> bool:
         """
         Queue a live steering message for the resident Pi extension.
 
@@ -178,7 +178,7 @@ def _latest_user_text(messages: list[Message], bridge_dir: Path) -> str:
     return ""
 
 
-def _content_to_text(content: Any, bridge_dir: Path) -> str:
+def _content_to_text(content: EnqueuedContent, bridge_dir: Path) -> str:
     """
     Normalize executor content into plain text for Pi.
 

--- a/omnigent/inner/qwen_native_executor.py
+++ b/omnigent/inner/qwen_native_executor.py
@@ -21,9 +21,9 @@ import logging
 import os
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any
 
 from omnigent.inner.executor import (
+    EnqueuedContent,
     Executor,
     ExecutorConfig,
     ExecutorError,
@@ -99,7 +99,7 @@ class QwenNativeExecutor(Executor):
         """:returns: ``True`` — messages can be injected mid-turn (steering)."""
         return True
 
-    async def enqueue_session_message(self, session_key: str, content: Any) -> bool:
+    async def enqueue_session_message(self, session_key: str, content: EnqueuedContent) -> bool:
         """Append a live steering message to the qwen TUI input file."""
         del session_key
         text = _content_to_text(content, self._bridge_dir)
@@ -152,7 +152,7 @@ def _latest_user_text(messages: list[Message], bridge_dir: Path) -> str:
     return ""
 
 
-def _content_to_text(content: Any, bridge_dir: Path) -> str:
+def _content_to_text(content: EnqueuedContent, bridge_dir: Path) -> str:
     """Normalize executor content into text the qwen TUI receives.
 
     Text blocks are extracted directly. Image/file blocks carrying a base64 data


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Use the canonical `EnqueuedContent` contract for live-message queue inputs and content normalization across the Claude, Cursor, Goose, Hermes, Kimi, Kiro, Pi, and Qwen native executors.
- Remove all eight adapters' local `Any` imports, eliminating 16 mypy diagnostics without changing runtime parsing or message delivery.

**ELI5:** Every native terminal adapter now uses the same name for the user content it receives instead of independently opting out of type checking.

```text
web message -> EnqueuedContent -> adapter runtime narrowing -> native terminal
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/mypy --no-incremental omnigent` (16 target diagnostics removed; no errors remain in the eight touched files)
- `.venv/bin/pytest -q tests/inner/test_{claude,cursor,goose,hermes,kimi,kiro,pi,qwen}_native_executor.py` (114 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed after rebase onto current `main`)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing native-executor tests cover text and attachment normalization, live-message queueing, turn delivery, failures, concurrency, and adapter-specific bridge behavior.
