### PR TITLE
refactor: narrow executor usage span

### DIFF
--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -428,7 +428,7 @@ class ExecutorAdapter(HarnessApp):
                                 _active_tool_parent = None
                         elif isinstance(event, TurnComplete):
                             response_text = event.response
-                            if event.usage is not None:
+                            if event.usage is not None and agent_span is not None:
                                 from omnigent.runtime.telemetry import record_llm_usage
 
                                 # Record usage on the agent span for


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Require a concrete agent span before recording `TurnComplete` usage telemetry.
- Align usage recording with the existing cancellation and span-finalization guards, removing the nullable-span mypy error.

**ELI5:** Usage data is now attached only after confirming the trace span it belongs to exists.

```text
TurnComplete usage + active agent span -> record telemetry
```

## Test Plan

- `.venv/bin/mypy --no-incremental omnigent` (target diagnostic removed; no `_executor_adapter.py` errors)
- `.venv/bin/pytest -q tests/runtime/harnesses/test_executor_adapter.py` (37 passed)
- `TMPDIR=/tmp SKIP=normalize-uv-lock-registry pre-commit run --all-files` (passed; lockfile normalization is outside this workstream)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing executor-adapter tests cover turn completion, cancellation, executor errors, tool events, request translation, and adapter configuration across 37 cases.
