### PR TITLE
fix(setup): count visual terminal lines for clear-on-exit erase

### DIFF
--- a/omnigent/onboarding/interactive.py
+++ b/omnigent/onboarding/interactive.py
@@ -214,6 +214,43 @@ def _render_menu(
     return buf.getvalue()
 
 
+def _count_terminal_lines(rendered: str, width: int) -> int:
+    """Count the visual terminal lines that *rendered* occupies.
+
+    ``rendered.count("\\n")`` undercounts when Rich wraps a logical line
+    across multiple terminal rows (e.g. a long status label near the edge).
+    Each logical line's display-cell width, divided by *width* (with ceiling),
+    gives the real number of rows it occupies — which is what the cursor-up
+    escape needs to erase the full frame.
+
+    :param rendered: ANSI-escaped string as produced by :func:`_render_menu`.
+    :param width: Terminal column count used when rendering.
+    :returns: Total visual rows the string occupies.
+    """
+    import re
+
+    if not rendered:
+        return 0
+    # Strip ANSI escape sequences to measure plain display width.
+    ansi_re = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+    total = 0
+    for line in rendered.split("\n"):
+        plain = ansi_re.sub("", line)
+        line_cells = cell_len(plain)
+        # A zero-width line still occupies one row — except the empty segment
+        # that split() produces after the very last newline (a phantom row).
+        if line_cells == 0:
+            total += 1
+        else:
+            total += max(1, -(-line_cells // width))  # ceiling division
+    # split() yields one extra empty segment after the final newline; the
+    # trailing newline itself is the line separator, not a new line, so
+    # subtract that phantom row.
+    if rendered.endswith("\n"):
+        total -= 1
+    return max(total, 0)
+
+
 def _normalize_selectable(options: list[str], selectable: list[bool] | None) -> list[bool]:
     """Validate/expand the *selectable* mask for a menu.
 
@@ -448,7 +485,7 @@ def select(
         sys.stdout.write("\033[J")  # Clear from cursor to end of screen.
         sys.stdout.write(rendered)
         sys.stdout.flush()
-        prev_lines[0] = rendered.count("\n")
+        prev_lines[0] = _count_terminal_lines(rendered, width)
 
     try:
         old_attrs = termios.tcgetattr(fd)

--- a/tests/onboarding/test_interactive.py
+++ b/tests/onboarding/test_interactive.py
@@ -477,3 +477,45 @@ def test_render_menu_compact_truncates_long_description_to_one_line() -> None:
     assert len(hint_lines) == 1
     assert "…" in hint_lines[0]
     assert len(hint_lines[0]) <= 40
+
+
+# ---------------------------------------------------------------------------
+# _count_terminal_lines
+# ---------------------------------------------------------------------------
+
+
+def test_count_terminal_lines_no_wrap() -> None:
+    """Short lines count as one row each; no wrapping."""
+    rendered = "foo\nbar\nbaz\n"
+    assert interactive._count_terminal_lines(rendered, width=80) == 3
+
+
+def test_count_terminal_lines_wraps_long_line() -> None:
+    """A line longer than *width* cells counts as two rows."""
+    # 'a' * 100 is 100 cells wide; at width=80 it wraps to 2 rows.
+    rendered = "a" * 100 + "\n"
+    assert interactive._count_terminal_lines(rendered, width=80) == 2
+
+
+def test_count_terminal_lines_exactly_full_width() -> None:
+    """A line exactly *width* cells wide does not wrap."""
+    rendered = "a" * 80 + "\n"
+    assert interactive._count_terminal_lines(rendered, width=80) == 1
+
+
+def test_count_terminal_lines_ansi_stripped() -> None:
+    """ANSI escape sequences are not counted as display cells."""
+    # Bold red 'hello' — escape sequences add bytes but no display cells.
+    rendered = "\x1b[1;31mhello\x1b[0m\n"
+    assert interactive._count_terminal_lines(rendered, width=80) == 1
+
+
+def test_count_terminal_lines_matches_naive_for_short_content() -> None:
+    """For content that never wraps, result equals the newline count."""
+    rendered = "line one\nline two\nline three\n"
+    newline_count = rendered.count("\n")
+    assert interactive._count_terminal_lines(rendered, width=80) == newline_count
+
+
+def test_count_terminal_lines_empty_string() -> None:
+    assert interactive._count_terminal_lines("", width=80) == 0


### PR DESCRIPTION
## Summary

- `rendered.count("\n")` undercounts visible terminal rows when Rich wraps a long status label (e.g. `✓ Isaac-Databricks-Ai-Gateway`) across multiple rows at the actual terminal width
- The cursor-up escape in `clear_on_exit` didn't move far enough, leaving stale menu frames — causing the `Configure harnesses` block to stack on every loop iteration of `_run_configure_harnesses_interactive()`
- Added `_count_terminal_lines(rendered, width)` which strips ANSI escapes and uses ceiling division of each line's cell width by terminal width to count actual visual rows

## Test Plan

- `pytest tests/onboarding/test_interactive.py` — all 28 tests pass, including 6 new tests covering `_count_terminal_lines` (no-wrap, wrapping, exactly-full-width, ANSI stripping, naive-count equivalence for short content, empty string)
- Manually reproduce by running `omnigent setup` at a narrow terminal where a provider name like `Isaac-Databricks-Ai-Gateway` is near the column edge, selecting a harness, and returning — the stale header should no longer accumulate

## Demo

<img width="658" height="369" alt="image" src="https://github.com/user-attachments/assets/4d22e577-251c-4a66-a34e-3303468b3c98" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test coverage

- [x] New tests added

## Coverage notes

New `_count_terminal_lines` unit tests cover the fix directly.