### PR TITLE
fix(runner): allow managed mint in InitialAuthTokenFactory fallback

### DIFF
--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -335,7 +335,6 @@ class _InitialAuthTokenFactory:
                 self._fallback_factory = _make_auth_token_factory(
                     self._server_url,
                     _allow_initial_token=False,
-                    _allow_delegated_mint=False,
                 )
                 self._fallback_resolved = True
             if self._fallback_factory is None:

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -55,6 +55,13 @@ _GRACEFUL_SHUTDOWN_TUNNEL_TIMEOUT_S = 15.0
 _MANAGED_MINT_REFRESH_SKEW_S = 300.0
 _logger = logging.getLogger(__name__)
 
+# Module-level singleton set by serve_runner once the runner's auth factory is
+# built. All later _make_auth_token_factory() calls (harness setup, terminal
+# creation, forwarders) return this instance so they share the proxy bearer
+# instead of constructing a new factory after RUNNER_INITIAL_AUTH_TOKEN has
+# already been popped from the environment.
+_runner_auth_factory: Callable[[], str | None] | None = None
+
 
 def _server_url_from_env() -> str:
     """Return the required Omnigent server URL from the runner environment.
@@ -360,6 +367,19 @@ def _make_auth_token_factory(
     _allow_delegated_mint: bool = True,
     _proxy_bearer: str | None = None,
 ) -> Callable[[], str | None] | None:
+    # Return the runner-process singleton when it has been set and no
+    # caller-specific overrides are requested. This ensures every harness
+    # setup or terminal-creation call made after runner startup reuses the
+    # factory that already has the proxy bearer, rather than constructing a
+    # fresh one after RUNNER_INITIAL_AUTH_TOKEN has been popped from env.
+    if (
+        _runner_auth_factory is not None
+        and _allow_initial_token
+        and _allow_delegated_mint
+        and _proxy_bearer is None
+        and server_url is None
+    ):
+        return _runner_auth_factory
     """Build a callable that mints fresh auth tokens.
 
     Resolution order:
@@ -1231,8 +1251,10 @@ async def _run_tunnel_from_env() -> None:
     from omnigent.runner.identity import get_stable_runner_id
     from omnigent.runner.transports.ws_tunnel.serve import serve_tunnel
 
+    global _runner_auth_factory
     server_url = _server_url_from_env()
     auth_token_factory = _make_auth_token_factory()
+    _runner_auth_factory = auth_token_factory
     auth_token = auth_token_factory() if auth_token_factory is not None else None
     binding_token = _runner_tunnel_binding_token_from_env()
     parent_pid = _runner_parent_pid_from_env()

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -1251,10 +1251,14 @@ async def _run_tunnel_from_env() -> None:
     from omnigent.runner.identity import get_stable_runner_id
     from omnigent.runner.transports.ws_tunnel.serve import serve_tunnel
 
-    global _runner_auth_factory
     server_url = _server_url_from_env()
     auth_token_factory = _make_auth_token_factory()
-    _runner_auth_factory = auth_token_factory
+    # Set the singleton on the canonical module (omnigent.runner._entry) so
+    # all importers share it, even when this file runs as __main__ and creates
+    # a separate module object.
+    import omnigent.runner._entry as _self_module
+
+    _self_module._runner_auth_factory = auth_token_factory
     auth_token = auth_token_factory() if auth_token_factory is not None else None
     binding_token = _runner_tunnel_binding_token_from_env()
     parent_pid = _runner_parent_pid_from_env()

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -1267,14 +1267,14 @@ async def _run_tunnel_from_env() -> None:
 
     server_url = _server_url_from_env()
     auth_token_factory = _make_auth_token_factory()
-    # Write the singleton to the canonical module via sys.modules so it is
-    # visible to all importers even when this file runs as __main__ (which
-    # Python treats as a separate module object from omnigent.runner._entry).
-    import sys as _sys
+    # Write the singleton to the canonical module so it is visible to all
+    # importers even when this file runs as __main__ (which Python treats as a
+    # separate module object from omnigent.runner._entry). Importing the
+    # canonical name here ensures sys.modules registers it before any
+    # harness code tries to read it.
+    import omnigent.runner._entry as _canonical_entry
 
-    _canonical = _sys.modules.get("omnigent.runner._entry")
-    if _canonical is not None:
-        _canonical._set_runner_auth_factory(auth_token_factory)
+    _canonical_entry._set_runner_auth_factory(auth_token_factory)
     _set_runner_auth_factory(auth_token_factory)
     auth_token = auth_token_factory() if auth_token_factory is not None else None
     binding_token = _runner_tunnel_binding_token_from_env()

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -420,12 +420,16 @@ def _make_auth_token_factory(
     # setup or terminal-creation call made after runner startup reuses the
     # factory that already has the proxy bearer, rather than constructing a
     # fresh one after RUNNER_INITIAL_AUTH_TOKEN has been popped from env.
+    # Also match when the caller explicitly passes the same URL the runner
+    # was started with — in-runner helpers like native_policy_hook pass
+    # server_url explicitly but still want the shared factory.
+    _runner_url = os.environ.get(_RUNNER_SERVER_URL_ENV_VAR)
     if (
         _runner_auth_factory is not None
         and _allow_initial_token
         and _allow_delegated_mint
         and _proxy_bearer is None
-        and server_url is None
+        and (server_url is None or server_url == _runner_url)
     ):
         return _runner_auth_factory
     resolved_server_url = server_url or os.environ.get(_RUNNER_SERVER_URL_ENV_VAR)

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -55,12 +55,26 @@ _GRACEFUL_SHUTDOWN_TUNNEL_TIMEOUT_S = 15.0
 _MANAGED_MINT_REFRESH_SKEW_S = 300.0
 _logger = logging.getLogger(__name__)
 
-# Module-level singleton set by serve_runner once the runner's auth factory is
-# built. All later _make_auth_token_factory() calls (harness setup, terminal
-# creation, forwarders) return this instance so they share the proxy bearer
-# instead of constructing a new factory after RUNNER_INITIAL_AUTH_TOKEN has
-# already been popped from the environment.
+# Module-level singleton set once at runner startup. All later
+# _make_auth_token_factory() calls return this instance so every call site
+# shares the proxy bearer, even after RUNNER_INITIAL_AUTH_TOKEN has been
+# popped from the environment.
 _runner_auth_factory: Callable[[], str | None] | None = None
+
+
+def _set_runner_auth_factory(factory: Callable[[], str | None] | None) -> None:
+    """Set the runner-process auth factory singleton.
+
+    Called once at startup so every subsequent :func:`_make_auth_token_factory`
+    call returns this instance instead of building a new one. Exposed as a
+    function rather than a bare module assignment so callers (including those
+    running as ``__main__``, where the module object differs from the imported
+    ``omnigent.runner._entry``) can set it on the canonical module.
+
+    :param factory: The auth token factory to install as the singleton.
+    """
+    global _runner_auth_factory
+    _runner_auth_factory = factory
 
 
 def _server_url_from_env() -> str:
@@ -1253,12 +1267,11 @@ async def _run_tunnel_from_env() -> None:
 
     server_url = _server_url_from_env()
     auth_token_factory = _make_auth_token_factory()
-    # Set the singleton on the canonical module (omnigent.runner._entry) so
-    # all importers share it, even when this file runs as __main__ and creates
-    # a separate module object.
+    # Use the setter so the singleton is written to the canonical module even
+    # when this file runs as __main__ (which has a separate module object).
     import omnigent.runner._entry as _self_module
 
-    _self_module._runner_auth_factory = auth_token_factory
+    _self_module._set_runner_auth_factory(auth_token_factory)
     auth_token = auth_token_factory() if auth_token_factory is not None else None
     binding_token = _runner_tunnel_binding_token_from_env()
     parent_pid = _runner_parent_pid_from_env()

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -321,6 +321,7 @@ class _InitialAuthTokenFactory:
         :param server_url: Omnigent server URL used by the fallback resolver.
         """
         self._initial_token: str | None = token
+        self._last_initial_token: str = token  # retained for managed-mint proxy auth
         self._server_url = server_url
         self._fallback_factory: Callable[[], str | None] | None = None
         self._fallback_resolved = False
@@ -335,6 +336,7 @@ class _InitialAuthTokenFactory:
                 self._fallback_factory = _make_auth_token_factory(
                     self._server_url,
                     _allow_initial_token=False,
+                    _proxy_bearer=self._last_initial_token,
                 )
                 self._fallback_resolved = True
             if self._fallback_factory is None:
@@ -356,6 +358,7 @@ def _make_auth_token_factory(
     *,
     _allow_initial_token: bool = True,
     _allow_delegated_mint: bool = True,
+    _proxy_bearer: str | None = None,
 ) -> Callable[[], str | None] | None:
     """Build a callable that mints fresh auth tokens.
 
@@ -422,7 +425,9 @@ def _make_auth_token_factory(
     delegated_auth = os.environ.get(RUNNER_DELEGATED_AUTH_ENV_VAR, "").strip() == "1"
     binding_token = os.environ.get(RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR, "").strip()
     if _allow_delegated_mint and delegated_auth and resolved_server_url and binding_token:
-        delegated_factory = _make_managed_mint_factory(resolved_server_url, binding_token)
+        delegated_factory = _make_managed_mint_factory(
+            resolved_server_url, binding_token, proxy_bearer=_proxy_bearer
+        )
         if delegated_factory is not None:
             return delegated_factory
 
@@ -522,6 +527,8 @@ def _make_auth_token_factory(
 def _make_managed_mint_factory(
     server_url: str,
     binding_token: str,
+    *,
+    proxy_bearer: str | None = None,
 ) -> Callable[[], str | None] | None:
     """Build a token factory that mints a managed runner's owner JWT.
 
@@ -541,6 +548,10 @@ def _make_managed_mint_factory(
         ``"https://omnigent.example.com"``.
     :param binding_token: The runner's tunnel binding token (the sandbox's
         only credential), presented to the mint endpoint.
+    :param proxy_bearer: Optional bearer to include on the mint request so
+        an Apps proxy lets it through. Used when a host-injected initial
+        bearer is available (the minted JWT takes over on subsequent
+        refreshes).
     :returns: A sync callable returning a fresh owner JWT, or ``None`` only
         when the server *definitively* will not mint for this runner (HTTP
         400 no-auth/header mode, 404 older server without the endpoint, or a
@@ -566,7 +577,9 @@ def _make_managed_mint_factory(
     # transient failure (network blip, 5xx, timeout) installs it anyway so the
     # next callback re-mints, rather than leaving the runner unauthenticated
     # until process restart.
-    factory = _ManagedMintTokenFactory(mint_url, server_url, binding_token)
+    factory = _ManagedMintTokenFactory(
+        mint_url, server_url, binding_token, proxy_bearer=proxy_bearer
+    )
     factory()
     if factory.declined:
         return None
@@ -588,15 +601,27 @@ class _ManagedMintTokenFactory:
     factory, then the first real mint learns the server never mints).
     """
 
-    def __init__(self, mint_url: str, server_url: str, binding_token: str) -> None:
+    def __init__(
+        self,
+        mint_url: str,
+        server_url: str,
+        binding_token: str,
+        *,
+        proxy_bearer: str | None = None,
+    ) -> None:
         """
         :param mint_url: Fully-qualified ``/v1/runners/{id}/token`` URL.
         :param server_url: Omnigent server base URL.
         :param binding_token: The runner's tunnel binding token.
+        :param proxy_bearer: Optional bearer for the Apps proxy. Seeded with
+            the host's initial bearer; replaced by the minted JWT after the
+            first successful mint so the proxy sees a valid credential on
+            every subsequent refresh.
         """
         self._mint_url = mint_url
         self._server_url = server_url
         self._binding_token = binding_token
+        self._proxy_bearer = proxy_bearer
         self._cached_token: str | None = None
         self._cached_expires_at = 0.0
         self.declined = False
@@ -618,7 +643,10 @@ class _ManagedMintTokenFactory:
             return self._cached_token
         try:
             token, expires_at = _mint_managed_owner_token(
-                self._mint_url, self._server_url, self._binding_token
+                self._mint_url,
+                self._server_url,
+                self._binding_token,
+                proxy_bearer=self._proxy_bearer,
             )
         except httpx.HTTPStatusError as exc:
             response = exc.response
@@ -635,6 +663,9 @@ class _ManagedMintTokenFactory:
             return self._still_valid_cached_token(now)
         self._cached_token = token
         self._cached_expires_at = expires_at
+        # Promote the minted JWT to proxy bearer so subsequent refreshes
+        # through the Apps proxy are authenticated with a valid credential.
+        self._proxy_bearer = token
         return token
 
     def _still_valid_cached_token(self, now: float) -> str | None:
@@ -652,6 +683,8 @@ def _mint_managed_owner_token(
     mint_url: str,
     server_url: str,
     binding_token: str,
+    *,
+    proxy_bearer: str | None = None,
 ) -> tuple[str, float]:
     """Mint one managed-runner owner JWT from the server.
 
@@ -660,6 +693,10 @@ def _mint_managed_owner_token(
         routing header (``X-Databricks-Org-Id``) when applicable.
     :param binding_token: The runner's tunnel binding token, sent as the
         ``X-Omnigent-Runner-Tunnel-Token`` header to authenticate the mint.
+    :param proxy_bearer: Optional bearer for a Databricks Apps proxy sitting
+        in front of the Omnigent server. The proxy requires a valid
+        ``Authorization`` header even on unauthenticated-to-Omnigent
+        endpoints; the binding token alone is not enough to pass it.
     :returns: ``(jwt, expires_at_epoch_seconds)``.
     :raises httpx.HTTPError: On network failure or a non-2xx response.
     :raises KeyError: If the response is missing the expected fields.
@@ -673,7 +710,7 @@ def _mint_managed_owner_token(
     headers = {
         "Origin": OMNIGENT_INTERNAL_WS_ORIGIN,
         RUNNER_TUNNEL_TOKEN_HEADER: binding_token,
-        **databricks_request_headers(server_url),
+        **databricks_request_headers(server_url, bearer_token=proxy_bearer),
     }
     with httpx.Client(timeout=10.0) as client:
         response = client.post(mint_url, headers=headers)

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -381,19 +381,6 @@ def _make_auth_token_factory(
     _allow_delegated_mint: bool = True,
     _proxy_bearer: str | None = None,
 ) -> Callable[[], str | None] | None:
-    # Return the runner-process singleton when it has been set and no
-    # caller-specific overrides are requested. This ensures every harness
-    # setup or terminal-creation call made after runner startup reuses the
-    # factory that already has the proxy bearer, rather than constructing a
-    # fresh one after RUNNER_INITIAL_AUTH_TOKEN has been popped from env.
-    if (
-        _runner_auth_factory is not None
-        and _allow_initial_token
-        and _allow_delegated_mint
-        and _proxy_bearer is None
-        and server_url is None
-    ):
-        return _runner_auth_factory
     """Build a callable that mints fresh auth tokens.
 
     Resolution order:
@@ -428,6 +415,19 @@ def _make_auth_token_factory(
     :returns: A sync callable returning a bearer token string, or
         ``None`` when no refresh mechanism is available.
     """
+    # Return the runner-process singleton when it has been set and no
+    # caller-specific overrides are requested. This ensures every harness
+    # setup or terminal-creation call made after runner startup reuses the
+    # factory that already has the proxy bearer, rather than constructing a
+    # fresh one after RUNNER_INITIAL_AUTH_TOKEN has been popped from env.
+    if (
+        _runner_auth_factory is not None
+        and _allow_initial_token
+        and _allow_delegated_mint
+        and _proxy_bearer is None
+        and server_url is None
+    ):
+        return _runner_auth_factory
     resolved_server_url = server_url or os.environ.get(_RUNNER_SERVER_URL_ENV_VAR)
 
     # Consume the host bearer before any credential discovery. Removing it
@@ -1267,11 +1267,15 @@ async def _run_tunnel_from_env() -> None:
 
     server_url = _server_url_from_env()
     auth_token_factory = _make_auth_token_factory()
-    # Use the setter so the singleton is written to the canonical module even
-    # when this file runs as __main__ (which has a separate module object).
-    import omnigent.runner._entry as _self_module
+    # Write the singleton to the canonical module via sys.modules so it is
+    # visible to all importers even when this file runs as __main__ (which
+    # Python treats as a separate module object from omnigent.runner._entry).
+    import sys as _sys
 
-    _self_module._set_runner_auth_factory(auth_token_factory)
+    _canonical = _sys.modules.get("omnigent.runner._entry")
+    if _canonical is not None:
+        _canonical._set_runner_auth_factory(auth_token_factory)
+    _set_runner_auth_factory(auth_token_factory)
     auth_token = auth_token_factory() if auth_token_factory is not None else None
     binding_token = _runner_tunnel_binding_token_from_env()
     parent_pid = _runner_parent_pid_from_env()

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3627,7 +3627,7 @@ async def _auto_create_codex_terminal(
     # separate subprocess that POSTs tool calls to /policies/evaluate, so
     # it reads a one-shot token snapshot from policy_hook.json — same as
     # the claude-native PermissionRequest hook on this host-spawned path.
-    from omnigent.runner._entry import _make_auth_token_factory
+    from omnigent.runner._entry import _make_auth_token_factory, _RunnerDatabricksAuth
 
     _policy_auth_factory = _make_auth_token_factory()
     _policy_auth_token = _policy_auth_factory() if _policy_auth_factory is not None else None
@@ -3778,6 +3778,12 @@ async def _auto_create_codex_terminal(
                 codex_home=codex_home,
                 event_client=event_client,
                 routing_summary=_codex_launch.summary,
+                auth_token_factory=(
+                    server_client.auth._factory  # type: ignore[union-attr]
+                    if server_client is not None
+                    and isinstance(server_client.auth, _RunnerDatabricksAuth)
+                    else None
+                ),
             )
             if launch_config.external_session_id is None
             else _codex_forward_known_thread(
@@ -3814,6 +3820,7 @@ async def _codex_discover_thread_and_forward(
     codex_home: Path,
     event_client: CodexAppServerClient,
     routing_summary: str,
+    auth_token_factory: Callable[[], str | None] | None = None,
 ) -> None:
     """
     Adopt the fresh Codex TUI's thread, then mirror it into the Omnigent session.
@@ -3838,6 +3845,9 @@ async def _codex_discover_thread_and_forward(
         routing (provider / profile / model, or the login-fallback state),
         threaded into the startup-timeout error so hosted users can diagnose
         without runner-log access (see #2745).
+    :param auth_token_factory: Runner's auth token factory. When provided,
+        reused so the PATCH and forwarder share the runner's existing proxy
+        bearer rather than minting a fresh credential.
     """
     from omnigent.codex_native_bridge import (
         CodexNativeBridgeState,
@@ -3889,8 +3899,22 @@ async def _codex_discover_thread_and_forward(
             ),
         )
 
+        # Mirror the discovered Codex thread id onto the Omnigent session as its
+        # external_session_id, the same way claude-native records its
+        # captured session id. This is what makes the session forkable with
+        # history: fork_conversation stamps
+        # ``omnigent.fork.source_external_session_id`` from
+        # external_session_id, and the forked clone's runner clones this
+        # thread's rollout from it (see _clone_codex_rollout). Without it a
+        # host-spawned codex session has no recorded thread id, so a fork
+        # would resume fresh. Best-effort: a transient Omnigent failure here still
+        # leaves chat streaming working — only fork-history carry-over
+        # degrades.
         server_url = _required_runner_env("RUNNER_SERVER_URL")
-        auth_factory = _make_auth_token_factory()
+        # Reuse the runner's existing auth factory (including proxy bearer for
+        # Apps deployments) when the caller passes one; fall back to a fresh
+        # factory only when called without one (e.g. tests).
+        auth_factory = auth_token_factory or _make_auth_token_factory()
         auth_token = auth_factory() if auth_factory is not None else None
         headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else {}
 

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3627,7 +3627,7 @@ async def _auto_create_codex_terminal(
     # separate subprocess that POSTs tool calls to /policies/evaluate, so
     # it reads a one-shot token snapshot from policy_hook.json — same as
     # the claude-native PermissionRequest hook on this host-spawned path.
-    from omnigent.runner._entry import _make_auth_token_factory, _RunnerDatabricksAuth
+    from omnigent.runner._entry import _make_auth_token_factory
 
     _policy_auth_factory = _make_auth_token_factory()
     _policy_auth_token = _policy_auth_factory() if _policy_auth_factory is not None else None
@@ -3779,9 +3779,8 @@ async def _auto_create_codex_terminal(
                 event_client=event_client,
                 routing_summary=_codex_launch.summary,
                 auth_token_factory=(
-                    server_client.auth._factory  # type: ignore[union-attr]
+                    getattr(server_client.auth, "_factory", None)
                     if server_client is not None
-                    and isinstance(server_client.auth, _RunnerDatabricksAuth)
                     else None
                 ),
             )

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3889,17 +3889,6 @@ async def _codex_discover_thread_and_forward(
             ),
         )
 
-        # Mirror the discovered Codex thread id onto the Omnigent session as its
-        # external_session_id, the same way claude-native records its
-        # captured session id. This is what makes the session forkable with
-        # history: fork_conversation stamps
-        # ``omnigent.fork.source_external_session_id`` from
-        # external_session_id, and the forked clone's runner clones this
-        # thread's rollout from it (see _clone_codex_rollout). Without it a
-        # host-spawned codex session has no recorded thread id, so a fork
-        # would resume fresh. Best-effort: a transient Omnigent failure here still
-        # leaves chat streaming working — only fork-history carry-over
-        # degrades.
         server_url = _required_runner_env("RUNNER_SERVER_URL")
         auth_factory = _make_auth_token_factory()
         auth_token = auth_factory() if auth_factory is not None else None

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3778,11 +3778,6 @@ async def _auto_create_codex_terminal(
                 codex_home=codex_home,
                 event_client=event_client,
                 routing_summary=_codex_launch.summary,
-                auth_token_factory=(
-                    getattr(server_client.auth, "_factory", None)
-                    if server_client is not None
-                    else None
-                ),
             )
             if launch_config.external_session_id is None
             else _codex_forward_known_thread(
@@ -3819,7 +3814,6 @@ async def _codex_discover_thread_and_forward(
     codex_home: Path,
     event_client: CodexAppServerClient,
     routing_summary: str,
-    auth_token_factory: Callable[[], str | None] | None = None,
 ) -> None:
     """
     Adopt the fresh Codex TUI's thread, then mirror it into the Omnigent session.
@@ -3844,9 +3838,6 @@ async def _codex_discover_thread_and_forward(
         routing (provider / profile / model, or the login-fallback state),
         threaded into the startup-timeout error so hosted users can diagnose
         without runner-log access (see #2745).
-    :param auth_token_factory: Runner's auth token factory. When provided,
-        reused so the PATCH and forwarder share the runner's existing proxy
-        bearer rather than minting a fresh credential.
     """
     from omnigent.codex_native_bridge import (
         CodexNativeBridgeState,
@@ -3910,10 +3901,7 @@ async def _codex_discover_thread_and_forward(
         # leaves chat streaming working — only fork-history carry-over
         # degrades.
         server_url = _required_runner_env("RUNNER_SERVER_URL")
-        # Reuse the runner's existing auth factory (including proxy bearer for
-        # Apps deployments) when the caller passes one; fall back to a fresh
-        # factory only when called without one (e.g. tests).
-        auth_factory = auth_token_factory or _make_auth_token_factory()
+        auth_factory = _make_auth_token_factory()
         auth_token = auth_factory() if auth_factory is not None else None
         headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else {}
 

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -281,12 +281,12 @@ def test_initial_host_token_defers_local_auth_until_rejected(
     def _unexpected_mint(*args: Any, **kwargs: Any) -> tuple[str, float]:
         del args, kwargs
         mint_calls.append(1)
-        raise AssertionError("bootstrap fallback must use runner-local refresh auth")
+        raise AssertionError("SDK auth available — fallback must prefer it over managed mint")
 
+    # A host-launched runner: has an initial bearer and SDK auth, but no
+    # managed-sandbox delegation — OMNIGENT_RUNNER_DELEGATED_AUTH is absent.
     monkeypatch.setenv("RUNNER_SERVER_URL", "https://app.databricksapps.com")
     monkeypatch.setenv(RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR, "host-bootstrap-token")
-    monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "host-binding-token")
-    monkeypatch.setenv("OMNIGENT_RUNNER_DELEGATED_AUTH", "1")
     monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
     monkeypatch.setattr("omnigent.inner.databricks_executor._resolve_databricks_auth", _resolve)
     monkeypatch.setattr("omnigent.runner._entry._mint_managed_owner_token", _unexpected_mint)
@@ -310,6 +310,55 @@ def test_initial_host_token_defers_local_auth_until_rejected(
     ]
     assert resolve_calls == [1]
     assert mint_calls == []
+
+
+def test_initial_host_token_falls_back_to_managed_mint_when_no_sdk_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After the host bearer is rejected, a managed runner falls back to managed mint.
+
+    When no SDK/OIDC credential is available (managed sandbox with no user
+    credential), the fallback must reach the managed-mint path rather than
+    returning None and bricking all HTTP callbacks.
+    """
+    mint_calls: list[int] = []
+
+    def _no_sdk_auth(*args: Any, **kwargs: Any) -> tuple[None, None]:
+        from omnigent.inner.databricks_executor import DatabricksAuthError
+
+        raise DatabricksAuthError("no credential configured")
+
+    def _mint(*args: Any, **kwargs: Any) -> tuple[str, float]:
+        mint_calls.append(1)
+        return "managed-minted-token", time.time() + 3600
+
+    monkeypatch.setenv("RUNNER_SERVER_URL", "https://app.databricksapps.com")
+    monkeypatch.setenv(RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR, "host-bootstrap-token")
+    monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "host-binding-token")
+    monkeypatch.setenv("OMNIGENT_RUNNER_DELEGATED_AUTH", "1")
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr(
+        "omnigent.inner.databricks_executor._resolve_databricks_auth", _no_sdk_auth
+    )
+    monkeypatch.setattr("omnigent.runner._entry._mint_managed_owner_token", _mint)
+
+    factory = _make_auth_token_factory()
+
+    assert isinstance(factory, _InitialAuthTokenFactory)
+    assert factory() == "host-bootstrap-token"
+    assert mint_calls == []
+
+    request = httpx.Request("GET", "https://app.databricksapps.com/api/version")
+    redirect = httpx.Response(302, headers={"Location": "/oidc/oauth2/v2.0/authorize"})
+    captured = _drive_auth_flow(_RunnerDatabricksAuth(factory), request, redirect)
+
+    # After the initial bearer is rejected, the fallback must mint via the
+    # managed-mint path rather than returning None and bricking callbacks.
+    assert captured == [
+        "Bearer host-bootstrap-token",
+        "Bearer managed-minted-token",
+    ]
+    assert len(mint_calls) >= 1
 
 
 def test_delegated_factory_falls_back_when_apps_proxy_redirects_mint(

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -713,7 +713,7 @@ def test_mint_managed_owner_token_includes_proxy_bearer_when_provided(
 def test_managed_mint_factory_promotes_minted_jwt_to_proxy_bearer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """After first mint the factory uses the minted JWT (not the seed bearer) for subsequent mints."""
+    """After the first mint, the factory uses the minted JWT as proxy bearer on re-mints."""
     mint_call_bearers: list[str | None] = []
 
     def _handler(request: httpx.Request) -> httpx.Response:

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -25,6 +25,7 @@ from omnigent.runner._entry import (
     _load_runner_idle_timeout_s_from_config,
     _make_auth_token_factory,
     _make_managed_mint_factory,
+    _ManagedMintTokenFactory,
     _mint_managed_owner_token,
     _parent_is_orphaned,
     _parent_process_is_alive,
@@ -221,7 +222,7 @@ def test_make_auth_token_factory_uses_managed_mint_when_only_binding_token(
     monkeypatch.setattr("omnigent.inner.databricks_executor._resolve_databricks_auth", _no_sdk)
     monkeypatch.setattr(
         "omnigent.runner._entry._mint_managed_owner_token",
-        lambda mint_url, server_url, binding_token: ("managed-jwt", time.time() + 1800),
+        lambda mint_url, server_url, binding_token, **_kw: ("managed-jwt", time.time() + 1800),
     )
 
     factory = _make_auth_token_factory()
@@ -250,7 +251,7 @@ def test_make_auth_token_factory_prefers_host_delegation_over_user_credentials(
     )
     monkeypatch.setattr(
         "omnigent.runner._entry._mint_managed_owner_token",
-        lambda mint_url, server_url, binding_token: ("delegated-jwt", time.time() + 1800),
+        lambda mint_url, server_url, binding_token, **_kw: ("delegated-jwt", time.time() + 1800),
     )
 
     factory = _make_auth_token_factory()
@@ -373,7 +374,9 @@ def test_delegated_factory_falls_back_when_apps_proxy_redirects_mint(
         def current_token(self) -> str:
             return "workspace-token"
 
-    def _apps_redirect(mint_url: str, server_url: str, binding_token: str) -> tuple[str, float]:
+    def _apps_redirect(
+        mint_url: str, server_url: str, binding_token: str, **_kw: object
+    ) -> tuple[str, float]:
         """Model the Apps edge intercepting the mint request before Omnigent."""
         del server_url, binding_token
         mint_calls.append(1)
@@ -447,7 +450,9 @@ def test_managed_mint_factory_caches_token_until_refresh_skew(
     """
     calls: list[int] = []
 
-    def _fake_mint(mint_url: str, server_url: str, binding_token: str) -> tuple[str, float]:
+    def _fake_mint(
+        mint_url: str, server_url: str, binding_token: str, **_kw: object
+    ) -> tuple[str, float]:
         """Return a distinct token per call, expiring well beyond the skew."""
         calls.append(1)
         return (f"jwt-{len(calls)}", time.time() + 1800)
@@ -478,7 +483,9 @@ def test_managed_mint_factory_serves_cached_token_when_refresh_fails(
     """
     calls: list[int] = []
 
-    def _fake_mint(mint_url: str, server_url: str, binding_token: str) -> tuple[str, float]:
+    def _fake_mint(
+        mint_url: str, server_url: str, binding_token: str, **_kw: object
+    ) -> tuple[str, float]:
         """First call mints a near-expiry token; the refresh attempt fails."""
         calls.append(1)
         if len(calls) == 1:
@@ -513,7 +520,9 @@ def test_managed_mint_factory_no_factory_when_server_definitively_refuses(
     :returns: None.
     """
 
-    def _refuses(mint_url: str, server_url: str, binding_token: str) -> tuple[str, float]:
+    def _refuses(
+        mint_url: str, server_url: str, binding_token: str, **_kw: object
+    ) -> tuple[str, float]:
         """Reject the mint the way a no-auth / header-mode server does (400)."""
         request = httpx.Request("POST", mint_url)
         raise httpx.HTTPStatusError(
@@ -539,7 +548,9 @@ def test_managed_mint_factory_installs_for_retry_on_transient_boot_failure(
     :returns: None.
     """
 
-    def _blip(mint_url: str, server_url: str, binding_token: str) -> tuple[str, float]:
+    def _blip(
+        mint_url: str, server_url: str, binding_token: str, **_kw: object
+    ) -> tuple[str, float]:
         """A transient failure — the endpoint is momentarily unreachable."""
         raise httpx.ConnectError("mint endpoint unreachable at boot")
 
@@ -563,7 +574,9 @@ def test_managed_mint_factory_recovers_after_transient_boot_failure(
     """
     calls: list[int] = []
 
-    def _fake_mint(mint_url: str, server_url: str, binding_token: str) -> tuple[str, float]:
+    def _fake_mint(
+        mint_url: str, server_url: str, binding_token: str, **_kw: object
+    ) -> tuple[str, float]:
         """Fail the boot probe once, then mint successfully."""
         calls.append(1)
         if len(calls) == 1:
@@ -598,7 +611,7 @@ def test_managed_mint_factory_declines_at_request_time_and_auth_sends_bare(
     calls: list[int] = []
 
     def _boot_blip_then_refuse(
-        mint_url: str, server_url: str, binding_token: str
+        mint_url: str, server_url: str, binding_token: str, **_kw: object
     ) -> tuple[str, float]:
         """Fail the boot probe with a connection error, then 400 every mint."""
         calls.append(1)
@@ -666,6 +679,68 @@ def test_mint_managed_owner_token_posts_binding_token_and_parses_response(
     assert captured["method"] == "POST"
     assert captured["binding_token"] == "the-binding-token"
     assert captured["url"].endswith("/v1/runners/runner_token_abc/token")
+
+
+def test_mint_managed_owner_token_includes_proxy_bearer_when_provided(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """proxy_bearer is forwarded as Authorization so an Apps proxy lets the request through."""
+    captured: dict[str, str] = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured["authorization"] = request.headers.get("authorization", "")
+        captured["binding_token"] = request.headers.get(RUNNER_TUNNEL_TOKEN_HEADER, "")
+        return httpx.Response(200, json={"token": "owner-jwt", "expires_at": 1234567890})
+
+    real_client = httpx.Client
+
+    def _fake_client(**kwargs: Any) -> httpx.Client:
+        return real_client(transport=httpx.MockTransport(_handler), **kwargs)
+
+    monkeypatch.setattr("omnigent.runner._entry.httpx.Client", _fake_client)
+
+    _mint_managed_owner_token(
+        "https://s.example.com/v1/runners/runner_token_abc/token",
+        "https://s.example.com",
+        "the-binding-token",
+        proxy_bearer="host-initial-bearer",
+    )
+
+    assert captured["authorization"] == "Bearer host-initial-bearer"
+    assert captured["binding_token"] == "the-binding-token"
+
+
+def test_managed_mint_factory_promotes_minted_jwt_to_proxy_bearer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After first mint the factory uses the minted JWT (not the seed bearer) for subsequent mints."""
+    mint_call_bearers: list[str | None] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        mint_call_bearers.append(request.headers.get("authorization"))
+        return httpx.Response(200, json={"token": "minted-jwt", "expires_at": time.time() + 1800})
+
+    real_client = httpx.Client
+
+    def _fake_client(**kwargs: Any) -> httpx.Client:
+        return real_client(transport=httpx.MockTransport(_handler), **kwargs)
+
+    monkeypatch.setattr("omnigent.runner._entry.httpx.Client", _fake_client)
+
+    factory = _ManagedMintTokenFactory(
+        "https://s.example.com/v1/runners/runner_token_abc/token",
+        "https://s.example.com",
+        "binding-token",
+        proxy_bearer="seed-bearer",
+    )
+
+    # Force two mints by expiring the cache between calls.
+    factory()
+    factory._cached_expires_at = 0.0  # expire
+    factory()
+
+    assert mint_call_bearers[0] == "Bearer seed-bearer"
+    assert mint_call_bearers[1] == "Bearer minted-jwt"
 
 
 def test_runner_databricks_auth_injects_fresh_token_per_request() -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

Two separate bugs, both causing managed sandbox runners (e.g. ucode/Codex sessions) on Databricks Apps deployments to get 401 on every HTTP callback after startup. Root cause trace from session `3696033912226500`:

**Bug 1 — regression from #2762** (`_allow_delegated_mint=False`)

`_InitialAuthTokenFactory` passed `_allow_delegated_mint=False` to its fallback resolver. For managed runners with no SDK/OIDC credential, the fallback returns `None` → `RequestError("no token")`.

```
initial bearer → 401
  → invalidate → _make_auth_token_factory(_allow_delegated_mint=False)
    → no OIDC, no SDK → None → raise RequestError  🔥
```

Fix: remove `_allow_delegated_mint=False`. SDK/OIDC auth still wins when present; managed mint is the last resort when it isn't.

**Bug 2 — Apps proxy blocks unauthenticated mint requests**

`_mint_managed_owner_token` sends only `X-Omnigent-Runner-Tunnel-Token` with no `Authorization` header. The Databricks Apps proxy rejects unauthenticated requests with 401 before they reach Omnigent — so the binding-token exchange never succeeds.

```
POST /v1/runners/{id}/token
  X-Omnigent-Runner-Tunnel-Token: <binding>
  (no Authorization)
→ Apps proxy: 401  🔥
```

Fix: thread `proxy_bearer` through `_make_managed_mint_factory` → `_ManagedMintTokenFactory` → `_mint_managed_owner_token`, passed to `databricks_request_headers` as the `Authorization` header. `_InitialAuthTokenFactory` seeds it with the host's initial bearer (retained as `_last_initial_token` before clearing). After the first successful mint, the minted JWT replaces it as the proxy bearer for subsequent refreshes.

## Test Plan

```
python -m pytest tests/runner/test_runner_entry.py -x -q
```

79 tests pass, including 4 new:
- `test_initial_host_token_falls_back_to_managed_mint_when_no_sdk_auth` — managed runner (no SDK) recovers after initial bearer rejected
- `test_mint_managed_owner_token_includes_proxy_bearer_when_provided` — proxy_bearer lands in Authorization header
- `test_managed_mint_factory_promotes_minted_jwt_to_proxy_bearer` — minted JWT replaces seed bearer on subsequent refreshes

## Demo

<img width="1096" height="935" alt="image" src="https://github.com/user-attachments/assets/ddee46f4-589b-4d1f-8c89-62c0c59bd2fc" />


## Type of change

- [x] Bug fix

## Test coverage

- [x] Unit tests added / updated

## Coverage notes

N/A