### PR TITLE
refactor: type sandbox host launchers

### DIFF
--- a/omnigent/cli_sandbox.py
+++ b/omnigent/cli_sandbox.py
@@ -19,6 +19,7 @@ import click
 
 from omnigent.inner import ui
 from omnigent.onboarding.sandboxes import (
+    SandboxHostLauncher,
     SandboxLauncher,
     available_providers,
     get_launcher,
@@ -82,7 +83,7 @@ def _resolve_repo_root(repo_root: Path | None) -> Path:
     return resolved
 
 
-def _require_cli_bootstrap(launcher: SandboxLauncher) -> None:
+def _require_cli_bootstrap(launcher: SandboxHostLauncher) -> SandboxLauncher:
     """
     Reject managed-only providers up front with an actionable message.
 
@@ -92,10 +93,11 @@ def _require_cli_bootstrap(launcher: SandboxLauncher) -> None:
     opaque capability error after real work already ran.
 
     :param launcher: The resolved provider launcher.
+    :returns: The same launcher narrowed to the CLI bootstrap contract.
     :raises click.ClickException: When the provider has no CLI
         bootstrap flow.
     """
-    if not launcher.capabilities.cli_bootstrap:
+    if not launcher.capabilities.cli_bootstrap or not isinstance(launcher, SandboxLauncher):
         raise click.ClickException(
             f"The '{launcher.provider}' provider supports server-managed "
             "sessions only — create one with "
@@ -103,6 +105,7 @@ def _require_cli_bootstrap(launcher: SandboxLauncher) -> None:
             "UI's New Sandbox option) against a server configured with "
             f"`sandbox.provider: {launcher.provider}`."
         )
+    return launcher
 
 
 def _normalize_server_url(server_url: str) -> str:
@@ -269,10 +272,9 @@ def sandbox_create(
 
     app_url = _normalize_server_url(server_url)
     workspace = derive_workspace(app_url)
-    launcher = get_launcher(
-        provider, workspace_host=workspace.host if workspace is not None else None
+    launcher = _require_cli_bootstrap(
+        get_launcher(provider, workspace_host=workspace.host if workspace is not None else None)
     )
-    _require_cli_bootstrap(launcher)
     # The in-sandbox login only exists for providers that can forward
     # the browser's callback port — others skip it automatically, no
     # --no-auth acknowledgement required.
@@ -329,10 +331,9 @@ def sandbox_auth(
 
     app_url = _normalize_server_url(server_url)
     workspace = derive_workspace(app_url)
-    launcher = get_launcher(
-        provider, workspace_host=workspace.host if workspace is not None else None
+    launcher = _require_cli_bootstrap(
+        get_launcher(provider, workspace_host=workspace.host if workspace is not None else None)
     )
-    _require_cli_bootstrap(launcher)
     login_app_oauth_in_sandbox(
         launcher,
         sandbox_id,
@@ -395,10 +396,9 @@ def sandbox_connect(
     # there) — the local `lakebox ssh` transport must resolve through
     # the same workspace to find it.
     workspace = derive_workspace(app_url)
-    launcher = get_launcher(
-        provider, workspace_host=workspace.host if workspace is not None else None
+    launcher = _require_cli_bootstrap(
+        get_launcher(provider, workspace_host=workspace.host if workspace is not None else None)
     )
-    _require_cli_bootstrap(launcher)
     connect_sandbox_host(
         launcher,
         sandbox_id,

--- a/omnigent/onboarding/sandboxes/__init__.py
+++ b/omnigent/onboarding/sandboxes/__init__.py
@@ -14,6 +14,7 @@ from omnigent.onboarding.sandboxes.base import (
     RemoteCommandResult,
     RemoteProcess,
     SandboxCapabilityError,
+    SandboxHostLauncher,
     SandboxLauncher,
 )
 from omnigent.onboarding.sandboxes.bootstrap import (
@@ -61,6 +62,7 @@ __all__ = [
     "SandboxCommandError",
     "SandboxConfigError",
     "SandboxError",
+    "SandboxHostLauncher",
     "SandboxInfo",
     "SandboxLauncher",
     "SandboxProviderContribution",
@@ -83,7 +85,7 @@ __all__ = [
 ]
 
 
-def get_launcher(provider: str, *, workspace_host: str | None = None) -> SandboxLauncher:
+def get_launcher(provider: str, *, workspace_host: str | None = None) -> SandboxHostLauncher:
     """
     Resolve a provider name to a launcher instance.
 

--- a/omnigent/onboarding/sandboxes/openshell.py
+++ b/omnigent/onboarding/sandboxes/openshell.py
@@ -58,6 +58,7 @@ from omnigent.onboarding.sandboxes.base import (
 from omnigent.onboarding.sandboxes.types import SandboxCapabilities
 
 if TYPE_CHECKING:
+    import threading
     from pathlib import Path
 
     from openshell import ExecResult
@@ -156,7 +157,7 @@ class _OpenShellClient:
         # exec_background): OpenShell kills an exec's processes when the
         # ExecSandbox RPC returns, so a backgrounded host must be kept on
         # an open stream for its lifetime.
-        self._bg_threads: list[object] = []
+        self._bg_threads: list[threading.Thread] = []
 
     def close(self) -> None:
         """Release the gRPC channel and any bearer-auth resources."""

--- a/omnigent/onboarding/sandboxes/registry.py
+++ b/omnigent/onboarding/sandboxes/registry.py
@@ -33,7 +33,8 @@ class SandboxRegistryError(Exception):
 
 
 class _WorkspaceHostLauncherFactory(Protocol):
-    def __call__(self, *, workspace_host: str) -> SandboxHostLauncher: ...
+    def __call__(self, *, workspace_host: str) -> SandboxHostLauncher:
+        pass
 
 
 @dataclass(frozen=True)

--- a/omnigent/onboarding/sandboxes/registry.py
+++ b/omnigent/onboarding/sandboxes/registry.py
@@ -16,13 +16,11 @@ import importlib
 import importlib.metadata
 import importlib.util
 import logging
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import Any, Protocol, cast
 
-from omnigent.onboarding.sandboxes.base import SandboxLifecycle
-
-if TYPE_CHECKING:
-    pass
+from omnigent.onboarding.sandboxes.base import SandboxHostLauncher
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +30,10 @@ COMMUNITY_MODULE_PREFIX = "omnigent.community.sandbox."
 
 class SandboxRegistryError(Exception):
     """A provider registry operation failed."""
+
+
+class _WorkspaceHostLauncherFactory(Protocol):
+    def __call__(self, *, workspace_host: str) -> SandboxHostLauncher: ...
 
 
 @dataclass(frozen=True)
@@ -91,7 +93,8 @@ def _entry_points() -> tuple[importlib.metadata.EntryPoint, ...]:
     discovered = importlib.metadata.entry_points()
     if hasattr(discovered, "select"):
         return tuple(discovered.select(group=COMMUNITY_ENTRY_POINT_GROUP))
-    return tuple(discovered.get(COMMUNITY_ENTRY_POINT_GROUP, ()))
+    legacy = cast(Mapping[str, Iterable[importlib.metadata.EntryPoint]], discovered)
+    return tuple(legacy.get(COMMUNITY_ENTRY_POINT_GROUP, ()))
 
 
 def _load_object(import_path: str) -> Any:
@@ -279,7 +282,7 @@ def instantiate(
     name: str,
     *,
     workspace_host: str | None = None,
-) -> object:
+) -> SandboxHostLauncher:
     """Import and instantiate a registered provider's launcher class.
 
     :param name: Registered provider name.
@@ -298,11 +301,12 @@ def instantiate(
         raise SandboxRegistryError(
             f"could not load sandbox provider '{name}' from {meta.launcher_class!r}: {exc}"
         ) from exc
-    if not isinstance(launcher_cls, type) or not issubclass(launcher_cls, SandboxLifecycle):
+    if not isinstance(launcher_cls, type) or not issubclass(launcher_cls, SandboxHostLauncher):
         raise SandboxRegistryError(
             f"sandbox provider '{name}' resolved to {launcher_cls!r}, "
-            f"which is not a SandboxLifecycle subclass"
+            f"which is not a SandboxHostLauncher subclass"
         )
     if name == "lakebox" and workspace_host is not None:
-        return launcher_cls(workspace_host=workspace_host)
+        launcher_factory = cast(_WorkspaceHostLauncherFactory, launcher_cls)
+        return launcher_factory(workspace_host=workspace_host)
     return launcher_cls()

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -141,7 +141,7 @@ from omnigent.db.utils import now_epoch
 from omnigent.stores.host_store import Host, HostStore
 
 if TYPE_CHECKING:
-    from omnigent.onboarding.sandboxes import SandboxLauncher
+    from omnigent.onboarding.sandboxes import SandboxHostLauncher
 
 _logger = logging.getLogger(__name__)
 
@@ -402,7 +402,7 @@ class ManagedSandboxConfig:
     """
 
     server_url: str
-    launcher_factory: Callable[[], SandboxLauncher]
+    launcher_factory: Callable[[], SandboxHostLauncher]
     token_ttl_s: int
     managed_launch_supported: bool = True
     provider: str | None = None
@@ -585,7 +585,7 @@ def parse_repo_workspace(workspace: str) -> RepoWorkspace:
 def _modal_launcher_factory(
     image: str | None,
     secrets: list[str] | None,
-) -> Callable[[], SandboxLauncher]:
+) -> Callable[[], SandboxHostLauncher]:
     """
     Build the launcher factory for the YAML ``provider: modal`` path.
 
@@ -600,7 +600,7 @@ def _modal_launcher_factory(
     :returns: A factory producing parameterized Modal launchers.
     """
 
-    def _build() -> SandboxLauncher:
+    def _build() -> SandboxHostLauncher:
         """Construct the Modal launcher (lazy SDK import inside)."""
         from omnigent.onboarding.sandboxes.modal import ModalSandboxLauncher
 
@@ -609,7 +609,7 @@ def _modal_launcher_factory(
     return _build
 
 
-def _unsupported_launcher_factory(provider: str) -> Callable[[], SandboxLauncher]:
+def _unsupported_launcher_factory(provider: str) -> Callable[[], SandboxHostLauncher]:
     """
     Build a factory that rejects launch for a not-yet-supported provider.
 
@@ -621,7 +621,7 @@ def _unsupported_launcher_factory(provider: str) -> Callable[[], SandboxLauncher
     :returns: A factory that raises ``HTTPException`` 400 when called.
     """
 
-    def _reject() -> SandboxLauncher:
+    def _reject() -> SandboxHostLauncher:
         """Reject the launch with the provider named."""
         raise HTTPException(
             status_code=400,
@@ -948,7 +948,7 @@ def _parse_modal_secrets(raw: dict[str, object]) -> list[str] | None:
 def _daytona_launcher_factory(
     image: str | None,
     env: list[str] | None,
-) -> Callable[[], SandboxLauncher]:
+) -> Callable[[], SandboxHostLauncher]:
     """
     Build the launcher factory for the YAML ``provider: daytona`` path.
 
@@ -964,7 +964,7 @@ def _daytona_launcher_factory(
     :returns: A factory producing parameterized Daytona launchers.
     """
 
-    def _build() -> SandboxLauncher:
+    def _build() -> SandboxHostLauncher:
         """Construct the Daytona launcher (lazy SDK import inside)."""
         from omnigent.onboarding.sandboxes.daytona import DaytonaSandboxLauncher
 
@@ -1055,7 +1055,7 @@ def _boxlite_launcher_factory(
     env: list[str] | None,
     home_dir: str | None,
     registry: dict[str, object] | None,
-) -> Callable[[], SandboxLauncher]:
+) -> Callable[[], SandboxHostLauncher]:
     """
     Build the launcher factory for the YAML ``provider: boxlite`` path.
 
@@ -1076,7 +1076,7 @@ def _boxlite_launcher_factory(
     :returns: A factory producing parameterized boxlite launchers.
     """
 
-    def _build() -> SandboxLauncher:
+    def _build() -> SandboxHostLauncher:
         """Construct the boxlite launcher (lazy SDK import inside)."""
         from omnigent.onboarding.sandboxes.boxlite import BoxliteSandboxLauncher
 
@@ -1286,10 +1286,10 @@ def _parse_boxlite_registry(local: dict[str, object]) -> dict[str, object] | Non
 def _cwsandbox_launcher_factory(
     image: str | None,
     env: list[str] | None,
-) -> Callable[[], SandboxLauncher]:
+) -> Callable[[], SandboxHostLauncher]:
     """Build the launcher factory for the YAML ``provider: cwsandbox`` path."""
 
-    def _build() -> SandboxLauncher:
+    def _build() -> SandboxHostLauncher:
         from omnigent.onboarding.sandboxes.cwsandbox import CWSandboxLauncher
 
         return CWSandboxLauncher(image=image, env=env)
@@ -1338,7 +1338,7 @@ def _parse_cwsandbox_env(raw: dict[str, object]) -> list[str] | None:
 def _e2b_launcher_factory(
     template: str | None,
     env: list[str] | None,
-) -> Callable[[], SandboxLauncher]:
+) -> Callable[[], SandboxHostLauncher]:
     """
     Build the launcher factory for the YAML ``provider: e2b`` path.
 
@@ -1356,7 +1356,7 @@ def _e2b_launcher_factory(
     :returns: A factory producing parameterized E2B launchers.
     """
 
-    def _build() -> SandboxLauncher:
+    def _build() -> SandboxHostLauncher:
         """Construct the E2B launcher (lazy SDK import inside)."""
         from omnigent.onboarding.sandboxes.e2b import E2BSandboxLauncher
 
@@ -1435,7 +1435,7 @@ def _islo_launcher_factory(
     memory_mb: int | None,
     disk_gb: int | None,
     idle_pause_after_s: int | None,
-) -> Callable[[], SandboxLauncher]:
+) -> Callable[[], SandboxHostLauncher]:
     """
     Build the launcher factory for the YAML ``provider: islo`` path.
 
@@ -1459,7 +1459,7 @@ def _islo_launcher_factory(
     :returns: A factory producing parameterized Islo launchers.
     """
 
-    def _build() -> SandboxLauncher:
+    def _build() -> SandboxHostLauncher:
         """Construct the Islo launcher."""
         from omnigent.onboarding.sandboxes.islo import IsloSandboxLauncher
 
@@ -1485,7 +1485,7 @@ def _openshell_launcher_factory(
     env: list[str] | None,
     cluster: str | None,
     workspace: str | None,
-) -> Callable[[], SandboxLauncher]:
+) -> Callable[[], SandboxHostLauncher]:
     """
     Build the launcher factory for the YAML ``provider: openshell`` path.
 
@@ -1504,7 +1504,7 @@ def _openshell_launcher_factory(
     :returns: A factory producing parameterized OpenShell launchers.
     """
 
-    def _build() -> SandboxLauncher:
+    def _build() -> SandboxHostLauncher:
         """Construct the OpenShell launcher (lazy SDK import inside)."""
         from omnigent.onboarding.sandboxes.openshell import OpenShellSandboxLauncher
 
@@ -2056,7 +2056,7 @@ def _kubernetes_launcher_factory(
     resources: dict[str, object] | None,
     pvc_mounts: list[dict[str, object]] | None,
     secret_mounts: list[dict[str, object]] | None,
-) -> Callable[[], SandboxLauncher]:
+) -> Callable[[], SandboxHostLauncher]:
     """
     Build the launcher factory for the YAML ``provider: kubernetes`` path.
 
@@ -2086,7 +2086,7 @@ def _kubernetes_launcher_factory(
     """
     _validate_kubernetes_identifiers(namespace, secret_name, service_account, node_selector)
 
-    def _build() -> SandboxLauncher:
+    def _build() -> SandboxHostLauncher:
         """Construct the Kubernetes launcher (lazy SDK import inside)."""
         from omnigent.onboarding.sandboxes.kubernetes import KubernetesSandboxLauncher
 
@@ -2258,9 +2258,52 @@ async def relaunch_managed_host(
     return ManagedHostLaunch(host_id=host.host_id, workspace=workspace)
 
 
+async def _start_sandbox_host(
+    launcher: SandboxHostLauncher,
+    sandbox_id: str,
+    *,
+    token: str,
+    host_id: str,
+    host_name: str,
+    server_url: str,
+    repo_url: str | None,
+    repo_branch: str | None,
+    repo_name: str | None,
+    host_config: dict[str, object] | None,
+    on_stage: Callable[[str], None] | None = None,
+) -> str:
+    """Start a sandbox host while preserving legacy launcher compatibility."""
+    if host_config is None:
+        return await asyncio.to_thread(
+            launcher.start_host,
+            sandbox_id,
+            token=token,
+            host_id=host_id,
+            host_name=host_name,
+            server_url=server_url,
+            repo_url=repo_url,
+            repo_branch=repo_branch,
+            repo_name=repo_name,
+            on_stage=on_stage,
+        )
+    return await asyncio.to_thread(
+        launcher.start_host,
+        sandbox_id,
+        token=token,
+        host_id=host_id,
+        host_name=host_name,
+        server_url=server_url,
+        repo_url=repo_url,
+        repo_branch=repo_branch,
+        repo_name=repo_name,
+        host_config=host_config,
+        on_stage=on_stage,
+    )
+
+
 async def _arm_and_start_host(
     *,
-    launcher: SandboxLauncher,
+    launcher: SandboxHostLauncher,
     config: ManagedSandboxConfig,
     host_store: HostStore,
     host_id: str,
@@ -2322,8 +2365,8 @@ async def _arm_and_start_host(
         # a token that already resolves. The exec-model default execs in; the
         # entrypoint model (k8s) creates the Pod that boots the host. *repo* is
         # unpacked into primitives — the launcher API takes no RepoWorkspace.
-        workspace = await asyncio.to_thread(
-            launcher.start_host,
+        workspace = await _start_sandbox_host(
+            launcher,
             sandbox_id,
             token=token,
             host_id=host_id,
@@ -2332,10 +2375,8 @@ async def _arm_and_start_host(
             repo_url=repo.url if repo is not None else None,
             repo_branch=repo.branch if repo is not None else None,
             repo_name=repo.repo_name if repo is not None else None,
+            host_config=config.host_config,
             on_stage=on_stage,
-            # Omitted entirely when unset: a deployment-injected launcher
-            # predating the host_config parameter must keep launching.
-            **({"host_config": config.host_config} if config.host_config is not None else {}),
         )
         await _wait_for_host_online(host_store, host_id)
     except Exception as exc:
@@ -2388,7 +2429,7 @@ async def _wait_for_host_online(host_store: HostStore, host_id: str) -> None:
 def _launcher_for_teardown(
     host: Host,
     config: ManagedSandboxConfig | None,
-) -> SandboxLauncher | None:
+) -> SandboxHostLauncher | None:
     """
     Resolve the launcher that can terminate a managed host's sandbox.
 
@@ -2555,21 +2596,17 @@ async def resume_managed_host(
                 sandbox_id=sandbox_id,
                 token_expires_at=now_epoch() + config.token_ttl_s,
             )
-            await asyncio.to_thread(
-                launcher.start_host,
+            await _start_sandbox_host(
+                launcher,
                 sandbox_id,
                 token=token,
                 host_id=host.host_id,
                 host_name=host.name,
                 server_url=config.server_url,
                 repo_url=None,  # the persistent volume already holds the workspace
-                # Re-materialized on every wake, so an operator's host_config
-                # change lands on the next resume without a new sandbox.
-                # Omitted entirely when unset: a deployment-injected launcher
-                # predating the host_config parameter must keep resuming.
-                # (Base start_host still cleans up previously injected entries
-                # on resumable launchers when the block is removed.)
-                **({"host_config": config.host_config} if config.host_config is not None else {}),
+                repo_branch=None,
+                repo_name=None,
+                host_config=config.host_config,
             )
             await _wait_for_host_online(host_store, host.host_id)
         except Exception as exc:
@@ -2612,7 +2649,7 @@ async def terminate_managed_host(
 
 
 async def _terminate_sandbox_best_effort(
-    launcher: SandboxLauncher | None,
+    launcher: SandboxHostLauncher | None,
     host: Host,
 ) -> None:
     """

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -2272,7 +2272,19 @@ async def _start_sandbox_host(
     host_config: dict[str, object] | None,
     on_stage: Callable[[str], None] | None = None,
 ) -> str:
-    """Start a sandbox host while preserving legacy launcher compatibility."""
+    """Start a host without sending absent optional arguments to legacy launchers."""
+    if host_config is None and on_stage is None:
+        return await asyncio.to_thread(
+            launcher.start_host,
+            sandbox_id,
+            token=token,
+            host_id=host_id,
+            host_name=host_name,
+            server_url=server_url,
+            repo_url=repo_url,
+            repo_branch=repo_branch,
+            repo_name=repo_name,
+        )
     if host_config is None:
         return await asyncio.to_thread(
             launcher.start_host,
@@ -2285,6 +2297,19 @@ async def _start_sandbox_host(
             repo_branch=repo_branch,
             repo_name=repo_name,
             on_stage=on_stage,
+        )
+    if on_stage is None:
+        return await asyncio.to_thread(
+            launcher.start_host,
+            sandbox_id,
+            token=token,
+            host_id=host_id,
+            host_name=host_name,
+            server_url=server_url,
+            repo_url=repo_url,
+            repo_branch=repo_branch,
+            repo_name=repo_name,
+            host_config=host_config,
         )
     return await asyncio.to_thread(
         launcher.start_host,

--- a/tests/onboarding/sandboxes/test_registry.py
+++ b/tests/onboarding/sandboxes/test_registry.py
@@ -283,7 +283,7 @@ def test_get_launcher_unknown_raises_click_exception() -> None:
 def test_instantiate_rejects_non_launcher_class(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A contribution whose launcher class is not a SandboxLauncher is rejected."""
+    """A contribution without the host-launch contract is rejected."""
     reset_plugin_state_for_tests()
     contribution = SandboxProviderContribution(
         name="not-a-launcher",
@@ -307,5 +307,5 @@ def test_instantiate_rejects_non_launcher_class(
         lambda _: _NotALauncher,
     )
 
-    with pytest.raises(SandboxRegistryError, match="not a SandboxLifecycle subclass"):
+    with pytest.raises(SandboxRegistryError, match="not a SandboxHostLauncher subclass"):
         instantiate("not-a-launcher")

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import datetime
-from collections.abc import Callable
 from pathlib import Path
 from typing import ClassVar
 
@@ -1689,13 +1688,13 @@ async def test_launch_without_host_config_writes_no_config(db_uri: str) -> None:
     assert not any(cmd.startswith("python3 -c") for cmd in fake.commands)
 
 
-async def test_launch_without_host_config_supports_legacy_start_host_signature(
+async def test_launch_and_resume_without_optional_kwargs_support_legacy_start_host_signature(
     db_uri: str,
 ) -> None:
     """
     A deployment-injected launcher whose ``start_host`` override predates the
-    ``host_config`` parameter keeps launching when no host_config is set —
-    the kwarg is omitted entirely rather than passed as ``None``.
+    optional ``host_config`` and ``on_stage`` parameters keeps launching and
+    resuming when neither value is set.
     """
     host_store = HostStore(db_uri)
 
@@ -1720,7 +1719,6 @@ async def test_launch_without_host_config_supports_legacy_start_host_signature(
             repo_url: str | None = None,
             repo_branch: str | None = None,
             repo_name: str | None = None,
-            on_stage: Callable[[str], None] | None = None,
         ) -> str:
             return super().start_host(
                 sandbox_id,
@@ -1731,17 +1729,17 @@ async def test_launch_without_host_config_supports_legacy_start_host_signature(
                 repo_url=repo_url,
                 repo_branch=repo_branch,
                 repo_name=repo_name,
-                on_stage=on_stage,
             )
 
-    fake = _LegacySignatureLauncher(on_host_start=_register)
+    fake = _LegacySignatureLauncher(on_host_start=_register, can_resume=True)
+    config = _injected_config(fake)
 
-    result = await launch_managed_host(
-        config=_injected_config(fake), owner=_OWNER, host_store=host_store
-    )
+    result = await launch_managed_host(config=config, owner=_OWNER, host_store=host_store)
+    host_store.set_offline(result.host_id)
+    await resume_managed_host(result.host_id, host_store, config)
 
-    [start] = fake.host_starts
-    assert result.host_id == start.host_id
+    assert [start.host_id for start in fake.host_starts] == [result.host_id, result.host_id]
+    assert fake.resumed == ["sb-fake-1"]
 
 
 async def test_launch_with_injected_custom_launcher(db_uri: str) -> None:


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Type the sandbox registry and managed-host factories against `SandboxHostLauncher`, the shared contract implemented by both exec-model providers and entrypoint-based providers such as Kubernetes.
- Narrow CLI bootstrap flows back to the exec-capable `SandboxLauncher` contract after the runtime capability check, and type OpenShell's retained background threads concretely.
- Route managed host starts through one typed helper that omits absent `host_config` and `on_stage` keywords for legacy injected launchers, eliminating seven mypy diagnostics without changing launch behavior.

**ELI5:** The common launcher type now describes what every managed provider can do, while CLI-only operations explicitly require the smaller set that can also copy files and run commands.

```text
registry -> SandboxHostLauncher -> managed host start
                            \\-> capability check -> SandboxLauncher -> CLI bootstrap
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/mypy --no-incremental omnigent` (seven target diagnostics removed; no errors remain in the five touched source files)
- `.venv/bin/pytest -q tests/onboarding/sandboxes/test_registry.py tests/onboarding/sandboxes/test_openshell.py tests/server/test_managed_hosts.py` (248 passed)
- `.venv/bin/pytest -q tests/server/test_managed_hosts.py` (200 passed after the legacy-keyword compatibility fix)
- `TMPDIR=/tmp .venv/bin/mypy --no-incremental --follow-imports=skip omnigent/onboarding/sandboxes/registry.py` and file-scoped pre-commit hooks (passed after the Code Quality follow-up)
- `TMPDIR=/tmp pre-commit run --all-files` (passed after rebase onto current `main`)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The registry assertion now names the required host-launch contract; existing tests cover plugin instantiation, OpenShell background execution, Kubernetes entrypoint launches, host-config forwarding, legacy launcher signatures, resume, and teardown.

