### PR TITLE
fix(runner): advertise smart routing tools

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2670,6 +2670,7 @@ def create_runner_app(
                 publish_event=_publish_event,
                 server_client=server_client,
                 ensure_comment_relay=_ensure_comment_relay_started,
+                session_init=init_context.envelope,
             )
             _launch_pre: Callable[[bool], Awaitable[PreLaunchResult]] | None = None
             _launch_build: (
@@ -4837,7 +4838,13 @@ def create_runner_app(
             return
         from omnigent.runner.tool_dispatch import build_native_relay_tool_schemas
 
-        relay_schemas: list[dict[str, Any]] = build_native_relay_tool_schemas(relay_spec)
+        startup_envelope = _fresh_session_init_envelope(session_id)
+        relay_schemas: list[dict[str, Any]] = build_native_relay_tool_schemas(
+            relay_spec,
+            smart_routing_available=(
+                startup_envelope.smart_routing_available if startup_envelope is not None else False
+            ),
+        )
 
         _captured_session_id = session_id
 
@@ -5089,6 +5096,7 @@ def create_runner_app(
         if instructions:
             harness_body["instructions"] = instructions
 
+        startup_envelope = _fresh_session_init_envelope(conv)
         if conv not in _session_tool_schemas:
             all_tools: list[dict[str, Any]] = []
             if cached_spec is not None:
@@ -5100,6 +5108,11 @@ def create_runner_app(
                     _tmgr = ToolManager(
                         cached_spec,
                         workdir=cached_spec_workdir or runner_workspace,
+                        smart_routing_available=(
+                            startup_envelope.smart_routing_available
+                            if startup_envelope is not None
+                            else False
+                        ),
                     )
                     all_tools.extend(_tmgr.get_tool_schemas())
                 except (
@@ -5162,7 +5175,6 @@ def create_runner_app(
 
         await _ensure_native_terminal_for_turn(conv, harness_name)
 
-        startup_envelope = _fresh_session_init_envelope(conv)
         startup_labels = startup_envelope.snapshot.labels if startup_envelope is not None else None
 
         if harness_name == "claude-native":

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -1715,6 +1715,7 @@ async def _auto_create_pi_terminal(
     server_client: httpx.AsyncClient | None,
     agent_spec: AgentSpec | ResolvedSpec | None = None,
     ensure_comment_relay: Callable[..., Awaitable[None]] | None = None,
+    smart_routing_available: bool = False,
 ) -> SessionResourceView:
     """
     Auto-create a Pi terminal for a pi-native session.
@@ -1728,6 +1729,8 @@ async def _auto_create_pi_terminal(
         terminal inherits the agent's ``os_env.sandbox`` rather than falling
         back to the platform default. ``None`` only when the session has no
         spec; callers must not pass ``None`` to paper over a resolution error.
+    :param smart_routing_available: Whether the owning server can execute
+        smart-routing tools for this runner session.
     :returns: Created terminal resource view.
     """
     await _cancel_auto_forwarder_task(session_id)
@@ -1777,7 +1780,10 @@ async def _auto_create_pi_terminal(
         from omnigent.runner.tool_dispatch import build_native_relay_tool_schemas
 
         spec_for_tools = _unwrap_resolved_spec(agent_spec)
-        pi_tools = build_native_relay_tool_schemas(spec_for_tools)
+        pi_tools = build_native_relay_tool_schemas(
+            spec_for_tools,
+            smart_routing_available=smart_routing_available,
+        )
     except Exception:  # noqa: BLE001 — tool registration is additive
         _logger.warning(
             "Failed to build pi-native tool schemas for session %s; "
@@ -6441,6 +6447,9 @@ async def _launch_pi(ctx: NativeLaunchContext) -> SessionResourceView:
         server_client=ctx.server_client,
         agent_spec=ctx.agent_spec,
         ensure_comment_relay=ctx.ensure_comment_relay,
+        smart_routing_available=(
+            ctx.session_init.smart_routing_available if ctx.session_init is not None else False
+        ),
     )
 
 

--- a/omnigent/runner/session_init_protocol.py
+++ b/omnigent/runner/session_init_protocol.py
@@ -43,6 +43,7 @@ class RunnerSessionInitEnvelope(BaseModel):  # type: ignore[explicit-any]  # Pyd
     agent_id: str
     sub_agent_name: str | None = None
     snapshot: RunnerSessionInitSnapshot
+    smart_routing_available: bool = False
     # When True the runner must skip crash-recovery turn detection on this
     # create_session call.  Set by the server whenever it calls session-init
     # immediately before forwarding a message — the forward carries the
@@ -56,6 +57,7 @@ def build_runner_session_init_payload(
     *,
     server_version: str,
     suppress_recovery_turn: bool = False,
+    smart_routing_available: bool = False,
 ) -> dict[str, object]:
     """Build the versioned initialization fields appended to the legacy body."""
     if conversation.agent_id is None:
@@ -67,6 +69,7 @@ def build_runner_session_init_payload(
         agent_id=conversation.agent_id,
         sub_agent_name=conversation.sub_agent_name,
         suppress_recovery_turn=suppress_recovery_turn,
+        smart_routing_available=smart_routing_available,
         snapshot=RunnerSessionInitSnapshot(
             created_at=conversation.created_at,
             updated_at=conversation.updated_at,

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -434,7 +434,11 @@ _NATIVE_RELAY_BUILTIN_TOOLS = (
 )
 
 
-def build_native_relay_tool_schemas(spec: AgentSpec | None) -> list[_JsonObject]:
+def build_native_relay_tool_schemas(
+    spec: AgentSpec | None,
+    *,
+    smart_routing_available: bool = False,
+) -> list[_JsonObject]:
     """Build the flat Omnigent tool surface for native harness bridges.
 
     Returns the same tool set the claude-native / codex-native relay advertises
@@ -451,6 +455,8 @@ def build_native_relay_tool_schemas(spec: AgentSpec | None) -> list[_JsonObject]
     :param spec: The session's resolved agent spec. ``None`` falls back to the
         always-on read/discovery surface (never the opt-in spawn writes, whose
         gate can't be evaluated without the spec), mirroring the relay.
+    :param smart_routing_available: Whether the owning server can execute
+        smart-routing tools for this runner session.
     :returns: Flat tool schemas for native bridges.
     """
     from omnigent.tools.builtins.agents import (
@@ -494,7 +500,10 @@ def build_native_relay_tool_schemas(spec: AgentSpec | None) -> list[_JsonObject]
     if spec is not None:
         from omnigent.tools.manager import ToolManager
 
-        for schema in ToolManager(spec).get_tool_schemas():
+        for schema in ToolManager(
+            spec,
+            smart_routing_available=smart_routing_available,
+        ).get_tool_schemas():
             function = _string_object_dict(schema.get("function"))
             if function is not None and function.get("name") in _NATIVE_RELAY_BUILTIN_TOOLS:
                 _append(function)

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -66,6 +66,7 @@ from omnigent.runner.identity import (
     token_bound_runner_id,
 )
 from omnigent.runner.routing import RunnerRouter
+from omnigent.runner.session_init_protocol import build_runner_session_init_payload
 from omnigent.runner.transports.ws_tunnel.registry import TunnelRegistry
 from omnigent.runtime import (
     get_policy_store,
@@ -124,6 +125,7 @@ from omnigent.server.routes._sessions.common import (  # noqa: F401
     set_server_runner_router,
     user_session_stream,
 )
+from omnigent.server.runner_session_init import smart_routing_available
 from omnigent.server.schemas import (
     ChildSessionSummary,
     CompletedEvent,
@@ -184,6 +186,7 @@ from omnigent.stores.conversation_store import (
 )
 from omnigent.stores.host_store import Host, HostStore
 from omnigent.stores.permission_store import PermissionStore
+from omnigent.version import VERSION
 
 
 def _codex_plan_mode_enabled(mode: str) -> bool:
@@ -7791,8 +7794,8 @@ async def _authorize_bundled_parent_and_inherit_runner(
 
 async def _notify_runner_of_bundled_child(
     session_id: str,
-    agent_id: str,
     runner_router: RunnerRouter | None,
+    conversation_store: ConversationStore,
 ) -> None:
     """
     Notify the inherited runner that a bundled child session exists.
@@ -7803,23 +7806,33 @@ async def _notify_runner_of_bundled_child(
     swallowed — the notify is additive and must not fail the create.
 
     :param session_id: The new child session id, e.g. ``"conv_abc123"``.
-    :param agent_id: The child's session-scoped agent id,
-        e.g. ``"ag_abc123"``.
     :param runner_router: Router used to resolve the bound runner's
         client; ``None`` falls back to the in-process runner.
+    :param conversation_store: Store used to load the newly created
+        child for the versioned initialization envelope.
     :returns: None.
     """
     runner_client = await _get_runner_client(session_id, runner_router)
     if runner_client is None:
         return
+    conversation = await asyncio.to_thread(
+        conversation_store.get_conversation,
+        session_id,
+    )
+    if conversation is None:
+        _logger.warning(
+            "Failed to notify runner about missing bundled session %s",
+            session_id,
+        )
+        return
     try:
         await runner_client.post(
             "/v1/sessions",
-            json={
-                "session_id": session_id,
-                "agent_id": agent_id,
-                "sub_agent_name": None,
-            },
+            json=build_runner_session_init_payload(
+                conversation,
+                server_version=VERSION,
+                smart_routing_available=smart_routing_available(),
+            ),
             timeout=10.0,
         )
     except (httpx.HTTPError, ConnectionError):

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -129,7 +129,10 @@ from omnigent.server.routes._sessions.common import (  # noqa: F401
 # Lower-layer helpers (SSE builders, publishers, persistence, runner-forward
 # primitives) live in _sessions.helpers.
 from omnigent.server.routes._sessions.helpers import *
-from omnigent.server.runner_session_init import RunnerSessionInitializer
+from omnigent.server.runner_session_init import (
+    RunnerSessionInitializer,
+    smart_routing_available,
+)
 from omnigent.server.schemas import (
     ChildSessionSummary,
     CreatedSessionResponse,
@@ -2919,6 +2922,7 @@ async def _ensure_runner_session_initialized(
                     conv,
                     server_version=VERSION,
                     suppress_recovery_turn=suppress_recovery_turn,
+                    smart_routing_available=smart_routing_available(),
                 ),
                 timeout=_RUNNER_SESSION_INIT_TIMEOUT_S,
             )

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -530,8 +530,8 @@ def register_core_routes(
         if inherited_runner_id is not None:
             await _notify_runner_of_bundled_child(
                 result.session_id,
-                result.agent_id,
                 runner_router,
+                conversation_store,
             )
         return result
 

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -273,22 +273,13 @@ def register_core_routes(
             _publish_terminal_pending(resp.id, True)
         _rc = await _get_runner_client(resp.id, runner_router)
         if _rc is not None and conv is not None:
-            try:
-                await _rc.post(
-                    "/v1/sessions",
-                    json={
-                        "session_id": resp.id,
-                        "agent_id": conv.agent_id,
-                        "sub_agent_name": conv.sub_agent_name,
-                    },
-                    timeout=10.0,
-                )
-            except (httpx.HTTPError, ConnectionError):
-                _logger.warning(
-                    "Failed to notify runner about session %s",
-                    resp.id,
-                    exc_info=True,
-                )
+            await _ensure_runner_session_initialized(
+                resp.id,
+                conv,
+                _rc,
+                conversation_store,
+                initializer=getattr(request.app.state, "runner_session_initializer", None),
+            )
         # Grant the creator ownership BEFORE any host launch so the
         # launch's session-ownership check (shared with
         # POST /v1/hosts/{host_id}/runners via resolve_host_launch)
@@ -1639,26 +1630,17 @@ def register_core_routes(
                     session_id,
                 )
                 if _runner_client is not None and conv is not None:
-                    try:
-                        runner_init_resp = await _runner_client.post(
-                            "/v1/sessions",
-                            json={
-                                "session_id": session_id,
-                                "agent_id": conv.agent_id,
-                                "sub_agent_name": conv.sub_agent_name,
-                            },
-                            timeout=10.0,
-                        )
-                        if runner_init_resp.status_code < 400:
-                            await _publish_runner_recovered_status(session_id, conversation_store)
-                    except (httpx.HTTPError, ConnectionError):
-                        # ConnectionError covers a tunnel close mid-POST
-                        # (same source as the relay's except clause).
-                        _logger.warning(
-                            "Failed to notify runner about session %s",
-                            session_id,
-                            exc_info=True,
-                        )
+                    await _ensure_runner_session_initialized(
+                        session_id,
+                        conv,
+                        _runner_client,
+                        conversation_store,
+                        initializer=getattr(
+                            request.app.state,
+                            "runner_session_initializer",
+                            None,
+                        ),
+                    )
                 if _runner_client is None:
                     # Runner deregistered between validation and
                     # lookup; PATCH still returns 200 but no

--- a/omnigent/server/runner_session_init.py
+++ b/omnigent/server/runner_session_init.py
@@ -9,9 +9,15 @@ import httpx
 
 from omnigent.entities import Conversation
 from omnigent.runner.session_init_protocol import build_runner_session_init_payload
+from omnigent.runtime import get_caps
 
 if TYPE_CHECKING:
     from omnigent.runner.transports.ws_tunnel.registry import TunnelRegistry
+
+
+def smart_routing_available() -> bool:
+    """Return whether this server has a configured routing client."""
+    return get_caps().routing_client is not None
 
 
 class RunnerSessionInitializer:
@@ -59,6 +65,7 @@ class RunnerSessionInitializer:
                         conversation,
                         server_version=self._server_version,
                         suppress_recovery_turn=suppress_recovery_turn,
+                        smart_routing_available=smart_routing_available(),
                     ),
                     timeout=timeout,
                 ),

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -115,6 +115,7 @@ class ToolManager:
         workdir: Path | None = None,
         sandbox_enabled: bool = True,
         os_env: OSEnvironment | None = None,
+        smart_routing_available: bool = False,
     ) -> None:
         """
         Initialize the tool manager and register built-in,
@@ -141,11 +142,14 @@ class ToolManager:
             tools use this shared instance instead of creating their
             own. ``None`` falls back to per-call creation via
             ``create_os_environment()``.
+        :param smart_routing_available: Whether the owning server can
+            execute smart-routing tools for this runner session.
         """
         self._spec = spec
         self._workdir = workdir
         self._sandbox_enabled = sandbox_enabled
         self._pre_resolved_os_env = os_env
+        self._smart_routing_available = smart_routing_available
         self._started = False
         self._tools: dict[str, Tool] = {}
         self._srt_available = is_srt_available()
@@ -486,10 +490,10 @@ class ToolManager:
         # Model awareness pairs with the dispatch grant: the per-worker
         # listing exists to pick a valid ``args.model`` for send.
         self._tools[SysListModelsTool.name()] = SysListModelsTool(spec=self._spec)
-        # Advise-models is capability-gated: expose it only when the server
-        # has a routing client configured. Hiding the tool prevents agents
-        # from probing router_on via a no-op call when routing is disabled.
-        if get_caps().routing_client is not None:
+        # Advise-models is capability-gated: expose it when routing is available
+        # in-process or was advertised by the owning server. Hiding the tool
+        # prevents agents from probing router_on when routing is disabled.
+        if get_caps().routing_client is not None or self._smart_routing_available:
             self._tools[SysAdviseModelsTool.name()] = SysAdviseModelsTool()
 
         # create: spawning OUTSIDE the declared list (existing agents

--- a/tests/e2e/test_smart_routing_tool_advertisement_e2e.py
+++ b/tests/e2e/test_smart_routing_tool_advertisement_e2e.py
@@ -2,11 +2,12 @@
 
 Starts real server and runner subprocesses, uploads a spawn-capable agent,
 drives one mock-LLM turn, and inspects the tool schemas received by the model.
-The two parameter rows differ only in whether the server has an ``llm:`` block.
+The parameter rows cover routing enabled/disabled and bundled-child creation.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import secrets
 import signal
@@ -33,6 +34,7 @@ from tests._helpers.compat import (
     server_executable,
 )
 from tests.e2e.conftest import (
+    build_agent_bundle,
     configure_mock_llm,
     create_runner_bound_session,
     find_free_port,
@@ -187,14 +189,15 @@ def _advertised_tool_names(request_body: dict[str, object]) -> set[str]:
 
 @pytest.mark.flaky(reruns=2, reruns_delay=5)
 @pytest.mark.parametrize(
-    "smart_routing_available",
-    [True, False],
-    ids=["routing-configured", "routing-disabled"],
+    ("smart_routing_available", "bundled_child"),
+    [(True, False), (False, False), (True, True)],
+    ids=["routing-configured", "routing-disabled", "routing-configured-bundled-child"],
 )
 def test_runner_advertises_advise_models_only_when_server_can_route(
     tmp_path: Path,
     mock_llm_server_url: str,
     smart_routing_available: bool,
+    bundled_child: bool,
 ) -> None:
     """The model sees ``sys_advise_models`` exactly when the server can route."""
     if compat_server_python() is not None or compat_runner_python() is not None:
@@ -232,6 +235,43 @@ def test_runner_advertises_advise_models_only_when_server_can_route(
                 agent_name=agent_name,
                 runner_id=runner_id,
             )
+            if bundled_child:
+                child_agent_dir = tmp_path / "bundled-child-agent"
+                child_agent_dir.mkdir()
+                (child_agent_dir / "config.yaml").write_text(
+                    yaml.safe_dump(
+                        {
+                            "spec_version": 1,
+                            "name": f"bundled-routing-tools-{uuid.uuid4().hex[:8]}",
+                            "prompt": "Reply briefly without calling tools.",
+                            "spawn": True,
+                            "executor": {
+                                "type": "omnigent",
+                                "config": {"harness": "openai-agents"},
+                            },
+                            "llm": {
+                                "model": model,
+                                "connection": {
+                                    "api_key": "mock-key",
+                                    "base_url": f"{mock_llm_server_url}/v1",
+                                },
+                            },
+                        }
+                    )
+                )
+                child_response = client.post(
+                    "/v1/sessions",
+                    data={"metadata": json.dumps({"parent_session_id": session_id})},
+                    files={
+                        "bundle": (
+                            "agent.tar.gz",
+                            build_agent_bundle(child_agent_dir),
+                            "application/gzip",
+                        )
+                    },
+                )
+                assert child_response.status_code == 201, child_response.text
+                session_id = str(child_response.json()["session_id"])
             response_id = send_user_message_to_session(
                 client,
                 session_id=session_id,

--- a/tests/e2e/test_smart_routing_tool_advertisement_e2e.py
+++ b/tests/e2e/test_smart_routing_tool_advertisement_e2e.py
@@ -1,0 +1,252 @@
+"""E2E coverage for smart-routing tool advertisement across runner isolation.
+
+Starts real server and runner subprocesses, uploads a spawn-capable agent,
+drives one mock-LLM turn, and inspects the tool schemas received by the model.
+The two parameter rows differ only in whether the server has an ``llm:`` block.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import signal
+import subprocess
+import time
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import httpx
+import pytest
+import yaml
+
+from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN, token_bound_runner_id
+from tests._helpers.compat import (
+    apply_runner_env,
+    apply_server_env,
+    compat_runner_cwd,
+    compat_runner_python,
+    compat_server_cwd,
+    compat_server_python,
+    runner_executable,
+    server_executable,
+)
+from tests.e2e.conftest import (
+    configure_mock_llm,
+    create_runner_bound_session,
+    find_free_port,
+    get_mock_requests,
+    poll_session_until_terminal,
+    register_inline_agent,
+    reset_mock_llm,
+    send_user_message_to_session,
+)
+from tests.e2e.helpers import HEALTH_TIMEOUT_S, POLL_INTERVAL_S
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@contextmanager
+def _server_runner_pair(
+    tmp_path: Path,
+    *,
+    mock_llm_server_url: str,
+    smart_routing_available: bool,
+) -> Iterator[tuple[str, str]]:
+    """Run a real server and runner with optional server-side routing.
+
+    :param tmp_path: Per-row directory for config, database, artifacts, and logs.
+    :param mock_llm_server_url: Mock LLM base URL without the ``/v1`` suffix.
+    :param smart_routing_available: Whether to give the server an ``llm:`` block.
+    :returns: ``(base_url, runner_id)`` for the live pair.
+    """
+    port = find_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    binding_token = secrets.token_urlsafe(32)
+    runner_id = token_bound_runner_id(binding_token)
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    server_log = tmp_path / "server.log"
+    runner_log = tmp_path / "runner.log"
+
+    env = {
+        **os.environ,
+        "OPENAI_API_KEY": "mock-key",
+        "OPENAI_BASE_URL": f"{mock_llm_server_url}/v1",
+        "OMNIGENT_SKIP_ONBOARD": "1",
+        "OMNIGENT_NO_UPDATE_CHECK": "1",
+    }
+    apply_server_env(env, _REPO_ROOT)
+
+    server_args = [
+        server_executable(),
+        "-m",
+        "omnigent.cli",
+        "server",
+        "--port",
+        str(port),
+        "--database-uri",
+        f"sqlite:///{tmp_path / 'e2e.db'}",
+        "--artifact-location",
+        str(artifact_dir),
+    ]
+    if smart_routing_available:
+        server_config = tmp_path / "server.yaml"
+        server_config.write_text(
+            yaml.safe_dump(
+                {
+                    "llm": {
+                        "model": "_policy_llm_",
+                        "connection": {
+                            "base_url": f"{mock_llm_server_url}/v1",
+                            "api_key": "mock-key",
+                        },
+                    }
+                }
+            )
+        )
+        server_args.extend(["--config", str(server_config)])
+
+    server_log_handle = open(server_log, "w")  # noqa: SIM115
+    server_proc = subprocess.Popen(
+        server_args,
+        env={**env, "OMNIGENT_RUNNER_TUNNEL_TOKEN": binding_token},
+        cwd=compat_server_cwd(),
+        stdout=server_log_handle,
+        stderr=subprocess.STDOUT,
+    )
+
+    runner_env = apply_runner_env(
+        {
+            **env,
+            "OMNIGENT_RUNNER_ID": runner_id,
+            "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
+            "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
+            "RUNNER_SERVER_URL": base_url,
+        }
+    )
+    runner_log_handle = open(runner_log, "w")  # noqa: SIM115
+    runner_proc = subprocess.Popen(
+        [runner_executable(), "-m", "omnigent.runner._entry"],
+        env=runner_env,
+        cwd=compat_runner_cwd(),
+        stdout=runner_log_handle,
+        stderr=subprocess.STDOUT,
+    )
+
+    try:
+        deadline = time.monotonic() + HEALTH_TIMEOUT_S
+        while time.monotonic() < deadline:
+            if server_proc.poll() is not None or runner_proc.poll() is not None:
+                break
+            try:
+                health = httpx.get(f"{base_url}/health", timeout=2)
+                status = httpx.get(f"{base_url}/v1/runners/{runner_id}/status", timeout=2)
+                if (
+                    health.status_code == 200
+                    and status.status_code == 200
+                    and status.json().get("online") is True
+                ):
+                    yield base_url, runner_id
+                    return
+            except httpx.HTTPError:
+                pass
+            time.sleep(POLL_INTERVAL_S)
+
+        server_tail = server_log.read_text()[-3000:] if server_log.exists() else ""
+        runner_tail = runner_log.read_text()[-3000:] if runner_log.exists() else ""
+        pytest.fail(
+            f"server/runner pair did not become ready\n"
+            f"server log:\n{server_tail}\nrunner log:\n{runner_tail}"
+        )
+    finally:
+        for proc in (runner_proc, server_proc):
+            if proc.poll() is None:
+                proc.send_signal(signal.SIGTERM)
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=5)
+        runner_log_handle.close()
+        server_log_handle.close()
+
+
+def _advertised_tool_names(request_body: dict[str, object]) -> set[str]:
+    """Return function names from an OpenAI Responses request's tool schemas."""
+    tools = request_body.get("tools")
+    if not isinstance(tools, list):
+        return set()
+    return {
+        name
+        for tool in tools
+        if isinstance(tool, dict) and isinstance(name := tool.get("name"), str)
+    }
+
+
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
+@pytest.mark.parametrize(
+    "smart_routing_available",
+    [True, False],
+    ids=["routing-configured", "routing-disabled"],
+)
+def test_runner_advertises_advise_models_only_when_server_can_route(
+    tmp_path: Path,
+    mock_llm_server_url: str,
+    smart_routing_available: bool,
+) -> None:
+    """The model sees ``sys_advise_models`` exactly when the server can route."""
+    if compat_server_python() is not None or compat_runner_python() is not None:
+        pytest.skip("smart-routing session-init E2E requires the current server and runner")
+
+    model = f"mock-routing-tools-{uuid.uuid4().hex[:8]}"
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(mock_llm_server_url, [{"text": "done"}], key=model)
+
+    with _server_runner_pair(
+        tmp_path,
+        mock_llm_server_url=mock_llm_server_url,
+        smart_routing_available=smart_routing_available,
+    ) as (base_url, runner_id):
+        with httpx.Client(
+            base_url=base_url,
+            headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+            timeout=30,
+        ) as client:
+            info = client.get("/v1/info")
+            info.raise_for_status()
+            assert info.json()["smart_routing_enabled"] is smart_routing_available
+            agent_name = register_inline_agent(
+                client,
+                name=f"routing-tools-{uuid.uuid4().hex[:8]}",
+                harness="openai-agents",
+                model=model,
+                profile="",
+                prompt="Reply briefly without calling tools.",
+                mock_llm_base_url=f"{mock_llm_server_url}/v1",
+                extra_config={"spawn": True},
+            )
+            session_id = create_runner_bound_session(
+                client,
+                agent_name=agent_name,
+                runner_id=runner_id,
+            )
+            response_id = send_user_message_to_session(
+                client,
+                session_id=session_id,
+                content="Reply with done and do not call any tools.",
+            )
+            body = poll_session_until_terminal(
+                client,
+                session_id=session_id,
+                response_id=response_id,
+                timeout=120,
+            )
+            assert body["status"] == "completed", body
+
+    requests = get_mock_requests(mock_llm_server_url, key=model)
+    assert requests, "runner-hosted turn never reached the mock LLM"
+    tool_names = _advertised_tool_names(requests[-1])
+    assert "sys_list_models" in tool_names
+    assert ("sys_advise_models" in tool_names) is smart_routing_available

--- a/tests/runner/test_app_sessions_native_workflow_init.py
+++ b/tests/runner/test_app_sessions_native_workflow_init.py
@@ -304,7 +304,12 @@ def _launch_ctx(**overrides: Any) -> NativeLaunchContext:
         (
             "pi-native",
             "_auto_create_pi_terminal",
-            {"server_client", "agent_spec", "ensure_comment_relay"},
+            {
+                "server_client",
+                "agent_spec",
+                "ensure_comment_relay",
+                "smart_routing_available",
+            },
         ),
         (
             "cursor-native",

--- a/tests/server/test_runner_session_init.py
+++ b/tests/server/test_runner_session_init.py
@@ -211,3 +211,20 @@ def test_reconnect_init_envelope_carries_fork_history_directives(db_uri: str) ->
     metadata = _claude_launch_metadata_from_envelope(envelope)
     assert metadata.fork_carry_history is True
     assert metadata.fork_source_external_id == "src-claude-sid"
+
+
+@pytest.mark.parametrize("smart_routing_available", [True, False])
+def test_init_envelope_carries_smart_routing_capability(
+    smart_routing_available: bool,
+) -> None:
+    """The server's routing capability survives the session-init boundary."""
+    payload = build_runner_session_init_payload(
+        _conversation(),
+        server_version="0.6.0.dev0",
+        smart_routing_available=smart_routing_available,
+    )
+
+    envelope = parse_runner_session_init_envelope(payload)
+
+    assert envelope is not None
+    assert envelope.smart_routing_available is smart_routing_available

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -546,6 +546,27 @@ def test_advise_models_exposed_when_routing_enabled() -> None:
     assert "sys_advise_models" in names
 
 
+@pytest.mark.parametrize(
+    ("smart_routing_available", "expected"),
+    [(True, True), (False, False)],
+)
+def test_advise_models_follows_runner_propagated_routing_capability(
+    smart_routing_available: bool,
+    expected: bool,
+) -> None:
+    """The runner advertises routing from its server-provided capability flag."""
+    caps = _FakeRoutingCaps(routing_client=None)
+    with patch("omnigent.runtime._globals._caps", new=caps):
+        names = {
+            schema["function"]["name"]
+            for schema in ToolManager(
+                _spawn_spec(),
+                smart_routing_available=smart_routing_available,
+            ).get_tool_schemas()
+        }
+    assert ("sys_advise_models" in names) is expected
+
+
 def test_share_non_public_registers_share_tool_without_public() -> None:
     """
     ``agent_session_sharing: non-public`` alone (no spawn / declared


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Propagate server smart-routing availability through the versioned runner session-init envelope.
- Pass that capability into SDK and native runner tool-schema builders so spawn-capable agents advertise `sys_advise_models` only when the server can execute it.
- Route ordinary create/rebind and bundled-child runner notifications through the same envelope initializer used for reconnects; the E2E test exposed that these paths were still sending the legacy three-field payload.
- Preserve the existing in-process `RuntimeCaps.routing_client` path and leave server-side tool execution unchanged.

ELI5: the server already knew the model advisor was available, but the separate runner process did not. The session handshake now carries one boolean so the runner can show the tool without copying the routing client across processes.

```text
Server RuntimeCaps -> session-init boolean -> runner ToolManager -> sys_advise_models schema
                                              |
                                              +-> execution still proxies to server
```

## Test Plan

- `python -m pytest tests/e2e/test_smart_routing_tool_advertisement_e2e.py -q -rs` — 3 passed. Starts real server and runner subprocesses, drives a mock-LLM turn, and verifies the advertised schemas with and without server smart routing.
- `python -m pytest tests/tools/test_manager.py::test_advise_models_hidden_when_routing_disabled tests/tools/test_manager.py::test_advise_models_exposed_when_routing_enabled tests/tools/test_manager.py::test_advise_models_follows_runner_propagated_routing_capability tests/server/test_runner_session_init.py -q` — 11 passed.
- `python -m pytest tests/server/test_runner_session_init.py tests/runner/test_suppress_recovery_turn.py tests/runner/test_app_sessions_native_terminals_autocreate.py tests/runner/test_app_sessions_native_workflow_init.py -q` — 122 passed.
- Full `tests/tools/test_manager.py` — 45 passed in a hermetic no-host-skills environment. From the repository root, five pre-existing tests fail because checked-in/global host skills add `read_skill_file`; reproduced on `origin/main`.
- `pre-commit run` — all applicable hooks passed.
- `python -m mypy --strict .` — blocked by the existing duplicate `app` module mapping; changed-file mypy also reports the runner modules' pre-existing strict-type backlog.

## Demo

N/A — non-visual runner/server capability wiring.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover both propagated flag values with no in-process routing client and round-trip the flag through the session-init envelope. `tests/e2e/test_smart_routing_tool_advertisement_e2e.py` exercises the real server configuration, WebSocket-bound runner subprocess, ordinary session-init/rebind and bundled-child routes, runner `ToolManager`, and final OpenAI Responses tool schemas; it asserts `sys_advise_models` is present only when routing is configured. No `tests/integration/` test was added because the repository's E2E convention supports deterministic real-process tests with the mock LLM, which covers the actual process boundary without a live gateway.

## Changelog

Runner-hosted orchestrators now expose the smart model advisor when routing is configured on the server.
