### PR TITLE
Add cognee knowledge-graph memory with tiered cross-agent access

### DIFF
--- a/designs/cognee-memory-integration.md
+++ b/designs/cognee-memory-integration.md
@@ -35,11 +35,25 @@ Decisions taken after the plan was drafted:
   `shared` | `peers`) and a `dataset` argument targeting one granted
   dataset; requests outside the grants return an error listing what is
   granted. Enforcement lives in the framework module, not the tools.
+- **Agent-registry mirroring (cognee ≥1.5):** on first memory use per
+  session, `ensure_agent_registered` (runtime/memory.py) mirrors the
+  resolved `MemoryGrants` into cognee's agent registry
+  (`cognee.modules.agents`) — connection named by the private dataset,
+  flat dataset names on the request, precise read/write split in
+  `metadata.grants`. Best-effort/fail-open on the background worker;
+  observability only — `MemoryGrants` stays the authorization source of
+  truth. Real per-user login/tenancy (cognee 1.5.2 defaults the *server*
+  API to `authentication=required, multi_tenant=enabled`) is deferred to
+  the served-cognee mode in Phase 5.
+- **cognee pinned via cooldown exemption:** 1.5.2 (published 2026-08-22)
+  taken through a dated `exclude-newer-package` entry in uv.toml; drop the
+  exemption once it ages past the P7D window.
 - **Implemented so far:** Phases 0–3 (extra + lock, `runtime/memory.py` gate +
   client boundary with timeouts/breaker/embedded store, `cognee_search` /
   `cognee_remember` builtins wired through the registry, runner dispatch,
-  native relay, and the gated framework instruction). Phases 4–7 (ingest
-  coordinator, server recall endpoint, push-based recall, hardening) remain.
+  native relay, and the gated framework instruction), plus the
+  agent-registry mirroring above. Phases 4–7 (ingest coordinator, server
+  recall endpoint, push-based recall, hardening) remain.
 
 ## Spine and rationale
 

--- a/designs/cognee-memory-integration.md
+++ b/designs/cognee-memory-integration.md
@@ -1,0 +1,193 @@
+# Cognee memory integration for omnigent — recommended phased plan
+
+## Status and decisions (2026-08-02)
+
+Decisions taken after the plan was drafted:
+
+- **Deployment shape: embedded local store** under `<data-dir>/cognee/`
+  (`OMNIGENT_DATA_DIR` honored; `cognee: data_root:` overrides). The hosted
+  cognee API is not wired in v1.
+- **Phase 1's zero-code MCP increment is dropped** — the builtin-tools lane
+  (Phase 3) is the only tool surface. The gate module still shipped.
+- **Phase 0 gate outcome: (A) in-process, with one base-pin change.** cognee
+  0.5.8 resolves, but only after lifting omnigent's `websockets>=10.4,<15`
+  base pin to `>=15.0.1,<16`. That pin guarded issue #1514, whose corrected
+  root cause is the `proxy=True` default websockets added in 15.0 — so every
+  omnigent client `connect()` now passes `proxy=None` (pre-15 behavior) and
+  the pin is safe to lift. The cognee extra carries a
+  `python_version < '3.15'` marker: on the resolver's speculative ≥3.15
+  split, cognee's dep tree forces `websockets>=16`.
+- **Cross-agent memory access layer** (added requirement, expanded twice):
+  each agent's memory isolates in its own dataset (config `dataset` →
+  `agent_id` → `conversation_id`). Cross-agent access is grant-based via
+  `MemoryGrants` in `omnigent/runtime/memory.py`, layered narrowest to
+  broadest:
+  - **Tier pools** — `user_dataset` / `team_dataset` / `org_dataset`:
+    read/write pools for all agents granted the same name (agent → user →
+    team → org). Each key falls back to the global `cognee:` config block,
+    so a deployment grants its tiers once and agents inherit them.
+  - **Ad-hoc exchange** — `shared_dataset`: a read/write pool outside the
+    hierarchy.
+  - **Peer grants** — `read_datasets` / `write_datasets` (csv of agent ids
+    or dataset names): search / publish access to specific other agents'
+    datasets; list a peer in both for full read/write.
+  Tools accept `scope` (`all` | `agent` | `user` | `team` | `org` |
+  `shared` | `peers`) and a `dataset` argument targeting one granted
+  dataset; requests outside the grants return an error listing what is
+  granted. Enforcement lives in the framework module, not the tools.
+- **Implemented so far:** Phases 0–3 (extra + lock, `runtime/memory.py` gate +
+  client boundary with timeouts/breaker/embedded store, `cognee_search` /
+  `cognee_remember` builtins wired through the registry, runner dispatch,
+  native relay, and the gated framework instruction). Phases 4–7 (ingest
+  coordinator, server recall endpoint, push-based recall, hardening) remain.
+
+## Spine and rationale
+
+**Primary spine: the risk-retirement ladder (design 3) executed with design 1's per-PR minimalism, deferring design 2's backend-agnostic `MemoryBackend` abstraction until a second backend or hot-path recall demands it.**
+
+- The repo already shipped exactly this integration shape once: Hindsight (`omnigent/tools/builtins/hindsight.py`, optional extra, `find_spec` gate, `_HINDSIGHT_TOOLS` unioned into `_NATIVE_RELAY_BUILTIN_TOOLS`). Cognee clones it file-for-file — this is the lowest-review-risk path, which matters since the integration author is also cognee's author.
+- Order is chosen to retire the two existential risks first: (1) **dependency resolution** against omnigent's tight base pins (`openai<2.45`, `pydantic<3`, `sqlalchemy<3`, `protobuf>=6,<7`, `websockets<15`, py3.12–3.14 wheels) — a single `uv lock` decides in-process vs out-of-process vs MCP-only before any product code exists; (2) **turn latency** — pull-based tools (zero hot-path cost) and async ingest ship before any automatic recall injection.
+- Design 2's ideas are grafted where they're cheap: the `MemoryIngestCoordinator` cloned from `BackgroundSessionTitleCoordinator`, compaction-first ingest, the structured `FrameworkInstructions` value (only when recall injection actually lands, per the `append_framework_instructions` docstring), and the untrusted-recall preamble.
+- Everything is default-off and triple-gated: env kill-switch → config block → per-agent opt-in. Memory must never fail or slow a turn: every cognee call is timeout-bounded, fail-open, behind a circuit breaker.
+
+Naming decisions baked in: pip extra is **`cognee`** (the `memory` extra is a deprecated hindsight alias, TODO(0.70) removal, pyproject.toml:221); tools are **`cognee_search` / `cognee_remember`** (hindsight precedent of vendor-named tools; a generic `memory_*` rename is an open question below); config block is **`cognee:`**.
+
+---
+
+## Phase 0 — Kill-risk spike: dependency resolution + latency + isolation (decision gate, no product code merged)
+
+**PR shape:** scratch branch + a short findings write-up in the PR description; only the lockfile change merges if clean.
+
+Work:
+- Add `cognee = ["cognee>=X,<Y"]` to `[project.optional-dependencies]` in `/Users/vasilije/orca/omnigent/pyproject.toml` (next to `hindsight` at line 215). Run `uv lock`, `just normalize-locks`, and the OSV audit. Verify resolution and wheels on py3.12/3.13/3.14 (cf. the pyarrow/cp314 note on the databricks extra ~line 251).
+- **Decision gate**, recorded in the PR:
+  - **(A) clean resolve** → in-process extra; Phases 2–6 as written below.
+  - **(B) conflict** → out-of-process package `integrations/cognee/` modeled on `/Users/vasilije/orca/omnigent/integrations/slack/pyproject.toml` (own dep universe, version-locked extra, `[tool.uv.sources]`, subprocess); the Phase 2 client boundary talks stdio/HTTP to it. Phases 3–6 unchanged above the client.
+  - **(C) worst case** → MCP-only (Phase 1 becomes the whole integration for now); as cognee's author you can also relax cognee's upstream pins and re-run the gate.
+- Latency spike (throwaway script, not committed): p50/p95 for `cognee.search` and `cognee.add + cognify`, cold/warm, local store vs hosted. These numbers set the Phase 6 recall budget (target ≤ ~300 ms or prefetch-only) and the Phase 3 tool timeouts.
+- Isolation spike: confirm dataset-per-`agent_id` + `node_set`-per-`root_conversation_id` gives strict partitioning and that search cannot cross datasets; document the key scheme against the spawn-tree fields on `SqlConversation` (`omnigent/db/db_models.py:745`).
+
+**Test plan:** `uv lock` succeeds; OSV audit green; spike numbers recorded. No pytest changes.
+
+---## Phase 1 — Zero-code MCP increment + the gate module (ships regardless of the gate outcome)
+
+**PR shape:** example bundle + docs + one small framework module. No behavior change for anyone who doesn't opt in.
+
+Files:
+- **New** `examples/cognee-memory/` agent bundle with `tools/mcp/cognee.yaml`: stdio `MCPServerConfig` (`spec/types.py:868` → `AgentSpec.mcp_servers:1541`) — `transport: stdio, command: uvx, args: [cognee-mcp], env: {LLM_API_KEY: ${COGNEE_LLM_API_KEY}}` (`${VAR}` expansion via `spec/parser.py` ~2449). Connection pooling and TOOL_CALL/TOOL_RESULT policy enforcement come free via `runner/mcp_manager.py` / `server/mcp_pool.py`.
+- **New** `/Users/vasilije/orca/omnigent/omnigent/runtime/memory.py` — the framework-owned gate module (created now, even before it does much): `cognee_enabled()` combining `OMNIGENT_DISABLE_COGNEE` env kill-switch (truthy convention per `onboarding/secrets.py:_keyring_disabled`), an optional top-level `cognee:` block read via `omnigent/config.py:load_effective_config` (`enabled: false` default; non-`harness` keys shallow-replace — document that), and `importlib.util.find_spec("cognee")`. Every later phase checks this one gate.
+- Docs / example README: state explicitly that spec-declared MCP servers reach SDK/subprocess harnesses only — `build_native_relay_tool_schemas` (`runner/tool_dispatch.py:437`) does not advertise MCP tools inside native TUIs (Phase 3 fixes that); document runtime attach via `POST /sessions/{id}/agent/mcp-servers` (`server/routes/session_mcp_servers.py`).
+
+**Test plan:** unit tests for the gate precedence (env > config > find_spec) in `tests/runtime/test_memory_gate.py`; manual e2e in the Test Plan section: attach cognee-mcp to a claude-sdk agent, cognify a note, restart session, search recalls it. `pre-commit run --all-files`.
+
+---
+
+## Phase 2 — Failure-domain boundary: cognee client wrapper, scoping, packaging
+
+**PR shape:** one module + packaging plumbing. Still no user-visible behavior.
+
+Files:
+- Extend `/Users/vasilije/orca/omnigent/omnigent/runtime/memory.py` (split into an `omnigent/memory/` package only if it outgrows one module):
+  - Lazy `import cognee` inside the client builder — never at module import (mirror `hindsight.py:_client()`).
+  - Hard `asyncio.wait_for` timeouts per operation class (search ~2 s for tools, ~300 ms recall budget from Phase 0, add ~5 s) and a simple circuit breaker (N consecutive failures → open M minutes, log once). All callers get empty results / silent no-op — **memory never fails a turn**.
+  - `resolve_scope(config, ctx)` — dataset from spec config → `ToolContext.agent_id` → `conversation_id`; `node_set` from `root_conversation_id` (hindsight `_bank()` shape, `hindsight.py:103`). Sub-agent trees share the root's node_set.
+  - Local store rooted at `<OMNIGENT_DATA_DIR>/cognee/` (path configurable in the `cognee:` block); LLM key via `keychain:<name>` refs through `onboarding/secrets.py` + `provider_config.py:resolve_secret`, defaulting to the provider key already stored during `omnigent setup`, with `${VAR}` fallback.
+- `pyproject.toml` (if gate outcome A): the `cognee` extra with the standard lazy-import comment; `[[tool.mypy.overrides]] module = "cognee.*", ignore_missing_imports = true` (mirror `hindsight_client.*` ~line 661); add cognee to the `dev` extra **only** if tests import the real package — prefer pure mocks (precedent: `test_hindsight.py`).
+- Expose a handle via runtime init: getter in `omnigent/runtime/__init__.py` beside `get_conversation_store` (line 79), wired through `omnigent/runtime/_globals.py:init` (163), constructed in the server bootstrap in `omnigent/cli.py` (~3550–3608). The runner process never imports cognee (see Phase 6).
+
+**Test plan:** `tests/runtime/test_cognee_client.py` with a mocked `cognee` module — timeout → empty result, breaker opens/self-heals, scope resolution (two agents / two session trees can never read each other's datasets), module import succeeds with cognee absent.
+
+---
+
+## Phase 3 — Pull-based memory tools reaching ALL ~15 harnesses (the core PR)
+
+**PR shape:** the hindsight clone. Zero turn-start latency; value ships here.
+
+Files:
+- **New** `/Users/vasilije/orca/omnigent/omnigent/tools/builtins/cognee.py`: `CogneeSearchTool` (`cognee_search`) and `CogneeRememberTool` (`cognee_remember`; `add` + backgrounded `cognify` so the tool returns fast — fire-and-forget with the Phase 2 breaker catching failures). Spec-level config dict (`dataset`, `node_set`, `${VAR}`-expanded keys); all calls through the Phase 2 client. Module docstring documents `tools.builtins: [{name: cognee_search, ...}]` usage. Defer `cognee_codify` (open question).
+- `omnigent/tools/builtins/__init__.py`: `_cognee_available()` `find_spec` probe + conditional `_BUILTIN_REGISTRY.update`, mirroring `_hindsight_available` (line 183) / the hindsight registry block (~293) — tools vanish cleanly when the extra is absent.
+- `omnigent/runner/tool_dispatch.py`: `_COGNEE_TOOLS` frozenset next to `_HINDSIGHT_TOOLS` (line 301); **union into `_NATIVE_RELAY_BUILTIN_TOOLS`** (line 410, beside `| _HINDSIGHT_TOOLS` at 433 — this is what makes the tools appear inside claude-native/codex-native/etc. via the serve-mcp relay and ACP `session/new.mcpServers`) and into `_ALL_LOCAL_TOOLS` (~586); `_cognee_config_from_spec` + `_execute_cognee_tool` mirroring 2783/2805 (cognee is asyncio-native — await directly, no `asyncio.to_thread`); `elif tool_name in _COGNEE_TOOLS` at the dispatch site (~4866). Runner-side execution proxies through the Phase 2 client boundary; if the runner host can't run cognee in-process, dispatch calls the server memory endpoint (added in Phase 5/6) instead.
+- `omnigent/onboarding/agent/tools/python/list_builtin_tools.py`: mirror the gate (hindsight pattern, lines 33–47).
+- **New** `omnigent/onboarding/cognee_setup.py` patterned on `cursor_auth.py`: `COGNEE_EXTRA = "cognee"`, guarded `find_spec`, `extra_install_command("cognee")` offer, `importlib.invalidate_caches()`.
+- **Static framework instruction (design 1's cheap win, same PR):** add `COGNEE_MEMORY_INSTRUCTION` to `runtime/memory.py` ("you have persistent memory tools: cognee_search / cognee_remember; search before non-trivial work; store durable facts") gated on the spec actually enabling a cognee builtin — mirroring `SHARED_SESSION_AUTHORSHIP_INSTRUCTION` + its gate in `runtime/prompt.py`. Wire the tuple at both composition call sites: `runner/app.py:_run_turn_bg_setup_and_stream` (~5029) and `runtime/workflow.py:_prepare_messages` (~2240). No adapter code — `append_framework_instructions` transports it everywhere.
+
+**Failure behavior:** cognee absent → tools unregistered; cognee broken/slow → tool returns an error string, never an exception that kills the turn.
+
+**Test plan:** `tests/tools/builtins/test_cognee.py` (mock cognee; template `test_hindsight.py`); `tests/runner/test_cognee_local_dispatch.py` (template `test_hindsight_local_dispatch.py`); registry-absent test; instruction-ordering test in `tests/runtime/` (spec → per-request → skills → cognee instruction; absent when not enabled). Manual: `uv pip install -e '.[cognee]'`, enable the builtins on an example agent, one SDK turn + **one claude-native turn** (explicit native check — the silent-SDK-only failure mode), confirm round-trip. `pre-commit run --all-files`.
+
+---
+
+## Phase 4 — Write path off the hot path: async ingest coordinator, compaction-first
+
+**PR shape:** one server-side coordinator + two scheduling call sites, gated by `cognee:` config (`ingest.enabled`, default off initially).
+
+Files:
+- **New** `/Users/vasilije/orca/omnigent/omnigent/server/memory_ingest.py`: `MemoryIngestCoordinator` cloned one-for-one from `BackgroundSessionTitleCoordinator` (`server/background_session_titles.py:94`) — debounced per-conversation background job; reads new items via `ConversationStore.list_items(conversation_id, after=cursor)` (`stores/conversation_store/__init__.py:516`); persists the cursor as a conversation label (compaction `last_item_id` pattern, `workflow.py:_load_initial_history:2444`); serializes with `ConversationItem.to_api_dict()` (`entities/conversation.py:744`); batches per debounce window (never cognify per item); failures log-and-drop.
+- Construct in `omnigent/server/app.py`, inject into sessions routes (exactly like the title coordinator).
+- Schedule from both persist paths in `server/routes/_sessions/orchestration.py`: the `response.completed` branch of `_relay_runner_stream` (line 4501, relay/SDK harnesses) and `_persist_external_conversation_item` (line 1706, native TUIs) — beside the existing `prepare_background_session_title` calls. This single path covers every harness including imports.
+- **Ingest policy:** default mode `compaction` — only `compaction` items (`workflow.py:_maybe_persist_compaction_item:2657`, runner `_handle_harness_compaction:5612`) plus user/assistant messages; `full` mode (function_call/output items) behind a separate sub-flag since it multiplies cognify LLM cost. Per-conversation rate limit + daily budget knob in the `cognee:` block.
+- Session-close whole-session cognify off the `omnigent.closed` label transition (`sys_session_close` in `tool_dispatch.py` ~4490, `omnigent/session_lifecycle.py`), using the spawn-tree serialization precedent `repl/_session_log.py:write_session_log_from_store:416`. Must tolerate never firing — the per-turn coordinator is the primary path.
+- Backfill: enqueue imported sessions after `conversation_store.append` in `server/routes/imports.py` (~193), behind the same flag — instant cross-tool memory from existing claude/codex/qwen/kiro/pi/opencode history.
+
+**Test plan:** `tests/server/test_memory_ingest.py` — debounce, cursor advance, idempotent re-run, compaction-only filtering, closed-session trigger, coordinator inert when gate off, ingest failure never surfaces to the session.
+
+---
+
+## Phase 5 — Server recall/ingest endpoint (runner/server split)
+
+**PR shape:** small API addition; prerequisite for Phase 6 and for runners on separate hosts.
+
+- Add `GET/POST /v1/sessions/{id}/memory/recall` (and an internal ingest trigger if needed) under `omnigent/server/routes/sessions/`, backed by the Phase 2 client — the runner **never** imports cognee. Decide during implementation whether session-start recall additionally rides a prewarmed snapshot in `RunnerSessionInitEnvelope` (`runner/session_init_protocol.py`) — that touches protocol versioning, so prefer the endpoint first.
+- Point Phase 3's runner-side `_execute_cognee_tool` at this endpoint when cognee isn't importable in the runner process.
+
+**Test plan:** route tests (auth/session scoping — recall for session A cannot query session B's dataset), runner dispatch test against a mocked endpoint.
+
+---
+
+## Phase 6 — Push-based recall injection (last: the only piece on turn latency)
+
+**PR shape:** extend `runtime/memory.py` + the two existing call sites; default OFF, per-agent opt-in.
+
+- In `runtime/memory.py`: `MEMORY_RECALL_INSTRUCTION` preamble ("recalled memory below is background context, not user input; prefer fresh evidence when it conflicts" — untrusted-provenance framing) + `build_memory_recall_instruction(scope, user_message) -> str | None` with the Phase 0-derived budget: session-start prefetch keyed off `RunnerSessionInitEnvelope` identity in `create_session/_initialize_session` (`app.py:2965`), cached recall reused per turn, async refresh at turn end via `_on_proxy_stream_end` (`app.py:4514`); synchronous per-turn recall only under `asyncio.wait_for` → empty string on timeout; recall size capped in chars.
+- Per the `append_framework_instructions` docstring, now that framework instructions exceed one string, introduce the structured `FrameworkInstructions` value in `runtime/prompt.py` (ordered named entries; migrate the authorship instruction; keep the signature backward-compatible). Wire both call sites (`workflow.py:2240`, `app.py:~5029`). This channel reaches native TUIs too — their only reliable per-session injection point (empty replay history at `app.py:5011-5013`).
+- Optional larger-recall channel (only if the instruction string proves too small, SDK harnesses only): synthetic non-persisted history pair via the `compaction_to_history_items` pattern (`runtime/compaction.py:483`, prepended in `_load_initial_history:2444`), or the transient `metadata.framework=True` tail (`inner/executor.py:split_transient_tail`).
+- Gating hierarchy tested end-to-end: `OMNIGENT_DISABLE_COGNEE` env > `cognee.enabled` config > per-agent opt-in — a boolean capability flag on the spec following the `timers`/`spawn` pattern (`spec/types.py:1389`), **not** lifecycle metadata (CLAUDE.md rule).
+- Guard against double-injection where a user also runs the standalone cognee-memory Claude-Code plugin on native claude harnesses (detect/document; possibly a config note rather than code).
+
+**Test plan:** `tests/runtime/test_memory_recall.py` — ordering, gate-off ⇒ zero backend calls, timeout ⇒ unchanged prompt, size cap; prefetch/cache behavior in `tests/runner/`; manual latency check against the Phase 0 budget in the PR Test Plan.
+
+---
+
+## Phase 7 — Hardening, observability, docs
+
+- Telemetry counters/spans (recall latency, ingest queue depth, breaker state, timeouts) per `omnigent/telemetry` conventions and the `ExecutorAdapter.run_turn` span pattern.
+- Chaos tests: package absent, store unreachable, invalid LLM key, slow cognee (> budget) — every case yields a normal turn with no memory.
+- Policy example that ASKs on `cognee_remember` (memory-poisoning mitigation); verify local-dispatch tools hit the same policy gate hindsight does.
+- Optional scheduled re-ingest/pruning via `stores/scheduled_task_store/` + `server/routes/scheduled_tasks.py`.
+- Docs page (config block, extra install, scoping model, MCP alternative, kill-switch reference), CHANGELOG, e2e smoke test (recall→ingest→tool round-trip, mock backend) in `tests/e2e`.
+
+---
+
+## Cross-cutting summary
+
+| Concern | Decision |
+|---|---|
+| Packaging | `cognee` extra (never `memory`), lazy imports, `find_spec` gates; escape valves: `integrations/cognee` subprocess (slack pattern) or MCP-only — decided by Phase 0 |
+| Enable/disable | `OMNIGENT_DISABLE_COGNEE` env > `cognee:` config block (default off) > per-agent spec opt-in / `tools.builtins` |
+| Recall injection | `runtime/memory.py` (owning module) → `append_framework_instructions` at `workflow.py:_prepare_messages` + `runner/app.py:_run_turn_bg_setup_and_stream`; structured `FrameworkInstructions` when it grows; adapters only transport |
+| Ingest | `MemoryIngestCoordinator` (title-coordinator clone) off both persist paths; compaction-first; cursor via conversation label; session-close + import backfill secondary |
+| Tools | `cognee_search`/`cognee_remember` builtins + `_COGNEE_TOOLS` ∪ `_NATIVE_RELAY_BUILTIN_TOOLS` (all harnesses); cognee-mcp via `MCPServerConfig` as zero-code secondary (SDK-only) |
+| Isolation | dataset per `agent_id` (config-overridable), node_set per `root_conversation_id`; spawn tree shares root node_set; verified by Phase 0 spike + Phase 2 tests |
+| Failure behavior | fail-open everywhere: timeouts, circuit breaker, empty recall, dropped ingest, tool-error strings; memory can never fail or block a turn |
+
+## Open questions for vasilije (cognee author decisions)
+
+1. **Does current cognee resolve against omnigent's base pins (`openai<2.45`, `pydantic<3`, `sqlalchemy<3`, `protobuf>=6,<7`) on py3.12–3.14?** If not, would you rather relax cognee's upstream pins than take the `integrations/` subprocess path? This single answer sets the whole architecture (Phase 0 gate).
+2. **Primary deployment shape:** embedded local store under `<data_dir>/cognee/` (SQLite/LanceDB/Kuzu) vs hosted cognee API? Default UX, secrets, and the recall latency budget all differ.
+3. **Tool surface & naming:** is `cognee_search` + `cognee_remember` enough for v1, or is `cognee_codify` worth including for a coding-agent audience? And should the tools eventually be generic `memory_search`/`memory_store` behind a backend abstraction (positioning cognee as THE omnigent memory layer, subsuming `search_conversations` and the hindsight lineage) — which would justify design 2's `MemoryBackend` protocol?
+4. **Scoping default:** per-agent dataset with conversation fallback (hindsight parity), or blend a per-user/workspace dataset so knowledge crosses agents? Is `workspace` the right tenant boundary on shared servers?
+5. **`cognee_remember` semantics:** await cognify inline (consistent, slow) vs fire-and-forget (fast, eventual consistency within the same session)?
+6. **Recall search type:** GRAPH_COMPLETION vs CHUNKS vs SUMMARIES for the Phase 6 injection path — and recall trigger granularity (per-turn vs session-start prefetch only)?
+7. **Cognify LLM key:** reuse the user's configured omnigent provider key by default (better UX, couples cost to their primary key) or require a dedicated cognee key?
+8. **MCP lane default:** `uvx cognee-mcp` (per-spawn resolution latency) or require a preinstalled console script in the example bundle?
+9. **Native-harness enhancement:** is the per-turn framework-instruction channel sufficient for native TUIs, or do you want Claude-Code `SessionStart`/`UserPromptSubmit` `additionalContext` hooks later (needs a maintainer ruling on the "adapters only transport" convention; also interacts with your existing cognee-memory Claude plugin — double-injection risk)?

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -45,7 +45,7 @@ from enum import Enum
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import FrameType
-from typing import TYPE_CHECKING, Protocol, TextIO, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, Protocol, TextIO, TypeAlias, cast
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
@@ -6127,26 +6127,37 @@ def _websocket_connect(
     # whose OpenSSL default cert path is empty. ws:// passes ssl=None (the
     # library default — no TLS). See omnigent/tls.py and issue #1730.
     ssl_ctx = client_ssl_context() if attach_url.startswith("wss://") else None
-    try:
-        return cast(
-            contextlib.AbstractAsyncContextManager[_WebSocketClient],
-            websockets.connect(
-                attach_url,
-                additional_headers=handshake_headers,
-                close_timeout=_CLAUDE_ATTACH_WS_CLOSE_TIMEOUT_S,
-                ssl=ssl_ctx,
-            ),
-        )
-    except TypeError:
-        return cast(
-            contextlib.AbstractAsyncContextManager[_WebSocketClient],
-            websockets.connect(
-                attach_url,
-                extra_headers=handshake_headers,
-                close_timeout=_CLAUDE_ATTACH_WS_CLOSE_TIMEOUT_S,
-                ssl=ssl_ctx,
-            ),
-        )
+    # Kwarg cascade across websockets releases: >=15 (additional_headers +
+    # proxy — passed as None so a system/env proxy never stalls the loopback
+    # handshake, issue #1514), 14.x (additional_headers, no proxy kwarg),
+    # then the legacy extra_headers name.
+    kwarg_variants: list[dict[str, Any]] = [
+        {"additional_headers": handshake_headers, "proxy": None},
+        {"additional_headers": handshake_headers},
+        {"extra_headers": handshake_headers},
+    ]
+    for variant in kwarg_variants[:-1]:
+        try:
+            return cast(
+                contextlib.AbstractAsyncContextManager[_WebSocketClient],
+                websockets.connect(
+                    attach_url,
+                    close_timeout=_CLAUDE_ATTACH_WS_CLOSE_TIMEOUT_S,
+                    ssl=ssl_ctx,
+                    **variant,
+                ),
+            )
+        except TypeError:
+            continue
+    return cast(
+        contextlib.AbstractAsyncContextManager[_WebSocketClient],
+        websockets.connect(
+            attach_url,
+            close_timeout=_CLAUDE_ATTACH_WS_CLOSE_TIMEOUT_S,
+            ssl=ssl_ctx,
+            **kwarg_variants[-1],
+        ),
+    )
 
 
 async def _stdin_to_websocket(

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -574,6 +574,9 @@ class CodexAppServerClient:
                 self._ws_url,
                 max_size=_MAX_WEBSOCKET_MESSAGE_SIZE_BYTES,
                 compression=None,
+                # Local app-server socket — never route through a system/env
+                # proxy (macOS does not bypass loopback; issue #1514).
+                proxy=None,
             )
         else:
             self._ws = await websockets.unix_connect(

--- a/omnigent/onboarding/agent/tools/python/list_builtin_tools.py
+++ b/omnigent/onboarding/agent/tools/python/list_builtin_tools.py
@@ -75,6 +75,27 @@ if _hindsight_available():
     )
 
 
+def _cognee_available() -> bool:
+    """Return True when the optional ``cognee`` package is usable."""
+    import importlib.util
+    import os
+
+    if os.environ.get("OMNIGENT_DISABLE_COGNEE", "").strip().lower() in ("true", "1", "yes"):
+        return False
+    return importlib.util.find_spec("cognee") is not None
+
+
+# Cognee memory tools (optional ``cognee`` extra). Advertised only when the
+# package is installed and not kill-switched.
+if _cognee_available():
+    _TOOL_CLASSES.update(
+        {
+            "cognee_search": ("omnigent.tools.builtins.cognee", "CogneeSearchTool"),
+            "cognee_remember": ("omnigent.tools.builtins.cognee", "CogneeRememberTool"),
+        }
+    )
+
+
 @tool
 def list_builtin_tools() -> str:
     """

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -346,6 +346,11 @@ _NIMBLE_EXTRACT_TOOLS = frozenset({"nimble_extract"})
 # falls through to the harness, which has no such tool, and silently no-ops.
 _HINDSIGHT_TOOLS = frozenset({"hindsight_retain", "hindsight_recall", "hindsight_reflect"})
 
+# Cognee knowledge-graph memory builtins. Runner-local for the same reason as
+# the Hindsight set above: without this entry a wrapped harness's call falls
+# through to the harness, which has no such tool, and silently no-ops.
+_COGNEE_TOOLS = frozenset({"cognee_search", "cognee_remember"})
+
 # Priority 5f.2: sys_list_models — runner-local because provider resolution
 # reads the runner host's config/credentials, same as the spawn paths.
 _LIST_MODELS_TOOLS = frozenset({"sys_list_models"})
@@ -469,6 +474,7 @@ _NATIVE_RELAY_BUILTIN_TOOLS = (
     # Memory builtins are relayed to native harnesses too — unlike web_search,
     # native harnesses have no built-in long-term memory of their own.
     | _HINDSIGHT_TOOLS
+    | _COGNEE_TOOLS
     # Skills ride the relay for the same reason memory does: ``load_skill`` is
     # what discovers host-scope skills (``.agents/skills`` and friends), and a
     # native session's only tool surface is this relay.
@@ -887,6 +893,7 @@ _ALL_LOCAL_TOOLS = (
     | _NIMBLE_RESEARCH_TOOLS
     | _NIMBLE_EXTRACT_TOOLS
     | _HINDSIGHT_TOOLS
+    | _COGNEE_TOOLS
     | _TIMER_TOOLS
     | _TASK_LIFECYCLE_TOOLS
     | _SKILL_TOOLS
@@ -3710,6 +3717,75 @@ async def _execute_hindsight_tool(
     return await asyncio.to_thread(tool.invoke, json.dumps(args), ctx)
 
 
+def _cognee_config_from_spec(agent_spec: Any | None, tool_name: str) -> dict[str, str]:
+    """
+    Return a cognee builtin's config dict from the parent spec.
+
+    Mirrors ``_hindsight_config_from_spec``: scans ``spec.tools.builtins`` for
+    the entry named *tool_name* (e.g. ``"cognee_search"``) and returns its
+    ``config`` (dataset, shared_dataset, etc.). Empty dict when declared bare
+    or absent.
+
+    :param agent_spec: Parent agent's spec, or ``None``.
+    :param tool_name: The cognee tool name to look up.
+    :returns: The builtin's config dict.
+    """
+    if agent_spec is None:
+        return {}
+    tools = getattr(agent_spec, "tools", None)
+    builtins = getattr(tools, "builtins", None) or []
+    for entry in builtins:
+        if getattr(entry, "name", None) == tool_name:
+            return getattr(entry, "config", None) or {}
+    return {}
+
+
+async def _execute_cognee_tool(
+    args: dict[str, Any],
+    *,
+    tool_name: str,
+    agent_spec: Any | None,
+    conversation_id: str | None = None,
+    task_id: str | None = None,
+    agent_id: str | None = None,
+) -> str:
+    """
+    Dispatch a cognee memory tool call (search / remember).
+
+    Builds the tool from the spec's builtin config and runs its synchronous
+    ``invoke`` off the event loop (it runs bounded cognee operations on a
+    private loop). The dataset is resolved inside the tool from
+    ``config.dataset`` → ``ctx.agent_id`` → ``ctx.conversation_id``, so the
+    real ``agent_id`` is threaded through here. The runtime kill-switch is
+    re-checked per call — the registry gate only runs at import time.
+
+    :param args: Parsed LLM arguments (``content`` for remember, ``query``
+        for search, plus the optional ``scope``).
+    :param tool_name: The cognee tool name being dispatched.
+    :param agent_spec: Parent agent's spec; carries the cognee builtin config.
+    :param conversation_id: Parent session id, threaded into the context.
+    :param task_id: Calling task id, threaded into the context.
+    :param agent_id: Calling agent id — the default memory dataset.
+    :returns: The tool's string result, or an error string.
+    """
+    from omnigent.runtime.memory import cognee_available
+    from omnigent.tools.base import ToolContext
+    from omnigent.tools.builtins import get_builtin_tool
+
+    if not cognee_available():
+        return f"cognee tool {tool_name!r} is not available (cognee memory is disabled)."
+    config = _cognee_config_from_spec(agent_spec, tool_name)
+    tool = get_builtin_tool(tool_name, config)
+    if tool is None:
+        return f"cognee tool {tool_name!r} is not available."
+    ctx = ToolContext(
+        task_id=task_id or tool_name,
+        agent_id=agent_id or tool_name,
+        conversation_id=conversation_id,
+    )
+    return await asyncio.to_thread(tool.invoke, json.dumps(args), ctx)
+
+
 def _has_subagent(
     sub_agent_name: str,
     agent_spec: AgentSpec | None,
@@ -6146,6 +6222,15 @@ async def execute_tool(
             )
         elif tool_name in _HINDSIGHT_TOOLS:
             output = await _execute_hindsight_tool(
+                args,
+                tool_name=tool_name,
+                agent_spec=agent_spec,
+                conversation_id=conversation_id,
+                task_id=task_id,
+                agent_id=agent_id,
+            )
+        elif tool_name in _COGNEE_TOOLS:
+            output = await _execute_cognee_tool(
                 args,
                 tool_name=tool_name,
                 agent_spec=agent_spec,

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -3717,7 +3717,7 @@ async def _execute_hindsight_tool(
     return await asyncio.to_thread(tool.invoke, json.dumps(args), ctx)
 
 
-def _cognee_config_from_spec(agent_spec: Any | None, tool_name: str) -> dict[str, str]:
+def _cognee_config_from_spec(agent_spec: AgentSpec | None, tool_name: str) -> dict[str, str]:
     """
     Return a cognee builtin's config dict from the parent spec.
 
@@ -3741,10 +3741,10 @@ def _cognee_config_from_spec(agent_spec: Any | None, tool_name: str) -> dict[str
 
 
 async def _execute_cognee_tool(
-    args: dict[str, Any],
+    args: _JsonObject,
     *,
     tool_name: str,
-    agent_spec: Any | None,
+    agent_spec: AgentSpec | None,
     conversation_id: str | None = None,
     task_id: str | None = None,
     agent_id: str | None = None,

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -3754,10 +3754,11 @@ async def _execute_cognee_tool(
 
     Builds the tool from the spec's builtin config and runs its synchronous
     ``invoke`` off the event loop (it runs bounded cognee operations on a
-    private loop). The dataset is resolved inside the tool from
-    ``config.dataset`` → ``ctx.agent_id`` → ``ctx.conversation_id``, so the
-    real ``agent_id`` is threaded through here. The runtime kill-switch is
-    re-checked per call — the registry gate only runs at import time.
+    private loop). The private dataset defaults to the agent's stable spec
+    name (injected into the config here); the tool falls back to
+    ``ctx.agent_id`` → ``ctx.conversation_id`` only when no name exists.
+    The runtime kill-switch is re-checked per call — the registry gate only
+    runs at import time.
 
     :param args: Parsed LLM arguments (``content`` for remember, ``query``
         for search, plus the optional ``scope``).
@@ -3775,6 +3776,12 @@ async def _execute_cognee_tool(
     if not cognee_available():
         return f"cognee tool {tool_name!r} is not available (cognee memory is disabled)."
     config = _cognee_config_from_spec(agent_spec, tool_name)
+    spec_name = getattr(agent_spec, "name", None)
+    if spec_name and not config.get("dataset"):
+        # Default the private memory dataset to the stable agent NAME:
+        # runtime agent ids are minted per registration, so an id-keyed
+        # dataset would silently reset every session.
+        config = {**config, "dataset": spec_name}
     tool = get_builtin_tool(tool_name, config)
     if tool is None:
         return f"cognee tool {tool_name!r} is not available."

--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -833,6 +833,9 @@ async def _serve_tunnel_once(
         close_timeout=close_timeout,
         max_size=RUNNER_TUNNEL_MAX_MESSAGE_BYTES,
         ssl=ssl_ctx,
+        # Never route through a system/env proxy: macOS does not bypass
+        # 127.0.0.1, so a configured proxy stalls the handshake (issue #1514).
+        proxy=None,
         # Protocol keepalive aligned to the server's 90 s app-level budget (not the
         # 20 s library default that drops a busy-but-healthy tunnel — issue #1116).
         # Also the runner's only liveness probe for a silently-dead server.

--- a/omnigent/runtime/memory.py
+++ b/omnigent/runtime/memory.py
@@ -462,7 +462,6 @@ def memory_add(
     fast — eventual consistency within the same session is accepted.
     Returns ``False`` (never raises) when the write failed.
     """
-    global _background_executor
     effective = cognee_settings() if settings is None else settings
     if not cognee_available() or not breaker.allow():
         return False
@@ -483,13 +482,19 @@ def memory_add(
         _logger.error("cognee add failed: %s", e)
         return False
 
+    _get_background_executor().submit(_cognify_blocking, dataset)
+    return True
+
+
+def _get_background_executor() -> ThreadPoolExecutor:
+    """Return the shared single-worker executor for off-turn cognee work."""
+    global _background_executor
     with _background_lock:
         if _background_executor is None:
             _background_executor = ThreadPoolExecutor(
-                max_workers=1, thread_name_prefix="cognee-cognify"
+                max_workers=1, thread_name_prefix="cognee-background"
             )
-    _background_executor.submit(_cognify_blocking, dataset)
-    return True
+        return _background_executor
 
 
 def _cognify_blocking(dataset: str) -> None:
@@ -505,3 +510,76 @@ def _cognify_blocking(dataset: str) -> None:
     except Exception as e:
         breaker.record_failure()
         _logger.error("cognee cognify failed for dataset %r: %s", dataset, e)
+
+
+# Agent connections already mirrored into cognee's registry this process,
+# keyed by (private dataset, session id) so a new session re-registers with
+# its current session id but repeat tool calls don't re-post.
+_registered_agent_connections: set[tuple[str, str]] = set()
+_registration_lock = threading.Lock()
+
+REGISTER_TIMEOUT_S = 10.0
+
+
+def ensure_agent_registered(
+    grants: MemoryGrants,
+    *,
+    session_id: str | None,
+    settings: dict[str, Any] | None = None,
+) -> None:
+    """Mirror this agent's :class:`MemoryGrants` into cognee's agent registry.
+
+    Best-effort observability only: cognee >=1.5 tracks agent connections
+    (``cognee.modules.agents``) so its tooling can show which agents touch
+    which memory pools. The registration runs on the background worker —
+    it never blocks a turn, never counts toward the circuit breaker, and
+    silently skips on cognee builds without the agents module (the extra
+    allows any 1.x). Authorization stays with :class:`MemoryGrants`; the
+    registration is a descriptive mirror, and the precise read/write split
+    rides ``metadata`` because ``RegisterAgentRequest`` only carries flat
+    dataset names.
+    """
+    if not cognee_available():
+        return
+    key = (grants.private, session_id or "")
+    with _registration_lock:
+        if key in _registered_agent_connections:
+            return
+        _registered_agent_connections.add(key)
+    effective = cognee_settings() if settings is None else settings
+    _get_background_executor().submit(_register_agent_blocking, grants, session_id, effective)
+
+
+def _register_agent_blocking(
+    grants: MemoryGrants,
+    session_id: str | None,
+    settings: dict[str, Any] | None,
+) -> None:
+    """Background worker body: post the agent connection, log-and-drop errors."""
+    try:
+        import importlib
+
+        _ensure_local_store(settings or {})
+        models = importlib.import_module("cognee.modules.agents.models")
+        operations = importlib.import_module("cognee.modules.agents.operations")
+        users = importlib.import_module("cognee.modules.users.methods")
+        readable = list(grants.readable())
+        writable = list(grants.writable())
+        request = models.RegisterAgentRequest(
+            agent_session_name=grants.private,
+            type="omnigent",
+            memory_mode="cognee",
+            session_id=session_id,
+            dataset_names=readable + [name for name in writable if name not in readable],
+            source="api",
+            origin_function="omnigent.runtime.memory",
+            metadata={"grants": {"readable": readable, "writable": writable}},
+        )
+
+        async def _register() -> Any:
+            user = await users.get_default_user()
+            return await operations.register_agent_from_request(user, request)
+
+        _run_bounded(_register, REGISTER_TIMEOUT_S)
+    except Exception as e:
+        _logger.debug("cognee agent registration skipped: %s", e)

--- a/omnigent/runtime/memory.py
+++ b/omnigent/runtime/memory.py
@@ -7,14 +7,16 @@ tool registration, runner dispatch, and the memory framework instruction —
 goes through this module, so the enable/disable policy lives in exactly
 one place (see CLAUDE.md "Framework-owned instructions").
 
-Gate precedence, strongest first:
+The availability gate (:func:`cognee_available`) has two conditions:
 
 1. ``OMNIGENT_DISABLE_COGNEE`` env kill-switch — truthy disables everything.
-2. The optional top-level ``cognee:`` block in config.yaml — settings such
-   as the store location and search behavior. Non-``harness`` config keys
-   shallow-replace between global and project config, so a project-level
-   ``cognee:`` block overrides the global one wholesale.
-3. ``importlib.util.find_spec("cognee")`` — the extra must be installed.
+2. ``importlib.util.find_spec("cognee")`` — the extra must be installed.
+
+Separately, the optional top-level ``cognee:`` block in config.yaml carries
+settings (store location, search behavior, tier-dataset grants) — it does
+not enable or disable the integration. Non-``harness`` config keys
+shallow-replace between global and project config, so a project-level
+``cognee:`` block overrides the global one wholesale.
 
 Memory must never fail or slow a turn: every cognee call is bounded by a
 timeout, failures return empty results / error strings (never raise), and a

--- a/omnigent/runtime/memory.py
+++ b/omnigent/runtime/memory.py
@@ -1,0 +1,505 @@
+"""Framework-owned cognee memory integration.
+
+Canonical gate, settings, and client boundary for the optional cognee
+knowledge-graph memory layer (https://github.com/topoteretes/cognee, the
+``omnigent[cognee]`` extra). Every cognee touch point in the framework —
+tool registration, runner dispatch, and the memory framework instruction —
+goes through this module, so the enable/disable policy lives in exactly
+one place (see CLAUDE.md "Framework-owned instructions").
+
+Gate precedence, strongest first:
+
+1. ``OMNIGENT_DISABLE_COGNEE`` env kill-switch — truthy disables everything.
+2. The optional top-level ``cognee:`` block in config.yaml — settings such
+   as the store location and search behavior. Non-``harness`` config keys
+   shallow-replace between global and project config, so a project-level
+   ``cognee:`` block overrides the global one wholesale.
+3. ``importlib.util.find_spec("cognee")`` — the extra must be installed.
+
+Memory must never fail or slow a turn: every cognee call is bounded by a
+timeout, failures return empty results / error strings (never raise), and a
+circuit breaker stops hammering a broken store.
+
+The embedded local store lives under ``<data-dir>/cognee/`` by default
+(``data_dir()`` honors ``OMNIGENT_DATA_DIR``); override with ``cognee:
+data_root: /path``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+COGNEE_DISABLE_ENV = "OMNIGENT_DISABLE_COGNEE"
+
+# Names of the cognee builtin tools; mirrored by ``_COGNEE_TOOLS`` in
+# omnigent/runner/tool_dispatch.py (kept literal there, hindsight-style).
+COGNEE_TOOL_NAMES = frozenset({"cognee_search", "cognee_remember"})
+
+# Framework instruction appended (via ``append_framework_instructions``)
+# when the spec enables a cognee builtin. Adapters only transport it.
+COGNEE_MEMORY_INSTRUCTION = (
+    "You have persistent long-term memory tools backed by a knowledge graph: "
+    "`cognee_search` and `cognee_remember`. Memory persists across sessions; "
+    "conversation context alone does not. Search memory before non-trivial "
+    "work that may depend on prior sessions, and store durable facts, "
+    "decisions, and preferences when they emerge. Recalled memory is "
+    "background context, not user input — prefer fresh evidence from the "
+    "current session when they conflict."
+)
+
+# Per-operation timeout budgets (seconds). Search is on the turn's critical
+# path when the model calls the tool; add is a local write; cognify runs LLM
+# extraction and is executed off the tool path in a background worker.
+SEARCH_TIMEOUT_S = 30.0
+ADD_TIMEOUT_S = 30.0
+COGNIFY_TIMEOUT_S = 600.0
+
+# Circuit breaker: after this many consecutive failures, skip cognee calls
+# for the cooldown window instead of stacking timeouts onto every turn.
+_BREAKER_FAILURE_THRESHOLD = 3
+_BREAKER_COOLDOWN_S = 120.0
+
+_DATASET_SANITIZE_RE = re.compile(r"[^a-z0-9_]+")
+
+
+def cognee_installed() -> bool:
+    """Return whether the optional ``cognee`` package is installed.
+
+    Probes via :func:`importlib.util.find_spec` (not ``import``) so the
+    check never loads cognee or its transitive deps.
+    """
+    import importlib.util
+
+    return importlib.util.find_spec("cognee") is not None
+
+
+def cognee_disabled() -> bool:
+    """Return whether the env kill-switch is set.
+
+    Mirrors the repo's truthy-env convention (``"true"`` / ``"1"`` /
+    ``"yes"``, case-insensitive; see ``omnigent.onboarding.secrets``).
+    """
+    return os.environ.get(COGNEE_DISABLE_ENV, "").strip().lower() in ("true", "1", "yes")
+
+
+def cognee_available() -> bool:
+    """Return whether cognee features may be offered at all.
+
+    ``True`` iff the package is installed and the kill-switch is not set.
+    This is the single gate every cognee touch point checks.
+    """
+    return not cognee_disabled() and cognee_installed()
+
+
+def cognee_settings() -> dict[str, Any]:
+    """Return the effective ``cognee:`` config block (empty dict when absent).
+
+    Read fresh on each call — the block is small and callers are not on a
+    hot path. Non-mapping values (a user typo like ``cognee: true``) are
+    treated as absent rather than crashing the caller.
+    """
+    from omnigent.config import load_effective_config
+
+    block = load_effective_config().get("cognee")
+    return block if isinstance(block, dict) else {}
+
+
+def cognee_data_root(settings: dict[str, Any] | None = None) -> Path:
+    """Return the embedded store's root directory.
+
+    Defaults to ``<data-dir>/cognee`` (``OMNIGENT_DATA_DIR`` honored);
+    override with ``cognee: data_root:`` in config.yaml.
+    """
+    from omnigent.process_logging import data_dir
+
+    effective = cognee_settings() if settings is None else settings
+    override = effective.get("data_root")
+    if isinstance(override, str) and override.strip():
+        return Path(override).expanduser()
+    return data_dir() / "cognee"
+
+
+def sanitize_dataset_name(raw: str) -> str:
+    """Normalize an identifier into a safe cognee dataset name.
+
+    Lowercases and collapses anything outside ``[a-z0-9_]`` to ``_`` so
+    agent/conversation ids map to stable, filesystem/DB-safe dataset names.
+    """
+    cleaned = _DATASET_SANITIZE_RE.sub("_", raw.strip().lower()).strip("_")
+    return cleaned or "default"
+
+
+def _csv_datasets(value: str | None) -> tuple[str, ...]:
+    """Parse a comma-separated grant list into sanitized dataset names.
+
+    Entries may be agent ids or raw dataset names — both normalize through
+    :func:`sanitize_dataset_name`, the same mapping an agent's own id gets,
+    so granting ``ag_Researcher`` and granting ``ag_researcher`` are the
+    same grant. Order is preserved, duplicates dropped.
+    """
+    if not value:
+        return ()
+    seen: list[str] = []
+    for entry in value.split(","):
+        if entry.strip():
+            name = sanitize_dataset_name(entry)
+            if name not in seen:
+                seen.append(name)
+    return tuple(seen)
+
+
+# Scope-tier hierarchy, narrowest first. Each tier maps to one dataset that
+# is read/write for every agent granted it: ``user`` pools an operator's
+# agents, ``team`` a group of users, ``org`` the whole deployment.
+MEMORY_TIERS = ("user", "team", "org")
+
+
+@dataclass(frozen=True)
+class MemoryGrants:
+    """An agent's resolved memory-access surface.
+
+    The framework-owned access layer for cross-agent memory: tools resolve
+    a :class:`MemoryGrants` from their spec config and may only touch the
+    datasets it exposes. ``private``, the tier datasets (``user`` /
+    ``team`` / ``org``), and ``shared`` are read/write for the owning
+    agent; ``readable_peers`` / ``writable_peers`` grant search / publish
+    access to specific other agents' datasets.
+
+    :param private: This agent's own dataset (always readable + writable).
+    :param user: The user-level pool (all agents run by one user), or
+        ``None`` when not granted.
+    :param team: The team-level pool, or ``None`` when not granted.
+    :param org: The org-level pool, or ``None`` when not granted.
+    :param shared: The generic exchange dataset granted via
+        ``shared_dataset``, or ``None`` — kept alongside the tiers for
+        ad-hoc pools that don't fit the hierarchy.
+    :param readable_peers: Peer datasets this agent may search
+        (``read_datasets`` config, csv of agent ids / dataset names).
+    :param writable_peers: Peer datasets this agent may publish into
+        (``write_datasets`` config). A peer listed in both grant lists
+        gets full read/write access.
+    """
+
+    private: str
+    user: str | None = None
+    team: str | None = None
+    org: str | None = None
+    shared: str | None = None
+    readable_peers: tuple[str, ...] = ()
+    writable_peers: tuple[str, ...] = ()
+
+    def tier(self, name: str) -> str | None:
+        """Return the dataset for tier *name* (``user``/``team``/``org``/``shared``)."""
+        return {
+            "user": self.user,
+            "team": self.team,
+            "org": self.org,
+            "shared": self.shared,
+        }.get(name)
+
+    def _pools(self) -> tuple[str | None, ...]:
+        return (self.user, self.team, self.org, self.shared)
+
+    def readable(self) -> tuple[str, ...]:
+        """Every dataset this agent may search, narrowest first."""
+        return self._dedup((self.private, *self._pools(), *self.readable_peers))
+
+    def writable(self) -> tuple[str, ...]:
+        """Every dataset this agent may store into, narrowest first."""
+        return self._dedup((self.private, *self._pools(), *self.writable_peers))
+
+    def can_read(self, dataset: str) -> bool:
+        return dataset in self.readable()
+
+    def can_write(self, dataset: str) -> bool:
+        return dataset in self.writable()
+
+    @staticmethod
+    def _dedup(names: tuple[str | None, ...]) -> tuple[str, ...]:
+        seen: list[str] = []
+        for name in names:
+            if name and name not in seen:
+                seen.append(name)
+        return tuple(seen)
+
+
+def resolve_grants(
+    config: dict[str, str],
+    *,
+    agent_id: str | None,
+    conversation_id: str | None,
+    settings: dict[str, Any] | None = None,
+) -> MemoryGrants:
+    """Resolve a tool config into this agent's :class:`MemoryGrants`.
+
+    The private dataset comes from ``config.dataset`` → *agent_id* →
+    *conversation_id* (sanitized). Tier datasets come from
+    ``user_dataset`` / ``team_dataset`` / ``org_dataset`` — per-agent tool
+    config first, falling back to the same keys in *settings* (the
+    ``cognee:`` config block), so a deployment can grant its tiers once
+    globally and agents inherit them. The exchange and peer grants come
+    from ``shared_dataset`` / ``read_datasets`` / ``write_datasets``
+    (tool config only — peer access stays an explicit per-agent grant).
+
+    :raises ValueError: When no private dataset can be resolved.
+    """
+    raw_private = config.get("dataset") or agent_id or conversation_id
+    if not raw_private:
+        raise ValueError(
+            "No cognee dataset could be resolved (no dataset, agent_id, or conversation_id)."
+        )
+    effective_settings = settings or {}
+
+    def _tier(name: str) -> str | None:
+        raw = config.get(f"{name}_dataset")
+        if raw is None:
+            fallback = effective_settings.get(f"{name}_dataset")
+            raw = fallback if isinstance(fallback, str) else None
+        return sanitize_dataset_name(raw) if raw and raw.strip() else None
+
+    shared_raw = config.get("shared_dataset")
+    return MemoryGrants(
+        private=sanitize_dataset_name(raw_private),
+        user=_tier("user"),
+        team=_tier("team"),
+        org=_tier("org"),
+        shared=sanitize_dataset_name(shared_raw) if shared_raw else None,
+        readable_peers=_csv_datasets(config.get("read_datasets")),
+        writable_peers=_csv_datasets(config.get("write_datasets")),
+    )
+
+
+def spec_declares_cognee_builtin(spec: Any | None) -> bool:
+    """Return whether the agent spec enables at least one cognee builtin.
+
+    Duck-typed (like the dispatch-side config lookup) so it works for both
+    the parsed :class:`AgentSpec` and the runner's SimpleNamespace mirrors.
+    """
+    if spec is None:
+        return False
+    tools = getattr(spec, "tools", None)
+    builtins = getattr(tools, "builtins", None) or []
+    return any(getattr(entry, "name", None) in COGNEE_TOOL_NAMES for entry in builtins)
+
+
+def cognee_framework_instructions(spec: Any | None) -> tuple[str, ...]:
+    """Return the memory framework instruction for this turn, or ``()``.
+
+    Gated on the spec actually enabling a cognee builtin AND the gate being
+    open — an agent without the tools must not be told it has them.
+    """
+    if spec_declares_cognee_builtin(spec) and cognee_available():
+        return (COGNEE_MEMORY_INSTRUCTION,)
+    return ()
+
+
+class _CircuitBreaker:
+    """Consecutive-failure breaker so a broken store degrades to no-ops.
+
+    After :data:`_BREAKER_FAILURE_THRESHOLD` consecutive failures the
+    breaker opens for :data:`_BREAKER_COOLDOWN_S`; while open, callers skip
+    cognee entirely. Thread-safe: tool invokes run on worker threads.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._consecutive_failures = 0
+        self._open_until = 0.0
+
+    def allow(self) -> bool:
+        with self._lock:
+            return time.monotonic() >= self._open_until
+
+    def record_success(self) -> None:
+        with self._lock:
+            self._consecutive_failures = 0
+
+    def record_failure(self) -> None:
+        with self._lock:
+            self._consecutive_failures += 1
+            if self._consecutive_failures >= _BREAKER_FAILURE_THRESHOLD:
+                self._open_until = time.monotonic() + _BREAKER_COOLDOWN_S
+                self._consecutive_failures = 0
+                _logger.warning(
+                    "cognee circuit breaker open for %.0fs after repeated failures",
+                    _BREAKER_COOLDOWN_S,
+                )
+
+    def reset(self) -> None:
+        with self._lock:
+            self._consecutive_failures = 0
+            self._open_until = 0.0
+
+
+breaker = _CircuitBreaker()
+
+# Serializes background cognify runs (LLM-heavy; one at a time is plenty)
+# and detaches them from the tool call's short-lived event loop. Daemon
+# threads: an in-flight cognify never blocks process exit.
+_background_executor: ThreadPoolExecutor | None = None
+_background_lock = threading.Lock()
+
+# The embedded store is configured once per process; cognee.config calls
+# are global, so repeating them per tool call is wasted work.
+_store_configured = False
+_store_lock = threading.Lock()
+
+
+def _ensure_local_store(settings: dict[str, Any]) -> None:
+    """Point cognee's global config at the embedded local store (once).
+
+    Also applies optional LLM settings from the ``cognee:`` block
+    (``llm_api_key`` / ``llm_provider`` / ``llm_model``) so the cognify
+    pipeline can run without a separate cognee config file. Absent keys
+    leave cognee's own defaults (its env vars / .env) untouched.
+    """
+    global _store_configured
+    with _store_lock:
+        if _store_configured:
+            return
+        import cognee
+
+        root = cognee_data_root(settings)
+        (root / "system").mkdir(parents=True, exist_ok=True)
+        (root / "data").mkdir(parents=True, exist_ok=True)
+        cognee.config.system_root_directory(str(root / "system"))
+        cognee.config.data_root_directory(str(root / "data"))
+        llm_api_key = settings.get("llm_api_key")
+        if isinstance(llm_api_key, str) and llm_api_key.strip():
+            cognee.config.set_llm_api_key(llm_api_key.strip())
+        llm_config = {
+            key: settings[cfg_key]
+            for key, cfg_key in (("llm_provider", "llm_provider"), ("llm_model", "llm_model"))
+            if isinstance(settings.get(cfg_key), str)
+        }
+        if llm_config:
+            cognee.config.set_llm_config(llm_config)
+        _store_configured = True
+
+
+def _run_bounded(coro_factory: Any, timeout_s: float) -> Any:
+    """Run an async cognee operation on a fresh loop, bounded by a timeout.
+
+    Tool ``invoke`` runs synchronously on a worker thread (the runner wraps
+    it in ``asyncio.to_thread``), so a private event loop per operation is
+    the simple, isolated choice.
+    """
+    return asyncio.run(asyncio.wait_for(coro_factory(), timeout=timeout_s))
+
+
+def _record_outcome(ok: bool) -> None:
+    if ok:
+        breaker.record_success()
+    else:
+        breaker.record_failure()
+
+
+def memory_search(
+    query: str,
+    datasets: list[str],
+    *,
+    settings: dict[str, Any] | None = None,
+    top_k: int = 10,
+) -> list[str]:
+    """Search cognee memory across *datasets*; empty list on any failure.
+
+    Never raises: timeouts, import errors, and store failures all log and
+    return ``[]`` — memory must never fail a turn.
+    """
+    effective = cognee_settings() if settings is None else settings
+    if not cognee_available() or not breaker.allow():
+        return []
+    try:
+        _ensure_local_store(effective)
+        import cognee
+
+        search_type_name = str(effective.get("search_type", "GRAPH_COMPLETION"))
+        search_type = getattr(cognee.SearchType, search_type_name, None)
+        if search_type is None:
+            search_type = cognee.SearchType.GRAPH_COMPLETION
+
+        async def _search() -> Any:
+            return await cognee.search(
+                query_type=search_type,
+                query_text=query,
+                datasets=datasets,
+                top_k=top_k,
+            )
+
+        results = _run_bounded(_search, SEARCH_TIMEOUT_S)
+        _record_outcome(True)
+        return [str(r) for r in results or []]
+    except Exception as e:
+        _record_outcome(False)
+        _logger.error("cognee search failed: %s", e)
+        return []
+
+
+def memory_add(
+    content: str,
+    dataset: str,
+    *,
+    settings: dict[str, Any] | None = None,
+    node_set: list[str] | None = None,
+) -> bool:
+    """Store *content* into *dataset* and schedule background cognify.
+
+    The ``add`` (local write) runs inline and bounded; the LLM-heavy
+    ``cognify`` is handed to the background worker so the tool returns
+    fast — eventual consistency within the same session is accepted.
+    Returns ``False`` (never raises) when the write failed.
+    """
+    global _background_executor
+    effective = cognee_settings() if settings is None else settings
+    if not cognee_available() or not breaker.allow():
+        return False
+    try:
+        _ensure_local_store(effective)
+        import cognee
+
+        async def _add() -> Any:
+            kwargs: dict[str, Any] = {"dataset_name": dataset}
+            if node_set:
+                kwargs["node_set"] = node_set
+            return await cognee.add(content, **kwargs)
+
+        _run_bounded(_add, ADD_TIMEOUT_S)
+        _record_outcome(True)
+    except Exception as e:
+        _record_outcome(False)
+        _logger.error("cognee add failed: %s", e)
+        return False
+
+    with _background_lock:
+        if _background_executor is None:
+            _background_executor = ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="cognee-cognify"
+            )
+    _background_executor.submit(_cognify_blocking, dataset)
+    return True
+
+
+def _cognify_blocking(dataset: str) -> None:
+    """Background worker body: run cognify for *dataset*, log-and-drop errors."""
+    try:
+        import cognee
+
+        async def _cognify() -> Any:
+            return await cognee.cognify(datasets=[dataset])
+
+        _run_bounded(_cognify, COGNIFY_TIMEOUT_S)
+        breaker.record_success()
+    except Exception as e:
+        breaker.record_failure()
+        _logger.error("cognee cognify failed for dataset %r: %s", dataset, e)

--- a/omnigent/runtime/prompt.py
+++ b/omnigent/runtime/prompt.py
@@ -48,13 +48,21 @@ def _framework_instructions_for(spec: AgentSpec) -> list[str]:
     ``spawn: true``) plus the ``web_fetch`` builtin, which dispatches the
     built-in web researcher through the same path.
 
+    The cognee memory announcement rides the same hook: it applies only when
+    the spec enables a cognee builtin and the memory gate is open, and the
+    gating itself lives in the owning module (:mod:`omnigent.runtime.memory`).
+
     :param spec: The parsed AgentSpec.
     :returns: The applicable spec-level framework instructions, possibly empty.
     """
+    from omnigent.runtime.memory import cognee_framework_instructions
+
+    instructions: list[str] = []
     dispatches_web_researcher = any(entry.name == "web_fetch" for entry in spec.tools.builtins)
     if spec.tools.agents or spec.spawn or dispatches_web_researcher:
-        return [SUBAGENT_WAKE_NOTICE_INSTRUCTION]
-    return []
+        instructions.append(SUBAGENT_WAKE_NOTICE_INSTRUCTION)
+    instructions.extend(cognee_framework_instructions(spec))
+    return instructions
 
 
 def append_framework_instructions(

--- a/omnigent/server/dictation.py
+++ b/omnigent/server/dictation.py
@@ -536,7 +536,9 @@ class _RemoteStream:
     def __init__(self, url: str) -> None:
         from websockets.sync.client import connect
 
-        self._ws = connect(url, open_timeout=5)
+        # proxy=None: direct connection to the relay worker — a system/env
+        # proxy would stall the loopback handshake on macOS (issue #1514).
+        self._ws = connect(url, open_timeout=5, proxy=None)
         try:
             deadline = time.monotonic() + _REMOTE_READY_TIMEOUT_S
             while True:

--- a/omnigent/tools/builtins/__init__.py
+++ b/omnigent/tools/builtins/__init__.py
@@ -221,6 +221,48 @@ def _create_hindsight_recall(config: dict[str, str]) -> Tool:
     return HindsightRecallTool(config=config)
 
 
+def _cognee_available() -> bool:
+    """
+    Return ``True`` if the optional ``cognee`` package is usable.
+
+    Probes via :func:`importlib.util.find_spec` (not ``import``) so the check
+    never loads cognee or its transitive deps, and honors the
+    ``OMNIGENT_DISABLE_COGNEE`` kill-switch inline (not via
+    :mod:`omnigent.runtime.memory` — the canonical gate — to keep this
+    module's import graph free of the runtime package).
+    """
+    import importlib.util
+    import os
+
+    if os.environ.get("OMNIGENT_DISABLE_COGNEE", "").strip().lower() in ("true", "1", "yes"):
+        return False
+    return importlib.util.find_spec("cognee") is not None
+
+
+def _create_cognee_search(config: dict[str, str]) -> Tool:
+    """
+    Lazy factory for CogneeSearchTool.
+
+    :param config: Tool config (dataset, shared_dataset, etc.).
+    :returns: A CogneeSearchTool instance.
+    """
+    from omnigent.tools.builtins.cognee import CogneeSearchTool
+
+    return CogneeSearchTool(config=config)
+
+
+def _create_cognee_remember(config: dict[str, str]) -> Tool:
+    """
+    Lazy factory for CogneeRememberTool.
+
+    :param config: Tool config (dataset, shared_dataset, etc.).
+    :returns: A CogneeRememberTool instance.
+    """
+    from omnigent.tools.builtins.cognee import CogneeRememberTool
+
+    return CogneeRememberTool(config=config)
+
+
 def _create_hindsight_reflect(config: dict[str, str]) -> Tool:
     """
     Lazy factory for HindsightReflectTool.
@@ -302,6 +344,17 @@ if _hindsight_available():
             "hindsight_retain": _create_hindsight_retain,
             "hindsight_recall": _create_hindsight_recall,
             "hindsight_reflect": _create_hindsight_reflect,
+        }
+    )
+
+# Cognee knowledge-graph memory (optional ``cognee`` extra). Registered only
+# when the package is installed and not kill-switched, so the tools are
+# absent from the builtin list on installs without the extra.
+if _cognee_available():
+    _BUILTIN_REGISTRY.update(
+        {
+            "cognee_search": _create_cognee_search,
+            "cognee_remember": _create_cognee_remember,
         }
     )
 

--- a/omnigent/tools/builtins/cognee.py
+++ b/omnigent/tools/builtins/cognee.py
@@ -318,8 +318,8 @@ class CogneeRememberTool(_CogneeToolBase):
                 return "cognee remember failed: the memory store is unavailable."
             if dataset != grants.private:
                 return (
-                    f"Stored to shared long-term memory dataset {dataset!r} "
-                    "(visible to agents granted access)."
+                    f"Stored to long-term memory dataset {dataset!r} "
+                    "(visible to agents granted access to it)."
                 )
             return "Stored to long-term memory."
         except Exception as e:

--- a/omnigent/tools/builtins/cognee.py
+++ b/omnigent/tools/builtins/cognee.py
@@ -27,8 +27,10 @@ Usage in config.yaml::
 
 Config keys (all optional):
 
-- ``dataset``: Private dataset name. Defaults to the agent id (falling back
-  to the conversation id), so memory isolates per agent out of the box.
+- ``dataset``: Private dataset name. When unset, the constructing layer
+  (ToolManager / runner dispatch) injects the agent's spec NAME so memory is
+  stable across sessions; the runtime agent id and conversation id are
+  last-resort fallbacks only (agent ids are minted per registration).
 - ``user_dataset`` / ``team_dataset`` / ``org_dataset``: Tier pools —
   read/write for every agent granted the same name. Each falls back to the
   same key in the global ``cognee:`` config block, so a deployment can set

--- a/omnigent/tools/builtins/cognee.py
+++ b/omnigent/tools/builtins/cognee.py
@@ -173,7 +173,11 @@ class CogneeSearchTool(_CogneeToolBase):
         }
 
     def invoke(self, arguments: str, ctx: ToolContext) -> str:
-        from omnigent.runtime.memory import memory_search, sanitize_dataset_name
+        from omnigent.runtime.memory import (
+            ensure_agent_registered,
+            memory_search,
+            sanitize_dataset_name,
+        )
 
         try:
             args = json.loads(arguments) if arguments else {}
@@ -181,6 +185,9 @@ class CogneeSearchTool(_CogneeToolBase):
             if not query:
                 return "Error: 'query' parameter is required."
             grants = self._grants(ctx)
+            ensure_agent_registered(
+                grants, session_id=ctx.conversation_id, settings=self._settings()
+            )
             if args.get("dataset"):
                 target = sanitize_dataset_name(args["dataset"])
                 if not grants.can_read(target):
@@ -283,7 +290,11 @@ class CogneeRememberTool(_CogneeToolBase):
         }
 
     def invoke(self, arguments: str, ctx: ToolContext) -> str:
-        from omnigent.runtime.memory import memory_add, sanitize_dataset_name
+        from omnigent.runtime.memory import (
+            ensure_agent_registered,
+            memory_add,
+            sanitize_dataset_name,
+        )
 
         try:
             args = json.loads(arguments) if arguments else {}
@@ -291,6 +302,9 @@ class CogneeRememberTool(_CogneeToolBase):
             if not content:
                 return "Error: 'content' parameter is required."
             grants = self._grants(ctx)
+            ensure_agent_registered(
+                grants, session_id=ctx.conversation_id, settings=self._settings()
+            )
             scope = args.get("scope") or "agent"
             if args.get("dataset"):
                 dataset = sanitize_dataset_name(args["dataset"])

--- a/omnigent/tools/builtins/cognee.py
+++ b/omnigent/tools/builtins/cognee.py
@@ -1,0 +1,327 @@
+"""Built-in tools: cognee knowledge-graph long-term memory.
+
+Exposes cognee (https://github.com/topoteretes/cognee) search / remember as
+built-in tools so an agent can persist and recall memory across runs, backed
+by an embedded local store under the Omnigent data dir. cognee is an optional
+dependency (``omnigent[cognee]``); all calls go through the framework-owned
+boundary in :mod:`omnigent.runtime.memory` (gate, timeouts, circuit breaker).
+
+Each agent's memory is isolated in its own dataset by default (resolved from
+the spec config, falling back to the run's identity in ``ToolContext``).
+Cross-agent access is grant-based (see
+:class:`omnigent.runtime.memory.MemoryGrants`), layered narrowest to
+broadest: **agent** (private) → **user** → **team** → **org** tier pools,
+plus a generic ``shared_dataset`` exchange and per-peer read/write grants.
+The tools can only touch datasets the grants expose.
+
+Usage in config.yaml::
+
+    tools:
+      builtins:
+        - name: cognee_search
+          team_dataset: platform_team
+          read_datasets: ag_researcher, ag_writer
+        - name: cognee_remember
+          team_dataset: platform_team
+          write_datasets: ag_researcher
+
+Config keys (all optional):
+
+- ``dataset``: Private dataset name. Defaults to the agent id (falling back
+  to the conversation id), so memory isolates per agent out of the box.
+- ``user_dataset`` / ``team_dataset`` / ``org_dataset``: Tier pools —
+  read/write for every agent granted the same name. Each falls back to the
+  same key in the global ``cognee:`` config block, so a deployment can set
+  its tiers once and agents inherit them.
+- ``shared_dataset``: Ad-hoc cross-agent exchange dataset outside the tier
+  hierarchy — read/write for every agent granted the same name.
+- ``read_datasets``: Comma-separated peer datasets (agent ids or dataset
+  names) this agent may search.
+- ``write_datasets``: Comma-separated peer datasets this agent may publish
+  into. List a peer in both keys for full read/write access.
+- ``search_type``: cognee search type (default ``GRAPH_COMPLETION``).
+- ``top_k``: max search results (default 10).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from omnigent.tools.base import Tool, ToolContext
+
+_logger = logging.getLogger(__name__)
+
+
+class _CogneeToolBase(Tool):
+    """Shared grant/settings resolution for the cognee memory tools.
+
+    The name starts with an underscore so the builtin-discovery test
+    (``_all_builtin_tool_subclasses``) skips it — only the concrete tools
+    below are user-facing.
+
+    :param config: Spec-level config from config.yaml (see module docstring).
+    """
+
+    def __init__(self, config: dict[str, str] | None = None) -> None:
+        self._config = config or {}
+
+    def _grants(self, ctx: ToolContext) -> Any:
+        """Resolve this agent's :class:`MemoryGrants` from config + context.
+
+        Passes the effective ``cognee:`` settings so tier datasets granted
+        globally (``user_dataset`` / ``team_dataset`` / ``org_dataset``)
+        are inherited without per-agent config.
+        """
+        from omnigent.runtime.memory import resolve_grants
+
+        return resolve_grants(
+            self._config,
+            agent_id=ctx.agent_id,
+            conversation_id=ctx.conversation_id,
+            settings=self._settings(),
+        )
+
+    @staticmethod
+    def _tier_not_granted(tier: str) -> str:
+        return (
+            f"No {tier}-level memory is granted to this agent (set "
+            f"'{tier}_dataset' in the tool config or the global 'cognee:' "
+            "config block)."
+        )
+
+    def _settings(self) -> dict[str, Any]:
+        """Effective cognee settings with spec-level search overrides applied."""
+        from omnigent.runtime.memory import cognee_settings
+
+        settings = dict(cognee_settings())
+        if self._config.get("search_type"):
+            settings["search_type"] = self._config["search_type"]
+        return settings
+
+    def _top_k(self) -> int:
+        return int(self._config.get("top_k", "10"))
+
+    @staticmethod
+    def _not_granted(action: str, dataset: str, granted: tuple[str, ...]) -> str:
+        granted_list = ", ".join(granted)
+        return (
+            f"Dataset {dataset!r} is not granted for {action} (granted: "
+            f"{granted_list}). Grants come from the tool config: "
+            "'shared_dataset', 'read_datasets', 'write_datasets'."
+        )
+
+
+class CogneeSearchTool(_CogneeToolBase):
+    """Search cognee long-term memory (own + granted shared/peer datasets)."""
+
+    @classmethod
+    def name(cls) -> str:
+        return "cognee_search"
+
+    @classmethod
+    def description(cls) -> str:
+        return (
+            "Search long-term memory (a cognee knowledge graph) for relevant "
+            "information — previously stored facts, decisions, preferences, "
+            "and context, including memories from shared or peer-agent "
+            "datasets this agent is granted. Call this BEFORE answering "
+            "anything that may depend on what you already know from past "
+            "sessions. Returns the matching memories, or a note that none "
+            "were found."
+        )
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name(),
+                "description": self.description(),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "The search query to find relevant memories.",
+                        },
+                        "scope": {
+                            "type": "string",
+                            "enum": ["all", "agent", "user", "team", "org", "shared", "peers"],
+                            "description": (
+                                "Which memory to search: 'agent' (this agent's "
+                                "private memory), 'user' / 'team' / 'org' (the "
+                                "granted tier pools, narrowest to broadest), "
+                                "'shared' (the ad-hoc exchange dataset), 'peers' "
+                                "(granted peer-agent datasets), or 'all' "
+                                "(everything granted; the default)."
+                            ),
+                        },
+                        "dataset": {
+                            "type": "string",
+                            "description": (
+                                "Search one specific granted dataset (e.g. a "
+                                "peer agent's id). Overrides 'scope'."
+                            ),
+                        },
+                    },
+                    "required": ["query"],
+                },
+            },
+        }
+
+    def invoke(self, arguments: str, ctx: ToolContext) -> str:
+        from omnigent.runtime.memory import memory_search, sanitize_dataset_name
+
+        try:
+            args = json.loads(arguments) if arguments else {}
+            query = args.get("query")
+            if not query:
+                return "Error: 'query' parameter is required."
+            grants = self._grants(ctx)
+            if args.get("dataset"):
+                target = sanitize_dataset_name(args["dataset"])
+                if not grants.can_read(target):
+                    return self._not_granted("reading", target, grants.readable())
+                datasets = [target]
+            else:
+                scope = args.get("scope") or "all"
+                if scope == "agent":
+                    datasets = [grants.private]
+                elif scope in ("user", "team", "org", "shared"):
+                    tier_dataset = grants.tier(scope)
+                    if not tier_dataset:
+                        if scope == "shared":
+                            return (
+                                "No shared memory is granted to this agent (set "
+                                "'shared_dataset' in the tool config to exchange "
+                                "memory with other agents)."
+                            )
+                        return self._tier_not_granted(scope)
+                    datasets = [tier_dataset]
+                elif scope == "peers":
+                    if not grants.readable_peers:
+                        return (
+                            "No peer-agent memory is granted to this agent "
+                            "(set 'read_datasets' in the tool config to read "
+                            "other agents' datasets)."
+                        )
+                    datasets = list(grants.readable_peers)
+                else:
+                    datasets = list(grants.readable())
+            results = memory_search(
+                query,
+                datasets,
+                settings=self._settings(),
+                top_k=self._top_k(),
+            )
+            if not results:
+                return "No relevant memories found."
+            return "\n".join(f"- {r}" for r in results)
+        except Exception as e:
+            _logger.error("cognee search failed: %s", e)
+            return f"cognee search failed: {e}"
+
+
+class CogneeRememberTool(_CogneeToolBase):
+    """Store information in cognee long-term memory."""
+
+    @classmethod
+    def name(cls) -> str:
+        return "cognee_remember"
+
+    @classmethod
+    def description(cls) -> str:
+        return (
+            "Persist information to long-term memory (a cognee knowledge "
+            "graph) so it survives across conversations and sessions. Call "
+            "this whenever a durable fact, preference, or decision emerges, "
+            "or the user asks you to remember something — conversation "
+            "context alone is lost between sessions. Use scope='user', "
+            "'team', or 'org' to store into a granted tier pool, "
+            "scope='shared' for the ad-hoc exchange dataset, or 'dataset' "
+            "to publish into a granted peer agent's memory."
+        )
+
+    def get_schema(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name(),
+                "description": self.description(),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "content": {
+                            "type": "string",
+                            "description": "The information to store in long-term memory.",
+                        },
+                        "scope": {
+                            "type": "string",
+                            "enum": ["agent", "user", "team", "org", "shared"],
+                            "description": (
+                                "Where to store: 'agent' (this agent's private "
+                                "memory; the default), 'user' / 'team' / 'org' "
+                                "(the granted tier pools), or 'shared' (the "
+                                "ad-hoc cross-agent exchange dataset)."
+                            ),
+                        },
+                        "dataset": {
+                            "type": "string",
+                            "description": (
+                                "Store into one specific granted dataset (e.g. "
+                                "a peer agent's id, when write access is "
+                                "granted). Overrides 'scope'."
+                            ),
+                        },
+                    },
+                    "required": ["content"],
+                },
+            },
+        }
+
+    def invoke(self, arguments: str, ctx: ToolContext) -> str:
+        from omnigent.runtime.memory import memory_add, sanitize_dataset_name
+
+        try:
+            args = json.loads(arguments) if arguments else {}
+            content = args.get("content")
+            if not content:
+                return "Error: 'content' parameter is required."
+            grants = self._grants(ctx)
+            scope = args.get("scope") or "agent"
+            if args.get("dataset"):
+                dataset = sanitize_dataset_name(args["dataset"])
+                if not grants.can_write(dataset):
+                    return self._not_granted("writing", dataset, grants.writable())
+            elif scope in ("user", "team", "org", "shared"):
+                tier_dataset = grants.tier(scope)
+                if not tier_dataset:
+                    if scope == "shared":
+                        return (
+                            "No shared memory is granted to this agent (set "
+                            "'shared_dataset' in the tool config to exchange "
+                            "memory with other agents)."
+                        )
+                    return self._tier_not_granted(scope)
+                dataset = tier_dataset
+            else:
+                dataset = grants.private
+            node_set = [ctx.conversation_id] if ctx.conversation_id else None
+            stored = memory_add(
+                content,
+                dataset,
+                settings=self._settings(),
+                node_set=node_set,
+            )
+            if not stored:
+                return "cognee remember failed: the memory store is unavailable."
+            if dataset != grants.private:
+                return (
+                    f"Stored to shared long-term memory dataset {dataset!r} "
+                    "(visible to agents granted access)."
+                )
+            return "Stored to long-term memory."
+        except Exception as e:
+            _logger.error("cognee remember failed: %s", e)
+            return f"cognee remember failed: {e}"

--- a/omnigent/tools/manager.py
+++ b/omnigent/tools/manager.py
@@ -365,6 +365,12 @@ class ToolManager:
             from omnigent.tools.builtins.upload_file import UploadFileTool
 
             return UploadFileTool()
+        if name in ("cognee_search", "cognee_remember"):
+            # Default the private memory dataset to the stable agent NAME:
+            # runtime agent ids are minted per registration, so an id-keyed
+            # dataset would silently reset every session.
+            if self._spec.name and not (config or {}).get("dataset"):
+                config = {**(config or {}), "dataset": self._spec.name}
         return get_builtin_tool(name, config=config)
 
     def _create_web_search(self, config: dict[str, str] | None) -> Tool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,7 +272,7 @@ nimble = ["nimble-python>=1.2.0,<2"]
 # memory tool need this extra. Bounded to the Python versions we ship wheels
 # for: on the resolver's speculative >=3.15 split, cognee's dep tree forces
 # websockets>=16, colliding with our websockets<16 cap.
-cognee = ["cognee>=0.2,<1 ; python_version < '3.15'"]
+cognee = ["cognee>=1,<2 ; python_version < '3.15'"]
 # Slack integration (`omni integration slack`). The @omnigent socket-mode bot
 # lives in the separate `omnigent-slack` package (heavy deps — slack_bolt /
 # aiohttp — kept out of the baseline install). The CLI launches it as a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,10 @@ dependencies = [
     "pyyaml>=6.0,<7",
     # OpenClaw stores its wrapped acpx registry as JSON5.
     "json5>=0.10,<1",
-    # openai-agents<0.18.2 omits a field required by openai>=2.45.
-    # Keep this cap until the websockets<15 compatibility pin can be lifted.
+    # openai-agents<0.18.2 omits a field required by openai>=2.45. The
+    # websockets<15 pin that used to block lifting this cap is gone
+    # (websockets is now >=15.0.1 with proxy=None at every client connect);
+    # the openai/openai-agents bump can now proceed on its own schedule.
     "openai>=1.0,<2.45",
     # >=14: the `e2b` extra's SDK (>=2.26) needs rich>=14 (was >=13,<14).
     "rich>=14,<15",
@@ -41,9 +43,12 @@ dependencies = [
     "mcp>=1.0,<2",
     "starlette>=1.0.1,<2",
     "uvicorn[standard]>=0.30,<1",
-    # websockets >=15 asyncio client hangs on macOS before emitting any handshake
-    # bytes; pin below 15 until upstream fixes the regression (see issue #1514).
-    "websockets>=10.4,<15",
+    # websockets 15.0 defaults connect() to proxy=True, which routes loopback
+    # tunnels through any configured system proxy on macOS and stalls the
+    # handshake (issue #1514). Every omnigent client connect() passes
+    # proxy=None to keep the pre-15 direct-connection behavior, which is what
+    # allows this floor. Capped <16 to match cognee's websockets window.
+    "websockets>=15.0.1,<16",
     "httpx>=0.27,<1",
     "ftfy>=6.0",
     # Portable zombie-aware PID liveness checks for the host daemon
@@ -261,6 +266,13 @@ hindsight = ["hindsight-client>=0.4.0"]
 # needs no client at runtime. Installing this extra is the opt-in signal that
 # surfaces both tools in the onboarding assistant's builtin list.
 nimble = ["nimble-python>=1.2.0,<2"]
+# Cognee knowledge-graph memory built-in tools (cognee_search / cognee_remember)
+# with an embedded local store under the Omnigent data dir. The tools and the
+# runtime memory gate import cognee lazily, so only users who enable a cognee
+# memory tool need this extra. Bounded to the Python versions we ship wheels
+# for: on the resolver's speculative >=3.15 split, cognee's dep tree forces
+# websockets>=16, colliding with our websockets<16 cap.
+cognee = ["cognee>=0.2,<1 ; python_version < '3.15'"]
 # Slack integration (`omni integration slack`). The @omnigent socket-mode bot
 # lives in the separate `omnigent-slack` package (heavy deps — slack_bolt /
 # aiohttp — kept out of the baseline install). The CLI launches it as a

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -22,6 +22,8 @@ ignore-missing-imports = [
     "boxlite.*",
     "blaxel",
     "blaxel.*",
+    "cognee",
+    "cognee.*",
     "copilot",
     "copilot.*",
     "cursor_sdk",

--- a/tests/runner/test_cognee_local_dispatch.py
+++ b/tests/runner/test_cognee_local_dispatch.py
@@ -1,0 +1,131 @@
+"""Tests for routing the cognee memory builtins through runner-local dispatch.
+
+Without runner-local dispatch a wrapped harness's (claude-sdk / codex / …)
+call to cognee_search falls through to the harness, which has no such tool,
+and silently no-ops. These lock in that the tools dispatch locally, are
+relayed to native harnesses, resolve the dataset from the threaded agent
+identity, and honor the runtime kill-switch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from omnigent.runner.tool_dispatch import (
+    _ALL_LOCAL_TOOLS,
+    _COGNEE_TOOLS,
+    _NATIVE_RELAY_BUILTIN_TOOLS,
+    _execute_cognee_tool,
+    should_dispatch_locally,
+)
+
+
+def _spec(config: dict[str, str], name: str = "cognee_search") -> SimpleNamespace:
+    return SimpleNamespace(
+        executor=SimpleNamespace(model="claude-opus-4-8"),
+        tools=SimpleNamespace(builtins=[SimpleNamespace(name=name, config=config)]),
+    )
+
+
+@pytest.fixture()
+def _cognee_usable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the runtime gate open and the registry to serve the tools."""
+    import omnigent.runtime.memory as memory_mod
+    import omnigent.tools.builtins as builtins_mod
+    from omnigent.tools.builtins.cognee import CogneeRememberTool, CogneeSearchTool
+
+    monkeypatch.setattr(memory_mod, "cognee_available", lambda: True)
+    monkeypatch.setattr(memory_mod, "cognee_settings", dict)
+    real_get = builtins_mod.get_builtin_tool
+
+    def serving_get(name: str, config: dict[str, str] | None = None) -> object | None:
+        if name == "cognee_search":
+            return CogneeSearchTool(config=config)
+        if name == "cognee_remember":
+            return CogneeRememberTool(config=config)
+        return real_get(name, config)
+
+    monkeypatch.setattr(builtins_mod, "get_builtin_tool", serving_get)
+
+
+def test_cognee_tool_set_is_exactly_the_two() -> None:
+    assert set(_COGNEE_TOOLS) == {"cognee_search", "cognee_remember"}
+
+
+@pytest.mark.parametrize("name", ["cognee_search", "cognee_remember"])
+def test_cognee_tools_are_runner_local(name: str) -> None:
+    assert name in _ALL_LOCAL_TOOLS
+    assert should_dispatch_locally(name) is True
+
+
+@pytest.mark.parametrize("name", ["cognee_search", "cognee_remember"])
+def test_cognee_tools_relayed_to_native_harnesses(name: str) -> None:
+    # Like the Hindsight memory builtins: native harnesses have no built-in
+    # long-term memory of their own, so the relay must advertise these.
+    assert name in _NATIVE_RELAY_BUILTIN_TOOLS
+
+
+@pytest.mark.usefixtures("_cognee_usable")
+def test_search_dispatch_uses_agent_id_as_dataset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no config dataset, the dataset defaults to the threaded agent_id."""
+    import omnigent.runtime.memory as memory_mod
+
+    search = MagicMock(return_value=["cognee is a knowledge graph"])
+    monkeypatch.setattr(memory_mod, "memory_search", search)
+    result = asyncio.run(
+        _execute_cognee_tool(
+            {"query": "what is cognee"},
+            tool_name="cognee_search",
+            agent_spec=_spec({}),
+            conversation_id="conv_1",
+            agent_id="ag_remy",
+        )
+    )
+    assert "knowledge graph" in result
+    assert search.call_args.args[1] == ["ag_remy"]
+
+
+@pytest.mark.usefixtures("_cognee_usable")
+def test_remember_dispatch_honors_shared_dataset_grant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A spec-granted shared_dataset lets agents exchange memory."""
+    import omnigent.runtime.memory as memory_mod
+
+    add = MagicMock(return_value=True)
+    monkeypatch.setattr(memory_mod, "memory_add", add)
+    spec = _spec({"shared_dataset": "team_knowledge"}, name="cognee_remember")
+    result = asyncio.run(
+        _execute_cognee_tool(
+            {"content": "release friday", "scope": "shared"},
+            tool_name="cognee_remember",
+            agent_spec=spec,
+            conversation_id="conv_1",
+            agent_id="ag_remy",
+        )
+    )
+    assert "shared" in result.lower()
+    assert add.call_args.args == ("release friday", "team_knowledge")
+
+
+def test_dispatch_reports_disabled_when_kill_switched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import omnigent.runtime.memory as memory_mod
+
+    monkeypatch.setattr(memory_mod, "cognee_available", lambda: False)
+    result = asyncio.run(
+        _execute_cognee_tool(
+            {"query": "q"},
+            tool_name="cognee_search",
+            agent_spec=_spec({}),
+            agent_id="ag_remy",
+        )
+    )
+    assert "not available" in result
+    json.dumps(result)  # result is a plain string

--- a/tests/runner/test_cognee_local_dispatch.py
+++ b/tests/runner/test_cognee_local_dispatch.py
@@ -71,8 +71,35 @@ def test_cognee_tools_relayed_to_native_harnesses(name: str) -> None:
 
 
 @pytest.mark.usefixtures("_cognee_usable")
+def test_search_dispatch_defaults_dataset_to_spec_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The private dataset defaults to the STABLE spec name, not the agent id.
+
+    Runtime agent ids are minted per registration, so an id-keyed dataset
+    silently resets every ``omnigent run`` — the exact bug this locks out.
+    """
+    import omnigent.runtime.memory as memory_mod
+
+    search = MagicMock(return_value=["m"])
+    monkeypatch.setattr(memory_mod, "memory_search", search)
+    spec = _spec({})
+    spec.name = "memory-test"
+    asyncio.run(
+        _execute_cognee_tool(
+            {"query": "q"},
+            tool_name="cognee_search",
+            agent_spec=spec,
+            conversation_id="conv_1",
+            agent_id="a6a5762aa32347c5a74d1b19d7608f8f",
+        )
+    )
+    assert search.call_args.args[1] == ["memory_test"]
+
+
+@pytest.mark.usefixtures("_cognee_usable")
 def test_search_dispatch_uses_agent_id_as_dataset(monkeypatch: pytest.MonkeyPatch) -> None:
-    """With no config dataset, the dataset defaults to the threaded agent_id."""
+    """Without a spec name or config dataset, the dataset falls back to agent_id."""
     import omnigent.runtime.memory as memory_mod
 
     search = MagicMock(return_value=["cognee is a knowledge graph"])

--- a/tests/runner/test_cognee_local_dispatch.py
+++ b/tests/runner/test_cognee_local_dispatch.py
@@ -41,6 +41,7 @@ def _cognee_usable(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(memory_mod, "cognee_available", lambda: True)
     monkeypatch.setattr(memory_mod, "cognee_settings", dict)
+    monkeypatch.setattr(memory_mod, "ensure_agent_registered", MagicMock())
     real_get = builtins_mod.get_builtin_tool
 
     def serving_get(name: str, config: dict[str, str] | None = None) -> object | None:

--- a/tests/runner/test_cognee_local_dispatch.py
+++ b/tests/runner/test_cognee_local_dispatch.py
@@ -109,7 +109,7 @@ def test_remember_dispatch_honors_shared_dataset_grant(
             agent_id="ag_remy",
         )
     )
-    assert "shared" in result.lower()
+    assert "'team_knowledge'" in result
     assert add.call_args.args == ("release friday", "team_knowledge")
 
 

--- a/tests/runner/test_cognee_memory_flow.py
+++ b/tests/runner/test_cognee_memory_flow.py
@@ -1,0 +1,154 @@
+"""End-to-end happy path for the cognee memory tools at the dispatch boundary.
+
+Exercises the full in-process stack — runner dispatch → builtin tool →
+``omnigent.runtime.memory`` boundary (store config, timeouts, background
+cognify) — against a fake ``cognee`` module that genuinely persists and
+recalls per-dataset, so remember → search round-trips are observed rather
+than asserted on mock call args. A live-store e2e (real cognee + LLM key)
+is tracked in ``designs/cognee-memory-integration.md`` hardening phase.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from collections.abc import Generator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from omnigent.runner.tool_dispatch import _execute_cognee_tool
+from omnigent.runtime import memory as memory_mod
+
+
+class _FakeStore:
+    """In-memory stand-in for cognee: per-dataset content with substring search."""
+
+    def __init__(self) -> None:
+        self.datasets: dict[str, list[str]] = {}
+        self.cognified: list[str] = []
+
+    async def add(self, content: str, dataset_name: str, **_: Any) -> None:
+        self.datasets.setdefault(dataset_name, []).append(content)
+
+    async def cognify(self, datasets: list[str], **_: Any) -> None:
+        self.cognified.extend(datasets)
+
+    async def search(self, *, query_text: str, datasets: list[str], **_: Any) -> list[str]:
+        needle = query_text.split()[0].lower()
+        return [
+            item for ds in datasets for item in self.datasets.get(ds, []) if needle in item.lower()
+        ]
+
+
+@pytest.fixture()
+def fake_store(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> Generator[_FakeStore, None, None]:
+    """Install a persisting fake cognee module and open the gate."""
+    store = _FakeStore()
+    fake = MagicMock()
+    fake.SearchType = SimpleNamespace(GRAPH_COMPLETION="graph_completion")
+    fake.add = AsyncMock(side_effect=store.add)
+    fake.cognify = AsyncMock(side_effect=store.cognify)
+    fake.search = AsyncMock(side_effect=store.search)
+    fake.config = MagicMock()
+    monkeypatch.setitem(sys.modules, "cognee", fake)
+    monkeypatch.setattr(memory_mod, "cognee_installed", lambda: True)
+    monkeypatch.delenv(memory_mod.COGNEE_DISABLE_ENV, raising=False)
+    monkeypatch.setattr(
+        memory_mod, "cognee_settings", lambda: {"data_root": str(tmp_path / "cognee")}
+    )
+    memory_mod.breaker.reset()
+    memory_mod._store_configured = False
+    # Serve the tools even though the real registry gated them out at import
+    # (the cognee package is absent from the dev environment).
+    import omnigent.tools.builtins as builtins_mod
+    from omnigent.tools.builtins.cognee import CogneeRememberTool, CogneeSearchTool
+
+    def serving_get(name: str, config: dict[str, str] | None = None) -> object | None:
+        if name == "cognee_search":
+            return CogneeSearchTool(config=config)
+        if name == "cognee_remember":
+            return CogneeRememberTool(config=config)
+        return None
+
+    monkeypatch.setattr(builtins_mod, "get_builtin_tool", serving_get)
+    yield store
+    memory_mod.breaker.reset()
+    memory_mod._store_configured = False
+    if memory_mod._background_executor is not None:
+        memory_mod._background_executor.shutdown(wait=True)
+        memory_mod._background_executor = None
+
+
+def _spec(config: dict[str, str], *names: str) -> SimpleNamespace:
+    builtins = [SimpleNamespace(name=n, config=config) for n in names]
+    return SimpleNamespace(tools=SimpleNamespace(builtins=builtins))
+
+
+def _dispatch(args: dict[str, Any], tool_name: str, spec: SimpleNamespace, agent_id: str) -> str:
+    return asyncio.run(
+        _execute_cognee_tool(
+            args,
+            tool_name=tool_name,
+            agent_spec=spec,
+            conversation_id="conv_flow",
+            agent_id=agent_id,
+        )
+    )
+
+
+def test_remember_then_search_round_trip(fake_store: _FakeStore) -> None:
+    """Happy path: enable tools → remember → search recalls the memory."""
+    spec = _spec({}, "cognee_remember", "cognee_search")
+    stored = _dispatch(
+        {"content": "DuckDB is the preferred analytics database"},
+        "cognee_remember",
+        spec,
+        agent_id="ag_flow",
+    )
+    assert stored == "Stored to long-term memory."
+    # The write landed in the agent's private dataset and was queued for
+    # background cognify (drain the worker so the assertion is deterministic).
+    assert fake_store.datasets["ag_flow"] == ["DuckDB is the preferred analytics database"]
+    assert memory_mod._background_executor is not None
+    memory_mod._background_executor.shutdown(wait=True)
+    assert fake_store.cognified == ["ag_flow"]
+
+    recalled = _dispatch({"query": "duckdb preference"}, "cognee_search", spec, agent_id="ag_flow")
+    assert recalled == "- DuckDB is the preferred analytics database"
+
+
+def test_cross_agent_exchange_round_trip(fake_store: _FakeStore) -> None:
+    """Agent A publishes to the shared pool; agent B recalls it."""
+    grant = {"shared_dataset": "team_pool"}
+    publisher = _spec(grant, "cognee_remember")
+    reader = _spec(grant, "cognee_search")
+    _dispatch(
+        {"content": "release is friday", "scope": "shared"},
+        "cognee_remember",
+        publisher,
+        agent_id="ag_a",
+    )
+    recalled = _dispatch({"query": "release date"}, "cognee_search", reader, agent_id="ag_b")
+    assert recalled == "- release is friday"
+    # Isolation: agent B's private search does not see A's publication.
+    private_only = _dispatch(
+        {"query": "release date", "scope": "agent"}, "cognee_search", reader, agent_id="ag_b"
+    )
+    assert private_only == "No relevant memories found."
+
+
+def test_kill_switch_degrades_gracefully(
+    fake_store: _FakeStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With the kill-switch set, dispatch reports unavailability, never raises."""
+    monkeypatch.setenv(memory_mod.COGNEE_DISABLE_ENV, "1")
+    spec = _spec({}, "cognee_search")
+    result = _dispatch({"query": "anything"}, "cognee_search", spec, agent_id="ag_flow")
+    assert "not available" in result
+    assert fake_store.datasets == {}

--- a/tests/runner/test_cognee_memory_flow.py
+++ b/tests/runner/test_cognee_memory_flow.py
@@ -62,8 +62,12 @@ def fake_store(
     monkeypatch.setattr(
         memory_mod, "cognee_settings", lambda: {"data_root": str(tmp_path / "cognee")}
     )
+    # Registration mirroring is covered by its own unit tests; keep it inert
+    # here so the flow doesn't reach the real cognee agent registry.
+    monkeypatch.setattr(memory_mod, "ensure_agent_registered", MagicMock())
     memory_mod.breaker.reset()
     memory_mod._store_configured = False
+    memory_mod._registered_agent_connections.clear()
     # Serve the tools even though the real registry gated them out at import
     # (the cognee package is absent from the dev environment).
     import omnigent.tools.builtins as builtins_mod

--- a/tests/runner/transports/ws_tunnel/test_serve.py
+++ b/tests/runner/transports/ws_tunnel/test_serve.py
@@ -760,6 +760,8 @@ async def test_serve_tunnel_once_sends_bearer_header(
         "max_size": serve_module.RUNNER_TUNNEL_MAX_MESSAGE_BYTES,
         "ping_interval": serve_module.TUNNEL_KEEPALIVE_PING_INTERVAL_S,
         "ping_timeout": serve_module.TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
+        # Never route the tunnel through a system/env proxy (issue #1514).
+        "proxy": None,
     }
     assert isinstance(captured["sent"], str)
 

--- a/tests/runtime/test_cognee_memory.py
+++ b/tests/runtime/test_cognee_memory.py
@@ -1,0 +1,379 @@
+"""Tests for the framework-owned cognee memory boundary.
+
+The optional ``cognee`` package is NOT in the dev set — it is simulated by
+injecting a fake module into ``sys.modules`` and forcing the installed-probe,
+so these tests run identically with and without the extra. Covers the gate
+precedence (env kill-switch > installed probe), settings/data-root
+resolution, dataset sanitization, the framework-instruction gate, the
+circuit breaker, and the bounded search/add/cognify paths.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from omnigent.runtime import memory as memory_mod
+from omnigent.runtime.memory import (
+    COGNEE_MEMORY_INSTRUCTION,
+    cognee_available,
+    cognee_data_root,
+    cognee_framework_instructions,
+    memory_add,
+    memory_search,
+    resolve_grants,
+    sanitize_dataset_name,
+    spec_declares_cognee_builtin,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_memory_state(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Isolate the module's process-level state between tests."""
+    monkeypatch.delenv(memory_mod.COGNEE_DISABLE_ENV, raising=False)
+    memory_mod.breaker.reset()
+    memory_mod._store_configured = False
+    yield
+    memory_mod.breaker.reset()
+    memory_mod._store_configured = False
+    if memory_mod._background_executor is not None:
+        memory_mod._background_executor.shutdown(wait=True)
+        memory_mod._background_executor = None
+
+
+def _fake_cognee(
+    *,
+    search_results: list[Any] | None = None,
+    search_error: Exception | None = None,
+) -> MagicMock:
+    """Build a fake ``cognee`` module with async search/add/cognify."""
+    fake = MagicMock()
+    fake.SearchType = SimpleNamespace(GRAPH_COMPLETION="graph_completion", CHUNKS="chunks")
+    if search_error is not None:
+        fake.search = AsyncMock(side_effect=search_error)
+    else:
+        fake.search = AsyncMock(return_value=search_results or [])
+    fake.add = AsyncMock()
+    fake.cognify = AsyncMock()
+    fake.config = MagicMock()
+    return fake
+
+
+def _install(
+    monkeypatch: pytest.MonkeyPatch,
+    fake: MagicMock,
+) -> None:
+    """Make the fake cognee importable and the installed-probe pass."""
+    monkeypatch.setitem(sys.modules, "cognee", fake)
+    monkeypatch.setattr(memory_mod, "cognee_installed", lambda: True)
+
+
+def _settings(tmp_path: Path, **extra: Any) -> dict[str, Any]:
+    return {"data_root": str(tmp_path / "cognee"), **extra}
+
+
+# ---------------------------------------------------------------------------
+# Gate precedence
+# ---------------------------------------------------------------------------
+
+
+def test_available_requires_package(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(memory_mod, "cognee_installed", lambda: False)
+    assert cognee_available() is False
+
+
+def test_env_kill_switch_beats_installed_package(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(memory_mod, "cognee_installed", lambda: True)
+    monkeypatch.setenv(memory_mod.COGNEE_DISABLE_ENV, "1")
+    assert cognee_available() is False
+
+
+@pytest.mark.parametrize("value", ["true", "TRUE", "yes", "1"])
+def test_kill_switch_truthy_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setattr(memory_mod, "cognee_installed", lambda: True)
+    monkeypatch.setenv(memory_mod.COGNEE_DISABLE_ENV, value)
+    assert cognee_available() is False
+
+
+def test_kill_switch_falsy_value_leaves_gate_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(memory_mod, "cognee_installed", lambda: True)
+    monkeypatch.setenv(memory_mod.COGNEE_DISABLE_ENV, "0")
+    assert cognee_available() is True
+
+
+# ---------------------------------------------------------------------------
+# Settings + data root + sanitization
+# ---------------------------------------------------------------------------
+
+
+def test_data_root_defaults_under_data_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    import omnigent.process_logging as process_logging
+
+    monkeypatch.setattr(process_logging, "data_dir", lambda: Path("/tmp/omnigent-data"))
+    assert cognee_data_root({}) == Path("/tmp/omnigent-data") / "cognee"
+
+
+def test_data_root_honors_config_override(tmp_path: Path) -> None:
+    assert cognee_data_root({"data_root": str(tmp_path)}) == tmp_path
+
+
+def test_settings_ignores_non_mapping_block(monkeypatch: pytest.MonkeyPatch) -> None:
+    import omnigent.config as config_mod
+
+    monkeypatch.setattr(config_mod, "load_effective_config", lambda: {"cognee": True})
+    assert memory_mod.cognee_settings() == {}
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("ag_ABC-123", "ag_abc_123"),
+        ("  Team Knowledge  ", "team_knowledge"),
+        ("___", "default"),
+    ],
+)
+def test_sanitize_dataset_name(raw: str, expected: str) -> None:
+    assert sanitize_dataset_name(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# Memory grants (cross-agent access layer)
+# ---------------------------------------------------------------------------
+
+
+def test_grants_private_resolution_precedence() -> None:
+    grants = resolve_grants({"dataset": "Custom DS"}, agent_id="ag_1", conversation_id="c_1")
+    assert grants.private == "custom_ds"
+    grants = resolve_grants({}, agent_id="ag_1", conversation_id="c_1")
+    assert grants.private == "ag_1"
+    grants = resolve_grants({}, agent_id=None, conversation_id="c_1")
+    assert grants.private == "c_1"
+
+
+def test_grants_require_a_resolvable_private_dataset() -> None:
+    with pytest.raises(ValueError):
+        resolve_grants({}, agent_id=None, conversation_id=None)
+
+
+def test_grants_parse_csv_peer_lists_sanitized_and_deduped() -> None:
+    grants = resolve_grants(
+        {
+            "read_datasets": "ag_Researcher, ag_writer,ag_researcher, ",
+            "write_datasets": "ag_writer",
+        },
+        agent_id="ag_me",
+        conversation_id=None,
+    )
+    assert grants.readable_peers == ("ag_researcher", "ag_writer")
+    assert grants.writable_peers == ("ag_writer",)
+
+
+def test_grants_readable_and_writable_surfaces() -> None:
+    grants = resolve_grants(
+        {
+            "shared_dataset": "team",
+            "read_datasets": "ag_peer_r",
+            "write_datasets": "ag_peer_w",
+        },
+        agent_id="ag_me",
+        conversation_id=None,
+    )
+    assert grants.readable() == ("ag_me", "team", "ag_peer_r")
+    assert grants.writable() == ("ag_me", "team", "ag_peer_w")
+    assert grants.can_read("ag_peer_r") is True
+    assert grants.can_read("ag_peer_w") is False
+    assert grants.can_write("ag_peer_w") is True
+    assert grants.can_write("ag_peer_r") is False
+    # Private and shared are always read/write for the owning agent.
+    assert grants.can_write("ag_me") is True
+    assert grants.can_write("team") is True
+
+
+def test_grants_dedup_peer_matching_private() -> None:
+    grants = resolve_grants(
+        {"read_datasets": "ag_me, ag_other"}, agent_id="ag_me", conversation_id=None
+    )
+    assert grants.readable() == ("ag_me", "ag_other")
+
+
+def test_grants_tier_pools_from_config() -> None:
+    grants = resolve_grants(
+        {"user_dataset": "u_vasilije", "team_dataset": "Platform Team", "org_dataset": "acme"},
+        agent_id="ag_me",
+        conversation_id=None,
+    )
+    assert grants.tier("user") == "u_vasilije"
+    assert grants.tier("team") == "platform_team"
+    assert grants.tier("org") == "acme"
+    # Tier pools are read/write, ordered narrowest first after private.
+    assert grants.readable() == ("ag_me", "u_vasilije", "platform_team", "acme")
+    assert grants.writable() == ("ag_me", "u_vasilije", "platform_team", "acme")
+
+
+def test_grants_tiers_inherit_from_global_settings() -> None:
+    grants = resolve_grants(
+        {"team_dataset": "spec_team"},
+        agent_id="ag_me",
+        conversation_id=None,
+        settings={"team_dataset": "global_team", "org_dataset": "global_org", "user_dataset": 3},
+    )
+    # Per-agent config wins over the global block; non-string globals ignored.
+    assert grants.tier("team") == "spec_team"
+    assert grants.tier("org") == "global_org"
+    assert grants.tier("user") is None
+
+
+def test_grants_tiers_absent_by_default() -> None:
+    grants = resolve_grants({}, agent_id="ag_me", conversation_id=None)
+    assert grants.tier("user") is None
+    assert grants.tier("team") is None
+    assert grants.tier("org") is None
+    assert grants.readable() == ("ag_me",)
+
+
+# ---------------------------------------------------------------------------
+# Framework instruction gate
+# ---------------------------------------------------------------------------
+
+
+def _spec_with(*names: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        tools=SimpleNamespace(builtins=[SimpleNamespace(name=n, config={}) for n in names])
+    )
+
+
+def test_spec_declaration_probe() -> None:
+    assert spec_declares_cognee_builtin(_spec_with("cognee_search")) is True
+    assert spec_declares_cognee_builtin(_spec_with("web_search")) is False
+    assert spec_declares_cognee_builtin(None) is False
+
+
+def test_instruction_present_only_when_declared_and_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(memory_mod, "cognee_installed", lambda: True)
+    assert cognee_framework_instructions(_spec_with("cognee_remember")) == (
+        COGNEE_MEMORY_INSTRUCTION,
+    )
+    assert cognee_framework_instructions(_spec_with("web_search")) == ()
+
+
+def test_instruction_absent_when_kill_switched(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(memory_mod, "cognee_installed", lambda: True)
+    monkeypatch.setenv(memory_mod.COGNEE_DISABLE_ENV, "1")
+    assert cognee_framework_instructions(_spec_with("cognee_search")) == ()
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker
+# ---------------------------------------------------------------------------
+
+
+def test_breaker_opens_after_consecutive_failures() -> None:
+    for _ in range(3):
+        memory_mod.breaker.record_failure()
+    assert memory_mod.breaker.allow() is False
+
+
+def test_breaker_success_resets_failure_streak() -> None:
+    memory_mod.breaker.record_failure()
+    memory_mod.breaker.record_failure()
+    memory_mod.breaker.record_success()
+    memory_mod.breaker.record_failure()
+    assert memory_mod.breaker.allow() is True
+
+
+# ---------------------------------------------------------------------------
+# Search / add / cognify
+# ---------------------------------------------------------------------------
+
+
+def test_search_returns_stringified_results(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake = _fake_cognee(search_results=["likes tea", {"fact": "NYC"}])
+    _install(monkeypatch, fake)
+    results = memory_search("about the user", ["ds_a"], settings=_settings(tmp_path))
+    assert results == ["likes tea", "{'fact': 'NYC'}"]
+    kwargs = fake.search.call_args.kwargs
+    assert kwargs["query_text"] == "about the user"
+    assert kwargs["datasets"] == ["ds_a"]
+    assert kwargs["query_type"] == "graph_completion"
+
+
+def test_search_honors_configured_search_type(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake = _fake_cognee(search_results=["m"])
+    _install(monkeypatch, fake)
+    memory_search("q", ["ds"], settings=_settings(tmp_path, search_type="CHUNKS"))
+    assert fake.search.call_args.kwargs["query_type"] == "chunks"
+
+
+def test_search_failure_returns_empty_and_counts_toward_breaker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake = _fake_cognee(search_error=RuntimeError("store down"))
+    _install(monkeypatch, fake)
+    settings = _settings(tmp_path)
+    for _ in range(3):
+        assert memory_search("q", ["ds"], settings=settings) == []
+    # Breaker is now open: the next call short-circuits without touching cognee.
+    fake.search.reset_mock()
+    assert memory_search("q", ["ds"], settings=settings) == []
+    fake.search.assert_not_called()
+
+
+def test_search_short_circuits_when_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(memory_mod, "cognee_installed", lambda: False)
+    assert memory_search("q", ["ds"]) == []
+
+
+def test_add_writes_and_schedules_background_cognify(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake = _fake_cognee()
+    _install(monkeypatch, fake)
+    cognified: list[str] = []
+    monkeypatch.setattr(memory_mod, "_cognify_blocking", cognified.append)
+    assert memory_add("fact", "ds_a", settings=_settings(tmp_path), node_set=["conv_1"]) is True
+    kwargs = fake.add.call_args.kwargs
+    assert kwargs["dataset_name"] == "ds_a"
+    assert kwargs["node_set"] == ["conv_1"]
+    assert memory_mod._background_executor is not None
+    memory_mod._background_executor.shutdown(wait=True)
+    assert cognified == ["ds_a"]
+
+
+def test_add_failure_returns_false_and_skips_cognify(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake = _fake_cognee()
+    fake.add = AsyncMock(side_effect=RuntimeError("disk full"))
+    _install(monkeypatch, fake)
+    cognified: list[str] = []
+    monkeypatch.setattr(memory_mod, "_cognify_blocking", cognified.append)
+    assert memory_add("fact", "ds_a", settings=_settings(tmp_path)) is False
+    assert cognified == []
+
+
+def test_local_store_configured_once_with_llm_settings(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake = _fake_cognee(search_results=["m"])
+    _install(monkeypatch, fake)
+    settings = _settings(tmp_path, llm_api_key="sk-test", llm_provider="openai")
+    memory_search("q", ["ds"], settings=settings)
+    memory_search("q", ["ds"], settings=settings)
+    root = tmp_path / "cognee"
+    fake.config.system_root_directory.assert_called_once_with(str(root / "system"))
+    fake.config.data_root_directory.assert_called_once_with(str(root / "data"))
+    fake.config.set_llm_api_key.assert_called_once_with("sk-test")
+    fake.config.set_llm_config.assert_called_once_with({"llm_provider": "openai"})
+    assert (root / "system").is_dir()
+    assert (root / "data").is_dir()

--- a/tests/runtime/test_cognee_memory.py
+++ b/tests/runtime/test_cognee_memory.py
@@ -38,9 +38,11 @@ def _reset_memory_state(monkeypatch: pytest.MonkeyPatch) -> Any:
     monkeypatch.delenv(memory_mod.COGNEE_DISABLE_ENV, raising=False)
     memory_mod.breaker.reset()
     memory_mod._store_configured = False
+    memory_mod._registered_agent_connections.clear()
     yield
     memory_mod.breaker.reset()
     memory_mod._store_configured = False
+    memory_mod._registered_agent_connections.clear()
     if memory_mod._background_executor is not None:
         memory_mod._background_executor.shutdown(wait=True)
         memory_mod._background_executor = None
@@ -360,6 +362,98 @@ def test_add_failure_returns_false_and_skips_cognify(
     monkeypatch.setattr(memory_mod, "_cognify_blocking", cognified.append)
     assert memory_add("fact", "ds_a", settings=_settings(tmp_path)) is False
     assert cognified == []
+
+
+class _InlineExecutor:
+    """Executor stub that runs submissions synchronously for assertions."""
+
+    def submit(self, fn: Any, *args: Any) -> None:
+        fn(*args)
+
+
+def test_agent_registration_submits_once_per_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(memory_mod, "cognee_installed", lambda: True)
+    monkeypatch.setattr(memory_mod, "_get_background_executor", _InlineExecutor)
+    posted: list[tuple[str, str | None]] = []
+    monkeypatch.setattr(
+        memory_mod,
+        "_register_agent_blocking",
+        lambda grants, session_id, settings: posted.append((grants.private, session_id)),
+    )
+    grants = resolve_grants({}, agent_id="ag_me", conversation_id=None)
+    memory_mod.ensure_agent_registered(grants, session_id="conv_1", settings={})
+    memory_mod.ensure_agent_registered(grants, session_id="conv_1", settings={})
+    memory_mod.ensure_agent_registered(grants, session_id="conv_2", settings={})
+    assert posted == [("ag_me", "conv_1"), ("ag_me", "conv_2")]
+
+
+def test_agent_registration_skips_when_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(memory_mod, "cognee_installed", lambda: False)
+    monkeypatch.setattr(
+        memory_mod,
+        "_register_agent_blocking",
+        lambda *a: pytest.fail("must not register when unavailable"),
+    )
+    grants = resolve_grants({}, agent_id="ag_me", conversation_id=None)
+    memory_mod.ensure_agent_registered(grants, session_id="conv_1", settings={})
+    assert memory_mod._registered_agent_connections == set()
+
+
+def _install_registration_fakes(
+    monkeypatch: pytest.MonkeyPatch, fake: MagicMock
+) -> tuple[MagicMock, AsyncMock]:
+    """Fake the cognee agent-registry submodules for the blocking body."""
+    _install(monkeypatch, fake)
+    models = MagicMock()
+    request_kwargs = MagicMock(side_effect=lambda **kw: kw)
+    models.RegisterAgentRequest = request_kwargs
+    operations = MagicMock()
+    operations.register_agent_from_request = AsyncMock()
+    users = MagicMock()
+    users.get_default_user = AsyncMock(return_value="default-user")
+    monkeypatch.setitem(sys.modules, "cognee.modules", MagicMock())
+    monkeypatch.setitem(sys.modules, "cognee.modules.agents", MagicMock())
+    monkeypatch.setitem(sys.modules, "cognee.modules.agents.models", models)
+    monkeypatch.setitem(sys.modules, "cognee.modules.agents.operations", operations)
+    monkeypatch.setitem(sys.modules, "cognee.modules.users", MagicMock())
+    monkeypatch.setitem(sys.modules, "cognee.modules.users.methods", users)
+    return request_kwargs, operations.register_agent_from_request
+
+
+def test_registration_mirrors_grants_into_request(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    request_kwargs, register = _install_registration_fakes(monkeypatch, _fake_cognee())
+    grants = resolve_grants(
+        {"shared_dataset": "team", "read_datasets": "ag_peer_r", "write_datasets": "ag_peer_w"},
+        agent_id="ag_me",
+        conversation_id=None,
+    )
+    memory_mod._register_agent_blocking(grants, "conv_9", _settings(tmp_path))
+    kwargs = request_kwargs.call_args.kwargs
+    assert kwargs["agent_session_name"] == "ag_me"
+    assert kwargs["session_id"] == "conv_9"
+    assert kwargs["type"] == "omnigent"
+    assert kwargs["memory_mode"] == "cognee"
+    # Readable first, then write-only grants — flat names for the request...
+    assert kwargs["dataset_names"] == ["ag_me", "team", "ag_peer_r", "ag_peer_w"]
+    # ...with the precise read/write split preserved in metadata.
+    assert kwargs["metadata"]["grants"] == {
+        "readable": ["ag_me", "team", "ag_peer_r"],
+        "writable": ["ag_me", "team", "ag_peer_w"],
+    }
+    assert register.await_count == 1
+
+
+def test_registration_failure_is_swallowed_and_spares_breaker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _, register = _install_registration_fakes(monkeypatch, _fake_cognee())
+    register.side_effect = RuntimeError("registry down")
+    grants = resolve_grants({}, agent_id="ag_me", conversation_id=None)
+    memory_mod._register_agent_blocking(grants, "conv_9", _settings(tmp_path))
+    # Observability-only: no exception escaped and the breaker is untouched.
+    assert memory_mod.breaker.allow() is True
 
 
 def test_local_store_configured_once_with_llm_settings(

--- a/tests/runtime/test_prompt.py
+++ b/tests/runtime/test_prompt.py
@@ -241,6 +241,26 @@ def test_subagent_wake_instruction_added_for_dispatching_agents(
     assert build_instructions_nullable(unauthored, None, []) == SUBAGENT_WAKE_NOTICE_INSTRUCTION
 
 
+def test_cognee_memory_instruction_rides_the_spec_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A spec that enables a cognee builtin gets the memory announcement.
+
+    The gating lives in ``omnigent.runtime.memory`` (builtin declared AND the
+    availability gate open); composition only has to route the hook. Force the
+    gate open so the test doesn't depend on the optional extra being installed.
+    """
+    import omnigent.runtime.memory as memory_mod
+
+    monkeypatch.setattr(memory_mod, "cognee_available", lambda: True)
+    with_memory = _spec("Agent prompt", builtins=("cognee_search",))
+    result = build_instructions(with_memory, None, [])
+    assert result == f"Agent prompt\n\n{memory_mod.COGNEE_MEMORY_INSTRUCTION}"
+
+    without_memory = _spec("Agent prompt")
+    assert build_instructions(without_memory, None, []) == "Agent prompt"
+
+
 def test_subagent_wake_notice_shape_matches_runner_notice() -> None:
     """
     The announced shape must track the notice the runner actually posts.

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -4864,6 +4864,8 @@ def test_websocket_connect_sets_short_close_timeout(monkeypatch: pytest.MonkeyPa
             "Origin": OMNIGENT_INTERNAL_WS_ORIGIN,
         },
         "close_timeout": claude_native._CLAUDE_ATTACH_WS_CLOSE_TIMEOUT_S,
+        # Never route the attach through a system/env proxy (issue #1514).
+        "proxy": None,
     }
 
 

--- a/tests/tools/builtins/test_cognee.py
+++ b/tests/tools/builtins/test_cognee.py
@@ -20,11 +20,18 @@ from omnigent.tools.builtins.cognee import CogneeRememberTool, CogneeSearchTool
 
 
 @pytest.fixture(autouse=True)
-def _default_settings(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Keep tool settings hermetic — never read the user's config.yaml."""
+def _default_settings(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Keep tool settings hermetic and registration inert.
+
+    Never read the user's config.yaml, and capture the agent-registry
+    mirroring instead of letting it reach a real store.
+    """
     import omnigent.runtime.memory as memory_mod
 
     monkeypatch.setattr(memory_mod, "cognee_settings", dict)
+    registered = MagicMock()
+    monkeypatch.setattr(memory_mod, "ensure_agent_registered", registered)
+    return registered
 
 
 def _patch_search(monkeypatch: pytest.MonkeyPatch, results: list[str]) -> MagicMock:
@@ -143,6 +150,22 @@ def test_search_missing_query_returns_error(
 ) -> None:
     _patch_search(monkeypatch, ["m"])
     assert "query" in CogneeSearchTool({}).invoke(json.dumps({}), tool_ctx).lower()
+
+
+def test_invoke_mirrors_grants_into_agent_registry(
+    monkeypatch: pytest.MonkeyPatch,
+    tool_ctx: ToolContext,
+    _default_settings: MagicMock,
+) -> None:
+    """Both tools register the agent connection (grants + session) on use."""
+    _patch_search(monkeypatch, ["m"])
+    _patch_add(monkeypatch)
+    CogneeSearchTool({}).invoke(json.dumps({"query": "q"}), tool_ctx)
+    CogneeRememberTool({}).invoke(json.dumps({"content": "x"}), tool_ctx)
+    assert _default_settings.call_count == 2
+    grants = _default_settings.call_args.args[0]
+    assert grants.private == "agent_test"
+    assert _default_settings.call_args.kwargs["session_id"] is None
 
 
 def test_search_passes_top_k_and_search_type(

--- a/tests/tools/builtins/test_cognee.py
+++ b/tests/tools/builtins/test_cognee.py
@@ -289,7 +289,8 @@ def test_remember_shared_scope_publishes_to_exchange_dataset(
     add = _patch_add(monkeypatch)
     tool = CogneeRememberTool({"shared_dataset": "team"})
     result = tool.invoke(json.dumps({"content": "x", "scope": "shared"}), tool_ctx)
-    assert "shared" in result.lower()
+    assert "'team'" in result
+    assert "granted access" in result
     assert add.call_args.args == ("x", "team")
 
 

--- a/tests/tools/builtins/test_cognee.py
+++ b/tests/tools/builtins/test_cognee.py
@@ -1,0 +1,390 @@
+"""Tests for the cognee knowledge-graph memory built-in tools.
+
+The ``cognee`` package (the optional ``cognee`` extra) is not in the dev
+set; the tools call the framework boundary in ``omnigent.runtime.memory``,
+which is patched directly — no cognee import, no network. Covers schema
+shape, dataset/scope resolution from ``ToolContext``, the cross-agent
+shared-dataset exchange, invoke paths, and the optional-extra registry gate.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from omnigent.tools.base import ToolContext
+from omnigent.tools.builtins.cognee import CogneeRememberTool, CogneeSearchTool
+
+
+@pytest.fixture(autouse=True)
+def _default_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep tool settings hermetic — never read the user's config.yaml."""
+    import omnigent.runtime.memory as memory_mod
+
+    monkeypatch.setattr(memory_mod, "cognee_settings", dict)
+
+
+def _patch_search(monkeypatch: pytest.MonkeyPatch, results: list[str]) -> MagicMock:
+    import omnigent.runtime.memory as memory_mod
+
+    mock = MagicMock(return_value=results)
+    monkeypatch.setattr(memory_mod, "memory_search", mock)
+    return mock
+
+
+def _patch_add(monkeypatch: pytest.MonkeyPatch, *, stored: bool = True) -> MagicMock:
+    import omnigent.runtime.memory as memory_mod
+
+    mock = MagicMock(return_value=stored)
+    monkeypatch.setattr(memory_mod, "memory_add", mock)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Names, descriptions, schemas
+# ---------------------------------------------------------------------------
+
+
+def test_names_and_descriptions() -> None:
+    assert CogneeSearchTool.name() == "cognee_search"
+    assert CogneeRememberTool.name() == "cognee_remember"
+    # description() must work without instantiation (used by tool discovery).
+    assert "memory" in CogneeSearchTool.description().lower()
+    assert "memory" in CogneeRememberTool.description().lower()
+
+
+@pytest.mark.parametrize(
+    ("cls", "param"),
+    [
+        (CogneeSearchTool, "query"),
+        (CogneeRememberTool, "content"),
+    ],
+)
+def test_schema_shape(cls: type[Any], param: str) -> None:
+    schema = cls({}).get_schema()
+    assert schema["type"] == "function"
+    fn = schema["function"]
+    assert fn["name"] == cls.name()
+    assert param in fn["parameters"]["properties"]
+    assert fn["parameters"]["required"] == [param]
+    assert "scope" in fn["parameters"]["properties"]
+
+
+# ---------------------------------------------------------------------------
+# Search: scope + dataset resolution
+# ---------------------------------------------------------------------------
+
+
+def test_search_defaults_to_private_dataset(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    search = _patch_search(monkeypatch, ["likes tea", "lives in NYC"])
+    result = CogneeSearchTool({}).invoke(json.dumps({"query": "about the user"}), tool_ctx)
+    assert result == "- likes tea\n- lives in NYC"
+    # conftest tool_ctx has agent_id="agent_test"
+    assert search.call_args.args[1] == ["agent_test"]
+
+
+def test_search_includes_granted_shared_dataset_by_default(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    search = _patch_search(monkeypatch, ["m"])
+    tool = CogneeSearchTool({"shared_dataset": "Team Knowledge"})
+    tool.invoke(json.dumps({"query": "q"}), tool_ctx)
+    assert search.call_args.args[1] == ["agent_test", "team_knowledge"]
+
+
+def test_search_scope_agent_excludes_shared(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    search = _patch_search(monkeypatch, ["m"])
+    tool = CogneeSearchTool({"shared_dataset": "team"})
+    tool.invoke(json.dumps({"query": "q", "scope": "agent"}), tool_ctx)
+    assert search.call_args.args[1] == ["agent_test"]
+
+
+def test_search_scope_shared_only(monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext) -> None:
+    search = _patch_search(monkeypatch, ["m"])
+    tool = CogneeSearchTool({"shared_dataset": "team"})
+    tool.invoke(json.dumps({"query": "q", "scope": "shared"}), tool_ctx)
+    assert search.call_args.args[1] == ["team"]
+
+
+def test_search_scope_shared_without_grant_explains(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    search = _patch_search(monkeypatch, ["m"])
+    result = CogneeSearchTool({}).invoke(json.dumps({"query": "q", "scope": "shared"}), tool_ctx)
+    assert "shared_dataset" in result
+    search.assert_not_called()
+
+
+def test_search_config_dataset_overrides_agent_id(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    search = _patch_search(monkeypatch, ["m"])
+    CogneeSearchTool({"dataset": "custom-DS"}).invoke(json.dumps({"query": "q"}), tool_ctx)
+    assert search.call_args.args[1] == ["custom_ds"]
+
+
+def test_search_empty_returns_fallback(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    _patch_search(monkeypatch, [])
+    result = CogneeSearchTool({}).invoke(json.dumps({"query": "anything"}), tool_ctx)
+    assert result == "No relevant memories found."
+
+
+def test_search_missing_query_returns_error(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    _patch_search(monkeypatch, ["m"])
+    assert "query" in CogneeSearchTool({}).invoke(json.dumps({}), tool_ctx).lower()
+
+
+def test_search_passes_top_k_and_search_type(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    search = _patch_search(monkeypatch, ["m"])
+    tool = CogneeSearchTool({"top_k": "5", "search_type": "CHUNKS"})
+    tool.invoke(json.dumps({"query": "q"}), tool_ctx)
+    assert search.call_args.kwargs["top_k"] == 5
+    assert search.call_args.kwargs["settings"]["search_type"] == "CHUNKS"
+
+
+# ---------------------------------------------------------------------------
+# Tier pools: user / team / org
+# ---------------------------------------------------------------------------
+
+
+def test_search_tier_scopes_target_their_pools(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    search = _patch_search(monkeypatch, ["m"])
+    config = {"user_dataset": "u_v", "team_dataset": "t_p", "org_dataset": "o_a"}
+    for scope, expected in (("user", "u_v"), ("team", "t_p"), ("org", "o_a")):
+        CogneeSearchTool(config).invoke(json.dumps({"query": "q", "scope": scope}), tool_ctx)
+        assert search.call_args.args[1] == [expected]
+
+
+def test_search_all_scope_layers_tiers_narrowest_first(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    search = _patch_search(monkeypatch, ["m"])
+    config = {"user_dataset": "u_v", "team_dataset": "t_p", "org_dataset": "o_a"}
+    CogneeSearchTool(config).invoke(json.dumps({"query": "q"}), tool_ctx)
+    assert search.call_args.args[1] == ["agent_test", "u_v", "t_p", "o_a"]
+
+
+def test_search_tier_scope_without_grant_explains(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    search = _patch_search(monkeypatch, ["m"])
+    result = CogneeSearchTool({}).invoke(json.dumps({"query": "q", "scope": "org"}), tool_ctx)
+    assert "org_dataset" in result
+    search.assert_not_called()
+
+
+def test_tiers_inherit_from_global_cognee_settings(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    import omnigent.runtime.memory as memory_mod
+
+    monkeypatch.setattr(memory_mod, "cognee_settings", lambda: {"org_dataset": "acme"})
+    search = _patch_search(monkeypatch, ["m"])
+    CogneeSearchTool({}).invoke(json.dumps({"query": "q", "scope": "org"}), tool_ctx)
+    assert search.call_args.args[1] == ["acme"]
+
+
+def test_remember_tier_scope_stores_to_pool(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    add = _patch_add(monkeypatch)
+    tool = CogneeRememberTool({"team_dataset": "t_p"})
+    result = tool.invoke(json.dumps({"content": "x", "scope": "team"}), tool_ctx)
+    assert add.call_args.args == ("x", "t_p")
+    assert "t_p" in result
+
+
+def test_remember_tier_scope_without_grant_explains(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    add = _patch_add(monkeypatch)
+    result = CogneeRememberTool({}).invoke(json.dumps({"content": "x", "scope": "user"}), tool_ctx)
+    assert "user_dataset" in result
+    add.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Search: peer-agent grants
+# ---------------------------------------------------------------------------
+
+
+def test_search_all_scope_includes_granted_peer_datasets(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    search = _patch_search(monkeypatch, ["m"])
+    tool = CogneeSearchTool({"shared_dataset": "team", "read_datasets": "ag_researcher"})
+    tool.invoke(json.dumps({"query": "q"}), tool_ctx)
+    assert search.call_args.args[1] == ["agent_test", "team", "ag_researcher"]
+
+
+def test_search_scope_peers_only(monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext) -> None:
+    search = _patch_search(monkeypatch, ["m"])
+    tool = CogneeSearchTool({"read_datasets": "ag_researcher, ag_writer"})
+    tool.invoke(json.dumps({"query": "q", "scope": "peers"}), tool_ctx)
+    assert search.call_args.args[1] == ["ag_researcher", "ag_writer"]
+
+
+def test_search_scope_peers_without_grant_explains(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    search = _patch_search(monkeypatch, ["m"])
+    result = CogneeSearchTool({}).invoke(json.dumps({"query": "q", "scope": "peers"}), tool_ctx)
+    assert "read_datasets" in result
+    search.assert_not_called()
+
+
+def test_search_dataset_param_targets_granted_peer(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    search = _patch_search(monkeypatch, ["m"])
+    tool = CogneeSearchTool({"read_datasets": "ag_researcher"})
+    tool.invoke(json.dumps({"query": "q", "dataset": "ag_Researcher"}), tool_ctx)
+    assert search.call_args.args[1] == ["ag_researcher"]
+
+
+def test_search_dataset_param_denied_when_not_granted(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    search = _patch_search(monkeypatch, ["m"])
+    result = CogneeSearchTool({}).invoke(
+        json.dumps({"query": "q", "dataset": "ag_other"}), tool_ctx
+    )
+    assert "not granted" in result
+    assert "agent_test" in result  # the error lists what IS granted
+    search.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Remember: scope + exchange semantics
+# ---------------------------------------------------------------------------
+
+
+def test_remember_stores_to_private_dataset(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    add = _patch_add(monkeypatch)
+    result = CogneeRememberTool({}).invoke(json.dumps({"content": "prefers dark mode"}), tool_ctx)
+    assert result == "Stored to long-term memory."
+    assert add.call_args.args == ("prefers dark mode", "agent_test")
+
+
+def test_remember_shared_scope_publishes_to_exchange_dataset(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    add = _patch_add(monkeypatch)
+    tool = CogneeRememberTool({"shared_dataset": "team"})
+    result = tool.invoke(json.dumps({"content": "x", "scope": "shared"}), tool_ctx)
+    assert "shared" in result.lower()
+    assert add.call_args.args == ("x", "team")
+
+
+def test_remember_shared_scope_without_grant_explains(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    add = _patch_add(monkeypatch)
+    result = CogneeRememberTool({}).invoke(
+        json.dumps({"content": "x", "scope": "shared"}), tool_ctx
+    )
+    assert "shared_dataset" in result
+    add.assert_not_called()
+
+
+def test_remember_tags_conversation_node_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    add = _patch_add(monkeypatch)
+    ctx = ToolContext(task_id="t", agent_id="a", conversation_id="conv_9")
+    CogneeRememberTool({}).invoke(json.dumps({"content": "x"}), ctx)
+    assert add.call_args.kwargs["node_set"] == ["conv_9"]
+
+
+def test_remember_store_unavailable_reports_failure(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    _patch_add(monkeypatch, stored=False)
+    result = CogneeRememberTool({}).invoke(json.dumps({"content": "x"}), tool_ctx)
+    assert "failed" in result.lower()
+    assert result != "Stored to long-term memory."
+
+
+def test_remember_missing_content_returns_error(
+    monkeypatch: pytest.MonkeyPatch, tool_ctx: ToolContext
+) -> None:
+    _patch_add(monkeypatch)
+    assert "content" in CogneeRememberTool({}).invoke(json.dumps({}), tool_ctx).lower()
+
+
+# ---------------------------------------------------------------------------
+# Optional-extra gating
+# ---------------------------------------------------------------------------
+
+
+def test_cognee_tools_registered_only_when_package_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The registry includes the cognee tools iff the package import probe
+    passes — pretend it is installed, reload, then pretend it is absent."""
+    import importlib
+    import importlib.util
+    from importlib.machinery import ModuleSpec
+
+    import omnigent.tools.builtins as builtins_mod
+
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name: str, package: str | None = None) -> ModuleSpec | None:
+        if name == "cognee":
+            return ModuleSpec("cognee", loader=None)
+        return real_find_spec(name, package)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    monkeypatch.delenv("OMNIGENT_DISABLE_COGNEE", raising=False)
+    importlib.reload(builtins_mod)
+    try:
+        assert "cognee_search" in builtins_mod.BUILTIN_NAMES
+        assert "cognee_remember" in builtins_mod.BUILTIN_NAMES
+        assert isinstance(builtins_mod.get_builtin_tool("cognee_search", {}), CogneeSearchTool)
+    finally:
+        monkeypatch.undo()
+        importlib.reload(builtins_mod)
+
+
+def test_cognee_tools_absent_when_kill_switched(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib
+    import importlib.util
+    from importlib.machinery import ModuleSpec
+
+    import omnigent.tools.builtins as builtins_mod
+
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name: str, package: str | None = None) -> ModuleSpec | None:
+        if name == "cognee":
+            return ModuleSpec("cognee", loader=None)
+        return real_find_spec(name, package)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    monkeypatch.setenv("OMNIGENT_DISABLE_COGNEE", "1")
+    importlib.reload(builtins_mod)
+    try:
+        assert "cognee_search" not in builtins_mod.BUILTIN_NAMES
+        assert "cognee_remember" not in builtins_mod.BUILTIN_NAMES
+        assert builtins_mod.get_builtin_tool("cognee_search", {}) is None
+    finally:
+        monkeypatch.undo()
+        importlib.reload(builtins_mod)

--- a/uv.lock
+++ b/uv.lock
@@ -3,10 +3,13 @@ revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*'",
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.14' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32')",
+    "(python_full_version == '3.13.*' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version == '3.13.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.13.*' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version == '3.13.*' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
     "python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform != 'win32'",
+    "(python_full_version < '3.13' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version < '3.13' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version < '3.13' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version and sys_platform == 'darwin') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'win32')",
 ]
 conflicts = [[
     { package = "omnigent", extra = "antigravity" },
@@ -180,6 +183,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiolimiter"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/23/b52debf471f7a1e42e362d959a3982bdcb4fe13a5d46e63d28868807a79c/aiolimiter-1.2.1.tar.gz", hash = "sha256:e02a37ea1a855d9e832252a105420ad4d15011505512a1a1d814647451b5cca9", size = 7185, upload-time = "2024-12-08T15:31:51.496Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/ba/df6e8e1045aebc4778d19b8a3a9bc1808adb1619ba94ca354d9ba17d86c3/aiolimiter-1.2.1-py3-none-any.whl", hash = "sha256:d3f249e9059a20badcb56b61601a83556133655c11d1eb3dd3e04ff069e5f3c7", size = 6711, upload-time = "2024-12-08T15:31:49.874Z" },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -247,6 +259,15 @@ wheels = [
 ]
 
 [[package]]
+name = "argcomplete"
+version = "3.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/6f/5a73f04007ca950701765949209f068da628bd11f9c2da287278ce91e0ee/argcomplete-3.7.2.tar.gz", hash = "sha256:aad8b69a0b9969edb62db0d1752354c0d50717b10e0cbb00e2a958381b9fc6b9", size = 74473, upload-time = "2026-08-06T04:53:21.662Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/bd/551ee6af426af84ca33e02622be722925c196608e9127d731ef17c47f06e/argcomplete-3.7.2-py3-none-any.whl", hash = "sha256:6029205678bdd9c1c728a155f5f9ecf5812393f969eef58807641a2bc2aa5b19", size = 43294, upload-time = "2026-08-06T04:53:20.246Z" },
+]
+
+[[package]]
 name = "argon2-cffi"
 version = "23.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -308,12 +329,110 @@ wheels = [
 ]
 
 [[package]]
+name = "bcrypt"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806, upload-time = "2025-09-25T19:49:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/44/dc/01eb79f12b177017a726cbf78330eb0eb442fae0e7b3dfd84ea2849552f3/bcrypt-5.0.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:200af71bc25f22006f4069060c88ed36f8aa4ff7f53e67ff04d2ab3f1e79a5b2", size = 268626, upload-time = "2025-09-25T19:49:06.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/cf/e82388ad5959c40d6afd94fb4743cc077129d45b952d46bdc3180310e2df/bcrypt-5.0.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:baade0a5657654c2984468efb7d6c110db87ea63ef5a4b54732e7e337253e44f", size = 271853, upload-time = "2025-09-25T19:49:08.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/86/7134b9dae7cf0efa85671651341f6afa695857fae172615e960fb6a466fa/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c58b56cdfb03202b3bcc9fd8daee8e8e9b6d7e3163aa97c631dfcfcc24d36c86", size = 269793, upload-time = "2025-09-25T19:49:09.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/6296688ac1b9e503d034e7d0614d56e80c5d1a08402ff856a4549cb59207/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4bfd2a34de661f34d0bda43c3e4e79df586e4716ef401fe31ea39d69d581ef23", size = 289930, upload-time = "2025-09-25T19:49:11.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/18/884a44aa47f2a3b88dd09bc05a1e40b57878ecd111d17e5bba6f09f8bb77/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ed2e1365e31fc73f1825fa830f1c8f8917ca1b3ca6185773b349c20fd606cec2", size = 272194, upload-time = "2025-09-25T19:49:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/8f/371a3ab33c6982070b674f1788e05b656cfbf5685894acbfef0c65483a59/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:83e787d7a84dbbfba6f250dd7a5efd689e935f03dd83b0f919d39349e1f23f83", size = 269381, upload-time = "2025-09-25T19:49:14.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/34/7e4e6abb7a8778db6422e88b1f06eb07c47682313997ee8a8f9352e5a6f1/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:137c5156524328a24b9fac1cb5db0ba618bc97d11970b39184c1d87dc4bf1746", size = 271750, upload-time = "2025-09-25T19:49:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f416be2499bd72123c70d98d36c6cd61a4e33d9b89562c22481c81bb30/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:38cac74101777a6a7d3b3e3cfefa57089b5ada650dce2baf0cbdd9d65db22a9e", size = 303757, upload-time = "2025-09-25T19:49:17.244Z" },
+    { url = "https://files.pythonhosted.org/packages/13/62/062c24c7bcf9d2826a1a843d0d605c65a755bc98002923d01fd61270705a/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:d8d65b564ec849643d9f7ea05c6d9f0cd7ca23bdd4ac0c2dbef1104ab504543d", size = 306740, upload-time = "2025-09-25T19:49:18.693Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c8/1fdbfc8c0f20875b6b4020f3c7dc447b8de60aa0be5faaf009d24242aec9/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:741449132f64b3524e95cd30e5cd3343006ce146088f074f31ab26b94e6c75ba", size = 334197, upload-time = "2025-09-25T19:49:20.523Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c1/8b84545382d75bef226fbc6588af0f7b7d095f7cd6a670b42a86243183cd/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:212139484ab3207b1f0c00633d3be92fef3c5f0af17cad155679d03ff2ee1e41", size = 352974, upload-time = "2025-09-25T19:49:22.254Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a6/ffb49d4254ed085e62e3e5dd05982b4393e32fe1e49bb1130186617c29cd/bcrypt-5.0.0-cp313-cp313t-win32.whl", hash = "sha256:9d52ed507c2488eddd6a95bccee4e808d3234fa78dd370e24bac65a21212b861", size = 148498, upload-time = "2025-09-25T19:49:24.134Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a9/259559edc85258b6d5fc5471a62a3299a6aa37a6611a169756bf4689323c/bcrypt-5.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f6984a24db30548fd39a44360532898c33528b74aedf81c26cf29c51ee47057e", size = 145853, upload-time = "2025-09-25T19:49:25.702Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/df/9714173403c7e8b245acf8e4be8876aac64a209d1b392af457c79e60492e/bcrypt-5.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9fffdb387abe6aa775af36ef16f55e318dcda4194ddbf82007a6f21da29de8f5", size = 139626, upload-time = "2025-09-25T19:49:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/14/c18006f91816606a4abe294ccc5d1e6f0e42304df5a33710e9e8e95416e1/bcrypt-5.0.0-cp314-cp314t-macosx_10_12_universal2.whl", hash = "sha256:4870a52610537037adb382444fefd3706d96d663ac44cbb2f37e3919dca3d7ef", size = 481862, upload-time = "2025-09-25T19:49:28.365Z" },
+    { url = "https://files.pythonhosted.org/packages/67/49/dd074d831f00e589537e07a0725cf0e220d1f0d5d8e85ad5bbff251c45aa/bcrypt-5.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48f753100931605686f74e27a7b49238122aa761a9aefe9373265b8b7aa43ea4", size = 268544, upload-time = "2025-09-25T19:49:30.39Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/91/50ccba088b8c474545b034a1424d05195d9fcbaaf802ab8bfe2be5a4e0d7/bcrypt-5.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f70aadb7a809305226daedf75d90379c397b094755a710d7014b8b117df1ebbf", size = 271787, upload-time = "2025-09-25T19:49:32.144Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e7/d7dba133e02abcda3b52087a7eea8c0d4f64d3e593b4fffc10c31b7061f3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:744d3c6b164caa658adcb72cb8cc9ad9b4b75c7db507ab4bc2480474a51989da", size = 269753, upload-time = "2025-09-25T19:49:33.885Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fc/5b145673c4b8d01018307b5c2c1fc87a6f5a436f0ad56607aee389de8ee3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a28bc05039bdf3289d757f49d616ab3efe8cf40d8e8001ccdd621cd4f98f4fc9", size = 289587, upload-time = "2025-09-25T19:49:35.144Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d7/1ff22703ec6d4f90e62f1a5654b8867ef96bafb8e8102c2288333e1a6ca6/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7f277a4b3390ab4bebe597800a90da0edae882c6196d3038a73adf446c4f969f", size = 272178, upload-time = "2025-09-25T19:49:36.793Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/88/815b6d558a1e4d40ece04a2f84865b0fef233513bd85fd0e40c294272d62/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:79cfa161eda8d2ddf29acad370356b47f02387153b11d46042e93a0a95127493", size = 269295, upload-time = "2025-09-25T19:49:38.164Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/e0db387c79ab4931fc89827d37608c31cc57b6edc08ccd2386139028dc0d/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a5393eae5722bcef046a990b84dff02b954904c36a194f6cfc817d7dca6c6f0b", size = 271700, upload-time = "2025-09-25T19:49:39.917Z" },
+    { url = "https://files.pythonhosted.org/packages/06/83/1570edddd150f572dbe9fc00f6203a89fc7d4226821f67328a85c330f239/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f4c94dec1b5ab5d522750cb059bb9409ea8872d4494fd152b53cca99f1ddd8c", size = 334034, upload-time = "2025-09-25T19:49:41.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f2/ea64e51a65e56ae7a8a4ec236c2bfbdd4b23008abd50ac33fbb2d1d15424/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0cae4cb350934dfd74c020525eeae0a5f79257e8a201c0c176f4b84fdbf2a4b4", size = 352766, upload-time = "2025-09-25T19:49:43.08Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d4/1a388d21ee66876f27d1a1f41287897d0c0f1712ef97d395d708ba93004c/bcrypt-5.0.0-cp314-cp314t-win32.whl", hash = "sha256:b17366316c654e1ad0306a6858e189fc835eca39f7eb2cafd6aaca8ce0c40a2e", size = 152449, upload-time = "2025-09-25T19:49:44.971Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/61/3291c2243ae0229e5bca5d19f4032cecad5dfb05a2557169d3a69dc0ba91/bcrypt-5.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:92864f54fb48b4c718fc92a32825d0e42265a627f956bc0361fe869f1adc3e7d", size = 149310, upload-time = "2025-09-25T19:49:46.162Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/89/4b01c52ae0c1a681d4021e5dd3e45b111a8fb47254a274fa9a378d8d834b/bcrypt-5.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dd19cf5184a90c873009244586396a6a884d591a5323f0e8a5922560718d4993", size = 143761, upload-time = "2025-09-25T19:49:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/6237f151fbfe295fe3e074ecc6d44228faa1e842a81f6d34a02937ee1736/bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b", size = 494553, upload-time = "2025-09-25T19:49:49.006Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009, upload-time = "2025-09-25T19:49:50.581Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029, upload-time = "2025-09-25T19:49:52.533Z" },
+    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907, upload-time = "2025-09-25T19:49:54.709Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7e/d4e47d2df1641a36d1212e5c0514f5291e1a956a7749f1e595c07a972038/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd", size = 296500, upload-time = "2025-09-25T19:49:56.013Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412, upload-time = "2025-09-25T19:49:57.356Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486, upload-time = "2025-09-25T19:49:59.116Z" },
+    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940, upload-time = "2025-09-25T19:50:00.869Z" },
+    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776, upload-time = "2025-09-25T19:50:02.393Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922, upload-time = "2025-09-25T19:50:04.232Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367, upload-time = "2025-09-25T19:50:05.559Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187, upload-time = "2025-09-25T19:50:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/461f352fdca663524b4643d8b09e8435b4990f17fbf4fea6bc2a90aa0cc7/bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538", size = 153752, upload-time = "2025-09-25T19:50:08.515Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/4190e60921927b7056820291f56fc57d00d04757c8b316b2d3c0d1d6da2c/bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9", size = 150881, upload-time = "2025-09-25T19:50:09.742Z" },
+    { url = "https://files.pythonhosted.org/packages/54/12/cd77221719d0b39ac0b55dbd39358db1cd1246e0282e104366ebbfb8266a/bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980", size = 144931, upload-time = "2025-09-25T19:50:11.016Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a", size = 495313, upload-time = "2025-09-25T19:50:12.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290, upload-time = "2025-09-25T19:50:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253, upload-time = "2025-09-25T19:50:15.089Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084, upload-time = "2025-09-25T19:50:16.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/fa6e16145e145e87f1fa351bbd54b429354fd72145cd3d4e0c5157cf4c70/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac", size = 297185, upload-time = "2025-09-25T19:50:18.525Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656, upload-time = "2025-09-25T19:50:19.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662, upload-time = "2025-09-25T19:50:21.567Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240, upload-time = "2025-09-25T19:50:23.305Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152, upload-time = "2025-09-25T19:50:24.597Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284, upload-time = "2025-09-25T19:50:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643, upload-time = "2025-09-25T19:50:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698, upload-time = "2025-09-25T19:50:31.347Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
+    { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
+]
+
+[[package]]
 name = "bidict"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/6e/026678aa5a830e07cd9498a05d3e7e650a4f56a42f267a53d22bcda1bdc9/bidict-0.23.1.tar.gz", hash = "sha256:03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71", size = 29093, upload-time = "2024-02-18T19:09:05.748Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/37/e8730c3587a65eb5645d4aba2d27aae48e8003614d6aaf15dda67f702f1f/bidict-0.23.1-py3-none-any.whl", hash = "sha256:5dae8d4d79b552a71cbabc7deb25dfe8ce710b17ff41711e13010ead2abfc3e5", size = 32764, upload-time = "2024-02-18T19:09:04.156Z" },
+]
+
+[[package]]
+name = "black"
+version = "26.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/99/7744b906703228264ef73bdd534df88ec1ef3de45c4e78f6d31b9e32d0c9/black-26.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4ad6fa01f941920f54f2bbb35f3df7673428a0ef98a0b0840c2eaef3b110efa8", size = 2012518, upload-time = "2026-05-18T17:05:20.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c0/c5a3b1636dfd09c42534f2b3cf33506814f6d3e066fb0879ffa16c1ae860/black-26.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3915f256e75a2d7cf88d8953d37f780455dc586cc72dee059c528fe77f581217", size = 1816016, upload-time = "2026-05-18T17:05:21.84Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/0e/36044316b65ca471d3bb6d3703fd06fb50c6b727c3562f6a5a3153634f88/black-26.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d98d4137277c75dfb898ec8d846c4fd68ba1e9cf77f95e2865c203dc18f4c3d", size = 1884150, upload-time = "2026-05-18T17:05:23.546Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/33/dafc5808c2af43672912111d7c3354af1615f7e2be3bed7a878461abbe4d/black-26.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:a1dca32d9f1784af512a13410ec204c6f7f0aa9797a111c42e1c03449821c264", size = 1486825, upload-time = "2026-05-18T17:05:25.004Z" },
+    { url = "https://files.pythonhosted.org/packages/82/14/b965ee6ad2a311f28bdbf692def3ee9848d2ae289dab28b27657fcee3e78/black-26.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1037d5ac7b7b310b2632ad867ec8d0e4c4819dcdb0b820f63135da746a24e418", size = 1288646, upload-time = "2026-05-18T17:05:26.477Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5c/c384363980e11e25ca6b93205949bb331fbf35f4e0dbec376dfa6326cec8/black-26.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3", size = 2009020, upload-time = "2026-05-18T17:05:28.132Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/df/9f31c5e0babbfed77d505fc5d120beb98b21b33feaeded3924ea941fe360/black-26.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0", size = 1813335, upload-time = "2026-05-18T17:05:31.266Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/24/8e7b9a2fa61b0afd82209efe937557d180a1fa055bd7f6161eb9defc3719/black-26.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294", size = 1881614, upload-time = "2026-05-18T17:05:32.718Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ad/b4e0d9365ba8ac34f6bbab62a4b1b2dd5d618fac3fa1b8db968c844201b5/black-26.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a", size = 1488925, upload-time = "2026-05-18T17:05:34.259Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4b/652b859bf5df88a751c30451b09338f7fd26a77d1271c666992f836b7711/black-26.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52", size = 1289883, upload-time = "2026-05-18T17:05:36.019Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168", size = 2004800, upload-time = "2026-05-18T17:05:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8a/a479296a19e383b70a725882a6cf3d786540601ff03cabbaaf1cce864c5a/black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3", size = 1815576, upload-time = "2026-05-18T17:05:40.309Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/cfaf3d39f25132c156a068f6b805576c9103a84086019507c70e1911ee7d/black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18", size = 1877927, upload-time = "2026-05-18T17:05:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
+    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
 ]
 
 [[package]]
@@ -446,7 +565,7 @@ name = "build"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "os_name == 'nt' or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-cwsandbox') or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-databricks') or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-modal') or (extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-dev') or (extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-lint')" },
+    { name = "colorama", marker = "(os_name == 'nt' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (os_name == 'nt' and sys_platform != 'darwin') or (os_name != 'nt' and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-cwsandbox') or (os_name != 'nt' and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-databricks') or (os_name != 'nt' and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-modal') or (os_name != 'nt' and extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-dev') or (os_name != 'nt' and extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-lint') or ('Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin' and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-cwsandbox') or ('Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin' and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-databricks') or ('Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin' and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-modal') or ('Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin' and extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-dev') or ('Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin' and extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-lint') or ('Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin' and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-cwsandbox') or ('Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin' and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-databricks') or ('Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin' and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-modal') or ('Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin' and extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-dev') or ('Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin' and extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-lint')" },
     { name = "packaging" },
     { name = "pyproject-hooks" },
 ]
@@ -705,6 +824,62 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "cognee"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "aiohttp" },
+    { name = "aiolimiter" },
+    { name = "aiosqlite" },
+    { name = "alembic" },
+    { name = "cbor2" },
+    { name = "cryptography" },
+    { name = "datamodel-code-generator" },
+    { name = "diskcache" },
+    { name = "fakeredis", extra = ["lua"] },
+    { name = "fastapi" },
+    { name = "fastapi-users", extra = ["sqlalchemy"] },
+    { name = "filelock" },
+    { name = "filetype" },
+    { name = "gunicorn" },
+    { name = "instructor" },
+    { name = "jinja2" },
+    { name = "ladybug", version = "0.17.1", source = { registry = "https://pypi.org/simple" }, marker = "('Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-cwsandbox') or ('Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-databricks') or ('Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-modal') or ('Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version and extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-dev') or ('Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version and extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-lint') or ('Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or ('Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin') or (sys_platform != 'darwin' and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-cwsandbox') or (sys_platform != 'darwin' and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-databricks') or (sys_platform != 'darwin' and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-modal') or (sys_platform != 'darwin' and extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-dev') or (sys_platform != 'darwin' and extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-lint')" },
+    { name = "ladybug", version = "0.19.0", source = { registry = "https://pypi.org/simple" }, marker = "('Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or ('Darwin Kernel Version 22.' in platform_version and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-cwsandbox') or ('Darwin Kernel Version 22.' in platform_version and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-databricks') or ('Darwin Kernel Version 22.' in platform_version and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-modal') or ('Darwin Kernel Version 22.' in platform_version and extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-dev') or ('Darwin Kernel Version 22.' in platform_version and extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-lint') or ('Darwin Kernel Version 23.' in platform_version and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-cwsandbox') or ('Darwin Kernel Version 23.' in platform_version and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-databricks') or ('Darwin Kernel Version 23.' in platform_version and extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-modal') or ('Darwin Kernel Version 23.' in platform_version and extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-dev') or ('Darwin Kernel Version 23.' in platform_version and extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-lint') or sys_platform != 'darwin'" },
+    { name = "lancedb" },
+    { name = "langdetect" },
+    { name = "limits" },
+    { name = "litellm" },
+    { name = "nbformat" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pylance" },
+    { name = "pympler" },
+    { name = "pypdf" },
+    { name = "python-dotenv" },
+    { name = "python-magic-bin", marker = "sys_platform == 'win32' or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-cwsandbox') or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-databricks') or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-modal') or (extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-dev') or (extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-lint')" },
+    { name = "python-multipart" },
+    { name = "rdflib" },
+    { name = "sqlalchemy" },
+    { name = "starlette" },
+    { name = "structlog" },
+    { name = "tenacity" },
+    { name = "tiktoken" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "uvicorn" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/6c/d59798a299dd7f28c18a3b14d0e711036e7f12941feb1e1666a539418870/cognee-1.5.3.tar.gz", hash = "sha256:49c4799c313990a0905cfcc90a0e0ba3e1521d1726134dd8bcca47e2f19c36ad", size = 27624449, upload-time = "2026-08-23T18:30:38.484Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/44/71d7f7fd0245ecbf6032b6dc3fb37d41e715b55d8c5477851c0f43d28ee5/cognee-1.5.3-py3-none-any.whl", hash = "sha256:575c2791a911edecfa70321c81e984a7ebbc16746f41562361f43636be76308f", size = 8194900, upload-time = "2026-08-23T18:30:35.031Z" },
 ]
 
 [[package]]
@@ -1018,10 +1193,13 @@ version = "0.67.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*'",
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.14' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32')",
+    "(python_full_version == '3.13.*' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version == '3.13.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.13.*' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version == '3.13.*' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
     "python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform != 'win32'",
+    "(python_full_version < '3.13' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version < '3.13' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version < '3.13' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version and sys_platform == 'darwin') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'win32')",
 ]
 dependencies = [
     { name = "google-auth", marker = "extra == 'extra-8-omnigent-antigravity'" },
@@ -1038,10 +1216,13 @@ version = "0.115.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*'",
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.14' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32')",
+    "(python_full_version == '3.13.*' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version == '3.13.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.13.*' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version == '3.13.*' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
     "python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform != 'win32'",
+    "(python_full_version < '3.13' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version < '3.13' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version < '3.13' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version and sys_platform == 'darwin') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'win32')",
 ]
 dependencies = [
     { name = "google-auth", marker = "extra == 'extra-8-omnigent-cwsandbox' or extra == 'extra-8-omnigent-databricks' or extra == 'extra-8-omnigent-modal' or extra == 'group-8-omnigent-dev' or extra == 'group-8-omnigent-lint' or extra != 'extra-8-omnigent-antigravity'" },
@@ -1051,6 +1232,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/be/49/1fd8121d4517849ea67fddbd827e535871b94037fab985235c011fdc60d1/databricks_sdk-0.115.0.tar.gz", hash = "sha256:a91f219313ea1afcde9575ea083825cbcb3dde2d00cb4c858c49d9dfd61b3129", size = 965481, upload-time = "2026-06-08T09:43:01.138Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/fd/80f87c4036b84a87102e95e87b1427b07c2b2de9e3101ff890bbf81ae2f4/databricks_sdk-0.115.0-py3-none-any.whl", hash = "sha256:4c6b32d7360442e99f4e662d8fe2638f217ce4dc3c1901a4d1ccc80e6c199f59", size = 912341, upload-time = "2026-06-08T09:42:59.327Z" },
+]
+
+[[package]]
+name = "datamodel-code-generator"
+version = "0.76.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argcomplete" },
+    { name = "black", marker = "sys_platform != 'emscripten' or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-cwsandbox') or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-databricks') or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-modal') or (extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-dev') or (extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-lint')" },
+    { name = "genson" },
+    { name = "inflect" },
+    { name = "isort", marker = "sys_platform != 'emscripten' or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-cwsandbox') or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-databricks') or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-modal') or (extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-dev') or (extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-lint')" },
+    { name = "jinja2" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/65/27983214b172cf5463209ef55b68f7bb180eaeb114fbca477f709e2ca721/datamodel_code_generator-0.76.0.tar.gz", hash = "sha256:782ad3d17ea53f3a2300347d4058e281ba749ff57821712464f88c1ce75876c8", size = 2184419, upload-time = "2026-08-29T02:04:09.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/72/801a441c9d3717c9fab3399a382ed2d146cc79df12b8ea45427ce26d55a3/datamodel_code_generator-0.76.0-py3-none-any.whl", hash = "sha256:cff9d19faa9072cfc19a04d11ac5e30d0e1a846bd1f843f05f37841941fe3e62", size = 643099, upload-time = "2026-08-29T02:04:07.519Z" },
 ]
 
 [[package]]
@@ -1171,6 +1371,15 @@ wheels = [
 ]
 
 [[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1186,6 +1395,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
 ]
 
 [[package]]
@@ -1209,6 +1427,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/df/929ee0b5d2c8bd8d713c45e71b94ab57c7e11e322130724d54f469b2cd48/dockerfile-parse-2.0.1.tar.gz", hash = "sha256:3184ccdc513221983e503ac00e1aa504a2aa8f84e5de673c46b0b6eee99ec7bc", size = 24556, upload-time = "2023-07-18T13:36:07.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/6c/79cd5bc1b880d8c1a9a5550aa8dacd57353fa3bb2457227e1fb47383eb49/dockerfile_parse-2.0.1-py2.py3-none-any.whl", hash = "sha256:bdffd126d2eb26acf1066acb54cb2e336682e1d72b974a40894fac76a4df17f6", size = 14845, upload-time = "2023-07-18T13:36:06.052Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -1244,12 +1471,43 @@ wheels = [
 ]
 
 [[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
 name = "execnet"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "fakeredis"
+version = "2.37.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/5e/fce3355d20d37dc18f7f4c422653ac69cabffa019afaaf607e26704fb829/fakeredis-2.37.1.tar.gz", hash = "sha256:9045851b0a9fe56312696aadc82435141aa43a193cab462d372c8fb583a7c087", size = 238182, upload-time = "2026-08-18T15:22:01.676Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/e0/fe1c760abd9e9cb5dfbce057b6582cb1ac36dfd8b5ce202e1445605c922d/fakeredis-2.37.1-py3-none-any.whl", hash = "sha256:f15c41be151c1e9206416dece764369a4dedb6b1341df3734c3c2c000e405508", size = 152738, upload-time = "2026-08-18T15:22:00.1Z" },
+]
+
+[package.optional-dependencies]
+lua = [
+    { name = "lupa" },
 ]
 
 [[package]]
@@ -1269,12 +1527,106 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi-users"
+version = "15.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "email-validator" },
+    { name = "fastapi" },
+    { name = "makefun" },
+    { name = "pwdlib", extra = ["argon2", "bcrypt"] },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/79/98b9d733274cfe0c776fde637dc53b421a0142f51a9e3e9fecd72741f7c1/fastapi_users-15.0.5.tar.gz", hash = "sha256:097f69701894e650c346df89b1cdb0a09cf139234f4cb9a8ece275af4e98e202", size = 121394, upload-time = "2026-03-27T09:01:17.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/8e/1ed6bbe36c486b98217c4be6769d61fcb98c38b334fb39706de661a905b6/fastapi_users-15.0.5-py3-none-any.whl", hash = "sha256:10fd4f3e85ed66f694a6ca2ecac609af4e59d1f9ec64d1557f5912dccfd87c7f", size = 39038, upload-time = "2026-03-27T09:01:16.158Z" },
+]
+
+[package.optional-dependencies]
+sqlalchemy = [
+    { name = "fastapi-users-db-sqlalchemy" },
+]
+
+[[package]]
+name = "fastapi-users-db-sqlalchemy"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastapi-users" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/12/bc9e6146ae31564741cefc87ee6e37fa5b566933f0afe8aa030779d60e60/fastapi_users_db_sqlalchemy-7.0.0.tar.gz", hash = "sha256:6823eeedf8a92f819276a2b2210ef1dcfd71fe8b6e37f7b4da8d1c60e3dfd595", size = 10877, upload-time = "2025-01-04T13:09:05.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/08/9968963c1fb8c34627b7f1fbcdfe9438540f87dc7c9bfb59bb4fd19a4ecf/fastapi_users_db_sqlalchemy-7.0.0-py3-none-any.whl", hash = "sha256:5fceac018e7cfa69efc70834dd3035b3de7988eb4274154a0dbe8b14f5aa001e", size = 6891, upload-time = "2025-01-04T13:09:02.869Z" },
+]
+
+[[package]]
+name = "fastjsonschema"
+version = "2.22.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/a4/9473c7c3b87009d9c1d74034e4a0f6a35ff0d42dd0f9866d0c3ec4e9217b/fastjsonschema-2.22.2.tar.gz", hash = "sha256:72064e12356a7d6ef02165be2946b9abadbdf238536e07eb587e3dbaa33099cf", size = 385171, upload-time = "2026-08-15T19:47:08.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/82/2755c7c982086f00d4dab85bc120ec35045a9fc2191893a6ce79afe94443/fastjsonschema-2.22.2-py3-none-any.whl", hash = "sha256:0fb3915616adac85ccfdd737d26be1089845d2019819505b42d39888458f74d4", size = 27413, upload-time = "2026-08-15T19:47:04.406Z" },
+]
+
+[[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
+    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/ae12dd39b9a39b55d7f90abb8971f1a5f3c321fd72d5aa83f90dc67fe9ed/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77a09cb7427e7af74c594e409f7731a0cf887221de2f698e1ca0ebf0f3139021", size = 510720, upload-time = "2025-10-19T22:42:34.633Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b0/a4b03ff5d00f563cc7546b933c28cb3f2a07344b2aec5834e874f7d44143/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9bd57289daf7b153bfa3e8013446aa144ce5e8c825e9e366d455155ede5ea2dc", size = 262024, upload-time = "2025-10-19T22:30:25.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6d/64aee0a0f6a58eeabadd582e55d0d7d70258ffdd01d093b30c53d668303b/fastuuid-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac60fc860cdf3c3f327374db87ab8e064c86566ca8c49d2e30df15eda1b0c2d5", size = 251679, upload-time = "2025-10-19T22:36:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f5/a7e9cda8369e4f7919d36552db9b2ae21db7915083bc6336f1b0082c8b2e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab32f74bd56565b186f036e33129da77db8be09178cd2f5206a5d4035fb2a23f", size = 277862, upload-time = "2025-10-19T22:36:23.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d3/8ce11827c783affffd5bd4d6378b28eb6cc6d2ddf41474006b8d62e7448e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33e678459cf4addaedd9936bbb038e35b3f6b2061330fd8f2f6a1d80414c0f87", size = 278278, upload-time = "2025-10-19T22:29:43.809Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/680fb6352d0bbade04036da46264a8001f74b7484e2fd1f4da9e3db1c666/fastuuid-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e3cc56742f76cd25ecb98e4b82a25f978ccffba02e4bdce8aba857b6d85d87b", size = 301788, upload-time = "2025-10-19T22:36:06.825Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7c/2014b5785bd8ebdab04ec857635ebd84d5ee4950186a577db9eff0fb8ff6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cb9a030f609194b679e1660f7e32733b7a0f332d519c5d5a6a0a580991290022", size = 459819, upload-time = "2025-10-19T22:35:31.623Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d2/524d4ceeba9160e7a9bc2ea3e8f4ccf1ad78f3bde34090ca0c51f09a5e91/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:09098762aad4f8da3a888eb9ae01c84430c907a297b97166b8abc07b640f2995", size = 478546, upload-time = "2025-10-19T22:26:03.023Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/354d04951ce114bf4afc78e27a18cfbd6ee319ab1829c2d5fb5e94063ac6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1383fff584fa249b16329a059c68ad45d030d5a4b70fb7c73a08d98fd53bcdab", size = 450921, upload-time = "2025-10-19T22:31:02.151Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/d7be8670151d16d88f15bb121c5b66cdb5ea6a0c2a362d0dcf30276ade53/fastuuid-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a0809f8cc5731c066c909047f9a314d5f536c871a7a22e815cc4967c110ac9ad", size = 154559, upload-time = "2025-10-19T22:36:36.011Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1d/5573ef3624ceb7abf4a46073d3554e37191c868abc3aecd5289a72f9810a/fastuuid-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0df14e92e7ad3276327631c9e7cec09e32572ce82089c55cb1bb8df71cf394ed", size = 156539, upload-time = "2025-10-19T22:33:35.898Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c9/8c7660d1fe3862e3f8acabd9be7fc9ad71eb270f1c65cce9a2b7a31329ab/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b852a870a61cfc26c884af205d502881a2e59cc07076b60ab4a951cc0c94d1ad", size = 510600, upload-time = "2025-10-19T22:43:44.17Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/a989c82f9a90d0ad995aa957b3e572ebef163c5299823b4027986f133dfb/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c7502d6f54cd08024c3ea9b3514e2d6f190feb2f46e6dbcd3747882264bb5f7b", size = 262069, upload-time = "2025-10-19T22:43:38.38Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6c/a1a24f73574ac995482b1326cf7ab41301af0fabaa3e37eeb6b3df00e6e2/fastuuid-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ca61b592120cf314cfd66e662a5b54a578c5a15b26305e1b8b618a6f22df714", size = 251543, upload-time = "2025-10-19T22:32:22.537Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/20/2a9b59185ba7a6c7b37808431477c2d739fcbdabbf63e00243e37bd6bf49/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa75b6657ec129d0abded3bec745e6f7ab642e6dba3a5272a68247e85f5f316f", size = 277798, upload-time = "2025-10-19T22:33:53.821Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/33/4105ca574f6ded0af6a797d39add041bcfb468a1255fbbe82fcb6f592da2/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a0dfea3972200f72d4c7df02c8ac70bad1bb4c58d7e0ec1e6f341679073a7f", size = 278283, upload-time = "2025-10-19T22:29:02.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8c/fca59f8e21c4deb013f574eae05723737ddb1d2937ce87cb2a5d20992dc3/fastuuid-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1bf539a7a95f35b419f9ad105d5a8a35036df35fdafae48fb2fd2e5f318f0d75", size = 301627, upload-time = "2025-10-19T22:35:54.985Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e2/f78c271b909c034d429218f2798ca4e89eeda7983f4257d7865976ddbb6c/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:9a133bf9cc78fdbd1179cb58a59ad0100aa32d8675508150f3658814aeefeaa4", size = 459778, upload-time = "2025-10-19T22:28:00.999Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f0/5ff209d865897667a2ff3e7a572267a9ced8f7313919f6d6043aed8b1caa/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_i686.whl", hash = "sha256:f54d5b36c56a2d5e1a31e73b950b28a0d83eb0c37b91d10408875a5a29494bad", size = 478605, upload-time = "2025-10-19T22:36:21.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c8/2ce1c78f983a2c4987ea865d9516dbdfb141a120fd3abb977ae6f02ba7ca/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8", size = 450837, upload-time = "2025-10-19T22:34:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/df/60/dad662ec9a33b4a5fe44f60699258da64172c39bd041da2994422cdc40fe/fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06", size = 154532, upload-time = "2025-10-19T22:35:18.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/da4db31001e854025ffd26bc9ba0740a9cbba2c3259695f7c5834908b336/fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a", size = 156457, upload-time = "2025-10-19T22:33:44.579Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1f/f9/f38573ed5844586db374d085911740a501ccfa373b455fc9413f09f85237/filelock-3.29.1.tar.gz", hash = "sha256:d97e6b1b9757569626c58caa07dc4beb1613f4a2938b1e8cc81afca398906c9e", size = 59335, upload-time = "2026-06-03T15:19:04.053Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/a0/614c5fe402fd88951df45f4dda2fa3b4e17a99ecd92340771929169b3b95/filelock-3.29.1-py3-none-any.whl", hash = "sha256:85199dfd706869641b72b2e8955d5416a4b2b7dc4b0e8e6d97b4cc1299a6983b", size = 40750, upload-time = "2026-06-03T15:19:02.959Z" },
+]
+
+[[package]]
+name = "filetype"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
 ]
 
 [[package]]
@@ -1451,6 +1803,15 @@ wheels = [
 ]
 
 [[package]]
+name = "fsspec"
+version = "2026.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", hash = "sha256:c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88", size = 317040, upload-time = "2026-07-28T16:34:51.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", hash = "sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279", size = 206583, upload-time = "2026-07-28T16:34:49.538Z" },
+]
+
+[[package]]
 name = "ftfy"
 version = "6.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1460,6 +1821,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a5/d3/8650919bc3c7c6e90ee3fa7fd618bf373cbbe55dff043bd67353dbb20cd8/ftfy-6.3.1.tar.gz", hash = "sha256:9b3c3d90f84fb267fe64d375a07b7f8912d817cf86009ae134aa03e1819506ec", size = 308927, upload-time = "2024-10-26T00:50:35.149Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/6e/81d47999aebc1b155f81eca4477a616a70f238a2549848c38983f3c22a82/ftfy-6.3.1-py3-none-any.whl", hash = "sha256:7c70eb532015cd2f9adb53f101fb6c7945988d023a085d127d1573dc49dd0083", size = 44821, upload-time = "2024-10-26T00:50:33.425Z" },
+]
+
+[[package]]
+name = "genson"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/53/de162dc8e03fccd9ebe59d17c7812378fe8bd2b604f6b1b94d00165140ac/genson-1.4.0.tar.gz", hash = "sha256:bc7f1c1bae87a21ca44d81149aec95a3f4468d676de9b8b08caa064f3c50b3da", size = 47908, upload-time = "2026-07-06T08:21:50.331Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/02/767f744ab6d4cb7761e5008acc3d534b7a0481af62563d52e391fbcb2140/genson-1.4.0-py3-none-any.whl", hash = "sha256:03bc71bbe52defde70660cc4dcd1ea1097997da5a1cbb90a9dbd3acc7c9e1b65", size = 24484, upload-time = "2026-07-06T08:21:49.046Z" },
 ]
 
 [[package]]
@@ -1934,14 +2304,14 @@ wheels = [
 
 [[package]]
 name = "gunicorn"
-version = "26.0.0"
+version = "23.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging", marker = "python_full_version == '3.13.*' or sys_platform != 'win32'" },
+    { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/b7/a4a3f632f823e432ce6bc65f62961b7980c898c77f075a2f7118cb3846fe/gunicorn-26.0.0.tar.gz", hash = "sha256:ca9346f85e3a4aeeb64d491045c16b9a35647abd37ea15efe53080eb8b090baf", size = 727286, upload-time = "2026-05-05T06:38:25.529Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/72/9614c465dc206155d93eff0ca20d42e1e35afc533971379482de953521a4/gunicorn-23.0.0.tar.gz", hash = "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec", size = 375031, upload-time = "2024-08-10T20:25:27.378Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/40/9c2384fc2be4ad25dd4a49decd5ad9ea5a3639814c11bd40ab77cb9f0a14/gunicorn-26.0.0-py3-none-any.whl", hash = "sha256:40233d26a5f0d1872916188c276e21641155111c2853f0c2cd55260aec0d24fc", size = 212009, upload-time = "2026-05-05T06:38:23.007Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7d/6dac2a6e1eba33ee43f318edbed4ff29151a49b5d37f080aad1e6469bca4/gunicorn-23.0.0-py3-none-any.whl", hash = "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d", size = 85029, upload-time = "2024-08-10T20:25:24.996Z" },
 ]
 
 [[package]]
@@ -1964,6 +2334,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/ab/522a2ab67f27971a9d48ca666d4fca85ef7d5282d142e31fd087e27b1bbe/hf_xet-1.6.0.tar.gz", hash = "sha256:2e58454a340b3556dfa4972d5451aff4fba8dd42a236600ba1a1d2b1514f0fef", size = 920527, upload-time = "2026-08-03T22:33:13.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/62/3c062f593bd92ef4e77a0ef39541e3d82a0a1d3947c8a777a02a13a27828/hf_xet-1.6.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:70cbb9c896901600128cb9b6f06e132954fbede1db30f31f7c6c63f84cb7c31d", size = 4074584, upload-time = "2026-08-03T22:32:47.364Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1e/c0ad437dd267a8e435bef594acf781bbc3874ff0b6435b4962d03ecf7cc4/hf_xet-1.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:23379c2f9ec8696d952b16414a2bae72cad86a52df869b050698ba60f538c675", size = 3867381, upload-time = "2026-08-03T22:32:49.049Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ee/7c0d7b6ab336167531b1c30af2af003f054af4c749becbd7209ae33a77c3/hf_xet-1.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f2f7278c05c22fd60cb436cda1269649b3e81db65ecdc8496e5e164aa4143e7b", size = 4453982, upload-time = "2026-08-03T22:32:50.568Z" },
+    { url = "https://files.pythonhosted.org/packages/63/06/ad8eab1c9525246650cbaa821caa3cdbaca734ab1a5b8c91bea09cbd8d69/hf_xet-1.6.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:948f15d3a9545cfe5932f6bd8b440f6ae630aee108f14b7bd6c561f7c2dcc522", size = 4249445, upload-time = "2026-08-03T22:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/26/1eee8aedb0dafc1ab9717dc9ac602cde33361b232dc06803f1f6ed18b58c/hf_xet-1.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5153e6bb103ad49d6ea9f1b2e230db5a2ea32551ad09a706d2f61d7c7c80d80e", size = 4451099, upload-time = "2026-08-03T22:32:54.114Z" },
+    { url = "https://files.pythonhosted.org/packages/67/57/0b88af1f194ab6c9c650547d9cc06bfeaab836ae4dcdb331676bfb8be95a/hf_xet-1.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:35cec30d75c6f9eb9c16a77cef68e85a103b72e24d4b473714ec9ff06428bab9", size = 4664712, upload-time = "2026-08-03T22:32:55.547Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a0/26b717a9d1840e8abf48dcec64b5ed8fbe472671d38ad28d30e147132b33/hf_xet-1.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5789835d7c6bc9436962853192082374297fb72d7eff7e7762ec25ceb7e25338", size = 4025906, upload-time = "2026-08-03T22:32:57.391Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f6/4a9966633c6fef83af997e2cff68ec1963676d412bdfd096df2a93b8e185/hf_xet-1.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:75765820ce4700db3750c94acc8fe27c5fae4c9ec000a0dbac3ca082acf97765", size = 3849221, upload-time = "2026-08-03T22:32:59.123Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/50/7afa2c9c787405864fc47a0d1bbc02c62e9101947ed43c1f43899fc7d91d/hf_xet-1.6.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:633dc0cd71d32da58ab8c03ad38e2fac452c15c2b0a2866ebf6ededfe0a5061d", size = 4071729, upload-time = "2026-08-03T22:33:00.721Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/69/55b8dcf636142ae660fec1869fcac14c4da2e8412e14d6eee1523be77e9f/hf_xet-1.6.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0906082d9932ae0c0057fa194041c22b4e2cdb46b2592ef3b91f020d62a081a", size = 3876287, upload-time = "2026-08-03T22:33:02.251Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4e/a28359bf1c1ecf11eba22123168c138698f7cb576ac678f5a2e16cd5da08/hf_xet-1.6.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d62671bb130879cef0ee4c9ebe47a14af6c66ec53e6d84dc15936e5ffdfac82f", size = 4464663, upload-time = "2026-08-03T22:33:03.802Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/69/1f0cbc2fb22ae6082d094f743d1b8945a3f36f6089cb95f42b7ee348cda7/hf_xet-1.6.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0e6e21fa3cdfcdcd76748564bf593870a5e013f47d97cf10aed63aa222cff5b7", size = 4262538, upload-time = "2026-08-03T22:33:05.287Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3a/4f4f2301ade26e404462d3336fa11f7958d914cabbabdd6e03c3c5d5658c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4fc74352a17015bd0ee90038bc9efe38db894cde45f268b6712b04fce8cd0acb", size = 4460520, upload-time = "2026-08-03T22:33:06.81Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/311725e2a905534dfee2dcb5b08414f249147f1f12252bfc2bd24caa075c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8fb4f71cba6129110c3374a33f919001ff130488fc23553698e34cc1c2a1198c", size = 4675937, upload-time = "2026-08-03T22:33:08.616Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b7/8c59a66d15205024662f1d66968136f13893f96df1ddc5087e2e281fc95f/hf_xet-1.6.0-cp38-abi3-win_amd64.whl", hash = "sha256:fb4fadde1b2b70bf4c0c14a6dccbe7194b1c28947fefd5bbe3fed9d940676c3b", size = 4033128, upload-time = "2026-08-03T22:33:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/73/63/ca511b6f802f28cf3489b280fe77475bcca8de85e81a6299d7916b5b5555/hf_xet-1.6.0-cp38-abi3-win_arm64.whl", hash = "sha256:3dc3e35441ba395006af5aaacc40ef2e603c51ef46c3530b9156185f00935ea3", size = 3859359, upload-time = "2026-08-03T22:33:11.725Z" },
 ]
 
 [[package]]
@@ -2090,6 +2484,26 @@ wheels = [
 ]
 
 [[package]]
+name = "huggingface-hub"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-cwsandbox') or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-databricks') or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-modal') or (extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-dev') or (extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-lint')" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
+]
+
+[[package]]
 name = "hvac"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2130,14 +2544,27 @@ wheels = [
 
 [[package]]
 name = "importlib-metadata"
-version = "9.0.0"
+version = "8.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "zipp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/72/c600ae4f68c28fc19f9c31b9403053e5dbb8cace2e6842c7b7c3e4d42fe9/importlib_metadata-8.9.0.tar.gz", hash = "sha256:58850626cef4bd2df100378b0f2aea9724a7b92f10770d547725b047078f99ee", size = 56140, upload-time = "2026-03-20T16:56:26.362Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f9/97f2ca8bb3ec6e4b1d64f983ebe98b9a192faddff67fac3d6303a537e670/importlib_metadata-8.9.0-py3-none-any.whl", hash = "sha256:e0f761b6ea91ced3b0844c14c9d955224d538105921f8e6754c00f6ca79fba7f", size = 27220, upload-time = "2026-03-20T16:56:25.07Z" },
+]
+
+[[package]]
+name = "inflect"
+version = "7.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+    { name = "typeguard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/c6/943357d44a21fd995723d07ccaddd78023eace03c1846049a2645d4324a3/inflect-7.5.0.tar.gz", hash = "sha256:faf19801c3742ed5a05a8ce388e0d8fe1a07f8d095c82201eb904f5d27ad571f", size = 73751, upload-time = "2024-12-28T17:11:18.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/eb/427ed2b20a38a4ee29f24dbe4ae2dafab198674fe9a85e3d6adf9e5f5f41/inflect-7.5.0-py3-none-any.whl", hash = "sha256:2aea70e5e70c35d8350b8097396ec155ffd68def678c7ff97f51aa69c1d92344", size = 35197, upload-time = "2024-12-28T17:11:15.931Z" },
 ]
 
 [[package]]
@@ -2147,6 +2574,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "instructor"
+version = "1.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "docstring-parser" },
+    { name = "jinja2" },
+    { name = "jiter" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tenacity" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/a4/832cfb15420360e26d2d85bd9d5fe1e4b839d52587574d389bc31284bf6f/instructor-1.15.1.tar.gz", hash = "sha256:c72406469d9025b742e83cf0c13e914b317db2089d08d889944e74fcd659ef94", size = 69948370, upload-time = "2026-04-03T01:51:30.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/c8/36c5d9b80aaf40ba9a7084a8fc18c967db6bf248a4cc8d0f0816b14284be/instructor-1.15.1-py3-none-any.whl", hash = "sha256:be81d17ba2b154a04ab4720808f24f9d6b598f80992f82eaf9cc79006099cf6c", size = 178156, upload-time = "2026-04-03T01:51:23.098Z" },
 ]
 
 [[package]]
@@ -2161,6 +2610,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c5/ee/1fa948386e45772343664eee0a6f955787c2bfb9b4df1ca02d6d6edf8590/islo-0.3.8.tar.gz", hash = "sha256:50b5e0d8069a2c30e353d48afdf562baf5e567119bf150dd47e277a479a4135c", size = 89513, upload-time = "2026-06-24T13:06:30.488Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/2d/b0194c60181f3dc2662ce7937759fafafbf2ff73e712f0df1ef9d200262c/islo-0.3.8-py3-none-any.whl", hash = "sha256:35965bb5bf715d1df1cc36f5553ee81eab3f87a8fcca4334a653defff1785460", size = 190684, upload-time = "2026-06-24T13:06:28.878Z" },
+]
+
+[[package]]
+name = "isort"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
 ]
 
 [[package]]
@@ -2228,74 +2686,70 @@ wheels = [
 
 [[package]]
 name = "jiter"
-version = "0.15.0"
+version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640, upload-time = "2026-05-19T10:09:48.361Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/53/4f6bddbcde3c71e56d0aa1337ec95950f3d27dd4153e25aadf0feac71751/jiter-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0e90a1c315a0226ec822d973817967f9223b7701546c8c2a7913e7ab0926294d", size = 308793, upload-time = "2026-05-19T10:07:35.25Z" },
-    { url = "https://files.pythonhosted.org/packages/01/84/c01099b59a285a1ebba64ae93f62bfa036675340fd1b0045ae65890a0442/jiter-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c9004af7c8d67cce7f1aae1026fb55607f4aa600710d08ede3a3ce4aeefe7e0", size = 309570, upload-time = "2026-05-19T10:07:36.919Z" },
-    { url = "https://files.pythonhosted.org/packages/58/64/8fb7f9d45bb98190355454cd04dad8d8f27223d6bd52f83af07f637168a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c210f8b35dc6f30aafd4b4365ca89b9d1189f21ab49b8e68fa6322a847aef138", size = 336783, upload-time = "2026-05-19T10:07:38.694Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/b6/f5739011d009b3a30f6a53c5240979030ba29ae46a8c67e3a15759f7c37d/jiter-0.15.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f30bae8bc1c2d613e28e5af3e8cceb09b742f1c8a8a5f839fb67afaffc03b61", size = 363555, upload-time = "2026-05-19T10:07:40.832Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/12/98a9d9f766665e8a3b6252454e17cb0c464606a28cf2fa09399b003345fa/jiter-0.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c60e71b6d10cfc284c9bf36bd885e8d44c46f688ce50aa91b5edd90181dea687", size = 452255, upload-time = "2026-05-19T10:07:42.62Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/d5/60f972840f79c5e7544fce567c56f1e4e50468f996baba3e78d823dd62a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ab068bce62a45aa3e7367eceaffb5dde60b7eb853be8dece45132e3d0ff4879", size = 373559, upload-time = "2026-05-19T10:07:44.201Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/cf/d46ef1234ba335aabc2f013210db8e0821a22f5e644a2e9449df199ecc23/jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa248c9eb220197d363f688818dac2fd4b2f0cd7d843ca7105d652034823427d", size = 346055, upload-time = "2026-05-19T10:07:46.005Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/63/4d2749d8d54d230bad9b3a6b0d00cc28c6ff6b2fdffc26a8ccf76cc5a974/jiter-0.15.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2a77aadd57cac1682e4401a72724d2796d89a4ba129b1a5812aa94ee480826eb", size = 351406, upload-time = "2026-05-19T10:07:47.855Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/b9/9965b990035d8773328e0a8c8b457a87bf2b19f6c4126d9d99296be5d16a/jiter-0.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2ae901f3a55bfafdde31d289590fa25e3245735a2b1e8c7cc15871710a002871", size = 389357, upload-time = "2026-05-19T10:07:49.665Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/55/9ddf903deda1413e87fed792f416b7123daee5b8efbad6a202a7421c36a5/jiter-0.15.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f0b271b462769543716f92d3a4f90527df6ef5ed05ee95ec4137f513e21e1b77", size = 517263, upload-time = "2026-05-19T10:07:51.537Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/76/a0c40ad064d3a20a4fde231e35d56e9a01ce82164278180e82d5daf85469/jiter-0.15.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2fb6a5d26af81fc0f00f9360a891e05cf755e149bba391c4d563adc54812973d", size = 548646, upload-time = "2026-05-19T10:07:53.196Z" },
-    { url = "https://files.pythonhosted.org/packages/23/4f/eca9b954942916ba2f453891b8593ab444cd872396fe66a3936616f236f3/jiter-0.15.0-cp312-cp312-win32.whl", hash = "sha256:c2f6bb8b5216ab9e7873bc08b5d7bef2b8abbb578a3069bf1cd14a45d71d771d", size = 206427, upload-time = "2026-05-19T10:07:55.307Z" },
-    { url = "https://files.pythonhosted.org/packages/95/bf/8ead82a87495149542748e828d153fd232a512a22c83b02c4815c1a9c7d8/jiter-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:40b2c7e92c44a84d748d21706c68dc6ff8161d80b59c99d774721a0d2317d7c7", size = 197300, upload-time = "2026-05-19T10:07:56.651Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/e4/9b8a78fb2d894471bc344e37f1949bdd784bd914d031dba0ba3a40c71dd7/jiter-0.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:cc0bc345cf2df9d1c00ac443f50d543c1ccfa8b0422cb85b1ab70d681c0b255b", size = 192702, upload-time = "2026-05-19T10:07:58.307Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/f4/f708c900ecee41b2025ef8413d5351e5649eb2125c506f6720cc69b06f5c/jiter-0.15.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1c11465f97e2abf45a014b83b730222f8f1c5335e802c7055a67d50de6f1f4e3", size = 307829, upload-time = "2026-05-19T10:07:59.704Z" },
-    { url = "https://files.pythonhosted.org/packages/86/59/db537c0949e83668c38481d426b9f2fd5ab758c4ee53a811dd0a510626a0/jiter-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d1e7b1776f0797956c509e123d0952d10d293a9492dea9f288ab9570ec01d1a5", size = 308445, upload-time = "2026-05-19T10:08:01.184Z" },
-    { url = "https://files.pythonhosted.org/packages/37/38/ea0e13b18c30ef951da0d47d39e7fa9edb82a93a62990ffbd7cea9b622d4/jiter-0.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:351a341c2105aa430b7047e30f1bf7975f6313b00165d3fc07be2edaf741f279", size = 336181, upload-time = "2026-05-19T10:08:02.688Z" },
-    { url = "https://files.pythonhosted.org/packages/58/fc/2303901b16c4ba05865588990a420c0b4156270b44379c20931544a1d962/jiter-0.15.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4ab395feec8d249ec4044e228e98a7033f043426a265df439dc3698823f0a4e4", size = 362985, upload-time = "2026-05-19T10:08:04.394Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/6f/11bace093c52e7d4d26c8e606ccd7ae8c972189622469ec0d9e28161e28b/jiter-0.15.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a2a438005b6f22d0273413484d6094d7c2c5d10ec1b3a3bf128e0d1d3ba53258", size = 453292, upload-time = "2026-05-19T10:08:05.967Z" },
-    { url = "https://files.pythonhosted.org/packages/22/db/987f2f086ca4d7a6582eb4ccd513f9b26b42d9e4243a087609a3137a8fc7/jiter-0.15.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f18f85e4218d1b40f000f42a92239a7a61a902cd42c65e6c360dbd17dcb20894", size = 373501, upload-time = "2026-05-19T10:08:07.857Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/7c/89fbcabb2739b7a5b8dc959a1b6c5761f6484f5fed3486854b3c789bb1de/jiter-0.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1aa62e277fc1cbd80e6deacae6f4d983b41b3d7728e0645c5d741a6149bba45", size = 344683, upload-time = "2026-05-19T10:08:09.431Z" },
-    { url = "https://files.pythonhosted.org/packages/30/6f/6cca7692e7dddfec6d8d76c54dc97f2af2a41df4ac0674b999df1f09a5f3/jiter-0.15.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:6550fa135c7deb8ead6af49ed7ff648532ea8334a1447fe34a36315ef79c5c29", size = 350892, upload-time = "2026-05-19T10:08:11.352Z" },
-    { url = "https://files.pythonhosted.org/packages/39/14/0338d6190cb8e6d22e677ab1d4eabd4117f67cca70c54cd04b82ff64e068/jiter-0.15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:066f8f33f18b2419cd8213b2436fa7fbc9c499f315971cfa3ce1f9820c001b1b", size = 388723, upload-time = "2026-05-19T10:08:12.912Z" },
-    { url = "https://files.pythonhosted.org/packages/90/31/cc19f4a1bdb6afb09ce6a2f2615aa8d44d994eba0d8e6105ed1af920e736/jiter-0.15.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:75e8a04e91432dde9f1838373cf93d23726c79d3e908d319acf0e796f85592e7", size = 516648, upload-time = "2026-05-19T10:08:14.808Z" },
-    { url = "https://files.pythonhosted.org/packages/49/9f/833c541512cd091b63c10c0381973dfe11bc7a503a818c16384417e0c81e/jiter-0.15.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a97261f1fccb8e50ecd2890a96e46efdc3f57c80a197324c6777827231eca712", size = 547382, upload-time = "2026-05-19T10:08:16.927Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/11/e7b70e91f90bc4477e8eee9e8a5f7cf3cb41b4525d6394dc98a714eb8f7f/jiter-0.15.0-cp313-cp313-win32.whl", hash = "sha256:c77496cb10bd7549690fbbab3e5ec05857b83e49276f4a9423a766ddd2afcd4c", size = 205845, upload-time = "2026-05-19T10:08:18.401Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/23/5c20d9ad6f02c493e4023e5d2d09e1c1f15fe2753c9102c544aff068a88e/jiter-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b15741f501469009ae0ae90b7147958a664a7dede40aa7ff174a8a4645f546d0", size = 196842, upload-time = "2026-05-19T10:08:20.131Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/11/1eb400ef248e8c925fd883fbe325daf5e42cd1b0d308539dd332bd4f7ffc/jiter-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d6a60072b44c3c2b797a7ddcbcbbf2b34ea3cfd4721580fbfd2a09d9d9b84ba", size = 192212, upload-time = "2026-05-19T10:08:21.807Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/60/2fd8d7c79da8acf9b7b277c7616847773779356b92acfc9bb158452174da/jiter-0.15.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ef1fd24d9413f6209e00d3d5a453e67acfe004a25cc6c8e8484faed4311ab9e8", size = 315065, upload-time = "2026-05-19T10:08:23.218Z" },
-    { url = "https://files.pythonhosted.org/packages/46/f4/008fb7d65e8ac2abf00811651a661e025c4ba80bbc6f378450384ddd3aed/jiter-0.15.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:144f8e72cb53dab146347b91cceac01f5481237f2b93b4a339a1ee8f8878b67c", size = 339444, upload-time = "2026-05-19T10:08:24.701Z" },
-    { url = "https://files.pythonhosted.org/packages/00/55/90b0c7b9c6896c0f2a591dd36d36b71d22e09674bfef178fa03ba3f81499/jiter-0.15.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:553fcac2ef2cb990877f9fc0833b8b629a3e6a5670b6b5fd58219b41a653ddc4", size = 347779, upload-time = "2026-05-19T10:08:26.408Z" },
-    { url = "https://files.pythonhosted.org/packages/51/6b/69666cec5000fd57734c118437394516c749ae8dbeea9fb66d6fef9c4775/jiter-0.15.0-cp313-cp313t-win_amd64.whl", hash = "sha256:774f93f65031856bf14ad9f59bdcab8b8cad501e5ceabd51ba3525f76937a25b", size = 200395, upload-time = "2026-05-19T10:08:28.055Z" },
-    { url = "https://files.pythonhosted.org/packages/39/04/a6aa62cd27e8149b0d28df5561f10f6cceaf7935a9ccf3f1c5a05f9a0cd8/jiter-0.15.0-cp313-cp313t-win_arm64.whl", hash = "sha256:f1e1754960f38ec40613a07e5e372df67acb3b890fb383b6fb3de3e49ddbf3c7", size = 190516, upload-time = "2026-05-19T10:08:29.35Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/d2/079f350ebf7859d081de30aa890f9e3be68516f754f3ba32366ffff4dcee/jiter-0.15.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:ac0d9ddea4350974be7a221fc25895f251a8fee748c889bdced2141c0fec1a49", size = 308884, upload-time = "2026-05-19T10:08:31.667Z" },
-    { url = "https://files.pythonhosted.org/packages/04/4e/a2c30a7f69b48c03b20935d647479106fe932f6e63f75faf53937197e05d/jiter-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01a8222cf05ab1128e239421156c207949808acaaea2bdfd33130ae666786e86", size = 310028, upload-time = "2026-05-19T10:08:33.304Z" },
-    { url = "https://files.pythonhosted.org/packages/40/90/2e7cdfd3cf8ca967be38c48f5cf474d79f089efaf559a40f15984a77ae69/jiter-0.15.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:182226cbc930c9fab81bc2e41a4da672f89539906dadb05e75670ac07b94f71f", size = 337485, upload-time = "2026-05-19T10:08:35.259Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/11/15a1aa28b120b8ee5b4f1fb894c125046225f09847738bd64233d3b84883/jiter-0.15.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71683c38c825452999b5717fcae07ea708e8c93003e808be4319c1b02e3d176e", size = 364223, upload-time = "2026-05-19T10:08:36.694Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/25/f442e8af5f3d0dcf47b39e83a0efd9ee45ea946aa6d04625dc3181eae3b6/jiter-0.15.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30f2218e6a9e5c18bc10fe6d41ac189c442c88eacf11bad9f28ef95a9bef00e6", size = 456387, upload-time = "2026-05-19T10:08:38.143Z" },
-    { url = "https://files.pythonhosted.org/packages/da/f4/37f2d2c9f64f49af7da652ed7532bb5a2372e588e6927c3fdd76f911db65/jiter-0.15.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5157de9f76eb4bc5ea74a1219366a25f945ad305641d74e04f59c54087091aa9", size = 374461, upload-time = "2026-05-19T10:08:39.869Z" },
-    { url = "https://files.pythonhosted.org/packages/60/28/edcfbbbf0cb15436f36664a8908a0df47ab9006298d4cd937dc08ea932d6/jiter-0.15.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c5db5527c221249a876160663ab891ace358c17f7b9c93ec1478b7f0550e5c", size = 345924, upload-time = "2026-05-19T10:08:41.668Z" },
-    { url = "https://files.pythonhosted.org/packages/47/13/89fba6398dab7f202b7278c4b4aac122399d2c0183971c4a57a3b7088df5/jiter-0.15.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:3e4540b8e74e4268811ac05db226a6a128ff572e7e0ce3f1163b693cadb184cd", size = 352283, upload-time = "2026-05-19T10:08:43.091Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/da/0f6af8cef2c565a1ab44d970f268c43ccaa72707386ea6388e6fe2b6cd26/jiter-0.15.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:62ebd14e47e9aed9df4472afcb2663668ce4d74891cd54f86bf6e44029d6dc89", size = 389985, upload-time = "2026-05-19T10:08:44.915Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/ec/b9cb7d6d29e24ee14910266157d2a279d7a8f60ee0df7fa840882976ba64/jiter-0.15.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0be6f5ad41a809f303f416d17cec92a7a725902fb9b4f3de3d19362ac0ef8554", size = 517695, upload-time = "2026-05-19T10:08:46.486Z" },
-    { url = "https://files.pythonhosted.org/packages/64/5e/6d1bda880723aae0ad86b4b763f044362448efe31e3e819635d41cb03451/jiter-0.15.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:813dfbb17d65328bf86e5f0905dd277ba2265d3ca20556e86c0c7035b7182e5a", size = 548868, upload-time = "2026-05-19T10:08:48.026Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/72/7de501cf38dcacaf35098796f3a50e0f2e338baba18a58946c618544b809/jiter-0.15.0-cp314-cp314-win32.whl", hash = "sha256:50e51156192722a9c58db112837d3f8ef96fb3c5ecc14e95f409134b08b158ec", size = 206380, upload-time = "2026-05-19T10:08:49.738Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/a9/e19addf4b0c1bdce52c6da12351e6bc42c340c45e7c09e2158e46d293ccc/jiter-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:30ce1a5d16b5641dc935d50ef775af6a0871e3d14ab05d6fc54dff371b78e558", size = 197687, upload-time = "2026-05-19T10:08:51.088Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/c9/776b1db01db25fc6c1d58d1979a37b0a9fe787e5f5b1d062d2eaacb77923/jiter-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:510c8b3c17a0ed9ac69850c0438dada3c9b82d9c4d589fcb62002a5a9cf3a866", size = 192571, upload-time = "2026-05-19T10:08:52.451Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/f6/45bb4670bacf300fd2c7abadbfb3af376e5f1b6ae75fd9bc069891d15870/jiter-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7553333dd0930c104a5a0db8df72bf7219fe663d731383b576bb6ed6351c984d", size = 317151, upload-time = "2026-05-19T10:08:53.867Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/68/ed635ad5acd7b73e454283083bbb7c8205ad10e88b0d9d7d793b09fe8226/jiter-0.15.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2143ab06181d2b029eedcb6af3cebe95f11bbac62441781860f98ee9330a6a6", size = 341243, upload-time = "2026-05-19T10:08:55.383Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/db/3ff4176b817b8ea33879e71e13d8bc2b0d481a7ed3fe9e080f333d415c16/jiter-0.15.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6eac374c5c975709b69c10f09afd199df74150172156ad10c8d4fd785b7da995", size = 363629, upload-time = "2026-05-19T10:08:56.928Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/24/5f8270e0ba9c883582f96f722f8a0b58015c7ce1f8c6d4571cf394e99b6b/jiter-0.15.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3b3b775e33d3bfaec9899edc526ae97b0da0bf9d071a46124ba419149a414f8", size = 456198, upload-time = "2026-05-19T10:08:58.618Z" },
-    { url = "https://files.pythonhosted.org/packages/45/5b/76fc02b0b5c54c3d18c60653156e2f76fde1816f9b4722db68d6ee2c897e/jiter-0.15.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3071db3346334beae1360b46da4606da57bf3528c167b3c38533afaf9f2c5", size = 373710, upload-time = "2026-05-19T10:09:00.151Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/52/4310821b0ea9277994d3e1f49fc6a4b34e4800caebacb2c0af81da59a454/jiter-0.15.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6694a173ecabc12eb60efbc0b474464ead1951ff65cd8b1e72100715c64512b", size = 349901, upload-time = "2026-05-19T10:09:01.621Z" },
-    { url = "https://files.pythonhosted.org/packages/93/fe/67648c35b3594fba8854ac64cc8a826d8bcd18324bbdb53d77697c60b6ef/jiter-0.15.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:a254e10b593624d230c365b6d616b22ca0ad65e63a16e6631c2b3466022e6ba8", size = 352438, upload-time = "2026-05-19T10:09:03.216Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/28/0a1879d07ad6b3e025a2750027363452ced93c2d16d1c9d4b153ffd51c91/jiter-0.15.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d8d2955167274e15d79a7a020afdd9b39c990eb80b2d89fca695d92dcfdd38ec", size = 388152, upload-time = "2026-05-19T10:09:04.741Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/78/46c6f6b56ba85c90021f4afd72ed42f691f8f84daacb5fe27277070e3858/jiter-0.15.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:acf4ee4d1fc55917239fe72972fb292dd773055d05eb040d36f4326e02cc2c0e", size = 517707, upload-time = "2026-05-19T10:09:06.231Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/cb/720662d4c88fcad606e826fef5424365527ba43ce4868a479aed8f8c507e/jiter-0.15.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:e7196e56f1cd69af1dbb07dff02dcfb260a50b45a82d409d92a06fedb32473b5", size = 548241, upload-time = "2026-05-19T10:09:08.093Z" },
-    { url = "https://files.pythonhosted.org/packages/60/e3/935b8034fd143f21125c87d51404a9e0e1449186a494405721ff5d1d695e/jiter-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:7f6163c0f10b055245f814dcc59f4818da60dfe72f3e72ab89fc24b6bd5e9c52", size = 207950, upload-time = "2026-05-19T10:09:09.616Z" },
-    { url = "https://files.pythonhosted.org/packages/93/59/984fd9ece895953dad3e0880a650e766f5a2da2c5514f0eafdaaabbeb5f9/jiter-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:980c256edb05b78a111b99c4de3b1d32e31634b867fd1fc2cf726e7b7bba9854", size = 200055, upload-time = "2026-05-19T10:09:11.367Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/a4/cf8d779feb133a27a2e3bc833bccb9e13aa332cdf820497ebf72c10ce8c3/jiter-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:66b1880df2d01e206e8339769d1c7c1753bcb653efd6289e203f6f24ebada0c0", size = 191244, upload-time = "2026-05-19T10:09:12.74Z" },
-    { url = "https://files.pythonhosted.org/packages/73/38/505941b2b092fd5bbbd60a52a880db1173f1690ae6751bed3af1c9ddcb4e/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:631f13a3d04e97d4e083993b10f4b99530e3a10d953e2eb5e196b7dc7f812ce0", size = 303769, upload-time = "2026-05-19T10:09:42.203Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/95/a06692b29e77473f286e1ec1f426d3ca44d7b5843be8ad21d7a5f3fcdcc0/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b6c0ffae686c39bf3737be60793783267628783ea42545632c10b291105aee45", size = 305128, upload-time = "2026-05-19T10:09:43.657Z" },
-    { url = "https://files.pythonhosted.org/packages/23/85/7270d7ad41d6061a25b950c6bf91d638bd9aacb113200a8c8d57a055fd67/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d54fb5b31dea401a41af3f8a7d2512e9b6a6a005491e6166c7e4ffab9639a9c", size = 340459, upload-time = "2026-05-19T10:09:45.452Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/8d/302cb2057b7513327b4d575cff6b1d066ee6431a5357fc3f8867cd684406/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d5d6090cdc1b7c9e780dfb04949a990adb1e301a2fc0bbcee7de4638d33f9a", size = 344469, upload-time = "2026-05-19T10:09:46.864Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/30/7687e4f87086829955013ca12a9233523349767f69653ebc27036313def9/jiter-0.13.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0a2bd69fc1d902e89925fc34d1da51b2128019423d7b339a45d9e99c894e0663", size = 307958, upload-time = "2026-02-02T12:35:57.165Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/27/e57f9a783246ed95481e6749cc5002a8a767a73177a83c63ea71f0528b90/jiter-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f917a04240ef31898182f76a332f508f2cc4b57d2b4d7ad2dbfebbfe167eb505", size = 318597, upload-time = "2026-02-02T12:35:58.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/52/e5719a60ac5d4d7c5995461a94ad5ef962a37c8bf5b088390e6fad59b2ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1e2b199f446d3e82246b4fd9236d7cb502dc2222b18698ba0d986d2fecc6152", size = 348821, upload-time = "2026-02-02T12:36:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/61/db/c1efc32b8ba4c740ab3fc2d037d8753f67685f475e26b9d6536a4322bcdd/jiter-0.13.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04670992b576fa65bd056dbac0c39fe8bd67681c380cb2b48efa885711d9d726", size = 364163, upload-time = "2026-02-02T12:36:01.937Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8a/fb75556236047c8806995671a18e4a0ad646ed255276f51a20f32dceaeec/jiter-0.13.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a1aff1fbdb803a376d4d22a8f63f8e7ccbce0b4890c26cc7af9e501ab339ef0", size = 483709, upload-time = "2026-02-02T12:36:03.41Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/16/43512e6ee863875693a8e6f6d532e19d650779d6ba9a81593ae40a9088ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b3fb8c2053acaef8580809ac1d1f7481a0a0bdc012fd7f5d8b18fb696a5a089", size = 370480, upload-time = "2026-02-02T12:36:04.791Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/4c/09b93e30e984a187bc8aaa3510e1ec8dcbdcd71ca05d2f56aac0492453aa/jiter-0.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdaba7d87e66f26a2c45d8cbadcbfc4bf7884182317907baf39cfe9775bb4d93", size = 360735, upload-time = "2026-02-02T12:36:06.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1b/46c5e349019874ec5dfa508c14c37e29864ea108d376ae26d90bee238cd7/jiter-0.13.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7b88d649135aca526da172e48083da915ec086b54e8e73a425ba50999468cc08", size = 391814, upload-time = "2026-02-02T12:36:08.368Z" },
+    { url = "https://files.pythonhosted.org/packages/15/9e/26184760e85baee7162ad37b7912797d2077718476bf91517641c92b3639/jiter-0.13.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e404ea551d35438013c64b4f357b0474c7abf9f781c06d44fcaf7a14c69ff9e2", size = 513990, upload-time = "2026-02-02T12:36:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/34/2c9355247d6debad57a0a15e76ab1566ab799388042743656e566b3b7de1/jiter-0.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1f4748aad1b4a93c8bdd70f604d0f748cdc0e8744c5547798acfa52f10e79228", size = 548021, upload-time = "2026-02-02T12:36:11.376Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4a/9f2c23255d04a834398b9c2e0e665382116911dc4d06b795710503cdad25/jiter-0.13.0-cp312-cp312-win32.whl", hash = "sha256:0bf670e3b1445fc4d31612199f1744f67f889ee1bbae703c4b54dc097e5dd394", size = 203024, upload-time = "2026-02-02T12:36:12.682Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ee/f0ae675a957ae5a8f160be3e87acea6b11dc7b89f6b7ab057e77b2d2b13a/jiter-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:15db60e121e11fe186c0b15236bd5d18381b9ddacdcf4e659feb96fc6c969c92", size = 205424, upload-time = "2026-02-02T12:36:13.93Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ae611edf913d3cbf02c97cdb90374af2082c48d7190d74c1111dde08bcdd/jiter-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:41f92313d17989102f3cb5dd533a02787cdb99454d494344b0361355da52fcb9", size = 186818, upload-time = "2026-02-02T12:36:15.308Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9c/7ee5a6ff4b9991e1a45263bfc46731634c4a2bde27dfda6c8251df2d958c/jiter-0.13.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1f8a55b848cbabf97d861495cd65f1e5c590246fabca8b48e1747c4dfc8f85bf", size = 306897, upload-time = "2026-02-02T12:36:16.748Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/02/be5b870d1d2be5dd6a91bdfb90f248fbb7dcbd21338f092c6b89817c3dbf/jiter-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f556aa591c00f2c45eb1b89f68f52441a016034d18b65da60e2d2875bbbf344a", size = 317507, upload-time = "2026-02-02T12:36:18.351Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/b25d2ec333615f5f284f3a4024f7ce68cfa0604c322c6808b2344c7f5d2b/jiter-0.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7e1d61da332ec412350463891923f960c3073cf1aae93b538f0bb4c8cd46efb", size = 350560, upload-time = "2026-02-02T12:36:19.746Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ec/74dcb99fef0aca9fbe56b303bf79f6bd839010cb18ad41000bf6cc71eec0/jiter-0.13.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3097d665a27bc96fd9bbf7f86178037db139f319f785e4757ce7ccbf390db6c2", size = 363232, upload-time = "2026-02-02T12:36:21.243Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/37/f17375e0bb2f6a812d4dd92d7616e41917f740f3e71343627da9db2824ce/jiter-0.13.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d01ecc3a8cbdb6f25a37bd500510550b64ddf9f7d64a107d92f3ccb25035d0f", size = 483727, upload-time = "2026-02-02T12:36:22.688Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d2/a71160a5ae1a1e66c1395b37ef77da67513b0adba73b993a27fbe47eb048/jiter-0.13.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed9bbc30f5d60a3bdf63ae76beb3f9db280d7f195dfcfa61af792d6ce912d159", size = 370799, upload-time = "2026-02-02T12:36:24.106Z" },
+    { url = "https://files.pythonhosted.org/packages/01/99/ed5e478ff0eb4e8aa5fd998f9d69603c9fd3f32de3bd16c2b1194f68361c/jiter-0.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fbafb6e88256f4454de33c1f40203d09fc33ed19162a68b3b257b29ca7f663", size = 359120, upload-time = "2026-02-02T12:36:25.519Z" },
+    { url = "https://files.pythonhosted.org/packages/16/be/7ffd08203277a813f732ba897352797fa9493faf8dc7995b31f3d9cb9488/jiter-0.13.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5467696f6b827f1116556cb0db620440380434591e93ecee7fd14d1a491b6daa", size = 390664, upload-time = "2026-02-02T12:36:26.866Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/e0787856196d6d346264d6dcccb01f741e5f0bd014c1d9a2ebe149caf4f3/jiter-0.13.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2d08c9475d48b92892583df9da592a0e2ac49bcd41fae1fec4f39ba6cf107820", size = 513543, upload-time = "2026-02-02T12:36:28.217Z" },
+    { url = "https://files.pythonhosted.org/packages/65/50/ecbd258181c4313cf79bca6c88fb63207d04d5bf5e4f65174114d072aa55/jiter-0.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:aed40e099404721d7fcaf5b89bd3b4568a4666358bcac7b6b15c09fb6252ab68", size = 547262, upload-time = "2026-02-02T12:36:29.678Z" },
+    { url = "https://files.pythonhosted.org/packages/27/da/68f38d12e7111d2016cd198161b36e1f042bd115c169255bcb7ec823a3bf/jiter-0.13.0-cp313-cp313-win32.whl", hash = "sha256:36ebfbcffafb146d0e6ffb3e74d51e03d9c35ce7c625c8066cdbfc7b953bdc72", size = 200630, upload-time = "2026-02-02T12:36:31.808Z" },
+    { url = "https://files.pythonhosted.org/packages/25/65/3bd1a972c9a08ecd22eb3b08a95d1941ebe6938aea620c246cf426ae09c2/jiter-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:8d76029f077379374cf0dbc78dbe45b38dec4a2eb78b08b5194ce836b2517afc", size = 202602, upload-time = "2026-02-02T12:36:33.679Z" },
+    { url = "https://files.pythonhosted.org/packages/15/fe/13bd3678a311aa67686bb303654792c48206a112068f8b0b21426eb6851e/jiter-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:bb7613e1a427cfcb6ea4544f9ac566b93d5bf67e0d48c787eca673ff9c9dff2b", size = 185939, upload-time = "2026-02-02T12:36:35.065Z" },
+    { url = "https://files.pythonhosted.org/packages/49/19/a929ec002ad3228bc97ca01dbb14f7632fffdc84a95ec92ceaf4145688ae/jiter-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa476ab5dd49f3bf3a168e05f89358c75a17608dbabb080ef65f96b27c19ab10", size = 316616, upload-time = "2026-02-02T12:36:36.579Z" },
+    { url = "https://files.pythonhosted.org/packages/52/56/d19a9a194afa37c1728831e5fb81b7722c3de18a3109e8f282bfc23e587a/jiter-0.13.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ade8cb6ff5632a62b7dbd4757d8c5573f7a2e9ae285d6b5b841707d8363205ef", size = 346850, upload-time = "2026-02-02T12:36:38.058Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4a/94e831c6bf287754a8a019cb966ed39ff8be6ab78cadecf08df3bb02d505/jiter-0.13.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9950290340acc1adaded363edd94baebcee7dabdfa8bee4790794cd5cfad2af6", size = 358551, upload-time = "2026-02-02T12:36:39.417Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ec/a4c72c822695fa80e55d2b4142b73f0012035d9fcf90eccc56bc060db37c/jiter-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2b4972c6df33731aac0742b64fd0d18e0a69bc7d6e03108ce7d40c85fd9e3e6d", size = 201950, upload-time = "2026-02-02T12:36:40.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/00/393553ec27b824fbc29047e9c7cd4a3951d7fbe4a76743f17e44034fa4e4/jiter-0.13.0-cp313-cp313t-win_arm64.whl", hash = "sha256:701a1e77d1e593c1b435315ff625fd071f0998c5f02792038a5ca98899261b7d", size = 185852, upload-time = "2026-02-02T12:36:42.077Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f5/f1997e987211f6f9bd71b8083047b316208b4aca0b529bb5f8c96c89ef3e/jiter-0.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cc5223ab19fe25e2f0bf2643204ad7318896fe3729bf12fde41b77bfc4fafff0", size = 308804, upload-time = "2026-02-02T12:36:43.496Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8f/5482a7677731fd44881f0204981ce2d7175db271f82cba2085dd2212e095/jiter-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9776ebe51713acf438fd9b4405fcd86893ae5d03487546dae7f34993217f8a91", size = 318787, upload-time = "2026-02-02T12:36:45.071Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b9/7257ac59778f1cd025b26a23c5520a36a424f7f1b068f2442a5b499b7464/jiter-0.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:879e768938e7b49b5e90b7e3fecc0dbec01b8cb89595861fb39a8967c5220d09", size = 353880, upload-time = "2026-02-02T12:36:47.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/87/719eec4a3f0841dad99e3d3604ee4cba36af4419a76f3cb0b8e2e691ad67/jiter-0.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:682161a67adea11e3aae9038c06c8b4a9a71023228767477d683f69903ebc607", size = 366702, upload-time = "2026-02-02T12:36:48.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/65/415f0a75cf6921e43365a1bc227c565cb949caca8b7532776e430cbaa530/jiter-0.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a13b68cd1cd8cc9de8f244ebae18ccb3e4067ad205220ef324c39181e23bbf66", size = 486319, upload-time = "2026-02-02T12:36:53.006Z" },
+    { url = "https://files.pythonhosted.org/packages/54/a2/9e12b48e82c6bbc6081fd81abf915e1443add1b13d8fc586e1d90bb02bb8/jiter-0.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87ce0f14c6c08892b610686ae8be350bf368467b6acd5085a5b65441e2bf36d2", size = 372289, upload-time = "2026-02-02T12:36:54.593Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/e4693f107a1789a239c759a432e9afc592366f04e901470c2af89cfd28e1/jiter-0.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c365005b05505a90d1c47856420980d0237adf82f70c4aff7aebd3c1cc143ad", size = 360165, upload-time = "2026-02-02T12:36:56.112Z" },
+    { url = "https://files.pythonhosted.org/packages/17/08/91b9ea976c1c758240614bd88442681a87672eebc3d9a6dde476874e706b/jiter-0.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1317fdffd16f5873e46ce27d0e0f7f4f90f0cdf1d86bf6abeaea9f63ca2c401d", size = 389634, upload-time = "2026-02-02T12:36:57.495Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/58325ef99390d6d40427ed6005bf1ad54f2577866594bcf13ce55675f87d/jiter-0.13.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c05b450d37ba0c9e21c77fef1f205f56bcee2330bddca68d344baebfc55ae0df", size = 514933, upload-time = "2026-02-02T12:36:58.909Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/25/69f1120c7c395fd276c3996bb8adefa9c6b84c12bb7111e5c6ccdcd8526d/jiter-0.13.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:775e10de3849d0631a97c603f996f518159272db00fdda0a780f81752255ee9d", size = 548842, upload-time = "2026-02-02T12:37:00.433Z" },
+    { url = "https://files.pythonhosted.org/packages/18/05/981c9669d86850c5fbb0d9e62bba144787f9fba84546ba43d624ee27ef29/jiter-0.13.0-cp314-cp314-win32.whl", hash = "sha256:632bf7c1d28421c00dd8bbb8a3bac5663e1f57d5cd5ed962bce3c73bf62608e6", size = 202108, upload-time = "2026-02-02T12:37:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/cdcf54dd0b0341db7d25413229888a346c7130bd20820530905fdb65727b/jiter-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:f22ef501c3f87ede88f23f9b11e608581c14f04db59b6a801f354397ae13739f", size = 204027, upload-time = "2026-02-02T12:37:03.075Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f9/724bcaaab7a3cd727031fe4f6995cb86c4bd344909177c186699c8dec51a/jiter-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:07b75fe09a4ee8e0c606200622e571e44943f47254f95e2436c8bdcaceb36d7d", size = 187199, upload-time = "2026-02-02T12:37:04.414Z" },
+    { url = "https://files.pythonhosted.org/packages/62/92/1661d8b9fd6a3d7a2d89831db26fe3c1509a287d83ad7838831c7b7a5c7e/jiter-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:964538479359059a35fb400e769295d4b315ae61e4105396d355a12f7fef09f0", size = 318423, upload-time = "2026-02-02T12:37:05.806Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/3b/f77d342a54d4ebcd128e520fc58ec2f5b30a423b0fd26acdfc0c6fef8e26/jiter-0.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e104da1db1c0991b3eaed391ccd650ae8d947eab1480c733e5a3fb28d4313e40", size = 351438, upload-time = "2026-02-02T12:37:07.189Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b3/ba9a69f0e4209bd3331470c723c2f5509e6f0482e416b612431a5061ed71/jiter-0.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e3a5f0cde8ff433b8e88e41aa40131455420fb3649a3c7abdda6145f8cb7202", size = 364774, upload-time = "2026-02-02T12:37:08.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/16/6cdb31fa342932602458dbb631bfbd47f601e03d2e4950740e0b2100b570/jiter-0.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57aab48f40be1db920a582b30b116fe2435d184f77f0e4226f546794cedd9cf0", size = 487238, upload-time = "2026-02-02T12:37:10.066Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b1/956cc7abaca8d95c13aa8d6c9b3f3797241c246cd6e792934cc4c8b250d2/jiter-0.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7772115877c53f62beeb8fd853cab692dbc04374ef623b30f997959a4c0e7e95", size = 372892, upload-time = "2026-02-02T12:37:11.656Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c4/97ecde8b1e74f67b8598c57c6fccf6df86ea7861ed29da84629cdbba76c4/jiter-0.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1211427574b17b633cfceba5040de8081e5abf114f7a7602f73d2e16f9fdaa59", size = 360309, upload-time = "2026-02-02T12:37:13.244Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d7/eabe3cf46715854ccc80be2cd78dd4c36aedeb30751dbf85a1d08c14373c/jiter-0.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7beae3a3d3b5212d3a55d2961db3c292e02e302feb43fce6a3f7a31b90ea6dfe", size = 389607, upload-time = "2026-02-02T12:37:14.881Z" },
+    { url = "https://files.pythonhosted.org/packages/df/2d/03963fc0804e6109b82decfb9974eb92df3797fe7222428cae12f8ccaa0c/jiter-0.13.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e5562a0f0e90a6223b704163ea28e831bd3a9faa3512a711f031611e6b06c939", size = 514986, upload-time = "2026-02-02T12:37:16.326Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6c/8c83b45eb3eb1c1e18d841fe30b4b5bc5619d781267ca9bc03e005d8fd0a/jiter-0.13.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c26a424569a59140fb51160a56df13f438a2b0967365e987889186d5fc2f6f9", size = 548756, upload-time = "2026-02-02T12:37:17.736Z" },
+    { url = "https://files.pythonhosted.org/packages/47/66/eea81dfff765ed66c68fd2ed8c96245109e13c896c2a5015c7839c92367e/jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6", size = 201196, upload-time = "2026-02-02T12:37:19.101Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/32/4ac9c7a76402f8f00d00842a7f6b83b284d0cf7c1e9d4227bc95aa6d17fa/jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8", size = 204215, upload-time = "2026-02-02T12:37:20.495Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/8e/7def204fea9f9be8b3c21a6f2dd6c020cf56c7d5ff753e0e23ed7f9ea57e/jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024", size = 187152, upload-time = "2026-02-02T12:37:22.124Z" },
+    { url = "https://files.pythonhosted.org/packages/80/60/e50fa45dd7e2eae049f0ce964663849e897300433921198aef94b6ffa23a/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:3d744a6061afba08dd7ae375dcde870cffb14429b7477e10f67e9e6d68772a0a", size = 305169, upload-time = "2026-02-02T12:37:50.376Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
 ]
 
 [[package]]
@@ -2350,6 +2804,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "jupyter-core"
+version = "5.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
 ]
 
 [[package]]
@@ -2477,12 +2944,189 @@ wheels = [
 ]
 
 [[package]]
+name = "ladybug"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.14' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version == '3.13.*' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version == '3.13.*' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version < '3.13' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version < '3.13' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f6/1511d2ab4391af8a4133c556ccaf79b613d79c6120e3fcced02c8d438982/ladybug-0.17.1.tar.gz", hash = "sha256:82efea498713c7da7f6f94f80252574599252d26ee10fb11e62ae932b5d8f2ba", size = 10160802, upload-time = "2026-06-02T20:08:43.241Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/0b/76ba668df9fe004c80bc2ee0cd46e76924467fa4d96853125962947d9c33/ladybug-0.17.1-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:1a5fd5f324df8c5659a8cd6a0c08c58b2f6efbf0319cde6ec7cdcc3480343129", size = 4185245, upload-time = "2026-06-02T20:07:52.826Z" },
+    { url = "https://files.pythonhosted.org/packages/25/54/11855f62e55a9b47e64c3c45c9d312e9830e5fc253c1f1b6d860f12faf74/ladybug-0.17.1-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:17e540cedd30816fad248e4d3cc6444bbc139a4b79e43af5f471acbe790a707a", size = 4668570, upload-time = "2026-06-02T20:07:55.132Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/94/1e8796e91ec8d741a2bcd10bfa99cd96f0a30f26fe55ca910a993e6bcb9f/ladybug-0.17.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:067e183bd3fb2094a040cc4e69269fdcc5a770579a89f2d9f5dd8c93da6c08bc", size = 7065841, upload-time = "2026-06-02T20:07:57.147Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/1a/12796133dd933b59a441eb39145ff604a36d1fa3b9c08deb90048233b38b/ladybug-0.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c11887032a14ca49941cbb5e9ac94adcba804c17fc7f823f598c8cceb5438612", size = 7921694, upload-time = "2026-06-02T20:07:59.278Z" },
+    { url = "https://files.pythonhosted.org/packages/11/59/24f4dfbebc4298ca05ace1755abda6fe096e37db19a019239ca08828ee4c/ladybug-0.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5a3e906981abb4a92f3c2add315ae44419b1c5487bbedfa50eb03a0e2040dc38", size = 7897206, upload-time = "2026-06-02T20:08:01.334Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/4b/5dbe3d4193866ae54b210f75552a11a9c0f5fd6408ea78e01332347d7422/ladybug-0.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bc0d0276b6181c26434f33eb675a304d33ce183fe6f90d04c91e7c001468b407", size = 8781956, upload-time = "2026-06-02T20:08:03.322Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/77/c71612d69c41c4813a7687ee547145d1787bea96cd5530a23cc67eb8d5d8/ladybug-0.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:4efc3f1117c16d7e9728afe9a0a87b89d4d3fb98c480d16d7f22c64be963a43b", size = 5290750, upload-time = "2026-06-02T20:08:05.597Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/78/a6c1d9fe146216fb92dc6dfc8c289a818db0d8563333aca751679329ad26/ladybug-0.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:4c50a9e3e288cb57ede865b16e84bb4fd0471c572a641481e548cd70c4e82973", size = 5258304, upload-time = "2026-06-02T20:08:07.441Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4a/8a5a208b5a53384c576870c49a940a178083b1740f1b20332f2433f9a846/ladybug-0.17.1-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:785c95d595754be8d16b2e35defc44a906ccbef329c180e97e47ac7df17776bf", size = 4185250, upload-time = "2026-06-02T20:08:09.137Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/1d/c4c2815475571c9eb32f44ae435957049e20ce7474fa5fc04aa74ac2b12e/ladybug-0.17.1-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:a168cdeea1f239b698ca222d680faa9b9b01b5ff96a1087b6235be23533d05e0", size = 4668500, upload-time = "2026-06-02T20:08:11.013Z" },
+    { url = "https://files.pythonhosted.org/packages/92/64/6233cb455e327f752b7938cdcbbc693cd9584a154723be429272b9fa694c/ladybug-0.17.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb2d88b4852689d73437c7c31057345fc95540e242c25e71999d541ad104f390", size = 7065427, upload-time = "2026-06-02T20:08:12.979Z" },
+    { url = "https://files.pythonhosted.org/packages/37/31/18875d6e46e29081d7c0b0072c60df3e20090d46de00d481eaecf71cf0ab/ladybug-0.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf0ec0e0c0cb06be60ef83e3d95a3f5c02e3df6fe0270fee576b5688d0e70d28", size = 7921542, upload-time = "2026-06-02T20:08:15.167Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ce/89eeaf428595146c790d7ebf982bdb53fa51b678daded5f09152a1454435/ladybug-0.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8fd79f020c5b2db9d2b2b689ac2616f86d43ebc5d36063a001ee1ce158f50bf8", size = 7898139, upload-time = "2026-06-02T20:08:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/44/b4c80147c547c380d35b9904245de01def0224342254b4fa36d8815210de/ladybug-0.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a9706c6a65365955ac3b18688a582c82ac3388362fdccab13a18e66b2c864e6b", size = 8782280, upload-time = "2026-06-02T20:08:19.49Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/39/f09366d5fe6d2f2c75a22d368e7c09f2e0194d1d80a4dfa7ece5b2deaa83/ladybug-0.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:616d5017ee21ac99c4e1251f75c569053b709f73e207bd2d97f7742169680286", size = 5291337, upload-time = "2026-06-02T20:08:21.538Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d4/e64ae350b011c0cacde3df87e47cc6ec59564366cd364fc13698d6d774ca/ladybug-0.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5e84e5329f74e833828eeddd468ac881323fbfdb54a8610ae9f2bbe7bc02f952", size = 5258364, upload-time = "2026-06-02T20:08:23.504Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e6/94dff21a9ef485fba3a933d76735197e8ced13184edd862361319ee2e253/ladybug-0.17.1-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:c8a71f90f2fe16396c98380aadd5519ed72346aed4d7872b06e2450e9470ac77", size = 4186197, upload-time = "2026-06-02T20:08:25.443Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/7c/a9fd639408629e8a33d014d482355eab272edfe525aea1c7a5305d32662e/ladybug-0.17.1-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:08934e417214ca03836934ed7bd1f6ebedf6959db3b4405541aa4389f60800a6", size = 4668982, upload-time = "2026-06-02T20:08:27.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/aa/ccd37c07d38e7305212ddd8d05dbfadd61a07ad5e56aebaf92fe4c6c23cb/ladybug-0.17.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2dbca5d77c309b6c992f5ab9f5d18b2a8002d4766f09ab7fa6ff9510df304b74", size = 7066952, upload-time = "2026-06-02T20:08:29.43Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a1/e9e987fdf72ec8c67bf57223295abba78489c7629bc126e851249cd4c24e/ladybug-0.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f206b635840a26dd76e0b2f74e00e25e33fad1eb4e913bcce98cd5e5cf0146d", size = 7921609, upload-time = "2026-06-02T20:08:31.751Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0b/8267a09d1589e9f19756c1118d406da88d9370fb04ede0285ae75b9b0d04/ladybug-0.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4c6701f0abce984e7820f8242754682b7e6ed82787b1316b614c192458bac99", size = 7898765, upload-time = "2026-06-02T20:08:33.864Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/06/5214d7ed85e3a302a855af067475234d44d45dbf220f5773bd9f476c7ee8/ladybug-0.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c53cf98ae5b414af6f6f2025ccbb06dcd368eb1142e9a675ab24ccc4b936ed5", size = 8782260, upload-time = "2026-06-02T20:08:36.309Z" },
+    { url = "https://files.pythonhosted.org/packages/45/d7/5ad430ad61b7db1b409fd3086f32fb1b64300c9a2f1d455dd0ca7b39adf0/ladybug-0.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:48efb95673096a7524a1f16943a1885ad016944ea8a5a000746d9939cf2a039b", size = 5455451, upload-time = "2026-06-02T20:08:39.118Z" },
+    { url = "https://files.pythonhosted.org/packages/af/da/75ca2ef8911bd554e997793c767f6e77892c8cb4761939f3abd225532ebc/ladybug-0.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:2ad869f14b0307c7eb2f91639da7ab887c666c2f93260c46a055c7969e082a09", size = 5400801, upload-time = "2026-06-02T20:08:41.114Z" },
+]
+
+[[package]]
+name = "ladybug"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32')",
+    "(python_full_version == '3.13.*' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version == '3.13.*' and sys_platform != 'darwin')",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "(python_full_version < '3.13' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version and sys_platform == 'darwin') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'win32')",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/f7/0ef0a9616d622c790c7fd559d10eb0fdd320c5880e79da035d0b23d2ab8d/ladybug-0.19.0.tar.gz", hash = "sha256:02a0725d29b36fd0de469dab14928c3bc8c5dfee4019acfd60ca504caffc4cd7", size = 10301849, upload-time = "2026-07-30T00:36:34.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/9c/62ebf8ff99509bcb6a274b18688f4690e300afe400156f04258a464e2f27/ladybug-0.19.0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:2189d4baccd8518bd37cb86212105f06b1033b8b711f0328fecb306159c0acca", size = 4561997, upload-time = "2026-07-30T00:35:51.77Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ab/013769e2a63c61e92d6c6aab5ef149e5959dad552f0402b188f7eefb15da/ladybug-0.19.0-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:a232e0eb484647f6573be2eec71a862d9a1c953353a954e0774b6d83e075b488", size = 4907061, upload-time = "2026-07-30T00:35:53.317Z" },
+    { url = "https://files.pythonhosted.org/packages/17/35/0a4ea3eef8d951820a8ea3bc5bc693afef2354be38b613cc83b415401835/ladybug-0.19.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f5333857dbfd871b6fc611ff9e08b98c9b2f09d6ddcf1ae53061de85837bd65", size = 7360691, upload-time = "2026-07-30T00:35:54.864Z" },
+    { url = "https://files.pythonhosted.org/packages/63/40/b5c9c84fd6adb544d559510cc7c0d69a1ba4e7fff4b04d9cd31ef59cc1d1/ladybug-0.19.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8c4d00d5cc55e13524eff56e3295732a3c1b8d272d001b30748c2cc348581827", size = 8255273, upload-time = "2026-07-30T00:35:56.687Z" },
+    { url = "https://files.pythonhosted.org/packages/57/5e/d4da91d8a5718ef1ec145cf7f178383a698f61b375820ec59e34b5d2bc3e/ladybug-0.19.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1dfb149912cc960e24a19f83688df5857d0679cc688f8553a896d10f4e8dd8f3", size = 8189623, upload-time = "2026-07-30T00:35:58.42Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/94/e787d51eae4e9d5d0f3188b35f5d1de191cc17a3d04ac1e12c3ac501e4be/ladybug-0.19.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aacd9f3c8f50b0ee1cbcb6a8ef8cb522b288784482ef13eda2ef1ead6e645cea", size = 9113674, upload-time = "2026-07-30T00:36:00.039Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/dd/863742a52f79570b561564efb3fc4957fdb921af20f352fef74df56b89db/ladybug-0.19.0-cp312-cp312-win_amd64.whl", hash = "sha256:42d15b5e090f3600a47efd4697b1809547fbb0a637f593024e906aa960e7c92b", size = 5720735, upload-time = "2026-07-30T00:36:02.014Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/4c/bee1ac2816aecc5fa5671599a36cefac9de37c24ce43bd32418079599494/ladybug-0.19.0-cp312-cp312-win_arm64.whl", hash = "sha256:e07c17db7834f95bb7f0003a8b0476390908549c91d93865465da60700565425", size = 8205067, upload-time = "2026-07-30T00:36:03.595Z" },
+    { url = "https://files.pythonhosted.org/packages/11/a1/4a79481cdaacbbff5225414aa6f9e565640687918fa875d0b3ccb18442ed/ladybug-0.19.0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:5470bbc0e3b3b544e16d91d33784aeba64e39a7e0f0ae3a04cc2d28e53b8f965", size = 4562061, upload-time = "2026-07-30T00:36:05.273Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/27/df981d8c273f98ef6b3b29130a23a952b204cd57783b648752658b3b257e/ladybug-0.19.0-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:e98bfbf891fb8cbcc345760124dae86d236621ef945d0993fed1fce6ef50ff7e", size = 4907180, upload-time = "2026-07-30T00:36:06.739Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/10/0ec2a931d858d0d510b15be5af9cdb226d3ca8735e5d92101abb48187f23/ladybug-0.19.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6116f000eaf7346ca242cf5ae9ee51b2536165a88d43d760e2e746cc8b67be58", size = 7360435, upload-time = "2026-07-30T00:36:08.504Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f8/9d13303b41f21c22c03918d3b87c785b5688a8a0edc2617f139eb50215ed/ladybug-0.19.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86c352593983e399ad4b43b1e7d7fe04591f763167ec7acf40e6c57f39005c7f", size = 8254852, upload-time = "2026-07-30T00:36:10.194Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/50/9a8e4733e7bcd6da90bfe8e9107fe7c36a7138cede8420d15dc6c812a851/ladybug-0.19.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a329b267bcad79cc9ea56bcd982d5d0c5ed91934219116ecb85910475f82d3f9", size = 8189088, upload-time = "2026-07-30T00:36:12.122Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fc/1d6d714e000c010a8dc762149e58003e3ef316cd57883a725ae92f6abde0/ladybug-0.19.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c035c4f00d97c6e1c89f166c43547a753e6a6e22ec3188a762770cecfb21c7e7", size = 9114190, upload-time = "2026-07-30T00:36:13.841Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/35/a9850cd10087fbece8ed5ecbecbeafdd9384b4c78deef466fd89564d2d4c/ladybug-0.19.0-cp313-cp313-win_amd64.whl", hash = "sha256:c32273d33360dcc89798ee6a4ae711614c95f18d65b0fc1082653ec55f2530f5", size = 5720836, upload-time = "2026-07-30T00:36:15.759Z" },
+    { url = "https://files.pythonhosted.org/packages/63/a2/2872a3caf7d9a8cc45cc5736a265ab956c1286cb63d0826854cc8e6c1f3f/ladybug-0.19.0-cp313-cp313-win_arm64.whl", hash = "sha256:0b0e88b49ed63f6a19a143d688b9e4c052ac09e1d11b92583d862d0512ee6bb2", size = 8205353, upload-time = "2026-07-30T00:36:17.477Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/96/b47d5c67f67002df8c4cdb9bfffadc3968f8ef4f7c4baece73e7ad2212cf/ladybug-0.19.0-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:4c2cdf36b2f904709b22518938e7828eec9718795b8b562512e3592af4b8466d", size = 4562927, upload-time = "2026-07-30T00:36:19.278Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/25/10a3f7fb496b2f9e5a26b55433970b2fa493f2f1765ac04651d4c8bfbcca/ladybug-0.19.0-cp314-cp314-macosx_15_0_x86_64.whl", hash = "sha256:088c5f79bd843ac15aee0bb44c417d70dce833a5295252569dcd139d348700dc", size = 4907779, upload-time = "2026-07-30T00:36:20.976Z" },
+    { url = "https://files.pythonhosted.org/packages/59/c5/f632c6f0a1a4a7c53c15c642d4e28c51809b920e831fdac53e6450c4f5de/ladybug-0.19.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ea03d4388dd024c5fa4629d607765c9c2c6f4fa4350aceabecee8d37b54289bb", size = 7361226, upload-time = "2026-07-30T00:36:22.46Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/30/2e42725df3c002b16204f44c055afc50cedd80ca93c0180656741493c575/ladybug-0.19.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f880a6d5329461088d25854a8cd77aec17ffbf00b2f3642ed32f94b5d001f452", size = 8255330, upload-time = "2026-07-30T00:36:24.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e7/a08b5179cbc07fc35f01dd3cfdbf523410cd6ca0a9a6fb5828b1e27da1ea/ladybug-0.19.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:be3035c3e9232d5c50f399a85fd39713f6b31574d2b198d696117e2f21f96d1b", size = 8190323, upload-time = "2026-07-30T00:36:25.825Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f0/060e015ce0384acfbfe19fb4bd1c54bd7da52de6a61f34da066a17f4e572/ladybug-0.19.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b3b2227e10d2004691b3fca755ec050da317eb9a7e1411f5358a395c2eaf19bb", size = 9113582, upload-time = "2026-07-30T00:36:27.522Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/58/0b8c6b7c73d3c3b86f1b646b7ea7fbd0055476e582ad12911f491733da28/ladybug-0.19.0-cp314-cp314-win_amd64.whl", hash = "sha256:1051bf29963eb73d35910f60256fb0649057cd1d0993237bdaf193654071507c", size = 5895460, upload-time = "2026-07-30T00:36:29.643Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b4/f74b3049cc049a04700dbdafb91b299fec6f804759c56e173dd907cbd768/ladybug-0.19.0-cp314-cp314-win_arm64.whl", hash = "sha256:69b8a3d05f04dbadde0f111e03a82e387675032232d3f8ccc91921b749fa8306", size = 8462283, upload-time = "2026-07-30T00:36:31.646Z" },
+]
+
+[[package]]
+name = "lance-namespace"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lance-namespace-urllib3-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/93/da5f7fcac690db9b282a3439ed9e34960c147619a0d6e1f4eb8cd240e7a5/lance_namespace-0.11.1.tar.gz", hash = "sha256:f67cfbbe0647b7cb42f23b673e7edf8a75b7d8a047265a916492f8d247ee1bc2", size = 11631, upload-time = "2026-08-18T17:40:06.294Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/bc/601f2b3cc4cfa0070d858a33223bc823fffdd7981a25c45984a5216ca952/lance_namespace-0.11.1-py3-none-any.whl", hash = "sha256:07643fce9a42ad4d58cc8bf91e3f592bc7f4cbd8d0ad5233223506debf67551c", size = 13507, upload-time = "2026-08-18T17:40:03.561Z" },
+]
+
+[[package]]
+name = "lance-namespace-urllib3-client"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/c5/2bdd0ff98b469894c8a73be809d26ffdad5402517b0e5f9e758026cba29e/lance_namespace_urllib3_client-0.11.1.tar.gz", hash = "sha256:145a9e9424d7597487249b5b95ee274423bf2910e1a9160b6a07b676b61ea46a", size = 237345, upload-time = "2026-08-18T17:40:07.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/eaaefd55d1190291207049fedc6b3eb22b506e57d6de91bae46bbaaa9c60/lance_namespace_urllib3_client-0.11.1-py3-none-any.whl", hash = "sha256:36537f529294da6d884ba0fe783704483f0a75463497c7705fd083a4d0257990", size = 406311, upload-time = "2026-08-18T17:40:04.842Z" },
+]
+
+[[package]]
+name = "lancedb"
+version = "0.37.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation" },
+    { name = "lance-namespace" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyarrow" },
+    { name = "pydantic" },
+    { name = "tqdm" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/2f/4ddcab82bb618c6c8de00725f3cf59585dcb9040964dde13cb0cae6ed3cd/lancedb-0.37.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c15c46f23cf6959c79fb93cdba2c76536cf784d3134386662da03dc6ccac3c26", size = 58474767, upload-time = "2026-08-10T10:41:45.675Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/5e/dac0fd9478a21685444f23e6ec937babf4ff48b1616b68e8137778d6ecb9/lancedb-0.37.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:35d872d920cbfdc3771fbcd33f2c63bff6ff7203d6d2ba8fe4330e98eb859d12", size = 61666580, upload-time = "2026-08-10T10:41:49.535Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/fa/ee1cdb1e904872d75fa0ff44ad35cd23494e810299c33e68de0687de7a71/lancedb-0.37.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:86597f4dbc51a33a07341550dc77d21a1ddd1f7539266eda5bb64c4f3bd11cca", size = 64802395, upload-time = "2026-08-10T10:41:52.969Z" },
+    { url = "https://files.pythonhosted.org/packages/42/55/65c69307373b7f05dea38465b7d3836c86390f0ebc79b5c56d2c0919f229/lancedb-0.37.1-cp310-abi3-win_amd64.whl", hash = "sha256:488eca15361dfc34439500c9e2607c4fb2b8bf190fa1003bd54b1d6eb40e0316", size = 70994296, upload-time = "2026-08-10T10:41:56.609Z" },
+]
+
+[[package]]
+name = "langdetect"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2569554f7c70f4a3c27712f40e3284d483e88094cc0e/langdetect-1.0.9.tar.gz", hash = "sha256:cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0", size = 981474, upload-time = "2021-05-07T07:54:13.562Z" }
+
+[[package]]
 name = "lark"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
+]
+
+[[package]]
+name = "limits"
+version = "4.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/c6/18c4676257f78add093babffbe4d101ff943e9b86e4f708ca5b8fad03a9e/limits-4.8.0.tar.gz", hash = "sha256:74a9691f8a2c82c37480ee9305de3490f6cab3df5b8c61dbde670550f2b34510", size = 95679, upload-time = "2025-04-23T21:00:28.166Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/c9/556846b9d112a3387397850d5560f5ec63464508c6aa068257f0516159d0/limits-4.8.0-py3-none-any.whl", hash = "sha256:de43d24969a0050b859dd29bbd61bd807a5de3ed9255f666aec1ea3dd3fc407e", size = 62028, upload-time = "2025-04-23T21:00:26.017Z" },
+]
+
+[[package]]
+name = "litellm"
+version = "1.98.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "boto3" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/97/c9da198af273d700bf44d7d82eb21c5b8078c82574b31856b71b1298234b/litellm-1.98.0.tar.gz", hash = "sha256:0e6ba5d645a73ca6d0ffb4e8ec539d94b6e8fad691f2a54c6819011e6d0de8bf", size = 17577139, upload-time = "2026-08-22T22:19:21.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/90/2ef5e33b0a67b309be124a77e5098a261beffe28439221dbbc28e5f02e2e/litellm-1.98.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9fda3497f1ec4686c943ce2aeab5767f8fb4a5989305d4b28d6d5d7e488b850c", size = 24026097, upload-time = "2026-08-22T22:19:03.567Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/56/b4569b4ef3640732d5770e0d3f46a395fd20f35594db1f65629595daed00/litellm-1.98.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b89b6a0fc179d881191579f5309e622173dca802ee991b92e382acb918eea437", size = 23683944, upload-time = "2026-08-22T22:19:06.952Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a7/9f03de0e8d767ff27964ea99bbf07e4c37a12f9d3c168c09f40e068535d4/litellm-1.98.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:3a95260f087a4cf763da85bbeeb2efa82caec243ad2394c9e6362ff747963738", size = 23824066, upload-time = "2026-08-22T22:19:09.714Z" },
+    { url = "https://files.pythonhosted.org/packages/69/de/ab46b521e2a6e6a94a5cb91ba3debd6c4e922feaeb47158a389400b0a0fe/litellm-1.98.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:150993180bf049feafa3e20cf46ca0978c69cc66e2ef1639a47e852c682a4721", size = 24190393, upload-time = "2026-08-22T22:19:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/0a/d2f549d906b9b267b38b406dde721eb93db21b46ec907ae0a7a2a89a50f6/litellm-1.98.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:54d0bc2aba84644de5e84a265f24e5d436d91592ca5b7cc61cee478db297b0c3", size = 23901211, upload-time = "2026-08-22T22:19:14.708Z" },
+    { url = "https://files.pythonhosted.org/packages/85/08/1bd1653297d9c92eaf04425f8a21da817fcde12e1d9469394c543df19d72/litellm-1.98.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5e546d4af197c257d320299af11f4619f8e5a29f9bb7ce2d9974dd4b1e045499", size = 24290140, upload-time = "2026-08-22T22:19:17.145Z" },
+    { url = "https://files.pythonhosted.org/packages/de/91/14d11ad7e290137400e5b30bcf23de86f811085f4a46756f60684ed0f064/litellm-1.98.0-cp310-abi3-win_amd64.whl", hash = "sha256:1daac9a9a9d052fdbe58ee711c9924dc81d349d4621286cbd96d77baa12158c4", size = 24079638, upload-time = "2026-08-22T22:19:19.558Z" },
 ]
 
 [[package]]
@@ -2509,6 +3153,67 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/9a/477d75bb2f19e92b4996493519af3e36eaeb1248e1e94637817cf60b6201/locust-2.46.1.tar.gz", hash = "sha256:ed26148522522d13fb453c5e4e281a82650a3b2ec5ad5f00a738ff22a0944808", size = 1478138, upload-time = "2026-07-21T19:01:43.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/71/9f3e058c4afd09c100bd7da5a2f45f4fc86aac97139c3a11f55963119e1a/locust-2.46.1-py3-none-any.whl", hash = "sha256:5111b14e856ee1e570276fdd621acb3b534557f8f0feb348fcfefc0571c680f4", size = 1497688, upload-time = "2026-07-21T19:01:41.367Z" },
+]
+
+[[package]]
+name = "lupa"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/a6/0f869fbb07c393f15473b1eefefb7b5bec162fb7481803d040ed4dc46002/lupa-2.8.tar.gz", hash = "sha256:d8022641b9ec8ecf2c5ecbe9f47e5a70e0b87c4b5ae921b92cb02a638e0acd08", size = 6156370, upload-time = "2026-04-15T20:08:30.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/21/9be4516ddd22f8eadba336d9ba065d17d79108465ae1b7f71424ab99b9d0/lupa-2.8-cp310-abi3-win32.whl", hash = "sha256:c2a5fd15dc62374e1661a55f01744c9ec1c56f291ba4a0749d3af2174556e78f", size = 1594887, upload-time = "2026-04-15T20:05:23.377Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/99/1557c9685d7034d9ce8dd2b54c40a26d6deb7c67c1fdb5c801abd1a02c3f/lupa-2.8-cp310-abi3-win_arm64.whl", hash = "sha256:9e304fb1c50cf23fd8882afbe1aa87525ef8a72667bcab3b37b2bbb2bc542269", size = 1371742, upload-time = "2026-04-15T20:05:27.417Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/0b/368f2f0bc750b25c69d4563e44f677925ab5dd3d2887f9b0c15465d21a2a/lupa-2.8-cp312-abi3-macosx_10_13_x86_64.whl", hash = "sha256:f4342f4de76ae7ce2ab0672d36003bdb7e1a33252f293b569298ddd792e70e33", size = 1194056, upload-time = "2026-04-15T20:05:55.794Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/0f/c89eb8dd36fdea4e50ae3f7f5275bea3b0cc5d4057b8ee7b3bbc78010422/lupa-2.8-cp312-abi3-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:4203fa1659315e939a5304e75001b8cc14234fb3cbb3ed86c049b0cc5d90fcee", size = 1434278, upload-time = "2026-04-15T20:05:57.94Z" },
+    { url = "https://files.pythonhosted.org/packages/47/30/c3b4d2cd8733621b404b8a4214e5f852955c4ba632546dc84123bea9ee89/lupa-2.8-cp312-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:81f2d843ce668b653146c007467570210ae44be51dac6926666c51d49536f307", size = 1150068, upload-time = "2026-04-15T20:06:01.04Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/d2/bac12c398519efafc6af84be1974edd0d7a4895fb4735b5c8d615d298595/lupa-2.8-cp312-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d3d0cde2c77588d1c60875a4f34f059513476c6e1775351897195b51e0f3df08", size = 1409532, upload-time = "2026-04-15T20:06:03.592Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6a/18b52e11962014026e07813530b0b108ee8bc0a2a13ef0eaea5d41dce023/lupa-2.8-cp312-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9e0d11b8f3a8dac6413f704fef7161d048bb10c58bdac6cbffa5e60efa56e9a3", size = 1242687, upload-time = "2026-04-15T20:06:06.863Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8e/7fd4eb049875f61429b96780d2eae4700f0e78fe0a52db8edb231b1cd09f/lupa-2.8-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:54cff414f21f8cd8c6be4aae52541f3b9cd39602b59e3a3db9b5c9f9f674ff18", size = 1856038, upload-time = "2026-04-15T20:06:09.358Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f9/37ad9d2773d30f2931890d310a4bdce28d45484206e6f48bc18b0325eabd/lupa-2.8-cp312-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:24b4d8af5558e549b70daf1547f5c1c1d664ecea9fc790f83efe5d75e9a93797", size = 1128982, upload-time = "2026-04-15T20:06:12.312Z" },
+    { url = "https://files.pythonhosted.org/packages/57/31/c0fd7984c24844ea79caa45c0235f61a06b38fd69a839f6c62770f8d684a/lupa-2.8-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:ce86dff1ee7f7cf45f5622065ae991949dd7bb1703581cbc58a630137bb7ccf9", size = 1457594, upload-time = "2026-04-15T20:06:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/a28e411be30ec1bf0db1eb0c087eebc73be9e7a1adcfe6ac209861ccc446/lupa-2.8-cp312-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:f4d01b2a08c70bbb883a9e082b6b36b89121ed5910b710f1ba11c73295ff4fba", size = 1425721, upload-time = "2026-04-15T20:06:18.009Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c1/359f767c4ae024be30d909fe8a9f0e9af266bad47ce2bd2ed248fb986fcf/lupa-2.8-cp312-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:7f210d5a8353e510ea1199c42cf3cbdd630553bf2bc8fb4c00fea06fdec7c798", size = 1253258, upload-time = "2026-04-15T20:06:21.17Z" },
+    { url = "https://files.pythonhosted.org/packages/17/52/473f11790c261fd02bbf318a546fe040e9ec9f677181272fa78d3b4112a4/lupa-2.8-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4f81a02806e7c7ad26d8c6fa222c8bef1b0c1b124347c879be880b41339d41e4", size = 2395272, upload-time = "2026-04-15T20:06:24.137Z" },
+    { url = "https://files.pythonhosted.org/packages/94/bf/75c8795655a8836eab6a11a630352c4b7c5dc5c54d075077bc9bffdeee45/lupa-2.8-cp312-abi3-win32.whl", hash = "sha256:360056453a7a4eaa4ac5a204c31a5a014b1eb2ee5490603234d2ba831684f1f2", size = 1606136, upload-time = "2026-04-15T20:06:27.815Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/29/11a2cdd612b6f55e506292dfb6ba343216e80a693e7fe3f876ef204ce9c6/lupa-2.8-cp312-abi3-win_arm64.whl", hash = "sha256:1628371c6592a6d5650497a9e31fb2bb3a7e9883c1f301d1111265e484045af9", size = 1364495, upload-time = "2026-04-15T20:06:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/17/fa834b6b09ad17e7df5d0f7715d64877a125a3776ada689751a1f9dc2959/lupa-2.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:450650f91c48c2415b0d59ab3abfcfda3b6efb5b858205f4d4bda8ad141fa529", size = 1190111, upload-time = "2026-04-15T20:06:32.84Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/43/45589901b7d1a0e3a9d91d19a311fb6a56924e8571536c3f2212160fd953/lupa-2.8-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:27044f3363047f946b3d3aab9157cbd172b3538ada9ec1baef43432bf7d03a78", size = 1812999, upload-time = "2026-04-15T20:06:35.664Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ac/4ade7d15ff5c61758d7943ac6f0a496bf1cc65b6c09f842b52a0702e664c/lupa-2.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8cf4f064a0e5531afce2d7d750120c10c10f9529139af6ca6150d13151034398", size = 2368731, upload-time = "2026-04-15T20:06:37.959Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/27/05f950d15b8ab120b39c43588b438ff3ace70c1b1b0225a960393a497483/lupa-2.8-cp312-cp312-win_amd64.whl", hash = "sha256:281bedc5deb92d31e649a3552edd662449365a635904fa4d5cb4509c7245e34e", size = 1941809, upload-time = "2026-04-15T20:06:40.302Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3f/19f83c3a0c84dc8bea8a58e7416dca6a3ede662c33c8d1ec758e5afc754a/lupa-2.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45fc9da0145ecb0083ef5ff9975116cc784bd0258bdc2bd131ba15483ce18398", size = 1201203, upload-time = "2026-04-15T20:06:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/89/0f/a14f0073f09610158038582e230618a48c14da6bd88185289461aa4cb854/lupa-2.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:58e18afed57955b41130e269c78f53d4123ab86e236b53816f4cbffa25cb5d30", size = 1806210, upload-time = "2026-04-15T20:06:45.486Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/14/48fff156c63a136001a7620878af7d31aa07e66b495ed621e3eddd73c294/lupa-2.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fc47f536ac13a79cef47d29a2b205576a22841f042a2bcec1676b95806e7706a", size = 2359005, upload-time = "2026-04-15T20:06:47.819Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/18/3ac638ec90edf178242b8a2b2f00f8adae694248c03a26341ef941bb746e/lupa-2.8-cp313-cp313-win_amd64.whl", hash = "sha256:ce9404c661dbac65cc9bed351ad45e797af93d30d70be309a3fa8209ac86d93b", size = 1936754, upload-time = "2026-04-15T20:06:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ef/5ee5fed6ea7459a671196359ce04bfeeaf26be1dac8ff24bf28e5c7a6e81/lupa-2.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:348c3f8ecabb6324dcbc05c2740d762ef8fcec7b06c79e45262ab97a217684e3", size = 1209388, upload-time = "2026-04-15T20:06:53.022Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b1/67a940d5542cb0384b443fe951b5a83ea9340d1333a733a258fdd1c619ba/lupa-2.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:951496471056061598a7d1729a6cdf48d662fec777a9f2d8aa5a1e62fd30e5a5", size = 1826821, upload-time = "2026-04-15T20:06:55.699Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/a2/b354e5ba3b911ec50686003dc8897e892b9e8c5c036b33219b03d54c4daf/lupa-2.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a591b9947ca347b41a63370e121d6e2b1458fe6dde9ae065029ec10a37f25ff4", size = 2366893, upload-time = "2026-04-15T20:06:58.9Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/52/d76066401f29539df5352f70ecded66576f32933b6045cd0bfc56cb770b9/lupa-2.8-cp314-cp314-win_amd64.whl", hash = "sha256:3903c9cf628dae2f56405503247b77a61a3a61bd2dda470e336950c74776d55d", size = 1994716, upload-time = "2026-04-15T20:07:19.194Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/bd/3efc437a4361c16d25e66478c50357c9a8e8ecfb718fe749eb9ca3176ef6/lupa-2.8-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f711a8ab0486b9ac6fdda94a22ddcfbc9f0d4a27e3a8cf1bf79c6e48b33017c1", size = 1251217, upload-time = "2026-04-15T20:07:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f4/2e9f8ecbaca854bfdf14af8a9b505ec0cbc640377b3b218921594b7563cd/lupa-2.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc51250e76367a3e27fcd01dc769b9bfcbbc34f48df48dde53d6af6e75b7eaa5", size = 1814701, upload-time = "2026-04-15T20:07:04.149Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/53/4000b1acaa8b1f3827fcff0cfcdff44d3befddda42cab7e685a49689b5a1/lupa-2.8-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8a22088a552828958603323f0a5c4b3e11e03b75d0bf4c965ef879de9b60a8d", size = 2348414, upload-time = "2026-04-15T20:07:07.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/78/26ee48d3890cddf03cefb65f433e3492759c0b3c0582180755bddbaab7bd/lupa-2.8-cp314-cp314t-win32.whl", hash = "sha256:4f7c553c1d8cfffbe85d81daef730d12cae4b6002d457542914da0ac8a1145b3", size = 1831611, upload-time = "2026-04-15T20:07:09.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/4a5cc64a3cad22821ae4c3f7a90456a08ca19457d8354f4abf46ad03c7e8/lupa-2.8-cp314-cp314t-win_amd64.whl", hash = "sha256:d8766aff03a78c80ad2d188a8bdb216de5ec838359cd87e05bbdfa56394a6105", size = 2209250, upload-time = "2026-04-15T20:07:11.906Z" },
+    { url = "https://files.pythonhosted.org/packages/37/7c/cdcb654daf668192aaf36b0aeb94f2281dad092aaa5003688691131736ea/lupa-2.8-cp314-cp314t-win_arm64.whl", hash = "sha256:91d622777febda3ab1bed1d45295f2f32a4680c7b3d7caf8c669998ed5c44118", size = 1126735, upload-time = "2026-04-15T20:07:15.434Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/44/de1961ad38e17cd326a53c246c7e3b91178ed578f4cf22ffcd5e7e11b041/lupa-2.8-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b036738282a5acd2e71fdddb317c9df8b87c1673aa57f403d05fcc2be8abc4ba", size = 1186020, upload-time = "2026-04-15T20:07:35.017Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c2/276f0b9dc8bcc5a8a58af5316dfa0e6f56be3613dd6dbcc8d3d2cb6559ba/lupa-2.8-cp39-abi3-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:ac6b6e8d0e617e26a98cbb44880bcd75de5d32b3ad7b3b3793583909292b47ed", size = 1468944, upload-time = "2026-04-15T20:07:37.782Z" },
+    { url = "https://files.pythonhosted.org/packages/63/38/52934e52a5180dc6425d20284d004fe4b27a4f9171a82dc99fb67af250bf/lupa-2.8-cp39-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ba3a7dd839f90c3d2e53bebe3c192b1f3f9fd720a6781256405123211fd0dce6", size = 1172998, upload-time = "2026-04-15T20:07:40.812Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/82/76b3809bd0839d9b3b4ec58d06591e08f17337b6d9576877cb9d48b34e94/lupa-2.8-cp39-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d7edb13a7a5250b5c6c22d1495d9e842b5c9fc5081c8fe6b5efe2112fe3e41f9", size = 1449975, upload-time = "2026-04-15T20:07:44.262Z" },
+    { url = "https://files.pythonhosted.org/packages/16/07/2f89d54f747c67c23b4b9ae4aa8c8dd06bb409155dedcf406157f2736b66/lupa-2.8-cp39-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:891f72e0bffbed1e4175f975aeb2a083956586a100066525e1be485f617f7b25", size = 1281944, upload-time = "2026-04-15T20:07:46.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/bd/7375d2b0fcae79d806baf52a76f26c96964593f58e1372d13ae5ac09c676/lupa-2.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a295f87b5b7ebbfd5191932e8cb0e51df3c7769101ac6b6c7d7c9fb27bfd1307", size = 1910455, upload-time = "2026-04-15T20:07:49.75Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0c/8abb3bc0e08b311fc01db05b6e9f9ff31a8f65e4fc3f0aeb05cfef75c8ac/lupa-2.8-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4fe5d7a810b64ea8511eb885fc8cdde042ee5ff7b7d08ae78f32449756acb177", size = 1155548, upload-time = "2026-04-15T20:07:52.657Z" },
+    { url = "https://files.pythonhosted.org/packages/80/2e/9eeecd3f493099721c1d3f31beeca23a4237db1a54223684df4dc96aa1bd/lupa-2.8-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:bfc470012ef66ad064c7bd77416af03a3452ef630b04b9012595ea13f2e54518", size = 1489232, upload-time = "2026-04-15T20:07:54.92Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/13/731c99dc2e7652ae818a6de45bdf0142049f7cb566049061c898355f1891/lupa-2.8-cp39-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:250e035fdaffe8c87093e3ebc206ac29a26131b1568ea711d780c26001ce96e7", size = 1466321, upload-time = "2026-04-15T20:07:57.627Z" },
+    { url = "https://files.pythonhosted.org/packages/de/71/3ad8cc4fc05a77dc0d3f7079348bd1cad4675a0d14c24f8e6a3ce5f008f7/lupa-2.8-cp39-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:b9bddb09acfffb4f828f790f444b11dc0cca591afea1a244d9329eea2d20c003", size = 1288577, upload-time = "2026-04-15T20:07:59.913Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/b2/1175f6d0aa7b68627fbe2f58bd1e8bea36a89d10dfd67671d2b024c96162/lupa-2.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2e64acbbd47e9b82a64405a39e0d2b36a5a7dad8ab41c0f3437f572f7d282ba3", size = 2444866, upload-time = "2026-04-15T20:08:02.753Z" },
+]
+
+[[package]]
+name = "makefun"
+version = "1.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/cf/6780ab8bc3b84a1cce3e4400aed3d64b6db7d5e227a2f75b6ded5674701a/makefun-1.16.0.tar.gz", hash = "sha256:e14601831570bff1f6d7e68828bcd30d2f5856f24bad5de0ccb22921ceebc947", size = 73565, upload-time = "2025-05-09T15:00:42.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/c0/4bc973defd1270b89ccaae04cef0d5fa3ea85b59b108ad2c08aeea9afb76/makefun-1.16.0-py2.py3-none-any.whl", hash = "sha256:43baa4c3e7ae2b17de9ceac20b669e9a67ceeadff31581007cca20a07bbe42c4", size = 22923, upload-time = "2025-05-09T15:00:41.042Z" },
 ]
 
 [[package]]
@@ -2976,12 +3681,45 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "narwhals"
 version = "2.22.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/62/3c/c4ef2164a71c1a63d7f1ae411c4082c5fa872405106db60a4b7114989ad7/narwhals-2.22.1.tar.gz", hash = "sha256:d62920805a0a43b7ff8b54b0c0d3142d796f8a9301836ada37e573d6a33cbcd9", size = 647493, upload-time = "2026-06-05T12:34:34.051Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl", hash = "sha256:60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53", size = 454815, upload-time = "2026-06-05T12:34:32.289Z" },
+]
+
+[[package]]
+name = "nbformat"
+version = "5.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastjsonschema" },
+    { name = "jsonschema" },
+    { name = "jupyter-core" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/72/b3446efab8756e7df4b8ec587f8e611cb5a7249e4323db480802f1d3be04/nbformat-5.11.1.tar.gz", hash = "sha256:32d4521c68c6e7d5b29c76defaeed9f42ea733142b9b19f88277ce10390b9c4d", size = 147775, upload-time = "2026-08-17T08:10:51.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/69/ee613f74085ca7103f79cd08d579c4f3177d1d26e5d3d9528d2d6536a707/nbformat-5.11.1-py3-none-any.whl", hash = "sha256:cc6698fa75f4fab8755ead786317815f13a6fee3b53311c0abb1a8b51d52f7ec", size = 79849, upload-time = "2026-08-17T08:10:50.18Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]
@@ -3205,6 +3943,9 @@ blaxel = [
 boxlite = [
     { name = "boxlite" },
 ]
+cognee = [
+    { name = "cognee", marker = "python_full_version < '3.15' or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-cwsandbox') or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-databricks') or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-modal') or (extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-dev') or (extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-lint')" },
+]
 copilot = [
     { name = "github-copilot-sdk" },
 ]
@@ -3348,6 +4089,7 @@ requires-dist = [
     { name = "certifi", specifier = ">=2023.7" },
     { name = "claude-agent-sdk", specifier = ">=0.1.62" },
     { name = "click", specifier = ">=8.0,<10" },
+    { name = "cognee", marker = "python_full_version < '3.15' and extra == 'cognee'", specifier = ">=1,<2" },
     { name = "cursor-sdk", marker = "extra == 'cursor'", specifier = ">=0.1.7" },
     { name = "cwsandbox", marker = "extra == 'cwsandbox'", specifier = ">=0.24,<1" },
     { name = "databricks-ai-bridge", marker = "extra == 'databricks'", specifier = ">=0.19" },
@@ -3418,10 +4160,10 @@ requires-dist = [
     { name = "tomlkit", specifier = ">=0.12,<1" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = ">=2024.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30,<1" },
-    { name = "websockets", specifier = ">=10.4,<15" },
+    { name = "websockets", specifier = ">=15.0.1,<16" },
     { name = "zstandard", specifier = ">=0.22,<1" },
 ]
-provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "kms", "s3", "vertex", "modal", "daytona", "blaxel", "boxlite", "cwsandbox", "e2b", "islo", "openshell", "kubernetes", "vault", "tracing", "agents-sdk", "antigravity", "copilot", "dictation", "cursor", "hindsight", "nimble", "slack", "databricks", "loadtest"]
+provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "kms", "s3", "vertex", "modal", "daytona", "blaxel", "boxlite", "cwsandbox", "e2b", "islo", "openshell", "kubernetes", "vault", "tracing", "agents-sdk", "antigravity", "copilot", "dictation", "cursor", "hindsight", "nimble", "cognee", "slack", "databricks", "loadtest"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3918,11 +4660,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "25.0"
+version = "24.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950, upload-time = "2024-11-08T09:47:47.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451, upload-time = "2024-11-08T09:47:44.722Z" },
 ]
 
 [[package]]
@@ -3970,6 +4712,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/1e/1bac1a839d12e6a82ec6cb40cda2edde64a2013a66963293696bbf31fbbb/pandas-2.3.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e3ebdb170b5ef78f19bfb71b0dc5dc58775032361fa188e814959b74d726dd5", size = 12121582, upload-time = "2025-09-29T23:30:43.391Z" },
     { url = "https://files.pythonhosted.org/packages/44/91/483de934193e12a3b1d6ae7c8645d083ff88dec75f46e827562f1e4b4da6/pandas-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d051c0e065b94b7a3cea50eb1ec32e912cd96dba41647eb24104b6c6c14c5788", size = 12699963, upload-time = "2025-09-29T23:31:10.009Z" },
     { url = "https://files.pythonhosted.org/packages/70/44/5191d2e4026f86a2a109053e194d3ba7a31a2d10a9c2348368c63ed4e85a/pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87", size = 13202175, upload-time = "2025-09-29T23:31:59.173Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -4284,10 +5035,13 @@ version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*'",
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.14' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32')",
+    "(python_full_version == '3.13.*' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version == '3.13.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.13.*' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version == '3.13.*' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
     "python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform != 'win32'",
+    "(python_full_version < '3.13' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version < '3.13' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version < '3.13' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version and sys_platform == 'darwin') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'win32')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
 wheels = [
@@ -4306,10 +5060,13 @@ version = "7.35.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*'",
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.14' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version >= '3.14' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version and sys_platform == 'darwin') or (python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'win32')",
+    "(python_full_version == '3.13.*' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version) or (python_full_version == '3.13.*' and sys_platform != 'darwin')",
+    "(python_full_version == '3.13.*' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version == '3.13.*' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
     "python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform != 'win32'",
+    "(python_full_version < '3.13' and 'Darwin Kernel Version 22.' in platform_version and sys_platform == 'darwin') or (python_full_version < '3.13' and 'Darwin Kernel Version 23.' in platform_version and sys_platform == 'darwin')",
+    "(python_full_version < '3.13' and 'Darwin Kernel Version 22.' not in platform_version and 'Darwin Kernel Version 23.' not in platform_version and sys_platform == 'darwin') or (python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'win32')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
 wheels = [
@@ -4415,6 +5172,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pwdlib"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/41/a7c0d8a003c36ce3828ae3ed0391fe6a15aad65f082dbd6bec817ea95c0b/pwdlib-0.3.0.tar.gz", hash = "sha256:6ca30f9642a1467d4f5d0a4d18619de1c77f17dfccb42dd200b144127d3c83fc", size = 215810, upload-time = "2025-10-25T12:44:24.395Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/0c/9086a357d02a050fbb3270bf5043ac284dbfb845670e16c9389a41defc9e/pwdlib-0.3.0-py3-none-any.whl", hash = "sha256:f86c15c138858c09f3bba0a10984d4f9178158c55deaa72eac0210849b1a140d", size = 8633, upload-time = "2025-10-25T12:44:23.406Z" },
+]
+
+[package.optional-dependencies]
+argon2 = [
+    { name = "argon2-cffi" },
+]
+bcrypt = [
+    { name = "bcrypt" },
 ]
 
 [[package]]
@@ -4639,6 +5413,36 @@ crypto = [
 ]
 
 [[package]]
+name = "pylance"
+version = "0.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pyarrow" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/13/f7f029d12a3dfdc9f3059d77b3999d40f9cc064ba85fef885a08bf65dcb2/pylance-0.36.0-cp39-abi3-macosx_10_15_x86_64.whl", hash = "sha256:160ed088dc5fb63a71c8c96640d43ea58464f64bca8aa23b0337b1a96fd47b79", size = 43403867, upload-time = "2025-09-12T20:29:25.507Z" },
+    { url = "https://files.pythonhosted.org/packages/95/95/defad18786260653b33d5ef8223736c0e481861c8d33311756bd471468ad/pylance-0.36.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ce43ad002b4e67ffb1a33925d05d472bbde77c57a5e84aca1728faa9ace0c086", size = 39777498, upload-time = "2025-09-12T20:27:02.906Z" },
+    { url = "https://files.pythonhosted.org/packages/19/33/7080ed4e45648d8c803a49cd5a206eb95176ef9dc06bff26748ec2109c65/pylance-0.36.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ad7b168b0d4b7864be6040bebaf6d9a3959e76a190ff401a84b165b75eade96", size = 41819489, upload-time = "2025-09-12T20:17:06.37Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9a/0c572994d96e03e70481dafb2b062033a9ce24beb5ac6045f00f013ca57c/pylance-0.36.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:353deeb7b19be505db490258b5f2fc897efd4a45255fa0d51455662e01ad59ab", size = 45366480, upload-time = "2025-09-12T20:19:53.924Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/82/a74f0436b6a983c2798d1f44699352cd98c42bc335781ece98a878cf63fb/pylance-0.36.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9cd963fc22257591d1daf281fa2369e05299d78950cb11980aa099d7cbacdf00", size = 41833322, upload-time = "2025-09-12T20:17:40.784Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f2/d28fa3487992c3bd46af6838da13cf9a00be24fcf4cf928f77feec52d8d6/pylance-0.36.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:40117569a87379e08ed12eccac658999158f81df946f2ed02693b77776b57597", size = 45347065, upload-time = "2025-09-12T20:19:26.435Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/ab/e7fc302950f1c6815a6e832d052d0860130374bfe4bd482b075299dc8384/pylance-0.36.0-cp39-abi3-win_amd64.whl", hash = "sha256:a2930738192e5075220bc38c8a58ff4e48a71d53b3ca2a577ffce0318609cac0", size = 46348996, upload-time = "2025-09-12T20:36:04.663Z" },
+]
+
+[[package]]
+name = "pympler"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32' or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-cwsandbox') or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-databricks') or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-modal') or (extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-dev') or (extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-lint')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/37/c384631908029676d8e7213dd956bb686af303a80db7afbc9be36bc49495/pympler-1.1.tar.gz", hash = "sha256:1eaa867cb8992c218430f1708fdaccda53df064144d1c5656b1e6f1ee6000424", size = 179954, upload-time = "2024-06-28T19:56:06.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/4f/a6a2e2b202d7fd97eadfe90979845b8706676b41cbd3b42ba75adf329d1f/Pympler-1.1-py3-none-any.whl", hash = "sha256:5b223d6027d0619584116a0cbc28e8d2e378f7a79c1e5e024f9ff3b673c58506", size = 165766, upload-time = "2024-06-28T19:56:05.087Z" },
+]
+
+[[package]]
 name = "pymysql"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4654,6 +5458,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.16.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/66/54212e75406afd9f3e933d0dda23072f6aecc55c5a273077dc2e0b028b23/pypdf-6.16.2.tar.gz", hash = "sha256:595647f6191de6f402cfde1d0c455d6cbccbd509aac32b34783009c032de5d6e", size = 7008996, upload-time = "2026-08-23T13:50:07.135Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/f1/a2da3b55acd4ab737bf728c97edaaed5ec1d3c1236acb639dcdfa97e42c7/pypdf-6.16.2-py3-none-any.whl", hash = "sha256:c8b09a59399062fb45a1b8156c18a787a10a3dae03ac9674397a226712c94604", size = 385060, upload-time = "2026-08-23T13:50:05.349Z" },
 ]
 
 [[package]]
@@ -4888,6 +5701,16 @@ wheels = [
 ]
 
 [[package]]
+name = "python-magic-bin"
+version = "0.4.14"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/2c/bbe8ad26591745da2c4692ea571145fb027c8ee1a0540407aa327684c4ce/python_magic_bin-0.4.14-py2.py3-none-macosx_10_6_intel.whl", hash = "sha256:7b1743b3dbf16601d6eedf4e7c2c9a637901b0faaf24ad4df4d4527e7d8f66a4", size = 334318, upload-time = "2017-10-02T16:30:13.6Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5d/10b9ac745d9fd2f7151a2ab901e6bb6983dbd70e87c71111f54859d1ca2e/python_magic_bin-0.4.14-py2.py3-none-win32.whl", hash = "sha256:34a788c03adde7608028203e2dbb208f1f62225ad91518787ae26d603ae68892", size = 397784, upload-time = "2017-10-02T16:30:15.806Z" },
+    { url = "https://files.pythonhosted.org/packages/07/c2/094e3d62b906d952537196603a23aec4bcd7c6126bf80eb14e6f9f4be3a2/python_magic_bin-0.4.14-py2.py3-none-win_amd64.whl", hash = "sha256:90be6206ad31071a36065a2fc169c5afb5e0355cbe6030e87641c6c62edc2b69", size = 409299, upload-time = "2017-10-02T16:30:18.545Z" },
+]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
@@ -4925,6 +5748,35 @@ wheels = [
 client = [
     { name = "requests" },
     { name = "websocket-client" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
+    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
+    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]
@@ -5051,6 +5903,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/59/a5f38970f9bf07cee96128de79590bb354917914a9be11272cfc7ff26af0/pyzmq-27.1.0-cp314-cp314t-win32.whl", hash = "sha256:1f0b2a577fd770aa6f053211a55d1c47901f4d537389a034c690291485e5fe92", size = 587472, upload-time = "2025-09-08T23:08:58.18Z" },
     { url = "https://files.pythonhosted.org/packages/70/d8/78b1bad170f93fcf5e3536e70e8fadac55030002275c9a29e8f5719185de/pyzmq-27.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:19c9468ae0437f8074af379e986c5d3d7d7bfe033506af442e8c879732bedbe0", size = 661401, upload-time = "2025-09-08T23:08:59.802Z" },
     { url = "https://files.pythonhosted.org/packages/81/d6/4bfbb40c9a0b42fc53c7cf442f6385db70b40f74a783130c5d0a5aa62228/pyzmq-27.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dc5dbf68a7857b59473f7df42650c621d7e8923fb03fa74a526890f4d33cc4d7", size = 575170, upload-time = "2025-09-08T23:09:01.418Z" },
+]
+
+[[package]]
+name = "rdflib"
+version = "7.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/7e/cb2d74466bd8495051ebe2d241b1cb1d4acf9740d481126aef19ef2697f5/rdflib-7.1.4.tar.gz", hash = "sha256:fed46e24f26a788e2ab8e445f7077f00edcf95abb73bcef4b86cefa8b62dd174", size = 4692745, upload-time = "2025-03-29T02:23:02.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/31/e9b6f04288dcd3fa60cb3179260d6dad81b92aef3063d679ac7d80a827ea/rdflib-7.1.4-py3-none-any.whl", hash = "sha256:72f4adb1990fa5241abd22ddaf36d7cafa5d91d9ff2ba13f3086d339b213d997", size = 565051, upload-time = "2025-03-29T02:22:44.987Z" },
+]
+
+[[package]]
+name = "redis"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/99/604f0b666d4c616d891cf77ebb9db6bb21601344c051aebf1b72b9ff915f/redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25", size = 5254356, upload-time = "2026-07-30T08:51:00.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/9d/c5731f6e3608663d4d3656fd8d3aecee8b509c3082818f5a13eae925baea/redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb", size = 560618, upload-time = "2026-07-30T08:50:58.497Z" },
 ]
 
 [[package]]
@@ -5492,6 +6365,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "sherpa-onnx"
 version = "1.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -5615,6 +6497,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.50"
 source = { registry = "https://pypi.org/simple" }
@@ -5653,6 +6544,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/e3/5aa06f167559f8c0bdae487e297d23ba548150ab016a3418265d617a4985/sqlalchemy-2.0.50-cp314-cp314t-win32.whl", hash = "sha256:1fbd55a969d7ac44a98e3dec75016074f809fa08f871585ace58dde110d1bf3e", size = 2150823, upload-time = "2026-05-24T20:08:58.644Z" },
     { url = "https://files.pythonhosted.org/packages/65/9b/112fb8f977582d7489d036e409e3723948bcf5320b3ac465f3c481bbe8f9/sqlalchemy-2.0.50-cp314-cp314t-win_amd64.whl", hash = "sha256:c5c3cdb753a9004183e1ccb634b41611654c989e61bc68617ce878e46d6f1e51", size = 2185794, upload-time = "2026-05-24T20:09:00.319Z" },
     { url = "https://files.pythonhosted.org/packages/d0/10/f7220e9b784d295d241c86ed99aeb537f92afcd469a64861f2717e9bb077/sqlalchemy-2.0.50-py3-none-any.whl", hash = "sha256:92064363517a3ff8212b5a93b8c62876579d8dfd1ca5b561335f30152d884fa9", size = 1943861, upload-time = "2026-05-24T19:59:01.119Z" },
+]
+
+[package.optional-dependencies]
+asyncio = [
+    { name = "greenlet" },
 ]
 
 [[package]]
@@ -5706,11 +6602,11 @@ wheels = [
 
 [[package]]
 name = "structlog"
-version = "26.1.0"
+version = "25.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/89/b4a0bcfdf4f71a3dea31379f095929613d7e4528a0996bca6aa964cd0dca/structlog-26.1.0.tar.gz", hash = "sha256:f63a716cbd1b1291cf7661de7794b455acfa4c43c5bcf1630e6ad5ddc1adb3b7", size = 1459881, upload-time = "2026-06-06T07:33:39.348Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/18/489c97b834dfff9cf2fc2507cede4bcd4b11e67f84bc462acd1992496f86/structlog-26.1.0-py3-none-any.whl", hash = "sha256:e081a26d6c373e6d201eca24eede26d8ffab07f88f477822e679183428d3d91e", size = 73764, upload-time = "2026-06-06T07:33:38.046Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
 ]
 
 [[package]]
@@ -5823,6 +6719,33 @@ wheels = [
 ]
 
 [[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
+]
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5895,6 +6818,42 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/b3/36c8ecf72e8925200671613332db156d84b99b3aee742a41c1938ebb0808/tqdm-4.68.1.tar.gz", hash = "sha256:fc163d96b287bd031e1aa24421ce4411b25559bd0a1be4fe649bdaa4d2c02bf5", size = 171236, upload-time = "2026-06-05T17:23:15.267Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/aa/218a0eb34de1f753c83e4d0d1c8e7c4cef27f20dcb8342e024f63a80dc86/tqdm-4.68.1-py3-none-any.whl", hash = "sha256:fea4a90e4023f764914569f7802a297277c5ab1a66be5144143e142e1a4031d8", size = 78354, upload-time = "2026-06-05T17:23:13.654Z" },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.16.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/2e/a7fbfe268c8a3b32546930c0297c101d65a4a14c304ad5790a9f478f0e4e/traitlets-5.16.1.tar.gz", hash = "sha256:ed900c2b631aa3a112811139fa97b8d2c3bad5e989656bba4b7e52c7852c18c1", size = 166137, upload-time = "2026-08-03T08:32:36.848Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/66/0d785f0bc5e4315a96c989bb476d0fc07ea4f85132550c7b156ca2035d52/traitlets-5.16.1-py3-none-any.whl", hash = "sha256:f775618166caa0396c8e337099240f2bd3e5e917d203b2e6fbe21a58d3cb1f6b", size = 86211, upload-time = "2026-08-03T08:32:34.48Z" },
+]
+
+[[package]]
+name = "typeguard"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/de/4420db493fa8fc0856d5e5c1b159c63a323d2de2317babe36b01568928e8/typeguard-4.6.0.tar.gz", hash = "sha256:e7414f09111317de3e335de92cd397c5c0ca00b1cc1676de12e1d444a79b3f21", size = 82330, upload-time = "2026-07-26T08:40:23.207Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/eb/461d5f167b6f5c7d97696f397c82f82e3480e003fce3f0a1cd1dd26e2eb2/typeguard-4.6.0-py3-none-any.whl", hash = "sha256:79878165bb86f2cf5d41d159a0ff1792a796cf496882d2fe1b1c6c7049b9cdd7", size = 36884, upload-time = "2026-07-26T08:40:21.868Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-cwsandbox') or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-databricks') or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-modal') or (extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-dev') or (extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-lint')" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/f7/57713ba479fd405eb76de31404b2c744c289e336b2d999511ebf51e496f7/typer-0.27.2.tar.gz", hash = "sha256:269b7eb9d3c202ca84b4bc9618cb04ebb43d3d4d1e567e4c768607232c05f945", size = 204045, upload-time = "2026-08-28T10:26:55.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/bf/205d0004930ede8f542fb58f601526fccf4ae7626075ca1e6c4de5d3d652/typer-0.27.2-py3-none-any.whl", hash = "sha256:b3a5fc4342d5fc8fda8fc3010b1cf117e9249aab7fae800c2eff62fd3842d97d", size = 123130, upload-time = "2026-08-28T10:26:53.752Z" },
 ]
 
 [[package]]
@@ -6164,33 +7123,33 @@ wheels = [
 
 [[package]]
 name = "websockets"
-version = "14.2"
+version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/54/8359678c726243d19fae38ca14a334e740782336c9f19700858c4eb64a1e/websockets-14.2.tar.gz", hash = "sha256:5059ed9c54945efb321f097084b4c7e52c246f2c869815876a69d1efc4ad6eb5", size = 164394, upload-time = "2025-01-19T21:00:56.431Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/81/04f7a397653dc8bec94ddc071f34833e8b99b13ef1a3804c149d59f92c18/websockets-14.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1f20522e624d7ffbdbe259c6b6a65d73c895045f76a93719aa10cd93b3de100c", size = 163096, upload-time = "2025-01-19T20:59:29.763Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/c5/de30e88557e4d70988ed4d2eabd73fd3e1e52456b9f3a4e9564d86353b6d/websockets-14.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:647b573f7d3ada919fd60e64d533409a79dcf1ea21daeb4542d1d996519ca967", size = 160758, upload-time = "2025-01-19T20:59:32.095Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/8c/d130d668781f2c77d106c007b6c6c1d9db68239107c41ba109f09e6c218a/websockets-14.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6af99a38e49f66be5a64b1e890208ad026cda49355661549c507152113049990", size = 160995, upload-time = "2025-01-19T20:59:33.527Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/bc/f6678a0ff17246df4f06765e22fc9d98d1b11a258cc50c5968b33d6742a1/websockets-14.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:091ab63dfc8cea748cc22c1db2814eadb77ccbf82829bac6b2fbe3401d548eda", size = 170815, upload-time = "2025-01-19T20:59:35.837Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/b2/8070cb970c2e4122a6ef38bc5b203415fd46460e025652e1ee3f2f43a9a3/websockets-14.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b374e8953ad477d17e4851cdc66d83fdc2db88d9e73abf755c94510ebddceb95", size = 169759, upload-time = "2025-01-19T20:59:38.216Z" },
-    { url = "https://files.pythonhosted.org/packages/81/da/72f7caabd94652e6eb7e92ed2d3da818626e70b4f2b15a854ef60bf501ec/websockets-14.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a39d7eceeea35db85b85e1169011bb4321c32e673920ae9c1b6e0978590012a3", size = 170178, upload-time = "2025-01-19T20:59:40.423Z" },
-    { url = "https://files.pythonhosted.org/packages/31/e0/812725b6deca8afd3a08a2e81b3c4c120c17f68c9b84522a520b816cda58/websockets-14.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0a6f3efd47ffd0d12080594f434faf1cd2549b31e54870b8470b28cc1d3817d9", size = 170453, upload-time = "2025-01-19T20:59:41.996Z" },
-    { url = "https://files.pythonhosted.org/packages/66/d3/8275dbc231e5ba9bb0c4f93144394b4194402a7a0c8ffaca5307a58ab5e3/websockets-14.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:065ce275e7c4ffb42cb738dd6b20726ac26ac9ad0a2a48e33ca632351a737267", size = 169830, upload-time = "2025-01-19T20:59:44.669Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/ae/e7d1a56755ae15ad5a94e80dd490ad09e345365199600b2629b18ee37bc7/websockets-14.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e9d0e53530ba7b8b5e389c02282f9d2aa47581514bd6049d3a7cffe1385cf5fe", size = 169824, upload-time = "2025-01-19T20:59:46.932Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/32/88ccdd63cb261e77b882e706108d072e4f1c839ed723bf91a3e1f216bf60/websockets-14.2-cp312-cp312-win32.whl", hash = "sha256:20e6dd0984d7ca3037afcb4494e48c74ffb51e8013cac71cf607fffe11df7205", size = 163981, upload-time = "2025-01-19T20:59:49.228Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/7d/32cdb77990b3bdc34a306e0a0f73a1275221e9a66d869f6ff833c95b56ef/websockets-14.2-cp312-cp312-win_amd64.whl", hash = "sha256:44bba1a956c2c9d268bdcdf234d5e5ff4c9b6dc3e300545cbe99af59dda9dcce", size = 164421, upload-time = "2025-01-19T20:59:50.674Z" },
-    { url = "https://files.pythonhosted.org/packages/82/94/4f9b55099a4603ac53c2912e1f043d6c49d23e94dd82a9ce1eb554a90215/websockets-14.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6f1372e511c7409a542291bce92d6c83320e02c9cf392223272287ce55bc224e", size = 163102, upload-time = "2025-01-19T20:59:52.177Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/b7/7484905215627909d9a79ae07070057afe477433fdacb59bf608ce86365a/websockets-14.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4da98b72009836179bb596a92297b1a61bb5a830c0e483a7d0766d45070a08ad", size = 160766, upload-time = "2025-01-19T20:59:54.368Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/a4/edb62efc84adb61883c7d2c6ad65181cb087c64252138e12d655989eec05/websockets-14.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8a86a269759026d2bde227652b87be79f8a734e582debf64c9d302faa1e9f03", size = 160998, upload-time = "2025-01-19T20:59:56.671Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/79/036d320dc894b96af14eac2529967a6fc8b74f03b83c487e7a0e9043d842/websockets-14.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:86cf1aaeca909bf6815ea714d5c5736c8d6dd3a13770e885aafe062ecbd04f1f", size = 170780, upload-time = "2025-01-19T20:59:58.085Z" },
-    { url = "https://files.pythonhosted.org/packages/63/75/5737d21ee4dd7e4b9d487ee044af24a935e36a9ff1e1419d684feedcba71/websockets-14.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b0f6c3ba3b1240f602ebb3971d45b02cc12bd1845466dd783496b3b05783a5", size = 169717, upload-time = "2025-01-19T20:59:59.545Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/3c/bf9b2c396ed86a0b4a92ff4cdaee09753d3ee389be738e92b9bbd0330b64/websockets-14.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:669c3e101c246aa85bc8534e495952e2ca208bd87994650b90a23d745902db9a", size = 170155, upload-time = "2025-01-19T21:00:01.887Z" },
-    { url = "https://files.pythonhosted.org/packages/75/2d/83a5aca7247a655b1da5eb0ee73413abd5c3a57fc8b92915805e6033359d/websockets-14.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eabdb28b972f3729348e632ab08f2a7b616c7e53d5414c12108c29972e655b20", size = 170495, upload-time = "2025-01-19T21:00:04.064Z" },
-    { url = "https://files.pythonhosted.org/packages/79/dd/699238a92761e2f943885e091486378813ac8f43e3c84990bc394c2be93e/websockets-14.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2066dc4cbcc19f32c12a5a0e8cc1b7ac734e5b64ac0a325ff8353451c4b15ef2", size = 169880, upload-time = "2025-01-19T21:00:05.695Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/c9/67a8f08923cf55ce61aadda72089e3ed4353a95a3a4bc8bf42082810e580/websockets-14.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ab95d357cd471df61873dadf66dd05dd4709cae001dd6342edafc8dc6382f307", size = 169856, upload-time = "2025-01-19T21:00:07.192Z" },
-    { url = "https://files.pythonhosted.org/packages/17/b1/1ffdb2680c64e9c3921d99db460546194c40d4acbef999a18c37aa4d58a3/websockets-14.2-cp313-cp313-win32.whl", hash = "sha256:a9e72fb63e5f3feacdcf5b4ff53199ec8c18d66e325c34ee4c551ca748623bbc", size = 163974, upload-time = "2025-01-19T21:00:08.698Z" },
-    { url = "https://files.pythonhosted.org/packages/14/13/8b7fc4cb551b9cfd9890f0fd66e53c18a06240319915533b033a56a3d520/websockets-14.2-cp313-cp313-win_amd64.whl", hash = "sha256:b439ea828c4ba99bb3176dc8d9b933392a2413c0f6b149fdcba48393f573377f", size = 164420, upload-time = "2025-01-19T21:00:10.182Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/c8/d529f8a32ce40d98309f4470780631e971a5a842b60aec864833b3615786/websockets-14.2-py3-none-any.whl", hash = "sha256:7a6ceec4ea84469f15cf15807a747e9efe57e369c384fa86e022b3bea679b79b", size = 157416, upload-time = "2025-01-19T21:00:54.843Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Related issue

Closes #5358


## Summary

- Adds **cognee** (knowledge-graph memory) as an optional extra (`omnigent[cognee]`, cognee 0.5.8) with an embedded local store under `<data-dir>/cognee/`.
- New framework-owned boundary `omnigent/runtime/memory.py`: gate (`OMNIGENT_DISABLE_COGNEE` env kill-switch → `cognee:` config block → `find_spec`), per-op timeouts, circuit breaker, background `cognify` — memory can never fail or slow a turn.
- New builtins `cognee_search` / `cognee_remember` (hindsight-shaped: registry gate, runner-local dispatch, relayed to native TUI harnesses), plus a gated framework instruction.
- **Tiered cross-agent access layer** (`MemoryGrants`): agent (private) → user → team → org read/write pools (config or global `cognee:` block), an ad-hoc `shared_dataset` exchange, and per-peer `read_datasets` / `write_datasets` grants. Enforcement lives in the framework module; ungranted requests return an error listing what is granted.
- **Base-pin change:** `websockets>=10.4,<15` → `>=15.0.1,<16` to satisfy cognee. The old cap guarded issue #1514, whose corrected root cause is websockets 15's `proxy=True` default; every omnigent client `connect()` now passes `proxy=None` (ws tunnel, claude-native attach, codex app-server, dictation relay), restoring pre-15 behavior.

ELI5: agents get a durable brain. Each agent has a private notebook; teams can share notebooks at user/team/org level; and an agent can be granted read or write access to another agent's notebook. If the brain is slow or broken, the agent just works without it.

```
agent turn ── cognee_search/remember ── runner dispatch (_COGNEE_TOOLS)
                                              │
                                   runtime/memory.py boundary
                              (gate → grants → timeout → breaker)
                                              │
                              embedded cognee store <data-dir>/cognee
                     datasets: agent | user | team | org | shared | peers
```

Remaining phases (ingest coordinator, server recall endpoint, push-based recall, hardening) are tracked in `designs/cognee-memory-integration.md` — hence WIP/draft.

- **Agent-registry mirroring (cognee ≥1.5):** on first memory use per session, the resolved `MemoryGrants` are registered as a cognee agent connection (`cognee.modules.agents`) — best-effort/fail-open on the background worker, observability only; `MemoryGrants` remains the authorization source of truth. cognee bumped to **1.5.2** via a dated `exclude-newer-package` cooldown exemption in `uv.toml`.

## Test Plan

- `uv run pytest tests/runtime/test_cognee_memory.py tests/tools/builtins/test_cognee.py tests/runner/test_cognee_local_dispatch.py` — 72 tests: gate precedence, grants/tier resolution and enforcement, breaker, bounded search/add/cognify with a mocked cognee module, registry gating, native-relay membership, dispatch identity threading.
- `uv run pytest tests/runner/transports/ws_tunnel/test_serve.py tests/test_codex_native_app_server.py tests/server/test_dictation_remote.py tests/test_claude_native.py` — websockets client call sites (updated kwargs assertions for `proxy=None`).
- `pre-commit run` clean on all changed files; `uv lock` resolves on py3.12–3.14 (cognee extra carries a `python_version < '3.15'` marker for the resolver's speculative ≥3.15 split).

## Demo

N/A (no UI changes).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The cognee package itself is mocked in tests (kept out of the dev set); a live end-to-end recall/ingest run against a real store is part of the remaining WIP phases.

## Changelog

Agents get optional cognee knowledge-graph memory (`omnigent[cognee]`): `cognee_search`/`cognee_remember` tools with private, user/team/org, shared, and per-peer dataset access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


