### PR TITLE
Handle non-JSON runner stream frames

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5585,6 +5585,7 @@ def create_runner_app(
                             else:
                                 event = None
 
+                            _defer_publish = False
                             if event is not None:
                                 if event.get("type") == "response.created":
                                     resp_obj = event.get("response") or {}
@@ -5593,8 +5594,6 @@ def create_runner_app(
                                         _resp_to_conv[_response_id] = conv_id
                                         _live_response_id[conv_id] = _response_id
                                         manager.mark_in_flight(conv_id, _response_id)
-
-                                _defer_publish = False
 
                                 _overflow = _is_context_overflow_error(event)
                                 if _overflow is not None:
@@ -5802,6 +5801,9 @@ def create_runner_app(
                                     )
                                     continue
 
+                            if event is None:
+                                yield raw_sse_bytes
+                                continue
                             if not _defer_publish and event.get("type") != "response.created":
                                 _publish_event(conv_id, event)
                             if dispatch is not None and event.get(_RUNNER_DISPATCHED_FIELD):

--- a/tests/runner/test_app_sessions_native_workflow_messages.py
+++ b/tests/runner/test_app_sessions_native_workflow_messages.py
@@ -66,6 +66,38 @@ def _build_blocking_app(
 
 
 @pytest.mark.asyncio
+async def test_proxy_stream_relays_non_json_sse_frame() -> None:
+    """A non-data SSE frame is relayed without entering JSON event handling."""
+    harness_client = _ScriptedHarnessClient(
+        [
+            "event: heartbeat\n\n",
+            _sse({"type": "response.created", "response": {"id": "resp_1"}}),
+            _sse({"type": "response.completed", "response": {"id": "resp_1"}}),
+        ]
+    )
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(harness_client),  # type: ignore[arg-type]
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        response = await client.post(
+            "/v1/sessions/49ed0bd1f0cae058f05f48057e9f98cf/events?stream=true",
+            json={
+                "type": "message",
+                "role": "user",
+                "model": "test-agent",
+                "content": [{"type": "input_text", "text": "hello"}],
+                "harness": "openai-agents",
+            },
+        )
+
+    assert response.status_code == 200
+    assert "event: heartbeat\n\n" in response.text
+    assert '"response.completed"' in response.text
+
+
+@pytest.mark.asyncio
 async def test_turn_sequencing_buffers_concurrent_message() -> None:
     """Second message during an active turn returns 202 (buffered)."""
     import asyncio as _aio


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Relay SSE frames without JSON `data:` payloads before entering event-only publication and dispatch logic.
- Initialize per-frame publication state before parsing so valid events retain the existing behavior.
- Add a regression test for a non-data heartbeat followed by normal response events.
- Remove four Pyrefly errors in the runner stream proxy, reducing the branch baseline from 53 to 49.

## Test Plan

- `uvx pyrefly check omnigent/runner/app.py` (two unrelated runner findings remain)
- `uvx pyrefly check omnigent` (49 errors; 4 fewer than `main`)
- `uv run --no-sync mypy omnigent/runner/app.py`
- `uv run --no-sync pytest -q tests/runner/test_app_sessions_native_workflow_messages.py`
- `pre-commit run --all-files`

## Demo

N/A — backend stream handling with no visual surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new regression test reproduces the previous `None.get()` failure with an SSE heartbeat frame and verifies it is relayed before normal response events. The full 24-test workflow-message suite passes.
