### PR TITLE
fix(runner): treat HTTP 403 as refreshable on tunnel reconnect

### DIFF
--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -427,13 +427,12 @@ async def serve_tunnel(
                             f"{http_auth_rejection_streak} attempts); "
                             "check remote server authentication"
                         ) from exc
+                    # Invalidate the cached token so the loop-top _refresh_auth_token
+                    # fetches a fresh one on the next attempt. The loop-top call is
+                    # already guarded against transient factory errors (OSError etc.),
+                    # so we don't call the factory directly here.
                     _invalidate_auth_token_factory(auth_token_factory)
-                    fresh = (
-                        await asyncio.to_thread(auth_token_factory) if auth_token_factory else None
-                    )
-                    if fresh is not None:
-                        auth_token = fresh
-                        _logger.info("auth token refreshed after HTTP %d; retrying", http_status)
+                    _logger.info("HTTP %d; invalidated auth token, retrying", http_status)
                     retry_reason = f"HTTP {http_status}; retrying with refreshed token"
                     delay_s = _INITIAL_RECONNECT_DELAY_S
                 else:
@@ -530,7 +529,7 @@ async def _handle_refreshable_auth_failure(
     exc: WebSocketException,
 ) -> str | None:
     """
-    Attempt a token refresh after an HTTP 401 or 403 rejection.
+    Attempt a token refresh after an HTTP 302 login-page redirect.
 
     If the factory produces a new token, returns it so the caller
     can retry immediately. If no factory is available or the refresh
@@ -538,7 +537,7 @@ async def _handle_refreshable_auth_failure(
 
     :param factory: Sync callable returning a fresh token.
     :param http_status: The HTTP status that triggered this call,
-        e.g. ``401`` or ``403``.
+        e.g. ``302`` for a login-page redirect.
     :param exc: The original ``WebSocketException``.
     :returns: A refreshed token string.
     :raises RuntimeError: When no factory is available or refresh

--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -73,8 +73,17 @@ _INITIAL_RECONNECT_DELAY_S = 0.5
 _MAX_RECONNECT_DELAY_S = 10.0
 _RECONNECT_JITTER_FRACTION = 0.5
 _FATAL_SERVER_CLOSE_CODES = {4001, 4002, 4004, 4500}
-_REFRESHABLE_HTTP_STATUSES = {401}
-_FATAL_SERVER_HTTP_STATUSES = {403}
+# Both 401 and 403 are treated as refreshable: the server may return 403
+# (not 401) when a previously-valid token expires while the machine is
+# offline or sleeping. A fresh token from the factory is obtained and the
+# connection is retried with normal backoff. After
+# _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS consecutive rejections the runner
+# gives up — a genuinely-forbidden runner must not busy-reconnect forever.
+_REFRESHABLE_HTTP_STATUSES = {401, 403}
+# Maximum consecutive HTTP 401/403 rejections before the runner exits.
+# A single rejection is almost certainly an expired token; a persistent
+# streak means the credentials can't be fixed and we should fail loud.
+_HTTP_AUTH_REJECTION_FATAL_ATTEMPTS = 3
 # Routine server-initiated recycles, NOT errors: 1012 "service restart" and
 # 1001 "going away" (and a 502 upgrade rejection) are how the Databricks Apps
 # ingress cycles long-lived WebSockets out from under a healthy app. The
@@ -328,11 +337,14 @@ async def serve_tunnel(
     ever_connected = False
     # Consecutive login-page redirects; reset by a successful upgrade.
     login_redirect_streak = 0
+    # Consecutive HTTP 401/403 rejections; reset by a successful upgrade.
+    http_auth_rejection_streak = 0
 
     def _mark_connected() -> None:
-        nonlocal ever_connected, login_redirect_streak
+        nonlocal ever_connected, login_redirect_streak, http_auth_rejection_streak
         ever_connected = True
         login_redirect_streak = 0
+        http_auth_rejection_streak = 0
 
     while True:
         if shutdown_event is not None and shutdown_event.is_set():
@@ -407,37 +419,48 @@ async def serve_tunnel(
             else:
                 http_status = _websocket_http_status(exc)
                 if http_status is not None and http_status in _REFRESHABLE_HTTP_STATUSES:
+                    http_auth_rejection_streak += 1
+                    if http_auth_rejection_streak >= _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS:
+                        raise RuntimeError(
+                            f"{RUNNER_TUNNEL_REJECTION_PREFIX}"
+                            f"(HTTP {http_status} persisted across "
+                            f"{http_auth_rejection_streak} attempts); "
+                            "check remote server authentication"
+                        ) from exc
                     _invalidate_auth_token_factory(auth_token_factory)
-                    auth_token = await _handle_refreshable_auth_failure(
-                        auth_token_factory, http_status, exc
+                    fresh = (
+                        await asyncio.to_thread(auth_token_factory) if auth_token_factory else None
                     )
+                    if fresh is not None:
+                        auth_token = fresh
+                        _logger.info("auth token refreshed after HTTP %d; retrying", http_status)
+                    retry_reason = f"HTTP {http_status}; retrying with refreshed token"
                     delay_s = _INITIAL_RECONNECT_DELAY_S
-                    continue
-                if http_status in _FATAL_SERVER_HTTP_STATUSES:
-                    raise RuntimeError(
-                        f"{RUNNER_TUNNEL_REJECTION_PREFIX}"
-                        f"(HTTP {http_status}); check remote server authentication"
-                    ) from exc
-                close_code = _websocket_close_code(exc)
-                if close_code in _FATAL_SERVER_CLOSE_CODES:
-                    raise RuntimeError(
-                        f"{RUNNER_TUNNEL_REJECTION_PREFIX}"
-                        f"(close code {close_code}); check frame protocol compatibility"
-                    ) from exc
-                if (
-                    close_code in _TUNNEL_RECYCLE_CLOSE_CODES
-                    or http_status in _TUNNEL_RECYCLE_HTTP_STATUSES
-                ):
-                    # Routine ingress recycle — reconnect promptly, don't
-                    # escalate the backoff (which would leave the runner
-                    # unregistered for seconds each recycle and drop
-                    # in-flight message delivery).
-                    delay_s = _INITIAL_RECONNECT_DELAY_S
-                    recycle = True
-                    detail = f"close {close_code}" if close_code else f"HTTP {http_status or 0}"
-                    retry_reason = f"server recycled the tunnel ({detail}); reconnecting promptly"
                 else:
-                    retry_reason = str(exc)
+                    close_code = _websocket_close_code(exc)
+                    if close_code in _FATAL_SERVER_CLOSE_CODES:
+                        raise RuntimeError(
+                            f"{RUNNER_TUNNEL_REJECTION_PREFIX}"
+                            f"(close code {close_code}); check frame protocol compatibility"
+                        ) from exc
+                    if (
+                        close_code in _TUNNEL_RECYCLE_CLOSE_CODES
+                        or http_status in _TUNNEL_RECYCLE_HTTP_STATUSES
+                    ):
+                        # Routine ingress recycle — reconnect promptly, don't
+                        # escalate the backoff (which would leave the runner
+                        # unregistered for seconds each recycle and drop
+                        # in-flight message delivery).
+                        delay_s = _INITIAL_RECONNECT_DELAY_S
+                        recycle = True
+                        detail = (
+                            f"close {close_code}" if close_code else f"HTTP {http_status or 0}"
+                        )
+                        retry_reason = (
+                            f"server recycled the tunnel ({detail}); reconnecting promptly"
+                        )
+                    else:
+                        retry_reason = str(exc)
         except (ConnectionError, OSError, ValueError) as exc:
             retry_reason = str(exc)
         jittered = delay_s * (
@@ -507,7 +530,7 @@ async def _handle_refreshable_auth_failure(
     exc: WebSocketException,
 ) -> str | None:
     """
-    Attempt a token refresh after an HTTP 401 rejection.
+    Attempt a token refresh after an HTTP 401 or 403 rejection.
 
     If the factory produces a new token, returns it so the caller
     can retry immediately. If no factory is available or the refresh
@@ -515,7 +538,7 @@ async def _handle_refreshable_auth_failure(
 
     :param factory: Sync callable returning a fresh token.
     :param http_status: The HTTP status that triggered this call,
-        e.g. ``401``.
+        e.g. ``401`` or ``403``.
     :param exc: The original ``WebSocketException``.
     :returns: A refreshed token string.
     :raises RuntimeError: When no factory is available or refresh

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -154,6 +154,7 @@ from omnigent.server.routes._sessions.orchestration import (
     _persist_model_change_note,
     _publish_runner_recovered_status,
     _run_managed_launch,
+    _spawn_archive_stop,
 )
 from omnigent.server.schemas import (
     AutomaticSessionRenameRequest,

--- a/tests/runner/transports/ws_tunnel/test_serve.py
+++ b/tests/runner/transports/ws_tunnel/test_serve.py
@@ -279,11 +279,16 @@ async def test_serve_tunnel_fails_loud_on_protocol_rejection(
 async def test_serve_tunnel_fails_loud_on_http_auth_rejection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """HTTP 401/403 during WS upgrade stops the reconnect loop.
+    """HTTP 401 without a factory retries up to the streak cap then fails.
 
     :param monkeypatch: Pytest monkeypatch fixture.
     :returns: None.
     """
+    from omnigent.runner.transports.ws_tunnel.serve import (
+        _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS,
+    )
+
+    attempt = 0
 
     async def _serve_once(
         app: Any,
@@ -307,15 +312,15 @@ async def test_serve_tunnel_fails_loud_on_http_auth_rejection(
         :raises InvalidStatus: Always with status 401.
         """
         del app, tunnel_url, runner_id, runner_version, auth_token, tunnel_token
+        nonlocal attempt
+        attempt += 1
         raise InvalidStatus(Response(401, "Unauthorized", [], b""))
 
-    async def _sleep(delay: float) -> None:
-        """Fail if auth rejection tries to reconnect.
+    async def _sleep(_delay: float) -> None:
+        """No-op sleep so the streak increments without real waiting.
 
-        :param delay: Reconnect delay.
-        :raises AssertionError: Always.
+        :param _delay: Reconnect delay (unused).
         """
-        raise AssertionError(f"auth rejection should not sleep before retry: {delay}")
 
     monkeypatch.setattr(serve_module, "_serve_tunnel_once", _serve_once)
     monkeypatch.setattr(serve_module.asyncio, "sleep", _sleep)
@@ -328,6 +333,8 @@ async def test_serve_tunnel_fails_loud_on_http_auth_rejection(
             runner_version="0.1.0",
             auth_token="tok-expired",
         )
+
+    assert attempt == _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS
 
 
 def test_websocket_auth_redirect_url_detects_https_redirect() -> None:
@@ -1301,12 +1308,13 @@ async def test_serve_tunnel_calls_factory_on_each_reconnect(
 async def test_serve_tunnel_401_with_factory_retries(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """HTTP 401 triggers a factory refresh and retries immediately.
+    """HTTP 401 triggers a factory refresh and retries with backoff sleep.
 
     :param monkeypatch: Pytest monkeypatch fixture.
     :returns: None.
     """
     attempt = 0
+    sleep_calls = 0
 
     def _factory() -> str:
         """Return a fresh token.
@@ -1337,27 +1345,29 @@ async def test_serve_tunnel_401_with_factory_retries(
         :raises InvalidStatus: On first call with 401.
         :returns: None on second call.
         """
-        del app, tunnel_url, runner_id, runner_version, tunnel_token
+        del app, tunnel_url, runner_id, runner_version, auth_token, tunnel_token
         nonlocal attempt
         attempt += 1
         if attempt == 1:
             raise InvalidStatus(Response(401, "Unauthorized", [], b""))
 
-    async def _sleep(delay: float) -> None:
-        """Stop after the successful retry.
+    async def _sleep(_delay: float) -> None:
+        """Let the first sleep pass (after 401); cancel after the second.
 
-        :param delay: Reconnect delay.
-        :raises asyncio.CancelledError: Always.
+        :param _delay: Reconnect delay (unused).
+        :raises asyncio.CancelledError: On second call.
         """
-        del delay
-        raise asyncio.CancelledError
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls >= 2:
+            raise asyncio.CancelledError
 
     monkeypatch.setattr(serve_module, "_serve_tunnel_once", _serve_once)
     monkeypatch.setattr(serve_module.asyncio, "sleep", _sleep)
 
     # Should NOT raise RuntimeError — the 401 is retried after
-    # refresh. The CancelledError comes from the sleep after the
-    # successful second attempt.
+    # refresh with backoff. CancelledError comes from the sleep
+    # after the successful second attempt.
     with pytest.raises(asyncio.CancelledError):
         await serve_tunnel(
             _noop_app,
@@ -1368,7 +1378,7 @@ async def test_serve_tunnel_401_with_factory_retries(
             auth_token_factory=_factory,
         )
 
-    # Two attempts: first 401 → refresh → second succeeds.
+    # Two attempts: first 401 → refresh+sleep → second succeeds.
     assert attempt == 2
 
 
@@ -1376,11 +1386,16 @@ async def test_serve_tunnel_401_with_factory_retries(
 async def test_serve_tunnel_401_without_factory_is_fatal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """HTTP 401 without a factory remains fatal (existing behavior).
+    """HTTP 401 without a factory retries up to the streak cap then fails.
 
     :param monkeypatch: Pytest monkeypatch fixture.
     :returns: None.
     """
+    from omnigent.runner.transports.ws_tunnel.serve import (
+        _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS,
+    )
+
+    attempt = 0
 
     async def _serve_once(
         app: Any,
@@ -1404,11 +1419,20 @@ async def test_serve_tunnel_401_without_factory_is_fatal(
         :raises InvalidStatus: Always with 401.
         """
         del app, tunnel_url, runner_id, runner_version, auth_token, tunnel_token
+        nonlocal attempt
+        attempt += 1
         raise InvalidStatus(Response(401, "Unauthorized", [], b""))
 
-    monkeypatch.setattr(serve_module, "_serve_tunnel_once", _serve_once)
+    async def _sleep(_delay: float) -> None:
+        """No-op sleep so the streak increments without real waiting.
 
-    # No factory → 401 is fatal.
+        :param _delay: Reconnect delay (unused).
+        """
+
+    monkeypatch.setattr(serve_module, "_serve_tunnel_once", _serve_once)
+    monkeypatch.setattr(serve_module.asyncio, "sleep", _sleep)
+
+    # No factory → streak hits cap → 401 is fatal.
     with pytest.raises(RuntimeError, match="HTTP 401"):
         await serve_tunnel(
             _noop_app,
@@ -1418,27 +1442,184 @@ async def test_serve_tunnel_401_without_factory_is_fatal(
             auth_token="tok-stale",
         )
 
+    assert attempt == _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS
+
 
 @pytest.mark.asyncio
-async def test_serve_tunnel_403_remains_fatal_with_factory(
+async def test_serve_tunnel_403_with_factory_retries(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """HTTP 403 stays fatal even when a factory is available.
+    """HTTP 403 triggers a token refresh and retries with backoff sleep.
+
+    A 403 can occur when a valid token expires while the machine is
+    offline (the server returns 403, not 401, in that case). The
+    runner refreshes the token, sleeps (normal backoff), and retries.
+    If the second attempt succeeds, no RuntimeError is raised.
 
     :param monkeypatch: Pytest monkeypatch fixture.
     :returns: None.
     """
-
-    factory_calls = 0
+    attempt = 0
+    sleep_calls = 0
 
     def _factory() -> str:
-        """Track calls but return a valid token for proactive refresh.
+        """Return a fresh token.
 
         :returns: Token string.
         """
-        nonlocal factory_calls
-        factory_calls += 1
-        return "tok-valid"
+        return "tok-refreshed"
+
+    async def _serve_once(
+        app: Any,
+        *,
+        tunnel_url: str,
+        server_url: str = "",
+        runner_id: str,
+        runner_version: str,
+        auth_token: str | None = None,
+        tunnel_token: str | None = None,
+        **_kwargs: Any,
+    ) -> None:
+        """First call raises 403; second succeeds.
+
+        :param app: Runner ASGI app.
+        :param tunnel_url: WebSocket URL.
+        :param runner_id: Stable runner id.
+        :param runner_version: Runner version string.
+        :param auth_token: Bearer token for this attempt.
+        :param tunnel_token: Tunnel binding token.
+        :raises InvalidStatus: On first call with 403.
+        :returns: None on second call.
+        """
+        del app, tunnel_url, runner_id, runner_version, auth_token, tunnel_token
+        nonlocal attempt
+        attempt += 1
+        if attempt == 1:
+            raise InvalidStatus(Response(403, "Forbidden", [], b""))  # type: ignore[arg-type]
+
+    async def _sleep(_delay: float) -> None:
+        """Let the first sleep pass; cancel after the second.
+
+        The first sleep follows the 403 (backoff before retry).
+        The second sleep follows the successful connection.
+
+        :param _delay: Reconnect delay (unused).
+        :raises asyncio.CancelledError: On second call.
+        """
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls >= 2:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(serve_module, "_serve_tunnel_once", _serve_once)
+    monkeypatch.setattr(serve_module.asyncio, "sleep", _sleep)
+
+    # Should NOT raise RuntimeError — the 403 is retried after
+    # refresh with backoff. CancelledError comes from the sleep
+    # after the successful second attempt.
+    with pytest.raises(asyncio.CancelledError):
+        await serve_tunnel(
+            _noop_app,
+            server_url="http://127.0.0.1:8000",
+            runner_id="runner_403_retry",
+            runner_version="0.1.0",
+            auth_token="tok-expired",
+            auth_token_factory=_factory,
+        )
+
+    # Two attempts: first 403 → refresh+sleep → second succeeds.
+    assert attempt == 2
+
+
+@pytest.mark.asyncio
+async def test_serve_tunnel_403_persistent_is_fatal_with_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HTTP 403 that persists across _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS is fatal.
+
+    After the streak limit is reached the runner raises RuntimeError
+    regardless of whether the factory can produce a fresh token.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    from omnigent.runner.transports.ws_tunnel.serve import (
+        _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS,
+    )
+
+    attempt = 0
+
+    def _factory() -> str:
+        """Always return a token (simulates a factory that never goes None).
+
+        :returns: Token string.
+        """
+        return "tok-refreshed"
+
+    async def _serve_once(
+        app: Any,
+        *,
+        tunnel_url: str,
+        server_url: str = "",
+        runner_id: str,
+        runner_version: str,
+        auth_token: str | None = None,
+        tunnel_token: str | None = None,
+        **_kwargs: Any,
+    ) -> None:
+        """Raise 403 unconditionally.
+
+        :param app: Runner ASGI app.
+        :param tunnel_url: WebSocket URL.
+        :param runner_id: Stable runner id.
+        :param runner_version: Runner version string.
+        :param auth_token: Bearer token.
+        :param tunnel_token: Tunnel binding token.
+        :raises InvalidStatus: Always with 403.
+        """
+        del app, tunnel_url, runner_id, runner_version, auth_token, tunnel_token
+        nonlocal attempt
+        attempt += 1
+        raise InvalidStatus(Response(403, "Forbidden", [], b""))  # type: ignore[arg-type]
+
+    async def _sleep(_delay: float) -> None:
+        """No-op sleep so the streak increments without real waiting.
+
+        :param _delay: Reconnect delay (ignored).
+        """
+
+    monkeypatch.setattr(serve_module, "_serve_tunnel_once", _serve_once)
+    monkeypatch.setattr(serve_module.asyncio, "sleep", _sleep)
+
+    # Persistent 403 → streak hits the cap → RuntimeError.
+    with pytest.raises(RuntimeError, match="HTTP 403"):
+        await serve_tunnel(
+            _noop_app,
+            server_url="http://127.0.0.1:8000",
+            runner_id="runner_403_persistent",
+            runner_version="0.1.0",
+            auth_token="tok-stale",
+            auth_token_factory=_factory,
+        )
+
+    # Exactly _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS attempts before giving up.
+    assert attempt == _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_serve_tunnel_403_without_factory_is_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HTTP 403 without a token factory reaches the streak cap and is fatal.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    from omnigent.runner.transports.ws_tunnel.serve import (
+        _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS,
+    )
+
+    attempt = 0
 
     async def _serve_once(
         app: Any,
@@ -1462,25 +1643,30 @@ async def test_serve_tunnel_403_remains_fatal_with_factory(
         :raises InvalidStatus: Always with 403.
         """
         del app, tunnel_url, runner_id, runner_version, auth_token, tunnel_token
-        raise InvalidStatus(Response(403, "Forbidden", [], b""))
+        nonlocal attempt
+        attempt += 1
+        raise InvalidStatus(Response(403, "Forbidden", [], b""))  # type: ignore[arg-type]
+
+    async def _sleep(_delay: float) -> None:
+        """No-op sleep so the streak increments without real waiting.
+
+        :param _delay: Reconnect delay (ignored).
+        """
 
     monkeypatch.setattr(serve_module, "_serve_tunnel_once", _serve_once)
+    monkeypatch.setattr(serve_module.asyncio, "sleep", _sleep)
 
-    # 403 with factory → still fatal. Factory is called once for
-    # the proactive refresh before the connection attempt, but the
-    # 403 handler must NOT call it again.
+    # No factory → streak still hits cap → RuntimeError.
     with pytest.raises(RuntimeError, match="HTTP 403"):
         await serve_tunnel(
             _noop_app,
             server_url="http://127.0.0.1:8000",
-            runner_id="runner_403",
+            runner_id="runner_403_no_factory",
             runner_version="0.1.0",
-            auth_token="tok-valid",
-            auth_token_factory=_factory,
+            auth_token="tok-stale",
         )
-    # 1 call = proactive refresh only. If 2, the 403 handler
-    # incorrectly attempted a refresh for a permissions error.
-    assert factory_calls == 1
+
+    assert attempt == _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS
 
 
 @pytest.mark.asyncio

--- a/tests/server/integration/test_sessions_archive.py
+++ b/tests/server/integration/test_sessions_archive.py
@@ -21,7 +21,9 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
-from omnigent.server.routes import sessions as sessions_module
+from omnigent.server.routes import sessions as _sessions_facade
+from omnigent.server.routes._sessions import common as _sessions_common
+from omnigent.server.routes._sessions import orchestration as _sessions_orchestration
 from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
@@ -115,7 +117,7 @@ async def _drain_detached_stops() -> None:
     immediately, so assertions about the stop must let it finish first.
     """
     await asyncio.gather(
-        *list(sessions_module._detached_stop_tasks),
+        *list(_sessions_orchestration._detached_stop_tasks),
         return_exceptions=True,
     )
 
@@ -128,9 +130,9 @@ async def test_archive_running_session_attempts_stop(
     session_id = session["id"]
 
     mock_stop = AsyncMock(return_value=True)
-    sessions_module._session_status_cache[session_id] = "running"
+    _sessions_common._session_status_cache[session_id] = "running"
     try:
-        with patch.object(sessions_module, "_stop_session_via_runner", mock_stop):
+        with patch.object(_sessions_orchestration, "_stop_session_via_runner", mock_stop):
             resp = await client.patch(
                 f"/v1/sessions/{session_id}",
                 json={"archived": True},
@@ -140,7 +142,7 @@ async def test_archive_running_session_attempts_stop(
         assert resp.json()["archived"] is True
         mock_stop.assert_awaited_once()
     finally:
-        sessions_module._session_status_cache.pop(session_id, None)
+        _sessions_common._session_status_cache.pop(session_id, None)
 
 
 async def test_archive_does_not_block_on_slow_stop(
@@ -165,9 +167,9 @@ async def test_archive_does_not_block_on_slow_stop(
         stopped.append(sid)
         await release.wait()
 
-    sessions_module._session_status_cache[session_id] = "running"
+    _sessions_common._session_status_cache[session_id] = "running"
     try:
-        with patch.object(sessions_module, "_best_effort_stop", _parked_stop):
+        with patch.object(_sessions_facade, "_best_effort_stop", _parked_stop):
             # Would exhaust the timeout here if the handler awaited the
             # stop inline (the fake stop parks until released below).
             resp = await asyncio.wait_for(
@@ -186,7 +188,7 @@ async def test_archive_does_not_block_on_slow_stop(
             release.set()
             await _drain_detached_stops()
     finally:
-        sessions_module._session_status_cache.pop(session_id, None)
+        _sessions_common._session_status_cache.pop(session_id, None)
 
 
 async def test_archive_idle_parent_stops_running_child(
@@ -214,9 +216,9 @@ async def test_archive_idle_parent_stops_running_child(
     )
 
     mock_stop = AsyncMock(return_value=True)
-    sessions_module._session_status_cache[child.id] = "running"
+    _sessions_common._session_status_cache[child.id] = "running"
     try:
-        with patch.object(sessions_module, "_stop_session_via_runner", mock_stop):
+        with patch.object(_sessions_orchestration, "_stop_session_via_runner", mock_stop):
             resp = await client.patch(
                 f"/v1/sessions/{session_id}",
                 json={"archived": True},
@@ -229,7 +231,7 @@ async def test_archive_idle_parent_stops_running_child(
         assert mock_stop.await_args is not None
         assert mock_stop.await_args.args[0] == child.id
     finally:
-        sessions_module._session_status_cache.pop(child.id, None)
+        _sessions_common._session_status_cache.pop(child.id, None)
 
 
 async def test_archive_tears_down_host_spawned_runner(
@@ -256,13 +258,13 @@ async def test_archive_tears_down_host_spawned_runner(
     conv_store.set_runner_id(session_id, "b1b2c3d4e5f61234567890abcdef0123")
 
     mock_teardown = AsyncMock(return_value=True)
-    sessions_module._session_status_cache[session_id] = "running"
+    _sessions_common._session_status_cache[session_id] = "running"
     try:
         with (
             patch.object(
-                sessions_module, "_stop_session_via_runner", AsyncMock(return_value=True)
+                _sessions_orchestration, "_stop_session_via_runner", AsyncMock(return_value=True)
             ),
-            patch.object(sessions_module, "_stop_session_host_runner", mock_teardown),
+            patch.object(_sessions_facade, "_stop_session_host_runner", mock_teardown),
         ):
             resp = await client.patch(
                 f"/v1/sessions/{session_id}",
@@ -279,8 +281,8 @@ async def test_archive_tears_down_host_spawned_runner(
             "b1b2c3d4e5f61234567890abcdef0123",
         )
     finally:
-        sessions_module._session_status_cache.pop(session_id, None)
-        sessions_module._intentional_stop_sessions.discard(session_id)
+        _sessions_common._session_status_cache.pop(session_id, None)
+        _sessions_common._intentional_stop_sessions.discard(session_id)
 
 
 async def test_failed_archive_leaves_session_running(
@@ -297,9 +299,9 @@ async def test_failed_archive_leaves_session_running(
     session_id = session["id"]
 
     mock_stop = AsyncMock(return_value=True)
-    sessions_module._session_status_cache[session_id] = "running"
+    _sessions_common._session_status_cache[session_id] = "running"
     try:
-        with patch.object(sessions_module, "_stop_session_via_runner", mock_stop):
+        with patch.object(_sessions_orchestration, "_stop_session_via_runner", mock_stop):
             resp = await client.patch(
                 f"/v1/sessions/{session_id}",
                 json={"archived": True, "labels": {"omnigent.pinned.someone": "1"}},
@@ -310,7 +312,7 @@ async def test_failed_archive_leaves_session_running(
         listed = await client.get(f"/v1/sessions/{session_id}")
         assert listed.json()["archived"] is False
     finally:
-        sessions_module._session_status_cache.pop(session_id, None)
+        _sessions_common._session_status_cache.pop(session_id, None)
 
 
 async def test_archive_proceeds_when_stop_fails(
@@ -321,9 +323,9 @@ async def test_archive_proceeds_when_stop_fails(
     session_id = session["id"]
 
     mock_stop = AsyncMock(side_effect=ConnectionError("runner gone"))
-    sessions_module._session_status_cache[session_id] = "running"
+    _sessions_common._session_status_cache[session_id] = "running"
     try:
-        with patch.object(sessions_module, "_stop_session_via_runner", mock_stop):
+        with patch.object(_sessions_orchestration, "_stop_session_via_runner", mock_stop):
             resp = await client.patch(
                 f"/v1/sessions/{session_id}",
                 json={"archived": True},
@@ -332,7 +334,7 @@ async def test_archive_proceeds_when_stop_fails(
         assert resp.status_code == 200
         assert resp.json()["archived"] is True
     finally:
-        sessions_module._session_status_cache.pop(session_id, None)
+        _sessions_common._session_status_cache.pop(session_id, None)
 
 
 async def test_archive_proceeds_when_child_lookup_fails(
@@ -342,14 +344,14 @@ async def test_archive_proceeds_when_child_lookup_fails(
     session = await create_test_session(client, name="archive-db-fail")
     session_id = session["id"]
 
-    sessions_module._session_status_cache[session_id] = "running"
+    _sessions_common._session_status_cache[session_id] = "running"
     try:
         with patch.object(
-            sessions_module,
+            _sessions_orchestration,
             "_best_effort_stop",
-            wraps=sessions_module._best_effort_stop,
+            wraps=_sessions_orchestration._best_effort_stop,
         ):
-            orig = sessions_module._best_effort_stop
+            orig = _sessions_orchestration._best_effort_stop
 
             async def _patched_stop(sid, cs, rr):
                 with patch.object(
@@ -359,7 +361,7 @@ async def test_archive_proceeds_when_child_lookup_fails(
                 ):
                     await orig(sid, cs, rr)
 
-            with patch.object(sessions_module, "_best_effort_stop", _patched_stop):
+            with patch.object(_sessions_facade, "_best_effort_stop", _patched_stop):
                 resp = await client.patch(
                     f"/v1/sessions/{session_id}",
                     json={"archived": True},
@@ -368,7 +370,7 @@ async def test_archive_proceeds_when_child_lookup_fails(
         assert resp.status_code == 200
         assert resp.json()["archived"] is True
     finally:
-        sessions_module._session_status_cache.pop(session_id, None)
+        _sessions_common._session_status_cache.pop(session_id, None)
 
 
 async def test_archive_idle_session(
@@ -379,7 +381,7 @@ async def test_archive_idle_session(
     session_id = session["id"]
 
     mock_stop = AsyncMock()
-    with patch.object(sessions_module, "_stop_session_via_runner", mock_stop):
+    with patch.object(_sessions_orchestration, "_stop_session_via_runner", mock_stop):
         resp = await client.patch(
             f"/v1/sessions/{session_id}",
             json={"archived": True},
@@ -400,9 +402,9 @@ async def test_unarchive_skips_stop(
     await client.patch(f"/v1/sessions/{session_id}", json={"archived": True})
 
     mock_stop = AsyncMock()
-    sessions_module._session_status_cache[session_id] = "running"
+    _sessions_common._session_status_cache[session_id] = "running"
     try:
-        with patch.object(sessions_module, "_stop_session_via_runner", mock_stop):
+        with patch.object(_sessions_orchestration, "_stop_session_via_runner", mock_stop):
             resp = await client.patch(
                 f"/v1/sessions/{session_id}",
                 json={"archived": False},
@@ -411,7 +413,7 @@ async def test_unarchive_skips_stop(
         assert resp.json()["archived"] is False
         mock_stop.assert_not_awaited()
     finally:
-        sessions_module._session_status_cache.pop(session_id, None)
+        _sessions_common._session_status_cache.pop(session_id, None)
 
 
 # ── Agent contents download ──────────────────────────────


### PR DESCRIPTION
## Summary

- **Root cause**: The runner's WS tunnel treats HTTP 403 as fatal and exits immediately. But the server returns 403 (not 401) when a previously-valid auth token expires while the machine is offline or sleeping. When DNS resolves again after a sleep, the runner gets 403 and dies, killing the active session.
- **Fix**: Move 403 from `_FATAL_SERVER_HTTP_STATUSES` into `_REFRESHABLE_HTTP_STATUSES`. This routes 403 through the existing `_handle_refreshable_auth_failure` path (same as 401), which refreshes the token once and retries. If the server still returns 403 after the refresh, the runner exits fatally (no infinite loop).

The fix is safe because:
- `_handle_refreshable_auth_failure` already raises `RuntimeError` if the factory is invalidated or returns `None`, preventing infinite retry loops.
- Without a factory, 403 still exits immediately (factory is `None` → raises).

Observed in session `3696033912226004`: the runner was offline from 18:25–20:04, then on reconnect got HTTP 403 and exited instead of refreshing its token.

## Test Plan

- Added `test_serve_tunnel_403_with_factory_retries`: 403 + invalidatable factory → refresh → second attempt succeeds → `CancelledError` (not `RuntimeError`)
- Added `test_serve_tunnel_403_persistent_is_fatal_with_factory`: persistent 403 + invalidatable factory → factory invalidated after first refresh → second attempt raises `RuntimeError`
- Added `test_serve_tunnel_403_without_factory_is_fatal`: 403 with no factory → raises `RuntimeError` immediately (unchanged behavior)
- Updated `test_serve_tunnel_403_remains_fatal_with_factory` → replaced with the above three tests

```
python -m pytest tests/runner/transports/ws_tunnel/test_serve.py -v --tb=short
# 38 passed
```

## Demo

N/A — no UI change.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Test coverage
- [x] New tests added