### PR TITLE
Bind MCP elicitation exception before dispatch

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -8096,9 +8096,9 @@ def create_runner_app(
                             }
                         },
                     )
-                try:
-                    from omnigent.tools.mcp import McpElicitationRequired
+                from omnigent.tools.mcp import McpElicitationRequired
 
+                try:
                     if input_responses is not None:
                         route = mcp_manager._resolve_tool_route(spec, tool_name)
                         if route is None:


### PR DESCRIPTION
## Related issue

Tracks #3644

## Summary

- Bind the lazily imported MCP elicitation exception before entering the tool-dispatch `try` block.
- Preserve lazy module loading and existing elicitation handling while guaranteeing the `except` target is initialized.
- Remove one Pyrefly error in `omnigent/runner/app.py`, reducing the branch baseline from 33 to 32.

## Test Plan

- `uvx pyrefly check omnigent/runner/app.py` (one unrelated runner finding remains)
- `uvx pyrefly check omnigent` (32 errors; 1 fewer than `main`)
- `uv run --no-sync mypy omnigent/runner/app.py`
- `uv run --no-sync pytest -q tests/runner/test_app_sessions_native_workflow_init.py -k 'mcp_execute'` (2 passed)
- `SKIP=normalize-uv-lock-registry pre-commit run` on the staged file

## Demo

N/A — internal MCP dispatch import lifecycle with no visual surface.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused tests exercise builtin and namespaced MCP tool dispatch through `/mcp/execute`; existing elicitation tests cover the exception's input-required response contract.
