### PR TITLE
refactor: narrow egress CA key types

### DIFF
--- a/omnigent/inner/egress/certs.py
+++ b/omnigent/inner/egress/certs.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
 from cryptography.x509.oid import NameOID
 
 logger = logging.getLogger(__name__)
@@ -36,7 +36,20 @@ class HostCertCache:
 
     def __init__(self, ca_cert_path: Path, ca_key_path: Path) -> None:
         self._ca_cert = x509.load_pem_x509_certificate(ca_cert_path.read_bytes())
-        self._ca_key = serialization.load_pem_private_key(ca_key_path.read_bytes(), password=None)
+        ca_public_key = self._ca_cert.public_key()
+        if not isinstance(
+            ca_public_key,
+            rsa.RSAPublicKey | dsa.DSAPublicKey | ec.EllipticCurvePublicKey,
+        ):
+            raise ValueError("CA certificate must use an RSA, DSA, or EC public key")
+        ca_key = serialization.load_pem_private_key(ca_key_path.read_bytes(), password=None)
+        if not isinstance(
+            ca_key,
+            rsa.RSAPrivateKey | dsa.DSAPrivateKey | ec.EllipticCurvePrivateKey,
+        ):
+            raise ValueError("CA private key must use an RSA, DSA, or EC signing key")
+        self._ca_public_key = ca_public_key
+        self._ca_key = ca_key
         self._get_or_create = functools.lru_cache(maxsize=_CACHE_MAX_SIZE)(self._generate)
 
     def get_ssl_context(self, hostname: str) -> ssl.SSLContext:
@@ -83,7 +96,7 @@ class HostCertCache:
                 critical=False,
             )
             .add_extension(
-                x509.AuthorityKeyIdentifier.from_issuer_public_key(self._ca_cert.public_key()),
+                x509.AuthorityKeyIdentifier.from_issuer_public_key(self._ca_public_key),
                 critical=False,
             )
         )

--- a/tests/inner/egress/test_certs.py
+++ b/tests/inner/egress/test_certs.py
@@ -2,13 +2,48 @@
 
 from __future__ import annotations
 
+import datetime
 import ssl
 from pathlib import Path
 
+import pytest
 from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography.x509.oid import NameOID
 
 from omnigent.inner.egress.ca import ensure_ca
 from omnigent.inner.egress.certs import HostCertCache
+
+
+def test_host_cert_cache_rejects_unsupported_ca_key(tmp_path: Path) -> None:
+    """Ed25519 CAs fail early because leaf signing uses SHA-256."""
+    key = ed25519.Ed25519PrivateKey.generate()
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Unsupported CA")])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .sign(key, algorithm=None)
+    )
+    cert_path = tmp_path / "ca.pem"
+    key_path = tmp_path / "ca-key.pem"
+    cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+    )
+
+    with pytest.raises(ValueError, match="RSA, DSA, or EC"):
+        HostCertCache(cert_path, key_path)
 
 
 def test_host_cert_cache_generates_valid_cert(tmp_path: Path) -> None:


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Narrow loaded egress CA certificates and private keys to RSA, DSA, or EC algorithms that support the proxy's SHA-256 leaf-signing flow.
- Retain the narrowed public key for authority-key identifiers and fail early with a clear error for unsupported key algorithms.
- Add regression coverage for an Ed25519 CA, removing two mypy diagnostics from the certificate cache.

**ELI5:** The proxy now checks that a loaded CA key can actually sign its generated certificates before trying to use it.

```text
CA PEM -> supported signing-key check -> cached leaf certificates
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/mypy --no-incremental omnigent` (two target diagnostics removed; local total 712 → 710)
- `TMPDIR=/tmp .venv/bin/pytest -q tests/inner/egress/test_certs.py tests/inner/egress/test_ca.py tests/inner/egress/test_proxy.py` (81 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new test covers unsupported CA algorithms; the existing certificate, CA, and proxy suites cover the generated RSA CA and leaf-signing path.

## Changelog

N/A (internal type cleanup)
