### PR TITLE
refactor: type Codex native boundaries

### DIFF
--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -2119,14 +2119,14 @@ def _codex_event_msg_record_for_message(
         return None
     content = payload.get("content", [])
     if not isinstance(content, list):
-        raise TypeError("Codex message content must be a list.")
+        return None
     text_parts: list[str] = []
     for block in content:
         if not isinstance(block, dict):
             continue
         block_text = block.get("text", "")
         if not isinstance(block_text, str):
-            raise TypeError("Codex message content text must be a string.")
+            raise click.ClickException("Codex message content text must be a string.")
         text_parts.append(block_text)
     text = " ".join(text_parts).strip()
     if not text:

--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -13,12 +13,12 @@ import shutil
 import socket
 import time
 import uuid
-from collections.abc import Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any
+from typing import TypeAlias
 
 import click
 import httpx
@@ -95,6 +95,8 @@ from omnigent.native_terminal import (
 )
 
 _logger = logging.getLogger(__name__)
+
+_JsonObject: TypeAlias = dict[str, object]
 
 _AGENT_NAME = "codex-native-ui"
 _DEFAULT_CODEX_COMMAND = "codex"
@@ -348,6 +350,13 @@ class PreparedCodexTerminal:
     reattached: bool
 
 
+def _require_codex_app_server_url(prepared: PreparedCodexTerminal) -> str:
+    """Return the prepared app-server URL or fail on inconsistent state."""
+    if prepared.app_server_url is None:
+        raise click.ClickException("Codex app-server transport was not initialized.")
+    return prepared.app_server_url
+
+
 def run_codex_native(
     *,
     server: str | None,
@@ -477,13 +486,16 @@ def _prompt_codex_resume_workspace_action(
     click.echo("Codex resume is workspace-scoped. Choose an action:", err=True)
     for option in options:
         click.echo(f"  {option.action:<6} - {option.label}", err=True)
-    return click.prompt(
+    action = click.prompt(
         "Resume action",
         type=click.Choice([option.action for option in options]),
         default=options[0].action,
         show_choices=True,
         err=True,
     )
+    if not isinstance(action, str):
+        raise click.ClickException("Codex resume action must be a string.")
+    return action
 
 
 def _codex_resume_workspace_action_options(
@@ -535,7 +547,7 @@ def _materialize_codex_agent_spec(
     executor: dict[str, str] = {"harness": "codex-native"}
     if model is not None:
         executor["model"] = model
-    raw: dict[str, Any] = {
+    raw: _JsonObject = {
         "name": _AGENT_NAME,
         "prompt": (
             "Codex is running in the session terminal. Web UI messages are "
@@ -861,7 +873,7 @@ async def _prepare_codex_terminal_via_daemon(
                     event_client=None,
                     reattached=True,
                 )
-            patch: dict[str, Any] = {}
+            patch: _JsonObject = {}
             if persist_args:
                 patch["terminal_launch_args"] = persist_args
             if model is not None:
@@ -1213,7 +1225,7 @@ async def _attach_with_forwarder(
     headers: dict[str, str],
     prepared: PreparedCodexTerminal,
     prompt: str | None,
-    recover: Any | None = None,
+    recover: Callable[[], Awaitable[None]] | None = None,
     auth: httpx.Auth | None = None,
 ) -> None:
     """
@@ -1255,7 +1267,7 @@ async def _attach_with_forwarder(
                     )
                     if prompt:
                         await _start_initial_turn(
-                            prepared.app_server_url,
+                            _require_codex_app_server_url(prepared),
                             prepared.thread_id,
                             prompt,
                         )
@@ -1275,7 +1287,11 @@ async def _attach_with_forwarder(
                     auth=auth,
                 )
                 if prompt:
-                    await _start_initial_turn(prepared.app_server_url, prepared.thread_id, prompt)
+                    await _start_initial_turn(
+                        _require_codex_app_server_url(prepared),
+                        prepared.thread_id,
+                        prompt,
+                    )
             await _attach_terminal_resource(
                 base_url=base_url,
                 headers=headers,
@@ -1320,13 +1336,14 @@ def _start_codex_forwarder(
     """
     if prepared.thread_id is None:
         raise click.ClickException("Codex thread id was not initialized.")
+    app_server_url = _require_codex_app_server_url(prepared)
     return asyncio.create_task(
         supervise_forwarder(
             base_url=base_url,
             headers=headers,
             session_id=prepared.session_id,
             bridge_dir=prepared.bridge_dir,
-            app_server_url=prepared.app_server_url,
+            app_server_url=app_server_url,
             thread_id=prepared.thread_id,
             client=prepared.event_client,
             auth=auth,
@@ -1358,6 +1375,7 @@ async def _initialize_fresh_terminal_thread(
     """
     if prepared.event_client is None:
         raise click.ClickException("Codex event listener was not initialized.")
+    app_server_url = _require_codex_app_server_url(prepared)
     thread_id = await _wait_for_thread_started(prepared.event_client)
     async with httpx.AsyncClient(
         base_url=base_url,
@@ -1369,7 +1387,7 @@ async def _initialize_fresh_terminal_thread(
         prepared.bridge_dir,
         CodexNativeBridgeState(
             session_id=prepared.session_id,
-            socket_path=prepared.app_server_url,
+            socket_path=app_server_url,
             thread_id=thread_id,
             codex_home=str(codex_home_for_bridge_dir(prepared.bridge_dir)),
         ),
@@ -1382,7 +1400,7 @@ async def _attach_terminal_resource(
     base_url: str,
     headers: dict[str, str],
     prepared: PreparedCodexTerminal,
-    recover: Any | None,
+    recover: Callable[[], Awaitable[None]] | None,
 ) -> None:
     """
     Attach the current terminal to the prepared Omnigent terminal resource.
@@ -1509,7 +1527,7 @@ async def _create_codex_session(
     labels = dict(_SESSION_LABELS)
     if bridge_id is not None:
         labels[CODEX_NATIVE_BRIDGE_ID_LABEL_KEY] = bridge_id
-    metadata = {
+    metadata: _JsonObject = {
         "labels": labels,
     }
     if terminal_launch_args:
@@ -1531,7 +1549,7 @@ async def _create_codex_session(
     return new_session_id
 
 
-async def _fetch_codex_session(client: httpx.AsyncClient, session_id: str) -> dict[str, Any]:
+async def _fetch_codex_session(client: httpx.AsyncClient, session_id: str) -> _JsonObject:
     """
     Fetch an existing Omnigent session.
 
@@ -1858,7 +1876,7 @@ def _codex_resume_rollout_path(codex_home: Path, external_session_id: str) -> Pa
 async def _fetch_all_session_items_for_codex_resume(
     client: httpx.AsyncClient,
     session_id: str,
-) -> list[dict[str, Any]]:
+) -> list[_JsonObject]:
     """
     Fetch committed Omnigent session items in chronological order.
 
@@ -1869,7 +1887,7 @@ async def _fetch_all_session_items_for_codex_resume(
     :raises click.ClickException: If an item page cannot be fetched or
         parsed.
     """
-    items: list[dict[str, Any]] = []
+    items: list[_JsonObject] = []
     after: str | None = None
     while True:
         params: dict[str, str | int] = {"limit": 1000, "order": "asc"}
@@ -1909,7 +1927,7 @@ async def _fetch_all_session_items_for_codex_resume(
 
 
 def _codex_rollout_records_from_session_items(
-    items: list[dict[str, Any]],
+    items: list[_JsonObject],
     *,
     session_id: str,
     external_session_id: str,
@@ -1917,7 +1935,7 @@ def _codex_rollout_records_from_session_items(
     model_provider: str,
     cli_version: str,
     terminal_launch_args: Sequence[str] | None = None,
-) -> list[dict[str, Any]]:
+) -> list[_JsonObject]:
     """
     Convert Omnigent session items into Codex rollout JSONL records.
 
@@ -1953,7 +1971,7 @@ def _codex_rollout_records_from_session_items(
     turn_context_policy_fields = _codex_turn_context_policy_fields_from_launch_args(
         terminal_launch_args
     )
-    records: list[dict[str, Any]] = [
+    records: list[_JsonObject] = [
         {
             "timestamp": timestamp,
             "type": "session_meta",
@@ -1978,17 +1996,18 @@ def _codex_rollout_records_from_session_items(
         if item.get("type") == "compaction":
             compacted_msgs = item.get("compacted_messages")
             if compacted_msgs:
-                compacted_record: dict[str, Any] = {
+                compacted_payload: _JsonObject = {
+                    "message": item.get("summary", ""),
+                    "replacement_history": compacted_msgs,
+                }
+                compacted_record: _JsonObject = {
                     "timestamp": timestamp,
                     "type": "compacted",
-                    "payload": {
-                        "message": item.get("summary", ""),
-                        "replacement_history": compacted_msgs,
-                    },
+                    "payload": compacted_payload,
                 }
                 w_id = item.get("window_id")
                 if w_id is not None:
-                    compacted_record["payload"]["window_id"] = w_id
+                    compacted_payload["window_id"] = w_id
                 # Replace all prior response_item records — the
                 # replacement_history is the new context baseline.
                 # Keep only session_meta and turn_context records.
@@ -2033,7 +2052,7 @@ def _codex_rollout_records_from_session_items(
 
 def _codex_turn_context_policy_fields_from_launch_args(
     terminal_launch_args: Sequence[str] | None,
-) -> dict[str, Any]:
+) -> _JsonObject:
     """Return rollout policy fields matching persisted Codex launch args."""
     approval_policy = "on-request"
     sandbox_mode: str | None = None
@@ -2067,17 +2086,17 @@ def _codex_turn_context_policy_fields_from_launch_args(
                 sandbox_mode = "danger-full-access"
             i += 1
         i += 1
-    fields: dict[str, Any] = {"approval_policy": approval_policy}
+    fields: _JsonObject = {"approval_policy": approval_policy}
     if sandbox_mode in {"read-only", "workspace-write", "danger-full-access"}:
         fields["sandbox_policy"] = {"type": sandbox_mode}
     return fields
 
 
 def _codex_event_msg_record_for_message(
-    payload: dict[str, Any],
+    payload: _JsonObject,
     *,
     timestamp: str,
-) -> dict[str, Any] | None:
+) -> _JsonObject | None:
     """
     Build the ``event_msg`` mirror record for a message ``response_item``.
 
@@ -2098,14 +2117,23 @@ def _codex_event_msg_record_for_message(
     """
     if payload.get("type") != "message":
         return None
-    text = " ".join(
-        block.get("text", "") for block in payload.get("content", []) if isinstance(block, dict)
-    ).strip()
+    content = payload.get("content", [])
+    if not isinstance(content, list):
+        raise TypeError("Codex message content must be a list.")
+    text_parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_text = block.get("text", "")
+        if not isinstance(block_text, str):
+            raise TypeError("Codex message content text must be a string.")
+        text_parts.append(block_text)
+    text = " ".join(text_parts).strip()
     if not text:
         return None
     role = payload.get("role")
     if role == "user":
-        event_payload: dict[str, Any] = {
+        event_payload: _JsonObject = {
             "type": "user_message",
             "message": text,
             "images": [],
@@ -2124,7 +2152,7 @@ def _codex_event_msg_record_for_message(
     return {"timestamp": timestamp, "type": "event_msg", "payload": event_payload}
 
 
-def _interrupted_response_ids_from_session_items(items: list[dict[str, Any]]) -> set[str]:
+def _interrupted_response_ids_from_session_items(items: list[_JsonObject]) -> set[str]:
     """
     Return response ids for Omnigent turns that ended interrupted.
 
@@ -2148,7 +2176,7 @@ def _interrupted_response_ids_from_session_items(items: list[dict[str, Any]]) ->
     return response_ids
 
 
-def _session_item_response_id(item: dict[str, Any]) -> str | None:
+def _session_item_response_id(item: _JsonObject) -> str | None:
     """
     Extract a non-empty Omnigent response id from a flat item.
 
@@ -2160,7 +2188,7 @@ def _session_item_response_id(item: dict[str, Any]) -> str | None:
     return response_id if isinstance(response_id, str) and response_id else None
 
 
-def _codex_response_item_from_session_item(item: dict[str, Any]) -> dict[str, Any] | None:
+def _codex_response_item_from_session_item(item: _JsonObject) -> _JsonObject | None:
     """
     Convert one Omnigent item into one Codex ``response_item`` payload.
 
@@ -2178,7 +2206,7 @@ def _codex_response_item_from_session_item(item: dict[str, Any]) -> dict[str, An
     return payload
 
 
-def _is_interrupted_assistant_session_item(item: dict[str, Any]) -> bool:
+def _is_interrupted_assistant_session_item(item: _JsonObject) -> bool:
     """
     Return whether an Omnigent item is an interrupted assistant partial.
 
@@ -2198,7 +2226,7 @@ def _is_interrupted_assistant_session_item(item: dict[str, Any]) -> bool:
     )
 
 
-def _codex_response_item_payload(item: dict[str, Any]) -> dict[str, Any] | None:
+def _codex_response_item_payload(item: _JsonObject) -> _JsonObject | None:
     """
     Convert one supported Omnigent item into a Codex response payload body.
 
@@ -2216,7 +2244,7 @@ def _codex_response_item_payload(item: dict[str, Any]) -> dict[str, Any] | None:
     return None
 
 
-def _codex_message_payload_from_session_item(item: dict[str, Any]) -> dict[str, Any] | None:
+def _codex_message_payload_from_session_item(item: _JsonObject) -> _JsonObject | None:
     """
     Convert an Omnigent message item into a Codex message payload.
 
@@ -2238,8 +2266,8 @@ def _codex_message_payload_from_session_item(item: dict[str, Any]) -> dict[str, 
 
 
 def _codex_function_call_payload_from_session_item(
-    item: dict[str, Any],
-) -> dict[str, Any] | None:
+    item: _JsonObject,
+) -> _JsonObject | None:
     """
     Convert an Omnigent function call item into a Codex function call payload.
 
@@ -2271,8 +2299,8 @@ def _codex_function_call_payload_from_session_item(
 
 
 def _codex_function_call_output_payload_from_session_item(
-    item: dict[str, Any],
-) -> dict[str, Any] | None:
+    item: _JsonObject,
+) -> _JsonObject | None:
     """
     Convert an Omnigent function output item into a Codex function output payload.
 
@@ -2303,7 +2331,7 @@ def _codex_content_blocks_from_api_content(
     content: object,
     *,
     api_type: str,
-) -> list[dict[str, Any]]:
+) -> list[_JsonObject]:
     """
     Extract text blocks from an Omnigent content array for Codex rollout items.
 
@@ -2315,7 +2343,7 @@ def _codex_content_blocks_from_api_content(
     """
     if not isinstance(content, list):
         return []
-    blocks: list[dict[str, Any]] = []
+    blocks: list[_JsonObject] = []
     for block in content:
         if not isinstance(block, dict) or block.get("type") != api_type:
             continue
@@ -2329,7 +2357,7 @@ def _codex_turn_id_for_session_item(
     *,
     session_id: str,
     external_session_id: str,
-    item: dict[str, Any],
+    item: _JsonObject,
     index: int,
 ) -> str:
     """

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -9971,6 +9971,33 @@ def test_rollout_records_includes_compacted_entry_from_compaction_item() -> None
     assert len(post_items) == 1
 
 
+def test_codex_event_msg_record_ignores_non_list_content() -> None:
+    """Malformed message content is skipped as it was before type narrowing."""
+    assert (
+        codex_native._codex_event_msg_record_for_message(
+            {"type": "message", "role": "user", "content": "not-a-list"},
+            timestamp="2026-08-02T00:00:00.000Z",
+        )
+        is None
+    )
+
+
+def test_codex_event_msg_record_reports_non_string_text_cleanly() -> None:
+    """Malformed block text produces a user-facing CLI error."""
+    with pytest.raises(
+        click.ClickException,
+        match="Codex message content text must be a string",
+    ):
+        codex_native._codex_event_msg_record_for_message(
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": 42}],
+            },
+            timestamp="2026-08-02T00:00:00.000Z",
+        )
+
+
 def test_rollout_records_without_compaction_item_has_no_compacted_entry() -> None:
     """Sessions without compaction produce no Compacted rollout record."""
     items: list[dict[str, Any]] = [


### PR DESCRIPTION
## Related issue

#3644

## Summary

- Replace broad `Any` annotations in the Codex-native session, reconnect, and rollout paths with concrete callback contracts and a JSON-object boundary.
- Validate app-server transport invariants before forwarding, initial turns, or bridge-state writes.
- Remove all 31 mypy diagnostics from `omnigent/codex_native.py` (`641 → 610` full-tree errors on the current baseline).

**ELI5:** Codex-native previously handed mypy several opaque bags of values. This labels those bags as JSON objects and proves optional runtime values exist before using them, without changing valid session behavior.

```text
HTTP/session JSON ──narrow──> JSON object ──build──> Codex rollout records
Prepared terminal ──validate URL/thread──> forwarder / initial turn / bridge state
```

## Test Plan

- `.venv/bin/pytest -q tests/test_codex_native.py` — 208 passed.
- `.venv/bin/mypy --no-incremental omnigent/codex_native.py` — no `codex_native.py` diagnostics (only the 14 existing generated protobuf diagnostics).
- `.venv/bin/mypy --no-incremental omnigent` — 610 errors in 10 files, down from 641 in 11 files.
- `TMPDIR=/tmp SKIP=normalize-uv-lock-registry pre-commit run --files omnigent/codex_native.py` — passed.

## Demo

N/A — non-visual typing refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing Codex-native suite covers session creation/resume, reconnect behavior, forwarder startup, app-server thread initialization, and synthesized rollout records.
