### PR TITLE
Type timed formatter options explicitly

### DIFF
--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -59,7 +59,6 @@ from omnigent_ui_sdk import (
 from omnigent_ui_sdk.terminal._completer import FileMentionCompleter
 from omnigent_ui_sdk.terminal._formatter import FormattedItem
 from omnigent_ui_sdk.terminal._theme import LIGHT_THEME, get_theme
-from omnigent_ui_sdk.terminal._tool_renderers import TerminalToolRendererRegistry
 from prompt_toolkit.completion import CompleteEvent, Completer, Completion, merge_completers
 from prompt_toolkit.document import Document
 from prompt_toolkit.formatted_text import StyleAndTextTuples
@@ -675,29 +674,7 @@ def _humanize_agent_name(agent_name: str) -> str:
 class TimedFormatter(RichBlockFormatter):  # type: ignore[misc]
     """Shows final elapsed time after response completes."""
 
-    def __init__(
-        self,
-        *,
-        accent_color: str = "#F43BA6",
-        code_theme: str | None = None,
-        max_result_lines: int = 30,
-        max_result_chars: int = 2000,
-        show_agent_labels: bool = False,
-        show_tool_output: bool = False,
-        tool_renderers: TerminalToolRendererRegistry | None = None,
-        theme: TerminalTheme | str = LIGHT_THEME,
-    ) -> None:
-        super().__init__(
-            accent_color=accent_color,
-            code_theme=code_theme,
-            max_result_lines=max_result_lines,
-            max_result_chars=max_result_chars,
-            show_agent_labels=show_agent_labels,
-            show_tool_output=show_tool_output,
-            tool_renderers=tool_renderers,
-            theme=theme,
-        )
-        self._start_time: float | None = None
+    _start_time: float | None = None
 
     def format_response_start(self, block: ResponseStartBlock) -> list[FormattedItem]:
         self._start_time = block.ctx.timestamp

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -59,6 +59,7 @@ from omnigent_ui_sdk import (
 from omnigent_ui_sdk.terminal._completer import FileMentionCompleter
 from omnigent_ui_sdk.terminal._formatter import FormattedItem
 from omnigent_ui_sdk.terminal._theme import LIGHT_THEME, get_theme
+from omnigent_ui_sdk.terminal._tool_renderers import TerminalToolRendererRegistry
 from prompt_toolkit.completion import CompleteEvent, Completer, Completion, merge_completers
 from prompt_toolkit.document import Document
 from prompt_toolkit.formatted_text import StyleAndTextTuples
@@ -674,8 +675,28 @@ def _humanize_agent_name(agent_name: str) -> str:
 class TimedFormatter(RichBlockFormatter):  # type: ignore[misc]
     """Shows final elapsed time after response completes."""
 
-    def __init__(self, **kwargs: object) -> None:
-        super().__init__(**kwargs)
+    def __init__(
+        self,
+        *,
+        accent_color: str = "#F43BA6",
+        code_theme: str | None = None,
+        max_result_lines: int = 30,
+        max_result_chars: int = 2000,
+        show_agent_labels: bool = False,
+        show_tool_output: bool = False,
+        tool_renderers: TerminalToolRendererRegistry | None = None,
+        theme: TerminalTheme | str = LIGHT_THEME,
+    ) -> None:
+        super().__init__(
+            accent_color=accent_color,
+            code_theme=code_theme,
+            max_result_lines=max_result_lines,
+            max_result_chars=max_result_chars,
+            show_agent_labels=show_agent_labels,
+            show_tool_output=show_tool_output,
+            tool_renderers=tool_renderers,
+            theme=theme,
+        )
         self._start_time: float | None = None
 
     def format_response_start(self, block: ResponseStartBlock) -> list[FormattedItem]:


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Let `TimedFormatter` inherit `RichBlockFormatter`'s keyword-only constructor and defaults directly.
- Initialize only the nullable elapsed-time state on the subclass, avoiding a duplicated constructor contract that could drift from the SDK base class.
- Remove eight Pyrefly errors at the REPL formatter boundary, reducing the branch baseline from 53 to 45.

## Test Plan

- `uvx pyrefly check omnigent/repl/_repl.py` (remaining unrelated REPL findings only)
- `uvx pyrefly check omnigent` (45 errors; 8 fewer than `main`)
- `uv run --no-sync mypy omnigent/repl/_repl.py`
- Constructed `TimedFormatter` with inherited keyword options and verified initial timer state
- `uv run --no-sync pytest -q tests/repl` (465 passed)
- `SKIP=normalize-uv-lock-registry pre-commit run --all-files` (the skipped hook rewrites the unrelated `uv.lock` on current `main`)

## Demo

N/A — typing-only terminal refactor with no visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Constructed `TimedFormatter` with inherited options and ran the complete 465-test REPL suite. The subclass now owns only elapsed-time state; its constructor contract and defaults come directly from `RichBlockFormatter`.
