### PR TITLE
fix(cli): make host status URLs explicit terminal hyperlinks

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -7469,6 +7469,71 @@ def _host_markup(text: _HostJsonValue, *, missing: str = "-") -> str:
     return escape(_host_display_value(text, missing=missing))
 
 
+_HOST_LINK_UNSAFE_CHARS = frozenset(" \t\n\r\x7f[]")
+
+
+def _host_link_safe(url: str) -> bool:
+    """
+    Report whether a URL can be embedded in Rich link markup.
+
+    Whitespace and control characters break the OSC 8 sequence, and square
+    brackets terminate the ``[link=...]`` tag early.
+
+    :param url: Candidate hyperlink target, e.g. ``"https://example.com"``.
+    :returns: ``True`` when the URL is safe to embed.
+    """
+    return bool(url) and not any(char in _HOST_LINK_UNSAFE_CHARS or char < " " for char in url)
+
+
+def _host_link_target(value: _HostJsonValue) -> str | None:
+    """
+    Build a hyperlink target from a server URL.
+
+    :param value: Candidate URL, e.g. ``"https://example.com"``.
+    :returns: The URL when it can be linked, otherwise ``None``.
+    """
+    url = _host_display_value(value, missing="")
+    if not url.startswith(("http://", "https://")):
+        return None
+    return url if _host_link_safe(url) else None
+
+
+def _host_log_link_target(value: _HostJsonValue) -> str | None:
+    """
+    Build a ``file://`` hyperlink target from a daemon log path.
+
+    :param value: Candidate log path, e.g. ``"/tmp/daemon.log"``.
+    :returns: The file URI when it can be linked, otherwise ``None``.
+    """
+    path_text = _host_display_value(value, missing="")
+    if not path_text:
+        return None
+    try:
+        url = Path(path_text).absolute().as_uri()
+    except ValueError:
+        return None
+    return url if _host_link_safe(url) else None
+
+
+def _host_linked(text: str, *, target: str | None) -> str:
+    """
+    Render display text as an explicit terminal hyperlink.
+
+    Terminals guess where a bare URL ends, so a shortened URL or one that
+    fills the line is opened with the surrounding status text glued on. An
+    OSC 8 link carries the real target and its exact bounds instead, which
+    lets the visible text stay shortened without breaking the click.
+
+    :param text: Display text, possibly shortened to fit the terminal.
+    :param target: Hyperlink target, or ``None`` to render plain text.
+    :returns: Rich markup for the display text.
+    """
+    escaped = _host_markup(text)
+    if target is None:
+        return escaped
+    return f"[link={target}]{escaped}[/link]"
+
+
 def _host_target_label(payload: _HostPayload, *, width: int) -> str:
     """
     Build a compact daemon target label.
@@ -7633,7 +7698,9 @@ def _echo_daemon_payloads(payloads: list[_HostPayload]) -> None:
         target = _host_target_label(payload, width=max(24, min(console.width - 2, 96)))
         process = _host_display_value(payload.get("process"), missing="unknown")
         host_status = _host_display_value(payload.get("host_status"), missing="unknown")
-        console.print(f"[bold cyan]{_host_markup(target)}[/bold cyan]")
+        server_link = _host_link_target(payload.get("server_url"))
+        target_link = server_link or _host_link_target(payload.get("target"))
+        console.print(f"[bold cyan]{_host_linked(target, target=target_link)}[/bold cyan]")
         console.print(
             "  "
             f"mode={_host_markup(payload.get('mode'))}  "
@@ -7645,10 +7712,15 @@ def _echo_daemon_payloads(payloads: list[_HostPayload]) -> None:
             payload.get("server_url"),
             max_chars=max(24, console.width - 11),
         )
-        console.print(f"  server={_host_markup(server_text)}")
+        console.print(f"  server={_host_linked(server_text, target=server_link)}")
         console.print(f"  host_id={_host_markup(payload.get('host_id'))}")
         if payload.get("log_path"):
-            console.print(f"  log={_host_markup(payload.get('log_path'))}")
+            log_text = _host_shorten(
+                payload.get("log_path"),
+                max_chars=max(24, console.width - 8),
+            )
+            log_link = _host_log_link_target(payload.get("log_path"))
+            console.print(f"  log={_host_linked(log_text, target=log_link)}")
         if payload.get("error"):
             message = _host_truncate(
                 payload.get("error"),

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -11,10 +11,13 @@ wiring that routes ``--server`` through them.
 from __future__ import annotations
 
 import hashlib
+import io
 import json
+import re
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import click
 import pytest
@@ -1042,7 +1045,9 @@ def test_host_status_wide_terminal_shows_full_session_and_runner_ids() -> None:
     """Wide ``host status`` tables preserve full session and runner ids."""
     session_id = "conv_1234567890abcdef1234567890abcdef12345678"
     runner_id = "runner_token_1234567890abcdef1234567890abcdef12345678"
-    console = Console(width=180, record=True, color_system=None)
+    # Rich only honours an explicit width when height is set too; otherwise
+    # it falls back to detecting the real terminal size.
+    console = Console(width=180, height=40, record=True, color_system=None)
 
     cli._add_host_payload_sessions_table(
         console,
@@ -1062,6 +1067,127 @@ def test_host_status_wide_terminal_shows_full_session_and_runner_ids() -> None:
     rendered = console.export_text()
     assert session_id in rendered
     assert runner_id in rendered
+
+
+_LONG_SERVER_URL = "https://omnigent-000000000000000.workspace.example.databricksapps.com"
+_LONG_LOG_PATH = "/Users/example/.omnigent/logs/host/host-20260801-095205-263883.log"
+
+_ANSI_RE = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b\[[0-9;]*[A-Za-z]")
+_OSC8_OPEN_RE = re.compile(r"\x1b\]8;[^;]*;([^\x1b\x07]+)(?:\x07|\x1b\\)")
+_OSC8_CLOSE_RE = re.compile(r"\x1b\]8;[^;]*;(?:\x07|\x1b\\)")
+
+
+def _render_host_status(*, width: int, payload: dict[str, Any]) -> str:
+    """Render one host-status payload through a fixed-width terminal console.
+
+    :param width: Terminal width in cells, e.g. ``60``.
+    :param payload: Daemon payload as built by ``_daemon_status_payload``.
+    :returns: Rendered output including ANSI and OSC escape sequences.
+    """
+    buffer = io.StringIO()
+    console = Console(
+        file=buffer,
+        width=width,
+        height=40,
+        force_terminal=True,
+        color_system="truecolor",
+        highlight=False,
+    )
+    with patch.object(cli, "_host_console", lambda: console):
+        cli._echo_daemon_payloads([payload])
+    return buffer.getvalue()
+
+
+def _daemon_payload(**overrides: Any) -> dict[str, Any]:
+    """Build a daemon status payload for host-status rendering tests.
+
+    :param overrides: Payload fields to replace, e.g. ``server_url``.
+    :returns: Payload accepted by ``_echo_daemon_payloads``.
+    """
+    payload: dict[str, Any] = {
+        "target": _LONG_SERVER_URL,
+        "mode": "server",
+        "server_url": _LONG_SERVER_URL,
+        "pid": 45867,
+        "process": "online",
+        "log_path": _LONG_LOG_PATH,
+        "host_id": "host_77599b2c44934910b00cfdfda3ba21fc",
+        "host_status": "online",
+        "sessions": [],
+        "error": None,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_host_status_links_the_full_server_url_when_display_is_shortened() -> None:
+    """A narrow ``host status`` still links the untruncated server URL.
+
+    Middle-truncating the URL into the visible text is fine, but the click
+    target must stay openable rather than pointing at ``https://omni…com``.
+    """
+    rendered = _render_host_status(width=60, payload=_daemon_payload())
+
+    targets = _OSC8_OPEN_RE.findall(rendered)
+    assert _LONG_SERVER_URL in targets, f"full server URL is not a link target: {targets!r}"
+    assert "…" in _ANSI_RE.sub("", rendered), "expected the narrow display text to be shortened"
+    assert not any("…" in target for target in targets), (
+        f"a truncated URL was used as a click target: {targets!r}"
+    )
+
+
+def test_host_status_hyperlinks_never_span_a_line_break() -> None:
+    """Every hyperlink opened by ``host status`` closes on the same line.
+
+    An unterminated OSC 8 run makes the terminal treat the rest of the
+    status block as part of the link, so clicking opens a URL with the
+    following lines glued on.
+    """
+    rendered = _render_host_status(width=60, payload=_daemon_payload(error="host not found"))
+
+    for line in rendered.split("\n"):
+        opens = len(_OSC8_OPEN_RE.findall(line))
+        closes = len(_OSC8_CLOSE_RE.findall(line))
+        assert opens == closes, f"unbalanced hyperlink escapes on line: {line!r}"
+
+
+def test_host_status_lines_fit_the_terminal_width() -> None:
+    """``host status`` lines stay inside the terminal width.
+
+    A line that fills or exceeds the width is soft-wrapped, and terminals
+    join soft-wrapped rows into one logical line when detecting links —
+    which is how the log path and the URL end up merged into one target.
+    """
+    width = 60
+    rendered = _render_host_status(width=width, payload=_daemon_payload())
+
+    for line in rendered.split("\n"):
+        visible = _ANSI_RE.sub("", line)
+        assert len(visible) < width, f"line fills or overflows the terminal: {visible!r}"
+
+
+def test_host_status_links_the_daemon_log_path() -> None:
+    """The daemon log path is emitted as a clickable ``file://`` link."""
+    rendered = _render_host_status(width=60, payload=_daemon_payload())
+
+    targets = _OSC8_OPEN_RE.findall(rendered)
+    assert f"file://{_LONG_LOG_PATH}" in targets, f"log path is not linked: {targets!r}"
+
+
+def test_host_status_plain_output_has_no_escape_sequences() -> None:
+    """Piped ``host status`` output stays free of hyperlink escapes.
+
+    Link markup must degrade to plain text so redirected output and
+    ``grep`` keep working.
+    """
+    buffer = io.StringIO()
+    console = Console(file=buffer, width=100, height=40, force_terminal=False, highlight=False)
+    with patch.object(cli, "_host_console", lambda: console):
+        cli._echo_daemon_payloads([_daemon_payload()])
+
+    rendered = buffer.getvalue()
+    assert "\x1b" not in rendered, f"unexpected escape sequences in piped output: {rendered!r}"
+    assert _LONG_SERVER_URL in rendered
 
 
 def test_host_sessions_subcommand_is_removed() -> None:


### PR DESCRIPTION
## Related issue

Closes #3861

## Summary

`omni host status` printed server URLs and daemon log paths as bare text sized
to the terminal, leaving the terminal to guess where each link started and
ended — and it guessed wrong. Clicking the server URL opened a malformed
address with newlines and neighbouring status text glued on.

Two things combined to cause it:

- **Truncated URLs were the click target.** On a narrow terminal the URL is
  middle-truncated for display (`https://omnigent-9775947…4.aws.…com`). With no
  separate click target, the terminal offered that unresolvable string as the
  link.
- **The `log=` line had no width budget,** so a long daemon log path was wrapped
  mid-path. Terminals treat soft-wrapped rows as one logical line when detecting
  links, which is how the URL, the log path, and the lines between them merged
  into a single detected "URL".

The fix emits explicit OSC 8 hyperlinks. The visible text may still be shortened
to fit, but the click target now carries the full, untruncated URL (or a
`file://` URI for the log) plus exact bounds, so the terminal no longer guesses.
The log line also gets a width budget so no line fills the terminal.

Links degrade to plain text when output is piped, so redirected output and
`grep` are unaffected.

## Test Plan

Tests were written first and confirmed failing against the unfixed renderer
(`3 failed, 2 passed`), then passing after the fix. New tests in
`tests/cli/test_backend.py` render `_echo_daemon_payloads` through a fixed-width
terminal console and assert:

- the full untruncated server URL is a link target, and no truncated string is;
- every hyperlink opens and closes on the same line;
- no line fills or overflows the terminal width;
- the daemon log path is linked as a `file://` URI;
- piped output contains no escape sequences.

```
uv run pytest tests/cli/test_backend.py tests/host/ -q   # 294 passed
uv run pre-commit run --files omnigent/cli.py tests/cli/test_backend.py
```

Also verified end to end by running the built CLI inside a 60-column pty against
real daemon records (see Demo).

Drive-by: `test_host_status_wide_terminal_shows_full_session_and_runner_ids` was
already failing on `main`. It built `Console(width=180)` without a `height`, and
Rich only honours an explicit width when height is set too — so it silently fell
back to the real terminal size (80) and asserted against the wrong width. Added
`height` so it tests what it claims.

## Demo

`omnigent host status` in a 60-column terminal, rendered through the real
`_echo_daemon_payloads` code path on each branch. Links are underlined; hover
one in the image's source to see it carries the full untruncated target.

![omnigent host status before and after: the log path wraps on main, and every URL is an explicit OSC 8 hyperlink after](https://raw.githubusercontent.com/randypitcherii/omnigent/pr-demo-assets/pr-demo/demo-3862-host-status.png)

The same two renderings as text, for anyone who wants to diff them:

**Before** — the log path wraps mid-path, URLs are truncated into unresolvable
text, and the output contains **0** real link targets, so every link is whatever
the terminal's heuristic grabs:

```
https://omnigent-977594739011404.aws.databricksapps.com
  mode=server  pid=45867  process=online  host=online
  server=https://omnigent-9775947…4.aws.databricksapps.com
  host_id=host_77599b2c44934910b00cfdfda3ba21fc
  log=/Users/example/.omnigent/logs/host/host-20260801
-095205-263883.log
  No owned sessions found.
```

**After** — nothing wraps, and every URL and log path is a real hyperlink
carrying its full target:

```
https://omnigent-977594739011404.aws.databricksapps.com
  mode=server  pid=45867  process=online  host=online
  server=https://omnigent-9775947…4.aws.databricksapps.com
  host_id=host_77599b2c44934910b00cfdfda3ba21fc
  log=/Users/example/.omn…20260801-095205-263883.log
  No owned sessions found.

clickable link targets: 8
  https://omnigent-977594739011404.aws.databricksapps.com
  file:///Users/example/.omnigent/logs/host/host-20260801-095205-263883.log
  ...
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran the patched CLI inside a 60-column pty against real
daemon records and confirmed the log path no longer wraps, that every server URL
and log path emits a properly terminated OSC 8 sequence, and that each link
target is the full untruncated URL rather than the shortened display text.

## Changelog

Server URLs and log paths in `omni host status` are now proper clickable links instead of text the terminal has to guess at

