### PR TITLE
fix(sessions): stop a refresh from blanking the skill menu

### DIFF
--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -450,6 +450,14 @@ _runner_skills_cache: dict[str, list[SkillSummary]] = {}
 _runner_skills_inflight: dict[str, asyncio.Task[None]] = {}
 
 
+# Sessions whose cached skills should be re-fetched at the next snapshot with a
+# live runner. A stale entry still SERVES in the meantime, mirroring
+# ``_model_options_stale``: skills resolve off the snapshot hot path, so
+# dropping them would make the invalidating snapshot answer a spurious ``[]``
+# and blank the client's slash-command menu.
+_runner_skills_stale: set[str] = set()
+
+
 _model_options_cache: dict[str, list[dict[str, Any]]] = {}
 
 
@@ -852,6 +860,7 @@ __all__ = [
     "_runner_relay_tasks",
     "_runner_skills_cache",
     "_runner_skills_inflight",
+    "_runner_skills_stale",
     "_server_host_registry",
     "_server_runner_router",
     "_session_active_response_cache",

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -3680,12 +3680,19 @@ def _invalidate_runner_backed_snapshot_state(
     *,
     cancel_inflight: bool,
     drop_model_options: bool,
+    drop_skills: bool = True,
 ) -> None:
     """
     Drop runner-derived session snapshot overlays for one session.
 
-    Skills are discovered from the bound runner, so they are dropped and
-    re-fetched at the next snapshot. The native model catalog is instead
+    Skills are discovered from the bound runner. They can be dropped outright
+    or, with ``drop_skills=False``, marked stale so the cached list keeps
+    SERVING while a re-fetch runs — the same contract the native model catalog
+    gets. Serving stale matters because skills resolve off the snapshot hot
+    path: dropping them makes the very snapshot that triggered the
+    invalidation answer ``skills: []``, and a client applying that response
+    blanks its slash-command menu until the session is re-opened.
+    The native model catalog is likewise
     marked stale by default: it must outlive runner death so the model
     picker stays populated (and offline model/effort changes stay possible)
     while the session is asleep — a stale catalog keeps serving until a
@@ -3702,8 +3709,17 @@ def _invalidate_runner_backed_snapshot_state(
         right away (refresh with a live runner) or no longer belongs to
         the session (agent switch); ``False`` keeps it serving while the
         session has no runner.
+    :param drop_skills: Drop the cached skills outright instead of marking
+        them stale. Defaults to ``True`` so callers opt IN to serving stale.
+        Pass ``False`` whenever the session keeps the same agent (a refresh,
+        a runner rebind) so the menu never blanks; ``True`` belongs to an
+        agent switch, where the cached skills are another agent's.
     """
-    _runner_skills_cache.pop(session_id, None)
+    if drop_skills:
+        _runner_skills_cache.pop(session_id, None)
+        _runner_skills_stale.discard(session_id)
+    else:
+        _runner_skills_stale.add(session_id)
     if cancel_inflight:
         inflight = _runner_skills_inflight.pop(session_id, None)
         if inflight is not None:
@@ -8482,6 +8498,7 @@ async def _load_runner_skills(
         _logger.debug("Runner skills payload malformed for %s", session_id)
         return
     _runner_skills_cache[session_id] = skills
+    _runner_skills_stale.discard(session_id)
     # Nudge any subscribed client to re-read the (now-warm) snapshot so
     # its slash-command menu fills without waiting for the next bind.
     _publish_runner_skills(session_id)

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -4661,7 +4661,7 @@ async def _relay_runner_stream(
         # land stale values from the dead runner; the model catalog is only
         # marked stale so the picker keeps serving it while the session sleeps.
         _invalidate_runner_backed_snapshot_state(
-            session_id, cancel_inflight=True, drop_model_options=False
+            session_id, cancel_inflight=True, drop_model_options=False, drop_skills=False
         )
 
 
@@ -6357,12 +6357,15 @@ async def _fetch_runner_skills(
     if runner_client is None:
         return []
     cached = _runner_skills_cache.get(session_id)
-    if cached is not None:
+    stale = session_id in _runner_skills_stale
+    if cached is not None and not stale:
         return cached
     # Don't await the runner here: this snapshot is polled continuously
     # (incl. mid-turn), and a per-poll runner round-trip pins the runner's
     # event loop and wedges the turn. Kick one background fetch (single-
     # flight) and return ``[]``; a later poll serves the cached result.
+    # A STALE entry keeps serving meanwhile, so an invalidation never makes
+    # this snapshot answer a spurious empty list.
     if session_id not in _runner_skills_inflight:
         task = asyncio.create_task(_load_runner_skills(runner_client, session_id))
         _runner_skills_inflight[session_id] = task
@@ -6371,7 +6374,9 @@ async def _fetch_runner_skills(
             _runner_skills_inflight.pop(session_id, None)
 
         task.add_done_callback(_clear_skills_inflight)
-    return []
+    # Serve the stale list while the re-fetch runs; ``[]`` only when nothing
+    # has ever been cached for this session.
+    return cached if cached is not None else []
 
 
 async def _fetch_model_options(
@@ -6569,6 +6574,10 @@ async def _get_session_snapshot(
             drop_model_options=(
                 runner_client is not None and wrapper != _CURSOR_NATIVE_WRAPPER_LABEL_VALUE
             ),
+            # Same agent, so the cached skills are still this session's: keep
+            # serving them while the re-fetch runs. Dropping them would make
+            # THIS snapshot answer [] and blank the client's menu.
+            drop_skills=False,
         )
 
     status = _session_status_from_cache(session_id)

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -18,6 +18,7 @@ from omnigent.server.routes.sessions import (
     _publish_subtree_cost_to_ancestors,
     _truncate_label,
 )
+from omnigent.server.schemas import SkillSummary
 from omnigent.spec.types import AgentSpec, ExecutorSpec
 
 
@@ -2285,3 +2286,108 @@ async def test_persist_error_labels_short_message_stored_verbatim() -> None:
         captured["d6e1678fb446a1cf5a892e0df60aaba3"]["omnigent.last_task_error_code"]
         == "runner_error"
     )
+
+
+# ---------------------------------------------------------------------------
+# Runner-skill cache survives a refresh (the "skills vanish mid-session" bug)
+# ---------------------------------------------------------------------------
+#
+# ``refresh_state=true`` invalidates runner-backed overlays, and skills are
+# fetched OFF the snapshot hot path — so dropping them outright makes that
+# snapshot answer ``skills: []`` even though the session has them. A client
+# that applies the response wipes its slash-command menu. Skills therefore get
+# the same contract the model catalog already has: a stale entry keeps SERVING
+# while a re-fetch runs. Only an agent switch (whose skills genuinely belong to
+# another agent) drops them.
+
+
+class _SkillsRunnerClient:
+    """Runner stub serving one skill, counting /skills round-trips."""
+
+    def __init__(self) -> None:
+        self.skill_calls = 0
+
+    async def get(self, url: str, timeout: float = 5.0):
+        self.skill_calls += 1
+
+        class _Resp:
+            status_code = 200
+
+            @staticmethod
+            def json() -> dict[str, object]:
+                return {"skills": [{"name": "brainstorming", "description": "d"}]}
+
+        return _Resp()
+
+
+@pytest.mark.asyncio
+async def test_refresh_keeps_serving_cached_skills_while_refetching() -> None:
+    """A refresh-driven invalidation must not blank the menu.
+
+    The cached list keeps serving (so the snapshot never answers a spurious
+    ``[]``) and a background re-fetch is scheduled to replace it.
+    """
+    from omnigent.server.routes import sessions as _mod
+
+    session_id = "conv_refresh_keeps_skills"
+    _mod._runner_skills_cache.clear()
+    _mod._runner_skills_inflight.clear()
+    _mod._runner_skills_cache[session_id] = [SkillSummary(name="brainstorming", description="d")]
+
+    _mod._invalidate_runner_backed_snapshot_state(
+        session_id, cancel_inflight=False, drop_model_options=False, drop_skills=False
+    )
+
+    client = _SkillsRunnerClient()
+    served = await _mod._fetch_runner_skills(client, session_id)  # type: ignore[arg-type]
+    assert [s.name for s in served] == ["brainstorming"], "stale entry must keep serving"
+
+    inflight = _mod._runner_skills_inflight.get(session_id)
+    assert inflight is not None, "a stale entry must schedule a re-fetch"
+    await inflight
+    assert client.skill_calls == 1
+    # Re-fetch landed: no longer stale, so a later poll schedules nothing new.
+    _mod._runner_skills_inflight.clear()
+    await _mod._fetch_runner_skills(client, session_id)  # type: ignore[arg-type]
+    assert session_id not in _mod._runner_skills_inflight
+    assert client.skill_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_agent_switch_drops_cached_skills() -> None:
+    """An agent switch DOES drop them — the old agent's skills aren't the new one's."""
+    from omnigent.server.routes import sessions as _mod
+
+    session_id = "conv_agent_switch_skills"
+    _mod._runner_skills_cache.clear()
+    _mod._runner_skills_inflight.clear()
+    _mod._runner_skills_cache[session_id] = [SkillSummary(name="old-agent-skill", description="d")]
+
+    _mod._invalidate_runner_backed_snapshot_state(
+        session_id, cancel_inflight=True, drop_model_options=True, drop_skills=True
+    )
+
+    assert session_id not in _mod._runner_skills_cache
+    client = _SkillsRunnerClient()
+    served = await _mod._fetch_runner_skills(client, session_id)  # type: ignore[arg-type]
+    assert served == [], "a dropped cache serves [] until the re-fetch lands"
+    inflight = _mod._runner_skills_inflight.get(session_id)
+    assert inflight is not None
+    await inflight
+    assert [s.name for s in _mod._runner_skills_cache[session_id]] == ["brainstorming"]
+
+
+@pytest.mark.asyncio
+async def test_invalidation_defaults_to_dropping_skills() -> None:
+    """``drop_skills`` defaults to True so callers opt IN to serving stale."""
+    from omnigent.server.routes import sessions as _mod
+
+    session_id = "conv_default_drop"
+    _mod._runner_skills_cache.clear()
+    _mod._runner_skills_inflight.clear()
+    _mod._runner_skills_cache[session_id] = [SkillSummary(name="s", description="d")]
+
+    _mod._invalidate_runner_backed_snapshot_state(
+        session_id, cancel_inflight=False, drop_model_options=False
+    )
+    assert session_id not in _mod._runner_skills_cache

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -3699,6 +3699,72 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
   });
 
   describe("refreshSessionState", () => {
+    it("keeps the existing skills when the refreshed snapshot reports none", async () => {
+      // A refresh invalidates the server's runner-skill cache, and skills
+      // resolve OFF the snapshot hot path — so that response can answer
+      // `skills: []` for a session that has them. Applying it blanks the
+      // slash-command menu mid-session (skills showed during terminal
+      // spin-up, then vanished once the runner came online). An empty list
+      // from a refresh means "not yet known", not "none".
+      useChatStore.setState({
+        conversationId: "conv_agy",
+        skills: [{ name: "superpowers:brainstorming", description: "d" }],
+      });
+      fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.split("?")[0] === "/v1/sessions/conv_agy" && (init?.method ?? "GET") === "GET") {
+          return mockResponse({
+            id: "conv_agy",
+            agent_id: "agent_agy",
+            agent_name: "Antigravity",
+            status: "idle",
+            created_at: 0,
+            items: [],
+            labels: { "omnigent.wrapper": "antigravity-native-ui" },
+            skills: [],
+          });
+        }
+        return defaultFetchHandler(input, init);
+      });
+
+      await useChatStore.getState().refreshSessionState("conv_agy");
+
+      expect(useChatStore.getState().skills).toEqual([
+        { name: "superpowers:brainstorming", description: "d" },
+      ]);
+      // The rest of the binding patch still applies.
+      expect(useChatStore.getState().boundAgentName).toBe("Antigravity");
+    });
+
+    it("still applies a non-empty skills list from a refreshed snapshot", async () => {
+      // The guard must not freeze the menu: a refresh that DOES resolve
+      // skills replaces whatever was there.
+      useChatStore.setState({
+        conversationId: "conv_agy2",
+        skills: [{ name: "stale-skill", description: "old" }],
+      });
+      fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.split("?")[0] === "/v1/sessions/conv_agy2" && (init?.method ?? "GET") === "GET") {
+          return mockResponse({
+            id: "conv_agy2",
+            agent_id: "agent_agy",
+            agent_name: "Antigravity",
+            status: "idle",
+            created_at: 0,
+            items: [],
+            labels: { "omnigent.wrapper": "antigravity-native-ui" },
+            skills: [{ name: "fresh-skill", description: "new" }],
+          });
+        }
+        return defaultFetchHandler(input, init);
+      });
+
+      await useChatStore.getState().refreshSessionState("conv_agy2");
+
+      expect(useChatStore.getState().skills).toEqual([{ name: "fresh-skill", description: "new" }]);
+    });
+
     it("forces a fresh snapshot and applies runner-backed Codex model options", async () => {
       useChatStore.setState({
         conversationId: "conv_codex",

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -3884,6 +3884,16 @@ async function refetchRunnerBackedSessionState(
           skills: session.skills ?? [],
           codexModelOptions: session.codexModelOptions ?? [],
         };
+  // A `refreshState` request invalidates the server's runner-skill cache and
+  // skills resolve off the snapshot hot path, so this response can answer an
+  // empty list for a session that has them. Treat that as "not yet known"
+  // rather than "none" and keep whatever the menu already holds — the
+  // `session_skills` event refills it when the re-fetch lands. Without this a
+  // runner-online refresh mid-session blanks the slash-command menu until the
+  // conversation is re-opened.
+  if (options.refreshState === true && (session.skills ?? []).length === 0) {
+    delete statePatch.skills;
+  }
   if (stickyModel != null) {
     statePatch.selectedModel = stickyModel;
     statePatch.sessionModelOverride = stickyModel;


### PR DESCRIPTION
## Related issue

N/A — found while using the harness; no existing issue filed. Happy to open one if
maintainers prefer an issue on record.

## Summary

The slash-command menu lists skills while a native terminal spins up, then **empties the
moment the agent replies**, and stays empty until the conversation is re-opened.

`refresh_state=true` invalidates runner-backed overlays, and skills are fetched **off the
snapshot hot path** — so that request drops the cache and answers `skills: []` in the
very same response. Reproduced against a live server:

```
GET /v1/sessions/<id>                      -> 17
GET /v1/sessions/<id>?refresh_state=true   ->  0    ← the clobber
GET /v1/sessions/<id>                      -> 17
```

`useRefreshSessionStateOnRunnerOnline` fires on a runner-liveness edge
(`unknown/false → true`), which for a native terminal lands right after the first reply.
It calls `refreshSessionState`, which pairs `refreshState: true` with
`applyBindingPatch: true` — so `sessionBindingPatch`'s `skills: session.skills ?? []`
writes that empty list straight over the menu.

Recovery exists (`session_skills` → refetch) but it's a **race**: the cache re-warms and
publishes *before* the cold response is applied, so the late clobber wins and nothing
publishes again.

Fixed on both sides, because each one is independently wrong:

- **Server** — skills now get the contract the native model catalog already has.
  `_invalidate_runner_backed_snapshot_state` takes `drop_skills` (default `True`, so
  callers opt in), and the same-agent call sites (a refresh, a runner rebind) mark them
  *stale* instead of dropping — a stale entry keeps **serving** while the re-fetch runs.
  An agent switch still drops, since those skills belong to another agent. This mirrors
  `_model_options_stale`, whose call site already passes `drop_model_options=False` so
  "the picker keeps serving it while the session sleeps"; skills simply never got the
  same treatment.
- **Client** — a `refreshState` response reporting no skills means "not yet known", not
  "none", so the existing list is kept. A refresh that *does* resolve skills still
  replaces them.

Either half alone fixes the symptom. Together, the snapshot stops lying and the client
stops trusting a known-cold answer.

Not agy-specific, though that's where it's most visible: agy's terminal takes long enough
that the runner-online edge lands *after* the menu first fills, so the clobber is the last
write. On faster harnesses the edge usually lands before the menu fills, hiding it.

## Test Plan

**Server** — 3 tests: a refresh-driven invalidation keeps serving the cached list *and*
schedules a re-fetch (and schedules nothing further once warm); an agent switch still
drops; `drop_skills` defaults to `True` so no caller silently changes behaviour.
`test_sessions_snapshot.py` → **44 passed**.

**Client** — 2 tests: a `refreshState` snapshot reporting `skills: []` leaves the menu
intact while the rest of the binding patch still applies; a refresh that *does* carry
skills replaces them (the guard must not freeze a stale menu).
`chatStore.test.ts` → **286 passed**. `tsc -b` clean, `pre-commit` clean.

Both tests were written first and observed failing for the right reason — the client test
reproduced the exact clobber before the fix.

**End-to-end**, driving the real `refresh_state` code path:

```
skills in the refresh_state response: 17   (was 0 before the fix)
after background re-fetch:            17
stale flag cleared:                   True
```

## Demo

N/A — non-visual change (the visible effect is a menu that no longer empties itself).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the live `refresh_state` A/B above (17 → 0 → 17 before, 17
throughout after), driven against a running server with a real native session — that
needs a live runner, so it isn't automated; the unit tests pin both halves.

One note for reviewers: I kept `drop_skills` defaulting to `True` so this change is
opt-in per call site rather than silently altering every caller. That leaves the default
as the *less* safe behaviour, which is arguable — if you'd rather flip the default to
`False` and have the agent-switch site opt into dropping, that's a one-line change and I'm
happy to make it.

## Changelog

The slash-command skill menu no longer empties itself when a session refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
