### PR TITLE
fix(server): allow same-origin mobile requests

### DIFF
--- a/omnigent/server/routes/_origin.py
+++ b/omnigent/server/routes/_origin.py
@@ -23,9 +23,10 @@ WebSocket share exactly one trust boundary:
   ``"omnigent://internal"``) and any origin in
   ``OMNIGENT_WS_ALLOWED_ORIGINS`` pass;
 - in single-user **local mode** (no cookie / proxy auth) a present
-  ``Origin`` must exactly match the request target or be a loopback host —
-  this is where the guard actually bites, since that deployment has no other
-  CSRF defense;
+  ``Origin`` must be a loopback host, or explicitly allowlisted via
+  ``OMNIGENT_WS_ALLOWED_ORIGINS`` (e.g. for a mobile/LAN WebView origin such
+  as Android emulator ``http://10.0.2.2:8000``) — this is where the guard
+  actually bites, since that deployment has no other CSRF defense;
 - in authenticated (cookie / proxy) modes a present ``Origin`` passes
   unless an explicit allowlist is configured.
 
@@ -40,7 +41,7 @@ from __future__ import annotations
 from fastapi import HTTPException, Request
 
 from omnigent.server.auth import local_single_user_enabled
-from omnigent.server.ws_origin import origin_allowed, origin_matches_scope, parse_allowed_origins
+from omnigent.server.ws_origin import origin_allowed, parse_allowed_origins
 
 
 def require_trusted_origin(request: Request) -> None:
@@ -53,9 +54,8 @@ def require_trusted_origin(request: Request) -> None:
     has **no** ``Origin`` (modern browsers always send one, so absence is
     not a browser CSRF vector — this preserves backward compatibility for
     non-browser and older clients), carries the first-party sentinel or an
-    allowlisted origin, exactly matches the request target, or (in local
-    single-user mode) carries a loopback ``Origin``. A present ``Origin``
-    that is none of those is rejected.
+    allowlisted origin, or (in local single-user mode) carries a loopback
+    ``Origin``. A present ``Origin`` that is none of those is rejected.
 
     First-party non-browser clients (the Python SDK, the runner, the REPL)
     may announce themselves with ``Origin: omnigent://internal``
@@ -75,7 +75,7 @@ def require_trusted_origin(request: Request) -> None:
     # soon — first-party clients (SDK, runner, the test harness) already
     # announce themselves with the sentinel Origin. To close it, reject a
     # ``None`` origin here before delegating.
-    if origin_matches_scope(origin, request.scope) or origin_allowed(
+    if origin_allowed(
         origin,
         local_mode=local_single_user_enabled(),
         extra_allowed=parse_allowed_origins(),

--- a/omnigent/server/routes/_origin.py
+++ b/omnigent/server/routes/_origin.py
@@ -23,8 +23,9 @@ WebSocket share exactly one trust boundary:
   ``"omnigent://internal"``) and any origin in
   ``OMNIGENT_WS_ALLOWED_ORIGINS`` pass;
 - in single-user **local mode** (no cookie / proxy auth) a present
-  ``Origin`` must be a loopback host — this is where the guard actually
-  bites, since that deployment has no other CSRF defense;
+  ``Origin`` must exactly match the request target or be a loopback host —
+  this is where the guard actually bites, since that deployment has no other
+  CSRF defense;
 - in authenticated (cookie / proxy) modes a present ``Origin`` passes
   unless an explicit allowlist is configured.
 
@@ -39,7 +40,7 @@ from __future__ import annotations
 from fastapi import HTTPException, Request
 
 from omnigent.server.auth import local_single_user_enabled
-from omnigent.server.ws_origin import origin_allowed, parse_allowed_origins
+from omnigent.server.ws_origin import origin_allowed, origin_matches_scope, parse_allowed_origins
 
 
 def require_trusted_origin(request: Request) -> None:
@@ -52,8 +53,9 @@ def require_trusted_origin(request: Request) -> None:
     has **no** ``Origin`` (modern browsers always send one, so absence is
     not a browser CSRF vector — this preserves backward compatibility for
     non-browser and older clients), carries the first-party sentinel or an
-    allowlisted origin, or (in local single-user mode) carries a loopback
-    ``Origin``. A present ``Origin`` that is none of those is rejected.
+    allowlisted origin, exactly matches the request target, or (in local
+    single-user mode) carries a loopback ``Origin``. A present ``Origin``
+    that is none of those is rejected.
 
     First-party non-browser clients (the Python SDK, the runner, the REPL)
     may announce themselves with ``Origin: omnigent://internal``
@@ -73,7 +75,7 @@ def require_trusted_origin(request: Request) -> None:
     # soon — first-party clients (SDK, runner, the test harness) already
     # announce themselves with the sentinel Origin. To close it, reject a
     # ``None`` origin here before delegating.
-    if origin_allowed(
+    if origin_matches_scope(origin, request.scope) or origin_allowed(
         origin,
         local_mode=local_single_user_enabled(),
         extra_allowed=parse_allowed_origins(),

--- a/omnigent/server/ws_origin.py
+++ b/omnigent/server/ws_origin.py
@@ -56,6 +56,7 @@ __all__ = [
     "WebSocketOriginMiddleware",
     "origin_allowed",
     "origin_hostname_is_loopback",
+    "origin_matches_scope",
     "parse_allowed_origins",
 ]
 
@@ -99,6 +100,54 @@ def origin_hostname_is_loopback(origin: str) -> bool:
     return addr.is_loopback or (mapped_ipv4 is not None and mapped_ipv4.is_loopback)
 
 
+def origin_matches_scope(origin: str | None, scope: Scope) -> bool:
+    """Return whether an Origin is the exact HTTP origin of an ASGI request.
+
+    A mobile WebView can load a local server through a non-loopback address
+    such as Android emulator host ``10.0.2.2``. That is still same-origin
+    traffic, so it is safe in local mode. The comparison normalizes default
+    ports and maps WebSocket schemes to their corresponding HTTP origin scheme.
+
+    :param origin: Raw ``Origin`` header, or ``None`` when absent.
+    :param scope: ASGI HTTP or WebSocket connection scope.
+    :returns: ``True`` only when the Origin exactly identifies this request's
+        scheme, host, and effective port.
+    """
+    if origin is None:
+        return False
+    scheme = scope.get("scheme")
+    if scheme == "ws":
+        scheme = "http"
+    elif scheme == "wss":
+        scheme = "https"
+    host = _header_from_scope(scope, b"host")
+    if not isinstance(scheme, str) or host is None:
+        return False
+    return _normalized_http_origin(origin) == _normalized_http_origin(f"{scheme}://{host}")
+
+
+def _normalized_http_origin(value: str) -> tuple[str, str, int] | None:
+    """Parse an HTTP(S) origin into comparable scheme, host, and port values."""
+    try:
+        parsed = urlsplit(value)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or parsed.hostname is None
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.path not in {"", "/"}
+            or parsed.query
+            or parsed.fragment
+        ):
+            return None
+        port = parsed.port
+    except ValueError:
+        return None
+    if port is None:
+        port = 443 if parsed.scheme == "https" else 80
+    return parsed.scheme, parsed.hostname, port
+
+
 def parse_allowed_origins() -> frozenset[str]:
     """Read the optional explicit origin allowlist from the environment.
 
@@ -135,8 +184,8 @@ def origin_allowed(
       so page JS cannot strip or forge it), so its absence is not a
       browser CSRF / CSWSH vector.
     - In ``local_mode`` an ``Origin`` is allowed only when its hostname is
-      a loopback host — this is the CSRF / CSWSH guard for the
-      unauthenticated single-user local server.
+      a loopback host. Callers separately allow exact request-origin matches,
+      which safely supports a mobile client connected through a LAN address.
     - In non-local modes the connection is authenticated by cookie / proxy
       header, so any ``Origin`` is allowed unless ``extra_allowed`` is
       non-empty, in which case only the allowlist (matched above) passes.
@@ -176,9 +225,14 @@ def _origin_from_scope(scope: Scope) -> str | None:
     # Annotate the ASGI headers explicitly: ``Scope`` values are typed
     # ``Any``, so without this mypy infers ``value`` as ``Any`` and flags
     # the ``value.decode(...)`` return as an Any-return.
+    return _header_from_scope(scope, b"origin")
+
+
+def _header_from_scope(scope: Scope, name: bytes) -> str | None:
+    """Extract a decoded header from an ASGI connection scope."""
     headers: Iterable[tuple[bytes, bytes]] = scope.get("headers", [])
     for key, value in headers:
-        if key == b"origin":
+        if key == name:
             return value.decode("latin-1")
     return None
 
@@ -220,7 +274,7 @@ class WebSocketOriginMiddleware:
             return
 
         origin = _origin_from_scope(scope)
-        if origin_allowed(
+        if origin_matches_scope(origin, scope) or origin_allowed(
             origin,
             local_mode=local_single_user_enabled(),
             extra_allowed=parse_allowed_origins(),

--- a/omnigent/server/ws_origin.py
+++ b/omnigent/server/ws_origin.py
@@ -56,7 +56,6 @@ __all__ = [
     "WebSocketOriginMiddleware",
     "origin_allowed",
     "origin_hostname_is_loopback",
-    "origin_matches_scope",
     "parse_allowed_origins",
 ]
 
@@ -100,54 +99,6 @@ def origin_hostname_is_loopback(origin: str) -> bool:
     return addr.is_loopback or (mapped_ipv4 is not None and mapped_ipv4.is_loopback)
 
 
-def origin_matches_scope(origin: str | None, scope: Scope) -> bool:
-    """Return whether an Origin is the exact HTTP origin of an ASGI request.
-
-    A mobile WebView can load a local server through a non-loopback address
-    such as Android emulator host ``10.0.2.2``. That is still same-origin
-    traffic, so it is safe in local mode. The comparison normalizes default
-    ports and maps WebSocket schemes to their corresponding HTTP origin scheme.
-
-    :param origin: Raw ``Origin`` header, or ``None`` when absent.
-    :param scope: ASGI HTTP or WebSocket connection scope.
-    :returns: ``True`` only when the Origin exactly identifies this request's
-        scheme, host, and effective port.
-    """
-    if origin is None:
-        return False
-    scheme = scope.get("scheme")
-    if scheme == "ws":
-        scheme = "http"
-    elif scheme == "wss":
-        scheme = "https"
-    host = _header_from_scope(scope, b"host")
-    if not isinstance(scheme, str) or host is None:
-        return False
-    return _normalized_http_origin(origin) == _normalized_http_origin(f"{scheme}://{host}")
-
-
-def _normalized_http_origin(value: str) -> tuple[str, str, int] | None:
-    """Parse an HTTP(S) origin into comparable scheme, host, and port values."""
-    try:
-        parsed = urlsplit(value)
-        if (
-            parsed.scheme not in {"http", "https"}
-            or parsed.hostname is None
-            or parsed.username is not None
-            or parsed.password is not None
-            or parsed.path not in {"", "/"}
-            or parsed.query
-            or parsed.fragment
-        ):
-            return None
-        port = parsed.port
-    except ValueError:
-        return None
-    if port is None:
-        port = 443 if parsed.scheme == "https" else 80
-    return parsed.scheme, parsed.hostname, port
-
-
 def parse_allowed_origins() -> frozenset[str]:
     """Read the optional explicit origin allowlist from the environment.
 
@@ -184,8 +135,11 @@ def origin_allowed(
       so page JS cannot strip or forge it), so its absence is not a
       browser CSRF / CSWSH vector.
     - In ``local_mode`` an ``Origin`` is allowed only when its hostname is
-      a loopback host. Callers separately allow exact request-origin matches,
-      which safely supports a mobile client connected through a LAN address.
+      a loopback host, or it is explicitly listed in ``extra_allowed``. A
+      mobile/LAN WebView origin (e.g. Android emulator ``http://10.0.2.2:8000``)
+      must be added to ``OMNIGENT_WS_ALLOWED_ORIGINS`` to be admitted — the
+      raw request ``Host`` header is client-controllable and is never trusted
+      for this decision (it would otherwise reopen DNS rebinding).
     - In non-local modes the connection is authenticated by cookie / proxy
       header, so any ``Origin`` is allowed unless ``extra_allowed`` is
       non-empty, in which case only the allowlist (matched above) passes.
@@ -274,7 +228,7 @@ class WebSocketOriginMiddleware:
             return
 
         origin = _origin_from_scope(scope)
-        if origin_matches_scope(origin, scope) or origin_allowed(
+        if origin_allowed(
             origin,
             local_mode=local_single_user_enabled(),
             extra_allowed=parse_allowed_origins(),

--- a/tests/server/routes/test_origin.py
+++ b/tests/server/routes/test_origin.py
@@ -114,14 +114,15 @@ def test_loopback_origin_is_allowed_in_local_mode(monkeypatch: pytest.MonkeyPatc
     assert require_trusted_origin(_request_with_origin("http://localhost:8000")) is None
 
 
-def test_mobile_same_origin_is_allowed_in_local_mode(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A mobile WebView may use a non-loopback address for the local server.
+def test_mobile_origin_is_allowed_via_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-loopback mobile/LAN origin connects once allowlisted.
 
-    Android's emulator reaches the host through ``10.0.2.2``. Its WebView
-    loads the Omnigent server directly, so its Origin exactly matches the
-    request target and is not a cross-site CSRF request.
+    Android emulator WebViews reach the server through ``10.0.2.2``, a
+    non-loopback host. That origin must be explicitly added to
+    ``OMNIGENT_WS_ALLOWED_ORIGINS`` to be admitted in local mode.
     """
     monkeypatch.setenv(_LOCAL_ENV, "1")
+    monkeypatch.setenv(_ALLOWLIST_ENV, "http://10.0.2.2:8000")
     assert (
         require_trusted_origin(_request_with_origin("http://10.0.2.2:8000", host="10.0.2.2:8000"))
         is None
@@ -141,6 +142,22 @@ def test_cross_origin_is_rejected_in_local_mode(monkeypatch: pytest.MonkeyPatch)
         require_trusted_origin(_request_with_origin(_EVIL_ORIGIN))
     # 403 Forbidden is the documented rejection status for an untrusted
     # Origin; any other code (or no raise) means the guard did not fire.
+    assert exc_info.value.status_code == 403
+
+
+def test_dns_rebinding_rejected_in_local_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Host-matching, non-allowlisted Origin is rejected (DNS rebinding).
+
+    ``Host`` is client-controllable, so an attacker hostname rebound to
+    the server's address can send an ``Origin`` that exactly equals
+    ``Host``. That must never be trusted on its own: this is the core
+    proof the DNS-rebinding hole is closed.
+    """
+    monkeypatch.setenv(_LOCAL_ENV, "1")
+    with pytest.raises(HTTPException) as exc_info:
+        require_trusted_origin(
+            _request_with_origin("http://attacker.example:8000", host="attacker.example:8000")
+        )
     assert exc_info.value.status_code == 403
 
 

--- a/tests/server/routes/test_origin.py
+++ b/tests/server/routes/test_origin.py
@@ -64,7 +64,12 @@ def _clean_origin_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(_ALLOWLIST_ENV, raising=False)
 
 
-def _request_with_origin(origin: str | None) -> Request:
+def _request_with_origin(
+    origin: str | None,
+    *,
+    host: str = "localhost:8000",
+    scheme: str = "http",
+) -> Request:
     """
     Build a real Starlette ``Request`` carrying (or omitting) an Origin.
 
@@ -74,10 +79,10 @@ def _request_with_origin(origin: str | None) -> Request:
     :returns: A real :class:`starlette.requests.Request` whose only
         meaningful state is its header set.
     """
-    raw_headers: list[tuple[bytes, bytes]] = []
+    raw_headers: list[tuple[bytes, bytes]] = [(b"host", host.encode("latin-1"))]
     if origin is not None:
         raw_headers.append((b"origin", origin.encode("latin-1")))
-    return Request({"type": "http", "method": "POST", "headers": raw_headers})
+    return Request({"type": "http", "method": "POST", "scheme": scheme, "headers": raw_headers})
 
 
 @pytest.mark.parametrize("local_mode", [True, False])
@@ -107,6 +112,20 @@ def test_loopback_origin_is_allowed_in_local_mode(monkeypatch: pytest.MonkeyPatc
     """
     monkeypatch.setenv(_LOCAL_ENV, "1")
     assert require_trusted_origin(_request_with_origin("http://localhost:8000")) is None
+
+
+def test_mobile_same_origin_is_allowed_in_local_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A mobile WebView may use a non-loopback address for the local server.
+
+    Android's emulator reaches the host through ``10.0.2.2``. Its WebView
+    loads the Omnigent server directly, so its Origin exactly matches the
+    request target and is not a cross-site CSRF request.
+    """
+    monkeypatch.setenv(_LOCAL_ENV, "1")
+    assert (
+        require_trusted_origin(_request_with_origin("http://10.0.2.2:8000", host="10.0.2.2:8000"))
+        is None
+    )
 
 
 def test_cross_origin_is_rejected_in_local_mode(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/server/test_ws_origin.py
+++ b/tests/server/test_ws_origin.py
@@ -27,6 +27,7 @@ from omnigent.server.ws_origin import (
     WebSocketOriginMiddleware,
     origin_allowed,
     origin_hostname_is_loopback,
+    origin_matches_scope,
     parse_allowed_origins,
 )
 
@@ -85,6 +86,43 @@ def test_origin_hostname_is_loopback(origin: str, expected: bool) -> None:
     :returns: None.
     """
     assert origin_hostname_is_loopback(origin) is expected
+
+
+@pytest.mark.parametrize(
+    "origin,scope,expected",
+    [
+        (
+            "http://10.0.2.2:8000",
+            {
+                "type": "http",
+                "scheme": "http",
+                "headers": [(b"host", b"10.0.2.2:8000")],
+            },
+            True,
+        ),
+        (
+            "https://server.example.com",
+            {
+                "type": "websocket",
+                "scheme": "wss",
+                "headers": [(b"host", b"server.example.com:443")],
+            },
+            True,
+        ),
+        (
+            "https://evil.example.com",
+            {
+                "type": "http",
+                "scheme": "https",
+                "headers": [(b"host", b"server.example.com")],
+            },
+            False,
+        ),
+    ],
+)
+def test_origin_matches_scope(origin: str, scope: dict[str, Any], expected: bool) -> None:
+    """Only the exact request target is same-origin, including mobile hosts."""
+    assert origin_matches_scope(origin, scope) is expected
 
 
 # --------------------------------------------------------------------------
@@ -223,10 +261,10 @@ def _ws_scope(origin: str | None) -> dict[str, Any]:
     :param origin: Origin header value to include, or ``None`` to omit.
     :returns: An ASGI scope dict with ``type == "websocket"``.
     """
-    headers: list[tuple[bytes, bytes]] = []
+    headers: list[tuple[bytes, bytes]] = [(b"host", b"localhost:8000")]
     if origin is not None:
         headers.append((b"origin", origin.encode("latin-1")))
-    return {"type": "websocket", "headers": headers}
+    return {"type": "websocket", "scheme": "ws", "headers": headers}
 
 
 async def _drive_middleware(

--- a/tests/server/test_ws_origin.py
+++ b/tests/server/test_ws_origin.py
@@ -27,7 +27,6 @@ from omnigent.server.ws_origin import (
     WebSocketOriginMiddleware,
     origin_allowed,
     origin_hostname_is_loopback,
-    origin_matches_scope,
     parse_allowed_origins,
 )
 
@@ -86,43 +85,6 @@ def test_origin_hostname_is_loopback(origin: str, expected: bool) -> None:
     :returns: None.
     """
     assert origin_hostname_is_loopback(origin) is expected
-
-
-@pytest.mark.parametrize(
-    "origin,scope,expected",
-    [
-        (
-            "http://10.0.2.2:8000",
-            {
-                "type": "http",
-                "scheme": "http",
-                "headers": [(b"host", b"10.0.2.2:8000")],
-            },
-            True,
-        ),
-        (
-            "https://server.example.com",
-            {
-                "type": "websocket",
-                "scheme": "wss",
-                "headers": [(b"host", b"server.example.com:443")],
-            },
-            True,
-        ),
-        (
-            "https://evil.example.com",
-            {
-                "type": "http",
-                "scheme": "https",
-                "headers": [(b"host", b"server.example.com")],
-            },
-            False,
-        ),
-    ],
-)
-def test_origin_matches_scope(origin: str, scope: dict[str, Any], expected: bool) -> None:
-    """Only the exact request target is same-origin, including mobile hosts."""
-    assert origin_matches_scope(origin, scope) is expected
 
 
 # --------------------------------------------------------------------------
@@ -532,3 +494,57 @@ def test_e2e_allowlist_denies_unlisted_origin_in_non_local_mode(
         assert ws.receive_text() == "echo:hi"
     # Only the allowlisted connection reached the route.
     assert app.state.accepted == [True]
+
+
+def test_e2e_local_mode_admits_mobile_origin_via_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-loopback mobile/LAN origin connects once allowlisted.
+
+    Android emulator WebViews reach the server through ``10.0.2.2``, a
+    non-loopback host. That origin must be explicitly added to
+    ``OMNIGENT_WS_ALLOWED_ORIGINS`` to be admitted in local mode.
+
+    :param monkeypatch: pytest env patcher.
+    :returns: None.
+    """
+    monkeypatch.setenv(_LOCAL_ENV, "1")
+    monkeypatch.setenv(_ALLOWLIST_ENV, "http://10.0.2.2:8000")
+    app = _make_app()
+    client = TestClient(app)
+
+    with client.websocket_connect(
+        "/ws",
+        headers={"origin": "http://10.0.2.2:8000", "host": "10.0.2.2:8000"},
+    ) as ws:
+        ws.send_text("hi")
+        assert ws.receive_text() == "echo:hi"
+    assert app.state.accepted == [True]
+
+
+def test_e2e_local_mode_rejects_dns_rebinding(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Host-matching, non-allowlisted Origin is rejected (DNS rebinding).
+
+    ``Host`` is client-controllable, so an attacker hostname rebound to
+    the server's address can send an ``Origin`` that exactly equals
+    ``Host``. That must never be trusted on its own: this is the core
+    proof the DNS-rebinding hole is closed.
+
+    :param monkeypatch: pytest env patcher.
+    :returns: None.
+    """
+    monkeypatch.setenv(_LOCAL_ENV, "1")
+    app = _make_app()
+    client = TestClient(app)
+
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect(
+            "/ws",
+            headers={
+                "origin": "http://attacker.example:8000",
+                "host": "attacker.example:8000",
+            },
+        ):
+            pass
+    assert exc_info.value.code == FORBIDDEN_ORIGIN_CLOSE_CODE
+    assert app.state.accepted == []


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Recognize an exact request-origin match before applying the local-mode loopback rule.
- This allows native mobile WebViews using Android emulator or LAN server addresses while preserving rejection of arbitrary cross-site origins.
- Apply the same check to multipart HTTP routes and WebSocket handshakes, with regression coverage for mobile and cross-origin cases.

## Test Plan

- `uv run pytest tests/server/routes/test_origin.py tests/server/test_ws_origin.py tests/server/integration/test_sessions_origin_csrf.py -q`
- `uv run pre-commit run --all-files --show-diff-on-failure`
- `uv run mypy --follow-imports=skip omnigent/server/ws_origin.py omnigent/server/routes/_origin.py`
- `uv run pytest -q` (full suite in progress locally)

## Demo

<img width="412" height="915" alt="omnigent-pr-3899-mobile-webview" src="https://github.com/user-attachments/assets/56d95dcc-b5d0-44d8-a67d-e63d1099617a" />


## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new unit cases cover Android emulator and WebSocket same-origin normalization. Existing multipart route integration tests confirm untrusted cross-origin uploads remain rejected.