### PR TITLE
feat(dictation): add secure, configurable composer dictation

### DIFF
--- a/designs/server-dictation.md
+++ b/designs/server-dictation.md
@@ -97,8 +97,13 @@ connections (default 2, `OMNIGENT_DICTATION_MAX_STREAMS`).
 | `OMNIGENT_DICTATION_MODEL_DIR` | `~/.omnigent/models/dictation/asr` | dir containing `encoder*.onnx`, `decoder*.onnx`, `joiner*.onnx`, `tokens.txt` |
 | `OMNIGENT_DICTATION_PUNCT_DIR` | `~/.omnigent/models/dictation/punct` | optional online-punctuation model dir (`model*.onnx` + `bpe.vocab`) |
 | `OMNIGENT_DICTATION_MAX_STREAMS` | `2` | concurrent dictation WebSockets |
+| `OMNIGENT_DICTATION_MAX_FRAME_BYTES` | `262144` | maximum binary PCM frame size; larger frames close with WebSocket code 1009 |
+| `OMNIGENT_DICTATION_MAX_TAKE_SECONDS` | `300` | maximum wall-clock or PCM-audio duration per take |
 | `OMNIGENT_DICTATION_ENGINE` | unset (`sherpa`) | engine to use by registered name (`sherpa`, `remote`, `fake`) |
 | `OMNIGENT_DICTATION_REMOTE_URL` | unset | worker stream URL for the `remote` engine, e.g. `ws://venus:8100/v1/dictation/stream` |
+| `OMNIGENT_DICTATION_WORKER_TOKEN` | unset | shared bearer token required by the worker and sent by the main relay |
+| `OMNIGENT_DICTATION_REMOTE_CA_FILE` | unset | optional PEM CA bundle for a private worker CA; normal hostname and certificate verification remain enabled |
+| `OMNIGENT_DICTATION_ALLOW_INSECURE_REMOTE` | unset | set to `1` only to permit plaintext `ws://` to a non-loopback worker |
 
 `scripts/fetch-dictation-models.sh` downloads a known-good pair (streaming
 Nemotron 0.6 B int8 + English online punctuation, both Apache-2.0 upstream)
@@ -143,22 +148,54 @@ transcript events down), so no new protocol or code path was needed. The
 browser never talks to the worker; the main server authenticates the user on
 its own route, then relays over a `websockets` client.
 
-Run the worker wherever the models live (it is **unauthenticated** — bind it
-to a trusted LAN/VPN only):
+Run the worker wherever the models live. Generate a high-entropy token and
+configure the same value on the worker and main server. The token is checked
+in constant time before the WebSocket is accepted:
 
 ```
 pip install omnigent[dictation] && scripts/fetch-dictation-models.sh
-python -m omnigent.server.dictation_worker --host 0.0.0.0 --port 8100
+export OMNIGENT_DICTATION_WORKER_TOKEN="$(openssl rand -hex 32)"
+python -m omnigent.server.dictation_worker \
+  --host 0.0.0.0 --port 8100 \
+  --tls-certfile /etc/omnigent/worker.crt \
+  --tls-keyfile /etc/omnigent/worker.key
 ```
 
-Then select the `remote` engine on the main server via env vars — no CLI
-integration is required:
+Then select the `remote` engine on the main server. For a certificate signed
+by a private CA, set `OMNIGENT_DICTATION_REMOTE_CA_FILE`; the relay builds a
+verified `SSLContext`, including hostname verification. There is no
+disable-verification mode:
 
 ```
 OMNIGENT_DICTATION_ENGINE=remote \
-OMNIGENT_DICTATION_REMOTE_URL=ws://<worker-host>:8100/v1/dictation/stream \
+OMNIGENT_DICTATION_REMOTE_URL=wss://<worker-host>:8100/v1/dictation/stream \
+OMNIGENT_DICTATION_WORKER_TOKEN="$OMNIGENT_DICTATION_WORKER_TOKEN" \
+OMNIGENT_DICTATION_REMOTE_CA_FILE=/etc/omnigent/private-ca.crt \
 omnigent server ...
 ```
+
+Plaintext `ws://` remains convenient for `localhost`, `127.0.0.0/8`, and
+`::1`. A non-loopback plaintext URL is rejected unless
+`OMNIGENT_DICTATION_ALLOW_INSECURE_REMOTE=1` is explicitly set; use that only
+inside a network whose confidentiality and integrity are provided elsewhere.
+The worker still authenticates plaintext connections with the shared token.
+
+Worker probes:
+
+- `GET /health` is public liveness and returns immediately, including during
+  model loading.
+- `GET /ready` requires `Authorization: Bearer <worker token>`. Model warmup
+  starts asynchronously at worker startup; readiness returns `503` with only
+  `warming` or `failed` until the engine is usable, without model paths or
+  exception details.
+
+Use `curl -f http://127.0.0.1:8100/health` for liveness and
+`curl -f -H "Authorization: Bearer $OMNIGENT_DICTATION_WORKER_TOKEN"
+https://worker.example:8100/ready` for readiness (add `--cacert` for a private
+CA). The main server exposes authenticated `GET /v1/dictation/status` for
+stable engine, capacity, limit, remote transport, token-presence, fallback,
+reason, and remediation diagnostics. It never returns tokens, URL credentials,
+query strings, filesystem paths, or exception text.
 
 `RemoteDictationEngine` registers by name like every other engine (no changes
 to the route, protocol, or selection logic). `_RemoteStream` bridges the
@@ -168,6 +205,9 @@ Fallback is per take: if the worker is unreachable and local models are
 installed, a lazily-built local sherpa engine serves the take instead (its
 weights cost no RAM until the worker actually goes down); each new take
 retries the worker first.
+
+The relay uses the `websockets` 14 client API (`additional_headers` for the
+bearer token and `SSLContext` for TLS), so the package minimum is 14.
 
 Client timeouts (`web/src/lib/dictation.ts`) are widened to exceed the
 worker's cold-load budget (`_REMOTE_READY_TIMEOUT_S` / `_REMOTE_STOP_TIMEOUT_S`
@@ -187,6 +227,11 @@ Availability rides the existing boot-time capability probe —
 `dictation_available` on **`GET /v1/info`** — rather than a dedicated
 endpoint; the UI needs one boolean, once per page load.
 
+Authenticated operators can query **`GET /v1/dictation/status`** for
+actionable, sanitized diagnostics. This endpoint follows the main server's
+identity auth policy and is not consumed by the browser settings UI in this
+phase.
+
 - **`WS /v1/dictation/stream`** — wire protocol (documented in the module
   docstring, mirroring `terminal_attach.py`):
   - **Client → server, binary frames**: raw 16 kHz mono s16le PCM.
@@ -205,6 +250,10 @@ endpoint; the UI needs one boolean, once per page load.
     - `{"type": "error", "message": ...}` — fatal; server closes.
 
 The route holds no session state; a connection is one dictation take.
+Binary frame size and take duration are bounded by the configuration above.
+OpenTelemetry exports low-cardinality counters/gauges/histograms for takes
+started/completed/rejected/active, audio bytes, model warmup, remote connection
+outcomes, and local fallback use under `omnigent.server.dictation.*`.
 
 ## Web
 

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2259,7 +2259,10 @@ def create_app(
     # (designs/server-dictation.md). Availability is probed lazily, so
     # registering unconditionally is free for servers without the extra.
     app.include_router(
-        create_dictation_router(auth_provider=auth_provider),
+        create_dictation_router(
+            auth_provider=auth_provider,
+            permission_store=permission_store,
+        ),
         prefix="/v1",
         tags=["dictation"],
     )

--- a/omnigent/server/dictation.py
+++ b/omnigent/server/dictation.py
@@ -76,12 +76,16 @@ import json
 import logging
 import os
 import re
+import ssl
 import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
+from urllib.parse import urlsplit
+
+from omnigent.server.dictation_metrics import metrics
 
 _logger = logging.getLogger(__name__)
 
@@ -89,9 +93,14 @@ ENGINE_ENV = "OMNIGENT_DICTATION_ENGINE"
 MODEL_DIR_ENV = "OMNIGENT_DICTATION_MODEL_DIR"
 PUNCT_DIR_ENV = "OMNIGENT_DICTATION_PUNCT_DIR"
 MAX_STREAMS_ENV = "OMNIGENT_DICTATION_MAX_STREAMS"
+MAX_FRAME_BYTES_ENV = "OMNIGENT_DICTATION_MAX_FRAME_BYTES"
+MAX_TAKE_SECONDS_ENV = "OMNIGENT_DICTATION_MAX_TAKE_SECONDS"
 #: Worker stream URL for the ``remote`` engine, e.g.
 #: ``ws://venus:8100/v1/dictation/stream``.
 REMOTE_URL_ENV = "OMNIGENT_DICTATION_REMOTE_URL"
+WORKER_TOKEN_ENV = "OMNIGENT_DICTATION_WORKER_TOKEN"
+REMOTE_CA_FILE_ENV = "OMNIGENT_DICTATION_REMOTE_CA_FILE"
+ALLOW_INSECURE_REMOTE_ENV = "OMNIGENT_DICTATION_ALLOW_INSECURE_REMOTE"
 
 #: Built-in engine names. The default (empty ``OMNIGENT_DICTATION_ENGINE``)
 #: resolves to the sherpa engine.
@@ -113,8 +122,13 @@ REASON_EXTRA_NOT_INSTALLED = "extra_not_installed"
 REASON_MODELS_MISSING = "models_missing"
 REASON_UNKNOWN_ENGINE = "unknown_engine"
 REASON_REMOTE_URL_MISSING = "remote_url_missing"
+REASON_REMOTE_TOKEN_MISSING = "remote_token_missing"
+REASON_INSECURE_REMOTE = "insecure_remote"
+REASON_INVALID_REMOTE_URL = "invalid_remote_url"
 
 DEFAULT_MAX_STREAMS = 2
+DEFAULT_MAX_FRAME_BYTES = 256 * 1024
+DEFAULT_MAX_TAKE_SECONDS = 300.0
 
 # Endpoint rules mirror sherpa-onnx defaults tuned for dictation: a long
 # hard stop (rule1, silence with no text yet), a shorter pause once
@@ -239,6 +253,30 @@ def max_streams() -> int:
     return value if value > 0 else DEFAULT_MAX_STREAMS
 
 
+def max_frame_bytes() -> int:
+    """Maximum bytes accepted in one browser or relay audio frame."""
+    return _positive_int_env(MAX_FRAME_BYTES_ENV, DEFAULT_MAX_FRAME_BYTES)
+
+
+def max_take_seconds() -> float:
+    """Maximum wall-clock and audio duration accepted for one take."""
+    raw = os.environ.get(MAX_TAKE_SECONDS_ENV, "")
+    try:
+        value = float(raw)
+    except ValueError:
+        return DEFAULT_MAX_TAKE_SECONDS
+    return value if value > 0 else DEFAULT_MAX_TAKE_SECONDS
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name, "")
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
 def _pick_model_file(model_dir: Path, stem: str) -> Path | None:
     """Find ``<stem>*.onnx`` in *model_dir*, preferring int8 variants.
 
@@ -303,8 +341,60 @@ def engine_availability() -> tuple[bool, str | None]:
     return entry.available()
 
 
+_STATUS_ACTIONS = {
+    REASON_EXTRA_NOT_INSTALLED: "Install the dictation extra.",
+    REASON_MODELS_MISSING: "Install or configure the dictation ASR model files.",
+    REASON_UNKNOWN_ENGINE: "Set a registered dictation engine name.",
+    REASON_REMOTE_URL_MISSING: "Set the remote worker WebSocket URL.",
+    REASON_REMOTE_TOKEN_MISSING: "Set the shared dictation worker token.",
+    REASON_INSECURE_REMOTE: "Use wss, loopback, or explicitly allow insecure remote transport.",
+    REASON_INVALID_REMOTE_URL: "Set a valid ws or wss remote worker URL.",
+}
+
+
+def engine_status() -> dict[str, object]:
+    """Return stable diagnostics without secrets, paths, or exception text."""
+    name = _selected_engine_name()
+    available, reason = engine_availability()
+    result: dict[str, object] = {
+        "available": available,
+        "engine": name,
+        "reason": reason,
+        "action": _STATUS_ACTIONS.get(reason) if reason is not None else None,
+        "capacity": {"max_streams": max_streams()},
+        "limits": {
+            "max_frame_bytes": max_frame_bytes(),
+            "max_take_seconds": max_take_seconds(),
+        },
+    }
+    if name == ENGINE_REMOTE:
+        url = _remote_url()
+        parsed = urlsplit(url)
+        result["remote"] = {
+            "configured": bool(url),
+            "secure": parsed.scheme == "wss",
+            "token_configured": bool(_worker_token()),
+            "fallback_available": _sherpa_available()[0],
+            "connection_state": _get_remote_connection_state(),
+        }
+    return result
+
+
 _engine_lock = threading.Lock()
 _engine: DictationEngine | None = None
+_remote_state_lock = threading.Lock()
+_remote_connection_state = "not_attempted"
+
+
+def _set_remote_connection_state(state: str) -> None:
+    global _remote_connection_state
+    with _remote_state_lock:
+        _remote_connection_state = state
+
+
+def _get_remote_connection_state() -> str:
+    with _remote_state_lock:
+        return _remote_connection_state
 
 
 def get_engine() -> DictationEngine:
@@ -424,7 +514,7 @@ class _SherpaStream:
 
     def feed_pcm16(self, data: bytes) -> DictationUpdate:
         """Decode one PCM chunk; fold an endpoint into ``finalized``."""
-        import numpy as np  # type: ignore[import-not-found]
+        import numpy as np
 
         # Drop a trailing odd byte rather than crash the take; the next
         # frame realigns (client frames are always whole samples).
@@ -491,6 +581,9 @@ class RemoteDictationEngine:
         self,
         url: str,
         *,
+        token: str | None = None,
+        ca_file: str | None = None,
+        allow_insecure: bool = False,
         fallback_factory: Callable[[], DictationEngine] | None = None,
     ) -> None:
         """
@@ -500,7 +593,12 @@ class RemoteDictationEngine:
             first use (lazy — its model weights cost ~real RAM), or
             ``None`` when no local model is installed.
         """
+        _validate_remote_url(url, allow_insecure=allow_insecure)
+        if not token:
+            raise ValueError("dictation worker token is required")
         self._url = url
+        self._token = token
+        self._ssl_context = _remote_ssl_context(url, ca_file)
         self._fallback_factory = fallback_factory
         self._fallback: DictationEngine | None = None
         self._fallback_lock = threading.Lock()
@@ -508,18 +606,24 @@ class RemoteDictationEngine:
     def create_stream(self) -> DictationStreamHandle:
         """Connect a take to the worker, or to the local fallback."""
         try:
-            return _RemoteStream(self._url)
+            stream = _RemoteStream(self._url, self._token, self._ssl_context)
+            _set_remote_connection_state("connected")
+            metrics.remote_connection("connected")
+            return stream
         except Exception:
+            _set_remote_connection_state("unavailable")
+            metrics.remote_connection("failed")
             if self._fallback_factory is None:
                 raise
             _logger.warning(
-                "dictation worker unreachable at %s; using local fallback engine",
-                self._url,
+                "dictation worker unreachable; using local fallback engine",
                 exc_info=True,
             )
             with self._fallback_lock:
                 if self._fallback is None:
                     self._fallback = self._fallback_factory()
+            _set_remote_connection_state("local_fallback")
+            metrics.fallback()
             return self._fallback.create_stream()
 
 
@@ -533,10 +637,16 @@ class _RemoteStream:
     relay just forwards it.
     """
 
-    def __init__(self, url: str) -> None:
+    def __init__(self, url: str, token: str, ssl_context: ssl.SSLContext | None) -> None:
         from websockets.sync.client import connect
 
-        self._ws = connect(url, open_timeout=5)
+        self._ws = connect(
+            url,
+            additional_headers={"Authorization": f"Bearer {token}"},
+            ssl=ssl_context,
+            open_timeout=5,
+            max_size=max_frame_bytes(),
+        )
         try:
             deadline = time.monotonic() + _REMOTE_READY_TIMEOUT_S
             while True:
@@ -599,13 +709,21 @@ class _RemoteStream:
             return DictationUpdate(partial=self._partial, finalized=finalized)
 
     def finish(self) -> str:
-        """Ask the worker to flush; return its tail utterance."""
-        with contextlib.suppress(Exception):
+        """Ask the worker to flush; return pending finals plus its tail."""
+        stopped = False
+        try:
             self._ws.send(json.dumps({"type": "stop"}))
-        self._stopped.wait(timeout=_REMOTE_STOP_TIMEOUT_S)
-        self.close()
+            stopped = self._stopped.wait(timeout=_REMOTE_STOP_TIMEOUT_S)
+        finally:
+            self.close()
+        if not stopped:
+            raise TimeoutError("dictation worker did not finish the take")
         with self._lock:
-            return self._tail
+            if self._dead:
+                raise RuntimeError("dictation worker connection lost while stopping")
+            parts = [*self._finals, self._tail]
+            self._finals.clear()
+            return " ".join(part for part in parts if part).strip()
 
     def close(self) -> None:
         """Close the worker socket, releasing its capacity slot.
@@ -622,6 +740,45 @@ def _remote_url() -> str:
     return os.environ.get(REMOTE_URL_ENV, "").strip()
 
 
+def _worker_token() -> str:
+    return os.environ.get(WORKER_TOKEN_ENV, "").strip()
+
+
+def _allow_insecure_remote() -> bool:
+    return os.environ.get(ALLOW_INSECURE_REMOTE_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+def _is_loopback_host(host: str | None) -> bool:
+    if not host:
+        return False
+    if host.lower() == "localhost":
+        return True
+    import ipaddress
+
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _validate_remote_url(url: str, *, allow_insecure: bool) -> None:
+    parsed = urlsplit(url)
+    if parsed.scheme not in {"ws", "wss"} or not parsed.hostname:
+        raise ValueError("dictation remote URL must use ws:// or wss://")
+    if parsed.scheme == "ws" and not _is_loopback_host(parsed.hostname) and not allow_insecure:
+        raise ValueError("plaintext remote dictation is denied for non-loopback hosts")
+
+
+def _remote_ssl_context(url: str, ca_file: str | None) -> ssl.SSLContext | None:
+    if urlsplit(url).scheme != "wss":
+        return None
+    return ssl.create_default_context(cafile=ca_file or None)
+
+
 def _remote_available() -> tuple[bool, str | None]:
     """Availability probe for the remote engine.
 
@@ -632,6 +789,14 @@ def _remote_available() -> tuple[bool, str | None]:
     """
     if not _remote_url():
         return False, REASON_REMOTE_URL_MISSING
+    if not _worker_token():
+        return False, REASON_REMOTE_TOKEN_MISSING
+    try:
+        _validate_remote_url(_remote_url(), allow_insecure=_allow_insecure_remote())
+    except ValueError as exc:
+        if "plaintext" in str(exc):
+            return False, REASON_INSECURE_REMOTE
+        return False, REASON_INVALID_REMOTE_URL
     return True, None
 
 
@@ -650,7 +815,13 @@ def _build_remote_engine() -> RemoteDictationEngine:
         if _sherpa_available()[0]
         else None
     )
-    return RemoteDictationEngine(url, fallback_factory=fallback)
+    return RemoteDictationEngine(
+        url,
+        token=_worker_token(),
+        ca_file=os.environ.get(REMOTE_CA_FILE_ENV, "").strip() or None,
+        allow_insecure=_allow_insecure_remote(),
+        fallback_factory=fallback,
+    )
 
 
 #: Scripted transcript the fake engine reveals; asserted verbatim by the

--- a/omnigent/server/dictation_metrics.py
+++ b/omnigent/server/dictation_metrics.py
@@ -1,0 +1,70 @@
+"""Low-cardinality OpenTelemetry metrics for server-side dictation."""
+
+from __future__ import annotations
+
+from opentelemetry import metrics as otel_metrics
+
+
+class DictationMetrics:
+    """Record dictation lifecycle, resource, and relay metrics."""
+
+    def __init__(self) -> None:
+        meter = otel_metrics.get_meter("omnigent.server.dictation")
+        self._started = meter.create_counter(
+            "omnigent.server.dictation.takes.started",
+            unit="{take}",
+        )
+        self._completed = meter.create_counter(
+            "omnigent.server.dictation.takes.completed",
+            unit="{take}",
+        )
+        self._rejected = meter.create_counter(
+            "omnigent.server.dictation.takes.rejected",
+            unit="{take}",
+        )
+        self._active = meter.create_up_down_counter(
+            "omnigent.server.dictation.takes.active",
+            unit="{take}",
+        )
+        self._audio_bytes = meter.create_counter(
+            "omnigent.server.dictation.audio.bytes",
+            unit="By",
+        )
+        self._warmup = meter.create_histogram(
+            "omnigent.server.dictation.warmup.duration",
+            unit="s",
+        )
+        self._remote_connections = meter.create_counter(
+            "omnigent.server.dictation.remote.connections",
+            unit="{connection}",
+        )
+        self._fallbacks = meter.create_counter(
+            "omnigent.server.dictation.fallbacks",
+            unit="{fallback}",
+        )
+
+    def started(self) -> None:
+        self._started.add(1)
+        self._active.add(1)
+
+    def completed(self, outcome: str) -> None:
+        self._completed.add(1, {"outcome": outcome})
+        self._active.add(-1)
+
+    def rejected(self, reason: str) -> None:
+        self._rejected.add(1, {"reason": reason})
+
+    def audio_bytes(self, count: int) -> None:
+        self._audio_bytes.add(count)
+
+    def warmup(self, duration_seconds: float, outcome: str) -> None:
+        self._warmup.record(duration_seconds, {"outcome": outcome})
+
+    def remote_connection(self, outcome: str) -> None:
+        self._remote_connections.add(1, {"outcome": outcome})
+
+    def fallback(self) -> None:
+        self._fallbacks.add(1, {"reason": "remote_unavailable"})
+
+
+metrics = DictationMetrics()

--- a/omnigent/server/dictation_worker.py
+++ b/omnigent/server/dictation_worker.py
@@ -23,27 +23,106 @@ Then start the main server pointed at it::
 The same ``OMNIGENT_DICTATION_*`` env vars configure the worker itself
 (model dirs, stream cap, fake engine for tests).
 
-Security: the worker has NO authentication — it accepts raw audio from
-anyone who can reach the port and returns transcripts. Bind it to a
-trusted network (LAN/VPN) only; the main server enforces user auth on
-its own dictation route before relaying.
+The worker requires a shared bearer token and supports TLS. Prefer TLS
+even on private networks; plaintext non-loopback relay URLs are rejected
+by the main server unless explicitly allowed.
 """
 
 from __future__ import annotations
 
 import argparse
+import asyncio
+import contextlib
+import hmac
 import logging
-from collections.abc import Sequence
+import os
+import time
+from collections.abc import AsyncIterator, Callable, Sequence
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Request, status
 
+from omnigent.server.dictation import WORKER_TOKEN_ENV, DictationEngine, get_engine
+from omnigent.server.dictation_metrics import metrics
 from omnigent.server.routes.dictation import create_dictation_router
 
 
-def create_worker_app() -> FastAPI:
-    """Build the single-route worker app."""
-    app = FastAPI(title="omnigent dictation worker")
-    app.include_router(create_dictation_router(), prefix="/v1")
+@dataclass
+class _Readiness:
+    state: str = "warming"
+
+
+def _has_token(request: Request, expected: str) -> bool:
+    authorization = request.headers.get("authorization", "")
+    prefix = "Bearer "
+    provided = authorization[len(prefix) :] if authorization.startswith(prefix) else ""
+    return bool(expected) and hmac.compare_digest(provided.encode(), expected.encode())
+
+
+def create_worker_app(
+    *,
+    engine_provider: Callable[[], DictationEngine] | None = None,
+    shared_token: str | None = None,
+) -> FastAPI:
+    """Build the authenticated worker app with asynchronous warmup."""
+    resolve_engine = engine_provider or get_engine
+    token = shared_token if shared_token is not None else os.environ.get(WORKER_TOKEN_ENV, "")
+    readiness = _Readiness()
+
+    async def warmup() -> None:
+        started_at = time.monotonic()
+        try:
+            engine = await asyncio.to_thread(resolve_engine)
+            create_task = asyncio.create_task(asyncio.to_thread(engine.create_stream))
+            try:
+                stream = await asyncio.shield(create_task)
+            except asyncio.CancelledError:
+                stream = await create_task
+                await asyncio.to_thread(stream.close)
+                raise
+            await asyncio.to_thread(stream.close)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            readiness.state = "failed"
+            metrics.warmup(time.monotonic() - started_at, "failed")
+            logging.getLogger(__name__).exception("dictation worker model warmup failed")
+        else:
+            readiness.state = "ready"
+            metrics.warmup(time.monotonic() - started_at, "ready")
+
+    @asynccontextmanager
+    async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+        task = asyncio.create_task(warmup())
+        yield
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    app = FastAPI(title="omnigent dictation worker", lifespan=lifespan)
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/ready")
+    async def ready(request: Request) -> dict[str, str]:
+        if not token or not _has_token(request, token):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required"
+            )
+        if readiness.state != "ready":
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={"status": readiness.state},
+            )
+        return {"status": "ready"}
+
+    app.include_router(
+        create_dictation_router(engine_provider=resolve_engine, shared_token=token),
+        prefix="/v1",
+    )
     return app
 
 
@@ -53,16 +132,30 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "--host",
         default="127.0.0.1",
-        help="bind address; use a LAN/VPN address for a remote main server "
-        "(the worker is unauthenticated — never expose it publicly)",
+        help="bind address",
     )
     parser.add_argument("--port", type=int, default=8100)
+    parser.add_argument("--tls-certfile", help="PEM server certificate chain")
+    parser.add_argument("--tls-keyfile", help="PEM server private key")
     args = parser.parse_args(argv)
+
+    token = os.environ.get(WORKER_TOKEN_ENV, "").strip()
+    if not token:
+        parser.error(f"{WORKER_TOKEN_ENV} must be set")
+    if bool(args.tls_certfile) != bool(args.tls_keyfile):
+        parser.error("--tls-certfile and --tls-keyfile must be provided together")
 
     import uvicorn
 
     logging.basicConfig(level=logging.INFO)
-    uvicorn.run(create_worker_app(), host=args.host, port=args.port, log_level="info")
+    uvicorn.run(
+        create_worker_app(shared_token=token),
+        host=args.host,
+        port=args.port,
+        log_level="info",
+        ssl_certfile=args.tls_certfile,
+        ssl_keyfile=args.tls_keyfile,
+    )
     return 0
 
 

--- a/omnigent/server/routes/dictation.py
+++ b/omnigent/server/routes/dictation.py
@@ -54,28 +54,43 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hmac
 import json
 import logging
 import time
 from collections.abc import Callable
-from typing import Final
+from typing import Final, TypeVar
 
 import anyio
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect, WebSocketException
+from fastapi import (
+    APIRouter,
+    HTTPException,
+    Request,
+    WebSocket,
+    WebSocketDisconnect,
+    WebSocketException,
+)
 from starlette import status
 
 from omnigent.server.auth import AuthProvider
 from omnigent.server.dictation import (
     DictationEngine,
     DictationStreamHandle,
+    engine_status,
     get_engine,
+    max_frame_bytes,
     max_streams,
+    max_take_seconds,
 )
+from omnigent.server.dictation_metrics import metrics
+from omnigent.stores.permission_store import PermissionStore
 
 _logger = logging.getLogger(__name__)
 
 _WS_CLOSE_TRY_AGAIN_LATER: Final[int] = 1013
 _WS_CLOSE_INTERNAL_ERROR: Final[int] = 1011
+_WS_CLOSE_MESSAGE_TOO_BIG: Final[int] = 1009
+_WS_CLOSE_POLICY_VIOLATION: Final[int] = 1008
 
 #: Minimum interval between partial-transcript pushes. Keeps the socket
 #: chatty enough for live text without a frame per audio chunk.
@@ -85,7 +100,9 @@ _PARTIAL_INTERVAL_S: Final[float] = 0.15
 def create_dictation_router(
     *,
     auth_provider: AuthProvider | None = None,
+    permission_store: PermissionStore | None = None,
     engine_provider: Callable[[], DictationEngine] | None = None,
+    shared_token: str | None = None,
 ) -> APIRouter:
     """Build the router carrying the dictation stream route.
 
@@ -103,12 +120,53 @@ def create_dictation_router(
     router = APIRouter()
     resolve_engine = engine_provider or get_engine
     # Router-scoped so each app (and each test app) gets its own cap.
-    slots = asyncio.Semaphore(max_streams())
+    stream_limit = max_streams()
+    slots = asyncio.Semaphore(stream_limit)
+    active_streams = 0
+
+    @router.get("/dictation/status")
+    async def dictation_status(request: Request) -> dict[str, object]:
+        """Return authenticated, sanitized operator diagnostics."""
+        if shared_token is not None and not _valid_http_bearer_token(request, shared_token):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required"
+            )
+        if auth_provider is not None and auth_provider.get_user_id(request) is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required"
+            )
+        if permission_store is not None:
+            user_id = auth_provider.get_user_id(request) if auth_provider is not None else None
+            if user_id is None:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Authentication required",
+                )
+            if not await asyncio.to_thread(permission_store.is_admin, user_id):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Admin privileges required for dictation diagnostics",
+                )
+        diagnostics = engine_status()
+        diagnostics["capacity"] = {
+            "max_streams": stream_limit,
+            "active_streams": active_streams,
+            "available_streams": max(0, stream_limit - active_streams),
+        }
+        return diagnostics
 
     @router.websocket("/dictation/stream")
     async def dictation_stream(websocket: WebSocket) -> None:
         """Transcribe one dictation take (see module docstring)."""
+        nonlocal active_streams
+        if shared_token is not None and not _valid_bearer_token(websocket, shared_token):
+            metrics.rejected("authentication")
+            raise WebSocketException(
+                code=status.WS_1008_POLICY_VIOLATION,
+                reason="authentication required",
+            )
         if auth_provider is not None and auth_provider.get_user_id(websocket) is None:
+            metrics.rejected("authentication")
             raise WebSocketException(
                 code=status.WS_1008_POLICY_VIOLATION,
                 reason="authentication required",
@@ -116,6 +174,7 @@ def create_dictation_router(
         await websocket.accept()
 
         if slots.locked():
+            metrics.rejected("capacity")
             await websocket.close(
                 code=_WS_CLOSE_TRY_AGAIN_LATER,
                 reason="dictation is at capacity; try again shortly",
@@ -123,18 +182,36 @@ def create_dictation_router(
             return
 
         async with slots:
+            active_streams += 1
+            metrics.started()
+            outcome = "disconnected"
             # Engine construction loads model weights — seconds on first
             # use. Run it off-loop; later takes reuse the shared engine.
             try:
                 engine = await asyncio.to_thread(resolve_engine)
-                handle: DictationStreamHandle = await asyncio.to_thread(engine.create_stream)
+                create_task = asyncio.create_task(asyncio.to_thread(engine.create_stream))
+                try:
+                    handle: DictationStreamHandle = await asyncio.shield(create_task)
+                except asyncio.CancelledError:
+                    # The worker thread cannot be cancelled. Recover and close
+                    # its result so a remote stream never leaks a worker slot.
+                    handle = await create_task
+                    await asyncio.to_thread(handle.close)
+                    raise
+            except asyncio.CancelledError:
+                metrics.completed("cancelled")
+                active_streams -= 1
+                raise
             except Exception:
+                outcome = "engine_unavailable"
                 _logger.exception("dictation engine failed to initialize")
                 with contextlib.suppress(RuntimeError):
                     await websocket.send_text(
                         json.dumps({"type": "error", "message": "dictation engine unavailable"})
                     )
                     await websocket.close(code=_WS_CLOSE_INTERNAL_ERROR)
+                metrics.completed(outcome)
+                active_streams -= 1
                 return
             # Release the take on every exit — normal stop, abrupt browser
             # disconnect, or a crash mid-send. For the in-process engines
@@ -142,7 +219,11 @@ def create_dictation_router(
             # close on the way out is enough.
             try:
                 await websocket.send_text(json.dumps({"type": "ready"}))
-                await _pump_dictation(websocket, handle)
+                try:
+                    outcome = await _pump_dictation(websocket, handle)
+                except asyncio.CancelledError:
+                    outcome = "cancelled"
+                    raise
             finally:
                 # An abrupt disconnect tears the ASGI task down via
                 # cancellation, which would cancel this close mid-await and
@@ -159,11 +240,27 @@ def create_dictation_router(
                         # engine, so fall back to a direct call on the loop.
                         with contextlib.suppress(Exception):
                             handle.close()
+                metrics.completed(outcome)
+                active_streams -= 1
 
     return router
 
 
-async def _pump_dictation(websocket: WebSocket, handle: DictationStreamHandle) -> None:
+def _valid_bearer_token(websocket: WebSocket, expected: str) -> bool:
+    return _valid_authorization(websocket.headers.get("authorization", ""), expected)
+
+
+def _valid_http_bearer_token(request: Request, expected: str) -> bool:
+    return _valid_authorization(request.headers.get("authorization", ""), expected)
+
+
+def _valid_authorization(authorization: str, expected: str) -> bool:
+    prefix = "Bearer "
+    provided = authorization[len(prefix) :] if authorization.startswith(prefix) else ""
+    return bool(expected) and hmac.compare_digest(provided.encode(), expected.encode())
+
+
+async def _pump_dictation(websocket: WebSocket, handle: DictationStreamHandle) -> str:
     """Shuttle audio in and transcript events out until stop/disconnect.
 
     :param websocket: The accepted browser-facing WebSocket.
@@ -171,15 +268,53 @@ async def _pump_dictation(websocket: WebSocket, handle: DictationStreamHandle) -
     """
     last_partial_sent = ""
     last_partial_at = 0.0
+    started_at = time.monotonic()
+    audio_bytes = 0
     try:
         while True:
-            message = await websocket.receive()
+            remaining = max_take_seconds() - (time.monotonic() - started_at)
+            if remaining <= 0:
+                metrics.rejected("take_too_long")
+                await websocket.close(
+                    code=_WS_CLOSE_POLICY_VIOLATION,
+                    reason="dictation take exceeds configured duration",
+                )
+                return "duration_limit"
+            try:
+                async with asyncio.timeout(remaining):
+                    message = await websocket.receive()
+            except TimeoutError:
+                metrics.rejected("take_too_long")
+                await websocket.close(
+                    code=_WS_CLOSE_POLICY_VIOLATION,
+                    reason="dictation take exceeds configured duration",
+                )
+                return "duration_limit"
             if message.get("type") == "websocket.disconnect":
-                return
+                return "disconnected"
 
             data = message.get("bytes")
             if data is not None:
-                update = await asyncio.to_thread(handle.feed_pcm16, data)
+                if len(data) > max_frame_bytes():
+                    metrics.rejected("frame_too_large")
+                    await websocket.close(
+                        code=_WS_CLOSE_MESSAGE_TOO_BIG,
+                        reason="dictation audio frame exceeds configured limit",
+                    )
+                    return "frame_limit"
+                audio_bytes += len(data)
+                metrics.audio_bytes(len(data))
+                if (
+                    time.monotonic() - started_at > max_take_seconds()
+                    or audio_bytes / 32000 > max_take_seconds()
+                ):
+                    metrics.rejected("take_too_long")
+                    await websocket.close(
+                        code=_WS_CLOSE_POLICY_VIOLATION,
+                        reason="dictation take exceeds configured duration",
+                    )
+                    return "duration_limit"
+                update = await _run_handle_call(handle.feed_pcm16, data)
                 if update.finalized:
                     await websocket.send_text(
                         json.dumps({"type": "final", "text": update.finalized})
@@ -206,15 +341,30 @@ async def _pump_dictation(websocket: WebSocket, handle: DictationStreamHandle) -
             except ValueError:
                 continue
             if isinstance(control, dict) and control.get("type") == "stop":
-                tail = await asyncio.to_thread(handle.finish)
+                tail = await _run_handle_call(handle.finish)
                 await websocket.send_text(json.dumps({"type": "stopped", "text": tail}))
                 await websocket.close()
-                return
+                return "stopped"
             # Unknown control messages are ignored for forward compat.
     except WebSocketDisconnect:
-        return
+        return "disconnected"
     except Exception:
         _logger.exception("dictation stream failed")
         with contextlib.suppress(RuntimeError):
             await websocket.send_text(json.dumps({"type": "error", "message": "dictation failed"}))
             await websocket.close(code=_WS_CLOSE_INTERNAL_ERROR)
+        return "failed"
+
+
+_T = TypeVar("_T")
+
+
+async def _run_handle_call(call: Callable[..., _T], *args: object) -> _T:
+    """Finish a non-cancellable thread call before stream cleanup runs."""
+    task = asyncio.create_task(asyncio.to_thread(call, *args))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        with anyio.CancelScope(shield=True):
+            await task
+        raise

--- a/openapi.json
+++ b/openapi.json
@@ -7658,6 +7658,30 @@
         "summary": "Branding Logo"
       }
     },
+    "/v1/dictation/status": {
+      "get": {
+        "description": "Return authenticated, sanitized operator diagnostics.",
+        "operationId": "dictation_status_v1_dictation_status_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Dictation Status V1 Dictation Status Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Dictation Status",
+        "tags": [
+          "dictation"
+        ]
+      }
+    },
     "/v1/harnesses": {
       "get": {
         "operationId": "list_harnesses_v1_harnesses_get",

--- a/tests/e2e_ui/chat/test_dictation.py
+++ b/tests/e2e_ui/chat/test_dictation.py
@@ -104,6 +104,37 @@ def test_dictation_streams_transcript_into_composer(
         context.close()
 
 
+def test_dictation_replaces_selected_composer_text(
+    browser: Browser,
+    browser_context_args: dict[str, Any],
+    seeded_session: tuple[str, str],
+) -> None:
+    """A server transcript replaces the selected range instead of appending."""
+    base_url, session_id = seeded_session
+    context, page = _open_server_dictation_page(
+        browser, browser_context_args, base_url, session_id
+    )
+    try:
+        composer = page.get_by_placeholder("Ask the agent anything…")
+        expect(composer).to_be_visible()
+        composer.fill("before replace-me after")
+        composer.evaluate("el => el.setSelectionRange(7, 17)")
+
+        mic = page.get_by_role("button", name="Voice dictation")
+        mic.click()
+        expect(mic).to_have_attribute("aria-pressed", "true")
+        expect(composer).to_have_value(
+            f"before {_FAKE_SCRIPT} after",
+            timeout=_TRANSCRIPT_TIMEOUT_MS,
+        )
+
+        mic.click()
+        expect(mic).to_have_attribute("aria-pressed", "false")
+        expect(composer).to_have_value(f"before {_FAKE_SCRIPT} after")
+    finally:
+        context.close()
+
+
 def test_hotkey_toggles_dictation(
     browser: Browser,
     browser_context_args: dict[str, Any],

--- a/tests/server/routes/test_dictation.py
+++ b/tests/server/routes/test_dictation.py
@@ -10,6 +10,7 @@ transcript by the number of PCM bytes they send.
 from __future__ import annotations
 
 import json
+import threading
 import time
 
 import httpx
@@ -34,6 +35,21 @@ class _NoIdentityAuthProvider:
         """Always return ``None`` (unauthenticated)."""
         del request
         return
+
+
+class _IdentityAuthProvider:
+    def get_user_id(self, request: object) -> str:
+        del request
+        return "test-user"
+
+
+class _PermissionStore:
+    def __init__(self, *, admin: bool) -> None:
+        self.admin = admin
+
+    def is_admin(self, user_id: str) -> bool:
+        assert user_id == "test-user"
+        return self.admin
 
 
 def _fake_app(**router_kwargs: object) -> FastAPI:
@@ -153,3 +169,126 @@ def test_stream_capacity_cap(monkeypatch: pytest.MonkeyPatch) -> None:
                 with pytest.raises(WebSocketDisconnect) as excinfo:
                     second.receive_text()
                 assert excinfo.value.code == 1013
+
+
+def test_worker_shared_token_is_required_before_accept() -> None:
+    app = _fake_app(shared_token="secret")
+    with TestClient(app) as tc:
+        with pytest.raises(WebSocketDisconnect):
+            with tc.websocket_connect("/v1/dictation/stream") as ws:
+                ws.receive_text()
+        with tc.websocket_connect(
+            "/v1/dictation/stream", headers={"Authorization": "Bearer secret"}
+        ) as ws:
+            assert json.loads(ws.receive_text()) == {"type": "ready"}
+
+
+def test_stream_rejects_oversized_frame(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(dictation_engine.MAX_FRAME_BYTES_ENV, "8")
+    with TestClient(_fake_app()) as tc, tc.websocket_connect("/v1/dictation/stream") as ws:
+        assert json.loads(ws.receive_text())["type"] == "ready"
+        ws.send_bytes(b"x" * 9)
+        with pytest.raises(WebSocketDisconnect) as excinfo:
+            ws.receive_text()
+        assert excinfo.value.code == 1009
+
+
+def test_stream_rejects_excess_audio_duration(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(dictation_engine.MAX_TAKE_SECONDS_ENV, "0.001")
+    with TestClient(_fake_app()) as tc, tc.websocket_connect("/v1/dictation/stream") as ws:
+        assert json.loads(ws.receive_text())["type"] == "ready"
+        ws.send_bytes(b"x" * 64)
+        with pytest.raises(WebSocketDisconnect) as excinfo:
+            ws.receive_text()
+        assert excinfo.value.code == 1008
+
+
+def test_disconnect_waits_for_in_flight_decode_before_close() -> None:
+    decode_started = threading.Event()
+    release_decode = threading.Event()
+
+    class _Stream:
+        closed_during_decode = False
+        decoding = False
+
+        def feed_pcm16(self, data: bytes) -> dictation_engine.DictationUpdate:
+            del data
+            self.decoding = True
+            decode_started.set()
+            release_decode.wait(timeout=5)
+            self.decoding = False
+            return dictation_engine.DictationUpdate(partial="")
+
+        def finish(self) -> str:
+            return ""
+
+        def close(self) -> None:
+            self.closed_during_decode = self.decoding
+
+    class _Engine:
+        def __init__(self) -> None:
+            self.stream = _Stream()
+
+        def create_stream(self) -> _Stream:
+            return self.stream
+
+    engine = _Engine()
+    with TestClient(_fake_app(engine_provider=lambda: engine)) as tc:
+        with tc.websocket_connect("/v1/dictation/stream") as ws:
+            assert json.loads(ws.receive_text())["type"] == "ready"
+            ws.send_bytes(_WORD_BYTES)
+            assert decode_started.wait(timeout=5)
+            threading.Timer(0.05, release_decode.set).start()
+            tc.close()
+            deadline = time.monotonic() + 5
+            while engine.stream.decoding and time.monotonic() < deadline:
+                time.sleep(0.01)
+    assert not engine.stream.closed_during_decode
+
+
+def test_status_requires_auth_and_sanitizes_remote_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dictation_engine, "_remote_connection_state", "not_attempted")
+    monkeypatch.setenv(dictation_engine.ENGINE_ENV, dictation_engine.ENGINE_REMOTE)
+    monkeypatch.setenv(
+        dictation_engine.REMOTE_URL_ENV,
+        "wss://user:password@worker.example/v1/dictation/stream?token=secret",
+    )
+    monkeypatch.setenv(dictation_engine.WORKER_TOKEN_ENV, "worker-secret")
+    with TestClient(_fake_app(auth_provider=_NoIdentityAuthProvider())) as tc:
+        assert tc.get("/v1/dictation/status").status_code == 401
+    with TestClient(_fake_app(auth_provider=_IdentityAuthProvider())) as tc:
+        response = tc.get("/v1/dictation/status")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["remote"] == {
+            "configured": True,
+            "secure": True,
+            "token_configured": True,
+            "fallback_available": False,
+            "connection_state": "not_attempted",
+        }
+        assert body["capacity"] == {
+            "max_streams": 2,
+            "active_streams": 0,
+            "available_streams": 2,
+        }
+        assert "password" not in response.text
+        assert "worker-secret" not in response.text
+
+
+def test_status_requires_admin_in_multi_user_mode() -> None:
+    with TestClient(
+        _fake_app(
+            auth_provider=_IdentityAuthProvider(),
+            permission_store=_PermissionStore(admin=False),
+        )
+    ) as tc:
+        assert tc.get("/v1/dictation/status").status_code == 403
+
+    with TestClient(
+        _fake_app(
+            auth_provider=_IdentityAuthProvider(),
+            permission_store=_PermissionStore(admin=True),
+        )
+    ) as tc:
+        assert tc.get("/v1/dictation/status").status_code == 200

--- a/tests/server/test_dictation_engine.py
+++ b/tests/server/test_dictation_engine.py
@@ -21,6 +21,10 @@ def _clean_engine_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(dictation.MODEL_DIR_ENV, raising=False)
     monkeypatch.delenv(dictation.PUNCT_DIR_ENV, raising=False)
     monkeypatch.delenv(dictation.MAX_STREAMS_ENV, raising=False)
+    monkeypatch.delenv(dictation.MAX_FRAME_BYTES_ENV, raising=False)
+    monkeypatch.delenv(dictation.MAX_TAKE_SECONDS_ENV, raising=False)
+    monkeypatch.delenv(dictation.WORKER_TOKEN_ENV, raising=False)
+    monkeypatch.delenv(dictation.ALLOW_INSECURE_REMOTE_ENV, raising=False)
 
 
 def _touch_asr_files(model_dir: Path) -> None:

--- a/tests/server/test_dictation_metrics.py
+++ b/tests/server/test_dictation_metrics.py
@@ -1,0 +1,61 @@
+"""Tests for low-cardinality dictation OpenTelemetry instruments."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from omnigent.server import dictation_metrics
+
+
+class _Instrument:
+    def __init__(self) -> None:
+        self.values: list[tuple[float, object]] = []
+
+    def add(self, value: float, attributes: object = None) -> None:
+        self.values.append((value, attributes))
+
+    def record(self, value: float, attributes: object = None) -> None:
+        self.values.append((value, attributes))
+
+
+class _Meter:
+    def __init__(self) -> None:
+        self.instruments: dict[str, _Instrument] = {}
+
+    def _create(self, name: str, **_: Any) -> _Instrument:
+        instrument = _Instrument()
+        self.instruments[name] = instrument
+        return instrument
+
+    create_counter = _create
+    create_up_down_counter = _create
+    create_histogram = _create
+
+
+def test_dictation_metrics_use_bounded_outcome_attributes(monkeypatch: Any) -> None:
+    meter = _Meter()
+    monkeypatch.setattr(dictation_metrics.otel_metrics, "get_meter", lambda _: meter)
+    recorder = dictation_metrics.DictationMetrics()
+
+    recorder.started()
+    recorder.audio_bytes(3200)
+    recorder.completed("stopped")
+    recorder.rejected("capacity")
+    recorder.warmup(1.5, "ready")
+    recorder.remote_connection("connected")
+    recorder.fallback()
+
+    assert meter.instruments["omnigent.server.dictation.takes.active"].values == [
+        (1, None),
+        (-1, None),
+    ]
+    assert meter.instruments["omnigent.server.dictation.takes.completed"].values == [
+        (1, {"outcome": "stopped"})
+    ]
+    assert meter.instruments["omnigent.server.dictation.takes.rejected"].values == [
+        (1, {"reason": "capacity"})
+    ]
+    assert meter.instruments["omnigent.server.dictation.audio.bytes"].values == [(3200, None)]
+    assert meter.instruments["omnigent.server.dictation.warmup.duration"].values == [
+        (1.5, {"outcome": "ready"})
+    ]

--- a/tests/server/test_dictation_remote.py
+++ b/tests/server/test_dictation_remote.py
@@ -18,12 +18,15 @@ import uvicorn
 
 from omnigent.server import dictation
 
+_TOKEN = "test-worker-token"
+
 
 @pytest.fixture(autouse=True)
 def _fake_engine_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """The spawned worker (same process) must resolve the fake engine."""
     monkeypatch.setenv(dictation.ENGINE_ENV, dictation.ENGINE_FAKE)
     monkeypatch.delenv(dictation.REMOTE_URL_ENV, raising=False)
+    monkeypatch.setenv(dictation.WORKER_TOKEN_ENV, _TOKEN)
     monkeypatch.setattr(dictation, "_engine", None)
 
 
@@ -32,7 +35,9 @@ def worker_url() -> Iterator[str]:
     """Run the real worker app on an ephemeral port; yield its stream URL."""
     from omnigent.server.dictation_worker import create_worker_app
 
-    config = uvicorn.Config(create_worker_app(), host="127.0.0.1", port=0, log_level="warning")
+    config = uvicorn.Config(
+        create_worker_app(shared_token=_TOKEN), host="127.0.0.1", port=0, log_level="warning"
+    )
     server = uvicorn.Server(config)
     thread = threading.Thread(target=server.run, daemon=True)
     thread.start()
@@ -64,7 +69,7 @@ def _drain_partial(handle: dictation.DictationStreamHandle, expected: str) -> No
 
 def test_remote_engine_relays_partials_and_finish(worker_url: str) -> None:
     """PCM up, partial state down, stop-flush returns the tail."""
-    engine = dictation.RemoteDictationEngine(worker_url)
+    engine = dictation.RemoteDictationEngine(worker_url, token=_TOKEN)
     handle = engine.create_stream()
     handle.feed_pcm16(_WORD * 3)
     # The worker throttles partial emission (~150 ms); poll until the
@@ -75,7 +80,7 @@ def test_remote_engine_relays_partials_and_finish(worker_url: str) -> None:
 
 def test_remote_engine_relays_finalized_utterances(worker_url: str) -> None:
     """A worker 'final' event surfaces as DictationUpdate.finalized."""
-    engine = dictation.RemoteDictationEngine(worker_url)
+    engine = dictation.RemoteDictationEngine(worker_url, token=_TOKEN)
     handle = engine.create_stream()
     handle.feed_pcm16(_WORD * len(_WORDS))
     deadline = time.monotonic() + 10
@@ -97,7 +102,7 @@ def test_remote_stream_close_releases_worker_slot(worker_url: str) -> None:
     streams: without the close, the third handshake would be rejected
     with the 1013 at-capacity close.
     """
-    engine = dictation.RemoteDictationEngine(worker_url)
+    engine = dictation.RemoteDictationEngine(worker_url, token=_TOKEN)
     for _ in range(3):
         handle = engine.create_stream()
         handle.feed_pcm16(_WORD)
@@ -108,6 +113,7 @@ def test_remote_engine_falls_back_when_worker_down() -> None:
     """Unreachable worker + local fallback → the take still serves."""
     engine = dictation.RemoteDictationEngine(
         "ws://127.0.0.1:9/v1/dictation/stream",  # port 9: nothing listens
+        token=_TOKEN,
         fallback_factory=dictation.FakeDictationEngine,
     )
     handle = engine.create_stream()
@@ -117,7 +123,7 @@ def test_remote_engine_falls_back_when_worker_down() -> None:
 
 def test_remote_engine_raises_without_fallback() -> None:
     """Unreachable worker and no local models → the take fails loudly."""
-    engine = dictation.RemoteDictationEngine("ws://127.0.0.1:9/v1/dictation/stream")
+    engine = dictation.RemoteDictationEngine("ws://127.0.0.1:9/v1/dictation/stream", token=_TOKEN)
     with pytest.raises(OSError):
         engine.create_stream()
 
@@ -133,7 +139,93 @@ def test_remote_engine_selected_by_name(monkeypatch: pytest.MonkeyPatch) -> None
     """OMNIGENT_DICTATION_ENGINE=remote + a URL selects the relay engine."""
     monkeypatch.setenv(dictation.ENGINE_ENV, dictation.ENGINE_REMOTE)
     monkeypatch.setenv(dictation.REMOTE_URL_ENV, "ws://example:8100/v1/dictation/stream")
+    monkeypatch.setenv(dictation.ALLOW_INSECURE_REMOTE_ENV, "1")
     monkeypatch.setattr(dictation, "_engine", None)
     assert dictation.engine_availability() == (True, None)
     engine = dictation.get_engine()
     assert isinstance(engine, dictation.RemoteDictationEngine)
+
+
+def test_remote_engine_denies_non_loopback_plaintext() -> None:
+    with pytest.raises(ValueError, match="plaintext"):
+        dictation.RemoteDictationEngine(
+            "ws://worker.example/v1/dictation/stream",
+            token=_TOKEN,
+        )
+
+
+def test_remote_engine_allows_loopback_plaintext() -> None:
+    engine = dictation.RemoteDictationEngine(
+        "ws://localhost:9/v1/dictation/stream",
+        token=_TOKEN,
+    )
+    with pytest.raises(OSError):
+        engine.create_stream()
+
+
+def test_wss_uses_verified_ssl_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_create_default_context(*, cafile: str | None = None) -> object:
+        captured["cafile"] = cafile
+        return object()
+
+    monkeypatch.setattr(dictation.ssl, "create_default_context", fake_create_default_context)
+    engine = dictation.RemoteDictationEngine(
+        "wss://worker.example/v1/dictation/stream",
+        token=_TOKEN,
+        ca_file="/private/ca.pem",
+    )
+    assert captured == {"cafile": "/private/ca.pem"}
+    assert engine._ssl_context is not None
+
+
+def test_remote_stream_relays_bearer_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class _Connection:
+        def recv(self, timeout: float | None = None) -> str:
+            del timeout
+            return '{"type":"ready"}'
+
+        def close(self) -> None:
+            return
+
+    def fake_connect(url: str, **kwargs: object) -> _Connection:
+        captured.update(url=url, **kwargs)
+        return _Connection()
+
+    monkeypatch.setattr("websockets.sync.client.connect", fake_connect)
+    stream = dictation._RemoteStream("ws://localhost/stream", _TOKEN, None)
+    stream.close()
+    assert captured["additional_headers"] == {"Authorization": f"Bearer {_TOKEN}"}
+
+
+def test_remote_finish_preserves_final_arriving_before_stopped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    messages = iter(
+        [
+            '{"type":"ready"}',
+            '{"type":"final","text":"complete utterance"}',
+            '{"type":"stopped","text":"tail words"}',
+        ]
+    )
+
+    class _Connection:
+        def recv(self, timeout: float | None = None) -> str:
+            del timeout
+            return next(messages)
+
+        def send(self, _: object) -> None:
+            return
+
+        def close(self) -> None:
+            return
+
+    monkeypatch.setattr(
+        "websockets.sync.client.connect",
+        lambda *_args, **_kwargs: _Connection(),
+    )
+    stream = dictation._RemoteStream("ws://localhost/stream", _TOKEN, None)
+    assert stream.finish() == "complete utterance tail words"

--- a/tests/server/test_dictation_worker.py
+++ b/tests/server/test_dictation_worker.py
@@ -1,0 +1,58 @@
+"""Tests for standalone dictation worker health, auth, and warmup."""
+
+from __future__ import annotations
+
+import threading
+
+from fastapi.testclient import TestClient
+
+from omnigent.server.dictation import FakeDictationEngine
+from omnigent.server.dictation_worker import create_worker_app
+
+_AUTH = {"Authorization": "Bearer worker-secret"}
+
+
+def test_health_public_ready_token_protected() -> None:
+    with TestClient(
+        create_worker_app(engine_provider=FakeDictationEngine, shared_token="worker-secret")
+    ) as client:
+        assert client.get("/health").json() == {"status": "ok"}
+        assert client.get("/ready").status_code == 401
+        assert client.get("/ready", headers=_AUTH).json() == {"status": "ready"}
+
+
+def test_ready_reports_warming_then_ready() -> None:
+    release = threading.Event()
+
+    def slow_engine() -> FakeDictationEngine:
+        release.wait(timeout=5)
+        return FakeDictationEngine()
+
+    with TestClient(
+        create_worker_app(engine_provider=slow_engine, shared_token="worker-secret")
+    ) as client:
+        response = client.get("/ready", headers=_AUTH)
+        assert response.status_code == 503
+        assert response.json()["detail"] == {"status": "warming"}
+        release.set()
+        for _ in range(100):
+            response = client.get("/ready", headers=_AUTH)
+            if response.status_code == 200:
+                break
+        assert response.json() == {"status": "ready"}
+
+
+def test_ready_sanitizes_warmup_failure() -> None:
+    def broken_engine() -> FakeDictationEngine:
+        raise RuntimeError("secret model path /private/models/token")
+
+    with TestClient(
+        create_worker_app(engine_provider=broken_engine, shared_token="worker-secret")
+    ) as client:
+        for _ in range(100):
+            response = client.get("/ready", headers=_AUTH)
+            if response.json().get("detail", {}).get("status") == "failed":
+                break
+        assert response.status_code == 503
+        assert response.json() == {"detail": {"status": "failed"}}
+        assert "/private/models" not in response.text

--- a/web/src/components/ComposerMicButton.test.tsx
+++ b/web/src/components/ComposerMicButton.test.tsx
@@ -20,27 +20,32 @@ import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { CapabilitiesContext } from "@/lib/CapabilitiesContext";
 import type { ServerInfo } from "@/lib/capabilities";
-import type { DictationSessionEvents } from "@/lib/dictation";
+import type { DictationSessionEvents, DictationSessionOptions } from "@/lib/dictation";
 import { ComposerMicButton } from "./ComposerMicButton";
 
 // Controllable DictationSession stand-in for the server-mode tests. The
 // factory reads the mutable spies at call time, so each test installs its
 // own behavior in beforeEach.
 interface SessionStub {
+  captureStream: MediaStream;
   stop: () => Promise<string>;
   cancel: () => void;
 }
-let sessionStartMock: Mock<(events: DictationSessionEvents) => Promise<SessionStub>>;
+let sessionStartMock: Mock<
+  (events: DictationSessionEvents, options?: DictationSessionOptions) => Promise<SessionStub>
+>;
 let sessionStopMock: Mock<() => Promise<string>>;
 let sessionCancelMock: Mock<() => void>;
 let sessionEvents: DictationSessionEvents | null;
+let sessionStream: MediaStream;
 
 vi.mock("@/lib/dictation", () => {
   class DictationBusyError extends Error {}
   return {
     DictationBusyError,
     DictationSession: {
-      start: (events: DictationSessionEvents) => sessionStartMock(events),
+      start: (events: DictationSessionEvents, options?: DictationSessionOptions) =>
+        sessionStartMock(events, options),
     },
   };
 });
@@ -49,9 +54,10 @@ function installDictationSession() {
   sessionEvents = null;
   sessionStopMock = vi.fn(async () => "");
   sessionCancelMock = vi.fn();
+  sessionStream = { getTracks: () => [] } as unknown as MediaStream;
   sessionStartMock = vi.fn(async (events: DictationSessionEvents) => {
     sessionEvents = events;
-    return { stop: sessionStopMock, cancel: sessionCancelMock };
+    return { captureStream: sessionStream, stop: sessionStopMock, cancel: sessionCancelMock };
   });
 }
 
@@ -59,8 +65,51 @@ function installDictationSession() {
 let handlers: Record<string, (event: unknown) => void>;
 let startSpy: ReturnType<typeof vi.fn>;
 let stopSpy: ReturnType<typeof vi.fn>;
+let recognitionLanguage: string;
+let getUserMediaMock: Mock;
 /** Original navigator.mediaDevices descriptor, restored after each test. */
 let originalMediaDevices: PropertyDescriptor | undefined;
+
+interface MeterMocks {
+  close: Mock;
+  createMediaStreamSource: Mock;
+  cancelAnimationFrame: Mock;
+}
+
+function installMeterAudio(): MeterMocks {
+  const close = vi.fn(function (this: { state: AudioContextState }) {
+    this.state = "closed";
+    return Promise.resolve();
+  });
+  const createMediaStreamSource = vi.fn(() => ({ connect: vi.fn() }));
+  const createAnalyser = vi.fn(() => ({
+    fftSize: 0,
+    smoothingTimeConstant: 0,
+    frequencyBinCount: 32,
+    getByteFrequencyData: vi.fn(),
+  }));
+  class FakeAudioContext {
+    state: AudioContextState = "running";
+    close = close;
+    createMediaStreamSource = createMediaStreamSource;
+    createAnalyser = createAnalyser;
+  }
+  const cancelAnimationFrame = vi.fn();
+  vi.stubGlobal("AudioContext", FakeAudioContext);
+  vi.stubGlobal(
+    "requestAnimationFrame",
+    vi.fn(() => 1),
+  );
+  vi.stubGlobal("cancelAnimationFrame", cancelAnimationFrame);
+  return { close, createMediaStreamSource, cancelAnimationFrame };
+}
+
+function mediaStream(stop = vi.fn()): { stream: MediaStream; stop: Mock } {
+  return {
+    stream: { getTracks: () => [{ stop }] } as unknown as MediaStream,
+    stop,
+  };
+}
 
 function installSpeechRecognition() {
   handlers = {};
@@ -71,7 +120,14 @@ function installSpeechRecognition() {
   class FakeRecognition {
     continuous = false;
     interimResults = false;
-    lang = "en-US";
+    private recognitionLang = "en-US";
+    get lang() {
+      return this.recognitionLang;
+    }
+    set lang(value: string) {
+      this.recognitionLang = value;
+      recognitionLanguage = value;
+    }
     start = startSpy;
     stop = stopSpy;
     addEventListener(type: string, handler: (event: unknown) => void) {
@@ -97,9 +153,10 @@ beforeEach(() => {
   // (unavailable in jsdom) is ever constructed. Capture the original descriptor
   // first so afterEach can restore it — otherwise this navigator stub leaks.
   originalMediaDevices = Object.getOwnPropertyDescriptor(navigator, "mediaDevices");
+  getUserMediaMock = vi.fn().mockRejectedValue(new Error("no mic"));
   Object.defineProperty(navigator, "mediaDevices", {
     configurable: true,
-    value: { getUserMedia: vi.fn().mockRejectedValue(new Error("no mic")) },
+    value: { getUserMedia: getUserMediaMock },
   });
 });
 
@@ -107,6 +164,7 @@ afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
   vi.clearAllMocks();
+  localStorage.clear();
   // Restore navigator.mediaDevices so the stub never leaks to other test files.
   if (originalMediaDevices) {
     Object.defineProperty(navigator, "mediaDevices", originalMediaDevices);
@@ -116,11 +174,12 @@ afterEach(() => {
 });
 
 describe("ComposerMicButton", () => {
-  it("renders nothing when the browser has no SpeechRecognition support", () => {
+  it("keeps the button disabled while fallback availability is loading", () => {
     vi.stubGlobal("SpeechRecognition", undefined);
     vi.stubGlobal("webkitSpeechRecognition", undefined);
-    const { container } = render(<ComposerMicButton onTranscript={vi.fn()} />);
-    expect(container).toBeEmptyDOMElement();
+    render(<ComposerMicButton onTranscript={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Voice dictation" })).toBeDisabled();
+    expect(screen.getByRole("status")).toBeEmptyDOMElement();
   });
 
   it("renders an idle, un-pressed dictation button when supported", () => {
@@ -135,10 +194,125 @@ describe("ComposerMicButton", () => {
 
     fireEvent.click(button);
     expect(startSpy).toHaveBeenCalledTimes(1);
+    expect(button).toHaveAttribute("aria-busy", "true");
+    expect(button).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("status")).toHaveTextContent("Starting dictation...");
 
     // The recognizer's "start" event flips the pressed state.
     act(() => handlers.start?.({}));
     expect(button).toHaveAttribute("aria-pressed", "true");
+    expect(button).toHaveAttribute("aria-busy", "false");
+    expect(screen.getByRole("status")).toHaveTextContent("Listening...");
+  });
+
+  it("times out a Web Speech start that never reports listening", () => {
+    vi.useFakeTimers();
+    try {
+      render(<ComposerMicButton onTranscript={vi.fn()} />);
+      const button = screen.getByRole("button", { name: "Voice dictation" });
+      fireEvent.click(button);
+
+      act(() => vi.advanceTimersByTime(45_000));
+
+      expect(stopSpy).toHaveBeenCalledOnce();
+      expect(button).toHaveAttribute("aria-busy", "false");
+      expect(screen.getByRole("status")).toHaveTextContent("Could not start dictation. Try again.");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("captures a separate owned stream for the Web Speech meter", async () => {
+    const meter = installMeterAudio();
+    const owned = mediaStream();
+    getUserMediaMock.mockResolvedValue(owned.stream);
+    render(<ComposerMicButton onTranscript={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Voice dictation" }));
+    await act(async () => handlers.start?.({}));
+
+    expect(getUserMediaMock).toHaveBeenCalledOnce();
+    expect(meter.createMediaStreamSource).toHaveBeenCalledWith(owned.stream);
+    expect(owned.stop).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["stop", () => handlers.end?.({})],
+    ["error", () => handlers.error?.({ error: "network" })],
+    [
+      "Escape",
+      () => window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })),
+    ],
+  ])("cleans up the owned Web Speech meter on %s", async (_name, finish) => {
+    const meter = installMeterAudio();
+    const owned = mediaStream();
+    getUserMediaMock.mockResolvedValue(owned.stream);
+    render(<ComposerMicButton onTranscript={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Voice dictation" }));
+    await act(async () => handlers.start?.({}));
+
+    act(finish);
+
+    expect(owned.stop).toHaveBeenCalledOnce();
+    expect(meter.close).toHaveBeenCalledOnce();
+    expect(meter.cancelAnimationFrame).toHaveBeenCalledWith(1);
+  });
+
+  it("cleans up the owned Web Speech meter when disabled", async () => {
+    const meter = installMeterAudio();
+    const owned = mediaStream();
+    getUserMediaMock.mockResolvedValue(owned.stream);
+    const { rerender } = render(<ComposerMicButton onTranscript={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Voice dictation" }));
+    await act(async () => handlers.start?.({}));
+
+    rerender(<ComposerMicButton onTranscript={vi.fn()} disabled />);
+
+    expect(owned.stop).toHaveBeenCalledOnce();
+    expect(meter.close).toHaveBeenCalledOnce();
+  });
+
+  it("stops a late Web Speech meter capture after unmount", async () => {
+    installMeterAudio();
+    const owned = mediaStream();
+    let resolveCapture: ((stream: MediaStream) => void) | undefined;
+    getUserMediaMock.mockReturnValue(
+      new Promise<MediaStream>((resolve) => {
+        resolveCapture = resolve;
+      }),
+    );
+    const { unmount } = render(<ComposerMicButton onTranscript={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Voice dictation" }));
+    act(() => handlers.start?.({}));
+
+    unmount();
+    await act(async () => resolveCapture?.(owned.stream));
+
+    expect(owned.stop).toHaveBeenCalledOnce();
+  });
+
+  it("stops its owned stream when meter setup fails", async () => {
+    const owned = mediaStream();
+    getUserMediaMock.mockResolvedValue(owned.stream);
+    function BrokenAudioContext() {
+      throw new Error("audio context failed");
+    }
+    vi.stubGlobal("AudioContext", BrokenAudioContext);
+    render(<ComposerMicButton onTranscript={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Voice dictation" }));
+
+    await act(async () => handlers.start?.({}));
+
+    expect(owned.stop).toHaveBeenCalledOnce();
+  });
+
+  it("uses the saved browser recognition language", () => {
+    localStorage.setItem(
+      "omnigent:dictation-preferences",
+      JSON.stringify({ path: "browser", browserLanguage: "de-DE", microphoneDeviceId: null }),
+    );
+    render(<ComposerMicButton onTranscript={vi.fn()} />);
+    expect(recognitionLanguage).toBe("de-DE");
   });
 
   it("stops recognition on a second click once recording", () => {
@@ -170,20 +344,45 @@ describe("ComposerMicButton", () => {
     expect(onTranscript).not.toHaveBeenCalled();
   });
 
-  it("surfaces a permission-denied error in the button tooltip", () => {
+  it("shows and announces actionable permission feedback", () => {
     render(<ComposerMicButton onTranscript={vi.fn()} />);
     const button = screen.getByRole("button", { name: "Voice dictation" });
 
+    fireEvent.click(button);
     act(() => handlers.error?.({ error: "not-allowed" }));
-    expect(button).toHaveAttribute("title", "Microphone permission denied");
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Microphone access denied. Allow access, then try again.",
+    );
+    expect(button).toHaveAttribute("aria-pressed", "false");
+    expect(button).toHaveAccessibleDescription(
+      "Microphone access denied. Allow access, then try again.",
+    );
   });
 
-  it("ignores routine no-speech/aborted errors (no tooltip change)", () => {
+  it("announces a routine recognizer stop without showing an error", () => {
     render(<ComposerMicButton onTranscript={vi.fn()} />);
     const button = screen.getByRole("button", { name: "Voice dictation" });
 
+    fireEvent.click(button);
     act(() => handlers.error?.({ error: "no-speech" }));
     expect(button).toHaveAttribute("title", "Voice dictation");
+    expect(screen.getByRole("status")).toHaveTextContent("Dictation stopped");
+  });
+
+  it("announces normal stop and discard outcomes", () => {
+    render(<ComposerMicButton onTranscript={vi.fn()} onVoiceDiscard={vi.fn()} />);
+    const button = screen.getByRole("button", { name: "Voice dictation" });
+    fireEvent.click(button);
+    act(() => handlers.start?.({}));
+    fireEvent.click(button);
+    expect(screen.getByRole("status")).toHaveTextContent("Stopping dictation...");
+    act(() => handlers.end?.({}));
+    expect(screen.getByRole("status")).toHaveTextContent("Dictation stopped");
+
+    fireEvent.click(button);
+    act(() => handlers.start?.({}));
+    act(() => window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" })));
+    expect(screen.getByRole("status")).toHaveTextContent("Dictation cancelled");
   });
 
   it("snapshots via onVoiceStart when dictation begins", () => {
@@ -307,24 +506,325 @@ async function clickMic() {
 }
 
 describe("ComposerMicButton (server dictation)", () => {
+  it("borrows the direct server capture for metering without another capture", async () => {
+    const meter = installMeterAudio();
+    const borrowed = mediaStream();
+    getUserMediaMock.mockResolvedValue(borrowed.stream);
+    sessionStartMock = vi.fn(async (events: DictationSessionEvents) => {
+      sessionEvents = events;
+      const captureStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      return { captureStream, stop: sessionStopMock, cancel: sessionCancelMock };
+    });
+    renderServerMode();
+
+    await clickMic();
+
+    expect(sessionStartMock).toHaveBeenCalledOnce();
+    expect(getUserMediaMock).toHaveBeenCalledOnce();
+    expect(meter.createMediaStreamSource).toHaveBeenCalledWith(borrowed.stream);
+    expect(borrowed.stop).not.toHaveBeenCalled();
+  });
+
+  it.each(["stop", "error", "disable", "Escape", "unmount"])(
+    "cleans up but never stops the borrowed server stream on %s",
+    async (finish) => {
+      const meter = installMeterAudio();
+      const borrowed = mediaStream();
+      sessionStream = borrowed.stream;
+      const view = renderServerMode();
+      await clickMic();
+
+      if (finish === "stop") await clickMic();
+      else if (finish === "error") act(() => sessionEvents?.onError("failed"));
+      else if (finish === "disable") {
+        view.rerender(
+          <CapabilitiesContext.Provider value={DICTATION_INFO}>
+            <ComposerMicButton onTranscript={vi.fn()} disabled />
+          </CapabilitiesContext.Provider>,
+        );
+      } else if (finish === "Escape") {
+        act(() =>
+          window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })),
+        );
+      } else view.unmount();
+
+      expect(borrowed.stop).not.toHaveBeenCalled();
+      expect(meter.close).toHaveBeenCalledOnce();
+      expect(meter.cancelAnimationFrame).toHaveBeenCalledWith(1);
+    },
+  );
+
+  it("cancels a session that resolves after unmount", async () => {
+    let resolveStart: ((session: SessionStub) => void) | undefined;
+    sessionStartMock = vi.fn(
+      () =>
+        new Promise<SessionStub>((resolve) => {
+          resolveStart = resolve;
+        }),
+    );
+    const { unmount } = renderServerMode();
+    fireEvent.click(screen.getByRole("button", { name: "Voice dictation" }));
+    unmount();
+
+    await act(async () =>
+      resolveStart?.({
+        captureStream: sessionStream,
+        stop: sessionStopMock,
+        cancel: sessionCancelMock,
+      }),
+    );
+    expect(sessionCancelMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["unmount", "disable", "toggle", "Escape"])(
+    "aborts a pending server start on %s without showing an error",
+    async (cancel) => {
+      let rejectStart: ((error: unknown) => void) | undefined;
+      sessionStartMock = vi.fn(
+        (_events, options) =>
+          new Promise<SessionStub>((_resolve, reject) => {
+            rejectStart = reject;
+            options?.signal?.addEventListener("abort", () =>
+              reject(new DOMException("aborted", "AbortError")),
+            );
+          }),
+      );
+      const view = renderServerMode();
+      const button = screen.getByRole("button", { name: "Voice dictation" });
+      fireEvent.click(button);
+      const signal = sessionStartMock.mock.calls[0]?.[1]?.signal;
+
+      if (cancel === "unmount") view.unmount();
+      else if (cancel === "disable") {
+        view.rerender(
+          <CapabilitiesContext.Provider value={DICTATION_INFO}>
+            <ComposerMicButton onTranscript={vi.fn()} disabled />
+          </CapabilitiesContext.Provider>,
+        );
+      } else if (cancel === "toggle") fireEvent.click(button);
+      else {
+        window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      }
+      await act(async () => {
+        if (!signal?.aborted) rejectStart?.(new Error("start was not aborted"));
+      });
+
+      expect(signal?.aborted).toBe(true);
+      if (cancel !== "unmount") {
+        expect(screen.getByRole("button", { name: "Voice dictation" })).toHaveAttribute(
+          "title",
+          "Voice dictation",
+        );
+      }
+    },
+  );
+
+  it("cancels a session that resolves after the composer becomes disabled", async () => {
+    let resolveStart: ((session: SessionStub) => void) | undefined;
+    sessionStartMock = vi.fn(
+      () =>
+        new Promise<SessionStub>((resolve) => {
+          resolveStart = resolve;
+        }),
+    );
+    const { rerender } = renderServerMode();
+    fireEvent.click(screen.getByRole("button", { name: "Voice dictation" }));
+    rerender(
+      <CapabilitiesContext.Provider value={DICTATION_INFO}>
+        <ComposerMicButton onTranscript={vi.fn()} disabled />
+      </CapabilitiesContext.Provider>,
+    );
+
+    await act(async () =>
+      resolveStart?.({
+        captureStream: sessionStream,
+        stop: sessionStopMock,
+        cancel: sessionCancelMock,
+      }),
+    );
+    expect(sessionCancelMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores transport events from a cancelled take after a new take starts", async () => {
+    const firstEvents: { current: DictationSessionEvents | null } = { current: null };
+    const onTranscript = vi.fn();
+    sessionStartMock = vi
+      .fn()
+      .mockImplementationOnce(async (events: DictationSessionEvents) => {
+        firstEvents.current = events;
+        return { captureStream: sessionStream, stop: sessionStopMock, cancel: sessionCancelMock };
+      })
+      .mockImplementationOnce(async (events: DictationSessionEvents) => {
+        sessionEvents = events;
+        return { captureStream: sessionStream, stop: sessionStopMock, cancel: sessionCancelMock };
+      });
+    renderServerMode({ onTranscript });
+    await clickMic();
+    act(() => window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" })));
+    await clickMic();
+
+    act(() => {
+      firstEvents.current?.onFinal("late final");
+      firstEvents.current?.onError("late failure");
+      sessionEvents?.onFinal("current final");
+    });
+
+    expect(onTranscript).toHaveBeenCalledOnce();
+    expect(onTranscript).toHaveBeenCalledWith("current final");
+    expect(screen.getByRole("status")).toHaveTextContent("Listening...");
+  });
+
+  it("shows cancelled and ignores late startup resolution when disabled", async () => {
+    let resolveStart: ((session: SessionStub) => void) | undefined;
+    sessionStartMock = vi.fn(
+      () =>
+        new Promise<SessionStub>((resolve) => {
+          resolveStart = resolve;
+        }),
+    );
+    const view = renderServerMode();
+    fireEvent.click(screen.getByRole("button", { name: "Voice dictation" }));
+    view.rerender(
+      <CapabilitiesContext.Provider value={DICTATION_INFO}>
+        <ComposerMicButton onTranscript={vi.fn()} disabled />
+      </CapabilitiesContext.Provider>,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent("Dictation cancelled");
+
+    await act(async () =>
+      resolveStart?.({
+        captureStream: sessionStream,
+        stop: sessionStopMock,
+        cancel: sessionCancelMock,
+      }),
+    );
+    expect(sessionCancelMock).toHaveBeenCalledOnce();
+    expect(screen.getByRole("button", { name: "Voice dictation" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("times out a cold server start and cancels a late session", async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveStart: ((session: SessionStub) => void) | undefined;
+      sessionStartMock = vi.fn(
+        () =>
+          new Promise<SessionStub>((resolve) => {
+            resolveStart = resolve;
+          }),
+      );
+      renderServerMode();
+      fireEvent.click(screen.getByRole("button", { name: "Voice dictation" }));
+
+      act(() => vi.advanceTimersByTime(45_000));
+
+      expect(sessionStartMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+      expect(screen.getByRole("status")).toHaveTextContent("Could not start dictation. Try again.");
+      await act(async () =>
+        resolveStart?.({
+          captureStream: sessionStream,
+          stop: sessionStopMock,
+          cancel: sessionCancelMock,
+        }),
+      );
+      expect(sessionCancelMock).toHaveBeenCalledOnce();
+      expect(screen.getByRole("button", { name: "Voice dictation" })).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("server mode bypasses Web Speech and passes the selected microphone", async () => {
+    localStorage.setItem(
+      "omnigent:dictation-preferences",
+      JSON.stringify({ path: "server", browserLanguage: "en-US", microphoneDeviceId: "mic-2" }),
+    );
+    render(
+      <CapabilitiesContext.Provider value={DICTATION_INFO}>
+        <ComposerMicButton onTranscript={vi.fn()} />
+      </CapabilitiesContext.Provider>,
+    );
+    await clickMic();
+
+    expect(startSpy).not.toHaveBeenCalled();
+    expect(sessionStartMock).toHaveBeenCalledWith(expect.any(Object), {
+      microphoneDeviceId: "mic-2",
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("browser mode never falls back to the server after a network error", async () => {
+    localStorage.setItem(
+      "omnigent:dictation-preferences",
+      JSON.stringify({ path: "browser", browserLanguage: "en-US", microphoneDeviceId: null }),
+    );
+    render(
+      <CapabilitiesContext.Provider value={DICTATION_INFO}>
+        <ComposerMicButton onTranscript={vi.fn()} />
+      </CapabilitiesContext.Provider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Voice dictation" }));
+    await act(async () => handlers.error?.({ error: "network" }));
+
+    expect(startSpy).toHaveBeenCalledTimes(1);
+    expect(sessionStartMock).not.toHaveBeenCalled();
+  });
+
+  it("shows the selected strict path as unavailable", () => {
+    localStorage.setItem(
+      "omnigent:dictation-preferences",
+      JSON.stringify({ path: "server", browserLanguage: "en-US", microphoneDeviceId: null }),
+    );
+    render(
+      <CapabilitiesContext.Provider value={NO_DICTATION_INFO}>
+        <ComposerMicButton onTranscript={vi.fn()} />
+      </CapabilitiesContext.Provider>,
+    );
+    expect(screen.getByRole("button", { name: "Voice dictation" })).toBeDisabled();
+    expect(screen.getByRole("status")).toHaveTextContent("Server dictation is unavailable.");
+  });
+
   it("renders the button when the server advertises dictation", () => {
     renderServerMode();
     expect(screen.getByRole("button", { name: "Voice dictation" })).toBeInTheDocument();
   });
 
-  it("renders nothing when neither Web Speech nor the server can help", () => {
-    const { container } = renderServerMode({}, NO_DICTATION_INFO);
-    expect(container).toBeEmptyDOMElement();
+  it("shows unavailable when neither Web Speech nor the server can help", () => {
+    renderServerMode({}, NO_DICTATION_INFO);
+    expect(screen.getByRole("button", { name: "Voice dictation" })).toBeDisabled();
+    expect(screen.getByRole("status")).toHaveTextContent("Voice dictation is unavailable.");
   });
 
   it("starts a session on click and reflects the recording state", async () => {
-    renderServerMode();
-    await clickMic();
-    expect(sessionStartMock).toHaveBeenCalledTimes(1);
-    expect(screen.getByRole("button", { name: "Voice dictation" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
+    let resolveStart: ((session: SessionStub) => void) | undefined;
+    sessionStartMock = vi.fn(
+      () =>
+        new Promise<SessionStub>((resolve) => {
+          resolveStart = resolve;
+        }),
     );
+    renderServerMode();
+    fireEvent.click(screen.getByRole("button", { name: "Voice dictation" }));
+    const button = screen.getByRole("button", { name: "Voice dictation" });
+    expect(button).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByRole("status")).toHaveTextContent("Starting dictation...");
+
+    await act(async () =>
+      resolveStart?.({
+        captureStream: sessionStream,
+        stop: sessionStopMock,
+        cancel: sessionCancelMock,
+      }),
+    );
+    expect(sessionStartMock).toHaveBeenCalledTimes(1);
+    expect(button).toHaveAttribute("aria-pressed", "true");
+    expect(button).toHaveAttribute("aria-busy", "false");
+    expect(screen.getByRole("status")).toHaveTextContent("Listening...");
   });
 
   it("routes partials to onInterim and finals to onTranscript", async () => {
@@ -367,15 +867,56 @@ describe("ComposerMicButton (server dictation)", () => {
     expect(onInterim).toHaveBeenCalledWith("");
   });
 
-  it("surfaces mic permission denial in the tooltip", async () => {
+  it("does not publish a late stop tail after disable or unmount", async () => {
+    let resolveStop: ((tail: string) => void) | undefined;
+    sessionStopMock = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveStop = resolve;
+        }),
+    );
+    const onTranscript = vi.fn();
+    const view = renderServerMode({ onTranscript });
+    await clickMic();
+    fireEvent.click(screen.getByRole("button", { name: "Voice dictation" }));
+
+    view.unmount();
+    await act(async () => resolveStop?.("late tail"));
+
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+
+  it("keeps Escape cancellation authoritative during an asynchronous stop", async () => {
+    let resolveStop: ((tail: string) => void) | undefined;
+    sessionStopMock = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveStop = resolve;
+        }),
+    );
+    const onTranscript = vi.fn();
+    const onVoiceDiscard = vi.fn();
+    renderServerMode({ onTranscript, onVoiceDiscard });
+    await clickMic();
+    fireEvent.click(screen.getByRole("button", { name: "Voice dictation" }));
+    act(() => window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" })));
+    expect(screen.getByRole("status")).toHaveTextContent("Dictation cancelled");
+    expect(onVoiceDiscard).toHaveBeenCalledOnce();
+
+    await act(async () => resolveStop?.("late tail"));
+
+    expect(onTranscript).not.toHaveBeenCalled();
+    expect(screen.getByRole("status")).toHaveTextContent("Dictation cancelled");
+  });
+
+  it("shows mic permission denial with recovery guidance", async () => {
     sessionStartMock = vi.fn(async () => {
       throw new DOMException("denied", "NotAllowedError");
     });
     renderServerMode();
     await clickMic();
-    expect(screen.getByRole("button", { name: "Voice dictation" })).toHaveAttribute(
-      "title",
-      "Microphone permission denied",
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Microphone access denied. Allow access, then try again.",
     );
   });
 
@@ -387,7 +928,7 @@ describe("ComposerMicButton (server dictation)", () => {
     act(() => sessionEvents?.onError("dictation failed"));
     const button = screen.getByRole("button", { name: "Voice dictation" });
     expect(button).toHaveAttribute("aria-pressed", "false");
-    expect(button).toHaveAttribute("title", "Dictation unavailable");
+    expect(screen.getByRole("status")).toHaveTextContent("Dictation connection lost. Try again.");
     expect(onInterim).toHaveBeenCalledWith("");
   });
 
@@ -397,20 +938,28 @@ describe("ComposerMicButton (server dictation)", () => {
     // build at runtime with "network". The take must fall back to server
     // dictation so the user's click still lands.
     const onInterim = vi.fn();
+    const onVoiceStart = vi.fn();
     render(
       <CapabilitiesContext.Provider value={DICTATION_INFO}>
-        <ComposerMicButton onTranscript={vi.fn()} onInterim={onInterim} />
+        <ComposerMicButton
+          onTranscript={vi.fn()}
+          onInterim={onInterim}
+          onVoiceStart={onVoiceStart}
+        />
       </CapabilitiesContext.Provider>,
     );
     const button = screen.getByRole("button", { name: "Voice dictation" });
 
     fireEvent.click(button);
     expect(startSpy).toHaveBeenCalledTimes(1);
+    act(() => handlers.start?.({}));
+    expect(onVoiceStart).toHaveBeenCalledOnce();
     await act(async () => handlers.error?.({ error: "network" }));
 
     // The take restarted on the server path, with no error tooltip for
     // the silent switch, and partials flow.
     expect(sessionStartMock).toHaveBeenCalledTimes(1);
+    expect(onVoiceStart).toHaveBeenCalledOnce();
     expect(button).toHaveAttribute("aria-pressed", "true");
     expect(button).toHaveAttribute("title", "Voice dictation");
     act(() => sessionEvents?.onPartial("via server"));
@@ -430,6 +979,44 @@ describe("ComposerMicButton (server dictation)", () => {
     expect(sessionStartMock).toHaveBeenCalledTimes(1);
   });
 
+  it("snapshots once when Web Speech falls back before its start event", async () => {
+    const onVoiceStart = vi.fn();
+    render(
+      <CapabilitiesContext.Provider value={DICTATION_INFO}>
+        <ComposerMicButton onTranscript={vi.fn()} onVoiceStart={onVoiceStart} />
+      </CapabilitiesContext.Provider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Voice dictation" }));
+
+    await act(async () => handlers.error?.({ error: "network" }));
+
+    expect(sessionStartMock).toHaveBeenCalledOnce();
+    expect(onVoiceStart).toHaveBeenCalledOnce();
+  });
+
+  it("switches from an owned Web Speech meter to the borrowed fallback stream", async () => {
+    const meter = installMeterAudio();
+    const owned = mediaStream();
+    const borrowed = mediaStream();
+    getUserMediaMock.mockResolvedValue(owned.stream);
+    sessionStream = borrowed.stream;
+    render(
+      <CapabilitiesContext.Provider value={DICTATION_INFO}>
+        <ComposerMicButton onTranscript={vi.fn()} />
+      </CapabilitiesContext.Provider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Voice dictation" }));
+    await act(async () => handlers.start?.({}));
+
+    await act(async () => handlers.error?.({ error: "network" }));
+
+    expect(getUserMediaMock).toHaveBeenCalledOnce();
+    expect(owned.stop).toHaveBeenCalledOnce();
+    expect(borrowed.stop).not.toHaveBeenCalled();
+    expect(meter.createMediaStreamSource).toHaveBeenNthCalledWith(1, owned.stream);
+    expect(meter.createMediaStreamSource).toHaveBeenNthCalledWith(2, borrowed.stream);
+  });
+
   it("reports a busy server distinctly from a broken one", async () => {
     const { DictationBusyError } = await import("@/lib/dictation");
     sessionStartMock = vi.fn(async () => {
@@ -437,10 +1024,7 @@ describe("ComposerMicButton (server dictation)", () => {
     });
     renderServerMode();
     await clickMic();
-    expect(screen.getByRole("button", { name: "Voice dictation" })).toHaveAttribute(
-      "title",
-      "Dictation is busy — try again shortly",
-    );
+    expect(screen.getByRole("status")).toHaveTextContent("Dictation is busy. Try again shortly.");
   });
 
   it("keeps the plain error path when the server offers no dictation", async () => {
@@ -453,7 +1037,7 @@ describe("ComposerMicButton (server dictation)", () => {
     fireEvent.click(button);
     await act(async () => handlers.error?.({ error: "network" }));
     expect(sessionStartMock).not.toHaveBeenCalled();
-    expect(button).toHaveAttribute("title", "Dictation unavailable");
+    expect(screen.getByRole("status")).toHaveTextContent("Could not start dictation. Try again.");
   });
 
   it("cancels the session when the composer goes disabled mid-take", async () => {

--- a/web/src/components/ComposerMicButton.tsx
+++ b/web/src/components/ComposerMicButton.tsx
@@ -4,10 +4,11 @@ import { Button } from "@/components/ui/button";
 import { useVoiceDictationHotkey } from "@/hooks/useVoiceDictationHotkey";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { DictationBusyError, DictationSession } from "@/lib/dictation";
+import { readDictationPreferences } from "@/lib/dictationPreferences";
 import { isElectronShell } from "@/lib/nativeBridge";
 import { cn } from "@/lib/utils";
 import { MicIcon, SquareIcon } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 // Local-only types; speech-input.tsx already augments Window globally.
 interface SpeechRecognitionLike {
@@ -57,6 +58,13 @@ const BAR_BINS: readonly (readonly [number, number])[] = [
 
 const BAR_BASELINE = 0.2;
 
+type MeterSource = { kind: "web-speech" } | { kind: "server"; stream: MediaStream };
+
+type DictationPhase = "idle" | "starting" | "listening" | "stopping";
+
+const STATUS_CLEAR_DELAY_MS = 2_500;
+const STARTUP_TIMEOUT_MS = 45_000;
+
 export interface ComposerMicButtonProps {
   onTranscript: (text: string) => void;
   /**
@@ -86,15 +94,21 @@ const isPermissionError = (error: unknown): boolean =>
   error instanceof DOMException &&
   (error.name === "NotAllowedError" || error.name === "SecurityError");
 
+const isMissingMicrophoneError = (error: unknown): boolean =>
+  error instanceof DOMException &&
+  (error.name === "NotFoundError" || error.name === "OverconstrainedError");
+
 export const ComposerMicButton = ({
   onTranscript,
   onInterim,
   disabled,
-  lang = "en-US",
+  lang,
   enableHotkey = false,
   onVoiceStart,
   onVoiceDiscard,
 }: ComposerMicButtonProps) => {
+  const [preferences] = useState(readDictationPreferences);
+  const recognitionLanguage = lang ?? preferences.browserLanguage;
   // Web Speech is primary whenever the browser has the constructor
   // (Chrome/Safari, unchanged behavior); with no constructor at all
   // (Firefox) takes use server dictation when GET /v1/info advertises it.
@@ -110,10 +124,15 @@ export const ComposerMicButton = ({
   // over [Ctor, lang]) see the current probe result.
   const serverAvailableRef = useRef(serverAvailable);
   serverAvailableRef.current = serverAvailable;
-  const [isListening, setIsListening] = useState(false);
+  const [phase, setPhase] = useState<DictationPhase>("idle");
   const [error, setError] = useState<string | null>(null);
+  const [completionStatus, setCompletionStatus] = useState<string | null>(null);
+  const statusId = useId();
+  const [meterSource, setMeterSource] = useState<MeterSource | null>(null);
   const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
   const sessionRef = useRef<DictationSession | null>(null);
+  const pendingServerStartRef = useRef<AbortController | null>(null);
+  const serverTakeIdRef = useRef(0);
   // Refs so handlers aren't re-attached on every parent re-render.
   const onTranscriptRef = useRef(onTranscript);
   onTranscriptRef.current = onTranscript;
@@ -132,6 +151,11 @@ export const ComposerMicButton = ({
   // disabled mid-utterance.
   const disabledRef = useRef(disabled);
   disabledRef.current = disabled;
+  const mountedRef = useRef(true);
+  const phaseRef = useRef<DictationPhase>("idle");
+  phaseRef.current = phase;
+  const webTakeActiveRef = useRef(false);
+  const voiceSnapshotTakenRef = useRef(false);
   // Click guard: true between toggle() and the matching start/end event.
   // Prevents rapid double-clicks from calling recognition.start() twice,
   // which throws InvalidStateError in Chrome.
@@ -142,7 +166,7 @@ export const ComposerMicButton = ({
   const serverBusyRef = useRef(false);
   // Lets the mount-time Web Speech error handler start the fallback take
   // without closing over toggleServer's identity.
-  const toggleServerRef = useRef<() => Promise<void>>(async () => {});
+  const toggleServerRef = useRef<(snapshot?: boolean) => Promise<void>>(async () => {});
 
   // Written via .style.transform from rAF — avoids 60Hz React re-renders.
   const barRefs = useRef<(HTMLSpanElement | null)[]>(BAR_BINS.map(() => null));
@@ -154,7 +178,7 @@ export const ComposerMicButton = ({
     // Keep listening until the user clicks stop — no auto-stop on silence.
     recognition.continuous = true;
     recognition.interimResults = false;
-    recognition.lang = lang;
+    recognition.lang = recognitionLanguage;
 
     // A dead recognizer keeps firing start/end/error after the take has
     // fallen back to the server; those stale events must not clobber the
@@ -163,43 +187,69 @@ export const ComposerMicButton = ({
 
     const handleStart = () => {
       if (serverTakeOwnsState()) return;
+      if (!webTakeActiveRef.current || disabledRef.current) {
+        try {
+          recognition.stop();
+        } catch {
+          // A cancelled start may already have stopped the recognizer.
+        }
+        return;
+      }
       transitionRef.current = false;
       discardingRef.current = false;
       setError(null);
-      setIsListening(true);
+      setPhase("listening");
+      setMeterSource({ kind: "web-speech" });
       // Snapshot point: let the parent record the text so Esc can revert to it.
       onVoiceStartRef.current?.();
+      voiceSnapshotTakenRef.current = true;
     };
     const handleEnd = () => {
       if (serverTakeOwnsState()) return;
       transitionRef.current = false;
-      setIsListening(false);
+      const wasActive = webTakeActiveRef.current;
+      webTakeActiveRef.current = false;
+      setPhase("idle");
+      setMeterSource(null);
+      if (wasActive)
+        setCompletionStatus(discardingRef.current ? "Dictation cancelled" : "Dictation stopped");
     };
     const handleError = (event: Event) => {
       if (serverTakeOwnsState()) return;
+      if (!webTakeActiveRef.current) return;
       transitionRef.current = false;
+      setMeterSource(null);
       const err = (event as SpeechRecognitionErrorEventLike).error;
       // "network" means the recognizer's cloud backend refused us —
       // always the case in Electron/plain Chromium, occasionally a
       // transient blip in real Chrome. Serve THIS take from the server
       // instead; the next take tries Web Speech again.
-      if (err === "network" && serverAvailableRef.current && !disabledRef.current) {
-        setIsListening(false);
-        void toggleServerRef.current();
+      if (
+        err === "network" &&
+        preferences.path === "auto" &&
+        serverAvailableRef.current &&
+        !disabledRef.current
+      ) {
+        webTakeActiveRef.current = false;
+        setPhase("idle");
+        void toggleServerRef.current(!voiceSnapshotTakenRef.current);
         return;
       }
       // "no-speech" / "aborted" are routine (silence timeout, user stop).
       if (err === "not-allowed" || err === "service-not-allowed") {
-        setError("Microphone permission denied");
+        setError("Microphone access denied. Allow access, then try again.");
       } else if (err && err !== "no-speech" && err !== "aborted") {
-        setError("Dictation unavailable");
+        setError("Could not start dictation. Try again.");
+      } else if (webTakeActiveRef.current) {
+        setCompletionStatus(discardingRef.current ? "Dictation cancelled" : "Dictation stopped");
       }
-      setIsListening(false);
+      webTakeActiveRef.current = false;
+      setPhase("idle");
     };
     const handleResult = (event: Event) => {
       // Drop late events that arrive after the composer went disabled, or after
       // an Esc discard the parent has already reverted.
-      if (disabledRef.current || discardingRef.current) return;
+      if (!webTakeActiveRef.current || disabledRef.current || discardingRef.current) return;
       const speechEvent = event as SpeechRecognitionEventLike;
       let finalTranscript = "";
       for (let i = speechEvent.resultIndex; i < speechEvent.results.length; i += 1) {
@@ -226,7 +276,33 @@ export const ComposerMicButton = ({
       recognition.stop();
       recognitionRef.current = null;
     };
-  }, [Ctor, lang]);
+  }, [Ctor, preferences.path, recognitionLanguage]);
+
+  useEffect(() => {
+    if (!completionStatus) return;
+    const timer = window.setTimeout(() => setCompletionStatus(null), STATUS_CLEAR_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, [completionStatus]);
+
+  useEffect(() => {
+    if (phase !== "starting") return;
+    const timer = window.setTimeout(() => {
+      if (pendingServerStartRef.current) {
+        serverTakeIdRef.current += 1;
+        pendingServerStartRef.current.abort();
+      }
+      webTakeActiveRef.current = false;
+      transitionRef.current = false;
+      try {
+        recognitionRef.current?.stop();
+      } catch {
+        // The recognizer may have failed without dispatching an event.
+      }
+      setPhase("idle");
+      setError("Could not start dictation. Try again.");
+    }, STARTUP_TIMEOUT_MS);
+    return () => window.clearTimeout(timer);
+  }, [phase]);
 
   // Auto-stop if the composer goes disabled mid-dictation. Stops the
   // recognizer; the disabledRef guard in handleResult catches any final
@@ -234,11 +310,21 @@ export const ComposerMicButton = ({
   // cancelled outright (no tail flush) — the take is moot once the
   // composer can't accept text.
   useEffect(() => {
-    if (!(disabled && isListening)) return;
+    if (!disabled) return;
+    if (pendingServerStartRef.current) {
+      serverTakeIdRef.current += 1;
+      pendingServerStartRef.current.abort();
+    }
+    if (phase === "idle") return;
+    webTakeActiveRef.current = false;
+    transitionRef.current = false;
+    setPhase("idle");
+    setCompletionStatus("Dictation cancelled");
+    setMeterSource(null);
     if (sessionRef.current) {
+      serverTakeIdRef.current += 1;
       sessionRef.current.cancel();
       sessionRef.current = null;
-      setIsListening(false);
       onInterimRef.current?.("");
       return;
     }
@@ -248,24 +334,31 @@ export const ComposerMicButton = ({
       // .stop() on an already-stopped recognizer can throw in some
       // browsers; safe to ignore — the end event will reconcile state.
     }
-  }, [disabled, isListening]);
+  }, [disabled, phase]);
 
   // Release the mic if the component unmounts mid-take (e.g. the
   // new-chat dialog closes while dictating).
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      webTakeActiveRef.current = false;
+      transitionRef.current = false;
+      pendingServerStartRef.current?.abort();
+      serverTakeIdRef.current += 1;
       sessionRef.current?.cancel();
       sessionRef.current = null;
-    },
-    [],
-  );
+    };
+  }, []);
 
-  // Second getUserMedia stream just for visualization — Web Speech API
-  // hides its audio buffer. Chrome batches the permission to one prompt.
+  // Web Speech hides its audio buffer, so it owns a separate visualizer
+  // capture. Server dictation lends the meter its existing capture stream.
   useEffect(() => {
-    if (!isListening) return;
+    if (!meterSource) return;
+    const sourceSpec = meterSource;
     let cancelled = false;
     let stream: MediaStream | null = null;
+    let ownsStream = false;
     let audioCtx: AudioContext | null = null;
     let rafId: number | null = null;
     // Snapshot so cleanup doesn't read a stale .current (exhaustive-deps).
@@ -273,41 +366,50 @@ export const ComposerMicButton = ({
 
     const start = async () => {
       try {
-        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      } catch {
-        // Mic permission denied just for the visualization stream — leave
-        // the bars at baseline. The speech recognition error handler will
-        // surface the user-facing message if it also fails.
-        return;
-      }
-      if (cancelled) {
-        for (const track of stream.getTracks()) track.stop();
-        return;
-      }
-      audioCtx = new AudioContext();
-      const source = audioCtx.createMediaStreamSource(stream);
-      const analyser = audioCtx.createAnalyser();
-      analyser.fftSize = 64;
-      // Built-in temporal smoothing so bars don't jitter frame-to-frame.
-      analyser.smoothingTimeConstant = 0.75;
-      source.connect(analyser);
-      const data = new Uint8Array(analyser.frequencyBinCount);
-
-      const tick = () => {
-        analyser.getByteFrequencyData(data);
-        for (let i = 0; i < BAR_BINS.length; i += 1) {
-          const [lo, hi] = BAR_BINS[i];
-          let sum = 0;
-          for (let j = lo; j < hi; j += 1) sum += data[j];
-          const avg = sum / (hi - lo) / 255;
-          // 1.6× headroom for quiet speech; clamp at 1 to fit the button.
-          const scale = Math.max(BAR_BASELINE, Math.min(1, avg * 1.6));
-          const el = bars[i];
-          if (el) el.style.transform = `scaleY(${scale})`;
+        ownsStream = sourceSpec.kind === "web-speech";
+        const nextStream =
+          sourceSpec.kind === "web-speech"
+            ? await navigator.mediaDevices.getUserMedia({ audio: true })
+            : sourceSpec.stream;
+        if (cancelled) {
+          if (ownsStream) {
+            for (const track of nextStream.getTracks()) track.stop();
+          }
+          return;
         }
+        stream = nextStream;
+        audioCtx = new AudioContext();
+        const source = audioCtx.createMediaStreamSource(nextStream);
+        const analyser = audioCtx.createAnalyser();
+        analyser.fftSize = 64;
+        // Built-in temporal smoothing so bars don't jitter frame-to-frame.
+        analyser.smoothingTimeConstant = 0.75;
+        source.connect(analyser);
+        const data = new Uint8Array(analyser.frequencyBinCount);
+
+        const tick = () => {
+          analyser.getByteFrequencyData(data);
+          for (let i = 0; i < BAR_BINS.length; i += 1) {
+            const [lo, hi] = BAR_BINS[i];
+            let sum = 0;
+            for (let j = lo; j < hi; j += 1) sum += data[j];
+            const avg = sum / (hi - lo) / 255;
+            // 1.6× headroom for quiet speech; clamp at 1 to fit the button.
+            const scale = Math.max(BAR_BASELINE, Math.min(1, avg * 1.6));
+            const el = bars[i];
+            if (el) el.style.transform = `scaleY(${scale})`;
+          }
+          rafId = requestAnimationFrame(tick);
+        };
         rafId = requestAnimationFrame(tick);
-      };
-      rafId = requestAnimationFrame(tick);
+      } catch {
+        if (stream && ownsStream) {
+          for (const track of stream.getTracks()) track.stop();
+          stream = null;
+        }
+        if (audioCtx && audioCtx.state !== "closed") void audioCtx.close();
+        audioCtx = null;
+      }
     };
 
     start();
@@ -315,7 +417,7 @@ export const ComposerMicButton = ({
     return () => {
       cancelled = true;
       if (rafId !== null) cancelAnimationFrame(rafId);
-      if (stream) {
+      if (stream && ownsStream) {
         for (const track of stream.getTracks()) track.stop();
       }
       if (audioCtx && audioCtx.state !== "closed") {
@@ -326,65 +428,131 @@ export const ComposerMicButton = ({
         if (el) el.style.transform = `scaleY(${BAR_BASELINE})`;
       }
     };
-  }, [isListening]);
+  }, [meterSource]);
 
   // Server-dictation toggle. Start resolves only once the mic + socket
   // handshake are up, so isListening flips exactly when audio flows.
-  const toggleServer = useCallback(async () => {
-    if (serverBusyRef.current) return;
-    serverBusyRef.current = true;
-    const session = sessionRef.current;
-    if (session) {
-      sessionRef.current = null;
-      const tail = (await session.stop()).trim();
-      if (!disabledRef.current) {
-        // A non-empty tail supersedes the pending interim via
-        // onTranscript; an empty one just clears the interim region.
-        if (tail) onTranscriptRef.current(tail);
-        else onInterimRef.current?.("");
+  const toggleServer = useCallback(
+    async (snapshot = true) => {
+      if (serverBusyRef.current) {
+        if (pendingServerStartRef.current) {
+          serverTakeIdRef.current += 1;
+          pendingServerStartRef.current.abort();
+          setPhase("idle");
+          setCompletionStatus("Dictation cancelled");
+        }
+        return;
       }
-      setIsListening(false);
-      serverBusyRef.current = false;
-      return;
-    }
-    try {
-      // Snapshot point: let the parent record the text so Esc can revert to it.
-      discardingRef.current = false;
-      onVoiceStartRef.current?.();
-      const next = await DictationSession.start({
-        onPartial: (text) => {
-          // Drop late partials after an Esc discard — they'd repopulate the
-          // composer the parent just reverted.
-          if (!disabledRef.current && !discardingRef.current) onInterimRef.current?.(text);
-        },
-        onFinal: (text) => {
-          const trimmed = text.trim();
-          if (trimmed && !disabledRef.current && !discardingRef.current) {
-            onTranscriptRef.current(trimmed);
-          }
-        },
-        onError: () => {
-          sessionRef.current = null;
-          setError("Dictation unavailable");
-          setIsListening(false);
-          onInterimRef.current?.("");
-        },
-      });
-      sessionRef.current = next;
+      serverBusyRef.current = true;
+      const session = sessionRef.current;
+      if (session) {
+        setPhase("stopping");
+        const stopTakeId = ++serverTakeIdRef.current;
+        sessionRef.current = null;
+        setMeterSource(null);
+        const tail = (await session.stop()).trim();
+        if (!mountedRef.current || disabledRef.current || serverTakeIdRef.current !== stopTakeId) {
+          serverBusyRef.current = false;
+          return;
+        }
+        if (!disabledRef.current) {
+          // A non-empty tail supersedes the pending interim via
+          // onTranscript; an empty one just clears the interim region.
+          if (tail) onTranscriptRef.current(tail);
+          else onInterimRef.current?.("");
+        }
+        setPhase("idle");
+        setCompletionStatus("Dictation stopped");
+        serverBusyRef.current = false;
+        return;
+      }
+      pendingServerStartRef.current?.abort();
+      const controller = new AbortController();
+      pendingServerStartRef.current = controller;
+      const takeId = ++serverTakeIdRef.current;
       setError(null);
-      setIsListening(true);
-    } catch (startError) {
-      setError(
-        startError instanceof DictationBusyError
-          ? "Dictation is busy — try again shortly"
-          : isPermissionError(startError)
-            ? "Microphone permission denied"
-            : "Dictation unavailable",
-      );
-      setIsListening(false);
-    }
-    serverBusyRef.current = false;
-  }, []);
+      setCompletionStatus(null);
+      setPhase("starting");
+      try {
+        // Snapshot point: let the parent record the text so Esc can revert to it.
+        discardingRef.current = false;
+        if (snapshot) {
+          onVoiceStartRef.current?.();
+          voiceSnapshotTakenRef.current = true;
+        }
+        const next = await DictationSession.start(
+          {
+            onPartial: (text) => {
+              // Drop late partials after an Esc discard — they'd repopulate the
+              // composer the parent just reverted.
+              if (
+                serverTakeIdRef.current === takeId &&
+                !disabledRef.current &&
+                !discardingRef.current
+              ) {
+                onInterimRef.current?.(text);
+              }
+            },
+            onFinal: (text) => {
+              const trimmed = text.trim();
+              if (
+                serverTakeIdRef.current === takeId &&
+                trimmed &&
+                !disabledRef.current &&
+                !discardingRef.current
+              ) {
+                onTranscriptRef.current(trimmed);
+              }
+            },
+            onError: () => {
+              if (!mountedRef.current || serverTakeIdRef.current !== takeId) return;
+              serverTakeIdRef.current += 1;
+              sessionRef.current = null;
+              setMeterSource(null);
+              setError("Dictation connection lost. Try again.");
+              setPhase("idle");
+              onInterimRef.current?.("");
+            },
+          },
+          { microphoneDeviceId: preferences.microphoneDeviceId, signal: controller.signal },
+        );
+        if (
+          !mountedRef.current ||
+          disabledRef.current ||
+          controller.signal.aborted ||
+          serverTakeIdRef.current !== takeId
+        ) {
+          next.cancel();
+          return;
+        }
+        sessionRef.current = next;
+        setMeterSource({ kind: "server", stream: next.captureStream });
+        setError(null);
+        setPhase("listening");
+      } catch (startError) {
+        if (startError instanceof DOMException && startError.name === "AbortError") return;
+        if (!mountedRef.current || disabledRef.current || serverTakeIdRef.current !== takeId)
+          return;
+        setMeterSource(null);
+        setError(
+          startError instanceof DictationBusyError
+            ? "Dictation is busy. Try again shortly."
+            : isPermissionError(startError)
+              ? "Microphone access denied. Allow access, then try again."
+              : isMissingMicrophoneError(startError)
+                ? "Selected microphone unavailable. Choose another in Settings."
+                : "Could not connect to dictation. Try again.",
+        );
+        setPhase("idle");
+      } finally {
+        if (pendingServerStartRef.current === controller) {
+          pendingServerStartRef.current = null;
+        }
+        serverBusyRef.current = false;
+      }
+    },
+    [preferences.microphoneDeviceId],
+  );
   toggleServerRef.current = toggleServer;
 
   const toggle = useCallback(() => {
@@ -399,7 +567,11 @@ export const ComposerMicButton = ({
     // to the server — a visible ~1s "fail then recover" on every first take.
     // When the server can serve, go straight to it and skip the doomed attempt.
     // (Real browsers keep Web Speech primary; it genuinely works there.)
-    if (!Ctor || (serverAvailable && isElectronShell())) {
+    if (preferences.path === "server") {
+      if (serverAvailable) void toggleServer();
+      return;
+    }
+    if (preferences.path === "auto" && (!Ctor || (serverAvailable && isElectronShell()))) {
       if (serverAvailable) void toggleServer();
       return;
     }
@@ -409,19 +581,38 @@ export const ComposerMicButton = ({
     if (!recognition) return;
     transitionRef.current = true;
     try {
-      if (isListening) recognition.stop();
-      else recognition.start();
+      if (phaseRef.current === "listening") {
+        setPhase("stopping");
+        setMeterSource(null);
+        recognition.stop();
+      } else {
+        webTakeActiveRef.current = true;
+        voiceSnapshotTakenRef.current = false;
+        discardingRef.current = false;
+        setError(null);
+        setCompletionStatus(null);
+        setPhase("starting");
+        recognition.start();
+      }
     } catch {
       // InvalidStateError from a double-call — drop the guard so the
       // user can try again, and let the next event reconcile state.
       transitionRef.current = false;
+      webTakeActiveRef.current = false;
+      setPhase("idle");
+      setError("Could not start dictation. Try again.");
     }
-  }, [isListening, Ctor, serverAvailable, toggleServer]);
+  }, [Ctor, preferences.path, serverAvailable, toggleServer]);
 
-  // ⌘⌥V toggles dictation from anywhere — same as clicking the button. Enabled
-  // whenever dictation could run (Web Speech OR the server path) and the
-  // composer isn't disabled, so the chord is inert when it can't do anything.
-  useVoiceDictationHotkey(toggle, enableHotkey && (Boolean(Ctor) || serverAvailable) && !disabled);
+  // ⌘⌥V toggles dictation anywhere in the focused Omnigent window. It isn't an
+  // OS-global shortcut. Keep it inert when the selected path cannot run.
+  const pathAvailable =
+    preferences.path === "server"
+      ? serverAvailable
+      : preferences.path === "browser"
+        ? Boolean(Ctor)
+        : Boolean(Ctor) || serverAvailable;
+  useVoiceDictationHotkey(toggle, enableHotkey && pathAvailable && !disabled);
 
   // While listening, Enter commits (end the take, keep the text) and Esc
   // cancels (end the take, discard back to the pre-dictation snapshot). Bound in
@@ -429,10 +620,13 @@ export const ComposerMicButton = ({
   // Path-aware: a live server take is torn down via the DictationSession, a Web
   // Speech take via the recognizer.
   useEffect(() => {
-    if (!isListening) return;
     const handler = (e: globalThis.KeyboardEvent): void => {
       if (e.repeat || e.metaKey || e.ctrlKey || e.altKey) return;
+      const pendingStart = pendingServerStartRef.current;
+      const currentPhase = phaseRef.current;
+      if (currentPhase === "idle" && !pendingStart) return;
       if (e.key === "Enter" && !e.shiftKey) {
+        if (currentPhase !== "listening") return;
         // Commit: end the take and keep the text. toggle() routes to the right
         // path — Web Speech stop, or a server stop that flushes the tail.
         e.preventDefault();
@@ -444,14 +638,28 @@ export const ComposerMicButton = ({
         e.preventDefault();
         e.stopPropagation();
         discardingRef.current = true;
-        onVoiceDiscardRef.current?.();
+        if (currentPhase === "listening" || currentPhase === "stopping" || pendingStart) {
+          onVoiceDiscardRef.current?.();
+        }
+        if (currentPhase === "stopping") serverTakeIdRef.current += 1;
+        setCompletionStatus("Dictation cancelled");
+        setPhase("idle");
+        if (pendingStart) {
+          serverTakeIdRef.current += 1;
+          pendingStart.abort();
+          return;
+        }
         const session = sessionRef.current;
         if (session) {
+          serverTakeIdRef.current += 1;
           sessionRef.current = null;
           serverBusyRef.current = false;
+          setMeterSource(null);
           session.cancel();
-          setIsListening(false);
         } else {
+          webTakeActiveRef.current = false;
+          transitionRef.current = false;
+          setMeterSource(null);
           try {
             recognitionRef.current?.stop();
           } catch {
@@ -462,53 +670,88 @@ export const ComposerMicButton = ({
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, [isListening, toggle]);
+  }, [toggle]);
 
-  if (!Ctor && !serverAvailable) return null;
+  const unavailableMessage =
+    preferences.path === "server"
+      ? "Server dictation is unavailable."
+      : preferences.path === "browser"
+        ? "Browser dictation is unavailable."
+        : "Voice dictation is unavailable.";
+  const isCapabilityLoading = serverInfo === "loading" && preferences.path !== "browser";
+  const status =
+    error ??
+    (phase === "starting"
+      ? "Starting dictation..."
+      : phase === "listening"
+        ? "Listening..."
+        : phase === "stopping"
+          ? "Stopping dictation..."
+          : (completionStatus ??
+            (!pathAvailable && !isCapabilityLoading ? unavailableMessage : null)));
+  const isBusy = phase === "starting" || phase === "stopping";
+  const isListening = phase === "listening";
 
   // Stable accessible name with aria-pressed signals toggle state to
   // screen readers. Error text takes over the tooltip when set.
   const a11yLabel = "Voice dictation";
-  const tooltip = error ?? a11yLabel;
+  const tooltip =
+    error ?? (!pathAvailable && !isCapabilityLoading ? unavailableMessage : a11yLabel);
 
   return (
-    <Button
-      type="button"
-      size="icon"
-      variant="ghost"
-      disabled={disabled}
-      onClick={toggle}
-      aria-pressed={isListening}
-      aria-label={a11yLabel}
-      title={tooltip}
-      className={cn(
-        "size-9 md:size-8",
-        isListening &&
-          "bg-muted/60 text-foreground hover:bg-destructive/10 hover:text-destructive focus-visible:bg-destructive/10 focus-visible:text-destructive",
-        error && "text-destructive",
-      )}
-    >
-      {isListening ? (
-        // Bars fade out and stop icon fades in on hover OR keyboard focus,
-        // so keyboard users get the stop affordance without needing hover.
-        <span className="relative flex size-4 items-center justify-center" aria-hidden>
-          <span className="flex h-full items-center gap-[2px] transition-opacity group-hover/button:opacity-0 group-focus-visible/button:opacity-0">
-            {BAR_BINS.map(([lo, hi], i) => (
-              <span
-                key={`${lo}-${hi}`}
-                ref={(el) => {
-                  barRefs.current[i] = el;
-                }}
-                className="block h-3 w-[2px] origin-center rounded-full bg-current"
-                style={{ transform: `scaleY(${BAR_BASELINE})` }}
-              />
-            ))}
+    <div className="flex min-w-0 items-center gap-1">
+      <Button
+        type="button"
+        size="icon"
+        variant="ghost"
+        disabled={disabled || !pathAvailable}
+        onClick={toggle}
+        aria-pressed={isListening}
+        aria-busy={isBusy}
+        aria-label={a11yLabel}
+        aria-describedby={status ? statusId : undefined}
+        title={tooltip}
+        className={cn(
+          "size-9 shrink-0 md:size-8",
+          isListening &&
+            "bg-muted/60 text-foreground hover:bg-destructive/10 hover:text-destructive focus-visible:bg-destructive/10 focus-visible:text-destructive",
+          error && "text-destructive",
+        )}
+      >
+        {isListening ? (
+          // Bars fade out and stop icon fades in on hover OR keyboard focus,
+          // so keyboard users get the stop affordance without needing hover.
+          <span className="relative flex size-4 items-center justify-center" aria-hidden>
+            <span className="flex h-full items-center gap-[2px] transition-opacity group-hover/button:opacity-0 group-focus-visible/button:opacity-0">
+              {BAR_BINS.map(([lo, hi], i) => (
+                <span
+                  key={`${lo}-${hi}`}
+                  ref={(el) => {
+                    barRefs.current[i] = el;
+                  }}
+                  className="block h-3 w-[2px] origin-center rounded-full bg-current"
+                  style={{ transform: `scaleY(${BAR_BASELINE})` }}
+                />
+              ))}
+            </span>
+            <SquareIcon className="absolute size-3 fill-current opacity-0 transition-opacity group-hover/button:opacity-100 group-focus-visible/button:opacity-100" />
           </span>
-          <SquareIcon className="absolute size-3 fill-current opacity-0 transition-opacity group-hover/button:opacity-100 group-focus-visible/button:opacity-100" />
-        </span>
-      ) : (
-        <MicIcon className="size-4" data-icon-size="16" />
-      )}
-    </Button>
+        ) : (
+          <MicIcon className="size-4" />
+        )}
+      </Button>
+      <span
+        id={statusId}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className={cn(
+          "max-w-36 text-xs leading-tight text-muted-foreground sm:max-w-48",
+          (error || (!pathAvailable && !isCapabilityLoading)) && "text-destructive",
+        )}
+      >
+        {status}
+      </span>
+    </div>
   );
 };

--- a/web/src/components/KeyboardShortcutsDialog.test.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.test.tsx
@@ -44,6 +44,12 @@ describe("KeyboardShortcutsDialog", () => {
     expect(screen.getByText("Navigate suggestions")).toBeTruthy();
   });
 
+  it("describes voice dictation as a focused-window shortcut", () => {
+    render(<KeyboardShortcutsDialog />);
+    toggleViaHotkey();
+    expect(screen.getByText("Toggle voice dictation (focused Omnigent window)")).toBeTruthy();
+  });
+
   it("toggles closed on a second hotkey press", async () => {
     render(<KeyboardShortcutsDialog />);
     toggleViaHotkey();

--- a/web/src/components/KeyboardShortcutsDialog.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.tsx
@@ -78,7 +78,7 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { label: "Recall previous prompt", keys: [UP] },
       { label: "Recall next prompt", keys: [DOWN] },
       { label: "Accept approval prompt", keys: [MOD_KEY, ENTER] },
-      { label: "Toggle voice dictation", keys: [MOD_KEY, ALT, "V"] },
+      { label: "Toggle voice dictation (focused Omnigent window)", keys: [MOD_KEY, ALT, "V"] },
       { label: "Stop response", keys: ["Esc"] },
     ],
   },

--- a/web/src/lib/dictation.test.ts
+++ b/web/src/lib/dictation.test.ts
@@ -4,8 +4,20 @@
 // with a mocked session, and the full loop runs in the Playwright e2e test
 // against the server's fake engine.
 
-import { describe, expect, it } from "vitest";
-import { parseDictationEvent } from "./dictation";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DictationSession, getDictationMediaStream, parseDictationEvent } from "./dictation";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (navigator as { mediaDevices?: unknown }).mediaDevices;
+});
+
+const installMediaDevices = (getUserMedia: ReturnType<typeof vi.fn>) => {
+  Object.defineProperty(navigator, "mediaDevices", {
+    configurable: true,
+    value: { getUserMedia },
+  });
+};
 
 describe("parseDictationEvent", () => {
   it("parses the transcript event shapes", () => {
@@ -37,5 +49,209 @@ describe("parseDictationEvent", () => {
     expect(parseDictationEvent('{"type":"partial"}')).toBeNull();
     expect(parseDictationEvent('{"type":"partial","text":7}')).toBeNull();
     expect(parseDictationEvent('{"type":"error"}')).toBeNull();
+  });
+});
+
+describe("getDictationMediaStream", () => {
+  it("uses the default microphone constraints when no device is selected", async () => {
+    const stream = {} as MediaStream;
+    const getUserMedia = vi.fn().mockResolvedValue(stream);
+    installMediaDevices(getUserMedia);
+
+    await expect(getDictationMediaStream(null)).resolves.toBe(stream);
+    expect(getUserMedia).toHaveBeenCalledWith({
+      audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true },
+    });
+  });
+
+  it.each(["NotFoundError", "OverconstrainedError"])(
+    "does not silently replace a missing selected microphone after %s",
+    async (name) => {
+      const error = new DOMException("missing", name);
+      const getUserMedia = vi.fn().mockRejectedValue(error);
+      installMediaDevices(getUserMedia);
+
+      await expect(getDictationMediaStream("mic-2")).rejects.toBe(error);
+      expect(getUserMedia).toHaveBeenCalledOnce();
+      expect(getUserMedia).toHaveBeenCalledWith({
+        audio: {
+          channelCount: 1,
+          echoCancellation: true,
+          noiseSuppression: true,
+          deviceId: { exact: "mic-2" },
+        },
+      });
+    },
+  );
+
+  it.each(["NotAllowedError", "SecurityError"])(
+    "does not retry permission error %s",
+    async (name) => {
+      const error = new DOMException("denied", name);
+      const getUserMedia = vi.fn().mockRejectedValue(error);
+      installMediaDevices(getUserMedia);
+
+      await expect(getDictationMediaStream("mic-2")).rejects.toBe(error);
+      expect(getUserMedia).toHaveBeenCalledTimes(1);
+    },
+  );
+});
+
+describe("DictationSession.start", () => {
+  const events = { onPartial: vi.fn(), onFinal: vi.fn(), onError: vi.fn() };
+
+  it("aborts while waiting for ready and closes the socket and capture", async () => {
+    const stop = vi.fn();
+    installMediaDevices(
+      vi.fn().mockResolvedValue({ getTracks: () => [{ stop }] } as unknown as MediaStream),
+    );
+    const close = vi.fn();
+    const constructed = vi.fn();
+    class FakeWebSocket {
+      static OPEN = 1;
+      readyState = 0;
+      binaryType = "";
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onerror: (() => void) | null = null;
+      onclose: ((event: CloseEvent) => void) | null = null;
+      close = close;
+      constructor() {
+        constructed();
+      }
+    }
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+    const controller = new AbortController();
+
+    const starting = DictationSession.start(events, { signal: controller.signal });
+    await vi.waitFor(() => expect(constructed).toHaveBeenCalledOnce());
+    controller.abort();
+
+    await expect(starting).rejects.toMatchObject({ name: "AbortError" });
+    expect(close).toHaveBeenCalledOnce();
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it("stops capture that resolves after an abort during media acquisition", async () => {
+    const stop = vi.fn();
+    let resolveCapture: ((stream: MediaStream) => void) | undefined;
+    installMediaDevices(
+      vi.fn(
+        () =>
+          new Promise<MediaStream>((resolve) => {
+            resolveCapture = resolve;
+          }),
+      ),
+    );
+    const controller = new AbortController();
+
+    const starting = DictationSession.start(events, { signal: controller.signal });
+    controller.abort();
+    await expect(starting).rejects.toMatchObject({ name: "AbortError" });
+    resolveCapture?.({ getTracks: () => [{ stop }] } as unknown as MediaStream);
+    await vi.waitFor(() => expect(stop).toHaveBeenCalledOnce());
+
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it("aborts during worklet setup and closes all acquired resources", async () => {
+    const stop = vi.fn();
+    installMediaDevices(
+      vi.fn().mockResolvedValue({ getTracks: () => [{ stop }] } as unknown as MediaStream),
+    );
+    const wsClose = vi.fn();
+    class FakeWebSocket {
+      static OPEN = 1;
+      readyState = FakeWebSocket.OPEN;
+      binaryType = "";
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onerror: (() => void) | null = null;
+      onclose: ((event: CloseEvent) => void) | null = null;
+      close = wsClose;
+      addEventListener() {}
+      removeEventListener() {}
+      constructor() {
+        queueMicrotask(() => this.onmessage?.({ data: '{"type":"ready"}' } as MessageEvent));
+      }
+    }
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+    const contextClose = vi.fn(function (this: { state: AudioContextState }) {
+      this.state = "closed";
+      return Promise.resolve();
+    });
+    const addModule = vi.fn(() => new Promise<void>(() => {}));
+    class FakeAudioContext {
+      state: AudioContextState = "running";
+      close = contextClose;
+      audioWorklet = { addModule };
+    }
+    vi.stubGlobal("AudioContext", FakeAudioContext);
+    const controller = new AbortController();
+
+    const starting = DictationSession.start(events, { signal: controller.signal });
+    await vi.waitFor(() => expect(addModule).toHaveBeenCalledOnce());
+    controller.abort();
+
+    await expect(starting).rejects.toMatchObject({ name: "AbortError" });
+    expect(wsClose).toHaveBeenCalledOnce();
+    expect(contextClose).toHaveBeenCalledOnce();
+    expect(stop).toHaveBeenCalledOnce();
+  });
+});
+
+describe("DictationSession lifecycle", () => {
+  it("ignores socket events after cancel", () => {
+    const events = { onPartial: vi.fn(), onFinal: vi.fn(), onError: vi.fn() };
+    const ws = {
+      readyState: WebSocket.OPEN,
+      close: vi.fn(),
+      send: vi.fn(),
+      onmessage: null,
+      onclose: null,
+    } as unknown as WebSocket;
+    const stream = { getTracks: () => [] } as unknown as MediaStream;
+    const context = { state: "running", close: vi.fn() } as unknown as AudioContext;
+    const worklet = { port: { onmessage: null } } as unknown as AudioWorkletNode;
+    const session = Reflect.construct(DictationSession, [events, ws, stream, context, worklet]) as {
+      cancel: () => void;
+    };
+
+    session.cancel();
+    (ws.onmessage as ((event: MessageEvent) => void) | null)?.({
+      data: '{"type":"error","message":"late"}',
+    } as MessageEvent);
+
+    expect(events.onError).not.toHaveBeenCalled();
+  });
+
+  it("resolves a pending stop immediately when the server reports an error", async () => {
+    const events = { onPartial: vi.fn(), onFinal: vi.fn(), onError: vi.fn() };
+    const ws = {
+      readyState: WebSocket.OPEN,
+      close: vi.fn(),
+      send: vi.fn(),
+      onmessage: null,
+      onclose: null,
+    } as unknown as WebSocket;
+    const stream = { getTracks: () => [] } as unknown as MediaStream;
+    const context = { state: "running", close: vi.fn() } as unknown as AudioContext;
+    const port = {
+      onmessage: null as ((event: MessageEvent<Int16Array<ArrayBuffer> | null>) => void) | null,
+      postMessage: vi.fn(() =>
+        queueMicrotask(() => port.onmessage?.({ data: null } as MessageEvent)),
+      ),
+    };
+    const worklet = { port } as unknown as AudioWorkletNode;
+    const session = Reflect.construct(DictationSession, [events, ws, stream, context, worklet]) as {
+      stop: () => Promise<string>;
+    };
+
+    const stopping = session.stop();
+    await vi.waitFor(() => expect(ws.send).toHaveBeenCalled());
+    (ws.onmessage as ((event: MessageEvent) => void) | null)?.({
+      data: '{"type":"error","message":"worker failed"}',
+    } as MessageEvent);
+
+    await expect(stopping).resolves.toBe("");
+    expect(events.onError).toHaveBeenCalledWith("worker failed");
   });
 });

--- a/web/src/lib/dictation.ts
+++ b/web/src/lib/dictation.ts
@@ -59,12 +59,35 @@ export interface DictationSessionEvents {
   onError: (message: string) => void;
 }
 
+export interface DictationSessionOptions {
+  microphoneDeviceId?: string | null;
+  signal?: AbortSignal;
+}
+
 /**
  * The server was reachable but at its concurrent-take cap (WS close 1013).
  * Transient by definition — callers should message "busy, try again",
  * not "unavailable".
  */
 export class DictationBusyError extends Error {}
+
+const dictationAudioConstraints = (microphoneDeviceId?: string | null): MediaTrackConstraints => ({
+  channelCount: 1,
+  echoCancellation: true,
+  noiseSuppression: true,
+  ...(microphoneDeviceId ? { deviceId: { exact: microphoneDeviceId } } : {}),
+});
+
+/** Acquire the selected input exactly, or the system default when none is selected. */
+export async function getDictationMediaStream(
+  microphoneDeviceId?: string | null,
+  signal?: AbortSignal,
+): Promise<MediaStream> {
+  throwIfAborted(signal);
+  return navigator.mediaDevices.getUserMedia({
+    audio: dictationAudioConstraints(microphoneDeviceId),
+  });
+}
 
 /**
  * Parse one text frame from the dictation socket into a typed event.
@@ -222,6 +245,7 @@ export class DictationSession {
       if (ws.readyState === WebSocket.OPEN) ws.send(msg.data.buffer);
     };
     ws.onmessage = (msg) => {
+      if (this.closed) return;
       if (typeof msg.data !== "string") return;
       const event = parseDictationEvent(msg.data);
       if (event === null) return;
@@ -238,23 +262,50 @@ export class DictationSession {
     };
   }
 
+  /** The live capture stream, exposed for read-only consumers such as metering. */
+  get captureStream(): MediaStream {
+    return this.mediaStream;
+  }
+
   /**
    * Acquire the mic, open the socket, and wait for the server's ready
    * handshake. Rejects (with everything torn down) when the mic is
    * denied, the socket fails, the server is at capacity
    * ({@link DictationBusyError}), or the engine never comes up.
    */
-  static async start(events: DictationSessionEvents): Promise<DictationSession> {
-    const mediaStream = await navigator.mediaDevices.getUserMedia({
-      audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true },
-    });
-
+  static async start(
+    events: DictationSessionEvents,
+    options: DictationSessionOptions = {},
+  ): Promise<DictationSession> {
+    const { signal } = options;
+    let mediaStream: MediaStream | null = null;
     let ws: WebSocket | null = null;
     let audioContext: AudioContext | null = null;
+    let cleanedUp = false;
+    const cleanup = () => {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      if (mediaStream) {
+        for (const track of mediaStream.getTracks()) track.stop();
+      }
+      if (audioContext && audioContext.state !== "closed") void audioContext.close();
+      ws?.close();
+    };
+    signal?.addEventListener("abort", cleanup, { once: true });
     try {
+      const mediaPromise = getDictationMediaStream(options.microphoneDeviceId, signal);
+      void mediaPromise.then(
+        (stream) => {
+          if (signal?.aborted) {
+            for (const track of stream.getTracks()) track.stop();
+          }
+        },
+        () => {},
+      );
+      mediaStream = await abortable(mediaPromise, signal);
       ws = new WebSocket(buildDictationUrl());
       ws.binaryType = "arraybuffer";
-      await waitForReady(ws);
+      await waitForReady(ws, signal);
       // Detect a close during the async audio-graph setup below: the
       // handler-swap in the constructor would otherwise never see it and
       // start() would resolve a dead session that silently drops audio.
@@ -272,7 +323,8 @@ export class DictationSession {
       } catch {
         audioContext = new AudioContext();
       }
-      await audioContext.audioWorklet.addModule(workletUrl());
+      await abortable(audioContext.audioWorklet.addModule(workletUrl()), signal);
+      throwIfAborted(signal);
       const source = audioContext.createMediaStreamSource(mediaStream);
       const node = new AudioWorkletNode(audioContext, "omnigent-pcm16-downsampler");
       // The worklet only renders while it reaches the destination; route
@@ -287,11 +339,12 @@ export class DictationSession {
       if (closedDuringSetup || ws.readyState !== WebSocket.OPEN) {
         throw new Error("dictation connection closed during setup");
       }
+      signal?.removeEventListener("abort", cleanup);
       return new DictationSession(events, ws, mediaStream, audioContext, node);
     } catch (error) {
-      for (const track of mediaStream.getTracks()) track.stop();
-      if (audioContext && audioContext.state !== "closed") void audioContext.close();
-      ws?.close();
+      cleanup();
+      signal?.removeEventListener("abort", cleanup);
+      if (signal?.aborted) throw abortError();
       throw error;
     }
   }
@@ -349,6 +402,9 @@ export class DictationSession {
     this.closed = true;
     this.teardownAudio();
     this.ws.close();
+    const resolve = this.stopResolve;
+    this.stopResolve = null;
+    resolve?.("");
     this.events.onError(message);
   }
 
@@ -363,35 +419,68 @@ export class DictationSession {
  * close (typed {@link DictationBusyError} for the 1013 at-capacity close),
  * or timeout.
  */
-function waitForReady(ws: WebSocket): Promise<void> {
+function waitForReady(ws: WebSocket, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
+    const settle = (callback: () => void) => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", handleAbort);
+      callback();
+    };
+    const handleAbort = () => settle(() => reject(abortError()));
     const timer = setTimeout(() => {
-      reject(new Error("dictation server did not become ready"));
+      settle(() => reject(new Error("dictation server did not become ready")));
     }, READY_TIMEOUT_MS);
+    signal?.addEventListener("abort", handleAbort, { once: true });
     ws.onmessage = (msg) => {
       if (typeof msg.data !== "string") return;
       const event = parseDictationEvent(msg.data);
       if (event?.type === "ready") {
-        clearTimeout(timer);
-        resolve();
+        settle(resolve);
       } else if (event?.type === "error") {
         // The engine failed to initialize; surface its message rather
         // than the generic close that follows.
-        clearTimeout(timer);
-        reject(new Error(event.message));
+        settle(() => reject(new Error(event.message)));
       }
     };
     ws.onerror = () => {
-      clearTimeout(timer);
-      reject(new Error("dictation connection failed"));
+      settle(() => reject(new Error("dictation connection failed")));
     };
     ws.onclose = (event) => {
-      clearTimeout(timer);
-      reject(
-        event.code === WS_CLOSE_TRY_AGAIN_LATER
-          ? new DictationBusyError("dictation is at capacity")
-          : new Error("dictation connection closed"),
+      settle(() =>
+        reject(
+          event.code === WS_CLOSE_TRY_AGAIN_LATER
+            ? new DictationBusyError("dictation is at capacity")
+            : new Error("dictation connection closed"),
+        ),
       );
     };
+    if (signal?.aborted) handleAbort();
+  });
+}
+
+function abortError(): DOMException {
+  return new DOMException("Dictation start aborted", "AbortError");
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw abortError();
+}
+
+function abortable<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  throwIfAborted(signal);
+  return new Promise<T>((resolve, reject) => {
+    const handleAbort = () => reject(abortError());
+    signal.addEventListener("abort", handleAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", handleAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", handleAbort);
+        reject(error);
+      },
+    );
   });
 }

--- a/web/src/lib/dictationPreferences.ts
+++ b/web/src/lib/dictationPreferences.ts
@@ -1,0 +1,87 @@
+export type DictationPath = "auto" | "server" | "browser";
+
+export interface DictationPreferences {
+  path: DictationPath;
+  browserLanguage: string;
+  microphoneDeviceId: string | null;
+}
+
+export const DEFAULT_DICTATION_PREFERENCES: DictationPreferences = {
+  path: "auto",
+  browserLanguage: "en-US",
+  microphoneDeviceId: null,
+};
+
+const STORAGE_KEY = "omnigent:dictation-preferences";
+const MAX_LANGUAGE_LENGTH = 64;
+const MAX_DEVICE_ID_LENGTH = 1024;
+
+const isDictationPath = (value: unknown): value is DictationPath =>
+  value === "auto" || value === "server" || value === "browser";
+
+export function normalizeDictationLanguage(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_LANGUAGE_LENGTH) return null;
+  try {
+    return new Intl.Locale(trimmed).toString();
+  } catch {
+    return null;
+  }
+}
+
+function normalizeDeviceId(value: unknown): string | null {
+  if (typeof value !== "string" || !value || value.length > MAX_DEVICE_ID_LENGTH) return null;
+  return value;
+}
+
+function normalizeDictationPreferences(value: DictationPreferences): DictationPreferences {
+  return {
+    path: isDictationPath(value.path) ? value.path : DEFAULT_DICTATION_PREFERENCES.path,
+    browserLanguage:
+      normalizeDictationLanguage(value.browserLanguage) ??
+      DEFAULT_DICTATION_PREFERENCES.browserLanguage,
+    microphoneDeviceId: normalizeDeviceId(value.microphoneDeviceId),
+  };
+}
+
+export function readDictationPreferences(): DictationPreferences {
+  if (typeof window === "undefined") return DEFAULT_DICTATION_PREFERENCES;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_DICTATION_PREFERENCES;
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return DEFAULT_DICTATION_PREFERENCES;
+    }
+    const value = parsed as Record<string, unknown>;
+    return {
+      path: isDictationPath(value.path) ? value.path : DEFAULT_DICTATION_PREFERENCES.path,
+      browserLanguage:
+        normalizeDictationLanguage(value.browserLanguage) ??
+        DEFAULT_DICTATION_PREFERENCES.browserLanguage,
+      microphoneDeviceId: normalizeDeviceId(value.microphoneDeviceId),
+    };
+  } catch {
+    return DEFAULT_DICTATION_PREFERENCES;
+  }
+}
+
+export function writeDictationPreferences(preferences: DictationPreferences): DictationPreferences {
+  const normalized = normalizeDictationPreferences(preferences);
+  if (typeof window === "undefined") return normalized;
+  try {
+    if (
+      normalized.path === DEFAULT_DICTATION_PREFERENCES.path &&
+      normalized.browserLanguage === DEFAULT_DICTATION_PREFERENCES.browserLanguage &&
+      normalized.microphoneDeviceId === DEFAULT_DICTATION_PREFERENCES.microphoneDeviceId
+    ) {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(normalized));
+    }
+  } catch {
+    // localStorage access errors should not disable dictation.
+  }
+  return normalized;
+}

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -4,12 +4,16 @@
 // Archived sessions list (which moved here out of the sidebar).
 
 import type { ReactNode } from "react";
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Conversation } from "@/hooks/useConversations";
 import type { ElectronUpdateBridge, UpdateConfig, UpdateStatus } from "@/lib/nativeBridge";
+
+let originalMediaDevices: PropertyDescriptor | undefined;
+let deviceChangeHandler: (() => void) | undefined;
+const enumerateDevices = vi.fn();
 
 const mocks = vi.hoisted(() => ({
   setTheme: vi.fn(),
@@ -203,6 +207,19 @@ beforeEach(() => {
   mocks.projectNames = [];
   mocks.hasNextPage = false;
   delete (window as unknown as Record<string, unknown>).omnigentDesktop;
+  originalMediaDevices = Object.getOwnPropertyDescriptor(navigator, "mediaDevices");
+  deviceChangeHandler = undefined;
+  enumerateDevices.mockReset().mockResolvedValue([]);
+  Object.defineProperty(navigator, "mediaDevices", {
+    configurable: true,
+    value: {
+      enumerateDevices,
+      addEventListener: vi.fn((_type: string, handler: () => void) => {
+        deviceChangeHandler = handler;
+      }),
+      removeEventListener: vi.fn(),
+    },
+  });
 });
 afterEach(() => {
   cleanup();
@@ -218,6 +235,11 @@ afterEach(() => {
     if (property.startsWith("--custom-")) document.documentElement.style.removeProperty(property);
   }
   delete (window as unknown as Record<string, unknown>).omnigentDesktop;
+  if (originalMediaDevices) {
+    Object.defineProperty(navigator, "mediaDevices", originalMediaDevices);
+  } else {
+    delete (navigator as { mediaDevices?: unknown }).mediaDevices;
+  }
 });
 
 const DEFAULT_UPDATE_CONFIG: UpdateConfig = {
@@ -260,6 +282,126 @@ function installUpdateBridge(config: UpdateConfig = DEFAULT_UPDATE_CONFIG) {
 }
 
 describe("SettingsPage", () => {
+
+  it("renders and persists device-local dictation preferences with privacy limitations", async () => {
+    enumerateDevices.mockResolvedValue([
+      { kind: "audioinput", deviceId: "mic-1", label: "Studio Mic", groupId: "", toJSON() {} },
+      { kind: "videoinput", deviceId: "camera", label: "Camera", groupId: "", toJSON() {} },
+    ]);
+    renderPage("/settings/dictation");
+
+    expect(screen.getByRole("heading", { name: "Dictation" })).toBeInTheDocument();
+    expect(screen.getByText(/stay in this browser and are not synced/)).toBeInTheDocument();
+    expect(screen.getByText(/Browser never sends audio to Omnigent's server/)).toBeInTheDocument();
+    expect(screen.getByText(/relay it to a private dictation worker/)).toBeInTheDocument();
+    expect(screen.getByText(/do not let Omnigent select the microphone/)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("Studio Mic")).toBeInTheDocument());
+    expect(screen.queryByText("Camera")).toBeNull();
+
+    fireEvent.change(screen.getByTestId("dictation-path-select"), { target: { value: "server" } });
+    fireEvent.change(screen.getByLabelText("Browser recognition language"), {
+      target: { value: " fr-fr " },
+    });
+    fireEvent.blur(screen.getByLabelText("Browser recognition language"));
+    fireEvent.change(screen.getByTestId("dictation-microphone-select"), {
+      target: { value: "mic-1" },
+    });
+    expect(JSON.parse(localStorage.getItem("omnigent:dictation-preferences") ?? "null")).toEqual({
+      path: "server",
+      browserLanguage: "fr-FR",
+      microphoneDeviceId: "mic-1",
+    });
+    expect(screen.getByLabelText("Browser recognition language")).toHaveValue("fr-FR");
+  });
+
+  it("keeps partial language input editable and reverts invalid values on blur", () => {
+    renderPage("/settings/dictation");
+    const language = screen.getByLabelText("Browser recognition language");
+
+    fireEvent.change(language, { target: { value: "fr-" } });
+    expect(language).toHaveValue("fr-");
+    expect(localStorage.getItem("omnigent:dictation-preferences")).toBeNull();
+
+    fireEvent.blur(language);
+    expect(language).toHaveValue("en-US");
+    expect(language).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it.each(["fr-FR", "not-a-locale-"])(
+    "cancels the language draft on Escape without persisting %s",
+    (draft) => {
+      renderPage("/settings/dictation");
+      const language = screen.getByLabelText("Browser recognition language");
+
+      fireEvent.change(language, { target: { value: draft } });
+      fireEvent.keyDown(language, { key: "Escape" });
+
+      expect(language).toHaveValue("en-US");
+      expect(language).not.toHaveAttribute("aria-invalid");
+      expect(localStorage.getItem("omnigent:dictation-preferences")).toBeNull();
+    },
+  );
+
+  it("filters empty, duplicate, and default microphone device ids", async () => {
+    enumerateDevices.mockResolvedValue([
+      { kind: "audioinput", deviceId: "", label: "Hidden Mic", groupId: "", toJSON() {} },
+      {
+        kind: "audioinput",
+        deviceId: "default",
+        label: "Browser Default",
+        groupId: "",
+        toJSON() {},
+      },
+      { kind: "audioinput", deviceId: "mic-1", label: "Studio Mic", groupId: "", toJSON() {} },
+      { kind: "audioinput", deviceId: "mic-1", label: "Duplicate Mic", groupId: "", toJSON() {} },
+    ]);
+    renderPage("/settings/dictation");
+
+    expect(await screen.findByText("Studio Mic")).toBeInTheDocument();
+    expect(screen.queryByText("Hidden Mic")).toBeNull();
+    expect(screen.queryByText("Browser Default")).toBeNull();
+    expect(screen.queryByText("Duplicate Mic")).toBeNull();
+    expect(screen.getAllByText("System default")).toHaveLength(1);
+  });
+
+  it("ignores an older device enumeration that resolves after a refresh", async () => {
+    let resolveInitial: ((devices: MediaDeviceInfo[]) => void) | undefined;
+    enumerateDevices
+      .mockReturnValueOnce(
+        new Promise<MediaDeviceInfo[]>((resolve) => {
+          resolveInitial = resolve;
+        }),
+      )
+      .mockResolvedValueOnce([
+        { kind: "audioinput", deviceId: "new", label: "New Mic", groupId: "", toJSON() {} },
+      ]);
+    renderPage("/settings/dictation");
+
+    await act(async () => deviceChangeHandler?.());
+    expect(await screen.findByText("New Mic")).toBeInTheDocument();
+    await act(async () =>
+      resolveInitial?.([
+        { kind: "audioinput", deviceId: "old", label: "Old Mic", groupId: "", toJSON() {} },
+      ]),
+    );
+
+    expect(screen.getByText("New Mic")).toBeInTheDocument();
+    expect(screen.queryByText("Old Mic")).toBeNull();
+  });
+
+  it("handles failed enumeration and refreshes audio inputs on devicechange", async () => {
+    enumerateDevices.mockRejectedValueOnce(new DOMException("blocked", "NotAllowedError"));
+    renderPage("/settings/dictation");
+    await waitFor(() => expect(enumerateDevices).toHaveBeenCalledTimes(1));
+    expect(screen.getByText("System default")).toBeInTheDocument();
+
+    enumerateDevices.mockResolvedValueOnce([
+      { kind: "audioinput", deviceId: "mic-2", label: "USB Mic", groupId: "", toJSON() {} },
+    ]);
+    await act(async () => deviceChangeHandler?.());
+    expect(await screen.findByText("USB Mic")).toBeInTheDocument();
+  });
+
   it("renders the Appearance section and applies a theme on card click", () => {
     renderPage("/settings/appearance");
     expect(screen.getByRole("heading", { name: "Appearance" })).toBeInTheDocument();

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -139,6 +139,13 @@ import {
 } from "@/lib/workspacePanelPreferences";
 import { readDefaultBaseBranch, writeDefaultBaseBranch } from "@/lib/baseBranchPreferences";
 import {
+  type DictationPath,
+  type DictationPreferences,
+  normalizeDictationLanguage,
+  readDictationPreferences,
+  writeDictationPreferences,
+} from "@/lib/dictationPreferences";
+import {
   DEFAULT_HIDE_UNCONFIGURED_HARNESSES,
   readHideUnconfiguredHarnesses,
   writeHideUnconfiguredHarnesses,
@@ -229,6 +236,7 @@ export function SettingsPage() {
   return (
     <PageScroll contentClassName="px-8" extraBottom="2.5rem">
       {section === "appearance" && <AppearanceSection />}
+      {section === "dictation" && <DictationSection />}
       {section === "git" && <GitSection />}
       {section === "shortcuts" && <ShortcutsSection />}
       {section === "account" && hasAuthSession && <AccountSection />}
@@ -236,6 +244,186 @@ export function SettingsPage() {
       {section === "cli" && isElectronShell() && <LocalCliSection />}
       {section === "updates" && isElectronShell() && <UpdatesSection />}
     </PageScroll>
+  );
+}
+
+function DictationSection() {
+  const [preferences, setPreferences] = useState(readDictationPreferences);
+  const [languageDraft, setLanguageDraft] = useState(preferences.browserLanguage);
+  const [languageInvalid, setLanguageInvalid] = useState(false);
+  const suppressLanguageBlurRef = useRef(false);
+  const [microphones, setMicrophones] = useState<MediaDeviceInfo[]>([]);
+
+  const update = useCallback((patch: Partial<DictationPreferences>) => {
+    setPreferences((current) => {
+      const next = { ...current, ...patch };
+      return writeDictationPreferences(next);
+    });
+  }, []);
+
+  useEffect(() => {
+    const mediaDevices = navigator.mediaDevices;
+    if (!mediaDevices?.enumerateDevices) return;
+    let active = true;
+    let refreshGeneration = 0;
+    const refresh = async () => {
+      const generation = ++refreshGeneration;
+      try {
+        const devices = await mediaDevices.enumerateDevices();
+        if (!active || generation !== refreshGeneration) return;
+        const seen = new Set<string>();
+        setMicrophones(
+          devices.filter((device) => {
+            if (
+              device.kind !== "audioinput" ||
+              !device.deviceId ||
+              device.deviceId === "default" ||
+              seen.has(device.deviceId)
+            ) {
+              return false;
+            }
+            seen.add(device.deviceId);
+            return true;
+          }),
+        );
+      } catch {
+        if (active && generation === refreshGeneration) setMicrophones([]);
+      }
+    };
+    void refresh();
+    mediaDevices.addEventListener?.("devicechange", refresh);
+    return () => {
+      active = false;
+      mediaDevices.removeEventListener?.("devicechange", refresh);
+    };
+  }, []);
+
+  const selectedMicrophoneMissing =
+    preferences.microphoneDeviceId !== null &&
+    !microphones.some((device) => device.deviceId === preferences.microphoneDeviceId);
+
+  const commitLanguage = useCallback(() => {
+    if (suppressLanguageBlurRef.current) {
+      suppressLanguageBlurRef.current = false;
+      return;
+    }
+    const normalized = normalizeDictationLanguage(languageDraft);
+    if (normalized === null) {
+      setLanguageDraft(preferences.browserLanguage);
+      setLanguageInvalid(true);
+      return;
+    }
+    const next = writeDictationPreferences({ ...preferences, browserLanguage: normalized });
+    setPreferences(next);
+    setLanguageDraft(next.browserLanguage);
+    setLanguageInvalid(false);
+  }, [languageDraft, preferences]);
+
+  return (
+    <Section
+      title="Dictation"
+      description="Choose how voice dictation works on this device. These preferences stay in this browser and are not synced to your account."
+    >
+      <div className="flex flex-col gap-8">
+        <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
+          <div className="flex min-w-0 flex-1 flex-col">
+            <span className="text-sm font-medium">Dictation path</span>
+            <span className="text-sm text-muted-foreground">
+              Auto prefers browser recognition and may fall back to the configured server. Browser
+              never sends audio to Omnigent's server. Server streams microphone audio to your
+              configured Omnigent server for transcription; operators may relay it to a private
+              dictation worker.
+            </span>
+          </div>
+          <Select
+            value={preferences.path}
+            onValueChange={(value) => update({ path: value as DictationPath })}
+          >
+            <SelectTrigger
+              className="w-full max-w-48 shrink-0"
+              data-testid="dictation-path-select"
+              aria-label="Dictation path"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="auto">Auto</SelectItem>
+              <SelectItem value="server">Server</SelectItem>
+              <SelectItem value="browser">Browser</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
+          <div className="flex min-w-0 flex-1 flex-col">
+            <span className="text-sm font-medium">Browser recognition language</span>
+            <span className="text-sm text-muted-foreground">
+              Used only by browser recognition. Availability and whether audio is processed locally
+              or by the browser vendor depend on your browser.
+            </span>
+          </div>
+          <Input
+            value={languageDraft}
+            onChange={(event) => {
+              setLanguageDraft(event.target.value);
+              setLanguageInvalid(false);
+            }}
+            onBlur={commitLanguage}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") event.currentTarget.blur();
+              if (event.key === "Escape") {
+                suppressLanguageBlurRef.current = true;
+                setLanguageDraft(preferences.browserLanguage);
+                setLanguageInvalid(false);
+                event.currentTarget.blur();
+              }
+            }}
+            aria-label="Browser recognition language"
+            aria-invalid={languageInvalid || undefined}
+            className="h-9 w-full max-w-48 shrink-0"
+            spellCheck={false}
+            maxLength={64}
+          />
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
+          <div className="flex min-w-0 flex-1 flex-col">
+            <span className="text-sm font-medium">Microphone</span>
+            <span className="text-sm text-muted-foreground">
+              Used for server dictation only. Browsers do not let Omnigent select the microphone
+              used by Web Speech; change that input in your browser or system settings.
+            </span>
+          </div>
+          <Select
+            value={preferences.microphoneDeviceId ?? "default"}
+            onValueChange={(value) =>
+              update({ microphoneDeviceId: value === "default" ? null : value })
+            }
+          >
+            <SelectTrigger
+              className="w-full max-w-64 shrink-0"
+              data-testid="dictation-microphone-select"
+              aria-label="Microphone"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="default">System default</SelectItem>
+              {selectedMicrophoneMissing && (
+                <SelectItem value={preferences.microphoneDeviceId!}>
+                  Selected microphone unavailable
+                </SelectItem>
+              )}
+              {microphones.map((device, index) => (
+                <SelectItem key={device.deviceId} value={device.deviceId}>
+                  {device.label || `Microphone ${index + 1}`}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+    </Section>
   );
 }
 

--- a/web/src/shell/settingsNav.tsx
+++ b/web/src/shell/settingsNav.tsx
@@ -13,6 +13,7 @@ import {
   DownloadIcon,
   GitBranchIcon,
   KeyboardIcon,
+  MicIcon,
   PaletteIcon,
   Share2Icon,
   ShieldCheckIcon,
@@ -31,6 +32,7 @@ import { SIDEBAR_ROW } from "./sidebarStyles";
 
 export type SettingsSectionId =
   | "appearance"
+  | "dictation"
   | "git"
   | "shortcuts"
   | "account"
@@ -43,6 +45,7 @@ export type SettingsSectionId =
 
 const SECTION_IDS: readonly SettingsSectionId[] = [
   "appearance",
+  "dictation",
   "git",
   "shortcuts",
   "account",
@@ -84,6 +87,7 @@ export function settingsNavGroups(
 ): SettingsNavGroup[] {
   const general: SettingsNavItem[] = [
     { id: "appearance", label: "Appearance", icon: PaletteIcon },
+    { id: "dictation", label: "Dictation", icon: MicIcon },
     { id: "git", label: "Git", icon: GitBranchIcon },
     { id: "shortcuts", label: "Keyboard shortcuts", icon: KeyboardIcon, hideOnMobile: true },
   ];


### PR DESCRIPTION

## Summary

- Add per-device controls for browser/server routing, browser language, and microphone selection, with clear privacy guidance.
- Secure remote workers with bearer authentication, verified TLS, health/readiness probes, bounded streams, admin diagnostics, and OpenTelemetry metrics.
- Insert dictated text at the caret or selection, reuse server capture for metering, and expose accessible starting/listening/error states.

**ELI5:** Dictation now lets users choose where speech is processed, puts text where the cursor is, explains its current state, and secures audio sent to a remote transcription worker.

```text
microphone -> browser or Omnigent server -> optional secured worker
                                      -> live partials -> composer selection
```

## Test Plan

- `uv run --python 3.12 --frozen pytest tests/server/test_dictation_engine.py tests/server/test_dictation_metrics.py tests/server/test_dictation_remote.py tests/server/test_dictation_worker.py tests/server/routes/test_dictation.py tests/server/test_openapi_drift.py -q` — 42 passed, 1 optional model smoke test skipped.
- Focused web dictation, settings, composer, and new-chat suites — 439 passed.
- `uv run --python 3.12 --frozen pytest tests/e2e_ui/chat/test_dictation.py -q` — 5 passed.
- `pnpm type-check`, `pnpm lint`, and `pre-commit run --all-files` — passed.

## Demo

### Dictation settings

<img width="1320" height="563" alt="Screenshot 2026-08-01 at 9 49 33 PM" src="https://github.com/user-attachments/assets/039fad7b-3983-4214-a00f-f71e825dadd6" />

### Before: dictation appends at the end
<img width="891" height="468" alt="Screenshot 2026-08-01 at 9 51 14 PM" src="https://github.com/user-attachments/assets/3fc41fac-225c-41d8-9e00-a938b9487f72" />

### After: dictation inserts at the caret or replaces a selection
<img width="879" height="417" alt="Screenshot 2026-08-01 at 9 50 19 PM" src="https://github.com/user-attachments/assets/57eb23e1-fa1d-4cc9-937a-57d7aaa4d834" />

### Live listening state
<img width="896" height="346" alt="Screenshot 2026-08-01 at 9 49 17 PM" src="https://github.com/user-attachments/assets/c0ef1854-e168-4289-9b27-2b7f726de457" />

## Type of change

- [x] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified settings and state transitions manually, regenerated OpenAPI, and exercised the fake-microphone browser-to-server-to-composer flow. Real sherpa transcription was also verified locally on Apple Silicon with the bundled model-fetch workflow.

## Changelog

Voice dictation now supports private server routing, microphone and language preferences, caret-aware insertion, accessible live status, and authenticated remote workers.
