### PR TITLE
Align compressed text dialect hooks

### DIFF
--- a/omnigent/db/compression.py
+++ b/omnigent/db/compression.py
@@ -99,12 +99,14 @@ class CompressedText(TypeDecorator[str]):
     impl = LargeBinary
     cache_ok = True
 
-    def process_bind_param(self, value: str | None, _dialect: object) -> bytes | None:
+    def process_bind_param(self, value: str | None, dialect: object) -> bytes | None:
         """Compress on the way into the database."""
+        del dialect
         return encode(value)
 
     def process_result_value(
-        self, value: bytes | str | memoryview | None, _dialect: object
+        self, value: bytes | str | memoryview | None, dialect: object
     ) -> str | None:
         """Decompress on the way out of the database."""
+        del dialect
         return decode(value)


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Match SQLAlchemy's `dialect` parameter name in both `CompressedText` type-decorator hooks.
- Explicitly discard the unused dialect value so Ruff and the override contract remain aligned.
- Remove both Pyrefly errors in `omnigent/db/compression.py`, reducing the branch baseline from 53 to 51.

## Test Plan

- `uvx pyrefly check omnigent/db/compression.py` (0 errors)
- `uvx pyrefly check omnigent` (51 errors; 2 fewer than `main`)
- `uv run --no-sync mypy omnigent/db/compression.py`
- `uv run --no-sync pytest -q tests/db/test_compression.py` (13 passed)
- `SKIP=normalize-uv-lock-registry pre-commit run --all-files` (the skipped hook rewrites the unrelated `uv.lock` on current `main`)

## Demo

N/A — internal database type-hook signatures with no visual surface.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The compression suite covers raw and compressed frames, Unicode data, driver value variants, and legacy plaintext rows.
