### PR TITLE
refactor: narrow server app router contracts

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2389,6 +2389,11 @@ def create_app(
                 prefix="/auth",
                 tags=["auth"],
             )
+        else:
+            _logger.debug(
+                "Skipping built-in auth routes for custom provider %s",
+                type(auth_provider).__name__,
+            )
 
         # Device Authorization Grant (RFC 8628): opt-in, default-off via
         # OMNIGENT_DEVICE_GRANT_ENABLED, and accounts-mode only. OIDC delegates

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2359,7 +2359,7 @@ def create_app(
                 prefix="/auth",
                 tags=["auth"],
             )
-        else:
+        elif isinstance(auth_provider, UnifiedAuthProvider):
             from omnigent.server.routes.auth import create_auth_router
 
             # OIDC invites are opt-in (OMNIGENT_OIDC_ALLOW_INVITES) and
@@ -2451,7 +2451,7 @@ def create_app(
     all_extra_routers = list(extra_routers or [])
     all_extra_routers.extend(_load_debug_routers(debug_router_modules))
     for router, prefix, tags in all_extra_routers:
-        app.include_router(router, prefix=prefix, tags=tags)
+        app.include_router(router, prefix=prefix, tags=[*tags])
 
     web_ui_dist = _WEB_UI_DIST
     web_ui_present = web_ui_dist.is_dir() and (web_ui_dist / "index.html").is_file()

--- a/tests/server/integration/test_app.py
+++ b/tests/server/integration/test_app.py
@@ -317,6 +317,7 @@ async def test_custom_auth_provider_skips_unified_login_routes(
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get("/v1/me")
 
+    assert response.status_code == 200
     assert response.json() == {"user_id": "custom@example.com", "is_admin": False}
 
 

--- a/tests/server/integration/test_app.py
+++ b/tests/server/integration/test_app.py
@@ -6,9 +6,11 @@ from pathlib import Path
 
 import httpx
 import pytest
+from starlette.requests import HTTPConnection
 
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.server import app as app_module
+from omnigent.server.auth import AuthProvider
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 from omnigent.stores.artifact_store.local import LocalArtifactStore
 from omnigent.stores.conversation_store.sqlalchemy_store import (
@@ -283,6 +285,37 @@ async def test_me_header_mode_behaviors(
     # Reserved name is rejected (returns None → route returns null).
     assert reserved.status_code == 200
     assert reserved.json() == {"user_id": None, "is_admin": False}
+
+
+async def test_custom_auth_provider_skips_unified_login_routes(
+    runtime_init: None,
+    db_uri: str,
+    tmp_path: Path,
+) -> None:
+    class _CustomAuthProvider(AuthProvider):
+        def get_user_id(self, request: HTTPConnection) -> str | None:
+            return "custom@example.com"
+
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    app = app_module.create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(
+            artifact_store=artifact_store,
+            cache_dir=tmp_path / "cache",
+        ),
+        permission_store=SqlAlchemyPermissionStore(db_uri),
+        auth_provider=_CustomAuthProvider(),
+    )
+
+    assert "/auth/login" not in {route.path for route in app.routes if hasattr(route, "path")}
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/v1/me")
+
+    assert response.json() == {"user_id": "custom@example.com", "is_admin": False}
 
 
 async def test_me_is_admin_honors_admin_list_before_db_promotion(

--- a/tests/server/integration/test_app.py
+++ b/tests/server/integration/test_app.py
@@ -293,6 +293,8 @@ async def test_custom_auth_provider_skips_unified_login_routes(
     tmp_path: Path,
 ) -> None:
     class _CustomAuthProvider(AuthProvider):
+        login_url = "/custom/login"
+
         def get_user_id(self, request: HTTPConnection) -> str | None:
             return "custom@example.com"
 


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Mount Unified-only login routes only when `auth_provider` is a `UnifiedAuthProvider`; custom providers continue powering protected routes without being passed to an incompatible router factory.
- Rebuild injected router tags at FastAPI's accepted tag boundary, removing the remaining list-invariance diagnostic.
- Add a regression proving a custom provider boots, serves `/v1/me`, and does not mount Unified login routes.

**ELI5:** The server now sends each router the exact provider and tag shapes it supports instead of relying on broader values that only happened to work in common configurations.

```text
Unified provider -> /auth routes
Custom provider  -> protected API only
string tags      -> FastAPI tag list
```

## Test Plan

- `.venv/bin/mypy --no-incremental omnigent` (both target diagnostics removed; no `server/app.py` errors)
- `.venv/bin/pytest -q tests/server/integration/test_app.py::test_custom_auth_provider_skips_unified_login_routes tests/server/integration/test_app.py::test_me_header_mode_behaviors tests/server/integration/test_oidc_auth_e2e.py tests/server/test_app.py -k 'custom_auth_provider or me_header_mode or auth or debug_router'` (18 passed)
- `TMPDIR=/tmp SKIP=normalize-uv-lock-registry pre-commit run --all-files` (passed; lockfile normalization is outside this workstream)

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new integration case covers custom-provider startup and identity routing; existing app, OIDC, and debug-router tests cover Unified auth and injected-router behavior.
