### PR TITLE
Clarify session usage accumulator type

### DIFF
--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -1200,7 +1200,7 @@ def _persist_native_cumulative_usage(
         return None
 
     conv = conversation_store.get_conversation(session_id)
-    current = dict(conv.session_usage) if conv and conv.session_usage else {}
+    current: dict[str, Any] = dict(conv.session_usage) if conv and conv.session_usage else {}
     # Native usage is cumulative (SET semantics), so the per-turn delta
     # for the daily rollup is new_total - old_total. Capture the old
     # cumulative + enforcement costs before the fields below overwrite them.


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Declare the native session usage accumulator with its existing heterogeneous `dict[str, Any]` store contract.
- Prevent Pyrefly from narrowing the accumulator to `dict[str, int]` based on its initial token writes.
- Remove the three remaining session orchestration errors, reducing the branch baseline from 66 to 63.

## Test Plan

- `uvx pyrefly check omnigent/server/routes/_sessions/orchestration.py`
- `uvx pyrefly check omnigent` (63 errors; 3 fewer than `main`)
- `uv run --no-sync mypy omnigent/server/routes/_sessions/orchestration.py`
- `uv run --no-sync pytest -q tests/server/routes/test_native_usage_attribution.py tests/server/integration/test_sessions_endpoints.py -k 'external_session_usage'`
- `pre-commit run --all-files`

## Demo

N/A — typing-only backend refactor with no visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The native usage attribution and external session usage integration tests cover cumulative tokens, costs, policy costs, model attribution, malformed input, and event publication.
