### PR TITLE
fix(api): include created_at in the flat conversation-item shape

### DIFF
--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -760,10 +760,18 @@ class ConversationItem(BaseModel):
         :func:`_to_api_item`) and the ``check_task`` tool
         (via :func:`_get_recent_activity_for_task`) consume it.
 
+        ``created_at`` is always present. It is required on the
+        entity and it is the only per-item timestamp, so a client
+        that reads history through this flat shape has no other way
+        to order or age an item; the nested rendering
+        (``SessionResponse.items``, which serialises the entity
+        directly) already carries it.
+
         :returns: Flat dict, e.g. for an assistant message::
 
             {"id": "msg_abc", "response_id": "resp_xyz",
              "type": "message", "status": "completed",
+             "created_at": 1735689600,
              "role": "assistant",
              "content": [{"type": "output_text", "text": "hi"}],
              "model": "databricks-gpt-5-4"}
@@ -773,6 +781,7 @@ class ConversationItem(BaseModel):
             "response_id": self.response_id,
             "type": self.type,
             "status": self.status,
+            "created_at": self.created_at,
             **self.data.model_dump(exclude_none=True, by_alias=True),
             # created_by is present only for human-authored items;
             # omitted (not null) for agent/tool/system messages so the

--- a/omnigent/server/API.md
+++ b/omnigent/server/API.md
@@ -314,8 +314,9 @@ Query parameters:
 ```
 
 Items include all input and output messages, function calls, and function call
-outputs accumulated across all responses in this conversation. Each item carries
-a `response_id` linking it to the response that produced it. Model-produced items
+outputs accumulated across all responses in this conversation. Every item carries
+`created_at` (Unix epoch seconds) — omitted from the examples above for brevity —
+and a `response_id` linking it to the response that produced it. Model-produced items
 (assistant messages, function calls, reasoning) include a `model` field identifying
 the agent. User messages and function call outputs do not have `model` — the agent
 is always recoverable from `response_id` if needed. To continue a conversation,

--- a/tests/entities/test_conversation.py
+++ b/tests/entities/test_conversation.py
@@ -39,6 +39,37 @@ def test_to_api_dict_omits_created_by_when_none() -> None:
     assert "created_by" not in api
 
 
+def test_to_api_dict_exposes_created_at() -> None:
+    """The flat API shape carries the item's own timestamp."""
+    item = ConversationItem(
+        id="msg_ts",
+        type="message",
+        status="completed",
+        response_id="resp_1",
+        created_at=1_735_689_600,
+        data=MessageData(
+            role="assistant",
+            agent="my-agent",
+            content=[{"type": "output_text", "text": "hi"}],
+        ),
+    )
+
+    assert item.to_api_dict()["created_at"] == 1_735_689_600
+
+
+def test_to_api_dict_created_at_matches_the_nested_rendering() -> None:
+    """Flat and nested renderings of one item agree on ``created_at``.
+
+    ``SessionResponse.items`` serialises the entity directly while
+    ``GET /v1/sessions/{id}/items`` goes through :meth:`to_api_dict`,
+    so a client must not get a different answer depending on which
+    endpoint it read the same item from.
+    """
+    item = _message_item(None).model_copy(update={"created_at": 1_700_000_000})
+
+    assert item.to_api_dict()["created_at"] == item.model_dump()["created_at"]
+
+
 def test_to_api_dict_exposes_interrupted_assistant_marker() -> None:
     """Interrupted assistant items surface the reload marker in API shape."""
     item = ConversationItem(

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -667,6 +667,8 @@ def test_append_error_item_round_trips_for_history(
         "response_id": "resp_failed",
         "type": "error",
         "status": "completed",
+        # Store-assigned, so pinned to what was read back rather than a literal.
+        "created_at": read_back.created_at,
         "source": "execution",
         "code": "native_terminal_start_failed",
         "message": "Native Codex requires the 'codex' CLI on PATH.",


### PR DESCRIPTION
## Related issue

Closes #3864

## Summary

- `ConversationItem.to_api_dict()` now emits `created_at`, so the **flat** item shape carries the same per-item timestamp the **nested** one already did.
- Before this, the *same item* had a timestamp from `GET /v1/sessions/{id}` (whose `items` are `list[ConversationItem]`, serialised from the entity) and none from `GET /v1/sessions/{id}/items`, `GET /v1/conversations/{id}/items`, or `response.output_item.done` — all of which render through `to_api_dict()`. `API.md` already claimed the two shapes match.
- Additive and always present: `created_at` is required on the entity, so there is no optional/`None` case and no new failure mode. Response models for these routes are untyped (`PaginatedList`), so `openapi.json` is unchanged.

**ELI5:** every stored item knows when it was made. One way of handing items to a client kept that; the other quietly dropped it. Now both keep it.

```
ConversationItem (entity)  ─┬─ SessionResponse.items ──────────────► had created_at
   id/type/status/          │
   response_id/created_at   └─ to_api_dict() ──► /sessions/{id}/items
   data/created_by                              /conversations/{id}/items   ✗ no created_at
                                                response.output_item.done      (now fixed)
```

Why it matters: a client reading history through the paginated items API had no server-authoritative time for an item. `response_id` groups items into a turn but neither orders nor ages them, and the conversation's `updated_at` is session-level — so every item in one session looks equally recent, and the only workarounds are a client-side clock (skewed, and unavailable for items that predate the client) or that session-level fallback.

Scope kept to `to_api_dict()`. Prior art: #3562 proposed the same field and was closed by its own author ("not pursuing upstream contribution"), never reviewed; it also touched the `session.input.consumed` SSE payload, which this PR deliberately leaves alone.

## Test Plan

- `uv run pytest tests/entities/test_conversation.py` — 22 passed. The two new tests **fail before the fix** (`KeyError: 'created_at'`) and pass after.
- `uv run pytest tests/stores/test_conversation_store.py` — 178 passed. `test_append_error_item_round_trips_for_history` asserts the exact `to_api_dict()` dict, so it is updated to include the store-assigned `created_at` (pinned to the read-back value, not a literal). It is the only exact-shape assertion on `to_api_dict()` in the suite.
- `uv run pytest tests/server` — running; will report in a comment.
- `uv run ruff check` + `ruff format --check` on the touched files — clean.

## Demo

N/A — non-visual.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the discovery path: on a running server, `GET /v1/sessions/{id}` returned items with `created_at` while `GET /v1/sessions/{id}/items` returned the same items without it. No e2e test is added — this is a field on an existing response shape, not new user-facing functionality, and the two new unit tests pin both halves (the field is present, and the flat and nested renderings agree).

## Changelog

Conversation items returned by the flat items APIs and `response.output_item.done` now include `created_at`.
