### PR TITLE
refactor: type project store session

### DIFF
--- a/omnigent/stores/project_store/sqlalchemy_store.py
+++ b/omnigent/stores/project_store/sqlalchemy_store.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from sqlalchemy import asc, select
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
 
 from omnigent.db.db_models import SqlProject, current_workspace_id
 from omnigent.db.utils import (
@@ -121,7 +122,7 @@ class SqlAlchemyProjectStore(ProjectStore):
 
     def _name_taken(
         self,
-        session,
+        session: Session,
         *,
         owner_user_id: str | None,
         name: str,


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Type the project-name availability helper's SQLAlchemy session parameter with `Session`.
- Remove the remaining project-store mypy diagnostic without changing runtime behavior.

**ELI5:** The helper now tells type-checkers that its database handle is a SQLAlchemy session.

```text
Project operation -> SQLAlchemy Session -> name availability query
```

## Test Plan

- `.venv/bin/mypy --no-incremental omnigent` (target diagnostic removed; no project-store errors)
- `uv run pytest -q tests/stores/test_project_store.py` (31 passed)
- `TMPDIR=/tmp SKIP=normalize-uv-lock-registry pre-commit run --all-files` (passed; lockfile normalization is outside this workstream)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing project-store tests cover creation, naming conflicts, updates, deletion, ordering, and workspace isolation across 31 cases.


