### PR TITLE
Type child status payload as JSON

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1997,7 +1997,7 @@ def create_runner_app(
         include_error: bool = False,
     ) -> _JsonObject:
         busy = status in ("running", "waiting")
-        child = {
+        child: _JsonObject = {
             "id": session_id,
             "title": meta.title,
             "tool": meta.tool,


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Declare native child-status payloads with the shared heterogeneous JSON object contract.
- Preserve the existing scalar status fields while allowing the structured `last_task_error` object already emitted at runtime.
- Remove one Pyrefly error in `omnigent/runner/app.py`, reducing the branch baseline from 33 to 32.

## Test Plan

- `uvx pyrefly check omnigent/runner/app.py` (one unrelated runner finding remains)
- `uvx pyrefly check omnigent` (32 errors; 1 fewer than `main`)
- `uv run --no-sync mypy omnigent/runner/app.py`
- `uv run --no-sync pytest -q tests/runner/test_app_sessions_native_supervision.py tests/runner/test_app_sessions_native_events_lifecycle.py` (68 passed)
- `SKIP=normalize-uv-lock-registry pre-commit run` on the staged file (all substantive all-files hooks passed; the all-files large-file hook stalled while scanning the checkout)

## Demo

N/A — internal runner status payload typing with no visual surface.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing supervision and native-event lifecycle tests cover running, idle, failed, interrupted, and stopped child-session status payloads.
