### PR TITLE
perf(package): resolve omnigent re-exports lazily instead of at import

### DIFF
--- a/omnigent/__init__.py
+++ b/omnigent/__init__.py
@@ -29,72 +29,152 @@ from omnigent._env_compat import mirror_legacy_env as _mirror_legacy_env  # noqa
 
 _mirror_legacy_env()
 
-from omnigent.inner.datamodel import (  # noqa: E402 — must follow md5 patch
-    AgentDef,
-    Connection,
-    Credentials,
-    History,
-    Memory,
-    MemoryConfig,
-    Message,
-    ParamDef,
-    SessionState,
-)
-from omnigent.inner.executor import (  # noqa: E402 — must follow md5 patch
-    Executor,
-    ExecutorConfig,
-    ExecutorError,
-    ExecutorEvent,
-    TextChunk,
-    ToolCallComplete,
-    ToolCallRequest,
-    TurnCancelled,
-    TurnComplete,
-)
-from omnigent.inner.policies import (  # noqa: E402 — must follow md5 patch
-    FunctionPolicy,
-    Policy,
-    PolicyAction,
-    PolicyResult,
-    PromptPolicy,
-)
-from omnigent.inner.tools import (  # noqa: E402 — must follow md5 patch
-    AgentTool,
-    CancellableFunctionTool,
-    FunctionTool,
-    HandoffTool,
-    InheritedTool,
-    MCPTool,
-    SkillTool,
-    Tool,
-)
+from typing import TYPE_CHECKING  # noqa: E402
 
-try:
-    from omnigent.inner.databricks_executor import DatabricksExecutor
-except (OSError, ImportError):
-    DatabricksExecutor = None  # type: ignore[misc,assignment]
-try:
+# Re-exports resolve on first access (PEP 562) instead of at import. Importing
+# this package eagerly pulled the executor / model-catalog / provider-config
+# chain — roughly 700ms — which every short-lived policy-hook subprocess paid at
+# startup while using none of it. The md5 patch and env mirror above stay eager,
+# so the "patch before any dependency import" ordering they require is unchanged
+# (dependencies now load strictly later, never earlier).
+_LAZY_EXPORTS = {
+    "AgentDef": "omnigent.inner.datamodel",
+    "Connection": "omnigent.inner.datamodel",
+    "Credentials": "omnigent.inner.datamodel",
+    "History": "omnigent.inner.datamodel",
+    "Memory": "omnigent.inner.datamodel",
+    "MemoryConfig": "omnigent.inner.datamodel",
+    "Message": "omnigent.inner.datamodel",
+    "ParamDef": "omnigent.inner.datamodel",
+    "SessionState": "omnigent.inner.datamodel",
+    "Executor": "omnigent.inner.executor",
+    "ExecutorConfig": "omnigent.inner.executor",
+    "ExecutorError": "omnigent.inner.executor",
+    "ExecutorEvent": "omnigent.inner.executor",
+    "TextChunk": "omnigent.inner.executor",
+    "ToolCallComplete": "omnigent.inner.executor",
+    "ToolCallRequest": "omnigent.inner.executor",
+    "TurnCancelled": "omnigent.inner.executor",
+    "TurnComplete": "omnigent.inner.executor",
+    "FunctionPolicy": "omnigent.inner.policies",
+    "Policy": "omnigent.inner.policies",
+    "PolicyAction": "omnigent.inner.policies",
+    "PolicyResult": "omnigent.inner.policies",
+    "PromptPolicy": "omnigent.inner.policies",
+    "AgentTool": "omnigent.inner.tools",
+    "CancellableFunctionTool": "omnigent.inner.tools",
+    "FunctionTool": "omnigent.inner.tools",
+    "HandoffTool": "omnigent.inner.tools",
+    "InheritedTool": "omnigent.inner.tools",
+    "MCPTool": "omnigent.inner.tools",
+    "SkillTool": "omnigent.inner.tools",
+    "Tool": "omnigent.inner.tools",
+    "load_agent_def": "omnigent.inner.loader",
+    "disable_tracing": "omnigent.inner.tracing",
+    "enable_tracing": "omnigent.inner.tracing",
+    "is_tracing_enabled": "omnigent.inner.tracing",
+}
+
+# Executors whose extras may be absent. The eager form wrapped each import in
+# ``try/except`` and fell back to ``None``; missing extras must keep degrading
+# gracefully rather than raising at attribute access.
+_OPTIONAL_EXPORTS = {
+    "DatabricksExecutor": ("omnigent.inner.databricks_executor", (OSError, ImportError)),
+    "ClaudeSDKExecutor": ("omnigent.inner.claude_sdk_executor", (ImportError,)),
+    "OpenResponsesExecutor": ("omnigent.inner.open_responses_sdk", (ImportError,)),
+    "OpenAIAgentsSDKExecutor": ("omnigent.inner.openai_agents_sdk_executor", (ImportError,)),
+    "CodexExecutor": ("omnigent.inner.codex_executor", (ImportError,)),
+}
+
+if TYPE_CHECKING:
+    # Static analysers cannot see ``__getattr__``-provided names; re-declare the
+    # re-exports so type checking and IDE completion behave as before.
     from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
-except ImportError:
-    ClaudeSDKExecutor = None  # type: ignore[misc,assignment]
-try:
-    from omnigent.inner.open_responses_sdk import OpenResponsesExecutor
-except ImportError:
-    OpenResponsesExecutor = None  # type: ignore[misc,assignment]
-try:
-    from omnigent.inner.openai_agents_sdk_executor import OpenAIAgentsSDKExecutor
-except ImportError:
-    OpenAIAgentsSDKExecutor = None  # type: ignore[misc,assignment]
-try:
     from omnigent.inner.codex_executor import CodexExecutor
-except ImportError:
-    CodexExecutor = None  # type: ignore[misc,assignment]
-from omnigent.inner.loader import load_agent_def  # noqa: E402 — must follow md5 patch
-from omnigent.inner.tracing import (  # noqa: E402 — must follow md5 patch
-    disable_tracing,
-    enable_tracing,
-    is_tracing_enabled,
-)
+    from omnigent.inner.databricks_executor import DatabricksExecutor
+    from omnigent.inner.datamodel import (
+        AgentDef,
+        Connection,
+        Credentials,
+        History,
+        Memory,
+        MemoryConfig,
+        Message,
+        ParamDef,
+        SessionState,
+    )
+    from omnigent.inner.executor import (
+        Executor,
+        ExecutorConfig,
+        ExecutorError,
+        ExecutorEvent,
+        TextChunk,
+        ToolCallComplete,
+        ToolCallRequest,
+        TurnCancelled,
+        TurnComplete,
+    )
+    from omnigent.inner.loader import load_agent_def
+    from omnigent.inner.open_responses_sdk import OpenResponsesExecutor
+    from omnigent.inner.openai_agents_sdk_executor import OpenAIAgentsSDKExecutor
+    from omnigent.inner.policies import (
+        FunctionPolicy,
+        Policy,
+        PolicyAction,
+        PolicyResult,
+        PromptPolicy,
+    )
+    from omnigent.inner.tools import (
+        AgentTool,
+        CancellableFunctionTool,
+        FunctionTool,
+        HandoffTool,
+        InheritedTool,
+        MCPTool,
+        SkillTool,
+        Tool,
+    )
+    from omnigent.inner.tracing import disable_tracing, enable_tracing, is_tracing_enabled
+
+
+def __getattr__(name: str) -> object:
+    """
+    Resolve a re-exported name on first access.
+
+    :param name: Attribute requested from the ``omnigent`` package.
+    :returns: The re-exported object, or ``None`` for an optional executor
+        whose extra is not installed.
+    :raises AttributeError: If *name* is not a documented re-export.
+    """
+    import importlib
+
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is not None:
+        value = getattr(importlib.import_module(module_name), name)
+        globals()[name] = value
+        return value
+
+    optional = _OPTIONAL_EXPORTS.get(name)
+    if optional is not None:
+        module_name, errors = optional
+        try:
+            value = getattr(importlib.import_module(module_name), name)
+        except (*errors, AttributeError):
+            value = None
+        globals()[name] = value
+        return value
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """
+    List the package's public names, including lazily-resolved re-exports.
+
+    :returns: Sorted public attribute names.
+    """
+    return sorted(set(__all__) | set(globals()))
+
 
 __all__ = [
     "AgentDef",


### PR DESCRIPTION
## Related issue

N/A

## Summary

`omnigent/__init__.py` eagerly imported the executor, policy, tool and loader graph, which transitively pulls `databricks_executor`, `model_catalog`, `model_fallbacks`, `onboarding.provider_config` and `spec.parser`. Every process that touched the package paid that at startup whether or not it used any of it.

The cost lands hardest on short-lived processes. Native-harness policy hooks spawn a fresh interpreter per `PreToolUse` / `PostToolUse` / `UserPromptSubmit` event, and `claude_native_status` spawns one on every status-line render. The runner, harness workers and CLI pay it once each.

This resolves the re-exports on first access (PEP 562 `__getattr__`) rather than at import. Same public surface, same objects; they just load when first touched.

**ELI5:** the package used to unpack every box on arrival in case you wanted something. Now it unpacks a box when you ask for it.

```
before:  import omnigent ──► datamodel, executor, policies, tools, loader, tracing
                             └► databricks_executor ─► model_catalog ─► spec.parser

after:   import omnigent ──► md5 patch + env mirror        (eager, unchanged)
                             └► everything else on first attribute access
```

Measured on one machine with the same method both sides (`python -X importtime`, cumulative, 5-run medians):

| | before | after |
|---|---|---|
| `import omnigent` | 1084 ms | **8.2 ms** |

Two things stay eager deliberately, because ordering depends on them: the FIPS `hashlib.md5` patch and `mirror_legacy_env()`. Their comments require running before any dependency import, and deferring the submodules strengthens that guarantee, since dependencies now load strictly later rather than earlier.

## Test Plan

```bash
uv run --frozen pytest tests/inner tests/tools tests/spec
```

3187 passed on this branch. The 5 failures in `tests/tools/test_manager.py` and the 2 collection errors in `tests/inner/test_databricks_executor.py` / `test_openai_agents_sdk_executor.py` are pre-existing and environmental — they reproduce identically with upstream's eager `__init__.py` in the same venv (the errors are `ModuleNotFoundError: No module named 'databricks'`, a missing optional extra).

Beyond the suite, equivalence was verified directly rather than assumed:

- Snapshotted all 40 `__all__` names from upstream's **eager** package (type, `__module__`, `__qualname__`), then asserted the lazy package produces an identical snapshot: none missing, none extra, none mismatched.
- FIPS md5 patch still applied at `import omnigent`.
- `from omnigent import Executor, Tool, load_agent_def` works.
- A missing optional extra still degrades to `None` rather than raising `ImportError` (verified under `python -S` with extras absent, where the fallback actually fires).
- Unknown attributes still raise `AttributeError`; `dir()` still covers `__all__`.
- 24 threads resolving 6 lazy attributes concurrently: no errors, stable identity.
- No `from omnigent import *` exists in the repo, so nothing silently re-eagerises the package.
- No import-time registration in the deferred modules (checked `tools`, `executor`, `policies`), which would have been the dangerous case.
- `mypy` passes; the `if TYPE_CHECKING:` block keeps every name visible to type checkers.

## Demo

N/A — no user-visible surface change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

No new tests. The change is behaviour-preserving by construction and the existing suite exercises these re-exports heavily: if any name failed to resolve, or resolved to a different object, large parts of the suite would fail rather than one targeted test.

What the suite does not guard is the laziness itself. Nothing fails if someone later re-adds an eager import to `__init__.py` and silently reverts the win. Happy to add a regression test asserting `import omnigent` leaves `omnigent.inner.executor` out of `sys.modules` if you would like that guard.

The optional-executor `None` fallback cannot fire in normal CI because all extras are installed; it was verified separately under `python -S` with extras absent.

## Changelog

Importing `omnigent` no longer loads the executor and model-catalog graph, cutting process startup time
