### PR TITLE
feat(cli): add `omnigent diagnose` environment snapshot

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3904,6 +3904,43 @@ def _internal_write_ledger(from_env: bool) -> None:
     click.echo(json.dumps({"path": str(ledger_path()), "source": ledger.ledger_source}))
 
 
+@cli.command("diagnose")
+@click.option(
+    "--server",
+    default=None,
+    help="Server URL to read the server version and auth mode from (GET /v1/info).",
+)
+@click.option("--json", "json_output", is_flag=True, help="Emit JSON.")
+def diagnose(server: str | None, json_output: bool) -> None:
+    """Print a read-only environment snapshot for bug reports.
+
+    Reports the CLI version, OS/Python, and the server auth mode. Pass
+    ``--server <url>`` to also read the server version and its real auth mode
+    (so version skew between CLI and server is visible). Contains no secrets —
+    safe to paste into an issue.
+    """
+    from omnigent.diagnostics import collect_snapshot
+
+    # Resolve a server URL the same way `session export` does: explicit flag,
+    # else the configured server; leave unset (local-only) when neither exists.
+    resolved = _resolve_attach_server(server, _load_effective_config().get("server"))
+    snap = collect_snapshot(server_url=resolved)
+
+    if json_output:
+        click.echo(json.dumps(snap, indent=2, sort_keys=True))
+        return
+
+    click.echo(f"cli     {snap['cli_version']}")
+    server_line = snap["server_version"] or (
+        "(pass --server to report)" if snap["server_url"] is None else "(unreachable)"
+    )
+    click.echo(f"server  {server_line}")
+    click.echo(f"url     {snap['server_url'] or '(none)'}")
+    click.echo(f"auth    {snap['auth_source']} ({snap['auth_source_origin']})")
+    click.echo(f"os      {snap['os']}")
+    click.echo(f"python  {snap['python']}")
+
+
 @cli.command("doctor")
 @click.option("--migrate-ledger", is_flag=True, help="Backfill install_ledger metadata.")
 @click.option("--deep", is_flag=True, help="Use package-manager and PATH probes.")

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1451,6 +1451,7 @@ _CLICK_SUBCOMMANDS: frozenset[str] = frozenset(
         "cursor",
         "debby",
         "debug",
+        "diagnose",
         "doctor",
         "goose",
         "hermes",

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3908,7 +3908,11 @@ def _internal_write_ledger(from_env: bool) -> None:
 @click.option(
     "--server",
     default=None,
-    help="Server URL to read the server version and auth mode from (GET /v1/info).",
+    help=(
+        "Trusted server URL to read the server version and auth mode from "
+        "(GET /v1/info). Stored/ambient credentials may be attached to the "
+        "request, so point it only at a server you trust."
+    ),
 )
 @click.option("--json", "json_output", is_flag=True, help="Emit JSON.")
 def diagnose(server: str | None, json_output: bool) -> None:
@@ -3916,8 +3920,11 @@ def diagnose(server: str | None, json_output: bool) -> None:
 
     Reports the CLI version, OS/Python, and the server auth mode. Pass
     ``--server <url>`` to also read the server version and its real auth mode
-    (so version skew between CLI and server is visible). Contains no secrets —
-    safe to paste into an issue.
+    (so version skew between CLI and server is visible). The output contains no
+    secrets — safe to paste into an issue. ``--server`` should point only at a
+    server you trust: reaching a managed server may attach your stored/ambient
+    credentials to the request (the same behavior as ``session export`` / ``run
+    --server``).
     """
     from omnigent.diagnostics import collect_snapshot
 

--- a/omnigent/diagnostics.py
+++ b/omnigent/diagnostics.py
@@ -32,6 +32,13 @@ def _redact_url(url: str | None) -> str | None:
     A ``--server`` value could carry embedded basic-auth (``https://user:pass@h``)
     or a query token; the snapshot is meant to be pasted into a bug report, so
     keep only scheme + host + port + path.
+
+    Redacts userinfo by dropping the ``user:pass@`` prefix of the authority
+    directly, rather than rebuilding it from ``hostname``/``port`` — the latter
+    lowercases the host and, for IPv6 literals, loses the required ``[...]``
+    brackets. Also handles scheme-less ``user:pass@host`` inputs, which
+    ``urlsplit`` misparses (the ``user:`` looks like a scheme), by scrubbing the
+    raw string when an ``@`` precedes any ``/``.
     """
     if not url:
         return url
@@ -39,12 +46,21 @@ def _redact_url(url: str | None) -> str | None:
         parts = urlsplit(url)
     except ValueError:
         return url
-    if not parts.scheme and not parts.netloc:
-        return url  # not URL-shaped (e.g. a bare host); leave as-is
-    # ``hostname``/``port`` drop any ``user:pass@`` userinfo; query+fragment cleared.
-    host = parts.hostname or ""
-    netloc = f"{host}:{parts.port}" if parts.port else host
-    return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+
+    if parts.scheme and parts.netloc:
+        # Well-formed URL: drop userinfo from the authority, keep host[:port] as
+        # written (preserves IPv6 brackets), clear query + fragment.
+        netloc = parts.netloc.rsplit("@", 1)[-1]
+        return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+
+    # Scheme-less or otherwise not cleanly split. If there's userinfo (an ``@``
+    # before the first ``/``), strip it so credentials never survive; otherwise
+    # leave the value as the user typed it.
+    authority = url.split("/", 1)[0]
+    if "@" in authority:
+        rest = url[len(authority) :]
+        return authority.rsplit("@", 1)[-1] + rest
+    return url
 
 
 def _local_version() -> str:

--- a/omnigent/diagnostics.py
+++ b/omnigent/diagnostics.py
@@ -1,0 +1,142 @@
+"""Read-only environment snapshot for ``omnigent diagnose``.
+
+A deliberately small, secret-free snapshot for bug reports: the version of the
+CLI and (when a server is reachable) the server, plus the OS/runtime and the
+server's auth mode. Reporting both versions makes skew visible — the same reason
+the session-info popover shows ``server · host``.
+
+:func:`collect_snapshot` returns a JSON-serializable dict. The CLI version and
+OS are always local. The **server version and auth mode are read from the server
+itself** via the unauthed ``GET /v1/info`` endpoint when a server URL is
+provided (``omnigent diagnose --server``), so they reflect the *actual* remote
+server rather than local guesses. When no server is reachable, ``auth_source``
+falls back to what this machine's environment *would* boot a server in, marked
+by ``auth_source_origin`` so the two are never confused.
+
+Invariant: **no secrets.** Only versions, OS, and the coarse auth mode
+(accounts | single_user | oidc | header) are reported — never keys, tokens, or
+config bodies. ``auth_source`` doubles as the OSS-vs-managed signal (there is no
+explicit install marker).
+"""
+
+from __future__ import annotations
+
+import platform
+from typing import Any
+
+
+def _local_version() -> str:
+    """The installed CLI/package version (same constant the runtime imports)."""
+    from omnigent.version import VERSION
+
+    return VERSION
+
+
+def _local_auth_source() -> str:
+    """The auth mode this machine's env would boot a server in (no network)."""
+    try:
+        from omnigent.server.auth import resolve_auth_source
+
+        return resolve_auth_source()
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def _fetch_server_info(server_url: str, *, timeout: float) -> dict[str, Any] | None:
+    """Fetch the server's ``/v1/info`` (unauthed). ``None`` when unreachable.
+
+    A snapshot for a bug report must degrade, never hang or raise, so any
+    transport/HTTP failure returns ``None``.
+    """
+    try:
+        import httpx
+
+        from omnigent.chat import _remote_headers
+
+        base = server_url.rstrip("/")
+        resp = httpx.get(
+            f"{base}/v1/info",
+            headers=_remote_headers(server_url=base),
+            timeout=timeout,
+            trust_env=False,
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            return data if isinstance(data, dict) else None
+    except Exception:  # noqa: BLE001 — an unreachable/misbehaving server is not an error here
+        return None
+    return None
+
+
+def _auth_source_from_info(info: dict[str, Any]) -> str:
+    """Derive the coarse auth mode from ``/v1/info`` fields.
+
+    ``/v1/info`` exposes booleans/urls rather than a raw source string, so map
+    them back to a coarse vocabulary:
+
+    - ``accounts_enabled`` → ``"accounts"`` (built-in username/password login).
+    - otherwise ``single_user`` → ``"single_user"`` (a local one-user runtime).
+      This branch comes before ``header`` because a local single-user server and
+      a multi-user header-auth deploy BOTH report ``accounts_enabled=false`` /
+      ``login_url=null``; ``single_user`` is the only field that tells them apart
+      (see ``/v1/info`` in ``omnigent/server/app.py``).
+    - otherwise a ``login_url`` is present → ``"oidc"`` (an external IdP owns the
+      login redirect).
+    - otherwise → ``"header"`` (a trusted upstream proxy injects identity — the
+      managed-deployment posture, and the OSS-vs-managed signal).
+    """
+    if info.get("accounts_enabled"):
+        return "accounts"
+    if info.get("single_user"):
+        return "single_user"
+    if info.get("login_url"):
+        return "oidc"
+    return "header"
+
+
+def collect_snapshot(*, server_url: str | None = None, timeout: float = 5.0) -> dict[str, Any]:
+    """Collect the read-only diagnostics snapshot.
+
+    :param server_url: When given and reachable, the server version and auth
+        mode are read from its ``/v1/info`` endpoint. When ``None`` (or
+        unreachable), ``server_version`` is ``None`` and ``auth_source`` falls
+        back to the local environment (see ``auth_source_origin``).
+    :param timeout: Per-request timeout (seconds) for the server probe.
+    :returns: A JSON-serializable dict::
+
+            {
+              "cli_version": "0.8.0.dev0",
+              "server_version": "0.8.0.dev0" | null,
+              "server_url": "http://..." | null,
+              "auth_source": "accounts" | "single_user" | "oidc" | "header" | "unknown",
+              "auth_source_origin": "server" | "local-env",
+              "os": "macOS-...",
+              "python": "3.12.13"
+            }
+
+        Contains no secrets.
+    """
+    server_version: str | None = None
+    auth_source = _local_auth_source()
+    auth_source_origin = "local-env"
+
+    if server_url:
+        info = _fetch_server_info(server_url, timeout=timeout)
+        if info is not None:
+            version = info.get("server_version")
+            server_version = str(version) if version else None
+            auth_source = _auth_source_from_info(info)
+            auth_source_origin = "server"
+
+    return {
+        "cli_version": _local_version(),
+        "server_version": server_version,
+        "server_url": server_url,
+        "auth_source": auth_source,
+        "auth_source_origin": auth_source_origin,
+        "os": platform.platform(),
+        "python": platform.python_version(),
+    }
+
+
+__all__ = ["collect_snapshot"]

--- a/omnigent/diagnostics.py
+++ b/omnigent/diagnostics.py
@@ -23,6 +23,28 @@ from __future__ import annotations
 
 import platform
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+
+def _redact_url(url: str | None) -> str | None:
+    """Strip userinfo and query/fragment from a URL so it's safe to print.
+
+    A ``--server`` value could carry embedded basic-auth (``https://user:pass@h``)
+    or a query token; the snapshot is meant to be pasted into a bug report, so
+    keep only scheme + host + port + path.
+    """
+    if not url:
+        return url
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return url
+    if not parts.scheme and not parts.netloc:
+        return url  # not URL-shaped (e.g. a bare host); leave as-is
+    # ``hostname``/``port`` drop any ``user:pass@`` userinfo; query+fragment cleared.
+    host = parts.hostname or ""
+    netloc = f"{host}:{parts.port}" if parts.port else host
+    return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
 
 
 def _local_version() -> str:
@@ -131,7 +153,7 @@ def collect_snapshot(*, server_url: str | None = None, timeout: float = 5.0) -> 
     return {
         "cli_version": _local_version(),
         "server_version": server_version,
-        "server_url": server_url,
+        "server_url": _redact_url(server_url),
         "auth_source": auth_source,
         "auth_source_origin": auth_source_origin,
         "os": platform.platform(),

--- a/omnigent/diagnostics.py
+++ b/omnigent/diagnostics.py
@@ -22,8 +22,8 @@ explicit install marker).
 from __future__ import annotations
 
 import platform
+import re
 from typing import Any
-from urllib.parse import urlsplit, urlunsplit
 
 
 def _redact_url(url: str | None) -> str | None:
@@ -33,34 +33,32 @@ def _redact_url(url: str | None) -> str | None:
     or a query token; the snapshot is meant to be pasted into a bug report, so
     keep only scheme + host + port + path.
 
-    Redacts userinfo by dropping the ``user:pass@`` prefix of the authority
-    directly, rather than rebuilding it from ``hostname``/``port`` — the latter
-    lowercases the host and, for IPv6 literals, loses the required ``[...]``
-    brackets. Also handles scheme-less ``user:pass@host`` inputs, which
-    ``urlsplit`` misparses (the ``user:`` looks like a scheme), by scrubbing the
-    raw string when an ``@`` precedes any ``/``.
+    Operates on the raw string with no ``urlsplit`` — that would (a) raise
+    ``ValueError`` on a malformed IPv6 URL, leaving a fallback that leaks the
+    credentials, and (b) misparse scheme-less ``user:pass@host`` inputs. String
+    surgery instead scrubs uniformly regardless of shape:
+
+    1. cut everything from the first ``?`` or ``#`` (query + fragment);
+    2. drop a ``user:pass@`` prefix from the authority (the part before the
+       first ``/`` after any scheme), preserving IPv6 ``[...]`` brackets and
+       host casing.
     """
     if not url:
         return url
-    try:
-        parts = urlsplit(url)
-    except ValueError:
-        return url
 
-    if parts.scheme and parts.netloc:
-        # Well-formed URL: drop userinfo from the authority, keep host[:port] as
-        # written (preserves IPv6 brackets), clear query + fragment.
-        netloc = parts.netloc.rsplit("@", 1)[-1]
-        return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+    # 1. Drop query + fragment (works on well-formed and scheme-less inputs).
+    without_qf = re.split(r"[?#]", url, maxsplit=1)[0]
 
-    # Scheme-less or otherwise not cleanly split. If there's userinfo (an ``@``
-    # before the first ``/``), strip it so credentials never survive; otherwise
-    # leave the value as the user typed it.
-    authority = url.split("/", 1)[0]
-    if "@" in authority:
-        rest = url[len(authority) :]
-        return authority.rsplit("@", 1)[-1] + rest
-    return url
+    # 2. Split an optional ``scheme://`` prefix, then strip userinfo from the
+    #    authority (up to the next ``/``). Also handles a scheme-less authority.
+    m = re.match(r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.-]*://)?(?P<rest>.*)", without_qf, re.DOTALL)
+    assert m is not None  # the pattern always matches
+    scheme = m.group("scheme") or ""
+    rest = m.group("rest")
+
+    authority, sep, path = rest.partition("/")
+    authority = authority.rsplit("@", 1)[-1]  # drop ``user:pass@`` if present
+    return f"{scheme}{authority}{sep}{path}"
 
 
 def _local_version() -> str:

--- a/tests/host/test_cli_diagnose.py
+++ b/tests/host/test_cli_diagnose.py
@@ -1,0 +1,74 @@
+"""CLI-level tests for ``omnigent diagnose`` (command wiring + output shape)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import respx
+from click.testing import CliRunner
+
+from omnigent.cli import cli
+from omnigent.version import VERSION
+
+_BASE = "http://localhost:6767"
+
+# Shape mirrors the real GET /v1/info (omnigent/server/app.py): a local
+# single-user server reports accounts_enabled=false, single_user=true.
+_INFO = {
+    "accounts_enabled": False,
+    "single_user": True,
+    "login_url": None,
+    "server_version": VERSION,
+}
+
+
+def _patch_server(base_url: str | None) -> Any:
+    """Patch server resolution so the CLI targets *base_url* without spawning one."""
+    return patch("omnigent.cli._resolve_attach_server", return_value=base_url)
+
+
+@respx.mock
+def test_diagnose_json_with_server() -> None:
+    """--json against a reachable server reports its version + derived auth mode."""
+    respx.get(f"{_BASE}/v1/info").mock(return_value=httpx.Response(200, json=_INFO))
+
+    with _patch_server(_BASE):
+        result = CliRunner().invoke(cli, ["diagnose", "--server", _BASE, "--json"])
+
+    assert result.exit_code == 0, result.output
+    snap = json.loads(result.output)
+    assert snap["cli_version"] == VERSION
+    assert snap["server_version"] == VERSION
+    assert snap["server_url"] == _BASE
+    assert snap["auth_source"] == "single_user"
+    assert snap["auth_source_origin"] == "server"
+
+
+@respx.mock
+def test_diagnose_human_output() -> None:
+    """Default (non-JSON) output renders the expected labeled lines."""
+    respx.get(f"{_BASE}/v1/info").mock(return_value=httpx.Response(200, json=_INFO))
+
+    with _patch_server(_BASE):
+        result = CliRunner().invoke(cli, ["diagnose", "--server", _BASE])
+
+    assert result.exit_code == 0, result.output
+    assert f"cli     {VERSION}" in result.output
+    assert f"server  {VERSION}" in result.output
+    assert "auth    single_user (server)" in result.output
+
+
+def test_diagnose_local_only_no_server() -> None:
+    """With no resolvable server, server fields are empty and auth is local-env."""
+    with _patch_server(None):
+        result = CliRunner().invoke(cli, ["diagnose", "--json"])
+
+    assert result.exit_code == 0, result.output
+    snap = json.loads(result.output)
+    assert snap["cli_version"] == VERSION
+    assert snap["server_version"] is None
+    assert snap["server_url"] is None
+    assert snap["auth_source_origin"] == "local-env"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -110,6 +110,12 @@ def test_snapshot_contains_no_secrets(monkeypatch: pytest.MonkeyPatch) -> None:
         # IPv6 literals must keep their required [...] brackets.
         ("http://[::1]:6767/x", "http://[::1]:6767/x"),
         ("https://u:p@[2001:db8::1]:443/api?t=x", "https://[2001:db8::1]:443/api"),
+        # Malformed URL (urlsplit would raise) must still drop userinfo, never
+        # fall back to the raw string.
+        ("http://user:pass@[::1", "http://[::1"),
+        # Scheme-less inputs must also drop query/fragment, not just userinfo.
+        ("user:pass@host?token=abc#frag", "host"),
+        ("host:6767/p?token=xyz#f", "host:6767/p"),
         (None, None),
     ],
 )

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -95,3 +95,25 @@ def test_snapshot_contains_no_secrets(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-should-not-appear")
     blob = repr(collect_snapshot(server_url=None))
     assert "sk-should-not-appear" not in blob
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("http://user:pass@host:6767/api", "http://host:6767/api"),
+        ("https://tok@example.com/path?token=abc#frag", "https://example.com/path"),
+        ("http://localhost:6767", "http://localhost:6767"),
+        ("localhost:6767", "localhost:6767"),  # not URL-shaped; left as-is
+        (None, None),
+    ],
+)
+def test_redact_url(raw: str | None, expected: str | None) -> None:
+    assert diagnostics._redact_url(raw) == expected
+
+
+def test_snapshot_redacts_server_url_userinfo(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A --server URL with embedded creds must not survive into the snapshot.
+    monkeypatch.setattr(diagnostics, "_fetch_server_info", lambda url, *, timeout: None)
+    snap = collect_snapshot(server_url="https://user:secretpw@host:6767/")
+    assert snap["server_url"] == "https://host:6767/"
+    assert "secretpw" not in repr(snap)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,97 @@
+"""Tests for the read-only ``omnigent diagnose`` snapshot."""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent import diagnostics
+from omnigent.diagnostics import collect_snapshot
+from omnigent.version import VERSION
+
+
+def test_snapshot_local_only_has_no_server_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OMNIGENT_AUTH_PROVIDER", raising=False)
+    snap = collect_snapshot(server_url=None)
+    assert snap["cli_version"] == VERSION
+    assert snap["server_url"] is None
+    assert snap["server_version"] is None  # can't know a server's version without asking
+    assert snap["auth_source_origin"] == "local-env"
+    assert snap["auth_source"]  # env-derived, always present
+    assert snap["os"]
+    assert snap["python"]
+
+
+def test_snapshot_reports_only_known_keys() -> None:
+    snap = collect_snapshot(server_url=None)
+    assert set(snap) == {
+        "cli_version",
+        "server_version",
+        "server_url",
+        "auth_source",
+        "auth_source_origin",
+        "os",
+        "python",
+    }
+
+
+def test_local_auth_source_reflects_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OMNIGENT_AUTH_PROVIDER", "OIDC")
+    snap = collect_snapshot(server_url=None)
+    assert snap["auth_source"] == "oidc"
+    assert snap["auth_source_origin"] == "local-env"
+
+
+def test_server_info_populates_version_and_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A reachable server supplies BOTH version and the real auth mode.
+    monkeypatch.setattr(
+        diagnostics,
+        "_fetch_server_info",
+        lambda url, *, timeout: {"server_version": "9.9.9", "accounts_enabled": True},
+    )
+    snap = collect_snapshot(server_url="http://example:6767")
+    assert snap["server_version"] == "9.9.9"
+    assert snap["server_url"] == "http://example:6767"
+    assert snap["auth_source"] == "accounts"
+    assert snap["auth_source_origin"] == "server"
+
+
+@pytest.mark.parametrize(
+    ("info", "expected"),
+    [
+        ({"accounts_enabled": True}, "accounts"),
+        # single_user must win over the header fallback: a local one-user server
+        # and a header-auth deploy both have accounts_enabled=false / no login_url.
+        ({"accounts_enabled": False, "single_user": True}, "single_user"),
+        ({"accounts_enabled": False, "single_user": False, "login_url": "https://idp"}, "oidc"),
+        ({"accounts_enabled": False, "single_user": False, "login_url": None}, "header"),
+    ],
+)
+def test_auth_source_derived_from_info(info: dict, expected: str) -> None:
+    assert diagnostics._auth_source_from_info(info) == expected
+
+
+def test_unreachable_server_falls_back_to_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OMNIGENT_AUTH_PROVIDER", "header")
+    monkeypatch.setattr(diagnostics, "_fetch_server_info", lambda url, *, timeout: None)
+    snap = collect_snapshot(server_url="http://127.0.0.1:6767")
+    assert snap["server_version"] is None
+    assert snap["auth_source"] == "header"
+    assert snap["auth_source_origin"] == "local-env"
+
+
+def test_fetch_server_info_degrades_on_transport_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A failing HTTP call returns None, never raises.
+    import httpx
+
+    def _boom(*args: object, **kwargs: object) -> object:
+        raise httpx.ConnectError("nope")
+
+    monkeypatch.setattr("httpx.get", _boom)
+    assert diagnostics._fetch_server_info("http://127.0.0.1:6767", timeout=1.0) is None
+
+
+def test_snapshot_contains_no_secrets(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Even with a secret-looking env var set, the snapshot never carries it.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-should-not-appear")
+    blob = repr(collect_snapshot(server_url=None))
+    assert "sk-should-not-appear" not in blob

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -103,7 +103,13 @@ def test_snapshot_contains_no_secrets(monkeypatch: pytest.MonkeyPatch) -> None:
         ("http://user:pass@host:6767/api", "http://host:6767/api"),
         ("https://tok@example.com/path?token=abc#frag", "https://example.com/path"),
         ("http://localhost:6767", "http://localhost:6767"),
-        ("localhost:6767", "localhost:6767"),  # not URL-shaped; left as-is
+        ("localhost:6767", "localhost:6767"),  # bare host, no userinfo; left as-is
+        # Scheme-less input with userinfo: urlsplit misparses it, but creds must
+        # still be stripped (the ``user:`` looks like a scheme to urlsplit).
+        ("user:pass@host:6767", "host:6767"),
+        # IPv6 literals must keep their required [...] brackets.
+        ("http://[::1]:6767/x", "http://[::1]:6767/x"),
+        ("https://u:p@[2001:db8::1]:443/api?t=x", "https://[2001:db8::1]:443/api"),
         (None, None),
     ],
 )


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Adds a read-only `omnigent diagnose` command that prints a small, **secret-free** environment snapshot for bug reports: CLI version, OS/Python, and the server's auth mode.
- With `--server <url>` (or a resolvable configured/local server) it reads the **server version and real auth mode** from the unauthed `GET /v1/info` endpoint, so version skew between CLI and server is visible — the same reason the session-info popover shows `server · host`.
- The auth mode doubles as the **OSS-vs-managed signal**: `accounts | single_user | oidc | header`, derived from `/v1/info` when the server is reachable and falling back to the local environment otherwise (tagged by `auth_source_origin` so the two are never confused).
- `omnigent doctor` (install-ledger migration) is **left untouched** — this is a separate, additive command.

Example (local server running):

```
$ omni diagnose --json
{
  "auth_source": "single_user",
  "auth_source_origin": "server",
  "cli_version": "0.8.0.dev0",
  "os": "macOS-26.5.2-arm64-arm-64bit",
  "python": "3.12.13",
  "server_url": "http://localhost:6767",
  "server_version": "0.8.0.dev0"
}
```

No auth is required for the local case (`/v1/info` is intentionally unauthed); for a remote/managed server, existing `omnigent login` credentials are attached via the same `_remote_headers` path `session export` uses. An unreachable server degrades gracefully (no hang, no error) to CLI-version-only + local-env auth.

## Test Plan

- `pytest tests/test_diagnostics.py` — 11 tests: local-only snapshot, server-info version+auth population, the `accounts/single_user/oidc/header` derivation table, unreachable-server fallback, transport-error degradation, and a no-secrets assertion.
- Manual: `omni diagnose`, `omni diagnose --json`, and `omni diagnose --server http://localhost:6767` against a running local server.
- `ruff format` + `ruff check` clean; pre-commit hooks pass.

## Demo

N/A (CLI text output shown in Summary)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran `omni diagnose` in all three forms (default, `--json`, `--server`) against a live local server and confirmed the reported `server_version` matches `cli_version` and `auth_source` reads `single_user` from `/v1/info`. The network probe / fallback paths are covered by unit tests via monkeypatching `_fetch_server_info` and `httpx.get`.

## Changelog

`omnigent diagnose` prints a secret-free environment snapshot (CLI/server versions, OS, auth mode) for bug reports

This pull request and its description were written by Isaac.