### PR TITLE
feat(claude-native): derive idle/working status from Claude's session file

### DIFF
--- a/omnigent/claude_native_status_file.py
+++ b/omnigent/claude_native_status_file.py
@@ -1,0 +1,351 @@
+"""Resolve and read Claude Code's per-session status metadata file.
+
+Claude Code writes a per-process JSON file at
+``<config_dir>/sessions/<pid>.json`` (its internal "concurrentSessions"
+registry, present since v2.1.139 — the file that also backs
+``claude agents``). For an interactive session it carries a ``status``
+field that flips ``idle`` ⇄ ``busy`` ⇄ ``waiting`` as the agent works,
+which is a cleaner running/idle signal than diffing the tmux pane.
+
+This module owns two pure pieces the claude-native status watcher builds
+on:
+
+- :func:`resolve_status_file` — find the file for a launched Claude,
+  keyed primarily by its pid (which equals the tmux ``#{pane_pid}`` on
+  the omnigent launch path), with a ``sessionId`` cross-check and a
+  bounded directory scan as fallback.
+- :func:`read_session_status` — read the file and map its interactive
+  status to the runner's ``running`` / ``idle`` vocabulary.
+
+The file is an **undocumented internal detail** of Claude Code, so the
+watcher that consumes this treats an unresolved / unreadable file as
+"fall back to the PTY watcher", never as an error.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+# Runner-side status vocabulary the file maps onto. ``busy`` and
+# ``waiting`` both mean "the turn is not finished" from the session's
+# point of view, so both map to ``running`` (Option A — ``waiting`` is
+# not yet surfaced as a distinct "needs input" state).
+RUNNING = "running"
+IDLE = "idle"
+
+# Claude interactive-session status literals (writer ``b3f`` in the
+# bundle). ``running``/``completed``/``failed`` belong to background jobs
+# and are not expected here, but map defensively rather than crash.
+_STATUS_TO_RUNNER: dict[str, str] = {
+    "busy": RUNNING,
+    "waiting": RUNNING,
+    "idle": IDLE,
+    # Background-job literals, mapped defensively for robustness.
+    "running": RUNNING,
+    "completed": IDLE,
+    "failed": IDLE,
+    "error": IDLE,
+    "done": IDLE,
+}
+
+# Only consider files touched within this window when scanning by
+# sessionId, so a heavy user's accumulated stale files (Claude does not
+# always unlink on crash) never turn resolution into an unbounded read.
+# A just-launched Claude's file is fresh by definition.
+_SCAN_FRESHNESS_WINDOW_S = 120.0
+
+
+@dataclass(frozen=True)
+class SessionStatus:
+    """A single read of the Claude session status file.
+
+    :param runner_status: Mapped runner vocabulary — :data:`RUNNING` or
+        :data:`IDLE`.
+    :param raw_status: The file's own ``status`` string, e.g. ``"busy"``,
+        ``"idle"``, ``"waiting"`` — kept for logging / future
+        "needs input" surfacing.
+    :param status_updated_at: The file's ``statusUpdatedAt`` epoch-ms
+        value, or ``None`` when absent.
+    """
+
+    runner_status: str
+    raw_status: str
+    status_updated_at: int | None
+
+
+def sessions_dir(config_dir: Path | None = None) -> Path:
+    """Return Claude Code's ``sessions`` directory.
+
+    Mirrors Claude's own resolution: ``CLAUDE_CONFIG_DIR`` when set,
+    otherwise ``~/.claude`` — matching :mod:`omnigent.session_import.local`.
+
+    :param config_dir: Explicit Claude config dir override (tests). When
+        ``None`` the environment / home default is used.
+    :returns: The ``<config_dir>/sessions`` path (not guaranteed to exist).
+    """
+    if config_dir is not None:
+        return config_dir / "sessions"
+    configured = os.environ.get("CLAUDE_CONFIG_DIR")
+    home = Path(configured).expanduser() if configured else Path.home() / ".claude"
+    return home / "sessions"
+
+
+def _read_json_file(path: Path) -> dict[str, object] | None:
+    """Read and parse a JSON object file, or ``None`` on any failure.
+
+    :param path: File to read.
+    :returns: The parsed object, or ``None`` when missing, unreadable, or
+        not a JSON object (a half-written file reads as ``None`` and the
+        caller simply retries next tick).
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _matches_session(
+    record: dict[str, object],
+    *,
+    expected_session_id: str | None,
+) -> bool:
+    """Whether a status record belongs to the launched Claude session.
+
+    When we know Claude's own session uuid (captured by the bridge from
+    hook events), require an exact match. When we don't yet (the first
+    hook has not fired), accept any interactive record — the pid-keyed
+    lookup already scoped it to this process.
+
+    :param record: A parsed ``<pid>.json`` object.
+    :param expected_session_id: Claude session uuid to match, or ``None``
+        to skip the cross-check.
+    :returns: ``True`` when the record is a usable match.
+    """
+    if record.get("kind") != "interactive":
+        return False
+    if expected_session_id is None:
+        return True
+    return record.get("sessionId") == expected_session_id
+
+
+def resolve_status_file(
+    *,
+    pane_pid: int | None,
+    expected_session_id: str | None,
+    config_dir: Path | None = None,
+    now: float | None = None,
+) -> Path | None:
+    """Resolve the status file for a launched Claude session.
+
+    Resolution order:
+
+    1. **Pid lookup** (``<pane_pid>.json``): on the omnigent launch path
+       tmux ``exec``s ``claude`` as the pane process, so the file's pid
+       equals ``#{pane_pid}``. This is the common O(1) case.
+    2. **SessionId scan**: if the pid file is absent or fails the
+       cross-check (e.g. a shell/sandbox wrapper sits between the pane and
+       ``claude``), scan recent files for a matching ``sessionId``. Only
+       runs when ``expected_session_id`` is known, bounded to files
+       modified within :data:`_SCAN_FRESHNESS_WINDOW_S`.
+
+    :param pane_pid: The tmux pane pid, or ``None`` when unknown.
+    :param expected_session_id: Claude session uuid from the bridge, or
+        ``None`` before the first hook reports it.
+    :param config_dir: Explicit Claude config dir override (tests).
+    :param now: Monotonic-independent wall clock override (tests); uses
+        :func:`time.time` when ``None``.
+    :returns: The resolved file path, or ``None`` when no confident match
+        exists yet (caller falls back to the PTY watcher).
+    """
+    directory = sessions_dir(config_dir)
+
+    if pane_pid is not None:
+        candidate = directory / f"{pane_pid}.json"
+        record = _read_json_file(candidate)
+        if record is not None and _matches_session(
+            record, expected_session_id=expected_session_id
+        ):
+            return candidate
+
+    if expected_session_id is None:
+        return None
+
+    clock = time.time() if now is None else now
+    try:
+        entries = list(directory.iterdir())
+    except OSError:
+        return None
+    for entry in entries:
+        if entry.suffix != ".json":
+            continue
+        try:
+            mtime = entry.stat().st_mtime
+        except OSError:
+            continue
+        if clock - mtime > _SCAN_FRESHNESS_WINDOW_S:
+            continue
+        record = _read_json_file(entry)
+        if record is not None and _matches_session(
+            record, expected_session_id=expected_session_id
+        ):
+            return entry
+    return None
+
+
+def read_session_status(path: Path) -> SessionStatus | None:
+    """Read a resolved status file and map it to the runner vocabulary.
+
+    :param path: A status file previously returned by
+        :func:`resolve_status_file`.
+    :returns: The mapped :class:`SessionStatus`, or ``None`` when the file
+        is missing, unreadable, or carries no recognized ``status`` (the
+        caller keeps its previous status and retries next tick).
+    """
+    record = _read_json_file(path)
+    if record is None:
+        return None
+    raw_status = record.get("status")
+    if not isinstance(raw_status, str):
+        return None
+    runner_status = _STATUS_TO_RUNNER.get(raw_status)
+    if runner_status is None:
+        return None
+    updated = record.get("statusUpdatedAt")
+    status_updated_at = updated if isinstance(updated, int) else None
+    return SessionStatus(
+        runner_status=runner_status,
+        raw_status=raw_status,
+        status_updated_at=status_updated_at,
+    )
+
+
+# Attempts to resolve the file before giving up and leaving the PTY
+# watcher authoritative for the session's lifetime. At the claude-native
+# poll cadence (~0.2s) this is a few seconds — long enough for a booting
+# Claude to write its file and for the first hook to report the session
+# id, short enough that an old Claude (pre-v2.1.139, no file) or a broken
+# config dir falls back promptly without scanning forever.
+_MAX_RESOLVE_ATTEMPTS = 40
+
+
+class SessionStatusPoller:
+    """Per-tick reader that turns the status file into status edges.
+
+    Owns the small amount of state the claude-native watcher needs across
+    ticks: the lazily-resolved file path, an mtime short-circuit so an
+    unchanged file costs one ``stat``, and edge-deduping so a status
+    callback fires only on ``running`` ⇄ ``idle`` transitions.
+
+    Lifecycle, all on the single watcher thread (no lock needed):
+
+    - **Resolving:** each :meth:`tick` retries :func:`resolve_status_file`
+      until it locks on or :data:`_MAX_RESOLVE_ATTEMPTS` is exhausted.
+      While resolving, :attr:`active` is ``False`` and the caller keeps
+      the PTY watcher authoritative for status.
+    - **Active:** once resolved, :attr:`active` is ``True`` (the caller
+      mutes PTY-derived status) and each tick reads the file and fires the
+      callback on a changed runner status.
+    - **Exhausted:** if resolution never succeeds, :attr:`active` stays
+      ``False`` permanently and the PTY watcher remains the status source.
+
+    :param on_status: Callback invoked with :data:`RUNNING` / :data:`IDLE`
+        on each status transition (and once on first read). Must not block
+        the watcher thread for long.
+    :param pane_pid_getter: Returns the terminal's current pane pid, or
+        ``None``. Called during resolution; on the omnigent launch path
+        this pid names the status file.
+    :param session_id_getter: Returns Claude's own session uuid once the
+        bridge has captured it, or ``None`` before the first hook. Used to
+        cross-check the pid file and to scan as a fallback.
+    :param config_dir: Explicit Claude config dir override (tests).
+    """
+
+    def __init__(
+        self,
+        *,
+        on_status: Callable[[str], None],
+        pane_pid_getter: Callable[[], int | None],
+        session_id_getter: Callable[[], str | None],
+        config_dir: Path | None = None,
+    ) -> None:
+        self._on_status = on_status
+        self._pane_pid_getter = pane_pid_getter
+        self._session_id_getter = session_id_getter
+        self._config_dir = config_dir
+        self._path: Path | None = None
+        self._attempts = 0
+        self._exhausted = False
+        self._last_mtime: float | None = None
+        self._last_runner_status: str | None = None
+
+    @property
+    def active(self) -> bool:
+        """Whether the file is currently the authoritative status source.
+
+        ``True`` only while a resolved file is still being read. The caller
+        reads this to decide whether to suppress the PTY-derived status
+        edges (file is authoritative) or keep them (still resolving, gave
+        up, or the file vanished). Goes back to ``False`` once the file
+        disappears — clean exit unlinks it — so the PTY watcher cleanly
+        reclaims status and exit detection.
+        """
+        return self._path is not None and not self._exhausted
+
+    def tick(self) -> None:
+        """Advance one poll: resolve if needed, then publish on change.
+
+        Safe to call every poll; a no-op once resolution is exhausted, and
+        an unchanged active file costs a single ``stat``.
+        """
+        if self._exhausted:
+            return
+        if self._path is None:
+            self._try_resolve()
+            if self._path is None:
+                return
+        self._read_and_publish()
+
+    def _try_resolve(self) -> None:
+        """Attempt one resolution, retiring to the PTY watcher on timeout."""
+        self._attempts += 1
+        path = resolve_status_file(
+            pane_pid=self._pane_pid_getter(),
+            expected_session_id=self._session_id_getter(),
+            config_dir=self._config_dir,
+        )
+        if path is not None:
+            self._path = path
+            return
+        if self._attempts >= _MAX_RESOLVE_ATTEMPTS:
+            self._exhausted = True
+
+    def _read_and_publish(self) -> None:
+        """Read the resolved file and fire the callback on a status change."""
+        assert self._path is not None
+        try:
+            mtime = self._path.stat().st_mtime
+        except OSError:
+            # File vanished (clean exit unlinks it, or a crash). Exit
+            # detection rides the PTY watcher, so just stop polling.
+            self._exhausted = True
+            return
+        if self._last_mtime is not None and mtime == self._last_mtime:
+            return
+        self._last_mtime = mtime
+        status = read_session_status(self._path)
+        if status is None:
+            return
+        if status.runner_status == self._last_runner_status:
+            return
+        self._last_runner_status = status.runner_status
+        self._on_status(status.runner_status)

--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -1506,6 +1506,7 @@ class TerminalInstance:
         *,
         on_activity: Callable[[], None] | None = None,
         on_exit: Callable[[], None] | None = None,
+        on_tick: Callable[[], None] | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
         replace: bool = False,
@@ -1544,6 +1545,12 @@ class TerminalInstance:
         :param on_exit: Optional sync callback invoked when the watcher
             observes that tmux has disappeared. Same non-blocking contract
             as *on_idle*.
+        :param on_tick: Optional sync callback invoked once per poll tick
+            (after the exit check, before the pane diff), regardless of
+            whether the pane changed. Lets a caller drive an out-of-band
+            status source — e.g. the claude-native watcher reading Claude's
+            ``sessions/<pid>.json`` — on the same cadence without a second
+            thread. Same non-blocking contract as *on_idle*.
         :param idle_threshold_s: Per-watcher diff-track idle threshold in
             seconds passed to :class:`_IdleDetector`, e.g. ``1.0`` for the
             claude-native status watcher. ``None`` uses the module
@@ -1559,11 +1566,11 @@ class TerminalInstance:
         """
         if not self.running:
             raise RuntimeError("Cannot start idle watcher before launch")
-        if on_idle is None and on_activity is None and on_exit is None:
+        if on_idle is None and on_activity is None and on_exit is None and on_tick is None:
             raise ValueError(
                 "start_idle_watcher_thread requires at least one of "
-                "on_idle / on_activity / on_exit — a watcher with none would poll "
-                "tmux forever with no effect."
+                "on_idle / on_activity / on_exit / on_tick — a watcher with none "
+                "would poll tmux forever with no effect."
             )
         if self._idle_thread is not None and self._idle_thread.is_alive():
             if not replace:
@@ -1578,6 +1585,7 @@ class TerminalInstance:
                 "on_idle": on_idle,
                 "on_activity": on_activity,
                 "on_exit": on_exit,
+                "on_tick": on_tick,
                 "idle_threshold_s": idle_threshold_s,
                 "poll_interval_s": poll_interval_s,
             },
@@ -1593,6 +1601,7 @@ class TerminalInstance:
         on_idle: Callable[[], None] | None = None,
         on_activity: Callable[[], None] | None = None,
         on_exit: Callable[[], None] | None = None,
+        on_tick: Callable[[], None] | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
     ) -> None:
@@ -1615,6 +1624,9 @@ class TerminalInstance:
             tick the pane content changed. Skipped when ``None``.
         :param on_exit: Optional callback fired when tmux disappears.
             Skipped when ``None``.
+        :param on_tick: Optional per-tick callback fired every poll after
+            the exit check (see :meth:`start_idle_watcher_thread`); skipped
+            when ``None``.
         :param idle_threshold_s: Per-watcher diff-track idle threshold in
             seconds forwarded to :class:`_IdleDetector`, e.g. ``1.0``.
             ``None`` uses the module default.
@@ -1653,6 +1665,12 @@ class TerminalInstance:
                 self.running = False
                 if on_exit is not None:
                     self._fire_watch_callback(on_exit, "exit")
+                return
+            # Per-tick out-of-band status hook (e.g. claude-native reading
+            # Claude's sessions/<pid>.json). Fired after the exit checks so
+            # it never runs for a dead pane, and before the pane diff so an
+            # authoritative file status can preempt the PTY-derived edge.
+            if on_tick is not None and not self._fire_watch_callback(on_tick, "tick"):
                 return
             # A pane change that lands within the recent-interaction window
             # is a client-driven repaint (attach/detach reflow, focus,
@@ -1715,6 +1733,30 @@ class TerminalInstance:
         except RuntimeError:
             return False
         return "1" in out.split()
+
+    def pane_pid_sync(self) -> int | None:
+        """Return the pid of the pane's foreground process, or ``None``.
+
+        This is the pid tmux ``exec``'d into the pane — for a native agent
+        terminal that's the agent CLI itself (e.g. ``claude``). Used by the
+        claude-native status watcher to key Claude's ``sessions/<pid>.json``
+        metadata file. Synchronous sibling of the other ``*_sync`` probes so
+        the threaded watcher can call it without an event loop.
+
+        :returns: The pane pid, or ``None`` when tmux fails or reports no
+            usable value (server gone, pane dead).
+        """
+        try:
+            out = self._tmux_output_sync("list-panes", "-t", self.tmux_target, "-F", "#{pane_pid}")
+        except RuntimeError:
+            return None
+        first = out.split()
+        if not first:
+            return None
+        try:
+            return int(first[0])
+        except ValueError:
+            return None
 
     def _fire_watch_callback(self, callback: Callable[[], None], kind: str) -> bool:
         """

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -37,6 +37,7 @@ from omnigent.entities.session_resources import (
 )
 
 if TYPE_CHECKING:
+    from omnigent.claude_native_status_file import SessionStatusPoller
     from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
     from omnigent.inner.os_env import OSEnvironment
     from omnigent.inner.terminal import TerminalInstance
@@ -1044,6 +1045,34 @@ class SessionResourceRegistry:
         # means "never emitted", so the first changed tick always fires.
         last_activity_emit: dict[str, float | None] = {"value": None}
 
+        def _publish_status(status: str) -> None:
+            # Publish one running/idle edge: dedup against the last value,
+            # memo for exit classification, and hop to the loop (publishers
+            # are loop-only). Shared by the PTY edges and the claude-native
+            # status-file poller so both go through the same dedup/memo.
+            if status_publisher is None or last_status["value"] == status:
+                return
+            last_status["value"] = status
+            self._set_session_status_memo(session_id, status)
+            loop.call_soon_threadsafe(status_publisher, session_id, status)
+
+        # claude-native prefers Claude's own ``sessions/<pid>.json`` status
+        # (present since Claude Code v2.1.139) over the PTY frame-diff: it
+        # flips on the real turn edge and distinguishes ``waiting`` (needs
+        # input) from ``busy``. Built only for the claude-native role; other
+        # native roles stay PTY-only. ``None`` (old Claude, missing file)
+        # leaves the PTY watcher authoritative — see ``poller.active`` gating
+        # in the PTY edges below.
+        status_poller = (
+            self._build_claude_native_status_poller(
+                session_id=session_id,
+                instance=instance,
+                on_status=_publish_status,
+            )
+            if emit_status and resource_role == CLAUDE_NATIVE_TERMINAL_ROLE
+            else None
+        )
+
         def _on_activity() -> None:
             # Runs on the watcher daemon thread; hop to the loop so the
             # loop-only publishers (queue.put_nowait) are touched safely.
@@ -1064,12 +1093,12 @@ class SessionResourceRegistry:
                     loop.call_soon_threadsafe(activity_publisher, session_id, resource_id)
             # Pane changed → the agent is working. Coalesce to the
             # idle→running edge so a continuously-redrawing pane doesn't
-            # re-emit ``running`` every poll.
-            if emit_status and status_publisher is not None and last_status["value"] != "running":
-                last_status["value"] = "running"
-                # Track for exit classification: a pane exit now reads as a crash.
-                self._set_session_status_memo(session_id, "running")
-                loop.call_soon_threadsafe(status_publisher, session_id, "running")
+            # re-emit ``running`` every poll. Skipped while the status-file
+            # poller is authoritative (it owns the edge, and the file
+            # distinguishes ``waiting`` from ``busy`` — which the pane
+            # diff can't); the PTY edge resumes if the poller falls back.
+            if emit_status and (status_poller is None or not status_poller.active):
+                _publish_status("running")
 
         def _on_exit() -> None:
             def _schedule() -> None:
@@ -1123,13 +1152,13 @@ class SessionResourceRegistry:
             # Pane quiet for the claude-native status threshold → the
             # agent has stopped. Edge-triggered: re-arms only after new
             # output mutates the pane (which flips back to ``running``).
-            if status_publisher is not None and last_status["value"] != "idle":
-                last_status["value"] = "idle"
-                # Track for exit classification: a pane exit now reads as clean.
-                # Edge ordering: the watcher thread runs idle/exit serially, so
-                # this idle commits before any later on_exit reads the memo.
-                self._set_session_status_memo(session_id, "idle")
-                loop.call_soon_threadsafe(status_publisher, session_id, "idle")
+            # Skipped while the status-file poller is authoritative — the
+            # 1s pane-quiescence heuristic would otherwise race the file's
+            # real turn edge; the PTY idle resumes if the poller falls back.
+            # Edge ordering: the watcher thread runs idle/exit serially, so
+            # this idle commits before any later on_exit reads the memo.
+            if status_poller is None or not status_poller.active:
+                _publish_status("idle")
             # Clear the activity throttle so the next working episode emits
             # its first pulse immediately, keeping the activity badge
             # aligned with the running-status edge (which also re-fires on
@@ -1137,13 +1166,71 @@ class SessionResourceRegistry:
             # behind it.
             last_activity_emit["value"] = None
 
+        def _on_tick() -> None:
+            # Drive the status-file poller on the watcher cadence. No-op
+            # once it resolves the file and every read is unchanged, cheap
+            # (one ``stat``) otherwise; retires to the PTY watcher if the
+            # file never appears (old Claude) or later vanishes.
+            if status_poller is not None:
+                status_poller.tick()
+
         instance.start_idle_watcher_thread(
             on_activity=_on_activity,
             on_idle=_on_idle,
             on_exit=_on_exit,
+            on_tick=_on_tick if status_poller is not None else None,
             idle_threshold_s=_CLAUDE_NATIVE_STATUS_IDLE_THRESHOLD_SECONDS,
             poll_interval_s=_CLAUDE_NATIVE_STATUS_POLL_INTERVAL_SECONDS,
             replace=replace,
+        )
+
+    def _build_claude_native_status_poller(
+        self,
+        *,
+        session_id: str,
+        instance: TerminalInstance,
+        on_status: Callable[[str], None],
+    ) -> SessionStatusPoller:
+        """Build the claude-native ``sessions/<pid>.json`` status poller.
+
+        Keyed primarily by the terminal's pane pid (which equals Claude's
+        pid on this launch path, so the file is ``<pane_pid>.json``), with
+        Claude's own session uuid — read lazily from the bridge state once
+        a hook reports it — as a cross-check and scan fallback.
+
+        Lazy-imported so the generic runner module keeps no claude-native
+        import at load time (mirrors the rest of the native wiring).
+
+        :param session_id: Owning session/conversation id, used to derive
+            the bridge directory holding the captured Claude session uuid.
+        :param instance: The launched terminal instance (exposes
+            ``pane_pid_sync``).
+        :param on_status: Callback fired with ``running`` / ``idle`` on each
+            status transition.
+        :returns: A ``SessionStatusPoller`` the watcher drives per tick.
+        """
+        from omnigent.claude_native_bridge import (
+            bridge_dir_for_conversation_id,
+            read_claude_session_id,
+        )
+        from omnigent.claude_native_status_file import SessionStatusPoller
+
+        bridge_dir = bridge_dir_for_conversation_id(session_id)
+
+        def _session_id_getter() -> str | None:
+            # Best-effort: the bridge records Claude's uuid only after the
+            # first hook fires. ``None`` before then simply means the poller
+            # relies on the pid match (already scoped to this process) until
+            # the cross-check becomes available.
+            try:
+                return read_claude_session_id(bridge_dir)
+            except Exception:  # noqa: BLE001 - best-effort cross-check; never break the watcher.
+                return None
+
+        return SessionStatusPoller(
+            on_status=on_status,
+            pane_pid_getter=instance.pane_pid_sync,
+            session_id_getter=_session_id_getter,
         )
 
     async def _handle_terminal_exit(

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -167,6 +167,59 @@ def test_threaded_idle_watcher_keeps_last_pane_text_on_exit(tmp_path: Path) -> N
     assert instance.last_pane_text() == "startup failed\ntry config"
 
 
+def test_threaded_idle_watcher_fires_on_tick_each_poll(tmp_path: Path) -> None:
+    """``on_tick`` fires every poll (not only on pane change), so the
+    claude-native status-file poller runs on the watcher cadence.
+
+    :param tmp_path: Temporary directory used for placeholder tmux paths.
+    """
+    instance = TerminalInstance(
+        name="runtime",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+    # A steady, unchanging pane: no activity edges, but ticks still fire.
+    instance._capture_pane_for_idle_or_none = lambda: "steady frame"  # type: ignore[method-assign]
+    instance._pane_is_dead = lambda: False  # type: ignore[method-assign]
+    ticks = threading.Event()
+    count = {"n": 0}
+
+    def _on_tick() -> None:
+        count["n"] += 1
+        if count["n"] >= 3:
+            ticks.set()
+
+    instance.start_idle_watcher_thread(on_tick=_on_tick, poll_interval_s=0.01)
+    assert ticks.wait(timeout=1.0)
+    instance._stop_idle_watcher_thread()
+    assert count["n"] >= 3
+
+
+def test_pane_pid_sync_returns_pane_process_pid(tmp_path: Path) -> None:
+    """``pane_pid_sync`` parses the tmux ``#{pane_pid}`` value.
+
+    :param tmp_path: Temporary directory used for placeholder tmux paths.
+    """
+    instance = TerminalInstance(
+        name="claude",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+    instance._tmux_output_sync = lambda *args: "54321\n"  # type: ignore[method-assign]
+    assert instance.pane_pid_sync() == 54321
+
+    # A tmux failure (server gone) yields ``None`` rather than raising.
+    def _raise(*args: object) -> str:
+        raise RuntimeError("no server")
+
+    instance._tmux_output_sync = _raise  # type: ignore[method-assign]
+    assert instance.pane_pid_sync() is None
+
+
 @dataclass
 class _ProcessWithStdout:
     """

--- a/tests/runner/test_app_sessions_native_events_lifecycle.py
+++ b/tests/runner/test_app_sessions_native_events_lifecycle.py
@@ -2367,11 +2367,12 @@ async def test_required_terminal_exit_publishes_deleted_and_failed(tmp_path: Pat
         *,
         on_activity: object | None = None,
         on_exit: object | None = None,
+        on_tick: object | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
         replace: bool = False,
     ) -> None:
-        del on_idle, on_activity, idle_threshold_s, poll_interval_s
+        del on_idle, on_activity, on_tick, idle_threshold_s, poll_interval_s
         callbacks["on_exit"] = on_exit
         callbacks["replace"] = replace
 
@@ -2508,11 +2509,12 @@ async def test_required_terminal_exit_while_idle_does_not_fail_session(tmp_path:
         *,
         on_activity: object | None = None,
         on_exit: object | None = None,
+        on_tick: object | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
         replace: bool = False,
     ) -> None:
-        del on_idle, on_activity, idle_threshold_s, poll_interval_s, replace
+        del on_idle, on_activity, on_tick, idle_threshold_s, poll_interval_s, replace
         callbacks["on_exit"] = on_exit
 
     instance.start_idle_watcher_thread = _capture_watcher  # type: ignore[method-assign]
@@ -2701,11 +2703,12 @@ async def test_external_idle_status_makes_required_terminal_exit_clean(tmp_path:
         *,
         on_activity: object | None = None,
         on_exit: object | None = None,
+        on_tick: object | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
         replace: bool = False,
     ) -> None:
-        del on_idle, on_activity, idle_threshold_s, poll_interval_s, replace
+        del on_idle, on_activity, on_tick, idle_threshold_s, poll_interval_s, replace
         callbacks["on_exit"] = on_exit
 
     instance.start_idle_watcher_thread = _capture_watcher  # type: ignore[method-assign]

--- a/tests/runner/test_resource_registry.py
+++ b/tests/runner/test_resource_registry.py
@@ -329,11 +329,12 @@ async def test_auxiliary_terminal_exit_publishes_resource_exit_only(tmp_path: Pa
         *,
         on_activity: object | None = None,
         on_exit: object | None = None,
+        on_tick: object | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
         replace: bool = False,
     ) -> None:
-        del on_idle, on_activity, idle_threshold_s, poll_interval_s
+        del on_idle, on_activity, on_tick, idle_threshold_s, poll_interval_s
         callbacks["on_exit"] = on_exit
         callbacks["replace"] = replace
 
@@ -373,6 +374,7 @@ async def _observe_native_agent_terminal_and_capture(
         *,
         on_activity: object | None = None,
         on_exit: object | None = None,
+        on_tick: object | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
         replace: bool = False,
@@ -381,6 +383,7 @@ async def _observe_native_agent_terminal_and_capture(
         callbacks["on_idle"] = on_idle
         callbacks["on_activity"] = on_activity
         callbacks["on_exit"] = on_exit
+        callbacks["on_tick"] = on_tick
 
     instance.start_idle_watcher_thread = _capture_watcher  # type: ignore[attr-defined]
     # A status publisher is required for the native agent terminal's watcher to
@@ -394,6 +397,129 @@ async def _observe_native_agent_terminal_and_capture(
         resource_role=CLAUDE_NATIVE_TERMINAL_ROLE,
     )
     return callbacks
+
+
+class _FakeStatusPoller:
+    """Controllable stand-in for the claude-native status-file poller.
+
+    Lets a test flip :attr:`active` (file resolved vs. falling back) and
+    fire status edges through the registry's callback, without touching a
+    real ``sessions/<pid>.json``.
+    """
+
+    def __init__(self, on_status: object) -> None:
+        self._on_status = on_status
+        self.active = False
+        self.ticks = 0
+
+    def tick(self) -> None:
+        self.ticks += 1
+
+    def emit(self, status: str) -> None:
+        """Simulate the file reporting a new status."""
+        self._on_status(status)
+
+
+async def _observe_native_with_fake_poller(
+    tmp_path: Path,
+    session_id: str,
+) -> tuple[dict[str, object], list[str], list[_FakeStatusPoller]]:
+    """Observe a claude-native terminal with an injected fake poller.
+
+    :returns: ``(callbacks, statuses, pollers)`` — the wired watcher
+        callbacks, the list the status publisher appends to, and the
+        single-element list holding the injected poller (so the test can
+        drive ``active`` / ``emit``).
+    """
+    terminal_registry = TerminalRegistry()
+    registry = SessionResourceRegistry(terminal_registry=terminal_registry)
+    instance = make_test_terminal_instance("claude", "main", tmp_path)
+    terminal_registry._by_conversation.setdefault(session_id, {})[("claude", "main")] = instance
+    statuses: list[str] = []
+    pollers: list[_FakeStatusPoller] = []
+    registry.set_session_status_publisher(lambda _sid, status: statuses.append(status))
+
+    def _fake_build(*, session_id: str, instance: object, on_status: object) -> _FakeStatusPoller:
+        del session_id, instance
+        poller = _FakeStatusPoller(on_status)
+        pollers.append(poller)
+        return poller
+
+    registry._build_claude_native_status_poller = _fake_build  # type: ignore[method-assign]
+
+    callbacks: dict[str, object] = {}
+
+    def _capture_watcher(
+        on_idle: object | None = None,
+        *,
+        on_activity: object | None = None,
+        on_exit: object | None = None,
+        on_tick: object | None = None,
+        idle_threshold_s: float | None = None,
+        poll_interval_s: float | None = None,
+        replace: bool = False,
+    ) -> None:
+        del idle_threshold_s, poll_interval_s, replace
+        callbacks["on_idle"] = on_idle
+        callbacks["on_activity"] = on_activity
+        callbacks["on_exit"] = on_exit
+        callbacks["on_tick"] = on_tick
+
+    instance.start_idle_watcher_thread = _capture_watcher  # type: ignore[attr-defined]
+    await registry.observe_required_terminal(
+        session_id, "claude", "main", instance, resource_role=CLAUDE_NATIVE_TERMINAL_ROLE
+    )
+    return callbacks, statuses, pollers
+
+
+@pytest.mark.asyncio
+async def test_claude_native_wires_status_poller_tick(tmp_path: Path) -> None:
+    """The claude-native watcher is wired with an ``on_tick`` that drives
+    the status-file poller."""
+    callbacks, _statuses, pollers = await _observe_native_with_fake_poller(tmp_path, "conv_tick")
+    assert len(pollers) == 1
+    on_tick = callbacks["on_tick"]
+    assert callable(on_tick)
+    on_tick()
+    on_tick()
+    assert pollers[0].ticks == 2
+
+
+@pytest.mark.asyncio
+async def test_status_file_preempts_pty_edges_when_active(tmp_path: Path) -> None:
+    """While the poller is active, the file's status wins and PTY pane
+    edges do not publish status."""
+    callbacks, statuses, pollers = await _observe_native_with_fake_poller(tmp_path, "conv_pre")
+    poller = pollers[0]
+    poller.active = True
+
+    # File says running; PTY activity must NOT double-publish.
+    poller.emit("running")
+    callbacks["on_activity"]()
+    # File says idle; PTY idle heuristic must NOT override it.
+    poller.emit("idle")
+    callbacks["on_idle"]()
+
+    # Status edges publish via loop.call_soon_threadsafe; let them drain.
+    await asyncio.sleep(0)
+    assert statuses == ["running", "idle"]
+
+
+@pytest.mark.asyncio
+async def test_pty_edges_drive_status_when_poller_inactive(tmp_path: Path) -> None:
+    """With no file (poller inactive), the PTY pane edges remain the status
+    source — the fallback path for old Claude versions."""
+    callbacks, statuses, pollers = await _observe_native_with_fake_poller(
+        tmp_path, "conv_fallback"
+    )
+    # Poller stays inactive (file never resolved).
+    assert pollers[0].active is False
+
+    callbacks["on_activity"]()  # → running
+    callbacks["on_idle"]()  # → idle
+    # Status edges publish via loop.call_soon_threadsafe; let them drain.
+    await asyncio.sleep(0)
+    assert statuses == ["running", "idle"]
 
 
 @pytest.mark.asyncio
@@ -507,11 +633,12 @@ async def test_required_terminal_exit_without_observed_status_is_failure(tmp_pat
         *,
         on_activity: object | None = None,
         on_exit: object | None = None,
+        on_tick: object | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
         replace: bool = False,
     ) -> None:
-        del on_idle, on_activity, idle_threshold_s, poll_interval_s, replace
+        del on_idle, on_activity, on_tick, idle_threshold_s, poll_interval_s, replace
         callbacks["on_exit"] = on_exit
 
     instance.start_idle_watcher_thread = _capture_watcher  # type: ignore[method-assign]

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -2269,8 +2269,10 @@ class _StubTerminalInstance:
         on_idle: Callable[[], None] | None = None,
         *,
         on_activity: Callable[[], None] | None = None,
+        **kwargs: object,
     ) -> None:
         """Record the activity callback instead of polling real tmux."""
+        del kwargs
         if on_activity is not None:
             self.activity_watchers.append(on_activity)
 

--- a/tests/runner/test_session_resources.py
+++ b/tests/runner/test_session_resources.py
@@ -1474,6 +1474,8 @@ class _WatcherCapture:
         ``None`` if none was wired.
     :param on_exit: The exit callback the registry passed, or ``None`` if none
         was wired.
+    :param on_tick: The per-tick callback the registry passed (drives the
+        claude-native status-file poller), or ``None`` if none was wired.
     :param idle_threshold_s: The per-watcher idle threshold the registry
         passed, or ``None`` for the module default.
     :param poll_interval_s: The per-watcher poll interval the registry
@@ -1484,6 +1486,7 @@ class _WatcherCapture:
     on_activity: Callable[[], None] | None = None
     on_idle: Callable[[], None] | None = None
     on_exit: Callable[[], None] | None = None
+    on_tick: Callable[[], None] | None = None
     idle_threshold_s: float | None = None
     poll_interval_s: float | None = None
     replace: bool = False
@@ -1518,6 +1521,7 @@ def _make_capturing_instance(
         *,
         on_activity: Callable[[], None] | None = None,
         on_exit: Callable[[], None] | None = None,
+        on_tick: Callable[[], None] | None = None,
         idle_threshold_s: float | None = None,
         poll_interval_s: float | None = None,
         replace: bool = False,
@@ -1526,6 +1530,7 @@ def _make_capturing_instance(
         capture.on_idle = on_idle
         capture.on_activity = on_activity
         capture.on_exit = on_exit
+        capture.on_tick = on_tick
         capture.idle_threshold_s = idle_threshold_s
         capture.poll_interval_s = poll_interval_s
         capture.replace = replace

--- a/tests/test_claude_native_status_file.py
+++ b/tests/test_claude_native_status_file.py
@@ -1,0 +1,213 @@
+"""Tests for the Claude Code ``sessions/<pid>.json`` status reader.
+
+Covers :mod:`omnigent.claude_native_status_file` — resolving the status
+file for a launched Claude, mapping its interactive status to the runner
+vocabulary, and the per-tick poller that turns it into status edges and
+falls back to the PTY watcher when the file never appears or vanishes.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from omnigent.claude_native_status_file import (
+    IDLE,
+    RUNNING,
+    SessionStatusPoller,
+    read_session_status,
+    resolve_status_file,
+    sessions_dir,
+)
+
+
+def _write_session_file(
+    directory: Path,
+    *,
+    pid: int,
+    session_id: str,
+    status: str,
+    kind: str = "interactive",
+) -> Path:
+    """Write a minimal ``<pid>.json`` matching Claude's schema.
+
+    :param directory: The ``sessions`` directory to write into.
+    :param pid: The pid the file is named by.
+    :param session_id: The Claude session uuid recorded in the file.
+    :param status: The raw status literal, e.g. ``"busy"``.
+    :param kind: The session kind, ``"interactive"`` by default.
+    :returns: The path written.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{pid}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "pid": pid,
+                "sessionId": session_id,
+                "cwd": "/repo",
+                "kind": kind,
+                "status": status,
+                "statusUpdatedAt": 1785480000000,
+                "updatedAt": 1785480000000,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_sessions_dir_honors_config_dir_env(monkeypatch) -> None:
+    """``CLAUDE_CONFIG_DIR`` overrides the ``~/.claude`` default."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/custom/cfg")
+    assert sessions_dir() == Path("/custom/cfg/sessions")
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    assert sessions_dir() == Path.home() / ".claude" / "sessions"
+
+
+def test_resolve_by_pid_with_session_cross_check(tmp_path: Path) -> None:
+    """The pid file is used when its ``sessionId`` matches."""
+    _write_session_file(tmp_path / "sessions", pid=42, session_id="sid-1", status="busy")
+    path = resolve_status_file(pane_pid=42, expected_session_id="sid-1", config_dir=tmp_path)
+    assert path is not None and path.name == "42.json"
+
+
+def test_resolve_pid_mismatch_falls_back_to_scan(tmp_path: Path) -> None:
+    """A wrong-pid file is rejected; a fresh sessionId match wins."""
+    sessions = tmp_path / "sessions"
+    # pid 99 exists but belongs to a different session.
+    _write_session_file(sessions, pid=99, session_id="other", status="idle")
+    # The real session's file is named by a pid we don't know.
+    _write_session_file(sessions, pid=123, session_id="sid-x", status="busy")
+    path = resolve_status_file(pane_pid=99, expected_session_id="sid-x", config_dir=tmp_path)
+    assert path is not None and path.name == "123.json"
+
+
+def test_resolve_cross_check_rejects_wrong_session(tmp_path: Path) -> None:
+    """A pid file for a different session is not returned."""
+    sessions = tmp_path / "sessions"
+    _write_session_file(sessions, pid=7, session_id="not-me", status="busy")
+    path = resolve_status_file(pane_pid=7, expected_session_id="mine", config_dir=tmp_path)
+    assert path is None
+
+
+def test_resolve_pre_hook_accepts_pid_only(tmp_path: Path) -> None:
+    """Before the session id is known, the pid file is accepted as-is."""
+    sessions = tmp_path / "sessions"
+    _write_session_file(sessions, pid=7, session_id="sid", status="busy")
+    path = resolve_status_file(pane_pid=7, expected_session_id=None, config_dir=tmp_path)
+    assert path is not None and path.name == "7.json"
+
+
+def test_resolve_scan_skips_stale_files(tmp_path: Path) -> None:
+    """A matching but stale file is skipped by the freshness window."""
+    sessions = tmp_path / "sessions"
+    stale = _write_session_file(sessions, pid=5, session_id="sid", status="idle")
+    old = time.time() - 10_000
+    import os
+
+    os.utime(stale, (old, old))
+    # pid unknown, so only the scan runs — the stale file is filtered out.
+    path = resolve_status_file(pane_pid=None, expected_session_id="sid", config_dir=tmp_path)
+    assert path is None
+
+
+def test_resolve_missing_pid_no_session_returns_none(tmp_path: Path) -> None:
+    """No pid file and no session id → nothing to resolve."""
+    (tmp_path / "sessions").mkdir()
+    path = resolve_status_file(pane_pid=999, expected_session_id=None, config_dir=tmp_path)
+    assert path is None
+
+
+def test_read_status_maps_interactive_vocabulary(tmp_path: Path) -> None:
+    """``busy``/``waiting`` → running, ``idle`` → idle."""
+    sessions = tmp_path / "sessions"
+    busy = _write_session_file(sessions, pid=1, session_id="s", status="busy")
+    waiting = _write_session_file(sessions, pid=2, session_id="s", status="waiting")
+    idle = _write_session_file(sessions, pid=3, session_id="s", status="idle")
+    assert read_session_status(busy).runner_status == RUNNING
+    assert read_session_status(waiting).runner_status == RUNNING
+    assert read_session_status(idle).runner_status == IDLE
+    # Raw status is preserved for future "needs input" surfacing.
+    assert read_session_status(waiting).raw_status == "waiting"
+
+
+def test_read_status_unknown_or_missing_is_none(tmp_path: Path) -> None:
+    """An unrecognized status or missing file reads as ``None``."""
+    sessions = tmp_path / "sessions"
+    weird = _write_session_file(sessions, pid=1, session_id="s", status="???")
+    assert read_session_status(weird) is None
+    assert read_session_status(sessions / "nope.json") is None
+
+
+class _StubPidGetter:
+    """A pane-pid getter whose value can change across ticks."""
+
+    def __init__(self, value: int | None) -> None:
+        self.value = value
+
+    def __call__(self) -> int | None:
+        return self.value
+
+
+def test_poller_publishes_edges_only(tmp_path: Path) -> None:
+    """The poller fires the callback on transitions, not on every tick."""
+    sessions = tmp_path / "sessions"
+    _write_session_file(sessions, pid=1, session_id="s", status="busy")
+    published: list[str] = []
+    poller = SessionStatusPoller(
+        on_status=published.append,
+        pane_pid_getter=_StubPidGetter(1),
+        session_id_getter=lambda: "s",
+        config_dir=tmp_path,
+    )
+
+    poller.tick()  # resolves + first read: busy → running
+    assert poller.active
+    assert published == [RUNNING]
+
+    poller.tick()  # unchanged mtime → no-op
+    assert published == [RUNNING]
+
+    # Turn ends: file flips to idle.
+    _write_session_file(sessions, pid=1, session_id="s", status="idle")
+    poller.tick()
+    assert published == [RUNNING, IDLE]
+
+
+def test_poller_gives_up_when_file_never_appears(tmp_path: Path) -> None:
+    """With no file (old Claude), the poller retires and stays inactive."""
+    (tmp_path / "sessions").mkdir()
+    published: list[str] = []
+    poller = SessionStatusPoller(
+        on_status=published.append,
+        pane_pid_getter=_StubPidGetter(404),
+        session_id_getter=lambda: None,
+        config_dir=tmp_path,
+    )
+    # Drive well past the resolve-attempt cap.
+    for _ in range(60):
+        poller.tick()
+    assert not poller.active
+    assert published == []
+
+
+def test_poller_deactivates_when_file_vanishes(tmp_path: Path) -> None:
+    """A clean exit unlinks the file; the poller goes inactive so the PTY
+    watcher reclaims status and exit detection."""
+    sessions = tmp_path / "sessions"
+    path = _write_session_file(sessions, pid=1, session_id="s", status="busy")
+    published: list[str] = []
+    poller = SessionStatusPoller(
+        on_status=published.append,
+        pane_pid_getter=_StubPidGetter(1),
+        session_id_getter=lambda: "s",
+        config_dir=tmp_path,
+    )
+    poller.tick()
+    assert poller.active and published == [RUNNING]
+
+    path.unlink()
+    poller.tick()
+    assert not poller.active


### PR DESCRIPTION
## Related issue

N/A

## Summary

The claude-native session's **Working/idle** badge is derived by diffing the tmux pane (the PTY watcher in `resource_registry`). That heuristic has two limits: it can't tell **"blocked on a prompt"** from **"working"**, and it only flips to idle after ~1s of pane quiescence rather than on the real turn edge.

Claude Code writes a per-process status file at `<config_dir>/sessions/<pid>.json` — its internal *"concurrentSessions"* registry, present since **v2.1.139** — whose `status` flips `idle`/`busy`/`waiting` on the actual turn edges. This PR prefers that file for the claude-native running/idle status, and **falls back to the existing PTY watcher** when the file is absent (older Claude, missing config dir) or never resolves — so nothing regresses for older `claude` binaries.

The migration is deliberately surgical: the file becomes the source of the **status** edge only. The PTY watcher keeps owning the **terminal-activity badge** and **exit detection**, and reclaims status if the file never resolves or later disappears.

- **New `omnigent/claude_native_status_file.py`:**
  - `resolve_status_file(...)` — resolves the file **pid-first** (`<pane_pid>.json`; tmux `exec`s `claude` as the pane process so the pid matches), with a `sessionId` cross-check (from the bridge's `read_claude_session_id`) and a freshness-bounded directory scan as fallback.
  - `read_session_status(...)` — maps Claude's interactive vocabulary: `busy`/`waiting` → `running`, `idle` → `idle`.
  - `SessionStatusPoller` — lazily resolves the file (bounded retries → gives up to the PTY watcher for old Claude), then mtime-short-circuits reads, edge-dedupes, and deactivates when the file is unlinked on clean exit.
- **`omnigent/inner/terminal.py`:** adds `pane_pid_sync()` and an `on_tick` hook on the threaded watcher so the poller runs on the existing poll cadence — **no second thread**.
- **`omnigent/runner/resource_registry.py`:** for the `claude-native` role only, builds the poller (lazy-imported to keep the module harness-agnostic) and drives it via `on_tick`. While the poller is `active`, the PTY `on_activity`/`on_idle` edges **defer** status to the file. Other native harnesses are untouched.

`waiting` maps to `running` for now (no new status vocabulary). Surfacing a distinct **"needs input"** state is a clean fast-follow — `raw_status` is already threaded through `SessionStatus` for exactly that.

### ELI5

Instead of squinting at the terminal to guess whether Claude is busy (watching the screen redraw), we now read the little status file Claude already writes about itself. It's faster and more accurate — and if that file isn't there (old Claude), we quietly go back to squinting at the terminal like before.

```mermaid
flowchart LR
  tick["watcher poll tick"] --> poller{"status file<br/>resolved?"}
  poller -- yes --> file["read sessions/&lt;pid&gt;.json<br/>busy/waiting→running, idle→idle"] --> pub["publish status edge"]
  poller -- "no (old Claude /<br/>file gone)" --> pty["PTY pane-diff<br/>on_activity / on_idle"] --> pub
  file -. "always" .-> badge["PTY watcher keeps<br/>activity badge + exit detection"]
```

## Test Plan

```bash
cd omnigent  # repo root
TMPDIR=/tmp uv run --no-sync pytest \
  tests/test_claude_native_status_file.py \
  tests/runner/test_resource_registry.py \
  tests/inner/test_terminal.py -q
```

- **Unit** (`tests/test_claude_native_status_file.py`, 12 tests): pid-first resolution, sessionId cross-check + rejection, freshness-bounded scan, status mapping, and poller edge-dedup / give-up / deactivate-on-vanish.
- **Wiring** (`tests/runner/test_resource_registry.py`, 3 tests): the claude-native watcher is wired with `on_tick`; file status preempts PTY edges while active; PTY edges remain the status source when the poller is inactive (fallback path).
- **Terminal** (`tests/inner/test_terminal.py`, 2 tests): `on_tick` fires every poll; `pane_pid_sync` parses `#{pane_pid}` and returns `None` on tmux failure.
- **Empirical E2E**: drove the real `SessionStatusPoller` against a live-shaped session file through `idle → busy → waiting(coalesced to running) → idle → unlink(deactivates)`.
- **Regression**: the touched suites pass. The only failures in the broader run are **pre-existing** `codex_native` tests (confirmed by stashing this change — they fail identically on `main` with `Terminal registry not configured`) and one real-tmux test that needs `TMPDIR=/tmp` due to the unix-socket path-length limit.

To verify manually: run `omnigent claude`, submit a turn from the web UI, and confirm the Working→idle badge flips on the real turn edge (snappier than the old ~1s pane-quiescence). To exercise the fallback, point `CLAUDE_CONFIG_DIR` at an empty dir and confirm the badge still works off the PTY watcher.

## Demo

N/A — no UI/frontend change (server-side status derivation; the existing badge behavior is unchanged for the user, just more accurate/snappier).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the empirical poller lifecycle (idle→busy→waiting→idle→unlink) against a live-shaped session file, plus confirming the pre-existing `codex_native` failures reproduce on clean `main`. A full `omnigent claude` web-UI run is the remaining manual check (steps above); there is no automated claude-native E2E harness for it.

## Changelog

claude-native sessions now derive their Working/idle status from Claude Code's own session file for faster, more accurate turn-edge detection (falls back to the terminal watcher on older Claude versions)
