### PR TITLE
fix: preserve completed reasoning across reconnects for all harnesses using reasoning delta

### DIFF
--- a/omnigent/antigravity_native_reader.py
+++ b/omnigent/antigravity_native_reader.py
@@ -1429,6 +1429,7 @@ async def _process_committed_step(
     if key not in state.seen:
         if _is_settled(step):
             state.seen.add(key)
+        step_index = _step_index(step)
         state.turn_active = await _emit_step(
             step,
             client=client,
@@ -1436,6 +1437,9 @@ async def _process_committed_step(
             cascade_id=cascade_id,
             allocator=state.allocator,
             turn_active=state.turn_active,
+            reasoning_text=(
+                state.reasoning_prefixes.get(step_index) if step_index is not None else None
+            ),
         )
         # Telemetry: model-change detection on USER_INPUT (design §10.4).
         await _maybe_emit_model_change(
@@ -1555,9 +1559,8 @@ async def _process_stream_step(
         state=state,
         on_pending_interaction=on_pending_interaction,
     )
-    # Once committed, the live block is retired by the committed message; drop both
-    # prefix trackers so a later same-index step (e.g. an agy timeout-retry reusing
-    # the slot) starts a fresh delta stream rather than diffing against stale text.
+    # Once committed, the live blocks have durable counterparts; drop both prefix
+    # trackers so a later same-index step starts fresh instead of diffing stale text.
     idx = _step_index(step)
     if idx is not None:
         state.prefixes.pop(idx, None)
@@ -1737,6 +1740,7 @@ async def _emit_step(
     cascade_id: str,
     allocator: _ToolCallIdAllocator,
     turn_active: bool,
+    reasoning_text: str | None = None,
 ) -> bool:
     """
     Emit one new step's status edges + mapped conversation items.
@@ -1758,7 +1762,12 @@ async def _emit_step(
         turn_active = True
         await _post_event(client, session_id, _status_event(_STATUS_RUNNING))
 
-    for event in map_step_to_events(step, conversation_id=cascade_id, allocator=allocator):
+    for event in map_step_to_events(
+        step,
+        conversation_id=cascade_id,
+        allocator=allocator,
+        reasoning_text=reasoning_text,
+    ):
         await _post_event(client, session_id, event)
 
     if _is_turn_close_step(step) and turn_active:

--- a/omnigent/antigravity_native_steps.py
+++ b/omnigent/antigravity_native_steps.py
@@ -530,14 +530,13 @@ def output_reasoning_delta_event(
     frames just like ``modifiedResponse``. The streaming reader prefix-diffs it
     and emits a *suffix* delta per frame so the SPA paints a live reasoning block
     (``sse.ts`` maps ``response.reasoning_text.delta`` → its ``reasoning_delta``).
-    Reasoning streams BEFORE the response (§10.2 ordering), and — unlike text —
-    has no committed conversation item: the SPA finalizes the reasoning block when
-    the committed assistant ``message`` arrives. The in-process antigravity
-    executor reaches the same SPA state by a different route: it emits only the
+    Reasoning streams BEFORE the response (§10.2 ordering). The deltas stay
+    transient; the DONE planner later persists one completed reasoning item. The
+    in-process antigravity executor reaches the same SPA state by a different
+    route: it emits only the
     ``reasoning_text`` deltas and relies on an IMPLICIT reasoning-start (the SPA
     opens the block on the first ``reasoning_delta``), whereas this path emits an
-    EXPLICIT ``response.reasoning.started`` first; both end with no committed
-    reasoning item. The SPA's
+    EXPLICIT ``response.reasoning.started`` first. The SPA's
     reasoning block is not keyed by a per-step id (unlike the text deltas'
     ``message_id``), so this carries no conversation id — only ``started`` and the
     growth ``delta``; ``step_index`` rides on the envelope for ordering/debug.
@@ -559,6 +558,28 @@ def output_reasoning_delta_event(
         data={
             "delta": delta,
             "started": started,
+        },
+        step_index=step_idx,
+    )
+
+
+def _reasoning_event(
+    *,
+    conversation_id: str,
+    step_idx: int,
+    text: str,
+) -> OutboundEvent:
+    """Build one completed reasoning conversation item."""
+    return OutboundEvent(
+        event_type="external_conversation_item",
+        data={
+            "item_type": "reasoning",
+            "item_data": {
+                "agent": _AGENT_NAME,
+                "summary": [],
+                "content": [{"type": "reasoning_text", "text": text}],
+            },
+            "response_id": _response_id(conversation_id, step_idx),
         },
         step_index=step_idx,
     )
@@ -878,13 +899,14 @@ def map_step_to_events(
     *,
     conversation_id: str,
     allocator: _ToolCallIdAllocator,
+    reasoning_text: str | None = None,
 ) -> list[OutboundEvent]:
     """
     Map one agy RPC step to Omnigent conversation-item events.
 
     This is the pure, no-delta mapping layer for the RPC-based read path. It
-    produces ``external_conversation_item`` events
-    (``message`` / ``function_call`` / ``function_call_output``) and emits no
+    produces ``external_conversation_item`` events (``reasoning`` / ``message`` /
+    ``function_call`` / ``function_call_output``) and emits no
     ``external_output_text_delta``. The user turn IS mirrored here (see below) —
     nothing else commits it on the TUI-inject write path.
 
@@ -896,9 +918,10 @@ def map_step_to_events(
       user turn, so without this the user message would never be committed
       (#1155). The reader dedups USER_INPUT by its per-turn ``executionId``, so
       this commits exactly once. An empty user turn → ``[]``.
-    * ``CORTEX_STEP_TYPE_PLANNER_RESPONSE`` **at status DONE** → one ``message``
-      item (role assistant) when ``plannerResponse.modifiedResponse`` (or
-      ``response``) is non-empty, then one ``function_call`` item per
+    * ``CORTEX_STEP_TYPE_PLANNER_RESPONSE`` **at status DONE** → one ``reasoning``
+      item when completed thinking is available, one ``message`` item
+      (role assistant) when ``plannerResponse.modifiedResponse`` (or ``response``)
+      is non-empty, then one ``function_call`` item per
       ``plannerResponse.toolCalls`` entry. A non-DONE (GENERATING) planner → ``[]``
       here; its partial text is conveyed only via the streaming reader's
       ``output_text_delta`` events, so committing a message pre-DONE would
@@ -932,6 +955,8 @@ def map_step_to_events(
         call ids).
     :param allocator: Fallback tool-call id allocator, used only when a step
         lacks the real agy ``id`` field (resume-mid-turn case).
+    :param reasoning_text: Completed reasoning accumulated by the streaming
+        reader when the terminal planner frame omits ``thinking``.
     :returns: Ordered events to POST for this step (possibly empty).
     """
     step_type = step.get("type")
@@ -965,9 +990,9 @@ def map_step_to_events(
     # incremental ``output_text_delta`` events; committing a message for it here too
     # would double-render — and on the poll path (which does NOT intercept GENERATING)
     # a step caught GENERATING then DONE would post TWO messages. Gating on DONE
-    # (symmetric with the tool-result gate below) yields exactly one committed message,
-    # with the FINAL text, on both the stream and poll paths. ERROR/other non-DONE →
-    # no committed item (any partial already streamed as deltas).
+    # (symmetric with the tool-result gate below) yields one completed reasoning
+    # item when available plus the final message, on both stream and poll paths.
+    # ERROR/other non-DONE → no committed reasoning item.
     if step_type == _TYPE_PLANNER_RESPONSE:
         if status == _STATUS_ERROR:
             # A model/turn ERROR (safety block, rate-limit, provider overload,
@@ -991,6 +1016,17 @@ def map_step_to_events(
         events: list[OutboundEvent] = []
         planner = step.get("plannerResponse")
         if isinstance(planner, dict):
+            final_reasoning = planner.get("thinking")
+            if not isinstance(final_reasoning, str) or not final_reasoning:
+                final_reasoning = reasoning_text
+            if isinstance(final_reasoning, str) and final_reasoning:
+                events.append(
+                    _reasoning_event(
+                        conversation_id=conversation_id,
+                        step_idx=step_idx,
+                        text=final_reasoning,
+                    )
+                )
             response_text = planner.get("response")
             # modifiedResponse is the post-moderation text; prefer it over
             # response when present.  Both fields appear in live fixtures and

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -4277,6 +4277,40 @@ async def _handle_completed_item(
     if item_type == "plan":
         await _post_plan_item(client, session_id, params, item)
         return
+    if item_type == "reasoning":
+        raw_summary = item.get("summary")
+        summary = (
+            [
+                {"type": "summary_text", "text": text}
+                for text in raw_summary
+                if isinstance(text, str) and text
+            ]
+            if isinstance(raw_summary, list)
+            else []
+        )
+        raw_content = item.get("content")
+        content = (
+            [
+                {"type": "reasoning_text", "text": text}
+                for text in raw_content
+                if isinstance(text, str) and text
+            ]
+            if isinstance(raw_content, list)
+            else []
+        )
+        if summary or content:
+            await _post_external_item(
+                client,
+                session_id,
+                item_type="reasoning",
+                item_data={
+                    "agent": _AGENT_NAME,
+                    "summary": summary,
+                    "content": content,
+                },
+                response_id=_response_id(params),
+            )
+        return
     if item_type in _REVIEW_MODE_ITEM_TYPES:
         await _post_review_mode_marker(client, session_id, params, item)
         return
@@ -6017,12 +6051,12 @@ async def _handle_reasoning_delta(
     Forward one live Codex reasoning (chain-of-thought) delta to AP.
 
     Codex emits ``item/reasoning/textDelta`` and
-    ``item/reasoning/summaryTextDelta`` while it thinks. Omnigent has no
-    completed reasoning conversation item — the reasoning block is
-    transient and is finalized when the turn's assistant message arrives —
-    so this only publishes a transient ``external_output_reasoning_delta``
-    so the web UI paints a live "thinking" block, matching the in-process
-    executor's wire shape (#1254). The first delta of a reasoning item
+    ``item/reasoning/summaryTextDelta`` while it thinks. These deltas stay
+    transient; the matching ``item/completed`` reasoning record is persisted
+    separately by :func:`_handle_completed_item`. This publishes an
+    ``external_output_reasoning_delta`` so the web UI paints a live "thinking"
+    block, matching the in-process executor's wire shape (#1254). The first delta
+    of a reasoning item
     opens the block (``started=True`` → ``response.reasoning.started``).
 
     :param client: HTTP client for Omnigent event posts.

--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -525,9 +525,9 @@ def _message_to_items(
 ) -> list[_MirrorItem]:
     """Convert one ``messages`` row to mirror items.
 
-    An assistant row with reasoning emits a one-shot
-    ``external_output_reasoning_delta`` item first, then a ``function_call``
-    item per call, followed by a ``message`` item if it also has prose content.
+    An assistant row with reasoning emits a one-shot live delta that is also
+    persisted as a completed reasoning item, then a ``function_call`` item per
+    call, followed by a ``message`` item if it also has prose content.
     A tool row emits a ``function_call_output`` item. Returns an empty list to
     skip.
     """
@@ -571,8 +571,9 @@ def _message_to_items(
                 _MirrorItem(
                     msg_id=msg_id,
                     item_type=_EXTERNAL_OUTPUT_REASONING_DELTA,
-                    item_data={"delta": thinking, "started": True},
+                    item_data={"delta": thinking, "started": True, "agent": agent_name},
                     response_id=response_id,
+                    role="assistant",
                 )
             )
         # Emit the prose FIRST, then the tool calls. An assistant row's text is
@@ -894,16 +895,33 @@ async def _post_conversation_item(
 ) -> None:
     """POST one mirrored item as the appropriate session event.
 
-    Reasoning items post a transient ``external_output_reasoning_delta`` (the
-    web finalizes the block when the assistant message lands); all others post
-    an ``external_conversation_item``.
+    Reasoning items post the live delta followed by one durable reasoning item;
+    all others post an ``external_conversation_item``.
     """
     if item.item_type == _EXTERNAL_OUTPUT_REASONING_DELTA:
+        delta = item.item_data.get("delta")
+        agent = item.item_data.get("agent")
         resp = await client.post(
             f"/v1/sessions/{session_id}/events",
             json={
                 "type": _EXTERNAL_OUTPUT_REASONING_DELTA,
-                "data": item.item_data,
+                "data": {"delta": delta, "started": True},
+            },
+        )
+        resp.raise_for_status()
+        resp = await client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={
+                "type": "external_conversation_item",
+                "data": {
+                    "item_type": "reasoning",
+                    "item_data": {
+                        "agent": agent,
+                        "summary": [],
+                        "content": [{"type": "reasoning_text", "text": delta}],
+                    },
+                    "response_id": item.response_id,
+                },
             },
         )
         resp.raise_for_status()

--- a/omnigent/kimi_native_forwarder.py
+++ b/omnigent/kimi_native_forwarder.py
@@ -18,8 +18,8 @@ and recency. Relevant wire events:
   → a user message.
 - ``{"type": "context.append_loop_event", "event": {"type": "content.part",
   "part": {"type": "text", "text": …}, "uuid": …}}`` → an assistant message.
-  (``part.type == "think"`` is reasoning, mirrored as a transient
-  ``external_output_reasoning_delta`` from ``part["think"]``; ``tool.call`` /
+  (``part.type == "think"`` is reasoning, mirrored live and persisted from
+  ``part["think"]``; ``tool.call`` /
   ``tool.result`` events are still skipped — the embedded terminal shows them.)
 
 Each mirrored turn is POSTed as an ``external_conversation_item`` to
@@ -246,9 +246,8 @@ def _row_to_item(line_no: int, row: dict[str, object]) -> KimiWireItem | None:
                 response_id=response_id,
             )
         if part_type == "think":
-            # Reasoning lives in ``part["think"]`` (not ``part["text"]``). Mirror it
-            # as a transient reasoning event so the web UI paints a thinking block —
-            # the kimi analogue of codex-native's #1254 reasoning fix.
+            # Reasoning lives in ``part["think"]`` (not ``part["text"]``). The
+            # forwarder paints it live, then persists the completed block.
             think = part.get("think")
             if not isinstance(think, str) or not think:
                 return None
@@ -358,8 +357,9 @@ async def _post_reasoning_item(
     headers: dict[str, str],
     session_id: str,
     item: KimiWireItem,
+    agent_name: str,
 ) -> None:
-    """POST one mirrored think block as a transient reasoning event.
+    """POST one mirrored think block live, then persist its completed item.
 
     Mirrors codex-native (#1254): a one-shot ``external_output_reasoning_delta``
     with ``started: true`` opens a reasoning block in the web UI. Kimi persists
@@ -371,6 +371,23 @@ async def _post_reasoning_item(
     }
     url = f"{base_url.rstrip('/')}/v1/sessions/{session_id}/events"
     resp = await client.post(url, headers=headers, json=body)
+    resp.raise_for_status()
+    resp = await client.post(
+        url,
+        headers=headers,
+        json={
+            "type": "external_conversation_item",
+            "data": {
+                "item_type": "reasoning",
+                "item_data": {
+                    "agent": agent_name,
+                    "summary": [],
+                    "content": [{"type": "reasoning_text", "text": item.text}],
+                },
+                "response_id": item.response_id,
+            },
+        },
+    )
     resp.raise_for_status()
 
 
@@ -428,6 +445,7 @@ async def forward_kimi_wire_to_session(
                                 headers=headers,
                                 session_id=session_id,
                                 item=item,
+                                agent_name=agent_name,
                             )
                         else:
                             await _post_conversation_item(

--- a/omnigent/opencode_native_forwarder.py
+++ b/omnigent/opencode_native_forwarder.py
@@ -193,6 +193,9 @@ class OpenCodeNativeForwarder:
         # the cumulative reasoning text on each ``part.updated``; we forward only
         # the new suffix so the web reasoning block grows once, not duplicated.
         self._reasoning_posted: dict[str, int] = {}
+        # reasoning part id -> (assistant message id, latest full text), flushed
+        # once when the step/turn completes so reconnects can rebuild the block.
+        self._pending_reasoning: dict[str, tuple[str | None, str]] = {}
         # The in-flight turn's assistant messageID (its per-turn ``response_id``),
         # captured from ``message.updated`` and stamped on the running/idle status
         # edges so the web chat renders this turn's tool calls live — the mirrored
@@ -482,6 +485,7 @@ class OpenCodeNativeForwarder:
         # can't grow across a long-lived session (the next turn's reasoning
         # parts carry fresh ids anyway).
         self._reasoning_posted.clear()
+        self._pending_reasoning.clear()
         # Stamp the terminal edge with the id the ``running`` edge actually went
         # out with (``_running_response_id``), then merge any caller-supplied
         # fields on top. If a turn produced more than one assistant messageID,
@@ -552,8 +556,9 @@ class OpenCodeNativeForwarder:
         elif part_type == "step-start":
             await self._begin_turn_if_needed()
         elif part_type == "step-finish":
-            # A step's assistant text is complete once the step closes; flush
-            # it so text and tool items land in the chat in step order.
+            # Reasoning precedes assistant text in the stream, so preserve that
+            # order when both become durable at the step boundary.
+            await self._flush_pending_reasoning()
             await self._flush_pending_text()
 
     def _accumulate_text_part(self, part: _JsonMapping) -> None:
@@ -642,14 +647,14 @@ class OpenCodeNativeForwarder:
             )
 
     async def _handle_reasoning_part(self, part: _JsonMapping) -> None:
-        """Forward an opencode ``reasoning`` part as transient reasoning deltas.
+        """Stream an opencode ``reasoning`` part and retain its final snapshot.
 
         opencode carries the cumulative chain-of-thought text on each
         ``part.updated`` (like text parts). We forward only the new suffix as an
         ``external_output_reasoning_delta`` so the web paints one growing
         reasoning block, with ``started`` set on the first chunk of each part
-        (the codex-native reasoning contract). Reasoning is transient — not
-        persisted as a chat item — so nothing is flushed on step end.
+        (the codex-native reasoning contract). The latest cumulative snapshot is
+        persisted once when the step or turn completes.
         """
         part_id = part.get("id")
         text = part.get("text")
@@ -659,6 +664,11 @@ class OpenCodeNativeForwarder:
         # to a user message, but guard anyway to match the text path.
         if self._msg_role.get(str(part.get("messageID"))) == "user":
             return
+        message_id = part.get("messageID")
+        self._pending_reasoning[part_id] = (
+            message_id if isinstance(message_id, str) else None,
+            text,
+        )
         posted = self._reasoning_posted.get(part_id, 0)
         if len(text) <= posted:
             return
@@ -669,6 +679,25 @@ class OpenCodeNativeForwarder:
             {"delta": delta, "started": posted == 0},
         )
         self._reasoning_posted[part_id] = len(text)
+
+    async def _flush_pending_reasoning(self) -> None:
+        """Persist each completed reasoning part once."""
+        for part_id, (message_id, text) in list(self._pending_reasoning.items()):
+            self._pending_reasoning.pop(part_id, None)
+            if not text or not self.state.mark(self._key("reasoning-final", part_id)):
+                continue
+            await self._post_event(
+                _EXTERNAL_ITEM,
+                {
+                    "item_type": "reasoning",
+                    "item_data": {
+                        "agent": _AGENT_NAME,
+                        "summary": [],
+                        "content": [{"type": "reasoning_text", "text": text}],
+                    },
+                    "response_id": self._response_id(message_id),
+                },
+            )
 
     async def _handle_file_part(self, part: _JsonMapping) -> None:
         """Mirror an opencode ``file`` part — images as image blocks, else a note.
@@ -733,6 +762,7 @@ class OpenCodeNativeForwarder:
     async def _on_session_idle(self, event: OpenCodeEvent) -> None:
         """Handle ``session.idle`` — finalize text, post usage, end the turn."""
         del event
+        await self._flush_pending_reasoning()
         await self._flush_pending_text()
         await self._post_session_usage()
         await self._end_turn()

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -392,6 +392,7 @@ class ExecutorAdapter(HarnessApp):
                     )
 
                 response_text: str | None = None
+                reasoning_blocks: list[dict[str, list[str]]] = []
                 async for event in executor.run_turn(
                     messages=messages,
                     tools=tools,
@@ -435,8 +436,41 @@ class ExecutorAdapter(HarnessApp):
                                 # aggregate visibility.
                                 record_llm_usage(agent_span, event.usage)
                     # --- End tracing ---
+                    if isinstance(event, ReasoningChunk):
+                        if event.event_type == "reasoning_started" or not reasoning_blocks:
+                            reasoning_blocks.append({"summary": [], "content": []})
+                        if event.event_type == "reasoning_summary" and event.delta:
+                            reasoning_blocks[-1]["summary"].append(event.delta)
+                        elif event.event_type == "reasoning_text" and event.delta:
+                            reasoning_blocks[-1]["content"].append(event.delta)
                     self._translate_event(event, ctx)
                     if isinstance(event, TurnComplete):
+                        for block in reasoning_blocks:
+                            summary_text = "".join(block["summary"])
+                            content_text = "".join(block["content"])
+                            if not summary_text and not content_text:
+                                continue
+                            ctx.emit(
+                                OutputItemDoneEvent(
+                                    type="response.output_item.done",
+                                    item={
+                                        "id": f"reasoning_{uuid.uuid4().hex[:12]}",
+                                        "type": "reasoning",
+                                        "status": "completed",
+                                        "agent": request.model or self._harness_label,
+                                        "summary": (
+                                            [{"type": "summary_text", "text": summary_text}]
+                                            if summary_text
+                                            else []
+                                        ),
+                                        "content": (
+                                            [{"type": "reasoning_text", "text": content_text}]
+                                            if content_text
+                                            else []
+                                        ),
+                                    },
+                                )
+                            )
                         if tctx is not None and agent_span is not None:
                             tctx.end_agent_span(agent_span, response=response_text)
                             agent_span = None

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -2413,9 +2413,8 @@ def _publish_external_output_reasoning_delta(session_id: str, body: SessionEvent
     publishes the standard reasoning SSE events the SPA already renders —
     ``response.reasoning.started`` once (when ``data.started`` is true, marking a
     new reasoning block) followed by ``response.reasoning_text.delta`` — without
-    persisting anything. Reasoning has no completed conversation item; the block
-    is finalized when the assistant message is persisted via
-    ``external_conversation_item``.
+    persisting the delta itself. Native forwarders may separately persist the
+    completed block through ``external_conversation_item``.
 
     :param session_id: Session/conversation identifier.
     :param body: ``POST /events`` body whose type is
@@ -5599,7 +5598,7 @@ def _extract_persistent_item_from_sse(
     Returns a ``NewConversationItem`` for:
 
     - ``response.output_item.done`` events carrying an assistant
-      message, function_call, or function_call_output.
+      message, function_call, function_call_output, or reasoning item.
     - ``compaction`` events carrying a conversation summary from
       the runner's compaction system.
 
@@ -5638,7 +5637,7 @@ def _extract_persistent_item_from_sse(
     if not isinstance(item, dict):
         return None
     item_type = item.get("type")
-    if item_type not in ("message", "function_call", "function_call_output"):
+    if item_type not in ("message", "function_call", "function_call_output", "reasoning"):
         return None
     # Skip transient observed function_call events (status
     # ``in_progress`` / ``action_required``).  Only ``completed``

--- a/tests/runtime/harnesses/test_executor_adapter.py
+++ b/tests/runtime/harnesses/test_executor_adapter.py
@@ -1514,6 +1514,64 @@ async def test_executor_adapter_builds_config_from_request() -> None:
 
 
 @pytest.mark.asyncio
+async def test_executor_adapter_emits_completed_reasoning_item() -> None:
+    """Wrapped harness reasoning deltas are committed once at turn completion."""
+    import asyncio
+
+    from omnigent.inner.executor import (
+        Executor,
+        ExecutorConfig,
+        Message,
+        ReasoningChunk,
+        ToolSpec,
+        TurnComplete,
+    )
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+    from omnigent.runtime.harnesses._scaffold import TurnContext
+    from omnigent.server.schemas import CreateResponseRequest
+
+    class _ReasoningExecutor(Executor):
+        async def run_turn(
+            self,
+            messages: list[Message],
+            tools: list[ToolSpec],
+            system_prompt: str,
+            config: ExecutorConfig | None = None,
+        ):
+            yield ReasoningChunk(delta="", event_type="reasoning_started")
+            yield ReasoningChunk(delta="think ", event_type="reasoning_text")
+            yield ReasoningChunk(delta="carefully", event_type="reasoning_text")
+            yield ReasoningChunk(delta="brief summary", event_type="reasoning_summary")
+            yield TurnComplete(response="ok")
+
+    adapter = ExecutorAdapter(executor_factory=lambda: _ReasoningExecutor())
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    ctx = TurnContext(response_id="resp_reason", event_queue=queue, cancelled=asyncio.Event())
+    await adapter.run_turn(CreateResponseRequest(model="test-agent", input="hi"), ctx)
+
+    events = []
+    while not queue.empty():
+        events.append(queue.get_nowait())
+    reasoning_items = [
+        event.item
+        for event in events
+        if getattr(event, "type", None) == "response.output_item.done"
+        and event.item.get("type") == "reasoning"
+    ]
+    assert len(reasoning_items) == 1
+    assert reasoning_items == [
+        {
+            "id": reasoning_items[0]["id"],
+            "type": "reasoning",
+            "status": "completed",
+            "agent": "test-agent",
+            "summary": [{"type": "summary_text", "text": "brief summary"}],
+            "content": [{"type": "reasoning_text", "text": "think carefully"}],
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_executor_adapter_forwards_model_override_to_config() -> None:
     """``request.model_override`` is threaded into ``ExecutorConfig.model``.
 

--- a/tests/server/routes/test_sessions_runner_relay.py
+++ b/tests/server/routes/test_sessions_runner_relay.py
@@ -70,6 +70,33 @@ class _HeartbeatStreamResponse:
         yield "data: [DONE]\n\n"
 
 
+def test_extract_persistent_reasoning_item_from_runner_sse() -> None:
+    """The runner relay accepts completed reasoning items for persistence."""
+    from omnigent.entities.conversation import ReasoningData
+    from omnigent.server.routes._sessions.helpers import _extract_persistent_item_from_sse
+
+    item = _extract_persistent_item_from_sse(
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "id": "reasoning_1",
+                "type": "reasoning",
+                "status": "completed",
+                "agent": "wrapped-harness",
+                "summary": [{"type": "summary_text", "text": "summary"}],
+                "content": [{"type": "reasoning_text", "text": "details"}],
+            },
+        },
+        response_id="resp_1",
+    )
+
+    assert item is not None
+    assert item.type == "reasoning"
+    assert item.response_id == "resp_1"
+    assert isinstance(item.data, ReasoningData)
+    assert item.data.content == [{"type": "reasoning_text", "text": "details"}]
+
+
 class _HeartbeatRunnerClient:
     """
     Fake runner client whose stream emits a ready heartbeat.

--- a/tests/test_antigravity_native_reader.py
+++ b/tests/test_antigravity_native_reader.py
@@ -1686,16 +1686,15 @@ async def test_stream_generating_emits_incremental_reasoning_deltas(
 
 
 @pytest.mark.asyncio
-async def test_stream_reasoning_precedes_text_and_has_no_committed_item(
+async def test_stream_reasoning_precedes_text_and_commits_reasoning_item(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     patched_discovery: None,
 ) -> None:
-    """Reasoning deltas precede text deltas (§10.2); DONE commits ONE message only.
+    """Reasoning deltas precede text deltas; DONE commits reasoning and message.
 
     Asserts the §10.2 ordering (thinking before response) within the frame and
-    that reasoning, unlike text, never produces a committed conversation item —
-    only the assistant ``message`` is committed on DONE.
+    that the accumulated reasoning becomes durable on DONE.
     """
     thinking = "First, parse intent. Then answer."
     text = "Sure — here is the answer."
@@ -1723,14 +1722,14 @@ async def test_stream_reasoning_precedes_text_and_has_no_committed_item(
     assert first_reasoning < first_text
     # Reasoning deltas concatenate to the full thinking text.
     assert "".join(cast(str, r["delta"]) for r in sink.reasonings()) == thinking
-    # Exactly ONE committed item — the assistant message; NO committed reasoning.
-    assert sink.item_types() == ["message"]
-    # Every reasoning post is a delta (transient); none is a conversation item.
-    assert all(
-        event_type != "external_conversation_item"
-        or cast(dict[str, Any], data).get("item_type") != "reasoning"
+    assert sink.item_types() == ["reasoning", "message"]
+    reasoning_item = next(
+        cast(dict[str, Any], data)
         for event_type, data in sink.posts
+        if event_type == "external_conversation_item"
+        and cast(dict[str, Any], data).get("item_type") == "reasoning"
     )
+    assert reasoning_item["item_data"]["content"] == [{"type": "reasoning_text", "text": thinking}]
 
 
 @pytest.mark.asyncio

--- a/tests/test_antigravity_native_steps.py
+++ b/tests/test_antigravity_native_steps.py
@@ -1193,31 +1193,23 @@ class TestOutputReasoningDeltaEvent:
         assert "message_id" not in event.data
 
 
-class TestMapStepEmitsNoReasoning:
-    """The pure mapper never emits a reasoning item — reasoning is delta-only."""
+class TestMapStepReasoning:
+    """Completed planner reasoning becomes durable history."""
 
-    def test_done_planner_with_thinking_emits_no_reasoning_item(self) -> None:
-        """
-        A DONE planner carrying ``thinking`` maps to message (+ tool calls) only.
-
-        Reasoning is surfaced solely as transient deltas by the streaming reader
-        (mirroring the in-process executor, which never commits a reasoning item).
-        The DONE-commit path must therefore not introduce a ``reasoning`` item or
-        any ``external_output_reasoning_delta``.
-        """
+    def test_done_planner_with_thinking_emits_reasoning_item(self) -> None:
         step = _load("planner_response_text")
         cast(dict[str, Any], step["plannerResponse"])["thinking"] = "internal chain of thought"
         events = map_step_to_events(step, conversation_id=_CID, allocator=_allocator())
 
-        for event in events:
-            assert event.event_type != "external_output_reasoning_delta"
-            if event.event_type == "external_conversation_item":
-                assert event.data.get("item_type") != "reasoning"
-        # The committed assistant message is still produced (text unchanged).
         item_types = [
             e.data.get("item_type") for e in events if e.event_type == "external_conversation_item"
         ]
-        assert "message" in item_types
+        assert item_types[:2] == ["reasoning", "message"]
+        assert events[0].data["item_data"] == {
+            "agent": "antigravity-native-ui",
+            "summary": [],
+            "content": [{"type": "reasoning_text", "text": "internal chain of thought"}],
+        }
 
 
 class TestExecutionDiscriminator:

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -1289,6 +1289,47 @@ async def test_completed_context_compaction_item_clears_spinner() -> None:
 
 
 @pytest.mark.asyncio
+async def test_completed_reasoning_item_is_persisted() -> None:
+    """A completed Codex reasoning item becomes durable conversation history."""
+    client = _RecordingClient()
+    state = fwd._CodexForwarderState()
+
+    await fwd._handle_completed_item(
+        client,
+        "conv_x",
+        {
+            "threadId": "thread_1",
+            "turnId": "turn_1",
+            "item": {
+                "type": "reasoning",
+                "id": "item_r",
+                "summary": ["Short summary"],
+                "content": ["Detailed reasoning"],
+            },
+        },
+        forwarder_state=state,
+    )
+
+    assert client.posts == [
+        (
+            "/v1/sessions/conv_x/events",
+            {
+                "type": "external_conversation_item",
+                "data": {
+                    "item_type": "reasoning",
+                    "item_data": {
+                        "agent": "codex-native-ui",
+                        "summary": [{"type": "summary_text", "text": "Short summary"}],
+                        "content": [{"type": "reasoning_text", "text": "Detailed reasoning"}],
+                    },
+                    "response_id": "codex_turn_1",
+                },
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
 async def test_reasoning_delta_opens_block_then_continues() -> None:
     """
     Codex reasoning deltas mirror as external_output_reasoning_delta (#1254).

--- a/tests/test_hermes_native_forwarder.py
+++ b/tests/test_hermes_native_forwarder.py
@@ -217,7 +217,7 @@ def test_read_new_items_maps_roles_and_strips_attachments(tmp_path: Path) -> Non
 
 
 def test_read_new_items_mirrors_reasoning_before_message(tmp_path: Path) -> None:
-    """An assistant row with reasoning posts a one-shot reasoning delta before the message."""
+    """An assistant row retains the completed reasoning before the message."""
     db = tmp_path / "state.db"
     con = sqlite3.connect(db)
     con.executescript(_SCHEMA)
@@ -236,7 +236,11 @@ def test_read_new_items_mirrors_reasoning_before_message(tmp_path: Path) -> None
     items = f._read_new_items(db, "s1", 0, "hermes-native-ui")
     posted = [i for i in items if i.item_type]
     assert posted[0].item_type == "external_output_reasoning_delta"
-    assert posted[0].item_data == {"delta": "thinking hard", "started": True}  # marker stripped
+    assert posted[0].item_data == {
+        "delta": "thinking hard",
+        "started": True,
+        "agent": "hermes-native-ui",
+    }
     assert posted[1].item_type == "message"
     assert posted[1].item_data["content"] == [{"type": "output_text", "text": "done"}]
 
@@ -417,14 +421,34 @@ async def test_post_conversation_item_posts_reasoning_delta(tmp_path) -> None:
     item = f._MirrorItem(
         msg_id=6,
         item_type="external_output_reasoning_delta",
-        item_data={"delta": "let me think", "started": True},
+        item_data={"delta": "let me think", "started": True, "agent": "Hermes"},
         response_id="hermes:6",
     )
     await f._post_conversation_item(client, session_id="conv_q", item=item)
-    url, body = client.posts[0]
-    assert url == "/v1/sessions/conv_q/events"
-    assert body["type"] == "external_output_reasoning_delta"
-    assert body["data"] == {"delta": "let me think", "started": True}
+    assert client.posts == [
+        (
+            "/v1/sessions/conv_q/events",
+            {
+                "type": "external_output_reasoning_delta",
+                "data": {"delta": "let me think", "started": True},
+            },
+        ),
+        (
+            "/v1/sessions/conv_q/events",
+            {
+                "type": "external_conversation_item",
+                "data": {
+                    "item_type": "reasoning",
+                    "item_data": {
+                        "agent": "Hermes",
+                        "summary": [],
+                        "content": [{"type": "reasoning_text", "text": "let me think"}],
+                    },
+                    "response_id": "hermes:6",
+                },
+            },
+        ),
+    ]
 
 
 async def test_forward_loop_discovers_and_mirrors_new_messages(tmp_path, monkeypatch) -> None:

--- a/tests/test_kimi_native_forwarder.py
+++ b/tests/test_kimi_native_forwarder.py
@@ -11,15 +11,69 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import httpx
+
 from omnigent.kimi_native_forwarder import (
     _discover_wire,
     _ForwardState,
+    _post_reasoning_item,
     _read_state,
     _row_to_item,
     _write_state,
     clear_kimi_bridge_state,
     read_kimi_wire_items,
 )
+
+
+async def test_post_reasoning_item_streams_and_persists() -> None:
+    posts: list[dict[str, object]] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        posts.append(json.loads(request.content))
+        return httpx.Response(200)
+
+    item = _row_to_item(
+        5,
+        {
+            "type": "context.append_loop_event",
+            "event": {
+                "type": "content.part",
+                "uuid": "abc123",
+                "part": {"type": "think", "think": "Let me reason."},
+            },
+        },
+    )
+    assert item is not None
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle), base_url="http://test"
+    ) as client:
+        await _post_reasoning_item(
+            client,
+            base_url="http://test",
+            headers={},
+            session_id="conv_1",
+            item=item,
+            agent_name="Kimi",
+        )
+
+    assert posts == [
+        {
+            "type": "external_output_reasoning_delta",
+            "data": {"delta": "Let me reason.", "started": True},
+        },
+        {
+            "type": "external_conversation_item",
+            "data": {
+                "item_type": "reasoning",
+                "item_data": {
+                    "agent": "Kimi",
+                    "summary": [],
+                    "content": [{"type": "reasoning_text", "text": "Let me reason."}],
+                },
+                "response_id": "kimi:abc123",
+            },
+        },
+    ]
 
 
 class TestRowToItem:

--- a/tests/test_opencode_native_forwarder.py
+++ b/tests/test_opencode_native_forwarder.py
@@ -280,16 +280,27 @@ async def test_session_error_generic_posts_failed_without_reauth() -> None:
 
 
 async def test_session_error_message_aborted_takes_idle_path() -> None:
-    """A MessageAbortedError is a user interrupt → the normal idle path."""
+    """An aborted turn drops unfinished reasoning and takes the idle path."""
     server, opencode = _RecordingServerClient(), _FakeOpenCodeClient()
     fwd = _forwarder(server, opencode)
+    await fwd.handle_event(_event("message.updated", info={"id": "msg_1", "role": "assistant"}))
+    await fwd.handle_event(
+        _event(
+            "message.part.updated",
+            part={"id": "prt_r", "messageID": "msg_1", "type": "reasoning", "text": "partial"},
+        )
+    )
     await fwd.handle_event(
         _event("session.error", error={"name": "MessageAbortedError", "data": {}})
     )
-    status = next(b["data"] for _u, b in server.posts if b["type"] == "external_session_status")
+    status = [b["data"] for _u, b in server.posts if b["type"] == "external_session_status"][-1]
     assert status["status"] == "idle"
     assert "reauth_required" not in status
     assert "output" not in status
+    assert not any(
+        body["type"] == "external_conversation_item" and body["data"]["item_type"] == "reasoning"
+        for _url, body in server.posts
+    )
 
 
 def _status_edges(posts: list[tuple[str, dict[str, Any]]]) -> list[dict[str, Any]]:
@@ -773,7 +784,7 @@ async def test_model_switched_mirrors_to_omnigent_and_dedupes() -> None:
 
 
 async def test_reasoning_part_streams_suffix_deltas() -> None:
-    """opencode reasoning parts → transient reasoning deltas (suffix-only)."""
+    """Reasoning streams suffix deltas and persists once at completion."""
     server, opencode = _RecordingServerClient(), _FakeOpenCodeClient()
     fwd = _forwarder(server, opencode)
     await fwd.handle_event(_event("message.updated", info={"id": "msg_1", "role": "assistant"}))
@@ -800,6 +811,33 @@ async def test_reasoning_part_streams_suffix_deltas() -> None:
     # First snapshot opens the block (started); second posts only the new suffix.
     assert deltas[0] == {"delta": "Let me", "started": True}
     assert deltas[1] == {"delta": " think", "started": False}
+    await fwd.handle_event(
+        _event(
+            "message.part.updated",
+            part={"id": "step_1", "messageID": "msg_1", "type": "step-finish"},
+        )
+    )
+    await fwd.handle_event(_event("session.idle"))
+    reasoning_items = [
+        body
+        for _url, body in server.posts
+        if body["type"] == "external_conversation_item"
+        and body["data"]["item_type"] == "reasoning"
+    ]
+    assert reasoning_items == [
+        {
+            "type": "external_conversation_item",
+            "data": {
+                "item_type": "reasoning",
+                "item_data": {
+                    "agent": "opencode",
+                    "summary": [],
+                    "content": [{"type": "reasoning_text", "text": "Let me think"}],
+                },
+                "response_id": "msg_1",
+            },
+        }
+    ]
 
 
 async def test_reasoning_part_no_repost_when_unchanged() -> None:

--- a/web/src/lib/renderItems.test.ts
+++ b/web/src/lib/renderItems.test.ts
@@ -342,7 +342,8 @@ describe("buildBubbles — bubble grouping", () => {
         hasCodeBlocks: false,
       },
     ];
-    const bubbles = buildBubbles(blocks, null);
+    const active: ActiveResponse = { responseId: "resp_1", state: "streaming", error: null };
+    const bubbles = buildBubbles(blocks, active);
     expect(bubbles.map((b) => b.kind)).toEqual([
       "user",
       "assistant",
@@ -359,6 +360,11 @@ describe("buildBubbles — bubble grouping", () => {
     expect(asst0.responseId).toBe("resp_1");
     expect(asst1.responseId).toBe("resp_1");
     expect(asst2.responseId).toBe("resp_1");
+    expect([asst0.lifecycle, asst1.lifecycle, asst2.lifecycle]).toEqual([
+      "completed",
+      "completed",
+      "streaming",
+    ]);
     expect(new Set([asst0.stableId, asst1.stableId, asst2.stableId]).size).toBe(3);
     // The third bubble has a text_done, so its stableId pins to the
     // canonical item id (stable across streaming → committed transition).

--- a/web/src/lib/renderItems.ts
+++ b/web/src/lib/renderItems.ts
@@ -209,9 +209,9 @@ export function createBubbleCache(): BubbleCache {
  *   (text/reasoning/tool/native_tool/error/retry), and `CompactionBlock`s.
  *   Lifecycle markers (`response_start`, `response_end`) are skipped.
  * @param activeResponse - lifecycle of the most recently sent response,
- *   or `null` when idle / pre-send. The bubble whose `responseId`
- *   matches inherits `state` and `error`; all other bubbles are
- *   `"completed"`.
+ *   or `null` when idle / pre-send. Only the latest matching assistant
+ *   segment inherits `"streaming"`; terminal states apply to every
+ *   matching segment. All other bubbles are `"completed"`.
  * @param cache - optional reuse cache (see `BubbleCache`). When supplied
  *   and the call is an append-only extension of the cached one, the
  *   finalized-bubble prefix is reused by reference and only the active
@@ -366,6 +366,7 @@ function walkBubbles(
   subIndexByResp: Map<string, number>,
 ): { bubbles: Bubble[]; lastBubbleStart: number } {
   const bubbles: Bubble[] = [...seedBubbles];
+  let latestStreamingSegment: { bubbleIndex: number; blocks: AnyBlock[] } | null = null;
   // One cross-bubble result index per walk: the relay backdates a
   // delayed function_call_output to its ORIGINAL turn's response id, so
   // a result can sit outside its call's bubble; pairing is keyed
@@ -492,13 +493,20 @@ function walkBubbles(
     if (groupBlocks.length > 0 && groupBlocks.every((bk) => bk.type === "tool_result")) {
       continue;
     }
-    const lifecycle =
-      groupHasInterruptedText(groupBlocks) || interruptedResponses.has(groupResponseId)
-        ? "cancelled"
-        : activeResponse?.responseId === groupResponseId
-          ? activeResponse.state
-          : "completed";
-    const error = activeResponse?.responseId === groupResponseId ? activeResponse.error : null;
+    const interrupted =
+      groupHasInterruptedText(groupBlocks) || interruptedResponses.has(groupResponseId);
+    const matchesActiveResponse = activeResponse?.responseId === groupResponseId;
+    const isStreamingCandidate =
+      !interrupted && matchesActiveResponse && activeResponse.state === "streaming";
+    const lifecycle = interrupted
+      ? "cancelled"
+      : matchesActiveResponse && activeResponse.state !== "streaming"
+        ? activeResponse.state
+        : "completed";
+    const error =
+      !interrupted && matchesActiveResponse && activeResponse.state !== "streaming"
+        ? activeResponse.error
+        : null;
 
     const subIndex = subIndexByResp.get(groupResponseId) ?? 0;
     subIndexByResp.set(groupResponseId, subIndex + 1);
@@ -509,6 +517,7 @@ function walkBubbles(
     const stableId = firstItemId ?? `${groupResponseId}:${subIndex}`;
 
     lastBubbleStart = groupStart;
+    const bubbleIndex = bubbles.length;
     bubbles.push({
       kind: "assistant",
       responseId: groupResponseId,
@@ -517,6 +526,21 @@ function walkBubbles(
       error,
       items: buildAssistantItems(groupBlocks, lifecycle, crossBubbleResults),
     });
+    if (isStreamingCandidate) {
+      latestStreamingSegment = { bubbleIndex, blocks: groupBlocks };
+    }
+  }
+
+  if (latestStreamingSegment !== null) {
+    const bubble = bubbles[latestStreamingSegment.bubbleIndex];
+    if (bubble?.kind === "assistant") {
+      bubbles[latestStreamingSegment.bubbleIndex] = {
+        ...bubble,
+        lifecycle: "streaming",
+        error: activeResponse?.error ?? null,
+        items: buildAssistantItems(latestStreamingSegment.blocks, "streaming", crossBubbleResults),
+      };
+    }
   }
 
   return { bubbles, lastBubbleStart };

--- a/web/src/pages/ChatPage.indicators.test.tsx
+++ b/web/src/pages/ChatPage.indicators.test.tsx
@@ -19,7 +19,7 @@ import {
 afterEach(() => {
   // Several tests poke sandboxStatus into the global zustand store; reset it
   // so a leftover launch band can't bleed into the next test.
-  useChatStore.setState({ sandboxStatus: null });
+  useChatStore.setState({ sandboxStatus: null, sessionStatus: "idle" });
   cleanup();
 });
 
@@ -174,6 +174,20 @@ describe("BubbleView dispatch", () => {
     items: [{ kind: "text", itemId: "i1", text, final: true }],
   });
 
+  const assistantReasoning = (
+    responseId: string,
+    lifecycle: AssistantBubble["lifecycle"],
+  ): AssistantBubble => ({
+    kind: "assistant",
+    responseId,
+    stableId: responseId,
+    lifecycle,
+    error: null,
+    items: [
+      { kind: "reasoning", itemId: null, text: `${responseId} reasoning`, duration: undefined },
+    ],
+  });
+
   it("renders a plain user message as a user bubble", () => {
     // WHY: the user branch of the dispatcher — text content renders inside a
     // user-role bubble.
@@ -199,6 +213,20 @@ describe("BubbleView dispatch", () => {
     expect(bubble).toHaveAttribute("data-role", "assistant");
     expect(bubble).toHaveTextContent("the answer is 42");
     expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+  });
+
+  it("animates reasoning only for the streaming assistant response", () => {
+    useChatStore.setState({ sessionStatus: "running" });
+
+    render(
+      <>
+        <BubbleView bubble={assistantReasoning("resp_completed", "completed")} />
+        <BubbleView bubble={assistantReasoning("resp_streaming", "streaming")} />
+      </>,
+    );
+
+    expect(screen.getAllByText("Thinking...")).toHaveLength(1);
+    expect(screen.getByText("Thought for a few seconds")).toBeInTheDocument();
   });
 
   it("marks a cancelled assistant turn as Interrupted", () => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3425,7 +3425,6 @@ function AssistantBubble({
   // assistant-side block exists, so `items` is non-empty here in the
   // common case. The "Working…" shimmer for the empty-items / streaming
   // gap is rendered at the page level, not inside this component.
-  const sessionStatus = useChatStore((s) => s.sessionStatus);
   // Getter computes the markdown lazily at click time — the hook must run
   // before the early return below (rules of hooks), but `markdownText` is
   // derived after it.
@@ -3453,7 +3452,7 @@ function AssistantBubble({
         <MessageContent className={isWide ? "w-full" : undefined}>
           <BlockRenderer
             items={bubble.items}
-            sessionStatus={sessionStatus}
+            sessionStatus={bubble.lifecycle === "streaming" ? "running" : "idle"}
             canApprove={canApprove}
           />
         </MessageContent>


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Persist completed reasoning blocks from Codex, OpenCode, Hermes, Kimi, Antigravity, and wrapped executor harnesses while leaving unfinished or aborted reasoning transient.
- Allow completed `response.output_item.done` reasoning items to use the existing conversation-item persistence path so reconnects can rebuild them without a database migration.
- Derive thinking animation state from each assistant bubble's lifecycle, including split responses, so only the active segment animates.

**ELI5:** live reasoning still streams directly to the browser, but once a reasoning block finishes we save one completed item alongside messages and tool calls. Reconnecting can then reload that completed block instead of losing it.

```text
live reasoning deltas ──> temporary UI block
                               │ completed
                               ▼
                     conversation_items
                               │ reconnect
                               ▼
                     restored reasoning block

unfinished / aborted reasoning ──> not persisted
```

## Test Plan

- `.venv/bin/pre-commit run --all-files`
- `.venv/bin/pytest -q tests/runtime/harnesses/test_executor_adapter.py tests/server/routes/test_sessions_runner_relay.py tests/test_antigravity_native_reader.py tests/test_antigravity_native_steps.py tests/test_codex_native.py tests/test_codex_native_forwarder.py tests/test_hermes_native_forwarder.py tests/test_kimi_native_forwarder.py tests/test_opencode_native_forwarder.py` — 611 passed.
- `pnpm --dir web exec vitest run src/lib/renderItems.test.ts src/pages/ChatPage.indicators.test.tsx` — 80 passed.
- `pnpm --dir web exec tsc --noEmit`
- `git diff --check`

## Demo

Reasoning preserved across host/session reconnections
<img width="823" height="1155" alt="Screenshot 2026-08-03 at 14 21 29" src="https://github.com/user-attachments/assets/f7cbe9ae-c495-4c3b-ad2d-b0c72d1e91d6" />

<img width="841" height="1168" alt="Screenshot 2026-08-03 at 14 26 54" src="https://github.com/user-attachments/assets/0709ac25-17b9-4f02-b7ad-76c5ccce067b" />

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage verifies completed reasoning persistence for each supported forwarding path, server relay persistence, split-response lifecycle handling, and historical thinking-animation behavior.

## Changelog

Completed reasoning blocks remain available after reconnecting to a session, and historical blocks no longer show an active thinking animation.
