### PR TITLE
Narrow process owner lock resources

### DIFF
--- a/omnigent/codex_native_process_registry.py
+++ b/omnigent/codex_native_process_registry.py
@@ -65,8 +65,9 @@ class CodexNativeProcessOwnerLock:
 
         :returns: None.
         """
-        with contextlib.suppress(OSError):
-            fcntl.flock(self.fd, fcntl.LOCK_UN)
+        if fcntl is not None:
+            with contextlib.suppress(OSError):
+                fcntl.flock(self.fd, fcntl.LOCK_UN)
         with contextlib.suppress(OSError):
             os.close(self.fd)
         with contextlib.suppress(OSError):
@@ -97,6 +98,7 @@ def acquire_codex_native_process_owner_lock() -> CodexNativeProcessOwnerLock | N
     if fcntl is None:
         return None
     root = _codex_native_state_root() / _OWNER_LOCK_DIR
+    fd: int | None = None
     try:
         root.mkdir(mode=0o700, parents=True, exist_ok=True)
         path = root / f"{uuid.uuid4().hex}.lock"
@@ -104,9 +106,11 @@ def acquire_codex_native_process_owner_lock() -> CodexNativeProcessOwnerLock | N
         fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except OSError:
         _logger.warning("codex-native process owner lock create failed", exc_info=True)
-        with contextlib.suppress(NameError, OSError):
-            os.close(fd)
+        if fd is not None:
+            with contextlib.suppress(OSError):
+                os.close(fd)
         return None
+    assert fd is not None
     return CodexNativeProcessOwnerLock(path=path, fd=fd)
 
 


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Guard owner-lock release when `fcntl` is unavailable on Windows.
- Initialize the owner-lock file descriptor before the failure path and close it only when allocation succeeded.
- Remove three Pyrefly lifecycle findings in the Codex native process registry, reducing the branch baseline from 53 to 50.

## Test Plan

- `uvx pyrefly check omnigent/codex_native_process_registry.py`
- `uvx pyrefly check omnigent` (50 errors; 3 fewer than `main`)
- `uv run --no-sync mypy omnigent/codex_native_process_registry.py`
- `uv run --no-sync pytest -q tests/test_codex_native_process_registry.py`
- `pre-commit run --all-files`

## Demo

N/A — backend process-lifecycle refactor with no visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The registry suite covers add/remove, reconciliation, owner-lock liveness, and file-lock serialization. The Windows-only `fcntl is None` path is guarded directly and does not alter POSIX behavior.
