### PR TITLE
feat(sessions): auto-connect a wakeable runner on shell create

### DIFF
--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -2595,7 +2595,11 @@ async def ensure_runner_connected(
     dead-ending on a 502. Only the wakeable states recover here:
 
     * runner already connected → returned as-is (the common fast path);
-    * host online, runner dead → ``_launch_runner_on_host`` + connect wait;
+    * host online, pinned runner still booting → wait the connect grace
+      (``_HOST_BOUND_RUNNER_CONNECT_GRACE_S``, racing a ``host.runner_status``
+      query) before treating it as dead, so a booting runner isn't orphaned
+      by an eager relaunch;
+    * host online, runner truly dead → ``_launch_runner_on_host`` + connect wait;
     * host tunnel gone but managed/resumable → ``_maybe_relaunch_managed_sandbox``
       / ``_maybe_wake_stale_resumable_managed_sandbox``.
 
@@ -2651,6 +2655,29 @@ async def ensure_runner_connected(
         host_conn = host_registry.get(conv.host_id) if host_registry is not None else None
         relaunched_runner_id: str | None = None
         if host_conn is not None:
+            # A session whose runner is merely booting already has a runner_id
+            # before its tunnel registers. Mirror post_event's connect grace:
+            # wait briefly for that pinned runner (racing a host.runner_status
+            # query, which cuts the wait short if the host reports it truly
+            # gone) before relaunching — otherwise we'd spawn a second runner
+            # and orphan the one still coming up.
+            if (
+                conv.runner_id is not None
+                and host_registry is not None
+                and _facade._HOST_BOUND_RUNNER_CONNECT_GRACE_S > 0
+            ):
+                runner_client = await _wait_for_host_bound_runner_client(
+                    session_id,
+                    runner_router,
+                    tunnel_registry,
+                    runner_id=conv.runner_id,
+                    timeout_s=_facade._HOST_BOUND_RUNNER_CONNECT_GRACE_S,
+                    runner_exit_reports=getattr(app_state, "runner_exit_reports", None),
+                    host_conn=host_conn,
+                    host_registry=host_registry,
+                )
+                if runner_client is not None:
+                    return runner_client, await _reread()
             launch_attempt = await _launch_runner_on_host(
                 conv,
                 conversation_store,

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -2572,6 +2572,119 @@ async def _maybe_wake_stale_resumable_managed_sandbox(
     )
 
 
+async def ensure_runner_connected(
+    *,
+    session_id: str,
+    conv: Conversation,
+    app_state: Any,
+    conversation_store: ConversationStore,
+    runner_router: RunnerRouter | None,
+) -> tuple[httpx.AsyncClient | None, Conversation]:
+    """
+    Bring a wakeable session's runner online for out-of-band resource access.
+
+    Mirrors the message-dispatch relaunch ladder in ``post_event`` — wake a
+    stale resumable managed sandbox, launch a runner on a live host, or
+    relaunch a dead managed sandbox — but without any of the message-specific
+    side effects (failed-turn persistence, session-init handshake, sub-agent
+    binding heal). It answers one question: "is a live runner reachable, and
+    if not, can we wake one right now?"
+
+    Used by resource routes (e.g. shell create) so a user acting on a session
+    whose runner merely went to sleep transparently reconnects it, instead of
+    dead-ending on a 502. Only the wakeable states recover here:
+
+    * runner already connected → returned as-is (the common fast path);
+    * host online, runner dead → ``_launch_runner_on_host`` + connect wait;
+    * host tunnel gone but managed/resumable → ``_maybe_relaunch_managed_sandbox``
+      / ``_maybe_wake_stale_resumable_managed_sandbox``.
+
+    Non-wakeable states (external host offline, not host-bound with a dead
+    runner) return ``(None, conv)`` — the caller keeps its existing
+    unavailable handling (the CLI reconnect path owns those).
+
+    :param session_id: Session/conversation identifier.
+    :param conv: Current session row.
+    :param app_state: ``request.app.state`` — supplies the registries,
+        managed-launch tracker, host store, and sandbox config.
+    :param conversation_store: Store holding the session row.
+    :param runner_router: The ``RunnerRouter``, or ``None`` for in-process.
+    :returns: ``(runner_client, conv)`` — the client is ``None`` when no
+        runner is reachable and none is wakeable; ``conv`` is re-read after
+        any wake/relaunch so the caller sees the rebound row.
+    :raises OmnigentError: 503 when a managed relaunch/wake failed or timed
+        out (propagated from ``_maybe_relaunch_managed_sandbox``).
+    """
+
+    from omnigent.server.routes import sessions as _facade
+
+    async def _reread() -> Conversation:
+        refreshed = await asyncio.to_thread(conversation_store.get_conversation, session_id)
+        return refreshed if refreshed is not None else conv
+
+    # Fast path: a live runner tunnel is already reachable.
+    runner_client = await _get_runner_client(session_id, runner_router)
+    if runner_client is not None:
+        return runner_client, conv
+
+    tunnel_registry = cast(TunnelRegistry | None, getattr(app_state, "tunnel_registry", None))
+    host_registry = cast(HostRegistry | None, getattr(app_state, "host_registry", None))
+
+    # A resumable managed host whose persisted liveness has gone stale wakes
+    # in place; re-read the row and re-resolve, since the wake may have
+    # relaunched the runner and rebound the session.
+    if conv.host_id is not None and await _maybe_wake_stale_resumable_managed_sandbox(
+        session_id=session_id,
+        conv=conv,
+        app_state=app_state,
+        conversation_store=conversation_store,
+    ):
+        conv = await _reread()
+        runner_client = await _get_runner_client(session_id, runner_router)
+        if runner_client is not None:
+            return runner_client, conv
+
+    # Host-bound but no runner: ask the still-online host to spawn one, or
+    # relaunch a managed sandbox whose host tunnel is gone. Mirrors the
+    # gating in post_event — host presence, then managed relaunch fallback.
+    if runner_client is None and conv.host_id is not None:
+        host_conn = host_registry.get(conv.host_id) if host_registry is not None else None
+        relaunched_runner_id: str | None = None
+        if host_conn is not None:
+            launch_attempt = await _launch_runner_on_host(
+                conv,
+                conversation_store,
+                host_registry,
+                host_conn,
+            )
+            # A harness-not-configured refusal is a real host-side error, but
+            # out of band there's no turn to persist it against — leave the
+            # binding and let the caller surface the transport failure.
+            if launch_attempt.error_code != _HARNESS_NOT_CONFIGURED_ERROR_CODE:
+                relaunched_runner_id = launch_attempt.runner_id
+        elif await _maybe_relaunch_managed_sandbox(
+            session_id=session_id,
+            conv=conv,
+            app_state=app_state,
+            conversation_store=conversation_store,
+        ):
+            conv = await _reread()
+            runner_client = await _get_runner_client(session_id, runner_router)
+
+        if runner_client is None:
+            runner_client = await _wait_for_runner_client(
+                session_id,
+                runner_router,
+                tunnel_registry,
+                runner_id=relaunched_runner_id,
+                timeout_s=_facade._HOST_RELAUNCH_RUNNER_CONNECT_TIMEOUT_S,
+                runner_exit_reports=getattr(app_state, "runner_exit_reports", None),
+            )
+            conv = await _reread()
+
+    return runner_client, conv
+
+
 def _kick_managed_relaunch(
     *,
     session_id: str,
@@ -6811,4 +6924,5 @@ __all__ = [
     "_wait_for_host_bound_runner_client",
     "_wake_parent_for_blocked_child",
     "configure_subagent_block_notifier",
+    "ensure_runner_connected",
 ]

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -691,7 +691,9 @@ def register_resources_routes(
         # the wakeable states recover; a non-host-bound stranded session or an
         # offline external host still falls through to the 502 below (the CLI
         # reconnect path owns those).
-        _runner_client, conv = await ensure_runner_connected(
+        # Called for its reconnect side effect; the proxy below re-resolves the
+        # (now-live) runner client itself, so neither return value is bound.
+        await ensure_runner_connected(
             session_id=session_id,
             conv=conv,
             app_state=request.app.state,

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -684,6 +684,20 @@ def register_resources_routes(
                     ),
                     code=ErrorCode.INVALID_INPUT,
                 )
+        # A session whose runner merely went to sleep (host still up, or a
+        # resumable managed sandbox) is transparently reconnected here, so
+        # opening a shell from the web wakes it instead of dead-ending on a
+        # 502 — the same relaunch the next chat message would trigger. Only
+        # the wakeable states recover; a non-host-bound stranded session or an
+        # offline external host still falls through to the 502 below (the CLI
+        # reconnect path owns those).
+        _runner_client, conv = await ensure_runner_connected(
+            session_id=session_id,
+            conv=conv,
+            app_state=request.app.state,
+            conversation_store=conversation_store,
+            runner_router=runner_router or get_server_runner_router(),
+        )
         path = f"/v1/sessions/{session_id}/resources/terminals"
         status, payload = await _proxy_post_to_runner(
             session_id,

--- a/tests/e2e_ui/shells/test_new_shell_reconnects.py
+++ b/tests/e2e_ui/shells/test_new_shell_reconnects.py
@@ -1,0 +1,128 @@
+"""E2E: the "+" → Shell affordance stays usable on a runner-asleep session.
+
+When the web app believes a session's runner is offline but its host is up
+(``runner_asleep`` liveness), the "+" ("Open new") menu must keep the "Shell"
+item enabled — a wakeable session reconnects on create rather than dead-ending
+on a disabled button or a "no runner available" 502. This pins the frontend
+half of that behavior (``NewTabMenu`` in ``web/src/shell/WorkspacePanel.tsx``):
+picking Shell while the UI reads runner-offline still opens a working shell.
+
+Scope / honesty about the harness: the runner really is alive server-side here
+(only the browser's *view* of liveness is patched runner-offline via
+``/health``), so the create route's wake ladder (``ensure_runner_connected`` in
+``_sessions/orchestration.py``) fast-paths on the live runner — the server-side
+relaunch itself is NOT exercised (that needs host/managed-sandbox infrastructure
+this harness doesn't stand up; it's covered by the backend unit test
+``tests/server/routes/test_ensure_runner_connected.py``). What this proves is
+the user-visible guard: perceived runner-offline liveness does not block shell
+creation from the UI. The complementary "genuinely offline / can't reconnect
+from the web" branch (Shell disabled + "Offline") is a pure frontend gate
+covered by vitest (``web/src/shell/WorkspacePanel.test.tsx``).
+
+Mirrors the liveness patching in ``files/test_offline_runner_host_served.py``
+and ``sessions/test_host_badge.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from urllib.parse import urlparse
+
+from playwright.sync_api import Page, Route, expect
+
+from tests.e2e_ui.conftest import open_right_rail
+
+# Unix seconds well before now so a session whose runner reads offline is
+# outside the startup grace and classifies runner_asleep (not "starting").
+_OLD_CREATED_AT = 1_700_000_000
+
+
+def _patch_runner_asleep(page: Page, session_id: str) -> None:
+    """Patch the browser's view of ``session_id`` into runner-asleep.
+
+    ``runner_online: false`` + ``host_online: true`` via ``/health`` is the
+    ``runner_asleep`` liveness the feature targets — the host relaunches the
+    runner on demand. The snapshot is patched host-bound with an old
+    ``created_at`` so the session escapes the startup grace and reads asleep
+    rather than "starting", and the sessions ``updates`` WS is blocked so a
+    real stream push can't revert liveness to the (truly online) runner.
+
+    :param page: Playwright page before navigation.
+    :param session_id: Session id to patch.
+    """
+
+    def _patch_snapshot(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != f"/v1/sessions/{session_id}":
+            route.continue_()
+            return
+        response = route.fetch()
+        payload = response.json()
+        payload["created_at"] = _OLD_CREATED_AT
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    def _patch_health(route: Route) -> None:
+        request = route.request
+        if request.method != "GET" or urlparse(request.url).path != "/health":
+            route.continue_()
+            return
+        response = route.fetch()
+        payload = response.json()
+        # Runner offline, host online → runner_asleep (host wakes it on demand).
+        live = {"runner_online": False, "host_online": True}
+        if isinstance(payload.get("sessions"), dict):
+            payload["sessions"][session_id] = live
+        if isinstance(payload.get("session"), dict):
+            payload["session"] = {**payload["session"], **live}
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    # Snapshot route registered last so it wins for /v1/sessions/{id} (Playwright
+    # matches most-recently-registered first); /health falls through via
+    # continue_() for anything it doesn't own.
+    page.route(re.compile(r"/health(\?|$)"), _patch_health)
+    page.route(re.compile(rf"/v1/sessions/{re.escape(session_id)}(\?|$)"), _patch_snapshot)
+    page.route_web_socket(re.compile(r"/v1/sessions/updates"), lambda ws: None)
+
+
+def test_new_shell_reconnects_asleep_runner(page: Page, terminal_session: tuple[str, str]) -> None:
+    """ "+" → Shell on a runner-asleep session stays enabled and opens a shell.
+
+    The UI believes the runner is offline (patched ``/health``), yet the "Shell"
+    item stays enabled and picking it opens a working shell tab. A regression
+    that re-gated shell creation on the UI's runner liveness would leave the
+    item disabled (or the create 502-ing), so no shell tab would ever appear.
+    (The server-side wake this rides on is unit-tested separately — see the
+    module docstring.)
+    """
+    base_url, session_id = terminal_session
+    _patch_runner_asleep(page, session_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+
+    # The "+" menu's Shell item is NOT disabled just because the runner reads
+    # offline — a wakeable session reconnects on create.
+    rail.get_by_role("button", name="Open new").click()
+    shell_item = page.get_by_role("menuitem", name=re.compile("Shell"))
+    expect(shell_item).not_to_have_attribute("aria-disabled", "true")
+    shell_item.click()
+
+    # The shell opens as a rail tab and its xterm connects — proving the woken
+    # runner served the create. Generous timeout: this waits on the wake ladder
+    # plus the PTY spin-up, not just a connect.
+    close_tab = rail.get_by_role("button", name=re.compile(r"^Close zsh · u-"))
+    expect(close_tab).to_be_visible(timeout=60_000)
+    terminal_view = rail.get_by_test_id("terminal-view").last
+    expect(terminal_view).to_be_visible(timeout=20_000)
+    expect(terminal_view).to_have_attribute("data-state", "connected", timeout=20_000)

--- a/tests/server/routes/test_ensure_runner_connected.py
+++ b/tests/server/routes/test_ensure_runner_connected.py
@@ -90,6 +90,9 @@ async def test_launches_runner_on_live_host_then_connects(
         return launch_attempt
 
     monkeypatch.setattr(orchestration, "_launch_runner_on_host", _launch)
+    # Pinned runner_old is truly gone: the connect grace yields nothing, so
+    # the helper relaunches rather than reusing it.
+    monkeypatch.setattr(orchestration, "_wait_for_host_bound_runner_client", _async_return(None))
     connected = object()
     waited: dict[str, Any] = {}
 
@@ -114,6 +117,49 @@ async def test_launches_runner_on_live_host_then_connects(
     assert launched.get("called") is True
     # The connect wait must target the freshly-launched runner id.
     assert waited["runner_id"] == "runner_new"
+    assert client is connected
+
+
+@pytest.mark.asyncio
+async def test_reuses_booting_runner_within_connect_grace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Host online + pinned runner still booting → wait the grace, don't relaunch.
+
+    Mirrors post_event's connect grace: a session whose runner_id is set but
+    whose tunnel hasn't registered yet must be given the grace to connect,
+    rather than eagerly spawning a second runner and orphaning the booting one.
+    """
+    monkeypatch.setattr(orchestration, "_get_runner_client", _async_return(None))
+    monkeypatch.setattr(
+        orchestration,
+        "_maybe_wake_stale_resumable_managed_sandbox",
+        _async_return(False),
+    )
+    # The booting runner connects within the grace window.
+    connected = object()
+    monkeypatch.setattr(
+        orchestration, "_wait_for_host_bound_runner_client", _async_return(connected)
+    )
+
+    def _boom(*_a: Any, **_k: Any) -> None:
+        raise AssertionError("must not relaunch while the pinned runner is still booting")
+
+    monkeypatch.setattr(orchestration, "_launch_runner_on_host", _boom)
+    monkeypatch.setattr(orchestration, "_wait_for_runner_client", _boom)
+
+    conv = _conv(host_id="host_1", runner_id="runner_booting", workspace="/w")
+    host_registry = SimpleNamespace(get=lambda _hid: object())
+    app_state = SimpleNamespace(host_registry=host_registry, tunnel_registry=None)
+
+    client, _ = await orchestration.ensure_runner_connected(
+        session_id="conv_1",
+        conv=conv,
+        app_state=app_state,
+        conversation_store=_Store(conv),
+        runner_router=None,
+    )
+
     assert client is connected
 
 

--- a/tests/server/routes/test_ensure_runner_connected.py
+++ b/tests/server/routes/test_ensure_runner_connected.py
@@ -1,0 +1,151 @@
+"""Unit tests for ``ensure_runner_connected`` — the out-of-band runner-wake
+ladder shared by resource routes (e.g. shell create).
+
+The full message-dispatch relaunch is exercised by the integration suites; here
+we pin the branch logic in isolation by patching the primitives the helper
+composes, so the three outcomes (already-connected fast path, wakeable →
+relaunch, non-wakeable → ``None``) can't silently regress.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from omnigent.entities.conversation import Conversation
+from omnigent.server.routes._sessions import orchestration
+
+
+def _conv(**kwargs: Any) -> Conversation:
+    base = {
+        "id": "conv_1",
+        "created_at": 1,
+        "updated_at": 1,
+        "root_conversation_id": "conv_1",
+        "agent_id": "agent_1",
+    }
+    base.update(kwargs)
+    return Conversation(**base)
+
+
+class _Store:
+    """Conversation store stub whose ``get_conversation`` returns a fixed row."""
+
+    def __init__(self, conv: Conversation) -> None:
+        self._conv = conv
+
+    def get_conversation(self, conversation_id: str) -> Conversation:
+        del conversation_id
+        return self._conv
+
+
+@pytest.mark.asyncio
+async def test_returns_existing_client_without_waking(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A live runner short-circuits — no wake/relaunch primitive is touched."""
+    sentinel = object()
+    monkeypatch.setattr(
+        orchestration,
+        "_get_runner_client",
+        _async_return(sentinel),
+    )
+
+    def _boom(*_a: Any, **_k: Any) -> None:
+        raise AssertionError("wake/relaunch must not run when a runner is live")
+
+    monkeypatch.setattr(orchestration, "_maybe_wake_stale_resumable_managed_sandbox", _boom)
+    monkeypatch.setattr(orchestration, "_launch_runner_on_host", _boom)
+
+    conv = _conv(runner_id="runner_1")
+    client, out_conv = await orchestration.ensure_runner_connected(
+        session_id="conv_1",
+        conv=conv,
+        app_state=SimpleNamespace(),
+        conversation_store=_Store(conv),
+        runner_router=None,
+    )
+
+    assert client is sentinel
+    assert out_conv is conv
+
+
+@pytest.mark.asyncio
+async def test_launches_runner_on_live_host_then_connects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Host-bound, host online, runner dead → launch on host, then connect."""
+    # No client on the first resolve; the connect wait then returns one.
+    monkeypatch.setattr(orchestration, "_get_runner_client", _async_return(None))
+    monkeypatch.setattr(
+        orchestration,
+        "_maybe_wake_stale_resumable_managed_sandbox",
+        _async_return(False),
+    )
+    launch_attempt = SimpleNamespace(runner_id="runner_new", error_code=None, error=None)
+    launched: dict[str, Any] = {}
+
+    async def _launch(conv: Conversation, *_a: Any, **_k: Any) -> Any:
+        launched["called"] = True
+        return launch_attempt
+
+    monkeypatch.setattr(orchestration, "_launch_runner_on_host", _launch)
+    connected = object()
+    waited: dict[str, Any] = {}
+
+    async def _wait(*_a: Any, runner_id: str | None = None, **_k: Any) -> Any:
+        waited["runner_id"] = runner_id
+        return connected
+
+    monkeypatch.setattr(orchestration, "_wait_for_runner_client", _wait)
+
+    conv = _conv(host_id="host_1", runner_id="runner_old", workspace="/w")
+    host_registry = SimpleNamespace(get=lambda _hid: object())
+    app_state = SimpleNamespace(host_registry=host_registry, tunnel_registry=None)
+
+    client, _ = await orchestration.ensure_runner_connected(
+        session_id="conv_1",
+        conv=conv,
+        app_state=app_state,
+        conversation_store=_Store(conv),
+        runner_router=None,
+    )
+
+    assert launched.get("called") is True
+    # The connect wait must target the freshly-launched runner id.
+    assert waited["runner_id"] == "runner_new"
+    assert client is connected
+
+
+@pytest.mark.asyncio
+async def test_non_wakeable_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Not host-bound, runner dead → nothing to wake; returns ``None``."""
+    monkeypatch.setattr(orchestration, "_get_runner_client", _async_return(None))
+
+    def _boom(*_a: Any, **_k: Any) -> None:
+        raise AssertionError("no host to launch/relaunch on for a stranded session")
+
+    monkeypatch.setattr(orchestration, "_launch_runner_on_host", _boom)
+
+    conv = _conv(host_id=None, runner_id="runner_dead")
+    app_state = SimpleNamespace(host_registry=None, tunnel_registry=None)
+
+    client, out_conv = await orchestration.ensure_runner_connected(
+        session_id="conv_1",
+        conv=conv,
+        app_state=app_state,
+        conversation_store=_Store(conv),
+        runner_router=None,
+    )
+
+    assert client is None
+    assert out_conv is conv
+
+
+def _async_return(value: Any):
+    """Build an async callable that ignores its args and returns ``value``."""
+
+    async def _fn(*_a: Any, **_k: Any) -> Any:
+        return value
+
+    return _fn

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1494,6 +1494,7 @@ export function AppShell() {
                     onFlatViewChange={handleFilesFlatViewChange}
                     filesPanelShowHidden={filesPanelShowHidden}
                     onShowHiddenChange={setFilesPanelShowHidden}
+                    liveness={liveness}
                   />
                 )}
               </div>

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useSessionAgent } from "@/hooks/useAgents";
+import type { SessionLiveness } from "@/hooks/useSessionLiveness";
 import type * as UseTerminalsModule from "@/hooks/useTerminals";
 import { useCreateTerminal, useTerminals } from "@/hooks/useTerminals";
 import type { ChangedSort } from "./FlatFileList";
@@ -85,6 +86,7 @@ function renderWorkspace(
     openTerminals?: string[];
     selectedTerminalKey?: string | null;
     maximized?: boolean;
+    liveness?: SessionLiveness;
   } = {},
 ) {
   const openFileViewer = vi.fn();
@@ -131,6 +133,7 @@ function renderWorkspace(
         onFlatViewChange={vi.fn()}
         filesPanelShowHidden={false}
         onShowHiddenChange={vi.fn()}
+        liveness={overrides.liveness}
       />
     </TooltipProvider>,
   );
@@ -474,6 +477,61 @@ describe('WorkspacePanel "+" new-tab menu', () => {
     expect(mutate).toHaveBeenCalledWith("bash", expect.any(Object));
 
     window.localStorage.removeItem("omnigent:preferred-shell");
+  });
+
+  it("keeps Shell enabled on a wakeable session — the server reconnects on create", async () => {
+    // A runner merely asleep (host up) is reconnected transparently by the
+    // server on create, so the item stays clickable and launches as normal.
+    declaresShell();
+    const mutate = vi.fn();
+    useCreateTerminalMock.mockReturnValue({
+      mutate,
+      isPending: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useCreateTerminal>);
+
+    renderWorkspace({ liveness: { kind: "runner_asleep" } });
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Open new" }), { button: 0 });
+    const shell = await screen.findByRole("menuitem", { name: /shell/i });
+    expect(shell).not.toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(shell);
+    expect(mutate).toHaveBeenCalledWith("zsh", expect.any(Object));
+  });
+
+  it("shows 'Reconnecting…' while a create is in flight on a wakeable session", async () => {
+    declaresShell();
+    useCreateTerminalMock.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: true,
+      isError: false,
+    } as unknown as ReturnType<typeof useCreateTerminal>);
+
+    renderWorkspace({ liveness: { kind: "host_asleep" } });
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Open new" }), { button: 0 });
+    expect(await screen.findByRole("menuitem", { name: /reconnecting/i })).toBeInTheDocument();
+  });
+
+  it("disables Shell and labels it Offline when the session can't be reconnected from the web", async () => {
+    // host_offline / local_stranded need a CLI reconnect — the browser can't
+    // wake them, so the item is disabled and marked Offline.
+    declaresShell();
+    const mutate = vi.fn();
+    useCreateTerminalMock.mockReturnValue({
+      mutate,
+      isPending: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useCreateTerminal>);
+
+    renderWorkspace({ liveness: { kind: "local_stranded" } });
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Open new" }), { button: 0 });
+    const shell = await screen.findByRole("menuitem", { name: /shell/i });
+    expect(shell).toHaveTextContent(/offline/i);
+    expect(shell).toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(shell);
+    expect(mutate).not.toHaveBeenCalled();
   });
 });
 

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -5,6 +5,7 @@ import {
   FilesIcon,
   GlobeIcon,
   ListTodoIcon,
+  Loader2Icon,
   MaximizeIcon,
   MinimizeIcon,
   PlusIcon,
@@ -30,6 +31,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { TerminalView } from "@/components/blocks/TerminalView";
 import { BrowserPane } from "@/components/BrowserPane/BrowserPane";
 import { useSessionAgent } from "@/hooks/useAgents";
+import type { SessionLiveness } from "@/hooks/useSessionLiveness";
 import { terminalTabKey, useCreateTerminal, useTerminals } from "@/hooks/useTerminals";
 import { FilesPanel } from "./FilesPanel";
 import { FileViewer } from "./FileViewer";
@@ -80,12 +82,43 @@ function readPreferredShell(): string | null {
 // "Shell" nests a submenu so the user picks which type to launch — the last
 // pick is remembered (check-marked, and launched on a plain "Shell" click).
 // Gated on the agent's spec declaring terminal access — renders nothing else.
+//
+// The "Shell" item also reflects the session's liveness so opening a shell on
+// a disconnected session isn't a silent 502:
+//   - online / wakeable (runner_asleep, host_asleep, starting): the item stays
+//     enabled — the server transparently reconnects the runner on create (see
+//     `ensure_runner_connected`). While the create is in flight on a wakeable
+//     session it reads "Reconnecting…" with a spinner, since the cold wake can
+//     take tens of seconds.
+//   - offline (host_offline, local_stranded): the web can't reconnect from the
+//     browser (a CLI `omnigent host` / `--resume` is required), so the item is
+//     disabled and labeled "Offline" — the chat reconnect banner owns recovery.
 // ---------------------------------------------------------------------------
+
+/** How the "Shell" item should behave given the session's liveness. */
+type ShellConnectState = "ready" | "wakeable" | "offline";
+
+function shellConnectState(liveness: SessionLiveness | undefined): ShellConnectState {
+  switch (liveness?.kind) {
+    case "host_offline":
+    case "local_stranded":
+      return "offline";
+    case "runner_asleep":
+    case "host_asleep":
+    case "starting":
+      return "wakeable";
+    // online, unknown, or absent: treat as ready (never block on an
+    // unresolved poll — matches useSessionLiveness's "assume online").
+    default:
+      return "ready";
+  }
+}
 
 function NewTabMenu({
   conversationId,
   onOpenTerminal,
   triggerClassName,
+  liveness,
 }: {
   conversationId: string;
   /** Open a freshly-created terminal as a rail tab by its tab key. */
@@ -93,9 +126,13 @@ function NewTabMenu({
   /** Extra classes on the trigger wrapper — used to cancel the open-tabs
    *  region's gap so the "+" hugs the last tab. */
   triggerClassName?: string;
+  /** Open session's derived liveness — drives the "Shell" item's connect
+   *  affordance. Absent is treated as ready. */
+  liveness?: SessionLiveness;
 }) {
   const { data: agent } = useSessionAgent(conversationId);
   const create = useCreateTerminal(conversationId);
+  const connectState = shellConnectState(liveness);
   // Remembered shell type, persisted across remounts/reloads. Seeded from
   // localStorage so the "+" in either strip spot agrees on the current pick.
   const [preferred, setPreferred] = useState<string | null>(() => readPreferredShell());
@@ -133,6 +170,27 @@ function NewTabMenu({
   // so the user picks which type to launch (mirrors NewTerminalButton's picker).
   const multipleShells = declaredTerminals.length > 1;
 
+  // Liveness-derived affordance for the "Shell" item. A create in flight on a
+  // wakeable session reads "Reconnecting…" (the server is waking the runner);
+  // an offline session disables the item since the browser can't reconnect it.
+  const isReconnecting = create.isPending && connectState === "wakeable";
+  const shellDisabled = create.isPending || connectState === "offline";
+  // Icon + label + trailing hint, shared by the single-item and submenu-trigger
+  // renders so both reflect the same connect state.
+  const shellItemContent = (
+    <>
+      {isReconnecting ? (
+        <Loader2Icon className="size-4 animate-spin" />
+      ) : (
+        <TerminalIcon className="size-4" />
+      )}
+      <span className="whitespace-nowrap">{isReconnecting ? "Reconnecting…" : "Shell"}</span>
+      {connectState === "offline" && (
+        <span className="ml-auto pl-4 text-xs text-muted-foreground">Offline</span>
+      )}
+    </>
+  );
+
   return (
     <DropdownMenu>
       <WorkspaceTabTooltip label="Open new" className={triggerClassName}>
@@ -147,7 +205,10 @@ function NewTabMenu({
           </button>
         </DropdownMenuTrigger>
       </WorkspaceTabTooltip>
-      <DropdownMenuContent align="start">
+      {/* min-w-44 floors the content wide enough for the longest item label
+          ("Reconnecting…" + spinner, and the sub-trigger's chevron) — the
+          default min-w-32 tracks the 32px "+" trigger and clips it. */}
+      <DropdownMenuContent align="start" className="min-w-44">
         <DropdownMenuLabel>Open new</DropdownMenuLabel>
         {multipleShells ? (
           <DropdownMenuSub>
@@ -157,21 +218,20 @@ function NewTabMenu({
                 lets the menu close on its own; preventDefault stops the click
                 from only toggling the submenu open. */}
             <DropdownMenuSubTrigger
-              disabled={create.isPending}
+              disabled={shellDisabled}
               onClick={(e) => {
                 e.preventDefault();
                 launchShell(defaultShell);
               }}
             >
-              <TerminalIcon className="size-4" />
-              Shell
+              {shellItemContent}
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
               {declaredTerminals.map((name) => (
                 <DropdownMenuItem
                   key={name}
                   onSelect={() => pickShell(name)}
-                  disabled={create.isPending}
+                  disabled={shellDisabled}
                 >
                   <CheckIcon
                     className={cn("size-4", name === defaultShell ? "opacity-100" : "opacity-0")}
@@ -184,10 +244,9 @@ function NewTabMenu({
         ) : (
           <DropdownMenuItem
             onSelect={() => launchShell(declaredTerminals[0])}
-            disabled={create.isPending}
+            disabled={shellDisabled}
           >
-            <TerminalIcon className="size-4" />
-            Shell
+            {shellItemContent}
           </DropdownMenuItem>
         )}
       </DropdownMenuContent>
@@ -531,6 +590,10 @@ interface WorkspacePanelProps {
   filesPanelShowHidden: boolean;
   /** Toggle hidden-file visibility in the Files panel. */
   onShowHiddenChange: (show: boolean) => void;
+  /** Open session's derived liveness — drives the "+ New shell" menu's
+   *  connect affordance (Reconnecting… / Offline). Absent is treated as
+   *  ready. */
+  liveness?: SessionLiveness;
 }
 
 /**
@@ -585,6 +648,7 @@ export function WorkspacePanel({
   onFlatViewChange,
   filesPanelShowHidden,
   onShowHiddenChange,
+  liveness,
 }: WorkspacePanelProps) {
   // Memoized so FileViewer's Escape-to-close effect doesn't re-subscribe its
   // window keydown listener on every render — an inline arrow would change
@@ -782,6 +846,7 @@ export function WorkspacePanel({
               conversationId={conversationId}
               onOpenTerminal={openTerminalTab}
               triggerClassName="ml-[2px]"
+              liveness={liveness}
             />
           </>
         )}
@@ -790,7 +855,11 @@ export function WorkspacePanel({
             the open-tabs region to trail the last tab (see above). Self-gates
             to nothing when the agent has no terminal access. */}
         {openFiles.length === 0 && openTerminals.length === 0 && (
-          <NewTabMenu conversationId={conversationId} onOpenTerminal={openTerminalTab} />
+          <NewTabMenu
+            conversationId={conversationId}
+            onOpenTerminal={openTerminalTab}
+            liveness={liveness}
+          />
         )}
         {/* Maximize/minimize toggle, pinned to the rightmost edge via ml-auto,
             which absorbs the free space before it. When open tabs exist their


### PR DESCRIPTION
## Related issue

N/A

## Summary

Opening a shell from the web UI on a session whose **runner had gone to sleep** dead-ended on a `502 no runner available` — even though the host was still up and the *next chat message* would have transparently woken it. The shell-create path just didn't run the wake ladder that message dispatch does.

- **server**: add `ensure_runner_connected` (in `_sessions/orchestration.py`) — the same runner-acquisition ladder `post_event` uses (wake a stale resumable managed sandbox → launch a runner on a live host → relaunch a managed sandbox), minus the message-specific side effects (failed-turn persistence, session-init handshake, sub-agent heal). `create_session_terminal` calls it before proxying. Wakeable states reconnect and the shell opens; a non-host-bound stranded session or an offline external host still `502`s (the CLI reconnect path owns those). Because it lives in the route, web / CLI / API all benefit.
- **web**: the `+` → **Shell** menu item now reflects liveness — stays enabled and shows **"Reconnecting…"** + spinner while the server wakes the runner on a wakeable session, and is **disabled + "Offline"** for states the browser can't reconnect (`host_offline` / `local_stranded`). Widened the menu (`min-w-44`) so the longer label isn't clipped.

I deliberately wrote `ensure_runner_connected` as a **standalone** helper reusing the existing lower-level primitives rather than refactoring `post_event`'s ladder into it — `post_event`'s ladder is braided with message-only concerns, so lifting it wasn't worth the blast radius on the hot path. The tradeoff is two copies of the ladder to keep in sync.

ELI5: the shell button used to give up if the agent's runner was napping. Now it nudges the runner awake first (just like sending a message does), then opens the shell.

## Test Plan

- `pytest tests/server/routes/test_ensure_runner_connected.py` — 3 new unit tests: already-connected fast path, host-online → launch → connect, and non-wakeable → `None`.
- `pytest tests/server/routes/test_session_resources.py` — existing 117 pass (the create fast-paths when a runner is already live).
- `vitest run src/shell/WorkspacePanel.test.tsx` — 34 pass, incl. 3 new: Shell enabled on a wakeable session, "Reconnecting…" while a create is in flight, disabled + "Offline" on `local_stranded`.
- `pytest tests/e2e_ui/shells/test_new_shell_reconnects.py` — new Playwright test: with the browser's liveness patched to `runner_asleep`, the Shell item stays enabled and a working shell tab opens (the whole `shells/` suite is green).
- Full `web` gate: `pnpm test` (4831 passed) + `pnpm run build` both green.

## Demo

https://github.com/user-attachments/assets/a3321492-f3fc-4f8f-a0f7-0ef01bbf26d0

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The e2e_ui test patches only the browser's *view* of liveness to `runner_asleep` (the harness runner is genuinely alive), so it proves the user-visible guard — perceived runner-offline liveness doesn't block shell creation — while `ensure_runner_connected`'s server-side wake ladder is covered by the unit test. The harness can't stand up the host / managed-sandbox infrastructure a true cold wake needs.

## Changelog

Opening a shell on a sleeping session now wakes its runner automatically instead of failing with "no runner available"

This pull request and its description were written by Isaac.