### PR TITLE
perf(runner): avoid blocking event loop on runner client DB lookups

### DIFF
--- a/omnigent/runner/routing.py
+++ b/omnigent/runner/routing.py
@@ -9,6 +9,7 @@ tunnel.
 
 from __future__ import annotations
 
+import asyncio
 import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -115,6 +116,60 @@ class RunnerRouter:
             code=ErrorCode.CONFLICT,
         )
 
+    def client_for_pinned_runner(self, runner_id: str) -> RoutedRunner:
+        """Return a runner client when the caller already knows the runner id.
+
+        Avoids a DB round-trip for callers that have a pre-fetched
+        conversation with ``runner_id`` already populated.
+
+        :param runner_id: Runner UUID from ``conversation.runner_id``.
+        :returns: Selected runner id and client.
+        :raises OmnigentError: If the runner is offline.
+        """
+        session = self._registry.get(runner_id)
+        if session is None:
+            raise OmnigentError(
+                f"runner {runner_id!r} is offline",
+                code=ErrorCode.RUNNER_UNAVAILABLE,
+            )
+        return RoutedRunner(runner_id=runner_id, client=self._client_for_runner(runner_id))
+
+    async def aclient_for_session_resources(self, conversation_id: str) -> RoutedRunner:
+        """Async variant of :meth:`client_for_session_resources`.
+
+        Fetches the conversation in a thread so the event loop is not
+        blocked by the synchronous DB call.  Prefer this from async
+        request handlers; use :meth:`client_for_session_resources` only
+        from sync contexts.
+
+        :param conversation_id: Conversation/session id, e.g.
+            ``"conv_0123456789abcdef"``.
+        :returns: Selected runner id and client.
+        :raises OmnigentError: If the conversation is missing, the
+            pinned runner is offline, or no online runner is available.
+        """
+        conv = await asyncio.to_thread(
+            self._conversation_store.get_conversation, conversation_id
+        )
+        if conv is None:
+            raise OmnigentError("conversation not found", code=ErrorCode.NOT_FOUND)
+        if conv.runner_id:
+            session = self._registry.get(conv.runner_id)
+            if session is None:
+                raise OmnigentError(
+                    f"runner {conv.runner_id!r} is offline for conversation {conversation_id!r}",
+                    code=ErrorCode.RUNNER_UNAVAILABLE,
+                )
+            return RoutedRunner(
+                runner_id=conv.runner_id,
+                client=self._client_for_runner(conv.runner_id),
+            )
+        raise OmnigentError(
+            f"conversation {conversation_id!r} is not bound to a runner; "
+            "resume the session to bind a registered runner",
+            code=ErrorCode.CONFLICT,
+        )
+
     def client_for_session_resources(self, conversation_id: str) -> RoutedRunner:
         """
         Return a runner client for session resource access.
@@ -149,6 +204,38 @@ class RunnerRouter:
             f"conversation {conversation_id!r} is not bound to a runner; "
             "resume the session to bind a registered runner",
             code=ErrorCode.CONFLICT,
+        )
+
+    async def aclient_for_existing_conversation(
+        self, conversation_id: str
+    ) -> RoutedRunner | None:
+        """Async variant of :meth:`client_for_existing_conversation`.
+
+        Fetches the conversation in a thread so the event loop is not
+        blocked by the synchronous DB call.  Prefer this from async
+        request handlers; use :meth:`client_for_existing_conversation`
+        only from sync contexts.
+
+        :param conversation_id: Conversation id, e.g.
+            ``"conv_0123456789abcdef"``.
+        :returns: A routed runner when the conversation is pinned;
+            ``None`` when it is not pinned or not found.
+        :raises OmnigentError: If the pinned runner is offline.
+        """
+        conv = await asyncio.to_thread(
+            self._conversation_store.get_conversation, conversation_id
+        )
+        if conv is None or not conv.runner_id:
+            return None
+        session = self._registry.get(conv.runner_id)
+        if session is None:
+            raise OmnigentError(
+                f"runner {conv.runner_id!r} is offline for conversation {conversation_id!r}",
+                code=ErrorCode.RUNNER_UNAVAILABLE,
+            )
+        return RoutedRunner(
+            runner_id=conv.runner_id,
+            client=self._client_for_runner(conv.runner_id),
         )
 
     def client_for_existing_conversation(self, conversation_id: str) -> RoutedRunner | None:

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2194,7 +2194,15 @@ def create_app(
                 conv.agent_id,
             )
             try:
-                routed = runner_router.client_for_session_resources(conv.id)
+                # conv is already fetched; skip the DB round-trip by using
+                # the pinned runner_id directly.
+                if not conv.runner_id:
+                    _logger.debug(
+                        "_on_runner_connect: session %s has no runner_id, skipping",
+                        conv.id,
+                    )
+                    continue
+                routed = runner_router.client_for_pinned_runner(conv.runner_id)
             except OmnigentError:
                 _logger.exception(
                     "Failed to resolve runner client for session %s on reconnect",

--- a/omnigent/server/background_session_titles.py
+++ b/omnigent/server/background_session_titles.py
@@ -69,7 +69,7 @@ class RunnerBackgroundTitleGenerator:
         self._timeout_seconds = timeout_seconds
 
     async def __call__(self, request: BackgroundTitleRequest) -> str | None:
-        routed = self._runner_router.client_for_existing_conversation(request.session_id)
+        routed = await self._runner_router.aclient_for_existing_conversation(request.session_id)
         if routed is None:
             return None
         response = await routed.client.post(

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -3839,7 +3839,7 @@ async def _get_runner_client_impl(
 
     if runner_router is not None:
         try:
-            routed = runner_router.client_for_session_resources(
+            routed = await runner_router.aclient_for_session_resources(
                 session_id,
             )
             return routed.client
@@ -4361,7 +4361,7 @@ async def _get_runner_client_for_resource_access_impl(
 
     runner_router = get_runner_router()
     if runner_router is not None:
-        routed_runner = runner_router.client_for_session_resources(session_id)
+        routed_runner = await runner_router.aclient_for_session_resources(session_id)
         return routed_runner.client
     return cast("httpx.AsyncClient | None", get_runner_client())
 

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -6481,7 +6481,7 @@ async def _get_session_snapshot(
     runner_router = get_runner_router()
     if runner_router is not None:
         try:
-            routed = runner_router.client_for_session_resources(session_id)
+            routed = await runner_router.aclient_for_session_resources(session_id)
             runner_client = routed.client
         except (LookupError, httpx.HTTPError, OmnigentError):
             _logger.debug(

--- a/omnigent/server/routes/session_mcp_servers.py
+++ b/omnigent/server/routes/session_mcp_servers.py
@@ -273,7 +273,7 @@ async def _reset_runner_session_agent_cache(
     if runner_router is None:
         return
     try:
-        routed = runner_router.client_for_session_resources(session_id)
+        routed = await runner_router.aclient_for_session_resources(session_id)
     except (LookupError, httpx.HTTPError, OmnigentError):
         # The session may not be runner-bound yet. Persisting the bundle is
         # still correct; the next runner bind resolves the updated spec.

--- a/tests/codex_parity/test_codex_goal.py
+++ b/tests/codex_parity/test_codex_goal.py
@@ -140,7 +140,7 @@ class _CodexGoalRunnerRouter:
     def __init__(self, client: _CodexGoalRunnerClient | None) -> None:
         self.client = client
 
-    def client_for_session_resources(self, session_id: str) -> _CodexGoalRoutedRunner:
+    async def aclient_for_session_resources(self, session_id: str) -> _CodexGoalRoutedRunner:
         if self.client is None or session_id == "conv_codex_no_runner":
             raise LookupError(session_id)
         return _CodexGoalRoutedRunner(self.client)

--- a/tests/server/integration/test_routes_sessions_aliases.py
+++ b/tests/server/integration/test_routes_sessions_aliases.py
@@ -244,7 +244,7 @@ async def test_delete_session_when_runner_offline(client: httpx.AsyncClient) -> 
     conv_id = snapshot["id"]
 
     class _OfflineRunnerRouter:
-        def client_for_session_resources(self, session_id: str) -> object:
+        async def aclient_for_session_resources(self, session_id: str) -> object:
             del session_id
             raise OmnigentError(
                 "runner 'runner_token_offline' is offline",

--- a/tests/server/integration/test_session_host_launch.py
+++ b/tests/server/integration/test_session_host_launch.py
@@ -1713,7 +1713,7 @@ async def test_offline_runner_serves_file_content_and_changes_from_host(
     # raise RUNNER_UNAVAILABLE (the host-fallback trigger). The test client
     # runs no lifespan, so install a router that reproduces that signal.
     class _OfflineRunnerRouter:
-        def client_for_session_resources(self, session_id: str) -> object:
+        async def aclient_for_session_resources(self, session_id: str) -> object:
             del session_id
             raise OmnigentError("runner is offline", code=ErrorCode.RUNNER_UNAVAILABLE)
 
@@ -1773,7 +1773,7 @@ async def test_offline_runner_no_host_still_returns_503(
     session_id = session["id"]
 
     class _OfflineRunnerRouter:
-        def client_for_session_resources(self, session_id: str) -> object:
+        async def aclient_for_session_resources(self, session_id: str) -> object:
             del session_id
             raise OmnigentError("runner is offline", code=ErrorCode.RUNNER_UNAVAILABLE)
 

--- a/tests/server/integration/test_sessions_tunnel_three_layer.py
+++ b/tests/server/integration/test_sessions_tunnel_three_layer.py
@@ -898,7 +898,7 @@ async def test_on_runner_connect_restarts_relay_via_router(
     # ensure spy does not chain through — the real helper would spawn
     # an SSE task that errors immediately against the stub client.
     router = ap_app.state.runner_router
-    real_resolver = router.client_for_session_resources
+    real_resolver = router.aclient_for_session_resources
     routed_calls: list[str] = []
     routed_clients: dict[str, Any] = {}
 
@@ -912,14 +912,14 @@ async def test_on_runner_connect_restarts_relay_via_router(
         async def post(self, *args: Any, **kwargs: Any) -> _StubResponse:
             return _StubResponse()
 
-    def _spy_resolver(conv_id: str):  # type: ignore[no-untyped-def]
+    async def _spy_resolver(conv_id: str):  # type: ignore[no-untyped-def]
         routed_calls.append(conv_id)
-        real_routed = real_resolver(conv_id)
+        real_routed = await real_resolver(conv_id)
         fake = RoutedRunner(runner_id=real_routed.runner_id, client=_StubClient())  # type: ignore[arg-type]
         routed_clients[conv_id] = fake.client
         return fake
 
-    router.client_for_session_resources = _spy_resolver  # type: ignore[method-assign]
+    router.aclient_for_session_resources = _spy_resolver  # type: ignore[method-assign]
 
     real_ensure = sessions_routes._ensure_runner_relay
     ensure_calls: list[tuple[str, str | None, Any]] = []
@@ -1023,7 +1023,7 @@ async def test_on_runner_connect_restarts_relay_via_router(
             f"{other_session_id!r} bound to {other_runner_id!r}."
         )
     finally:
-        router.client_for_session_resources = real_resolver  # type: ignore[method-assign]
+        router.aclient_for_session_resources = real_resolver  # type: ignore[method-assign]
         sessions_routes._ensure_runner_relay = real_ensure  # type: ignore[assignment]
         if new_forwarder_task is not None:
             new_forwarder_task.cancel()
@@ -1063,7 +1063,7 @@ async def _reconnect_fires_connect_hook(
     from omnigent.server.routes import sessions as sessions_routes
 
     router = ap_app.state.runner_router
-    real_resolver = router.client_for_session_resources
+    real_resolver = router.aclient_for_session_resources
 
     class _StubResponse:
         status_code = 200
@@ -1075,11 +1075,11 @@ async def _reconnect_fires_connect_hook(
         async def post(self, *args: Any, **kwargs: Any) -> _StubResponse:
             return _StubResponse()
 
-    def _spy_resolver(conv_id: str):  # type: ignore[no-untyped-def]
-        real_routed = real_resolver(conv_id)
+    async def _spy_resolver(conv_id: str):  # type: ignore[no-untyped-def]
+        real_routed = await real_resolver(conv_id)
         return RoutedRunner(runner_id=real_routed.runner_id, client=_StubClient())  # type: ignore[arg-type]
 
-    router.client_for_session_resources = _spy_resolver  # type: ignore[method-assign]
+    router.aclient_for_session_resources = _spy_resolver  # type: ignore[method-assign]
 
     real_ensure = sessions_routes._ensure_runner_relay
 
@@ -1141,7 +1141,7 @@ async def _reconnect_fires_connect_hook(
 
         yield recovered_calls
     finally:
-        router.client_for_session_resources = real_resolver  # type: ignore[method-assign]
+        router.aclient_for_session_resources = real_resolver  # type: ignore[method-assign]
         sessions_routes._ensure_runner_relay = real_ensure  # type: ignore[assignment]
         sessions_routes._publish_runner_recovered_status = real_recover  # type: ignore[assignment]
         if forwarder_task is not None:

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -412,7 +412,7 @@ class _FakeRunnerRouter:
         self.client = client
         self.resource_calls: list[str] = []
 
-    def client_for_session_resources(self, session_id: str) -> _RoutedRunner:
+    async def aclient_for_session_resources(self, session_id: str) -> _RoutedRunner:
         self.resource_calls.append(session_id)
         return _RoutedRunner(self.client)
 

--- a/tests/server/routes/test_sessions_mcp_proxy.py
+++ b/tests/server/routes/test_sessions_mcp_proxy.py
@@ -33,7 +33,7 @@ class _RaisingRunnerClient:
 class _RaisingRunnerRouter:
     """RunnerRouter stub that hands back a client whose POST raises."""
 
-    def client_for_session_resources(self, conversation_id: str) -> RoutedRunner:
+    async def aclient_for_session_resources(self, conversation_id: str) -> RoutedRunner:
         """Return a routed runner whose client fails on use.
 
         :param conversation_id: Ignored session id.

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -572,7 +572,7 @@ async def test_session_snapshot_uses_router_when_singleton_unset(
         def __init__(self) -> None:
             self.resolved_for: list[str] = []
 
-        def client_for_session_resources(self, conversation_id: str) -> RoutedRunner:
+        async def aclient_for_session_resources(self, conversation_id: str) -> RoutedRunner:
             self.resolved_for.append(conversation_id)
             return RoutedRunner(runner_id="runner_test", client=fake_client)  # type: ignore[arg-type]
 
@@ -1861,7 +1861,7 @@ async def test_session_snapshot_prefers_router_over_singleton(
     singleton_client = _Client("idle")
 
     class _FakeRouter:
-        def client_for_session_resources(self, conversation_id: str) -> RoutedRunner:
+        async def aclient_for_session_resources(self, conversation_id: str) -> RoutedRunner:
             return RoutedRunner(runner_id="runner_test", client=router_client)  # type: ignore[arg-type]
 
     monkeypatch.setattr(

--- a/tests/server/routes/test_shell_permission_gate.py
+++ b/tests/server/routes/test_shell_permission_gate.py
@@ -178,7 +178,7 @@ class _FakeRunnerRouter:
     def __init__(self, client: _RecordingRunnerClient) -> None:
         self.client = client
 
-    def client_for_session_resources(self, session_id: str) -> _RoutedRunner:
+    async def aclient_for_session_resources(self, session_id: str) -> _RoutedRunner:
         return _RoutedRunner(self.client)
 
 

--- a/tests/server/routes/test_subagent_status_forward_recovery.py
+++ b/tests/server/routes/test_subagent_status_forward_recovery.py
@@ -299,7 +299,7 @@ async def test_recover_real_body_retry_resolves_healed_runner() -> None:
     class _Router:
         """Re-reads the conv's CURRENT runner_id; resolves only the live one."""
 
-        def client_for_session_resources(self, conversation_id: str) -> Any:
+        async def aclient_for_session_resources(self, conversation_id: str) -> Any:
             runner_id = convs[conversation_id].runner_id
             if runner_id != "R_live":
                 raise LookupError(f"runner {runner_id} offline")

--- a/tests/server/test_background_session_titles.py
+++ b/tests/server/test_background_session_titles.py
@@ -410,7 +410,7 @@ class _FakeRunnerRouter:
         self.client = client
         self.session_ids: list[str] = []
 
-    def client_for_existing_conversation(self, session_id: str) -> _FakeRoutedRunner:
+    async def aclient_for_existing_conversation(self, session_id: str) -> _FakeRoutedRunner:
         self.session_ids.append(session_id)
         return _FakeRoutedRunner(self.client)
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

Several high-traffic endpoints (`GET .../filesystem`, `/changes`, `/items`, `GET /sessions/{id}`) showed P50 latency of 350–750 ms but P95/P99 in the 20–30 s range. The bimodal distribution points to event-loop starvation under concurrent load.

Root cause: `RunnerRouter.client_for_session_resources()` and `client_for_existing_conversation()` called `conversation_store.get_conversation()` — a synchronous DB call — directly on the event loop thread. Every filesystem, changes, environment, and session-items request hit this path. Under load, one slow DB call stalled the loop for all concurrent requests, inflating the tail dramatically.

Fix: add async variants that route the DB call through `asyncio.to_thread`, plus a zero-cost variant for callers that already hold the conversation.

- `aclient_for_session_resources()` — async, DB in thread pool; used by all async request handlers
- `aclient_for_existing_conversation()` — same pattern for the existing-conversation path
- `client_for_pinned_runner(runner_id)` — no DB call; used in `app._on_runner_connect` which already has the conversation from `list_conversations_by_runner_id`
- Sync methods kept intact for sync callers (`workflow.py`, `_runner_ws_tunnel.py`) — fully backwards compatible

Updated async call sites: `helpers._get_runner_client_for_resource_access_impl`, `helpers._get_runner_client_impl`, `orchestration` (snapshot build), `session_mcp_servers` (agent-cache reset), `background_session_titles`, `app._on_runner_connect`.

## Test Plan

- [x] Routing unit tests pass (`tests/runner/test_routing.py`)
- [x] All test fakes updated from `def client_for_session_resources` to `async def aclient_for_session_resources`
- [ ] Performance validation against latency dashboard after deploy

## Verification Commands

```bash
python -m pytest tests/runner/test_routing.py tests/server/test_background_session_titles.py tests/server/routes/test_session_resources.py -x -q
```

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The async variants have identical logic to their sync counterparts; the only behavioral change is that the DB call runs in a thread pool instead of on the event loop.