### PR TITLE
Part 1

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -21,11 +21,14 @@
     ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
     "Noto Color Emoji";
   --font-mono: "Geist Mono Variable", "JetBrains Mono", ui-monospace, monospace;
-  /* 13px/20px text step between text-xs (12px) and text-sm (14px) —
+  /* 13px/18px text step between text-xs (12px) and text-sm (14px) —
      * generates the `text-13` utility. Used for compact UI chrome like
      * the composer footer selectors and slash-command menu rows. */
   --text-13: 13px;
-  --text-13--line-height: 20px;
+  --text-13--line-height: 18px;
+  /* Chat thread body text — 14px/22px; generates the `text-chat` utility. */
+  --text-chat: 14px;
+  --text-chat--line-height: 22px;
   /* Hero/title step — overrides Tailwind's default text-3xl (30/36)
      * with a slightly larger 32px face on the same 36px line. */
   --text-3xl: 32px;
@@ -46,6 +49,8 @@
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);
+  /* Weaker panel border for low-contrast dividers. */
+  --color-border-weak: var(--border-weak);
   /* Stronger border for higher-contrast dividers/outlines. */
   --color-border-strong: var(--border-strong);
   /* Neutral border specifically for buttons (lighter than --border-strong). */
@@ -71,6 +76,8 @@
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
+  /* Tertiary text for lighter/disabled labels. */
+  --color-foreground-tertiary: var(--foreground-tertiary);
   --color-muted: var(--muted);
   --color-secondary-foreground: var(--secondary-foreground);
   --color-secondary: var(--secondary);
@@ -180,11 +187,13 @@
      * The auth pages (outside the gradient shell) use this as their
      * full-page canvas. */
   --background: #fff;
-  --foreground: #11171c;
+  --foreground: #27272a;
+  /* Tertiary gray for lighter/disabled/placeholder text. */
+  --foreground-tertiary: #a1a1aa;
   --card: #fff;
   /* Light --card is already opaque; the solid form only diverges in dark. */
   --card-solid: #fff;
-  --card-foreground: #11171c;
+  --card-foreground: #27272a;
   /* Tray surface (composer footer tray): white, applied translucently
      * via opacity modifiers so the page gradient shows through. */
   --tray: #fff;
@@ -197,9 +206,9 @@
   /* Light grey fill so secondary badges/headers read as surfaces (a
      * fully-transparent value left them as bare floating text). */
   --secondary: #eceef1;
-  --secondary-foreground: #11171c;
+  --secondary-foreground: #27272a;
   --muted: #0000000f;
-  --muted-foreground: #6f6f6f;
+  --muted-foreground: #71717a;
   /* Dedicated chip background for inline code — a hair darker than the
      * white card so the chip reads as a tile. Kept separate from --muted
      * (now a translucent black wash reused for hover/quote surfaces). */
@@ -217,12 +226,14 @@
      * that harmonizes with the brand blues (#2272b4 / #3b8ff5) and reads
      * with strong contrast on the white card surface. */
   --session-active: #2f7fd4;
-  --border: #e8ecf0;
+  --border: #e4e4e7;
+  /* Weaker panel border for low-contrast dividers. */
+  --border-weak: #ececee;
   /* Stronger divider/outline + a dedicated neutral button border. */
-  --border-strong: #a3b1bf;
+  --border-strong: #a1a1aa;
   --button-border: #d6d6d6;
-  --button-icon-hover-color: #11171c;
-  --input: #e8ecf0;
+  --button-icon-hover-color: #27272a;
+  --input: #e4e4e7;
   /* Focus ring matches --primary. */
   --ring: #11171c;
   /* Brand pink — reserved for brand moments, not status. */
@@ -244,6 +255,18 @@
   --radius-otto-md: 12px;
   --ease-otto: cubic-bezier(0.34, 1.4, 0.64, 1);
   --duration-otto-fast: 180ms;
+  /* Elevation scale from the brand mock; -otto suffix keeps them off
+     * Tailwind's built-in shadow-*. */
+  --shadow-otto-composer: 0 0 12px -6px rgba(0, 0, 0, 0.12);
+  --shadow-otto-composer-focus: 0 0 20px -4px rgba(0, 0, 0, 0.12);
+  --shadow-otto-xs: 0 2px 8px rgba(0, 0, 0, 0.04);
+  --shadow-otto-sm: 0 4px 10px -6px rgba(0, 0, 0, 0.09);
+  --shadow-otto-md: 0 6px 12px -6px rgba(0, 0, 0, 0.12);
+  --shadow-otto-lg: 0 6px 20px -4px rgba(0, 0, 0, 0.12);
+  --shadow-otto-menu: 0 8px 28px rgba(60, 40, 10, 0.12);
+  --shadow-otto-xl: 0 12px 44px rgba(60, 40, 10, 0.16);
+  --shadow-otto-card: 0 4px 16px -2px rgba(60, 40, 10, 0.1), 0 1px 0 rgba(0, 0, 0, 0.02);
+  --shadow-otto-tooltip: 0 3px 6px rgba(0, 0, 0, 0.05);
   /* Sidebar + workspace cards are white (--card); they float on the
      * near-white .app-shell gradient canvas. --sidebar matches that
      * gradient's lightest tone so bg-sidebar surfaces (the app-shell's
@@ -251,13 +274,16 @@
      * message copy button) blend into the canvas rather than painting
      * a lavender band. */
   --sidebar: #fdfafa;
-  --sidebar-foreground: #11171c;
+  --sidebar-foreground: #27272a;
   --sidebar-primary: #2272b4;
   --sidebar-primary-foreground: #fff;
   --sidebar-accent: #d7edfe;
   --sidebar-accent-foreground: #04355d;
-  --sidebar-border: #e8ecf0;
+  --sidebar-border: #e4e4e7;
   --sidebar-ring: #2272b4;
+  /* Faint dot-grid tint on the light-mode sidebar canvas (see the
+     * html:not(.dark) .conversations-sidebar rule). Tunable. */
+  --sidebar-dot-color: #8e537333;
   --sidebar-hover: color-mix(in srgb, var(--sidebar-foreground) 3%, transparent);
   --sidebar-active: color-mix(in srgb, var(--sidebar-foreground) 7%, var(--sidebar));
   --sidebar-active-foreground: var(--sidebar-foreground);
@@ -265,20 +291,18 @@
 
 .dark {
   /* Dark mode tokens — semi-transparent for glassmorphism backdrop-filter */
-  --background: #0d1218;
+  --background: #0e1013;
   --foreground: oklch(0.965 0.003 240);
-  --card: rgba(40, 34, 58, 0.6);
+  --card: rgba(31, 39, 45, 0.6);
   /* Opaque stand-in for the glass --card. The composer card uses this
      * instead of --card: its trays tuck their square corners behind the
      * card (negative-margin overlap), and a translucent card lets the
-     * tucked strip ghost through its edges. Not --card's raw RGB
-     * (#28223a) — full-alpha that read lighter than the neighboring
-     * glass surfaces; this approximates the glass card's perceived
-     * color: 60% of #28223a composited over the dark canvas gradient. */
-  --card-solid: #201c30;
+     * tucked strip ghost through its edges. Approximates the glass card's
+     * perceived color on the dark canvas. */
+  --card-solid: #181f25;
   --card-foreground: oklch(0.965 0.003 240);
   /* Dark counterpart of the tray surface — semi-transparent for glass effect */
-  --tray: rgba(40, 34, 58, 0.6);
+  --tray: rgba(31, 39, 45, 0.6);
   --popover: rgba(26, 33, 41, 0.8);
   --popover-foreground: oklch(0.965 0.003 240);
   --primary: #e8ecf0;
@@ -286,11 +310,10 @@
   --secondary: #1f272d;
   --secondary-foreground: #e8ecf0;
   /* Active/selected states, hover backgrounds, subtle containers. */
-  /* Opaque base (#28223a is var(--card)'s solid form — the dark-mode --card
-       itself is translucent). bg-muted backs ~160 solid utility surfaces (code
-       blocks, badges, hover rows) that must not let the canvas gradient bleed
-       through; the frosted look is reserved for the .dark .bg-card rule. */
-  --muted: color-mix(in srgb, var(--muted-foreground) 15%, #28223a);
+  /* Opaque slate base: bg-muted backs ~160 solid utility surfaces (code
+       blocks, badges, hover rows) that must stay opaque; the frosted look is
+       reserved for the .dark .bg-card rule. */
+  --muted: color-mix(in srgb, var(--muted-foreground) 15%, #262f36);
   --muted-foreground: #92a4b3;
   --code-bg: oklch(0.38 0.005 240);
   --accent: #04355d;
@@ -324,11 +347,8 @@
   --chart-3: oklch(0.68 0.15 145);
   --chart-4: oklch(0.75 0.16 70);
   --chart-5: oklch(0.65 0.008 240);
-  /* bg-sidebar surfaces blend into the dark .app-shell gradient — a 45°
-     * diagonal sweeping green (rgb 17,24,28) → purple (rgb 19,13,33);
-     * --sidebar sits in the green-dominant region and stays translucent
-     * so it tracks the canvas underneath (a flat color can't match a
-     * diagonal everywhere). Mirrors the light-mode treatment. */
+  /* Translucent so the sidebar's own layers (see .dark .conversations-sidebar)
+     * and the canvas read through it. */
   --sidebar: rgba(17, 23, 28, 0.75);
   --sidebar-foreground: oklch(0.965 0.003 240);
   --sidebar-primary: oklch(0.64 0.22 254);
@@ -338,45 +358,60 @@
   --sidebar-border: oklch(0.28 0.005 240);
   --sidebar-ring: oklch(0.92 0.003 240 / 0.4);
   --tooltip-bg: #2a2440;
+  /* White dot-grid tint for the dark sidebar (see .dark .conversations-sidebar). */
+  --sidebar-dot-color: rgba(255, 255, 255, 0.12);
 }
 
 .sidebar-compact-text {
   font-size: var(--sidebar-font-size);
 }
 
-/* App-shell canvas gradient. Copied verbatim from the brand mock
- * (agentic-ux-2026, "modern-1" layout): a near-white 45° gradient with the
- * faintest warm/pink drift, painted over the lavender --background. The
- * lavender base is effectively never seen (the opaque gradient covers it),
- * exactly as on the mock — it remains the fallback. The white sidebar /
- * workspace cards float on this near-white canvas, delineated by their
- * border + shadow rather than background contrast. --sidebar is set to the
- * gradient's near-white so bg-sidebar chrome stays invisible against this
- * canvas. */
+/* App-shell canvas — the transparent <main> shows it through. Light: flat
+ * white. Dark: purple-tinted near-black, two faint radial blooms over a 145°
+ * gradient (from the agentic-ux-2026 mock). The rails paint their own layers
+ * (below) and are excluded from the .dark glass rule, so they read as canvas,
+ * not frosted cards. */
 .app-shell {
-  background: linear-gradient(
-    45deg,
-    rgb(253, 250, 250),
-    rgb(253, 249, 251) 8%,
-    rgb(253, 249, 251) 17%,
-    rgb(253, 249, 252) 25%,
-    rgb(254, 248, 253) 33%,
-    rgb(254, 248, 252) 42%,
-    rgb(254, 251, 252) 50%,
-    rgb(254, 251, 251) 58%,
-    rgb(254, 251, 251) 67%,
-    rgb(254, 251, 251) 75%,
-    rgb(254, 251, 251) 83%,
-    rgb(254, 251, 251) 92%,
-    rgb(254, 253, 253)
-  );
+  background: var(--background);
 }
 .dark .app-shell {
   background:
-    radial-gradient(ellipse at 20% 50%, rgba(100, 40, 180, 0.15) 0%, transparent 50%),
-    radial-gradient(ellipse at 80% 20%, rgba(80, 30, 140, 0.1) 0%, transparent 45%),
-    radial-gradient(ellipse at 60% 80%, rgba(140, 30, 100, 0.08) 0%, transparent 40%),
-    linear-gradient(145deg, #1e1035 0%, #11171c 50%, #161020 100%);
+    radial-gradient(rgba(100, 40, 180, 0.12), transparent 50%),
+    radial-gradient(at 80% 20%, rgba(80, 30, 140, 0.08), transparent 45%),
+    linear-gradient(145deg, #1a0e2d, #0e1418, #130e1b);
+}
+
+/* Left sidebar canvas — a 20px dot-grid (--sidebar-dot-color, themed) over a
+ * themed base. Light: the near-white brand gradient + a pink corner glow,
+ * lifted by an inset edge shadow. Dark: transparent base (the canvas shows) +
+ * a purple bottom wash + the diagonal white sheen. */
+html:not(.dark) .conversations-sidebar {
+  background:
+    radial-gradient(var(--sidebar-dot-color) 0.6px, transparent 0.8px) 0 0 / 20px 20px,
+    radial-gradient(104% 74% at 112% 108%, rgba(248, 177, 215, 0.16), transparent 66%),
+    linear-gradient(
+      45deg,
+      rgb(253, 250, 250),
+      rgb(253, 249, 251) 8%,
+      rgb(253, 249, 251) 17%,
+      rgb(253, 249, 252) 25%,
+      rgb(254, 248, 253) 33%,
+      rgb(254, 248, 252) 42%,
+      rgb(254, 251, 252) 50%,
+      rgb(254, 251, 251) 58%,
+      rgb(254, 251, 251) 67%,
+      rgb(254, 251, 251) 75%,
+      rgb(254, 251, 251) 83%,
+      rgb(254, 251, 251) 92%,
+      rgb(254, 253, 253)
+    );
+  box-shadow: rgba(0, 0, 0, 0.05) -12px 0 24px -14px inset;
+}
+.dark .conversations-sidebar {
+  background:
+    radial-gradient(var(--sidebar-dot-color) 0.6px, transparent 0.8px) 0 0 / 20px 20px,
+    linear-gradient(transparent 35%, rgba(92, 48, 108, 0.2)),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.04), transparent 60%);
 }
 
 /* Chat scroll fade: the ChatHeader overlay paints no background (a flat
@@ -419,9 +454,7 @@
 }
 
 /* Elevated surfaces — frosted glass effect with backdrop blur.
- * Targets top-level cards only, including responsive card surfaces like
- * the workspace panel's md:bg-card (so its chrome matches the sidebar's
- * glass border in dark mode). A bg-card nested inside another bg-card
+ * Targets top-level cards only. A bg-card nested inside another bg-card
  * (e.g. FilesPanel inside the workspace panel, toolbars inside the
  * composer) is an interior fill, and re-decorating it with its own
  * border/shadow visually carves the parent card into pieces.
@@ -432,11 +465,13 @@
  * aria-hidden: Radix's modal a11y hiding sets aria-hidden="true" on open
  * panels while a menu/dialog is up, and dropping this rule's 1px border
  * then reflowed every sidebar row 2px wider. Not [inert] either: this
- * React version drops the boolean inert attribute from the DOM.) */
+ * React version drops the boolean inert attribute from the DOM.)
+ * Both rails (Workspace, Conversations) are excluded — they paint their own
+ * canvas layers above, not a glass card. */
 .dark
   :is(.bg-card, [class*="md:bg-card"]):not(
     :is(.bg-card, [class*="md:bg-card"]) :is(.bg-card, [class*="md:bg-card"])
-  ):not([data-collapsed]) {
+  ):not([data-collapsed]):not([aria-label="Workspace"]):not([aria-label="Conversations"]) {
   /* -webkit- must come BEFORE the unprefixed property: LightningCSS (vite
    * build) collapses the pair and keeps only the last declaration. */
   -webkit-backdrop-filter: blur(32px) saturate(180%) !important;
@@ -461,6 +496,17 @@
   border-right: none !important;
   border-top: none !important;
   border-bottom: none !important;
+}
+
+/* Right rail (workspace panel) in dark: blends into the canvas, keeping only
+ * its left divider. Excluded from the glass rule above, so this just clears
+ * the rail's md:bg-card fill and the bg-card fills its panel contents paint
+ * (FilesPanel/TerminalsPanel/SubagentsPanel + the graph surface). */
+.dark aside[aria-label="Workspace"],
+.dark
+  aside[aria-label="Workspace"]
+  :is([data-workspace-panel-content] > *, [data-workspace-panel-surface]) {
+  background: transparent !important;
 }
 
 /* Popovers/menus — same glass treatment */

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2562,7 +2562,7 @@ export function JumpToTopButton({
           // variant's hover (bg-muted) is a translucent black wash (--muted is
           // #0000000f), so over the faded chat text behind the pill it bleeds
           // through and reads as transparent. bg-background is opaque (#fff /
-          // #0d1218); hover feedback comes from a brightness filter, which keeps
+          // #0e1013); hover feedback comes from a brightness filter, which keeps
           // the fill fully opaque.
           "bg-background hover:bg-background hover:brightness-95",
           "dark:bg-background dark:hover:bg-background dark:hover:brightness-125",

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -328,7 +328,7 @@ const LIGHT_MODE_PREVIEW: PaletteSwatch = {
   text: "#11171c",
 };
 const DARK_MODE_PREVIEW: PaletteSwatch = {
-  bg: "#0d1218",
+  bg: "#0e1013",
   card: "#232a33",
   accent: "#5b6672",
   border: "#2b333d",

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -1073,8 +1073,8 @@ describe("Workspace rail maximize", () => {
     fireEvent.click(screen.getByRole("button", { name: "Full screen" }));
     expect(rail().className).toContain("md:absolute");
     expect(rail().className).toContain("md:inset-0");
-    // Still keeps the docked card inset/rounding — only the width changes.
-    expect(rail().className).toContain("md:m-2");
+    // Still keeps the docked flush/bordered styling — only the width changes.
+    expect(rail().className).toContain("md:border-l");
     expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "false");
 
     // Minimize → back to the docked flex child, and the sidebar is restored to

--- a/web/src/shell/Sidebar.subagentHighlight.test.tsx
+++ b/web/src/shell/Sidebar.subagentHighlight.test.tsx
@@ -154,14 +154,13 @@ describe("sidebar highlight while viewing a sub-agent", () => {
     expect(wordmark.getAttribute("src")).toContain("omnigent-wordmark");
   });
 
-  it("uses the same Otto structural-container radius as the workspace rail", () => {
+  it("sits flush to the window edge, no floating margin or border", () => {
     mockConversations([]);
     renderAt("/");
 
-    expect(screen.getByRole("complementary", { name: "Conversations" })).toHaveClass(
-      "md:rounded-[var(--radius-otto-md)]",
-      "md:m-2",
-    );
+    const sidebar = screen.getByRole("complementary", { name: "Conversations" });
+    expect(sidebar).toHaveClass("md:m-0");
+    expect(sidebar).not.toHaveClass("md:m-2", "md:rounded-[var(--radius-otto-md)]", "md:border");
   });
 
   it("highlights the top-level parent row when the active session is its child", async () => {

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -648,15 +648,14 @@ export function Sidebar({ open, onClose, dragProgress = null, onOpenSearch }: Si
         // and gated to mobile so the desktop floating card is unaffected.
         "max-md:transition-transform max-md:duration-200 max-md:ease-out",
         effectiveOpen ? "translate-x-0" : "-translate-x-full",
-        // Desktop: a floating card. Detached from the window edges by a
-        // margin, rounded, and lifted off the bg-sidebar canvas with a
-        // full border + shadow. Width (the user-resizable variable) animates
-        // →0 to push main; when closed the margin/border collapse too so
-        // nothing lingers.
+        // Desktop: a full-height panel flush to the window edge, carrying
+        // the brand gradient canvas (see html:not(.dark) .conversations-sidebar
+        // in index.css) and separated from the white content by a right
+        // divider — no outer margin or rounding. Width (the user-resizable
+        // variable) animates →0 to push main; when closed the border
+        // collapses too so nothing lingers.
         "md:relative md:inset-auto md:translate-x-0 md:overflow-hidden",
-        open
-          ? "md:m-2 md:w-[var(--sidebar-width)] md:rounded-[var(--radius-otto-md)] md:border md:border-border"
-          : "md:m-0 md:w-0 md:border-0",
+        open ? "md:m-0 md:w-[var(--sidebar-width)] " : "md:m-0 md:w-0 md:border-0",
       )}
       style={
         {

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -148,12 +148,12 @@ function renderWorkspace(
 }
 
 describe("WorkspacePanel surface presentation", () => {
-  it("uses an evenly inset desktop surface instead of clearing the header", () => {
+  it("sits flush to the window edge with a left divider, no floating card frame", () => {
     renderWorkspace();
 
     const panel = screen.getByRole("complementary", { name: "Workspace" });
-    expect(panel).toHaveClass("md:m-2", "md:rounded-lg");
-    expect(panel).not.toHaveClass("md:mt-14", "md:mr-2", "md:mb-2");
+    expect(panel).toHaveClass("md:border-l", "md:border-border");
+    expect(panel).not.toHaveClass("md:m-2", "md:rounded-lg", "md:shadow-lg");
   });
 
   it("presents the fixed pane tabs as compact icon controls with accessible labels", () => {
@@ -551,11 +551,11 @@ describe("WorkspacePanel maximize", () => {
     const toggle = screen.getByRole("button", { name: "Exit full screen" });
     expect(toggle).toHaveAttribute("aria-pressed", "true");
     // The rail breaks out of the docked flex sizing to cover the region, but
-    // keeps the same card styling (m-2 inset + rounded) so only the width
-    // changes — the height is unaffected.
+    // keeps the same flush/bordered styling so only the width changes — the
+    // height is unaffected.
     const panel = screen.getByRole("complementary", { name: "Workspace" });
-    expect(panel).toHaveClass("md:absolute", "md:inset-0", "md:m-2", "md:rounded-lg");
-    expect(panel).not.toHaveClass("md:shrink-0");
+    expect(panel).toHaveClass("md:absolute", "md:inset-0", "md:border-l");
+    expect(panel).not.toHaveClass("md:shrink-0", "md:m-2", "md:rounded-lg");
   });
 });
 

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -671,21 +671,22 @@ export function WorkspacePanel({
     <aside
       aria-label="Workspace"
       inert={inert}
-      // Floating desktop surface: 8px from every edge. AppShell reserves the
-      // panel width from ChatHeader, so the pane can extend to the top without
-      // sitting underneath the existing session action cluster.
+      // Full-height desktop surface flush to the window edge, separated from
+      // the main content by a left divider — no outer margin, rounding, or
+      // shadow (mirrors the left sidebar). AppShell reserves the panel width
+      // from ChatHeader, so the pane extends to the top without sitting under
+      // the existing session action cluster.
       // ``@container/rail`` makes the rail a named container-query context so
       // the tab strip can switch scroll behavior on the rail's own width
       // (see the strip below) without a JS width listener.
       //
       // Maximized: break out of the flex row and stretch across the content
-      // region (absolute inset-0) so the rail owns the full width. It keeps the
-      // same m-2 / rounded-lg / bordered card styling as when docked — only the
-      // width changes, the 8px inset (and thus the height) stays identical. The
-      // resize handle is suppressed in that state — there's no neighbor to
-      // resize against.
+      // region (absolute inset-0) so the rail owns the full width, keeping the
+      // same flush/bordered styling — only the width changes. The resize
+      // handle is suppressed in that state — there's no neighbor to resize
+      // against.
       className={cn(
-        "@container/rail relative z-40 hidden md:m-2 md:flex md:min-h-0 md:flex-col md:overflow-hidden md:rounded-lg md:border md:border-border md:bg-card md:shadow-lg",
+        "@container/rail relative z-40 hidden md:flex md:min-h-0 md:flex-col md:overflow-hidden md:border-l md:border-border md:bg-card",
         maximized ? "md:absolute md:inset-0" : "md:shrink-0",
       )}
       // Width is fixed by the resize handle normally; maximized ignores it and

--- a/web/src/shell/codeViewerHelpers.ts
+++ b/web/src/shell/codeViewerHelpers.ts
@@ -238,10 +238,10 @@ const MODEL_VIEWER_THEMES: Record<ResolvedThemeMode, ModelViewerTheme> = {
     ambientIntensity: 1.0,
     keyIntensity: 1.2,
   },
-  // Dark: the app's dark panel color (`--background: #0d1218`), a lighter grey
+  // Dark: the app's dark panel color (`--background: #0e1013`), a lighter grey
   // surface, and brighter lights so the mesh doesn't sink into the background.
   dark: {
-    background: 0x0d1218,
+    background: 0x0e1013,
     stlMaterial: 0xc4c9ce,
     ambientIntensity: 1.5,
     keyIntensity: 1.6,


### PR DESCRIPTION
## Related issue

N/A — part 1 of the Omnigent Eng/UX tracker visual-alignment work (no single issue).

## Summary

Aligns the web app's background/canvas system with the agentic-ux-2026 design prototype, and de-spaghettis the related CSS.

- **Design tokens (light):** repoint text greys and borders onto the shadcn Zinc scale, add `--border-weak` / `--foreground-tertiary`, retune body text to 13/18 and add a 14/22 `text-chat` step, and add the `--shadow-otto-*` elevation scale from the mock.
- **Canvas & rails:** the app background is flat (white in light); the brand gradient + dot-grid + glow now live on the left sidebar. Both rails (left Conversations, right Workspace) sit flush — no floating margin, rounding, or card fill — and read as part of the canvas.
- **Dark mode:** neutral-slate surfaces (no more purple-tinted cards), the prototype's purple canvas gradient, a dark sidebar dot-grid + purple wash, and both rails de-glassed (no blur/sheen/fill) so they blend into the canvas.
- **Cleanup:** the background/canvas/rail CSS is consolidated — one rule owns each surface's full `background`, rails are *excluded* from the shared glass rule rather than fighting it with overrides, and the dead `::before` dot overlay is gone.

## Test Plan

- `npm run test` for the touched suites — `index.css.test.ts` (glass-rule regression + selector DOM checks), `Sidebar`, `AppShell`, `WorkspacePanel`, `Sidebar.subagentHighlight`: all pass (updated the flush-layout and workspace-surface assertions to match the new design).
- `npm run type-check`, `oxlint`, and `prettier --check` clean.
- Manual verification in light and dark against the prototype screenshots (canvas, both rails, sidebar dot-grid/glow, dark surfaces).

## Demo

<!-- TODO: attach light + dark before/after screenshots of the canvas, sidebar, and right rail. -->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Behavior here is visual, so unit tests cover the structural contracts that can regress silently — the dark-mode glass-rule minification/selector guards in `index.css.test.ts`, and the sidebar/workspace-panel layout classes. The actual colours and gradients were verified manually in both themes against the prototype (flat canvas, flush rails, sidebar dot-grid + glow, neutral dark surfaces, de-glassed rails).

## Changelog

Refreshed the app's light and dark backgrounds, sidebar, and panels to match the new design.
