### PR TITLE
Narrow detected harness credential families

### DIFF
--- a/omnigent/onboarding/harness_auth.py
+++ b/omnigent/onboarding/harness_auth.py
@@ -284,7 +284,12 @@ def detect_adoptable_credentials() -> list[DetectedCredential]:
         family = getattr(provider, "family", None)
         kind = getattr(provider, "kind", None)
         source = getattr(provider, "source", None)
-        if family not in _SUPPORTED_FAMILIES or kind != "key" or not isinstance(source, str):
+        if (
+            not isinstance(family, str)
+            or family not in _SUPPORTED_FAMILIES
+            or kind != "key"
+            or not isinstance(source, str)
+        ):
             continue
         # Only env-var sources are adoptable by reference (env:<VAR>); a CLI
         # login isn't a key the UI can point a provider entry at.


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Require ambient credential family metadata to be a string before checking supported families.
- Preserve the existing allowlist and env-key filtering while rejecting malformed provider metadata.
- Remove both Pyrefly errors in `omnigent/onboarding/harness_auth.py`, reducing the branch baseline from 53 to 51.

## Test Plan

- `uvx pyrefly check omnigent/onboarding/harness_auth.py` (0 errors)
- `uvx pyrefly check omnigent` (51 errors; 2 fewer than `main`)
- `uv run --no-sync mypy omnigent/onboarding/harness_auth.py`
- `uv run --no-sync pytest -q tests/onboarding/test_harness_auth.py` (15 passed)
- `SKIP=normalize-uv-lock-registry pre-commit run --all-files` (the skipped hook rewrites the unrelated `uv.lock` on current `main`)

## Demo

N/A — backend credential metadata validation with no visual surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing tests cover supported env-key credentials, unsupported families, non-key credentials, non-env sources, and detection failures.
