### PR TITLE
refactor: type REPL session contracts

### DIFF
--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -18,7 +18,7 @@ import sys
 import tempfile
 from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Protocol, TextIO
+from typing import TYPE_CHECKING, Protocol, TextIO, TypeAlias
 
 from omnigent_client import (
     BlockContext,
@@ -70,6 +70,8 @@ from rich.text import Text
 from omnigent.spec.types import SkillSpec
 
 if TYPE_CHECKING:
+    from omnigent_client._tool_handler import ToolCallInfo
+
     from omnigent.server.schemas import SessionStatusEvent
 
 _log = logging.getLogger(__name__)
@@ -126,15 +128,6 @@ def _is_recoverable_sse_transport_error(exc: BaseException) -> bool:
     return False
 
 
-# Type aliases for the slash-command dispatch contract. Every
-# ``_cmd_*`` handler binds these in the same order; centralizing
-# the alias keeps a future signature change to a single edit.
-SlashCommandHandler = Callable[
-    [str, Session, OmnigentClient, TerminalHost, RichBlockFormatter],
-    Awaitable[None],
-]
-
-
 class _SessionSnapshot(Protocol):
     """
     Minimal snapshot shape returned by ``client.sessions``.
@@ -159,13 +152,32 @@ class _SessionSnapshot(Protocol):
         context-ring on resume without waiting for the first response.
     """
 
-    agent_id: str
-    agent_name: str | None
-    runner_id: str | None
-    reasoning_effort: str | None
-    llm_model: str | None
-    context_window: int | None
-    last_total_tokens: int | None
+    @property
+    def agent_id(self) -> str: ...
+
+    @property
+    def agent_name(self) -> str | None: ...
+
+    @property
+    def runner_id(self) -> str | None: ...
+
+    @property
+    def reasoning_effort(self) -> str | None: ...
+
+    @property
+    def model_override(self) -> str | None: ...
+
+    @property
+    def llm_model(self) -> str | None: ...
+
+    @property
+    def harness(self) -> str | None: ...
+
+    @property
+    def context_window(self) -> int | None: ...
+
+    @property
+    def last_total_tokens(self) -> int | None: ...
 
 
 # Key-binding hints rendered on the welcome panel's second line.
@@ -953,7 +965,7 @@ class _FieldInputState:
 
 def _build_elicitation_content_from_schema(
     schema: dict[str, object],
-) -> dict[str, object] | None:
+) -> dict[str, str | int | float | bool | list[str] | None] | None:
     """
     Delegate to the shared schema auto-fill utility.
 
@@ -1071,9 +1083,11 @@ def _make_elicitation_prompt(
             ctx.mode == "url"
             and isinstance(ctx.url, str)
             and not ctx.url.startswith("/approve/")
-            and server_url
+            and server_url is not None
         )
         if _is_external_url:
+            assert server_url is not None
+            assert isinstance(ctx.url, str)
             # External URL (OAuth, MCP server, etc.) — show the link,
             # block keyboard approval.
             full_url = f"{server_url.rstrip('/')}{ctx.url}"
@@ -1256,7 +1270,11 @@ class _SessionsChatReplAdapter:
         self,
         client: OmnigentClient,
         agent_name: str,
-        tool_callables: dict[str, object] | None = None,
+        tool_callables: dict[
+            str,
+            Callable[[ToolCallInfo], object | Awaitable[object]],
+        ]
+        | None = None,
         hooks: StreamHooks | None = None,
         session_id: str | None = None,
         session_bundle: bytes | None = None,
@@ -1377,6 +1395,7 @@ class _SessionsChatReplAdapter:
         self._context_window: int | None = None
         self._last_total_tokens: int | None = None
         self._pending_local_tasks: dict[str, asyncio.Task[None]] = {}
+        self._turn_done: asyncio.Event
         # FIFO counter: local sends are already echoed by ``on_input``,
         # so their ``session.input.consumed`` events are suppressed.
         self._pending_local_user_sends: int = 0
@@ -2108,7 +2127,7 @@ class _SessionsChatReplAdapter:
         input: str | list[dict[str, object]],
         *,
         files: list[str] | None = None,
-    ):
+    ) -> AsyncGenerator[object, None]:
         """
         Post a user message. Rendering is push-based via ``_on_event``.
 
@@ -2171,7 +2190,7 @@ class _SessionsChatReplAdapter:
         # uses this to know it should handle streaming text deltas
         # and tool rendering inline rather than as history items.
         self._is_streaming = True
-        self._turn_done: asyncio.Event = asyncio.Event()
+        self._turn_done = asyncio.Event()
         self._pending_local_user_sends += 1
 
         try:
@@ -2269,7 +2288,7 @@ class _SessionsChatReplAdapter:
             event_payload["model_override"] = self._model_override
 
         self._is_streaming = True
-        self._turn_done: asyncio.Event = asyncio.Event()
+        self._turn_done = asyncio.Event()
         command_key = (skill_name, arguments)
         self._pending_local_skill_slash_commands.append(command_key)
 
@@ -2383,7 +2402,11 @@ class _SessionsChatReplAdapter:
 
         task = asyncio.create_task(_run(), name=f"client-tool-{call_id}")
         self._pending_local_tasks[call_id] = task
-        task.add_done_callback(lambda _t, _k=call_id: self._pending_local_tasks.pop(_k, None))
+
+        def _discard_task(_task: asyncio.Task[None]) -> None:
+            self._pending_local_tasks.pop(call_id, None)
+
+        task.add_done_callback(_discard_task)
 
     async def _handle_elicitation(
         self,
@@ -2487,7 +2510,8 @@ class _SessionsChatReplAdapter:
         if not properties or not isinstance(properties, dict):
             return None
 
-        required = set(schema.get("required", []))
+        required_value = schema.get("required", [])
+        required = set(required_value) if isinstance(required_value, list) else set()
         content: dict[str, str | int | float | bool | list[str] | None] = {}
 
         for key, prop in properties.items():
@@ -2714,6 +2738,15 @@ class _SessionsChatReplAdapter:
             self._stream_task = None
         self._session_id = new_session_id
         self._bound_runner_id = None  # Force re-bind on next send
+
+
+_ReplSession: TypeAlias = Session | _SessionsChatReplAdapter
+
+# Every slash-command handler binds these parameters in the same order.
+SlashCommandHandler = Callable[
+    [str, _ReplSession, OmnigentClient, TerminalHost, RichBlockFormatter],
+    Awaitable[None],
+]
 
 
 @dataclass(frozen=True)
@@ -3120,20 +3153,19 @@ async def run_repl(
     # The ToolHandler's ``execute`` callable matches the
     # SessionsChat ToolCallable contract closely enough; the
     # name → callable indirection is what SessionsChat expects.
-    tool_callables: dict[str, object] | None = None
+    tool_callables: (
+        dict[
+            str,
+            Callable[[ToolCallInfo], object | Awaitable[object]],
+        ]
+        | None
+    ) = None
     if tool_handler is not None:
-        tool_callables = {
-            schema["name"]: tool_handler.execute
-            for schema in tool_handler.schemas
-            if isinstance(schema, dict) and "name" in schema
-        }
-    # ``Session`` typing here is intentional: the adapter
-    # is duck-compatible with the legacy surface the REPL
-    # uses (send/cancel/current_response_id/model/
-    # is_streaming/reset/resume_from_response/
-    # set_reasoning_effort/reasoning_effort). mypy is
-    # appeased via the runtime cast; the static type
-    # mismatch surfaces in tests, not at runtime.
+        tool_callables = {}
+        for schema in tool_handler.schemas:
+            name = schema.get("name")
+            if isinstance(name, str):
+                tool_callables[name] = tool_handler.execute
     session = _SessionsChatReplAdapter(
         client=client,
         agent_name=agent_name,
@@ -4499,7 +4531,7 @@ async def run_repl(
 
 async def _maybe_write_session_log(
     client: OmnigentClient,
-    session: Session,
+    session: _ReplSession,
     agent_name: str,
     log_dir: pathlib.Path,
     host: TerminalHost,
@@ -4590,7 +4622,7 @@ def _cmd(
 @_cmd("/help", "Show this help")
 async def _cmd_help(
     arg: str,  # noqa: ARG001 — dispatch-contract params (see COMMANDS docstring)
-    session: Session,  # noqa: ARG001
+    session: _ReplSession,  # noqa: ARG001
     client: OmnigentClient,  # noqa: ARG001
     host: TerminalHost,
     fmt: RichBlockFormatter,
@@ -4639,7 +4671,7 @@ _THEME_CLEAR_ALIASES = {"default", "auto", "reset"}
 @_cmd("/theme", "Show/set terminal theme; /theme light or /theme dark")
 async def _cmd_theme(
     arg: str,
-    session: Session,  # noqa: ARG001 — dispatch-contract params
+    session: _ReplSession,  # noqa: ARG001 — dispatch-contract params
     client: OmnigentClient,  # noqa: ARG001 — dispatch-contract params
     host: TerminalHost,
     fmt: RichBlockFormatter,
@@ -4694,7 +4726,7 @@ _EFFORT_CLEAR_ALIASES = {"default", "off", "reset"}
 
 
 async def _set_session_reasoning_effort(
-    session: Session,
+    session: _ReplSession,
     effort: str | None,
 ) -> None:
     """
@@ -4719,7 +4751,7 @@ async def _set_session_reasoning_effort(
 @_cmd("/effort", "Show/set reasoning effort; /effort lists options")
 async def _cmd_effort(
     arg: str,
-    session: Session,
+    session: _ReplSession,
     client: OmnigentClient,  # noqa: ARG001 — dispatch-contract params
     host: TerminalHost,
     fmt: RichBlockFormatter,
@@ -4801,7 +4833,7 @@ def _model_readout_harness(active_model: str | None) -> str:
     return "claude-sdk"
 
 
-def _session_readout_harness(session: Session) -> str:
+def _session_readout_harness(session: _ReplSession) -> str:
     """Resolve the harness the ``/model`` readout should describe.
 
     Prefers the session's actual bound harness
@@ -5051,7 +5083,7 @@ def _model_validation_warning(model: str) -> str | None:
 @_cmd("/model", "Show/set the LLM model for this session")
 async def _cmd_model(
     arg: str,
-    session: Session,
+    session: _ReplSession,
     client: OmnigentClient,  # noqa: ARG001 — dispatch-contract params
     host: TerminalHost,
     fmt: RichBlockFormatter,
@@ -5125,7 +5157,12 @@ async def _cmd_model(
 
     candidate = value.split("/", 1)[0] if "/" in value else value
     matched = _match_configured_provider(config, candidate)
-    if matched is not None and active_name is not None and matched != active_name:
+    if (
+        matched is not None
+        and active is not None
+        and active_name is not None
+        and matched != active_name
+    ):
         active_label = f"{kind_glyph(active.kind)} {provider_display_name(active_name)}".strip()
         target_label = f"{provider_display_name(matched)}"
         host.output(
@@ -5191,7 +5228,7 @@ async def _cmd_model(
 
 
 async def _start_new_conversation(
-    session: Session,
+    session: _ReplSession,
     host: TerminalHost,
     fmt: RichBlockFormatter,  # noqa: ARG001 — reserved for future banner styling
 ) -> bool:
@@ -5221,7 +5258,7 @@ async def _start_new_conversation(
 @_cmd("/new", "Start a new conversation (keeps scrollback)")
 async def _cmd_new(
     arg: str,  # noqa: ARG001 — dispatch-contract params
-    session: Session,
+    session: _ReplSession,
     client: OmnigentClient,  # noqa: ARG001
     host: TerminalHost,
     fmt: RichBlockFormatter,
@@ -5241,7 +5278,7 @@ async def _cmd_new(
 @_cmd("/clear", "Clear the screen and start a new conversation")
 async def _cmd_clear(
     arg: str,  # noqa: ARG001 — dispatch-contract params
-    session: Session,
+    session: _ReplSession,
     client: OmnigentClient,  # noqa: ARG001
     host: TerminalHost,
     fmt: RichBlockFormatter,
@@ -5263,7 +5300,7 @@ async def _cmd_clear(
 @_cmd("/switch", "List or switch conversations")
 async def _cmd_switch(
     arg: str,
-    session: Session,
+    session: _ReplSession,
     client: OmnigentClient,
     host: TerminalHost,
     fmt: RichBlockFormatter,
@@ -5311,7 +5348,9 @@ async def _cmd_switch(
             # session.reset() / resume_from_response() are no-ops
             # in sessions mode, so without this the REPL keeps
             # sending to the original session.
-            await session.switch_to_session(arg)  # type: ignore[attr-defined]
+            if not isinstance(session, _SessionsChatReplAdapter):
+                raise RuntimeError("Session switching requires the sessions API.")
+            await session.switch_to_session(arg)
             # Drop the prior session's sub-agent tree so its agents don't
             # linger under the switched-to session's root.
             host.clear_subagents()
@@ -5336,7 +5375,7 @@ async def _cmd_switch(
 
 async def _attach_to_conversation(
     conversation_id: str,
-    session: Session,
+    session: _ReplSession,
     client: OmnigentClient,
     host: TerminalHost,
     fmt: RichBlockFormatter,
@@ -5474,6 +5513,8 @@ async def _attach_to_conversation(
 
             effective = _items_for_context_token_count(items)
             llm = getattr(session, "llm_model", None) or getattr(session, "_agent_name", "")
+            if not isinstance(llm, str):
+                llm = ""
             tokens = count_tokens(
                 [dict(i) for i in effective],
                 llm,
@@ -5484,7 +5525,7 @@ async def _attach_to_conversation(
 @_cmd("/fork", "Fork the current conversation into a new session")
 async def _cmd_fork(
     arg: str,
-    session: Session,
+    session: _ReplSession,
     client: OmnigentClient,
     host: TerminalHost,
     fmt: RichBlockFormatter,
@@ -5545,7 +5586,7 @@ async def _cmd_fork(
 @_cmd("/history", "Show current conversation history")
 async def _cmd_history(
     arg: str,  # noqa: ARG001 — dispatch-contract params
-    session: Session,
+    session: _ReplSession,
     client: OmnigentClient,
     host: TerminalHost,
     fmt: RichBlockFormatter,
@@ -5619,7 +5660,7 @@ class _ContextItems:
 
 
 async def _fetch_context_items(
-    session: Session,
+    session: _ReplSession,
     client: OmnigentClient,
 ) -> _ContextItems:
     """
@@ -5711,7 +5752,7 @@ def _items_for_context_token_count(
 
 
 async def _refresh_session_metadata(
-    session: Session,
+    session: _ReplSession,
     client: OmnigentClient,
     host: TerminalHost,
     fmt: RichBlockFormatter,
@@ -5764,7 +5805,7 @@ async def _refresh_session_metadata(
 
 
 async def _update_context_ring_estimate(
-    session: Session,
+    session: _ReplSession,
     client: OmnigentClient,
     host: TerminalHost,
     context_window: int,
@@ -5913,7 +5954,7 @@ def _render_context_tree(
 @_cmd("/compact", "Compact conversation context now")
 async def _cmd_compact(
     arg: str,  # noqa: ARG001 — dispatch-contract params
-    session: Session,
+    session: _ReplSession,
     client: OmnigentClient,  # noqa: ARG001 — dispatch-contract params
     host: TerminalHost,
     fmt: RichBlockFormatter,
@@ -5952,7 +5993,7 @@ async def _cmd_compact(
 @_cmd("/context", "Show context window usage")
 async def _cmd_context(
     arg: str,  # noqa: ARG001 — dispatch-contract params
-    session: Session,
+    session: _ReplSession,
     client: OmnigentClient,
     host: TerminalHost,
     fmt: RichBlockFormatter,
@@ -6016,7 +6057,7 @@ async def _cmd_context(
 @_cmd("/cancel", "Cancel the current response")
 async def _cmd_cancel(
     arg: str,  # noqa: ARG001 — dispatch-contract params
-    session: Session,
+    session: _ReplSession,
     client: OmnigentClient,  # noqa: ARG001
     host: TerminalHost,
     fmt: RichBlockFormatter,
@@ -6091,7 +6132,7 @@ def _build_github_issue_url(
 @_cmd("/logs", "Collect current session logs into a zip")
 async def _cmd_logs(
     arg: str,
-    session: Session,
+    session: _ReplSession,
     client: OmnigentClient,
     host: TerminalHost,
     fmt: RichBlockFormatter,
@@ -6156,7 +6197,7 @@ async def _cmd_logs(
 @_cmd("/report", "Open a pre-filled GitHub issue for this session")
 async def _cmd_report(
     arg: str,
-    session: Session,
+    session: _ReplSession,
     client: OmnigentClient,  # noqa: ARG001 — dispatch-contract param
     host: TerminalHost,
     fmt: RichBlockFormatter,
@@ -6202,7 +6243,7 @@ async def _cmd_report(
 @_cmd("/quit", "Exit")
 async def _cmd_quit(
     arg: str,  # noqa: ARG001 — dispatch-contract params
-    session: Session,  # noqa: ARG001
+    session: _ReplSession,  # noqa: ARG001
     client: OmnigentClient,  # noqa: ARG001
     host: TerminalHost,
     fmt: RichBlockFormatter,  # noqa: ARG001
@@ -6381,7 +6422,7 @@ async def _refresh_subagent_tree(
 
 async def _collect_overview_targets(
     client: OmnigentClient,
-    session: Session,
+    session: _ReplSession,
 ) -> list[OverlayTarget]:
     """
     Enumerate the debug overview's sidebar targets.
@@ -7290,7 +7331,7 @@ async def _build_debug_overview(
     target: OverlayTarget,
     *,
     client: OmnigentClient,
-    session: Session,
+    session: _ReplSession,
     agent_name: str,
     fmt: RichBlockFormatter,
     server_log_path: pathlib.Path | None = None,
@@ -8242,7 +8283,7 @@ def register_skill_commands(skills: list[SkillSpec]) -> list[str]:
 
             async def _skill_handler(
                 arg: str,
-                session: Session,
+                session: _ReplSession,
                 client: OmnigentClient,  # noqa: ARG001 — dispatch-contract params
                 host: TerminalHost,
                 fmt: RichBlockFormatter,
@@ -8577,7 +8618,7 @@ async def _run_bang_command(
 
 async def handle_slash_command(
     line: str,
-    session: Session,
+    session: _ReplSession,
     client: OmnigentClient,
     host: TerminalHost,
     fmt: RichBlockFormatter,


### PR DESCRIPTION
## Related issue

#3644

## Summary

- Model the REPL's legacy SDK `Session` and sessions-API adapter as the two supported session implementations across slash commands and shared helpers.
- Make immutable session snapshots, client tool callables, async generators, and turn lifecycle state explicit instead of relying on duck-typing comments and ignores.
- Narrow elicitation, provider, schema, and token-count values at their runtime boundaries.
- Remove all 29 mypy diagnostics from `omnigent/repl/_repl.py` (`641 → 612` full-tree errors on the current baseline).

**ELI5:** The REPL can run on either the old chat session or the newer sessions adapter. The code already supported both at runtime; this teaches mypy that both are intentional and describes their different sync/async methods precisely.

```text
legacy SDK Session ─────┐
                        ├──> shared REPL commands and helpers
sessions API adapter ───┘
```

## Test Plan

- `.venv/bin/pytest -q tests/repl` — 464 passed.
- `.venv/bin/mypy --no-incremental omnigent/repl/_repl.py` — no `_repl.py` diagnostics (only the 14 existing generated protobuf diagnostics).
- `.venv/bin/mypy --no-incremental omnigent` — 612 errors in 10 files, down from 641 in 11 files.
- `TMPDIR=/tmp SKIP=normalize-uv-lock-registry pre-commit run --files omnigent/repl/_repl.py` — passed.

## Demo

N/A — non-visual typing refactor.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The complete REPL suite covers both session implementations, slash-command dispatch, session switching, elicitation handling, client tool execution, model/effort updates, history, logs, context accounting, and sub-agent interactions.
