### PR TITLE
refactor: type Antigravity MCP config

### DIFF
--- a/omnigent/antigravity_native_bridge.py
+++ b/omnigent/antigravity_native_bridge.py
@@ -15,7 +15,6 @@ import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 _logger = logging.getLogger(__name__)
 
@@ -369,7 +368,7 @@ def build_mcp_config(
     bridge_dir: Path,
     *,
     python_executable: str | None = None,
-) -> dict[str, Any]:
+) -> dict[str, object]:
     """Build agy's ``mcp_config.json`` payload for the Omnigent relay server.
 
     Mirrors cursor #742's :func:`omnigent.cursor_native_bridge.build_mcp_config`


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Type the Antigravity MCP configuration builder as a string-keyed JSON object.
- Remove the file's final explicit `Any` and its now-unused import without changing the emitted relay configuration.

**ELI5:** The bridge now tells type-checkers that its MCP configuration is a normal JSON object instead of an unknown dictionary.

```text
bridge paths + environment -> dict[str, object] -> mcp_config.json
```

## Test Plan

- `.venv/bin/mypy --no-incremental omnigent` (target diagnostic removed; no `antigravity_native_bridge.py` errors)
- `.venv/bin/pytest -q tests/test_antigravity_native_bridge.py -k 'mcp_config'` (4 passed)
- `TMPDIR=/tmp SKIP=normalize-uv-lock-registry pre-commit run --all-files` (passed; lockfile normalization is outside this workstream)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing MCP-config tests cover the relay command, arguments, enabled tools, environment pinning, default interpreter, and isolated config target.
