### PR TITLE
refactor: type Hermes model config

### DIFF
--- a/omnigent/onboarding/hermes_auth.py
+++ b/omnigent/onboarding/hermes_auth.py
@@ -80,7 +80,7 @@ class HermesConfigSummary:
         return self.provider or self.model or "Configured"
 
 
-def _model_section() -> dict:
+def _model_section() -> dict[str, object]:
     """Return the ``model`` mapping from ``~/.hermes/config.yaml`` (best-effort).
 
     Returns ``{}`` on a missing file, parse failure, or a non-mapping top-level
@@ -97,7 +97,9 @@ def _model_section() -> dict:
     if not isinstance(data, dict):
         return {}
     model = data.get("model")
-    return model if isinstance(model, dict) else {}
+    if not isinstance(model, dict):
+        return {}
+    return {key: value for key, value in model.items() if isinstance(key, str)}
 
 
 def hermes_config_summary() -> HermesConfigSummary:

--- a/tests/onboarding/test_hermes_auth.py
+++ b/tests/onboarding/test_hermes_auth.py
@@ -75,6 +75,19 @@ def test_summary_accepts_model_alternate_key(tmp_path: Path, monkeypatch) -> Non
     assert summary.describe() == "openrouter / moonshot/kimi-k2"
 
 
+def test_summary_ignores_non_string_model_keys(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(hermes_auth, "hermes_cli_installed", lambda: True)
+    _write_config(
+        tmp_path,
+        {1: "irrelevant", "default": "z-ai/glm-5.2", "provider": "openrouter"},
+    )
+
+    summary = hermes_config_summary()
+    assert summary.provider == "openrouter"
+    assert summary.model == "z-ai/glm-5.2"
+
+
 def test_summary_missing_config_is_not_configured(tmp_path: Path, monkeypatch) -> None:
     """No ``~/.hermes/config.yaml`` at all → installed but not configured."""
     monkeypatch.setenv("HOME", str(tmp_path))


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Type the parsed Hermes `model` section as `dict[str, object]`.
- Validate the YAML mapping boundary by retaining only string keys instead of relying on an unparameterized dictionary.
- Cover mixed-key YAML input while preserving provider/model reporting behavior.

**ELI5:** Hermes configuration can contain arbitrary YAML keys; setup now hands the rest of the code only the string-keyed entries it understands.

```text
YAML object -> mapping check -> string-key filter -> Hermes summary
```

## Test Plan

- `.venv/bin/mypy --no-incremental omnigent` (target diagnostic removed; no `onboarding/hermes_auth.py` errors)
- `.venv/bin/pytest -q tests/onboarding/test_hermes_auth.py` (19 passed)
- `TMPDIR=/tmp SKIP=normalize-uv-lock-registry pre-commit run --all-files` (passed; lockfile normalization is outside this workstream)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new case verifies non-string YAML keys are ignored while provider and model values remain available; existing tests cover absent, malformed, scaffold, alternate-key, and configured states.
