### PR TITLE
fix(codex-native): stop leaking codex app-server processes across all teardown paths

### DIFF
--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -1227,6 +1227,18 @@ def create_app(
         _pane_reaper = getattr(app.state, "native_pane_reaper", None)
         if _pane_reaper is not None:
             await _pane_reaper.start()
+        # Backstop for a hard host/runner death (SIGKILL / OOM / crash) that
+        # ran no graceful teardown: a codex app-server spawned in its own
+        # session outlives its runner. Reconciling the crash-safe registry at
+        # boot reaps any such orphan whose owner lock is no longer held (its
+        # runner is gone), so a fresh runner on the host cleans up what a dead
+        # predecessor left. Held owner locks (live sibling runners) are skipped.
+        from omnigent.codex_native_process_registry import (
+            reconcile_codex_native_process_registry,
+        )
+
+        with contextlib.suppress(Exception):
+            await asyncio.to_thread(reconcile_codex_native_process_registry)
 
     async def _stop_pm() -> None:
         """Stop runner-owned resources for graceful process exit.
@@ -1236,6 +1248,14 @@ def create_app(
         _pane_reaper = getattr(app.state, "native_pane_reaper", None)
         if _pane_reaper is not None:
             await _pane_reaper.shutdown()
+        # Close host-spawned codex-native app-servers before the process exits.
+        # Each is spawned in its own session (survives the runner's death), and a
+        # host-initiated stop tears the runner down without a per-session DELETE,
+        # so without this they orphan as lingering ``codex`` processes.
+        from omnigent.runner.native import teardown_all_codex_native_app_servers
+
+        with contextlib.suppress(Exception):
+            await teardown_all_codex_native_app_servers()
         await pm.shutdown()
         await _terminal_registry.shutdown()
         if mcp_manager is not None:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2156,6 +2156,15 @@ def create_runner_app(
                 "session_id": event.session_id,
             },
         )
+        # A codex TUI pane that exits on its own (crash / OOM / host recycle)
+        # never runs the DELETE-session cleanup, so its per-session app-server
+        # + forwarder would linger with no TUI. Tear them down here; no-op for
+        # any session without a registered codex app-server.
+        _teardown_task = asyncio.create_task(
+            _native_runtime.teardown_codex_native_app_server(event.session_id)
+        )
+        _teardown_task.add_done_callback(_background_tasks.discard)
+        _background_tasks.add(_teardown_task)
         if event.lifecycle != TerminalLifecycle.REQUIRED:
             return
 
@@ -8440,6 +8449,11 @@ def create_runner_app(
         async def _reap_native_pane(pane: PaneRef) -> None:
             try:
                 await resource_registry.close_terminal(pane.conversation_id, pane.terminal_id)
+                # Closing the codex TUI pane leaves its per-session app-server
+                # (and forwarder) running — no-op for other harnesses. Tear it
+                # down too so an idle-reaped codex session doesn't orphan a
+                # ``codex app-server`` process for the runner's lifetime.
+                await _native_runtime.teardown_codex_native_app_server(pane.conversation_id)
             finally:
                 _publish_terminal_deleted_event(
                     conversation_id=pane.conversation_id,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -8449,12 +8449,13 @@ def create_runner_app(
         async def _reap_native_pane(pane: PaneRef) -> None:
             try:
                 await resource_registry.close_terminal(pane.conversation_id, pane.terminal_id)
+            finally:
                 # Closing the codex TUI pane leaves its per-session app-server
                 # (and forwarder) running — no-op for other harnesses. Tear it
-                # down too so an idle-reaped codex session doesn't orphan a
-                # ``codex app-server`` process for the runner's lifetime.
+                # down in ``finally`` so an idle-reaped codex session can't orphan
+                # a ``codex app-server`` for the runner's lifetime even when the
+                # pane close above partially fails (the very leak this guards).
                 await _native_runtime.teardown_codex_native_app_server(pane.conversation_id)
-            finally:
                 _publish_terminal_deleted_event(
                     conversation_id=pane.conversation_id,
                     terminal_name=pane.terminal_name,

--- a/omnigent/runner/native/__init__.py
+++ b/omnigent/runner/native/__init__.py
@@ -122,6 +122,7 @@ from omnigent.runner.native.orchestration import (
     _terminal_lookup_miss_reason,
     _terminal_tmux_pane,
     _unwrap_resolved_spec,
+    teardown_all_codex_native_app_servers,
     teardown_codex_native_app_server,
 )
 
@@ -248,5 +249,6 @@ __all__ = [
     "_terminal_lookup_miss_reason",
     "_terminal_tmux_pane",
     "_unwrap_resolved_spec",
+    "teardown_all_codex_native_app_servers",
     "teardown_codex_native_app_server",
 ]

--- a/omnigent/runner/native/__init__.py
+++ b/omnigent/runner/native/__init__.py
@@ -122,6 +122,7 @@ from omnigent.runner.native.orchestration import (
     _terminal_lookup_miss_reason,
     _terminal_tmux_pane,
     _unwrap_resolved_spec,
+    teardown_codex_native_app_server,
 )
 
 __all__ = [
@@ -247,4 +248,5 @@ __all__ = [
     "_terminal_lookup_miss_reason",
     "_terminal_tmux_pane",
     "_unwrap_resolved_spec",
+    "teardown_codex_native_app_server",
 ]

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -188,6 +188,38 @@ async def _cancel_auto_forwarder_task(session_id: str) -> None:
         )
 
 
+async def teardown_codex_native_app_server(session_id: str) -> None:
+    """
+    Tear down a host-spawned codex-native session's app-server subprocess.
+
+    Only the ``DELETE /v1/sessions`` teardown runs the full native cleanup;
+    the codex TUI pane can also disappear on its own — the idle pane reaper
+    closes the tmux pane after the idle window, and an unexpected TUI exit
+    (crash / OOM / host recycle) evicts it — neither of which cancels the
+    forwarder. Left alone, the per-session ``codex app-server`` (and its
+    forwarder) survives with no TUI, so long-lived multi-session runners
+    (e.g. Polly, which dispatches every ``codex`` sub-agent this way)
+    accumulate orphaned ``codex`` processes.
+
+    Cancelling the forwarder closes the app-server via the forwarder's own
+    ``finally`` (see :func:`_codex_discover_thread_and_forward`); the pop
+    below is the belt-and-suspenders close for the discovery-failed case
+    where no forwarder ever adopted the server. No-op for a session that
+    has no registered codex app-server, so this is safe to call from the
+    shared pane-teardown paths regardless of harness.
+
+    :param session_id: Session/conversation id, e.g. ``"conv_abc123"``.
+    :returns: None.
+    """
+    if session_id not in _AUTO_CODEX_APP_SERVERS:
+        return
+    await _cancel_auto_forwarder_task(session_id)
+    leftover_app_server = _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+    if leftover_app_server is not None:
+        with contextlib.suppress(Exception):
+            await leftover_app_server.close()
+
+
 def _register_auto_forwarder_task(session_id: str, task: asyncio.Task[object]) -> None:
     """
     Register a session's transcript-forwarder task in the keyed registry.

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -220,6 +220,32 @@ async def teardown_codex_native_app_server(session_id: str) -> None:
             await leftover_app_server.close()
 
 
+async def teardown_all_codex_native_app_servers() -> None:
+    """
+    Tear down every host-spawned codex-native app-server on this runner.
+
+    Called from the runner's shutdown path (``_stop_pm``) so a graceful host
+    or runner stop — the host SIGTERMs its runners on ``host.stop_runner`` and
+    on its own exit — takes the per-session ``codex app-server`` subprocesses
+    down with it. Each app-server is spawned ``start_new_session=True`` (its
+    own process group), so it is NOT killed by the runner's death; without an
+    explicit close here it is reparented to init and lingers as an orphaned
+    ``codex`` process. Per-session teardown normally runs on
+    ``DELETE /v1/sessions``, but a host stop tears the runner down without
+    deleting each session first, so those never fire.
+
+    Iterates a snapshot of the registered session ids and delegates to
+    :func:`teardown_codex_native_app_server` (which cancels the forwarder and
+    closes the server). Best-effort and idempotent: a session already torn
+    down is a no-op.
+
+    :returns: None.
+    """
+    for session_id in list(_AUTO_CODEX_APP_SERVERS):
+        with contextlib.suppress(Exception):
+            await teardown_codex_native_app_server(session_id)
+
+
 def _register_auto_forwarder_task(session_id: str, task: asyncio.Task[object]) -> None:
     """
     Register a session's transcript-forwarder task in the keyed registry.

--- a/tests/runner/test_app_sessions_native_wake_forwarders.py
+++ b/tests/runner/test_app_sessions_native_wake_forwarders.py
@@ -460,6 +460,65 @@ async def test_teardown_codex_native_app_server_noop_without_registered_server()
 
 
 @pytest.mark.asyncio
+async def test_teardown_all_codex_native_app_servers_closes_every_session() -> None:
+    """
+    Runner shutdown closes every registered codex app-server.
+
+    A host-initiated stop SIGTERMs the runner without a per-session
+    ``DELETE /v1/sessions``, so the shutdown sweep is the only thing that
+    closes the host-spawned codex app-servers (each spawned in its own
+    session, so it outlives the runner otherwise). Every registered session
+    must be torn down, and the registry left empty.
+    """
+    session_ids = [
+        "aaaa0000aaaa0000aaaa0000aaaa0000",
+        "bbbb1111bbbb1111bbbb1111bbbb1111",
+        "cccc2222cccc2222cccc2222cccc2222",
+    ]
+    runs = [_ForwarderRun() for _ in session_ids]
+    closed: list[str] = []
+
+    def _make_parked(run: _ForwarderRun) -> Any:
+        async def _parked() -> None:
+            run.task = asyncio.current_task()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                run.cancelled = True
+                raise
+
+        return _parked
+
+    class _FakeAppServer:
+        def __init__(self, sid: str) -> None:
+            self._sid = sid
+
+        async def close(self) -> None:
+            closed.append(self._sid)
+
+    try:
+        for sid, run in zip(session_ids, runs, strict=True):
+            task = asyncio.create_task(_make_parked(run)())
+            runner_app_mod._register_auto_forwarder_task(sid, task)
+            runner_app_mod._AUTO_CODEX_APP_SERVERS[sid] = _FakeAppServer(sid)
+        await asyncio.sleep(0)
+
+        await runner_app_mod.teardown_all_codex_native_app_servers()
+
+        assert sorted(closed) == sorted(session_ids), "every app-server must be closed"
+        assert all(sid not in runner_app_mod._AUTO_CODEX_APP_SERVERS for sid in session_ids)
+        assert all(sid not in runner_app_mod._AUTO_FORWARDER_TASKS for sid in session_ids)
+        assert all(run.cancelled for run in runs), "every forwarder must be cancelled"
+        # Idempotent: a second sweep with an empty registry is a no-op.
+        await runner_app_mod.teardown_all_codex_native_app_servers()
+    finally:
+        for sid in session_ids:
+            runner_app_mod._AUTO_FORWARDER_TASKS.pop(sid, None)
+            runner_app_mod._AUTO_CODEX_APP_SERVERS.pop(sid, None)
+        await _drain_forwarder_runs(runs)
+
+
+@pytest.mark.asyncio
 async def test_register_auto_forwarder_task_replaces_incumbent_and_survives_stale_evict() -> None:
     """
     Re-registration cancels the incumbent; its done-callback can't evict the successor.

--- a/tests/runner/test_app_sessions_native_wake_forwarders.py
+++ b/tests/runner/test_app_sessions_native_wake_forwarders.py
@@ -381,6 +381,85 @@ async def test_cancel_auto_forwarder_task_cancels_and_awaits_registered_task() -
 
 
 @pytest.mark.asyncio
+async def test_teardown_codex_native_app_server_cancels_forwarder_and_closes_server() -> None:
+    """
+    Codex pane teardown cancels the forwarder and closes the app-server.
+
+    The idle pane reaper and an unexpected TUI exit both close only the tmux
+    pane; without this helper the per-session ``codex app-server`` (and its
+    forwarder) survives with no TUI, orphaning a ``codex`` process for the
+    runner's lifetime. Teardown must both cancel the registered forwarder and
+    close the registered app-server so neither leaks.
+    """
+    session_id = "c0d3f00d0000000000000000deadbeef"
+    run = _ForwarderRun()
+    closed = False
+
+    async def _parked() -> None:
+        run.task = asyncio.current_task()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            run.cancelled = True
+            raise
+
+    class _FakeAppServer:
+        async def close(self) -> None:
+            nonlocal closed
+            closed = True
+
+    try:
+        task = asyncio.create_task(_parked())
+        runner_app_mod._register_auto_forwarder_task(session_id, task)
+        runner_app_mod._AUTO_CODEX_APP_SERVERS[session_id] = _FakeAppServer()
+        await asyncio.sleep(0)
+
+        await runner_app_mod.teardown_codex_native_app_server(session_id)
+
+        assert task.cancelled(), "forwarder must be finished-cancelled after teardown"
+        assert run.cancelled is True
+        assert closed is True, "registered codex app-server must be closed"
+        assert session_id not in runner_app_mod._AUTO_CODEX_APP_SERVERS
+        assert session_id not in runner_app_mod._AUTO_FORWARDER_TASKS
+    finally:
+        runner_app_mod._AUTO_FORWARDER_TASKS.pop(session_id, None)
+        runner_app_mod._AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+        await _drain_forwarder_runs([run])
+
+
+@pytest.mark.asyncio
+async def test_teardown_codex_native_app_server_noop_without_registered_server() -> None:
+    """
+    Teardown is a no-op for a session with no registered codex app-server.
+
+    The shared pane-teardown paths (reaper, terminal-exit publisher) fire for
+    every native harness, so calling this for a non-codex session — or a codex
+    session whose server is already gone — must not touch that session's
+    forwarder or raise.
+    """
+    session_id = "1111111122222222aaaaaaaabbbbbbbb"
+    run = _ForwarderRun()
+
+    async def _parked() -> None:
+        run.task = asyncio.current_task()
+        await asyncio.Event().wait()
+
+    try:
+        task = asyncio.create_task(_parked())
+        runner_app_mod._register_auto_forwarder_task(session_id, task)
+        await asyncio.sleep(0)
+
+        await runner_app_mod.teardown_codex_native_app_server(session_id)
+
+        # No registered codex app-server -> the forwarder is left untouched.
+        assert not task.done()
+        assert session_id in runner_app_mod._AUTO_FORWARDER_TASKS
+    finally:
+        runner_app_mod._AUTO_FORWARDER_TASKS.pop(session_id, None)
+        await _drain_forwarder_runs([run])
+
+
+@pytest.mark.asyncio
 async def test_register_auto_forwarder_task_replaces_incumbent_and_survives_stale_evict() -> None:
     """
     Re-registration cancels the incumbent; its done-callback can't evict the successor.


### PR DESCRIPTION
## Related issue

N/A <!-- reported in #omnigents-qa Slack, no tracking issue -->

## Summary

Codex-native sessions (the harness Polly dispatches every `codex` sub-agent through) leaked `codex` processes on the runner. Each session runs **two** codex processes: the `codex app-server` backend and the `codex --remote` TUI pane. The app-server is spawned `start_new_session=True`, so it survives its runner's death and must be closed explicitly. Only the `DELETE /v1/sessions` teardown did that; several other exit paths didn't, so app-servers piled up (the omnigents-qa report). This PR closes every leak path:

**1. Idle pane reaper** — reaped the TUI tmux pane after the idle window but never touched the app-server, and the forwarder kept it alive. Now the reaper also tears down the app-server (in a `finally`, so it runs even if the pane close partially fails).

**2. Unexpected TUI exit** (crash / OOM / host recycle) — evicted the pane without cancelling the forwarder. The terminal-exit publisher now tears the app-server down too.

**3. Runner shutdown** — every orderly runner exit (SIGTERM, `host.stop_runner`, idle-timeout self-shutdown, tunnel disconnect, graceful host-death) funnels through the lifespan `__aexit__` → `_stop_pm()`, which closed the pane registry but **never** `_AUTO_CODEX_APP_SERVERS` — so even a clean runner stop leaked every host-spawned app-server. `_stop_pm()` now closes them all.

**4. Hard death** (runner/host SIGKILL, OOM, crash, or the parent-death hard-exit backstop) — nothing graceful runs. The crash-safe registry was only reconciled when a *new* codex session started, so orphans lingered indefinitely. `_start_pm()` now reconciles the registry at runner boot, so a fresh runner reaps orphans a dead predecessor left (a held owner-lock = live sibling runner, skipped).

The `--remote` TUI self-exits when its app-server dies (every orphan observed in the field was an app-server, zero orphaned TUIs) and the graceful path already closes TUI panes via the terminal registry, so no tmux-name plumbing was added.

### Coverage of runner-exit paths

| Trigger | Reaches `_stop_pm`? | Covered by |
|---|---|---|
| SIGTERM/SIGINT, `host.stop_runner`, host cleanup | ✅ | `_stop_pm` teardown |
| Idle-timeout self-shutdown | ✅ | `_stop_pm` teardown |
| Tunnel disconnect | ✅ | `_stop_pm` teardown |
| Graceful host (parent) death | ✅ | `_stop_pm` teardown |
| Parent-death hard-exit backstop | ❌ | boot reconcile |
| Runner/host SIGKILL, OOM, crash | ❌ | boot reconcile |

## Test Plan

- `pytest tests/runner/test_app_sessions_native_wake_forwarders.py` — 20 passed (incl. 3 new: per-session teardown cancels forwarder + closes server; no-op without a registered server; shutdown sweep closes every session + idempotent)
- `pytest tests/test_codex_native_process_registry.py` — 9 passed
- `pytest tests/terminals/test_pane_reaper.py tests/runner/test_app_sessions_native_terminals_runtime.py` — passed
- `python -c "import omnigent.runner._entry"` — clean
- `pre-commit run` on changed files — passed

Manual: launch a codex-native session, then (a) stop the runner gracefully and confirm `ps -Ao command | grep '[o]mnigent_crash_teardown_tag.*app-server'` is empty; (b) `kill -9` the runner, start a fresh one, and confirm the boot reconcile reaps the orphan.

## Demo

N/A — non-visual runner-side process-lifecycle fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests cover the per-session teardown (cancel-forwarder + close-server; no-op when unregistered) and the shutdown sweep (`teardown_all_codex_native_app_servers` closes every session and is idempotent). The `_start_pm` / `_stop_pm` wirings and the reaper / terminal-exit call sites are closure-local and hard to unit-test directly; verified manually by tracing each exit path to `__aexit__` → `_stop_pm`, plus the boot reconcile for the hard-death paths. Existing reaper, registry, and native-terminal suites confirm no regression.

## Changelog

Fixed a leak where native Codex sub-agents left orphaned `codex app-server` processes after idle reaping, TUI exit, runner shutdown, or a hard host/runner death
