### PR TITLE
Narrow validated server request fields

### DIFF
--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -744,7 +744,7 @@ def parse_sandbox_config(raw: object) -> ManagedSandboxConfig | None:
     if not isinstance(raw, dict):
         raise ValueError("server config 'sandbox' must be a mapping")
     provider = raw.get("provider")
-    if provider not in SUPPORTED_SANDBOX_PROVIDERS:
+    if not isinstance(provider, str) or provider not in SUPPORTED_SANDBOX_PROVIDERS:
         supported = ", ".join(sorted(SUPPORTED_SANDBOX_PROVIDERS))
         raise ValueError(
             f"server config 'sandbox.provider' must be one of: {supported} (got {provider!r})"

--- a/omnigent/server/routes/_codex_elicitation.py
+++ b/omnigent/server/routes/_codex_elicitation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from omnigent.codex_native_elicitation import is_codex_request_id
 from omnigent.errors import ErrorCode, OmnigentError
@@ -81,7 +81,7 @@ def parse_codex_elicitation_request(payload: dict[str, Any]) -> CodexElicitation
     """
     method = payload.get("method")
     params = payload.get("params")
-    request_id = payload.get("id")
+    request_id: object = payload.get("id")
     if not isinstance(method, str) or not method:
         raise OmnigentError(
             "Codex elicitation request must include a non-empty method string.",
@@ -97,6 +97,7 @@ def parse_codex_elicitation_request(payload: dict[str, Any]) -> CodexElicitation
             "Codex elicitation request must include a string or integer id.",
             code=ErrorCode.INVALID_INPUT,
         )
+    typed_request_id = cast(int | str, request_id)
     adapter = _CODEX_ELICITATION_ADAPTERS.get(method)
     if adapter is None:
         raise OmnigentError(
@@ -104,9 +105,9 @@ def parse_codex_elicitation_request(payload: dict[str, Any]) -> CodexElicitation
             code=ErrorCode.INVALID_INPUT,
         )
     return CodexElicitationRequest(
-        params=adapter.build_params(request_id, method, params),
+        params=adapter.build_params(typed_request_id, method, params),
         method=method,
-        request_id=request_id,
+        request_id=typed_request_id,
         codex_params=params,
         response_builder=adapter.build_response,
     )


### PR DESCRIPTION
## Related issue

Relates to #3644

## Summary

- Require sandbox providers to be strings before dispatching provider-specific configuration.
- Bind validated Codex elicitation request IDs to their concrete JSON-RPC type.
- Remove two Pyrefly errors at server input boundaries without changing valid-request behavior.

## Test Plan

- `uvx pyrefly check omnigent` (**21 errors**, down from the 23-error `main` baseline)
- `.venv/bin/pytest tests/server/routes/test_codex_elicitation.py tests/server/test_managed_hosts.py -k 'parse_non_modal_provider_yields_rejecting_factory or parse_invalid_config_fails_loud or missing_id or valid_mcp_form_request or valid_command_approval'` (49 passed)
- `SKIP=normalize-uv-lock-registry pre-commit run`

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing parser tests cover valid and invalid sandbox providers plus valid and missing Codex request IDs.
