### PR TITLE
fix(omnidev): pin the pod's backend to Python 3.12

### DIFF
--- a/dev/omnidev/src/install.rs
+++ b/dev/omnidev/src/install.rs
@@ -14,7 +14,7 @@ use crate::paths;
 pub const DEFAULT_REPO: &str = "https://github.com/omnigent-ai/omnigent.git";
 pub const DEFAULT_REF: &str = "main";
 pub const DEFAULT_EXTRA: &str = "databricks";
-const PYTHON_VERSION: &str = "3.12";
+pub const PYTHON_VERSION: &str = "3.12";
 
 /// Durable record of how the user wants omnigent installed. Persisted so
 /// `update` reinstalls the same repo/ref/extras without re-specifying them.

--- a/dev/omnidev/src/main.rs
+++ b/dev/omnidev/src/main.rs
@@ -8,7 +8,7 @@
 //!   keep a git-based omnigent up to date. These need no checkout and run
 //!   anywhere.
 //! - **omnigent passthrough** (`omnidev omnigent …`): run any omnigent command
-//!   against the current checkout's pod via `uv run --python 3.12 omnigent …`, with the pod's
+//!   against the current checkout's pod via pinned `uv run --python …`, with the pod's
 //!   isolated env applied. Requires a checkout, like the supervisor.
 
 mod install;
@@ -81,7 +81,7 @@ enum Command {
     Refresh,
     /// Print a shell snippet to eval from .zshrc/.bashrc for daily checks.
     ShellHook,
-    /// Run an omnigent command against this checkout's pod (`uv run --python 3.12 omnigent …`).
+    /// Run an omnigent command against this checkout's pod (pinned `uv run --python …`).
     ///
     /// Everything after the subcommand is forwarded verbatim to omnigent. The
     /// pod's isolated env (data dir, database, config, server URL) is applied,
@@ -172,7 +172,7 @@ fn main() -> Result<()> {
 }
 
 /// `omnidev omnigent …` — run an arbitrary omnigent command against this
-/// checkout's pod via `uv run --python 3.12 omnigent …`, with the pod's isolated env (data
+/// checkout's pod via pinned `uv run --python …`, with the pod's isolated env (data
 /// dir, database URI, config home, server URL) applied on top of the inherited
 /// parent env. Resolves the repo root and pod dir (same as the supervisor),
 /// ensures the pod tree exists, then spawns in the foreground inheriting stdio.

--- a/dev/omnidev/src/main.rs
+++ b/dev/omnidev/src/main.rs
@@ -8,16 +8,16 @@
 //!   keep a git-based omnigent up to date. These need no checkout and run
 //!   anywhere.
 //! - **omnigent passthrough** (`omnidev omnigent …`): run any omnigent command
-//!   against the current checkout's pod via `uv run omnigent …`, with the pod's
+//!   against the current checkout's pod via `uv run --python 3.12 omnigent …`, with the pod's
 //!   isolated env applied. Requires a checkout, like the supervisor.
 
 mod install;
 mod lan;
 mod lock;
 mod logs;
+mod omnigent_cmd;
 mod paths;
 mod pod;
-mod omnigent_cmd;
 mod ports;
 mod process;
 mod shellhook;
@@ -81,7 +81,7 @@ enum Command {
     Refresh,
     /// Print a shell snippet to eval from .zshrc/.bashrc for daily checks.
     ShellHook,
-    /// Run an omnigent command against this checkout's pod (`uv run omnigent …`).
+    /// Run an omnigent command against this checkout's pod (`uv run --python 3.12 omnigent …`).
     ///
     /// Everything after the subcommand is forwarded verbatim to omnigent. The
     /// pod's isolated env (data dir, database, config, server URL) is applied,
@@ -172,7 +172,7 @@ fn main() -> Result<()> {
 }
 
 /// `omnidev omnigent …` — run an arbitrary omnigent command against this
-/// checkout's pod via `uv run omnigent …`, with the pod's isolated env (data
+/// checkout's pod via `uv run --python 3.12 omnigent …`, with the pod's isolated env (data
 /// dir, database URI, config home, server URL) applied on top of the inherited
 /// parent env. Resolves the repo root and pod dir (same as the supervisor),
 /// ensures the pod tree exists, then spawns in the foreground inheriting stdio.

--- a/dev/omnidev/src/omnigent_cmd.rs
+++ b/dev/omnidev/src/omnigent_cmd.rs
@@ -1,5 +1,5 @@
 //! `omnidev omnigent …` — run an arbitrary omnigent command against this
-//! checkout's pod via `uv run --python 3.12 omnigent …`.
+//! checkout's pod via `uv run --python <pinned> omnigent …`.
 //!
 //! Unlike the supervised `process::ProcSpec`s, this runs in the foreground
 //! (inheriting the user's stdio) and does *not* inject the log-mirror env
@@ -11,9 +11,10 @@
 
 use std::path::PathBuf;
 
+use crate::install::PYTHON_VERSION;
 use crate::pod::Pod;
 
-/// A resolved `uv run --python 3.12 omnigent …` invocation for the passthrough subcommand.
+/// A resolved `uv run --python <pinned> omnigent …` invocation for the passthrough subcommand.
 pub struct OmnigentCmd {
     pub program: String,
     pub args: Vec<String>,
@@ -21,13 +22,13 @@ pub struct OmnigentCmd {
     pub cwd: PathBuf,
 }
 
-/// Build the command line + env for `uv run --python 3.12 omnigent <passthrough…>` rooted at
+/// Build the command line + env for `uv run --python <pinned> omnigent <passthrough…>` rooted at
 /// the pod's repo, with the pod's `OMNIGENT_*` overrides applied.
 pub fn build(pod: &Pod, passthrough: &[String]) -> OmnigentCmd {
     let mut args = vec![
         "run".to_string(),
         "--python".to_string(),
-        "3.12".to_string(),
+        PYTHON_VERSION.to_string(),
         "omnigent".to_string(),
     ];
     args.extend_from_slice(passthrough);
@@ -94,7 +95,7 @@ mod tests {
             vec![
                 "run",
                 "--python",
-                "3.12",
+                PYTHON_VERSION,
                 "omnigent",
                 "agent",
                 "run",
@@ -110,7 +111,7 @@ mod tests {
         let cmd = build(&pod, &[]);
         assert_eq!(
             cmd.args.iter().map(String::as_str).collect::<Vec<_>>(),
-            vec!["run", "--python", "3.12", "omnigent"]
+            vec!["run", "--python", PYTHON_VERSION, "omnigent"]
         );
     }
 

--- a/dev/omnidev/src/omnigent_cmd.rs
+++ b/dev/omnidev/src/omnigent_cmd.rs
@@ -1,5 +1,5 @@
 //! `omnidev omnigent …` — run an arbitrary omnigent command against this
-//! checkout's pod via `uv run omnigent …`.
+//! checkout's pod via `uv run --python 3.12 omnigent …`.
 //!
 //! Unlike the supervised `process::ProcSpec`s, this runs in the foreground
 //! (inheriting the user's stdio) and does *not* inject the log-mirror env
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 
 use crate::pod::Pod;
 
-/// A resolved `uv run omnigent …` invocation for the passthrough subcommand.
+/// A resolved `uv run --python 3.12 omnigent …` invocation for the passthrough subcommand.
 pub struct OmnigentCmd {
     pub program: String,
     pub args: Vec<String>,
@@ -21,10 +21,15 @@ pub struct OmnigentCmd {
     pub cwd: PathBuf,
 }
 
-/// Build the command line + env for `uv run omnigent <passthrough…>` rooted at
+/// Build the command line + env for `uv run --python 3.12 omnigent <passthrough…>` rooted at
 /// the pod's repo, with the pod's `OMNIGENT_*` overrides applied.
 pub fn build(pod: &Pod, passthrough: &[String]) -> OmnigentCmd {
-    let mut args = vec!["run".to_string(), "omnigent".to_string()];
+    let mut args = vec![
+        "run".to_string(),
+        "--python".to_string(),
+        "3.12".to_string(),
+        "omnigent".to_string(),
+    ];
     args.extend_from_slice(passthrough);
     OmnigentCmd {
         program: "uv".into(),
@@ -82,14 +87,19 @@ mod tests {
     #[test]
     fn forwards_passthrough_args_after_uv_run_omnigent() {
         let pod = make_pod();
-        let cmd = build(
-            &pod,
-            &["agent".into(), "run".into(), "fix tests".into()],
-        );
+        let cmd = build(&pod, &["agent".into(), "run".into(), "fix tests".into()]);
         assert_eq!(cmd.program, "uv");
         assert_eq!(
             cmd.args.iter().map(String::as_str).collect::<Vec<_>>(),
-            vec!["run", "omnigent", "agent", "run", "fix tests"]
+            vec![
+                "run",
+                "--python",
+                "3.12",
+                "omnigent",
+                "agent",
+                "run",
+                "fix tests"
+            ]
         );
         assert_eq!(cmd.cwd, pod.repo_root);
     }
@@ -100,7 +110,7 @@ mod tests {
         let cmd = build(&pod, &[]);
         assert_eq!(
             cmd.args.iter().map(String::as_str).collect::<Vec<_>>(),
-            vec!["run", "omnigent"]
+            vec!["run", "--python", "3.12", "omnigent"]
         );
     }
 
@@ -138,7 +148,11 @@ mod tests {
     fn omits_log_mirror_env() {
         let pod = make_pod();
         let cmd = build(&pod, &["host".into()]);
-        assert!(cmd.env.iter().find(|(k, _)| k == "OMNIGENT_LOG_TTY_FD").is_none());
+        assert!(cmd
+            .env
+            .iter()
+            .find(|(k, _)| k == "OMNIGENT_LOG_TTY_FD")
+            .is_none());
         assert!(cmd
             .env
             .iter()

--- a/dev/omnidev/src/process.rs
+++ b/dev/omnidev/src/process.rs
@@ -2,6 +2,7 @@
 
 use std::path::PathBuf;
 
+use crate::install::PYTHON_VERSION;
 use crate::pod::Pod;
 
 /// A resolved command line + working dir for one process. Env is applied by the
@@ -24,7 +25,7 @@ impl ProcSpec {
         ]
     }
 
-    /// `uv run --python 3.12 omnigent --log-to-stderr server --host 127.0.0.1 --port <p>
+    /// `uv run --python <pinned> omnigent --log-to-stderr server --host 127.0.0.1 --port <p>
     /// --database-uri <db> --artifact-location <dir>`, from the repo root.
     pub fn server(pod: &Pod) -> ProcSpec {
         ProcSpec {
@@ -32,7 +33,7 @@ impl ProcSpec {
             args: vec![
                 "run".into(),
                 "--python".into(),
-                "3.12".into(),
+                PYTHON_VERSION.into(),
                 "omnigent".into(),
                 "--log-to-stderr".into(),
                 "server".into(),
@@ -50,7 +51,7 @@ impl ProcSpec {
         }
     }
 
-    /// `uv run --python 3.12 omnigent --log-to-stderr host --server http://127.0.0.1:<p>`,
+    /// `uv run --python <pinned> omnigent --log-to-stderr host --server http://127.0.0.1:<p>`,
     /// from the repo root.
     pub fn host(pod: &Pod) -> ProcSpec {
         ProcSpec {
@@ -58,7 +59,7 @@ impl ProcSpec {
             args: vec![
                 "run".into(),
                 "--python".into(),
-                "3.12".into(),
+                PYTHON_VERSION.into(),
                 "omnigent".into(),
                 "--log-to-stderr".into(),
                 "host".into(),
@@ -152,7 +153,7 @@ mod tests {
                     .take(4)
                     .map(String::as_str)
                     .collect::<Vec<_>>(),
-                vec!["run", "--python", "3.12", "omnigent"]
+                vec!["run", "--python", PYTHON_VERSION, "omnigent"]
             );
             assert!(
                 spec.args.iter().any(|arg| arg == "--log-to-stderr"),

--- a/dev/omnidev/src/process.rs
+++ b/dev/omnidev/src/process.rs
@@ -24,13 +24,15 @@ impl ProcSpec {
         ]
     }
 
-    /// `uv run omnigent --log-to-stderr server --host 127.0.0.1 --port <p>
+    /// `uv run --python 3.12 omnigent --log-to-stderr server --host 127.0.0.1 --port <p>
     /// --database-uri <db> --artifact-location <dir>`, from the repo root.
     pub fn server(pod: &Pod) -> ProcSpec {
         ProcSpec {
             program: "uv".into(),
             args: vec![
                 "run".into(),
+                "--python".into(),
+                "3.12".into(),
                 "omnigent".into(),
                 "--log-to-stderr".into(),
                 "server".into(),
@@ -48,13 +50,15 @@ impl ProcSpec {
         }
     }
 
-    /// `uv run omnigent --log-to-stderr host --server http://127.0.0.1:<p>`,
+    /// `uv run --python 3.12 omnigent --log-to-stderr host --server http://127.0.0.1:<p>`,
     /// from the repo root.
     pub fn host(pod: &Pod) -> ProcSpec {
         ProcSpec {
             program: "uv".into(),
             args: vec![
                 "run".into(),
+                "--python".into(),
+                "3.12".into(),
                 "omnigent".into(),
                 "--log-to-stderr".into(),
                 "host".into(),
@@ -142,6 +146,14 @@ mod tests {
         .unwrap();
 
         for spec in [ProcSpec::server(&pod), ProcSpec::host(&pod)] {
+            assert_eq!(
+                spec.args
+                    .iter()
+                    .take(4)
+                    .map(String::as_str)
+                    .collect::<Vec<_>>(),
+                vec!["run", "--python", "3.12", "omnigent"]
+            );
             assert!(
                 spec.args.iter().any(|arg| arg == "--log-to-stderr"),
                 "omnigent command should request stderr logging: {:?}",


### PR DESCRIPTION
## Related issue

N/A

## Summary

`omnidev` starts the pod's server, host, and passthrough commands with `uv run omnigent …`, which lets an inherited `UV_PYTHON` win over the repo's own pin. On a machine that exports `UV_PYTHON=3.11` (common when several projects share a shell profile), the pod fails immediately:

```
[server ] Using CPython 3.11.15
[server ] error: The requested interpreter resolved to Python 3.11.15, which is
          incompatible with the project's Python requirement: `>=3.12`
```

The interpreter is now requested explicitly (`uv run --python 3.12 omnigent …`) for the supervised server and host processes and for the `omnidev omnigent …` passthrough, matching the version `omnidev install` already pins and the repo's `.python-version`. Unit tests assert the resolved argv so the flag cannot silently drop off.

## Test Plan

- `cargo test --manifest-path dev/omnidev/Cargo.toml --bin omnidev` — 36 passed.
- `rustfmt --edition 2021 --check` on the changed files.
- Reproduced the failure with `UV_PYTHON=3.11 uv run omnigent --version` (fails as above), then confirmed `UV_PYTHON=3.11 cargo run -q --manifest-path dev/omnidev/Cargo.toml -- omnigent --version` prints `omnigent 0.8.0.dev0` and `just dev` boots the pod cleanly with the same variable exported.

Note: `cargo test` for the whole crate currently fails to compile `tests/pod_setup.rs`, which still calls `pod.needs_npm_install()` after the rename to `needs_pnpm_install`. That is pre-existing on `main` and untouched here, so the binary's unit tests were run directly.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests assert that the server, host, and passthrough commands request Python 3.12. The environment-inheritance half can only be exercised by spawning `uv` against a real toolchain, so that was verified manually with `UV_PYTHON=3.11` exported.

## Changelog

`omnidev` no longer fails to start when a global `UV_PYTHON` points at an unsupported interpreter
