### PR TITLE
refactor: type session route boundaries

### DIFF
--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -11,7 +11,7 @@ import asyncio
 import json
 import secrets
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any, Literal, cast
 
 import httpx
@@ -485,7 +485,7 @@ def _labels_for_viewer(labels: dict[str, str], user_id: str | None) -> dict[str,
 def _build_session_list_item(
     conv: Conversation,
     *,
-    agent_names_by_id: dict[str, str | None],
+    agent_names_by_id: Mapping[str, str | None],
     grants: list[SessionPermission],
     user_id: str | None,
     user_is_admin: bool,

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -1944,12 +1944,13 @@ def register_core_routes(
         # agent belongs to one conversation (possibly another user's) and
         # must never be cloned across sessions.
         base_agent = source_agent
-        switching_agent = body.agent_id is not None and body.agent_id != source.agent_id
-        if switching_agent:
-            target_agent = await asyncio.to_thread(agent_store.get, body.agent_id)
+        target_agent_id = body.agent_id
+        switching_agent = target_agent_id is not None and target_agent_id != source.agent_id
+        if target_agent_id is not None and switching_agent:
+            target_agent = await asyncio.to_thread(agent_store.get, target_agent_id)
             if target_agent is None or target_agent.session_id is not None:
                 raise OmnigentError(
-                    f"Agent not found or not bindable: {body.agent_id!r}",
+                    f"Agent not found or not bindable: {target_agent_id!r}",
                     code=ErrorCode.NOT_FOUND,
                 )
             base_agent = target_agent

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import secrets
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 import httpx
 from fastapi import (
@@ -1076,7 +1076,10 @@ def register_events_routes(
                 _runner_needs_session_init = _is_native_terminal_session(conv)
         if runner_client is None and conv.host_id is not None:
             _tunnel_registry = getattr(request.app.state, "tunnel_registry", None)
-            _grace_host_reg = getattr(request.app.state, "host_registry", None)
+            _grace_host_reg = cast(
+                HostRegistry | None,
+                getattr(request.app.state, "host_registry", None),
+            )
             _grace_host_conn = (
                 _grace_host_reg.get(conv.host_id) if _grace_host_reg is not None else None
             )
@@ -1103,7 +1106,7 @@ def register_events_routes(
                     conv.runner_id,
                     session_id,
                 )
-                if _grace_host_conn is not None:
+                if _grace_host_reg is not None and _grace_host_conn is not None:
                     runner_client = await _wait_for_host_bound_runner_client(
                         session_id,
                         runner_router,

--- a/omnigent/server/routes/sessions/routes_permissions.py
+++ b/omnigent/server/routes/sessions/routes_permissions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import TypedDict
 
 from fastapi import (
     APIRouter,
@@ -65,6 +66,11 @@ from omnigent.spec.types import (
 )
 from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.permission_store import PermissionStore
+
+
+class _PermissionListResponse(TypedDict):
+    permissions: list[PermissionObject]
+    next_cursor: str | None
 
 
 def register_permissions_routes(
@@ -287,7 +293,7 @@ def register_permissions_routes(
         session_id: str,
         limit: int = Query(default=100, ge=1, le=1000),
         after: str | None = Query(default=None, description="Cursor: user_id to start after"),
-    ) -> dict:
+    ) -> _PermissionListResponse:
         """List permission grants on a session with cursor pagination.
 
         Requires manage-level access.
@@ -324,8 +330,6 @@ def register_permissions_routes(
             ],
             "next_cursor": next_cursor,
         }
-
-    return router
 
 
 def _policy_type(spec: PolicySpec) -> str:


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Type the session permission-list response with a dedicated `TypedDict` and remove the stray router return from the registration function.
- Accept read-only agent-name mappings when assembling session rows, and preserve the narrowed target agent ID through fork lookup.
- Narrow the dynamically stored host registry before the host-bound runner grace path, eliminating six mypy diagnostics without changing route behavior.

**ELI5:** These routes already passed the right data at runtime; their type contracts now describe those values precisely enough for mypy to verify them.

```text
stores / app state -> typed route boundary -> session response
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/mypy --no-incremental omnigent` (all six targeted diagnostics removed; 722 local errors remain)
- `.venv/bin/pytest -q tests/server/routes/test_sessions_fork.py tests/server/routes/test_session_updates_ws.py tests/server/integration/test_sessions_permissions.py::test_list_permissions_shows_all_grants tests/server/integration/test_session_host_launch.py::test_host_session_message_waits_for_bound_runner_before_relaunch` (47 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing fork, session-update, permission-list, and host-bound runner tests exercise the narrowed contracts.

## Changelog

N/A (internal type cleanup)
