### PR TITLE
fix(pi-native): allow tool relay bridge root

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -198,8 +198,8 @@ def _trusted_parent_for_bridge_dir(target: Path) -> Path:
     Return the trusted parent for an allowed bridge directory.
 
     Claude-native files live below the uid-scoped temp bridge root.
-    Codex-, Cursor-, Qwen-, Hermes-, Antigravity-, and OpenCode-native reuse the
-    relay/MCP implementation but keep bridge files below their own bridge roots.
+    Codex-, Pi-, Cursor-, Qwen-, Hermes-, Antigravity-, and OpenCode-native reuse
+    the relay/MCP implementation but keep bridge files below their own bridge roots.
     All roots use the same owner-only ancestor validation; only the trusted
     anchor differs.
 
@@ -223,6 +223,18 @@ def _trusted_parent_for_bridge_dir(target: Path) -> Path:
         trusted_parent = codex_root.parent
         if codex_root.name == "codex-native" and codex_root.parent.name == ".omnigent":
             trusted_parent = codex_root.parent.parent
+        return _absolute_syntactic_path(trusted_parent)
+
+    from omnigent.pi_native_bridge import bridge_root as pi_bridge_root
+
+    pi_root = _absolute_syntactic_path(pi_bridge_root())
+    if target.is_relative_to(pi_root):
+        # Pi-native uses the same $HOME/.omnigent/<harness>-native layout as
+        # Codex-native. Trust $HOME in production, while allowing tests to
+        # monkeypatch the bridge root to a different shape.
+        trusted_parent = pi_root.parent
+        if pi_root.name == "pi-native" and pi_root.parent.name == ".omnigent":
+            trusted_parent = pi_root.parent.parent
         return _absolute_syntactic_path(trusted_parent)
 
     from omnigent.cursor_native_bridge import bridge_root as cursor_bridge_root
@@ -297,7 +309,7 @@ def _trusted_parent_for_bridge_dir(target: Path) -> Path:
 
     raise RuntimeError(
         f"bridge dir {target!s} is not under an allowed bridge root "
-        f"({claude_root!s}, {codex_root!s}, {cursor_root!s}, "
+        f"({claude_root!s}, {codex_root!s}, {pi_root!s}, {cursor_root!s}, "
         f"{antigravity_root!s}, {qwen_root!s}, {hermes_root!s}, {opencode_root!s}, "
         f"{kiro_root!s}, {acp_root!s})"
     )

--- a/omnigent/pi_native_bridge.py
+++ b/omnigent/pi_native_bridge.py
@@ -33,6 +33,11 @@ _INBOX_DIR = "inbox"
 _SESSIONS_DIR = "sessions"
 
 
+def bridge_root() -> Path:
+    """Return the root directory used for native Pi bridge files."""
+    return _BRIDGE_ROOT
+
+
 def bridge_dir_for_session_id(session_id: str) -> Path:
     """
     Return the bridge directory for a native Pi session.

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -3873,6 +3873,48 @@ async def test_serve_mcp_survives_handler_exception_and_keeps_serving(
 
 
 @pytest.mark.asyncio
+async def test_start_tool_relay_accepts_pi_native_bridge_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Relay startup accepts Pi-native's persistent bridge root."""
+    from omnigent import pi_native_bridge
+
+    pi_root = tmp_path / ".omnigent" / "pi-native"
+    monkeypatch.setattr("omnigent.pi_native_bridge._BRIDGE_ROOT", pi_root)
+    bridge_dir = pi_native_bridge.prepare_bridge_dir("conv_pi")
+    relay_file = bridge_dir / claude_native_bridge._TOOL_RELAY_FILE
+
+    async def _executor(name: str, arguments: dict[str, object]) -> dict[str, object]:
+        """Return an empty result for the unused relay tool callback."""
+        del name, arguments
+        return {}
+
+    relay = None
+    try:
+        relay = start_tool_relay(
+            bridge_dir=bridge_dir,
+            tools=[
+                {
+                    "name": "sys_session_list",
+                    "description": "List Omnigent sessions.",
+                    "parameters": {"type": "object", "properties": {}},
+                }
+            ],
+            tool_executor=_executor,
+            loop=asyncio.get_running_loop(),
+        )
+        assert relay_file.exists(), (
+            "Pi-native relay did not write tool_relay.json under the persistent bridge root"
+        )
+        relay_info = json.loads(relay_file.read_text(encoding="utf-8"))
+        assert relay_info["tools"][0]["name"] == "sys_session_list"
+    finally:
+        if relay is not None:
+            relay.close()
+
+
+@pytest.mark.asyncio
 async def test_start_tool_relay_accepts_codex_native_bridge_root(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Related issue

Closes #3917

## Summary

- Allow Pi-native session directories below `~/.omnigent/pi-native` to pass the shared tool relay's secure bridge-root validation.
- Expose Pi-native's bridge root and add a focused relay-startup regression test.

## Test Plan

- `uv run --extra dev pytest tests/test_claude_native_bridge.py -k 'pi_native_bridge_root or accepts_codex_native_bridge_root' -q` — 2 passed.
- `uv run --extra dev ruff check omnigent/claude_native_bridge.py omnigent/pi_native_bridge.py tests/test_claude_native_bridge.py` — passed.
- `uv run --extra dev ruff format --check omnigent/claude_native_bridge.py omnigent/pi_native_bridge.py tests/test_claude_native_bridge.py` — passed.
- Live Pi-native launch against a local Omnigent server and runner — Pi called `sys_session_list` through the managed relay and returned the live session count.

## Demo

Real Pi 0.82.1 running against the managed local Omnigent server. The screenshot shows Pi calling `sys_session_list` through the restored managed relay and returning the live session count:

![Pi successfully using the managed Omnigent relay](https://raw.githubusercontent.com/dgokeeffe/omnigent/d74f23c459faef3063c1f14169acc31ac0f40320/pr-evidence/pi-native-relay-live.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regression test prepares a Pi-native bridge directory, starts the shared tool relay, and verifies that its advertisement file contains the expected system tool. Manual verification launched the real Pi-native TUI through a local server and runner, called `sys_session_list` through the managed relay, and received the live session count.

## Changelog

Pi-native sessions now retain Omnigent system tools and the comment relay.
