### PR TITLE
refactor: narrow Claude hook payloads

### DIFF
--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -11,7 +11,6 @@ import sys
 import time
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
 
 import httpx
 
@@ -458,8 +457,12 @@ def _create_clear_replacement_session(
     if not isinstance(agent_id, str) or not agent_id:
         raise RuntimeError(f"session {old_session_id!r} has no agent_id")
     runner_id = old.get("runner_id")
-    labels = old.get("labels") if isinstance(old.get("labels"), dict) else {}
-    labels = {str(key): str(value) for key, value in labels.items()}
+    raw_labels = old.get("labels")
+    labels = (
+        {str(key): str(value) for key, value in raw_labels.items()}
+        if isinstance(raw_labels, dict)
+        else {}
+    )
     labels.setdefault(BRIDGE_ID_LABEL_KEY, read_bridge_id(bridge_dir) or old_session_id)
 
     create_resp = client.post(
@@ -620,7 +623,7 @@ def _conversation_url_for_active_session(
 def _post_hook_with_reattach(
     url: str,
     headers: dict[str, str],
-    payload: dict[str, Any],
+    payload: dict[str, object],
     hook_label: str,
     reauth: Callable[[], dict[str, str] | None] | None = None,
 ) -> httpx.Response | None:


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Narrow session snapshot labels once before normalizing them for `/clear` replacement sessions.
- Type reattachable permission-hook payloads as object-valued dictionaries instead of explicit `Any`.
- Remove both remaining mypy diagnostics from the Claude native hook without changing its wire payloads.

**ELI5:** The hook now checks the labels object once and gives its retry payload the same concrete shape used elsewhere.

```text
Claude hook JSON -> shape narrowing -> existing session / permission flow
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/mypy --no-incremental omnigent` (two target diagnostics removed; local total 696 → 694)
- `TMPDIR=/tmp .venv/bin/pytest -q tests/test_claude_native_hook.py` (39 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The full Claude native hook suite covers session rotation, permission retries, reauthentication, policy evaluation, and AskUserQuestion payload conversion.

## Changelog

N/A (internal type cleanup)
