### PR TITLE
Clarify subprocess handle types

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -3344,7 +3344,7 @@ def _start_local_server(
 
     try:
         with child_logging_popen_kwargs(child_env) as logging_kwargs:
-            server_proc = subprocess.Popen(
+            server_proc: subprocess.Popen[bytes] = subprocess.Popen(
                 [
                     sys.executable,
                     "-m",

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3169,7 +3169,7 @@ def _start_cli_runner_process(
         env[PROCESS_LOG_FILE_ENV_VAR] = str(log_path)
     try:
         with child_logging_popen_kwargs(env) as logging_kwargs:
-            runner_proc = subprocess.Popen(
+            runner_proc: subprocess.Popen[bytes] = subprocess.Popen(
                 [sys.executable, "-m", "omnigent.runner._entry"],
                 env=env,
                 stdout=log_fh,

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1175,7 +1175,7 @@ class HostProcess:
             env[PROCESS_LOG_FILE_ENV_VAR] = str(log_path)
             try:
                 with child_logging_popen_kwargs(env) as logging_kwargs:
-                    proc = subprocess.Popen(
+                    proc: subprocess.Popen[bytes] = subprocess.Popen(
                         [sys.executable, "-m", "omnigent.runner._entry"],
                         env=env,
                         # Runners are WS-tunnel clients with no interactive input.

--- a/omnigent/host/local_server.py
+++ b/omnigent/host/local_server.py
@@ -648,7 +648,7 @@ def _spawn_local_server(port: int) -> _SpawnedLocalServer:
 
     try:
         with child_logging_popen_kwargs(child_env) as logging_kwargs:
-            proc = subprocess.Popen(
+            proc: subprocess.Popen[bytes] = subprocess.Popen(
                 [
                     sys.executable,
                     "-m",


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Make the binary-mode `subprocess.Popen` result explicit at four spawn boundaries where unpacked kwargs prevent Pyrefly from selecting the correct overload.
- Align local server and runner process handles with their existing `Popen[bytes]` dataclass and helper contracts.
- Reduce the dependency-aware Pyrefly baseline from 66 to 61 errors without runtime changes.

## Test Plan

- `uvx pyrefly check omnigent` (61 errors; 5 fewer than `main`)
- `uv run --no-sync mypy omnigent/chat.py omnigent/cli.py omnigent/host/connect.py omnigent/host/local_server.py`
- `uv run --no-sync pytest -q tests/cli/test_chat.py::test_start_local_server_spawns_runner_as_sibling tests/cli/test_cli.py::test_start_cli_runner_process_uses_token_bound_runner_id tests/cli/test_cli.py::test_start_cli_runner_process_binds_stable_local_runner_to_generated_token tests/cli/test_cli.py::test_start_cli_runner_process_reports_captured_log_path tests/host/test_connect.py::test_host_spawned_runner_has_parent_pid_env tests/host/test_local_server.py::test_ensure_local_omnigent_server_spawns_when_none_healthy tests/host/test_local_server.py::test_ensure_local_omnigent_server_spawn_records_and_returns_log_path`
- `pre-commit run --all-files`

## Demo

N/A — typing-only refactor with no visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing process-spawn lifecycle tests cover all four annotated boundaries; the change only clarifies static return types.
