### PR TITLE
fix(bridge): thread resolved sandbox spec into claude-native bridge MCP

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -4075,16 +4075,33 @@ def _empty_object_schema() -> _JsonObject:
 
 
 def _sandbox_spec_to_json(sandbox: OSEnvSandboxSpec) -> dict[str, object]:
-    """Serialise an ``OSEnvSandboxSpec`` to a plain JSON-safe dict."""
+    """Serialise an ``OSEnvSandboxSpec`` to a plain JSON-safe dict.
+
+    Covers all policy-controllable fields (``_SANDBOX_OVERRIDE_KEYS`` in
+    ``omnigent.policies.builtins.safety``) so the bridge MCP subprocess
+    is sandboxed identically to the Claude terminal it serves.
+    """
     out: dict[str, object] = {"type": sandbox.type}
     if sandbox.read_paths is not None:
         out["read_paths"] = sandbox.read_paths
     if sandbox.write_paths is not None:
         out["write_paths"] = sandbox.write_paths
+    if sandbox.write_files is not None:
+        out["write_files"] = sandbox.write_files
     if not sandbox.allow_network:
         out["allow_network"] = sandbox.allow_network
+    if sandbox.cwd_allow_hidden is not None:
+        out["cwd_allow_hidden"] = sandbox.cwd_allow_hidden
     if sandbox.env_passthrough is not None:
         out["env_passthrough"] = sandbox.env_passthrough
+    if sandbox.egress_rules is not None:
+        out["egress_rules"] = sandbox.egress_rules
+    if sandbox.egress_allow_private_destinations:
+        out["egress_allow_private_destinations"] = sandbox.egress_allow_private_destinations
+    if sandbox.cwd_hidden_scan_max_entries != 50000:
+        out["cwd_hidden_scan_max_entries"] = sandbox.cwd_hidden_scan_max_entries
+    if sandbox.cwd_hidden_scan_overflow != "warn":
+        out["cwd_hidden_scan_overflow"] = sandbox.cwd_hidden_scan_overflow
     return out
 
 
@@ -4092,12 +4109,30 @@ def _sandbox_spec_from_json(raw: object) -> OSEnvSandboxSpec:
     """Deserialise a ``bridge.json`` sandbox dict into an ``OSEnvSandboxSpec``."""
     if not isinstance(raw, dict):
         return OSEnvSandboxSpec(type="none")
+
+    def _str_list(val: object) -> list[str] | None:
+        if isinstance(val, list):
+            return [str(v) for v in val]
+        return None
+
     return OSEnvSandboxSpec(
-        type=raw.get("type", "none") or "none",
-        read_paths=raw.get("read_paths"),
-        write_paths=raw.get("write_paths"),
-        allow_network=bool(raw.get("allow_network", True)),
-        env_passthrough=raw.get("env_passthrough"),
+        type=raw.get("type", "none") if isinstance(raw.get("type"), str) else "none",
+        read_paths=_str_list(raw.get("read_paths")),
+        write_paths=_str_list(raw.get("write_paths")),
+        write_files=_str_list(raw.get("write_files")),
+        allow_network=bool(raw["allow_network"]) if "allow_network" in raw else True,
+        cwd_allow_hidden=_str_list(raw.get("cwd_allow_hidden")),
+        env_passthrough=_str_list(raw.get("env_passthrough")),
+        egress_rules=_str_list(raw.get("egress_rules")),
+        egress_allow_private_destinations=bool(raw["egress_allow_private_destinations"])
+        if "egress_allow_private_destinations" in raw
+        else False,
+        cwd_hidden_scan_max_entries=int(raw["cwd_hidden_scan_max_entries"])
+        if isinstance(raw.get("cwd_hidden_scan_max_entries"), int)
+        else 50000,
+        cwd_hidden_scan_overflow=str(raw["cwd_hidden_scan_overflow"])
+        if isinstance(raw.get("cwd_hidden_scan_overflow"), str)
+        else "warn",
     )
 
 

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -4115,18 +4115,21 @@ def _sandbox_spec_from_json(raw: object) -> OSEnvSandboxSpec:
             return [str(v) for v in val]
         return None
 
+    def _bool(val: object, default: bool) -> bool:
+        return val if isinstance(val, bool) else default
+
     return OSEnvSandboxSpec(
         type=raw.get("type", "none") if isinstance(raw.get("type"), str) else "none",
         read_paths=_str_list(raw.get("read_paths")),
         write_paths=_str_list(raw.get("write_paths")),
         write_files=_str_list(raw.get("write_files")),
-        allow_network=bool(raw["allow_network"]) if "allow_network" in raw else True,
+        allow_network=_bool(raw.get("allow_network"), True),
         cwd_allow_hidden=_str_list(raw.get("cwd_allow_hidden")),
         env_passthrough=_str_list(raw.get("env_passthrough")),
         egress_rules=_str_list(raw.get("egress_rules")),
-        egress_allow_private_destinations=bool(raw["egress_allow_private_destinations"])
-        if "egress_allow_private_destinations" in raw
-        else False,
+        egress_allow_private_destinations=_bool(
+            raw.get("egress_allow_private_destinations"), False
+        ),
         cwd_hidden_scan_max_entries=int(raw["cwd_hidden_scan_max_entries"])
         if isinstance(raw.get("cwd_hidden_scan_max_entries"), int)
         else 50000,

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -820,6 +820,7 @@ def prepare_bridge_dir(
     bridge_id: str | None = None,
     workspace: Path,
     launch_model: str | None = None,
+    sandbox: OSEnvSandboxSpec | None = None,
 ) -> Path:
     """
     Create or refresh the bridge directory for a native Claude session.
@@ -834,6 +835,11 @@ def prepare_bridge_dir(
         forwarder can re-inject it when Claude Code's ``/model``
         normalizes the name to one the gateway rejects.  ``None`` when
         no ucode profile is active.
+    :param sandbox: Resolved sandbox spec from the agent's ``os_env``.
+        Persisted into ``bridge.json`` so the bridge MCP subprocess can
+        honour the same sandbox type (and path grants) as the Claude
+        terminal it serves.  ``None`` leaves the bridge at its default
+        ``type="none"``.
     :returns: Bridge directory path.
     """
     resolved_bridge_id = bridge_id or conversation_id
@@ -853,6 +859,8 @@ def prepare_bridge_dir(
     }
     if launch_model is not None:
         payload["launch_model"] = launch_model
+    if sandbox is not None:
+        payload["sandbox"] = _sandbox_spec_to_json(sandbox)
     _write_json_file(bridge_dir / _CONFIG_FILE, payload)
     # Keep ``_PERMISSION_HOOK_FILE`` — the PermissionRequest command hook
     # reads the Omnigent server URL from it at runtime, so wiping it on re-prep
@@ -4066,6 +4074,33 @@ def _empty_object_schema() -> _JsonObject:
     return {"type": "object", "properties": {}}
 
 
+def _sandbox_spec_to_json(sandbox: OSEnvSandboxSpec) -> dict[str, object]:
+    """Serialise an ``OSEnvSandboxSpec`` to a plain JSON-safe dict."""
+    out: dict[str, object] = {"type": sandbox.type}
+    if sandbox.read_paths is not None:
+        out["read_paths"] = sandbox.read_paths
+    if sandbox.write_paths is not None:
+        out["write_paths"] = sandbox.write_paths
+    if not sandbox.allow_network:
+        out["allow_network"] = sandbox.allow_network
+    if sandbox.env_passthrough is not None:
+        out["env_passthrough"] = sandbox.env_passthrough
+    return out
+
+
+def _sandbox_spec_from_json(raw: object) -> OSEnvSandboxSpec:
+    """Deserialise a ``bridge.json`` sandbox dict into an ``OSEnvSandboxSpec``."""
+    if not isinstance(raw, dict):
+        return OSEnvSandboxSpec(type="none")
+    return OSEnvSandboxSpec(
+        type=raw.get("type", "none") or "none",
+        read_paths=raw.get("read_paths"),
+        write_paths=raw.get("write_paths"),
+        allow_network=bool(raw.get("allow_network", True)),
+        env_passthrough=raw.get("env_passthrough"),
+    )
+
+
 def _build_tools(config: _JsonObject) -> tuple[dict[str, Tool], Callable[[], None]]:
     """
     Build Omnigent MCP tools served by the bridge.
@@ -4078,10 +4113,11 @@ def _build_tools(config: _JsonObject) -> tuple[dict[str, Tool], Callable[[], Non
     workspace = Path(workspace_raw) if isinstance(workspace_raw, str) and workspace_raw else None
     os_env: OSEnvironment | None = None
     if workspace is not None:
+        sandbox = _sandbox_spec_from_json(config.get("sandbox"))
         spec = OSEnvSpec(
             type="caller_process",
             cwd=str(workspace),
-            sandbox=OSEnvSandboxSpec(type="none"),
+            sandbox=sandbox,
             fork=False,
         )
         os_env = create_os_environment(spec)

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -5559,7 +5559,16 @@ async def _auto_create_claude_terminal(
     )
 
     _pre_wipe_claude_sid = _read_csid_pre_wipe(_bridge_dir_for_bridge_id(bridge_id))
-    bridge_dir = prepare_bridge_dir(session_id, bridge_id=bridge_id, workspace=Path(workspace))
+    # Resolve the agent's sandbox spec early so it can be persisted into
+    # bridge.json before the MCP subprocess reads it. The same spec is used
+    # again below when building the terminal env.
+    _agent_os_env_early = _agent_os_env_from_spec(agent_spec)
+    bridge_dir = prepare_bridge_dir(
+        session_id,
+        bridge_id=bridge_id,
+        workspace=Path(workspace),
+        sandbox=_agent_os_env_early.sandbox if _agent_os_env_early is not None else None,
+    )
     # Cancel any surviving forwarder BEFORE wiping its cursor/seen state, else it
     # re-posts with fresh dedup state alongside the forwarder spawned below.
     await _cancel_auto_forwarder_task(session_id)
@@ -5877,7 +5886,7 @@ async def _auto_create_claude_terminal(
     # egress_rules and env_passthrough are honoured. Without ``sandbox`` here
     # and ``parent_os_env`` below, launch_terminal falls back to
     # _default_sandbox_for_platform (linux_bwrap), overriding the YAML config.
-    agent_os_env = _agent_os_env_from_spec(agent_spec)
+    agent_os_env = _agent_os_env_early
     env_spec = TerminalEnvSpec(
         os_env=OSEnvSpec(
             type="caller_process",

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -5933,3 +5933,186 @@ def test_hook_record_non_stop_event_has_zero_background_tasks() -> None:
         )
     )
     assert record.background_task_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Sandbox spec round-trip and _build_tools integration
+# ---------------------------------------------------------------------------
+
+
+def test_sandbox_spec_roundtrip_minimal() -> None:
+    """A minimal bwrap spec (type only) round-trips without loss."""
+    from omnigent.claude_native_bridge import _sandbox_spec_from_json, _sandbox_spec_to_json
+    from omnigent.inner.datamodel import OSEnvSandboxSpec
+
+    spec = OSEnvSandboxSpec(type="linux_bwrap")
+    assert _sandbox_spec_from_json(_sandbox_spec_to_json(spec)) == spec
+
+
+def test_sandbox_spec_roundtrip_full() -> None:
+    """All policy-controllable fields survive a to_json/from_json round-trip."""
+    from omnigent.claude_native_bridge import _sandbox_spec_from_json, _sandbox_spec_to_json
+    from omnigent.inner.datamodel import OSEnvSandboxSpec
+
+    spec = OSEnvSandboxSpec(
+        type="linux_bwrap",
+        read_paths=["/tmp", "~/projects"],
+        write_paths=["~/projects/out"],
+        write_files=["~/.claude.json"],
+        allow_network=False,
+        cwd_allow_hidden=[".venv", ".git"],
+        env_passthrough=["GITHUB_TOKEN"],
+        egress_rules=["GET api.github.com/**"],
+        egress_allow_private_destinations=True,
+        cwd_hidden_scan_max_entries=10000,
+        cwd_hidden_scan_overflow="error",
+    )
+    assert _sandbox_spec_from_json(_sandbox_spec_to_json(spec)) == spec
+
+
+def test_sandbox_spec_roundtrip_defaults_omitted() -> None:
+    """Default values are omitted from the JSON to keep bridge.json compact."""
+    from omnigent.claude_native_bridge import _sandbox_spec_to_json
+    from omnigent.inner.datamodel import OSEnvSandboxSpec
+
+    spec = OSEnvSandboxSpec(type="linux_bwrap")
+    result = _sandbox_spec_to_json(spec)
+    assert result == {"type": "linux_bwrap"}
+    assert "allow_network" not in result
+    assert "egress_allow_private_destinations" not in result
+    assert "cwd_hidden_scan_max_entries" not in result
+    assert "cwd_hidden_scan_overflow" not in result
+
+
+def test_sandbox_spec_from_json_missing_key_returns_none_type() -> None:
+    """``_sandbox_spec_from_json`` on a missing/non-dict value returns ``type='none'``."""
+    from omnigent.claude_native_bridge import _sandbox_spec_from_json
+    from omnigent.inner.datamodel import OSEnvSandboxSpec
+
+    assert _sandbox_spec_from_json(None) == OSEnvSandboxSpec(type="none")
+    assert _sandbox_spec_from_json("bad") == OSEnvSandboxSpec(type="none")
+    assert _sandbox_spec_from_json(42) == OSEnvSandboxSpec(type="none")
+
+
+def test_sandbox_spec_from_json_handles_unknown_type() -> None:
+    """An unrecognised or empty ``type`` string in raw JSON stays verbatim."""
+    from omnigent.claude_native_bridge import _sandbox_spec_from_json
+
+    spec = _sandbox_spec_from_json({"type": "darwin_seatbelt"})
+    assert spec.type == "darwin_seatbelt"
+
+
+def test_sandbox_spec_from_json_non_list_paths_ignored() -> None:
+    """Non-list ``read_paths`` / ``write_paths`` values are treated as ``None``."""
+    from omnigent.claude_native_bridge import _sandbox_spec_from_json
+
+    spec = _sandbox_spec_from_json({"type": "linux_bwrap", "read_paths": "not-a-list"})
+    assert spec.read_paths is None
+
+
+def test_prepare_bridge_dir_persists_sandbox(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``prepare_bridge_dir`` writes the sandbox spec into bridge.json."""
+    from omnigent.inner.datamodel import OSEnvSandboxSpec
+
+    root = tmp_path / "root"
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", root)
+
+    sandbox = OSEnvSandboxSpec(
+        type="linux_bwrap",
+        write_paths=["~/out"],
+        egress_rules=["GET api.github.com/**"],
+    )
+    bridge_dir = prepare_bridge_dir("conv_sb", workspace=tmp_path, sandbox=sandbox)
+    config = json.loads((bridge_dir / "bridge.json").read_text(encoding="utf-8"))
+
+    assert "sandbox" in config
+    sb = config["sandbox"]
+    assert sb["type"] == "linux_bwrap"
+    assert sb["write_paths"] == ["~/out"]
+    assert sb["egress_rules"] == ["GET api.github.com/**"]
+
+
+def test_prepare_bridge_dir_omits_sandbox_when_none(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``sandbox`` key is absent from bridge.json when no sandbox is provided."""
+    root = tmp_path / "root"
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", root)
+
+    bridge_dir = prepare_bridge_dir("conv_no_sb", workspace=tmp_path)
+    config = json.loads((bridge_dir / "bridge.json").read_text(encoding="utf-8"))
+    assert "sandbox" not in config
+
+
+def test_build_tools_uses_sandbox_from_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_build_tools`` passes the sandbox from config to ``create_os_environment``."""
+    from omnigent import claude_native_bridge
+    from omnigent.inner.datamodel import OSEnvSandboxSpec
+
+    received: list[object] = []
+
+    class _FakeEnv:
+        def close(self) -> None:
+            pass
+
+    def _fake_create(spec: object) -> _FakeEnv:
+        received.append(spec)
+        return _FakeEnv()
+
+    monkeypatch.setattr(claude_native_bridge, "create_os_environment", _fake_create)
+    monkeypatch.setattr(claude_native_bridge, "build_os_env_tools", lambda _env: [])
+
+    config = {
+        "workspace": str(tmp_path),
+        "sandbox": {
+            "type": "linux_bwrap",
+            "write_paths": ["/tmp/work"],
+            "egress_rules": ["GET api.example.com/**"],
+        },
+    }
+    _tools, close = claude_native_bridge._build_tools(config)
+    close()
+
+    assert len(received) == 1
+    spec = received[0]
+    assert hasattr(spec, "sandbox")
+    sb: OSEnvSandboxSpec = spec.sandbox
+    assert sb.type == "linux_bwrap"
+    assert sb.write_paths == ["/tmp/work"]
+    assert sb.egress_rules == ["GET api.example.com/**"]
+
+
+def test_build_tools_defaults_to_none_sandbox_when_absent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without a ``sandbox`` key in config, ``_build_tools`` uses ``type='none'``."""
+    from omnigent import claude_native_bridge
+    from omnigent.inner.datamodel import OSEnvSandboxSpec
+
+    received: list[object] = []
+
+    class _FakeEnv:
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(
+        claude_native_bridge,
+        "create_os_environment",
+        lambda s: (_FakeEnv(), received.append(s))[0],
+    )
+    monkeypatch.setattr(claude_native_bridge, "build_os_env_tools", lambda _env: [])
+
+    _tools, close = claude_native_bridge._build_tools({"workspace": str(tmp_path)})
+    close()
+
+    assert len(received) == 1
+    sb: OSEnvSandboxSpec = received[0].sandbox
+    assert sb.type == "none"

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -6010,6 +6010,38 @@ def test_sandbox_spec_from_json_non_list_paths_ignored() -> None:
     assert spec.read_paths is None
 
 
+def test_sandbox_spec_from_json_non_bool_network_uses_default() -> None:
+    """String ``\"false\"`` for ``allow_network`` must not be treated as ``True``."""
+    from omnigent.claude_native_bridge import _sandbox_spec_from_json
+
+    # The real JSON boolean False disables network.
+    assert (
+        _sandbox_spec_from_json({"type": "linux_bwrap", "allow_network": False}).allow_network
+        is False
+    )
+    # A non-bool value falls back to the default (True) rather than coercing.
+    assert (
+        _sandbox_spec_from_json({"type": "linux_bwrap", "allow_network": "false"}).allow_network
+        is True
+    )
+    assert (
+        _sandbox_spec_from_json({"type": "linux_bwrap", "allow_network": 0}).allow_network is True
+    )
+    # egress_allow_private_destinations has default False.
+    assert (
+        _sandbox_spec_from_json(
+            {"type": "linux_bwrap", "egress_allow_private_destinations": True}
+        ).egress_allow_private_destinations
+        is True
+    )
+    assert (
+        _sandbox_spec_from_json(
+            {"type": "linux_bwrap", "egress_allow_private_destinations": "true"}
+        ).egress_allow_private_destinations
+        is False
+    )
+
+
 def test_prepare_bridge_dir_persists_sandbox(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Fixes #3790.

The bridge MCP subprocess (`_build_tools` in `claude_native_bridge.py`) unconditionally hardcoded `OSEnvSandboxSpec(type="none")`, so a `force_sandbox` policy was correctly evaluated by the policy engine and applied to the Claude terminal process, but the bridge's own MCP subprocess — which provides the `sys_os_*` shell/file tools — always ran with full unrestricted host access. Silent, no error, no warning.

The sandbox subsystem (`resolve_sandbox`, bwrap/seatbelt backends) is mature and correct; it just had no caller from this code path.

### Changes

- **`prepare_bridge_dir()`** — new optional `sandbox: OSEnvSandboxSpec | None` parameter. When provided, key fields (`type`, `read_paths`, `write_paths`, `allow_network`, `env_passthrough`) are persisted into `bridge.json`.
- **`_sandbox_spec_to_json` / `_sandbox_spec_from_json`** — helpers to round-trip the spec through the JSON config file (the bridge MCP subprocess has no server connection, so the policy decision must be baked in at bridge-dir prep time).
- **`_build_tools()`** — reads `sandbox` from config and constructs a real `OSEnvSandboxSpec` instead of hardcoding `type="none"`.
- **`_auto_create_claude_terminal()`** — resolves `agent_os_env` before `prepare_bridge_dir` (was already done later for the terminal env) and passes its sandbox through. The same resolved value is then reused for the terminal env build to avoid a redundant call.

### How it works

The policy verdict is already fully resolved in the runner process before `prepare_bridge_dir` is called. Threading the result through `bridge.json` is the minimal, correct data path — the bridge subprocess reads it at startup, builds the `OSEnvSandboxSpec`, and passes it to `create_os_environment`. No round-trip to the policy engine from inside the subprocess needed.

## Test Plan

- Configure `force_sandbox` with `sandbox_type: linux_bwrap` (Linux with `bwrap` on PATH) or `darwin_seatbelt` (macOS).
- Start a claude-native session.
- Confirm `bridge.json` now contains `"sandbox": {"type": "linux_bwrap", ...}`.
- Confirm that a shell command that writes outside the allowed `write_paths` is rejected by the sandbox (previously it succeeded silently).
- Confirm sessions with no `force_sandbox` policy (`sandbox` absent from `bridge.json`) still run as before (`type="none"` falls back via `_sandbox_spec_from_json`).

## Demo

N/A — server-side policy enforcement change, no UI.

## Type of change

- [x] Bug fix

## Test coverage

- [x] Manual verification completed

## Coverage notes

Sandbox enforcement is integration-tested against a live bubblewrap environment. Unit test would require mocking `create_os_environment` and asserting the spec it receives — can be added as a follow-up if desired.