### PR TITLE
Fix duplicate ACP approval delivery

### DIFF
--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -600,16 +600,18 @@ class TurnContext:
         """
         Internal: resolve a pending elicitation Future.
 
-        Completed ids are tombstoned so a duplicate ``approval``
-        delivery (after ``elicit`` pops the Future) still returns
-        success to the resolve path. Never-seen ids return False
-        so the route can 404.
+        Tombstones only after a real approval verdict is delivered
+        via ``set_result``. Cancelled / abandoned Futures (interrupt)
+        are done without a verdict and must not become idempotent
+        204s — a later stale approval for that id stays unknown (404).
+        Duplicate delivery after a real complete still returns True.
 
         :param elicitation_id: The id from the URL path.
         :param result: The MCP-shaped reply body.
         :returns: ``True`` if this id was newly resolved or was
-            already completed (idempotent), ``False`` if the id
-            was never registered on this turn.
+            already completed with a real verdict (idempotent),
+            ``False`` if the id was never registered, or only
+            cancelled without delivery.
         """
         if elicitation_id in self._completed_elicitations:
             return True
@@ -617,7 +619,17 @@ class TurnContext:
         if future is None:
             return False
         if future.done():
-            # Race: resolved elsewhere, not yet tombstoned.
+            # Interrupt/cancel abandons are done() without a verdict.
+            # Only a successful set_result delivery is idempotent.
+            if future.cancelled():
+                return False
+            try:
+                exc = future.exception()
+            except asyncio.CancelledError:
+                return False
+            if exc is not None:
+                return False
+            # Race: real result already set, tombstone not yet recorded.
             self._completed_elicitations.add(elicitation_id)
             return True
         future.set_result(result)

--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -274,9 +274,9 @@ class ApprovalEvent(BaseModel):
     elicitation.
 
     Resolves the parked Future on whichever in-flight turn
-    registered the elicitation. Single-shot — an unknown
-    ``elicitation_id`` is a hard 404 because the URL path's
-    correlation token must match an outstanding elicitation.
+    registered the elicitation. Unknown never-seen
+    ``elicitation_id`` values are a hard 404. Already-completed
+    ids are idempotent (204) so duplicate delivery never 404s.
 
     Wire shape mirrors MCP's ``elicitation/create`` response per
     Principle 8 — same ``action`` + ``content`` fields as
@@ -400,6 +400,10 @@ class TurnContext:
         # Future[ElicitationResult]. Populated by ``elicit``;
         # resolved by the ``approval`` /events handler.
         self._pending_elicitations: dict[str, asyncio.Future[ElicitationResult]] = {}
+        # Tombstones for elicitation ids that already completed so
+        # duplicate ``approval`` deliveries stay idempotent after
+        # ``elicit``'s finally pops the Future (never-seen → 404).
+        self._completed_elicitations: set[str] = set()
         # Layer 3 per-policy-evaluation state:
         # ``evaluation_id`` → Future[PolicyVerdictPayload].
         # Populated by ``evaluate_policy``; resolved by the
@@ -596,16 +600,28 @@ class TurnContext:
         """
         Internal: resolve a pending elicitation Future.
 
+        Completed ids are tombstoned so a duplicate ``approval``
+        delivery (after ``elicit`` pops the Future) still returns
+        success to the resolve path. Never-seen ids return False
+        so the route can 404.
+
         :param elicitation_id: The id from the URL path.
         :param result: The MCP-shaped reply body.
-        :returns: ``True`` if a pending elicitation was resolved,
-            ``False`` if the id didn't match anything outstanding
-            (the route returns 404 in that case).
+        :returns: ``True`` if this id was newly resolved or was
+            already completed (idempotent), ``False`` if the id
+            was never registered on this turn.
         """
+        if elicitation_id in self._completed_elicitations:
+            return True
         future = self._pending_elicitations.get(elicitation_id)
-        if future is None or future.done():
+        if future is None:
             return False
+        if future.done():
+            # Race: resolved elsewhere, not yet tombstoned.
+            self._completed_elicitations.add(elicitation_id)
+            return True
         future.set_result(result)
+        self._completed_elicitations.add(elicitation_id)
         return True
 
     async def evaluate_policy(
@@ -763,6 +779,10 @@ class HarnessApp:
         # at its REST boundary), but stored as a dict so the route
         # handlers can look up by id without assuming uniqueness.
         self._in_flight: dict[str, TurnContext] = {}
+        # Process-lifetime tombstones for elicitation ids that already
+        # completed. Survives turn teardown so a duplicate ``approval``
+        # after ``_in_flight`` drop still returns 204 (never-seen 404).
+        self._completed_elicitations: set[str] = set()
         # The currently active turn context, or ``None`` when idle.
         # Set under ``_lock`` when a turn starts, cleared
         # synchronously when the streaming generator finishes
@@ -1677,19 +1697,25 @@ class HarnessApp:
         :class:`ApprovalEvent`.
 
         Invoked by :meth:`_post_session_event` for ``approval``
-        events. The id MUST belong to an outstanding elicitation
-        on one of the in-flight turns; otherwise raises 404.
+        events. First delivery completes the parked Future.
+        Duplicate delivery of a completed id is idempotent (204).
+        Never-seen ids raise 404.
 
         :param elicitation_id: Correlation id from the event body.
         :param body: MCP-shape :class:`ElicitationResult` adapted
             from the :class:`ApprovalEvent`.
-        :returns: 204 on success.
-        :raises OmnigentError: 404 if no pending elicitation
-            matches the id (across all in-flight turns).
+        :returns: 204 on success (including idempotent redelivery).
+        :raises OmnigentError: 404 if no in-flight turn knows this
+            elicitation id (never outstanding, never completed).
         """
         for ctx in self._in_flight.values():
             if ctx._complete_elicitation(elicitation_id, body):
+                self._completed_elicitations.add(elicitation_id)
                 return Response(status_code=status.HTTP_204_NO_CONTENT)
+        # Turn may have already torn down after the first resolve;
+        # completed ids stay idempotent (204). Never-seen still 404.
+        if elicitation_id in self._completed_elicitations:
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
         raise OmnigentError(
             f"no outstanding elicitation {elicitation_id!r}",
             code=ErrorCode.NOT_FOUND,

--- a/tests/runtime/harnesses/test_scaffold.py
+++ b/tests/runtime/harnesses/test_scaffold.py
@@ -1444,6 +1444,74 @@ async def test_resolve_elicitation_duplicate_returns_204_not_404() -> None:
     assert exc_info.value.code == ErrorCode.NOT_FOUND
 
 
+
+@pytest.mark.asyncio
+async def test_complete_elicitation_after_cancel_is_not_idempotent() -> None:
+    """Cancelled Future (interrupt) must not get completed-approval treatment.
+
+    Interrupt cancels parked elicitations without delivering a verdict.
+    A later stale approval for that id must not return True / tombstone the
+    way a real duplicate-after-complete does — only successful set_result
+    deliveries are idempotent.
+    """
+    from omnigent.server.schemas import ElicitationResult
+
+    ctx = TurnContext("resp_elicit_cancel", asyncio.Queue(), asyncio.Event())
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future = loop.create_future()
+    eid = "elicit_cancelled_before_verdict"
+    ctx._pending_elicitations[eid] = future
+    future.cancel()
+    assert future.done() and future.cancelled()
+
+    stale = ElicitationResult(action="accept", content=None)
+    assert ctx._complete_elicitation(eid, stale) is False, (
+        "stale approval after cancel must not count as successful delivery"
+    )
+    assert eid not in ctx._completed_elicitations, (
+        "cancel must not tombstone an id as completed approval"
+    )
+    # elicit() finally cleanup after cancelled wait unwinds
+    ctx._pending_elicitations.pop(eid, None)
+    assert ctx._complete_elicitation(eid, stale) is False
+    assert eid not in ctx._completed_elicitations
+
+
+@pytest.mark.asyncio
+async def test_resolve_elicitation_after_cancel_returns_404_not_204() -> None:
+    """HarnessApp: approval after interrupt-cancel is 404, not idempotent 204."""
+    from omnigent.server.schemas import ElicitationResult
+
+    class _Stub(HarnessApp):
+        async def run_turn(self, request: CreateResponseRequest, ctx: TurnContext) -> None:
+            del request, ctx
+
+    app = _Stub()
+    ctx = TurnContext("resp_resolve_cancel", asyncio.Queue(), asyncio.Event())
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future = loop.create_future()
+    eid = "elicit_resolve_cancelled"
+    ctx._pending_elicitations[eid] = future
+    app._in_flight[ctx.response_id] = ctx
+
+    # Same path interrupt uses: cancel parked futures without set_result.
+    ctx._cancel_pending()
+    assert future.cancelled()
+
+    with pytest.raises(OmnigentError) as exc_info:
+        await app._resolve_elicitation(eid, ElicitationResult(action="accept"))
+    assert exc_info.value.code == ErrorCode.NOT_FOUND
+    assert eid not in app._completed_elicitations
+    assert eid not in ctx._completed_elicitations
+
+    # After pop/teardown, still never-completed → 404 (not 204).
+    ctx._pending_elicitations.pop(eid, None)
+    app._in_flight.clear()
+    with pytest.raises(OmnigentError) as exc_info2:
+        await app._resolve_elicitation(eid, ElicitationResult(action="accept"))
+    assert exc_info2.value.code == ErrorCode.NOT_FOUND
+
+
 async def test_session_approval_accept_once_duplicate_idempotent(
     use_elicitation: None,
     manager: HarnessProcessManager,

--- a/tests/runtime/harnesses/test_scaffold.py
+++ b/tests/runtime/harnesses/test_scaffold.py
@@ -1374,6 +1374,180 @@ async def test_session_approval_event_404s_on_conversation_id_mismatch(
         await side_client.aclose()
 
 
+
+@pytest.mark.asyncio
+async def test_complete_elicitation_duplicate_after_pop_is_idempotent() -> None:
+    """Duplicate approval for a completed elicitation must not look unknown.
+
+    After the first accept, ``elicit``'s finally pops the Future. A second
+    delivery of the same id must still count as complete (no 404 path) via
+    tombstone. Never-seen ids stay False so real misroutes 404.
+    """
+    from omnigent.server.schemas import ElicitationResult
+
+    ctx = TurnContext("resp_elicit_dup", asyncio.Queue(), asyncio.Event())
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future = loop.create_future()
+    eid = "elicit_once"
+    ctx._pending_elicitations[eid] = future
+
+    first = ElicitationResult(action="accept", content=None)
+    assert ctx._complete_elicitation(eid, first) is True
+    assert future.done()
+    assert future.result().action == "accept"
+    # Simulate elicit() finally cleanup after the parked wait returns.
+    ctx._pending_elicitations.pop(eid, None)
+
+    second = ElicitationResult(action="accept", content=None)
+    assert ctx._complete_elicitation(eid, second) is True, (
+        "completed elicitation must stay idempotent after Future is popped"
+    )
+    assert ctx._complete_elicitation("elicit_never_seen", second) is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_elicitation_duplicate_returns_204_not_404() -> None:
+    """HarnessApp approval resolve: first accept 204, duplicate 204, unknown 404."""
+    from omnigent.server.schemas import ElicitationResult
+
+    class _Stub(HarnessApp):
+        async def run_turn(self, request: CreateResponseRequest, ctx: TurnContext) -> None:
+            del request, ctx
+
+    app = _Stub()
+    ctx = TurnContext("resp_resolve_dup", asyncio.Queue(), asyncio.Event())
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future = loop.create_future()
+    eid = "elicit_resolve_once"
+    ctx._pending_elicitations[eid] = future
+    app._in_flight[ctx.response_id] = ctx
+
+    first = await app._resolve_elicitation(eid, ElicitationResult(action="accept"))
+    assert first.status_code == 204
+    assert future.done()
+    ctx._pending_elicitations.pop(eid, None)
+
+    dup = await app._resolve_elicitation(eid, ElicitationResult(action="accept"))
+    assert dup.status_code == 204
+
+    # After turn teardown drops the context, redelivery still 204.
+    app._in_flight.clear()
+    after_teardown = await app._resolve_elicitation(
+        eid, ElicitationResult(action="accept")
+    )
+    assert after_teardown.status_code == 204
+
+    with pytest.raises(OmnigentError) as exc_info:
+        await app._resolve_elicitation(
+            "elicit_never_seen", ElicitationResult(action="accept")
+        )
+    assert exc_info.value.code == ErrorCode.NOT_FOUND
+
+
+async def test_session_approval_accept_once_duplicate_idempotent(
+    use_elicitation: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """One accept completes the turn once; duplicate delivery is 204 not 404.
+
+    Contract: accept runs once and completes; redelivery of the same
+    elicitation_id is idempotent. Question-style elicitations share
+    ``ctx.elicit`` / ``_resolve_elicitation`` so the same guarantee applies.
+    """
+    conv_id = "conv_session_elicit_dup_accept"
+    stream_client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
+    side_client = _make_side_client(str(manager.socket_path(conv_id)))
+    events: list[_ParsedSSEEvent] = []
+    start_body = {
+        "type": "message",
+        "role": "user",
+        "model": "test-agent",
+        "content": [],
+    }
+    try:
+        async with stream_client.stream(
+            "POST",
+            f"/v1/sessions/{conv_id}/events",
+            json=start_body,
+        ) as response:
+            replied = False
+            async for event in _stream_iter(response):
+                events.append(event)
+                if not replied and event.event == "response.elicitation_request":
+                    body = {
+                        "type": "approval",
+                        "elicitation_id": "elicit_test_1",
+                        "action": "accept",
+                    }
+                    first = await side_client.post(
+                        f"/v1/sessions/{conv_id}/events", json=body
+                    )
+                    assert first.status_code == 204
+                    # Immediate redelivery (retry / double click).
+                    second = await side_client.post(
+                        f"/v1/sessions/{conv_id}/events", json=body
+                    )
+                    assert second.status_code == 204, (
+                        f"duplicate accept must not 404; got {second.status_code}"
+                    )
+                    replied = True
+        text_deltas = [e for e in events if e.event == "response.output_text.delta"]
+        assert len(text_deltas) == 1
+        assert text_deltas[0].data["delta"] == "action:accept"
+        completed = [e for e in events if e.event == "response.completed"]
+        assert len(completed) == 1
+    finally:
+        await side_client.aclose()
+
+
+async def test_session_approval_decline_cancels_and_duplicate_idempotent(
+    use_elicitation: None,
+    manager: HarnessProcessManager,
+) -> None:
+    """First decline resolves as cancel/refuse; duplicate delivery stays 204."""
+    conv_id = "conv_session_elicit_dup_decline"
+    stream_client = await manager.get_client(conv_id, _TEST_HARNESS_NAME)
+    side_client = _make_side_client(str(manager.socket_path(conv_id)))
+    events: list[_ParsedSSEEvent] = []
+    start_body = {
+        "type": "message",
+        "role": "user",
+        "model": "test-agent",
+        "content": [],
+    }
+    try:
+        async with stream_client.stream(
+            "POST",
+            f"/v1/sessions/{conv_id}/events",
+            json=start_body,
+        ) as response:
+            replied = False
+            async for event in _stream_iter(response):
+                events.append(event)
+                if not replied and event.event == "response.elicitation_request":
+                    body = {
+                        "type": "approval",
+                        "elicitation_id": "elicit_test_1",
+                        "action": "decline",
+                    }
+                    first = await side_client.post(
+                        f"/v1/sessions/{conv_id}/events", json=body
+                    )
+                    assert first.status_code == 204
+                    second = await side_client.post(
+                        f"/v1/sessions/{conv_id}/events", json=body
+                    )
+                    assert second.status_code == 204, (
+                        f"duplicate decline must not 404; got {second.status_code}"
+                    )
+                    replied = True
+        text_deltas = [e for e in events if e.event == "response.output_text.delta"]
+        assert len(text_deltas) == 1
+        assert text_deltas[0].data["delta"] == "action:decline"
+    finally:
+        await side_client.aclose()
+
+
 async def test_session_message_event_without_previous_response_id_injects_active_turn(
     use_injection: None,
     manager: HarnessProcessManager,


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Keep completed ACP elicitation approvals idempotent after the waiting turn has cleaned up its pending future.
- Preserve a 404 for approvals that were never registered or were cancelled before a verdict.
- Add unit and session-level regression coverage for duplicate accept and decline deliveries.

## Test Plan

- Ran the focused elicitation coverage.
- Ran the full harness scaffold suite.

## Demo

N/A — non-visual runtime behavior.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Changelog

ACP approval retries no longer fail after a completed approval.