### PR TITLE
docs(openclaw): reflect live-verified compatibility status

### DIFF
--- a/docs/openclaw.md
+++ b/docs/openclaw.md
@@ -99,15 +99,25 @@ servers.
 
 ### Compatibility status
 
-The protocol-level path matches for initialization, session creation, prompts,
-cancellation, and streaming updates. Manual validation against a live Gateway
-has also confirmed the configured worktree, native shell/filesystem tools, and
-Omni conversation resume. Bidirectional synchronization with the OpenClaw
-Control UI and per-session Omnigent MCP are not supported by this integration.
+This integration has been validated end-to-end against a live OpenClaw Gateway.
+The full turn cycle works: initialization, session creation, prompts,
+cancellation, and **streaming assistant replies** (final messages arrive in the
+Omni conversation). Live validation also confirmed the configured worktree,
+native shell/filesystem tool execution, ACP permission requests (approvals route
+through ACP rather than OpenClaw's chat), and Omni conversation resume after
+close.
+
+Known limitation: bidirectional synchronization with the OpenClaw Control UI is
+not supported. Omni owns the outer conversation; the Control UI is a separate
+Gateway client, so messages entered there while Omni is offline are not imported
+into the Omni conversation. Per-session Omnigent MCP is also unsupported (see
+[Why `omnigent_mcp` must be false](#why-omnigent_mcp-must-be-false)).
+
 OpenClaw cannot be installed or run in the project's managed development and CI
-environments.
+environments, so this path is not exercised by automated CI; changes to the ACP
+client should be re-validated manually against a Gateway.
 
 If session creation reports that `mcpServers` is unsupported, confirm that the
-entry contains `omnigent_mcp: false` and restart the Omnigent session. If the
-turn reaches OpenClaw but no final reply appears, capture both Omnigent and
-OpenClaw logs and report the behavior before relying on the integration.
+entry contains `omnigent_mcp: false` and restart the Omnigent session. If a turn
+reaches OpenClaw but no final reply appears, capture both Omnigent and OpenClaw
+logs and file an issue.


### PR DESCRIPTION
## Related issue

N/A (doc follow-up to #3420 / #3388)

## Summary

`docs/openclaw.md`'s "Compatibility status" undersold what PR #3420 actually verified. #3420 validated the OpenClaw Gateway ACP integration end-to-end against a live Gateway (streaming replies, native tool execution, ACP permission routing, session resume), but the doc still read as if streaming was only "protocol-level matched" and closed with "before relying on the integration" — which reads as provisional.

- Rewrite the compatibility section to state what live validation confirmed, including that **final assistant replies stream back** into the Omni conversation.
- Reframe the remaining OpenClaw Control-UI-sync gap (and per-session Omnigent MCP) as a **known limitation**, not an open question.
- Keep the accurate note that OpenClaw can't run in managed CI, so the path isn't automated and ACP-client changes need manual re-validation.

Docs only — no code change.

## Test Plan

N/A — documentation only. `pre-commit run --files docs/openclaw.md` passes.

## Demo

N/A — no UI or code change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Documentation-only change to `docs/openclaw.md`; no code paths exercised, so automated test coverage does not apply. The behavior described was manually validated in PR #3420 against a live OpenClaw Gateway.

This pull request and its description were written by Isaac.
