### PR TITLE
perf(runner): bound per-runner memory via glibc arenas + threadpool cap

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3161,6 +3161,10 @@ def _start_cli_runner_process(
         env[RUNNER_ISOLATE_SESSION_ENV_VAR] = "1"
     if prewarm_spec_path is not None:
         env["RUNNER_PREWARM_SPEC_PATH"] = str(Path(prewarm_spec_path).expanduser().resolve())
+    # Bound glibc allocator RSS in the runner (no-op off Linux). setdefault so
+    # an explicit operator export in the parent env still wins.
+    for _k, _v in _proc.malloc_tuning_env().items():
+        env.setdefault(_k, _v)
 
     log_path: Path | None = None
     log_fh: BinaryIO | None = None

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -74,6 +74,7 @@ from omnigent.host.git_worktree import (
 )
 from omnigent.host.identity import HostIdentity, load_or_create_host_identity
 from omnigent.host.runner_zygote import ZygoteManager, ZygoteRunnerProc, ZygoteUnavailable
+from omnigent.inner import _proc
 from omnigent.onboarding.harness_auth import (
     adopt_env_credential,
     detect_adoptable_credentials,
@@ -638,6 +639,11 @@ def _build_runner_env(
         env[RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR] = initial_auth_token
     env[RUNNER_WORKSPACE_ENV_VAR] = workspace
     env[RUNNER_PARENT_PID_ENV_VAR] = str(parent_pid)
+    # Bound glibc allocator RSS in the runner (no-op off Linux). Injected
+    # explicitly because the allowlist above would otherwise drop an inherited
+    # MALLOC_ARENA_MAX. setdefault so an operator override still wins.
+    for key, value in _proc.malloc_tuning_env().items():
+        env.setdefault(key, value)
     return env
 
 

--- a/omnigent/host/runner_zygote.py
+++ b/omnigent/host/runner_zygote.py
@@ -207,6 +207,12 @@ class ZygoteManager:
         :raises OSError: If the interpreter could not be spawned.
         """
         env = {**os.environ, ZYGOTE_CONTROL_FD_ENV_VAR: str(child_fd)}
+        # glibc reads these once, when its allocator initializes at exec. This is
+        # the only exec on the zygote path — forked runners just replace
+        # os.environ, far too late to matter — so the cap must be applied here to
+        # reach every child. setdefault keeps an operator override winning.
+        for key, value in _proc.malloc_tuning_env().items():
+            env.setdefault(key, value)
         with contextlib.ExitStack() as stack:
             # The zygote's own stdout/stderr go to its log file when configured,
             # else inherit the daemon's; stdin is always /dev/null.

--- a/omnigent/inner/_proc.py
+++ b/omnigent/inner/_proc.py
@@ -29,9 +29,47 @@ from typing import Protocol, TypedDict
 
 import psutil  # type: ignore[import-untyped]
 
-from omnigent._platform import IS_POSIX
+from omnigent._platform import IS_LINUX, IS_POSIX
 
 logger = logging.getLogger(__name__)
+
+# glibc allocator defaults for spawned children. glibc creates up to 8*ncpu
+# malloc arenas by default; on a many-core host a threaded child (the runner
+# uses asyncio.to_thread heavily) multiplies RSS across arenas that never
+# return to the OS. Capping arenas and setting a trim threshold bounds that
+# growth. Both are read by the C runtime at startup, so the parent must set
+# them in the child env before exec.
+_DEFAULT_MALLOC_ARENA_MAX = "2"
+_DEFAULT_MALLOC_TRIM_THRESHOLD = "134217728"  # 128 MiB
+
+
+def malloc_tuning_env() -> dict[str, str]:
+    """Env vars that bound glibc allocator RSS for a spawned child.
+
+    Returns an empty dict off Linux (macOS has no ``mallopt``; Windows and musl
+    ignore these), so callers can merge unconditionally without a platform
+    branch. Honors operator overrides ``OMNIGENT_RUNNER_MALLOC_ARENA_MAX``
+    (default ``"2"``; ``"0"`` disables the cap) and
+    ``OMNIGENT_RUNNER_MALLOC_TRIM_THRESHOLD`` (default 128 MiB).
+
+    :returns: Mapping to merge into a child ``env`` dict, e.g.
+        ``{"MALLOC_ARENA_MAX": "2", "MALLOC_TRIM_THRESHOLD_": "134217728"}``.
+    """
+    if not IS_LINUX:
+        return {}
+    out: dict[str, str] = {}
+    arena_max = os.environ.get(
+        "OMNIGENT_RUNNER_MALLOC_ARENA_MAX", _DEFAULT_MALLOC_ARENA_MAX
+    ).strip()
+    if arena_max and arena_max != "0":
+        out["MALLOC_ARENA_MAX"] = arena_max
+    trim = os.environ.get(
+        "OMNIGENT_RUNNER_MALLOC_TRIM_THRESHOLD", _DEFAULT_MALLOC_TRIM_THRESHOLD
+    ).strip()
+    if trim:
+        out["MALLOC_TRIM_THRESHOLD_"] = trim
+    return out
+
 
 # Resolved via getattr so this module type-checks and imports on Windows, where
 # process groups and SIGKILL do not exist. None on non-POSIX hosts.

--- a/omnigent/inner/_proc.py
+++ b/omnigent/inner/_proc.py
@@ -46,6 +46,11 @@ _DEFAULT_MALLOC_TRIM_THRESHOLD = "134217728"  # 128 MiB
 def malloc_tuning_env() -> dict[str, str]:
     """Env vars that bound glibc allocator RSS for a spawned child.
 
+    Arena multiplication is specific to glibc's allocator. macOS libmalloc uses
+    per-CPU magazines with madvise-based reclaim and exposes no equivalent knob
+    (``MALLOC_ARENA_MAX`` is simply ignored there), so macOS hosts get their
+    reduction from the threadpool cap instead — see ``_entry`` — not from here.
+
     Returns an empty dict off Linux (macOS has no ``mallopt``; Windows and musl
     ignore these), so callers can merge unconditionally without a platform
     branch. Honors operator overrides ``OMNIGENT_RUNNER_MALLOC_ARENA_MAX``

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import gc
 import logging
 import os
 import signal
@@ -42,6 +43,11 @@ _RUNNER_VERSION = VERSION
 _RUNNER_CONFIG_HOME_ENV_VAR = "OMNIGENT_CONFIG_HOME"
 _DEFAULT_RUNNER_IDLE_TIMEOUT_S = 60 * 60
 _RUNNER_IDLE_MONITOR_MAX_POLL_INTERVAL_S = 60.0
+# The runner offloads short native-CLI/IPC ops via asyncio.to_thread. Python's
+# default executor sizes to min(32, cpu+4) threads, which on a many-core host
+# inflates RSS (thread stacks + glibc arenas) for little benefit. Cap it small.
+_DEFAULT_RUNNER_THREADPOOL_MAX_WORKERS = 8
+_RUNNER_THREADPOOL_MAX_WORKERS_ENV_VAR = "OMNIGENT_RUNNER_THREADPOOL_MAX_WORKERS"
 # Backstop on how long a graceful (idle-reaper) shutdown waits for the tunnel
 # to drain its session streams and complete its close handshake before we give
 # up and tear it down anyway. Comfortably above serve_tunnel's own drain +
@@ -144,6 +150,55 @@ def _load_runner_idle_timeout_s_from_config() -> float:
     if timeout_s < 0:
         raise RuntimeError("runner.idle_timeout_s must be a non-negative number of seconds")
     return timeout_s
+
+
+def _runner_threadpool_max_workers() -> int:
+    """Load the runner's asyncio default-executor size.
+
+    Reads ``runner.threadpool_max_workers`` from the global config file,
+    overridable by ``OMNIGENT_RUNNER_THREADPOOL_MAX_WORKERS``. Missing config
+    defaults to 8. Non-positive, boolean, or non-integer values fail loud so a
+    misconfiguration surfaces at startup rather than silently reverting.
+
+    :returns: Positive worker count for the runner threadpool.
+    :raises RuntimeError: If the configured value is invalid.
+    """
+    raw_env = os.environ.get(_RUNNER_THREADPOOL_MAX_WORKERS_ENV_VAR)
+    if raw_env is not None and raw_env.strip():
+        try:
+            workers = int(raw_env)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"{_RUNNER_THREADPOOL_MAX_WORKERS_ENV_VAR} must be a positive integer"
+            ) from exc
+        if workers < 1:
+            raise RuntimeError(
+                f"{_RUNNER_THREADPOOL_MAX_WORKERS_ENV_VAR} must be a positive integer"
+            )
+        return workers
+
+    import yaml
+
+    path = _runner_config_path()
+    if not path.exists():
+        return _DEFAULT_RUNNER_THREADPOOL_MAX_WORKERS
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        raise RuntimeError(f"failed to read runner config from {path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        return _DEFAULT_RUNNER_THREADPOOL_MAX_WORKERS
+    runner_cfg = raw.get("runner")
+    if runner_cfg is None:
+        return _DEFAULT_RUNNER_THREADPOOL_MAX_WORKERS
+    if not isinstance(runner_cfg, dict):
+        raise RuntimeError("runner config must be a mapping")
+    raw_workers = runner_cfg.get("threadpool_max_workers")
+    if raw_workers is None:
+        return _DEFAULT_RUNNER_THREADPOOL_MAX_WORKERS
+    if isinstance(raw_workers, bool) or not isinstance(raw_workers, int) or raw_workers < 1:
+        raise RuntimeError("runner.threadpool_max_workers must be a positive integer")
+    return raw_workers
 
 
 async def _run_inactivity_monitor(
@@ -1298,8 +1353,20 @@ async def _run_tunnel_from_env() -> None:
 
     :returns: None.
     """
+    from concurrent.futures import ThreadPoolExecutor
+
     from omnigent.runner.identity import get_stable_runner_id
     from omnigent.runner.transports.ws_tunnel.serve import serve_tunnel
+
+    # Bound the asyncio default executor before anything uses it (create_app,
+    # telemetry, and every to_thread offload). Setting it here means Python's
+    # lazy min(32, cpu+4)-thread default pool is never created.
+    asyncio.get_running_loop().set_default_executor(
+        ThreadPoolExecutor(
+            max_workers=_runner_threadpool_max_workers(),
+            thread_name_prefix="runner",
+        )
+    )
 
     server_url = _server_url_from_env()
     auth_token_factory = _make_auth_token_factory()
@@ -1334,6 +1401,9 @@ async def _run_tunnel_from_env() -> None:
     # starlette 1.x removed Router.startup/shutdown; drive the lifespan manually.
     _lifespan_cm = app.router.lifespan_context(app)
     await _lifespan_cm.__aenter__()
+    # Move the now-static import graph out of GC's tracked set: cheaper cyclic
+    # collections and fewer dirtied pages over the runner's life.
+    gc.freeze()
     stop_event = asyncio.Event()
     loop = asyncio.get_running_loop()
     last_activity_at = loop.time()

--- a/tests/host/test_runner_zygote.py
+++ b/tests/host/test_runner_zygote.py
@@ -260,6 +260,60 @@ def test_unstarted_manager_reports_not_running() -> None:
     assert mgr.pid is None
 
 
+def test_malloc_tuning_is_applied_at_the_zygote_exec(monkeypatch, tmp_path) -> None:
+    """The glibc arena cap rides on the zygote's exec, not on a fork payload.
+
+    glibc reads MALLOC_ARENA_MAX once, when its allocator initializes at exec.
+    The zygote's Popen is the only exec on this path — forked runners merely
+    replace ``os.environ``, far too late to configure an allocator — so the cap
+    must be set here or it silently stops applying to every runner.
+
+    :param monkeypatch: Fixture used to force the Linux tuning branch.
+    :param tmp_path: Temp dir for the zygote log path.
+    """
+    monkeypatch.setattr("omnigent.inner._proc.IS_LINUX", True)
+    captured: dict[str, str] = {}
+
+    class _FakePopen:
+        pid = 4321
+
+        def __init__(self, argv, env, **kwargs) -> None:
+            captured.update(env)
+
+    monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+    mgr = ZygoteManager(log_path=tmp_path / "zygote.log")
+    mgr._spawn_zygote_process(child_fd=7)
+
+    assert captured["MALLOC_ARENA_MAX"] == "2"
+    assert captured["MALLOC_TRIM_THRESHOLD_"] == "134217728"
+
+
+def test_operator_malloc_override_wins_at_the_zygote_exec(monkeypatch, tmp_path) -> None:
+    """An explicit MALLOC_ARENA_MAX in the daemon env is not overwritten.
+
+    The tuning is merged with setdefault so an operator who exported a value
+    keeps it.
+
+    :param monkeypatch: Fixture used to force Linux and seed the parent env.
+    :param tmp_path: Temp dir for the zygote log path.
+    """
+    monkeypatch.setattr("omnigent.inner._proc.IS_LINUX", True)
+    monkeypatch.setenv("MALLOC_ARENA_MAX", "16")
+    captured: dict[str, str] = {}
+
+    class _FakePopen:
+        pid = 4321
+
+        def __init__(self, argv, env, **kwargs) -> None:
+            captured.update(env)
+
+    monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+    mgr = ZygoteManager(log_path=tmp_path / "zygote.log")
+    mgr._spawn_zygote_process(child_fd=7)
+
+    assert captured["MALLOC_ARENA_MAX"] == "16"
+
+
 # ── Harness-fork path (fork_harness) ──────────────────────────────
 #
 # The zygote also forks HARNESS children on request, sharing the harness import

--- a/tests/inner/test_proc_and_platform.py
+++ b/tests/inner/test_proc_and_platform.py
@@ -453,3 +453,43 @@ def test_cli_fallback_dirs_no_nvm_dir_is_safe(monkeypatch, tmp_path):
     monkeypatch.setattr(_platform.Path, "home", staticmethod(lambda: tmp_path))
     dirs = _platform._cli_fallback_dirs()
     assert tmp_path / ".local" / "bin" in dirs
+
+
+def test_malloc_tuning_env_empty_off_linux(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Off Linux the tuning helper is a no-op so callers need no platform branch."""
+    monkeypatch.setattr(_proc, "IS_LINUX", False)
+    assert _proc.malloc_tuning_env() == {}
+
+
+def test_malloc_tuning_env_defaults_on_linux(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On Linux the helper caps arenas and sets a trim threshold by default."""
+    monkeypatch.setattr(_proc, "IS_LINUX", True)
+    monkeypatch.delenv("OMNIGENT_RUNNER_MALLOC_ARENA_MAX", raising=False)
+    monkeypatch.delenv("OMNIGENT_RUNNER_MALLOC_TRIM_THRESHOLD", raising=False)
+    assert _proc.malloc_tuning_env() == {
+        "MALLOC_ARENA_MAX": "2",
+        "MALLOC_TRIM_THRESHOLD_": "134217728",
+    }
+
+
+def test_malloc_tuning_env_arena_max_zero_disables_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``OMNIGENT_RUNNER_MALLOC_ARENA_MAX=0`` drops the arena cap (revert knob)."""
+    monkeypatch.setattr(_proc, "IS_LINUX", True)
+    monkeypatch.setenv("OMNIGENT_RUNNER_MALLOC_ARENA_MAX", "0")
+    monkeypatch.delenv("OMNIGENT_RUNNER_MALLOC_TRIM_THRESHOLD", raising=False)
+    env = _proc.malloc_tuning_env()
+    assert "MALLOC_ARENA_MAX" not in env
+    assert env["MALLOC_TRIM_THRESHOLD_"] == "134217728"
+
+
+def test_malloc_tuning_env_honors_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Operator overrides flow through to the child env values."""
+    monkeypatch.setattr(_proc, "IS_LINUX", True)
+    monkeypatch.setenv("OMNIGENT_RUNNER_MALLOC_ARENA_MAX", "1")
+    monkeypatch.setenv("OMNIGENT_RUNNER_MALLOC_TRIM_THRESHOLD", "65536")
+    assert _proc.malloc_tuning_env() == {
+        "MALLOC_ARENA_MAX": "1",
+        "MALLOC_TRIM_THRESHOLD_": "65536",
+    }

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -19,6 +19,7 @@ import pytest
 
 from omnigent.runner._entry import (
     _DEFAULT_RUNNER_IDLE_TIMEOUT_S,
+    _DEFAULT_RUNNER_THREADPOOL_MAX_WORKERS,
     _agent_cache_dest,
     _InitialAuthTokenFactory,
     _install_crash_logging,
@@ -33,6 +34,7 @@ from omnigent.runner._entry import (
     _run_inactivity_monitor,
     _run_parent_death_killer,
     _runner_parent_pid_from_env,
+    _runner_threadpool_max_workers,
     _runner_tunnel_binding_token_from_env,
     _runner_workspace_from_env,
     _RunnerDatabricksAuth,
@@ -1212,6 +1214,116 @@ def test_load_runner_idle_timeout_rejects_invalid_values(
 
     with pytest.raises(RuntimeError, match="runner"):
         _load_runner_idle_timeout_s_from_config()
+
+
+def test_runner_threadpool_defaults_when_config_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Missing runner config uses the default threadpool size.
+
+    :param monkeypatch: Pytest environment patch fixture.
+    :param tmp_path: Isolated config home.
+    :returns: None.
+    """
+    monkeypatch.delenv("OMNIGENT_RUNNER_THREADPOOL_MAX_WORKERS", raising=False)
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+
+    assert _runner_threadpool_max_workers() == _DEFAULT_RUNNER_THREADPOOL_MAX_WORKERS
+
+
+def test_runner_threadpool_reads_nested_runner_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``runner.threadpool_max_workers`` configures the default executor size.
+
+    :param monkeypatch: Pytest environment patch fixture.
+    :param tmp_path: Isolated config home.
+    :returns: None.
+    """
+    monkeypatch.delenv("OMNIGENT_RUNNER_THREADPOOL_MAX_WORKERS", raising=False)
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "runner:\n  threadpool_max_workers: 4\n",
+        encoding="utf-8",
+    )
+
+    assert _runner_threadpool_max_workers() == 4
+
+
+def test_runner_threadpool_env_overrides_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The env override wins over the config file value.
+
+    :param monkeypatch: Pytest environment patch fixture.
+    :param tmp_path: Isolated config home.
+    :returns: None.
+    """
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "runner:\n  threadpool_max_workers: 4\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OMNIGENT_RUNNER_THREADPOOL_MAX_WORKERS", "16")
+
+    assert _runner_threadpool_max_workers() == 16
+
+
+@pytest.mark.parametrize(
+    "config_text",
+    [
+        pytest.param("runner: disabled\n", id="runner-not-mapping"),
+        pytest.param("runner:\n  threadpool_max_workers: 0\n", id="zero"),
+        pytest.param("runner:\n  threadpool_max_workers: -1\n", id="negative"),
+        pytest.param("runner:\n  threadpool_max_workers: true\n", id="boolean"),
+        pytest.param("runner:\n  threadpool_max_workers: many\n", id="string"),
+    ],
+)
+def test_runner_threadpool_rejects_invalid_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    config_text: str,
+) -> None:
+    """Invalid threadpool config fails loud during runner startup.
+
+    :param monkeypatch: Pytest environment patch fixture.
+    :param tmp_path: Isolated config home.
+    :param config_text: Invalid config body under test.
+    :returns: None.
+    """
+    monkeypatch.delenv("OMNIGENT_RUNNER_THREADPOOL_MAX_WORKERS", raising=False)
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(config_text, encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="runner"):
+        _runner_threadpool_max_workers()
+
+
+@pytest.mark.parametrize(
+    "raw_env",
+    [
+        pytest.param("0", id="zero"),
+        pytest.param("-3", id="negative"),
+        pytest.param("lots", id="non-integer"),
+    ],
+)
+def test_runner_threadpool_rejects_invalid_env(
+    monkeypatch: pytest.MonkeyPatch,
+    raw_env: str,
+) -> None:
+    """Invalid ``OMNIGENT_RUNNER_THREADPOOL_MAX_WORKERS`` fails loud.
+
+    :param monkeypatch: Pytest environment patch fixture.
+    :param raw_env: Invalid env value under test.
+    :returns: None.
+    """
+    monkeypatch.setenv("OMNIGENT_RUNNER_THREADPOOL_MAX_WORKERS", raw_env)
+
+    with pytest.raises(RuntimeError, match="THREADPOOL_MAX_WORKERS"):
+        _runner_threadpool_max_workers()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

N/A

## Summary

Each session spawns its own runner process, and each grows to ~200MB in prod, over-using host resources. Profiling shows ~123MB is the irreducible import floor; the growth on top is runtime bloat from threaded Python on glibc: the runner offloads heavily via `asyncio.to_thread`, the default executor sizes to `min(32, cpu+4)` threads, and glibc opens up to `8*ncpu` malloc arenas that never return to the OS. Nothing tuned any of this.

Three low-risk, env-gated levers (all no-ops or benign off Linux):

- **`MALLOC_ARENA_MAX=2`** + a 128 MiB trim threshold, injected into the runner child env at both spawn sites (`cli.py`, `host/connect.py`) via a shared `_proc.malloc_tuning_env()` helper. Empty off Linux; `OMNIGENT_RUNNER_MALLOC_ARENA_MAX=0` reverts.
- **Cap the asyncio default executor at 8 workers** (`runner.threadpool_max_workers` config key, `OMNIGENT_RUNNER_THREADPOOL_MAX_WORKERS` env override), set before any `to_thread` use so the 20-thread default pool is never created.
- **`gc.freeze()`** after app construction to drop the static import graph from GC's tracked set.

This targets the runtime growth, not the import floor; collapsing the floor itself (a copy-on-write zygote) is tracked separately.

## Test Plan

- New unit tests: `_proc.malloc_tuning_env()` (empty off Linux; arena+trim defaults on Linux; `ARENA_MAX=0` disables the cap; operator overrides honored) and `_runner_threadpool_max_workers()` (default when config missing; nested config; env override; invalid config and env values fail loud).
- `pre-commit run` on all changed files — ruff format + check pass.
- Manual smoke: runner module imports cleanly; `_runner_threadpool_max_workers()` returns 8 by default, honors the env override, and rejects invalid values; `malloc_tuning_env()` returns the expected dict on the simulated Linux path and `{}` on macOS.

## Demo

N/A — non-visual (runtime/memory tuning).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor / chore
- [ ] UI / frontend change
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the two new config/env helpers and the platform branching in `malloc_tuning_env`. The runtime effects (arena cap, executor size, `gc.freeze`) were verified manually on macOS (helpers return correct values; runner boots to the executor-set point); their memory impact is Linux-only and best measured under a real session load on a Linux host, which is out of scope for this unit-level change.

## Changelog

DELETE THIS WHOLE SECTION — internal runtime tuning, no user-facing change.