### PR TITLE
refactor: type runner service contracts

### DIFF
--- a/omnigent/runner/background_titles/service.py
+++ b/omnigent/runner/background_titles/service.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Protocol, cast
+
+import httpx
 
 from omnigent.harness_plugins import (
     BackgroundTitleGeneratorSpec,
@@ -34,7 +36,7 @@ class BackgroundTitleProcessManager(Protocol):
         harness_name: str,
         *,
         env: dict[str, str] | None = None,
-    ) -> Any: ...
+    ) -> httpx.AsyncClient: ...
 
     async def release(self, conversation_id: str) -> None: ...
 

--- a/omnigent/runner/background_titles/service.py
+++ b/omnigent/runner/background_titles/service.py
@@ -36,9 +36,11 @@ class BackgroundTitleProcessManager(Protocol):
         harness_name: str,
         *,
         env: dict[str, str] | None = None,
-    ) -> httpx.AsyncClient: ...
+    ) -> httpx.AsyncClient:
+        pass
 
-    async def release(self, conversation_id: str) -> None: ...
+    async def release(self, conversation_id: str) -> None:
+        pass
 
 
 @dataclass(frozen=True)

--- a/omnigent/runner/pending_approvals.py
+++ b/omnigent/runner/pending_approvals.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
-from typing import Any
 
 # Default wait budget for a UI verdict, in seconds. Held at one day
 # (86400s) — matching the deciding policy's default ``ask_timeout``: an ASK
@@ -139,7 +138,7 @@ async def wait_for_user_approval(
     *,
     elicitation_id: str,
     conversation_id: str,
-    publish_event: Callable[[str, dict[str, Any]], None],
+    publish_event: Callable[[str, dict[str, object]], None],
     timeout_seconds: float | None = None,
 ) -> bool:
     """


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Type the background-title process-manager client as `httpx.AsyncClient`, matching the concrete harness process manager and the stream/post operations generators require.
- Type approval-resolution publisher payloads as object-valued event dictionaries instead of explicit `Any`.
- Remove two mypy diagnostics from isolated runner service contracts without changing runtime behavior.

**ELI5:** These helpers now name the concrete HTTP client and event shape they already use instead of opting out of type checking.

```text
runner service -> typed client / event payload -> existing behavior
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/mypy --no-incremental omnigent` (two target diagnostics removed; local total 709 → 707)
- `TMPDIR=/tmp .venv/bin/pytest -q tests/runner/test_pending_approvals.py tests/runner/test_background_session_title.py tests/test_ask_timeout.py` (33 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)
- `TMPDIR=/tmp .venv/bin/mypy --no-incremental --follow-imports=skip omnigent/runner/background_titles/service.py`, file-scoped pre-commit, and `tests/runner/test_background_session_title.py` (15 passed after the Code Quality follow-up)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing approval lifecycle, timeout, SDK background-title, native-title, and plugin-dispatch tests exercise both contracts.

## Changelog

N/A (internal type cleanup)

