### PR TITLE
fix(runtime): guard _sweep_orphans against PermissionError on shared hosts

### DIFF
--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -1351,11 +1351,33 @@ class HarnessProcessManager:
         """
         if not self._tmp_parent.exists():
             return
-        for child in self._tmp_parent.iterdir():
-            if not child.is_dir() or not child.name.startswith("ap-"):
+        try:
+            children = list(self._tmp_parent.iterdir())
+        except OSError as exc:
+            _logger.warning(
+                "could not list harness tmp parent %s: %s; skipping orphan sweep",
+                self._tmp_parent,
+                exc,
+            )
+            return
+        for child in children:
+            try:
+                is_dir = child.is_dir()
+            except OSError:
+                continue
+            if not is_dir or not child.name.startswith("ap-"):
                 continue
             sentinel = child / _AP_PID_FILE
-            if not sentinel.exists():
+            try:
+                sentinel_exists = sentinel.exists()
+            except OSError as exc:
+                _logger.warning(
+                    "could not stat AP_PID sentinel at %s: %s; skipping",
+                    sentinel,
+                    exc,
+                )
+                continue
+            if not sentinel_exists:
                 # No sentinel — directory either pre-dates the
                 # convention or is mid-creation. Leave alone.
                 continue

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -929,6 +929,47 @@ async def test_orphan_sweep_preserves_live_omnigent_dirs(
         await fresh.shutdown()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX permissions only")
+@pytest.mark.skipif(os.getuid() == 0, reason="root bypasses filesystem permissions")
+async def test_sweep_orphans_skips_unlistable_parent(
+    short_tmp_parent: Path,
+) -> None:
+    """Orphan sweep does not crash when the tmp parent is not listable.
+
+    On a shared-parent deployment (OMNIGENT_HARNESS_TMP_PARENT pointing at a
+    directory owned by another user with no read bit), iterdir() raises
+    PermissionError. The sweep should warn and return, not abort boot.
+    """
+    short_tmp_parent.chmod(0o333)
+    try:
+        mgr = HarnessProcessManager(tmp_parent=short_tmp_parent)
+        await mgr._sweep_orphans()
+    finally:
+        short_tmp_parent.chmod(0o700)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX permissions only")
+@pytest.mark.skipif(os.getuid() == 0, reason="root bypasses filesystem permissions")
+async def test_sweep_orphans_skips_inaccessible_child(
+    short_tmp_parent: Path,
+) -> None:
+    """Orphan sweep skips ap-* siblings it cannot inspect.
+
+    A foreign ap-* directory with mode 0o000 blocks sentinel.exists()
+    with PermissionError. The sweep should warn, leave the directory
+    alone, and continue rather than propagating the error.
+    """
+    foreign = short_tmp_parent / "ap-foreign"
+    foreign.mkdir(mode=0o000)
+    try:
+        mgr = HarnessProcessManager(tmp_parent=short_tmp_parent)
+        await mgr._sweep_orphans()
+        assert foreign.exists()
+    finally:
+        foreign.chmod(0o700)
+        shutil.rmtree(foreign, ignore_errors=True)
+
+
 # ── Helper-level tests (small, fast) ───────────────────────────
 
 


### PR DESCRIPTION
## Related issue

Closes #2404

## Summary

`_sweep_orphans()` documents best-effort behaviour but only guarded `sentinel.read_text()`. Two other raise points could abort runner startup:

- `self._tmp_parent.iterdir()` raises `PermissionError` when the parent is not listable (e.g. a shared `OMNIGENT_HARNESS_TMP_PARENT` with the read bit cleared)
- `sentinel.exists()` raises `PermissionError` (Python 3.12+) when an `ap-*` sibling directory cannot be traversed

This PR adds the two missing `OSError` guards: `iterdir()` warns and returns early; `sentinel.exists()` warns and skips the entry. `child.is_dir()` is also wrapped to handle the mode-0o000 child case.

As a side effect, `list(iterdir())` snapshots the children before the loop, which closes the directory file descriptor before the `await self._kill_orphan_runners(child)` call. Strictly better than holding it open across the await.

## Test Plan

Two new tests in `tests/runtime/harnesses/test_process_manager.py`, both skipped on Windows and when running as root:

- `test_sweep_orphans_skips_unlistable_parent`: chmods the parent to `0o333` (no read bit), calls `_sweep_orphans()` directly, asserts no exception.
- `test_sweep_orphans_skips_inaccessible_child`: creates an `ap-foreign` dir with mode `0o000`, calls `_sweep_orphans()`, asserts the dir is left alone and no exception propagates.

## Demo

This is a defensive bug fix with no UI or visible output to demonstrate.
The change is verified by the two unit tests in the Test Plan -- they
reproduce the exact failure modes (unlistable parent, inaccessible child)
and assert no exception propagates.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes