### PR TITLE
fix(onboarding): stop marking current Kimi Code as outdated against the legacy kimi-cli floor

### DIFF
--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -101,8 +101,6 @@ KIRO_KEY = "kiro"
 #   2026-06-01. The first Codex release after the cutoff is 0.137.0.
 # - cursor: Cursor's CLI uses ``YYYY.MM.DD[-build]`` date versions. Default
 #   to the day after 2026-06-01 so we don't support stale pre-June builds.
-# - kimi: first ``kimi-cli`` release after 2026-06-01 is 1.47.0
-#   (https://github.com/MoonshotAI/kimi-cli/blob/main/CHANGELOG.md).
 # - hermes: parent_session_id schema was introduced in v0.17.0, but Hermes now
 #   ships date-tagged releases; the first one after 2026-06-01 is 2026.06.05.
 _CODEX_MIN_VERSION = "0.137.0"
@@ -113,7 +111,6 @@ _HERMES_MIN_VERSION = "2026.06.05"
 _KIRO_MIN_VERSION = "2.10.0"
 _CLAUDE_MIN_VERSION = "2.1.161"
 _CURSOR_MIN_VERSION = "2026.06.02"
-_KIMI_MIN_VERSION = "1.47.0"
 
 # OpenCode native harness CLI (``opencode serve`` / ``opencode attach``),
 # installed via the ``opencode-ai`` npm package. No login/logout/status argv
@@ -234,9 +231,9 @@ _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
         login_args=("login",),
         logout_args=("logout",),
         install_hint="curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",
-        # First kimi-cli release after 2026-06-01. Older builds may lack
-        # newer TUI/session wiring needed by the native harness.
-        min_version=_KIMI_MIN_VERSION,
+        # Deliberately unbounded: Kimi Code (code.kimi.com, 0.x line) is a
+        # different product from the legacy kimi-cli (1.x), and no harness code
+        # requires a minimum. Any future floor must come from the 0.x line.
     ),
     KIRO_KEY: HarnessInstallSpec(
         "Kiro",

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -1078,7 +1078,6 @@ def test_ui_setup_steps_generic_for_non_installable() -> None:
     [
         (hi.OPENCODE_KEY, "1.17.7", "1.18.0"),
         (hi.CURSOR_KEY, "2026.06.02", None),
-        (hi.KIMI_KEY, "1.47.0", None),
         (ANTHROPIC_FAMILY, "2.1.161", None),
         (OPENAI_FAMILY, "0.137.0", None),
         (hi.PI_KEY, "0.79.0", None),
@@ -1096,6 +1095,33 @@ def test_versioned_specs_declare_bounds(
     assert spec is not None
     assert spec.min_version == min_version
     assert spec.max_version_exclusive == max_version_exclusive
+
+
+@pytest.mark.parametrize("reported", ["0.31.1", "0.5.0", "0.12.3"])
+def test_kimi_code_current_versions_are_accepted(
+    monkeypatch: pytest.MonkeyPatch, reported: str
+) -> None:
+    """Kimi Code ships a ``0.x`` line; those versions must count as installed.
+
+    Regression: the spec previously declared a ``1.47.0`` floor copied from the
+    unrelated legacy ``kimi-cli`` project, so every real Kimi Code build was
+    rejected as outdated.
+    """
+    monkeypatch.setattr(hi.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        hi.subprocess,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess(a[0], 0, stdout=reported, stderr=""),
+    )
+    assert hi.harness_cli_installed(hi.KIMI_KEY) is True
+
+
+def test_kimi_spec_declares_no_version_bounds() -> None:
+    """Kimi Code has no code-derived minimum, so the spec stays unbounded."""
+    spec = hi.harness_install_spec(hi.KIMI_KEY)
+    assert spec is not None
+    assert spec.min_version is None
+    assert spec.max_version_exclusive is None
 
 
 @pytest.mark.parametrize(
@@ -1130,7 +1156,6 @@ def test_harness_cli_installed_checks_version_for_versioned_specs(
     "key",
     [
         hi.CURSOR_KEY,
-        hi.KIMI_KEY,
         ANTHROPIC_FAMILY,
         OPENAI_FAMILY,
         hi.PI_KEY,
@@ -1192,7 +1217,7 @@ def test_harness_cli_installed_ignores_upper_bound_for_unversioned_specs(
         ("cursor-agent 2026.07.01-777f564", "2026.07.01"),
         ("2026.06.19-20-24-33-653a7fb", "2026.06.19"),
         ("2026.05.24.1.dda726e", "2026.05.24"),
-        ("kimi version 1.47.0", "1.47.0"),
+        ("kimi version 0.31.1", "0.31.1"),
         ("1.17.7-rc1", "1.17.7-rc1"),
     ],
 )
@@ -1206,7 +1231,6 @@ def test_parse_harness_cli_version_normalizes_date_versions(raw: str, expected: 
     "key,outdated,satisfying",
     [
         (hi.CURSOR_KEY, "2026.05.24", "2026.06.22"),
-        (hi.KIMI_KEY, "1.46.0", "1.48.0"),
         (hi.HERMES_KEY, "2026.05.29", "2026.06.19"),
     ],
 )
@@ -1216,7 +1240,7 @@ def test_harness_cli_installed_enforces_default_post_2026_06_01_floors(
     outdated: str,
     satisfying: str,
 ) -> None:
-    """Cursor and Kimi default to the first release after 2026-06-01."""
+    """Cursor and Hermes default to the first release after 2026-06-01."""
     monkeypatch.setattr(hi.shutil, "which", lambda name: f"/usr/bin/{name}")
 
     def _run(argv: list[str], **k: object) -> subprocess.CompletedProcess[str]:

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -8,6 +8,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from packaging.version import Version
 
 import omnigent._platform as _platform
 from omnigent.onboarding import harness_install as hi
@@ -1122,6 +1123,24 @@ def test_kimi_spec_declares_no_version_bounds() -> None:
     assert spec is not None
     assert spec.min_version is None
     assert spec.max_version_exclusive is None
+
+
+def test_kimi_floor_can_never_come_from_the_legacy_cli_line() -> None:
+    """Any Kimi floor must belong to the Kimi Code 0.x line.
+
+    Omnigent installs Kimi Code from code.kimi.com, whose releases are 0.x.
+    The legacy MoonshotAI kimi-cli project is on a separate 1.x line; a floor
+    borrowed from it rejects every real Kimi Code build.
+    """
+    spec = hi.harness_install_spec(hi.KIMI_KEY)
+    assert spec is not None
+    assert spec.install_hint is not None and "code.kimi.com" in spec.install_hint
+    for bound in (spec.min_version, spec.max_version_exclusive):
+        if bound is not None:
+            assert Version(bound) < Version("1.0.0"), (
+                f"Kimi bound {bound!r} looks like a legacy kimi-cli version; "
+                "Kimi Code releases are 0.x"
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -570,6 +570,30 @@ def test_configured_harness_map_reports_version_too_low_for_outdated_clis(
         )
 
 
+def test_kimi_code_zero_x_is_ready_not_version_too_low(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A current Kimi Code build reads as ready across every kimi surface.
+
+    Regression: the spec's floor came from the legacy kimi-cli 1.x line, so a
+    real 0.x Kimi Code install badged ``version-too-low`` and the harness could
+    not be selected at all.
+    """
+    monkeypatch.setattr(hi.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    def _run(argv: list[str], **k: object) -> subprocess.CompletedProcess[str]:
+        if len(argv) >= 2 and argv[1] == "--version":
+            return subprocess.CompletedProcess(args=argv, returncode=0, stdout="0.31.1", stderr="")
+        # Any other probe (e.g. `claude auth status`) is not this test's concern;
+        # a non-zero exit keeps other harnesses' readiness deterministic.
+        return subprocess.CompletedProcess(args=argv, returncode=1, stdout="", stderr="")
+
+    monkeypatch.setattr(hi.subprocess, "run", _run)
+    result = configured_harness_map()
+    for harness in ("kimi", "kimi-code", "kimi-native", "native-kimi"):
+        assert result[harness] is True, f"{harness} should be ready, got {result[harness]!r}"
+
+
 def test_antigravity_native_requires_credential(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #3787

## Summary

Omnigent installs the **Kimi Code** CLI (`code.kimi.com/kimi-code`, release line `0.x`, currently `0.31.1`) but validated it against `_KIMI_MIN_VERSION = "1.47.0"` — a floor sourced from the changelog of the **legacy `kimi-cli`** project (MoonshotAI on PyPI, a separate `1.x` line, currently `1.49.0`). Two different products, one version comparison.

The generic PEP 440 check therefore read current Kimi Code `0.31.1` as older than `1.47.0`. `harness_cli_installed()` returned `False`, `_binary_availability_reason` saw a binary on `PATH` that wasn't "installed" and reported `version-too-low`, and **all four Kimi surfaces** (`kimi`, `kimi-code`, `kimi-native`, `native-kimi`) became unselectable. Not a cosmetic badge — a total block on the harness.

Both halves of the mismatch were visible in one file: `harness_install.py` set the install hint to `code.kimi.com/kimi-code` while the comment above the constant cited `MoonshotAI/kimi-cli/CHANGELOG.md`.

**This PR removes the floor rather than retargeting it to a `0.x` value**, for three reasons:

1. **Nothing requires a minimum.** No Kimi harness module (`kimi_executor.py`, `kimi_native_executor.py`, `kimi_native.py`, `kimi_native_bridge.py`) gates on a CLI version. The old comment — "older builds may lack newer TUI/session wiring" — was speculative *and* written about the wrong product.
2. **No `0.x` floor can be honestly sourced.** `code.kimi.com` exposes only a `/latest` endpoint; there is no release index, and `binaries/<v>/manifest.json` returns `302` for every probed version. The "first release after 2026-06-01" rule used for the other harnesses cannot be applied to this release line with real data.
3. **Pinning to today's latest would be the same bug, narrower.** `min_version="0.31.1"` would falsely reject every user one release behind.

This restores presence-on-`PATH` gating for Kimi only — the same treatment `GEMINI_FAMILY` already gets. A guard test ensures any future Kimi bound must come from the `0.x` line.

**No other harness is affected.** All nine other floors are untouched: Codex `0.137.0`, Pi `0.79.0`, Qwen `0.18.1`, Goose `1.38.0`, Hermes `2026.06.05`, Kiro `2.10.0`, Claude `2.1.161`, Cursor `2026.06.02`, OpenCode `1.17.7`. The `version-too-low` path and its web UI badge are unchanged — they simply stop firing for Kimi.

### ELI5

Omnigent was checking a Honda's mileage against a Toyota's service schedule. The number was real, the car was real, but they were never the same vehicle — so a perfectly current Honda kept being told it was overdue.

```mermaid
graph TD
    A["kimi --version → 0.31.1"] --> B{"PEP 440 compare<br/>vs min_version"}
    B -->|"BEFORE: floor 1.47.0<br/>(from legacy kimi-cli 1.x)"| C["0.31.1 &lt; 1.47.0 → False"]
    C --> D["harness_cli_installed = False"]
    D --> E["_binary_availability_reason<br/>→ version-too-low"]
    E --> F["kimi / kimi-code / kimi-native /<br/>native-kimi all unselectable"]
    B -->|"AFTER: no bounds declared"| G["short-circuits → True"]
    G --> H["harness_cli_installed = True"]
    H --> I["all four surfaces ready"]
    style F fill:#ffdddd,stroke:#cc0000,color:#000
    style I fill:#ddffdd,stroke:#00aa00,color:#000
```

## Test Plan

```bash
uv sync --extra dev
uv run pytest tests/onboarding/test_harness_install.py \
              tests/onboarding/test_harness_readiness.py \
              tests/cli/test_cli.py \
              tests/inner/test_kimi_harness.py -q -p no:randomly
pre-commit run --all-files
```

Result: **467/468 pass.** The single failure, `test_claude_ready_via_configured_provider_without_cli_login`, is **pre-existing and unrelated** — it reproduces identically at the merge base (`297425b0`) on an unpatched tree and concerns Claude's provider fast path, not Kimi. 20/21 pre-commit hooks pass; `web-ios-swift-lint` fails on SwiftLint config warnings with no file-specific findings (no Swift/iOS files are touched by this change).

**End-to-end reproduction** against a stub CLI reporting the current Kimi Code version:

```bash
mkdir -p /tmp/kimi-fake/bin
printf '#!/bin/sh\n[ "$1" = "--version" ] && echo "0.31.1"\nexit 0\n' > /tmp/kimi-fake/bin/kimi
chmod +x /tmp/kimi-fake/bin/kimi
PATH="/tmp/kimi-fake/bin:$PATH" uv run python -c "
from omnigent.onboarding.harness_install import KIMI_KEY, harness_cli_installed, harness_cli_version
from omnigent.onboarding.harness_readiness import configured_harness_map
print('installed :', harness_cli_installed(KIMI_KEY))
print('version   :', harness_cli_version(KIMI_KEY))
print('readiness :', {k: v for k, v in configured_harness_map().items() if 'kimi' in k})"
```

| | Before (`origin/main`) | After (this branch) |
|---|---|---|
| `installed` | `False` | `True` |
| `version` | `('0.31.1', '>=1.47.0')` | `('0.31.1', None)` |
| `readiness` | all four `version-too-low` | all four `True` |

The `None` range is correct — it means the spec declares no bounds. `cli_config.py:1361` guards with `if range_str:`, so nothing renders `None` into user-facing copy; this is the same path unbounded specs already take.

**Every test was verified to fail before it passed.** Each new test was run against a temporarily reintroduced `min_version="1.47.0"` and observed red (e.g. `AssertionError: kimi should be ready, got 'version-too-low'`) before the floor was removed. The guard test was additionally proven not to over-fire: with `min_version="0.40.0"` it passes, since `0.x` floors are legitimate and only `1.x` ones are the bug. Reintroducing the bad floor today fails **6 tests** across both files.

## Demo

N/A — backend-only change. No UI was modified; the existing `version-too-low` badge simply stops firing for Kimi.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Five Kimi tests, each proven red-before-green (see Test Plan):

- `test_kimi_code_current_versions_are_accepted` — `0.31.1` / `0.5.0` / `0.12.3` all count as installed.
- `test_kimi_spec_declares_no_version_bounds` — the spec stays unbounded.
- `test_kimi_code_zero_x_is_ready_not_version_too_low` — all four Kimi spellings report ready at the readiness layer.
- `test_kimi_floor_can_never_come_from_the_legacy_cli_line` — recurrence guard; any future Kimi bound must be `< 1.0.0`.
- `test_parse_harness_cli_version_normalizes_date_versions` — the Kimi fixture now uses a real Kimi Code version instead of a legacy `1.47.0` one.

Regressions for the other harnesses are pinned by the existing `test_versioned_specs_declare_bounds` (nine rows), `test_harness_cli_installed_checks_minimum_for_other_versioned_specs`, and `test_harness_cli_installed_enforces_default_post_2026_06_01_floors` (Cursor and Hermes keep their rows).

Manual verification: the before/after table above, run against a stub CLI on both `origin/main` and this branch.

**One trade-off worth stating plainly:** with no floor, a genuinely ancient `0.x` build lacking the argv in `kimi_executor.py:315-326` (`--output-format`, `--plan`, `--skills-dir`) would now fail at runtime instead of being caught during setup. This is not a regression — the previous floor rejected 100% of real Kimi Code builds, so it protected nothing — and no defensible `0.x` floor can be sourced today. If the vendor later publishes a release index, the guard test permits any floor below `1.0.0`.

## Changelog

Kimi Code is no longer reported as outdated during setup; the CLI version check now matches the Kimi Code release line instead of the unrelated legacy kimi-cli one.
