### PR TITLE
refactor: type Claude native boundaries

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -28,16 +28,22 @@ import uuid
 if sys.platform != "win32":
     import termios
     import tty
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import IO, TYPE_CHECKING, Any
+from types import FrameType
+from typing import TYPE_CHECKING, Protocol, TextIO, TypeAlias, cast
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
+    from prompt_toolkit.application import Application
+    from prompt_toolkit.key_binding import KeyBindings, KeyPressEvent
+    from prompt_toolkit.layout.controls import FormattedTextControl
+    from prompt_toolkit.styles import Style
+
     from omnigent.onboarding.provider_config import ProviderEntry
     from omnigent.spec.types import AgentSpec
 
@@ -118,6 +124,35 @@ from omnigent.terminals.ws_bridge import (
 )
 
 _logger = logging.getLogger(__name__)
+
+_JsonObject: TypeAlias = dict[str, object]
+_TermiosAttrs: TypeAlias = list[int | list[bytes | int]]
+_SignalHandler: TypeAlias = (
+    Callable[[int, FrameType | None], object] | int | signal.Handlers | None
+)
+
+
+class _WebSocketClient(Protocol):
+    """WebSocket operations used by the native terminal bridge."""
+
+    def __aiter__(self) -> AsyncIterator[str | bytes]: ...
+
+    async def close(self, code: int = 1000, reason: str = "") -> None: ...
+
+    async def send(self, message: str | bytes) -> None: ...
+
+
+class _TerminalAttach(Protocol):
+    """Async terminal attach callable shared by native wrappers."""
+
+    def __call__(
+        self,
+        attach_url: str,
+        *,
+        headers: dict[str, str],
+        terminal_gone_probe: Callable[[], Awaitable[bool]] | None = None,
+    ) -> Awaitable[bool]: ...
+
 
 _AGENT_NAME = "claude-native-ui"
 _DEFAULT_CLAUDE_COMMAND = "claude"
@@ -903,13 +938,16 @@ def _prompt_resume_workspace_action_text(
     )
     for option in options:
         click.echo(f"  {option.action:<6} - {option.label}", err=True)
-    return click.prompt(
+    action = click.prompt(
         "Resume action",
         type=click.Choice([option.action for option in options]),
         default=options[0].action,
         show_choices=True,
         err=True,
     )
+    if not isinstance(action, str):
+        raise click.ClickException("Claude resume action must be a string.")
+    return action
 
 
 def _pick_resume_workspace_action_prompt_toolkit(
@@ -917,8 +955,8 @@ def _pick_resume_workspace_action_prompt_toolkit(
     *,
     recorded_path: Path,
     current: Path,
-    out: IO[str],
-    in_: IO[str],
+    out: TextIO,
+    in_: TextIO,
 ) -> str:
     """
     Run the interactive workspace action selector.
@@ -952,9 +990,9 @@ def _resume_workspace_action_application(
     *,
     recorded_path: Path,
     current: Path,
-    out: IO[str],
-    in_: IO[str],
-) -> Any:
+    out: TextIO,
+    in_: TextIO,
+) -> Application[str]:
     """
     Build the prompt-toolkit application for the action selector.
 
@@ -975,7 +1013,7 @@ def _resume_workspace_action_application(
         recorded_path=recorded_path,
         current=current,
     )
-    return Application(
+    return Application[str](
         layout=Layout(Window(content=control, wrap_lines=True, always_hide_cursor=True)),
         key_bindings=_resume_workspace_action_key_bindings(state),
         style=_resume_workspace_action_style(),
@@ -992,7 +1030,7 @@ def _resume_workspace_action_control(
     *,
     recorded_path: Path,
     current: Path,
-) -> Any:
+) -> FormattedTextControl:
     """
     Build the formatted-text control for the action selector.
 
@@ -1013,7 +1051,9 @@ def _resume_workspace_action_control(
     )
 
 
-def _resume_workspace_action_key_bindings(state: _ResumeWorkspaceActionPickerState) -> Any:
+def _resume_workspace_action_key_bindings(
+    state: _ResumeWorkspaceActionPickerState,
+) -> KeyBindings:
     """
     Build keybindings for the workspace action selector.
 
@@ -1031,7 +1071,7 @@ def _resume_workspace_action_key_bindings(state: _ResumeWorkspaceActionPickerSta
 
 
 def _bind_resume_workspace_action_navigation(
-    key_bindings: Any,
+    key_bindings: KeyBindings,
     state: _ResumeWorkspaceActionPickerState,
 ) -> None:
     """
@@ -1044,7 +1084,7 @@ def _bind_resume_workspace_action_navigation(
 
     @key_bindings.add("up")
     @key_bindings.add("k")
-    def _move_up(event: Any) -> None:
+    def _move_up(event: KeyPressEvent) -> None:
         """
         Move the highlighted action upward.
 
@@ -1056,7 +1096,7 @@ def _bind_resume_workspace_action_navigation(
 
     @key_bindings.add("down")
     @key_bindings.add("j")
-    def _move_down(event: Any) -> None:
+    def _move_down(event: KeyPressEvent) -> None:
         """
         Move the highlighted action downward.
 
@@ -1068,7 +1108,7 @@ def _bind_resume_workspace_action_navigation(
 
 
 def _bind_resume_workspace_action_completion(
-    key_bindings: Any,
+    key_bindings: KeyBindings,
     state: _ResumeWorkspaceActionPickerState,
 ) -> None:
     """
@@ -1080,7 +1120,7 @@ def _bind_resume_workspace_action_completion(
     """
 
     @key_bindings.add("enter")
-    def _select(event: Any) -> None:
+    def _select(event: KeyPressEvent) -> None:
         """
         Select the highlighted action.
 
@@ -1092,7 +1132,7 @@ def _bind_resume_workspace_action_completion(
     @key_bindings.add("q")
     @key_bindings.add("escape")
     @key_bindings.add("c-d")
-    def _leave(event: Any) -> None:
+    def _leave(event: KeyPressEvent) -> None:
         """
         Leave without resuming.
 
@@ -1102,7 +1142,7 @@ def _bind_resume_workspace_action_completion(
         event.app.exit(result=_RESUME_ACTION_LEAVE)
 
 
-def _bind_resume_workspace_action_interrupt(key_bindings: Any) -> None:
+def _bind_resume_workspace_action_interrupt(key_bindings: KeyBindings) -> None:
     """
     Add Ctrl+C handling to the action selector.
 
@@ -1111,7 +1151,7 @@ def _bind_resume_workspace_action_interrupt(key_bindings: Any) -> None:
     """
 
     @key_bindings.add("c-c")
-    def _interrupt(event: Any) -> None:
+    def _interrupt(event: KeyPressEvent) -> None:
         """
         Propagate Ctrl+C as KeyboardInterrupt.
 
@@ -1121,7 +1161,7 @@ def _bind_resume_workspace_action_interrupt(key_bindings: Any) -> None:
         event.app.exit(exception=KeyboardInterrupt)
 
 
-def _resume_workspace_action_style() -> Any:
+def _resume_workspace_action_style() -> Style:
     """
     Build prompt-toolkit styles for the workspace action selector.
 
@@ -1256,7 +1296,7 @@ def _has_running_event_loop() -> bool:
     return True
 
 
-def _stream_is_tty(stream: IO[str]) -> bool:
+def _stream_is_tty(stream: TextIO) -> bool:
     """
     Return whether *stream* is attached to a terminal.
 
@@ -2382,7 +2422,7 @@ async def _attach_with_transcript_forwarder(
     prepared: PreparedClaudeTerminal,
     agent_name: str,
     attach_url: str,
-    attach: Callable[..., Any],
+    attach: _TerminalAttach,
     recover: Callable[[], Awaitable[None]] | None = None,
     auth: httpx.Auth | None = None,
     run_transcript_forwarder: bool = True,
@@ -2517,7 +2557,7 @@ async def _attach_with_transcript_forwarder(
 
 async def _attach_with_reconnect(
     *,
-    attach: Callable[..., Any],
+    attach: _TerminalAttach,
     attach_url: str,
     headers: dict[str, str],
     recover: Callable[[], Awaitable[None]] | None,
@@ -2593,7 +2633,6 @@ async def _attach_with_reconnect(
                 )
         first_attempt = False
         try:
-            attach_kwargs: dict[str, Any] = {"headers": headers}
             if (
                 close_attach_on_terminal_gone
                 and base_url is not None
@@ -2621,8 +2660,13 @@ async def _attach_with_reconnect(
                         timeout_s=_CLAUDE_TERMINAL_GONE_WATCH_HTTP_TIMEOUT_S,
                     )
 
-                attach_kwargs["terminal_gone_probe"] = _terminal_gone_probe
-            user_requested_exit = await attach(current_attach_url, **attach_kwargs)
+                user_requested_exit = await attach(
+                    current_attach_url,
+                    headers=headers,
+                    terminal_gone_probe=_terminal_gone_probe,
+                )
+            else:
+                user_requested_exit = await attach(current_attach_url, headers=headers)
         except ConnectionClosed as exc:
             if _is_terminal_detached_close(exc):
                 # The user detached from tmux: the session (and Claude)
@@ -2656,7 +2700,7 @@ async def _attach_with_reconnect(
         else:
             if user_requested_exit or recover is None:
                 return _AttachOutcome.EXITED
-            if base_url is not None and session_id is not None and terminal_id is not None:
+            if base_url is not None and current_session_id is not None and terminal_id is not None:
                 terminal_gone = await _is_terminal_resource_gone(
                     base_url=base_url,
                     headers=headers,
@@ -3721,7 +3765,7 @@ async def _ensure_local_claude_resume_transcript(
 async def _fetch_all_session_items_for_claude_resume(
     client: httpx.AsyncClient,
     session_id: str,
-) -> list[dict[str, Any]]:
+) -> list[_JsonObject]:
     """
     Fetch committed session items in chronological order.
 
@@ -3733,7 +3777,7 @@ async def _fetch_all_session_items_for_claude_resume(
     :raises click.ClickException: If an item page cannot be fetched or
         parsed.
     """
-    items: list[dict[str, Any]] = []
+    items: list[_JsonObject] = []
     after: str | None = None
     while True:
         params: dict[str, str | int] = {"limit": 1000, "order": "asc"}
@@ -3749,20 +3793,21 @@ async def _fetch_all_session_items_for_claude_resume(
                 f"({resp.status_code}): {error_text(resp)}"
             )
         try:
-            payload = resp.json()
+            payload = _json_object(resp.json())
         except ValueError as exc:
             raise click.ClickException(
                 f"History fetch for {session_id!r} returned non-JSON body: {exc}"
             ) from exc
-        data = payload.get("data") if isinstance(payload, dict) else None
+        data = payload.get("data") if payload is not None else None
         if not isinstance(data, list):
             raise click.ClickException(
                 f"History fetch for {session_id!r} returned an invalid item list."
             )
         for item in data:
-            if isinstance(item, dict):
-                items.append(item)
-        if not payload.get("has_more"):
+            parsed_item = _json_object(item)
+            if parsed_item is not None:
+                items.append(parsed_item)
+        if payload is None or not payload.get("has_more"):
             return items
         last_id = payload.get("last_id")
         if not isinstance(last_id, str) or not last_id:
@@ -3776,8 +3821,8 @@ async def _resolve_session_item_file_references(
     client: httpx.AsyncClient,
     *,
     session_id: str,
-    items: list[dict[str, Any]],
-) -> list[dict[str, Any]]:
+    items: list[_JsonObject],
+) -> list[_JsonObject]:
     """
     Inline ``file_id`` attachment blocks as base64 data URIs.
 
@@ -3800,23 +3845,32 @@ async def _resolve_session_item_file_references(
         content = item.get("content")
         if item.get("type") != "message" or not isinstance(content, list):
             continue
-        item["content"] = [
-            (await resolve_file_id_block(block, session_id=session_id, client=client) or block)
-            if isinstance(block, dict) and has_unresolved_file_id(block)
-            else block
-            for block in content
-        ]
+        resolved_content: list[object] = []
+        for block in content:
+            parsed_block = _json_object(block)
+            if parsed_block is not None and has_unresolved_file_id(parsed_block):
+                resolved_content.append(
+                    await resolve_file_id_block(
+                        parsed_block,
+                        session_id=session_id,
+                        client=client,
+                    )
+                    or parsed_block
+                )
+            else:
+                resolved_content.append(block)
+        item["content"] = resolved_content
     return items
 
 
 def _claude_transcript_records_from_session_items(
-    items: list[dict[str, Any]],
+    items: list[_JsonObject],
     *,
     session_id: str,
     external_session_id: str,
     cwd: Path,
     bridge_dir: Path,
-) -> list[dict[str, Any]]:
+) -> list[_JsonObject]:
     """
     Convert Omnigent session items into Claude Code transcript records.
 
@@ -3833,7 +3887,7 @@ def _claude_transcript_records_from_session_items(
         blocks are re-materialized under its ``uploads/`` subdirectory.
     :returns: Claude JSONL record dictionaries.
     """
-    records: list[dict[str, Any]] = []
+    records: list[_JsonObject] = []
     parent_uuid: str | None = None
     tool_parent_by_call_id: dict[str, str] = {}
     for index, item in enumerate(items):
@@ -3841,8 +3895,8 @@ def _claude_transcript_records_from_session_items(
         # all prior records with the compacted messages so the
         # reconstructed transcript reflects the compacted state.
         if item.get("type") == "compaction":
-            compacted_msgs = item.get("compacted_messages")
-            if compacted_msgs:
+            compacted_messages = item.get("compacted_messages")
+            if isinstance(compacted_messages, list) and compacted_messages:
                 records.clear()
                 parent_uuid = None
                 tool_parent_by_call_id.clear()
@@ -3876,15 +3930,18 @@ def _claude_transcript_records_from_session_items(
                     }
                 )
                 parent_uuid = boundary_uuid
-                for ci, cm in enumerate(compacted_msgs):
+                for compacted_index, compacted_value in enumerate(compacted_messages):
+                    compacted_message = _json_object(compacted_value)
+                    if compacted_message is None:
+                        continue
                     cm_uuid = _synthetic_claude_transcript_uuid(
                         session_id=session_id,
                         external_session_id=external_session_id,
-                        item=cm,
-                        index=ci,
+                        item=compacted_message,
+                        index=compacted_index,
                     )
                     cm_record = _claude_transcript_record_from_session_item(
-                        cm,
+                        compacted_message,
                         session_id=external_session_id,
                         record_uuid=cm_uuid,
                         parent_uuid=parent_uuid,
@@ -3921,14 +3978,14 @@ def _claude_transcript_records_from_session_items(
 
 
 def _claude_transcript_record_from_session_item(
-    item: dict[str, Any],
+    item: _JsonObject,
     *,
     session_id: str,
     record_uuid: str,
     parent_uuid: str | None,
     cwd: Path,
     bridge_dir: Path,
-) -> dict[str, Any] | None:
+) -> _JsonObject | None:
     """
     Convert one Omnigent item into one Claude transcript record.
 
@@ -3948,23 +4005,23 @@ def _claude_transcript_record_from_session_item(
         empty Omnigent items.
     """
     item_type = item.get("type")
-    message: dict[str, Any] | None = None
+    message: _JsonObject | None = None
     record_type: str | None = None
-    extra: dict[str, Any] = {}
+    extra: _JsonObject = {}
     if item_type == "message":
         role = item.get("role")
         if role == "user":
-            content = _claude_user_content_from_api_blocks(item.get("content"), bridge_dir)
-            if content is None:
+            user_content = _claude_user_content_from_api_blocks(item.get("content"), bridge_dir)
+            if user_content is None:
                 return None
             record_type = "user"
-            message = {"role": "user", "content": content}
+            message = {"role": "user", "content": user_content}
         elif role == "assistant":
-            content = _claude_assistant_content_from_api_blocks(item.get("content"))
-            if content is None:
+            assistant_content = _claude_assistant_content_from_api_blocks(item.get("content"))
+            if assistant_content is None:
                 return None
             record_type = "assistant"
-            message = {"role": "assistant", "content": content}
+            message = {"role": "assistant", "content": assistant_content}
             model = item.get("model")
             if isinstance(model, str) and model:
                 message["model"] = model
@@ -4014,7 +4071,7 @@ def _claude_transcript_record_from_session_item(
         # so ``claude --resume`` sends screenshots as images — not as ~250K
         # tokens of base64 text — and the model actually sees them again.
         content_blocks = _claude_tool_result_content_blocks(output)
-        content: str | list[dict[str, Any]] = (
+        tool_result_content: str | list[_JsonObject] = (
             content_blocks if content_blocks is not None else output
         )
         message = {
@@ -4023,7 +4080,7 @@ def _claude_transcript_record_from_session_item(
                 {
                     "type": "tool_result",
                     "tool_use_id": call_id,
-                    "content": content,
+                    "content": tool_result_content,
                 }
             ],
         }
@@ -4048,7 +4105,7 @@ def _synthetic_claude_transcript_uuid(
     *,
     session_id: str,
     external_session_id: str,
-    item: dict[str, Any],
+    item: _JsonObject,
     index: int,
 ) -> str:
     """
@@ -4076,7 +4133,7 @@ def _synthetic_claude_transcript_uuid(
 def _claude_user_content_from_api_blocks(
     content: object,
     bridge_dir: Path,
-) -> str | list[dict[str, Any]] | None:
+) -> str | list[_JsonObject] | None:
     """
     Convert Omnigent user message blocks into Claude message content.
 
@@ -4098,14 +4155,15 @@ def _claude_user_content_from_api_blocks(
     if not blocks:
         return None
     if len(blocks) == 1:
-        return str(blocks[0]["text"])
+        text = blocks[0].get("text")
+        return text if isinstance(text, str) else None
     return blocks
 
 
 def _claude_attachment_text_blocks_from_api_content(
     content: object,
     bridge_dir: Path,
-) -> list[dict[str, Any]]:
+) -> list[_JsonObject]:
     """
     Re-materialize attachment blocks as transcript text references.
 
@@ -4124,14 +4182,18 @@ def _claude_attachment_text_blocks_from_api_content(
 
     if not isinstance(content, list):
         return []
-    return [
-        {"type": "text", "text": attachment_reference_line(block, bridge_dir)}
-        for block in content
-        if isinstance(block, dict) and block.get("type") in ("input_image", "input_file")
-    ]
+    blocks: list[_JsonObject] = []
+    for value in content:
+        block = _json_object(value)
+        if block is None or block.get("type") not in ("input_image", "input_file"):
+            continue
+        blocks.append({"type": "text", "text": attachment_reference_line(block, bridge_dir)})
+    return blocks
 
 
-def _claude_assistant_content_from_api_blocks(content: object) -> list[dict[str, Any]] | None:
+def _claude_assistant_content_from_api_blocks(
+    content: object,
+) -> list[_JsonObject] | None:
     """
     Convert Omnigent assistant message blocks into Claude text blocks.
 
@@ -4148,7 +4210,7 @@ def _claude_text_blocks_from_api_content(
     content: object,
     *,
     api_type: str,
-) -> list[dict[str, Any]]:
+) -> list[_JsonObject]:
     """
     Extract text blocks from an Omnigent content array.
 
@@ -4160,9 +4222,10 @@ def _claude_text_blocks_from_api_content(
     """
     if not isinstance(content, list):
         return []
-    blocks: list[dict[str, Any]] = []
-    for block in content:
-        if not isinstance(block, dict) or block.get("type") != api_type:
+    blocks: list[_JsonObject] = []
+    for value in content:
+        block = _json_object(value)
+        if block is None or block.get("type") != api_type:
             continue
         text = block.get("text")
         if isinstance(text, str) and text:
@@ -4170,7 +4233,16 @@ def _claude_text_blocks_from_api_content(
     return blocks
 
 
-def _json_object_from_string(value: object) -> dict[str, Any]:
+def _json_object(value: object) -> _JsonObject | None:
+    """Return a string-keyed object for a decoded JSON mapping."""
+    if not isinstance(value, dict):
+        return None
+    if not all(isinstance(key, str) for key in value):
+        return None
+    return {key: item for key, item in value.items() if isinstance(key, str)}
+
+
+def _json_object_from_string(value: object) -> _JsonObject:
     """
     Parse a JSON object string, returning ``{}`` on non-object input.
 
@@ -4185,7 +4257,7 @@ def _json_object_from_string(value: object) -> dict[str, Any]:
         parsed = json.loads(value)
     except json.JSONDecodeError:
         return {}
-    return parsed if isinstance(parsed, dict) else {}
+    return _json_object(parsed) or {}
 
 
 def _json_safe_tool_use_result(output: str) -> str:
@@ -4244,7 +4316,7 @@ def _strip_unparseable_image_output(output: str) -> str:
     return output
 
 
-def _claude_tool_result_content_blocks(output: str) -> list[dict[str, Any]] | None:
+def _claude_tool_result_content_blocks(output: str) -> list[_JsonObject] | None:
     """
     Rehydrate a stringified content-block array into real blocks.
 
@@ -4273,11 +4345,13 @@ def _claude_tool_result_content_blocks(output: str) -> list[dict[str, Any]] | No
         return None
     if not isinstance(parsed, list) or not parsed:
         return None
-    if not all(
-        isinstance(block, dict) and block.get("type") in ("text", "image") for block in parsed
-    ):
-        return None
-    return parsed
+    blocks: list[_JsonObject] = []
+    for value in parsed:
+        block = _json_object(value)
+        if block is None or block.get("type") not in ("text", "image"):
+            return None
+        blocks.append(block)
+    return blocks
 
 
 def _preflight_local_tools(command: str) -> None:
@@ -4339,7 +4413,7 @@ async def _create_claude_session(
     labels = dict(_SESSION_LABELS)
     if bridge_id is not None:
         labels[BRIDGE_ID_LABEL_KEY] = bridge_id
-    metadata: dict[str, Any] = {"labels": labels}
+    metadata: _JsonObject = {"labels": labels}
     if terminal_launch_args:
         metadata["terminal_launch_args"] = terminal_launch_args
     # Stamp the wrapped claude's real effortLevel so the pill isn't a guess.
@@ -4536,7 +4610,7 @@ def _claude_terminal_request(
     claude_config: ClaudeNativeUcodeConfig | None = None,
     append_system_prompt: str | None = None,
     allowed_tools: tuple[str, ...] = (),
-) -> dict[str, Any]:
+) -> _JsonObject:
     """
     Build the terminal resource creation body for Claude Code.
 
@@ -4574,7 +4648,7 @@ def _claude_terminal_request(
     # command/args to wrap the same fully-augmented Claude launch. Identity by
     # default. See omnigent.claude_launcher.
     command, args = resolve_claude_launch(command, args)
-    spec: dict[str, Any] = {
+    spec: _JsonObject = {
         "command": command,
         "args": args,
         "os_env_type": "caller_process",
@@ -4719,7 +4793,7 @@ async def attach_local_terminal(
 
 
 async def _close_ws_when_terminal_gone(
-    ws: Any,
+    ws: _WebSocketClient,
     *,
     terminal_gone_probe: Callable[[], Awaitable[bool]],
     poll_interval_s: float,
@@ -4755,7 +4829,11 @@ async def _close_ws_when_terminal_gone(
         return
 
 
-def _websocket_connect(attach_url: str, *, headers: dict[str, str]) -> Any:
+def _websocket_connect(
+    attach_url: str,
+    *,
+    headers: dict[str, str],
+) -> contextlib.AbstractAsyncContextManager[_WebSocketClient]:
     """
     Return a websockets connection context manager.
 
@@ -4783,23 +4861,29 @@ def _websocket_connect(attach_url: str, *, headers: dict[str, str]) -> Any:
     # library default — no TLS). See omnigent/tls.py and issue #1730.
     ssl_ctx = client_ssl_context() if attach_url.startswith("wss://") else None
     try:
-        return websockets.connect(
-            attach_url,
-            additional_headers=handshake_headers,
-            close_timeout=_CLAUDE_ATTACH_WS_CLOSE_TIMEOUT_S,
-            ssl=ssl_ctx,
+        return cast(
+            contextlib.AbstractAsyncContextManager[_WebSocketClient],
+            websockets.connect(
+                attach_url,
+                additional_headers=handshake_headers,
+                close_timeout=_CLAUDE_ATTACH_WS_CLOSE_TIMEOUT_S,
+                ssl=ssl_ctx,
+            ),
         )
     except TypeError:
-        return websockets.connect(
-            attach_url,
-            extra_headers=handshake_headers,
-            close_timeout=_CLAUDE_ATTACH_WS_CLOSE_TIMEOUT_S,
-            ssl=ssl_ctx,
+        return cast(
+            contextlib.AbstractAsyncContextManager[_WebSocketClient],
+            websockets.connect(
+                attach_url,
+                extra_headers=handshake_headers,
+                close_timeout=_CLAUDE_ATTACH_WS_CLOSE_TIMEOUT_S,
+                ssl=ssl_ctx,
+            ),
         )
 
 
 async def _stdin_to_websocket(
-    ws: Any,
+    ws: _WebSocketClient,
     stdin_fd: int,
     *,
     eof_event: asyncio.Event | None = None,
@@ -4825,7 +4909,7 @@ async def _stdin_to_websocket(
         await ws.send(data)
 
 
-async def _websocket_to_stdout(ws: Any, stdout_fd: int) -> None:
+async def _websocket_to_stdout(ws: _WebSocketClient, stdout_fd: int) -> None:
     """
     Copy terminal WebSocket bytes to local stdout.
 
@@ -4900,7 +4984,7 @@ async def _read_fd_with_reader(loop: asyncio.AbstractEventLoop, fd: int) -> byte
                 loop.remove_reader(fd)
 
 
-async def _send_resize(ws: Any, stdin_fd: int) -> None:
+async def _send_resize(ws: _WebSocketClient, stdin_fd: int) -> None:
     """
     Send the current local terminal size over the attach protocol.
 
@@ -4913,7 +4997,7 @@ async def _send_resize(ws: Any, stdin_fd: int) -> None:
     await ws.send(json.dumps({"type": "resize", "cols": size.columns, "rows": size.lines}))
 
 
-def _enter_raw_mode(fd: int) -> list[Any] | None:
+def _enter_raw_mode(fd: int) -> _TermiosAttrs | None:
     """
     Put *fd* into raw mode when it is a TTY.
 
@@ -4923,12 +5007,12 @@ def _enter_raw_mode(fd: int) -> list[Any] | None:
     """
     if not os.isatty(fd):
         return None
-    old_attrs = termios.tcgetattr(fd)
+    old_attrs = cast(_TermiosAttrs, termios.tcgetattr(fd))
     tty.setraw(fd)
     return old_attrs
 
 
-def _restore_terminal(fd: int, old_attrs: list[Any] | None) -> None:
+def _restore_terminal(fd: int, old_attrs: _TermiosAttrs | None) -> None:
     """
     Restore termios attributes saved by :func:`_enter_raw_mode`.
 
@@ -4958,7 +5042,10 @@ class _SignalRestore:
     received_signal: int | None = None
 
 
-def _install_attach_signal_handlers(ws: Any, stdin_fd: int) -> _SignalRestore:
+def _install_attach_signal_handlers(
+    ws: _WebSocketClient,
+    stdin_fd: int,
+) -> _SignalRestore:
     """
     Install resize and stop signal handlers for local attach.
 
@@ -4968,7 +5055,7 @@ def _install_attach_signal_handlers(ws: Any, stdin_fd: int) -> _SignalRestore:
     """
     loop = asyncio.get_running_loop()
     stop_event = asyncio.Event()
-    previous: dict[signal.Signals, Any] = {}
+    previous: dict[signal.Signals, _SignalHandler] = {}
     resize_tasks: set[asyncio.Task[None]] = set()
     restore_handle = _SignalRestore(lambda: None, stop_event)
 
@@ -4988,7 +5075,7 @@ def _install_attach_signal_handlers(ws: Any, stdin_fd: int) -> _SignalRestore:
         signal.SIGTERM: lambda: _request_stop(signal.SIGTERM),
         signal.SIGHUP: lambda: _request_stop(signal.SIGHUP),
     }.items():
-        previous[sig] = signal.getsignal(sig)
+        previous[sig] = cast(_SignalHandler, signal.getsignal(sig))
         try:
             loop.add_signal_handler(sig, handler)
         except (NotImplementedError, RuntimeError):

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -4237,9 +4237,12 @@ def _json_object(value: object) -> _JsonObject | None:
     """Return a string-keyed object for a decoded JSON mapping."""
     if not isinstance(value, dict):
         return None
-    if not all(isinstance(key, str) for key in value):
-        return None
-    return {key: item for key, item in value.items() if isinstance(key, str)}
+    result: _JsonObject = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            return None
+        result[key] = item
+    return result
 
 
 def _json_object_from_string(value: object) -> _JsonObject:


### PR DESCRIPTION
## Related issue

Relates to #3644

## Summary

- Replaces broad `Any` usage in `claude_native.py` with explicit prompt-toolkit, terminal attach, WebSocket, signal, termios, and JSON object contracts.
- Validates decoded session/transcript mappings at runtime before consuming them.
- Keeps clean-close terminal probes aligned with the active session id after `/clear` transfers.
- Removes all 59 mypy errors from `claude_native.py`, reducing the full-tree baseline from 559 to 500 errors.

**ELI5:** Claude's native wrapper previously handed the type checker many unlabeled boxes. This labels the boxes and checks external JSON before opening them, without changing valid runtime behavior.

```text
prompt-toolkit / session JSON / WebSocket
                  |
          typed boundary checks
                  |
          Claude native wrapper
```

## Test Plan

- `uv run --no-sync pytest tests/test_claude_native.py tests/test_claude_native_daemon.py tests/test_claude_native_status.py tests/test_claude_launcher.py tests/test_claude_native_message_display_hook.py tests/test_claude_native_hook.py` — 241 passed.
- `uv run --no-sync pytest tests/test_codex_native.py tests/test_antigravity_native.py` — 235 passed.
- `uv run --no-sync mypy omnigent` — 559 → 500 errors; no `claude_native.py` diagnostics remain.
- `uv run --no-sync pre-commit run --all-files` — passed.

## Demo

N/A — type-contract refactor with no visual changes.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing Claude-native, shared reconnect, Codex-native, and Antigravity-native suites exercise the typed boundaries and cross-wrapper attach contract.

