### PR TITLE
Type native terminal close metadata

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -136,6 +136,12 @@ _SignalHandler: TypeAlias = (
 class _WebSocketClient(Protocol):
     """WebSocket operations used by the native terminal bridge."""
 
+    @property
+    def close_code(self) -> int | None: ...
+
+    @property
+    def close_reason(self) -> str | None: ...
+
     def __aiter__(self) -> AsyncIterator[str | bytes]: ...
 
     async def close(self, code: int = 1000, reason: str = "") -> None: ...
@@ -4935,10 +4941,10 @@ async def _websocket_to_stdout(ws: _WebSocketClient, stdout_fd: int) -> None:
         if isinstance(message, str):
             continue
         await asyncio.to_thread(os.write, stdout_fd, bytes(message))
-    close_code = getattr(ws, "close_code", None)
+    close_code = ws.close_code
     if close_code == WS_CLOSE_TERMINAL_NOT_FOUND:
         raise ConnectionClosedError(
-            Close(close_code, getattr(ws, "close_reason", None) or ""),
+            Close(WS_CLOSE_TERMINAL_NOT_FOUND, ws.close_reason or ""),
             None,
         )
 


### PR DESCRIPTION
## Related issue

Relates to #3644

## Summary

- Add close code and reason metadata to the native terminal WebSocket protocol.
- Use the typed metadata when surfacing terminal-not-found closures.
- Remove one Pyrefly error without changing reconnect behavior.

## Test Plan

- `uvx pyrefly check omnigent` (**22 errors**, down from the 23-error `main` baseline)
- `.venv/bin/pytest tests/test_claude_native.py -k 'attach_exits_on_real_websocket_close_with_4404 or websocket_to_stdout'` (2 passed)
- `SKIP=normalize-uv-lock-registry pre-commit run`

## Demo

N/A — non-visual type cleanup.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing tests cover real 4404 terminal closures and normal binary-frame output.
