### PR TITLE
Honor ucode model defaults for native Databricks harnesses

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -50,6 +50,7 @@ from omnigent.inner.codex_executor import (
     _provider_codex_config_overrides,
 )
 from omnigent.inner.databricks_executor import _databricks_gateway_host
+from omnigent.onboarding.ucode_state import read_ucode_agent_model
 
 _logger = logging.getLogger(__name__)
 
@@ -1465,9 +1466,11 @@ def build_codex_native_server(
                 "with a host visible to the runner process."
             )
         host = host.rstrip("/")
+        default_model = read_ucode_agent_model(host, "codex")
         config_overrides.extend(
             _databricks_codex_config_overrides(
                 model=model
+                or default_model
                 or model_catalog.resolve_catalog_model("databricks", family="openai").model_id,
                 base_url=_databricks_codex_base_url(host),
                 auth_command=_databricks_codex_auth_command(host, profile),

--- a/omnigent/onboarding/ucode_state.py
+++ b/omnigent/onboarding/ucode_state.py
@@ -208,6 +208,24 @@ def read_ucode_state(workspace_url: str) -> UcodeWorkspaceState | None:
     )
 
 
+def read_ucode_agent_model(workspace_url: str | None, agent_name: str) -> str | None:
+    """Return ucode's configured model for one workspace and agent.
+
+    :param workspace_url: Databricks workspace URL, e.g.
+        ``"https://example.databricks.com"``.
+    :param agent_name: ucode agent key, e.g. ``"codex"`` or ``"pi"``.
+    :returns: The configured model id, or ``None`` when the workspace state,
+        agent entry, or model is unavailable.
+    """
+    if not workspace_url:
+        return None
+    state = read_ucode_state(workspace_url)
+    if state is None:
+        return None
+    agent = state.agent(agent_name)
+    return agent.model if agent is not None else None
+
+
 def read_current_ucode_state() -> UcodeWorkspaceState | None:
     """Return the current ucode workspace state, or ``None``.
 

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -44,6 +44,7 @@ from omnigent.onboarding.provider_config import (
     default_provider_for_harness,
     load_config,
 )
+from omnigent.onboarding.ucode_state import read_ucode_agent_model
 from omnigent.pi_model_compatibility import (
     SYSTEM_AI_RESPONSES_KEYWORDS,
     unsupported_in_pi,
@@ -354,7 +355,9 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         provider_id=_PI_PROVIDER_ID,
         base_url=f"{host}{_DATABRICKS_ANTHROPIC_GATEWAY_PATH}",
         api="anthropic-messages",
-        model=model or model_catalog.resolve_catalog_model("databricks", family="claude").model_id,
+        model=model
+        or read_ucode_agent_model(host, "pi")
+        or model_catalog.resolve_catalog_model("databricks", family="claude").model_id,
         # Pi resolves a "!command" apiKey at request time, so the gateway
         # bearer token is refreshed per request (the auth command itself
         # force-refreshes), matching codex-native's refresh semantics.
@@ -749,7 +752,9 @@ def _cli_config_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         provider_id=_PI_PROVIDER_ID,
         base_url=_gateway_anthropic_base_url(transport.base_url),
         api="anthropic-messages",
-        model=model or model_catalog.resolve_catalog_model("databricks", family="claude").model_id,
+        model=model
+        or read_ucode_agent_model(real_workspace_url, "pi")
+        or model_catalog.resolve_catalog_model("databricks", family="claude").model_id,
         # Pi resolves a "!command" apiKey at request time, so the gateway
         # bearer token (the codex auth command prints it) is refreshed per
         # request — matching codex-native's refresh semantics.

--- a/tests/onboarding/test_ucode_state.py
+++ b/tests/onboarding/test_ucode_state.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 from omnigent.onboarding.ucode_state import (
     UcodeWorkspaceState,
     read_current_ucode_state,
+    read_ucode_agent_model,
     read_ucode_state,
 )
 
@@ -151,6 +152,26 @@ def test_read_ucode_state_returns_none_for_unknown_workspace(tmp_path: Path) -> 
 
     with patch("omnigent.onboarding.ucode_state._STATE_PATH", state_file):
         assert read_ucode_state("https://example-other-workspace.cloud.databricks.com") is None
+
+
+def test_read_ucode_agent_model_returns_workspace_agent_model(tmp_path: Path) -> None:
+    """Workspace lookup returns the selected ucode agent model."""
+    state_file = _write_state(tmp_path, _VALID_STATE)
+
+    with patch("omnigent.onboarding.ucode_state._STATE_PATH", state_file):
+        model = read_ucode_agent_model(_WORKSPACE_URL, "codex")
+
+    assert model == "databricks-gpt-5-5"
+
+
+def test_read_ucode_agent_model_returns_none_for_missing_agent(tmp_path: Path) -> None:
+    """Missing per-agent state leaves callers on their fallback path."""
+    state_file = _write_state(tmp_path, _VALID_STATE)
+
+    with patch("omnigent.onboarding.ucode_state._STATE_PATH", state_file):
+        model = read_ucode_agent_model(_WORKSPACE_URL, "qwen")
+
+    assert model is None
 
 
 def test_read_current_ucode_state_uses_current_workspace(tmp_path: Path) -> None:

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -428,6 +428,46 @@ def test_build_codex_native_server_uses_profile_host_without_static_token(
     assert 'databricks auth token --profile \\"oss\\"' in overrides
 
 
+def test_build_codex_native_server_uses_ucode_agent_model(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Native Codex uses the model ucode selected for the profile."""
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server._find_codex_cli",
+        lambda: sys.executable,
+    )
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server._databricks_gateway_host",
+        lambda _profile: "https://example.cloud.databricks.com",
+    )
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.read_ucode_agent_model",
+        lambda profile, agent_name: "system.ai.gpt-5",
+    )
+
+    def _unexpected_catalog(*args: object, **kwargs: object) -> object:
+        raise AssertionError("catalog fallback should not run when ucode defines a model")
+
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.model_catalog.resolve_catalog_model",
+        _unexpected_catalog,
+    )
+
+    app_server = build_codex_native_server(
+        socket_path=tmp_path / "codex.sock",
+        codex_home=tmp_path / "codex-home",
+        cwd=tmp_path,
+        model=None,
+        profile="oss",
+        bridge_dir=tmp_path / "bridge",
+        ap_server_url=None,
+        ap_auth_headers={},
+    )
+
+    assert 'model="system.ai.gpt-5"' in app_server.config_overrides
+
+
 def test_build_codex_native_server_without_bypass_emits_no_bypass_config(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -14,6 +14,7 @@ from omnigent import pi_native_credentials as creds
 
 @pytest.fixture(autouse=True)
 def _stub_catalog_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(creds, "read_ucode_agent_model", lambda profile, agent_name: None)
     monkeypatch.setattr(
         "omnigent.model_catalog.resolve_catalog_model",
         lambda provider_name, *, family, **kwargs: SimpleNamespace(
@@ -56,6 +57,34 @@ def test_resolves_databricks_default_to_anthropic_gateway(monkeypatch: pytest.Mo
     # apiKey is a "!command" so Pi refreshes the gateway token per request.
     assert provider.api_key.startswith("!")
     assert "demo-staging" in provider.api_key
+
+
+def test_databricks_default_uses_ucode_pi_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Native Pi uses the model ucode selected for the Databricks profile."""
+    from omnigent.inner import databricks_executor
+
+    monkeypatch.setattr(
+        databricks_executor,
+        "_read_databrickscfg_host",
+        lambda profile: "https://wkspc.example.com/",
+    )
+
+    def _ucode_model(workspace_url: str | None, agent_name: str) -> str:
+        assert workspace_url == "https://wkspc.example.com"
+        assert agent_name == "pi"
+        return "system.ai.claude-opus-4-8"
+
+    monkeypatch.setattr(creds, "read_ucode_agent_model", _ucode_model)
+    monkeypatch.setattr(
+        creds.model_catalog,
+        "resolve_catalog_model",
+        lambda *args, **kwargs: pytest.fail("catalog fallback should not run"),
+    )
+
+    provider = creds.resolve_pi_native_provider(config_loader=_databricks_config)
+
+    assert provider is not None
+    assert provider.model == "system.ai.claude-opus-4-8"
 
 
 def test_databricks_unresolvable_host_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -415,6 +444,36 @@ def test_cli_config_databricks_resolves_to_anthropic_gateway(
     assert provider.api_key == (
         "!jq -r .access_token /Users/me/.databricks/model-serving-token.json"
     )
+
+
+def test_cli_config_databricks_uses_ucode_pi_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The omni setup cli-config path uses ucode's Pi model selection."""
+    _write_codex_config(tmp_path, _DATABRICKS_CODEX_CONFIG)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(
+        creds,
+        "_databricks_workspace_url_for_gateway",
+        lambda _base_url: "https://wkspc.example.com",
+    )
+
+    def _ucode_model(workspace_url: str | None, agent_name: str) -> str:
+        assert workspace_url == "https://wkspc.example.com"
+        assert agent_name == "pi"
+        return "system.ai.claude-opus-4-8"
+
+    monkeypatch.setattr(creds, "read_ucode_agent_model", _ucode_model)
+    monkeypatch.setattr(
+        creds.model_catalog,
+        "resolve_catalog_model",
+        lambda *args, **kwargs: pytest.fail("catalog fallback should not run"),
+    )
+
+    provider = creds.resolve_pi_native_provider(config_loader=_cli_config_databricks_config)
+
+    assert provider is not None
+    assert provider.model == "system.ai.claude-opus-4-8"
 
 
 def test_cli_config_databricks_respects_model_override(


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Make native Codex and Pi prefer the per-workspace model selected by ucode before falling back to the MLflow model catalog.
- Apply the Pi precedence to both direct Databricks OAuth providers and the Codex `cli-config` route adopted by `omni setup`.
- Keep compatibility with missing or legacy ucode state by retaining the existing catalog fallback.

**ELI5:** Omnigent now asks ucode which model it selected for the workspace instead of immediately choosing a separate bundled default.

```text
explicit session model
        |
        v
ucode agents.<harness>.model
        |
        v
MLflow catalog compatibility fallback
```

## Test Plan

- `.venv/bin/pytest tests/onboarding/test_ucode_state.py tests/test_codex_native_app_server.py tests/test_pi_native_credentials.py tests/runtime/test_pi_spawn_env.py -q` — 108 passed.
- `.venv/bin/pre-commit run --all-files` — passed.
- Manually resolved native Codex with the `ai-specialist` Databricks OAuth profile and confirmed it selected the current ucode value `system.ai.gpt-5`.
- Manually launched Pi 0.80.7 through the exact `omni setup` Databricks `cli-config` route with `ai-specialist`; with the catalog fallback forced to fail, Pi selected `system.ai.claude-opus-4-8`, exited 0, and returned `OK`.

## Demo

N/A — non-visual provider-resolution change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification used the real `ai-specialist` OAuth profile. Codex resolved its model from the current ucode workspace state. Pi was exercised end-to-end through a generated `models.json` and the actual Pi CLI while the catalog resolver was deliberately disabled, proving the selected model came from `agents.pi.model`.

## Changelog

Native Codex and Pi now honor the models selected by ucode for Databricks OAuth providers.
