### PR TITLE
chore(ci): update Discord watch rotation

### DIFF
--- a/.github/scripts/rotation_roster.json
+++ b/.github/scripts/rotation_roster.json
@@ -21,9 +21,7 @@
     "Dhruv Gupta": { "slack_id": "U0A76097E1F", "tz": "America/Los_Angeles" },
     "Edwin He": { "slack_id": "U077B1V6WQJ", "tz": "America/Los_Angeles" },
     "Pat Sukprasert": { "slack_id": "U05HRKWFY81", "tz": "Asia/Singapore" },
-    "Sabhya Chhabria": { "slack_id": "U07A1KQDXAB", "tz": "America/Los_Angeles" },
     "Serena Ruan": { "slack_id": "U0571L5KNLR", "tz": "Asia/Singapore" },
-    "Shivam Mittal": { "slack_id": "U09FZKX9S6B", "tz": "America/Los_Angeles" },
     "Tomu Hirata": { "slack_id": "U07TX4PR5MZ", "tz": "Asia/Singapore" },
     "Zeyi (Rice) Fan": { "slack_id": "U09L5HT4CH0", "tz": "America/Los_Angeles" }
   }

--- a/.github/scripts/rotation_schedule.json
+++ b/.github/scripts/rotation_schedule.json
@@ -18,7 +18,7 @@
     },
     {
       "date": "2026-08-04",
-      "name": "Shivam Mittal"
+      "name": "Aravind Segu"
     },
     {
       "date": "2026-08-05",
@@ -54,7 +54,7 @@
     },
     {
       "date": "2026-08-17",
-      "name": "Sabhya Chhabria"
+      "name": "Bryan Qiu"
     },
     {
       "date": "2026-08-18",
@@ -62,7 +62,7 @@
     },
     {
       "date": "2026-08-19",
-      "name": "Shivam Mittal"
+      "name": "Daniel Lok"
     },
     {
       "date": "2026-08-20",
@@ -98,7 +98,7 @@
     },
     {
       "date": "2026-09-01",
-      "name": "Sabhya Chhabria"
+      "name": "Dhruv Gupta"
     },
     {
       "date": "2026-09-02",
@@ -106,7 +106,7 @@
     },
     {
       "date": "2026-09-03",
-      "name": "Shivam Mittal"
+      "name": "Edwin He"
     },
     {
       "date": "2026-09-04",
@@ -142,7 +142,7 @@
     },
     {
       "date": "2026-09-16",
-      "name": "Sabhya Chhabria"
+      "name": "Tomu Hirata"
     },
     {
       "date": "2026-09-17",
@@ -150,7 +150,7 @@
     },
     {
       "date": "2026-09-18",
-      "name": "Shivam Mittal"
+      "name": "Zeyi (Rice) Fan"
     },
     {
       "date": "2026-09-21",
@@ -186,7 +186,7 @@
     },
     {
       "date": "2026-10-01",
-      "name": "Sabhya Chhabria"
+      "name": "Aravind Segu"
     },
     {
       "date": "2026-10-02",
@@ -194,7 +194,7 @@
     },
     {
       "date": "2026-10-05",
-      "name": "Shivam Mittal"
+      "name": "Bryan Qiu"
     },
     {
       "date": "2026-10-06",
@@ -230,47 +230,47 @@
     },
     {
       "date": "2026-10-16",
-      "name": "Sabhya Chhabria"
-    },
-    {
-      "date": "2026-10-19",
-      "name": "Serena Ruan"
-    },
-    {
-      "date": "2026-10-20",
-      "name": "Shivam Mittal"
-    },
-    {
-      "date": "2026-10-21",
-      "name": "Tomu Hirata"
-    },
-    {
-      "date": "2026-10-22",
-      "name": "Zeyi (Rice) Fan"
-    },
-    {
-      "date": "2026-10-23",
-      "name": "Aravind Segu"
-    },
-    {
-      "date": "2026-10-26",
-      "name": "Bryan Qiu"
-    },
-    {
-      "date": "2026-10-27",
       "name": "Daniel Lok"
     },
     {
-      "date": "2026-10-28",
+      "date": "2026-10-19",
       "name": "Dhruv Gupta"
     },
     {
-      "date": "2026-10-29",
+      "date": "2026-10-20",
       "name": "Edwin He"
     },
     {
-      "date": "2026-10-30",
+      "date": "2026-10-21",
       "name": "Pat Sukprasert"
+    },
+    {
+      "date": "2026-10-22",
+      "name": "Serena Ruan"
+    },
+    {
+      "date": "2026-10-23",
+      "name": "Tomu Hirata"
+    },
+    {
+      "date": "2026-10-26",
+      "name": "Zeyi (Rice) Fan"
+    },
+    {
+      "date": "2026-10-27",
+      "name": "Aravind Segu"
+    },
+    {
+      "date": "2026-10-28",
+      "name": "Bryan Qiu"
+    },
+    {
+      "date": "2026-10-29",
+      "name": "Daniel Lok"
+    },
+    {
+      "date": "2026-10-30",
+      "name": "Dhruv Gupta"
     }
   ]
 }


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Update the Discord-watch roster (`rotation_roster.json`), leaving 9 people in the rotation.
- Prune elapsed dates (before 2026-08-03) from `rotation_schedule.json` and extend the horizon through 2026-10-30 via `rotation_maintain.py`, so every upcoming weekday is assigned to a current roster member with no dangling references.

## Test Plan

- `python3 .github/scripts/rotation_maintain.py --check --today 2026-08-03` → exits 0 (schedule at full horizon, consistent with what CI would generate).
- `python3 .github/scripts/rotation.py` dry-run resolves today's assignee correctly.
- Verified no adjacent duplicate assignees and no dangling references in the schedule.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Data-only change to the Discord-watch rotation roster/schedule. Verified with the existing `rotation.py` dry-run and `rotation_maintain.py --check`; no application code changed.
