### PR TITLE
Type Bedrock client configuration

### DIFF
--- a/omnigent/llms/adapters/bedrock.py
+++ b/omnigent/llms/adapters/bedrock.py
@@ -12,13 +12,20 @@ import asyncio
 import json
 import time
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import Any, TypedDict
 
 from omnigent.llms.adapters._content import parse_data_uri
 from omnigent.llms.adapters.base import BaseAdapter
 
 # Default connect timeout: 30s to establish TCP connection.
 _BOTO_CONNECT_TIMEOUT = 30
+
+
+class _BotoClientKwargs(TypedDict, total=False):
+    region_name: str
+    aws_access_key_id: str
+    aws_secret_access_key: str
+    aws_session_token: str
 
 
 # Bedrock Converse API ``document.format`` accepts a fixed enum:
@@ -90,15 +97,16 @@ def _boto_config(
     """
     from botocore.config import Config
 
-    retries = (
-        {"max_attempts": max_retries, "mode": "adaptive"}
-        if max_retries is not None
-        else {"max_attempts": 0}
-    )
+    if max_retries is not None:
+        return Config(
+            connect_timeout=_BOTO_CONNECT_TIMEOUT,
+            read_timeout=read_timeout,
+            retries={"max_attempts": max_retries, "mode": "adaptive"},
+        )
     return Config(
         connect_timeout=_BOTO_CONNECT_TIMEOUT,
         read_timeout=read_timeout,
-        retries=retries,
+        retries={"max_attempts": 0},
     )
 
 
@@ -132,7 +140,7 @@ class BedrockAdapter(BaseAdapter):
         """
         import boto3
 
-        boto_kwargs: dict[str, str] = {}
+        boto_kwargs: _BotoClientKwargs = {}
         if connection_params:
             if region := connection_params.get("aws_region"):
                 boto_kwargs["region_name"] = region


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Keep botocore retry dictionaries contextually typed instead of widening heterogeneous values.
- Describe the optional AWS client keyword set with a `TypedDict` before forwarding it to boto3.
- Remove both Pyrefly errors in `omnigent/llms/adapters/bedrock.py`, reducing the branch baseline from 53 to 51.

## Test Plan

- `uvx pyrefly check omnigent/llms/adapters/bedrock.py` (0 errors)
- `uvx pyrefly check omnigent` (51 errors; 2 fewer than `main`)
- `uv run --no-sync mypy omnigent/llms/adapters/bedrock.py`
- `uv run --no-sync pytest -q tests/llms/test_bedrock_adapter.py` (45 passed)
- `SKIP=normalize-uv-lock-registry pre-commit run --all-files` (the skipped hook rewrites the unrelated `uv.lock` on current `main`)

## Demo

N/A — backend AWS client typing with no visual surface.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The adapter suite covers request translation, response translation, streaming chunks, retry-related request construction, and supported content formats.
