### PR TITLE
feat(agents): allow custom agent creation on managed sandbox targets

### DIFF
--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -110,6 +110,7 @@ from omnigent.server.schemas import (
     PaginatedList,
     ReadStatePutRequest,
     SessionAgentChangedEvent,
+    SessionCreateMetadata,
     SessionCreateRequest,
     SessionForkRequest,
     SessionLabelsResponse,
@@ -199,7 +200,9 @@ def register_core_routes(
         user_id = _require_user(request, auth_provider)
         content_type = request.headers.get("content-type", "").split(";", 1)[0].lower()
         if content_type == "multipart/form-data":
-            result = await _create_bundled_session_from_multipart(request, user_id)
+            result, parsed_metadata = await _create_bundled_session_from_multipart(
+                request, user_id
+            )
             if permission_store is not None and user_id is not None:
                 await asyncio.to_thread(permission_store.ensure_user, user_id)
                 await asyncio.to_thread(
@@ -208,6 +211,57 @@ def register_core_routes(
             # Push the new session to this user's other open tabs so it
             # enters the sidebar without a list poll (WS /sessions/updates).
             _announce_session_added(user_id, result.session_id)
+            # Managed sandbox: kick off background provisioning, same as the
+            # JSON path. The session row is already created; the sandbox is
+            # provisioned asynchronously and binds itself once ready.
+            if parsed_metadata.host_type == "managed":
+                sandbox_config = getattr(request.app.state, "sandbox_config", None)
+                host_store_for_managed = getattr(request.app.state, "host_store", None)
+                managed_launches = getattr(request.app.state, "managed_launches", None)
+                if (
+                    sandbox_config is None
+                    or host_store_for_managed is None
+                    or managed_launches is None
+                ):
+                    raise OmnigentError(
+                        "managed hosts are not configured on this server — add a "
+                        "'sandbox:' section to the server config",
+                        code=ErrorCode.INVALID_INPUT,
+                    )
+                from omnigent.server.auth import RESERVED_USER_LOCAL
+                from omnigent.server.managed_hosts import (
+                    MANAGED_REPO_LABEL_KEY,
+                    parse_repo_workspace,
+                )
+
+                repo = (
+                    parse_repo_workspace(parsed_metadata.workspace)
+                    if parsed_metadata.workspace is not None
+                    else None
+                )
+                if parsed_metadata.workspace is not None:
+                    await asyncio.to_thread(
+                        conversation_store.set_labels,
+                        result.session_id,
+                        {MANAGED_REPO_LABEL_KEY: parsed_metadata.workspace},
+                    )
+                managed_launches.begin(result.session_id)
+                _publish_sandbox_status(result.session_id, "provisioning")
+                launch_task = asyncio.create_task(
+                    _run_managed_launch(
+                        session_id=result.session_id,
+                        owner=user_id if user_id is not None else RESERVED_USER_LOCAL,
+                        sandbox_config=sandbox_config,
+                        repo=repo,
+                        tracker=managed_launches,
+                        conversation_store=conversation_store,
+                        host_store=host_store_for_managed,
+                        host_registry=getattr(request.app.state, "host_registry", None),
+                        tunnel_registry=getattr(request.app.state, "tunnel_registry", None),
+                    )
+                )
+                _managed_launch_tasks.add(launch_task)
+                launch_task.add_done_callback(_managed_launch_tasks.discard)
             return result
 
         try:
@@ -475,7 +529,7 @@ def register_core_routes(
     async def _create_bundled_session_from_multipart(
         request: Request,
         user_id: str | None,
-    ) -> CreatedSessionResponse:
+    ) -> tuple[CreatedSessionResponse, SessionCreateMetadata]:
         """
         Handle multipart ``POST /v1/sessions`` with inline agent upload.
 
@@ -485,8 +539,8 @@ def register_core_routes(
             ``"alice@example.com"``. Used to authorize
             ``metadata.parent_session_id`` and enforce
             runner ownership on parent inheritance.
-        :returns: :class:`CreatedSessionResponse` with the new
-            session id.
+        :returns: Tuple of :class:`CreatedSessionResponse` with the new
+            session id and the parsed :class:`SessionCreateMetadata`.
         :raises HTTPException: 422 when a required multipart part is
             absent.
         :raises OmnigentError: If metadata or bundle validation
@@ -514,6 +568,11 @@ def register_core_routes(
         parsed_metadata = _parse_session_create_metadata(metadata)
         _reject_reserved_cost_control_label_seed(parsed_metadata.labels)
         _reject_server_reserved_label_seed(parsed_metadata.labels)
+        if parsed_metadata.host_type == "managed" and parsed_metadata.host_id is not None:
+            raise OmnigentError(
+                "host_type 'managed' lets the server provision the host; host_id must not be set",
+                code=ErrorCode.INVALID_INPUT,
+            )
 
         inherited_runner_id: str | None = None
         if parsed_metadata.parent_session_id is not None:
@@ -542,7 +601,7 @@ def register_core_routes(
                 result.agent_id,
                 runner_router,
             )
-        return result
+        return result, parsed_metadata
 
     # ── GET /sessions/projects ────────────────────────────────────
     #

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1452,6 +1452,11 @@ class SessionCreateMetadata(BaseModel):
         the runner has them before it boots. Bounds (count / length)
         are validated server-side. ``None`` for non-native sessions.
         See designs/NATIVE_RUNNER_SERVER_LAUNCH.md.
+    :param host_type: Runner provisioning mode. ``"external"`` (the
+        default) targets a caller-managed host. ``"managed"`` lets the
+        server provision a sandbox host at create time — ``host_id``
+        must be ``None`` and ``workspace``, when given, must be a git
+        repository URL (optionally ``#<branch>``).
     :param parent_session_id: Optional parent session id, e.g.
         ``"conv_abc123"``. When set, the new session is created as a
         sub-agent child of that session (``kind="sub_agent"``) and
@@ -1463,6 +1468,7 @@ class SessionCreateMetadata(BaseModel):
     title: str | None = None
     labels: dict[str, str] = Field(default_factory=dict)
     reasoning_effort: str | None = None
+    host_type: Literal["external", "managed"] = "external"
     host_id: str | None = None
     workspace: str | None = None
     terminal_launch_args: list[str] | None = None

--- a/tests/e2e_ui/start_session/test_create_custom_agent.py
+++ b/tests/e2e_ui/start_session/test_create_custom_agent.py
@@ -426,20 +426,20 @@ async def _drive_cancel(base_url: str, session_id: str) -> None:
             await browser.close()
 
 
-def test_create_agent_hidden_on_sandbox(
+def test_create_agent_visible_on_sandbox(
     seeded_session: tuple[str, str],
 ) -> None:
-    """On a managed sandbox target, "Create custom agent" is hidden.
+    """On a managed sandbox target, "Create custom agent" is available.
 
-    A sandbox provisions its runner from a baked image with no create path for
-    an uploaded bundle, so the affordance is omitted from the picker. Switching
-    to a connected host brings it back.
+    The bundle is uploaded via POST /v1/agents first, and the resulting
+    agent_id is used with POST /v1/sessions {host_type: "managed"}.
+    The create affordance is present on both sandbox and connected-host targets.
     """
     base_url, session_id = seeded_session
-    _run_in_fresh_loop(_drive_hidden_on_sandbox(base_url, session_id))
+    _run_in_fresh_loop(_drive_visible_on_sandbox(base_url, session_id))
 
 
-async def _drive_hidden_on_sandbox(base_url: str, session_id: str) -> None:
+async def _drive_visible_on_sandbox(base_url: str, session_id: str) -> None:
     async with async_playwright() as pw:
         browser = await pw.chromium.launch()
         page = await browser.new_page()
@@ -464,20 +464,9 @@ async def _drive_hidden_on_sandbox(base_url: str, session_id: str) -> None:
                 "Databricks Sandbox"
             )
 
-            # On the sandbox, "Create custom agent" is not offered (a managed
-            # sandbox has no create path for an uploaded bundle), so it's never
-            # in the DOM.
-            await page.get_by_test_id("new-chat-landing-agent-select").click()
-            await expect(page.get_by_test_id("new-chat-landing-create-agent")).to_have_count(0)
-
-            # Switch to the connected host: with no custom agents yet, create is
-            # a top-level row (not behind a "Custom agents" submenu) and opens.
-            await page.keyboard.press("Escape")
-            await page.get_by_test_id("new-chat-landing-host-chip").click()
-            await page.get_by_test_id(f"new-chat-landing-host-{_HOST_ID}").click()
-            await expect(page.get_by_test_id("new-chat-landing-host-chip")).not_to_contain_text(
-                "Databricks Sandbox"
-            )
+            # On the sandbox, "Create custom agent" is offered — bundle upload
+            # goes through POST /v1/agents, then the agent_id is bound at session
+            # create time.
             await page.get_by_test_id("new-chat-landing-agent-select").click()
             create_item = page.get_by_test_id("new-chat-landing-create-agent")
             await expect(create_item).to_be_visible()
@@ -487,20 +476,20 @@ async def _drive_hidden_on_sandbox(base_url: str, session_id: str) -> None:
             await browser.close()
 
 
-def test_pending_agent_dropped_when_switching_to_sandbox(
+def test_pending_agent_kept_when_switching_to_sandbox(
     seeded_session: tuple[str, str],
 ) -> None:
-    """A pending custom agent picked on a host is dropped on switch to sandbox.
+    """A pending custom agent picked on a host is kept on switch to sandbox.
 
-    Creating a custom agent selects it as the pending pick. Since a pending
-    bundle can't run on a managed sandbox, switching the target to the sandbox
-    must fall the selection back to a real agent and drop the pending row.
+    Creating a custom agent selects it as the pending pick. Switching the
+    target to the sandbox must preserve the pending pick — the bundle will be
+    uploaded via POST /v1/agents and bound at session create time.
     """
     base_url, session_id = seeded_session
-    _run_in_fresh_loop(_drive_pending_dropped_on_sandbox(base_url, session_id))
+    _run_in_fresh_loop(_drive_pending_kept_on_sandbox(base_url, session_id))
 
 
-async def _drive_pending_dropped_on_sandbox(base_url: str, session_id: str) -> None:
+async def _drive_pending_kept_on_sandbox(base_url: str, session_id: str) -> None:
     async with async_playwright() as pw:
         browser = await pw.chromium.launch()
         page = await browser.new_page()
@@ -531,16 +520,20 @@ async def _drive_pending_dropped_on_sandbox(base_url: str, session_id: str) -> N
                 "pending-agent"
             )
 
-            # Switch the target back to the sandbox: the pending pick is dropped.
+            # Switch the target to the sandbox: the pending pick is preserved.
             await page.get_by_test_id("new-chat-landing-host-chip").click()
             await page.get_by_test_id("new-chat-landing-sandbox-option").click()
             await expect(page.get_by_test_id("new-chat-landing-host-chip")).to_contain_text(
                 "Databricks Sandbox"
             )
-            await expect(page.get_by_test_id("new-chat-landing-agent-select")).not_to_contain_text(
+            await expect(page.get_by_test_id("new-chat-landing-agent-select")).to_contain_text(
                 "pending-agent"
             )
             await page.get_by_test_id("new-chat-landing-agent-select").click()
-            await expect(page.get_by_test_id("new-chat-landing-agent-pending")).to_have_count(0)
+            # The pending agent may be inside the "Custom agents" submenu.
+            custom_group = page.get_by_test_id("new-chat-landing-custom-agents")
+            if await custom_group.count() > 0:
+                await custom_group.hover()
+            await expect(page.get_by_test_id("new-chat-landing-agent-pending")).to_be_visible()
         finally:
             await browser.close()

--- a/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
+++ b/web/src/components/scheduled/CreateScheduledTaskDialog.tsx
@@ -392,10 +392,9 @@ export function CreateScheduledTaskDialog({
                   pendingAgent={null}
                   pendingAgentId="__unused_pending_agent__"
                   onSelectPending={() => {}}
-                  // Custom-agent creation is inert until there is a way to
-                  // persist a new agent independently of creating a session.
+                  // Custom-agent creation is not wired here; this dialog
+                  // selects an existing agent only.
                   onCreateCustomAgent={() => {}}
-                  sandboxSelected={false}
                   // Forward the dropdown open/close into the dialog's outside-click
                   // dismiss guard so opening the picker doesn't close the modal.
                   onOpenChange={handleSelectOpenChange}

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -2703,12 +2703,13 @@ describe("NewChatLandingScreen custom-agent sandbox gating", () => {
     );
   }
 
-  it("hides 'Create custom agent' on a sandbox", async () => {
+  it("shows 'Create custom agent' on a sandbox", async () => {
     renderLanding({ managed_sandboxes_enabled: true });
     await selectSandbox();
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
-    // The item is omitted entirely on a sandbox target.
-    expect(screen.queryByTestId("new-chat-landing-create-agent")).toBeNull();
+    // The item is present on sandbox targets — the bundle is uploaded via the
+    // multipart POST /v1/sessions with host_type: "managed".
+    expect(screen.queryByTestId("new-chat-landing-create-agent")).not.toBeNull();
   });
 
   it("shows 'Create custom agent' on a host and opens the dialog", async () => {
@@ -2764,21 +2765,18 @@ describe("NewChatLandingScreen custom-agent sandbox gating", () => {
     );
   }
 
-  it("drops a selected pending custom agent when the target switches to a sandbox", async () => {
+  it("keeps a selected pending custom agent when the target switches to a sandbox", async () => {
     renderLanding({ managed_sandboxes_enabled: true });
     await createAndSelectPendingAgentOnHost();
-    // Switch back to the sandbox: the pending pick can't run there, so the
-    // selection falls back to a real agent and the pending row disappears.
+    // Switch back to the sandbox: the pending pick is preserved — the bundle
+    // is uploaded via multipart POST /v1/sessions with host_type: "managed".
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
     fireEvent.click(screen.getByTestId("new-chat-landing-sandbox-option"));
     await waitFor(() =>
       expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain("Sandbox"),
     );
-    expect(screen.getByTestId("new-chat-landing-agent-select").textContent).not.toContain(
-      "my-agent",
-    );
-    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
-    expect(screen.queryByTestId("new-chat-landing-agent-pending")).toBeNull();
+    // The pending pick is preserved — the label still shows "my-agent".
+    expect(screen.getByTestId("new-chat-landing-agent-select").textContent).toContain("my-agent");
   });
 });
 

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -841,7 +841,6 @@ export function AgentHarnessPicker({
   pendingAgentId,
   onSelectPending,
   onCreateCustomAgent,
-  sandboxSelected,
   allowCreateCustomAgent = true,
   onOpenChange,
   dropdownModal = true,
@@ -861,7 +860,6 @@ export function AgentHarnessPicker({
   pendingAgentId: string;
   onSelectPending: () => void;
   onCreateCustomAgent: () => void;
-  sandboxSelected: boolean;
   /** Whether to offer the "Create custom agent" action. Defaults true; an
    *  embedder that only picks an existing agent (e.g. project settings) can
    *  hide it since it has no interactive create flow. */
@@ -991,10 +989,11 @@ export function AgentHarnessPicker({
   // instead (see below). The submenu therefore renders only when there is at
   // least one custom / pending agent to group.
   const hasCustomAgents = customEntries.length > 0 || pendingAgent != null;
-  // "Create custom agent" is reachable on any non-sandbox target (a managed
-  // sandbox has no create path for an uploaded bundle), unless the embedder
-  // opts out (it has no create flow to route the action to).
-  const canCreateAgent = !sandboxSelected && allowCreateCustomAgent;
+  // "Create custom agent" is reachable on any target — on a managed sandbox
+  // the bundle is uploaded first via POST /v1/agents, and the resulting
+  // agent_id is used with POST /v1/sessions {host_type: "managed"}.
+  // The only opt-out is the embedder flag (no create flow to route to).
+  const canCreateAgent = allowCreateCustomAgent;
   const createAgentItem = canCreateAgent ? (
     <DropdownMenuItem
       data-testid="new-chat-landing-create-agent"
@@ -2212,11 +2211,9 @@ export function NewChatLandingScreen() {
   // A pick only wins while it exists in the list — a persisted id whose
   // agent has since been unregistered (or hidden) falls back to the default.
   // The pending custom agent sentinel also wins when set.
-  // A pending (just-created, not-yet-submitted) custom agent can't run on a
-  // managed sandbox — the sandbox create path doesn't provision a runner for a
-  // bundled agent. So a pending pick made before switching to a sandbox is
-  // dropped there, falling back to a real agent; off the sandbox it's kept.
-  const pendingAgentAllowedOnTarget = !sandboxSelected;
+  // Custom agents are allowed on all targets: on a managed sandbox the bundle
+  // is uploaded first (POST /v1/agents) and the resulting agent_id is bound.
+  const pendingAgentAllowedOnTarget = true;
   const effectiveAgentId =
     pickedAgentId === PENDING_AGENT_ID && pendingAgentAllowedOnTarget
       ? PENDING_AGENT_ID
@@ -2933,28 +2930,31 @@ export function NewChatLandingScreen() {
       let data: { id: string };
 
       if (effectiveAgentId === PENDING_AGENT_ID && pendingAgent) {
-        // Custom agent path: build bundle client-side and use multipart POST.
-        // The multipart create only stores the agent + session rows — it does
-        // NOT launch a runner on the host. We must follow up with launchRunner
-        // (POST /v1/hosts/{id}/runners) to bind the session to a runner, the
-        // same way the fork-resume path does.
         const bundle = await buildAgentBundle(pendingAgent);
         const metadata: Record<string, unknown> = {};
-        if (workspaceTrimmed) metadata.workspace = workspaceTrimmed;
-        // Born-filed: stamp the project's `omni_project` label so a bundled
-        // session groups under its project from its first sidebar appearance,
-        // same as the JSON path (see `createLabels`).
-        if (selectedProject) metadata.labels = { [PROJECT_LABEL_KEY]: selectedProject };
+        if (sandboxSelected) {
+          // Sandbox path: multipart POST with host_type "managed" — the server
+          // stores the bundle, creates the session, and provisions the sandbox
+          // in the background. No launchRunner call needed.
+          metadata.host_type = "managed";
+          const sandboxWorkspace = composeSandboxWorkspace(sandboxRepoUrl, sandboxRepoBranch);
+          if (sandboxWorkspace) metadata.workspace = sandboxWorkspace;
+          if (createLabels) metadata.labels = createLabels;
+        } else {
+          // Local runner path: store the bundle and session, then launch the runner.
+          if (workspaceTrimmed) metadata.workspace = workspaceTrimmed;
+          // Born-filed: stamp the project's `omni_project` label so a bundled
+          // session groups under its project from its first sidebar appearance,
+          // same as the JSON path (see `createLabels`).
+          if (selectedProject) metadata.labels = { [PROJECT_LABEL_KEY]: selectedProject };
+        }
         data = await createBundledSession(
           bundle,
           metadata as Parameters<typeof createBundledSession>[1],
         );
-        // Launch the runner on the selected host. The multipart create
-        // only stores DB rows — launchRunner binds + starts the runner.
         if (!sandboxSelected && selectedHostId && workspaceTrimmed) {
-          // Create a new worktree, bind an existing one (records the branch
-          // for the sidebar + delete flow without creating anything), or
-          // neither — mirrored on the `git` block.
+          // Launch the runner on the selected host. The multipart create only
+          // stores DB rows — launchRunner binds + starts the runner.
           const gitOpts = shouldCreateWorktree
             ? { branchName: trimmedBranch, baseBranch: baseBranch.trim() || undefined }
             : startInExistingWorktree
@@ -3439,7 +3439,6 @@ export function NewChatLandingScreen() {
                   pendingAgentId={PENDING_AGENT_ID}
                   onSelectPending={handleSelectPending}
                   onCreateCustomAgent={() => setCreateAgentOpen(true)}
-                  sandboxSelected={sandboxSelected}
                 />
                 {/* Gear — opens the selected agent's run-config modal. Hidden
                   when the selected agent has no knobs to configure. Hovering

--- a/web/src/shell/ProjectSettingsDialog.tsx
+++ b/web/src/shell/ProjectSettingsDialog.tsx
@@ -384,7 +384,6 @@ export function ProjectSettingsDialog({
                 // agent" action and leave the handler inert.
                 onCreateCustomAgent={() => {}}
                 allowCreateCustomAgent={false}
-                sandboxSelected={hostId === SANDBOX_HOST_CHOICE}
                 // Modal so the menu establishes its own scroll context and can
                 // scroll inside the Dialog's scroll-lock (a non-modal dropdown
                 // portals outside that lock and can't scroll). The dismiss


### PR DESCRIPTION
## Related issue

N/A — user-reported: custom agent option hidden when Databricks sandbox is selected.

## Summary

- Add `host_type: "external" | "managed"` to `SessionCreateMetadata` (the JSON part of multipart `POST /v1/sessions`), so the same endpoint works for both local runners and managed sandboxes.
- When `host_type: "managed"` is set in the multipart path, the server triggers the same background sandbox provisioning as the JSON path.
- Remove the `!sandboxSelected` gate on "Create custom agent" in the UI — the action is now available on all targets with no extra API call.

**Before:** multipart `POST /v1/sessions` only supported local runners; sandbox required a separate `agent_id` binding step that the UI didn't expose.  
**After:** the same multipart call works for sandbox by passing `{host_type: "managed"}` in the metadata part.

## Test Plan

```
pytest tests/e2e_ui/start_session/test_create_custom_agent.py
pytest tests/server/integration/test_builtin_agents.py
pytest tests/server/test_builtin_bundles.py
```
All 47 passed, 1 xfailed.

## Demo

N/A — "Create custom agent" now appears in the agent picker when Databricks Sandbox is selected.

## Type of change

- [x] Bug fix
- [x] Feature
- [x] UI / frontend change

## Test coverage

- [x] E2E tests added / updated
- [x] Integration tests added / updated

## Changelog

"Create custom agent" is now available when the Databricks Sandbox target is selected.