### PR TITLE
Clarify executor cleanup lifecycles

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -1239,12 +1239,12 @@ def prepare_tight_cli_process_path(
             exc,
         )
         return real_cli_path
-
-    if not sandbox.active:
-        return real_cli_path
-    sandbox = with_additional_write_roots(sandbox, _claude_internal_write_roots())
-    sandbox = with_additional_write_files(sandbox, _claude_internal_write_files())
-    return create_exec_launcher(real_cli_path, sandbox)
+    else:
+        if not sandbox.active:
+            return real_cli_path
+        sandbox = with_additional_write_roots(sandbox, _claude_internal_write_roots())
+        sandbox = with_additional_write_files(sandbox, _claude_internal_write_files())
+        return create_exec_launcher(real_cli_path, sandbox)
 
 
 @dataclass(frozen=True)

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -1433,10 +1433,8 @@ class _CodexAppServerSession:
         if stdin is not None:
             with suppress(Exception):
                 stdin.close()
-            wait_closed = getattr(stdin, "wait_closed", None)
-            if callable(wait_closed):
-                with suppress(Exception):
-                    await wait_closed()
+            with suppress(Exception):
+                await stdin.wait_closed()
         for task in (self._reader_task, self._stderr_task):
             if task is not None:
                 task.cancel()


### PR DESCRIPTION
## Related issue

Relates to #3644

## Summary

- Keep tight Claude CLI sandbox handling inside the successful resolution branch.
- Await the typed Codex subprocess stdin close method directly.
- Remove two Pyrefly lifecycle errors while preserving cleanup behavior.

## Test Plan

- `uvx pyrefly check omnigent` (**21 errors**, down from the 23-error `main` baseline)
- `.venv/bin/pytest tests/inner/test_codex_executor.py::TestCodexExecutor::test_close_uses_process_tree_termination tests/inner/test_claude_sdk_executor.py::test_prepare_tight_cli_process_path_bypasses_wrapper_when_env_set` (2 passed)
- `SKIP=normalize-uv-lock-registry pre-commit run`

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing tests cover Codex process cleanup and the tight Claude CLI sandbox bypass path.
