### PR TITLE
refactor: resolve remaining REPL type errors

### DIFF
--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -3672,12 +3672,12 @@ async def run_repl(
                         if isinstance(call_id, str) and name is not None:
                             call_id_to_tool_metadata[call_id] = (name, arguments or {})
                     if tape_entry is not None:
-                        captured: list[object] = []
+                        captured: list[FormattedItem | None] = []
                         original_output = host.output
 
-                        def _capturing_output(it: object) -> None:
-                            captured.append(it)
-                            original_output(it)
+                        def _capturing_output(item: FormattedItem | None) -> None:
+                            captured.append(item)
+                            original_output(item)
 
                         host.output = _capturing_output
                         try:
@@ -4107,9 +4107,11 @@ async def run_repl(
     # Warp) and prompt-toolkit binds it cleanly.
     from omnigent_ui_sdk import Overlay
 
-    async def _overview_builder(target: OverlayTarget) -> RenderableType:
+    async def _overview_builder(target: OverlayTarget | None) -> RenderableType:
         from omnigent.cli_diagnostics import current_cli_log_path
 
+        if target is None:
+            return Text.from_markup("[dim]No debug target available.[/dim]")
         return await _build_debug_overview(
             target,
             client=client,
@@ -5237,10 +5239,9 @@ async def _start_new_conversation(
     """
     from rich.text import Text
 
-    starter = getattr(session, "start_new_conversation", None)
-    if callable(starter):
+    if isinstance(session, _SessionsChatReplAdapter):
         try:
-            await starter()
+            await session.start_new_conversation()
         except Exception as exc:  # noqa: BLE001 — REPL boundary
             _log.exception("New conversation failed")
             host.output(Text.from_markup(f"  [bold red]New conversation failed: {exc}[/]"))
@@ -5445,9 +5446,8 @@ async def _attach_to_conversation(
     # local REPL right away — without this, they only surface after
     # the local user sends a message and triggers the lazy bind.
     # Idempotent: a later ``send()`` short-circuits in ``_ensure_session``.
-    ensure = getattr(session, "_ensure_session", None)
-    if callable(ensure):
-        await ensure()
+    if isinstance(session, _SessionsChatReplAdapter):
+        await session._ensure_session()
 
     items = await _list_all_conversation_items(client, conversation_id)
 
@@ -8286,8 +8286,7 @@ def register_skill_commands(skills: list[SkillSpec]) -> list[str]:
                 host: TerminalHost,
                 fmt: RichBlockFormatter,
             ) -> None:
-                send_skill = getattr(session, "send_skill_slash_command", None)
-                if not callable(send_skill):
+                if not isinstance(session, _SessionsChatReplAdapter):
                     raise RuntimeError("Skill slash commands require the sessions API adapter")
                 if arg:
                     host.output(Text.from_markup(f"  [{fmt.muted}]/{sk.name}[/{fmt.muted}]"))
@@ -8299,7 +8298,7 @@ def register_skill_commands(skills: list[SkillSpec]) -> list[str]:
                     )
                 host.start_timer()
                 await asyncio.sleep(0)
-                async for _ in send_skill(sk.name, arg):
+                async for _ in session.send_skill_slash_command(sk.name, arg):
                     pass
 
             return _skill_handler

--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -2424,7 +2424,7 @@ def test_render_history_item_renders_slash_command_metadata() -> None:
     assert "/grill-me review this plan" in rendered
 
 
-class _StubSkillSession:
+class _StubSkillSession(_SessionsChatReplAdapter):
     """Session stub that records structured skill slash-command sends."""
 
     model = "agent"
@@ -2604,15 +2604,16 @@ async def test_new_command_resets_session_without_clearing_screen(
     )
 
 
-class _StubSessionsModeSession:
+class _StubSessionsModeSession(_SessionsChatReplAdapter):
     """``_StubSession`` plus the async ``start_new_conversation`` hook the
     sessions-mode adapter exposes. Used to assert the slash-command
     handlers prefer the new async method over sync ``reset()``."""
 
+    model = "agent"
+
     def __init__(self, *, raise_on_start: Exception | None = None) -> None:
         self.reset_calls = 0
         self.start_new_calls = 0
-        self.model = "agent"
         self._raise_on_start = raise_on_start
 
     def reset(self) -> None:


### PR DESCRIPTION
## Related issue

Part of #3644

## Summary

- Remove the final six Pyrefly errors in `omnigent/repl/_repl.py` by matching the terminal output callback's exact type, handling an empty overlay target, and narrowing sessions-only lifecycle calls to `_SessionsChatReplAdapter`.
- Update REPL test doubles to model the sessions adapter contract directly.
- Together with #3962, this completes the cleanup phase and brings the expected `omnigent` Pyrefly baseline from 930 errors to zero.

**ELI5:** the REPL supports a legacy session and a newer sessions adapter. This change tells the type checker exactly which path owns the async lifecycle methods instead of discovering them dynamically at runtime.

```text
_ReplSession
├── Session                      → synchronous legacy reset
└── _SessionsChatReplAdapter     → async lifecycle and skill methods
```

### Cleanup series

[#3934](https://github.com/omnigent-ai/omnigent/pull/3934), [#3935](https://github.com/omnigent-ai/omnigent/pull/3935), [#3936](https://github.com/omnigent-ai/omnigent/pull/3936), [#3937](https://github.com/omnigent-ai/omnigent/pull/3937), [#3938](https://github.com/omnigent-ai/omnigent/pull/3938), [#3939](https://github.com/omnigent-ai/omnigent/pull/3939), [#3940](https://github.com/omnigent-ai/omnigent/pull/3940), [#3941](https://github.com/omnigent-ai/omnigent/pull/3941), [#3942](https://github.com/omnigent-ai/omnigent/pull/3942), [#3944](https://github.com/omnigent-ai/omnigent/pull/3944), [#3945](https://github.com/omnigent-ai/omnigent/pull/3945), [#3946](https://github.com/omnigent-ai/omnigent/pull/3946), [#3947](https://github.com/omnigent-ai/omnigent/pull/3947), [#3948](https://github.com/omnigent-ai/omnigent/pull/3948), [#3953](https://github.com/omnigent-ai/omnigent/pull/3953), [#3954](https://github.com/omnigent-ai/omnigent/pull/3954), [#3956](https://github.com/omnigent-ai/omnigent/pull/3956), [#3957](https://github.com/omnigent-ai/omnigent/pull/3957), [#3958](https://github.com/omnigent-ai/omnigent/pull/3958), [#3959](https://github.com/omnigent-ai/omnigent/pull/3959), [#3960](https://github.com/omnigent-ai/omnigent/pull/3960), [#3961](https://github.com/omnigent-ai/omnigent/pull/3961), [#3962](https://github.com/omnigent-ai/omnigent/pull/3962), [#3963](https://github.com/omnigent-ai/omnigent/pull/3963)

## Test Plan

- `uv run pytest tests/repl/test_repl.py -q` — 111 passed.
- `SKIP=normalize-uv-lock-registry pre-commit run` — passed.
- `uvx pyrefly check omnigent` against current `main` plus this change — 0 errors.

## Demo

N/A — type-only refactor with no visual change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing REPL tests cover legacy reset behavior, sessions-adapter lifecycle dispatch, skill slash commands, and error rendering.
