### PR TITLE
Type Pi model catalog entries explicitly

### DIFF
--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -251,6 +251,7 @@ class PiProviderConfig:
 
     def to_models_config(self) -> _PiModelsConfig:
         """Render this provider as a Pi ``models.json`` mapping."""
+        models: list[_PiModelEntry]
         if self.extra_models:
             # Include all known models, ensuring the selected model is present.
             # The selected model may be a newer id not yet in the static list.


### PR DESCRIPTION
## Related issue

Relates to #3644

## Summary

- Declare the rendered Pi model list as the existing `_PiModelEntry` TypedDict collection.
- Keep both single-model and expanded-catalog branches under the same provider payload contract.
- Remove one Pyrefly inference error without changing generated `models.json`.

## Test Plan

- `uvx pyrefly check omnigent` (**22 errors**, down from the 23-error `main` baseline)
- `.venv/bin/pytest tests/test_pi_native_credentials.py` (54 passed)
- `SKIP=normalize-uv-lock-registry pre-commit run`

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The Pi credential suite verifies generated provider/model payloads for single-model, expanded, and multi-provider configurations.
