### PR TITLE
refactor: centralize Python JSON type aliases

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -22,6 +22,8 @@ import subprocess
 import sys
 import uuid
 
+from omnigent.json_types import JsonObject as _JsonObject
+
 # termios/tty are POSIX-only and drive the native (tmux/PTY) Claude terminal,
 # which is disabled on Windows. Guard the import (special-cased by mypy, which
 # type-checks on Linux) so importing this module never crashes the CLI there.
@@ -125,7 +127,6 @@ from omnigent.terminals.ws_bridge import (
 
 _logger = logging.getLogger(__name__)
 
-_JsonObject: TypeAlias = dict[str, object]
 _TermiosAttrs: TypeAlias = list[int | list[bytes | int]]
 _SignalHandler: TypeAlias = (
     Callable[[int, FrameType | None], object] | int | signal.Handlers | None

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -66,6 +66,7 @@ from omnigent.host.local_server import (
 )
 from omnigent.inner import _proc, ui
 from omnigent.integration_daemon import IntegrationDaemon
+from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.onboarding.sandboxes import available_providers as _sandbox_providers
 from omnigent.process_logging import LOG_LEVEL_ENV_VAR, LOG_TO_STDERR_ENV_VAR
 
@@ -515,7 +516,6 @@ _HostJsonValue: TypeAlias = (
 _HostJsonObject: TypeAlias = dict[str, _HostJsonValue]
 _HostSessionRow: TypeAlias = dict[str, _HostJsonValue]
 _HostPayload: TypeAlias = dict[str, _HostJsonValue]
-_JsonObject: TypeAlias = dict[str, object]
 
 
 def _effective_global_config_path() -> Path:

--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -18,7 +18,6 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TypeAlias
 
 import click
 import httpx
@@ -74,6 +73,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
@@ -96,7 +96,6 @@ from omnigent.native_terminal import (
 
 _logger = logging.getLogger(__name__)
 
-_JsonObject: TypeAlias = dict[str, object]
 
 _AGENT_NAME = "codex-native-ui"
 _DEFAULT_CODEX_COMMAND = "codex"

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -24,6 +24,7 @@ from cachetools import TTLCache
 from websockets.asyncio.client import ClientConnection
 
 from omnigent import model_catalog
+from omnigent.json_types import JsonObject as _JsonObject
 
 if TYPE_CHECKING:
     from omnigent.onboarding.provider_config import ProviderEntry
@@ -53,7 +54,6 @@ from omnigent.inner.databricks_executor import _databricks_gateway_host
 
 _logger = logging.getLogger(__name__)
 
-_JsonObject: TypeAlias = dict[str, object]
 CodexMessage: TypeAlias = _JsonObject
 CodexParams: TypeAlias = _JsonObject
 

--- a/omnigent/cursor_native_bridge.py
+++ b/omnigent/cursor_native_bridge.py
@@ -21,16 +21,16 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING
 
 import click
 
 from omnigent._platform import stable_user_id
+from omnigent.json_types import JsonObject as _JsonObject
 
 if TYPE_CHECKING:
     from omnigent.cursor_native import CursorModelOption
 
-_JsonObject: TypeAlias = dict[str, object]
 
 #: Env var carrying the bridge dir into the harness executor process.
 BRIDGE_DIR_ENV_VAR = "HARNESS_CURSOR_NATIVE_BRIDGE_DIR"

--- a/omnigent/goose_native.py
+++ b/omnigent/goose_native.py
@@ -25,7 +25,6 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TypeAlias
 
 import click
 import httpx
@@ -44,6 +43,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
@@ -59,8 +59,6 @@ from omnigent.native_terminal import (
     normalize_extra_args as _normalize_extra_args,
 )
 from omnigent.native_terminal import url_component
-
-_JsonObject: TypeAlias = dict[str, object]
 
 _DEFAULT_GOOSE_COMMAND = "goose"
 _GOOSE_PATH_ENV = "OMNIGENT_GOOSE_PATH"

--- a/omnigent/hermes_native.py
+++ b/omnigent/hermes_native.py
@@ -24,7 +24,6 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TypeAlias
 
 import click
 import httpx
@@ -43,6 +42,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
@@ -58,8 +58,6 @@ from omnigent.native_terminal import (
     normalize_extra_args as _normalize_extra_args,
 )
 from omnigent.native_terminal import url_component
-
-_JsonObject: TypeAlias = dict[str, object]
 
 _DEFAULT_HERMES_COMMAND = "hermes"
 _HERMES_PATH_ENV = "OMNIGENT_HERMES_PATH"

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -22,9 +22,9 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TypeAlias
 
 from omnigent.harness_availability import HarnessAvailability, is_harness_availability
+from omnigent.json_types import JsonObject as _JsonObject
 
 # Structured error code carried in ``HostLaunchRunnerResultFrame.error_code``
 # when the host refuses a launch because the session's harness is not
@@ -32,8 +32,6 @@ from omnigent.harness_availability import HarnessAvailability, is_harness_availa
 # by the daemon (producer), server (maps it to
 # ``ErrorCode.HARNESS_NOT_CONFIGURED``), and tests.
 HARNESS_NOT_CONFIGURED_ERROR_CODE = "harness_not_configured"
-
-_JsonObject: TypeAlias = dict[str, object]
 
 
 class HostFrameKind(str, Enum):

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -46,6 +46,7 @@ from omnigent import model_catalog
 from omnigent._platform import resolve_cli_binary, stable_user_id
 from omnigent.inner import _proc
 from omnigent.inner.bundle_skills import ensure_bundle_plugin_manifest
+from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 from omnigent.llms.adapters._content import parse_data_uri as _parse_replay_data_uri
 from omnigent.reasoning_effort import CLAUDE_EFFORTS, validate_effort
@@ -98,7 +99,6 @@ _GATEWAY_AUTH_REFRESH_MS = 900_000
 
 # Parsed tool arguments / tool result dict — JSON-shaped bags exchanged
 # with the Omnigent tool executor and the SDK's MCP bridge.
-_JsonObject: TypeAlias = dict[str, object]
 ToolArgs: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
 ToolResult: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
 

--- a/omnigent/inner/cursor_executor.py
+++ b/omnigent/inner/cursor_executor.py
@@ -52,6 +52,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol, TypeAlias, TypedDict
 
+from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 
 from .datamodel import OSEnvSpec
@@ -77,7 +78,6 @@ logger = logging.getLogger(__name__)
 # Omnigent's bridged-tool callback: (tool_name, args) -> awaitable result.
 # Installed by the runtime adapter (see ``_executor_adapter``); mirrors the
 # claude-sdk executor's ``ToolExecutor``.
-_JsonObject: TypeAlias = dict[str, object]
 ToolExecutor: TypeAlias = Callable[[str, _JsonObject], Awaitable[object]]
 PolicyEvaluator: TypeAlias = Callable[[str, _JsonObject], Awaitable[object]]
 ElicitationHandler: TypeAlias = Callable[[str, _JsonObject], Awaitable[bool]]

--- a/omnigent/inner/open_responses_sdk.py
+++ b/omnigent/inner/open_responses_sdk.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, TypeAlias, cast
 import pydantic
 
 from omnigent import model_catalog
+from omnigent.json_types import JsonValue
 from omnigent.llms.adapters._content import redact_inline_data_uris
 from omnigent.spec.types import RetryPolicy
 
@@ -55,9 +56,6 @@ logger = logging.getLogger(__name__)
 # duplicate OpenAI's own SDK types.
 ResponsesItem: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
 OpenAIKwargs: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
-
-# Plain JSON value — recursive union used by ``_to_plain_data``.
-JsonValue: TypeAlias = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
 
 
 def _redact_inline_base64(value: Any) -> Any:  # type: ignore[explicit-any]

--- a/omnigent/inner/openai_agents_sdk_executor.py
+++ b/omnigent/inner/openai_agents_sdk_executor.py
@@ -27,6 +27,7 @@ from typing import Any, Literal, Protocol, TypeAlias, cast
 import httpx
 
 from omnigent import model_catalog
+from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 from omnigent.llms.errors import is_context_length_exceeded as _is_context_length_exceeded
 from omnigent.reasoning_effort import OPENAI_AGENTS_EFFORTS, validate_effort
@@ -72,7 +73,6 @@ _EMPTY_TURN_MAX_ATTEMPTS = 2
 # retried.
 _NON_OUTPUT_ITEM_TYPES: frozenset[str] = frozenset({"reasoning_item", "compaction_item"})
 
-_JsonObject: TypeAlias = dict[str, object]
 
 # Replay items persisted to the SDK Session — heterogeneous Responses-API
 # input items (function_call / function_call_output / message / etc.).

--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict, cast
 from urllib.parse import urlparse, urlunparse
 
 from omnigent._platform import IS_WINDOWS, WINDOWS_ENV_PASSTHROUGH
+from omnigent.json_types import JsonValue
 from omnigent.runner.identity import (
     OMNIGENT_SESSION_ENV_VAR,
     strip_runner_auth_secrets,
@@ -54,10 +55,6 @@ if TYPE_CHECKING:
 from .sandbox import (
     run_launcher as _run_launcher,
 )
-
-# Any JSON-shaped leaf — used for the encode/decode serializer helpers that
-# mirror the pattern in ``omnigent/sandbox.py`` and ``omnigent/uc_tools.py``.
-JsonValue: TypeAlias = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
 
 # Result dict returned by ``read`` / ``write`` / ``edit`` / ``shell`` and the
 # corresponding ``_*_impl`` helpers. Keys vary by op (content/offset/total_lines

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -51,6 +51,8 @@ from urllib.parse import urlparse as _urlparse
 from omnigent import model_catalog
 from omnigent.inner.agent_env import clean_agent_env
 from omnigent.inner.native_attachments import parse_data_uri
+from omnigent.json_types import JsonObject as _JsonObject
+from omnigent.json_types import JsonValue
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 from omnigent.model_metadata import ModelMetadata, ModelWireAPI
 from omnigent.onboarding.provider_config import CHAT_WIRE_API, RESPONSES_WIRE_API
@@ -126,11 +128,6 @@ NativePolicyGate: TypeAlias = Callable[  # type: ignore[explicit-any]
     [str, dict[str, Any]],
     Awaitable[dict[str, Any]] | dict[str, Any],
 ]
-
-# Plain JSON value — recursive union used by ``_check_blocked`` to walk
-# parsed Pi tool-result payloads.
-JsonValue: TypeAlias = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
-_JsonObject: TypeAlias = dict[str, object]
 
 
 class _PiProviderConfig(TypedDict):

--- a/omnigent/inner/sandbox.py
+++ b/omnigent/inner/sandbox.py
@@ -14,8 +14,9 @@ from abc import ABC, abstractmethod
 from collections.abc import MutableMapping, Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Protocol, TypeAlias, cast
+from typing import Protocol, cast
 
+from omnigent.json_types import JsonValue
 from omnigent.runner.identity import RUNNER_AUTH_SECRET_ENV_VARS
 
 from .datamodel import CredentialProxySpec, OSEnvSandboxSpec, OSEnvSpec
@@ -47,11 +48,6 @@ _LAUNCHER_PRIVATE_TMPDIR_ENV = "OMNIGENT_LAUNCHER_SPAWN_PRIVATE_TMPDIR"
 # work ``activate_sandbox`` does. ``none`` is a no-op backend so it
 # doesn't need a wrap.
 _SPAWN_WRAP_BACKENDS = frozenset({"linux_bwrap", "darwin_seatbelt"})
-
-# JSON-shaped payload passed across the parent/launcher boundary: the
-# SandboxPolicy serialized via `to_jsonable()` plus whatever `json.loads`
-# returns on the helper side.
-JsonValue: TypeAlias = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
 
 
 @dataclass

--- a/omnigent/install_ledger.py
+++ b/omnigent/install_ledger.py
@@ -12,9 +12,9 @@ from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import NotRequired, TypeAlias, TypedDict, cast
+from typing import NotRequired, TypedDict, cast
 
-_JsonObject: TypeAlias = dict[str, object]
+from omnigent.json_types import JsonObject as _JsonObject
 
 SCHEMA_VERSION = 1
 LEDGER_NAME = "install_ledger.json"

--- a/omnigent/json_types.py
+++ b/omnigent/json_types.py
@@ -1,0 +1,6 @@
+"""Shared contracts for open JSON objects and serializable JSON values."""
+
+from typing import TypeAlias
+
+JsonObject: TypeAlias = dict[str, object]
+JsonValue: TypeAlias = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]

--- a/omnigent/json_types.py
+++ b/omnigent/json_types.py
@@ -1,4 +1,8 @@
-"""Shared contracts for open JSON objects and serializable JSON values."""
+"""Shared JSON type contracts.
+
+``JsonObject`` is an open object bag whose values are narrowed at use sites.
+``JsonValue`` is recursively constrained to JSON-serializable values.
+"""
 
 from typing import TypeAlias
 

--- a/omnigent/kimi_native.py
+++ b/omnigent/kimi_native.py
@@ -22,7 +22,6 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TypeAlias
 
 import click
 import httpx
@@ -41,6 +40,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
@@ -56,8 +56,6 @@ from omnigent.native_terminal import (
     normalize_extra_args as _normalize_extra_args,
 )
 from omnigent.native_terminal import url_component
-
-_JsonObject: TypeAlias = dict[str, object]
 
 _DEFAULT_KIMI_COMMAND = "kimi"
 _KIMI_PATH_ENV = "OMNIGENT_KIMI_PATH"

--- a/omnigent/kimi_native_bridge.py
+++ b/omnigent/kimi_native_bridge.py
@@ -19,11 +19,9 @@ import subprocess
 import tempfile
 import time
 from pathlib import Path
-from typing import TypeAlias
 
 from omnigent._platform import stable_user_id
-
-_JsonObject: TypeAlias = dict[str, object]
+from omnigent.json_types import JsonObject as _JsonObject
 
 #: Env var carrying the bridge dir into the harness executor process.
 BRIDGE_DIR_ENV_VAR = "HARNESS_KIMI_NATIVE_BRIDGE_DIR"

--- a/omnigent/kiro_native.py
+++ b/omnigent/kiro_native.py
@@ -11,7 +11,6 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TypeAlias
 
 import click
 import httpx
@@ -30,6 +29,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
@@ -45,8 +45,6 @@ from omnigent.native_terminal import (
     normalize_extra_args as _normalize_extra_args,
 )
 from omnigent.native_terminal import url_component
-
-_JsonObject: TypeAlias = dict[str, object]
 
 _DEFAULT_KIRO_COMMAND = "kiro-cli"
 _KIRO_PATH_ENV = "OMNIGENT_KIRO_PATH"

--- a/omnigent/kiro_native_bridge.py
+++ b/omnigent/kiro_native_bridge.py
@@ -12,11 +12,10 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import TypeAlias, TypedDict
+from typing import TypedDict
 
 from omnigent._platform import stable_user_id
-
-_JsonObject: TypeAlias = dict[str, object]
+from omnigent.json_types import JsonObject as _JsonObject
 
 
 class _McpServerEntry(TypedDict):

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -44,6 +44,7 @@ import httpx
 from cachetools import TTLCache
 
 from omnigent._platform import default_shell_argv
+from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.llms.anthropic_model_metadata import parse_anthropic_model_metadata
 from omnigent.model_fallbacks import StaticModelFallback, static_model_fallback
 from omnigent.model_metadata import (
@@ -107,7 +108,6 @@ _ProviderHarness: TypeAlias = Literal[
     "kimi",
     "qwen",
 ]
-_JsonObject: TypeAlias = dict[str, object]
 
 # Harness spellings -> the workflow harness whose provider resolution they
 # share; natives resolve via their SDK sibling (the resolve_native_* rule).

--- a/omnigent/opencode_http_transport.py
+++ b/omnigent/opencode_http_transport.py
@@ -17,6 +17,7 @@ from collections.abc import AsyncIterator, Callable, Mapping
 from pathlib import Path
 from typing import TypeAlias
 
+from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.native_server_transport import (
     NativeEvent,
     NativeLaunchConfig,
@@ -37,7 +38,6 @@ _logger = logging.getLogger(__name__)
 
 ClientFactory = Callable[[], OpenCodeClient]
 
-_JsonObject: TypeAlias = dict[str, object]
 _JsonMapping: TypeAlias = Mapping[str, object]
 
 # Public surface of this transport module. ``ClientFactory`` is the documented

--- a/omnigent/opencode_native.py
+++ b/omnigent/opencode_native.py
@@ -26,7 +26,6 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TypeAlias
 
 import click
 import httpx
@@ -44,6 +43,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
@@ -66,8 +66,6 @@ _logger = logging.getLogger(__name__)
 # Built-in native-UI agent name (matches the descriptor's
 # ``wrapper_agent_name`` and the web native registry).
 _AGENT_NAME = "opencode-native-ui"
-
-_JsonObject: TypeAlias = dict[str, object]
 
 
 def _materialize_opencode_agent_spec(

--- a/omnigent/opencode_native_client.py
+++ b/omnigent/opencode_native_client.py
@@ -25,6 +25,8 @@ from typing import TypeAlias
 
 import httpx
 
+from omnigent.json_types import JsonObject as _JsonObject
+
 _logger = logging.getLogger(__name__)
 
 # Pinned OpenCode CLI/API version range. The source monorepo reports
@@ -34,7 +36,6 @@ OPENCODE_MAX_VERSION_EXCLUSIVE = "1.18.0"
 
 _DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
 
-_JsonObject: TypeAlias = dict[str, object]
 _JsonMapping: TypeAlias = Mapping[str, object]
 
 

--- a/omnigent/opencode_native_forwarder.py
+++ b/omnigent/opencode_native_forwarder.py
@@ -29,6 +29,7 @@ from urllib.parse import quote
 
 import httpx
 
+from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.opencode_native_bridge import update_active_message_id, update_last_event_id
 from omnigent.opencode_native_client import OpenCodeClient, OpenCodeEvent
 from omnigent.opencode_native_permissions import (
@@ -77,7 +78,6 @@ _OPENCODE_REAUTH_HINT = (
 # Bound the dedupe set so a long-lived session can't grow it without limit.
 _MAX_DEDUPE_KEYS = 8192
 
-_JsonObject: TypeAlias = dict[str, object]
 _JsonMapping: TypeAlias = Mapping[str, object]
 
 

--- a/omnigent/opencode_native_permissions.py
+++ b/omnigent/opencode_native_permissions.py
@@ -19,6 +19,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Literal, TypeAlias
 
+from omnigent.json_types import JsonObject as _JsonObject
+
 OPENCODE_NATIVE_HARNESS = "opencode-native"
 
 # OpenCode's accepted reply tokens.
@@ -27,7 +29,6 @@ OpenCodeReply = Literal["once", "always", "reject"]
 # Omnigent-side normalized decisions used by the forwarder.
 PolicyDecision = Literal["allow_once", "allow_always", "reject", "ask"]
 
-_JsonObject: TypeAlias = dict[str, object]
 _JsonMapping: TypeAlias = Mapping[str, object]
 
 

--- a/omnigent/pi_native.py
+++ b/omnigent/pi_native.py
@@ -11,7 +11,6 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TypeAlias
 
 import click
 import httpx
@@ -30,6 +29,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
@@ -49,7 +49,6 @@ from omnigent.pi_native_bridge import bridge_dir_for_session_id
 
 _logger = logging.getLogger(__name__)
 
-_JsonObject: TypeAlias = dict[str, object]
 
 _DEFAULT_PI_COMMAND = "pi"
 _PI_PATH_ENV = "OMNIGENT_PI_PATH"

--- a/omnigent/pi_native_bridge.py
+++ b/omnigent/pi_native_bridge.py
@@ -12,9 +12,8 @@ import time
 import uuid
 from importlib.resources import files
 from pathlib import Path
-from typing import TypeAlias
 
-_JsonObject: TypeAlias = dict[str, object]
+from omnigent.json_types import JsonObject as _JsonObject
 
 # Per-process tiebreaker for inbox ordering. The extension delivers inbox
 # files in lexicographic filename order, so a high-resolution timestamp alone

--- a/omnigent/pi_native_resume.py
+++ b/omnigent/pi_native_resume.py
@@ -38,11 +38,12 @@ import re
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TypeAlias, cast
+from typing import cast
 
 import httpx
 
 from omnigent.host.daemon_launch import error_text
+from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.native_terminal import url_component
 
 # Pi session ids are UUIDv7 hex with dashes (e.g.
@@ -61,8 +62,6 @@ _PI_SESSION_VERSION = 3
 
 # 8-char hex entry ids, matching Pi's own ``SessionEntryBase.id`` shape.
 _ENTRY_ID_LEN = 8
-
-_JsonObject: TypeAlias = dict[str, object]
 
 
 def is_safe_pi_session_id(external_session_id: str) -> bool:

--- a/omnigent/qwen_native.py
+++ b/omnigent/qwen_native.py
@@ -25,7 +25,6 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TypeAlias
 
 import click
 import httpx
@@ -44,6 +43,7 @@ from omnigent.host.daemon_launch import (
     wait_for_host_online,
     wait_for_runner_online,
 )
+from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.native_coding_agents import native_shell_terminal_spec
 from omnigent.native_terminal import (
     DAEMON_HOST_ONLINE_TIMEOUT_S as _DAEMON_HOST_ONLINE_TIMEOUT_S,
@@ -59,8 +59,6 @@ from omnigent.native_terminal import (
     normalize_extra_args as _normalize_extra_args,
 )
 from omnigent.native_terminal import url_component
-
-_JsonObject: TypeAlias = dict[str, object]
 
 _DEFAULT_QWEN_COMMAND = "qwen"
 _QWEN_PATH_ENV = "OMNIGENT_QWEN_PATH"

--- a/omnigent/qwen_native_bridge.py
+++ b/omnigent/qwen_native_bridge.py
@@ -40,11 +40,9 @@ import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TypeAlias
 
 from omnigent._platform import stable_user_id
-
-_JsonObject: TypeAlias = dict[str, object]
+from omnigent.json_types import JsonObject as _JsonObject
 
 #: Env var carrying the bridge dir into the harness executor process.
 BRIDGE_DIR_ENV_VAR = "HARNESS_QWEN_NATIVE_BRIDGE_DIR"

--- a/omnigent/runner/mcp_manager.py
+++ b/omnigent/runner/mcp_manager.py
@@ -15,13 +15,12 @@ import httpx
 from mcp.types import ElicitRequestParams, ElicitResult
 from mcp.types import Tool as McpToolDef
 
+from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.spec.types import AgentSpec, MCPServerConfig, RetryPolicy
 from omnigent.tools.base import is_valid_tool_name
 from omnigent.tools.mcp import McpServerConnection
 
 _logger = logging.getLogger(__name__)
-
-_JsonObject = dict[str, object]
 
 
 def _build_accept_content(

--- a/omnigent/runner/proxy_mcp_manager.py
+++ b/omnigent/runner/proxy_mcp_manager.py
@@ -31,6 +31,7 @@ from typing import cast
 
 import httpx
 
+from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.runner import pending_approvals
 from omnigent.runner.mcp_manager import McpSchemasResult
 from omnigent.runner.tool_dispatch import MCP_PROXY_CALL_TIMEOUT_S
@@ -38,7 +39,6 @@ from omnigent.spec.types import AgentSpec
 
 _logger = logging.getLogger(__name__)
 
-_JsonObject = dict[str, object]
 _EventPublisher = Callable[[str, _JsonObject], None]
 
 

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -33,6 +33,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
+from omnigent.json_types import JsonObject as _JsonObject
+
 if TYPE_CHECKING:
     from omnigent.runtime.filesystem_registry import FilesystemRegistry
     from omnigent.spec.types import AgentSpec
@@ -104,7 +106,6 @@ from omnigent.tools.builtins.upload_file import UploadFileTool, safe_resolve
 
 _logger = logging.getLogger(__name__)
 
-_JsonObject = dict[str, object]
 _EventPublisher = Callable[[str, _JsonObject], None]
 
 

--- a/omnigent/runner/transports/ws_tunnel/frames.py
+++ b/omnigent/runner/transports/ws_tunnel/frames.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import cast
 
-_JsonObject = dict[str, object]
+from omnigent.json_types import JsonObject as _JsonObject
 
 
 class FrameKind(str, Enum):

--- a/omnigent/spec/_omnigent_legacy_shim.py
+++ b/omnigent/spec/_omnigent_legacy_shim.py
@@ -42,8 +42,9 @@ import importlib
 import inspect
 import json
 from collections.abc import Awaitable, Mapping
-from typing import Protocol, TypeAlias, cast
+from typing import Protocol, cast
 
+from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.policies.types import EvaluationContext
 from omnigent.spec.types import Phase
 
@@ -58,8 +59,6 @@ from omnigent.spec.types import Phase
 # reshaped.
 _LEGACY_FIRST_PARAM = "content"
 _LEGACY_SECOND_PARAM = "phase"
-
-_JsonObject: TypeAlias = dict[str, object]
 
 
 class _PolicyCallable(Protocol):


### PR DESCRIPTION
## Related issue

Related to #3644

## Summary

Repeated generic JSON aliases had drifted into dozens of modules during the mypy cleanup. This PR:

- introduces dependency-free shared `JsonObject` and recursive `JsonValue` contracts
- replaces 33 local `_JsonObject` definitions and four recursive `JsonValue` definitions
- preserves private `_JsonObject` names at call sites to keep the refactor mechanical and type-neutral

**ELI5:** instead of 37 files independently describing the same JSON shapes, they now import one canonical description.

```text
Before: module A ─┐
        module B ─┼─> repeated JSON aliases
        module C ─┘

After:  module A ─┐
        module B ─┼─> omnigent/json_types.py
        module C ─┘
```

## Test Plan

- `uv run --no-sync pre-commit run --all-files`
- `uv run --no-sync mypy omnigent` (expected existing baseline: exactly 469 errors in the same 6 files)

## Demo

N/A — type-only refactor with no visual or runtime behavior change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

This only centralizes static type aliases. Full pre-commit passes, and full-tree mypy remains exactly at the pre-change 469-error baseline across the same files.
