### PR TITLE
fix(spec): read SKILL.md as UTF-8 and reject misplaced executor auth

### DIFF
--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -639,6 +639,17 @@ def _parse_executor(
     # numbers round-trip as their string form (the omnigent
     # harness/profile fields are both strings in the source YAML).
     raw_config = raw.get("config")
+    if isinstance(raw_config, dict) and "auth" in raw_config and "auth" not in raw:
+        # ``harness`` and ``model`` live under ``config``, so ``auth`` looks
+        # like it belongs there too. It doesn't — it is read from the executor
+        # block itself, and ``config`` values are string-coerced below, so a
+        # misplaced credential would be silently discarded and the launch would
+        # fail much later complaining about a missing default credential.
+        raise OmnigentError(
+            "executor.config.auth is not read: move the auth block up to "
+            "executor.auth (a sibling of executor.config)",
+            code=ErrorCode.INVALID_INPUT,
+        )
     config: dict[str, object] = {}
     if isinstance(raw_config, dict):
         config = {
@@ -2372,10 +2383,14 @@ def _parse_skill(skill_md: Path) -> SkillSpec:
         ``strict=False``) can catch them uniformly.
     """
     try:
-        text = skill_md.read_text()
+        # Read as UTF-8 explicitly. Without it Python uses the platform's
+        # locale encoding, which on Windows is a legacy code page — every
+        # SKILL.md carrying a curly quote or an em dash is then skipped as
+        # unreadable on Windows while loading fine elsewhere.
+        text = skill_md.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
-        # UnicodeDecodeError (a non-UTF-8 SKILL.md) is a ValueError, not an
-        # OSError — funnel it through OmnigentError too so the lenient
+        # UnicodeDecodeError (a genuinely non-UTF-8 SKILL.md) is a ValueError,
+        # not an OSError — funnel it through OmnigentError too so the lenient
         # scanner in _discover_skills and the per-skill guards in the menu
         # providers catch it and skip the file instead of 500-ing the menu.
         raise OmnigentError(

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -629,6 +629,28 @@ def test_parse_skill_non_utf8_raises_omnigent_error(agent_dir: Path) -> None:
         parse(agent_dir)
 
 
+def test_parse_skill_utf8_regardless_of_locale_encoding(agent_dir: Path) -> None:
+    """A UTF-8 SKILL.md loads even when the platform locale encoding is not UTF-8.
+
+    ``read_text()`` without an explicit encoding uses the locale encoding, which
+    on Windows is a legacy code page. Every SKILL.md containing a curly quote or
+    an em dash was then skipped as unreadable there while loading fine on Linux
+    and macOS.
+    """
+    skill_dir = agent_dir / "skills" / "smart-quotes"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: smart-quotes\ndescription: Uses “curly” quotes — and a dash.\n---\nbody",
+        encoding="utf-8",
+    )
+
+    spec = parse(agent_dir)
+
+    skill = next(s for s in spec.skills if s.name == "smart-quotes")
+    assert "“curly”" in skill.description
+    assert "—" in skill.description
+
+
 # Reproduces the exact ``argument-hint:`` line from the upstream
 # Claude Code skill at
 # https://github.com/databricks-field-eng/vibe/blob/main/plugins/fe-databricks-tools/skills/databricks-data-generation/SKILL.md
@@ -3271,6 +3293,50 @@ def test_parse_executor_auth_provider(tmp_path: Path) -> None:
     assert isinstance(spec.executor.auth, ProviderAuth)
     assert spec.executor.auth.name == "litellm"
     assert spec.executor.auth.type == "provider"
+
+
+def test_parse_executor_auth_under_config_raises(tmp_path: Path) -> None:
+    """``auth`` nested under ``executor.config`` fails loud, not silently.
+
+    ``harness`` and ``model`` live under ``config``, so authors reasonably put
+    ``auth`` there too. Config values are string-coerced, so the credential was
+    discarded without a word and the launch failed much later asking for a
+    default credential — pointing at the wrong problem entirely.
+    """
+    config = {
+        "spec_version": 1,
+        "executor": {
+            "type": "omnigent",
+            "config": {
+                "harness": "openai-agents",
+                "auth": {"type": "provider", "name": "cerebras"},
+            },
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    with pytest.raises(OmnigentError, match=r"move the auth block up to executor\.auth"):
+        parse(tmp_path)
+
+
+def test_parse_executor_auth_at_executor_level_wins_over_config(tmp_path: Path) -> None:
+    """A correctly-placed ``executor.auth`` parses even when ``config`` also has one.
+
+    The guard must not fire when the author already supplied the real thing —
+    otherwise a spec that works today starts failing.
+    """
+    config = {
+        "spec_version": 1,
+        "executor": {
+            "type": "omnigent",
+            "config": {"harness": "openai-agents", "auth": "ignored"},
+            "auth": {"type": "provider", "name": "cerebras"},
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    spec = parse(tmp_path)
+
+    assert isinstance(spec.executor.auth, ProviderAuth)
+    assert spec.executor.auth.name == "cerebras"
 
 
 def test_parse_executor_auth_provider_missing_name_raises(tmp_path: Path) -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

Two independent spec-parser defects, both found while bringing an Omnigent host
up on Windows 11. Happy to split into two PRs if you'd prefer them separate —
they share a file but nothing else.

### 1. `SKILL.md` is read with the platform locale encoding

`_parse_skill` called `skill_md.read_text()` with no `encoding`, so Python used
the locale encoding. On Windows that is a legacy code page (cp1252 here), and
**any** `SKILL.md` containing a curly quote or an em dash raised
`UnicodeDecodeError` and was skipped.

Observed live — 12 skills silently dropped from one user's library on launch,
including every skill in one plugin:

```
Warning: skipped 12 skill(s) with frontmatter errors:
  - ...\skills\azure-prepare\SKILL.md: SKILL.md could not be read:
    'charmap' codec can't decode byte 0x9d in position 2551
  - ...\skills\microsoft-foundry\SKILL.md: ... 0x8f in position 24875
  ...
```

Those files are valid UTF-8; the reader was wrong, not the files. The existing
comment called this "a non-UTF-8 SKILL.md", which is what made it look like
user error. Reading as UTF-8 explicitly fixes it on every platform, and the
`UnicodeDecodeError` arm still catches genuinely mis-encoded files.

ELI5: we opened a UTF-8 file with a decoder for a different alphabet. Anything
plain-ASCII survived, so the bug only showed up on the nicely-typeset skills.

### 2. `executor.config.auth` is silently discarded

`harness` and `model` live under `executor.config`, so `auth` looks like it
belongs there too. It doesn't — `_parse_executor_auth` reads the executor block
itself, and `config` values are string-coerced, so the credential became the
string `"{'type': 'provider', 'name': 'cerebras'}"` and vanished.

```
executor:
  type: omnigent
  config:
    harness: openai-agents
    auth: {type: provider, name: cerebras}   # silently ignored
```

The launch then failed with a message about a completely different subject:

```
Error: The 'databricks-sdk' package is required for Databricks authentication
but is not installed, and no OPENAI_API_KEY or OPENAI_BASE_URL environment
variables are set.
```

Nothing in that points at the misplaced key. It now fails at parse time and
names the fix. The guard only fires when there is no `executor.auth` to use, so
specs that already work are untouched.

```
before:  config.auth → string-coerced → dropped → misleading Databricks error
after:   config.auth → OmnigentError("move the auth block up to executor.auth")
```

## Test Plan

- `pytest tests/spec/test_parser.py` → 222 passed, 5 failed. The 5
  (`test_discover_host_skills_skips_*`) fail identically on `origin/main` on
  Windows — they read the real `~/.claude/skills` because the HOME patch does
  not redirect skill discovery there. Pre-existing and out of scope.
- `ruff check` / `ruff format --check` clean on both files.
- Manual, same Windows host: after the encoding fix, a real `omnigent run`
  went from **12** `SKILL.md could not be read` warnings to **0**, and the
  previously-dropped skills load.

## Demo

N/A — non-visual. The user-visible effect of (1) is the absence of the skipped-
skill warning block; of (2), a parse-time error naming the real problem.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Three tests added:

- `test_parse_skill_utf8_regardless_of_locale_encoding` — a SKILL.md with curly
  quotes and an em dash parses and keeps those characters.
- `test_parse_executor_auth_under_config_raises` — the misplacement fails loud.
- `test_parse_executor_auth_at_executor_level_wins_over_config` — the guard does
  not fire when a real `executor.auth` is present, so working specs keep working.

Manual verification is listed because the encoding failure only reproduces on a
non-UTF-8 locale, which CI does not run.

## Changelog

Skills whose `SKILL.md` contains non-ASCII text now load on Windows, and a
credential block placed under `executor.config` fails with a message naming the
fix instead of a misleading Databricks error.
