### PR TITLE
Narrow CLI lifecycle type checks

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3746,7 +3746,6 @@ def server(
     # a clean shutdown doesn't leave a stale record.
     if _is_canonical_local_server:
         from omnigent.host.local_server import (
-            clear_local_server_record,
             register_local_server,
         )
 
@@ -3821,6 +3820,8 @@ def server(
         pass
     finally:
         if _is_canonical_local_server:
+            from omnigent.host.local_server import clear_local_server_record
+
             clear_local_server_record()
 
 

--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -3164,7 +3164,7 @@ def _set_opencode_default_model(current: str | None) -> str | None:
     if current is not None:
         clear_index = len(options)
         options.append("Clear default (use OpenCode's own default)")
-    default = models.index(current) if current in models else 0
+    default = models.index(current) if current is not None and current in models else 0
     # Even filtered to reachable providers the list can exceed the screen, so
     # bound the picker to a scrolling viewport sized to the terminal (leaving
     # room for the title / status / footer / "N more" markers).


### PR DESCRIPTION
## Related issue

Relates to #3644

## Summary

- Keep the canonical local-server cleanup import inside the same guarded shutdown path that uses it.
- Narrow the optional OpenCode model before looking up its picker index.
- Remove two Pyrefly errors without changing CLI behavior.

## Test Plan

- `uvx pyrefly check omnigent` (**21 errors**, down from the 23-error `main` baseline)
- `uv run pytest tests/cli/test_opencode_setup.py -k 'default_model'` (4 passed)
- `uv run pytest tests/cli/test_cli.py::test_server_command_reads_tunnel_token_and_does_not_spawn_runner tests/cli/test_cli.py::test_server_with_explicit_db_does_not_reuse_canonical_server tests/cli/test_cli.py::test_server_with_explicit_port_does_not_check_canonical_server` (3 passed)
- `SKIP=normalize-uv-lock-registry pre-commit run`

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing CLI tests cover canonical server cleanup, explicit-server paths, and OpenCode default-model selection.
