### PR TITLE
refactor: type generated build info

### DIFF
--- a/omnigent/_build_info.pyi
+++ b/omnigent/_build_info.pyi
@@ -1,0 +1,2 @@
+BUILD_TIME_EPOCH: int
+COMMIT_SHA: str

--- a/setup.py
+++ b/setup.py
@@ -229,6 +229,7 @@ class _GenerateBuildInfo(build_py):
         any later non-build code path that does ``from omnigent
         import _build_info`` works without re-running the build.
         """
+        # Keep generated names and types aligned with omnigent/_build_info.pyi.
         target = Path(__file__).resolve().parent / "omnigent" / "_build_info.py"
         commit = _git_sha()
         # Use repr() for the SHA so quoting is always correct, even


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Add a checked stub for the two constants exported by the generated `omnigent._build_info` module.
- Remove the fresh-checkout mypy error without committing or changing the generated runtime module.
- Mark the generator/stub type contract where the runtime constants are emitted so future changes stay synchronized.

**ELI5:** Clean source checkouts now know the shape of a module that only appears when a wheel is built.

```text
_build_info.pyi (static contract) -> mypy
_build_info.py  (generated values) -> Python runtime
```

## Test Plan

- `.venv/bin/mypy --no-incremental omnigent` without generated `omnigent/_build_info.py` (one target diagnostic removed; fresh-checkout total 689 → 688, no `update_check.py` errors)
- `.venv/bin/pytest -q tests/cli/test_update_check.py -k 'build_info'` (8 passed)
- `TMPDIR=/tmp SKIP=normalize-uv-lock-registry pre-commit run --all-files` (passed; lockfile normalization is outside this workstream)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing build-info tests cover missing, present, malformed, empty-SHA, and fallback behavior; the new stub has no runtime effect.

