### PR TITLE
fix(agy): wait for model readiness before cold start

### DIFF
--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -4475,6 +4475,10 @@ def _mint_runner_agy_conversation_id() -> str:
 # afterward and keeps polling discovery as a functional fallback.
 _AGY_COLD_START_PORT_TIMEOUT_S = 20.0
 _AGY_COLD_START_PORT_POLL_INTERVAL_S = 0.25
+# A non-empty model catalog is the first reliable signal that agy post-login
+# initialization has reached the model service. Live cold starts still needed a
+# short settling window after that response before StartCascade was reliable.
+_AGY_COLD_START_MODEL_STABILIZATION_S = 4.0
 
 
 async def _agy_cold_start_poll_sleep(seconds: float) -> None:
@@ -4517,7 +4521,9 @@ async def _cold_start_agy_conversation(
     pane is reachable (remote runner), or once our agy is up in the pane but its
     port is not lsof-attributable; while our agy is NOT yet up in the pane it keeps
     polling rather than risk a foreign-agy candidate. This polls that resolver
-    until a port binds, then ``StartCascade``s a runner-generated
+    until a port binds and ``GetAvailableModels`` returns a non-empty catalog,
+    allows agy post-login initialization to settle, then ``StartCascade``s a
+    runner-generated
     ``uuid4`` and writes THAT real id into bridge state (replacing the
     ``agy_conv_*`` placeholder) so :func:`read_bridge_state` returns the real id
     and the reader/executor address the cold-started conversation directly.
@@ -4534,7 +4540,8 @@ async def _cold_start_agy_conversation(
     if a future caller forgets the resume gate.
 
     **Best-effort, never raises.** A bootstrap failure (no port within
-    *timeout_s*, or ``StartCascade`` erroring) must NOT abort the auto-create:
+    *timeout_s*, no ready model catalog within *timeout_s*, or ``StartCascade``
+    erroring) must NOT abort the auto-create:
     that would leave a registered terminal with no reader (which a later
     ensure sees and returns 200 for, never self-healing). On failure this logs
     and returns ``None`` (the placeholder stays; the reader's discovery then binds
@@ -4554,7 +4561,8 @@ async def _cold_start_agy_conversation(
         ``None`` (remote runner / no local pane) falls back to the candidate scan.
     :param tmux_target: This session's tmux target (e.g. ``"main"``), paired with
         ``tmux_socket`` for the pane-scoped port resolution.
-    :param timeout_s: Total seconds to wait for agy's connect-RPC port to bind.
+    :param timeout_s: Total seconds to wait for agy's connect-RPC port and model
+        catalog to become ready.
     :returns: The real (cold-started) cascade/conversation id on success, or
         ``None`` when no port answered in time or ``StartCascade`` failed.
     """
@@ -4565,6 +4573,7 @@ async def _cold_start_agy_conversation(
     )
     from omnigent.antigravity_native_rpc import (
         AntigravityRpcError,
+        get_available_models,
         resolve_cold_start_agy_rpc_port,
         start_cascade,
     )
@@ -4587,18 +4596,25 @@ async def _cold_start_agy_conversation(
         # local pane is reachable or the pane is not resolvable yet.
         port = await asyncio.to_thread(resolve_cold_start_agy_rpc_port, tmux_socket, tmux_target)
         if port is not None:
-            break
+            try:
+                catalog = await asyncio.to_thread(get_available_models, port)
+            except (httpx.HTTPError, ValueError):
+                catalog = {}
+            models = catalog.get("models")
+            if isinstance(models, dict) and models:
+                break
         if time.monotonic() >= deadline:
             _logger.warning(
-                "Antigravity cold-start: no agy connect-RPC port bound within %.0fs for "
-                "session %s; leaving the placeholder conversation id for the reader to "
-                "bind once a turn creates the conversation.",
+                "Antigravity cold-start: agy did not expose a ready model catalog within "
+                "%.0fs for session %s; leaving the placeholder conversation id for the "
+                "reader to bind once a turn creates the conversation.",
                 timeout_s,
                 session_id,
             )
             return None
         await _agy_cold_start_poll_sleep(_AGY_COLD_START_PORT_POLL_INTERVAL_S)
 
+    await _agy_cold_start_poll_sleep(_AGY_COLD_START_MODEL_STABILIZATION_S)
     cascade_id = str(uuid.uuid4())
     try:
         await asyncio.to_thread(start_cascade, port, cascade_id)

--- a/tests/runner/test_app_sessions_native_terminals_runtime.py
+++ b/tests/runner/test_app_sessions_native_terminals_runtime.py
@@ -1816,6 +1816,11 @@ async def _run_antigravity_auto_create(
 
     monkeypatch.setattr(runner_app_mod, "_agy_cold_start_poll_sleep", _no_sleep)
     monkeypatch.setattr(rpc_mod, "_candidate_agy_rpc_ports", lambda: list(candidate_ports))
+    monkeypatch.setattr(
+        rpc_mod,
+        "get_available_models",
+        lambda _port: {"models": {"ready": {"model": "ready"}}},
+    )
     start_cascade_calls: list[tuple[int, str]] = []
 
     def _fake_start_cascade(port: int, cascade_id: str, **_kwargs: Any) -> None:
@@ -2146,6 +2151,120 @@ async def test_cold_start_agy_conversation_returns_early_on_real_id_in_bridge_st
     state = bridge_mod.read_bridge_state(bridge_dir)
     assert state is not None
     assert state.conversation_id == real_id
+
+
+@pytest.mark.asyncio
+async def test_cold_start_agy_conversation_waits_for_model_readiness(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """StartCascade runs only after models appear and the settling delay passes."""
+    import omnigent.antigravity_native_rpc as rpc_mod
+    from omnigent import antigravity_native_bridge as bridge_mod
+    from omnigent.runner.native import orchestration as runner_app_mod
+
+    monkeypatch.setattr(bridge_mod, "_BRIDGE_ROOT", tmp_path / "antigravity-native")
+    session_id = "158889f76b7143cd97d1c564db115235"
+    bridge_dir = bridge_mod.prepare_bridge_dir(session_id)
+    bridge_mod.write_bridge_state(
+        bridge_dir,
+        bridge_mod.AntigravityNativeBridgeState(
+            session_id=session_id,
+            conversation_id=f"agy_conv_{'a' * 32}",
+        ),
+    )
+
+    events: list[tuple[str, object]] = []
+    catalogs = iter(
+        [
+            {},
+            {"models": {}},
+            {"models": {"gemini": {"model": "MODEL_GEMINI"}}},
+        ]
+    )
+    monkeypatch.setattr(
+        rpc_mod,
+        "resolve_cold_start_agy_rpc_port",
+        lambda *_args: 52548,
+    )
+
+    def _models(port: int) -> dict[str, object]:
+        events.append(("models", port))
+        return next(catalogs)
+
+    monkeypatch.setattr(rpc_mod, "get_available_models", _models)
+
+    def _start(port: int, cascade_id: str) -> None:
+        events.append(("start", (port, cascade_id)))
+
+    monkeypatch.setattr(rpc_mod, "start_cascade", _start)
+
+    async def _sleep(seconds: float) -> None:
+        events.append(("sleep", seconds))
+
+    monkeypatch.setattr(runner_app_mod, "_agy_cold_start_poll_sleep", _sleep)
+
+    result = await runner_app_mod._cold_start_agy_conversation(
+        bridge_dir,
+        session_id,
+        timeout_s=1.0,
+    )
+
+    assert result is not None
+    assert events[:-1] == [
+        ("models", 52548),
+        ("sleep", runner_app_mod._AGY_COLD_START_PORT_POLL_INTERVAL_S),
+        ("models", 52548),
+        ("sleep", runner_app_mod._AGY_COLD_START_PORT_POLL_INTERVAL_S),
+        ("models", 52548),
+        ("sleep", 4.0),
+    ]
+    assert events[-1] == ("start", (52548, result))
+
+
+@pytest.mark.asyncio
+async def test_cold_start_agy_conversation_model_timeout_keeps_placeholder(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bound RPC port without models never receives StartCascade."""
+    import omnigent.antigravity_native_rpc as rpc_mod
+    from omnigent import antigravity_native_bridge as bridge_mod
+    from omnigent.runner.native import orchestration as runner_app_mod
+
+    monkeypatch.setattr(bridge_mod, "_BRIDGE_ROOT", tmp_path / "antigravity-native")
+    session_id = "4908a3a50e4c4323a3f0183013ea79ba"
+    bridge_dir = bridge_mod.prepare_bridge_dir(session_id)
+    placeholder = f"agy_conv_{'b' * 32}"
+    bridge_mod.write_bridge_state(
+        bridge_dir,
+        bridge_mod.AntigravityNativeBridgeState(
+            session_id=session_id,
+            conversation_id=placeholder,
+        ),
+    )
+    monkeypatch.setattr(
+        rpc_mod,
+        "resolve_cold_start_agy_rpc_port",
+        lambda *_args: 52548,
+    )
+    monkeypatch.setattr(rpc_mod, "get_available_models", lambda _port: {"models": {}})
+
+    def _unexpected_start(_port: int, _cascade_id: str) -> None:
+        raise AssertionError("StartCascade must wait for a non-empty model catalog")
+
+    monkeypatch.setattr(rpc_mod, "start_cascade", _unexpected_start)
+
+    result = await runner_app_mod._cold_start_agy_conversation(
+        bridge_dir,
+        session_id,
+        timeout_s=0.0,
+    )
+
+    assert result is None
+    state = bridge_mod.read_bridge_state(bridge_dir)
+    assert state is not None
+    assert state.conversation_id == placeholder
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

Closes #3877

## Summary

- Poll `GetAvailableModels` after AGY connect-RPC port discovery and require a non-empty model catalog before `StartCascade`.
- Preserve a four-second post-readiness settling interval observed to avoid the first-turn disconnect during background authentication.
- Keep cold start best-effort: model-readiness timeout leaves the placeholder for the reader instead of aborting terminal creation.

ELI5: AGY can open its door before it has finished loading its models. Omnigent now waits until AGY says models are available, gives initialization a moment to settle, and only then starts the conversation.

```text
port discovered
      |
      v
GetAvailableModels -- empty/error --> poll (bounded)
      | non-empty
      v
4s stabilization --> StartCascade
```

## Test Plan

- `uv run pytest -q tests/runner/test_app_sessions_native_terminals_runtime.py -k "antigravity_cold_start or cold_start_agy_conversation"` (9 passed)
- `uv run pytest -q tests/runner/test_app_sessions_native_terminals_runtime.py` (34 passed)
- `uv run ruff check omnigent/runner/native/orchestration.py tests/runner/test_app_sessions_native_terminals_runtime.py`
- `uv run ruff format --check omnigent/runner/native/orchestration.py tests/runner/test_app_sessions_native_terminals_runtime.py`

## Demo

N/A — native runner lifecycle change with no UI surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

A live 0.7.0 deployment reproduced the timing race. Instrumentation showed the model catalog becoming ready after OAuth; applying this ordering plus the four-second stabilization interval produced a successful first AGY response with no runner disconnect or manual resend. The PR adds deterministic unit coverage for delayed readiness, ordering, and timeout fallback against current `main`.

## Changelog

Antigravity workers now wait for model initialization before starting a fresh conversation.