### PR TITLE
fix: validate Polly worker readiness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,12 @@ Run the `pre-commit` hook before committing (`pre-commit run --all-files`, or
 let it run on staged files via `git commit`). Fix any issues it reports so the
 commit lands clean — CI runs the same checks.
 
+## Git hosting
+
+Preserve the forge already used by an existing repository. For a new project
+that does not already exist on GitHub, prefer the user's private GitLab instance
+over creating a new GitHub repository; use `glab` when it is configured.
+
 ## Local development shortcuts
 
 Use `just` for common tasks; run `just --list` for grouped recipes.

--- a/deploy/kubernetes/overlays/sandbox-runners/namespace-sandboxes.yaml
+++ b/deploy/kubernetes/overlays/sandbox-runners/namespace-sandboxes.yaml
@@ -12,12 +12,9 @@ metadata:
   labels:
     app.kubernetes.io/name: omnigent
     app.kubernetes.io/component: runner
-    # Pod Security Admission: enforce the `restricted` standard in the runner
-    # namespace. Defense-in-depth — even though the server SA holds pods/create
-    # here, it cannot create a privileged / hostPath / host-namespace Pod. The
-    # launcher's generated runner Pod is already restricted-compliant
-    # (runAsNonRoot, drop ALL caps, seccompProfile RuntimeDefault, no privilege
-    # escalation), so enforcement does not reject legitimate runners.
+    # Pod Security Admission: restricted matches the launcher's secure default.
+    # Deployments opting into sandbox.kubernetes.run_as_root must lower this to
+    # baseline; baseline still rejects privileged / hostPath / host-namespace Pods.
     pod-security.kubernetes.io/enforce: restricted
     pod-security.kubernetes.io/enforce-version: latest
     pod-security.kubernetes.io/warn: restricted

--- a/deploy/kubernetes/overlays/sandbox-runners/sandbox-config.yaml
+++ b/deploy/kubernetes/overlays/sandbox-runners/sandbox-config.yaml
@@ -45,6 +45,7 @@ data:
         # resources:                 # runner Pod sizing (defaults: 0.5-2 cpu / 1-4Gi)
         #   requests: {cpu: "500m", memory: "1Gi"}
         #   limits: {cpu: "2", memory: "4Gi"}
+        # run_as_root: false         # opt in only when agents must apt-get install packages
         # pvc_mounts:                # pre-created PVCs (in the runner namespace) mounted into every runner Pod
         #   - claim_name: omnigent-datasets
         #     mount_path: /mnt/datasets

--- a/examples/polly/agents/agy/config.yaml
+++ b/examples/polly/agents/agy/config.yaml
@@ -29,9 +29,10 @@ prompt: |
   - Co-sign every commit you author: end each commit message with a blank line
     followed by this exact trailer as its final line —
     `Co-authored-by: omnigent <noreply@omnigent.ai>`
-  - When green, push your task branch and open a PR with `gh pr create` (clear
-    title, what changed, how you verified). Never push to a protected branch
-    (e.g. main) or force-push — open a PR and let it be reviewed/merged.
+  - When green, push your task branch and open a PR/MR on the repository's
+    existing forge (`gh` for GitHub, `glab` for GitLab). For a new project that
+    does not already exist on GitHub, prefer the user's private GitLab instance.
+    Never push to a protected branch or force-push.
 
   REVIEW — verify another agent's diff (you are given the diff + the acceptance
   contract):

--- a/examples/polly/agents/claude_code/config.yaml
+++ b/examples/polly/agents/claude_code/config.yaml
@@ -27,9 +27,10 @@ prompt: |
   - Co-sign every commit you author: end each commit message with a blank line
     followed by this exact trailer as its final line —
     `Co-authored-by: omnigent <noreply@omnigent.ai>`
-  - When green, push your task branch and open a PR with `gh pr create` (clear
-    title, what changed, how you verified). Never push to a protected branch
-    (e.g. main) or force-push — open a PR and let it be reviewed/merged.
+  - When green, push your task branch and open a PR/MR on the repository's
+    existing forge (`gh` for GitHub, `glab` for GitLab). For a new project that
+    does not already exist on GitHub, prefer the user's private GitLab instance.
+    Never push to a protected branch or force-push.
 
   REVIEW — verify another agent's diff (you are given the diff + the acceptance
   contract):

--- a/examples/polly/agents/codex/config.yaml
+++ b/examples/polly/agents/codex/config.yaml
@@ -27,9 +27,10 @@ prompt: |
   - Co-sign every commit you author: end each commit message with a blank line
     followed by this exact trailer as its final line —
     `Co-authored-by: omnigent <noreply@omnigent.ai>`
-  - When green, push your task branch and open a PR with `gh pr create` (clear
-    title, what changed, how you verified). Never push to a protected branch
-    (e.g. main) or force-push — open a PR and let it be reviewed/merged.
+  - When green, push your task branch and open a PR/MR on the repository's
+    existing forge (`gh` for GitHub, `glab` for GitLab). For a new project that
+    does not already exist on GitHub, prefer the user's private GitLab instance.
+    Never push to a protected branch or force-push.
 
   REVIEW — verify another agent's diff (you are given the diff + the acceptance
   contract):

--- a/examples/polly/agents/cursor/config.yaml
+++ b/examples/polly/agents/cursor/config.yaml
@@ -37,9 +37,10 @@ prompt: |
   - Co-sign every commit you author: end each commit message with a blank line
     followed by this exact trailer as its final line —
     `Co-authored-by: omnigent <noreply@omnigent.ai>`
-  - When green, push your task branch and open a PR with `gh pr create` (clear
-    title, what changed, how you verified). Never push to a protected branch
-    (e.g. main) or force-push — open a PR and let it be reviewed/merged.
+  - When green, push your task branch and open a PR/MR on the repository's
+    existing forge (`gh` for GitHub, `glab` for GitLab). For a new project that
+    does not already exist on GitHub, prefer the user's private GitLab instance.
+    Never push to a protected branch or force-push.
 
   REVIEW — verify another agent's diff (you are given the diff + the acceptance
   contract):

--- a/examples/polly/agents/hermes/config.yaml
+++ b/examples/polly/agents/hermes/config.yaml
@@ -27,9 +27,10 @@ prompt: |
   - Co-sign every commit you author: end each commit message with a blank line
     followed by this exact trailer as its final line —
     `Co-authored-by: omnigent <noreply@omnigent.ai>`
-  - When green, push your task branch and open a PR with `gh pr create` (clear
-    title, what changed, how you verified). Never push to a protected branch
-    (e.g. main) or force-push — open a PR and let it be reviewed/merged.
+  - When green, push your task branch and open a PR/MR on the repository's
+    existing forge (`gh` for GitHub, `glab` for GitLab). For a new project that
+    does not already exist on GitHub, prefer the user's private GitLab instance.
+    Never push to a protected branch or force-push.
 
   REVIEW — verify another agent's diff (you are given the diff + the acceptance
   contract):

--- a/examples/polly/agents/opencode/config.yaml
+++ b/examples/polly/agents/opencode/config.yaml
@@ -28,9 +28,10 @@ prompt: |
   - Co-sign every commit you author: end each commit message with a blank line
     followed by this exact trailer as its final line —
     `Co-authored-by: omnigent <noreply@omnigent.ai>`
-  - When green, push your task branch and open a PR with `gh pr create` (clear
-    title, what changed, how you verified). Never push to a protected branch
-    (e.g. main) or force-push — open a PR and let it be reviewed/merged.
+  - When green, push your task branch and open a PR/MR on the repository's
+    existing forge (`gh` for GitHub, `glab` for GitLab). For a new project that
+    does not already exist on GitHub, prefer the user's private GitLab instance.
+    Never push to a protected branch or force-push.
 
   REVIEW — verify another agent's diff (you are given the diff + the acceptance
   contract):

--- a/examples/polly/agents/pi/config.yaml
+++ b/examples/polly/agents/pi/config.yaml
@@ -26,9 +26,10 @@ prompt: |
   - Co-sign every commit you author: end each commit message with a blank line
     followed by this exact trailer as its final line —
     `Co-authored-by: omnigent <noreply@omnigent.ai>`
-  - When green, push your task branch and open a PR with `gh pr create` (clear
-    title, what changed, how you verified). Never push to a protected branch
-    (e.g. main) or force-push — open a PR and let it be reviewed/merged.
+  - When green, push your task branch and open a PR/MR on the repository's
+    existing forge (`gh` for GitHub, `glab` for GitLab). For a new project that
+    does not already exist on GitHub, prefer the user's private GitLab instance.
+    Never push to a protected branch or force-push.
 
   REVIEW — verify another agent's diff (you are given the diff + the acceptance
   contract):

--- a/examples/polly/config.yaml
+++ b/examples/polly/config.yaml
@@ -73,16 +73,18 @@ prompt: |
   `opencode`, `cursor-agent` for `cursor`, `hermes` for `hermes`, `pi` for `pi`,
   `agy` for `agy`.
   Before delegating anything, run exactly ONE
-  `sys_os_shell("command -v claude codex opencode cursor-agent hermes pi agy || true")`. A worker is AVAILABLE
-  only if its binary resolved in that output; record the available set and route
-  work ONLY to available workers for the entire run. Do this in the same first
+  `sys_os_shell("command -v claude codex opencode cursor-agent hermes pi agy || true")`
+  AND call `sys_list_models`. A worker is AVAILABLE only if its binary resolved
+  AND its `sys_list_models` row does not say that dispatches cannot run or that
+  no usable provider is configured. Record the available set and route work
+  ONLY to available workers for the entire run. Do this in the same first
   turn you start planning (the preflight `sys_os_shell` call counts as acting —
   don't end the turn on the preflight alone). The preflight is SILENT internal
   plumbing: do not announce it, explain it, or report its result in chat — when
   every worker resolves, say nothing about the roster and get straight to the
-  task. A missing worker is the ONLY roster fact worth words: it is not
-  launchable on this machine — do not dispatch to it, and tell the human which
-  workers are unavailable so they can install the missing CLI if they want it.
+  task. An unavailable worker is the ONLY roster fact worth words: do not
+  dispatch to it, and tell the human whether it needs its CLI installed or its
+  model provider configured.
 
   Every dispatch may carry an explicit `args.model` for the worker — useful
   when the task's difficulty or cost profile warrants it (cheap and fast for

--- a/omnigent/onboarding/sandboxes/kubernetes.py
+++ b/omnigent/onboarding/sandboxes/kubernetes.py
@@ -35,10 +35,10 @@ Platform notes that shape this launcher:
   PID 1, so the container command is a tiny supervisor that spawns
   ``omnigent host``, reaps any children, and forwards SIGTERM for prompt,
   graceful termination.
-- **Least privilege.** ``automountServiceAccountToken: false`` keeps the runner
-  SA's (absent) rights out of the sandbox, the Pod runs as a non-root user,
-  drops all capabilities, and disables privilege escalation. The root
-  filesystem stays writable (the host writes ``/tmp`` and ``~/.omnigent``).
+- **Least privilege by default.** ``automountServiceAccountToken: false`` keeps
+  the runner SA's (absent) rights out of the sandbox. Pods run as non-root unless
+  the operator explicitly enables root for package installation; both modes
+  drop all capabilities and disable privilege escalation.
 - **No CLI bootstrap / port forward.** Like Modal/Daytona/Islo, the launcher
   exists for server-managed hosts only.
 """
@@ -477,6 +477,7 @@ def build_pod_manifest(
     resources: dict[str, object] | None = None,
     pvc_mounts: Sequence[Mapping[str, object]] | None = None,
     secret_mounts: Sequence[Mapping[str, object]] | None = None,
+    run_as_root: bool = False,
 ) -> dict[str, object]:
     """
     Build the sandbox Pod manifest as a plain dict.
@@ -498,10 +499,10 @@ def build_pod_manifest(
     - The launch token is referenced via ``secretKeyRef`` (never in the spec);
       the host identity rides literal env; harness credentials are projected via
       ``envFrom`` when *harness_secret* is set.
-    - Pod + container ``securityContext`` satisfy Pod Security "restricted"
-      (runAsNonRoot as the image's ``sandbox`` user :data:`_RUN_AS_UID`, drop ALL
-      caps, ``seccompProfile: RuntimeDefault``, no privilege escalation). The
-      root filesystem stays writable (the host writes ``/tmp`` + ``~/.omnigent``).
+    - By default, Pod + container ``securityContext`` satisfy Pod Security
+      "restricted". With *run_as_root*, the Pod uses uid 0 so agents can install
+      OS packages; it still drops ALL capabilities, uses RuntimeDefault seccomp,
+      disables privilege escalation, and mounts no service-account token.
     - ``kubernetes.io/arch: amd64`` is the default; a *node_selector* entry for
       that key overrides it (e.g. ``arm64`` — the host image is multi-arch).
     - Operator *pvc_mounts* become ``persistentVolumeClaim`` volumes mounted on
@@ -549,6 +550,8 @@ def build_pod_manifest(
     :param secret_mounts: Normalized Secret mounts (``{secret_name,
         mount_path}``) added as read-only ``secret`` volumes on the host
         container only, or ``None``.
+    :param run_as_root: Run both containers as uid/gid 0 so package managers can
+        modify the image filesystem. Defaults to ``False``.
     :returns: The Pod manifest dict.
     """
     pod_resources = _resolve_pod_resources(resources)
@@ -670,6 +673,8 @@ def build_pod_manifest(
     if harness_secret:
         host_container["envFrom"] = [{"secretRef": {"name": harness_secret}}]
 
+    run_uid = 0 if run_as_root else _RUN_AS_UID
+    run_gid = 0 if run_as_root else _RUN_AS_GID
     spec: dict[str, object] = {
         "restartPolicy": "Never",
         "automountServiceAccountToken": False,
@@ -679,10 +684,10 @@ def build_pod_manifest(
         # the host image is published multi-arch).
         "nodeSelector": {"kubernetes.io/arch": "amd64", **(node_selector or {})},
         "securityContext": {
-            "runAsNonRoot": True,
-            "runAsUser": _RUN_AS_UID,
-            "runAsGroup": _RUN_AS_GID,
-            "fsGroup": _RUN_AS_GID,
+            "runAsNonRoot": not run_as_root,
+            "runAsUser": run_uid,
+            "runAsGroup": run_gid,
+            "fsGroup": run_gid,
             "fsGroupChangePolicy": "OnRootMismatch",
             "seccompProfile": {"type": "RuntimeDefault"},
         },
@@ -885,6 +890,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
         resources: dict[str, object] | None = None,
         pvc_mounts: Sequence[Mapping[str, object]] | None = None,
         secret_mounts: Sequence[Mapping[str, object]] | None = None,
+        run_as_root: bool = False,
     ) -> None:
         """
         Initialize the launcher.
@@ -913,6 +919,8 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
             (validated at parse time), or ``None`` for none.
         :param secret_mounts: Normalized ``sandbox.kubernetes.secret_mounts``
             entries (validated at parse time), or ``None`` for none.
+        :param run_as_root: Run sandbox containers as root so agents can install
+            OS packages. Defaults to ``False``.
         """
         self._image_ref = image
         self._namespace = namespace
@@ -925,6 +933,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
         self._resources = resources
         self._pvc_mounts = list(pvc_mounts) if pvc_mounts else None
         self._secret_mounts = list(secret_mounts) if secret_mounts else None
+        self._run_as_root = run_as_root
         self._core: k8s_client.CoreV1Api | None = None
         self._api_client: k8s_client.ApiClient | None = None
 
@@ -1222,6 +1231,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
                     resources=self._resources,
                     pvc_mounts=self._pvc_mounts,
                     secret_mounts=self._secret_mounts,
+                    run_as_root=self._run_as_root,
                 )
                 # Secret before Pod so the Pod's secretKeyRef resolves
                 # immediately — a Pod referencing a missing Secret would sit in

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -1838,6 +1838,23 @@ async def _execute_subagent_tool(
                     f"Install/upgrade it with: {install} "
                     f"(or don't dispatch to {sub_agent_name!r} here)."
                 )
+            # Binary presence proves only that the harness can be invoked. A
+            # provider-less CLI still fails immediately (for example Pi asks
+            # for /login), leaving a doomed child session behind. Use the same
+            # provider resolver that backs sys_list_models and reject before
+            # child creation.
+            from omnigent.model_catalog import NONE_KIND, resolve_model_provider
+
+            sub_spec = _find_subagent_spec(str(sub_agent_name), agent_spec)
+            if sub_spec is not None and child_harness in {"pi", "pi-native"}:
+                provider = resolve_model_provider(sub_spec, child_harness)
+                if provider.kind == NONE_KIND:
+                    return (
+                        f"Error: sub-agent {sub_agent_name!r} can't start on this "
+                        f"machine: harness {child_harness!r} has no usable model "
+                        f"provider ({provider.detail}). Configure its provider or "
+                        "choose a worker reported as usable by sys_list_models."
+                    )
         # Create child session on the server (no initial items —
         # those go via a separate POST so the server forwards them
         # to the runner and triggers a turn).

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -838,6 +838,7 @@ def parse_sandbox_config(raw: object) -> ManagedSandboxConfig | None:
                     "resources",
                     "pvc_mounts",
                     "secret_mounts",
+                    "run_as_root",
                 },
                 "sandbox.kubernetes",
             )
@@ -856,6 +857,7 @@ def parse_sandbox_config(raw: object) -> ManagedSandboxConfig | None:
             resources=_parse_kubernetes_resources(raw),
             pvc_mounts=pvc_mounts,
             secret_mounts=secret_mounts,
+            run_as_root=_parse_provider_bool(raw, "kubernetes", "run_as_root") or False,
         )
         token_ttl_s = KUBERNETES_MANAGED_TOKEN_TTL_S
     else:
@@ -2056,6 +2058,7 @@ def _kubernetes_launcher_factory(
     resources: dict[str, object] | None,
     pvc_mounts: list[dict[str, object]] | None,
     secret_mounts: list[dict[str, object]] | None,
+    run_as_root: bool = False,
 ) -> Callable[[], SandboxHostLauncher]:
     """
     Build the launcher factory for the YAML ``provider: kubernetes`` path.
@@ -2081,6 +2084,8 @@ def _kubernetes_launcher_factory(
         or ``None``.
     :param secret_mounts: Normalized Secret file-mount entries added to every
         runner Pod (rotation-friendly credential volumes), or ``None``.
+    :param run_as_root: Whether runner containers use uid/gid 0 for package
+        installation. The default parser value is ``False``.
     :returns: A factory producing parameterized Kubernetes launchers.
     :raises ValueError: When a name or node-selector label is malformed.
     """
@@ -2102,6 +2107,7 @@ def _kubernetes_launcher_factory(
             resources=resources,
             pvc_mounts=pvc_mounts,
             secret_mounts=secret_mounts,
+            run_as_root=run_as_root,
         )
 
     return _build

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -364,6 +364,20 @@ def test_build_pod_manifest_is_restricted_and_least_privilege() -> None:
     assert host["securityContext"]["capabilities"] == {"drop": ["ALL"]}
 
 
+def test_build_pod_manifest_root_opt_in_supports_apt_without_extra_capabilities() -> None:
+    """Root mode permits package installs while retaining the other pod defenses."""
+    manifest = build_pod_manifest(**_MANIFEST_KW, run_as_root=True)
+    spec = manifest["spec"]
+    assert spec["securityContext"]["runAsNonRoot"] is False
+    assert spec["securityContext"]["runAsUser"] == 0
+    assert spec["securityContext"]["runAsGroup"] == 0
+    assert spec["securityContext"]["fsGroup"] == 0
+    assert spec["securityContext"]["seccompProfile"] == {"type": "RuntimeDefault"}
+    for container in [*spec["initContainers"], *spec["containers"]]:
+        assert container["securityContext"]["allowPrivilegeEscalation"] is False
+        assert container["securityContext"]["capabilities"] == {"drop": ["ALL"]}
+
+
 @pytest.mark.parametrize(
     ("clone_dir", "repo_url", "repo_branch", "expect_clone", "expect_branch"),
     [

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -3160,6 +3160,67 @@ async def test_sys_session_send_blocks_fresh_dispatch_when_harness_cli_missing(
 
 
 @pytest.mark.asyncio
+async def test_sys_session_send_blocks_fresh_dispatch_without_model_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A present harness CLI is not enough when it has no usable provider."""
+    from omnigent.model_catalog import NONE_KIND, ResolvedModelProvider
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    monkeypatch.setattr(
+        "omnigent.model_catalog.resolve_model_provider",
+        lambda _spec, _harness: ResolvedModelProvider(
+            kind=NONE_KIND,
+            detail="no model provider configured",
+        ),
+    )
+    monkeypatch.setattr(runner_app, "get_session_agent_id", lambda _sid: "ag_parent")
+
+    create_posts = 0
+    session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        nonlocal create_posts
+        if (
+            request.method == "GET"
+            and request.url.path == "/v1/sessions/conv_parent_noprovider/child_sessions"
+        ):
+            return httpx.Response(200, json={"data": []})
+        if request.method == "POST" and request.url.path == "/v1/sessions":
+            create_posts += 1
+            return httpx.Response(201, json={"id": "conv_should_not_exist"})
+        return httpx.Response(404, json={"error": str(request.url)})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        try:
+            output = await execute_tool(
+                tool_name="sys_session_send",
+                arguments=json.dumps(
+                    {
+                        "agent": "worker",
+                        "title": "research-models",
+                        "args": {"input": "research the available models"},
+                    }
+                ),
+                server_client=server_client,
+                conversation_id="conv_parent_noprovider",
+                agent_spec=_spec_with_subagent_harness("pi"),
+                session_inbox=session_inbox,
+            )
+        finally:
+            runner_app._session_inboxes_ref.pop("conv_parent_noprovider", None)
+
+    assert output.startswith("Error:")
+    assert "no usable model provider" in output
+    assert "sys_list_models" in output
+    assert create_posts == 0
+
+
+@pytest.mark.asyncio
 async def test_sys_session_send_model_rejected_for_existing_child(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/server/helpers.py
+++ b/tests/server/helpers.py
@@ -213,6 +213,7 @@ class FakeSandboxLauncher(SandboxLauncher):
         self.resources: dict[str, object] | None = None
         self.pvc_mounts: list[dict[str, object]] | None = None
         self.secret_mounts: list[dict[str, object]] | None = None
+        self.run_as_root = False
         self.prepared = False
         self.provisioned_names: list[str] = []
         self.commands: list[str] = []
@@ -544,6 +545,7 @@ def install_fake_kubernetes_launcher(
         resources: dict[str, object] | None = None,
         pvc_mounts: list[dict[str, object]] | None = None,
         secret_mounts: list[dict[str, object]] | None = None,
+        run_as_root: bool = False,
     ) -> FakeSandboxLauncher:
         """Stand-in constructor recording the construction wiring."""
         fake.image = image
@@ -557,6 +559,7 @@ def install_fake_kubernetes_launcher(
         fake.resources = resources
         fake.pvc_mounts = pvc_mounts
         fake.secret_mounts = secret_mounts
+        fake.run_as_root = run_as_root
         return fake
 
     monkeypatch.setattr(kubernetes_mod, "KubernetesSandboxLauncher", _ctor)

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -750,6 +750,24 @@ def test_parse_kubernetes_without_pvc_mounts_is_none(monkeypatch: pytest.MonkeyP
     assert fake.pvc_mounts is None
 
 
+def test_parse_kubernetes_run_as_root_reaches_launcher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The explicit root opt-in is passed to the Kubernetes launcher."""
+    fake = FakeSandboxLauncher()
+    install_fake_kubernetes_launcher(monkeypatch, fake)
+    config = parse_sandbox_config(
+        {
+            "provider": "kubernetes",
+            "server_url": "http://server",
+            "kubernetes": {"run_as_root": True},
+        }
+    )
+    assert config is not None
+    config.launcher_factory()
+    assert fake.run_as_root is True
+
+
 @pytest.mark.parametrize(
     ("pvc_mounts", "expected_fragment"),
     [


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Treat Pi as unavailable when its CLI exists but no model provider is configured, and reject doomed Pi dispatches before child creation.
- Make Kubernetes sandbox root execution an explicit opt-in for deployments that need runtime package installation while retaining dropped capabilities, seccomp, and no service-account token.
- Make Polly and its workers preserve existing forges and prefer private GitLab for new projects not already on GitHub.

ELI5: Polly now checks that Pi can actually talk to a model, not merely that the `pi` command exists. Kubernetes operators can also deliberately let isolated agents install apt packages without enabling privileged containers.

```text
Polly preflight -> CLI present? -> provider usable? -> dispatch
                                      no -> unavailable
```

## Test Plan

- `python -m pytest tests/runner/test_runner_dispatch.py::test_sys_session_send_blocks_fresh_dispatch_without_model_provider tests/runner/test_runner_dispatch.py::test_sys_session_send_blocks_fresh_dispatch_when_harness_cli_missing tests/onboarding/sandboxes/test_kubernetes.py -q`
- `python -m compileall -q omnigent/onboarding/sandboxes/kubernetes.py omnigent/server/managed_hosts.py omnigent/runner/tool_dispatch.py tests/server/helpers.py tests/server/test_managed_hosts.py`
- `pre-commit run --files <all changed files>`

## Demo

N/A

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The dispatch and generated Kubernetes manifest behavior are covered at their direct unit-test seams.

## Changelog

Polly no longer launches Pi when Pi has no configured model provider, and Kubernetes sandboxes can opt into installing OS packages.