### PR TITLE
feat(web): add curated MCP integration catalog

### DIFF
--- a/tests/e2e_ui/start_session/test_create_custom_agent.py
+++ b/tests/e2e_ui/start_session/test_create_custom_agent.py
@@ -323,6 +323,46 @@ def test_create_agent_with_mcp_server(
     _run_in_fresh_loop(_drive_mcp_server(base_url, session_id))
 
 
+def test_create_agent_adds_searched_mcp_preset(
+    seeded_session: tuple[str, str],
+) -> None:
+    """Searching the integration catalog adds an editable preset row."""
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_mcp_preset(base_url, session_id))
+
+
+async def _drive_mcp_preset(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            await _register_routes(page, created_session_id=session_id, create_requests=[])
+            await _seed_workspace(page)
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            await _open_create_agent(page)
+
+            await page.get_by_test_id("create-agent-add-mcp").click()
+            search = page.get_by_test_id("mcp-integration-search")
+            await search.fill("Microsoft")
+            await expect(page.get_by_text("AWS Knowledge")).to_be_hidden()
+            await page.get_by_test_id("create-agent-add-preset-microsoft-learn").click()
+
+            entry = page.get_by_test_id("create-agent-mcp-entry")
+            await expect(entry).to_be_visible()
+            await expect(page.get_by_test_id("create-agent-mcp-name")).to_have_value(
+                "microsoft-learn"
+            )
+            await expect(page.get_by_test_id("create-agent-mcp-url")).to_have_value(
+                "https://learn.microsoft.com/api/mcp"
+            )
+        finally:
+            await browser.close()
+
+
 async def _drive_mcp_server(base_url: str, session_id: str) -> None:
     async with async_playwright() as pw:
         browser = await pw.chromium.launch()

--- a/tests/e2e_ui/start_session/test_create_custom_agent.py
+++ b/tests/e2e_ui/start_session/test_create_custom_agent.py
@@ -391,6 +391,7 @@ async def _drive_mcp_server(base_url: str, session_id: str) -> None:
 
             # Add an MCP server.
             await page.get_by_test_id("create-agent-add-mcp").click()
+            await page.get_by_test_id("create-agent-add-custom-mcp").click()
 
             # An MCP entry card should appear.
             mcp_entry = page.get_by_test_id("create-agent-mcp-entry")

--- a/web/src/lib/agentBundle.test.ts
+++ b/web/src/lib/agentBundle.test.ts
@@ -166,6 +166,28 @@ describe("buildAgentBundle", () => {
     expect(yaml).toContain("      GITHUB_TOKEN: ghp_test");
   });
 
+  it("serializes the Azure DevOps MCP preset", async () => {
+    const input: AgentBundleInput = {
+      name: "ado-agent",
+      harness: "claude-sdk",
+      model: "claude-sonnet-4-20250514",
+      mcpServers: [
+        {
+          name: "azure-devops",
+          transport: "stdio",
+          command: "npx",
+          args: ["-y", "@azure-devops/mcp", "contoso", "--authentication", "azcli"],
+        },
+      ],
+    };
+    const yaml = await extractConfigYaml(await buildAgentBundle(input));
+    expect(yaml).toContain("  azure-devops:");
+    expect(yaml).toContain("    command: npx");
+    expect(yaml).toContain('    args: [-y, "@azure-devops/mcp", contoso, --authentication, azcli]');
+    expect(yaml).not.toContain("ADO_MCP_AUTH_TOKEN");
+    expect(yaml).not.toContain("PERSONAL_ACCESS_TOKEN");
+  });
+
   it("includes inline MCP servers (http)", async () => {
     const input: AgentBundleInput = {
       name: "http-agent",

--- a/web/src/lib/mcpPresets.test.ts
+++ b/web/src/lib/mcpPresets.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { getMCPServerPreset, groupMCPServerPresets, MCP_SERVER_PRESETS } from "./mcpPresets";
+
+describe("MCP server presets", () => {
+  it("is provider-neutral and groups integrations by capability", () => {
+    expect(MCP_SERVER_PRESETS.length).toBeGreaterThanOrEqual(14);
+    expect(new Set(MCP_SERVER_PRESETS.map((preset) => preset.provider))).toEqual(
+      new Set(["AWS", "Cloudflare", "Devin", "Exa", "HashiCorp", "Microsoft", "Upstash"]),
+    );
+    expect(
+      groupMCPServerPresets([...MCP_SERVER_PRESETS].reverse()).map(([category]) => category),
+    ).toEqual([
+      "Documentation",
+      "Web and research",
+      "Browser automation",
+      "Cloud infrastructure",
+      "Developer tools",
+      "Data and analytics",
+    ]);
+  });
+
+  it("only exposes integrations that need no stored secret", () => {
+    expect(new Set(MCP_SERVER_PRESETS.map((preset) => preset.auth))).toEqual(
+      new Set(["ambient", "none"]),
+    );
+  });
+
+  it("creates public documentation servers without credentials", () => {
+    expect(getMCPServerPreset("microsoft-learn")?.create({})).toEqual({
+      name: "microsoft-learn",
+      transport: "http",
+      url: "https://learn.microsoft.com/api/mcp",
+    });
+    expect(getMCPServerPreset("aws-knowledge")?.create({})).toEqual({
+      name: "aws-knowledge",
+      transport: "http",
+      url: "https://knowledge-mcp.global.api.aws",
+    });
+  });
+
+  it("creates a read-only Azure server using the local credential chain", () => {
+    expect(getMCPServerPreset("azure")?.create({})).toEqual({
+      name: "azure",
+      transport: "stdio",
+      command: "npx",
+      args: ["-y", "@azure/mcp@latest", "server", "start", "--mode", "single", "--read-only"],
+    });
+  });
+
+  it("creates a secret-free Azure DevOps configuration from declared fields", () => {
+    const preset = getMCPServerPreset("azure-devops");
+    expect(preset?.fields).toEqual([
+      { id: "organization", label: "Organization", placeholder: "contoso", required: true },
+    ]);
+    expect(preset?.create({ organization: "  contoso  " })).toEqual({
+      name: "azure-devops",
+      transport: "stdio",
+      command: "npx",
+      args: ["-y", "@azure-devops/mcp", "contoso", "--authentication", "azcli"],
+    });
+  });
+});

--- a/web/src/lib/mcpPresets.ts
+++ b/web/src/lib/mcpPresets.ts
@@ -1,0 +1,307 @@
+import type { MCPServerInput } from "./agentBundle";
+
+export type MCPIntegrationIcon = "book" | "browser" | "cloud" | "data" | "dev-tools" | "search";
+export type MCPIntegrationAuth = "ambient" | "none";
+
+export interface MCPIntegrationField {
+  id: string;
+  label: string;
+  placeholder?: string;
+  required?: boolean;
+}
+
+export interface MCPServerPreset {
+  id: string;
+  provider: string;
+  category:
+    | "Browser automation"
+    | "Cloud infrastructure"
+    | "Data and analytics"
+    | "Developer tools"
+    | "Documentation"
+    | "Web and research";
+  label: string;
+  description: string;
+  prerequisites?: string;
+  auth: MCPIntegrationAuth;
+  icon: MCPIntegrationIcon;
+  fields?: MCPIntegrationField[];
+  create: (values: Record<string, string>) => MCPServerInput;
+}
+
+const MCP_INTEGRATION_CATEGORY_ORDER: readonly MCPServerPreset["category"][] = [
+  "Documentation",
+  "Web and research",
+  "Browser automation",
+  "Cloud infrastructure",
+  "Developer tools",
+  "Data and analytics",
+];
+
+export const MCP_SERVER_PRESETS: readonly MCPServerPreset[] = [
+  {
+    id: "microsoft-learn",
+    provider: "Microsoft",
+    category: "Documentation",
+    label: "Microsoft Learn",
+    description: "Search current Microsoft documentation and code samples.",
+    prerequisites: "Public and free.",
+    auth: "none",
+    icon: "book",
+    create: () => ({
+      name: "microsoft-learn",
+      transport: "http",
+      url: "https://learn.microsoft.com/api/mcp",
+    }),
+  },
+  {
+    id: "aws-knowledge",
+    provider: "AWS",
+    category: "Documentation",
+    label: "AWS Knowledge",
+    description: "Search AWS documentation, announcements, and architecture guidance.",
+    prerequisites: "Public and free. Subject to rate limits.",
+    auth: "none",
+    icon: "book",
+    create: () => ({
+      name: "aws-knowledge",
+      transport: "http",
+      url: "https://knowledge-mcp.global.api.aws",
+    }),
+  },
+  {
+    id: "deepwiki",
+    provider: "Devin",
+    category: "Documentation",
+    label: "DeepWiki",
+    description:
+      "Read repository documentation and ask grounded questions about public GitHub repos.",
+    prerequisites: "Public and free for public repositories.",
+    auth: "none",
+    icon: "book",
+    create: () => ({
+      name: "deepwiki",
+      transport: "http",
+      url: "https://mcp.deepwiki.com/mcp",
+    }),
+  },
+  {
+    id: "cloudflare-docs",
+    provider: "Cloudflare",
+    category: "Documentation",
+    label: "Cloudflare Docs",
+    description: "Search current Cloudflare developer documentation.",
+    prerequisites: "Public documentation endpoint.",
+    auth: "none",
+    icon: "book",
+    create: () => ({
+      name: "cloudflare-docs",
+      transport: "http",
+      url: "https://docs.mcp.cloudflare.com/mcp",
+    }),
+  },
+  {
+    id: "cloudflare-agents-docs",
+    provider: "Cloudflare",
+    category: "Documentation",
+    label: "Cloudflare Agents SDK Docs",
+    description: "Search token-efficient documentation for Cloudflare's Agents SDK.",
+    prerequisites: "Public documentation endpoint.",
+    auth: "none",
+    icon: "book",
+    create: () => ({
+      name: "cloudflare-agents-docs",
+      transport: "http",
+      url: "https://agents.cloudflare.com/mcp",
+    }),
+  },
+  {
+    id: "cloudflare-blog",
+    provider: "Cloudflare",
+    category: "Documentation",
+    label: "Cloudflare Blog",
+    description: "Search and read technical posts from the Cloudflare Blog.",
+    prerequisites: "Public content endpoint.",
+    auth: "none",
+    icon: "book",
+    create: () => ({
+      name: "cloudflare-blog",
+      transport: "http",
+      url: "https://blog.mcp.cloudflare.com/mcp",
+    }),
+  },
+  {
+    id: "context7",
+    provider: "Upstash",
+    category: "Documentation",
+    label: "Context7",
+    description: "Retrieve current library and framework documentation and examples.",
+    prerequisites: "Anonymous usage is rate-limited. Add a custom server later for API-key access.",
+    auth: "none",
+    icon: "book",
+    create: () => ({
+      name: "context7",
+      transport: "http",
+      url: "https://mcp.context7.com/mcp",
+    }),
+  },
+  {
+    id: "exa-search",
+    provider: "Exa",
+    category: "Web and research",
+    label: "Exa Search",
+    description: "Search the web and fetch pages as clean, agent-ready content.",
+    prerequisites: "Anonymous usage has a free, rate-limited quota.",
+    auth: "none",
+    icon: "search",
+    create: () => ({
+      name: "exa-search",
+      transport: "http",
+      url: "https://mcp.exa.ai/mcp",
+    }),
+  },
+  {
+    id: "exa-fetch",
+    provider: "Exa",
+    category: "Web and research",
+    label: "Exa Fetch",
+    description: "Fetch known webpages as clean Markdown without exposing search tools.",
+    prerequisites: "Anonymous usage has a free, rate-limited quota.",
+    auth: "none",
+    icon: "search",
+    create: () => ({
+      name: "exa-fetch",
+      transport: "http",
+      url: "https://mcp.exa.ai/mcp?tools=web_fetch_exa",
+    }),
+  },
+  {
+    id: "playwright",
+    provider: "Microsoft",
+    category: "Browser automation",
+    label: "Playwright",
+    description: "Automate browser workflows using structured accessibility snapshots.",
+    prerequisites: "Requires Node.js 18+, npx, and a Chromium-compatible browser on the host.",
+    auth: "none",
+    icon: "browser",
+    create: () => ({
+      name: "playwright",
+      transport: "stdio",
+      command: "npx",
+      args: ["-y", "@playwright/mcp@latest", "--isolated"],
+    }),
+  },
+  {
+    id: "azure",
+    provider: "Microsoft",
+    category: "Cloud infrastructure",
+    label: "Azure",
+    description: "Inspect Azure resources through the consolidated Azure tool.",
+    prerequisites: "Requires Node.js, npx, Azure CLI, and az login on the selected host.",
+    auth: "ambient",
+    icon: "cloud",
+    create: () => ({
+      name: "azure",
+      transport: "stdio",
+      command: "npx",
+      args: ["-y", "@azure/mcp@latest", "server", "start", "--mode", "single", "--read-only"],
+    }),
+  },
+  {
+    id: "aws-documentation",
+    provider: "AWS",
+    category: "Cloud infrastructure",
+    label: "AWS Documentation",
+    description: "Search AWS documentation through the local AWS Labs server.",
+    prerequisites: "Requires uv/uvx on the selected host. No AWS credentials required.",
+    auth: "none",
+    icon: "cloud",
+    create: () => ({
+      name: "aws-documentation",
+      transport: "stdio",
+      command: "uvx",
+      args: ["awslabs.aws-documentation-mcp-server@latest"],
+    }),
+  },
+  {
+    id: "terraform-registry",
+    provider: "HashiCorp",
+    category: "Cloud infrastructure",
+    label: "Terraform Registry",
+    description: "Search public Terraform providers, modules, and policies.",
+    prerequisites: "Requires a running Docker installation on the selected host.",
+    auth: "none",
+    icon: "cloud",
+    create: () => ({
+      name: "terraform-registry",
+      transport: "stdio",
+      command: "docker",
+      args: ["run", "-i", "--rm", "hashicorp/terraform-mcp-server:1.1.0"],
+    }),
+  },
+  {
+    id: "azure-devops",
+    provider: "Microsoft",
+    category: "Developer tools",
+    label: "Azure DevOps",
+    description: "Work with repositories, pull requests, work items, pipelines, wikis, and tests.",
+    prerequisites: "Requires Node.js 20+, npx, Azure CLI, and az login on the selected host.",
+    auth: "ambient",
+    icon: "dev-tools",
+    fields: [
+      {
+        id: "organization",
+        label: "Organization",
+        placeholder: "contoso",
+        required: true,
+      },
+    ],
+    create: (values) => ({
+      name: "azure-devops",
+      transport: "stdio",
+      command: "npx",
+      args: [
+        "-y",
+        "@azure-devops/mcp",
+        values.organization?.trim() ?? "",
+        "--authentication",
+        "azcli",
+      ],
+    }),
+  },
+  {
+    id: "aws-open-data",
+    provider: "AWS",
+    category: "Data and analytics",
+    label: "AWS Open Data",
+    description: "Discover and preview public datasets in the Registry of Open Data on AWS.",
+    prerequisites: "Requires uv/uvx on the selected host. No AWS account required.",
+    auth: "none",
+    icon: "data",
+    create: () => ({
+      name: "aws-open-data",
+      transport: "stdio",
+      command: "uvx",
+      args: ["awslabs.roda-mcp-server@latest"],
+    }),
+  },
+];
+
+export function getMCPServerPreset(id: string): MCPServerPreset | undefined {
+  return MCP_SERVER_PRESETS.find((preset) => preset.id === id);
+}
+
+export function groupMCPServerPresets(
+  presets: readonly MCPServerPreset[] = MCP_SERVER_PRESETS,
+): [MCPServerPreset["category"], MCPServerPreset[]][] {
+  const groups = new Map<MCPServerPreset["category"], MCPServerPreset[]>();
+  for (const preset of presets) {
+    const group = groups.get(preset.category) ?? [];
+    group.push(preset);
+    groups.set(preset.category, group);
+  }
+  return MCP_INTEGRATION_CATEGORY_ORDER.flatMap((category) => {
+    const group = groups.get(category);
+    return group ? [[category, group]] : [];
+  });
+}

--- a/web/src/shell/CreateAgentDialog.test.tsx
+++ b/web/src/shell/CreateAgentDialog.test.tsx
@@ -1,0 +1,138 @@
+import type * as AgentLabelsModule from "@/lib/agentLabels";
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AgentBundleInput } from "@/lib/agentBundle";
+import { CreateAgentDialog } from "./CreateAgentDialog";
+
+vi.mock("@/lib/agentLabels", async (importOriginal) => ({
+  ...(await importOriginal<typeof AgentLabelsModule>()),
+  useBrainHarnessLabels: () => ({ "claude-sdk": "Claude SDK" }),
+}));
+
+afterEach(cleanup);
+
+describe("CreateAgentDialog MCP integrations", () => {
+  it("adds an editable Azure DevOps stdio server without requesting a secret", async () => {
+    const onCreate = vi.fn<(input: AgentBundleInput) => void>();
+    render(<CreateAgentDialog open onOpenChange={vi.fn()} onCreate={onCreate} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add server" }));
+    expect(await screen.findByText("Custom server")).toBeTruthy();
+    expect(screen.getByText("Microsoft Learn")).toBeTruthy();
+    expect(screen.getByText("AWS Knowledge")).toBeTruthy();
+    expect(screen.getByText("Azure")).toBeTruthy();
+    expect(screen.getByText("Context7")).toBeTruthy();
+    expect(screen.getByText("DeepWiki")).toBeTruthy();
+    expect(screen.getByText("Exa Search")).toBeTruthy();
+    expect(screen.queryByText("No auth")).toBeNull();
+    expect(screen.queryByText("Uses local login")).toBeNull();
+    expect(screen.getByRole("listbox")).toHaveClass("overflow-y-auto", "overscroll-contain");
+    fireEvent.click(screen.getByTestId("create-agent-add-preset-azure-devops"));
+    expect(await screen.findByText("Azure DevOps")).toBeTruthy();
+    expect(screen.getByText(/Node.js 20\+/)).toBeTruthy();
+    expect(screen.queryByText(/personal access token/i)).toBeNull();
+
+    const addButton = screen.getByTestId("mcp-preset-add");
+    expect(addButton).toBeDisabled();
+    fireEvent.change(screen.getByTestId("mcp-preset-field-organization"), {
+      target: { value: "contoso" },
+    });
+    fireEvent.click(addButton);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("create-agent-mcp-name")).toHaveValue("azure-devops"),
+    );
+    expect(screen.getByTestId("create-agent-mcp-command")).toHaveValue("npx");
+    expect(screen.getByTestId("create-agent-mcp-args")).toHaveValue(
+      "-y @azure-devops/mcp contoso --authentication azcli",
+    );
+    expect(screen.getByTestId("create-agent-mcp-env")).toHaveValue("");
+
+    fireEvent.change(screen.getByTestId("create-agent-name"), {
+      target: { value: "ado-agent" },
+    });
+    fireEvent.change(screen.getByTestId("create-agent-model"), {
+      target: { value: "claude-sonnet-4-20250514" },
+    });
+    fireEvent.click(screen.getByTestId("create-agent-submit"));
+
+    expect(onCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mcpServers: [
+          {
+            name: "azure-devops",
+            transport: "stdio",
+            command: "npx",
+            args: ["-y", "@azure-devops/mcp", "contoso", "--authentication", "azcli"],
+          },
+        ],
+      }),
+    );
+  });
+
+  it("searches integrations across provider and category metadata", async () => {
+    render(<CreateAgentDialog open onOpenChange={vi.fn()} onCreate={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add server" }));
+    fireEvent.change(await screen.findByTestId("mcp-integration-search"), {
+      target: { value: "cloudflare" },
+    });
+
+    expect(screen.getByText("Cloudflare Docs")).toBeTruthy();
+    expect(screen.getByText("Cloudflare Agents SDK Docs")).toBeTruthy();
+    expect(screen.queryByText("Microsoft Learn")).toBeNull();
+  });
+
+  it("adds Microsoft Learn without additional configuration", async () => {
+    render(<CreateAgentDialog open onOpenChange={vi.fn()} onCreate={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add server" }));
+    fireEvent.click(await screen.findByTestId("create-agent-add-preset-microsoft-learn"));
+
+    expect(screen.getByTestId("create-agent-mcp-name")).toHaveValue("microsoft-learn");
+    expect(screen.getByTestId("create-agent-mcp-transport")).toHaveTextContent("http");
+    expect(screen.getByTestId("create-agent-mcp-url")).toHaveValue(
+      "https://learn.microsoft.com/api/mcp",
+    );
+  });
+
+  it("renders and adds a non-Microsoft integration through the same registry", async () => {
+    render(<CreateAgentDialog open onOpenChange={vi.fn()} onCreate={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add server" }));
+    expect(await screen.findByText("Documentation")).toBeTruthy();
+    expect(screen.getAllByText("AWS").length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByTestId("create-agent-add-preset-aws-knowledge"));
+
+    expect(screen.getByTestId("create-agent-mcp-name")).toHaveValue("aws-knowledge");
+    expect(screen.getByTestId("create-agent-mcp-url")).toHaveValue(
+      "https://knowledge-mcp.global.api.aws",
+    );
+  });
+
+  it("adds Azure in read-only mode using local credentials", async () => {
+    render(<CreateAgentDialog open onOpenChange={vi.fn()} onCreate={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add server" }));
+    fireEvent.click(await screen.findByTestId("create-agent-add-preset-azure"));
+
+    expect(screen.getByTestId("create-agent-mcp-name")).toHaveValue("azure");
+    expect(screen.getByTestId("create-agent-mcp-command")).toHaveValue("npx");
+    expect(screen.getByTestId("create-agent-mcp-args")).toHaveValue(
+      "-y @azure/mcp@latest server start --mode single --read-only",
+    );
+  });
+
+  it("keeps manual MCP configuration as the primary neutral path", async () => {
+    render(<CreateAgentDialog open onOpenChange={vi.fn()} onCreate={vi.fn()} />);
+
+    expect(screen.queryByRole("button", { name: "Add Azure DevOps" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Add server" }));
+    fireEvent.click(await screen.findByTestId("create-agent-add-custom-mcp"));
+
+    expect(screen.getByTestId("create-agent-mcp-name")).toHaveValue("");
+    expect(screen.getByTestId("create-agent-mcp-command")).toHaveValue("");
+  });
+});

--- a/web/src/shell/CreateAgentDialog.tsx
+++ b/web/src/shell/CreateAgentDialog.tsx
@@ -1,5 +1,16 @@
 import { useState } from "react";
-import { PlusIcon, TrashIcon } from "lucide-react";
+import {
+  BlocksIcon,
+  BookOpenIcon,
+  BotIcon,
+  CloudIcon,
+  DatabaseIcon,
+  PlusIcon,
+  SearchIcon,
+  ServerIcon,
+  TrashIcon,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -11,6 +22,15 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -18,13 +38,29 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { BRAIN_HARNESS_LABELS, useBrainHarnessLabels } from "@/lib/agentLabels";
+import { cn } from "@/lib/utils";
 import type { AgentBundleInput, MCPServerInput } from "@/lib/agentBundle";
+import {
+  getMCPServerPreset,
+  groupMCPServerPresets,
+  type MCPIntegrationIcon,
+  type MCPServerPreset,
+} from "@/lib/mcpPresets";
 
 /**
  * Harness options for the picker. "default" uses the server's default
  * executor (no explicit harness in the bundle).
  */
 const DEFAULT_HARNESS = Object.keys(BRAIN_HARNESS_LABELS)[0];
+
+const MCP_INTEGRATION_ICONS: Record<MCPIntegrationIcon, LucideIcon> = {
+  book: BookOpenIcon,
+  browser: BotIcon,
+  cloud: CloudIcon,
+  data: DatabaseIcon,
+  "dev-tools": BlocksIcon,
+  search: SearchIcon,
+};
 
 /** A single MCP server row in the form. */
 interface MCPFormEntry {
@@ -49,6 +85,23 @@ function emptyMCPEntry(key: number): MCPFormEntry {
     command: "",
     args: "",
     env: "",
+  };
+}
+
+function mcpInputToFormEntry(input: MCPServerInput, key: number): MCPFormEntry {
+  return {
+    key,
+    name: input.name,
+    transport: input.transport,
+    url: input.url ?? "",
+    headers: Object.entries(input.headers ?? {})
+      .map(([name, value]) => `${name}: ${value}`)
+      .join("\n"),
+    command: input.command ?? "",
+    args: input.args?.join(" ") ?? "",
+    env: Object.entries(input.env ?? {})
+      .map(([name, value]) => `${name}=${value}`)
+      .join("\n"),
   };
 }
 
@@ -137,6 +190,9 @@ export function CreateAgentDialog({
   const [model, setModel] = useState("");
   const [mcpEntries, setMcpEntries] = useState<MCPFormEntry[]>([]);
   const [nextKey, setNextKey] = useState(0);
+  const [presetOpen, setPresetOpen] = useState(false);
+  const [selectedPresetId, setSelectedPresetId] = useState<string | null>(null);
+  const [presetValues, setPresetValues] = useState<Record<string, string>>({});
 
   function reset() {
     setName("");
@@ -146,6 +202,9 @@ export function CreateAgentDialog({
     setModel("");
     setMcpEntries([]);
     setNextKey(0);
+    setPresetOpen(false);
+    setSelectedPresetId(null);
+    setPresetValues({});
   }
 
   function handleOpenChange(next: boolean) {
@@ -153,9 +212,33 @@ export function CreateAgentDialog({
     onOpenChange(next);
   }
 
+  function closePicker() {
+    setPresetOpen(false);
+    setSelectedPresetId(null);
+    setPresetValues({});
+  }
+
   function addMCPServer() {
     setMcpEntries((prev) => [...prev, emptyMCPEntry(nextKey)]);
     setNextKey((k) => k + 1);
+    setPresetOpen(false);
+  }
+
+  function addMCPPreset(preset: MCPServerPreset) {
+    setMcpEntries((prev) => [...prev, mcpInputToFormEntry(preset.create(presetValues), nextKey)]);
+    setNextKey((key) => key + 1);
+    setSelectedPresetId(null);
+    setPresetValues({});
+    setPresetOpen(false);
+  }
+
+  function selectPreset(preset: MCPServerPreset) {
+    if (!preset.fields?.length) {
+      addMCPPreset(preset);
+      return;
+    }
+    setSelectedPresetId(preset.id);
+    setPresetValues({});
   }
 
   function removeMCPServer(key: number) {
@@ -183,144 +266,297 @@ export function CreateAgentDialog({
   }
 
   const canSubmit = name.trim().length > 0 && model.trim().length > 0;
+  const selectedPreset = selectedPresetId ? getMCPServerPreset(selectedPresetId) : undefined;
+  const canAddSelectedPreset =
+    selectedPreset?.fields?.every(
+      (field) => !field.required || Boolean(presetValues[field.id]?.trim()),
+    ) ?? false;
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         data-testid="create-agent-dialog"
-        className="flex max-h-[85vh] flex-col gap-4 sm:max-w-lg"
+        className={cn(
+          "flex max-h-[85vh] flex-col gap-4 sm:max-w-lg",
+          presetOpen && "h-[min(85vh,40rem)]",
+        )}
       >
         <DialogHeader>
-          <DialogTitle>Create custom agent</DialogTitle>
+          <DialogTitle>{presetOpen ? "Add MCP integration" : "Create custom agent"}</DialogTitle>
         </DialogHeader>
 
-        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
-          {/* Name */}
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="create-agent-name"
-              className="text-sm font-medium text-muted-foreground"
-            >
-              Name <span className="text-destructive">*</span>
-            </label>
-            <Input
-              id="create-agent-name"
-              data-testid="create-agent-name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="my-agent"
-              autoFocus
-            />
-          </div>
-
-          {/* Description */}
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="create-agent-description"
-              className="text-sm font-medium text-muted-foreground"
-            >
-              Description
-            </label>
-            <Input
-              id="create-agent-description"
-              data-testid="create-agent-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="A short summary of what this agent does"
-            />
-          </div>
-
-          {/* Harness */}
-          <div className="flex flex-col gap-1.5">
-            <label className="text-sm font-medium text-muted-foreground">
-              Harness <span className="text-destructive">*</span>
-            </label>
-            <Select value={harness} onValueChange={setHarness}>
-              <SelectTrigger data-testid="create-agent-harness" className="w-full">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {harnessOptions.map((opt) => (
-                  <SelectItem key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </SelectItem>
+        {presetOpen ? (
+          selectedPreset ? (
+            <>
+              <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
+                <div className="flex flex-col gap-1">
+                  <span className="text-sm font-medium">{selectedPreset.label}</span>
+                  <span className="text-sm text-muted-foreground">
+                    {selectedPreset.description}
+                  </span>
+                </div>
+                {selectedPreset.fields?.map((field, index) => (
+                  <div key={field.id} className="flex flex-col gap-1.5">
+                    <label
+                      htmlFor={`mcp-preset-${field.id}`}
+                      className="text-xs font-medium text-muted-foreground"
+                    >
+                      {field.label}
+                    </label>
+                    <Input
+                      id={`mcp-preset-${field.id}`}
+                      data-testid={`mcp-preset-field-${field.id}`}
+                      value={presetValues[field.id] ?? ""}
+                      onChange={(event) =>
+                        setPresetValues((values) => ({
+                          ...values,
+                          [field.id]: event.target.value,
+                        }))
+                      }
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" && canAddSelectedPreset) {
+                          event.preventDefault();
+                          addMCPPreset(selectedPreset);
+                        }
+                      }}
+                      placeholder={field.placeholder}
+                      autoFocus={index === 0}
+                    />
+                  </div>
                 ))}
-              </SelectContent>
-            </Select>
-          </div>
+                {selectedPreset.prerequisites ? (
+                  <p className="text-sm leading-relaxed text-muted-foreground">
+                    {selectedPreset.prerequisites}
+                  </p>
+                ) : null}
+              </div>
+              <DialogFooter>
+                <Button
+                  variant="ghost"
+                  onClick={() => {
+                    setSelectedPresetId(null);
+                    setPresetValues({});
+                  }}
+                >
+                  Back
+                </Button>
+                <Button
+                  data-testid="mcp-preset-add"
+                  disabled={!canAddSelectedPreset}
+                  onClick={() => addMCPPreset(selectedPreset)}
+                >
+                  Add {selectedPreset.label}
+                </Button>
+              </DialogFooter>
+            </>
+          ) : (
+            <>
+              <Command className="-mx-1 min-h-0 flex-1 bg-transparent p-0">
+                <CommandInput
+                  data-testid="mcp-integration-search"
+                  placeholder="Search integrations, providers, or categories..."
+                />
+                <CommandList className="max-h-none min-h-0 flex-1 overflow-y-auto overscroll-contain">
+                  <CommandEmpty>No matching integrations.</CommandEmpty>
+                  {groupMCPServerPresets().map(([category, presets]) => (
+                    <CommandGroup key={category} heading={category}>
+                      {presets.map((preset) => (
+                        <MCPIntegrationOption
+                          key={preset.id}
+                          preset={preset}
+                          onClick={() => selectPreset(preset)}
+                        />
+                      ))}
+                    </CommandGroup>
+                  ))}
+                  <CommandSeparator />
+                  <CommandGroup heading="Advanced">
+                    <CommandItem
+                      value="custom server manual command remote url advanced"
+                      onSelect={addMCPServer}
+                      data-testid="create-agent-add-custom-mcp"
+                      className="items-start py-2"
+                    >
+                      <ServerIcon className="mt-0.5 size-4 text-muted-foreground" />
+                      <span className="flex flex-col gap-0.5">
+                        <span className="text-sm font-medium">Custom server</span>
+                        <span className="text-xs text-muted-foreground">
+                          Enter a command or remote URL manually.
+                        </span>
+                      </span>
+                    </CommandItem>
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+              <DialogFooter>
+                <Button variant="ghost" onClick={closePicker}>
+                  Back
+                </Button>
+              </DialogFooter>
+            </>
+          )
+        ) : (
+          <>
+            <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
+              {/* Name */}
+              <div className="flex flex-col gap-1.5">
+                <label
+                  htmlFor="create-agent-name"
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  Name <span className="text-destructive">*</span>
+                </label>
+                <Input
+                  id="create-agent-name"
+                  data-testid="create-agent-name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="my-agent"
+                  autoFocus
+                />
+              </div>
 
-          {/* Model */}
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="create-agent-model"
-              className="text-sm font-medium text-muted-foreground"
-            >
-              Model <span className="text-destructive">*</span>
-            </label>
-            <Input
-              id="create-agent-model"
-              data-testid="create-agent-model"
-              value={model}
-              onChange={(e) => setModel(e.target.value)}
-              placeholder="claude-sonnet-4-20250514"
-            />
-          </div>
+              {/* Description */}
+              <div className="flex flex-col gap-1.5">
+                <label
+                  htmlFor="create-agent-description"
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  Description
+                </label>
+                <Input
+                  id="create-agent-description"
+                  data-testid="create-agent-description"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="A short summary of what this agent does"
+                />
+              </div>
 
-          {/* Instructions / System Prompt */}
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="create-agent-instructions"
-              className="text-sm font-medium text-muted-foreground"
-            >
-              System instructions
-            </label>
-            <Textarea
-              id="create-agent-instructions"
-              data-testid="create-agent-instructions"
-              value={instructions}
-              onChange={(e) => setInstructions(e.target.value)}
-              placeholder="You are a helpful assistant that..."
-              className="min-h-[120px]"
-            />
-          </div>
+              {/* Harness */}
+              <div className="flex flex-col gap-1.5">
+                <label className="text-xs font-medium text-muted-foreground">
+                  Harness <span className="text-destructive">*</span>
+                </label>
+                <Select value={harness} onValueChange={setHarness}>
+                  <SelectTrigger data-testid="create-agent-harness" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {harnessOptions.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
 
-          {/* MCP Servers */}
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-medium text-muted-foreground">MCP Tools</span>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={addMCPServer}
-                data-testid="create-agent-add-mcp"
-                className="h-6 gap-1 px-2 text-sm text-muted-foreground"
-              >
-                <PlusIcon className="size-3" />
-                Add server
-              </Button>
+              {/* Model */}
+              <div className="flex flex-col gap-1.5">
+                <label
+                  htmlFor="create-agent-model"
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  Model <span className="text-destructive">*</span>
+                </label>
+                <Input
+                  id="create-agent-model"
+                  data-testid="create-agent-model"
+                  value={model}
+                  onChange={(e) => setModel(e.target.value)}
+                  placeholder="claude-sonnet-4-20250514"
+                />
+              </div>
+
+              {/* Instructions / System Prompt */}
+              <div className="flex flex-col gap-1.5">
+                <label
+                  htmlFor="create-agent-instructions"
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  System instructions
+                </label>
+                <Textarea
+                  id="create-agent-instructions"
+                  data-testid="create-agent-instructions"
+                  value={instructions}
+                  onChange={(e) => setInstructions(e.target.value)}
+                  placeholder="You are a helpful assistant that..."
+                  className="min-h-[120px]"
+                />
+              </div>
+
+              {/* MCP Servers */}
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-xs font-medium text-muted-foreground">MCP Tools</span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    data-testid="create-agent-add-mcp"
+                    className="h-6 gap-1 px-2 text-xs text-muted-foreground"
+                    onClick={() => setPresetOpen(true)}
+                  >
+                    <PlusIcon className="size-3" />
+                    Add server
+                  </Button>
+                </div>
+                {mcpEntries.map((entry) => (
+                  <MCPServerRow
+                    key={entry.key}
+                    entry={entry}
+                    onChange={(patch) => updateMCPEntry(entry.key, patch)}
+                    onRemove={() => removeMCPServer(entry.key)}
+                  />
+                ))}
+              </div>
             </div>
-            {mcpEntries.map((entry) => (
-              <MCPServerRow
-                key={entry.key}
-                entry={entry}
-                onChange={(patch) => updateMCPEntry(entry.key, patch)}
-                onRemove={() => removeMCPServer(entry.key)}
-              />
-            ))}
-          </div>
-        </div>
 
-        <DialogFooter>
-          <Button variant="ghost" onClick={() => handleOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button data-testid="create-agent-submit" onClick={handleSubmit} disabled={!canSubmit}>
-            Create
-          </Button>
-        </DialogFooter>
+            <DialogFooter>
+              <Button variant="ghost" onClick={() => handleOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button
+                data-testid="create-agent-submit"
+                onClick={handleSubmit}
+                disabled={!canSubmit}
+              >
+                Create
+              </Button>
+            </DialogFooter>
+          </>
+        )}
       </DialogContent>
     </Dialog>
+  );
+}
+
+function MCPIntegrationOption({
+  preset,
+  onClick,
+}: {
+  preset: MCPServerPreset;
+  onClick: () => void;
+}) {
+  const Icon = MCP_INTEGRATION_ICONS[preset.icon];
+  return (
+    <CommandItem
+      value={`${preset.label} ${preset.provider} ${preset.category} ${preset.description}`}
+      data-testid={`create-agent-add-preset-${preset.id}`}
+      className="items-start py-2"
+      onSelect={onClick}
+    >
+      <Icon className="mt-0.5 size-4 text-muted-foreground" />
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="flex items-center gap-1.5 text-sm font-medium">
+          <span>{preset.label}</span>
+          <span className="text-xs font-normal text-muted-foreground">{preset.provider}</span>
+        </span>
+        <span className="text-xs text-muted-foreground">{preset.description}</span>
+      </span>
+    </CommandItem>
   );
 }
 
@@ -390,7 +626,7 @@ function MCPServerRow({
             value={entry.env}
             onChange={(e) => onChange({ env: e.target.value })}
             placeholder={"Environment variables (KEY=VALUE per line)\ne.g. GITHUB_TOKEN=ghp_..."}
-            className="min-h-[60px] font-mono text-sm"
+            className="min-h-[60px] font-mono text-xs"
           />
         </>
       ) : (
@@ -406,7 +642,7 @@ function MCPServerRow({
             value={entry.headers}
             onChange={(e) => onChange({ headers: e.target.value })}
             placeholder={"HTTP headers (one per line)\ne.g. Authorization: Bearer tok_..."}
-            className="min-h-[60px] font-mono text-sm"
+            className="min-h-[60px] font-mono text-xs"
           />
         </>
       )}


### PR DESCRIPTION
## Related issue

N/A

## Summary

Adding an MCP server to a custom agent meant typing a command or URL by hand, so you had to leave the app to look up the right invocation. This adds a curated catalog to the **Create custom agent** dialog.

- **A provider-neutral registry.** `web/src/lib/mcpPresets.ts` holds the data: each entry declares its provider, capability category, description, prerequisites, optional input fields, and a factory that produces the MCP server config. The dialog renders entries generically, so adding an integration is a data change, not a UI change.
- **A searchable, grouped picker.** "Add server" opens a full-height view inside the dialog with search across name, provider, category, and description, grouped by capability. Manual configuration is still there under **Custom server**, and every added entry lands in the normal, editable MCP row.
- **Only integrations that work without stored secrets.** The first entries are official, maintained servers needing either no credentials (Microsoft Learn, AWS Knowledge, DeepWiki, Cloudflare docs/blog, Context7, Exa, Playwright, AWS Documentation, Terraform Registry, AWS Open Data) or an existing local login (Azure, Azure DevOps).

Integrations that require OAuth or a static API token (GitHub, Notion, Linear, Slack, Sentry, Stripe, Atlassian) are deliberately left out. Omnigent has no MCP OAuth client or secret-reference mechanism yet, so listing them today would either produce configurations that cannot authenticate or push users to paste long-lived tokens into an agent bundle. They become one-line registry additions once that support lands.

```
CreateAgentDialog ──renders──> MCP_SERVER_PRESETS (data)
       │                              │
       │                              ├── provider / category / description
       │                              ├── prerequisites
       │                              ├── fields[]  (e.g. Azure DevOps organization)
       │                              └── create(values) -> MCPServerInput
       │
       └──> editable MCP row ──> agent bundle YAML
```

## Test Plan

- `pnpm exec vitest run src/shell src/lib/mcpPresets.test.ts src/lib/agentBundle.test.ts` — 1725 passed, 2 expected failures, 88 files.
- `pnpm type-check`, `pnpm exec oxlint --deny-warnings`, `pnpm exec prettier --check`, and `pnpm build` all pass.
- `pre-commit run --files <changed files>` passes.
- Manually in the dev pod: opened **Create custom agent → MCP Tools → Add server**, searched by provider ("cloudflare") and category, scrolled the full list, added Microsoft Learn (HTTP) and Azure DevOps (organization step), confirmed the generated rows are editable and contain no secrets, and confirmed **Custom server** still yields a blank row.

New tests cover the registry contract (grouping, provider neutrality, generated configs) and the dialog (search, adding a no-field integration, adding a field-backed integration, and the manual path).

## Demo

https://github.com/user-attachments/assets/placeholder-replace-with-recording

<!-- Screen recording of the picker: search, grouped list, Azure DevOps organization step. -->

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the registry and the dialog interactions. The remote endpoints themselves are not contacted in tests; I verified connectivity manually in the dev pod, since asserting against third-party MCP servers would make the suite network-dependent and flaky.

## Changelog

Add MCP servers from a searchable catalog of curated integrations when creating a custom agent
