### PR TITLE
Narrow workspace text decoding state

### DIFF
--- a/omnigent/workspace_fs.py
+++ b/omnigent/workspace_fs.py
@@ -256,9 +256,9 @@ class WorkspaceReader:
             capped = capped[:_MAX_READ_BYTES]
             truncated = True
 
+        text: str | None = None
         try:
             text = capped.decode("utf-8")
-            is_text = True
         except UnicodeDecodeError as exc:
             # A byte-cap truncation can split a multi-byte codepoint at the very
             # end, which would otherwise flip an oversize *text* file to base64.
@@ -271,16 +271,13 @@ class WorkspaceReader:
             if truncated and exc.start >= len(capped) - 3:
                 capped = capped[: exc.start]
                 text = capped.decode("utf-8")
-                is_text = True
-            else:
-                is_text = False
 
         payload: _WorkspacePayload = {
             "object": "session.environment.filesystem.file_content",
             "path": rel,
             "content_type": content_type_guess,
         }
-        if is_text:
+        if text is not None:
             if limit is not None:
                 lines = text.splitlines(keepends=True)
                 if len(lines) > limit:


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Model decoded workspace text as `str | None` instead of maintaining a separate boolean flag.
- Preserve UTF-8 truncation recovery and binary base64 fallback behavior while making initialization explicit.
- Remove both Pyrefly errors in `omnigent/workspace_fs.py`, reducing the branch baseline from 53 to 51.

## Test Plan

- `uvx pyrefly check omnigent/workspace_fs.py` (0 errors)
- `uvx pyrefly check omnigent` (51 errors; 2 fewer than `main`)
- `uv run mypy omnigent/workspace_fs.py`
- `uv run pytest -q tests/test_workspace_fs.py` (18 passed)
- `SKIP=normalize-uv-lock-registry pre-commit run --all-files` (the skipped hook rewrites the unrelated `uv.lock` on current `main`)

## Demo

N/A — internal filesystem payload typing with no visual surface.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing workspace reader tests cover UTF-8 text, binary base64 fallback, byte-cap truncation at a split codepoint, and genuinely binary truncated data.
