### PR TITLE
fix(cli): sync preregistered agent descriptions

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1267,18 +1267,28 @@ def _preregister_agent(  # type: ignore[explicit-any]  # agent_store / artifact_
     # prior task — which makes the next ``--continue``
     # filter by ``agent_id`` return zero conversations and
     # exit ``"No prior conversation for agent ..."``. Update
-    # the bundle in place and only refresh
-    # ``bundle_location`` when the content hash actually
-    # changed so the row stays stable across no-op restarts.
+    # the bundle in place and refresh separately stored metadata
+    # whenever it drifts. A metadata-only refresh matters for rows
+    # written by versions that updated the bundle pointer but left
+    # ``description`` stale.
     bundle_hash = hashlib.sha256(bundle_bytes).hexdigest()
     existing = agent_store.get_by_name(spec.name)
     if existing is not None:
-        new_loc = f"{existing.id}/{bundle_hash}"
-        # Sha-segment compare: legacy rows keep an ``ag_``-prefixed left
-        # segment (physical artifact key); only the sha encodes content.
-        if existing.bundle_location.rsplit("/", 1)[-1] != bundle_hash:
+        location_prefix, current_hash = existing.bundle_location.rsplit("/", 1)
+        new_loc = f"{location_prefix}/{bundle_hash}"
+        # Legacy rows may keep an ``ag_``-prefixed physical artifact key.
+        # Preserve that prefix and compare only the content-addressed suffix.
+        bundle_changed = current_hash != bundle_hash
+        description_changed = existing.description != spec.description
+        if bundle_changed:
             artifact_store.put(new_loc, bundle_bytes)
-            agent_store.update(existing.id, bundle_location=new_loc)
+        if bundle_changed or description_changed:
+            agent_store.update(
+                existing.id,
+                bundle_location=(new_loc if bundle_changed else existing.bundle_location),
+                description=spec.description,
+            )
+        if bundle_changed:
             # Swap the cache's extracted bundle in lockstep. Without
             # this, ``AgentCache.load`` will hit Tier 2 (disk —
             # ``cache_dir/<agent_id>/``) on the next request and

--- a/omnigent/stores/agent_store/__init__.py
+++ b/omnigent/stores/agent_store/__init__.py
@@ -8,6 +8,13 @@ from abc import ABC, abstractmethod
 from omnigent.entities import Agent, PagedList
 
 
+class _UnsetDescription:
+    """Sentinel for bundle-only updates that preserve agent metadata."""
+
+
+_UNSET_DESCRIPTION = _UnsetDescription()
+
+
 class AgentStore(ABC):
     """
     Abstract base for agent persistence.
@@ -120,16 +127,20 @@ class AgentStore(ABC):
         self,
         agent_id: str,
         bundle_location: str,
+        *,
+        description: str | None | _UnsetDescription = _UNSET_DESCRIPTION,
     ) -> Agent | None:
         """
-        Update an agent's bundle location, bump its version, and
-        set ``updated_at``. Returns the updated agent, or ``None``
-        if no agent with the given ID exists.
+        Update an agent's bundle location and optional description,
+        bump its version, and set ``updated_at``. Returns the updated
+        agent, or ``None`` if no agent with the given ID exists.
 
         :param agent_id: Unique agent identifier,
             e.g. ``"agent_abc123"``.
         :param bundle_location: New artifact store key for the
             bundle, e.g. ``"ag_abc123/a1b2c3d4e5f6..."``.
+        :param description: Replacement description. Omit to preserve
+            the existing description; pass ``None`` to clear it.
         :returns: The updated :class:`Agent`, or ``None`` if not
             found.
         """

--- a/omnigent/stores/agent_store/sqlalchemy_store.py
+++ b/omnigent/stores/agent_store/sqlalchemy_store.py
@@ -21,7 +21,11 @@ from omnigent.db.utils import (
     now_epoch,
 )
 from omnigent.entities import Agent, PagedList
-from omnigent.stores.agent_store import AgentStore
+from omnigent.stores.agent_store import (
+    _UNSET_DESCRIPTION,
+    AgentStore,
+    _UnsetDescription,
+)
 
 
 class SqlAlchemyAgentStore(AgentStore):
@@ -260,15 +264,19 @@ class SqlAlchemyAgentStore(AgentStore):
         self,
         agent_id: str,
         bundle_location: str,
+        *,
+        description: str | None | _UnsetDescription = _UNSET_DESCRIPTION,
     ) -> Agent | None:
         """
-        Update an agent's bundle location, bump version, and set
-        ``updated_at``.
+        Update an agent's bundle location and optional description,
+        bump version, and set ``updated_at``.
 
         :param agent_id: Unique agent identifier,
             e.g. ``"agent_abc123"``.
         :param bundle_location: New artifact store key for the
             bundle, e.g. ``"ag_abc123/a1b2c3d4e5f6..."``.
+        :param description: Replacement description. Omit to preserve
+            the existing description; pass ``None`` to clear it.
         :returns: The updated :class:`Agent`, or ``None`` if not
             found.
         """
@@ -277,6 +285,8 @@ class SqlAlchemyAgentStore(AgentStore):
             if not row:
                 return None
             row.bundle_location = bundle_location
+            if not isinstance(description, _UnsetDescription):
+                row.description = description
             row.version = row.version + 1
             row.updated_at = now_epoch()
         # Reverse lookup targets the AP DB — see _session_id_for_agent.

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2723,13 +2723,31 @@ class _RecordingAgentStore:
     ``AttributeError`` instead of silently returning a MagicMock.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, existing: SimpleNamespace | None = None) -> None:
+        self.existing = existing
         self.created: list[dict[str, Any]] = []
+        self.updated: list[dict[str, Any]] = []
 
-    def get_by_name(self, name: str) -> None:
-        """:returns: Always ``None`` — fresh store, no collisions."""
+    def get_by_name(self, name: str) -> SimpleNamespace | None:
+        """:returns: The configured existing agent, if any."""
         del name
-        return
+        return self.existing
+
+    def update(
+        self,
+        agent_id: str,
+        bundle_location: str,
+        *,
+        description: str | None,
+    ) -> None:
+        """Record an in-place refresh for assertions."""
+        self.updated.append(
+            {
+                "agent_id": agent_id,
+                "bundle_location": bundle_location,
+                "description": description,
+            },
+        )
 
     def delete(self, agent_id: str) -> None:
         """Stubbed — replace-path not exercised by these tests."""
@@ -2933,6 +2951,170 @@ def test_preregister_agent_stored_tarball_rehydrates(tmp_path: Path) -> None:
     with tempfile.TemporaryDirectory() as extracted_dir:
         spec = load(stored_bytes, dest=Path(extracted_dir))
     assert spec.name == "supervisor-probe"
+
+
+def test_preregister_agent_repairs_stale_description_without_replacing_bundle(
+    tmp_path: Path,
+) -> None:
+    """A current bundle still reconciles separately stored agent metadata."""
+    agent_dir = tmp_path / "metadata-agent"
+    agent_dir.mkdir()
+    _write_config(
+        agent_dir,
+        {
+            "spec_version": 1,
+            "name": "metadata-agent",
+            "description": "Current route description.",
+            "executor": {"config": {"harness": "openai-agents"}},
+        },
+    )
+
+    first_store = _RecordingAgentStore()
+    first_artifacts = _RecordingArtifactStore()
+    _preregister_agent(agent_dir, first_store, first_artifacts, _RecordingAgentCache())
+    created = first_store.created[0]
+
+    existing = SimpleNamespace(
+        id=created["agent_id"],
+        bundle_location=f"ag_{created['bundle_location']}",
+        description="Retired route description.",
+    )
+    refresh_store = _RecordingAgentStore(existing)
+    refresh_artifacts = _RecordingArtifactStore()
+    refresh_cache = _RecordingAgentCache()
+
+    _preregister_agent(agent_dir, refresh_store, refresh_artifacts, refresh_cache)
+
+    assert refresh_store.updated == [
+        {
+            "agent_id": created["agent_id"],
+            "bundle_location": existing.bundle_location,
+            "description": "Current route description.",
+        },
+    ]
+    assert refresh_artifacts.puts == []
+    assert refresh_cache.replaces == []
+
+
+def test_preregister_agent_clears_stale_description_when_spec_omits_it(
+    tmp_path: Path,
+) -> None:
+    """The registered spec is authoritative when it has no description."""
+    agent_dir = tmp_path / "undescribed-agent"
+    agent_dir.mkdir()
+    _write_config(
+        agent_dir,
+        {
+            "spec_version": 1,
+            "name": "undescribed-agent",
+            "executor": {"config": {"harness": "openai-agents"}},
+        },
+    )
+    first_store = _RecordingAgentStore()
+    _preregister_agent(
+        agent_dir,
+        first_store,
+        _RecordingArtifactStore(),
+        _RecordingAgentCache(),
+    )
+    created = first_store.created[0]
+    existing = SimpleNamespace(
+        id=created["agent_id"],
+        bundle_location=created["bundle_location"],
+        description="Description absent from the authoritative spec.",
+    )
+    refresh_store = _RecordingAgentStore(existing)
+
+    _preregister_agent(
+        agent_dir,
+        refresh_store,
+        _RecordingArtifactStore(),
+        _RecordingAgentCache(),
+    )
+
+    assert refresh_store.updated[0]["description"] is None
+
+
+def test_preregister_agent_no_drift_is_a_noop(tmp_path: Path) -> None:
+    """Current bundle and metadata do not bump the agent version."""
+    agent_dir = tmp_path / "current-agent"
+    agent_dir.mkdir()
+    _write_config(
+        agent_dir,
+        {
+            "spec_version": 1,
+            "name": "current-agent",
+            "description": "Already current.",
+            "executor": {"config": {"harness": "openai-agents"}},
+        },
+    )
+    first_store = _RecordingAgentStore()
+    _preregister_agent(
+        agent_dir,
+        first_store,
+        _RecordingArtifactStore(),
+        _RecordingAgentCache(),
+    )
+    created = first_store.created[0]
+    existing = SimpleNamespace(
+        id=created["agent_id"],
+        bundle_location=created["bundle_location"],
+        description="Already current.",
+    )
+    refresh_store = _RecordingAgentStore(existing)
+    refresh_artifacts = _RecordingArtifactStore()
+    refresh_cache = _RecordingAgentCache()
+
+    _preregister_agent(agent_dir, refresh_store, refresh_artifacts, refresh_cache)
+
+    assert refresh_store.updated == []
+    assert refresh_artifacts.puts == []
+    assert refresh_cache.replaces == []
+
+
+def test_preregister_agent_refreshes_description_with_changed_bundle(
+    tmp_path: Path,
+) -> None:
+    """A bundle replacement and its list-facing description stay atomic."""
+    agent_dir = tmp_path / "replace-agent"
+    agent_dir.mkdir()
+    config = {
+        "spec_version": 1,
+        "name": "replace-agent",
+        "description": "Old route description.",
+        "executor": {"config": {"harness": "openai-agents"}},
+    }
+    _write_config(agent_dir, config)
+
+    first_store = _RecordingAgentStore()
+    _preregister_agent(
+        agent_dir,
+        first_store,
+        _RecordingArtifactStore(),
+        _RecordingAgentCache(),
+    )
+    created = first_store.created[0]
+    config["description"] = "New route description."
+    _write_config(agent_dir, config)
+
+    existing = SimpleNamespace(
+        id=created["agent_id"],
+        bundle_location=f"ag_{created['bundle_location']}",
+        description="Old route description.",
+    )
+    refresh_store = _RecordingAgentStore(existing)
+    refresh_artifacts = _RecordingArtifactStore()
+    refresh_cache = _RecordingAgentCache()
+
+    _preregister_agent(agent_dir, refresh_store, refresh_artifacts, refresh_cache)
+
+    assert refresh_store.updated[0]["description"] == "New route description."
+    assert refresh_store.updated[0]["bundle_location"] != created["bundle_location"]
+    assert refresh_store.updated[0]["bundle_location"].startswith(
+        f"ag_{created['agent_id']}/",
+    )
+    assert refresh_artifacts.puts[0][0] == refresh_store.updated[0]["bundle_location"]
+    assert refresh_cache.replaces[0][1] == refresh_store.updated[0]["bundle_location"]
 
 
 # ── no-AGENT harness launch ───────────────────────────

--- a/tests/stores/test_agent_store.py
+++ b/tests/stores/test_agent_store.py
@@ -213,11 +213,12 @@ def test_list_asc_with_after_cursor(agent_store: SqlAlchemyAgentStore) -> None:
 
 
 def test_update_agent(agent_store: SqlAlchemyAgentStore) -> None:
-    """update() changes bundle_location, bumps version, sets updated_at."""
+    """update() changes bundle state while preserving omitted metadata."""
     agent = agent_store.create(
         agent_id="409a6849f6efefc6ba8da809a29b9b0b",
         name="updatable",
         bundle_location="ag_test_upd/hash1",
+        description="Keep this description.",
     )
     # version=1 and updated_at=None on creation
     assert agent.version == 1
@@ -230,6 +231,33 @@ def test_update_agent(agent_store: SqlAlchemyAgentStore) -> None:
     assert updated.updated_at is not None
     # Name stays the same
     assert updated.name == "updatable"
+    assert updated.description == "Keep this description."
+
+
+def test_update_agent_description(agent_store: SqlAlchemyAgentStore) -> None:
+    """update() can replace or explicitly clear list-facing metadata."""
+    agent_store.create(
+        agent_id="f1d61fe1fc6f4b85bea07984f2cc3f9a",
+        name="described",
+        bundle_location="described/hash1",
+        description="Old description.",
+    )
+
+    replaced = agent_store.update(
+        "f1d61fe1fc6f4b85bea07984f2cc3f9a",
+        "described/hash2",
+        description="New description.",
+    )
+    assert replaced is not None
+    assert replaced.description == "New description."
+
+    cleared = agent_store.update(
+        "f1d61fe1fc6f4b85bea07984f2cc3f9a",
+        "described/hash3",
+        description=None,
+    )
+    assert cleared is not None
+    assert cleared.description is None
 
 
 def test_update_nonexistent_agent(agent_store: SqlAlchemyAgentStore) -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Keep an existing registered agent's list-facing description synchronized with its authoritative bundle spec.
- Repair metadata drift even when the bundle hash is already current, without touching artifacts or caches.
- Preserve legacy artifact-key prefixes and the existing bundle-only `AgentStore.update()` contract.

ELI5: refreshing an agent previously replaced the agent itself but left its label card behind. This updates the card at the same time, including repairing cards left stale by older versions.

```text
bundle spec ──hash changed?── yes ──> artifact + row + cache
     │
     └─description changed?── yes ──> row metadata only
```

## Test Plan

- `OMNIGENT_DATA_DIR=/private/tmp/omnigent-description-sync-test-20260802 uv run --extra dev pytest tests/cli/test_cli.py tests/stores/test_agent_store.py -q` (277 passed)
- `OMNIGENT_DATA_DIR=/private/tmp/omnigent-description-sync-test-20260802 uv run --extra dev mypy omnigent/cli.py omnigent/stores/agent_store`
- `OMNIGENT_DATA_DIR=/private/tmp/omnigent-description-sync-test-20260802 uv run --extra dev pre-commit run --files omnigent/cli.py omnigent/stores/agent_store/__init__.py omnigent/stores/agent_store/sqlalchemy_store.py tests/cli/test_cli.py tests/stores/test_agent_store.py`

## Demo

N/A — non-visual registration metadata fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New regressions cover metadata-only repair, authoritative clearing, no-drift no-op behavior, changed-bundle refresh, legacy key preservation, and store-level replace/clear semantics.

## Changelog

Agent descriptions now stay current when registered bundles are refreshed.
