### PR TITLE
refactor: type compressed text column

### DIFF
--- a/omnigent/db/compression.py
+++ b/omnigent/db/compression.py
@@ -84,7 +84,7 @@ def decode(value: bytes | str | memoryview | None) -> str | None:
     return payload.decode("utf-8")
 
 
-class CompressedText(TypeDecorator):
+class CompressedText(TypeDecorator[str]):
     """A ``str`` column stored as a zstd-compressed ``BLOB`` / ``BYTEA``.
 
     Transparent at the ORM boundary: callers read and write ``str`` exactly as


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Parameterize `CompressedText` as `TypeDecorator[str]`, matching its Python-side bind/result contract while retaining `LargeBinary` storage.
- Remove the remaining mypy diagnostic from the transparent compressed-column codec with no runtime behavior change.

**ELI5:** SQLAlchemy now knows this binary-backed database column appears as text to Python callers.

```text
Python str <-> CompressedText[str] <-> database bytes
```

## Test Plan

- `TMPDIR=/tmp .venv/bin/mypy --no-incremental omnigent` (one target diagnostic removed; local total 694 → 693)
- `TMPDIR=/tmp .venv/bin/pytest -q tests/db/test_compression.py tests/db/test_migration_workspace.py::test_compressed_columns_are_binary_at_head` (14 passed)
- `TMPDIR=/tmp pre-commit run --all-files` (passed)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing codec tests cover raw, zstd, legacy text/bytes, memoryview, and null round trips; the migration test verifies compressed columns remain binary at schema head.

## Changelog

N/A (internal type cleanup)
