### PR TITLE
feat(web): move Chat/Terminal switcher into the header

### DIFF
--- a/tests/e2e_ui/messages/test_message_render_parity.py
+++ b/tests/e2e_ui/messages/test_message_render_parity.py
@@ -76,12 +76,13 @@ def _ensure_chat_view(page: Page) -> None:
 
     :param page: The Playwright page, on the session's chat surface.
     """
-    view_mode = page.get_by_role("group", name="View mode")
+    view_mode = page.get_by_test_id("view-mode-toggle")
     if view_mode.count() == 0:
         return
-    chat_button = view_mode.get_by_role("button", name="Chat")
-    expect(chat_button).to_be_visible(timeout=30_000)
-    chat_button.click()
+    view_mode.click()
+    chat_item = page.get_by_role("menuitemradio", name="Chat")
+    expect(chat_item).to_be_visible(timeout=30_000)
+    chat_item.click()
 
 
 def _turn_prompt(index: int, user_marker: str, assistant_token: str) -> str:

--- a/tests/e2e_ui/messages/test_native_claude_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_claude_render_parity.py
@@ -65,11 +65,12 @@ def _open_terminal_view(page: Page) -> None:
 
     :param page: The Playwright page, on the session's chat surface.
     """
-    view_mode = page.get_by_role("group", name="View mode")
+    view_mode = page.get_by_test_id("view-mode-toggle")
     expect(view_mode).to_be_visible(timeout=_TERMINAL_READY_TIMEOUT_MS)
-    terminal_button = view_mode.get_by_role("button", name="Terminal")
-    expect(terminal_button).to_be_visible(timeout=30_000)
-    terminal_button.click()
+    view_mode.click()
+    terminal_item = page.get_by_role("menuitemradio", name="Terminal")
+    expect(terminal_item).to_be_visible(timeout=30_000)
+    terminal_item.click()
 
 
 def _wait_terminal_connected(page: Page) -> None:

--- a/tests/e2e_ui/messages/test_native_codex_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_codex_render_parity.py
@@ -67,11 +67,12 @@ def _open_terminal_view(page: Page) -> None:
 
     :param page: The Playwright page, on the session's chat surface.
     """
-    view_mode = page.get_by_role("group", name="View mode")
+    view_mode = page.get_by_test_id("view-mode-toggle")
     expect(view_mode).to_be_visible(timeout=_TERMINAL_READY_TIMEOUT_MS)
-    terminal_button = view_mode.get_by_role("button", name="Terminal")
-    expect(terminal_button).to_be_visible(timeout=30_000)
-    terminal_button.click()
+    view_mode.click()
+    terminal_item = page.get_by_role("menuitemradio", name="Terminal")
+    expect(terminal_item).to_be_visible(timeout=30_000)
+    terminal_item.click()
 
 
 def _wait_terminal_connected(page: Page) -> None:

--- a/tests/e2e_ui/messages/test_native_cursor_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_cursor_render_parity.py
@@ -146,11 +146,12 @@ def _open_terminal_view(page: Page) -> None:
 
     :param page: The Playwright page, on the session's chat surface.
     """
-    view_mode = page.get_by_role("group", name="View mode")
+    view_mode = page.get_by_test_id("view-mode-toggle")
     expect(view_mode).to_be_visible(timeout=_TERMINAL_READY_TIMEOUT_MS)
-    terminal_button = view_mode.get_by_role("button", name="Terminal")
-    expect(terminal_button).to_be_visible(timeout=30_000)
-    terminal_button.click()
+    view_mode.click()
+    terminal_item = page.get_by_role("menuitemradio", name="Terminal")
+    expect(terminal_item).to_be_visible(timeout=30_000)
+    terminal_item.click()
 
 
 def _wait_terminal_connected(page: Page) -> None:

--- a/tests/e2e_ui/messages/test_native_goose_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_goose_render_parity.py
@@ -93,11 +93,12 @@ pytestmark = pytest.mark.skipif(
 
 def _open_terminal_view(page: Page) -> None:
     """Switch a terminal-first session to its Terminal (TUI) view."""
-    view_mode = page.get_by_role("group", name="View mode")
+    view_mode = page.get_by_test_id("view-mode-toggle")
     expect(view_mode).to_be_visible(timeout=_TERMINAL_READY_TIMEOUT_MS)
-    terminal_button = view_mode.get_by_role("button", name="Terminal")
-    expect(terminal_button).to_be_visible(timeout=30_000)
-    terminal_button.click()
+    view_mode.click()
+    terminal_item = page.get_by_role("menuitemradio", name="Terminal")
+    expect(terminal_item).to_be_visible(timeout=30_000)
+    terminal_item.click()
 
 
 def _wait_terminal_connected(page: Page) -> None:

--- a/tests/e2e_ui/messages/test_native_hermes_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_hermes_render_parity.py
@@ -93,11 +93,12 @@ pytestmark = pytest.mark.skipif(
 
 def _open_terminal_view(page: Page) -> None:
     """Switch a terminal-first session to its Terminal (TUI) view."""
-    view_mode = page.get_by_role("group", name="View mode")
+    view_mode = page.get_by_test_id("view-mode-toggle")
     expect(view_mode).to_be_visible(timeout=_TERMINAL_READY_TIMEOUT_MS)
-    terminal_button = view_mode.get_by_role("button", name="Terminal")
-    expect(terminal_button).to_be_visible(timeout=30_000)
-    terminal_button.click()
+    view_mode.click()
+    terminal_item = page.get_by_role("menuitemradio", name="Terminal")
+    expect(terminal_item).to_be_visible(timeout=30_000)
+    terminal_item.click()
 
 
 def _wait_terminal_connected(page: Page) -> None:

--- a/tests/e2e_ui/messages/test_native_kiro_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_kiro_render_parity.py
@@ -82,11 +82,12 @@ pytestmark = pytest.mark.skipif(
 
 def _open_terminal_view(page: Page) -> None:
     """Switch a terminal-first session to its Terminal (TUI) view."""
-    view_mode = page.get_by_role("group", name="View mode")
+    view_mode = page.get_by_test_id("view-mode-toggle")
     expect(view_mode).to_be_visible(timeout=_TERMINAL_READY_TIMEOUT_MS)
-    terminal_button = view_mode.get_by_role("button", name="Terminal")
-    expect(terminal_button).to_be_visible(timeout=30_000)
-    terminal_button.click()
+    view_mode.click()
+    terminal_item = page.get_by_role("menuitemradio", name="Terminal")
+    expect(terminal_item).to_be_visible(timeout=30_000)
+    terminal_item.click()
 
 
 def _wait_terminal_connected(page: Page) -> None:

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -635,10 +635,6 @@
     padding-bottom: 0.25rem;
   }
 
-  [data-ios-native] .terminal-first-switcher-container {
-    padding-bottom: calc(0.35rem + var(--omnigent-safe-bottom));
-  }
-
   /* Reserve room for the native Liquid Glass switcher that floats over the web
      view (the in-page pill is suppressed in the iOS shell). Height is the
      shared bottom inset — the native bar footprint (sourced from the shell, see
@@ -650,70 +646,6 @@
   [data-ios-native] .omnigent-native-bottom-spacer--chat {
     height: var(--omnigent-inset-bottom);
     flex: none;
-  }
-
-  [data-ios-native] .terminal-first-switcher {
-    min-height: 46px;
-    gap: 0.25rem;
-    padding: 0.25rem;
-    border-color: color-mix(in srgb, var(--border) 72%, transparent);
-    background: color-mix(in srgb, var(--card) 88%, transparent);
-    -webkit-backdrop-filter: saturate(180%) blur(18px);
-    backdrop-filter: saturate(180%) blur(18px);
-    box-shadow:
-      0 12px 28px rgb(0 0 0 / 0.13),
-      0 1px 0 rgb(255 255 255 / 0.55) inset;
-    font-size: 16px;
-    line-height: 1;
-  }
-
-  [data-ios-native] .terminal-first-switcher > div {
-    gap: 0.25rem;
-  }
-
-  [data-ios-native] .terminal-first-switcher-option {
-    min-height: 38px;
-    gap: 0.45rem;
-    padding: 0 0.85rem;
-    font-size: 16px;
-    font-weight: 500;
-    letter-spacing: 0;
-    transition:
-      background-color 160ms ease,
-      color 160ms ease,
-      box-shadow 160ms ease,
-      transform 160ms ease;
-  }
-
-  [data-ios-native] .terminal-first-switcher-option:active:not(:disabled) {
-    transform: scale(0.97);
-  }
-
-  [data-ios-native] .terminal-first-switcher-option[aria-pressed="true"] {
-    background: color-mix(in srgb, var(--background) 82%, white 18%);
-    box-shadow:
-      0 3px 10px rgb(0 0 0 / 0.1),
-      0 1px 0 rgb(255 255 255 / 0.72) inset;
-  }
-
-  [data-ios-native] .terminal-first-switcher-option svg {
-    width: 1.15rem;
-    height: 1.15rem;
-  }
-
-  .dark [data-ios-native] .terminal-first-switcher {
-    border-color: color-mix(in srgb, var(--border) 82%, transparent);
-    background: color-mix(in srgb, var(--card) 78%, transparent);
-    box-shadow:
-      0 14px 30px rgb(0 0 0 / 0.35),
-      0 1px 0 rgb(255 255 255 / 0.1) inset;
-  }
-
-  .dark [data-ios-native] .terminal-first-switcher-option[aria-pressed="true"] {
-    background: color-mix(in srgb, var(--muted) 82%, white 6%);
-    box-shadow:
-      0 3px 12px rgb(0 0 0 / 0.28),
-      0 1px 0 rgb(255 255 255 / 0.12) inset;
   }
 
   :is([data-ios-native], [data-android-native])

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -25,11 +25,9 @@ import {
   GitForkIcon,
   ImageIcon,
   Loader2Icon,
-  MessageSquareIcon,
   PaperclipIcon,
   SettingsIcon,
   SquareIcon,
-  TerminalIcon,
   WifiOffIcon,
   XIcon,
 } from "lucide-react";
@@ -2788,15 +2786,11 @@ export function ConnectionIndicator({
     );
   }
 
-  // Terminal-first sessions own the Chat/Terminal toggle for EVERY
-  // reachable state — `online`, `unknown` (pre-poll), `starting`
-  // (spinning up / relaunching), AND `runner_asleep` (stopped, host
-  // alive). Only the unreachable states above replace it with the banner.
-  // Keeping the pill visible through `runner_asleep` is why stopping a
-  // runner no longer makes the toggle vanish: the pill stays, and the
-  // next send (or a fresh launch) drives its own terminal-pending spinner
-  // as the runner comes back. The strict `runner_online` still gates the
-  // inline PTY *view* (it needs a live tunnel) — but not the toggle.
+  // Terminal-first sessions: the Chat/Terminal toggle lives in the header
+  // (ViewModeToggle) for every reachable state — only the unreachable
+  // states above replace this band with the reconnect banner. In the iOS
+  // shell the toggle is the native Liquid Glass bar, so this band still
+  // reserves a spacer for its footprint.
   if (terminalFirst?.isTerminalFirst) {
     // In the iOS shell the toggle is the native bar (driven above). Render only
     // a spacer reserving its fixed footprint so the composer clears it — and
@@ -2814,13 +2808,10 @@ export function ConnectionIndicator({
         />
       ) : null;
     }
-    // A rail-opened shell owns the main view chrome-free — no pill: a
-    // "Chat" option under someone else's shell misreads as the shell
-    // being the agent. The shell view carries its own close affordance
-    // (MainTerminalView's X) back to chat.
-    if (terminalFirst.isShellView) return null;
-    if (keyboardVisible) return null;
-    return <ConnectedTerminalFirstPill ctx={terminalFirst} />;
+    // Outside the iOS shell the Chat/Terminal switcher lives in the header
+    // (ViewModeToggle) — this band renders nothing for terminal-first
+    // sessions now that the in-page pill is gone.
+    return null;
   }
 
   // A regular (non-terminal-first) session whose runner is still spinning
@@ -3057,80 +3048,6 @@ function useNativeChatTerminalBar(
     if (!native) return;
     return onNativeViewModeChanged((mode) => setViewRef.current?.(mode));
   }, [native]);
-}
-
-/**
- * Chat/Terminal segmented control for terminal-first sessions. Status
- * lives in the sidebar — this band is purely a view toggle.
- *
- * Only rendered outside the iOS shell; inside it the switcher is drawn natively
- * (Liquid Glass) over the web view — see {@link useNativeChatTerminalBar}.
- */
-function ConnectedTerminalFirstPill({
-  ctx,
-}: {
-  ctx: NonNullable<ReturnType<typeof useTerminalFirst>>;
-}) {
-  // `terminalStartingUp` is the single loading signal — AppShell folds the
-  // launch (liveness `starting`) and PTY-creation (`terminalPending`)
-  // sources into it. The button is disabled whenever no terminal is
-  // reachable: greyed-and-spinning reads as "loading", greyed-and-static as
-  // "no terminal / stopped".
-  const { view, setView, terminalsAvailable, terminalStartingUp } = ctx;
-
-  return (
-    <div
-      className={cn(
-        "terminal-first-switcher-container mx-auto flex w-full items-center justify-center px-6 pb-1.5",
-        CHAT_COLUMN_WIDTH,
-      )}
-    >
-      <div
-        role="group"
-        aria-label="View mode"
-        className="terminal-first-switcher flex items-center gap-1 rounded-full border border-border bg-card/90 p-1 text-xs shadow-sm"
-      >
-        <div className="flex items-center gap-0.5">
-          <button
-            type="button"
-            aria-pressed={view === "chat"}
-            aria-label="Chat"
-            onClick={() => setView("chat")}
-            className={cn(
-              "terminal-first-switcher-option flex cursor-pointer items-center gap-1 rounded-full px-2 py-0.5 transition-colors",
-              view === "chat"
-                ? "bg-muted text-foreground"
-                : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
-            )}
-          >
-            <MessageSquareIcon className="size-3.5 shrink-0" />
-            <span>Chat</span>
-          </button>
-          <button
-            type="button"
-            aria-pressed={view === "terminal"}
-            aria-label="Terminal"
-            disabled={!terminalsAvailable}
-            title={terminalStartingUp ? "Terminal is starting up…" : undefined}
-            onClick={() => setView("terminal")}
-            className={cn(
-              "terminal-first-switcher-option flex cursor-pointer items-center gap-1 rounded-full px-2 py-0.5 transition-colors disabled:cursor-not-allowed disabled:opacity-50",
-              view === "terminal"
-                ? "bg-muted text-foreground"
-                : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
-            )}
-          >
-            {terminalStartingUp ? (
-              <Loader2Icon className="size-3.5 shrink-0 animate-spin" aria-hidden />
-            ) : (
-              <TerminalIcon className="size-3.5 shrink-0" />
-            )}
-            <span>Terminal</span>
-          </button>
-        </div>
-      </div>
-    </div>
-  );
 }
 
 /**

--- a/web/src/pages/ConnectionIndicator.test.tsx
+++ b/web/src/pages/ConnectionIndicator.test.tsx
@@ -11,7 +11,7 @@ import {
 /**
  * Build a TerminalFirstContextValue with sensible defaults so each test
  * overrides only the fields it exercises. `terminalStartingUp` defaults to
- * false (the steady state) — spinner tests set it explicitly.
+ * false (the steady state).
  */
 function makeCtx(overrides: Partial<TerminalFirstContextValue> = {}): TerminalFirstContextValue {
   return {
@@ -66,74 +66,21 @@ describe("ConnectionIndicator", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("renders the segmented Chat/Terminal toggle for online terminal-first sessions", () => {
-    renderWithContext(ONLINE, makeCtx());
-    const group = screen.getByRole("group", { name: /view mode/i });
-    expect(group).toBeInTheDocument();
-    // Status text has been intentionally removed — the toggle is the
-    // entire content now.
-    expect(group).not.toHaveTextContent(/agent connected/i);
-    expect(screen.getByRole("button", { name: /^chat$/i })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByRole("button", { name: /^terminal$/i })).toHaveAttribute(
-      "aria-pressed",
-      "false",
-    );
+  it("renders nothing for online terminal-first sessions (toggle lives in the header)", () => {
+    // The Chat/Terminal switcher moved to the header (ViewModeToggle); this
+    // band no longer renders the in-page pill for reachable terminal-first
+    // sessions.
+    const { container } = renderWithContext(ONLINE, makeCtx());
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByRole("group", { name: /view mode/i })).toBeNull();
   });
 
   it("renders nothing while a shell owns the main view (isShellView)", () => {
-    // A rail-opened shell is chrome-free: a "Chat" option under
-    // someone else's shell misreads as the shell being the agent. The
-    // shell view's own close X (MainTerminalView) is the way back. A
-    // visible pill here means ConnectionIndicator dropped the
-    // isShellView gate.
     const { container } = renderWithContext(
       ONLINE,
       makeCtx({ isShellView: true, view: "terminal" }),
     );
     expect(container).toBeEmptyDOMElement();
-  });
-
-  it("disables the Terminal pill and shows a spinner while the terminal is coming up", () => {
-    // Coming up: no terminal yet AND the consolidated startingUp flag is
-    // set (AppShell folds launch + PTY-creation into it). The greyed button
-    // reads as "loading".
-    renderWithContext(ONLINE, makeCtx({ terminalsAvailable: false, terminalStartingUp: true }));
-    const terminalButton = screen.getByRole("button", { name: /^terminal$/i });
-    expect(terminalButton).toBeDisabled();
-    // The starting-up state swaps the static terminal glyph for an
-    // animated spinner so the greyed-out button reads as "loading".
-    expect(terminalButton.querySelector(".animate-spin")).not.toBeNull();
-    expect(terminalButton).toHaveAttribute("title", expect.stringMatching(/starting up/i));
-  });
-
-  it("disables the Terminal pill WITHOUT a spinner when no terminal exists and none is coming up", () => {
-    // Killed-remotely / stopped-idle: the button is greyed out but must
-    // NOT spin, since nothing is actually starting up.
-    renderWithContext(ONLINE, makeCtx({ terminalsAvailable: false, terminalStartingUp: false }));
-    const terminalButton = screen.getByRole("button", { name: /^terminal$/i });
-    expect(terminalButton).toBeDisabled();
-    expect(terminalButton.querySelector(".animate-spin")).toBeNull();
-    expect(terminalButton).not.toHaveAttribute("title");
-  });
-
-  it("shows the terminal icon (no spinner) once a terminal is available", () => {
-    // Available wins: an openable terminal is never "loading" (AppShell
-    // keeps startingUp false whenever terminalsAvailable is true).
-    renderWithContext(ONLINE, makeCtx({ terminalsAvailable: true, terminalStartingUp: false }));
-    const terminalButton = screen.getByRole("button", { name: /^terminal$/i });
-    expect(terminalButton).toBeEnabled();
-    expect(terminalButton.querySelector(".animate-spin")).toBeNull();
-    expect(terminalButton).not.toHaveAttribute("title");
-  });
-
-  it("invokes setView when pill buttons are clicked", () => {
-    const setView = vi.fn();
-    renderWithContext(ONLINE, makeCtx({ setView }));
-    fireEvent.click(screen.getByRole("button", { name: /^terminal$/i }));
-    expect(setView).toHaveBeenCalledWith("terminal");
-
-    fireEvent.click(screen.getByRole("button", { name: /^chat$/i }));
-    expect(setView).toHaveBeenCalledWith("chat");
   });
 
   it("renders the reconnect button for a local_stranded session, regardless of context", () => {
@@ -143,9 +90,6 @@ describe("ConnectionIndicator", () => {
     expect(button).toBeInTheDocument();
     fireEvent.click(button);
     expect(onShow).toHaveBeenCalledTimes(1);
-    // Switching views while unreachable isn't useful — the terminal
-    // panel would be stale anyway — so the toggle is not rendered.
-    expect(screen.queryByRole("group", { name: /view mode/i })).toBeNull();
   });
 
   it("keeps the host-offline banner in the terminal-first TERMINAL view (no composer badge there)", () => {
@@ -170,22 +114,19 @@ describe("ConnectionIndicator", () => {
   it("renders NOTHING for a runner_asleep NON-terminal-first session — composer stays open", () => {
     // Core UX goal: when the host is alive the chat box stays open and
     // the runner relaunches on the next message, so the band shows no
-    // disconnect banner. A regular session has no toggle to keep, so the
-    // band is empty.
+    // disconnect banner.
     const { container } = renderWithContext({ kind: "runner_asleep" }, null);
     expect(screen.queryByTestId("disconnected-indicator")).toBeNull();
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("KEEPS the Chat/Terminal pill for a runner_asleep terminal-first session", () => {
-    // Stopping a runner must NOT make the toggle vanish: the pill stays so
-    // the user can flip views and the next send relaunches the runner
-    // (driving the pill's own spinner). Regression for the "pill disappears
-    // after stop and never comes back" report.
-    renderWithContext({ kind: "runner_asleep" }, makeCtx());
-    expect(screen.getByRole("group", { name: /view mode/i })).toBeInTheDocument();
-    // No disconnect banner — the host is alive, the chat stays open.
+  it("renders nothing (no banner) for a runner_asleep terminal-first session", () => {
+    // Stopping a runner keeps the chat open (host alive); the header toggle
+    // stays available and the next send relaunches the runner. This band
+    // shows no disconnect banner.
+    const { container } = renderWithContext({ kind: "runner_asleep" }, makeCtx());
     expect(screen.queryByTestId("disconnected-indicator")).toBeNull();
+    expect(container).toBeEmptyDOMElement();
   });
 
   it("renders nothing while liveness is unknown (pre-poll)", () => {
@@ -202,32 +143,18 @@ describe("ConnectionIndicator", () => {
     expect(indicator).toHaveTextContent(/connecting/i);
     expect(indicator.tagName).toBe("DIV");
     expect(indicator.querySelector(".animate-spin")).not.toBeNull();
-    // It must not be the reconnect/fork banner.
     expect(screen.queryByTestId("disconnected-indicator")).toBeNull();
   });
 
-  it("shows the Chat/Terminal pill (not the Connecting band) for a terminal-first starting session", () => {
-    // Regression guard: terminal-first sessions keep their toggle during
-    // spin-up — the pill's own terminal-pending spinner covers startup, so
-    // the generic Connecting band must NOT take over here.
-    renderWithContext(
+  it("does NOT show the Connecting band for a terminal-first starting session", () => {
+    // Terminal-first sessions surface startup elsewhere (header toggle +
+    // RunnerStartingIndicator), so the generic Connecting band must not take
+    // over this band.
+    const { container } = renderWithContext(
       { kind: "starting" },
       makeCtx({ terminalsAvailable: false, terminalStartingUp: true }),
     );
-    expect(screen.getByRole("group", { name: /view mode/i })).toBeInTheDocument();
     expect(screen.queryByTestId("connecting-indicator")).toBeNull();
-    // The pill's own spin-up spinner is present.
-    expect(
-      screen.getByRole("button", { name: /^terminal$/i }).querySelector(".animate-spin"),
-    ).not.toBeNull();
-  });
-
-  it("shows the Chat/Terminal pill for a terminal-first unknown (pre-poll) session", () => {
-    // `unknown` reads as "assume online until proven otherwise" — the
-    // toggle stays visible rather than flickering out before the first
-    // poll resolves.
-    renderWithContext({ kind: "unknown" }, makeCtx());
-    expect(screen.getByRole("group", { name: /view mode/i })).toBeInTheDocument();
-    expect(screen.queryByTestId("connecting-indicator")).toBeNull();
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -230,13 +230,10 @@ import { useChatStore } from "@/store/chatStore";
 
 /**
  * Test-only consumer of the TerminalFirstContext provided by AppShell.
- * The production view toggle now lives inside ChatPage's
- * ConnectionIndicator; these tests are scoped to the shell's state
- * machine, so we use a probe component with the exact same
- * `aria-label`s as the production pill ("Chat" / "Terminal" — see
- * ConnectedTerminalFirstPill in ChatPage.tsx) to drive `setView`. If
- * the production labels ever change, these tests fail loudly instead
- * of drifting silently.
+ * The production view toggle lives in the header (ViewModeToggle); these
+ * tests are scoped to the shell's state machine, so we use a probe
+ * component with its own "Chat" / "Terminal" buttons to drive `setView`
+ * and read the context's derived flags off data attributes.
  */
 function TerminalFirstViewProbe() {
   const ctx = useTerminalFirst();

--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -1,9 +1,14 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Agent } from "@/hooks/useAgents";
 import { ChatHeader } from "./ChatHeader";
+import {
+  TerminalFirstContextProvider,
+  type TerminalFirstContextValue,
+} from "./TerminalFirstContext";
 
 // Minimal mobile-menu prop block. All gating booleans are false / counts are
 // zero so the mobile FAB and three-dot menu never render — these tests only
@@ -184,5 +189,100 @@ describe("ChatHeader — sub-agent affordance", () => {
       "/c/parent-123",
     );
     expect(screen.getByText("Sub-agent")).toBeInTheDocument();
+  });
+});
+
+function makeTerminalFirstCtx(
+  overrides: Partial<TerminalFirstContextValue> = {},
+): TerminalFirstContextValue {
+  return {
+    isClaudeNative: true,
+    isNativeWrapper: true,
+    isTerminalFirst: true,
+    isShellView: false,
+    view: "chat",
+    terminalViewKey: null,
+    setView: () => {},
+    terminalsAvailable: true,
+    terminalStartingUp: false,
+    ...overrides,
+  };
+}
+
+/**
+ * Renders the header with an active session (conversationId set) under the
+ * TerminalFirstContext, so the header's Chat/Terminal switcher (ViewModeToggle)
+ * mounts. QueryClientProvider covers AgentInfoButton's react-query hooks; it
+ * self-hides here (no agent info), leaving the toggle as the asserted control.
+ */
+function renderHeaderWithSession(ctx: TerminalFirstContextValue | null) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MemoryRouter initialEntries={["/c/sess-1"]}>
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          {ctx ? (
+            <TerminalFirstContextProvider value={ctx}>
+              <ChatHeader
+                sidebarOpen
+                onOpenSidebar={() => {}}
+                isChildSession={false}
+                parentSessionId={undefined}
+                conversationId="sess-1"
+                boundAgent={undefined}
+                canShare={false}
+                onShare={() => {}}
+                hasAgentInfo={false}
+                onAgentInfo={() => {}}
+                hasHeaderMenu={false}
+                showFilesPanel={false}
+                hasRailContent={false}
+                rightPanelOpen={false}
+                onToggleRightPanel={() => {}}
+                mobileMenu={mobileMenu}
+              />
+            </TerminalFirstContextProvider>
+          ) : (
+            <ChatHeader
+              sidebarOpen
+              onOpenSidebar={() => {}}
+              isChildSession={false}
+              parentSessionId={undefined}
+              conversationId="sess-1"
+              boundAgent={undefined}
+              canShare={false}
+              onShare={() => {}}
+              hasAgentInfo={false}
+              onAgentInfo={() => {}}
+              hasHeaderMenu={false}
+              showFilesPanel={false}
+              hasRailContent={false}
+              rightPanelOpen={false}
+              onToggleRightPanel={() => {}}
+              mobileMenu={mobileMenu}
+            />
+          )}
+        </TooltipProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("ChatHeader — Chat/Terminal switcher wiring", () => {
+  it("mounts the ViewModeToggle for a terminal-first session", () => {
+    renderHeaderWithSession(makeTerminalFirstCtx());
+    expect(
+      screen.getByRole("button", { name: /switch between chat and terminal/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("omits the toggle for a non-terminal-first session", () => {
+    renderHeaderWithSession(makeTerminalFirstCtx({ isTerminalFirst: false }));
+    expect(screen.queryByRole("button", { name: /switch between chat and terminal/i })).toBeNull();
+  });
+
+  it("omits the toggle when there is no TerminalFirst context", () => {
+    renderHeaderWithSession(null);
+    expect(screen.queryByRole("button", { name: /switch between chat and terminal/i })).toBeNull();
   });
 });

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -27,6 +27,7 @@ import { PresenceAvatars } from "@/components/PresenceAvatars";
 import type { Agent } from "@/hooks/useAgents";
 import { cn } from "@/lib/utils";
 import { TAB_BADGE_BASE } from "./railTabs";
+import { ViewModeToggle } from "./ViewModeToggle";
 
 /**
  * Gating flags + handlers for the mobile-only session-menu FAB (the
@@ -272,6 +273,9 @@ export function ChatHeader({
         {/* Agent info: tools & policies for the bound agent. Desktop-only
             popover; self-hides when the agent has neither configured. */}
         {conversationId && <AgentInfoButton agent={boundAgent} sessionId={conversationId} />}
+        {/* Chat/Terminal switcher for terminal-first sessions — self-gates to
+            null otherwise (and in the iOS shell, where it's the native bar). */}
+        {conversationId && <ViewModeToggle />}
         {/* Mobile-only three-dot menu folding the action buttons above
             (Share · Agent info) so the header stays
             uncluttered on a phone. The right-panel/rail control is

--- a/web/src/shell/ViewModeToggle.test.tsx
+++ b/web/src/shell/ViewModeToggle.test.tsx
@@ -1,0 +1,160 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { ViewModeToggle } from "./ViewModeToggle";
+import {
+  TerminalFirstContextProvider,
+  type TerminalFirstContextValue,
+} from "./TerminalFirstContext";
+
+// The header toggle is suppressed in the iOS shell (the switcher is the native
+// Liquid Glass bar there); default the mock to "not iOS" for the web cases.
+const isIOSShellMock = vi.fn(() => false);
+vi.mock("@/lib/nativeBridge", () => ({
+  isIOSShell: () => isIOSShellMock(),
+}));
+
+function makeCtx(overrides: Partial<TerminalFirstContextValue> = {}): TerminalFirstContextValue {
+  return {
+    isClaudeNative: true,
+    isNativeWrapper: true,
+    isTerminalFirst: true,
+    isShellView: false,
+    view: "chat",
+    terminalViewKey: null,
+    setView: vi.fn(),
+    terminalsAvailable: true,
+    terminalStartingUp: false,
+    ...overrides,
+  };
+}
+
+function renderToggle(ctx: TerminalFirstContextValue | null) {
+  return render(
+    <TooltipProvider>
+      {ctx ? (
+        <TerminalFirstContextProvider value={ctx}>
+          <ViewModeToggle />
+        </TerminalFirstContextProvider>
+      ) : (
+        <ViewModeToggle />
+      )}
+    </TooltipProvider>,
+  );
+}
+
+beforeEach(() => {
+  isIOSShellMock.mockReturnValue(false);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ViewModeToggle", () => {
+  it("renders the MessagesSquare trigger for terminal-first sessions", () => {
+    renderToggle(makeCtx());
+    expect(
+      screen.getByRole("button", { name: /switch between chat and terminal/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing for a non-terminal-first session", () => {
+    const { container } = renderToggle(makeCtx({ isTerminalFirst: false }));
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("labels the trigger 'Terminal view' on hover in the terminal view", async () => {
+    renderToggle(makeCtx({ view: "terminal" }));
+    const trigger = screen.getByRole("button", { name: /switch between chat and terminal/i });
+    fireEvent.pointerEnter(trigger);
+    // The tooltip content mirrors the active view (portalled, so it appears
+    // in addition to the menu item's own label).
+    await screen.findByRole("tooltip", { name: /^terminal view$/i });
+  });
+
+  it("labels the trigger 'Chat view' on hover in the chat view", async () => {
+    renderToggle(makeCtx({ view: "chat" }));
+    const trigger = screen.getByRole("button", { name: /switch between chat and terminal/i });
+    fireEvent.pointerEnter(trigger);
+    await screen.findByRole("tooltip", { name: /^chat view$/i });
+  });
+
+  it("suppresses the tooltip while the menu is open", async () => {
+    renderToggle(makeCtx({ view: "chat" }));
+    const trigger = screen.getByRole("button", { name: /switch between chat and terminal/i });
+    // Hover shows the tooltip…
+    fireEvent.pointerEnter(trigger);
+    await screen.findByRole("tooltip", { name: /^chat view$/i });
+    // …but opening the menu must hide it so it doesn't overlap the dropdown.
+    fireEvent.pointerDown(trigger, { button: 0 });
+    await screen.findByRole("menuitemradio", { name: /^chat$/i });
+    expect(screen.queryByRole("tooltip", { name: /^chat view$/i })).toBeNull();
+  });
+
+  it("renders nothing outside a provider", () => {
+    const { container } = renderToggle(null);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing while a shell owns the main view (isShellView)", () => {
+    const { container } = renderToggle(makeCtx({ isShellView: true, view: "terminal" }));
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing in the iOS shell (native bar owns the switcher)", () => {
+    isIOSShellMock.mockReturnValue(true);
+    const { container } = renderToggle(makeCtx());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("marks the current view as checked in the menu", async () => {
+    renderToggle(makeCtx({ view: "terminal" }));
+    // Radix menus open on pointerdown, not click.
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: /switch between chat and terminal/i }),
+      { button: 0 },
+    );
+    const terminalItem = await screen.findByRole("menuitemradio", { name: /^terminal$/i });
+    expect(terminalItem).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByRole("menuitemradio", { name: /^chat$/i })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+  });
+
+  it("invokes setView when a menu option is selected", async () => {
+    const setView = vi.fn();
+    renderToggle(makeCtx({ setView }));
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: /switch between chat and terminal/i }),
+      { button: 0 },
+    );
+    fireEvent.click(await screen.findByRole("menuitemradio", { name: /^terminal$/i }));
+    expect(setView).toHaveBeenCalledWith("terminal");
+  });
+
+  it("disables the Terminal option and shows a spinner while the terminal is coming up", async () => {
+    renderToggle(makeCtx({ terminalsAvailable: false, terminalStartingUp: true }));
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: /switch between chat and terminal/i }),
+      { button: 0 },
+    );
+    const terminalItem = await screen.findByRole("menuitemradio", { name: /^terminal$/i });
+    expect(terminalItem).toHaveAttribute("aria-disabled", "true");
+    expect(terminalItem.querySelector(".animate-spin")).not.toBeNull();
+    expect(terminalItem).toHaveAttribute("title", expect.stringMatching(/starting up/i));
+  });
+
+  it("disables the Terminal option WITHOUT a spinner when no terminal exists and none is coming up", async () => {
+    renderToggle(makeCtx({ terminalsAvailable: false, terminalStartingUp: false }));
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: /switch between chat and terminal/i }),
+      { button: 0 },
+    );
+    const terminalItem = await screen.findByRole("menuitemradio", { name: /^terminal$/i });
+    expect(terminalItem).toHaveAttribute("aria-disabled", "true");
+    expect(terminalItem.querySelector(".animate-spin")).toBeNull();
+  });
+});

--- a/web/src/shell/ViewModeToggle.tsx
+++ b/web/src/shell/ViewModeToggle.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { ChevronDownIcon, Loader2Icon, MessagesSquareIcon, TerminalIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { isIOSShell } from "@/lib/nativeBridge";
-import { useTerminalFirst } from "./TerminalFirstContext";
+import { type TerminalFirstView, useTerminalFirst } from "./TerminalFirstContext";
 
 /**
  * Header Chat/Terminal switcher for terminal-first sessions. A
@@ -33,6 +33,11 @@ export function ViewModeToggle() {
   // one Button merges two Slots and the tooltip's listeners can get dropped.
   // Suppress it while the menu is open so it never overlaps the dropdown.
   const [hovered, setHovered] = useState(false);
+  // Tracks how the last menu interaction ended so close-focus handling can tell
+  // a pointer close (suppress refocus — a restored ghost-button focus ring reads
+  // as a stuck highlight) from a keyboard close (restore focus so keyboard/AT
+  // users keep their place).
+  const closedByPointerRef = useRef(false);
   if (!ctx || !ctx.isTerminalFirst || ctx.isShellView || isIOSShell()) return null;
 
   const { view, setView, terminalsAvailable, terminalStartingUp } = ctx;
@@ -78,14 +83,21 @@ export function ViewModeToggle() {
       <DropdownMenuContent
         align="end"
         className="min-w-40"
-        // Don't snap focus back to the trigger on close — a ghost button keeps
-        // its focus-visible highlight lit until the next click, reading as a
-        // stuck "selected" state after picking a view or clicking away.
-        onCloseAutoFocus={(e) => e.preventDefault()}
+        // On a pointer close, don't snap focus back to the trigger: a ghost
+        // button keeps its focus ring lit until the next click, reading as a
+        // stuck "selected" state. On a keyboard close, let focus return so
+        // keyboard/AT users keep their place.
+        onCloseAutoFocus={(e) => {
+          if (closedByPointerRef.current) e.preventDefault();
+          closedByPointerRef.current = false;
+        }}
+        onPointerDownCapture={() => {
+          closedByPointerRef.current = true;
+        }}
       >
         <DropdownMenuRadioGroup
           value={view}
-          onValueChange={(next) => setView(next as "chat" | "terminal")}
+          onValueChange={(next) => setView(next as TerminalFirstView)}
         >
           <DropdownMenuRadioItem value="chat" className="gap-2">
             <MessagesSquareIcon className="size-4" />

--- a/web/src/shell/ViewModeToggle.tsx
+++ b/web/src/shell/ViewModeToggle.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { ChevronDownIcon, Loader2Icon, MessagesSquareIcon, TerminalIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { isIOSShell } from "@/lib/nativeBridge";
+import { useTerminalFirst } from "./TerminalFirstContext";
+
+/**
+ * Header Chat/Terminal switcher for terminal-first sessions. A
+ * MessagesSquare + chevron trigger opens a small menu with Chat and
+ * Terminal options (the current view is checked), replacing the old
+ * in-page pill above the composer. Status lives in the sidebar — this is
+ * purely a view toggle.
+ *
+ * Self-gates to null when there's nothing to toggle:
+ *   - non-terminal-first sessions,
+ *   - the iOS shell (the switcher is the native Liquid Glass bar there),
+ *   - a rail-opened shell owning the main view (isShellView) — its own
+ *     close affordance is the way back to chat.
+ */
+export function ViewModeToggle() {
+  const ctx = useTerminalFirst();
+  const [open, setOpen] = useState(false);
+  // Drive the tooltip from the trigger's own hover/focus rather than a nested
+  // TooltipTrigger: stacking TooltipTrigger + DropdownMenuTrigger asChild onto
+  // one Button merges two Slots and the tooltip's listeners can get dropped.
+  // Suppress it while the menu is open so it never overlaps the dropdown.
+  const [hovered, setHovered] = useState(false);
+  if (!ctx || !ctx.isTerminalFirst || ctx.isShellView || isIOSShell()) return null;
+
+  const { view, setView, terminalsAvailable, terminalStartingUp } = ctx;
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      {/* Tooltip anchors to a wrapper span (a single clean Slot) rather than
+          stacking TooltipTrigger + DropdownMenuTrigger onto the same Button —
+          two merged Slots on one node drop the tooltip's hover listeners. The
+          span carries the hover/focus that drives the controlled tooltip; the
+          DropdownMenuTrigger keeps anchoring the menu to the Button. Suppressed
+          while the menu is open so it never overlaps the dropdown. */}
+      <Tooltip open={hovered && !open}>
+        <TooltipTrigger asChild>
+          <span
+            className="inline-flex"
+            onPointerEnter={() => setHovered(true)}
+            onPointerLeave={() => setHovered(false)}
+            onFocus={() => setHovered(true)}
+            onBlur={() => setHovered(false)}
+          >
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="default"
+                aria-label="Switch between chat and terminal"
+                data-testid="view-mode-toggle"
+                className="h-8 w-11 gap-1 px-0 text-muted-foreground hover:text-foreground"
+              >
+                <MessagesSquareIcon className="size-4" />
+                <ChevronDownIcon className="size-3 opacity-60" />
+              </Button>
+            </DropdownMenuTrigger>
+          </span>
+        </TooltipTrigger>
+        {/* Bottom placement: the header sits at top-0, so a top-side tooltip
+            would render above the viewport edge and get clipped. */}
+        <TooltipContent side="bottom">
+          {view === "terminal" ? "Terminal view" : "Chat view"}
+        </TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent
+        align="end"
+        className="min-w-40"
+        // Don't snap focus back to the trigger on close — a ghost button keeps
+        // its focus-visible highlight lit until the next click, reading as a
+        // stuck "selected" state after picking a view or clicking away.
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
+        <DropdownMenuRadioGroup
+          value={view}
+          onValueChange={(next) => setView(next as "chat" | "terminal")}
+        >
+          <DropdownMenuRadioItem value="chat" className="gap-2">
+            <MessagesSquareIcon className="size-4" />
+            Chat
+          </DropdownMenuRadioItem>
+          {/* Terminal disabled until a PTY is reachable; a spinner while it's
+              coming up reads as "loading" rather than a dead option. */}
+          <DropdownMenuRadioItem
+            value="terminal"
+            className="gap-2"
+            disabled={!terminalsAvailable}
+            title={terminalStartingUp ? "Terminal is starting up…" : undefined}
+          >
+            {terminalStartingUp ? (
+              <Loader2Icon className="size-4 animate-spin" aria-hidden />
+            ) : (
+              <TerminalIcon className="size-4" />
+            )}
+            Terminal
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Terminal-first sessions previously switched between chat and terminal with an in-page pill above the composer. This moves the switcher into the `ChatHeader` as a `MessagesSquare` + chevron icon button (next to the agent-info icon) that opens a Chat/Terminal dropdown, freeing the composer area and grouping it with the other session controls.
- The new `ViewModeToggle` reads the same `TerminalFirstContext` the pill did, so behavior is unchanged: it self-gates for non-terminal-first sessions, the iOS shell (native Liquid Glass bar owns the switcher there), and rail-opened shell views; the Terminal option stays disabled (with a spinner while starting up) until a PTY is reachable; a tooltip names the current view.
- Removes the old pill (`ConnectedTerminalFirstPill`), its dead CSS, and the now-redundant iOS keyboard guard (subsumed by the `isIOSShell()` gate).

## Test Plan

- `cd web && npm test` — full vitest suite: 4840 passed, 3 expected-fail, 1 skipped.
- `cd web && npm run build` — `tsc -b` + `vite build` clean.
- New/updated unit tests:
  - `ViewModeToggle.test.tsx` — gating (non-terminal-first, no provider, shell view, iOS), tooltip labels ("Chat view" / "Terminal view"), tooltip suppressed while the menu is open, current-view checked state, `setView` on select, Terminal disabled + spinner while starting up / disabled without spinner when stopped.
  - `ChatHeader.test.tsx` — toggle mounts for terminal-first sessions and is omitted otherwise / without context.
  - `ConnectionIndicator.test.tsx` — terminal-first band now renders nothing (pill removed) while reconnect banners are preserved.
- Manual: verified in a live claude-native (terminal-first) session — switcher opens the dropdown, switches views, Terminal disabled until the runner connects, tooltip shows the current view, and no stuck focus highlight after selecting/closing.

## Demo

https://github.com/user-attachments/assets/9e70e072-74bf-421d-ae6d-5ede51292f31

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: drove a live terminal-first session and confirmed the header switcher opens the Chat/Terminal dropdown, toggles views, keeps Terminal disabled until the PTY is reachable, shows the current-view tooltip, and leaves no stuck focus-highlight after close. Automated unit tests cover the component gating, tooltip, menu state, and header wiring; the pre-existing label-timing delay (toggle appears once the session snapshot loads) is unchanged by this PR and intentionally out of scope.

## Changelog

Moved the Chat/Terminal switcher for terminal-first sessions from the composer into the session header

This pull request and its description were written by Isaac.