### PR TITLE
Narrow resolved egress addresses

### DIFF
--- a/omnigent/inner/egress/proxy.py
+++ b/omnigent/inner/egress/proxy.py
@@ -1028,16 +1028,19 @@ class EgressProxy:
             ) from exc
         pinned_ip: str | None = None
         for family, _type, _proto, _canon, sockaddr in infos:
-            if family == socket.AF_INET:
-                ip_str = sockaddr[0]
-            elif family == socket.AF_INET6:
-                ip_str = sockaddr[0]
+            if family not in (socket.AF_INET, socket.AF_INET6):
+                continue
+            raw_ip = sockaddr[0]
+            if not isinstance(raw_ip, str):
+                raise PermissionError(
+                    f"unparseable address {raw_ip!r} for host {host!r}"
+                ) from None
+            ip_str = raw_ip
+            if family == socket.AF_INET6:
                 # IPv6 stores the address as the first tuple element
                 # already; strip any zone-id suffix like "%en0".
                 if "%" in ip_str:
                     ip_str = ip_str.split("%", 1)[0]
-            else:
-                continue
             try:
                 addr = ipaddress.ip_address(ip_str)
             except ValueError:


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Correlate `getaddrinfo()` results with the selected IPv4/IPv6 family before treating the socket address as text.
- Fail closed when an IPv4/IPv6 record unexpectedly carries a non-string address, preserving the proxy's deny-by-default security boundary.
- Remove three Pyrefly errors in egress destination validation, reducing the branch baseline from 53 to 50.

## Test Plan

- `uvx pyrefly check omnigent/inner/egress/proxy.py`
- `uvx pyrefly check omnigent` (50 errors; 3 fewer than `main`)
- `uv run --no-sync mypy omnigent/inner/egress/proxy.py`
- `uv run --no-sync pytest -q tests/inner/egress/test_proxy.py -k 's2_'` (14 passed)
- `pre-commit run --all-files`

## Demo

N/A — backend validation and typing change with no visual surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

All 14 destination-validation and DNS-rebinding tests pass. The full proxy file was also attempted; its unrelated Unix-socket smoke test fails on this macOS checkout because pytest's temporary path exceeds the AF_UNIX path limit before exercising proxy logic.
