### PR TITLE
chore(lint): enforce Pyrefly type checking

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-# Runs the project's pre-commit hooks (ruff, TypeScript lint, custom
+# Runs the project's pre-commit hooks (ruff, Pyrefly, TypeScript lint, custom
 # anti-pattern grep hooks, etc.) on every non-draft PR and on push to main.
 # Surfaces as the `Pre-commit checks` check, a REQUIRED gate entry in
 # merge-ready.yml. Draft PRs are skipped; `ready_for_review` refires so the
@@ -128,7 +128,7 @@ jobs:
           chmod +x /tmp/ktlint
           sudo mv /tmp/ktlint /usr/local/bin/ktlint
 
-      - name: Run formatting and lint checks
+      - name: Run formatting, lint, and type checks
         run: uv run pre-commit run --all-files --show-diff-on-failure
 
   # The four packages release in lockstep (identical versions + `==` sibling

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
-# Pre-commit hooks for this repository: ruff (format + check) plus standard
-# file-hygiene checks. Heavier validation (typing, lockfile freshness,
-# OpenAPI drift) runs in CI rather than as commit-time hooks.
+# Pre-commit hooks for this repository: ruff, Pyrefly, project-specific lint,
+# and standard file-hygiene checks.
 #
 # A built web-UI bundle may be committed at this path (vendored, minified
 # JS/CSS) — never lint or "fix" it.
@@ -19,6 +18,13 @@ repos:
         language: system
         entry: .venv/bin/python -m ruff check --fix --force-exclude
         types: [python]
+
+      - id: pyrefly
+        name: pyrefly
+        language: system
+        entry: .venv/bin/pyrefly check
+        pass_filenames: false
+        files: ^(omnigent/.*\.pyi?|pyproject\.toml|pyrefly\.toml|uv\.lock)$
 
       # Project-specific test-quality lint rules (dev/lint/). Run on test
       # files only — the patterns never occur in production code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,9 +44,12 @@ source .venv/bin/activate    # or prefix commands with `uv run`
 
 Common checks:
 
+Pyrefly is the canonical Python type checker for the repository.
+
 ```bash
 uv run pytest                      # Python tests (e2e/live skipped by default)
 uv run ruff check . && uv run ruff format --check .
+uv run --no-sync pyrefly check     # Python type checking (omnigent/)
 uv run pre-commit run --all-files
 ```
 

--- a/justfile
+++ b/justfile
@@ -10,6 +10,7 @@ DEVICE := env("OMNIGENT_IOS_SIMULATOR", "iPhone 17 Pro")
 
 _check-uv:
     uv run --no-sync ruff --version
+    uv run --no-sync pyrefly --version
     uv run --no-sync pre-commit --version
 
 _ensure-uv:
@@ -91,6 +92,10 @@ lint: _ensure-uv
 [group('lint')]
 lint-all: _ensure-uv
     uv run pre-commit run --all-files
+
+[group('lint')]
+typecheck-python: _ensure-uv
+    uv run --no-sync pyrefly check
 
 [group('lint')]
 lint-ts:

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -2910,7 +2910,7 @@ def _should_inject_openai_env_auth_for_executor(
         present and no explicit auth/profile/provider declaration
         should take precedence.
     """
-    if harness not in _OPENAI_AGENTS_HARNESSES:
+    if harness is None or harness not in _OPENAI_AGENTS_HARNESSES:
         return False
     if not os.environ.get(_OPENAI_API_KEY_ENV_VAR):
         return False

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -3454,7 +3454,7 @@ def _start_http_ingress(
     handler_cls = _handler_factory(token, notification_queue)
     httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
     host, port = _http_server_host_port(httpd)
-    server_info = {
+    server_info: _JsonObject = {
         "url": f"http://{host}:{port}",
         "token": token,
         "pid": os.getpid(),

--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -3867,7 +3867,7 @@ def _run_configure_harnesses_interactive() -> None:
             _manage_cursor_harness()
         elif selected_target == COPILOT_KEY:
             _manage_copilot_harness()
-        elif selected_target in families:
+        elif isinstance(selected_target, str) and selected_target in families:
             _manage_harness_providers(selected_target)
         elif selected_target == _ANTIGRAVITY:
             _manage_antigravity_harness()

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -3247,7 +3247,9 @@ async def _handle_mcp_startup_status(
     """
     name = params.get("name")
     status = params.get("status")
-    if not (isinstance(name, str) and name and status in MCP_STARTUP_STATES):
+    if not (
+        isinstance(name, str) and name and isinstance(status, str) and status in MCP_STARTUP_STATES
+    ):
         _logger.info("Codex forwarder ignored malformed MCP startup update: %r", params)
         return
     error = params.get("error")

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1922,6 +1922,7 @@ class HostProcess:
                     if listing.source == "openai-compatible"
                     else None
                 )
+                models: list[dict[str, object]]
                 if provider is not None and is_direct_openai_provider(provider):
                     available_ids = {model.id for model in listing.models}
                     models = []

--- a/omnigent/inner/sandbox.py
+++ b/omnigent/inner/sandbox.py
@@ -50,6 +50,10 @@ _LAUNCHER_PRIVATE_TMPDIR_ENV = "OMNIGENT_LAUNCHER_SPAWN_PRIVATE_TMPDIR"
 _SPAWN_WRAP_BACKENDS = frozenset({"linux_bwrap", "darwin_seatbelt"})
 
 
+def _json_string_list(values: Sequence[object]) -> list[JsonValue]:
+    return cast(list[JsonValue], [str(value) for value in values])
+
+
 @dataclass
 class SandboxPolicy:
     """
@@ -197,30 +201,36 @@ class SandboxPolicy:
             "backend_type": self.backend_type,
             "active": self.active,
             "read_roots": (
-                [str(root) for root in self.read_roots] if self.read_roots is not None else None
+                _json_string_list(self.read_roots) if self.read_roots is not None else None
             ),
-            "write_roots": [str(root) for root in self.write_roots],
-            "write_files": [str(path) for path in self.write_files],
+            "write_roots": _json_string_list(self.write_roots),
+            "write_files": _json_string_list(self.write_files),
             "allow_network": self.allow_network,
             "cwd_allow_hidden": (
-                list(self.cwd_allow_hidden) if self.cwd_allow_hidden is not None else None
+                _json_string_list(self.cwd_allow_hidden)
+                if self.cwd_allow_hidden is not None
+                else None
             ),
             "cwd_hidden_scan_max_entries": self.cwd_hidden_scan_max_entries,
             "cwd_hidden_scan_overflow": self.cwd_hidden_scan_overflow,
             "cwd_hidden_scan_recursive": self.cwd_hidden_scan_recursive,
             "mask_paths": (
-                [str(path) for path in self.mask_paths] if self.mask_paths is not None else None
+                _json_string_list(self.mask_paths) if self.mask_paths is not None else None
             ),
             "env_passthrough": (
-                list(self.env_passthrough) if self.env_passthrough is not None else None
+                _json_string_list(self.env_passthrough)
+                if self.env_passthrough is not None
+                else None
             ),
             "spawn_env_allowlist": (
-                list(self.spawn_env_allowlist) if self.spawn_env_allowlist is not None else None
+                _json_string_list(self.spawn_env_allowlist)
+                if self.spawn_env_allowlist is not None
+                else None
             ),
             "egress_relay_port": self.egress_relay_port,
             "egress_socket_path": self.egress_socket_path,
             "deny_unix_socket_paths": (
-                [str(path) for path in self.deny_unix_socket_paths]
+                _json_string_list(self.deny_unix_socket_paths)
                 if self.deny_unix_socket_paths is not None
                 else None
             ),

--- a/omnigent/pi_native_bridge.py
+++ b/omnigent/pi_native_bridge.py
@@ -133,7 +133,7 @@ def enqueue_user_message(bridge_dir: Path, content: str) -> str:
     :returns: Opaque message id.
     """
     message_id = f"msg_{uuid.uuid4().hex}"
-    payload = {
+    payload: _JsonObject = {
         "id": message_id,
         "type": "user_message",
         "content": content,
@@ -156,7 +156,7 @@ def enqueue_interrupt(bridge_dir: Path) -> str:
     :returns: Opaque interrupt id.
     """
     interrupt_id = f"interrupt_{uuid.uuid4().hex}"
-    payload = {
+    payload: _JsonObject = {
         "id": interrupt_id,
         "type": "interrupt",
         "created_at": time.time(),
@@ -213,7 +213,7 @@ def enqueue_model_change(bridge_dir: Path, model: str) -> str:
     :returns: Opaque model-change id.
     """
     model_change_id = f"model_change_{uuid.uuid4().hex}"
-    payload = {
+    payload: _JsonObject = {
         "id": model_change_id,
         "type": "model_change",
         "model": model,

--- a/omnigent/policies/builtins/cost.py
+++ b/omnigent/policies/builtins/cost.py
@@ -500,7 +500,7 @@ def cost_budget(
             a new soft checkpoint is newly crossed; ALLOW otherwise.
         """
         phase = event.get("type")
-        if phase not in _GATED_PHASES:
+        if not isinstance(phase, str) or phase not in _GATED_PHASES:
             return _ALLOW
         context = event.get("context") or {}
         if _usage_is_unpriced(context.get("usage") or {}):
@@ -679,7 +679,7 @@ def user_daily_cost_budget(
             otherwise.
         """
         phase = event.get("type")
-        if phase not in _GATED_PHASES:
+        if not isinstance(phase, str) or phase not in _GATED_PHASES:
             return _ALLOW
         context = event.get("context") or {}
         if _usage_is_unpriced(context.get("usage") or {}):
@@ -823,7 +823,7 @@ def subagent_cost_budget(
             a new soft checkpoint is newly crossed; ALLOW otherwise.
         """
         phase = event.get("type")
-        if phase not in _GATED_PHASES:
+        if not isinstance(phase, str) or phase not in _GATED_PHASES:
             return _ALLOW
         context = event.get("context") or {}
         if _usage_is_unpriced(context.get("subtree_usage") or {}):

--- a/omnigent/policies/function.py
+++ b/omnigent/policies/function.py
@@ -91,8 +91,6 @@ class FunctionPolicy(Policy):
         (dict-form spec).
     """
 
-    spec: FunctionPolicySpec
-
     def __init__(
         self,
         spec: FunctionPolicySpec,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -8826,7 +8826,7 @@ async def _evaluate_agent_start_gate(
 
     sandbox_dict: _JsonObject | None = None
     if spec.os_env is not None and spec.os_env.sandbox is not None:
-        sandbox_dict = dataclasses.asdict(spec.os_env.sandbox)
+        sandbox_dict = cast(_JsonObject, dataclasses.asdict(spec.os_env.sandbox))
 
     return await gate.evaluate_tool_call(
         "sys_agent_start",

--- a/omnigent/runner/background_titles/service.py
+++ b/omnigent/runner/background_titles/service.py
@@ -33,13 +33,17 @@ class BackgroundTitleProcessManager(Protocol):
     async def get_client(
         self,
         conversation_id: str,
-        harness_name: str,
-        *,
+        harness: str,
         env: dict[str, str] | None = None,
     ) -> httpx.AsyncClient:
         pass
 
-    async def release(self, conversation_id: str) -> None:
+    async def release(
+        self,
+        conversation_id: str,
+        *,
+        only_if_idle_cutoff: float | None = None,
+    ) -> None:
         pass
 
 

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3995,7 +3995,7 @@ async def _codex_discover_thread_and_forward(
         server_url = _required_runner_env("RUNNER_SERVER_URL")
         auth_factory = _make_auth_token_factory()
         auth_token = auth_factory() if auth_factory is not None else None
-        headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else {}
+        headers: dict[str, str] = {"Authorization": f"Bearer {auth_token}"} if auth_token else {}
 
         # Mirror the discovered Codex thread id onto the Omnigent session as its
         # external_session_id, the same way claude-native records its

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -6515,9 +6515,12 @@ async def _handle_mcp_tools_call(
         for eid, req_entry in input_requests.items():
             req_params = req_entry.get("params", {}) if isinstance(req_entry, dict) else {}
             elicit_params = ElicitationRequestParams(
-                mode=req_params.get("mode", "form"),
+                mode=cast(Literal["form", "url"], req_params.get("mode", "form")),
                 message=req_params.get("message", "Approval required"),
-                requestedSchema=req_params.get("requestedSchema"),
+                requestedSchema=cast(
+                    Mapping[str, Any] | None,
+                    req_params.get("requestedSchema"),
+                ),
             )
             elicit_result = await _publish_and_wait_for_harness_elicitation(
                 request,

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import secrets
 from collections.abc import Callable
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import httpx
 from fastapi import (
@@ -843,7 +843,7 @@ def register_events_routes(
             return {"queued": False}
         if body.type == _EXTERNAL_SESSION_STATUS_TYPE:
             status = body.data.get("status")
-            if status not in _EXTERNAL_SESSION_STATUS_VALUES:
+            if not isinstance(status, str) or status not in _EXTERNAL_SESSION_STATUS_VALUES:
                 raise OmnigentError(
                     f"external_session_status requires data.status in "
                     f"{sorted(_EXTERNAL_SESSION_STATUS_VALUES)}; got {status!r}",
@@ -983,6 +983,7 @@ def register_events_routes(
                 if not (
                     isinstance(server_name, str)
                     and server_name
+                    and isinstance(record_status, str)
                     and record_status in _EXTERNAL_MCP_STARTUP_STATUS_VALUES
                 ):
                     raise OmnigentError(
@@ -993,7 +994,10 @@ def register_events_routes(
                     )
                 record_error = record.get("error")
                 mcp_servers[server_name] = McpServerStartup(
-                    status=record_status,
+                    status=cast(
+                        Literal["starting", "ready", "failed", "cancelled"],
+                        record_status,
+                    ),
                     error=record_error if isinstance(record_error, str) and record_error else None,
                 )
             _publish_mcp_startup(session_id, mcp_servers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,6 +300,7 @@ dev = [
     "filelock>=3.0",
     "ruff>=0.6",
     "mypy>=1.10",
+    "pyrefly==1.1.1",
     "pre-commit>=3.5",
     "types-PyYAML>=6.0",
     "filelock>=3.0",

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -1,11 +1,46 @@
 project-includes = [
-   "**/*.py"
+    "omnigent/**/*.py",
+    "omnigent/**/*.pyi",
 ]
 
 project-excludes = []
 
-search-path = []
+python-version = "3.12"
+
+search-path = ["."]
 
 disable-search-path-heuristics = true
-ignore-missing-imports = ["*"]
+
+# Optional/proprietary integrations are intentionally absent from the
+# standard development environment.
+ignore-missing-imports = [
+    "boxlite",
+    "boxlite.*",
+    "copilot",
+    "copilot.*",
+    "cursor_sdk",
+    "cursor_sdk.*",
+    "cwsandbox",
+    "cwsandbox.*",
+    "databricks",
+    "databricks.*",
+    "daytona",
+    "daytona.*",
+    "e2b",
+    "e2b.*",
+    "google.auth",
+    "google.auth.*",
+    "islo",
+    "islo.*",
+    "kubernetes",
+    "kubernetes.*",
+    "modal",
+    "modal.*",
+    "numpy",
+    "numpy.*",
+    "omnigent.onboarding.internal_beta",
+    "openshell",
+    "openshell.*",
+]
+
 ignore-errors-in-generated-code = true

--- a/uv.lock
+++ b/uv.lock
@@ -3011,6 +3011,7 @@ dev = [
     { name = "mypy" },
     { name = "pathspec" },
     { name = "pre-commit" },
+    { name = "pyrefly" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -3131,6 +3132,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0,<3" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8,<3" },
     { name = "pymysql", marker = "extra == 'databricks'", specifier = ">=1.1,<2" },
+    { name = "pyrefly", marker = "extra == 'dev'", specifier = "==1.1.1" },
     { name = "pyte", marker = "sys_platform != 'win32'", specifier = ">=0.8,<1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },
@@ -4291,6 +4293,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyrefly"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/20/976165fa4b1517a1a92f393b3f4d4badabfff1165eff09d4cd4908428183/pyrefly-1.1.1.tar.gz", hash = "sha256:6deda959f8603a7dbdf112c48983e2275b2903cf33c8c739ed65d7e71a4fd520", upload-time = "2026-06-18T23:45:43.785Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/d6/02ba666018c6a1cb4ddfa2db98ada721adddd374db5c29ba47a0bf2637fa/pyrefly-1.1.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f4b8595f91885bc8b5e3c282ab68d1df21201668a84e6508b1e15f2feec0bb8d", upload-time = "2026-06-18T23:45:13.923Z" },
+    { url = "https://files.pythonhosted.org/packages/71/47/7a3457dbbddb513a83cf4fe527d5d5ebda5201a1010ad2a6034030e3e358/pyrefly-1.1.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d6b238e1362622d47a6eb5af704fd8b613c94e8c303386efd6350e3da59fecc8", upload-time = "2026-06-18T23:45:16.865Z" },
+    { url = "https://files.pythonhosted.org/packages/84/df/70f4b3f42d58ed686a80df31e04eca54d88036cea4f9b96195c64ad0b2b5/pyrefly-1.1.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b50d4510e4f8aaea79e2c4b343a4d7a060c9451c0b2aa9bfe10d7ca1ef33d68d", upload-time = "2026-06-18T23:45:19.644Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/53/12a19bd6c7af985bcbc13c6910d0f9f6684069ead2282a5c08c2bfbb5d03/pyrefly-1.1.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f330cf039ef3da3b910c84f3a7e431f0cf8d0c1d2dad26491d6cadf3c7cd4759", upload-time = "2026-06-18T23:45:22.252Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f0/e55c48a50076fc0f9ecf4bdedec50456db383e01162f5e2121f8468be071/pyrefly-1.1.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a6342d87c52b04f72156da04f554c4d57f3616f2b32d1763969efb22d05a1407", upload-time = "2026-06-18T23:45:24.858Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e7/30e085b31fed978ecb675bdbb54df566673ab550469e5af2d350f6af0be6/pyrefly-1.1.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c08b814ad03175e9cf47111390537161828b472044c39ab3320252b3ac6b2edd", upload-time = "2026-06-18T23:45:27.247Z" },
+    { url = "https://files.pythonhosted.org/packages/47/58/49c3e67641133d3fe5d8d9a660dc0826c6c37ca197d86cad05fa7dd8bfd6/pyrefly-1.1.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d50cad97f19fc893b04deff7239626cffff5dd27ffb29b7d303a1b770247b208", upload-time = "2026-06-18T23:45:29.775Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1e/65a7ba8355e2c39d8331832905fb74dcc85fc122a3f1dfd6dbf2a88907ad/pyrefly-1.1.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2150b450ee6a6bcbe69b2d45d9a4ebc934a609e1abcf65e490433f38eb873d84", upload-time = "2026-06-18T23:45:32.576Z" },
+    { url = "https://files.pythonhosted.org/packages/37/de/b7ee1ab2392c36945738246fba7524439810befa3cfcc03cb6157567fc10/pyrefly-1.1.1-py3-none-win32.whl", hash = "sha256:5ffd8a8ed62fe4e6bf0afe1837d1bad149bb3b9f80e928ef248c96b836db3742", upload-time = "2026-06-18T23:45:35.419Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9c/a0f5b52934bf80e9c7eff08222e7caf318287b9aef76acb8d9ac5740581b/pyrefly-1.1.1-py3-none-win_amd64.whl", hash = "sha256:4e0430f3ef69c8ac73505fd6584db70ed504665a9f0816fef7f723de510f26cb", upload-time = "2026-06-18T23:45:38.375Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/4c6bcb3d456835f51445d3662a428f56c3ea5643ec798c577030ae34298c/pyrefly-1.1.1-py3-none-win_arm64.whl", hash = "sha256:83baf0db71e172665db1fca0ced50b8f7773f5192ca57e8ac6773a772b6d2fc5", upload-time = "2026-06-18T23:45:41.026Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Related issue

Closes #3644

## Summary

- Make Pyrefly the canonical Python type checker, pinned at `1.1.1`, with a project-scoped configuration that resolves internal `omnigent.*` imports instead of treating them as `Any`.
- Fix the 22 cross-module errors exposed by the corrected search path, while limiting missing-import exceptions to documented optional integrations.
- Run the same full-project check from pre-commit and the required `Pre-commit checks` CI job; add `just typecheck-python` and contributor documentation.

**ELI5:** Pyrefly previously checked files without seeing the rest of the package, so some real errors were invisible. It now sees the complete project and blocks new errors both locally and in CI.

```text
commit / pull request
        |
        v
pre-commit: pyrefly check
        |
        v
required CI: Pre-commit checks
```

<details>
<summary>Pyrefly cleanup series</summary>

- [#3934](https://github.com/omnigent-ai/omnigent/pull/3934) — sessions wildcard-import chain
- [#3935](https://github.com/omnigent-ai/omnigent/pull/3935) — binary subprocess handle contracts
- [#3936](https://github.com/omnigent-ai/omnigent/pull/3936) — server health liveness fallbacks
- [#3937](https://github.com/omnigent-ai/omnigent/pull/3937) — session usage accumulator contract
- [#3938](https://github.com/omnigent-ai/omnigent/pull/3938) — REPL timed formatter options
- [#3939](https://github.com/omnigent-ai/omnigent/pull/3939) — egress resolved-address narrowing
- [#3940](https://github.com/omnigent-ai/omnigent/pull/3940) — Codex process owner-lock resources
- [#3941](https://github.com/omnigent-ai/omnigent/pull/3941) — lazy import lifecycle boundaries
- [#3942](https://github.com/omnigent-ai/omnigent/pull/3942) — non-JSON runner stream frames
- [#3944](https://github.com/omnigent-ai/omnigent/pull/3944) — workspace text decoding state
- [#3945](https://github.com/omnigent-ai/omnigent/pull/3945) — detected harness credential families
- [#3946](https://github.com/omnigent-ai/omnigent/pull/3946) — Bedrock client configuration
- [#3947](https://github.com/omnigent-ai/omnigent/pull/3947) — UUID dialect hook signatures
- [#3948](https://github.com/omnigent-ai/omnigent/pull/3948) — compressed-text dialect hook signatures
- [#3953](https://github.com/omnigent-ai/omnigent/pull/3953) — child-status JSON payload
- [#3954](https://github.com/omnigent-ai/omnigent/pull/3954) — MCP elicitation exception lifecycle
- [#3956](https://github.com/omnigent-ai/omnigent/pull/3956) — CLI server/model lifecycle narrowing
- [#3957](https://github.com/omnigent-ai/omnigent/pull/3957) — validated server request fields
- [#3958](https://github.com/omnigent-ai/omnigent/pull/3958) — executor cleanup lifecycles
- [#3959](https://github.com/omnigent-ai/omnigent/pull/3959) — runner JSON/export/auth boundaries
- [#3960](https://github.com/omnigent-ai/omnigent/pull/3960) — default policy phase literals
- [#3961](https://github.com/omnigent-ai/omnigent/pull/3961) — Pi model catalog entries
- [#3962](https://github.com/omnigent-ai/omnigent/pull/3962) — model-backed event snapshots
- [#3963](https://github.com/omnigent-ai/omnigent/pull/3963) — native terminal close metadata
- [#3966](https://github.com/omnigent-ai/omnigent/pull/3966) — final REPL protocol/lifecycle errors

</details>

## Test Plan

- `UV_DEFAULT_INDEX=https://pypi.org/simple uv lock --check`
- `uv run --no-sync pyrefly check` — 0 errors
- `uv run --no-sync pre-commit run pyrefly --all-files`
- `uv run --no-sync pre-commit run --show-diff-on-failure` — all staged hooks passed
- Focused unit suites across the changed boundaries — 631 passed; one unrelated macOS temp-path failure in `test_relay_close_keeps_advertisement_owned_by_newer_relay`

## Demo

N/A — non-visual type-checking and CI change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing focused tests exercise the adjusted runtime guards and protocol boundaries. The enforcement itself is verified through the new pre-commit hook and required CI job.
