### PR TITLE
fix(windows): stabilize local host and SDK harnesses

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -3429,7 +3429,7 @@ def _wait_for_server(port: int, server: LocalServer, timeout: float = 45.0) -> N
                 )
                 if runner_resp.status_code == 200 and runner_resp.json()["online"] is True:
                     return
-        except httpx.ConnectError:
+        except (httpx.ConnectError, httpx.TimeoutException):
             pass
         elapsed = time.monotonic() - start
         poll_interval = (

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -67,7 +67,7 @@ from omnigent.host.local_server import (
 from omnigent.inner import _proc, ui
 from omnigent.integration_daemon import IntegrationDaemon
 from omnigent.onboarding.sandboxes import available_providers as _sandbox_providers
-from omnigent.process_logging import LOG_LEVEL_ENV_VAR, LOG_TO_STDERR_ENV_VAR
+from omnigent.process_logging import LOG_LEVEL_ENV_VAR, LOG_TO_STDERR_ENV_VAR, data_dir
 
 if TYPE_CHECKING:
     import socket
@@ -1955,7 +1955,12 @@ def _runner_loopback_host(host: str) -> str:
     return "127.0.0.1" if host in {"0.0.0.0", "::", ""} else host
 
 
-_HOST_PID_PATH = Path.home() / ".omnigent" / "host.pid"
+_HOST_PID_PATH: Path | None = None
+
+
+def _host_pid_path() -> Path:
+    """Return the daemon pidfile path, honoring ``OMNIGENT_DATA_DIR``."""
+    return _HOST_PID_PATH or data_dir() / "host.pid"
 
 
 # host.pid records the daemon PID + the "target" it serves: a normalized
@@ -2159,7 +2164,7 @@ def _daemon_registry_dir() -> Path:
     :returns: Registry directory path, e.g.
         ``Path("~/.omnigent/daemons")``.
     """
-    return _HOST_PID_PATH.parent / "daemons"
+    return _host_pid_path().parent / "daemons"
 
 
 def _daemon_record_path(target: str) -> Path:
@@ -2265,7 +2270,7 @@ def _delete_daemon_record(record: _HostDaemonRecord) -> None:
     legacy = _read_host_pid_file()
     if legacy is not None and legacy[1] == record.target:
         with contextlib.suppress(OSError):
-            _HOST_PID_PATH.unlink()
+            _host_pid_path().unlink()
 
 
 def _legacy_daemon_record() -> _HostDaemonRecord | None:
@@ -2607,7 +2612,7 @@ def _persist_spawned_daemon(
             config_sig=config_sig,
         )
     )
-    _HOST_PID_PATH.write_text(f"{spawned.pid}\n{target}\n")
+    _host_pid_path().write_text(f"{spawned.pid}\n{target}\n")
 
 
 def _foreground_daemon_record(
@@ -2725,10 +2730,10 @@ def _load_or_create_host_id() -> str | None:
     host_id = _load_existing_host_id()
     if host_id is not None:
         return host_id
-    from omnigent.host.identity import CONFIG_PATH, load_or_create_host_identity
+    from omnigent.host.identity import load_or_create_host_identity
 
     try:
-        return load_or_create_host_identity(CONFIG_PATH).host_id
+        return load_or_create_host_identity().host_id
     except OSError:
         return None
 
@@ -2752,7 +2757,7 @@ def _ensure_host_daemon(server_url: str | None) -> bool:
     if not decision.config_changed and _local_daemon_serves_target(target, server_url):
         return False
 
-    _HOST_PID_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _host_pid_path().parent.mkdir(parents=True, exist_ok=True)
     mode_args = ["--local"] if not server_url else ["--server", server_url]
     args = [sys.executable, "-m", "omnigent.host._daemon_entry", *mode_args]
     spawned = _spawn_host_daemon_process(
@@ -2824,10 +2829,11 @@ def _read_host_pid_file() -> tuple[int, str] | None:
 
     :returns: ``(pid, server_url)`` if well-formed, ``None`` otherwise.
     """
-    if not _HOST_PID_PATH.exists():
+    host_pid_path = _host_pid_path()
+    if not host_pid_path.exists():
         return None
     try:
-        lines = _HOST_PID_PATH.read_text().strip().splitlines()
+        lines = host_pid_path.read_text().strip().splitlines()
         if len(lines) < 2:
             return None
         return int(lines[0]), lines[1]

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -70,7 +70,11 @@ from omnigent.host.git_worktree import (
     list_worktrees,
     remove_worktree,
 )
-from omnigent.host.identity import HostIdentity, load_or_create_host_identity
+from omnigent.host.identity import (
+    HostIdentity,
+    host_identity_config_path,
+    load_or_create_host_identity,
+)
 from omnigent.onboarding.harness_auth import (
     adopt_env_credential,
     detect_adoptable_credentials,
@@ -304,6 +308,15 @@ def _url_is_loopback(url: str) -> bool:
 _RECONNECT_BASE_S = 0.5
 _RECONNECT_CAP_S = 10.0
 _RECONNECT_JITTER = 0.5
+
+
+def _console_safe_text(text: str) -> str:
+    """Return text encodable by the active stdout stream."""
+    encoding = getattr(sys.stdout, "encoding", None)
+    if not encoding:
+        return text
+    return text.encode(encoding, errors="replace").decode(encoding)
+
 
 # Host-environment variables a spawned runner is allowed to inherit.
 # Deliberately an allowlist (not ``{**os.environ}``): the host runs as the
@@ -2452,12 +2465,12 @@ class HostProcess:
         # success line after the noisy ``databricks.sdk`` warnings —
         # otherwise the terminal goes silent after auth and there's no
         # signal the WS handshake actually completed.
-        print(
+        connected_message = (
             f"✓ Connected as {self._identity.name!r} "
             f"({self._identity.host_id}), {len(hello.runners)} live runner(s). "
-            "Listening for sessions — Ctrl-C to disconnect.",
-            flush=True,
+            "Listening for sessions — Ctrl-C to disconnect."
         )
+        print(_console_safe_text(connected_message), flush=True)
 
         loop = asyncio.get_running_loop()
         next_quick_refresh = loop.time() + HARNESS_READINESS_REFRESH_INTERVAL_S
@@ -2622,9 +2635,7 @@ def run_host_process(
 
     telemetry.init("omni-host")
 
-    from omnigent.host.identity import CONFIG_PATH
-
-    path = config_path or CONFIG_PATH
+    path = config_path or host_identity_config_path()
     identity = load_or_create_host_identity(path)
     if not path.exists():
         print(f"Auto-generated {path} ({identity.host_id}, name: {identity.name})")

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1060,9 +1060,12 @@ class HostProcess:
                 # terminal — print once per redirect streak so a foreground
                 # `omnigent host` shows the auth problem and its fix instead
                 # of sitting silent while it retries.
-                print(
+                warning = (
                     f"⚠ {cause} Retrying — this also happens briefly while "
-                    f"the server restarts. {self._credentials_fix_hint()}",
+                    f"the server restarts. {self._credentials_fix_hint()}"
+                )
+                print(
+                    _console_safe_text(warning),
                     file=sys.stderr,
                     flush=True,
                 )
@@ -1236,12 +1239,12 @@ class HostProcess:
         # host's own terminal shows lifecycle lines, but the runner's real
         # output — the agent turn, tracebacks — lands only in this file.
         session_line = f"\n    session: {frame.session_id}" if frame.session_id else ""
-        print(
+        lifecycle_message = (
             f"  ↑ Runner started: {runner_id} (pid={proc.pid})\n"
             f"    log: {_display_log_path(log_path)}"
-            f"{session_line}",
-            flush=True,
+            f"{session_line}"
         )
+        print(_console_safe_text(lifecycle_message), flush=True)
         return HostLaunchRunnerResultFrame(
             request_id=frame.request_id,
             status="launched",
@@ -1274,10 +1277,8 @@ class HostProcess:
                 handle.proc.kill()
                 handle.proc.wait()
         _logger.info("Stopped runner %s", frame.runner_id)
-        print(
-            f"  ↓ Runner stopped: {frame.runner_id}",
-            flush=True,
-        )
+        lifecycle_message = f"  ↓ Runner stopped: {frame.runner_id}"
+        print(_console_safe_text(lifecycle_message), flush=True)
         return HostStopRunnerResultFrame(
             request_id=frame.request_id,
             status="stopped",
@@ -2660,5 +2661,6 @@ def run_host_process(
         # Fail loud: a permanent connection failure must not look like the
         # process is still working. Print the cause + fix, then exit non-zero
         # instead of the old behavior of reconnecting silently forever.
-        print(f"\n✗ Could not connect to {server_url}.\n{exc}", file=sys.stderr, flush=True)
+        failure = f"\n✗ Could not connect to {server_url}.\n{exc}"
+        print(_console_safe_text(failure), file=sys.stderr, flush=True)
         raise SystemExit(1) from exc

--- a/omnigent/host/identity.py
+++ b/omnigent/host/identity.py
@@ -70,8 +70,15 @@ def _normalize_host_id(host_id: str) -> str:
     return host_id
 
 
+def host_identity_config_path() -> Path:
+    """Return the effective config path for the persistent host identity."""
+    from omnigent.config import global_config_path
+
+    return global_config_path(CONFIG_PATH)
+
+
 def load_or_create_host_identity(
-    path: Path = CONFIG_PATH,
+    path: Path | None = None,
 ) -> HostIdentity:
     """Load host identity from config.yaml, or create it if absent.
 
@@ -88,11 +95,12 @@ def load_or_create_host_identity(
     launcher bug and fails loud.
 
     :param path: Path to the config YAML file, e.g.
-        ``Path("~/.omnigent/config.yaml")``. Defaults to
-        :data:`CONFIG_PATH`.
+        ``Path("~/.omnigent/config.yaml")``. ``None`` uses
+        ``OMNIGENT_CONFIG_HOME`` when set, else :data:`CONFIG_PATH`.
     :returns: The loaded or newly created :class:`HostIdentity`.
     :raises ValueError: If exactly one of the identity env vars is set.
     """
+    resolved_path = path or host_identity_config_path()
     env_host_id = os.environ.get(HOST_ID_ENV_VAR)
     env_name = os.environ.get(HOST_NAME_ENV_VAR)
     if (env_host_id is None) != (env_name is None):
@@ -104,8 +112,8 @@ def load_or_create_host_identity(
         return HostIdentity(host_id=_normalize_host_id(env_host_id), name=env_name)
 
     cfg: dict[str, object] = {}
-    if path.exists():
-        with open(path) as f:
+    if resolved_path.exists():
+        with open(resolved_path) as f:
             cfg = yaml.safe_load(f) or {}
 
     host_section = cfg.get("host")
@@ -120,8 +128,8 @@ def load_or_create_host_identity(
     identity = HostIdentity(host_id=host_id, name=name)
 
     cfg["host"] = {"host_id": identity.host_id, "name": identity.name}
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
+    resolved_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(resolved_path, "w") as f:
         yaml.safe_dump(cfg, f, default_flow_style=False, sort_keys=True)
 
     return identity

--- a/omnigent/inner/agent_env.py
+++ b/omnigent/inner/agent_env.py
@@ -47,6 +47,19 @@ BASE_ALLOW_EXACT: frozenset[str] = frozenset(
     {
         "HOME",
         "PATH",
+        # Windows process-runtime essentials. Node-based CLI launchers can
+        # abort during cryptographic RNG initialization when SYSTEMROOT is
+        # stripped, while COMSPEC/PATHEXT are required for .cmd shims.
+        "SYSTEMROOT",
+        "SYSTEMDRIVE",
+        "WINDIR",
+        "COMSPEC",
+        "PATHEXT",
+        # These three are jointly required by the Windows Codex/Node launcher;
+        # with any one omitted it exits cleanly before its JSON-RPC handshake.
+        "USERPROFILE",
+        "APPDATA",
+        "LOCALAPPDATA",
         "TERM",
         "TMPDIR",
         "TMP",

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -43,7 +43,7 @@ from types import ModuleType
 from typing import Any, Protocol, TypeAlias, cast
 
 from omnigent import model_catalog
-from omnigent._platform import resolve_cli_binary, stable_user_id
+from omnigent._platform import IS_WINDOWS, resolve_cli_binary, stable_user_id
 from omnigent.inner import _proc
 from omnigent.inner.bundle_skills import ensure_bundle_plugin_manifest
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
@@ -915,7 +915,23 @@ def _find_system_claude() -> str | None:
     beta flags the Databricks gateway doesn't support. Returns the absolute
     path, or ``None`` if not found.
     """
-    return resolve_cli_binary("claude", env_var=_CLAUDE_PATH_ENV)
+    resolved = resolve_cli_binary("claude", env_var=_CLAUDE_PATH_ENV)
+    if not IS_WINDOWS or resolved is None:
+        return resolved
+
+    # npm exposes Claude on Windows through ``claude.cmd``. The Claude Agent
+    # SDK launches ``cli_path`` with CreateProcess directly, which cannot
+    # execute a batch shim and fails with WinError 193. Current Claude npm
+    # packages place the real native launcher beside that shim under the
+    # package's ``bin`` directory, so prefer it when present.
+    path = pathlib.Path(resolved)
+    if path.suffix.lower() in {".bat", ".cmd", ".ps1"}:
+        native_launcher = (
+            path.parent / "node_modules" / "@anthropic-ai" / "claude-code" / "bin" / "claude.exe"
+        )
+        if native_launcher.is_file():
+            return str(native_launcher)
+    return resolved
 
 
 def _resolve_gateway_env(
@@ -1166,6 +1182,19 @@ def prepare_claude_cli_path(
     if not sandbox.allow_network:
         # The Claude CLI itself must reach the provider, so we cannot run the
         # whole native-tool process tree inside a network-denying sandbox.
+        return PreparedClaudeCli(cli_path=real_cli_path, enable_native_tools=False)
+    if sandbox.backend_type == "windows_jobobject":
+        # ``create_exec_launcher`` is a Python script. POSIX can execute that
+        # shebang launcher directly, but the Claude Agent SDK uses
+        # CreateProcess on Windows and a ``.py`` cli_path fails with WinError
+        # 193. A Job Object also cannot enforce the filesystem/network rules
+        # that make Claude's native tools safe, so keep those tools disabled
+        # and give the SDK the real native Claude executable instead.
+        logger.warning(
+            "Windows Job Objects cannot provide an executable Claude SDK "
+            "sandbox launcher; running the Claude CLI unwrapped with native "
+            "tools disabled (file/shell access stays confined to sys_os_* tools)."
+        )
         return PreparedClaudeCli(cli_path=real_cli_path, enable_native_tools=False)
 
     sandbox = with_additional_read_roots(sandbox, _claude_internal_write_roots())

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Any, Protocol, TypeAlias
 
 from omnigent import model_catalog
-from omnigent._platform import resolve_cli_binary
+from omnigent._platform import IS_WINDOWS, resolve_cli_binary
 from omnigent.inner.agent_env import clean_agent_env, declared_passthrough
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 from omnigent.reasoning_effort import CODEX_EFFORTS, EFFORT_ALIASES, validate_effort
@@ -1260,6 +1260,23 @@ def _dynamic_tool_result_payload(result: CodexToolResult) -> CodexParams:
     }
 
 
+def _default_model_from_codex_list(response: CodexMessage) -> str:
+    """Return Codex's live default model from a ``model/list`` response."""
+    result = response.get("result")
+    data = result.get("data") if isinstance(result, dict) else None
+    if not isinstance(data, list):
+        raise RuntimeError("Codex model/list response did not contain a model list")
+    models = [item for item in data if isinstance(item, dict)]
+    preferred = next((item for item in models if item.get("isDefault") is True), None)
+    if preferred is None and models:
+        preferred = models[0]
+    if preferred is not None:
+        raw_model = preferred.get("model") or preferred.get("id")
+        if isinstance(raw_model, str) and raw_model:
+            return raw_model
+    raise RuntimeError("Codex model/list response did not contain a usable default model")
+
+
 @dataclass
 class _PendingToolResult:
     """Tracks a dynamic tool invocation pending a Codex result event.
@@ -1317,6 +1334,7 @@ class _CodexAppServerSession:
         # a fresh thread so it is re-sent. ``turn/start`` carries no ``effort``
         # field (it is silently dropped), hence the separate settings update.
         self._applied_effort: str | None = None
+        self._resolved_default_model: str | None = None
         self._recent_stderr: list[str] = []
         self._recent_events: list[CodexMessage] = []
         self._process_cwd: Path | None = None
@@ -1333,7 +1351,7 @@ class _CodexAppServerSession:
             return
         self._loop = asyncio.get_running_loop()
         codex_home_root = Path(tempfile.gettempdir())
-        if self._cwd and self._cwd != "/":
+        if not IS_WINDOWS and self._cwd and self._cwd != "/":
             try:
                 codex_home_root = Path(self._cwd) / ".codex-tmp"
                 codex_home_root.mkdir(parents=True, exist_ok=True)
@@ -1419,6 +1437,7 @@ class _CodexAppServerSession:
             self._loop = None
             self.thread_id = None
             self.active_turn_id = None
+            self._resolved_default_model = None
             self._cleanup_process_cwd()
             return
 
@@ -1455,6 +1474,7 @@ class _CodexAppServerSession:
         self._loop = None
         self.thread_id = None
         self.active_turn_id = None
+        self._resolved_default_model = None
         self._recent_events.clear()
         self._cleanup_process_cwd()
 
@@ -1557,13 +1577,20 @@ class _CodexAppServerSession:
         messages: list[Message],
         tools: list[ToolSpec],
         system_prompt: str,
-        model: str,
+        model: str | None,
         cwd: str,
         sandbox: str,
         reasoning_effort: str | None = None,
     ) -> AsyncIterator[ExecutorEvent]:
         await self.start()
         assert self._proc is not None
+
+        if model is None:
+            if self._resolved_default_model is None:
+                self._resolved_default_model = _default_model_from_codex_list(
+                    await self._request("model/list", {"includeHidden": False})
+                )
+            model = self._resolved_default_model
 
         is_new_thread = self.thread_id is None
         if is_new_thread:
@@ -2117,6 +2144,19 @@ class _CodexAppServerSession:
             raise
         except Exception as exc:  # noqa: BLE001 — reader loop logs and exits on any unexpected error  # pragma: no cover - defensive
             logger.debug("Codex App Server reader loop ended: %s", exc)
+        finally:
+            if self._pending_requests:
+                stderr_detail = "; ".join(self._recent_stderr[-3:])
+                returncode = self._proc.returncode
+                detail = f" (exit code {returncode})" if returncode is not None else ""
+                if stderr_detail:
+                    detail += f": {stderr_detail}"
+                error = RuntimeError(f"Codex App Server closed before replying{detail or '.'}")
+                pending = list(self._pending_requests.values())
+                self._pending_requests.clear()
+                for future in pending:
+                    if not future.done():
+                        future.set_exception(error)
 
     async def _stderr_loop(self) -> None:
         assert self._proc is not None and self._proc.stderr is not None
@@ -2138,7 +2178,7 @@ class _CodexAppServerSession:
 @dataclass
 class _CodexSessionState:
     app_session: _CodexAppServerSession | None = None
-    signature: tuple[str, str, str, str] | None = None
+    signature: tuple[str | None, str, str, str] | None = None
 
 
 class _AppSessionFactory(Protocol):
@@ -2486,7 +2526,7 @@ class CodexExecutor(Executor):
         self,
         state: _CodexSessionState,
         *,
-        signature: tuple[str, str, str, str],
+        signature: tuple[str | None, str, str, str],
         effective_cwd: str,
     ) -> _CodexAppServerSession:
         if state.signature == signature and state.app_session is not None:
@@ -2520,7 +2560,7 @@ class CodexExecutor(Executor):
         # cfg.model (per-request /model override) wins over the spec default.
         # An unresolved default comes from the active provider catalog.
         model = cfg.model or self._model_override
-        if model is None:
+        if model is None and self._gateway:
             provider_name = "databricks" if self._gateway_uses_databricks_profile else "openai"
             resolution = await run_sync_on_thread(
                 model_catalog.resolve_catalog_model,

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -969,10 +969,13 @@ def harness_cli_logged_in(key: str) -> bool:
     binary = resolve_cli_binary(spec.binary) if key == GEMINI_FAMILY else shutil.which(spec.binary)
     if binary is None:
         return False
-    argv_binary = binary if key == GEMINI_FAMILY else spec.binary
+    # Spawn the resolved path, never the bare name: on Windows an npm-installed
+    # CLI is a ``.CMD`` shim that ``CreateProcess`` can't launch by name, so the
+    # probe would raise ``FileNotFoundError`` and report a signed-in CLI as
+    # needing auth.
     try:
         result = subprocess.run(
-            [argv_binary, *spec.status_args],
+            [binary, *spec.status_args],
             check=False,
             timeout=30,
             capture_output=True,
@@ -1022,7 +1025,6 @@ def harness_login(key: str) -> bool:
     binary = resolve_cli_binary(spec.binary) if key == GEMINI_FAMILY else shutil.which(spec.binary)
     if binary is None:
         return False
-    argv_binary = binary if key == GEMINI_FAMILY else spec.binary
     if harness_cli_logged_in(key):
         return True
     try:
@@ -1038,7 +1040,7 @@ def harness_login(key: str) -> bool:
                 tty_fd = os.open("/dev/tty", os.O_RDWR)
             except OSError:
                 tty_fd = None
-        argv = [argv_binary, *spec.login_args]
+        argv = [binary, *spec.login_args]
         try:
             if tty_fd is not None:
                 subprocess.run(

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -888,6 +888,11 @@ def _agent_cache_dest(spec_cache_root: Path, agent_id: str, version: str) -> Pat
     return dest
 
 
+def _spec_cache_temp_prefix(runner_id: str) -> str:
+    """Return a compact Windows prefix to preserve room below ``MAX_PATH``."""
+    return "og-rs-" if IS_WINDOWS else f"runner-specs-{runner_id}-"
+
+
 async def _resolve_agent_spec_from_server(
     server_client: httpx.AsyncClient,
     spec_cache_root: Path,
@@ -1063,7 +1068,7 @@ def create_app(
     # references.
     import tempfile
 
-    _spec_cache_root = Path(tempfile.mkdtemp(prefix=f"runner-specs-{_runner_id}-"))
+    _spec_cache_root = Path(tempfile.mkdtemp(prefix=_spec_cache_temp_prefix(_runner_id)))
 
     async def spec_resolver(agent_id: str, session_id: str | None = None) -> ResolvedSpec | None:
         """

--- a/omnigent/server/routes/_session_create_validation.py
+++ b/omnigent/server/routes/_session_create_validation.py
@@ -106,6 +106,7 @@ async def validate_existing_host_workspace(
     """Validate a connected-host workspace against the agent's os_env boundary."""
     from omnigent.server.routes._workspace_validation import (
         WorkspaceValidationError,
+        _is_absolute_host_path,
         validate_workspace,
     )
 
@@ -114,9 +115,9 @@ async def validate_existing_host_workspace(
             "workspace required when host_id is set",
             code=ErrorCode.INVALID_INPUT,
         )
-    if not workspace.startswith("/"):
+    if not _is_absolute_host_path(workspace):
         raise OmnigentError(
-            "workspace must be an absolute path starting with /",
+            "workspace must be an absolute path on the host",
             code=ErrorCode.INVALID_INPUT,
         )
     if agent_cache is None:

--- a/omnigent/server/routes/_workspace_validation.py
+++ b/omnigent/server/routes/_workspace_validation.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import secrets
+from pathlib import PurePosixPath, PureWindowsPath
 from typing import Any
 
 from omnigent.host.frames import HostStatFrame, encode_host_frame
@@ -149,15 +150,26 @@ def _is_relative_cwd(spec_cwd: str | None) -> bool:
     return False
 
 
+def _is_windows_absolute_host_path(path: str) -> bool:
+    """Return whether *path* is absolute under Windows path semantics."""
+    return PureWindowsPath(path).is_absolute()
+
+
+def _is_absolute_host_path(path: str) -> bool:
+    """Return whether *path* is absolute under POSIX or Windows semantics."""
+    return PurePosixPath(path).is_absolute() or _is_windows_absolute_host_path(path)
+
+
 def _is_subpath_of(canonical_workspace: str, canonical_boundary: str) -> bool:
     """
     Return ``True`` when ``canonical_workspace`` equals the
     boundary or is a subdirectory of it.
 
-    Pure string comparison on canonicalized absolute paths — both
-    inputs are realpaths returned by ``host.stat``, so symlinks
-    are already resolved and ``..`` segments are gone. Without the
-    canonicalization step, this comparison would be unsafe.
+    Uses the matching POSIX or Windows pure-path semantics for both
+    canonicalized absolute paths. Both inputs are realpaths returned
+    by ``host.stat``, so symlinks are already resolved and ``..``
+    segments are gone. Without the canonicalization step, this
+    comparison would be unsafe.
 
     :param canonical_workspace: Realpath returned by host.stat for
         the workspace, e.g. ``"/Users/corey/universe/src/foo"``.
@@ -166,16 +178,14 @@ def _is_subpath_of(canonical_workspace: str, canonical_boundary: str) -> bool:
     :returns: ``True`` when the workspace is the boundary or
         nested under it.
     """
-    if canonical_workspace == canonical_boundary:
-        return True
-    # Add a trailing separator so ``/a/foo`` is not treated as a
-    # subpath of ``/a/fo`` (prefix collision). ``/`` is the only
-    # separator the host stat returns since ``canonical_path`` is
-    # always absolute.
-    boundary_with_sep = (
-        canonical_boundary if canonical_boundary.endswith("/") else canonical_boundary + "/"
-    )
-    return canonical_workspace.startswith(boundary_with_sep)
+    workspace_is_windows = _is_windows_absolute_host_path(canonical_workspace)
+    boundary_is_windows = _is_windows_absolute_host_path(canonical_boundary)
+    if workspace_is_windows != boundary_is_windows:
+        return False
+    path_cls = PureWindowsPath if workspace_is_windows else PurePosixPath
+    workspace_path = path_cls(canonical_workspace)
+    boundary_path = path_cls(canonical_boundary)
+    return workspace_path == boundary_path or boundary_path in workspace_path.parents
 
 
 async def validate_workspace(
@@ -199,8 +209,9 @@ async def validate_workspace(
     :param host_id: Target host's stable id, e.g.
         ``"host_a1b2c3d4..."``.
     :param workspace: User-supplied absolute path on the host, e.g.
-        ``"/Users/corey/universe/src/foo"``. Tilde-prefixed and
-        relative paths are rejected upstream by the request schema.
+        ``"/Users/corey/universe/src/foo"`` or
+        ``"C:\\Users\\corey\\universe\\src\\foo"``. Tilde-prefixed
+        and relative paths are rejected upstream by the request schema.
     :param spec_cwd: Value of the bound agent's ``os_env.cwd``
         from its YAML (or ``None`` when the agent has no os_env
         block). Drives boundary computation.
@@ -214,11 +225,11 @@ async def validate_workspace(
         The exception message is suitable for surfacing to the
         API caller verbatim.
     """
-    if not workspace.startswith("/"):
+    if not _is_absolute_host_path(workspace):
         # Belt-and-suspenders. The Pydantic schema layer also
         # rejects this; pin it here so direct callers (tests,
         # other server-internal paths) can't bypass.
-        raise WorkspaceValidationError("workspace must be an absolute path starting with /")
+        raise WorkspaceValidationError("workspace must be an absolute path on the host")
 
     display_host = host_name_for_errors or host_id
 
@@ -293,7 +304,12 @@ async def validate_workspace(
         # Build under the canonical workspace so any symlinks in the
         # picked path are already resolved — without that, a user
         # whose workspace is a symlink could fool the existence check.
-        subdir_path = canonical_workspace.rstrip("/") + "/" + subdir
+        path_cls = (
+            PureWindowsPath
+            if _is_windows_absolute_host_path(canonical_workspace)
+            else PurePosixPath
+        )
+        subdir_path = str(path_cls(canonical_workspace) / subdir)
         subdir_stat = await _ask_host_stat(
             host_registry=host_registry,
             host_conn=host_conn,

--- a/omnigent/stores/artifact_store/local.py
+++ b/omnigent/stores/artifact_store/local.py
@@ -2,9 +2,22 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
 from omnigent.stores.artifact_store import ArtifactStore
+
+
+def _io_path(path: Path) -> Path:
+    """Return a Windows extended-length path for filesystem I/O."""
+    if os.name != "nt":
+        return path
+    raw_path = str(path)
+    if raw_path.startswith("\\\\?\\"):
+        return path
+    if raw_path.startswith("\\\\"):
+        return Path("\\\\?\\UNC\\" + raw_path[2:])
+    return Path("\\\\?\\" + raw_path)
 
 
 class LocalArtifactStore(ArtifactStore):
@@ -80,7 +93,7 @@ class LocalArtifactStore(ArtifactStore):
             e.g. ``"agents/agent_abc123/bundle.tar.gz"``.
         :param data: Raw bytes to write.
         """
-        path = self._resolve(key)
+        path = _io_path(self._resolve(key))
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(data)
 
@@ -93,7 +106,7 @@ class LocalArtifactStore(ArtifactStore):
         :returns: The raw bytes of the file.
         :raises KeyError: If no file exists at the resolved path.
         """
-        path = self._resolve(key)
+        path = _io_path(self._resolve(key))
         if not path.exists():
             raise KeyError(key)
         return path.read_bytes()
@@ -106,7 +119,7 @@ class LocalArtifactStore(ArtifactStore):
         :param key: Forward-slash-separated artifact key,
             e.g. ``"agents/agent_abc123/bundle.tar.gz"``.
         """
-        path = self._resolve(key)
+        path = _io_path(self._resolve(key))
         if path.exists():
             path.unlink()
 
@@ -118,4 +131,4 @@ class LocalArtifactStore(ArtifactStore):
             e.g. ``"agents/agent_abc123/bundle.tar.gz"``.
         :returns: ``True`` if the file exists, ``False`` otherwise.
         """
-        return self._resolve(key).exists()
+        return _io_path(self._resolve(key)).exists()

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -42,6 +42,14 @@ from omnigent.cli import (
 from omnigent.host.local_server import LocalServerStartup
 
 
+def test_host_pid_path_honors_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Daemon registry state follows ``OMNIGENT_DATA_DIR`` by default."""
+    monkeypatch.setattr(cli, "_HOST_PID_PATH", None)
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path))
+
+    assert cli._host_pid_path() == tmp_path / "host.pid"
+
+
 @pytest.fixture(autouse=True)
 def _stable_current_host_id(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep daemon-reuse tests independent of the developer's real config."""

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -253,11 +253,14 @@ def test_wait_for_server_uses_fast_poll_before_backoff(
         sleep_calls.append(seconds)
 
     def _fake_get(url: str, timeout: float) -> _Resp:
-        """Fail twice, then report ready on the third probe."""
-        del url, timeout
+        """Time out once, refuse once, then report ready."""
+        del timeout
         http_calls["count"] += 1
-        if http_calls["count"] < 3:
-            raise __import__("httpx").ConnectError("not ready")
+        request = httpx.Request("GET", url)
+        if http_calls["count"] == 1:
+            raise httpx.ConnectTimeout("not ready", request=request)
+        if http_calls["count"] == 2:
+            raise httpx.ConnectError("not ready", request=request)
         return _Resp(200)
 
     monkeypatch.setattr("omnigent.chat.time.monotonic", _fake_monotonic)

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -19,6 +19,7 @@ from omnigent.host.connect import (
     HostConnectError,
     HostProcess,
     _build_runner_env,
+    _console_safe_text,
     _RunnerHandle,
     run_host_process,
 )
@@ -61,6 +62,15 @@ from omnigent.runner.identity import (
 )
 
 pytestmark = pytest.mark.asyncio
+
+
+async def test_console_safe_text_replaces_unencodable_status_symbol(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Windows code-page stdout must not crash the host after handshake."""
+    monkeypatch.setattr("omnigent.host.connect.sys.stdout", SimpleNamespace(encoding="cp1252"))
+
+    assert _console_safe_text("✓ Connected") == "? Connected"
 
 
 async def test_handle_model_options_uses_host_claude_configuration(

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -70,7 +70,9 @@ async def test_console_safe_text_replaces_unencodable_status_symbol(
     """A Windows code-page stdout must not crash the host after handshake."""
     monkeypatch.setattr("omnigent.host.connect.sys.stdout", SimpleNamespace(encoding="cp1252"))
 
-    assert _console_safe_text("✓ Connected") == "? Connected"
+    assert _console_safe_text("✓ Connected ↑ started ↓ stopped") == (
+        "? Connected ? started ? stopped"
+    )
 
 
 async def test_handle_model_options_uses_host_claude_configuration(

--- a/tests/host/test_identity.py
+++ b/tests/host/test_identity.py
@@ -33,6 +33,17 @@ def test_create_identity_when_no_config(tmp_path: Path) -> None:
     assert identity.name == socket.gethostname()
 
 
+def test_default_identity_path_honors_config_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The implicit identity path must respect ``OMNIGENT_CONFIG_HOME``."""
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+
+    load_or_create_host_identity()
+
+    assert (tmp_path / "config.yaml").exists()
+
+
 def test_load_existing_identity(tmp_path: Path) -> None:
     """
     Verify that load_or_create reads the host section from an

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -2975,6 +2975,41 @@ def test_prepare_claude_cli_path_bypasses_wrapper_when_env_set(
     ]
 
 
+def test_prepare_claude_cli_path_uses_native_executable_for_windows_jobobject(
+    monkeypatch,
+) -> None:
+    """CreateProcess cannot execute the Python sandbox launcher on Windows."""
+    from omnigent.inner.claude_sdk_executor import prepare_claude_cli_path
+    from omnigent.inner.datamodel import OSEnvSpec
+    from omnigent.inner.sandbox import SandboxPolicy
+
+    monkeypatch.setattr(
+        "omnigent.inner.claude_sdk_executor.resolve_sandbox",
+        lambda *args, **kwargs: SandboxPolicy(
+            backend_type="windows_jobobject",
+            active=True,
+            read_roots=[],
+            write_roots=[],
+            write_files=[],
+            allow_network=True,
+        ),
+    )
+    monkeypatch.setattr(
+        "omnigent.inner.claude_sdk_executor.create_exec_launcher",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("Windows Job Objects must not create a .py cli_path")
+        ),
+    )
+
+    prepared = prepare_claude_cli_path(
+        r"C:\claude\claude.exe",
+        OSEnvSpec(type="caller_process", cwd=r"C:\workspace"),
+    )
+
+    assert prepared.cli_path == r"C:\claude\claude.exe"
+    assert prepared.enable_native_tools is False
+
+
 def test_prepare_tight_cli_process_path_bypasses_wrapper_when_env_set(monkeypatch) -> None:
     """``prepare_tight_cli_process_path`` must also honor the bypass env."""
     from omnigent.inner.claude_sdk_executor import prepare_tight_cli_process_path
@@ -4443,6 +4478,22 @@ def test_find_system_claude_delegates_to_shared_resolver(monkeypatch) -> None:
     monkeypatch.setattr(cse, "resolve_cli_binary", fake_resolve)
     assert cse._find_system_claude() == "/opt/homebrew/bin/claude"
     assert captured == {"name": "claude", "env_var": "OMNIGENT_CLAUDE_PATH"}
+
+
+def test_find_system_claude_uses_native_npm_launcher_on_windows(monkeypatch, tmp_path) -> None:
+    """The SDK cannot execute npm's ``.cmd`` shim via CreateProcess."""
+    from omnigent.inner import claude_sdk_executor as cse
+
+    shim = tmp_path / "claude.cmd"
+    shim.write_text("@echo off", encoding="utf-8")
+    launcher = tmp_path / "node_modules" / "@anthropic-ai" / "claude-code" / "bin" / "claude.exe"
+    launcher.parent.mkdir(parents=True)
+    launcher.write_bytes(b"MZ")
+
+    monkeypatch.setattr(cse, "IS_WINDOWS", True)
+    monkeypatch.setattr(cse, "resolve_cli_binary", lambda *args, **kwargs: str(shim))
+
+    assert cse._find_system_claude() == str(launcher)
 
 
 def test_claude_sdk_does_not_claim_live_message_queue() -> None:

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -20,6 +20,7 @@ from omnigent.inner.codex_executor import (
     _codex_cli_version,
     _CodexAppServerSession,
     _databricks_codex_config_overrides,
+    _default_model_from_codex_list,
     _dynamic_tool_result_payload,
     _goal_objective_from_content,
     _prompt_for_turn,
@@ -413,7 +414,7 @@ class TestCodexExecutor(unittest.TestCase):
             self.assertIsInstance(events[2], ToolCallComplete)
             self.assertIsInstance(events[3], TurnComplete)
             self.assertEqual(fake_session.calls[0]["system_prompt"], "Be helpful.")
-            self.assertEqual(fake_session.calls[0]["model"], "catalog-openai-openai-default")
+            self.assertIsNone(fake_session.calls[0]["model"])
             self.assertEqual(fake_session.calls[0]["tools"][0]["name"], "calculate")
 
         _run(_t())
@@ -1790,6 +1791,89 @@ class TestCodexExecutor(unittest.TestCase):
 # two codex app-server failure paths. Kept outside the unittest class
 # above to comply with the project-wide function-based test rule —
 # the class-style tests above pre-date that rule.
+
+
+async def test_reader_eof_fails_pending_request_immediately() -> None:
+    """A dead app-server must not strand initialize until the turn watchdog."""
+    session = _CodexAppServerSession(
+        codex_path="/bin/echo",
+        cwd="/tmp/workspace",
+        env={},
+        tool_executor=None,
+    )
+    proc = _FakeProcess()
+    proc.returncode = 134
+    session._proc = proc
+    future = asyncio.get_running_loop().create_future()
+    session._pending_requests[1] = future
+    session._recent_stderr.append("Node CSPRNG initialization failed")
+
+    await session._reader_loop()
+
+    with pytest.raises(RuntimeError, match=r"exit code 134.*CSPRNG"):
+        await future
+
+
+def test_default_model_uses_codex_live_catalog_default() -> None:
+    """Subscription turns must use Codex's account-compatible default id."""
+    response = {
+        "result": {
+            "data": [
+                {"id": "gpt-5.6-sol", "model": "gpt-5.6-sol", "isDefault": True},
+                {"id": "gpt-5.4", "model": "gpt-5.4", "isDefault": False},
+            ]
+        }
+    }
+
+    assert _default_model_from_codex_list(response) == "gpt-5.6-sol"
+
+
+async def test_windows_private_codex_home_stays_outside_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Windows executor infrastructure must not write into a read-only workspace."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    temp_root = tmp_path / "temp"
+    temp_root.mkdir()
+    captured_env: dict[str, str] = {}
+    fake_proc = _FakeProcess()
+
+    async def _fake_create_subprocess_exec(*args: object, **kwargs: object) -> _FakeProcess:
+        captured_env.update(kwargs["env"])  # type: ignore[arg-type]
+        return fake_proc
+
+    monkeypatch.setattr("omnigent.inner.codex_executor.IS_WINDOWS", True)
+    monkeypatch.setattr(
+        "omnigent.inner.codex_executor.tempfile.gettempdir", lambda: str(temp_root)
+    )
+    monkeypatch.setattr(
+        "omnigent.inner.codex_executor._create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+    monkeypatch.setattr(
+        "omnigent.inner.codex_executor.populate_codex_skills_from_bundle",
+        lambda *args: None,
+    )
+    monkeypatch.setattr(
+        "omnigent.inner.codex_executor._populate_codex_home_config",
+        lambda *args: None,
+    )
+    session = _CodexAppServerSession(
+        codex_path="codex",
+        cwd=str(workspace),
+        env={},
+        tool_executor=None,
+    )
+    session._request = AsyncMock(return_value={"result": {}})
+
+    await session.start()
+    try:
+        codex_home = Path(captured_env["CODEX_HOME"])
+        assert codex_home.parent == temp_root
+        assert not (workspace / ".codex-tmp").exists()
+    finally:
+        await session.close()
 
 
 async def test_run_turn_turn_failed_emits_retryable_executor_error() -> None:

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -491,8 +491,8 @@ def test_try_install_prepends_resolved_dir_so_login_can_find_binary(
     """After install, the resolving dir is on ``PATH`` for the later login step.
 
     The install verdict resolves via the full ladder, but the setup wizard's
-    subsequent ``harness_login`` / ``harness_cli_logged_in`` shell out with the
-    bare binary name and only bare ``shutil.which`` (i.e. ``PATH``). If install
+    subsequent ``harness_login`` / ``harness_cli_logged_in`` locate the binary
+    with bare ``shutil.which`` (i.e. ``PATH``) alone. If install
     succeeds via a fallback dir (nvm/homebrew/…) without putting that dir on
     ``PATH``, login would fail to find the binary just installed. Assert the
     install prepends the resolving dir so a bare ``PATH`` lookup then succeeds —
@@ -639,8 +639,8 @@ def test_harness_login_skips_when_already_logged_in(monkeypatch: pytest.MonkeyPa
 @pytest.mark.parametrize(
     "key,expected_argv",
     [
-        (ANTHROPIC_FAMILY, ["claude", "auth", "login", "--claudeai"]),
-        (OPENAI_FAMILY, ["codex", "login"]),
+        (ANTHROPIC_FAMILY, ["/usr/bin/claude", "auth", "login", "--claudeai"]),
+        (OPENAI_FAMILY, ["/usr/bin/codex", "login"]),
         (GEMINI_FAMILY, ["/usr/bin/agy"]),
     ],
 )
@@ -865,13 +865,33 @@ def test_harness_cli_logged_in_uses_claude_json_verdict(
     monkeypatch.setattr(hi.shutil, "which", lambda name: f"/usr/bin/{name}")
 
     def _run(argv: list[str], **k: object):
-        assert argv == ["claude", "auth", "status"]  # the status subcommand
+        assert argv == ["/usr/bin/claude", "auth", "status"]  # the status subcommand
         return subprocess.CompletedProcess(
             args=argv, returncode=returncode, stdout=stdout, stderr=""
         )
 
     monkeypatch.setattr(hi.subprocess, "run", _run)
     assert hi.harness_cli_logged_in(ANTHROPIC_FAMILY) is expected
+
+
+def test_harness_cli_logged_in_spawns_resolved_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The status probe spawns the resolved path, not the bare binary name.
+
+    On Windows an npm-installed CLI resolves to a ``.CMD`` shim, which
+    ``CreateProcess`` cannot launch by name — spawning ``"claude"`` raises
+    ``FileNotFoundError`` and a signed-in user is reported as needing auth.
+    """
+    shim = r"C:\Users\u\AppData\Roaming\npm\claude.CMD"
+    monkeypatch.setattr(hi.shutil, "which", lambda name: shim)
+
+    def _run(argv: list[str], **k: object):
+        assert argv[0] == shim
+        return subprocess.CompletedProcess(
+            args=argv, returncode=0, stdout='{"loggedIn": true}', stderr=""
+        )
+
+    monkeypatch.setattr(hi.subprocess, "run", _run)
+    assert hi.harness_cli_logged_in(ANTHROPIC_FAMILY) is True
 
 
 @pytest.mark.parametrize(
@@ -892,7 +912,7 @@ def test_harness_cli_logged_in_codex_uses_exit_code(
     monkeypatch.setattr(hi.shutil, "which", lambda name: f"/usr/bin/{name}")
 
     def _run(argv: list[str], **k: object):
-        assert argv == ["codex", "login", "status"]  # the status subcommand
+        assert argv == ["/usr/bin/codex", "login", "status"]  # the status subcommand
         return subprocess.CompletedProcess(
             args=argv, returncode=returncode, stdout=stdout, stderr=""
         )
@@ -923,7 +943,7 @@ def test_harness_cli_logged_in_uses_cursor_json_verdict(
     monkeypatch.setattr(hi.shutil, "which", lambda name: f"/usr/bin/{name}")
 
     def _run(argv: list[str], **k: object):
-        assert argv == ["cursor-agent", "status", "--format", "json"]
+        assert argv == ["/usr/bin/cursor-agent", "status", "--format", "json"]
         return subprocess.CompletedProcess(
             args=argv, returncode=returncode, stdout=stdout, stderr=""
         )

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -36,6 +36,7 @@ from omnigent.runner._entry import (
     _runner_workspace_from_env,
     _RunnerDatabricksAuth,
     _server_url_from_env,
+    _spec_cache_temp_prefix,
     main,
 )
 from omnigent.runner.identity import (
@@ -50,6 +51,13 @@ from omnigent.runner.transports.ws_tunnel.serve import RUNNER_TUNNEL_REJECTION_P
 # here (via import_module, so there is no bound-but-unused import) resolves and
 # caches it with the real type.
 importlib.import_module("mcp.client.streamable_http")
+
+
+def test_spec_cache_temp_prefix_is_compact_on_windows(monkeypatch) -> None:
+    """Verify Windows runner extraction leaves room below ``MAX_PATH``."""
+    monkeypatch.setattr("omnigent.runner._entry.IS_WINDOWS", True)
+
+    assert _spec_cache_temp_prefix("runner_token_" + "a" * 32) == "og-rs-"
 
 
 class _TrackingTerminalRegistry:

--- a/tests/server/routes/test_workspace_validation.py
+++ b/tests/server/routes/test_workspace_validation.py
@@ -268,6 +268,23 @@ async def test_relative_cwd_skips_boundary_check(
     assert canonical == "/tmp/scratch"
 
 
+async def test_windows_workspace_with_relative_cwd_accepted(
+    host_setup: tuple[HostRegistry, _FakeWebSocket, asyncio.Task[None]],
+) -> None:
+    """Verify a Windows absolute workspace reaches host validation."""
+    registry, _, _ = host_setup
+    workspace = "C:\\projects\\active\\fixture"
+    _set_stat(registry, workspace, canonical=workspace)
+
+    canonical = await validate_workspace(
+        host_registry=registry,
+        host_id=_HOST_ID,
+        workspace=workspace,
+        spec_cwd=".",
+    )
+    assert canonical == workspace
+
+
 # ── Steps 2/3/5: boundary check ─────────────────────────
 
 

--- a/tests/server/routes/test_workspace_validation_helpers.py
+++ b/tests/server/routes/test_workspace_validation_helpers.py
@@ -7,9 +7,29 @@ connection, so we test only the synchronous helpers here.
 from __future__ import annotations
 
 from omnigent.server.routes._workspace_validation import (
+    _is_absolute_host_path,
     _is_relative_cwd,
     _is_subpath_of,
 )
+
+
+class TestIsAbsoluteHostPath:
+    """Tests for cross-platform absolute host path detection."""
+
+    def test_posix_absolute(self) -> None:
+        assert _is_absolute_host_path("/Users/alice/project") is True
+
+    def test_windows_drive_absolute(self) -> None:
+        assert _is_absolute_host_path(r"C:\Users\alice\project") is True
+
+    def test_windows_unc_absolute(self) -> None:
+        assert _is_absolute_host_path(r"\\server\share\project") is True
+
+    def test_windows_drive_relative(self) -> None:
+        assert _is_absolute_host_path(r"C:project") is False
+
+    def test_relative(self) -> None:
+        assert _is_absolute_host_path("project/src") is False
 
 
 class TestIsRelativeCwd:
@@ -58,3 +78,15 @@ class TestIsSubpathOf:
 
     def test_trailing_slash_boundary(self) -> None:
         assert _is_subpath_of("/a/b/c", "/a/b/") is True
+
+    def test_windows_child_path(self) -> None:
+        assert _is_subpath_of(r"C:\a\b\c", r"C:\a\b") is True
+
+    def test_windows_paths_are_case_insensitive(self) -> None:
+        assert _is_subpath_of(r"c:\A\B\c", r"C:\a\b") is True
+
+    def test_windows_prefix_collision(self) -> None:
+        assert _is_subpath_of(r"C:\a\foo", r"C:\a\fo") is False
+
+    def test_windows_different_drive(self) -> None:
+        assert _is_subpath_of(r"D:\a\b", r"C:\a") is False

--- a/tests/stores/test_artifact_store.py
+++ b/tests/stores/test_artifact_store.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from omnigent.stores.artifact_store.local import LocalArtifactStore
@@ -18,6 +20,20 @@ def store(tmp_path):
 def test_put_and_get(store):
     store.put("abc123", b"hello world")
     assert store.get("abc123") == b"hello world"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows long-path regression")
+def test_windows_extended_length_artifact_round_trip(store):
+    """Verify artifact I/O works when the resolved path exceeds MAX_PATH."""
+    key = f"{'a' * 100}/{'b' * 100}/{'c' * 100}"
+    assert len(str(store._resolve(key))) > 260
+
+    store.put(key, b"long-path-data")
+
+    assert store.exists(key)
+    assert store.get(key) == b"long-path-data"
+    store.delete(key)
+    assert not store.exists(key)
 
 
 def test_put_overwrites(store):

--- a/tests/test_agent_spawn_env_canary.py
+++ b/tests/test_agent_spawn_env_canary.py
@@ -181,6 +181,24 @@ def test_real_builders_pass_node_extra_ca_certs(monkeypatch):
         assert env.get("NODE_EXTRA_CA_CERTS") == "/etc/corp-ca.pem", harness
 
 
+def test_real_builders_keep_windows_process_runtime(monkeypatch):
+    """Windows Node launchers need these non-secret process variables."""
+    windows_runtime = {
+        "SYSTEMROOT": r"C:\Windows",
+        "SYSTEMDRIVE": "C:",
+        "WINDIR": r"C:\Windows",
+        "COMSPEC": r"C:\Windows\System32\cmd.exe",
+        "PATHEXT": ".COM;.EXE;.BAT;.CMD",
+        "USERPROFILE": r"C:\Users\test",
+        "APPDATA": r"C:\Users\test\AppData\Roaming",
+        "LOCALAPPDATA": r"C:\Users\test\AppData\Local",
+    }
+    monkeypatch.setattr("os.environ", windows_runtime)
+    for harness, build in sorted(SPAWN_ENV_BUILDERS.items()):
+        env = build()
+        assert all(env.get(name) == value for name, value in windows_runtime.items()), harness
+
+
 @pytest.mark.parametrize("harness", sorted(HARNESS_PREFIXES))
 def test_no_harness_inherits_unrelated_secrets(harness, hostile_env):
     env = clean_agent_env(allow_prefixes=HARNESS_PREFIXES[harness], source=hostile_env)


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Make Omnigent's local server, host, runner, workspace validation, artifact storage, and Codex harness honor Windows-safe config/data/temp paths.
- Keep the host tunnel alive on legacy Windows console encodings by sanitizing lifecycle symbols.
- Launch Claude Agent SDK through the packaged native `claude.exe` and avoid an unexecutable Python launcher under Windows Job Objects; native Claude tools remain disabled when the sandbox cannot enforce them.

ELI5: Windows uses different process-launch and path rules than Unix. These changes keep Omnigent's state out of agent workspaces, use executables Windows can actually launch, and prevent a console glyph from disconnecting the host.

```mermaid
flowchart LR
  UI[Omnigent UI] --> Host[Windows host]
  Host --> Runner[Runner with isolated state]
  Runner --> Codex[Codex SDK]
  Runner --> Claude[Native claude.exe]
```

## Test Plan

- `.venv\Scripts\python.exe -m pytest <12 Windows regression node IDs> -q` — 12 passed.
- `.venv\Scripts\ruff.exe check` on the four follow-up source/test files — passed.
- `.venv\Scripts\ruff.exe format --check` on those files — passed after formatting.
- Manual verification: authenticated public UI launched SDK-backed Codex and Claude fixture sessions on Windows; both returned the expected facts and continuity marker, and the host stayed connected.
- `pre-commit run --all-files` was attempted, but this checkout's hooks invoke Unix-only `.venv/bin/python` and WSL `/bin/bash`, neither of which exists on this Windows host. The hook also attempted repository-wide line-ending rewrites; those unrelated edits were discarded before this branch was committed.

## Demo

N/A — non-visual Windows runtime fixes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The added unit tests cover Windows data/config roots, workspace and artifact paths, process runtime selection, console encoding, Codex state isolation, and Claude executable selection. Manual verification exercised real Codex and Claude sessions through the Windows host.

## Changelog

Windows hosts can run Codex and Claude SDK sessions without path, console-encoding, or launcher failures.