### PR TITLE
refactor: type Goose tmux payload

### DIFF
--- a/omnigent/goose_native_bridge.py
+++ b/omnigent/goose_native_bridge.py
@@ -23,7 +23,6 @@ import subprocess
 import tempfile
 import time
 from pathlib import Path
-from typing import Any
 
 from omnigent._platform import stable_user_id
 
@@ -109,7 +108,7 @@ def write_tmux_target(
 ) -> None:
     """Advertise the tmux socket + target for the running Goose terminal."""
     _ensure_dir(bridge_dir)
-    payload: dict[str, Any] = {
+    payload: dict[str, object] = {
         "socket_path": str(socket_path),
         "tmux_target": tmux_target,
         "updated_at": time.time(),


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Type Goose's tmux advertisement record as a string-keyed JSON object.
- Remove the bridge module's final explicit `Any` and unused import without changing the persisted payload.

**ELI5:** The bridge now describes its small tmux JSON record using normal JSON value types instead of an unknown dictionary.

```text
socket + target + timestamp + optional PID -> dict[str, object] -> tmux.json
```

## Test Plan

- `.venv/bin/mypy --no-incremental omnigent` (target diagnostic removed; no `goose_native_bridge.py` errors)
- `.venv/bin/pytest -q tests/runtime/test_goose_spawn_env.py` (3 passed)
- Direct `write_tmux_target` / `read_tmux_info` round-trip including optional PID (passed)
- `TMPDIR=/tmp SKIP=normalize-uv-lock-registry pre-commit run --all-files` (passed; lockfile normalization is outside this workstream)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The direct round-trip verified the persisted socket, target, and optional PID; existing spawn-env tests cover bridge-directory creation and Goose environment overrides.
