### PR TITLE
fix(windows): probe harness CLI login via its resolved path

### DIFF
--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -969,10 +969,13 @@ def harness_cli_logged_in(key: str) -> bool:
     binary = resolve_cli_binary(spec.binary) if key == GEMINI_FAMILY else shutil.which(spec.binary)
     if binary is None:
         return False
-    argv_binary = binary if key == GEMINI_FAMILY else spec.binary
+    # Spawn the resolved path, never the bare name: on Windows an npm-installed
+    # CLI is a ``.CMD`` shim that ``CreateProcess`` can't launch by name, so the
+    # probe would raise ``FileNotFoundError`` and report a signed-in CLI as
+    # needing auth.
     try:
         result = subprocess.run(
-            [argv_binary, *spec.status_args],
+            [binary, *spec.status_args],
             check=False,
             timeout=30,
             capture_output=True,
@@ -1022,7 +1025,6 @@ def harness_login(key: str) -> bool:
     binary = resolve_cli_binary(spec.binary) if key == GEMINI_FAMILY else shutil.which(spec.binary)
     if binary is None:
         return False
-    argv_binary = binary if key == GEMINI_FAMILY else spec.binary
     if harness_cli_logged_in(key):
         return True
     try:
@@ -1038,7 +1040,7 @@ def harness_login(key: str) -> bool:
                 tty_fd = os.open("/dev/tty", os.O_RDWR)
             except OSError:
                 tty_fd = None
-        argv = [argv_binary, *spec.login_args]
+        argv = [binary, *spec.login_args]
         try:
             if tty_fd is not None:
                 subprocess.run(

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -491,8 +491,8 @@ def test_try_install_prepends_resolved_dir_so_login_can_find_binary(
     """After install, the resolving dir is on ``PATH`` for the later login step.
 
     The install verdict resolves via the full ladder, but the setup wizard's
-    subsequent ``harness_login`` / ``harness_cli_logged_in`` shell out with the
-    bare binary name and only bare ``shutil.which`` (i.e. ``PATH``). If install
+    subsequent ``harness_login`` / ``harness_cli_logged_in`` locate the binary
+    with bare ``shutil.which`` (i.e. ``PATH``) alone. If install
     succeeds via a fallback dir (nvm/homebrew/…) without putting that dir on
     ``PATH``, login would fail to find the binary just installed. Assert the
     install prepends the resolving dir so a bare ``PATH`` lookup then succeeds —
@@ -639,8 +639,8 @@ def test_harness_login_skips_when_already_logged_in(monkeypatch: pytest.MonkeyPa
 @pytest.mark.parametrize(
     "key,expected_argv",
     [
-        (ANTHROPIC_FAMILY, ["claude", "auth", "login", "--claudeai"]),
-        (OPENAI_FAMILY, ["codex", "login"]),
+        (ANTHROPIC_FAMILY, ["/usr/bin/claude", "auth", "login", "--claudeai"]),
+        (OPENAI_FAMILY, ["/usr/bin/codex", "login"]),
         (GEMINI_FAMILY, ["/usr/bin/agy"]),
     ],
 )
@@ -865,13 +865,33 @@ def test_harness_cli_logged_in_uses_claude_json_verdict(
     monkeypatch.setattr(hi.shutil, "which", lambda name: f"/usr/bin/{name}")
 
     def _run(argv: list[str], **k: object):
-        assert argv == ["claude", "auth", "status"]  # the status subcommand
+        assert argv == ["/usr/bin/claude", "auth", "status"]  # the status subcommand
         return subprocess.CompletedProcess(
             args=argv, returncode=returncode, stdout=stdout, stderr=""
         )
 
     monkeypatch.setattr(hi.subprocess, "run", _run)
     assert hi.harness_cli_logged_in(ANTHROPIC_FAMILY) is expected
+
+
+def test_harness_cli_logged_in_spawns_resolved_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The status probe spawns the resolved path, not the bare binary name.
+
+    On Windows an npm-installed CLI resolves to a ``.CMD`` shim, which
+    ``CreateProcess`` cannot launch by name — spawning ``"claude"`` raises
+    ``FileNotFoundError`` and a signed-in user is reported as needing auth.
+    """
+    shim = r"C:\Users\u\AppData\Roaming\npm\claude.CMD"
+    monkeypatch.setattr(hi.shutil, "which", lambda name: shim)
+
+    def _run(argv: list[str], **k: object):
+        assert argv[0] == shim
+        return subprocess.CompletedProcess(
+            args=argv, returncode=0, stdout='{"loggedIn": true}', stderr=""
+        )
+
+    monkeypatch.setattr(hi.subprocess, "run", _run)
+    assert hi.harness_cli_logged_in(ANTHROPIC_FAMILY) is True
 
 
 @pytest.mark.parametrize(
@@ -892,7 +912,7 @@ def test_harness_cli_logged_in_codex_uses_exit_code(
     monkeypatch.setattr(hi.shutil, "which", lambda name: f"/usr/bin/{name}")
 
     def _run(argv: list[str], **k: object):
-        assert argv == ["codex", "login", "status"]  # the status subcommand
+        assert argv == ["/usr/bin/codex", "login", "status"]  # the status subcommand
         return subprocess.CompletedProcess(
             args=argv, returncode=returncode, stdout=stdout, stderr=""
         )
@@ -923,7 +943,7 @@ def test_harness_cli_logged_in_uses_cursor_json_verdict(
     monkeypatch.setattr(hi.shutil, "which", lambda name: f"/usr/bin/{name}")
 
     def _run(argv: list[str], **k: object):
-        assert argv == ["cursor-agent", "status", "--format", "json"]
+        assert argv == ["/usr/bin/cursor-agent", "status", "--format", "json"]
         return subprocess.CompletedProcess(
             args=argv, returncode=returncode, stdout=stdout, stderr=""
         )


### PR DESCRIPTION
## Related issue

N/A

## Summary

On Windows, a signed-in Claude Code (or Codex, or Cursor) is reported as
`needs-auth`, so the web UI shows "Claude Code isn't configured on `<host>`" and
points the user at `omni setup` — which can't help, because nothing is actually
missing.

`harness_cli_logged_in` resolves the CLI with `shutil.which(...)` but then
spawns the **bare binary name**:

```py
binary = ... shutil.which(spec.binary)      # C:\...\npm\claude.CMD
argv_binary = binary if key == GEMINI_FAMILY else spec.binary   # "claude"
subprocess.run([argv_binary, *spec.status_args])                # boom
```

An npm-installed CLI on Windows is a `.CMD` shim. `CreateProcess` won't launch
a `.CMD` by name, so `subprocess.run(["claude", ...])` raises `FileNotFoundError`,
the `except OSError` arm swallows it, and the probe returns `False`. Spawning the
already-resolved absolute path works on every platform.

ELI5: we looked up the CLI's address, then threw the address away and shouted its
name down the hallway. On Windows nobody answers to the name.

```
                        shutil.which("claude")
                                 |
                    C:\...\npm\claude.CMD   <-- resolved, then discarded
                                 |
   before:  subprocess.run(["claude", ...])       -> FileNotFoundError -> needs-auth
   after:   subprocess.run([<resolved path>, ...]) -> {"loggedIn": true} -> ready
```

Both `harness_cli_logged_in` and `harness_login` now spawn the resolved path.
The Gemini/`agy` branch already did this — this generalizes it to the rest, and
`argv_binary` disappears since it's now always just `binary`.

Affects every `shutil.which`-resolved family on Windows: `anthropic` (Claude),
`openai` (Codex), and `cursor`.

## Test Plan

- `pytest tests/onboarding/test_harness_install.py tests/onboarding/test_harness_readiness.py`
  → 156 passed, 2 failed. Both failures (`test_try_install_prepends_resolved_dir_so_login_can_find_binary`,
  `test_install_harness_cli_refreshes_user_local_bin`) fail identically on
  `origin/main` on Windows — they build POSIX `#!/bin/sh` fixtures and assert on
  `shutil.which`, which needs `PATHEXT` extensions on Windows. Pre-existing and
  out of scope here.
- `ruff check` / `ruff format --check` clean on both files.
- Manual, on Windows 11 with Claude Code installed via npm and signed in to a
  Claude subscription:

  ```
  # before
  >>> harness_cli_logged_in("anthropic")
  False
  >>> configured_harness_map()["claude-native"]
  'needs-auth'

  # after
  >>> harness_cli_logged_in("anthropic")
  True
  >>> configured_harness_map()["claude-native"]
  True
  ```

  and `GET /v1/hosts` on the running server flipped that host's
  `configured_harnesses["claude-native"]` from `"needs-auth"` to `true`,
  clearing the New Chat warning.

## Demo

N/A — non-visual change. (The user-visible effect is the *absence* of the
"isn't configured" warning in the New Chat dialog.)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added `test_harness_cli_logged_in_spawns_resolved_path`, which pins a `.CMD`
shim path through `shutil.which` and asserts `argv[0]` is that path — the exact
shape that failed on Windows.

The three existing argv assertions (Claude / Codex / Cursor) and the
`harness_login` parametrization encoded the bare name; they now expect the
resolved path. One docstring that justified the post-install `PATH` prepend by
"shell out with the bare binary name" was reworded — the prepend is still needed,
since `shutil.which` is still how the binary gets resolved at all.

Manual verification is listed because the failure only reproduces on Windows,
where CI doesn't run the onboarding suite.

## Changelog

Claude Code, Codex, and Cursor no longer show as "not configured" on Windows
hosts when they are installed and signed in.
