### PR TITLE
fix(web): keep session scope tabs during bulk selection

### DIFF
--- a/web/src/shell/Sidebar.selectionTabs.test.tsx
+++ b/web/src/shell/Sidebar.selectionTabs.test.tsx
@@ -1,0 +1,200 @@
+// Behaviour tests for the My sessions / Shared with me scope tabs during bulk
+// selection mode. Two guarantees:
+//   1. The tabs stay visible while selection mode is active (previously the
+//      whole strip was hidden, stranding the viewer on one scope).
+//   2. Switching tabs exits selection mode, so the bulk-action count never
+//      carries stale rows from the other (disjoint, ownership-scoped) tab.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { Conversation } from "@/hooks/useConversations";
+
+vi.mock("@/hooks/useConversations", () => ({
+  useConversations: vi.fn(),
+  useConnectedConversations: () => [],
+  useStopAndDeleteConversation: () => ({ mutate: vi.fn() }),
+  usePinnedConversations: () => ({
+    data: { conversations: [], filterHonored: true },
+    isSuccess: true,
+  }),
+  useTogglePinnedConversation: () => ({ mutate: vi.fn() }),
+  setConversationPinned: vi.fn(() => Promise.resolve({})),
+  PINNED_CONVERSATIONS_KEY: ["pinned-conversations"],
+  useRenameConversation: () => ({ mutate: vi.fn() }),
+  useArchiveConversation: () => ({ mutate: vi.fn() }),
+  useBulkArchiveConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkDeleteConversations: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useBulkStopSessions: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useStopSession: () => ({ mutate: vi.fn() }),
+  useProjects: () => ({ data: [] }),
+  useProjectSessions: () => ({
+    data: undefined,
+    isLoading: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+  }),
+  useMoveToProject: () => ({ mutate: vi.fn() }),
+  useDeleteProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useRenameProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useCreateProject: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useProjectConfig: () => ({ data: undefined, isLoading: false }),
+  useUpdateProjectConfig: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  fetchProjectSessionIds: () => Promise.resolve([]),
+  PROJECT_LABEL_KEY: "omni_project",
+}));
+
+vi.mock("@/components/PermissionsModal", () => ({ PermissionsModal: () => null }));
+
+// The scope tabs only render on a multi-user (non-local) server; force it so
+// the tabs are present. jsdom's loopback origin would otherwise read as
+// single-user and hide them.
+vi.mock("@/lib/serverOrigin", () => ({
+  isCurrentServerLocal: () => false,
+  isLocalServerOrigin: (origin: string) =>
+    ["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"].includes(new URL(origin).hostname),
+}));
+
+import { useConversations } from "@/hooks/useConversations";
+import { Sidebar } from "./Sidebar";
+
+const useConvMock = vi.mocked(useConversations);
+
+function conv(id: string, partial: Partial<Conversation> = {}): Conversation {
+  return {
+    id,
+    object: "conversation",
+    title: id,
+    created_at: 0,
+    updated_at: 0,
+    labels: {},
+    permission_level: null,
+    status: "idle",
+    ...partial,
+  };
+}
+
+// The resolved viewer id is null in tests, so a null/absent owner reads as
+// owned ("My sessions") and any non-null owner reads as shared.
+const OWNED = conv("conv_mine", { owner: null });
+const SHARED = conv("conv_shared", { owner: "other@example.com" });
+
+function mockConversations(conversations: Conversation[]) {
+  useConvMock.mockImplementation(
+    () =>
+      ({
+        data: {
+          pages: [
+            {
+              data: conversations,
+              first_id: conversations[0]?.id ?? null,
+              last_id: conversations.at(-1)?.id ?? null,
+              has_more: false,
+            },
+          ],
+          pageParams: [undefined],
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+        fetchNextPage: vi.fn(),
+        hasNextPage: false,
+        isFetchingNextPage: false,
+      }) as unknown as ReturnType<typeof useConversations>,
+  );
+}
+
+function renderSidebar() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <TooltipProvider>
+        <MemoryRouter initialEntries={["/"]}>
+          <Sidebar open={true} onClose={vi.fn()} />
+        </MemoryRouter>
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+/** Radix Tabs triggers activate on primary-button mousedown, not click. */
+function switchTo(testId: "sidebar-tab-mine" | "sidebar-tab-shared") {
+  fireEvent.mouseDown(screen.getByTestId(testId), { button: 0 });
+}
+
+beforeEach(() => {
+  mockConversations([OWNED, SHARED]);
+});
+
+afterEach(cleanup);
+
+describe("scope tabs during selection mode", () => {
+  it("keeps the My sessions / Shared with me tabs visible after entering selection mode", () => {
+    renderSidebar();
+
+    fireEvent.click(screen.getByRole("button", { name: "Select sessions" }));
+
+    // In selection mode the bulk-action bar is up...
+    expect(screen.getByRole("button", { name: "Exit selection mode" })).toBeInTheDocument();
+    // ...and the scope tabs are still reachable, so the viewer can switch
+    // between owned and shared sessions without leaving selection first.
+    expect(screen.getByTestId("sidebar-tab-mine")).toBeInTheDocument();
+    expect(screen.getByTestId("sidebar-tab-shared")).toBeInTheDocument();
+  });
+
+  it("exits selection mode when the viewer switches tabs", () => {
+    renderSidebar();
+
+    // Enter selection mode and pick the owned session.
+    fireEvent.click(screen.getByRole("button", { name: "Select sessions" }));
+    fireEvent.click(screen.getByRole("link", { name: /conv_mine/ }));
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+
+    // Switching to the Shared tab drops selection mode entirely (rather than
+    // carrying the owned selection into a disjoint scope with a stale count).
+    switchTo("sidebar-tab-shared");
+    expect(screen.queryByRole("button", { name: "Exit selection mode" })).toBeNull();
+    expect(screen.queryByText(/\d+ selected/)).toBeNull();
+
+    // The shared session is now shown and not pre-selected; re-entering
+    // selection here starts clean.
+    expect(screen.getByText("conv_shared")).toBeInTheDocument();
+  });
+
+  it("starts a fresh selection after switching tabs (no rows carried over)", () => {
+    renderSidebar();
+
+    // Select on the Shared tab first.
+    switchTo("sidebar-tab-shared");
+    fireEvent.click(screen.getByRole("button", { name: "Select sessions" }));
+    fireEvent.click(screen.getByRole("link", { name: /conv_shared/ }));
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+
+    // Back to My sessions: selection mode is gone. Re-entering shows a clean
+    // zero count — the shared row's selection did not bleed across.
+    switchTo("sidebar-tab-mine");
+    expect(screen.queryByText("1 selected")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Select sessions" }));
+    expect(screen.getByText("0 selected")).toBeInTheDocument();
+  });
+
+  it("exits selection mode when 'New session' snaps the tab back to mine", () => {
+    renderSidebar();
+
+    // Enter selection mode on the Shared tab and pick the shared session.
+    switchTo("sidebar-tab-shared");
+    fireEvent.click(screen.getByRole("button", { name: "Select sessions" }));
+    fireEvent.click(screen.getByRole("link", { name: /conv_shared/ }));
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+
+    // "New session" snaps the tab back to "mine" outside the Tabs
+    // onValueChange path; it must still drop selection mode (not strand a
+    // stale shared-scope count under the My-sessions header).
+    fireEvent.click(screen.getByTestId("new-chat-button"));
+    expect(screen.queryByRole("button", { name: "Exit selection mode" })).toBeNull();
+    expect(screen.queryByText("1 selected")).toBeNull();
+  });
+});

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -485,6 +485,20 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
     setSelectionMode(true);
   }, []);
 
+  // Switch the visible scope tab. Selection is a single global set while the
+  // tabs show disjoint, ownership-scoped slices, so leaving selection mode on
+  // switch keeps the bulk-action count honest with the visible tab (the viewer
+  // re-enters per tab) instead of carrying stale rows across. Every path that
+  // changes the tab must go through here — not a bare setActiveTab — or the
+  // selection cleanup is skipped (e.g. the "New session" snap-back below).
+  const switchTab = useCallback(
+    (tab: SidebarTab) => {
+      if (selectionMode) exitSelectionMode();
+      setActiveTab(tab);
+    },
+    [selectionMode, exitSelectionMode],
+  );
+
   // One paginated session list — sessions are no longer split by
   // connection state, so the sidebar fetches a single undifferentiated
   // list. Archived sessions are included (`includeArchived: true`) and
@@ -777,7 +791,7 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
               <Link
                 to="/"
                 onClick={(e) => {
-                  setActiveTab("mine");
+                  switchTab("mine");
                   onNavClick(e);
                 }}
               >
@@ -836,13 +850,13 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
           {/* Session-scope tabs: split the viewer's own sessions ("My
           sessions") from ones shared with them ("Shared with me"). Sits above
           the scrolling list (non-scrolling) so it stays put while the list
-          scrolls. Hidden during selection mode to keep the strip quiet while
-          the bulk-action bar sits under the Sessions header. */}
-          {multiUser && !selectionMode && (
+          scrolls. Stays visible during selection mode so the viewer can still
+          switch scopes while bulk-selecting. */}
+          {multiUser && (
             <div className="px-2 pb-2">
               <Tabs
                 value={activeTab}
-                onValueChange={(v) => setActiveTab(v as SidebarTab)}
+                onValueChange={(v) => switchTab(v as SidebarTab)}
                 className="w-full"
               >
                 <TabsList className="w-full">


### PR DESCRIPTION
## Related issue

N/A

## Summary

- When the user entered bulk selection mode in the sidebar, the "My sessions" / "Shared with me" scope tabs disappeared, stranding them on whichever scope they were on. This keeps the tabs visible during selection so the scope stays switchable.
- Selection is a single global set while the two tabs show disjoint, ownership-scoped slices. So changing the visible tab now exits selection mode — otherwise the bulk-action bar would show a stale "N selected" count carried over from the other tab.
- Centralized in a `switchTab` helper used by both the tabs' `onValueChange` **and** the "New session" snap-back (which sets the tab outside Radix's `onValueChange` path), so no tab change can skip the selection cleanup.

## Test Plan

- Added `web/src/shell/Sidebar.selectionTabs.test.tsx` (4 cases): tabs stay visible in selection mode; switching tabs exits selection mode; re-entering starts a clean zero count (no cross-tab bleed); the "New session" snap-back also exits selection mode.
- `npm test` — 4832 passed, full suite green.
- `npm run build` — passes (tsc + vite).

## Demo

<!-- Screen recording to be attached: enter bulk selection on Shared with me, confirm the tabs remain visible, switch to My sessions and confirm selection resets. -->

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified in the running web app: entered bulk selection mode on both tabs, confirmed the scope switch stays visible, and that switching tabs (or clicking "New session") exits selection mode with a clean count rather than carrying rows across scopes.

## Changelog

The sidebar's My sessions / Shared with me switch stays visible while bulk-selecting sessions
