### PR TITLE
fix(pi): preserve provider resolution errors

### DIFF
--- a/omnigent/errors.py
+++ b/omnigent/errors.py
@@ -115,6 +115,15 @@ class OmnigentError(Exception):
         return _CODE_TO_HTTP_STATUS.get(self.code, 500)
 
 
+class ProviderCredentialError(OmnigentError):
+    """A configured provider credential cannot currently be resolved.
+
+    This is distinct from other provider/configuration errors so multi-family
+    harnesses can skip an unconfigured family without hiding malformed config.
+    """
+
+
+
 class ElicitationDeclinedError(Exception):
     """Raised when a user explicitly declines an elicitation (action == "decline").
 

--- a/omnigent/errors.py
+++ b/omnigent/errors.py
@@ -123,7 +123,6 @@ class ProviderCredentialError(OmnigentError):
     """
 
 
-
 class ElicitationDeclinedError(Exception):
     """Raised when a user explicitly declines an elicitation (action == "decline").
 

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -53,7 +53,7 @@ from omnigent.env_credentials import (
     getenv_with_omnigent_prefix,
     omnigent_prefixed_env_name,
 )
-from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.errors import ErrorCode, OmnigentError, ProviderCredentialError
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.spec.parser import check_unresolved_env_vars
 
@@ -450,7 +450,7 @@ def resolve_secret(ref: str) -> str:
 
         value = secrets.load_secret(name)
         if value is None:
-            raise OmnigentError(
+            raise ProviderCredentialError(
                 f"no stored secret named {name!r}; run "
                 "`omnigent setup --no-internal-beta` to set it.",
                 code=ErrorCode.INVALID_INPUT,
@@ -462,7 +462,7 @@ def resolve_secret(ref: str) -> str:
         if resolved is None:
             prefixed = omnigent_prefixed_env_name(var)
             fallback = f" or ${prefixed}" if prefixed != var else ""
-            raise OmnigentError(
+            raise ProviderCredentialError(
                 f"Unresolved environment variable '${var}' referenced by "
                 f"'env:{var}'. Set ${var}{fallback} in the environment.",
                 code=ErrorCode.INVALID_INPUT,

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -32,7 +32,7 @@ from omnigent.entities import (
     NewConversationItem,
 )
 from omnigent.env_credentials import expand_envvars_with_omnigent_prefix
-from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.errors import ErrorCode, OmnigentError, ProviderCredentialError
 from omnigent.llms import Client as LLMClient
 from omnigent.model_catalog import resolve_catalog_model
 from omnigent.model_resolver import ModelResolutionError
@@ -822,7 +822,7 @@ def _optional_provider_family(entry: ProviderEntry, family_name: str) -> FamilyC
     """
     try:
         return entry.family(family_name)
-    except OmnigentError:
+    except ProviderCredentialError:
         return None
 
 

--- a/tests/runtime/test_provider_spawn_env.py
+++ b/tests/runtime/test_provider_spawn_env.py
@@ -520,6 +520,61 @@ def test_pi_threads_generic_openai_wire_api(config_home: Path) -> None:
     assert env["HARNESS_PI_GATEWAY_OPENAI_WIRE_API"] == "responses"
 
 
+def test_pi_resolves_env_api_key_ref_through_spawn_path(
+    config_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pi resolves an ``env:`` credential when reached through the runner."""
+    monkeypatch.setenv("MY_TOKEN", "token-from-env")
+    _write_config(
+        config_home,
+        {
+            "providers": {
+                "my-gateway": {
+                    "kind": "gateway",
+                    "default": "pi",
+                    "openai": {
+                        "api_key_ref": "env:MY_TOKEN",
+                        "base_url": "https://example.com/v1",
+                        "models": {"default": "some-model-id"},
+                    },
+                }
+            }
+        },
+    )
+
+    env = _build_pi_spawn_env(_make_spec(harness="pi"), workdir=None)
+
+    assert env["HARNESS_PI_GATEWAY"] == "true"
+    assert env["HARNESS_PI_GATEWAY_BASE_URLS"] == '{"openai": "https://example.com/v1"}'
+    assert env["HARNESS_PI_GATEWAY_AUTH_COMMAND"] == "printf %s token-from-env"
+    assert env["HARNESS_PI_MODEL"] == "some-model-id"
+
+
+def test_pi_does_not_hide_non_credential_provider_errors(
+    config_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pi must not turn malformed family resolution into a generic auth error."""
+    monkeypatch.setenv("MY_TOKEN", "token-from-env")
+    _write_config(
+        config_home,
+        {
+            "providers": {
+                "my-gateway": {
+                    "kind": "gateway",
+                    "default": "pi",
+                    "openai": {
+                        "api_key_ref": "env:MY_TOKEN",
+                        "base_url": "$MISSING_BASE_URL",
+                    },
+                }
+            }
+        },
+    )
+
+    with pytest.raises(Exception, match="MISSING_BASE_URL"):
+        _build_pi_spawn_env(_make_spec(harness="pi"), workdir=None)
+
+
 # ── Named ProviderAuth selection ───────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Fix Pi gateway provider resolution so credential-unavailable families can be skipped without masking unrelated provider configuration errors.

## Test Plan

- `uv run pytest tests/runtime/test_provider_spawn_env.py tests/runtime/test_pi_spawn_env.py tests/onboarding/test_provider_config.py -q`
- Result: 131 passed
- `git diff --check`
- Python compilation passed

## Demo

N/A — this is a backend/runtime fix (provider credential-resolution error handling). No UI or frontend surface is touched; the change only alters an internal error path in the runner. Per the contributing guide, `N/A` applies to non-visual changes.

## Type of change

- [x] Bug fix
- [x] Test coverage
- [ ] UI / frontend change

## Coverage notes

Added regression coverage for `api_key_ref: env:MY_TOKEN` through the Pi spawn path and for preserving non-credential provider errors.