### PR TITLE
refactor: type Kimi executor boundaries

### DIFF
--- a/omnigent/inner/kimi_executor.py
+++ b/omnigent/inner/kimi_executor.py
@@ -63,7 +63,6 @@ import shutil
 import time
 from collections.abc import AsyncIterator, Sequence
 from pathlib import Path
-from typing import Any
 
 from omnigent.harness_startup_config import resolve_harness_path
 from omnigent.inner.agent_env import clean_agent_env, declared_passthrough
@@ -336,7 +335,7 @@ class KimiExecutor(Executor):
         argv.extend(["-p", prompt_text])
         return argv
 
-    def _translate_event(self, payload: dict[str, Any]) -> list[ExecutorEvent]:
+    def _translate_event(self, payload: dict[str, object]) -> list[ExecutorEvent]:
         """Translate one kimi stream-json line into Omnigent events.
 
         Upstream emits whole messages (not deltas). Roles seen:
@@ -595,8 +594,14 @@ class KimiExecutor(Executor):
 
 
 async def _create_subprocess_exec(
-    *args: Any,
-    **kwargs: Any,
+    program: str,
+    *args: str,
+    stdin: int,
+    stdout: int,
+    stderr: int,
+    cwd: str | None,
+    env: dict[str, str],
+    limit: int,
 ) -> asyncio.subprocess.Process:
     """Indirection point so tests can stub subprocess creation.
 
@@ -604,4 +609,13 @@ async def _create_subprocess_exec(
     tricky because asyncio caches the bound method. Tests patch this
     module-level helper instead.
     """
-    return await asyncio.create_subprocess_exec(*args, **kwargs)
+    return await asyncio.create_subprocess_exec(
+        program,
+        *args,
+        stdin=stdin,
+        stdout=stdout,
+        stderr=stderr,
+        cwd=cwd,
+        env=env,
+        limit=limit,
+    )

--- a/omnigent/inner/kimi_executor.py
+++ b/omnigent/inner/kimi_executor.py
@@ -61,7 +61,7 @@ import os
 import re
 import shutil
 import time
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Mapping, Sequence
 from pathlib import Path
 
 from omnigent.harness_startup_config import resolve_harness_path
@@ -335,7 +335,7 @@ class KimiExecutor(Executor):
         argv.extend(["-p", prompt_text])
         return argv
 
-    def _translate_event(self, payload: dict[str, object]) -> list[ExecutorEvent]:
+    def _translate_event(self, payload: Mapping[str, object]) -> list[ExecutorEvent]:
         """Translate one kimi stream-json line into Omnigent events.
 
         Upstream emits whole messages (not deltas). Roles seen:
@@ -600,7 +600,7 @@ async def _create_subprocess_exec(
     stdout: int,
     stderr: int,
     cwd: str | None,
-    env: dict[str, str],
+    env: Mapping[str, str],
     limit: int,
 ) -> asyncio.subprocess.Process:
     """Indirection point so tests can stub subprocess creation.


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Type Kimi stream records as object-valued dictionaries, matching the runtime `isinstance` narrowing already used for nested fields.
- Give the subprocess indirection an exact signature for Kimi's argv, stdio, cwd, environment, and stream-limit call shape.
- Remove both remaining mypy diagnostics from the Kimi inner executor without changing process behavior.

**ELI5:** Kimi's executor now describes the JSON records and subprocess arguments it already receives instead of accepting arbitrary values.

```text
Kimi JSONL / argv -> typed executor boundary -> existing event stream
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/mypy --no-incremental omnigent` (two target diagnostics removed; local total 696 → 694)
- `TMPDIR=/tmp .venv/bin/pytest -q tests/inner/test_kimi_harness.py tests/test_agent_spawn_env_canary.py -k 'kimi or Kimi'` (62 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)
- Full-tree mypy, file-scoped pre-commit, and the same 62 focused tests passed after the Copilot `Mapping` follow-up

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing Kimi executor tests cover JSON event translation, subprocess spawning, session resume, cancellation, sandbox launch, and harness configuration.

## Changelog

N/A (internal type cleanup)

