### PR TITLE
refactor: type native shell terminals

### DIFF
--- a/omnigent/native_coding_agents.py
+++ b/omnigent/native_coding_agents.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from omnigent._platform import installed_interactive_shells
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.harness_plugins import (
@@ -93,7 +91,7 @@ def native_coding_agent_for_terminal_name(name: str | None) -> NativeCodingAgent
     return _BY_TERMINAL_NAME.get(name or "")
 
 
-def native_shell_terminal_spec() -> dict[str, Any]:
+def native_shell_terminal_spec() -> dict[str, dict[str, object]]:
     """The user-shell terminals every native wrapper declares.
 
     Native sessions expose the web UI's "+ New shell" affordance, which lets a


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Type native-wrapper shell declarations as a mapping from shell names to terminal configuration objects.
- Remove the registry module's final explicit `Any` and unused import without changing generated agent specs.

**ELI5:** Each installed shell now has a clearly typed terminal-settings object instead of an unknown nested dictionary.

```text
installed shells -> dict[shell name, terminal config]
```

## Test Plan

- `.venv/bin/mypy --no-incremental omnigent` (target diagnostic removed; no `native_coding_agents.py` errors)
- `.venv/bin/pytest -q tests/test_native_coding_agents.py` (9 passed)
- `TMPDIR=/tmp SKIP=normalize-uv-lock-registry pre-commit run --all-files` (passed; lockfile normalization is outside this workstream)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing registry tests cover canonical and aliased harness lookup, wrapper-name presentation, shell ordering, and generated terminal configuration across nine cases.
