### PR TITLE
Narrow server liveness fallbacks

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1654,8 +1654,13 @@ def create_app(
         # Missing ids default to reachable / no-host, matching the bulk
         # lookup's own missing-row terminal.
         _missing = SessionLiveness(runner_online=True, host_online=None)
+
+        def _liveness_or_missing(sid: str) -> SessionLiveness:
+            found = liveness.get(sid)
+            return found if found is not None else _missing
+
         if session_id is not None:
-            single = liveness.get(session_id) or _missing
+            single = _liveness_or_missing(session_id)
             result["session"] = {
                 "id": session_id,
                 "runner_online": single.runner_online,
@@ -1665,7 +1670,7 @@ def create_app(
         if session_ids is not None:
             result["sessions"] = {
                 sid: {
-                    "runner_online": (sl := liveness.get(sid) or _missing).runner_online,
+                    "runner_online": (sl := _liveness_or_missing(sid)).runner_online,
                     "host_online": sl.host_online,
                     "host_version": sl.host_version,
                 }

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1655,7 +1655,7 @@ def create_app(
         # lookup's own missing-row terminal.
         _missing = SessionLiveness(runner_online=True, host_online=None)
         if session_id is not None:
-            single = liveness.get(session_id, _missing)
+            single = liveness.get(session_id) or _missing
             result["session"] = {
                 "id": session_id,
                 "runner_online": single.runner_online,
@@ -1665,7 +1665,7 @@ def create_app(
         if session_ids is not None:
             result["sessions"] = {
                 sid: {
-                    "runner_online": (sl := liveness.get(sid, _missing)).runner_online,
+                    "runner_online": (sl := liveness.get(sid) or _missing).runner_online,
                     "host_online": sl.host_online,
                     "host_version": sl.host_version,
                 }


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Make the existing missing-session liveness fallback explicit after `dict.get()` for both single and batch health responses.
- Preserve the current default of `runner_online=True`, `host_online=None`, and `host_version=None` for unknown session IDs.
- Remove all six Pyrefly findings in `omnigent/server/app.py`, reducing the branch baseline from 66 to 60 errors.

## Test Plan

- `uvx pyrefly check omnigent/server/app.py`
- `uvx pyrefly check omnigent` (60 errors; 6 fewer than `main`)
- `uv run --no-sync mypy omnigent/server/app.py`
- `uv run --no-sync pytest -q tests/server/test_app.py -k health`
- `pre-commit run --all-files`

## Demo

N/A — typing-only backend refactor with no visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing health-route tests cover bare, single-session, batch, missing-session, host-version, and runner-liveness responses.
