### PR TITLE
refactor: distinguish launcher temp directories

### DIFF
--- a/omnigent/inner/sandbox.py
+++ b/omnigent/inner/sandbox.py
@@ -799,14 +799,14 @@ def run_launcher(encoded_sandbox: str, target_path: str, argv: list[str]) -> int
         # tempdir root, which the profile only granted a subpath of —
         # ``FileNotFoundError: No usable temporary directory`` on
         # seatbelt (bwrap masked it via its ``--tmpfs /tmp`` fallback).
-        tmpdir = create_private_tmpdir()
+        host_tmpdir = create_private_tmpdir()
         try:
-            sandbox = with_additional_write_roots(sandbox, [tmpdir])
-            set_temp_env(os.environ, tmpdir)
+            sandbox = with_additional_write_roots(sandbox, [host_tmpdir])
+            set_temp_env(os.environ, host_tmpdir)
             encoded_sandbox = _encode_json_arg(sandbox.to_jsonable())
             # Name the dir for the in-wrap pass: it adopts this exact
             # path (no second mint) and owns the cleanup on exit.
-            os.environ[_LAUNCHER_PRIVATE_TMPDIR_ENV] = str(tmpdir)
+            os.environ[_LAUNCHER_PRIVATE_TMPDIR_ENV] = str(host_tmpdir)
             # Re-invoke run_launcher via an INLINE python -c script
             # rather than re-running the launcher tempfile. Reason:
             # bwrap mounts ``/tmp`` as a fresh tmpfs, so the host's
@@ -851,7 +851,7 @@ def run_launcher(encoded_sandbox: str, target_path: str, argv: list[str]) -> int
             # ``except`` only fires if the wrap/exec never handed off.
             os.execvp(wrapped[0], wrapped)
         except BaseException:
-            cleanup_private_tmpdir(tmpdir)
+            cleanup_private_tmpdir(host_tmpdir)
             raise
 
     tmpdir: Path | None = None


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Give the host-side launcher scratch directory a distinct name from the in-wrap directory state.
- Remove mypy's local-variable redefinition error without changing scratch-directory creation, propagation, or cleanup.

**ELI5:** The launcher has two passes that each handle a temporary directory; their variables now have different names so type-checkers cannot confuse their lifetimes.

```text
host pass: host_tmpdir -> wrap environment
in-wrap pass: tmpdir   -> target process
```

## Test Plan

- `.venv/bin/mypy --no-incremental omnigent` (target diagnostic removed; no `inner/sandbox.py` errors)
- `.venv/bin/pytest -q tests/inner/test_sandbox.py tests/inner/test_seatbelt_sandbox.py::test_run_launcher_spawn_wrap_private_tmpdir_boots_under_seatbelt` (15 passed)
- `TMPDIR=/tmp SKIP=normalize-uv-lock-registry pre-commit run --all-files` (passed; lockfile normalization is outside this workstream)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing launcher tests cover environment pruning, return codes, strace wrapping, policy serialization, subprocess execution, and the real seatbelt two-pass scratch-directory flow.
