### PR TITLE
Align UUID dialect hook signatures

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -154,14 +154,16 @@ class Uuid16(TypeDecorator[str]):
             return dialect.type_descriptor(MySQLBinary(16))
         return dialect.type_descriptor(LargeBinary(16))
 
-    def process_bind_param(self, value: str | uuid.UUID | None, _dialect: object) -> bytes | None:
+    def process_bind_param(self, value: str | uuid.UUID | None, dialect: object) -> bytes | None:
+        del dialect
         if value is None:
             return None
         return uuid_to_bytes(value)
 
     def process_result_value(
-        self, value: bytes | memoryview | str | None, _dialect: object
+        self, value: bytes | memoryview | str | None, dialect: object
     ) -> str | None:
+        del dialect
         if value is None:
             return None
         if isinstance(value, str):


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Match SQLAlchemy's `dialect` parameter name in both `Uuid16` type-decorator hooks.
- Explicitly discard the unused dialect value so Ruff and the override contract remain aligned.
- Remove both Pyrefly errors in `omnigent/db/db_models.py`, reducing the branch baseline from 53 to 51.

## Test Plan

- `uvx pyrefly check omnigent/db/db_models.py` (0 errors)
- `uvx pyrefly check omnigent` (51 errors; 2 fewer than `main`)
- `uv run --no-sync mypy omnigent/db/db_models.py`
- `uv run --no-sync pytest -q tests/db/test_uuid16.py` (35 passed)
- `SKIP=normalize-uv-lock-registry pre-commit run --all-files` (the skipped hook rewrites the unrelated `uv.lock` on current `main`)

## Demo

N/A — internal database type-hook signatures with no visual surface.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The UUID type suite covers bind conversion, result decoding, accepted UUID forms, and malformed identifiers.
