### PR TITLE
fix(antigravity-native): never rotate onto an agy subagent cascade

### DIFF
--- a/omnigent/antigravity_native_reader.py
+++ b/omnigent/antigravity_native_reader.py
@@ -436,6 +436,43 @@ def _cascade_is_idle(summaries: dict[str, object], bound_cascade_id: str) -> boo
     return summary.get("status") == _CASCADE_RUN_STATUS_IDLE
 
 
+def _summary_is_child_trajectory(cascade_id: str, summary: dict[str, object]) -> bool:
+    """
+    Whether a cascade summary describes a SUBAGENT (child) conversation.
+
+    agy spawns each subagent as its own conversation that reports
+    ``trajectoryType == CORTEX_TRAJECTORY_TYPE_CASCADE`` — byte-identical to a real
+    root — so the type alone cannot tell them apart (live-verified, agy 1.1.9).
+    The distinction lives in ``trajectoryMetadata``, where a child carries a
+    ``parentConversationId`` and a ``rootConversationId`` pointing at its PARENT,
+    while a root's ``rootConversationId`` is its own id::
+
+        root:  {"rootConversationId": "<self>"}
+        child: {"parentConversationId": "<parent>", "rootConversationId": "<parent>",
+                "nestingDepth": 1, "subagentSpec": {...}}
+
+    This matters because a subagent is ALWAYS more recently active than the parent
+    idling while it works, so without this test every spawned subagent looks like a
+    ``/clear`` rotation — promoting a sub-conversation to a new top-level session
+    and dragging the agy pane onto it.
+
+    Fail-open: a summary with no (or malformed) metadata is NOT treated as a child,
+    so a genuine ``/clear`` on an agy build that omits these fields still rotates.
+
+    :param cascade_id: The summary's own key (its conversation id).
+    :param summary: One ``trajectorySummaries`` entry.
+    :returns: ``True`` when the entry is a subagent/child trajectory.
+    """
+    metadata = summary.get("trajectoryMetadata")
+    if not isinstance(metadata, dict):
+        return False
+    parent = metadata.get("parentConversationId")
+    if isinstance(parent, str) and parent:
+        return True
+    root = metadata.get("rootConversationId")
+    return isinstance(root, str) and bool(root) and root != cascade_id
+
+
 def _detect_rotated_cascade(summaries: dict[str, object], bound_cascade_id: str) -> str | None:
     """
     Return the id of a newer-active root cascade than the bound one, else ``None``.
@@ -487,7 +524,9 @@ def _detect_rotated_cascade(summaries: dict[str, object], bound_cascade_id: str)
         if not isinstance(summary, dict):
             continue
         if summary.get("trajectoryType") != _TRAJECTORY_TYPE_CASCADE:
-            continue  # never rotate to a subagent/child trajectory
+            continue  # never rotate to a non-cascade trajectory
+        if _summary_is_child_trajectory(cascade_id, summary):
+            continue  # a subagent works FOR the bound cascade; it is not a new one
         if cascade_id == bound_cascade_id:
             continue
         activity = _summary_activity(summary)

--- a/tests/test_antigravity_native_reader.py
+++ b/tests/test_antigravity_native_reader.py
@@ -2994,6 +2994,114 @@ def test_detect_rotation_older_sibling_returns_none() -> None:
     assert reader._detect_rotated_cascade(summaries, _BOUND_CASCADE) is None
 
 
+def _child_summary(
+    *,
+    parent_cascade_id: str,
+    last_user_input_time: str = "2026-08-01T10:48:37.887431Z",
+    include_parent_id: bool = True,
+) -> dict[str, Any]:
+    """Build a real agy SUBAGENT summary (live capture, agy 1.1.9).
+
+    Captured from a live ``GetAllCascadeTrajectories`` while agy ran a subagent:
+    the child is typed ``CORTEX_TRAJECTORY_TYPE_CASCADE`` — byte-identical to its
+    parent — and is distinguishable ONLY by ``trajectoryMetadata``, which carries
+    ``parentConversationId`` / a foreign ``rootConversationId`` / ``nestingDepth``
+    / ``subagentSpec``.
+
+    :param parent_cascade_id: The parent (root) conversation id this child hangs off.
+    :param include_parent_id: When ``False``, omit ``parentConversationId`` so the
+        foreign ``rootConversationId`` is the only remaining child signal.
+    """
+    metadata: dict[str, Any] = {
+        "createdAt": "2026-08-01T09:34:51.639408Z",
+        "initializationStateId": "11e484d0-0000-4000-8000-000000000000",
+        "rootConversationId": parent_cascade_id,
+        "nestingDepth": 1,
+        "subagentSpec": {"typeName": "self", "role": "Task 4 Reviewer", "inherit": True},
+    }
+    if include_parent_id:
+        metadata["parentConversationId"] = parent_cascade_id
+    return {
+        "trajectoryId": "82e9fb54-9f16-46eb-88d7-a84fd40deec3",
+        "status": "CASCADE_RUN_STATUS_IDLE",
+        # NOT a distinct type — the same value a real root cascade reports.
+        "trajectoryType": "CORTEX_TRAJECTORY_TYPE_CASCADE",
+        "lastUserInputTime": last_user_input_time,
+        "summary": "MetricsStore Implementation Code Review",
+        "trajectoryMetadata": metadata,
+    }
+
+
+def test_detect_rotation_subagent_child_is_never_a_rotation_target() -> None:
+    """A running agy SUBAGENT must never be rotated onto.
+
+    agy spawns each subagent as a child conversation that reports the SAME
+    ``trajectoryType`` as a real root, and is always more recently active than the
+    parent it is working for. Rotating onto it promotes a sub-conversation to a
+    new top-level Omnigent session (and drags the tmux pane with it), which is
+    what made a single subagent fan-out explode into a session per agent.
+    """
+    summaries = {
+        _BOUND_CASCADE: _summary(last_user_input_time="2026-08-01T10:49:38.660037Z"),
+        _OTHER_CASCADE: _child_summary(
+            parent_cascade_id=_BOUND_CASCADE,
+            # Strictly newer than the parent — the subagent is mid-turn while the
+            # parent sits idle waiting for it, so activity alone always favours it.
+            last_user_input_time="2026-08-01T10:50:00.000000Z",
+        ),
+    }
+    assert reader._detect_rotated_cascade(summaries, _BOUND_CASCADE) is None
+
+
+def test_detect_rotation_child_detected_without_explicit_parent_id() -> None:
+    """A foreign ``rootConversationId`` alone marks a child, with no parent field."""
+    summaries = {
+        _BOUND_CASCADE: _summary(last_user_input_time="2026-08-01T10:49:38.660037Z"),
+        _OTHER_CASCADE: _child_summary(
+            parent_cascade_id=_BOUND_CASCADE,
+            last_user_input_time="2026-08-01T10:50:00.000000Z",
+            include_parent_id=False,
+        ),
+    }
+    assert reader._detect_rotated_cascade(summaries, _BOUND_CASCADE) is None
+
+
+def test_detect_rotation_child_of_a_third_cascade_is_also_excluded() -> None:
+    """A subagent of some OTHER root is still a child — not a rotation target.
+
+    The child test must not degenerate into "is it my own child": a subagent
+    belonging to a different root is equally not the user's top-level conversation.
+    """
+    summaries = {
+        _BOUND_CASCADE: _summary(last_user_input_time="2026-08-01T10:49:38.660037Z"),
+        _OTHER_CASCADE: _child_summary(
+            parent_cascade_id="ffffffff-1111-4222-8333-444444444444",
+            last_user_input_time="2026-08-01T10:50:00.000000Z",
+        ),
+    }
+    assert reader._detect_rotated_cascade(summaries, _BOUND_CASCADE) is None
+
+
+def test_detect_rotation_real_clear_mint_still_rotates_with_self_root_metadata() -> None:
+    """A genuine /clear rotation still fires when metadata is self-referential.
+
+    The live capture shows a real root carries ``rootConversationId == <its own
+    key>``, so the child test must not swallow the /clear case this detector
+    exists for.
+    """
+    other = dict(_summary(last_user_input_time="2026-08-01T10:50:00.000000Z"))
+    other["trajectoryMetadata"] = {
+        "createdAt": "2026-08-01T10:49:34.181600Z",
+        "initializationStateId": "87966e34-057b-4b63-afa2-a437cd67ea9d",
+        "rootConversationId": _OTHER_CASCADE,
+    }
+    summaries = {
+        _BOUND_CASCADE: _summary(last_user_input_time="2026-08-01T10:49:38.660037Z"),
+        _OTHER_CASCADE: other,
+    }
+    assert reader._detect_rotated_cascade(summaries, _BOUND_CASCADE) == _OTHER_CASCADE
+
+
 def test_detect_rotation_non_cascade_sibling_returns_none() -> None:
     """A newer NON-cascade (subagent) sibling must not be a rotation target.
 


### PR DESCRIPTION
## Related issue

N/A — found while using the harness; no existing issue filed. Happy to open one if
maintainers prefer an issue on record.

## Summary

Running an agy subagent fan-out (a skill that dispatches several agents) spawns **one
top-level Omnigent session per agent** instead of nesting them under the parent — and
transfers the live agy tmux pane onto each new session in turn. One run produced 10
stray sessions off a single conversation.

The `/clear`-rotation detector (`antigravity_native_reader.py`) tries to exclude
subagents by trajectory type:

```python
if summary.get("trajectoryType") != _TRAJECTORY_TYPE_CASCADE:
    continue  # never rotate to a subagent/child trajectory
```

**That assumption is false.** Captured live from a running agy 1.1.9 via
`GetAllCascadeTrajectories`, a subagent reports `CORTEX_TRAJECTORY_TYPE_CASCADE` —
byte-identical to its parent:

| cascade | `trajectoryType` | `rootConversationId` | child? |
| --- | --- | --- | --- |
| `578b4a5b` (parent) | `…TYPE_CASCADE` | itself | no |
| `e2aed541` (bare `/clear` mint) | `…TYPE_CASCADE` | itself | no |
| **`e7276bb4` (subagent)** | `…TYPE_CASCADE` | **`578b4a5b`** | **yes** |

agy's own conversation store agrees: all 39 conversations record `trajectory_type = 4`
with an empty `parent_references` table. And the existing guard test asserted against
`CORTEX_TRAJECTORY_TYPE_SUBAGENT` — a value that appears nowhere in the binary's enum
(21 real `CORTEX_TRAJECTORY_TYPE_*` values, none of them `SUBAGENT`) — so it passed
against a fiction.

The real discriminator is `trajectoryMetadata`. A child populates it with
`parentConversationId`, a `rootConversationId` pointing at the **parent**,
`nestingDepth: 1`, and a `subagentSpec` (`{"role": "Task 4 Reviewer", ...}`); a root's
`rootConversationId` is its own id.

Because a subagent is *always* more recently active than the parent idling while it
works, every spawn read as a `/clear` rotation. Each rotation then created a new session
whose runner launched **another agy on the shared `--gemini_dir`**, minting a fresh
conversation that became the next sibling — a self-feeding loop. Collateral seen in the
runner logs: six concurrent `GetAllCascadeTrajectories` pollers and
`terminal transfer failed: Terminal 'antigravity':'main' already exists`.

This adds `_summary_is_child_trajectory` and skips such entries. **Fail-open**: absent or
malformed metadata is not treated as a child, so a genuine `/clear` still rotates on
builds that omit these fields.

Scope: this stops the runaway. Surfacing agy subagents *nested under* the parent — what
users actually expect from the Agents panel — is separate follow-up work, and would
reuse the parent linkage `sys_session_send` already builds.

## Test Plan

**Unit** — 4 tests added, fixtures copied from the live capture (a child whose
`trajectoryType` equals a root's, distinguished only by metadata):

- a running subagent is never a rotation target;
- a foreign `rootConversationId` alone marks a child (no `parentConversationId`);
- a subagent of some *other* root is excluded too (the test isn't "is it my own child");
- **regression guard**: a genuine `/clear` mint with self-referential metadata still
  rotates, so the fix can't swallow the case this detector exists for.

`test_antigravity_native_reader.py` → **89 passed**; adjacent
`test_antigravity_native_rpc.py` + `test_antigravity_native_bridge.py` → **189 passed**.
`pre-commit` clean.

**A/B against the real capture** — the untouched `GetAllCascadeTrajectories` body from
the affected agy, with the subagent's `lastUserInputTime` advanced to model the mid-turn
moment when rotation actually fires (every other field verbatim):

```
PRE-FIX   rotation target = e7276bb4-…   ← rotates onto the subagent
POST-FIX  rotation target = None
```

Classification on the unmodified capture: `578b4a5b → False`, `e2aed541 → False`,
`e7276bb4 → True`.

## Demo

N/A — non-visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the live RPC capture and the pre/post A/B above, driven against a
real agy 1.1.9 process mid-incident. That can't be automated here (it needs a live agy
that has actually spawned a subagent), so the unit tests pin the classifier against
fixtures taken verbatim from that capture.

One note for reviewers: the rotation path currently emits **no logging at all** — the
session creates and pane transfers in the incident were entirely silent, and I had to
reconstruct them from httpx request lines and label archaeology. Adding an `info` line at
the rotation decision would make the next occurrence of anything in this area far cheaper
to diagnose. Happy to include it here or leave it for a follow-up.

## Changelog

Antigravity subagents no longer spawn a stray top-level session for every agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
