### PR TITLE
refactor: narrow Antigravity response text

### DIFF
--- a/omnigent/antigravity_native_steps.py
+++ b/omnigent/antigravity_native_steps.py
@@ -996,14 +996,20 @@ def map_step_to_events(
             # response when present.  Both fields appear in live fixtures and
             # are equal when no moderation has occurred.
             modified = planner.get("modifiedResponse")
-            text = modified if isinstance(modified, str) and modified else response_text
-            if isinstance(text, str) and text:
+            planner_text = (
+                modified
+                if isinstance(modified, str) and modified
+                else response_text
+                if isinstance(response_text, str)
+                else None
+            )
+            if planner_text:
                 # ONE message event — NO delta (the double-render fix).
                 events.append(
                     _message_event(
                         conversation_id=conversation_id,
                         step_idx=step_idx,
-                        text=text,
+                        text=planner_text,
                     )
                 )
             tool_calls = planner.get("toolCalls")


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Separate planner-response text from the earlier user-message local in the step mapper.
- Narrow both `modifiedResponse` and fallback `response` to concrete strings before emitting an assistant message.

**ELI5:** Antigravity can return dynamic response fields; the mapper now confirms the chosen field is text before treating it as a message.

```text
modifiedResponse (preferred) / response (fallback) -> string check -> message event
```

## Test Plan

- `.venv/bin/mypy --no-incremental omnigent` (target diagnostic removed; no `antigravity_native_steps.py` errors)
- `.venv/bin/pytest -q tests/test_antigravity_native_steps.py` (87 passed)
- `TMPDIR=/tmp SKIP=normalize-uv-lock-registry pre-commit run --all-files` (passed; lockfile normalization is outside this workstream)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing step-mapper tests cover modified-response precedence, response fallback, empty/malformed fields, committed messages, tool calls, errors, and pending interactions across 87 cases.
