### PR TITLE
Type default policy phases explicitly

### DIFF
--- a/omnigent/inner/policies.py
+++ b/omnigent/inner/policies.py
@@ -56,6 +56,11 @@ PolicyCallableResult: TypeAlias = object
 # ``{"action": str, "reason": str|None, "set_labels": dict}`` but values
 # arrive from LLM output, so we keep them open and narrow field-by-field.
 PolicyResponsePayload: TypeAlias = dict[str, object]
+PolicyPhase: TypeAlias = Literal["request", "response", "tool_call", "tool_result"]
+
+
+def _default_policy_phases() -> list[PolicyPhase]:
+    return ["request", "response"]
 
 
 class _LabelRule(Protocol):
@@ -121,9 +126,7 @@ class Policy:
     # (rare — most paths pass a name from the YAML loader or a test).
     # Error messages and executor IDs fall back to ``"<unnamed>"``.
     name: str | None = None
-    on: list[Literal["request", "response", "tool_call", "tool_result"]] = field(
-        default_factory=lambda: ["request", "response"]
-    )
+    on: list[PolicyPhase] = field(default_factory=_default_policy_phases)
     _runtime_context: PolicyRuntimeContext | None = field(
         default=None,
         init=False,


### PR DESCRIPTION
## Related issue

Relates to #3644

## Summary

- Name the supported policy-phase literal type.
- Build the default request/response phase list through a typed factory.
- Remove one Pyrefly inference error without changing policy defaults.

## Test Plan

- `uvx pyrefly check omnigent` (**22 errors**, down from the 23-error `main` baseline)
- `.venv/bin/pytest tests/inner/test_policies.py` (21 passed)
- `SKIP=normalize-uv-lock-registry pre-commit run`

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing policy suite exercises default and explicit policy phases across policy implementations.
