### PR TITLE
fix(web): hide empty Projects header kebab when no projects

### DIFF
--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -316,6 +316,17 @@ describe("quick pin/unpin hover button", () => {
     expect(screen.getByTestId("project-list-actions")).not.toHaveClass("size-7");
   });
 
+  it("hides the Projects list-actions kebab when there are no projects", () => {
+    // With no projects, the kebab has nothing to offer (no expand/collapse, no
+    // sessions to select) and would open empty — so it's hidden entirely,
+    // leaving just the "New project" button.
+    mocks.projects = [];
+    renderSidebar();
+
+    expect(screen.queryByTestId("project-list-actions")).toBeNull();
+    expect(screen.getByTestId("new-project")).toBeInTheDocument();
+  });
+
   it("toggles the pin without opening the kebab menu, moving the row under Pinned", () => {
     renderSidebar();
 

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -2151,50 +2151,55 @@ function ProjectHeaderActions({
   const showExpandControls = !collapsed && projectNames.length > 0;
   const allExpanded =
     projectNames.length > 0 && projectNames.every((name) => expandedProjects.includes(name));
+  // The kebab only carries the expand/collapse and "Select sessions" items; with
+  // neither applicable (e.g. no projects yet) it would open empty, so hide it.
+  const showMenu = showExpandControls || hasProjectSessions;
 
   return (
     <div className="flex items-center gap-0.5">
       <NewProjectButton onCreated={onProjectCreated} />
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            aria-label="Project list actions"
-            data-testid="project-list-actions"
-            onClick={(event) => event.stopPropagation()}
-          >
-            <MoreHorizontalIcon className="size-3.5" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="min-w-40 [&_[role=menuitem]]:text-xs">
-          {showExpandControls &&
-            (allExpanded ? (
-              <DropdownMenuItem data-testid="revert-projects" onSelect={() => onRevert()}>
-                <Minimize2Icon className="size-3.5" />
-                Collapse to previous
-              </DropdownMenuItem>
-            ) : (
-              <DropdownMenuItem
-                data-testid="expand-all-projects"
-                onSelect={() => onExpandAll(projectNames)}
-              >
-                <Maximize2Icon className="size-3.5" />
-                Expand all
-              </DropdownMenuItem>
-            ))}
-          {hasProjectSessions && (
-            <DropdownMenuItem
-              data-testid="projects-select-sessions"
-              onSelect={() => onEnterSelectionMode()}
+      {showMenu && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label="Project list actions"
+              data-testid="project-list-actions"
+              onClick={(event) => event.stopPropagation()}
             >
-              <ListChecksIcon className="size-3.5" />
-              Select sessions
-            </DropdownMenuItem>
-          )}
-        </DropdownMenuContent>
-      </DropdownMenu>
+              <MoreHorizontalIcon className="size-3.5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="min-w-40 [&_[role=menuitem]]:text-xs">
+            {showExpandControls &&
+              (allExpanded ? (
+                <DropdownMenuItem data-testid="revert-projects" onSelect={() => onRevert()}>
+                  <Minimize2Icon className="size-3.5" />
+                  Collapse to previous
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem
+                  data-testid="expand-all-projects"
+                  onSelect={() => onExpandAll(projectNames)}
+                >
+                  <Maximize2Icon className="size-3.5" />
+                  Expand all
+                </DropdownMenuItem>
+              ))}
+            {hasProjectSessions && (
+              <DropdownMenuItem
+                data-testid="projects-select-sessions"
+                onSelect={() => onEnterSelectionMode()}
+              >
+                <ListChecksIcon className="size-3.5" />
+                Select sessions
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The Projects group-header kebab (⋯) rendered next to **New project** even when its menu had nothing to show. With no projects filed, neither the expand/collapse controls (need `projectNames.length > 0`) nor **Select sessions** (needs project sessions) apply, so clicking the kebab opened an empty popover.
- Gate the kebab on whether either menu item is actually available (`showMenu = showExpandControls || hasProjectSessions`), leaving only the **New project** button when there's nothing to offer. The kebab reappears once a project (or a project session) exists.

## Test Plan

- `cd web && npm test` — 4829 passing, incl. new case `hides the Projects list-actions kebab when there are no projects` in `Sidebar.rowActions.test.tsx`.
- `cd web && npm run build` — passes (tsc + vite).
- Manual: open the sidebar with no projects → Projects header shows only **New project**, no empty ⋯. Create a project → kebab reappears with Expand all / Select sessions.

## Demo

Before: empty kebab popover on the Projects header when no projects exist. After: the kebab is hidden, leaving just the **New project** button. (UI preview build attached via the `ui-preview` label.)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added a unit test asserting the kebab is absent with zero projects while **New project** remains. Manually verified the empty-popover no longer appears and that the kebab returns once a project exists.

## Changelog

Hide the empty Projects header menu (⋯) when you have no projects

This pull request and its description were written by Isaac.
