### PR TITLE
Narrow lazy import boundaries

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -598,8 +598,9 @@ def _build_runner_env(
     # ``api_key_ref: env:MY_TOKEN``) would need to manually add it to
     # OMNIGENT_RUNNER_ENV_PASSTHROUGH — their credential resolves fine in
     # the CLI/daemon but silently drops before reaching the runner subprocess.
+    from omnigent.errors import OmnigentError as _OmnigentError
+
     try:
-        from omnigent.errors import OmnigentError as _OmnigentError
         from omnigent.onboarding.provider_config import (
             load_config,
             provider_credential_env_vars,

--- a/omnigent/onboarding/hermes_auth.py
+++ b/omnigent/onboarding/hermes_auth.py
@@ -90,7 +90,10 @@ def _model_section() -> dict[str, object]:
     path = hermes_config_path()
     try:
         import yaml
+    except ImportError:
+        return {}
 
+    try:
         data = yaml.safe_load(path.read_text(encoding="utf-8"))
     except (OSError, yaml.YAMLError):
         return {}

--- a/omnigent/server/auth.py
+++ b/omnigent/server/auth.py
@@ -33,6 +33,7 @@ import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from enum import Enum
+from typing import TYPE_CHECKING
 
 from starlette.requests import HTTPConnection
 
@@ -698,6 +699,6 @@ def create_auth_provider() -> AuthProvider:
 # Backwards-compatible re-export of forward-referenced config
 # types — both are imported lazily inside `create_auth_provider`
 # to keep startup cost off the import path that doesn't use them.
-if False:  # TYPE_CHECKING equivalent without the import
+if TYPE_CHECKING:
     from omnigent.server.accounts_config import AccountsConfig
     from omnigent.server.oidc import OIDCConfig


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Define the host runner's `OmnigentError` exception before the lazy provider-config import it guards.
- Handle an unavailable optional YAML parser before referencing `yaml.YAMLError` in Hermes config reporting.
- Replace the auth module's `if False` type-only imports with standard `TYPE_CHECKING` imports.
- Remove four Pyrefly import-lifecycle findings, reducing the branch baseline from 53 to 49.

## Test Plan

- `uvx pyrefly check omnigent/host/connect.py omnigent/onboarding/hermes_auth.py omnigent/server/auth.py`
- `uvx pyrefly check omnigent` (49 errors; 4 fewer than `main`)
- `uv run --no-sync mypy omnigent/host/connect.py omnigent/onboarding/hermes_auth.py omnigent/server/auth.py`
- `uv run --no-sync pytest -q tests/onboarding/test_hermes_auth.py tests/host/test_connect.py -k 'hermes or build_runner_env'`
- `uv run --no-sync pytest -q tests/server/test_permissions.py`
- `pre-commit run --all-files`

## Demo

N/A — backend import and typing cleanup with no visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The 74 focused tests cover Hermes config failures, host runner environment construction, and unified auth/permission behavior.
