### PR TITLE
refactor: narrow provider discovery payloads

### DIFF
--- a/omnigent/databricks_model_discovery.py
+++ b/omnigent/databricks_model_discovery.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any
 
 import httpx
 
@@ -68,7 +67,7 @@ def _list_model_service_ids(
             params=params,
         )
         response.raise_for_status()
-        payload: Any = response.json()
+        payload: object = response.json()
         if not isinstance(payload, dict):
             raise ValueError("Databricks model-services response must be an object")
         services = payload.get("model_services")
@@ -111,7 +110,7 @@ def _list_anthropic_gateway_ids(
         headers=headers,
     )
     response.raise_for_status()
-    payload: Any = response.json()
+    payload: object = response.json()
     if not isinstance(payload, dict):
         raise ValueError("Databricks Anthropic models response must be an object")
     data = payload.get("data")

--- a/omnigent/onboarding/detected.py
+++ b/omnigent/onboarding/detected.py
@@ -331,7 +331,7 @@ def effective_config_with_detected(
     # Explicit entries override synthesized ones of the same name.
     merged: dict[str, object] = {**synthesized, **explicit}
 
-    explicit_config = {"providers": explicit}
+    explicit_config: dict[str, object] = {"providers": explicit}
     merged_parsed = load_providers({"providers": merged})
     for family in _FAMILIES:
         # An explicit default for this family always wins — never overridden.


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Treat Databricks model-list responses as opaque `object` values until their dictionary/list shapes are validated at runtime.
- Give the synthesized ambient-provider wrapper its intended `dict[str, object]` type, eliminating three mypy diagnostics without changing discovery behavior.

**ELI5:** Discovery data is now marked “unknown until checked” instead of bypassing type checking or inferring an overly narrow dictionary.

```text
HTTP/ambient input -> object/config wrapper -> runtime validation -> discovered providers
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/mypy --no-incremental omnigent` (three target diagnostics removed; no errors remain in the two touched files)
- `.venv/bin/pytest -q tests/test_databricks_model_discovery.py tests/onboarding/test_detected.py` (34 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing tests cover model-service pagination and malformed payloads, Anthropic gateway fallback, provider synthesis, explicit defaults, dismissals, and ambient subscription handling.
