### PR TITLE
refactor: narrow spec parsing boundaries

### DIFF
--- a/omnigent/spec/omnigent.py
+++ b/omnigent/spec/omnigent.py
@@ -51,15 +51,12 @@ from omnigent.inner.tools import (
 from omnigent.llms.routing import infer_harness_from_model as _infer_harness_from_model
 from omnigent.spec.types import (
     AgentSpec,
-    ApiKeyAuth,
-    DatabricksAuth,
     ExecutorAuth,
     ExecutorSpec,
     GuardrailsSpec,
     LLMConfig,
     LocalToolInfo,
     MCPServerConfig,
-    ProviderAuth,
     SharePolicy,
     ToolRuntime,
     ToolsConfig,
@@ -1762,7 +1759,7 @@ def _translate_executor_from_def(
     # goes through _translate_executor_from_def(raw_executor=...).
     auth: ExecutorAuth | None = None
     if oa_executor is not None and oa_executor.auth is not None:
-        if not isinstance(oa_executor.auth, ApiKeyAuth | DatabricksAuth | ProviderAuth):
+        if not isinstance(oa_executor.auth, ExecutorAuth):
             raise OmnigentError(
                 "executor auth must be a parsed auth configuration",
                 code=ErrorCode.INVALID_INPUT,

--- a/omnigent/spec/omnigent.py
+++ b/omnigent/spec/omnigent.py
@@ -53,11 +53,13 @@ from omnigent.spec.types import (
     AgentSpec,
     ApiKeyAuth,
     DatabricksAuth,
+    ExecutorAuth,
     ExecutorSpec,
     GuardrailsSpec,
     LLMConfig,
     LocalToolInfo,
     MCPServerConfig,
+    ProviderAuth,
     SharePolicy,
     ToolRuntime,
     ToolsConfig,
@@ -1758,9 +1760,14 @@ def _translate_executor_from_def(
     # ``auth`` is now parsed by the loader into OmniExecutorSpec.auth;
     # fall back to raw_executor for the top-level agent path that still
     # goes through _translate_executor_from_def(raw_executor=...).
-    auth: ApiKeyAuth | DatabricksAuth | None = None
+    auth: ExecutorAuth | None = None
     if oa_executor is not None and oa_executor.auth is not None:
-        auth = oa_executor.auth  # type: ignore[assignment]
+        if not isinstance(oa_executor.auth, ApiKeyAuth | DatabricksAuth | ProviderAuth):
+            raise OmnigentError(
+                "executor auth must be a parsed auth configuration",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        auth = oa_executor.auth
     elif raw_executor is not None:
         from omnigent.spec.parser import _parse_executor_auth
 

--- a/omnigent/spec/skill_sources.py
+++ b/omnigent/spec/skill_sources.py
@@ -119,7 +119,7 @@ def resolve_harness_skills(ctx: SkillSourceContext, harness: str | None) -> list
 
 
 def _read_json(path: Path) -> dict[str, object] | None:
-    """Best-effort JSON read; ``None`` on missing/unreadable/non-dict."""
+    """Best-effort JSON read; ``None`` unless it is a string-keyed object."""
     try:
         data = json.loads(path.read_text())
     except (OSError, ValueError):

--- a/omnigent/spec/skill_sources.py
+++ b/omnigent/spec/skill_sources.py
@@ -17,7 +17,7 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any
+from typing import cast
 
 from omnigent.errors import OmnigentError
 from omnigent.spec.parser import _discover_skills, _parse_skill, discover_host_skills
@@ -118,13 +118,15 @@ def resolve_harness_skills(ctx: SkillSourceContext, harness: str | None) -> list
     return [s for s in _dedup(provider(ctx)) if s.user_invocable]
 
 
-def _read_json(path: Path) -> dict[str, Any] | None:
+def _read_json(path: Path) -> dict[str, object] | None:
     """Best-effort JSON read; ``None`` on missing/unreadable/non-dict."""
     try:
         data = json.loads(path.read_text())
     except (OSError, ValueError):
         return None
-    return data if isinstance(data, dict) else None
+    if not isinstance(data, dict) or not all(isinstance(key, str) for key in data):
+        return None
+    return cast(dict[str, object], data)
 
 
 def _enabled_plugin_settings_files(ctx: SkillSourceContext) -> list[Path]:


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Use the shared `ExecutorAuth` union when translating parsed specs, with explicit runtime narrowing at the intentionally opaque inner-model boundary.
- Validate decoded plugin-settings object keys before exposing them as `dict[str, object]`.
- Remove two mypy diagnostics from spec translation and skill discovery without weakening their dynamic boundaries.

**ELI5:** Parsed auth and JSON settings now pass through small validation gates before the typed spec code uses them.

```text
opaque loader value -> runtime shape check -> typed spec value
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/mypy --no-incremental omnigent` (two target diagnostics removed; local total 709 → 707)
- `TMPDIR=/tmp .venv/bin/pytest -q tests/spec/test_skill_sources.py tests/spec/test_omnigent_adapter.py tests/spec/test_parser.py::test_parse_executor_auth_provider` (114 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)
- Isolated mypy, file-scoped pre-commit, and the same 114 focused tests passed after the Copilot follow-up

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing spec-adapter, provider-auth parsing, and harness skill-discovery tests cover both narrowed boundaries.

## Changelog

N/A (internal type cleanup)

