### PR TITLE
refactor: validate runner compaction responses

### DIFF
--- a/omnigent/runtime/compaction.py
+++ b/omnigent/runtime/compaction.py
@@ -457,6 +457,7 @@ async def _summarize_via_runner_uncached(
     :returns: Dict with ``"text"`` (summary) and ``"token_count"``
         (approximate tiktoken estimate) keys.
     :raises httpx.HTTPStatusError: On non-2xx responses from the runner.
+    :raises RuntimeError: If the runner returns a malformed summary payload.
     """
     payload: dict[str, Any] = {"messages": messages_to_summarize, "model": model}
     if connection:
@@ -470,7 +471,11 @@ async def _summarize_via_runner_uncached(
         raise RuntimeError("runner summarize response was not an object")
     text = data.get("text")
     token_count = data.get("token_count")
-    if not isinstance(text, str) or not isinstance(token_count, int):
+    if (
+        not isinstance(text, str)
+        or not isinstance(token_count, int)
+        or isinstance(token_count, bool)
+    ):
         raise RuntimeError("runner summarize response had invalid summary fields")
     return {"text": text, "token_count": token_count}
 

--- a/omnigent/runtime/compaction.py
+++ b/omnigent/runtime/compaction.py
@@ -465,7 +465,14 @@ async def _summarize_via_runner_uncached(
         payload["session_id"] = conversation_id
     resp = await runner_client.post("/v1/summarize", json=payload, timeout=120.0)
     resp.raise_for_status()
-    return resp.json()
+    data = resp.json()
+    if not isinstance(data, dict):
+        raise RuntimeError("runner summarize response was not an object")
+    text = data.get("text")
+    token_count = data.get("token_count")
+    if not isinstance(text, str) or not isinstance(token_count, int):
+        raise RuntimeError("runner summarize response had invalid summary fields")
+    return {"text": text, "token_count": token_count}
 
 
 def compaction_to_history_items(

--- a/tests/runtime/test_compaction.py
+++ b/tests/runtime/test_compaction.py
@@ -940,7 +940,17 @@ async def test_summarize_history_validates_runner_response() -> None:
 
 
 @pytest.mark.asyncio
-async def test_summarize_history_rejects_malformed_runner_response() -> None:
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"text": 12, "token_count": 3},
+        {"text": "Runner summary", "token_count": "three"},
+        {"text": "Runner summary", "token_count": True},
+    ],
+)
+async def test_summarize_history_rejects_malformed_runner_response(
+    payload: object,
+) -> None:
     """Runner summarization fails clearly when required fields are malformed."""
 
     class _Response:
@@ -948,7 +958,7 @@ async def test_summarize_history_rejects_malformed_runner_response() -> None:
             pass
 
         def json(self) -> object:
-            return {"text": 12, "token_count": "three"}
+            return payload
 
     class _RunnerClient:
         async def post(self, *_args: object, **_kwargs: object) -> _Response:

--- a/tests/runtime/test_compaction.py
+++ b/tests/runtime/test_compaction.py
@@ -915,6 +915,55 @@ async def test_summarize_history_returns_text_and_token_count() -> None:
 
 
 @pytest.mark.asyncio
+async def test_summarize_history_validates_runner_response() -> None:
+    """Runner summarization accepts the documented object shape only."""
+
+    class _Response:
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> object:
+            return {"text": "Runner summary", "token_count": 3}
+
+    class _RunnerClient:
+        async def post(self, *_args: object, **_kwargs: object) -> _Response:
+            return _Response()
+
+    result = await summarize_history(
+        [{"role": "user", "content": "prior conversation"}],
+        _RaisesIfCalled(),
+        "openai/gpt-4o",
+        runner_client=_RunnerClient(),
+    )
+
+    assert result == {"text": "Runner summary", "token_count": 3}
+
+
+@pytest.mark.asyncio
+async def test_summarize_history_rejects_malformed_runner_response() -> None:
+    """Runner summarization fails clearly when required fields are malformed."""
+
+    class _Response:
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> object:
+            return {"text": 12, "token_count": "three"}
+
+    class _RunnerClient:
+        async def post(self, *_args: object, **_kwargs: object) -> _Response:
+            return _Response()
+
+    with pytest.raises(RuntimeError, match="invalid summary fields"):
+        await summarize_history(
+            [{"role": "user", "content": "prior conversation"}],
+            _RaisesIfCalled(),
+            "openai/gpt-4o",
+            runner_client=_RunnerClient(),
+        )
+
+
+@pytest.mark.asyncio
 async def test_summarize_history_recursive_prompt_includes_continuation_prefix() -> None:
     """
     When history starts with a prior summary, the summarization prompt


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Validate that runner-delegated summarization returns an object with string `text` and integer `token_count` fields.
- Return a freshly typed summary payload instead of leaking `httpx.Response.json()`'s `Any` value into compaction.
- Add success and malformed-response coverage, removing the remaining mypy diagnostic from runtime compaction.

**ELI5:** Compaction now checks the runner's summary receipt before trusting and storing it.

```text
runner /v1/summarize -> response validation -> typed compaction summary
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/mypy --no-incremental omnigent` (one target diagnostic removed; local total 694 → 693)
- `TMPDIR=/tmp .venv/bin/pytest -q tests/runtime/test_compaction.py` (39 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New tests cover valid and malformed runner summary payloads; the full compaction suite covers all three compaction layers and token accounting.

## Changelog

N/A (internal type cleanup)
