### PR TITLE
refactor: type resume picker boundaries

### DIFF
--- a/omnigent/repl/_resume_picker.py
+++ b/omnigent/repl/_resume_picker.py
@@ -26,10 +26,22 @@ from __future__ import annotations
 import asyncio
 import sys
 import time
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import IO, Any, Protocol
+from typing import TYPE_CHECKING, Protocol, TextIO
+
+if TYPE_CHECKING:
+    from omnigent_client import OmnigentClient
+    from prompt_toolkit.key_binding import KeyBindings
+    from prompt_toolkit.key_binding.key_processor import KeyPressEvent
+    from prompt_toolkit.styles import Style
+    from rich.console import Console
+    from rich.text import Text
+
+    from omnigent.entities.conversation import ConversationItem
+    from omnigent.stores.conversation_store import ConversationStore
 
 from omnigent._terminal_picker_theme import (
     PICKER_ACCENT as _ACCENT,
@@ -126,7 +138,7 @@ class _PageRowRender:
     :param lines: Rich-renderable lines printed for one conversation.
     """
 
-    lines: list[Any]
+    lines: list[Text]
 
 
 class _ConversationRow(Protocol):
@@ -155,10 +167,22 @@ class _ConversationRow(Protocol):
         "no wrapper" and falls through to ``[chat]``.
     """
 
-    id: str
-    title: str | None
-    created_at: int
-    labels: dict[str, str] | None
+    @property
+    def id(self) -> str: ...
+
+    @property
+    def title(self) -> str | None: ...
+
+    @property
+    def created_at(self) -> int: ...
+
+    @property
+    def labels(self) -> Mapping[str, str] | None: ...
+
+
+class _LaunchState(Protocol):
+    @property
+    def working_directory(self) -> str: ...
 
 
 def _runtime_badge(row: _ConversationRow) -> str:
@@ -193,14 +217,14 @@ def _runtime_badge(row: _ConversationRow) -> str:
 
 
 def pick_conversation(
-    conversations: list[_ConversationRow],
+    conversations: Sequence[_ConversationRow],
     *,
     agent_name: str,
     previews: dict[str, _Preview | None] | None = None,
     show_runtime: bool = False,
     show_workspace: bool = False,
-    out: IO[str] | None = None,
-    in_: IO[str] | None = None,
+    out: TextIO | None = None,
+    in_: TextIO | None = None,
 ) -> str | None:
     """
     Run the interactive picker over a pre-fetched conversation list.
@@ -248,8 +272,8 @@ def pick_conversation(
     :returns: The selected ``conversation_id``, or ``None`` when
         the user cancels (q / Esc / EOF).
     """
-    out_stream: IO[str] = out if out is not None else sys.stderr
-    in_stream: IO[str] = in_ if in_ is not None else sys.stdin
+    out_stream: TextIO = out if out is not None else sys.stderr
+    in_stream: TextIO = in_ if in_ is not None else sys.stdin
 
     if not conversations:
         _print_empty(agent_name, out_stream)
@@ -277,14 +301,14 @@ def pick_conversation(
 
 
 def _pick_conversation_line_buffered(
-    conversations: list[_ConversationRow],
+    conversations: Sequence[_ConversationRow],
     *,
     agent_name: str,
     previews: dict[str, _Preview | None] | None,
     show_runtime: bool,
     show_workspace: bool,
-    out: IO[str],
-    in_: IO[str],
+    out: TextIO,
+    in_: TextIO,
 ) -> str | None:
     """
     Run the resume picker with line-buffered input.
@@ -378,7 +402,7 @@ class _PromptToolkitPickerState:
     :param selected_index: Zero-based selected conversation index.
     """
 
-    conversations: list[_ConversationRow]
+    conversations: Sequence[_ConversationRow]
     agent_name: str
     previews: dict[str, _Preview | None] | None
     show_runtime: bool
@@ -396,7 +420,7 @@ class _PromptToolkitPickerState:
         return _page_start_for_selection(self.selected_index)
 
     @property
-    def page(self) -> list[_ConversationRow]:
+    def page(self) -> Sequence[_ConversationRow]:
         """
         Visible conversation slice for the current selection.
 
@@ -443,14 +467,14 @@ class _PromptToolkitPickerState:
 
 
 def _pick_conversation_prompt_toolkit(
-    conversations: list[_ConversationRow],
+    conversations: Sequence[_ConversationRow],
     *,
     agent_name: str,
     previews: dict[str, _Preview | None] | None,
     show_runtime: bool,
     show_workspace: bool,
-    out: IO[str],
-    in_: IO[str],
+    out: TextIO,
+    in_: TextIO,
 ) -> str | None:
     """
     Run the interactive TTY picker using prompt-toolkit.
@@ -524,7 +548,7 @@ def _has_running_event_loop() -> bool:
     return True
 
 
-def _prompt_toolkit_key_bindings(state: _PromptToolkitPickerState) -> Any:
+def _prompt_toolkit_key_bindings(state: _PromptToolkitPickerState) -> KeyBindings:
     """
     Build keybindings for the prompt-toolkit picker.
 
@@ -537,7 +561,7 @@ def _prompt_toolkit_key_bindings(state: _PromptToolkitPickerState) -> Any:
     key_bindings = KeyBindings()
 
     @key_bindings.add("up")
-    def _move_up(event: Any) -> None:
+    def _move_up(event: KeyPressEvent) -> None:
         """
         Move the picker selection one row upward.
 
@@ -548,7 +572,7 @@ def _prompt_toolkit_key_bindings(state: _PromptToolkitPickerState) -> Any:
         event.app.invalidate()
 
     @key_bindings.add("down")
-    def _move_down(event: Any) -> None:
+    def _move_down(event: KeyPressEvent) -> None:
         """
         Move the picker selection one row downward.
 
@@ -560,7 +584,7 @@ def _prompt_toolkit_key_bindings(state: _PromptToolkitPickerState) -> Any:
 
     @key_bindings.add("n")
     @key_bindings.add("right")
-    def _next_page(event: Any) -> None:
+    def _next_page(event: KeyPressEvent) -> None:
         """
         Move the picker selection to the next page.
 
@@ -572,7 +596,7 @@ def _prompt_toolkit_key_bindings(state: _PromptToolkitPickerState) -> Any:
 
     @key_bindings.add("p")
     @key_bindings.add("left")
-    def _previous_page(event: Any) -> None:
+    def _previous_page(event: KeyPressEvent) -> None:
         """
         Move the picker selection to the previous page.
 
@@ -583,7 +607,7 @@ def _prompt_toolkit_key_bindings(state: _PromptToolkitPickerState) -> Any:
         event.app.invalidate()
 
     @key_bindings.add("enter")
-    def _select(event: Any) -> None:
+    def _select(event: KeyPressEvent) -> None:
         """
         Resume the currently highlighted conversation.
 
@@ -595,7 +619,7 @@ def _prompt_toolkit_key_bindings(state: _PromptToolkitPickerState) -> Any:
     @key_bindings.add("q")
     @key_bindings.add("escape")
     @key_bindings.add("c-d")
-    def _cancel(event: Any) -> None:
+    def _cancel(event: KeyPressEvent) -> None:
         """
         Cancel the picker without selecting a conversation.
 
@@ -605,7 +629,7 @@ def _prompt_toolkit_key_bindings(state: _PromptToolkitPickerState) -> Any:
         event.app.exit(result=None)
 
     @key_bindings.add("c-c")
-    def _interrupt(event: Any) -> None:
+    def _interrupt(event: KeyPressEvent) -> None:
         """
         Propagate Ctrl+C as :class:`KeyboardInterrupt`.
 
@@ -617,7 +641,7 @@ def _prompt_toolkit_key_bindings(state: _PromptToolkitPickerState) -> Any:
     return key_bindings
 
 
-def _prompt_toolkit_style() -> Any:
+def _prompt_toolkit_style() -> Style:
     """
     Build prompt-toolkit style classes for the picker.
 
@@ -874,14 +898,13 @@ def _page_start_for_selection(selected_index: int) -> int:
 
 
 async def pick_conversation_from_sdk(
-    # ``Any`` to avoid coupling the repl package to the client's load order.
-    client: Any,
+    client: OmnigentClient,
     *,
     agent_name: str,
     agent_id: str | None = None,
     agent_name_filter: str | None = None,
-    out: IO[str] | None = None,
-    in_: IO[str] | None = None,
+    out: TextIO | None = None,
+    in_: TextIO | None = None,
 ) -> str | None:
     """Fetch sessions via ``/v1/sessions`` and run the picker.
 
@@ -905,12 +928,12 @@ async def pick_conversation_from_sdk(
 
 
 async def pick_conversation_by_wrapper_label_from_sdk(
-    client: Any,
+    client: OmnigentClient,
     *,
     wrapper_value: str,
     agent_name: str,
-    out: IO[str] | None = None,
-    in_: IO[str] | None = None,
+    out: TextIO | None = None,
+    in_: TextIO | None = None,
 ) -> str | None:
     """Picker scoped to one wrapper kind (``omnigent.wrapper=<value>``).
 
@@ -945,10 +968,10 @@ async def pick_conversation_by_wrapper_label_from_sdk(
 
 
 async def pick_conversation_cross_agent_from_sdk(
-    client: Any,
+    client: OmnigentClient,
     *,
-    out: IO[str] | None = None,
-    in_: IO[str] | None = None,
+    out: TextIO | None = None,
+    in_: TextIO | None = None,
 ) -> str | None:
     """Cross-agent variant: lists every session the caller can see
     via ``/v1/sessions`` and renders runtime metadata for
@@ -970,17 +993,11 @@ async def pick_conversation_cross_agent_from_sdk(
 
 
 def pick_conversation_from_store(
-    # ``Any`` rather than the concrete store types so the picker
-    # stays decoupled from the SqlAlchemy implementations — only
-    # the ``ConversationStore`` abstract methods used here
-    # (``list_conversations``) actually matter, and importing the
-    # abstract base here would still add a non-trivial dependency
-    # surface for a typing-only win.
-    conv_store: Any,
+    conv_store: ConversationStore,
     *,
     agent_name: str,
-    out: IO[str] | None = None,
-    in_: IO[str] | None = None,
+    out: TextIO | None = None,
+    in_: TextIO | None = None,
 ) -> str | None:
     """
     Sync sibling for the one-shot ``-p`` path. Lists conversations
@@ -1000,7 +1017,7 @@ def pick_conversation_from_store(
     :returns: Selected conversation_id, or ``None`` on cancel /
         empty list / unknown agent.
     """
-    out_stream: IO[str] = out if out is not None else sys.stderr
+    out_stream: TextIO = out if out is not None else sys.stderr
     page = conv_store.list_conversations(
         agent_name=agent_name,
         has_agent_id=True,
@@ -1019,12 +1036,12 @@ def pick_conversation_from_store(
 
 
 def _print_page(
-    page: list[_ConversationRow],
+    page: Sequence[_ConversationRow],
     page_start: int,
     selected_index: int,
     total: int,
     agent_name: str,
-    out: IO[str],
+    out: TextIO,
     previews: dict[str, _Preview | None] | None = None,
     *,
     show_runtime: bool = False,
@@ -1073,7 +1090,7 @@ def _page_header_text(
     page_len: int,
     total: int,
     agent_name: str,
-) -> Any:
+) -> Text:
     """
     Build the list header for one resume-picker page.
 
@@ -1135,7 +1152,7 @@ def _list_item_lines(
     return _PageRowRender(lines=lines)
 
 
-def _list_item_title(conv: _ConversationRow, *, absolute_index: int, selected: bool) -> Any:
+def _list_item_title(conv: _ConversationRow, *, absolute_index: int, selected: bool) -> Text:
     """
     Build the primary title line for a resume-picker list item.
 
@@ -1166,7 +1183,7 @@ def _list_item_metadata(
     show_runtime: bool,
     show_workspace: bool,
     current_cwd: Path | None,
-) -> Any:
+) -> Text:
     """
     Build the metadata line for a resume-picker list item.
 
@@ -1196,7 +1213,7 @@ def _list_item_metadata(
     return text
 
 
-def _list_item_preview(preview: _Preview | None) -> Any:
+def _list_item_preview(preview: _Preview | None) -> Text:
     """
     Build the preview line for a resume-picker list item.
 
@@ -1209,7 +1226,7 @@ def _list_item_preview(preview: _Preview | None) -> Any:
     return Text("    ") + text
 
 
-def _print_list_item(console: Any, rendered: _PageRowRender, *, is_last: bool) -> None:
+def _print_list_item(console: Console, rendered: _PageRowRender, *, is_last: bool) -> None:
     """
     Print one rendered resume-picker list item.
 
@@ -1223,7 +1240,7 @@ def _print_list_item(console: Any, rendered: _PageRowRender, *, is_last: bool) -
         console.print()
 
 
-def _print_page_footer(console: Any) -> None:
+def _print_page_footer(console: Console) -> None:
     """
     Print the resume-picker keybinding footer and trailing spacer.
 
@@ -1246,7 +1263,7 @@ def _print_page_footer(console: Any) -> None:
     console.print()
 
 
-def _print_empty(agent_name: str, out: IO[str]) -> None:
+def _print_empty(agent_name: str, out: TextIO) -> None:
     """
     Render the "no prior conversations" notice.
 
@@ -1269,7 +1286,7 @@ def _print_empty(agent_name: str, out: IO[str]) -> None:
     )
 
 
-def _print_invalid(out: IO[str]) -> None:
+def _print_invalid(out: TextIO) -> None:
     """
     Render the "invalid selection" notice between picker re-prompts.
 
@@ -1284,7 +1301,7 @@ def _print_invalid(out: IO[str]) -> None:
     console.print(Text.from_markup(f"  [{_ACCENT}]Invalid selection.[/]  [{_MUTED}]Try again.[/]"))
 
 
-def _make_console(out: IO[str]) -> Any:
+def _make_console(out: TextIO) -> Console:
     """
     Build a :class:`rich.console.Console` aimed at *out*.
 
@@ -1304,7 +1321,7 @@ def _make_console(out: IO[str]) -> Any:
     return Console(file=out, highlight=False, soft_wrap=True)
 
 
-def _render_preview_cell(preview: _Preview | None) -> Any:
+def _render_preview_cell(preview: _Preview | None) -> Text:
     """
     Render a :class:`_Preview` as a list-item preview line.
 
@@ -1329,7 +1346,7 @@ def _render_preview_cell(preview: _Preview | None) -> Any:
     )
 
 
-def _render_workspace_cell(row: _ConversationRow, *, current_cwd: Path) -> Any | None:
+def _render_workspace_cell(row: _ConversationRow, *, current_cwd: Path) -> Text | None:
     """
     Render the workspace metadata value for one picker row.
 
@@ -1398,7 +1415,7 @@ def _workspace_metadata(row: _ConversationRow, *, current_cwd: Path) -> tuple[st
     return working_directory, recorded != current_cwd
 
 
-def _launch_state_for_row(row: _ConversationRow) -> Any | None:
+def _launch_state_for_row(row: _ConversationRow) -> _LaunchState | None:
     """
     Read native launch state using the row's wrapper label.
 
@@ -1434,8 +1451,8 @@ def _escape_for_markup(text: str) -> str:
 
 
 async def _collect_previews_async(
-    client: Any,
-    conversations: list[_ConversationRow],
+    client: OmnigentClient,
+    conversations: Sequence[_ConversationRow],
 ) -> dict[str, _Preview | None]:
     """
     Fetch the latest message for each conversation in parallel.
@@ -1474,8 +1491,8 @@ async def _collect_previews_async(
 
 
 def _collect_previews_sync(
-    conv_store: Any,
-    conversations: list[_ConversationRow],
+    conv_store: ConversationStore,
+    conversations: Sequence[_ConversationRow],
 ) -> dict[str, _Preview | None]:
     """
     Sync sibling for the one-shot ``-p`` path.
@@ -1507,7 +1524,7 @@ def _collect_previews_sync(
 
 
 def _last_message_preview_from_dicts(
-    items: list[dict[str, Any]],
+    items: Sequence[object],
 ) -> _Preview | None:
     """
     Extract the latest message preview from API-shape item dicts.
@@ -1525,7 +1542,7 @@ def _last_message_preview_from_dicts(
         conversation has only tool calls, or is empty).
     """
     for item in items:
-        if not isinstance(item, dict):
+        if not isinstance(item, Mapping):
             continue
         if item.get("type") != "message":
             continue
@@ -1540,7 +1557,7 @@ def _last_message_preview_from_dicts(
     return None
 
 
-def _last_message_preview_from_entities(items: list[Any]) -> _Preview | None:
+def _last_message_preview_from_entities(items: Sequence[ConversationItem]) -> _Preview | None:
     """
     Extract the latest message preview from store entity items.
 
@@ -1570,7 +1587,7 @@ def _last_message_preview_from_entities(items: list[Any]) -> _Preview | None:
     return None
 
 
-def _extract_text_from_content_blocks(content: Any) -> str:
+def _extract_text_from_content_blocks(content: object) -> str:
     """
     Reduce a Responses-API message ``content`` to one preview line.
 
@@ -1645,7 +1662,7 @@ def _format_when(created_at: int) -> str:
     return datetime.fromtimestamp(created_at).strftime("%b %d %H:%M")
 
 
-def _read_line_choice(in_: IO[str]) -> str | None:
+def _read_line_choice(in_: TextIO) -> str | None:
     """
     Read one line-buffered picker choice.
 
@@ -1663,7 +1680,7 @@ def _read_line_choice(in_: IO[str]) -> str | None:
     return _SELECT_TOKEN if choice == "" else choice
 
 
-def _is_tty(in_: IO[str]) -> bool:
+def _is_tty(in_: TextIO) -> bool:
     """
     Predicate: is *in_* an interactive terminal?
 

--- a/omnigent/repl/_resume_picker.py
+++ b/omnigent/repl/_resume_picker.py
@@ -207,7 +207,7 @@ def _runtime_badge(row: _ConversationRow) -> str:
         without raising.
     """
     labels = getattr(row, "labels", None)
-    if isinstance(labels, dict):
+    if isinstance(labels, Mapping):
         native_agent = native_coding_agent_for_wrapper_label(
             labels.get(_CLAUDE_NATIVE_WRAPPER_LABEL_KEY)
         )
@@ -1424,7 +1424,7 @@ def _launch_state_for_row(row: _ConversationRow) -> _LaunchState | None:
         or ``None`` when the row has no supported wrapper state.
     """
     labels = getattr(row, "labels", None)
-    if not isinstance(labels, dict):
+    if not isinstance(labels, Mapping):
         return None
     wrapper = labels.get(_CLAUDE_NATIVE_WRAPPER_LABEL_KEY)
     if wrapper == _CLAUDE_NATIVE_WRAPPER_LABEL_VALUE:

--- a/tests/repl/test_resume_picker.py
+++ b/tests/repl/test_resume_picker.py
@@ -24,9 +24,11 @@ Three layers:
 from __future__ import annotations
 
 import io
+from collections.abc import Mapping
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
+from types import MappingProxyType, SimpleNamespace
 
 import pytest
 
@@ -839,7 +841,7 @@ class _BadgeRow:
     id: str = "e1f7c651c9f97fac088ea70ef633409d"
     title: str | None = "test"
     created_at: int = 0
-    labels: dict[str, str] | None = None
+    labels: Mapping[str, str] | None = None
 
 
 def test_runtime_badge_claude_native() -> None:
@@ -867,6 +869,22 @@ def test_runtime_badge_codex_native() -> None:
     assert _runtime_badge(row) == "[codex]"
 
 
+def test_read_only_mapping_labels_drive_badge_and_launch_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All Mapping implementations follow the same wrapper-label paths."""
+    from omnigent.repl import _resume_picker
+
+    state = SimpleNamespace(working_directory="/tmp/workspace")
+    monkeypatch.setattr(_resume_picker, "_read_codex_launch_state", lambda _session_id: state)
+    row = _BadgeRow(
+        labels=MappingProxyType({"omnigent.wrapper": "codex-native-ui"}),
+    )
+
+    assert _resume_picker._runtime_badge(row) == "[codex]"
+    assert _resume_picker._launch_state_for_row(row) is state
+
+
 @pytest.mark.parametrize(
     "labels",
     [
@@ -878,7 +896,7 @@ def test_runtime_badge_codex_native() -> None:
         None,
     ],
 )
-def test_runtime_badge_non_claude_native(labels: dict[str, str] | None) -> None:
+def test_runtime_badge_non_claude_native(labels: Mapping[str, str] | None) -> None:
     """
     Everything that isn't explicitly claude-native renders as
     ``[chat]``. Covers the empty-labels case (no labels written


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- ELI5: the resume picker used generic “anything” labels for its UI toolkit, SDK, store, and render objects; this gives each object its real interface so mypy can verify how they are used.
- Type prompt-toolkit key events/styles, Rich render values, text streams, SDK/store clients, preview records, and native launch state.
- Use read-only row protocols and covariant sequences so both SDK session rows and persisted conversation rows satisfy the same picker contract, removing all 32 diagnostics from `omnigent/repl/_resume_picker.py`.

```text
SDK sessions / store rows -> read-only picker protocol -> Rich + prompt-toolkit UI
```

## Test Plan

- `pytest -q tests/repl/test_resume_picker.py tests/test_resume_dispatch.py tests/test_wrapper_labels.py` — 74 passed.
- `mypy --no-incremental omnigent` — 609 errors in 10 files on this branch versus 641 in 11 files on rebased `main`; no diagnostics remain in `omnigent/repl/_resume_picker.py`.
- `TMPDIR=/tmp SKIP=normalize-uv-lock-registry pre-commit run --files omnigent/repl/_resume_picker.py` — passed.

## Demo

N/A — non-visual type cleanup with unchanged picker behavior.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The dedicated picker suite covers line-buffered and prompt-toolkit interaction, SDK/store fetching, previews, runtime badges, workspace state, and resume dispatch.
