### PR TITLE
refactor: isolate psutil typing boundaries

### DIFF
--- a/omnigent/host/local_server.py
+++ b/omnigent/host/local_server.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import click
-import psutil
+import psutil  # type: ignore[import-untyped]
 
 from omnigent.config import global_config_path
 from omnigent.inner import _proc

--- a/omnigent/server/performance_metrics.py
+++ b/omnigent/server/performance_metrics.py
@@ -1161,6 +1161,6 @@ def _current_rss_bytes() -> int:
             return int(usage.ru_maxrss)
         return int(usage.ru_maxrss) * 1024
 
-    import psutil
+    import psutil  # type: ignore[import-untyped]
 
     return int(psutil.Process().memory_info().rss)


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Mark the two `psutil` imports as precise third-party `import-untyped` boundaries.
- Remove both remaining diagnostics from local-server liveness and Windows RSS fallback code without adding stub dependencies or touching `uv.lock`.

**ELI5:** Omnigent still uses `psutil` normally at runtime; mypy now knows these two imports are the exact places where the library's missing typing metadata enters the codebase.

```text
untyped psutil package -> two documented import boundaries -> typed Omnigent code
```

## Test Plan

- `.venv/bin/mypy --no-incremental omnigent` (both target diagnostics removed; no `local_server.py` or `performance_metrics.py` errors)
- `.venv/bin/pytest -q tests/host/test_local_server.py tests/server/test_performance_metrics.py` (51 passed)
- `TMPDIR=/tmp SKIP=normalize-uv-lock-registry pre-commit run --all-files` (passed; lockfile normalization is outside this workstream)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing tests cover local-server process liveness and lifecycle plus HTTP, WebSocket, logging, and process-memory metrics across 51 cases.
