### PR TITLE
Type model-backed event snapshots

### DIFF
--- a/omnigent/repl/_event_tape.py
+++ b/omnigent/repl/_event_tape.py
@@ -19,7 +19,7 @@ import pathlib
 import time
 from collections import deque
 from dataclasses import dataclass
-from typing import TextIO
+from typing import Protocol, TextIO, runtime_checkable
 
 from rich.console import Group, RenderableType
 from rich.text import Text
@@ -41,6 +41,11 @@ _GAP_THRESHOLD_MS = 1000.0
 # panel is the primary inspection surface.
 _DETAIL_PAYLOAD_MAX_CHARS = 500
 _DETAIL_PAYLOAD_MAX_LINES = 60
+
+
+@runtime_checkable
+class _ModelDumpEvent(Protocol):
+    def model_dump(self) -> dict[str, object]: ...
 
 
 # ── Stage enumeration ─────────────────────────────────────────────────
@@ -83,10 +88,9 @@ def _snapshot_event(event: object) -> dict[str, object] | None:
     :returns: A dict of the event's fields, or ``None`` on failure.
     """
     # Pydantic models (server-side events).
-    model_dump = getattr(event, "model_dump", None)
-    if model_dump is not None and callable(model_dump):
+    if isinstance(event, _ModelDumpEvent):
         try:
-            return model_dump()
+            return event.model_dump()
         except Exception:  # noqa: BLE001 — best-effort snapshot
             pass
 

--- a/tests/repl/test_event_tape.py
+++ b/tests/repl/test_event_tape.py
@@ -678,6 +678,16 @@ def test_full_pipeline_walkthrough() -> None:
 # ── _snapshot_event ────────────────────────────────────────────────────
 
 
+def test_snapshot_event_model_dump() -> None:
+    """Model-backed events are captured through ``model_dump``."""
+
+    class _ModelEvent:
+        def model_dump(self) -> dict[str, object]:
+            return {"status": "complete", "sequence": 3}
+
+    assert _snapshot_event(_ModelEvent()) == {"status": "complete", "sequence": 3}
+
+
 def test_snapshot_event_dataclass() -> None:
     """Dataclass events are captured via ``dataclasses.asdict``."""
     event = _FakeTextDelta(delta="hello world")


### PR DESCRIPTION
## Related issue

Relates to #3644

## Summary

- Represent model-backed debug events with a runtime-checkable `model_dump` protocol.
- Snapshot model payloads through the typed protocol instead of dynamic attribute lookup.
- Add direct coverage for the model-backed snapshot path and remove one Pyrefly error.

## Test Plan

- `uvx pyrefly check omnigent` (**22 errors**, down from the 23-error `main` baseline)
- `.venv/bin/pytest tests/repl/test_event_tape.py` (42 passed)
- `SKIP=normalize-uv-lock-registry pre-commit run`

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added direct coverage for the previously untested `model_dump()` snapshot branch.
