### PR TITLE
refactor: type native prompt builder

### DIFF
--- a/omnigent/native_server_harness.py
+++ b/omnigent/native_server_harness.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
-from typing import Any
 
 from omnigent.inner.executor import (
     EnqueuedContent,
@@ -39,7 +38,7 @@ _logger = logging.getLogger(__name__)
 # Resolve the native session id from bridge state (``None`` until ready).
 SessionResolver = Callable[[], Awaitable[str | None]]
 # Build a :class:`NativePrompt` from message content.
-PromptBuilder = Callable[[Any], NativePrompt | None]
+PromptBuilder = Callable[[EnqueuedContent], NativePrompt | None]
 
 
 class NativeServerHarness(Executor):


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Reuse the executor layer's `EnqueuedContent` alias for native prompt-builder inputs.
- Remove the harness module's duplicate explicit `Any` and unused import while preserving arbitrary text/structured user payload support.

**ELI5:** Native prompt builders now use the shared name for user-supplied content instead of declaring another unknown type locally.

```text
Message content / queued content -> EnqueuedContent -> NativePrompt
```

## Test Plan

- `.venv/bin/mypy --no-incremental omnigent` (target diagnostic removed; no `native_server_harness.py` errors)
- `.venv/bin/pytest -q tests/test_native_server_harness.py` (14 passed)
- `TMPDIR=/tmp SKIP=normalize-uv-lock-registry pre-commit run --all-files` (passed; lockfile normalization is outside this workstream)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing harness tests cover prompt construction, model overrides, bridge polling, interruption, enqueue behavior, transport errors, and capability reporting across 14 cases.
