### PR TITLE
fix(databricks): wire project_store in the Databricks Apps entrypoint

### DIFF
--- a/deploy/databricks/src/app.py
+++ b/deploy/databricks/src/app.py
@@ -153,6 +153,9 @@ try:
         SqlAlchemyPermissionStore,
     )
     from omnigent.stores.policy_store.sqlalchemy_store import SqlAlchemyPolicyStore
+    from omnigent.stores.project_store.sqlalchemy_store import (
+        SqlAlchemyProjectStore,
+    )
     from omnigent.stores.scheduled_task_store.sqlalchemy_store import (
         SqlAlchemyScheduledTaskStore,
     )
@@ -182,6 +185,7 @@ try:
     file_comment_store = SqlAlchemyCommentStore(DB_URI)
     permission_store = SqlAlchemyPermissionStore(DB_URI)
     policy_store = SqlAlchemyPolicyStore(DB_URI)
+    project_store = SqlAlchemyProjectStore(DB_URI)
     host_store = HostStore(DB_URI)
     scheduled_task_store = SqlAlchemyScheduledTaskStore(DB_URI)
 
@@ -215,6 +219,7 @@ try:
         comment_store=file_comment_store,
         permission_store=permission_store,
         policy_store=policy_store,
+        project_store=project_store,
         host_store=host_store,
         scheduled_task_store=scheduled_task_store,
         auth_provider=auth_provider,


### PR DESCRIPTION
## Related issue

Fixes #3863

## Summary

- First-class Projects are non-functional on every Databricks Apps deployment: `create_app` mounts the projects router only when a `project_store` is wired, and `deploy/databricks/src/app.py` built every other store but never a `ProjectStore`. The bundled web UI ships the "New project" button unconditionally, so project creation visibly fails.
- Same bug class as the Docker entrypoint gap fixed in #3400 (issue #3101): construct `SqlAlchemyProjectStore` from the resolved DB URI and pass it to `create_app`, mirroring the other SqlAlchemy stores. The CLI server path (`omnigent/cli.py`) and Docker entrypoint already wire it; the Databricks entrypoint was the last startup path missing it.
- Minimal 5-line change: one import, one store construction, one `create_app` kwarg. No refactoring of the startup paths.

## Test Plan

- `uv run --no-project --python 3.12 python -m py_compile deploy/databricks/src/app.py` — compiles clean.
- `ruff check` and `ruff format --check` (ruff 0.15.16, matching `uv.lock`) on the changed file — pass.
- Confirmed `create_app` accepts `project_store` (`omnigent/server/app.py`) and that `SqlAlchemyProjectStore(db_uri)` matches the construction used by the CLI and Docker paths.

No new automated test: unlike `deploy/docker/entrypoint.py` (which exposes `build_app()`/`main()` and is covered by `tests/deploy/test_docker_entrypoint_import.py`), this entrypoint executes its entire boot sequence at module import — required env vars, `WorkspaceClient()`, Alembic migrations, store construction — so there is no cheap test seam to assert the wiring without standing up heavy scaffolding. (The #3400 Docker fix for the same bug class also shipped as a wiring-only change with no new test.) Happy to add coverage if maintainers want the entrypoint refactored behind a `build_app()` seam first, but that felt out of scope for a wiring fix.

## Demo

N/A (backend wiring fix; the visible effect is that project creation on a Databricks Apps deployment succeeds instead of failing).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was py_compile + ruff on the changed file plus tracing that `create_app(project_store=...)` mounts the projects router. The Databricks entrypoint has no import-time test seam (it boots at module import and needs Databricks Apps env/credentials), so an automated test would require refactoring the entrypoint — see Test Plan.

## Changelog

Project creation now works on Databricks Apps deployments — the entrypoint wires the project store so the Projects API is mounted.

---

This pull request and its description were written by Isaac.

https://claude.ai/code/session_01P9dr2dYHrwMvnXvJsjLDKk
