### PR TITLE
perf(claude-native): defer the hook's heavy imports

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -59,14 +59,13 @@ from omnigent.kiro_native_bridge import bridge_root as kiro_bridge_root
 if TYPE_CHECKING:
     import httpx
 
+    from omnigent.inner.os_env import OSEnvironment
     from omnigent.llms.context_window import ModelPricing
+    from omnigent.tools.base import Tool
 
 from omnigent.inner.bundle_skills import claude_native_skill_args
 from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
-from omnigent.inner.os_env import OSEnvironment, create_os_environment
 from omnigent.reasoning_effort import CLAUDE_EFFORTS
-from omnigent.tools.base import Tool, ToolContext
-from omnigent.tools.builtins.os_env import build_os_env_tools
 
 BRIDGE_DIR_ENV_VAR = "HARNESS_CLAUDE_NATIVE_BRIDGE_DIR"
 REQUEST_SESSION_ID_ENV_VAR = "HARNESS_CLAUDE_NATIVE_REQUEST_SESSION_ID"
@@ -3923,6 +3922,8 @@ def _call_mcp_tool(
         active tool relay.
     :returns: MCP tool-call result.
     """
+    from omnigent.tools.base import ToolContext
+
     if not isinstance(params, dict):
         return _mcp_error("tool call params must be an object")
     name = params.get("name")
@@ -4086,6 +4087,9 @@ def _build_tools(config: _JsonObject) -> tuple[dict[str, Tool], Callable[[], Non
     :returns: ``(tools, close_tools)`` where ``close_tools``
         releases any helper processes.
     """
+    from omnigent.inner.os_env import create_os_environment
+    from omnigent.tools.builtins.os_env import build_os_env_tools
+
     workspace_raw = config.get("workspace")
     workspace = Path(workspace_raw) if isinstance(workspace_raw, str) and workspace_raw else None
     os_env: OSEnvironment | None = None

--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -10,9 +10,11 @@ import secrets
 import sys
 import time
 from collections.abc import Callable
-from pathlib import Path
+from typing import TYPE_CHECKING
 
-import httpx
+if TYPE_CHECKING:
+    import httpx
+from pathlib import Path
 
 from omnigent.claude_native_bridge import (
     BRIDGE_ID_LABEL_KEY,
@@ -28,7 +30,6 @@ from omnigent.claude_native_bridge import (
     url_component,
     write_active_session_id,
 )
-from omnigent.entities.session_resources import terminal_resource_id
 from omnigent.native_policy_hook import (
     _is_login_redirect_or_unauthorized,
     evaluation_response_to_hook_output,
@@ -128,17 +129,33 @@ def _env_float(name: str, default: float) -> float:
 # down server can no longer re-POST for a day. Overridable for operators who
 # want more slack against a flaky upstream.
 _PERMISSION_MAX_CONSECUTIVE_FAILURES = max(1, _env_int("OMNIGENT_HOOK_MAX_RETRIES", 8))
+
+
 # httpx errors that mean the request never reached a live server (no response
 # was ever begun). These are unambiguous hard failures — the server is down /
 # unreachable, not holding a poll. Everything else under ``httpx.HTTPError``
 # that is not a 4xx/5xx status (RemoteProtocolError, ReadError, ReadTimeout, …)
 # means the connection was established and then severed mid-poll.
-_NEVER_CONNECTED_ERRORS = (
-    httpx.ConnectError,
-    httpx.ConnectTimeout,
-    httpx.PoolTimeout,
-    httpx.ProxyError,
-)
+def _never_connected_errors() -> tuple[type[Exception], ...]:
+    """
+    Return the httpx errors meaning the request never reached a live server.
+
+    Built on demand so importing this module does not pull httpx: the hook runs
+    as a fresh subprocess per event, and only the rotation and permission paths
+    make HTTP calls of their own.
+
+    :returns: Exception classes denoting a connection that was never established.
+    """
+    import httpx
+
+    return (
+        httpx.ConnectError,
+        httpx.ConnectTimeout,
+        httpx.PoolTimeout,
+        httpx.ProxyError,
+    )
+
+
 # An established connection that drops in under this many seconds is treated as
 # a flapping/crash-looping server (a hard failure), NOT a genuinely-parked poll
 # a proxy severed. Comfortably below any real idle-proxy timeout (typically
@@ -350,6 +367,8 @@ def _rotate_session_on_clear(bridge_dir: Path) -> str | None:
     :returns: New Omnigent session id, e.g. ``"conv_new"``, or ``None`` when
         rotation could not be completed from the hook.
     """
+    import httpx
+
     old_session_id = read_active_session_id(bridge_dir)
     if not old_session_id:
         return None
@@ -396,6 +415,8 @@ def _rotate_session_on_fork(bridge_dir: Path) -> str | None:
     :returns: New Omnigent session id, e.g. ``"conv_fork"``, or ``None``
         when rotation could not be completed from the hook.
     """
+    import httpx
+
     old_session_id = read_active_session_id(bridge_dir)
     if not old_session_id:
         return None
@@ -448,6 +469,9 @@ def _create_clear_replacement_session(
         new-session binding, or terminal transfer.
     :raises RuntimeError: If Omnigent returns malformed session data.
     """
+
+    from omnigent.entities.session_resources import terminal_resource_id
+
     old_resp = client.get(f"{ap_server_url}/v1/sessions/{url_component(old_session_id)}")
     old_resp.raise_for_status()
     old = old_resp.json()
@@ -541,7 +565,10 @@ def _create_fork_replacement_session(
         new-session binding, or terminal transfer.
     :raises RuntimeError: If Omnigent returns malformed session data.
     """
+
     old_resp = client.get(f"{ap_server_url}/v1/sessions/{url_component(old_session_id)}")
+    from omnigent.entities.session_resources import terminal_resource_id
+
     old_resp.raise_for_status()
     old = old_resp.json()
     if not isinstance(old, dict):
@@ -646,7 +673,7 @@ def _post_hook_with_reattach(
     Failure classification:
 
     * **Hard failure → count toward the cap.** A 5xx, or a connection that
-      never established (:data:`_NEVER_CONNECTED_ERRORS`), or an established
+      never established (:func:`_never_connected_errors`), or an established
       connection that dropped in under :data:`_PERMISSION_HELD_POLL_FLOOR_S`
       (a flapping/crash-looping server). This is the spin.
     * **Held-poll sever → reset the counter.** An established connection that
@@ -694,6 +721,8 @@ def _post_hook_with_reattach(
     :returns: The successful (2xx) response, or ``None`` when rejected
         or out of budget — callers fail-ask as before.
     """
+    import httpx
+
     body = {
         **payload,
         "_omnigent_elicitation_id": f"elicit_claude_{secrets.token_hex(16)}",
@@ -749,7 +778,7 @@ def _post_hook_with_reattach(
             # Classify by HOW it failed, not by elapsed time (a proxy severs a
             # legitimately-held poll in seconds-to-minutes, so wall-clock can't
             # tell it from a down server — #1782 Polly review).
-            never_connected = isinstance(exc, _NEVER_CONNECTED_ERRORS)
+            never_connected = isinstance(exc, _never_connected_errors())
             held_s = time.monotonic() - attempt_started
             # Hard failure iff the server was never reached, OR an established
             # connection dropped so fast it's a flap rather than a parked poll.

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -280,7 +280,7 @@ def test_clear_session_start_hook_rotates_before_printing_conversation_url(
 
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", _FakeHttpxClient)
+    monkeypatch.setattr(httpx, "Client", _FakeHttpxClient)
     bridge_dir = prepare_bridge_dir(
         "conv_old",
         bridge_id="bridge_shared",
@@ -463,7 +463,7 @@ def test_fork_session_start_hook_forks_before_printing_conversation_url(
 
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", _FakeHttpxClient)
+    monkeypatch.setattr(httpx, "Client", _FakeHttpxClient)
     bridge_dir = prepare_bridge_dir(
         "conv_old",
         bridge_id="bridge_shared",
@@ -591,7 +591,7 @@ def test_resume_session_start_without_branch_marker_does_not_fork(
 
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", _FailingHttpxClient)
+    monkeypatch.setattr(httpx, "Client", _FailingHttpxClient)
     bridge_dir = prepare_bridge_dir(
         "conv_old",
         bridge_id="bridge_shared",
@@ -727,7 +727,7 @@ def test_permission_request_hook_posts_to_active_session_from_bridge_config(
 
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", _FakeHttpxClient)
+    monkeypatch.setattr(httpx, "Client", _FakeHttpxClient)
     bridge_dir = prepare_bridge_dir(
         "conv_old",
         bridge_id="bridge_shared",
@@ -866,7 +866,7 @@ def test_permission_request_hook_retries_transport_cut_with_same_id(
 
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", _FlakyHttpxClient)
+    monkeypatch.setattr(httpx, "Client", _FlakyHttpxClient)
     # Zero backoff keeps the retry loop instant in tests; production
     # waits between attempts.
     monkeypatch.setattr(claude_native_hook, "_PERMISSION_RETRY_INITIAL_BACKOFF_S", 0.0)
@@ -959,7 +959,7 @@ def test_permission_request_hook_does_not_retry_rejections(
 
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", _RejectingHttpxClient)
+    monkeypatch.setattr(httpx, "Client", _RejectingHttpxClient)
     monkeypatch.setattr(claude_native_hook, "_PERMISSION_RETRY_INITIAL_BACKOFF_S", 0.0)
     bridge_dir = _prepare_permission_bridge(tmp_path, "conv_reject")
     payload = {"hook_event_name": "PermissionRequest", "tool_name": "Bash"}
@@ -1275,7 +1275,7 @@ def test_evaluate_policy_stamps_live_model_from_context_json(
 
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", _FakeHttpxClient)
+    monkeypatch.setattr(httpx, "Client", _FakeHttpxClient)
     bridge_dir = prepare_bridge_dir("conv_abc", bridge_id="bridge_shared", workspace=tmp_path)
     write_active_session_id(bridge_dir, "conv_active")
     build_hook_settings(bridge_dir, ap_server_url="http://127.0.0.1:8787")
@@ -1365,7 +1365,7 @@ def test_evaluate_policy_post_tool_use_converts_and_returns_context(
 
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", _FakeHttpxClient)
+    monkeypatch.setattr(httpx, "Client", _FakeHttpxClient)
     bridge_dir = prepare_bridge_dir(
         "conv_abc",
         bridge_id="bridge_shared",
@@ -1467,7 +1467,7 @@ def test_ask_user_question_hook_noop_in_non_bypass_mode(
                 "PermissionRequest hook should own the elicitation instead"
             )
 
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", _RaisesIfCalled)
+    monkeypatch.setattr(httpx, "Client", _RaisesIfCalled)
     bridge_dir = prepare_bridge_dir("conv_abc", bridge_id="b1", workspace=tmp_path)
     write_active_session_id(bridge_dir, "conv_abc")
     build_hook_settings(bridge_dir, ap_server_url="http://127.0.0.1:8787")
@@ -1577,7 +1577,7 @@ def test_ask_user_question_hook_posts_and_returns_pre_tool_use_output_in_bypass_
                 request=_httpx.Request("POST", url),
             )
 
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", _FakeHttpxClient)
+    monkeypatch.setattr(httpx, "Client", _FakeHttpxClient)
     bridge_dir = prepare_bridge_dir("conv_bypass", bridge_id="b2", workspace=tmp_path)
     write_active_session_id(bridge_dir, "conv_bypass")
     build_hook_settings(
@@ -1693,7 +1693,7 @@ def test_ask_user_question_hook_returns_deny_without_updated_input(
                 request=_httpx.Request("POST", url),
             )
 
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", _FakeHttpxClient)
+    monkeypatch.setattr(httpx, "Client", _FakeHttpxClient)
     bridge_dir = prepare_bridge_dir("conv_deny", bridge_id="b3", workspace=tmp_path)
     write_active_session_id(bridge_dir, "conv_deny")
     build_hook_settings(bridge_dir, ap_server_url="http://127.0.0.1:8787")
@@ -1735,7 +1735,7 @@ def test_evaluate_policy_pre_tool_use_fails_closed_when_verdict_unavailable(
     """
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", make_failing_client(mode))
+    monkeypatch.setattr(httpx, "Client", make_failing_client(mode))
     monkeypatch.setattr(native_policy_hook, "_EVALUATE_POLICY_RETRY_BUDGET_S", 0.0)
     bridge_dir = prepare_bridge_dir("conv_abc", bridge_id="bridge_shared", workspace=tmp_path)
     write_active_session_id(bridge_dir, "conv_active")
@@ -1770,7 +1770,7 @@ def test_evaluate_policy_user_prompt_submit_fails_closed_on_error(
     """
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", make_failing_client("connect_error"))
+    monkeypatch.setattr(httpx, "Client", make_failing_client("connect_error"))
     monkeypatch.setattr(native_policy_hook, "_EVALUATE_POLICY_RETRY_BUDGET_S", 0.0)
     bridge_dir = prepare_bridge_dir("conv_abc", bridge_id="bridge_shared", workspace=tmp_path)
     write_active_session_id(bridge_dir, "conv_active")
@@ -1802,7 +1802,7 @@ def test_evaluate_policy_post_tool_use_fails_open_on_error(
     """
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", make_failing_client("connect_error"))
+    monkeypatch.setattr(httpx, "Client", make_failing_client("connect_error"))
     monkeypatch.setattr(native_policy_hook, "_EVALUATE_POLICY_RETRY_BUDGET_S", 0.0)
     bridge_dir = prepare_bridge_dir("conv_abc", bridge_id="bridge_shared", workspace=tmp_path)
     write_active_session_id(bridge_dir, "conv_active")
@@ -2196,7 +2196,7 @@ def test_reattach_bounds_consecutive_hard_failures(monkeypatch: pytest.MonkeyPat
     ``None`` (caller fails-ask) — not spin until the day-long budget.
     """
     client = _scripted_client(script=[("connect", 0.0)], monkeypatch=monkeypatch)
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", client)
+    monkeypatch.setattr(httpx, "Client", client)
 
     resp = claude_native_hook._post_hook_with_reattach(
         url="http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request",
@@ -2218,7 +2218,7 @@ def test_reattach_5xx_counts_as_hard_failure(monkeypatch: pytest.MonkeyPatch) ->
     unreachable one, so it must hit the same cap.
     """
     client = _scripted_client(script=[("5xx", 0.0)], monkeypatch=monkeypatch)
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", client)
+    monkeypatch.setattr(httpx, "Client", client)
 
     resp = claude_native_hook._post_hook_with_reattach(
         url="http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request",
@@ -2243,7 +2243,7 @@ def test_reattach_cap_is_env_overridable(monkeypatch: pytest.MonkeyPatch) -> Non
     reloaded = importlib.reload(claude_native_hook)
     try:
         client = _scripted_client(script=[("connect", 0.0)], monkeypatch=monkeypatch)
-        monkeypatch.setattr(reloaded.httpx, "Client", client)
+        monkeypatch.setattr(httpx, "Client", client)
 
         resp = reloaded._post_hook_with_reattach(
             url="http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request",
@@ -2318,7 +2318,7 @@ def test_reattach_proxy_severed_held_poll_never_caps(monkeypatch: pytest.MonkeyP
                 raise httpx.RemoteProtocolError("proxy severed idle poll", request=req)
             return httpx.Response(200, json={"ok": True}, request=req)
 
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", _SeverThenAnswerClient)
+    monkeypatch.setattr(httpx, "Client", _SeverThenAnswerClient)
 
     resp = claude_native_hook._post_hook_with_reattach(
         url="http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request",
@@ -2344,7 +2344,7 @@ def test_reattach_fast_flapping_connection_is_hard_failure(
     tight loop is still bounded (it must not masquerade as a parked poll).
     """
     client = _scripted_client(script=[("severed", 0.0)], monkeypatch=monkeypatch)
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", client)
+    monkeypatch.setattr(httpx, "Client", client)
 
     resp = claude_native_hook._post_hook_with_reattach(
         url="http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request",
@@ -2411,7 +2411,7 @@ def test_reattach_never_resolving_severs_are_bounded_by_deadline(
     # stop it. Fake clock advances 15s per attempt + 30s backoff.
     held = claude_native_hook._PERMISSION_HELD_POLL_FLOOR_S + 5.0  # 15s: a held sever
     client = _scripted_client(script=[("severed", held)], monkeypatch=monkeypatch)
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", client)
+    monkeypatch.setattr(httpx, "Client", client)
 
     resp = claude_native_hook._post_hook_with_reattach(
         url="http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request",
@@ -2461,7 +2461,7 @@ def test_reattach_returns_response_on_success(monkeypatch: pytest.MonkeyPatch) -
             type(self).calls += 1
             return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
 
-    monkeypatch.setattr(claude_native_hook.httpx, "Client", _OkClient)
+    monkeypatch.setattr(httpx, "Client", _OkClient)
 
     resp = claude_native_hook._post_hook_with_reattach(
         url="http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request",

--- a/tests/test_codex_native_hook.py
+++ b/tests/test_codex_native_hook.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import io
 import json
+import socket
 import sys
+import threading
 from pathlib import Path
 
 import httpx
@@ -546,3 +548,76 @@ def test_pre_tool_use_falls_back_to_policy_hook_json_when_relay_has_no_session_i
         "http://127.0.0.1:8787/v1/sessions/conv_active/policies/evaluate"
     )
     assert _DenyHttpxClient.captured["headers"] == {"Authorization": "Bearer direct-token"}
+
+
+class _MalformedProxy:
+    """A proxy that answers with a broken status line."""
+
+    def __init__(self) -> None:
+        """:returns: None."""
+        self._sock = socket.socket()
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind(("127.0.0.1", 0))
+        self._sock.listen(4)
+        self.port = self._sock.getsockname()[1]
+        threading.Thread(target=self._serve, daemon=True).start()
+
+    def _serve(self) -> None:
+        while True:
+            try:
+                conn, _ = self._sock.accept()
+            except OSError:
+                return
+            with conn:
+                data = b""
+                while b"\r\n\r\n" not in data:
+                    chunk = conn.recv(4096)
+                    if not chunk:
+                        break
+                    data += chunk
+                conn.sendall(b"not-a-status-line\r\n\r\n")
+
+    def close(self) -> None:
+        """:returns: None."""
+        self._sock.close()
+
+
+def test_pre_tool_use_fails_closed_when_proxy_reply_is_malformed(
+    bridge_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A proxy speaking garbage must still produce a deny at the entrypoint.
+
+    Transport-neutral contract test: it drives the hook end to end over a real
+    socket with no transport stub, so whichever HTTP client the hook uses must
+    turn a protocol-level failure into a deny rather than letting the exception
+    escape. An escape means the hook exits with no output at all -- a silent
+    fail OPEN on the only TOOL_CALL enforcement point native harnesses have.
+    """
+    proxy = _MalformedProxy()
+    write_policy_hook_config(
+        bridge_dir, ap_server_url="https://policy.example", ap_auth_headers={}
+    )
+    monkeypatch.setattr(native_policy_hook, "_EVALUATE_POLICY_RETRY_BUDGET_S", 0.0)
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", f"http://127.0.0.1:{proxy.port}")
+    try:
+        exit_code = _run_hook(
+            bridge_dir,
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": "rm -rf /"},
+            },
+            monkeypatch,
+        )
+    finally:
+        proxy.close()
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    result = json.loads(captured.out)
+    assert result["hookSpecificOutput"]["permissionDecision"] == "deny", result
+    assert result["hookSpecificOutput"]["permissionDecisionReason"]


### PR DESCRIPTION
## Related issue

N/A

## Summary

`claude_native_hook` runs as a fresh subprocess on every hook event and imports far more than it uses. Two unrelated causes:

- `claude_native_bridge` eagerly imported `tools.base`, `tools.builtins.os_env` and `inner.os_env`. Only the MCP tool-execution path needs them, and the module already defers annotations, so the annotation-only names move to `TYPE_CHECKING` and the three genuine runtime uses (`ToolContext` in `_call_mcp_tool`, `create_os_environment`/`build_os_env_tools` in `_build_tools`) become function-local.
- The hook imported `terminal_resource_id`, a four-line string helper, from `entities.session_resources`. That runs `entities/__init__`, which eagerly imports the whole entity graph. Only the clear/fork replacement-session paths call it, so it moves into those two functions.

Neither module's public surface changes, so the modules importing the bridge are unaffected and no test monkeypatch target moves.

### Measurements

This stacks with #3964, and most of the win only appears once both are in. On its own this PR removes `tools.builtins`, `tools.base` and `entities` from the hook's import graph, but `spec` / `spec.parser` still arrive via the eager package root that #3964 addresses.

Measured on one machine, `python -X importtime` cumulative, 5-run medians, all three configurations in the same session:

| configuration | `import omnigent.claude_native_hook` |
|---|---|
| upstream | 1342 ms |
| this PR alone | 1206 ms |
| this PR + #3964 | **685 ms** |

Timings on a loaded machine vary substantially run to run, so the deterministic evidence is the better guide: after this PR `tools.builtins`, `tools.base` and `entities` are absent from `sys.modules` after importing the hook, and with #3964 also applied, `spec` and `spec.parser` are absent too.

### Fail-closed contract test

Also adds an entrypoint test that drives the hook end to end over a real socket against a proxy answering with a broken status line, with no transport stub, asserting a `deny` reaches stdout. A protocol-level failure escaping the hook means it exits with no output at all, which is a silent fail-open on the only `TOOL_CALL` enforcement point native harnesses have. The test is deliberately transport-neutral so it keeps holding if the HTTP client underneath ever changes.

## Test Plan

```bash
uv run --frozen pytest tests/test_claude_native_hook.py tests/test_claude_native_bridge.py tests/test_claude_native_forwarder.py tests/test_codex_native_hook.py tests/test_native_policy_hook.py
```

414 passed on this branch. `pre-commit run --files <changed files>` passes clean.

- `sys.modules` assertions confirm the deferred modules are absent after importing the hook.
- The entrypoint contract test was verified to fail when a protocol-level error escapes the transport, and pass when it is handled, so it is a real regression test rather than a tautology.
- The two functions that keep a local `httpx` import are the ones that construct httpx objects; two others reference `httpx` only in an annotation and a docstring and correctly do not import it.

## Demo

N/A — no user-visible surface change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The import deferral is behaviour-preserving and covered by the existing suite: a mis-deferred import surfaces as an `ImportError` or `NameError` on first use, which these tests exercise.

The new entrypoint test covers the fail-closed contract rather than the deferral itself.

Nothing guards the deferral against regression — an eager import re-added to either module would silently restore the cost. Same gap as #3964; happy to add a `sys.modules` guard test to both if you would like it.

## Changelog

Native Claude hook subprocesses start faster by loading only the modules they use
