### PR TITLE
fix(host): keep a live host online when a newer tunnel takes over

### DIFF
--- a/omnigent/server/host_registry.py
+++ b/omnigent/server/host_registry.py
@@ -237,6 +237,12 @@ class HostConnection:
         Resolved when the host sends ``host.store_secret_result``. Values carry
         the result fields (``status``, ``configured_harnesses``, ``error``) —
         never the secret. Same ``Any`` typing rationale as ``pending_stats``.
+    :param db_write_lock: Serializes this connection's ``hosts``-row writes.
+        A heartbeat already running in a worker thread cannot be cancelled,
+        so without this it can land after the route's ``set_offline`` and
+        leave a host with no tunnel reading online for a full liveness TTL.
+        A ``threading`` lock, not an asyncio one: it is held in the worker
+        thread that performs the write.
     :param credential_write_lock: Serializes credential writes to this host so
         two overlapping requests (a double-click, or key + gateway in quick
         succession) can't interleave the daemon's non-atomic
@@ -299,6 +305,7 @@ class HostConnection:
     pending_credential_detects: dict[str, asyncio.Future[dict[str, Any]]] = field(
         default_factory=dict,
     )
+    db_write_lock: threading.Lock = field(default_factory=threading.Lock)
     credential_write_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     pending_fs_requests: dict[str, asyncio.Future[dict[str, Any]]] = field(
         default_factory=dict,
@@ -382,19 +389,40 @@ class HostRegistry:
             self._hosts[key] = conn
         return conn
 
-    def deregister(self, host_id: str, workspace_id: int | None = None) -> None:
+    def deregister(
+        self,
+        host_id: str,
+        workspace_id: int | None = None,
+        conn: HostConnection | None = None,
+    ) -> HostConnection | None:
         """Remove a host connection.
 
         No-op if ``(workspace_id, host_id)`` is not registered.
 
         :param host_id: Host identifier to remove, in any accepted
             spelling (see :func:`_canonical_host_id`).
-        :param workspace_id: Tenant partition; defaults to
-            :func:`current_workspace_id`.
+        :param workspace_id: Tenant partition; defaults to the
+            connection's own workspace when *conn* is given (as
+            ``send_text`` does), otherwise :func:`current_workspace_id`.
+        :param conn: Optional generation guard. When provided,
+            deregistration only removes the registry entry if the
+            current entry is this exact connection object. This prevents
+            stale route handlers from deleting a newer tunnel.
+        :returns: The removed connection, or ``None`` when the host is
+            already offline or the guard did not match.
         """
-        ws_id = current_workspace_id() if workspace_id is None else workspace_id
+        if workspace_id is not None:
+            ws_id = workspace_id
+        elif conn is not None:
+            ws_id = conn.workspace_id
+        else:
+            ws_id = current_workspace_id()
         with self._lock:
-            self._hosts.pop((ws_id, _canonical_host_id(host_id)), None)
+            key = (ws_id, _canonical_host_id(host_id))
+            current = self._hosts.get(key)
+            if current is None or (conn is not None and current is not conn):
+                return None
+            return self._hosts.pop(key)
 
     def get(self, host_id: str, workspace_id: int | None = None) -> HostConnection | None:
         """Look up a live host connection.

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -2545,8 +2545,11 @@ async def _maybe_wake_stale_resumable_managed_sandbox(
     ):
         return False
 
-    if host_registry is not None:
-        host_registry.deregister(conv.host_id)
+    if host_registry is not None and host_conn is not None:
+        # Guarded on the connection this wake decision was made about: a
+        # fresh tunnel can register during the liveness awaits above, and
+        # dropping that one would strand a host that just came back.
+        host_registry.deregister(conv.host_id, conn=host_conn)
     if tunnel_registry is not None and conv.runner_id is not None:
         tunnel_registry.deregister(conv.runner_id)
 

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -227,6 +227,38 @@ def create_host_tunnel_router(
 
         await ws.accept()
         conn: HostConnection | None = None
+        released = False
+
+        async def _release_host(*, announce: bool) -> None:
+            """Run this connection's disconnect cleanup at most once.
+
+            Skipped when a NEWER tunnel holds the registry slot: that
+            connection owns the host now, and flipping the row offline
+            would report a connected host as gone. An already-empty slot
+            is different — nothing newer exists to protect and this
+            handler is the last owner, so the row still needs marking
+            offline (the managed-wake path deregisters out of band).
+
+            :param announce: Whether to fire ``on_host_disconnect``.
+            """
+            nonlocal released
+            if conn is None or released:
+                return
+            if host_registry.deregister(host_id, conn=conn) is None:
+                superseded = host_registry.get(conn.host_id, conn.workspace_id) is not None
+                if superseded:
+                    return
+            released = True
+            await asyncio.to_thread(_write_offline, conn, host_store, host_id)
+            if announce and on_host_disconnect is not None:
+                try:
+                    await on_host_disconnect(host_id, tunnel_owner)
+                except Exception:
+                    _logger.exception(
+                        "on_host_disconnect callback failed for %s",
+                        host_id,
+                    )
+
         try:
             raw = await ws.receive_text()
             frame = decode_host_frame(raw)
@@ -274,7 +306,7 @@ def create_host_tunnel_router(
                 name=f"host-sender:{host_id}",
             )
             ping_task = asyncio.create_task(
-                _ping_loop(ws, conn, host_id, host_store),
+                _ping_loop(ws, conn, host_id, host_store, host_registry),
                 name=f"host-ping:{host_id}",
             )
             receive_task = asyncio.create_task(
@@ -325,41 +357,18 @@ def create_host_tunnel_router(
                     receive_task,
                     return_exceptions=True,
                 )
-                host_registry.deregister(host_id)
-                await asyncio.to_thread(host_store.set_offline, host_id)
-                if on_host_disconnect is not None:
-                    try:
-                        await on_host_disconnect(host_id, tunnel_owner)
-                    except Exception:
-                        _logger.exception(
-                            "on_host_disconnect callback failed for %s",
-                            host_id,
-                        )
+                await _release_host(announce=True)
 
         except WebSocketDisconnect:
             _logger.warning("Host %s disconnected", host_id)
-            # Only run disconnect cleanup if we actually registered this
-            # host on THIS connection. A connect that failed before
-            # register — e.g. the upsert IntegrityError when a peer
-            # connects with another owner's host_id — must not deregister
-            # or flip that owner's host offline (cross-user DoS).
-            if conn is not None:
-                host_registry.deregister(host_id)
-                await asyncio.to_thread(host_store.set_offline, host_id)
-                if on_host_disconnect is not None:
-                    try:
-                        await on_host_disconnect(host_id, tunnel_owner)
-                    except Exception:
-                        _logger.exception(
-                            "on_host_disconnect callback failed for %s",
-                            host_id,
-                        )
+            # A connect that failed before register — e.g. the upsert
+            # IntegrityError when a peer connects with another owner's
+            # host_id — must not flip that owner's host offline (cross-user
+            # DoS). ``_release_host`` covers that: no conn, no cleanup.
+            await _release_host(announce=True)
         except Exception:
             _logger.exception("Host tunnel error for %s", host_id)
-            # Same guard as above: don't touch a host we never registered.
-            if conn is not None:
-                host_registry.deregister(host_id)
-                await asyncio.to_thread(host_store.set_offline, host_id)
+            await _release_host(announce=False)
 
     return router
 
@@ -383,6 +392,53 @@ async def _refuse_upgrade(ws: WebSocket, *, status: int, reason: str) -> None:
         await ws.send_denial_response(PlainTextResponse(reason, status_code=status))
     else:
         await ws.close(code=4009, reason=reason)
+
+
+def _write_heartbeat(
+    conn: HostConnection,
+    host_store: HostStore,
+    host_id: str,
+    host_registry: HostRegistry,
+) -> None:
+    """Persist a heartbeat, unless this connection is no longer registered.
+
+    Runs in a worker thread. A thread that has already started cannot be
+    cancelled, so this can reach the write after the route tore the
+    connection down — and the heartbeat rewrites ``status="online"``.
+    Re-checking registration *inside* the lock makes that case a no-op:
+    cleanup always pops the connection before writing offline.
+
+    :param conn: The connection whose tunnel was alive at dispatch time.
+    :param host_store: Persistent host store to write to.
+    :param host_id: Host identifier to refresh.
+    :param host_registry: Registry that decides whether this connection
+        still speaks for the host.
+    """
+    with conn.db_write_lock:
+        if host_registry.get(conn.host_id, conn.workspace_id) is not conn:
+            return
+        host_store.heartbeat(host_id)
+
+
+def _write_offline(conn: HostConnection, host_store: HostStore, host_id: str) -> None:
+    """Mark the host offline as the last word for a dead tunnel.
+
+    Runs in a worker thread. Ordering against a late heartbeat comes from
+    cleanup popping the connection *before* this runs, plus
+    :func:`_write_heartbeat`'s in-lock registration check — not from the
+    lock alone, which only excludes, never orders.
+
+    Not atomic against a *different* connection: a new tunnel can upsert
+    itself online between this connection's registry pop and this write,
+    leaving a live host with an offline row. Its own heartbeat converges
+    that within one ping interval.
+
+    :param conn: The connection being torn down.
+    :param host_store: Persistent host store to write to.
+    :param host_id: Host identifier to mark offline.
+    """
+    with conn.db_write_lock:
+        host_store.set_offline(host_id)
 
 
 async def _sender_loop(ws: WebSocket, conn: HostConnection) -> None:
@@ -679,6 +735,7 @@ async def _ping_loop(
     conn: HostConnection,
     host_id: str,
     host_store: HostStore,
+    host_registry: HostRegistry,
 ) -> None:
     """Send pings every PING_INTERVAL_S; declare dead after misses.
 
@@ -694,9 +751,16 @@ async def _ping_loop(
     :param conn: Host connection for timing checks.
     :param host_id: Host id for logging.
     :param host_store: Persistent host store the heartbeat is written to.
+    :param host_registry: Registry consulted each tick so a connection a
+        newer tunnel replaced stops writing.
     """
     while True:
         await asyncio.sleep(PING_INTERVAL_S)
+        if host_registry.get(conn.host_id, conn.workspace_id) is not conn:
+            # A newer tunnel serves this host now, so stop the loop rather
+            # than hop to a thread only to no-op. The write-side check in
+            # ``_write_heartbeat`` is what actually guarantees this.
+            return
         elapsed = time.time() - conn.last_frame_at
         if elapsed > PING_INTERVAL_S * PING_MISS_THRESHOLD:
             _logger.warning(
@@ -710,7 +774,7 @@ async def _ping_loop(
             return
         # The host is still within the liveness window — refresh its
         # last-seen so the freshness gate keeps it in the online set.
-        await asyncio.to_thread(host_store.heartbeat, host_id)
+        await asyncio.to_thread(_write_heartbeat, conn, host_store, host_id, host_registry)
         try:
             ping_text = encode_frame(PingFrame(ts=int(time.time() * 1000)))
             conn.outbound_queue.put_nowait(ping_text)

--- a/omnigent/stores/host_store.py
+++ b/omnigent/stores/host_store.py
@@ -523,8 +523,13 @@ class HostStore:
         Bumps ``updated_at`` to now so the liveness freshness gate
         (see :data:`HOST_LIVENESS_TTL_S`) keeps treating the host as
         online. Called from the host tunnel's ping loop every
-        ``PING_INTERVAL_S``. Does not change ``status`` — a host whose
-        ping loop is running is, by construction, still ``"online"``.
+        ``PING_INTERVAL_S``.
+
+        Also rewrites ``status`` to ``"online"``, repairing a row that a
+        peer process flipped offline — a replica whose socket teardown
+        lags a reconnect elsewhere, or a second local server sharing one
+        data dir. Registries are per-process, so nothing here can see
+        that write; this converges the row in one ``PING_INTERVAL_S``.
 
         No-op if the host does not exist.
 
@@ -541,7 +546,7 @@ class HostStore:
                     SqlHost.workspace_id == current_workspace_id(),
                     SqlHost.host_id == host_id,
                 )
-                .values(updated_at=now_epoch())
+                .values(status=encode_host_status("online"), updated_at=now_epoch())
             )
 
     def is_online(self, host_id: str) -> bool:

--- a/tests/server/integration/test_host_session_binding.py
+++ b/tests/server/integration/test_host_session_binding.py
@@ -8,6 +8,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 import pytest_asyncio
@@ -1178,9 +1179,20 @@ async def test_resumable_managed_wake_drops_fresh_local_tunnels_when_provider_pa
         tracker.begin(conv.id)
         tracker.finish(conv.id)
 
-    def _deregister_host(host_id: str) -> None:
+    def _deregister_host(
+        host_id: str,
+        workspace_id: int | None = None,
+        conn: object | None = None,
+    ) -> object | None:
+        # Tracks HostRegistry.deregister's signature; nothing type-checks
+        # this stub, so update it whenever that signature changes.
+        del workspace_id
         host_deregistered.append(host_id)
+        # The wake path guards on the connection it read.
+        assert conn is fresh_host_conn
+        removed = host_registry_state["conn"]
         host_registry_state["conn"] = None
+        return removed
 
     monkeypatch.setattr(sessions_module, "_kick_managed_wake", _finish_wake)
     app_state = SimpleNamespace(
@@ -1210,6 +1222,132 @@ async def test_resumable_managed_wake_drops_fresh_local_tunnels_when_provider_pa
     assert calls == ["wake"]
     assert host_deregistered == ["055e31f38d07908f171ebad4ff5cbe9c"]
     assert runner_deregistered == ["runner_stale_tunnel"]
+
+
+async def test_resumable_managed_wake_keeps_a_tunnel_that_reconnected_mid_decision(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A wake must not drop a host tunnel that registered while it decided.
+
+    The wake path reads the host connection, then awaits several liveness
+    checks in worker threads. A fresh tunnel can land in that window;
+    dropping it would strand a host that had just come back and leave the
+    session waiting on a tunnel nobody serves.
+    """
+    from omnigent.server.routes import sessions as sessions_module
+
+    host_id = "0b0c1a4e1f2d4f8ba7c6d5e4f3021988"
+    host_store = HostStore(db_uri)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    host_store.register_managed_host(
+        host_id=host_id,
+        name="managed-reconnect-race",
+        user_id=RESERVED_USER_LOCAL,
+        token="tok-reconnect-race",
+        provider="islo",
+        sandbox_id="sb-reconnect-race",
+        token_expires_at=9_999_999_999,
+    )
+    host_store.upsert_on_connect(
+        host_id=host_id,
+        name="managed-reconnect-race",
+        user_id=RESERVED_USER_LOCAL,
+    )
+    conv = conv_store.create_conversation(
+        agent_id=None,
+        host_id=host_id,
+        workspace="/root/workspace",
+    )
+    conv_store.set_runner_id(conv.id, "runner_reconnect_race")
+    conv = conv_store.get_conversation(conv.id)
+    assert conv is not None
+
+    hello = HostHelloFrame(
+        version="0.1.0-test",
+        frame_protocol_version=1,
+        name="managed-reconnect-race",
+    )
+    registry = HostRegistry()
+    stale_conn = registry.register(host_id, cast(Any, SimpleNamespace()), hello, owner=None)
+    # The reconnect that lands while the wake decision is still in flight.
+    fresh_conn = registry.register(host_id, cast(Any, SimpleNamespace()), hello, owner=None)
+    # Guards seen by deregister, so the test can prove it reached that line
+    # rather than passing by bailing out at an earlier gate.
+    guards: list[object] = []
+
+    class _StaleReadRegistry:
+        """Registry view whose first ``get`` returns the replaced connection.
+
+        Stands in for the real timeline: the wake path captures the
+        connection before its awaits, a newer tunnel takes the slot
+        during them, and every later read sees the truth.
+        """
+
+        def __init__(self) -> None:
+            self._served_stale = False
+
+        def get(self, host_id_: str) -> object:
+            """Serve the pre-await capture once, then the real registry."""
+            if not self._served_stale:
+                self._served_stale = True
+                return stale_conn
+            return registry.get(host_id_)
+
+        @staticmethod
+        def deregister(
+            host_id_: str,
+            workspace_id: int | None = None,
+            conn: object | None = None,
+        ) -> object | None:
+            """Delegate to the real registry so the guard actually runs."""
+            guards.append(conn)
+            return registry.deregister(host_id_, workspace_id, conn=cast(Any, conn))
+
+    fake = FakeSandboxLauncher(can_resume=True)
+    fake.provider = "islo"  # type: ignore[misc]
+    fake.is_running = lambda _sandbox_id: False  # type: ignore[method-assign]
+    config = ManagedSandboxConfig(
+        server_url="https://managed-test.example.com",
+        launcher_factory=lambda: fake,
+        token_ttl_s=3600,
+        provider="islo",
+    )
+    tracker = ManagedLaunchTracker()
+    calls: list[str] = []
+
+    def _finish_wake(**kwargs: object) -> None:
+        del kwargs
+        calls.append("wake")
+        tracker.begin(conv.id)
+        tracker.finish(conv.id)
+
+    monkeypatch.setattr(sessions_module, "_kick_managed_wake", _finish_wake)
+    app_state = SimpleNamespace(
+        host_store=host_store,
+        sandbox_config=config,
+        managed_launches=tracker,
+        host_registry=_StaleReadRegistry(),
+        tunnel_registry=SimpleNamespace(
+            get=lambda _runner_id: None,
+            deregister=lambda _runner_id: None,
+        ),
+    )
+
+    woke = await sessions_module._maybe_wake_stale_resumable_managed_sandbox(
+        session_id=conv.id,
+        conv=conv,
+        app_state=app_state,
+        conversation_store=conv_store,
+    )
+
+    # Reached the teardown at all — otherwise everything below is vacuous.
+    assert len(guards) == 1, "the wake never reached its host-registry teardown"
+    assert registry.get(host_id) is fresh_conn, "the wake dropped a freshly reconnected tunnel"
+    assert guards == [stale_conn], "the teardown must be guarded on the captured connection"
+    # With its tunnel intact the host needs no wake, so nothing was kicked.
+    assert woke is False
+    assert calls == []
 
 
 async def test_managed_wake_fails_when_runner_never_reconnects(

--- a/tests/server/integration/test_host_tunnel_route.py
+++ b/tests/server/integration/test_host_tunnel_route.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import threading
+from dataclasses import dataclass, field
+from typing import Any, cast
 
 import pytest
 from asgiref.testing import ApplicationCommunicator
@@ -19,9 +22,9 @@ from omnigent.host.frames import (
     encode_host_frame,
 )
 from omnigent.server.auth import AuthProvider
-from omnigent.server.host_registry import HostRegistry
+from omnigent.server.host_registry import HostConnection, HostRegistry
 from omnigent.server.routes.host_tunnel import create_host_tunnel_router
-from omnigent.stores.host_store import HostStore
+from omnigent.stores.host_store import HostStore, host_is_live
 
 pytestmark = pytest.mark.asyncio
 
@@ -163,6 +166,27 @@ async def _wait_offline(
         await asyncio.sleep(0.01)
 
 
+async def _wait_count(
+    events: list[str],
+    count: int,
+    *,
+    timeout_s: float = 2.0,
+) -> None:
+    """Poll until *events* holds at least *count* entries.
+
+    :param events: Recorded callback announcements.
+    :param count: Number of entries to wait for.
+    :param timeout_s: Max seconds to poll before raising.
+    :raises asyncio.TimeoutError: If the count is not reached in time.
+    """
+
+    async def _poll() -> None:
+        while len(events) < count:
+            await asyncio.sleep(0.01)
+
+    await asyncio.wait_for(_poll(), timeout=timeout_s)
+
+
 async def _wait_updated_at_at_least(
     store: HostStore,
     host_id: str,
@@ -238,10 +262,274 @@ async def test_host_tunnel_ping_loop_persists_heartbeat(
 
     host = store.get_host(_HOST_ID)
     assert host is not None
-    assert host.status == "online", "heartbeat must not change status"
+    assert host.status == "online", "heartbeat must keep a live host online"
 
     # Clean up the live tunnel so the loop stops.
     await comm.send_input({"type": "websocket.disconnect", "code": 1000})
+
+
+@dataclass
+class _IdleWebSocket:
+    """WebSocket stand-in for driving ``_ping_loop`` without a route.
+
+    :param closed: Close codes the loop asked for, if it ever did.
+    """
+
+    closed: list[int] = field(default_factory=list)
+
+    async def send_text(self, data: str) -> None:
+        """Discard an outbound frame.
+
+        :param data: The text frame content.
+        """
+        del data
+
+    async def receive_text(self) -> str:
+        """Block forever — the ping loop never reads.
+
+        :returns: Never returns in practice.
+        """
+        await asyncio.sleep(3600)
+        return ""  # pragma: no cover
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        """Record a close request.
+
+        :param code: WebSocket close code.
+        :param reason: Close reason, ignored.
+        """
+        del reason
+        self.closed.append(code)
+
+
+async def test_ping_loop_stops_heartbeating_after_takeover(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A superseded connection's ping loop must stop refreshing last-seen.
+
+    ``updated_at`` is the liveness freshness gate. Once a newer tunnel
+    holds the host, the old loop no longer speaks for it, so a heartbeat
+    from there would keep a dead generation looking fresh — and would
+    fight the very cleanup a takeover is supposed to settle.
+    """
+    import omnigent.server.routes.host_tunnel as tunnel_mod
+
+    monkeypatch.setattr(tunnel_mod, "PING_INTERVAL_S", 0.01)
+
+    registry = HostRegistry()
+    store = HostStore(db_uri)
+    store.upsert_on_connect(_HOST_ID, "test-laptop", "alice@example.com")
+    stale = now_epoch() - 10_000
+    engine = get_or_create_engine(db_uri)
+    with Session(engine) as session:
+        session.execute(
+            update(SqlHost).where(SqlHost.host_id == _HOST_ID).values(updated_at=stale)
+        )
+        session.commit()
+
+    hello = HostHelloFrame(version="0.1.0-test", frame_protocol_version=1, name="test-laptop")
+    ws = _IdleWebSocket()
+    old_conn = registry.register(_HOST_ID, ws, hello, owner=None)
+    # A newer tunnel takes the host over.
+    registry.register(_HOST_ID, _IdleWebSocket(), hello, owner=None)
+
+    task = asyncio.create_task(
+        tunnel_mod._ping_loop(cast(Any, ws), old_conn, _HOST_ID, store, registry),
+    )
+    # Many intervals' worth of grace — long enough that a loop still
+    # writing would have written dozens of times.
+    done, _pending = await asyncio.wait({task}, timeout=0.5)
+
+    host = store.get_host(_HOST_ID)
+    assert host is not None
+    assert host.updated_at == stale, "a superseded ping loop must not refresh last-seen"
+    assert task in done, "a superseded ping loop must exit rather than keep spinning"
+    assert ws.closed == [], "a takeover is not a ping timeout; the loop must not close the socket"
+
+
+class _ProbeLock:
+    """Write-lock stand-in that exposes acquisition ordering to tests.
+
+    Two knobs, one per test: *hold_first* parks the first acquirer at
+    ``gate`` (modelling a thread that started but has not yet taken the
+    lock), and ``contended`` fires when an acquirer has to wait for a
+    current holder — a signal, so tests never infer blocking from elapsed
+    time.
+
+    :param hold_first: Whether to park the first acquirer at the gate.
+    """
+
+    def __init__(self, *, hold_first: bool = False) -> None:
+        self._lock = threading.Lock()
+        self._hold_first = hold_first
+        self.at_gate = threading.Event()
+        self.gate = threading.Event()
+        self.contended = threading.Event()
+
+    def acquire(self, *args: object, **kwargs: object) -> bool:
+        """Acquire, signalling gate arrival and contention.
+
+        :returns: Whether the underlying lock was acquired.
+        """
+        if self._hold_first:
+            self._hold_first = False
+            self.at_gate.set()
+            assert self.gate.wait(timeout=5.0), "gate was never opened"
+        if self._lock.acquire(blocking=False):
+            return True
+        self.contended.set()
+        return self._lock.acquire()
+
+    def release(self) -> None:
+        """Release the underlying lock."""
+        self._lock.release()
+
+    def __enter__(self) -> _ProbeLock:
+        """Acquire on context entry.
+
+        :returns: This lock.
+        """
+        self.acquire()
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        """Release on context exit.
+
+        :returns: ``False`` so exceptions propagate.
+        """
+        self.release()
+        return False
+
+
+async def test_set_offline_waits_out_an_inflight_heartbeat(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """set_offline must take the same lock a running heartbeat holds.
+
+    Cancelling the ping task cannot stop a ``to_thread`` heartbeat that
+    already started, and the heartbeat rewrites ``status="online"``. This
+    pins the exclusion half: while that write is in progress, the route's
+    ``set_offline`` waits rather than interleaving with it.
+    """
+    import omnigent.server.routes.host_tunnel as tunnel_mod
+
+    store = HostStore(db_uri)
+    store.upsert_on_connect(_HOST_ID, "test-laptop", "alice@example.com")
+    registry = HostRegistry()
+    hello = HostHelloFrame(version="0.1.0-test", frame_protocol_version=1, name="test-laptop")
+    conn = registry.register(_HOST_ID, _IdleWebSocket(), hello, owner=None)
+    lock = _ProbeLock()
+    conn.db_write_lock = cast(Any, lock)
+
+    entered = threading.Event()
+    release = threading.Event()
+    real_heartbeat = store.heartbeat
+
+    def _slow_heartbeat(host_id: str) -> None:
+        """Hold the connection's write lock until the test releases it.
+
+        :param host_id: Host identifier forwarded to the real heartbeat.
+        """
+        entered.set()
+        assert release.wait(timeout=5.0), "heartbeat was never released"
+        real_heartbeat(host_id)
+
+    monkeypatch.setattr(store, "heartbeat", _slow_heartbeat)
+
+    beat = asyncio.create_task(
+        asyncio.to_thread(tunnel_mod._write_heartbeat, conn, store, _HOST_ID, registry),
+    )
+    assert await asyncio.to_thread(entered.wait, 5.0), "heartbeat never started"
+
+    offline = asyncio.create_task(
+        asyncio.to_thread(tunnel_mod._write_offline, conn, store, _HOST_ID),
+    )
+    # Signalled, not timed: the offline worker reached the lock and blocked.
+    assert await asyncio.to_thread(lock.contended.wait, 5.0), (
+        "set_offline never waited for the connection lock"
+    )
+    blocked = store.get_host(_HOST_ID)
+    assert blocked is not None
+    assert blocked.status == "online", "offline landed while the heartbeat held the lock"
+
+    release.set()
+    await asyncio.wait_for(asyncio.gather(beat, offline), timeout=5.0)
+
+    host = store.get_host(_HOST_ID)
+    assert host is not None
+    assert host.status == "offline", "a late heartbeat must not resurrect a dead host"
+    assert not host_is_live(host)
+
+
+async def test_late_heartbeat_after_cleanup_does_not_resurrect_host(
+    db_uri: str,
+) -> None:
+    """A heartbeat reaching its write after cleanup must be a no-op.
+
+    The write lock only excludes, it does not order: a heartbeat thread
+    that started before teardown can take the lock *after* ``set_offline``
+    released it, rewriting ``status="online"`` for a host with no tunnel.
+    Cleanup pops the connection first, so the write-side registration
+    check is what makes that late heartbeat harmless.
+    """
+    import omnigent.server.routes.host_tunnel as tunnel_mod
+
+    store = HostStore(db_uri)
+    store.upsert_on_connect(_HOST_ID, "test-laptop", "alice@example.com")
+    registry = HostRegistry()
+    hello = HostHelloFrame(version="0.1.0-test", frame_protocol_version=1, name="test-laptop")
+    conn = registry.register(_HOST_ID, _IdleWebSocket(), hello, owner=None)
+    late = _ProbeLock(hold_first=True)
+    conn.db_write_lock = cast(Any, late)
+
+    # The heartbeat is dispatched and running, but parked before the lock.
+    beat = asyncio.create_task(
+        asyncio.to_thread(tunnel_mod._write_heartbeat, conn, store, _HOST_ID, registry),
+    )
+    assert await asyncio.to_thread(late.at_gate.wait, 5.0), "heartbeat never reached the lock"
+
+    # Route teardown runs to completion while the heartbeat is parked.
+    registry.deregister(_HOST_ID, conn=conn)
+    await asyncio.to_thread(tunnel_mod._write_offline, conn, store, _HOST_ID)
+    assert store.get_host(_HOST_ID).status == "offline"  # type: ignore[union-attr]
+
+    # Only now does the heartbeat get the lock — strictly after offline.
+    late.gate.set()
+    await asyncio.wait_for(beat, timeout=5.0)
+
+    host = store.get_host(_HOST_ID)
+    assert host is not None
+    assert host.status == "offline", "a late heartbeat must not resurrect a dead host"
+    assert not host_is_live(host)
+
+
+async def test_host_tunnel_marks_offline_after_an_out_of_band_deregister(
+    db_uri: str,
+) -> None:
+    """An empty registry slot still needs the row marked offline.
+
+    The managed-wake path deregisters the live connection out of band. The
+    route's own teardown then finds an empty slot — which is NOT a
+    takeover, so suppressing cleanup would leave the row online for a
+    liveness TTL with no hosts-changed nudge for clients.
+    """
+    app, registry, store, _connects, disconnects = _announcing_app(db_uri)
+    comm = await _connect_route(app, _TUNNEL_PATH)
+    await _send_hello_and_wait(comm, registry)
+
+    # The wake path drops the current connection; no newer tunnel exists.
+    assert registry.deregister(_HOST_ID) is not None
+    assert registry.get(_HOST_ID) is None
+
+    await comm.send_input({"type": "websocket.disconnect", "code": 1000})
+    await asyncio.wait_for(comm.future, timeout=2.0)
+
+    host = store.get_host(_HOST_ID)
+    assert host is not None
+    assert host.status == "offline", "an empty slot is not a takeover; the row must go offline"
+    assert disconnects == [_HOST_ID], "clients still need exactly one hosts-changed nudge"
 
 
 async def test_host_tunnel_accepts_and_registers(
@@ -388,6 +676,118 @@ async def test_host_tunnel_sets_offline_on_disconnect(
     host = store.get_host(_HOST_ID)
     assert host is not None
     assert host.status == "offline"
+
+
+def _announcing_app(
+    db_uri: str,
+) -> tuple[FastAPI, HostRegistry, HostStore, list[str], list[str]]:
+    """Build a host-tunnel app that records its connect/disconnect announcements.
+
+    :param db_uri: SQLite URI from the shared fixture.
+    :returns: Tuple of (app, registry, store, connects, disconnects),
+        the two lists collecting announced host ids in call order.
+    """
+    registry = HostRegistry()
+    store = HostStore(db_uri)
+    connects: list[str] = []
+    disconnects: list[str] = []
+
+    async def _on_host_connect(host_id: str, _owner: str | None) -> None:
+        connects.append(host_id)
+
+    async def _on_host_disconnect(host_id: str, _owner: str | None) -> None:
+        disconnects.append(host_id)
+
+    app = FastAPI()
+    app.include_router(
+        create_host_tunnel_router(
+            registry,
+            store,
+            on_host_connect=_on_host_connect,
+            on_host_disconnect=_on_host_disconnect,
+        ),
+        prefix="/v1",
+    )
+    return app, registry, store, connects, disconnects
+
+
+async def _overlap_tunnels(
+    app: FastAPI,
+    registry: HostRegistry,
+    connects: list[str],
+) -> tuple[ApplicationCommunicator, HostConnection]:
+    """Open a second tunnel for an already-connected host and let the first unwind.
+
+    The second connect announcement — not a registry poll — is the
+    "replacement is live" signal: a buggy cleanup can empty the registry
+    between polls, which would look like the takeover never happened.
+
+    :param app: App hosting the tunnel route.
+    :param registry: Registry the tunnels register in.
+    :param connects: Connect announcements recorded by the app.
+    :returns: Tuple of (surviving communicator, the superseded connection).
+    """
+    comm_old = await _connect_route(app, _TUNNEL_PATH)
+    await _send_hello_and_wait(comm_old, registry)
+    old_conn = registry.get(_HOST_ID)
+    assert old_conn is not None
+
+    comm_new = await _connect_route(app, _TUNNEL_PATH)
+    await comm_new.send_input({"type": "websocket.receive", "text": _make_hello()})
+    await _wait_count(connects, 2)
+
+    # Barrier: the superseded handler's task has finished, so whatever
+    # cleanup it does has already happened — no sleep-based guessing.
+    await asyncio.wait_for(comm_old.future, timeout=2.0)
+    return comm_new, old_conn
+
+
+async def test_host_tunnel_takeover_keeps_replacement_online(
+    db_uri: str,
+) -> None:
+    """A second tunnel for one host_id must not leave the live host offline.
+
+    Registration is newest-wins: the second tunnel poisons the first's
+    outbound queue and takes the registry slot. The first handler then
+    unwinds cleanly — and must not run disconnect cleanup, or it
+    deregisters the replacement and flips the DB row offline while a
+    perfectly good tunnel is up. Nothing rewrites ``status`` until the
+    next reconnect, so the host would read offline for the whole life of
+    a working tunnel.
+    """
+    app, registry, store, connects, _disconnects = _announcing_app(db_uri)
+    comm_new, old_conn = await _overlap_tunnels(app, registry, connects)
+
+    live = registry.get(_HOST_ID)
+    assert live is not None, "superseded handler deregistered the live tunnel"
+    assert live is not old_conn, "the replacement should hold the registry slot"
+
+    host = store.get_host(_HOST_ID)
+    assert host is not None
+    assert host.status == "online", "superseded handler flipped the live host offline"
+    assert host_is_live(host), "the live tunnel's host must still read as live"
+
+    await comm_new.send_input({"type": "websocket.disconnect", "code": 1000})
+
+
+async def test_host_tunnel_takeover_suppresses_disconnect_callback(
+    db_uri: str,
+) -> None:
+    """Takeover announces nothing; the survivor's real close announces once.
+
+    ``on_host_disconnect`` drives the SSE "hosts changed" nudge, so firing
+    it for a superseded connection tells clients a live host went away.
+    """
+    app, registry, store, connects, disconnects = _announcing_app(db_uri)
+    comm_new, _old_conn = await _overlap_tunnels(app, registry, connects)
+
+    assert disconnects == [], "a superseded connection must not announce a disconnect"
+
+    await comm_new.send_input({"type": "websocket.disconnect", "code": 1000})
+    await asyncio.wait_for(comm_new.future, timeout=2.0)
+
+    assert disconnects == [_HOST_ID], "the survivor's real close must announce exactly once"
+    await asyncio.wait_for(_wait_offline(store, _HOST_ID), timeout=2.0)
 
 
 async def test_host_tunnel_rejects_bad_protocol_version(

--- a/tests/server/test_host_registry.py
+++ b/tests/server/test_host_registry.py
@@ -98,6 +98,81 @@ def test_deregister_noop_for_unknown() -> None:
     registry.deregister("host_nonexistent")
 
 
+def test_deregister_with_matching_guard_removes_and_returns_connection() -> None:
+    """
+    Verify the generation guard removes the entry when it matches.
+
+    The returned connection is how the tunnel handler learns it still
+    owns the rest of the disconnect cleanup (set-offline, disconnect
+    announcement).
+    """
+    registry = HostRegistry()
+    conn = registry.register("host_bb1", FakeWebSocket(), _make_hello(), owner="bob")
+
+    assert registry.deregister("host_bb1", conn=conn) is conn
+    assert registry.get("host_bb1") is None
+
+
+def test_deregister_with_stale_guard_keeps_the_replacement() -> None:
+    """
+    Verify a superseded connection cannot deregister its replacement.
+
+    A reconnect takes the registry slot (newest wins) while the old
+    handler is still unwinding. If that handler's cleanup removed the
+    entry, the live tunnel would go missing and the host would be
+    marked offline while connected.
+    """
+    registry = HostRegistry()
+    old_conn = registry.register("host_bb2", FakeWebSocket(), _make_hello(), owner="bob")
+    new_conn = registry.register("host_bb2", FakeWebSocket(), _make_hello(), owner="bob")
+
+    assert registry.deregister("host_bb2", conn=old_conn) is None
+    assert registry.get("host_bb2") is new_conn
+
+
+def test_deregister_without_guard_pops_unconditionally() -> None:
+    """
+    Verify an unguarded deregister still removes whatever is registered.
+
+    Callers holding no connection reference must keep the old behaviour,
+    so the guard has to stay strictly opt-in.
+    """
+    registry = HostRegistry()
+    registry.register("host_bb3", FakeWebSocket(), _make_hello(), owner="bob")
+    new_conn = registry.register("host_bb3", FakeWebSocket(), _make_hello(), owner="bob")
+
+    assert registry.deregister("host_bb3") is new_conn
+    assert registry.get("host_bb3") is None
+    # Nothing left to remove on a second call.
+    assert registry.deregister("host_bb3") is None
+
+
+def test_deregister_guard_keys_off_the_connection_workspace() -> None:
+    """
+    Verify a guarded deregister stays inside the connection's workspace.
+
+    One stable host_id can be live in two workspaces. The guard resolves
+    the key from the connection itself, so cleanup for one workspace must
+    not evict the other's tunnel even when the caller's ambient workspace
+    is the other one.
+    """
+    registry = HostRegistry()
+    host_id = "00112233445566778899aabbccddeeff"
+    with workspace_scope(111):
+        conn_a = registry.register(host_id, FakeWebSocket(), _make_hello(), owner="alice")
+    with workspace_scope(222):
+        conn_b = registry.register(host_id, FakeWebSocket(), _make_hello(), owner="alice")
+
+    # Ambient workspace is 222, but the guard names workspace 111's conn.
+    with workspace_scope(222):
+        assert registry.deregister(host_id, conn=conn_a) is conn_a
+
+    with workspace_scope(111):
+        assert registry.get(host_id) is None
+    with workspace_scope(222):
+        assert registry.get(host_id) is conn_b
+
+
 def test_online_host_ids() -> None:
     """
     Verify that online_host_ids returns all registered hosts

--- a/tests/stores/test_host_store.py
+++ b/tests/stores/test_host_store.py
@@ -408,17 +408,16 @@ def test_set_offline_noop_for_unknown_host(
     host_store.set_offline("aababcc3941edb738172734a9ab7bb8c")
 
 
-def test_heartbeat_advances_updated_at_without_changing_status(
+def test_heartbeat_advances_updated_at(
     host_store: HostStore,
     db_uri: str,
 ) -> None:
     """
-    Verify heartbeat refreshes last-seen but leaves status alone.
+    Verify heartbeat refreshes last-seen.
 
     The ping loop calls this every interval to keep a live host fresh.
     If it doesn't advance ``updated_at``, a long-lived host would age
-    past the TTL and wrongly drop offline; if it flipped ``status``,
-    it would fight the connect/disconnect writers.
+    past the TTL and wrongly drop offline.
     """
     host_store.upsert_on_connect("12b05166b1e4ccd4dce299285b12442f", "laptop", "alice@example.com")
     # Stand last-seen well in the past, as if the last touch was long ago.
@@ -431,8 +430,32 @@ def test_heartbeat_advances_updated_at_without_changing_status(
     # Last-seen jumped back to ~now (within a generous window for clock
     # granularity), proving the heartbeat wrote a fresh timestamp.
     assert fetched.updated_at >= now_epoch() - 5
-    # Status is untouched — heartbeat only refreshes liveness.
-    assert fetched.status == "online"
+
+
+def test_heartbeat_restores_online_status(
+    host_store: HostStore,
+    db_uri: str,
+) -> None:
+    """
+    Verify heartbeat repairs a row another process flipped offline.
+
+    Registries are per-process, so a lagging teardown on one replica —
+    or a second local server sharing the data dir — can mark the row
+    offline while a tunnel elsewhere is live. Nothing but the heartbeat
+    is positioned to fix that, and only if it writes ``status``.
+    """
+    host_id = "6e5b1ac54c1e4b6ca2b9f6b0d2b7e311"
+    host_store.upsert_on_connect(host_id, "laptop", "dana@example.com")
+    host_store.set_offline(host_id)
+    _set_updated_at(db_uri, host_id, now_epoch() - 10_000)
+
+    host_store.heartbeat(host_id)
+
+    fetched = host_store.get_host(host_id)
+    assert fetched is not None
+    assert fetched.status == "online", "heartbeat must restore a wrongly-offline row"
+    assert fetched.updated_at >= now_epoch() - 5
+    assert host_is_live(fetched)
 
 
 def test_heartbeat_noop_for_unknown_host(host_store: HostStore) -> None:


### PR DESCRIPTION
## Related issue

N/A — this is a standalone fix. Related but deliberately **not** closed by it: #3967, which covers the daemon-keying / host-identity model that makes overlapping tunnels common in the first place.

## Summary

A connected host flips to `offline` in the UI and stays there, so sessions can't be started from the desktop app — the host goes offline while the user is typing a prompt.

**ELI5:** two tunnels for the same machine arrive, the second one wins the slot, and then the *first* one's shutdown code turns off the lights on its way out — switching off the connection that just took over. Nothing turns them back on, because the keepalive only updates "last seen", never "is online".

- `HostRegistry.register` is newest-wins: it poisons the old connection's outbound queue and overwrites its registry slot. `_sender_loop` returns *cleanly* on that poison pill, so the old handler's cleanup ran with no exception and unconditionally called `deregister(host_id)` + `set_offline(host_id)` — deregistering and marking offline the connection that had just replaced it. Since `heartbeat` refreshed `updated_at` but never `status`, `host_is_live` stayed false for the entire life of the live tunnel.
- `HostRegistry.deregister` gains an optional `conn` generation guard — the same shape `TunnelRegistry.deregister` already uses for runner tunnels, whose docstring says it "prevents stale route handlers from deleting a newer tunnel". The host side never got the equivalent. All tunnel cleanup now routes through one idempotent `_release_host` that tells "a newer connection owns the slot" (suppress) from "the slot is empty" (still mark offline — the managed-wake path deregisters out of band).
- `heartbeat` now reasserts `status="online"`. Registries are per-process, so the guard can't see a peer process's write: a replica whose teardown lags a reconnect elsewhere, or a second local server sharing one data dir (`db_uri` derives from `_local_data_dir()`, so they share one `hosts` row). Cancelling a task doesn't stop an already-dispatched `to_thread` call, so the heartbeat and offline writes share a per-connection lock and the heartbeat rechecks registration *inside* it — cleanup always pops the connection first, making a late heartbeat a no-op rather than resurrecting a dead host.
- The managed-sandbox wake path in `_sessions/orchestration.py` had the same shape — capture the connection, await liveness checks in worker threads, then deregister unconditionally — and now passes the captured connection as its guard.

```mermaid
sequenceDiagram
    participant A as Tunnel A (old)
    participant R as HostRegistry
    participant DB as hosts row
    participant B as Tunnel B (live)
    B->>DB: upsert_on_connect → online
    B->>R: register (poisons A's queue, takes slot)
    A->>A: _sender_loop returns cleanly
    rect rgb(255, 236, 236)
    A->>R: deregister(host_id) — pops B
    A->>DB: set_offline → B reads offline forever
    end
    Note over A,DB: after: A's guard sees B in the slot and skips both
```

### Known limitation

A different-connection interleave remains reachable and is documented at the offline write: a new tunnel can upsert itself online between this connection's registry pop and its offline write, leaving a live host with an offline row until its own heartbeat converges it (≤ one `PING_INTERVAL_S`). Closing it properly needs a persisted connection epoch on the row — a `updated_at` comparison can't work, since it's second-granularity. This change reduces "offline forever" to "offline for at most one heartbeat".

Separately, `useHosts` only falls back to a 60s poll, so a cross-process offline followed by a silent heartbeat repair can stay visible in the UI a little longer than the row takes to heal.

The field trigger for overlapping tunnels — daemon registry records keyed on an unnormalized target string, so `local`, `http://127.0.0.1:6767`, and `http://localhost:6767` are three records for one server and one `host_id` — is **not** addressed here; it's raised separately in #3967. This PR does not depend on that discussion, and neither change subsumes the other: the race is reachable with a single daemon too, since teardown of a replaced socket is asynchronous, and via the cross-process path in a multi-replica deployment.

## Test Plan

```bash
uv run pytest tests/server/test_host_registry.py tests/stores/test_host_store.py \
  tests/server/integration/test_host_tunnel_route.py \
  tests/server/integration/test_host_session_binding.py -q      # 93 passed

uv run pytest tests/server tests/stores -q                      # 3389 passed
uv run pre-commit run --files <the 8 touched files>              # clean
```

- **Fail-before/pass-after:** with the four production files stashed and the tests kept, 13 of the new/strengthened tests fail; with them applied, all 93 pass.
- **Mutation check:** reverting *only* the two-line in-lock registration check in `_write_heartbeat` fails exactly `test_late_heartbeat_after_cleanup_does_not_resurrect_host` and nothing else, confirming that test pins the guarantee rather than a signature change.
- **Pre-existing failures:** `tests/server tests/stores` reports 9 failures in `tests/server/routes/test_sessions_snapshot.py`. These are order-dependent and reproduce identically on unmodified `main` (that file passes 41/41 in isolation on both). Not related to this change.
- New tests drive ordering with events and a contention-signalling lock probe rather than sleeps, so they don't depend on executor timing.

## Demo

https://github.com/user-attachments/assets/2ad18fbc-4b0b-45da-9ba5-b63ecf15d5b1

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

See demo video. Involves standing up multilple hosts and observing the behavior when another alias (localhost vs 127.0.0.1) takes over the slot. The same sequence we executed in both sessions in the recording, and only the new one recovered + worked. The version from origin/main never recovers unless hosts are cleanly cycled.

New coverage, by layer:

- `tests/server/test_host_registry.py` — the guard itself: matching guard removes and returns the connection; stale guard preserves the replacement; no guard pops unconditionally (proving existing callers are unaffected); guard keys off the connection's own workspace.
- `tests/server/integration/test_host_tunnel_route.py` — takeover keeps the replacement online; takeover suppresses the disconnect callback while the survivor's real disconnect still fires it exactly once; the ping loop stops heartbeating after a takeover; `set_offline` waits out an in-flight heartbeat; a late heartbeat after cleanup does not resurrect the host; an out-of-band deregister still leaves the row offline.
- `tests/stores/test_host_store.py` — heartbeat restores `online` on a row that was set offline, and still advances `updated_at`. The pre-existing heartbeat test asserted status on an already-online row, which was vacuous either way; it's been split so the freshness and status behaviours are each pinned.
- `tests/server/integration/test_host_session_binding.py` — a wake that reconnects mid-decision keeps the fresh tunnel. The pre-existing paused-provider wake test is strengthened, not retargeted: all four original assertions stand, plus its stub now asserts the guard argument is passed.

Reviewed by Codex over two rounds; its findings on cleanup ownership, in-flight heartbeat ordering, and test determinism are folded in.

## Changelog

A host connected from the desktop app no longer flips to offline moments after connecting, so sessions can be started without the host dropping out mid-prompt.
