### PR TITLE
feat(auth): add an opt-in OAuth2 client_credentials grant for machine clients

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -95,7 +95,7 @@ jobs:
         # checked here so Electron's large native devDependencies are not fetched.
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
-        run: pnpm install --frozen-lockfile --filter web --filter omnigent-vscode --filter @omnigent/canvas
+        run: pnpm install --frozen-lockfile --filter web --filter omnigent-vscode
 
       # The pnpm equivalent of the `uv sync --locked` gate above.
       # `pnpm install --frozen-lockfile` only checks the lockfile is CONSISTENT

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -52,16 +52,13 @@ jobs:
         # so the Electron package's large native devDependencies are not fetched.
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
-        run: pnpm install --frozen-lockfile --filter web --filter @omnigent/canvas
+        run: pnpm install --frozen-lockfile --filter web
 
       - name: Check formatting
         run: pnpm --filter web run format:check
 
       - name: Run tests with coverage
         run: pnpm --filter web run test:coverage
-
-      - name: Canvas extension tests
-        run: pnpm --filter @omnigent/canvas test
 
       # Distill the v8 json-summary into a single total.txt, mirroring the
       # backend's coverage-report job. ui-code-coverage.yml (privileged

--- a/designs/CLIENT_CREDENTIALS.md
+++ b/designs/CLIENT_CREDENTIALS.md
@@ -1,0 +1,281 @@
+# Machine Auth — Client Credentials Grant (RFC 6749 §4.4)
+
+> **IMPLEMENTED.**
+>
+> A single confidential client exchanges its own credentials for a delegated,
+> path-scoped access token acting as a fixed machine principal. No browser, no
+> per-user consent, no polling — the client *is* the resource owner.
+>
+> Server: `omnigent/server/routes/client_credentials.py` (the grant handler,
+> the `MachineClientConfig` env registry, and the principal guards). It owns
+> no route: `create_oauth_token_router` in
+> `omnigent/server/routes/device_auth.py` owns the app's one
+> `POST /oauth/token` and dispatches to this grant by `grant_type`. It reuses
+> `mint_delegated_token` / `DELEGATED_SCOPE` from that same module, the scope
+> enforcement in `omnigent/server/auth.py` (`delegated_path_allowed`), and the
+> response helpers + sliding-window throttle both grants share in
+> `omnigent/server/routes/_oauth.py`. Wired in `omnigent/server/app.py`,
+> **opt-in and default-off**: the handler is built only when a machine client
+> is configured and its principal is vetted, and only in the cookie-based auth
+> modes (`oidc` and `accounts`). Unconfigured, `client_credentials` exchanges
+> answer `unsupported_grant_type`.
+>
+> Tests: `tests/server/test_client_credentials.py`,
+> `tests/server/integration/test_client_credentials_e2e.py`, and
+> `tests/server/test_oauth_shared.py` for the helpers both grants share.
+
+## Problem
+
+The device grant (`designs/DEVICE_AUTH.md`) answers "a browserless client must
+act **as a human**, without ever holding that human's credentials". It does not
+answer the other case: a headless process that acts **as itself** — a scheduled
+job, a webhook receiver, an internal service calling the sessions API. There is
+no human to consent, so a flow built around out-of-band browser consent has
+nothing to ask.
+
+Before this grant, such a process had two bad options: drive the interactive
+login of a service account (a browser in a job), or be handed the server's
+cookie-signing key and mint its own session tokens (unbounded privilege, no
+audit trail, no way to distinguish it from a human session).
+
+## Role mapping
+
+| RFC 6749 role        | Here                                            |
+|----------------------|-------------------------------------------------|
+| Authorization Server | Omnigent server (`POST /oauth/token`)           |
+| Resource Server      | Omnigent server (existing `/v1/**` APIs)        |
+| Client               | The headless process, holding the client secret |
+| Resource Owner       | The client itself — no third party              |
+
+## Configuration
+
+One confidential client, read from the environment at mount. No table, no
+migration: a second client would need a real registry, and the single-client
+case covers "this deployment has an automation identity".
+
+| Variable | Meaning |
+|----------|---------|
+| `OMNIGENT_MACHINE_CLIENT_ID` | The client identifier presented at the token endpoint. An operator-chosen label: nothing allocates it, and it has no charset or length validation. That is fine per RFC 6749 §2.2 — `client_id` is public and not a secret — but it means **all the security rests on the secret below**, not on the id being hard to guess. |
+| `OMNIGENT_MACHINE_CLIENT_SECRET_HASH` | The client secret in **stored form only** — its `hash_secret` digest (HMAC-SHA256 keyed by `cookie_secret`, so 64 hex characters). The raw secret never reaches the server's config, and a value that is not that digest's shape is refused at startup rather than 401ing forever. Generate the secret with `secrets.token_urlsafe(32)` or equivalent: because only the digest is configured, the server cannot measure the secret's entropy, so that part is operator discipline — see row 3 of the threat table for the half that *is* enforced. |
+| `OMNIGENT_MACHINE_SUB` | The machine principal the minted token acts as (the `sub` claim). Must be a distinct, non-admin identity. |
+| `OMNIGENT_MACHINE_TOKEN_TTL` | Access-token lifetime in seconds (default 3600, and **capped** at 3600). |
+
+All three of the first group must be set to enable the grant, or all unset to
+leave it off. **All unset is the default and builds no handler**, so a
+`client_credentials` exchange answers `unsupported_grant_type` — the config is
+the opt-in, and no other flag turns this grant on. (The device grant needs a
+separate `OMNIGENT_DEVICE_GRANT_ENABLED` because its endpoints are useful with
+zero config; this grant has nothing to serve without a configured client.)
+
+Anything else — two of three, a malformed secret hash, a reserved principal,
+an unparseable / non-positive / over-ceiling TTL — raises at startup. A
+half-configured deploy that came up anyway would look like a client bug from
+the outside; failing to start puts the error where the operator can act on it.
+
+The TTL ceiling is enforced, not advised: expiry is this grant's only
+revocation (below), so the TTL is the whole bound on a stolen token. 3600s
+also matches the device grant's fixed access-token lifetime.
+
+The one-hour cap with no refresh token is a deliberate boundary, not an
+oversight: this grant is for a process that starts, mints, does its work inside
+the hour, and exits. A daemon that must stay authenticated for days is the
+login grant's case (`designs/DEVICE_AUTH.md`, `issue_login_grant`), which has
+the refresh machinery and the store-backed revocation to match.
+
+### Provisioning a secret
+
+Generate the secret, then configure only its digest. `hash_secret` is
+HMAC-SHA256 keyed by the hex-decoded `cookie_secret`, so the digest depends on
+the server's `OMNIGENT_ACCOUNTS_COOKIE_SECRET` (or the OIDC equivalent):
+
+```python
+import hashlib, hmac, os, secrets
+
+SECRET = secrets.token_urlsafe(32)  # give this to the client
+cookie_secret = bytes.fromhex(os.environ["OMNIGENT_ACCOUNTS_COOKIE_SECRET"])
+print(hmac.new(cookie_secret, SECRET.encode(), hashlib.sha256).hexdigest())
+```
+
+Print the digest into `OMNIGENT_MACHINE_CLIENT_SECRET_HASH` and keep `SECRET`
+only where the client can read it.
+
+**Rotation is a hard cutover.** One hash is configurable, so there is no
+two-secret grace window: the moment the server takes a new digest, the old
+secret stops working. Change both sides together, or accept failed mints in
+between — the client re-mints on a bounded TTL, so the window is the client's
+retry, not a permanent outage.
+
+`cookie_secret` is the shared root of trust: it keys both the stored
+secret-hash comparison and the signature on issued tokens. Rotating it
+therefore invalidates the configured hash **and** every live machine token —
+the startup log says so where an operator will see it.
+
+## Flow
+
+```
+  client                                       server
+    |  POST /oauth/token                         |
+    |  grant_type=client_credentials             |
+    |  + Basic base64(id:secret)  ─────────────► |  dispatch on grant_type
+    |                                            |  throttle, then constant-time id + digest check
+    |                                            |  re-vet the sub, then mint_delegated_token
+    |                                            |  (scope set, no grant_id)
+    |  ◄── {access_token, Bearer, expires_in,    |
+    |       scope}                               |
+    |                                            |
+    |  Authorization: Bearer <jwt>  ───────────► |  path allowlist, no cache, no denylist lookup
+```
+
+Client authentication accepts either RFC 6749 §2.3.1 form: HTTP Basic (which
+takes precedence) or `client_id` / `client_secret` form fields. Both halves of
+the comparison always run and are combined without short-circuiting, so a
+failure leaks nothing through timing about which half was wrong. Per §2.3.1 the
+two halves of a Basic credential are form-urlencoded before the base64, so they
+are urldecoded after the split on `:` (a secret containing `:`, `%`, `+` or a
+space would otherwise be read wrong); the scheme token itself is matched
+case-insensitively per RFC 7235 §2.1. One consequence of that urldecode: `a+b`
+and `a b` presented over Basic collapse to the same secret, so a self-chosen
+passphrase containing `+`, `%` or a space has slightly less effective entropy
+than its length suggests. The recommended `secrets.token_urlsafe(32)` output is
+base64url and contains none of those characters, so it is unaffected.
+
+The endpoint is throttled per source IP — the same in-memory sliding-window
+limiter the device grant applies to its public authorize endpoint, now shared in
+`omnigent/server/routes/_oauth.py`. It gates the endpoint ahead of the
+credential comparison, not just failed authentications: a limiter that only
+counted failures would still answer the guess that happened to be right, so the
+guess *rate* is the thing bounded. Ten requests per minute per IP is far above
+honest use, since a machine client mints once per token TTL.
+
+A successful response carries `scope` alongside the token. RFC 6749 §5.1 makes
+it REQUIRED when the granted scope differs from one the client requested, and
+this grant always issues `DELEGATED_SCOPE` regardless of what §4.4.2 lets the
+client ask for — so it always differs, and is always stated.
+
+Error shapes are the RFC's: any other `grant_type` is `unsupported_grant_type`;
+an absent, malformed, or mismatched client is `401 invalid_client`; a client
+that authenticates but whose principal no longer passes the admin check is
+`400 unauthorized_client` (§5.2 puts the error codes at 400 unless it says
+otherwise); a source over the throttle is `429 slow_down` (the shape RFC 8628
+§3.5 registers, and what the device grant's throttle already answers with).
+There is no "configured but inactive" answer — an unconfigured or refused grant
+simply has no handler, so `client_credentials` is `unsupported_grant_type` like
+any other grant type the server does not serve.
+
+### One token endpoint
+
+`POST /oauth/token` is mounted in every accounts/oidc deploy with a permission
+store, because login-issued refresh grants need it whether or not the device
+flow is on. This grant is therefore a `grant_type` branch of that one endpoint,
+never a router of its own. A second router on the same path is not an error
+FastAPI reports: it registers both and resolves first-match-wins, so the loser
+goes silent while its startup log still claims it is enabled. The branch also
+keeps the throttle scoped to this grant — hoisting it to the whole endpoint
+would newly rate-limit login-grant refreshes, which is costly behind a shared
+NAT egress address where many hosts renew through one source IP.
+
+Every response from the endpoint carries `Cache-Control: no-store` and
+`Pragma: no-cache` (RFC 6749 §5.1, and §5.2 for the error shape). A `401
+invalid_client` that rejected an `Authorization` header also carries the
+`WWW-Authenticate: Basic` challenge §5.2 requires; form credentials get no
+challenge, since there is no header attempt to retry.
+
+## Token shape
+
+The minted token is the delegated JWT the device grant already defines, with
+one difference: the `scope` claim is set and `grant_id` is **absent**.
+
+- `scope` puts the token under the fail-closed path allowlist
+  (`delegated_path_allowed`), so it can never reach admin or user-management
+  endpoints, and keeps it out of the token-keyed credential cache — a cached
+  entry replayed on a non-allowlisted path would skip the allowlist.
+- No `grant_id` means no store-backed grant and so no per-token revocation
+  lookup. Revocation here is by expiry and secret rotation; a deployment that
+  needs immediate, per-token kill should use the store-backed device grant.
+- `act` carries `{"client_id": ...}` so every action stays attributable to the
+  configured client.
+
+The two claims are independent, and `_check_cookie` reads each for its own
+question. Confinement keys off **`scope` being present**, revocation off
+**`grant_id` being present**, which gives the server three token shapes:
+
+| Token | `scope` | `grant_id` | Path allowlist | Revocation denylist |
+|-------|---------|------------|----------------|---------------------|
+| Device grant (third-party client acting for a human) | set | set | confined | checked |
+| Login grant (first-party `omnigent-cli`) | absent | set | full authority | checked |
+| Machine client (this grant) | set | absent | confined | skipped |
+
+The middle row is deliberate: a login grant renews the session JWT it replaced
+and keeps that same authority. Getting the key wrong inverts two rows at once —
+confining on `grant_id`'s *absence* would hand a machine token full authority
+while confining the login grant that is supposed to have it, and running the
+revocation lookup unguarded would reject every machine token, since the lookup
+fails closed on an unknown grant. `test_token_authority_table` and
+`test_revocation_denylist_applies_only_to_stored_grants` pin all three rows
+together so the pair cannot drift apart again.
+
+## Security analysis
+
+| # | Threat | Mitigation |
+|---|--------|-----------|
+| 1 | Leaked client secret → token minting | The secret is a fixed operator config held only by the client, never user-supplied and never in a browser. Rotation is a config change on both sides; the stored form is a keyed digest, so a config leak alone does not yield a usable secret. |
+| 2 | Server-side config leak → secret recovery | Only the `hash_secret` digest is configured; the raw secret is never stored or logged. |
+| 3 | Credential probing / timing oracle | Client id and secret digest are compared with `hmac.compare_digest` and combined non-short-circuiting; every failure is the same `401 invalid_client`. The endpoint is also unauthenticated by definition, so it is rate-limited per source IP ahead of the comparison (`429 slow_down`), bounding the guess rate — **but only below the limiter's key-table ceiling** (`RATE_LIMITER_MAX_KEYS`). Past that the limiter fails open by design (availability over a soft throttle), so an attacker who first exhausts the table from disposable source addresses (trivial over an IPv6 /64) then guesses unthrottled from a fresh one. The throttle is a speed bump, not the boundary. The secret's own entropy is not machine-checkable — only its digest is configured — so that half is stated as operator guidance in the configuration table above rather than pretended to be enforced. |
+| 4 | Token used beyond its purpose | Fail-closed path allowlist on every request (no cache shortcut), plus an enforced TTL ceiling and no refresh token. |
+| 5 | **Privilege escalation through an admin principal** | The allowlist confines *paths*, not privilege: `/v1/sessions` grants `LEVEL_OWNER` to any `is_admin` identity, so an admin `sub` would own every tenant's session. The permission store is asked whether the configured `sub` is an admin at mount (the handler is not built if so) **and again before every mint** (`400 unauthorized_client`), so promoting the principal later stops new tokens without a restart. Both checks fail closed if the store cannot answer, and the refusal names which of the two it hit, so a store outage is not misread as a bad `sub`. Tokens already issued to a since-promoted `sub` live out their TTL — bounded by row 7's ceiling. |
+| 6 | Identity confusion with a human account | Operator discipline, with the machine-checkable part enforced and the rest warned about. A reserved sentinel (`local`, `__public__`) is refused outright. At mount the server also scans the user roster and **logs a warning if `OMNIGENT_MACHINE_SUB` matches an existing account**, since pointing it at a real person's address silently mints tokens acting as that person. The scan is advisory, not a gate: `list_users` is bounded (1000 rows), so a larger deploy may not spot the match, and a store fault leaves the warning unsaid — neither changes whether the grant runs. The standing guidance is unchanged: **give the machine client a fresh, dedicated identity** so audit stays legible and it inherits no human's grants. |
+| 7 | Stolen token cannot be revoked | Accepted, and bounded: the TTL is capped at 3600s (`OMNIGENT_MACHINE_TOKEN_TTL` above that refuses to start), and secret rotation stops re-minting. Per-token revocation is the store-backed device grant's model, not this one. |
+| 8 | Cookie-secret rotation silently breaking auth | One key underpins both the secret check and token signing; the startup log states the coupling so rotation is not debugged twice. |
+| 9 | Token cached by a proxy or client | Every token-endpoint response sends `Cache-Control: no-store` + `Pragma: no-cache` (RFC 6749 §5.1), as does the device grant's `POST /oauth/device/authorize` 200, whose `device_code` + `user_code` are as sensitive (RFC 8628 §3.2). The shared header mapping is read-only, so a caller cannot mutate the constant every grant router hands to its responses. |
+
+### Deliberate limits
+
+- **No path-prefixing reverse proxy.** `delegated_path_allowed` matches
+  `request.url.path`, which includes any ASGI `root_path`. Mount the server
+  under a prefix (`root_path="/api"`) and every confined token is refused on
+  every route, including the ones it should reach — the allowlist compares
+  `/api/v1/sessions` against a table of unprefixed prefixes. It fails closed,
+  so this is a broken grant rather than a bypass, but it is silent. The
+  existing device grant shares the assumption, since it reads the same
+  allowlist. Making the match `root_path`-aware is a follow-up if a
+  prefixed deployment ever needs to be supported.
+- **One client.** A second confidential client needs a persisted registry with
+  its own lifecycle; the env-configured single entry covers the automation
+  identity case without one.
+- **Shared scope with the device grant.** `scope="sessions"` reuses the
+  existing delegated allowlist, which also covers `/v1/agents`, `/v1/hosts` and
+  `/v1/runners`. Narrowing it per grant would change the
+  `delegated_path_allowed` contract both grants read, so a machine token
+  inherits whatever those prefixes hold — the same surface the device grant
+  already exposes. Confining it further is the per-grant-scopes follow-up
+  below; this grant adds no new reachable path.
+- **No refresh token.** The client re-mints; there is nothing to rotate or
+  replay-detect.
+- **In-process throttle.** The limiter is per replica and keyed by source IP,
+  the same shape and the same limits the device grant already runs on. A
+  multi-replica deployment multiplies the ceiling by the replica count, and a
+  distributed guesser spreads across source IPs; a shared-store limiter is the
+  fix if that ever matters. It is a rate bound, not the security boundary —
+  that is the secret's entropy, which the server cannot check because only the
+  digest is configured.
+
+## Out of scope / follow-ups
+
+- A persisted multi-client registry with per-client scopes and an admin UI.
+- Per-grant scopes, so a machine token can be confined more tightly than the
+  shared session-API allowlist.
+- Asymmetric client authentication (`private_key_jwt`, RFC 7523) for
+  deployments that would rather not distribute a shared secret at all.
+- **The throttle counts successful mints too**, so a legitimate client's budget
+  is burnable by anyone sharing its source address — a neighbour behind the
+  same NAT egress, or an unauthenticated cross-site POST that only has to reach
+  the endpoint to cost a hit. Refunding the hit on a successful mint is the
+  one-line fix; the client re-mints on a bounded TTL, so today's blast radius
+  is a delayed mint rather than a lost session.
+- **A confined request that is denied is not attributable.** The allowlist
+  refusal happens in `_check_cookie`, which returns `None` without recording
+  which client, `sub` or path was refused — so a machine client probing off its
+  allowlist leaves no audit trail to alert on. Logging the refusal (at a
+  bounded rate, since the path is attacker-reachable) is the follow-up.
+- `root_path`-aware allowlist matching, so the grant survives a
+  path-prefixing reverse proxy (see *Deliberate limits* above).

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -3234,6 +3234,36 @@ def create_app(
                 type(auth_provider).__name__,
             )
 
+        # Client-credentials grant (RFC 6749 §4.4): a machine client mints a
+        # delegated, path-scoped token with no browser in the loop. It is a
+        # grant_type BRANCH of the one /oauth/token mounted below, never a
+        # second router on that path — FastAPI resolves first-match-wins, so a
+        # duplicate route would be shadowed with no warning. Opt-in and
+        # default-off: the factory returns None unless a machine client is
+        # configured and its principal passes the admin vetting.
+        # See designs/CLIENT_CREDENTIALS.md.
+        handle_client_credentials = None
+        if isinstance(auth_provider, UnifiedAuthProvider) and auth_provider._source in (
+            "oidc",
+            "accounts",
+        ):
+            from omnigent.server.routes.client_credentials import (
+                create_client_credentials_handler,
+            )
+
+            handle_client_credentials = create_client_credentials_handler(
+                auth_provider, permission_store
+            )
+            if handle_client_credentials is not None and device_grant_store is None:
+                # Both /oauth/token mounts below require the grant store, so
+                # without one there is no endpoint to carry this branch.
+                handle_client_credentials = None
+                _logger.warning(
+                    "client-credentials: a machine client is configured, but this "
+                    "deploy has no permission store, so /oauth/token is not mounted "
+                    "and the grant cannot answer. Configure a permission store."
+                )
+
         # Device Authorization Grant (RFC 8628): opt-in, default-off via
         # OMNIGENT_DEVICE_GRANT_ENABLED. Supported in accounts and oidc
         # modes (both own a server-minted session cookie). Header mode has
@@ -3257,7 +3287,11 @@ def create_app(
             from omnigent.server.routes.device_auth import create_device_auth_router
 
             app.include_router(
-                create_device_auth_router(auth_provider, device_grant_store),
+                create_device_auth_router(
+                    auth_provider,
+                    device_grant_store,
+                    handle_client_credentials=handle_client_credentials,
+                ),
                 tags=["oauth"],
             )
             _logger.info("device-grant: /oauth/* routes enabled")
@@ -3292,7 +3326,11 @@ def create_app(
             from omnigent.server.routes.device_auth import create_oauth_token_router
 
             app.include_router(
-                create_oauth_token_router(auth_provider, device_grant_store),
+                create_oauth_token_router(
+                    auth_provider,
+                    device_grant_store,
+                    handle_client_credentials=handle_client_credentials,
+                ),
                 tags=["oauth"],
             )
             _logger.info("login-grant: /oauth/token + /oauth/revoke enabled")

--- a/omnigent/server/auth.py
+++ b/omnigent/server/auth.py
@@ -48,14 +48,23 @@ RESERVED_USER_PUBLIC = "__public__"
 _RESERVED_USERS = frozenset({RESERVED_USER_LOCAL, RESERVED_USER_PUBLIC})
 _TRUTHY_STRINGS = ("1", "true", "yes")
 
-# Path prefixes a delegated (device-grant) access token may reach.
+# Path prefixes a restricted (device-grant or machine client-credential)
+# access token may reach.
 # Fail-closed allowlist: a token carrying a ``scope`` claim is rejected on
 # any path not covered here, so it can never touch admin / user-management
 # endpoints (``/auth/users``, ``/auth/invite``, ``/auth/setup`` …) even if
-# its underlying identity is an admin. Delegated clients only need these.
+# its underlying identity is an admin. Restricted clients only need these.
 # First-party login-grant tokens carry no ``scope`` and are NOT restricted
 # here — they renew the session JWT and keep its authority (see
 # ``_check_cookie`` and ``routes/device_auth.LOGIN_GRANT_CLIENT_ID``).
+#
+# The allowlist confines the PATH, not the privilege LEVEL within one: the
+# ``is_admin`` → ``LEVEL_OWNER`` override inside /v1/sessions keys off the
+# token's identity, so an admin subject reaches every tenant's sessions
+# there. For a device grant that is delegation working as intended — the
+# subject is the human who approved consent. The machine client-credential
+# grant delegates no human, so it additionally requires its configured
+# subject to be a non-admin principal; see routes/client_credentials.py.
 _DELEGATED_ALLOWED_PREFIXES = (
     "/health",
     "/v1/agents",
@@ -604,23 +613,31 @@ class UnifiedAuthProvider(AuthProvider):
         if not isinstance(user_id, str) or not user_id or user_id in _RESERVED_USERS:
             return None
 
-        # Grant-derived tokens carry a ``grant_id`` claim. They get
-        # request-scoped checks — a live revocation lookup, plus (for
-        # restricted tokens) a fail-closed path allowlist — so they are
-        # never served from the plain user-id cache (which would skip both).
+        # Machine-issued tokens carry ``grant_id`` (store-backed grant),
+        # ``scope`` (restricted authority), or both. Each claim gets its own
+        # request-scoped check below, and a token carrying either is never
+        # served from the plain user-id cache — the cache is token-keyed, so
+        # a hit on one path would replay past both checks on every other.
         grant_id = payload.get("grant_id")
-        if grant_id is not None:
-            if not isinstance(grant_id, str):
-                return None
-            if self._grant_revoked is not None and self._grant_revoked(grant_id):
-                return None
-            # The allowlist restricts DELEGATED tokens — a third-party
-            # client (e.g. Slack) acting on a user's behalf, marked by the
-            # ``scope`` claim. A first-party login grant carries no scope:
-            # its bearer is the user's own CLI/host, and the token renews
-            # the session JWT it replaced, so it keeps that same authority
-            # (still revocable via ``grant_id`` above).
-            if payload.get("scope") is not None and not delegated_path_allowed(request.url.path):
+        scope = payload.get("scope")
+        if grant_id is not None or scope is not None:
+            # A ``grant_id`` names a revocable stored grant, so it is checked
+            # live against the denylist. The client-credentials grant has no
+            # stored grant and omits the claim; the lookup is skipped for it
+            # (its revocation is secret rotation plus the capped TTL) rather
+            # than run with ``None``, which fails closed on every request.
+            if grant_id is not None:
+                if not isinstance(grant_id, str):
+                    return None
+                if self._grant_revoked is not None and self._grant_revoked(grant_id):
+                    return None
+            # The allowlist confines any token whose authority was RESTRICTED
+            # at mint — a third-party device client acting for a user, or a
+            # machine client acting as itself — both marked by ``scope``. A
+            # first-party login grant carries no scope: its bearer is the
+            # user's own CLI/host and the token renews the session JWT it
+            # replaced, so it keeps that authority (revocable via ``grant_id``).
+            if scope is not None and not delegated_path_allowed(request.url.path):
                 return None
             return user_id
 

--- a/omnigent/server/device_grant_store.py
+++ b/omnigent/server/device_grant_store.py
@@ -40,10 +40,12 @@ from omnigent.entities import DeviceGrant
 def hash_secret(secret: str, key: bytes) -> str:
     """Return the HMAC-SHA256 hex digest of a secret.
 
-    Used to hash the ``device_code`` and refresh tokens before they
-    touch the database. Keyed with the server's cookie secret so a
-    leaked DB alone (without the key) cannot be used to precompute a
-    reverse lookup.
+    The server's one stored-secret form. Hashes the ``device_code`` and
+    refresh tokens before they touch the database, and the machine
+    client's configured secret in
+    :mod:`omnigent.server.routes.client_credentials`. Keyed with the
+    server's cookie secret so a leaked store or config alone (without
+    the key) cannot be used to precompute a reverse lookup.
 
     :param secret: The raw secret string.
     :param key: HMAC key — the server's ``cookie_secret``.

--- a/omnigent/server/routes/_oauth.py
+++ b/omnigent/server/routes/_oauth.py
@@ -1,0 +1,103 @@
+"""Shared OAuth helpers for the token-granting route modules.
+
+Every OAuth grant router answers failures with the same RFC-shaped body, sends
+the same no-store headers on anything carrying a token, and throttles its
+unauthenticated endpoints with the same limiter, so all three live here rather
+than once per module::
+
+    from omnigent.server.routes._oauth import NO_STORE_HEADERS, oauth_error
+
+    return oauth_error("invalid_client", status_code=401)
+    return JSONResponse(status_code=200, content=body, headers=NO_STORE_HEADERS)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from types import MappingProxyType
+
+from starlette.responses import JSONResponse
+
+# RFC 6749 §5.1: a response carrying tokens or credentials must not be cached.
+# §5.2's error response carries the same pair, so every token-endpoint answer —
+# success or failure — sends them. Read-only, because this one mapping is passed
+# to responses from both grant routers: were it mutable, a caller that edited it
+# would silently re-header every later token response in the process.
+NO_STORE_HEADERS: Mapping[str, str] = MappingProxyType(
+    {"Cache-Control": "no-store", "Pragma": "no-cache"}
+)
+
+
+def oauth_error(
+    error: str,
+    status_code: int = 400,
+    headers: Mapping[str, str] | None = None,
+) -> JSONResponse:
+    """Build an RFC 6749 / 8628 shaped OAuth error response.
+
+    :param error: The OAuth error code, e.g. ``"invalid_client"``.
+    :param status_code: HTTP status to answer with.
+    :param headers: Extra headers merged over :data:`NO_STORE_HEADERS`, e.g.
+        the ``WWW-Authenticate`` challenge RFC 6749 §5.2 requires on a 401
+        that rejected an ``Authorization`` header.
+    :returns: A ``JSONResponse`` carrying ``{"error": <error>}``.
+    """
+    return JSONResponse(
+        status_code=status_code,
+        content={"error": error},
+        headers={**NO_STORE_HEADERS, **(headers or {})},
+    )
+
+
+# Hard cap on distinct keys a limiter tracks at once. Bounds memory even
+# under a spray from many source IPs (e.g. a whole IPv6 /64) — without it a
+# key hit once and never revisited would live forever. When the cap is hit
+# the whole table is swept of aged-out keys; if still full, the limiter
+# fails OPEN for a new key (availability over a soft throttle — the real
+# anti-abuse control in production is the confidential client secret).
+RATE_LIMITER_MAX_KEYS = 10_000
+
+
+class SlidingWindowRateLimiter:
+    """Minimal per-key sliding-window limiter (in-memory, single-process).
+
+    Keyed by client IP. Adequate for a single-process deployment; a
+    multi-replica server would want a shared store, but each grant's own
+    semantics (single-use device codes, a capped token TTL) already bound
+    abuse.
+
+    Memory is bounded by :data:`RATE_LIMITER_MAX_KEYS`: keys are dropped
+    when they age out (on touch) and, when the cap is reached, a full sweep
+    reclaims every aged-out key before admitting a new one.
+    """
+
+    def __init__(self, max_events: int, window_seconds: int, max_keys: int) -> None:
+        self._max = max_events
+        self._window = window_seconds
+        self._max_keys = max_keys
+        self._hits: dict[str, list[float]] = {}
+
+    def _sweep(self, cutoff: float) -> None:
+        """Drop every key whose hits have all aged out."""
+        dead = [k for k, ts in self._hits.items() if not any(t > cutoff for t in ts)]
+        for k in dead:
+            self._hits.pop(k, None)
+
+    def allow(self, key: str, now: float) -> bool:
+        cutoff = now - self._window
+        # New key while at capacity: sweep aged-out keys first; if the table
+        # is still full of live keys, fail open rather than grow unbounded.
+        if key not in self._hits and len(self._hits) >= self._max_keys:
+            self._sweep(cutoff)
+            if len(self._hits) >= self._max_keys:
+                return True
+        hits = [t for t in self._hits.get(key, ()) if t > cutoff]
+        # Opportunistically bound memory: drop keys that fully aged out.
+        if not hits:
+            self._hits.pop(key, None)
+        if len(hits) >= self._max:
+            self._hits[key] = hits
+            return False
+        hits.append(now)
+        self._hits[key] = hits
+        return True

--- a/omnigent/server/routes/client_credentials.py
+++ b/omnigent/server/routes/client_credentials.py
@@ -372,7 +372,7 @@ def _warn_if_sub_is_a_real_account(permission_store: PermissionStore | None, sub
         return
     try:
         accounts = permission_store.list_users(limit=_ACCOUNT_SCAN_LIMIT)
-    except Exception:
+    except Exception:  # noqa: BLE001 (advisory scan, must never gate the mount)
         _logger.debug(
             "client-credentials: could not scan the roster to check whether %s=%r is a "
             "real account",

--- a/omnigent/server/routes/client_credentials.py
+++ b/omnigent/server/routes/client_credentials.py
@@ -1,0 +1,569 @@
+"""OAuth 2.0 client-credentials grant (RFC 6749 §4.4).
+
+A single confidential client exchanges its own credentials for a delegated,
+path-scoped access token acting as a fixed machine principal — no browser,
+no per-user consent, no device flow. This is the grant a headless process
+uses when it is its own resource owner rather than acting for a human.
+
+This module owns no route. It builds the ``client_credentials`` branch of
+the app's one ``POST /oauth/token``, which
+:func:`omnigent.server.routes.device_auth.create_oauth_token_router` owns and
+dispatches by ``grant_type``. A second router on that path would be shadowed
+silently, since FastAPI resolves first-match-wins.
+
+On success the branch returns ``{access_token, token_type, expires_in,
+scope}``. A bad / absent / mismatched client is ``401 invalid_client``; a
+principal that fails its admin vetting is ``400 unauthorized_client``; more
+requests from one source than the throttle allows is ``429 slow_down``. The
+client check runs before anything has authenticated, so the branch carries
+the same per-IP sliding-window limiter the device grant's public authorize
+endpoint uses.
+
+**Opt-in and default-off**: the machine client's env config *is* the opt-in.
+With none configured the handler is never built, and ``client_credentials``
+exchanges answer ``unsupported_grant_type`` like any other unhandled grant.
+The device grant needs its own ``OMNIGENT_DEVICE_GRANT_ENABLED`` flag because
+its endpoints are useful with zero config (a public client); this grant has
+nothing to serve without a configured client, so a separate flag would only be
+a second way to say the same thing. Built in the cookie-based auth modes
+(``oidc`` and ``accounts``) — it needs the HS256 ``cookie_secret`` both configs
+expose, which is also the key the minted token is validated against.
+
+The confidential client is a single env-configured registry entry — no
+database, no migration:
+
+- ``OMNIGENT_MACHINE_CLIENT_ID`` — the client identifier. An operator-chosen
+  label with no charset or length validation and nothing that allocates it;
+  all the security rests on the secret below.
+- ``OMNIGENT_MACHINE_CLIENT_SECRET_HASH`` — the client secret, stored only as
+  its :func:`hash_secret` digest (HMAC-SHA256 keyed by ``cookie_secret``),
+  never the raw secret. Must have that digest's shape (64 hex characters) and
+  is verified in constant time. Only the digest is configured, so the server
+  cannot measure the secret's entropy — generate it with
+  ``secrets.token_urlsafe(32)`` or equivalent. The throttle below bounds how
+  fast a secret can be guessed *below the limiter's key-table ceiling*: past
+  it the limiter fails open, so an attacker who first fills the table from
+  disposable source addresses (trivial over IPv6) then guesses unthrottled
+  from a fresh one. The secret's entropy, not the throttle, is what makes
+  guessing hopeless. One hash is configurable, so rotation is a hard cutover
+  on both sides — there is no two-secret grace window.
+- ``OMNIGENT_MACHINE_SUB`` — the machine principal the minted token acts as.
+- ``OMNIGENT_MACHINE_TOKEN_TTL`` — access-token lifetime in seconds (default
+  3600, and capped there: expiry is this model's only revocation, so the TTL
+  is what bounds a stolen token). The client re-mints rather than refreshing —
+  there is no refresh token and no store-backed per-token revocation (that is
+  the store-backed delegated grant's job).
+
+All three of the first group must be set to enable the grant, or all unset to
+leave it off; any other combination — a malformed secret hash, an unusable
+TTL — is an operator error and refuses to start rather than coming up with a
+grant branch that answers every request ``invalid_request``, which reads as a
+client bug.
+
+The minted token reuses the delegated JWT shape
+(:func:`omnigent.server.routes.device_auth.mint_delegated_token`) with the
+``scope`` claim set and no ``grant_id``: the auth layer confines it to the
+delegated path allowlist and, seeing no ``grant_id``, skips the
+revocation-denylist lookup.
+
+That allowlist is a PATH confinement only. It does NOT limit the token's
+privilege within an allowlisted path: the ``is_admin → LEVEL_OWNER`` override
+inside /v1/sessions keys off the token's identity, so an admin ``sub`` would
+own every tenant's session. The machine ``sub`` must therefore be a distinct,
+non-admin principal — vetted at mount and again on every mint, so promoting it
+to admin later stops new tokens instead of waiting for a restart.
+
+See ``designs/CLIENT_CREDENTIALS.md`` for the full design + threat model.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hmac
+import logging
+import os
+import re
+import secrets
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
+from urllib.parse import unquote_plus
+
+from fastapi import Request
+from starlette.datastructures import FormData
+from starlette.responses import JSONResponse, Response
+
+from omnigent.server.auth import (
+    RESERVED_USER_LOCAL,
+    RESERVED_USER_PUBLIC,
+    UnifiedAuthProvider,
+)
+from omnigent.server.device_grant_store import hash_secret
+from omnigent.server.routes._oauth import (
+    NO_STORE_HEADERS,
+    RATE_LIMITER_MAX_KEYS,
+    SlidingWindowRateLimiter,
+    oauth_error,
+)
+from omnigent.server.routes.device_auth import DELEGATED_SCOPE, mint_delegated_token
+from omnigent.stores.permission_store import PermissionStore
+
+_logger = logging.getLogger(__name__)
+
+_DEFAULT_TOKEN_TTL_SECONDS = 3600
+# Hard ceiling on the configured TTL. Expiry is this model's only revocation
+# (no refresh token, no per-token denylist), so a long-lived token would leave
+# theft unbounded. Matches the device grant's fixed access-token lifetime.
+_MAX_TOKEN_TTL_SECONDS = 3600
+# The stored secret's shape — :func:`hash_secret` is HMAC-SHA256, hex-encoded.
+# Anchored in the pattern, so the strictness survives a caller that reaches for
+# ``match`` or ``search`` instead of ``fullmatch``. ``\Z`` rather than ``$``:
+# ``$`` would also accept a trailing newline.
+_SECRET_HASH_RE = re.compile(r"\A[0-9a-fA-F]{64}\Z")
+# Protection space named by the WWW-Authenticate challenge on a 401.
+_TOKEN_ENDPOINT_REALM = "omnigent"
+
+# ── Abuse control on the unauthenticated client check ─────────────
+# The branch answers before anything has authenticated, so the client-secret
+# comparison is reachable by anyone who can reach the port — the same exposure
+# the device grant throttles on its public authorize endpoint. Only the secret's
+# digest is configured, so the server cannot require entropy of the secret
+# itself; a coarse per-IP sliding window slows the guess rate, up to the
+# limiter's key-table ceiling, past which it fails open (see
+# RATE_LIMITER_MAX_KEYS). The secret's entropy is the actual boundary. The
+# ceiling sits far above honest use: a machine client mints once per token TTL,
+# not once per request. Scoped to this grant rather than the whole token
+# endpoint so it never throttles a login grant's refresh traffic.
+_TOKEN_RATE_MAX = 10  # max token requests…
+_TOKEN_RATE_WINDOW_SECONDS = 60  # …per client IP per this window.
+
+# Bound on the mount-time roster scan behind the dedicated-identity warning.
+# Advisory only: a deploy with more users than this may not spot a match, which
+# leaves the warning unsaid rather than changing what the grant does.
+_ACCOUNT_SCAN_LIMIT = 1000
+
+_CLIENT_ID_ENV = "OMNIGENT_MACHINE_CLIENT_ID"
+_CLIENT_SECRET_HASH_ENV = "OMNIGENT_MACHINE_CLIENT_SECRET_HASH"
+_SUB_ENV = "OMNIGENT_MACHINE_SUB"
+_TOKEN_TTL_ENV = "OMNIGENT_MACHINE_TOKEN_TTL"
+
+
+def _token_ttl_from_env() -> int:
+    """Read the configured access-token TTL in seconds.
+
+    :returns: The configured TTL, or :data:`_DEFAULT_TOKEN_TTL_SECONDS`.
+    :raises RuntimeError: If the value is not an integer, is not positive, or
+        exceeds :data:`_MAX_TOKEN_TTL_SECONDS`.
+    """
+    raw_ttl = os.environ.get(_TOKEN_TTL_ENV, "").strip()
+    if not raw_ttl:
+        return _DEFAULT_TOKEN_TTL_SECONDS
+    try:
+        token_ttl = int(raw_ttl)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"client-credentials: {_TOKEN_TTL_ENV}={raw_ttl!r} is not an integer number of seconds"
+        ) from exc
+    if token_ttl <= 0:
+        raise RuntimeError(
+            f"client-credentials: {_TOKEN_TTL_ENV}={raw_ttl!r} must be a positive "
+            "number of seconds"
+        )
+    if token_ttl > _MAX_TOKEN_TTL_SECONDS:
+        raise RuntimeError(
+            f"client-credentials: {_TOKEN_TTL_ENV}={raw_ttl!r} exceeds the "
+            f"{_MAX_TOKEN_TTL_SECONDS}s ceiling — expiry is this grant's only "
+            "revocation, so the TTL is what bounds a stolen token"
+        )
+    return token_ttl
+
+
+@dataclass(frozen=True)
+class MachineClientConfig:
+    """The single confidential machine client, read from the environment.
+
+    :param client_id: The client identifier presented at the token endpoint.
+    :param secret_hash: The client secret's :func:`hash_secret` digest — the
+        stored form, never the raw secret.
+    :param sub: The machine principal the minted token acts as (``sub``).
+    :param token_ttl_seconds: Minted access-token lifetime in seconds.
+    """
+
+    client_id: str
+    secret_hash: str
+    sub: str
+    token_ttl_seconds: int
+
+    @staticmethod
+    def from_env() -> MachineClientConfig | None:
+        """Build the machine-client config, or ``None`` when unconfigured.
+
+        Every ``OMNIGENT_MACHINE_*`` variable unset is the one clean "off", and
+        is what leaves the grant unbuilt. Any other unusable combination is an
+        operator error and raises, so a deploy that meant to turn machine auth
+        on cannot come up silently without it.
+
+        :returns: The configured client, or ``None`` when the grant is off.
+        :raises RuntimeError: On a partial config, a secret hash that is not a
+            keyed SHA-256 digest, a reserved principal, or a token TTL that is
+            not a positive integer within the allowed ceiling.
+        """
+        client_id = os.environ.get(_CLIENT_ID_ENV, "").strip()
+        secret_hash = os.environ.get(_CLIENT_SECRET_HASH_ENV, "").strip()
+        sub = os.environ.get(_SUB_ENV, "").strip()
+        if not (client_id or secret_hash or sub):
+            return None
+        if not (client_id and secret_hash and sub):
+            raise RuntimeError(
+                f"client-credentials: {_CLIENT_ID_ENV}, {_CLIENT_SECRET_HASH_ENV} "
+                f"and {_SUB_ENV} must all be set to enable the grant, or all be "
+                "unset to leave it off"
+            )
+        # Catches the raw secret pasted where its digest belongs. Unchecked,
+        # that config would simply never match: a token endpoint that 401s
+        # every correct credential, with nothing in the log to say why.
+        if not _SECRET_HASH_RE.fullmatch(secret_hash):
+            raise RuntimeError(
+                f"client-credentials: {_CLIENT_SECRET_HASH_ENV} must be the client "
+                "secret's 64-character hex hash_secret digest, not the raw secret "
+                f"(got {len(secret_hash)} characters)"
+            )
+        # The machine principal must be a real, distinct identity — the
+        # reserved sentinels resolve to no account the grant could scope to.
+        if sub in (RESERVED_USER_LOCAL, RESERVED_USER_PUBLIC):
+            raise RuntimeError(
+                f"client-credentials: {_SUB_ENV}={sub!r} is a reserved identity; "
+                "point it at a distinct, dedicated principal"
+            )
+
+        return MachineClientConfig(
+            client_id=client_id,
+            # hash_secret emits lowercase and the comparison is on the exact
+            # string, so an uppercased digest would silently never match.
+            secret_hash=secret_hash.lower(),
+            sub=sub,
+            token_ttl_seconds=_token_ttl_from_env(),
+        )
+
+
+def _presented_client(request: Request, form: FormData) -> tuple[str, str] | None:
+    """Resolve the presented ``(client_id, client_secret)`` pair, or ``None``.
+
+    RFC 6749 §2.3.1: a confidential client may authenticate with HTTP Basic
+    (``Authorization: Basic base64(client_id:client_secret)``) or with
+    ``client_id`` / ``client_secret`` form fields. Basic takes precedence
+    when present. Returns ``None`` when neither carries a usable pair, which
+    the caller maps to ``invalid_client``.
+
+    Both halves of a Basic credential are ``application/x-www-form-urlencoded``
+    before the base64, so both are decoded after the split on ``":"`` — a
+    secret containing ``":"``, ``"%"``, ``"+"`` or a space is otherwise read
+    wrong. Form fields need no such step: the form parser already decoded them.
+    """
+    scheme, _, param = request.headers.get("Authorization", "").partition(" ")
+    # RFC 7235 §2.1: auth schemes are matched case-insensitively.
+    if scheme.lower() == "basic":
+        try:
+            decoded = base64.b64decode(param.strip(), validate=True).decode("utf-8")
+        except (binascii.Error, ValueError, UnicodeDecodeError):
+            return None
+        client_id, sep, secret = decoded.partition(":")
+        if not sep:
+            return None
+        return (unquote_plus(client_id), unquote_plus(secret))
+    client_id = str(form.get("client_id") or "")
+    secret = str(form.get("client_secret") or "")
+    if client_id and secret:
+        return (client_id, secret)
+    return None
+
+
+def _client_matches(
+    client_id: str,
+    secret: str,
+    config: MachineClientConfig,
+    cookie_secret: bytes,
+) -> bool:
+    """Constant-time check of a presented client id + secret against config.
+
+    The secret is compared as its :func:`hash_secret` digest (the raw secret
+    is never stored). Both the id and the secret-digest comparisons run and
+    are combined without short-circuiting, so a mismatch reveals nothing
+    through timing about which half was wrong.
+    """
+    id_ok = hmac.compare_digest(client_id.encode("utf-8"), config.client_id.encode("utf-8"))
+    presented_hash = hash_secret(secret, cookie_secret)
+    secret_ok = hmac.compare_digest(
+        presented_hash.encode("utf-8"), config.secret_hash.encode("utf-8")
+    )
+    return id_ok and secret_ok
+
+
+def _invalid_client(request: Request) -> JSONResponse:
+    """Build the ``401 invalid_client`` answer to a failed client authentication.
+
+    RFC 6749 §5.2: when the client authenticated through the ``Authorization``
+    header the 401 must carry a ``WWW-Authenticate`` naming the scheme it used.
+    A client that sent form credentials gets no challenge — it has no header
+    attempt to retry.
+    """
+    headers = {}
+    if request.headers.get("Authorization"):
+        headers["WWW-Authenticate"] = f'Basic realm="{_TOKEN_ENDPOINT_REALM}", charset="UTF-8"'
+    return oauth_error("invalid_client", status_code=401, headers=headers)
+
+
+class _SubVerdict(str, Enum):
+    """Outcome of vetting the machine principal against the permission store.
+
+    ``ADMIN`` and ``UNVERIFIABLE`` both refuse the grant, but they are separate
+    values so a caller's log can name the cause it actually hit: a store that
+    could not answer is not an admin principal, and reporting it as one sends
+    the operator to audit config that is fine.
+    """
+
+    OK = "ok"
+    ADMIN = "admin"
+    UNVERIFIABLE = "unverifiable"
+
+
+def _vet_machine_sub(permission_store: PermissionStore | None, sub: str) -> _SubVerdict:
+    """Vet the machine *sub* against the ``is_admin`` → OWNER override.
+
+    The path allowlist confines a machine token to the session APIs but does
+    not limit its privilege there: /v1/sessions grants ``LEVEL_OWNER`` to any
+    ``is_admin`` identity, so an admin ``sub`` would own every tenant's
+    session. Enabling such a client is a misconfiguration, checked at mount and
+    again before every mint.
+
+    :param permission_store: The permission store, or ``None`` when the deploy
+        has none — the store-backed override cannot fire then, so the sub is
+        ``OK``.
+    :param sub: The configured machine principal.
+    :returns: ``OK`` when the sub may be granted, ``ADMIN`` when it inherits
+        the override, ``UNVERIFIABLE`` when the store could not answer. The
+        last fails closed: a machine client we cannot vet gets no token.
+    """
+    if permission_store is None:
+        return _SubVerdict.OK
+    try:
+        is_admin = permission_store.is_admin(sub)
+    except Exception:
+        _logger.exception(
+            "client-credentials: the permission store could not answer whether %s=%r is an admin",
+            _SUB_ENV,
+            sub,
+        )
+        return _SubVerdict.UNVERIFIABLE
+    return _SubVerdict.ADMIN if is_admin else _SubVerdict.OK
+
+
+def _warn_if_sub_is_a_real_account(permission_store: PermissionStore | None, sub: str) -> None:
+    """Warn at mount when the machine principal is an identity a human uses.
+
+    Nothing forces ``OMNIGENT_MACHINE_SUB`` to be a *dedicated* identity, so
+    pointing it at a real person's address silently mints tokens acting as that
+    person. The roster scan is bounded and advisory — a store fault or a deploy
+    larger than :data:`_ACCOUNT_SCAN_LIMIT` just leaves the warning unsaid.
+    """
+    if permission_store is None:
+        return
+    try:
+        accounts = permission_store.list_users(limit=_ACCOUNT_SCAN_LIMIT)
+    except Exception:
+        _logger.debug(
+            "client-credentials: could not scan the roster to check whether %s=%r is a "
+            "real account",
+            _SUB_ENV,
+            sub,
+            exc_info=True,
+        )
+        return
+    if not any(account.id == sub for account in accounts):
+        return
+    _logger.warning(
+        "client-credentials: %s=%r is an existing account. Tokens minted by this "
+        "grant will act as that identity, and its session history and grants are "
+        "indistinguishable from the machine client's. Point %s at a dedicated "
+        "principal that no human logs in as.",
+        _SUB_ENV,
+        sub,
+        _SUB_ENV,
+    )
+
+
+def create_client_credentials_handler(
+    auth_provider: UnifiedAuthProvider,
+    permission_store: PermissionStore | None,
+) -> Callable[[Request, FormData], Response] | None:
+    """Build the ``client_credentials`` branch of ``POST /oauth/token``.
+
+    Pass the result to
+    :func:`omnigent.server.routes.device_auth.create_oauth_token_router` as
+    ``handle_client_credentials``. That router owns the route and has already
+    matched ``grant_type`` and parsed the form when it calls this handler.
+
+    :param auth_provider: The active provider. Must be a cookie-based mode
+        (``oidc`` or ``accounts``); its cookie config supplies the HS256
+        signing key.
+    :param permission_store: The session-permission store, used to refuse an
+        admin ``sub`` (see :func:`_vet_machine_sub`). ``None`` when the deploy
+        has no store — the store-backed OWNER override cannot fire then.
+    :returns: The handler, or ``None`` when no machine client is configured
+        (the grant's default-off state) or the configured principal is
+        refused. Either way ``client_credentials`` exchanges answer
+        ``unsupported_grant_type`` rather than a permanently broken grant.
+    :raises RuntimeError: If *auth_provider* is not a cookie-based mode or
+        exposes no cookie secret, or the machine client is misconfigured.
+    """
+    if auth_provider._source not in ("oidc", "accounts"):
+        raise RuntimeError(
+            "create_client_credentials_handler requires oidc or accounts auth "
+            f"(got {auth_provider._source!r})"
+        )
+    cookie_config = (
+        auth_provider._oidc_config
+        if auth_provider._source == "oidc"
+        else auth_provider._accounts_config
+    )
+    if cookie_config is None:
+        raise RuntimeError(
+            "create_client_credentials_handler needs the HS256 cookie secret, but "
+            f"{auth_provider._source!r} auth carries no cookie config"
+        )
+    cookie_secret = cookie_config.cookie_secret
+    provider_name = auth_provider._source
+
+    config = MachineClientConfig.from_env()
+    if config is None:
+        _logger.debug(
+            "client-credentials: no machine client configured (%s unset); the grant stays off",
+            _CLIENT_ID_ENV,
+        )
+        return None
+    # Vetting the principal needs a live store, so an unsuitable or
+    # unverifiable sub leaves the grant unbuilt rather than refusing to
+    # start — unlike a bad config, which raises above.
+    verdict = _vet_machine_sub(permission_store, config.sub)
+    if verdict is _SubVerdict.ADMIN:
+        _logger.error(
+            "client-credentials: %s=%r is an admin principal; refusing to enable "
+            "the machine grant. The path allowlist does NOT cover the "
+            "is_admin→OWNER override in /v1/sessions, so an admin machine client "
+            "would own every session. Point %s at a distinct, non-admin identity.",
+            _SUB_ENV,
+            config.sub,
+            _SUB_ENV,
+        )
+        return None
+    if verdict is _SubVerdict.UNVERIFIABLE:
+        _logger.error(
+            "client-credentials: the permission store could not say whether %s=%r "
+            "is an admin (traceback above); refusing to enable the machine grant "
+            "rather than allow an unvetted principal. This is a store fault, not "
+            "necessarily a bad %s — retry once the store answers.",
+            _SUB_ENV,
+            config.sub,
+            _SUB_ENV,
+        )
+        return None
+    if permission_store is None:
+        _logger.warning(
+            "client-credentials: no permission store wired — the admin-sub guard "
+            "could not run for %s=%r (the store-backed OWNER override is inert "
+            "without a store)",
+            _SUB_ENV,
+            config.sub,
+        )
+    _warn_if_sub_is_a_real_account(permission_store, config.sub)
+    _logger.info(
+        "client-credentials: grant_type=client_credentials enabled on /oauth/token "
+        "for client_id=%s (sub=%s); cookie_secret keys both %s verification and "
+        "token signing, so rotating it invalidates the stored hash and every "
+        "issued token",
+        config.client_id,
+        config.sub,
+        _CLIENT_SECRET_HASH_ENV,
+    )
+
+    _rate_limiter = SlidingWindowRateLimiter(
+        _TOKEN_RATE_MAX, _TOKEN_RATE_WINDOW_SECONDS, RATE_LIMITER_MAX_KEYS
+    )
+
+    def handle_client_credentials(request: Request, form: FormData) -> Response:
+        """Exchange machine client credentials for a delegated token.
+
+        The principal is re-vetted once the client has authenticated, so
+        promoting the machine ``sub`` to admin stops new tokens without a
+        restart (issued ones are bounded by the TTL).
+        """
+        # Ahead of the credential comparison: a limiter that only counted
+        # failed authentications would still answer the guess that happened to
+        # be right, so the guess RATE is what has to be bounded. ``slow_down``
+        # + 429 is the shape the device grant's throttle already answers with
+        # (RFC 8628 §3.5).
+        client_ip = request.client.host if request.client else "unknown"
+        if not _rate_limiter.allow(client_ip, time.time()):
+            return oauth_error("slow_down", status_code=429)
+
+        presented = _presented_client(request, form)
+        if presented is None:
+            return _invalid_client(request)
+        client_id, secret = presented
+        if not _client_matches(client_id, secret, config, cookie_secret):
+            return _invalid_client(request)
+
+        verdict = _vet_machine_sub(permission_store, config.sub)
+        if verdict is _SubVerdict.ADMIN:
+            _logger.error(
+                "oauth/token: refusing to mint for %s=%r — the principal is now an "
+                "admin, and an admin machine token would own every session",
+                _SUB_ENV,
+                config.sub,
+            )
+            return oauth_error("unauthorized_client")
+        if verdict is _SubVerdict.UNVERIFIABLE:
+            _logger.error(
+                "oauth/token: refusing to mint for %s=%r — the permission store "
+                "could not say whether the principal is an admin (traceback "
+                "above), so the grant fails closed until it answers",
+                _SUB_ENV,
+                config.sub,
+            )
+            return oauth_error("unauthorized_client")
+
+        access_token = mint_delegated_token(
+            config.sub,
+            cookie_secret,
+            config.token_ttl_seconds,
+            provider_name,
+            # No stored grant to revoke, so no claim — this is what tells the
+            # auth layer to skip the denylist lookup for a machine token.
+            grant_id=None,
+            client_id=config.client_id,
+            jti=secrets.token_urlsafe(16),
+            scope=DELEGATED_SCOPE,
+        )
+        _logger.info(
+            "oauth/token: issued client-credentials token for client_id=%s (sub=%s)",
+            config.client_id,
+            config.sub,
+        )
+        return JSONResponse(
+            status_code=200,
+            content={
+                "access_token": access_token,
+                "token_type": "Bearer",
+                "expires_in": config.token_ttl_seconds,
+                # RFC 6749 §5.1: REQUIRED when the granted scope differs from
+                # any the client asked for. A client-sent ``scope`` is ignored
+                # — this grant always issues DELEGATED_SCOPE — so it always
+                # differs and is always sent.
+                "scope": DELEGATED_SCOPE,
+            },
+            headers=NO_STORE_HEADERS,
+        )
+
+    return handle_client_credentials

--- a/omnigent/server/routes/device_auth.py
+++ b/omnigent/server/routes/device_auth.py
@@ -58,10 +58,17 @@ from collections.abc import Callable
 
 import jwt
 from fastapi import APIRouter, HTTPException, Request
+from starlette.datastructures import FormData
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 
 from omnigent.server.auth import UnifiedAuthProvider
 from omnigent.server.device_grant_store import DeviceGrantStore, hash_secret
+from omnigent.server.routes._oauth import (
+    NO_STORE_HEADERS,
+    RATE_LIMITER_MAX_KEYS,
+    SlidingWindowRateLimiter,
+)
+from omnigent.server.routes._oauth import oauth_error as _oauth_error
 from omnigent.server.routes._origin import require_trusted_origin
 
 _logger = logging.getLogger(__name__)
@@ -186,36 +193,45 @@ def mint_delegated_token(
     ttl_seconds: int,
     provider: str,
     *,
-    grant_id: str,
+    grant_id: str | None,
     client_id: str,
     jti: str,
     scope: str | None = DELEGATED_SCOPE,
 ) -> str:
-    """Mint a grant-derived access token.
+    """Mint a grant-derived or client-credential access token.
 
     Same HS256 shape as
     :func:`omnigent.server.oidc.mint_session_token` (so
     :meth:`UnifiedAuthProvider._check_cookie` validates it unchanged),
-    plus grant claims:
+    plus the delegated claims:
 
-    - ``scope`` — present ⇒ the auth layer restricts the token to the
-      session APIs and refuses admin endpoints. ``None`` omits the claim,
-      giving the token the SAME authority as the session JWT it renews —
-      used ONLY for first-party login grants, whose bearer is the
-      authenticated user's own CLI/host, not a third-party client.
-    - ``grant_id`` — the grant this token was issued from, checked against
-      the revocation denylist so revoking the grant immediately kills the
-      token. Carried regardless of scope.
+    - ``scope`` — present ⇒ the auth layer confines the token to the
+      fail-closed path allowlist and refuses admin endpoints. ``None``
+      omits the claim, giving the token the SAME authority as the session
+      JWT it renews — used ONLY for first-party login grants, whose bearer
+      is the authenticated user's own CLI/host, not a third-party client.
+    - ``grant_id`` — the store-backed grant this token was issued from,
+      checked against the revocation denylist so revoking the grant
+      immediately kills the token. ``None`` omits the claim, for the
+      client-credentials grant, which has no stored grant to revoke
+      (rotation and expiry are its revocation); the auth layer skips the
+      denylist lookup when it is absent.
     - ``jti`` — unique token id, for audit/log correlation.
     - ``act`` — provenance (RFC 8693 style), ``{"client_id": "<app>"}``,
-      naming the application that obtained the grant so every action is
-      attributable to it.
+      naming the application the token acts on behalf of so every action
+      is attributable to it.
+
+    The two claims are independent: a device grant carries both, a login
+    grant only ``grant_id``, a machine client only ``scope``.
 
     :param user_id: The Omnigent identity the token acts as (``sub``).
     :param cookie_secret: HMAC key for HS256 signing.
     :param ttl_seconds: Token lifetime in seconds (kept short — ≤ 1 h).
     :param provider: Identity provider name (informational claim).
-    :param grant_id: The grant id.
+    :param grant_id: The grant id, or ``None`` for a client-credentials
+        token (no ``grant_id`` claim is emitted). Required keyword with no
+        default: omitting it must be a deliberate statement, since a token
+        that silently loses the claim also skips the revocation lookup.
     :param client_id: The client id (the requesting application,
         e.g. ``"slack"``); recorded in the ``act`` claim for audit.
     :param jti: Unique token id.
@@ -229,18 +245,14 @@ def mint_delegated_token(
         "iat": now,
         "exp": now + ttl_seconds,
         "provider": provider,
-        "grant_id": grant_id,
         "jti": jti,
         "act": {"client_id": client_id},
     }
+    if grant_id is not None:
+        payload["grant_id"] = grant_id
     if scope is not None:
         payload["scope"] = scope
     return jwt.encode(payload, cookie_secret, algorithm="HS256")
-
-
-def _oauth_error(error: str, status_code: int = 400) -> JSONResponse:
-    """Return an RFC 6749 / 8628 shaped OAuth error response."""
-    return JSONResponse(status_code=status_code, content={"error": error})
 
 
 def _require_browser_origin(request: Request) -> None:
@@ -272,57 +284,8 @@ _AUTHORIZE_RATE_WINDOW_SECONDS = 60  # …per client per this window.
 _PURGE_MIN_INTERVAL_SECONDS = 300
 
 
-# Hard cap on distinct keys the limiter tracks at once. Bounds memory even
-# under a spray from many source IPs (e.g. a whole IPv6 /64) — without it a
-# key hit once and never revisited would live forever. When the cap is hit
-# the whole table is swept of aged-out keys; if still full, the limiter
-# fails OPEN for a new key (availability over a soft throttle — the real
-# anti-abuse control in production is the confidential client secret).
-_RATE_LIMITER_MAX_KEYS = 10_000
-
-
-class _SlidingWindowRateLimiter:
-    """Minimal per-key sliding-window limiter (in-memory, single-process).
-
-    Keyed by client IP. Adequate for a single-process socket-mode
-    deployment; a multi-replica server would want a shared store, but the
-    grant table's own single-use/expiry semantics already bound abuse.
-
-    Memory is bounded by :data:`_RATE_LIMITER_MAX_KEYS`: keys are dropped
-    when they age out (on touch) and, when the cap is reached, a full sweep
-    reclaims every aged-out key before admitting a new one.
-    """
-
-    def __init__(self, max_events: int, window_seconds: int, max_keys: int) -> None:
-        self._max = max_events
-        self._window = window_seconds
-        self._max_keys = max_keys
-        self._hits: dict[str, list[float]] = {}
-
-    def _sweep(self, cutoff: float) -> None:
-        """Drop every key whose hits have all aged out."""
-        dead = [k for k, ts in self._hits.items() if not any(t > cutoff for t in ts)]
-        for k in dead:
-            self._hits.pop(k, None)
-
-    def allow(self, key: str, now: float) -> bool:
-        cutoff = now - self._window
-        # New key while at capacity: sweep aged-out keys first; if the table
-        # is still full of live keys, fail open rather than grow unbounded.
-        if key not in self._hits and len(self._hits) >= self._max_keys:
-            self._sweep(cutoff)
-            if len(self._hits) >= self._max_keys:
-                return True
-        hits = [t for t in self._hits.get(key, ()) if t > cutoff]
-        # Opportunistically bound memory: drop keys that fully aged out.
-        if not hits:
-            self._hits.pop(key, None)
-        if len(hits) >= self._max:
-            self._hits[key] = hits
-            return False
-        hits.append(now)
-        self._hits[key] = hits
-        return True
+# The limiter itself lives in routes/_oauth.py: the client-credentials grant
+# throttles its own unauthenticated endpoint with the same primitive.
 
 
 def _resolve_signing_config(auth_provider: UnifiedAuthProvider) -> tuple[bytes, str]:
@@ -404,6 +367,7 @@ def create_oauth_token_router(
     device_grant_store: DeviceGrantStore,
     *,
     handle_device_code: Callable[[str], Response] | None = None,
+    handle_client_credentials: Callable[[Request, FormData], Response] | None = None,
     client_secret_ok: Callable[[Request], bool] | None = None,
 ) -> APIRouter:
     """Build the ``/oauth/token`` + ``/oauth/revoke`` router.
@@ -414,6 +378,11 @@ def create_oauth_token_router(
     RFC 8628 device-code consent flow (which stays accounts-only behind
     ``OMNIGENT_DEVICE_GRANT_ENABLED``).
 
+    This is the app's ONE ``POST /oauth/token``. Every grant type dispatches
+    from the single handler below, and a grant with no handler injected
+    answers ``unsupported_grant_type`` — a second router claiming the same
+    path would be shadowed silently, since FastAPI resolves first-match-wins.
+
     :param auth_provider: The active provider — ``accounts`` or ``oidc``.
     :param device_grant_store: Persistence for grants.
     :param handle_device_code: Optional device-code grant handler.
@@ -421,6 +390,11 @@ def create_oauth_token_router(
         the full flow keeps one token endpoint; standalone mounts leave
         it ``None`` and ``device_code`` exchanges get
         ``unsupported_grant_type``.
+    :param handle_client_credentials: Optional client-credentials grant
+        handler, from
+        :func:`omnigent.server.routes.client_credentials.create_client_credentials_handler`.
+        ``None`` (no machine client configured) leaves that grant type
+        answering ``unsupported_grant_type``.
     :param client_secret_ok: Optional client-secret gate (callable that validates
         the request). When ``None`` (standalone mounts), builds the gate from
         the ``OMNIGENT_DEVICE_CLIENT_SECRET`` env var. When provided
@@ -475,11 +449,11 @@ def create_oauth_token_router(
 
     @router.post("/oauth/token", dependencies=[])
     async def token(request: Request) -> Response:
-        """Exchange a device_code or refresh_token for an access token.
+        """Exchange a device_code, refresh_token or client credential.
 
         RFC 8628 / 6749 error shapes: ``authorization_pending``,
         ``slow_down``, ``expired_token``, ``access_denied``,
-        ``invalid_grant``, ``unsupported_grant_type``.
+        ``invalid_grant``, ``invalid_client``, ``unsupported_grant_type``.
         """
         form = await request.form()
         grant_type = str(form.get("grant_type") or "")
@@ -497,6 +471,13 @@ def create_oauth_token_router(
             return handle_device_code(str(form.get("device_code") or ""))
         if grant_type == "refresh_token":
             return _handle_refresh_grant(str(form.get("refresh_token") or ""))
+        if grant_type == "client_credentials":
+            # RFC 6749 §4.4: the machine client presents its OWN credential,
+            # so it authenticates itself rather than passing the device
+            # client-secret gate. Its handler carries the throttle.
+            if handle_client_credentials is None:
+                return _oauth_error("unsupported_grant_type")
+            return handle_client_credentials(request, form)
         return _oauth_error("unsupported_grant_type")
 
     def _handle_refresh_grant(refresh_token: str) -> Response:
@@ -549,6 +530,7 @@ def create_oauth_token_router(
                     "token_type": "Bearer",
                     "expires_in": _ACCESS_TOKEN_TTL_SECONDS,
                 },
+                headers=NO_STORE_HEADERS,
             )
 
         new_refresh = _mint_refresh_token()
@@ -579,6 +561,7 @@ def create_oauth_token_router(
                 "token_type": "Bearer",
                 "expires_in": _ACCESS_TOKEN_TTL_SECONDS,
             },
+            headers=NO_STORE_HEADERS,
         )
 
     # ── Revocation ────────────────────────────────────────────────
@@ -630,6 +613,8 @@ def create_oauth_token_router(
 def create_device_auth_router(
     auth_provider: UnifiedAuthProvider,
     device_grant_store: DeviceGrantStore,
+    *,
+    handle_client_credentials: Callable[[Request, FormData], Response] | None = None,
 ) -> APIRouter:
     """Build the ``/oauth/*`` device-grant router.
 
@@ -638,6 +623,9 @@ def create_device_auth_router(
         and public base URL. Header mode has no server-mintable identity
         and raises.
     :param device_grant_store: Persistence for device grants.
+    :param handle_client_credentials: Optional client-credentials handler,
+        forwarded to the token router this builds. The device flow and the
+        machine grant share that one ``POST /oauth/token``.
     :returns: APIRouter to mount at the app root.
     """
     cookie_secret, provider_name = _resolve_signing_config(auth_provider)
@@ -665,8 +653,8 @@ def create_device_auth_router(
     _grant_max_lifetime = _grant_max_lifetime_seconds()
 
     router = APIRouter()
-    _rate_limiter = _SlidingWindowRateLimiter(
-        _AUTHORIZE_RATE_MAX, _AUTHORIZE_RATE_WINDOW_SECONDS, _RATE_LIMITER_MAX_KEYS
+    _rate_limiter = SlidingWindowRateLimiter(
+        _AUTHORIZE_RATE_MAX, _AUTHORIZE_RATE_WINDOW_SECONDS, RATE_LIMITER_MAX_KEYS
     )
     # Last time we purged expired grants; gates the opportunistic purge on
     # authorize so the table stays bounded without a separate scheduler.
@@ -757,6 +745,9 @@ def create_device_auth_router(
                 "expires_in": _DEVICE_CODE_TTL_SECONDS,
                 "interval": _POLL_INTERVAL_SECONDS,
             },
+            # RFC 8628 §3.2 carries the bearer device_code and user_code here,
+            # so this body is as sensitive as a token response.
+            headers=NO_STORE_HEADERS,
         )
 
     # ── Browser consent page ──────────────────────────────────────
@@ -967,6 +958,7 @@ def create_device_auth_router(
                 "token_type": "Bearer",
                 "expires_in": _ACCESS_TOKEN_TTL_SECONDS,
             },
+            headers=NO_STORE_HEADERS,
         )
 
     router.include_router(
@@ -974,6 +966,7 @@ def create_device_auth_router(
             auth_provider,
             device_grant_store,
             handle_device_code=_handle_device_code_grant,
+            handle_client_credentials=handle_client_credentials,
             client_secret_ok=_client_secret_ok,
         )
     )

--- a/tests/server/integration/test_client_credentials_e2e.py
+++ b/tests/server/integration/test_client_credentials_e2e.py
@@ -1,0 +1,488 @@
+"""End-to-end integration for the OAuth 2.0 client-credentials grant.
+
+Drives a production-shaped FastAPI app in accounts mode, using
+``httpx.AsyncClient`` + ``ASGITransport`` so the async ASGI pipeline runs the
+way it does in production. ``POST /oauth/token`` is mounted either way — the
+app serves login-issued refresh grants there regardless — and this grant is one
+``grant_type`` branch of it. Proves the whole path:
+
+- with no machine client configured, ``client_credentials`` is refused as an
+  unsupported grant type — the grant is opt-in and default-off;
+- a valid client mints a bearer token;
+- that token authenticates the delegated session APIs (``/v1/sessions*``,
+  ``/v1/agents``) but is rejected on the admin / user-management paths;
+- a login-grant token minted through the real ``/auth/login`` + refresh flow in
+  the SAME app KEEPS full authority — confinement keys off ``scope``, not off
+  ``grant_id``'s absence;
+- the minted machine principal — a brand-new identity — can create a session
+  (``ensure_user`` + owner grant), operate it (post events, resolve an
+  elicitation), and delete it (the owner path);
+- a scope token allowed on one path is NOT then accepted on a disallowed
+  path (the token-keyed credential cache can't bypass the allowlist);
+- with the device grant enabled the machine client still mints — both grants
+  dispatch from the one token endpoint rather than racing for the route;
+- a half-configured machine client fails startup, so a typo cannot hide.
+
+Network-free: accounts mode needs no IdP discovery.
+"""
+
+from __future__ import annotations
+
+import secrets
+from collections.abc import AsyncIterator
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from omnigent.server.auth import LEVEL_OWNER
+from omnigent.server.device_grant_store import hash_secret
+from tests.server.helpers import build_agent_bundle
+
+pytestmark = pytest.mark.asyncio
+
+_COOKIE_SECRET_HEX = "ab" * 32
+_COOKIE_SECRET = bytes.fromhex(_COOKIE_SECRET_HEX)
+_CLIENT_ID = "svc-integration"
+_CLIENT_SECRET = "top-secret-machine-key"
+_MACHINE_SUB = "machine@example.com"
+
+
+def _build_app(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    machine_client: bool = True,
+    device_grant: bool = False,
+    partial_machine_config: bool = False,
+) -> SimpleNamespace:
+    """Build an accounts-mode app, with or without the machine client configured.
+
+    :param tmp_path: Per-test directory for HOME, the sqlite db and artifacts.
+    :param monkeypatch: Fixture used to set the server's env.
+    :param machine_client: When False, leave every ``OMNIGENT_MACHINE_*``
+        variable unset — the grant's default-off state.
+    :param device_grant: When True, enable the device grant, which shares
+        ``POST /oauth/token`` with this grant — both dispatch from it.
+    :param partial_machine_config: When True, set only one ``OMNIGENT_MACHINE_*``
+        variable, which the config parser rejects as an operator error.
+    :returns: The built app and its permission store.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("OMNIGENT_OIDC_ISSUER", raising=False)
+    monkeypatch.setenv("OMNIGENT_AUTH_PROVIDER", "accounts")
+    monkeypatch.setenv("OMNIGENT_ACCOUNTS_COOKIE_SECRET", _COOKIE_SECRET_HEX)
+    monkeypatch.setenv("OMNIGENT_ACCOUNTS_BASE_URL", "http://localhost:8000")
+    monkeypatch.setenv("OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD", "admin-pw-12345")
+    monkeypatch.setenv("OMNIGENT_ACCOUNTS_INIT_ADMIN_USERNAME", "admin")
+    monkeypatch.setenv("OMNIGENT_ADMIN_CREDENTIALS_PATH", str(tmp_path / "admin-creds"))
+    monkeypatch.setenv("OMNIGENT_ACCOUNTS_AUTO_OPEN", "0")
+    # Device grant OFF by default. Either way /oauth/token is mounted, for
+    # login-issued refresh grants; turning the device flow on just adds its own
+    # grant types and endpoints beside this one.
+    if device_grant:
+        monkeypatch.setenv("OMNIGENT_DEVICE_GRANT_ENABLED", "1")
+    else:
+        monkeypatch.delenv("OMNIGENT_DEVICE_GRANT_ENABLED", raising=False)
+    # Machine client — the secret is stored only as its keyed hash. Leaving
+    # these unset is the grant's opt-out: /oauth/token stays mounted and
+    # answers client_credentials with unsupported_grant_type.
+    for var in (
+        "OMNIGENT_MACHINE_CLIENT_ID",
+        "OMNIGENT_MACHINE_CLIENT_SECRET_HASH",
+        "OMNIGENT_MACHINE_SUB",
+        "OMNIGENT_MACHINE_TOKEN_TTL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    if machine_client:
+        monkeypatch.setenv("OMNIGENT_MACHINE_CLIENT_ID", _CLIENT_ID)
+        monkeypatch.setenv(
+            "OMNIGENT_MACHINE_CLIENT_SECRET_HASH", hash_secret(_CLIENT_SECRET, _COOKIE_SECRET)
+        )
+        monkeypatch.setenv("OMNIGENT_MACHINE_SUB", _MACHINE_SUB)
+        monkeypatch.setenv("OMNIGENT_MACHINE_TOKEN_TTL", "1800")
+    if partial_machine_config:
+        monkeypatch.setenv("OMNIGENT_MACHINE_CLIENT_ID", _CLIENT_ID)
+
+    db_url = f"sqlite:///{tmp_path}/test.db"
+    from omnigent.db.utils import get_or_create_engine
+    from omnigent.runtime import init as init_runtime
+    from omnigent.runtime import telemetry
+    from omnigent.runtime.agent_cache import AgentCache
+    from omnigent.runtime.caps import RuntimeCaps
+    from omnigent.server.accounts_store import SqlAlchemyAccountStore
+    from omnigent.server.app import create_app
+    from omnigent.server.auth import create_auth_provider
+    from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+    from omnigent.stores.artifact_store.local import LocalArtifactStore
+    from omnigent.stores.comment_store.sqlalchemy_store import SqlAlchemyCommentStore
+    from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+    from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+    from omnigent.stores.host_store import HostStore
+    from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+
+    get_or_create_engine(db_url)
+    telemetry.init()
+    permission_store = SqlAlchemyPermissionStore(db_url)
+    agent_store = SqlAlchemyAgentStore(db_url)
+    conversation_store = SqlAlchemyConversationStore(db_url)
+    file_store = SqlAlchemyFileStore(db_url)
+    comment_store = SqlAlchemyCommentStore(db_url)
+    host_store = HostStore(db_url)
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    agent_cache = AgentCache(artifact_store=artifact_store, cache_dir=tmp_path / "cache")
+    init_runtime(
+        agent_cache=agent_cache,
+        caps=RuntimeCaps(),
+        agent_store=agent_store,
+        file_store=file_store,
+        conversation_store=conversation_store,
+        artifact_store=artifact_store,
+        comment_store=comment_store,
+    )
+    auth_provider = create_auth_provider()
+    account_store = SqlAlchemyAccountStore(db_url)
+    app = create_app(
+        agent_store=agent_store,
+        file_store=file_store,
+        conversation_store=conversation_store,
+        artifact_store=artifact_store,
+        agent_cache=agent_cache,
+        comment_store=comment_store,
+        permission_store=permission_store,
+        host_store=host_store,
+        auth_provider=auth_provider,
+        account_store=account_store,
+    )
+    return SimpleNamespace(app=app, permission_store=permission_store)
+
+
+@pytest_asyncio.fixture
+async def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[SimpleNamespace]:
+    """The app, its permission store, and an in-process HTTP client."""
+    from omnigent.db.utils import clear_engine_cache
+
+    built = _build_app(tmp_path, monkeypatch)
+    transport = httpx.ASGITransport(app=built.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield SimpleNamespace(
+            client=client,
+            app=built.app,
+            permission_store=built.permission_store,
+        )
+    clear_engine_cache()
+
+
+@pytest_asyncio.fixture
+async def unconfigured_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> AsyncIterator[httpx.AsyncClient]:
+    """The same app with no machine client configured — the default deployment."""
+    from omnigent.db.utils import clear_engine_cache
+
+    built = _build_app(tmp_path, monkeypatch, machine_client=False)
+    transport = httpx.ASGITransport(app=built.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+    clear_engine_cache()
+
+
+async def _mint_token(client: httpx.AsyncClient) -> str:
+    """Run the grant and return the minted access token."""
+    resp = await client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": _CLIENT_ID,
+            "client_secret": _CLIENT_SECRET,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["token_type"] == "Bearer"
+    assert body["expires_in"] == 1800
+    token: str = body["access_token"]
+    return token
+
+
+async def test_default_deployment_does_not_serve_the_grant(
+    unconfigured_env: httpx.AsyncClient,
+) -> None:
+    """BLOCKING contract: the grant stays off for a deployment that never opted in.
+
+    ``/oauth/token`` itself is routed regardless — the app mounts it for
+    login-issued refresh grants — so the default-off signal is the grant type
+    being refused, with no token minted and no credential even examined.
+    """
+    resp = await unconfigured_env.post(
+        "/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": _CLIENT_ID,
+            "client_secret": _CLIENT_SECRET,
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["error"] == "unsupported_grant_type"
+    assert "access_token" not in resp.text
+
+
+async def test_token_authenticates_session_apis_and_rejects_admin(env: SimpleNamespace) -> None:
+    """The minted token reaches the delegated session APIs, not admin surfaces."""
+    token = await _mint_token(env.client)
+    auth = {"Authorization": f"Bearer {token}"}
+
+    assert (await env.client.get("/v1/sessions", headers=auth)).status_code == 200
+    assert (await env.client.get("/v1/agents", headers=auth)).status_code == 200
+    # /auth/users is not on the delegated allowlist → rejected at the door.
+    assert (await env.client.get("/auth/users", headers=auth)).status_code in (401, 403)
+
+
+async def _login_grant_token(client: httpx.AsyncClient) -> str:
+    """Run the real login + refresh flow and return a login-grant access token.
+
+    ``/auth/login`` with ``issue_refresh`` hands back refresh material; trading
+    it at ``/oauth/token`` mints the first-party token shape — ``grant_id``
+    present, ``scope`` absent.
+    """
+    login = await client.post(
+        "/auth/login",
+        json={"username": "admin", "password": "admin-pw-12345", "issue_refresh": True},
+    )
+    assert login.status_code == 200, login.text
+    refresh_token = login.json()["refresh_token"]
+
+    refreshed = await client.post(
+        "/oauth/token",
+        data={"grant_type": "refresh_token", "refresh_token": refresh_token},
+    )
+    assert refreshed.status_code == 200, refreshed.text
+    token: str = refreshed.json()["access_token"]
+    # Login set a session cookie, and the auth layer reads the cookie BEFORE
+    # the bearer header. Drop it so each request below is decided by the token
+    # it actually carries.
+    client.cookies.clear()
+    return token
+
+
+async def test_login_grant_keeps_full_authority_beside_the_machine_grant(
+    env: SimpleNamespace,
+) -> None:
+    """BLOCKING invariant: the two token shapes must not swap authority.
+
+    In one app, one process: a machine token (``scope``, no ``grant_id``) is
+    confined to the delegated allowlist, while a login-grant token
+    (``grant_id``, no ``scope``) keeps the authority of the session JWT it
+    renewed. Confinement keys off ``scope`` being PRESENT — keying it off
+    ``grant_id`` being ABSENT inverts both rows at once.
+    """
+    machine_auth = {"Authorization": f"Bearer {await _mint_token(env.client)}"}
+    login_auth = {"Authorization": f"Bearer {await _login_grant_token(env.client)}"}
+
+    # Both reach the allowlisted session APIs.
+    assert (await env.client.get("/v1/sessions", headers=machine_auth)).status_code == 200
+    assert (await env.client.get("/v1/sessions", headers=login_auth)).status_code == 200
+
+    # /v1/me is off the allowlist and NOT separately admin-gated, so it
+    # separates "confined by the allowlist" from "allowed but refused later" —
+    # which /auth/users cannot, since it 403s a non-admin either way.
+    assert (await env.client.get("/v1/me", headers=machine_auth)).status_code in (401, 403)
+    assert (await env.client.get("/v1/me", headers=login_auth)).status_code == 200
+
+    # The admin surface: reachable only by the full-authority login grant.
+    assert (await env.client.get("/auth/users", headers=machine_auth)).status_code in (401, 403)
+    assert (await env.client.get("/auth/users", headers=login_auth)).status_code == 200
+
+
+async def test_bad_client_is_rejected(env: SimpleNamespace) -> None:
+    bad = await env.client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": _CLIENT_ID,
+            "client_secret": "wrong",
+        },
+    )
+    assert bad.status_code == 401 and bad.json()["error"] == "invalid_client"
+
+    other = await env.client.post("/oauth/token", data={"grant_type": "password"})
+    assert other.status_code == 400 and other.json()["error"] == "unsupported_grant_type"
+
+
+async def test_machine_client_owns_and_operates_its_own_session(env: SimpleNamespace) -> None:
+    """The brand-new principal can create, operate, and delete its session.
+
+    Create runs ``ensure_user`` + an owner grant, so the machine client is
+    LEVEL_OWNER on the session it made and passes every owner/edit gate that
+    follows.
+    """
+    token = await _mint_token(env.client)
+    auth = {"Authorization": f"Bearer {token}"}
+
+    # Create (multipart bundled create) — the ensure_user +
+    # LEVEL_OWNER-on-create path. The principal has never been seen before.
+    bundle = build_agent_bundle(name="cc-machine-agent")
+    created = await env.client.post(
+        "/v1/sessions",
+        data={"metadata": "{}"},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+        headers=auth,
+    )
+    assert created.status_code == 201, created.text
+    session_id = created.json()["session_id"]
+
+    # ensure_user + owner grant actually landed for the machine principal.
+    grant = env.permission_store.get(_MACHINE_SUB, session_id)
+    assert grant is not None and grant.level >= LEVEL_OWNER
+
+    # Owner can read its own session's agent.
+    agent = await env.client.get(f"/v1/sessions/{session_id}/agent", headers=auth)
+    assert agent.status_code == 200
+
+    # Post an event (owner satisfies the LEVEL_EDIT gate — not rejected).
+    # Bounded above too: a 500 is a failure, not a pass, for "not rejected".
+    posted = await env.client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={"type": "interrupt", "data": {}},
+        headers=auth,
+    )
+    assert posted.status_code not in (401, 403) and posted.status_code < 500, posted.text
+
+    # Resolve an elicitation (owner passes the gate; a missing elicitation
+    # degrades gracefully rather than being an authz failure).
+    resolved = await env.client.post(
+        f"/v1/sessions/{session_id}/elicitations/{secrets.token_hex(8)}/resolve",
+        json={"action": "cancel"},
+        headers=auth,
+    )
+    assert resolved.status_code not in (401, 403) and resolved.status_code < 500, resolved.text
+
+    # Delete its own session (the owner-only path).
+    deleted = await env.client.delete(f"/v1/sessions/{session_id}", headers=auth)
+    assert deleted.status_code == 200, deleted.text
+
+
+# Paths off the delegated allowlist that a machine token must never reach:
+# the admin user list, and the identity endpoint the auth layer keeps out of
+# the allowlist. Named individually rather than snapshotted as a route
+# inventory — the allowlist is fail-closed, so what this grant has to prove is
+# that off-allowlist paths stay shut, not that the app's route table is frozen.
+_FORBIDDEN_PATHS = ("/auth/users", "/v1/me")
+
+# The subset of the above that actually DISCRIMINATES. /auth/users is
+# separately admin-gated, so it answers 403 for an unauthenticated caller, a
+# confined token, and a full-authority non-admin token alike — asserting on it
+# alone would pass with confinement deleted. /v1/me is off the allowlist and
+# not admin-gated, so only confinement can refuse it.
+_CONFINEMENT_PROBE = "/v1/me"
+
+
+async def test_token_is_refused_on_off_allowlist_paths(env: SimpleNamespace) -> None:
+    """The machine token cannot reach anything outside the delegated allowlist.
+
+    The probe carries its own positive control: the same path answers 200 to a
+    full-authority login-grant token, so a refusal here is confinement doing
+    the work rather than the endpoint refusing everyone.
+    """
+    machine_auth = {"Authorization": f"Bearer {await _mint_token(env.client)}"}
+
+    for path in _FORBIDDEN_PATHS:
+        resp = await env.client.get(path, headers=machine_auth)
+        assert resp.status_code in (401, 403), f"{path} answered {resp.status_code}"
+
+    login_auth = {"Authorization": f"Bearer {await _login_grant_token(env.client)}"}
+    control = await env.client.get(_CONFINEMENT_PROBE, headers=login_auth)
+    assert control.status_code == 200, (
+        f"positive control failed: {_CONFINEMENT_PROBE} answered {control.status_code} "
+        "to a full-authority token, so the refusals above prove nothing"
+    )
+
+
+async def test_scope_token_cache_does_not_bypass_allowlist(env: SimpleNamespace) -> None:
+    """A prior allowed call must not let a later disallowed path through.
+
+    End-to-end mirror of the unit cache-bypass test: the credential cache is
+    keyed by token, so caching a scope token would skip the allowlist on a
+    replay. The same token, same process, must still be refused on
+    :data:`_CONFINEMENT_PROBE` after succeeding on ``/v1/sessions``.
+
+    Probes ``/v1/me`` rather than ``/auth/users``: the latter is separately
+    admin-gated and refuses every non-admin caller, so it would answer 403
+    whether or not the allowlist ran. The positive control below pins that
+    distinction — the same path answers 200 to a full-authority token.
+    """
+    auth = {"Authorization": f"Bearer {await _mint_token(env.client)}"}
+
+    assert (await env.client.get("/v1/sessions", headers=auth)).status_code == 200
+    assert (await env.client.get(_CONFINEMENT_PROBE, headers=auth)).status_code in (401, 403)
+    # And once more, to be sure repetition never warms a bypassing cache entry.
+    assert (await env.client.get(_CONFINEMENT_PROBE, headers=auth)).status_code in (401, 403)
+    assert (await env.client.get("/v1/sessions", headers=auth)).status_code == 200
+
+    # Positive control: without it, deleting confinement outright would leave
+    # this test green.
+    login_auth = {"Authorization": f"Bearer {await _login_grant_token(env.client)}"}
+    control = await env.client.get(_CONFINEMENT_PROBE, headers=login_auth)
+    assert control.status_code == 200, (
+        f"positive control failed: {_CONFINEMENT_PROBE} answered {control.status_code} "
+        "to a full-authority token, so the refusals above prove nothing"
+    )
+
+
+async def test_machine_client_still_mints_with_the_device_grant_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """BLOCKING regression: the device grant must not shadow the machine grant.
+
+    Both used to claim ``POST /oauth/token`` with their own router. FastAPI
+    registers duplicates and resolves first-match-wins with no warning, so
+    whichever lost went quiet behind a startup log still calling it enabled.
+    They now share one endpoint and dispatch on ``grant_type``, so enabling the
+    device flow leaves the machine client minting.
+    """
+    from omnigent.db.utils import clear_engine_cache
+
+    built = _build_app(tmp_path, monkeypatch, machine_client=True, device_grant=True)
+    transport = httpx.ASGITransport(app=built.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/oauth/token",
+            data={
+                "grant_type": "client_credentials",
+                "client_id": _CLIENT_ID,
+                "client_secret": _CLIENT_SECRET,
+            },
+        )
+        # The device flow's own endpoints are up in the same app.
+        device = await client.post(
+            "/oauth/device/authorize",
+            data={"client_id": "some-device-client"},
+        )
+    clear_engine_cache()
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["token_type"] == "Bearer"
+    assert resp.json()["scope"] == "sessions"
+    assert device.status_code == 200, device.text
+
+
+async def test_malformed_machine_config_fails_startup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A half-configured machine client is a startup error, not a silent off.
+
+    An operator who set one variable meant to enable the grant, so the deploy
+    fails immediately rather than coming up healthy with the grant absent.
+    """
+    from omnigent.db.utils import clear_engine_cache
+
+    with pytest.raises(RuntimeError, match="must all be set"):
+        _build_app(
+            tmp_path,
+            monkeypatch,
+            machine_client=False,
+            device_grant=True,
+            partial_machine_config=True,
+        )
+    clear_engine_cache()

--- a/tests/server/test_client_credentials.py
+++ b/tests/server/test_client_credentials.py
@@ -1,0 +1,1109 @@
+"""Unit tests for the OAuth 2.0 client-credentials (machine-auth) grant.
+
+Three layers, all network-free:
+
+1. :class:`MachineClientConfig` env parsing — enabled, cleanly off, and the
+   misconfigurations (partial, malformed secret hash, reserved principal, bad
+   or over-ceiling TTL) that raise.
+2. The handler factory and the folded ``POST /oauth/token`` route on a minimal
+   OIDC-mode app — default-off (no handler at all when unconfigured or when the
+   principal is refused), the token shape, the RFC 6749 §5.1 / §5.2 response
+   headers, the per-source throttle in front of the pre-authentication client
+   check, coexistence with the device/refresh grants on the one route, and
+   every error shape.
+3. The ``UnifiedAuthProvider._check_cookie`` claim gate — which of the three
+   token shapes the server mints is confined to the delegated path allowlist,
+   which keeps full authority, and which consults the revocation denylist.
+   :func:`test_token_authority_table` pins all three together.
+"""
+
+from __future__ import annotations
+
+import base64
+import time
+from unittest.mock import MagicMock
+from urllib.parse import quote_plus
+
+import jwt
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.datastructures import FormData
+
+from omnigent.entities import Account
+from omnigent.server.auth import UnifiedAuthProvider
+from omnigent.server.device_grant_store import hash_secret
+from omnigent.server.oidc import OIDCConfig, mint_session_token
+from omnigent.server.routes.client_credentials import (
+    _SECRET_HASH_RE,
+    _TOKEN_RATE_MAX,
+    MachineClientConfig,
+    _client_matches,
+    _presented_client,
+    create_client_credentials_handler,
+)
+from omnigent.server.routes.device_auth import (
+    LOGIN_GRANT_CLIENT_ID,
+    create_device_auth_router,
+    create_oauth_token_router,
+    mint_delegated_token,
+)
+
+_COOKIE_SECRET = b"c" * 32
+_CLIENT_ID = "svc-omnigent"
+_CLIENT_SECRET = "top-secret-machine-key"
+_SECRET_HASH = hash_secret(_CLIENT_SECRET, _COOKIE_SECRET)
+_MACHINE_SUB = "machine@example.com"
+
+
+class _FakeStore:
+    """Duck-typed permission store: only what the grant actually calls.
+
+    The grant touches the store through ``is_admin`` — at mount and again
+    before every mint — and through ``list_users`` once at mount, for the
+    dedicated-identity warning. A minimal stand-in avoids implementing the
+    whole ABC.
+    """
+
+    def __init__(self, *, admins: tuple[str, ...] = (), users: tuple[str, ...] = ()) -> None:
+        self.admins = set(admins)
+        self.users = set(users)
+
+    def is_admin(self, user_id: str) -> bool:
+        return user_id in self.admins
+
+    def list_users(self, *, limit: int = 1000) -> list[Account]:
+        return [
+            Account(
+                id=user_id,
+                is_admin=user_id in self.admins,
+                created_at=None,
+                last_login_at=None,
+                has_password=False,
+            )
+            for user_id in sorted(self.users)[:limit]
+        ]
+
+
+class _FakeGrantStore:
+    """Duck-typed device-grant store: enough for the non-machine grant types.
+
+    Only the refresh path is exercised here, and only to prove the machine
+    branch did not shadow it — so every lookup misses and the housekeeping
+    purge is a no-op.
+    """
+
+    def get_by_refresh_hash(self, refresh_hash: str) -> None:
+        return None
+
+    def get_by_prev_refresh_hash(self, refresh_hash: str) -> None:
+        return None
+
+    def purge_expired(self, now_epoch_seconds: int, *, max_lifetime_seconds: int) -> int:
+        return 0
+
+
+# ── Fixtures / helpers ────────────────────────────────────────────
+
+
+def _make_oidc_provider(*, provider_type: str = "github") -> UnifiedAuthProvider:
+    """An OIDC provider (no discovery fetch, no network).
+
+    Defaults to GitHub-flavoured. The device-grant router refuses that
+    provider type, so the test that mounts the full device flow asks for a
+    standard OIDC one instead.
+    """
+    config = OIDCConfig(
+        issuer="https://github.com",
+        client_id="oidc-client",
+        client_secret="oidc-secret",
+        redirect_uri="http://localhost:8000/auth/callback",
+        cookie_secret=_COOKIE_SECRET,
+        scopes="read:user user:email",
+        session_ttl_hours=8,
+        logout_redirect_uri=None,
+        allowed_domains=None,
+        provider_type=provider_type,
+        authorization_endpoint="https://github.com/login/oauth/authorize",
+        token_endpoint="https://github.com/login/oauth/access_token",
+        jwks_uri=None,
+        userinfo_endpoint="https://api.github.com/user",
+        allow_invites=False,
+    )
+    return UnifiedAuthProvider(source="oidc", oidc_config=config)
+
+
+def _configure(monkeypatch: pytest.MonkeyPatch, *, ttl: str | None = None) -> None:
+    monkeypatch.setenv("OMNIGENT_MACHINE_CLIENT_ID", _CLIENT_ID)
+    monkeypatch.setenv("OMNIGENT_MACHINE_CLIENT_SECRET_HASH", _SECRET_HASH)
+    monkeypatch.setenv("OMNIGENT_MACHINE_SUB", _MACHINE_SUB)
+    if ttl is not None:
+        monkeypatch.setenv("OMNIGENT_MACHINE_TOKEN_TTL", ttl)
+    else:
+        monkeypatch.delenv("OMNIGENT_MACHINE_TOKEN_TTL", raising=False)
+
+
+def _clear(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "OMNIGENT_MACHINE_CLIENT_ID",
+        "OMNIGENT_MACHINE_CLIENT_SECRET_HASH",
+        "OMNIGENT_MACHINE_SUB",
+        "OMNIGENT_MACHINE_TOKEN_TTL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _handler(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    configure: bool = True,
+    ttl: str | None = None,
+    store: _FakeStore | None = None,
+):
+    """Build the grant handler (or ``None``) the way ``app.py`` does.
+
+    Env must be set BEFORE the handler is created — the machine-client config
+    is read once at mount, matching how the other auth env vars behave.
+    """
+    _clear(monkeypatch)
+    if configure:
+        _configure(monkeypatch, ttl=ttl)
+    return create_client_credentials_handler(
+        _make_oidc_provider(),
+        _FakeStore() if store is None else store,  # type: ignore[arg-type]
+    )
+
+
+def _token_app(handler) -> FastAPI:
+    """Build the real token router carrying *handler* as its machine branch."""
+    app = FastAPI()
+    app.include_router(
+        create_oauth_token_router(
+            _make_oidc_provider(),
+            _FakeGrantStore(),  # type: ignore[arg-type]
+            handle_client_credentials=handler,
+        )
+    )
+    return app
+
+
+def _app_with(handler) -> TestClient:
+    """A TestClient over the real, folded ``POST /oauth/token``."""
+    return TestClient(_token_app(handler))
+
+
+def _client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    ttl: str | None = None,
+    store: _FakeStore | None = None,
+) -> TestClient:
+    """Build a minimal app whose /oauth/token carries the machine grant.
+
+    The store defaults to one where the machine sub is a non-admin identity,
+    so the grant is enabled.
+    """
+    handler = _handler(monkeypatch, ttl=ttl, store=store)
+    assert handler is not None, "expected the grant to be enabled for this config"
+    return _app_with(handler)
+
+
+# ── MachineClientConfig.from_env ──────────────────────────────────
+
+
+def test_config_enabled_reads_all_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure(monkeypatch, ttl="900")
+    config = MachineClientConfig.from_env()
+    assert config is not None
+    assert config.client_id == _CLIENT_ID
+    assert config.secret_hash == _SECRET_HASH
+    assert config.sub == _MACHINE_SUB
+    assert config.token_ttl_seconds == 900
+
+
+def test_config_disabled_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear(monkeypatch)
+    assert MachineClientConfig.from_env() is None
+
+
+@pytest.mark.parametrize(
+    "present",
+    [
+        "OMNIGENT_MACHINE_CLIENT_ID",
+        "OMNIGENT_MACHINE_CLIENT_SECRET_HASH",
+        "OMNIGENT_MACHINE_SUB",
+    ],
+)
+def test_config_partial_is_an_error(monkeypatch: pytest.MonkeyPatch, present: str) -> None:
+    """A half-config raises instead of quietly resolving to "off".
+
+    An operator who set one variable meant to enable the grant; coming up
+    without it would surface later as a grant that answers every request
+    ``unsupported_grant_type``.
+    """
+    _clear(monkeypatch)
+    monkeypatch.setenv(present, "value")
+    with pytest.raises(RuntimeError, match="must all be set"):
+        MachineClientConfig.from_env()
+
+
+def test_config_raw_secret_in_place_of_hash_is_an_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The stored form must be the digest — the raw secret is the trap.
+
+    Unvalidated it would parse fine and then never match, leaving a token
+    endpoint that 401s every correct credential for no visible reason.
+    """
+    _configure(monkeypatch)
+    monkeypatch.setenv("OMNIGENT_MACHINE_CLIENT_SECRET_HASH", _CLIENT_SECRET)
+    with pytest.raises(RuntimeError, match="hash_secret digest"):
+        MachineClientConfig.from_env()
+
+
+@pytest.mark.parametrize("bad", ["deadbeef", "z" * 64, _SECRET_HASH + "00"])
+def test_config_malformed_secret_hash_is_an_error(
+    monkeypatch: pytest.MonkeyPatch, bad: str
+) -> None:
+    """Too short, non-hex, and too long are all refused."""
+    _configure(monkeypatch)
+    monkeypatch.setenv("OMNIGENT_MACHINE_CLIENT_SECRET_HASH", bad)
+    with pytest.raises(RuntimeError, match="hash_secret digest"):
+        MachineClientConfig.from_env()
+
+
+def test_secret_hash_pattern_is_anchored() -> None:
+    """The pattern carries its own anchors, not just the caller's ``fullmatch``.
+
+    Were the strictness only in the call site, a later refactor to ``match`` or
+    ``search`` would silently widen the check to "contains 64 hex characters
+    somewhere" — which the raw-secret trap could then slip through.
+    """
+    assert _SECRET_HASH_RE.fullmatch(_SECRET_HASH) is not None
+    assert _SECRET_HASH_RE.match(_SECRET_HASH + "extra") is None
+    assert _SECRET_HASH_RE.search("junk" + _SECRET_HASH) is None
+    # ``\Z`` rather than ``$``: ``$`` would accept a trailing newline.
+    assert _SECRET_HASH_RE.match(_SECRET_HASH + "\n") is None
+
+
+def test_config_uppercase_secret_hash_is_normalised(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An uppercased digest still matches — the comparison is exact-string."""
+    _configure(monkeypatch)
+    monkeypatch.setenv("OMNIGENT_MACHINE_CLIENT_SECRET_HASH", _SECRET_HASH.upper())
+    config = MachineClientConfig.from_env()
+    assert config is not None
+    assert _client_matches(_CLIENT_ID, _CLIENT_SECRET, config, _COOKIE_SECRET) is True
+
+
+@pytest.mark.parametrize("reserved", ["local", "__public__"])
+def test_config_reserved_principal_is_an_error(
+    monkeypatch: pytest.MonkeyPatch, reserved: str
+) -> None:
+    """The machine principal must be a distinct identity, never a sentinel."""
+    _configure(monkeypatch)
+    monkeypatch.setenv("OMNIGENT_MACHINE_SUB", reserved)
+    with pytest.raises(RuntimeError, match="reserved identity"):
+        MachineClientConfig.from_env()
+
+
+def test_config_default_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure(monkeypatch)
+    config = MachineClientConfig.from_env()
+    assert config is not None and config.token_ttl_seconds == 3600
+
+
+@pytest.mark.parametrize(
+    ("bad", "message"),
+    [("not-an-int", "not an integer"), ("0", "must be a positive"), ("-5", "must be a positive")],
+)
+def test_config_bad_ttl_is_an_error(
+    monkeypatch: pytest.MonkeyPatch, bad: str, message: str
+) -> None:
+    """An unusable TTL raises rather than silently taking the default."""
+    _configure(monkeypatch, ttl=bad)
+    with pytest.raises(RuntimeError, match=message):
+        MachineClientConfig.from_env()
+
+
+def test_config_ttl_above_ceiling_is_an_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Expiry is the only revocation, so the TTL ceiling is enforced, not advised."""
+    _configure(monkeypatch, ttl="3601")
+    with pytest.raises(RuntimeError, match="exceeds the 3600s ceiling"):
+        MachineClientConfig.from_env()
+    _configure(monkeypatch, ttl="3600")
+    config = MachineClientConfig.from_env()
+    assert config is not None and config.token_ttl_seconds == 3600
+
+
+# ── Credential presentation + verification ────────────────────────
+
+
+def _basic(client_id: str, secret: str, *, scheme: str = "Basic") -> str:
+    raw = base64.b64encode(f"{client_id}:{secret}".encode()).decode("ascii")
+    return f"{scheme} {raw}"
+
+
+def test_presented_client_from_form() -> None:
+    request = MagicMock()
+    request.headers = {}
+    form = FormData([("client_id", _CLIENT_ID), ("client_secret", _CLIENT_SECRET)])
+    assert _presented_client(request, form) == (_CLIENT_ID, _CLIENT_SECRET)
+
+
+def test_presented_client_from_basic_header_takes_precedence() -> None:
+    request = MagicMock()
+    request.headers = {"Authorization": _basic("basic-id", "basic-secret")}
+    form = FormData([("client_id", _CLIENT_ID), ("client_secret", _CLIENT_SECRET)])
+    assert _presented_client(request, form) == ("basic-id", "basic-secret")
+
+
+@pytest.mark.parametrize("scheme", ["basic", "BASIC", "BaSiC"])
+def test_presented_client_basic_scheme_is_case_insensitive(scheme: str) -> None:
+    """RFC 7235 §2.1: the auth scheme is a case-insensitive token."""
+    request = MagicMock()
+    request.headers = {"Authorization": _basic(_CLIENT_ID, _CLIENT_SECRET, scheme=scheme)}
+    assert _presented_client(request, FormData([])) == (_CLIENT_ID, _CLIENT_SECRET)
+
+
+def test_presented_client_none_when_secret_absent() -> None:
+    request = MagicMock()
+    request.headers = {}
+    form = FormData([("client_id", _CLIENT_ID)])
+    assert _presented_client(request, form) is None
+
+
+def test_presented_client_basic_credentials_are_form_urldecoded() -> None:
+    """RFC 6749 §2.3.1: both halves are form-urlencoded before the base64.
+
+    Without the decode a secret containing ``:``, ``%``, ``+`` or a space is
+    read as its encoded form and never matches.
+    """
+    request = MagicMock()
+    raw = base64.b64encode(b"svc%3Aone:p%40ss+word%25").decode("ascii")
+    request.headers = {"Authorization": f"Basic {raw}"}
+    assert _presented_client(request, FormData([])) == ("svc:one", "p@ss word%")
+
+
+def test_presented_client_none_on_malformed_basic() -> None:
+    request = MagicMock()
+    request.headers = {"Authorization": "Basic !!!not-base64!!!"}
+    assert _presented_client(request, FormData([])) is None
+
+
+def test_client_matches_true_for_correct_pair(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure(monkeypatch)
+    config = MachineClientConfig.from_env()
+    assert config is not None
+    assert _client_matches(_CLIENT_ID, _CLIENT_SECRET, config, _COOKIE_SECRET) is True
+
+
+def test_client_matches_false_for_wrong_secret_or_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure(monkeypatch)
+    config = MachineClientConfig.from_env()
+    assert config is not None
+    assert _client_matches(_CLIENT_ID, "wrong", config, _COOKIE_SECRET) is False
+    assert _client_matches("wrong-id", _CLIENT_SECRET, config, _COOKIE_SECRET) is False
+
+
+# ── Enabling the grant: opt-in, default-off ───────────────────────
+
+
+def test_unconfigured_grant_builds_no_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BLOCKING contract: no machine client → no handler.
+
+    The grant is opt-in like the device grant next door; a deployment that
+    configures none must not gain a working ``client_credentials`` exchange.
+    """
+    assert _handler(monkeypatch, configure=False) is None
+
+
+def test_unconfigured_grant_is_an_unsupported_grant_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The end an operator sees: the grant type is simply not served.
+
+    ``/oauth/token`` itself stays routed — main mounts it for login-issued
+    refresh grants regardless — so the default-off signal is the grant-type
+    refusal, not a 404 on the path.
+    """
+    _clear(monkeypatch)
+    client = _app_with(_handler(monkeypatch, configure=False))
+    resp = client.post("/oauth/token", data={"grant_type": "client_credentials"})
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "unsupported_grant_type"
+
+
+def test_admin_sub_is_not_enabled(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """BLOCKING guard: an admin ``sub`` refuses to enable the grant.
+
+    The path allowlist confines the token to the session APIs but not its
+    privilege there — /v1/sessions' ``is_admin → LEVEL_OWNER`` override would
+    make such a client OWNER of every tenant's session.
+    """
+    with caplog.at_level("ERROR"):
+        handler = _handler(monkeypatch, store=_FakeStore(admins=(_MACHINE_SUB,)))
+    assert handler is None
+    assert any("admin principal" in r.message for r in caplog.records)
+
+
+def test_non_admin_sub_enables_grant(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-admin ``sub`` enables an active grant and mints a token."""
+    client = _client(monkeypatch, store=_FakeStore(admins=("someone-else@example.com",)))
+    resp = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": _CLIENT_ID,
+            "client_secret": _CLIENT_SECRET,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+
+class _BrokenStore(_FakeStore):
+    """A permission store whose admin lookup always raises."""
+
+    def is_admin(self, user_id: str) -> bool:
+        raise RuntimeError("store down")
+
+
+class _FlakyStore(_FakeStore):
+    """A store that answers until ``broken`` is set — a fault after mount."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.broken = False
+
+    def is_admin(self, user_id: str) -> bool:
+        if self.broken:
+            raise RuntimeError("store down")
+        return False
+
+
+def test_store_error_at_mount_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If the admin check raises at mount, fail closed — no handler is built."""
+    assert _handler(monkeypatch, store=_BrokenStore()) is None
+
+
+def test_store_error_at_mount_is_not_reported_as_an_admin_sub(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The refusal names the store fault instead of blaming the ``sub``.
+
+    Both outcomes refuse the grant, but an operator told their ``sub`` is an
+    admin will go audit a config that is fine while the store stays broken.
+    """
+    with caplog.at_level("ERROR"):
+        assert _handler(monkeypatch, store=_BrokenStore()) is None
+    refusals = [r.message for r in caplog.records if "refusing to enable" in r.message]
+    assert refusals, "expected a refusal to be logged"
+    assert not any("is an admin principal" in m for m in refusals)
+    assert any("could not say whether" in m for m in refusals)
+
+
+def test_factory_rejects_non_cookie_mode() -> None:
+    """The grant needs the HS256 cookie secret, so header mode can't build it."""
+    with pytest.raises(RuntimeError, match="oidc or accounts"):
+        create_client_credentials_handler(UnifiedAuthProvider(source="header"), None)
+
+
+def test_machine_sub_matching_a_real_account_warns(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Nothing forces the machine sub to be a DEDICATED identity.
+
+    Pointing it at a real person's address silently mints tokens acting as
+    that person, so the operator is told at mount. Advisory: the grant is
+    still enabled.
+    """
+    with caplog.at_level("WARNING"):
+        handler = _handler(monkeypatch, store=_FakeStore(users=(_MACHINE_SUB, "someone@x.com")))
+    assert handler is not None
+    assert any("is an existing account" in r.message for r in caplog.records)
+
+
+def test_dedicated_machine_sub_does_not_warn(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A sub that matches no account is the intended shape and stays quiet."""
+    with caplog.at_level("WARNING"):
+        handler = _handler(monkeypatch, store=_FakeStore(users=("someone@x.com",)))
+    assert handler is not None
+    assert not any("is an existing account" in r.message for r in caplog.records)
+
+
+# ── /oauth/token route: success + token shape ─────────────────────
+
+
+def test_token_form_credentials_succeed(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(monkeypatch, ttl="1800")
+    resp = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": _CLIENT_ID,
+            "client_secret": _CLIENT_SECRET,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["token_type"] == "Bearer"
+    assert body["expires_in"] == 1800
+
+    claims = jwt.decode(body["access_token"], _COOKIE_SECRET, algorithms=["HS256"])
+    assert claims["sub"] == _MACHINE_SUB
+    assert claims["scope"] == "sessions"
+    assert claims["act"] == {"client_id": _CLIENT_ID}
+    # Rotation-model MVP: a client-credentials token carries NO grant_id.
+    assert "grant_id" not in claims
+    assert claims["exp"] - claims["iat"] == 1800
+
+
+def test_token_response_carries_the_granted_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    """RFC 6749 §5.1: ``scope`` is REQUIRED when it differs from the request.
+
+    This grant ignores a client-sent ``scope`` (§4.4.2 permits sending one) and
+    always issues ``DELEGATED_SCOPE``, so the granted scope always differs from
+    whatever was asked for and the response always states it.
+    """
+    client = _client(monkeypatch)
+    resp = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": _CLIENT_ID,
+            "client_secret": _CLIENT_SECRET,
+            "scope": "admin everything",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["scope"] == "sessions"
+    claims = jwt.decode(resp.json()["access_token"], _COOKIE_SECRET, algorithms=["HS256"])
+    assert claims["scope"] == "sessions"
+
+
+def test_token_basic_auth_credentials_succeed(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(monkeypatch)
+    resp = client.post(
+        "/oauth/token",
+        data={"grant_type": "client_credentials"},
+        headers={"Authorization": _basic(_CLIENT_ID, _CLIENT_SECRET)},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["token_type"] == "Bearer"
+
+
+def test_token_basic_auth_urlencoded_secret_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A secret needing form-urlencoding round-trips through the Basic header."""
+    secret = "p@ss word/+%"
+    _clear(monkeypatch)
+    monkeypatch.setenv("OMNIGENT_MACHINE_CLIENT_ID", _CLIENT_ID)
+    monkeypatch.setenv("OMNIGENT_MACHINE_CLIENT_SECRET_HASH", hash_secret(secret, _COOKIE_SECRET))
+    monkeypatch.setenv("OMNIGENT_MACHINE_SUB", _MACHINE_SUB)
+    handler = create_client_credentials_handler(
+        _make_oidc_provider(),
+        _FakeStore(),  # type: ignore[arg-type]
+    )
+    assert handler is not None
+
+    credential = f"{quote_plus(_CLIENT_ID)}:{quote_plus(secret)}".encode()
+    resp = _app_with(handler).post(
+        "/oauth/token",
+        data={"grant_type": "client_credentials"},
+        headers={"Authorization": f"Basic {base64.b64encode(credential).decode('ascii')}"},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_token_response_is_not_cacheable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """RFC 6749 §5.1: a response carrying a token must not be cached."""
+    client = _client(monkeypatch)
+    resp = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": _CLIENT_ID,
+            "client_secret": _CLIENT_SECRET,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["cache-control"] == "no-store"
+    assert resp.headers["pragma"] == "no-cache"
+
+
+# ── /oauth/token route: one endpoint, three grant types ───────────
+
+
+def test_machine_grant_registers_no_second_token_route(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BLOCKING contract: the grant is a branch, never a second route.
+
+    FastAPI resolves first-match-wins with no warning, so a parallel router on
+    ``POST /oauth/token`` would leave whichever registered second as dead code
+    behind a startup log claiming it was enabled.
+    """
+    handler = _handler(monkeypatch)
+    assert handler is not None
+    router = create_oauth_token_router(
+        _make_oidc_provider(),
+        _FakeGrantStore(),  # type: ignore[arg-type]
+        handle_client_credentials=handler,
+    )
+    paths = [getattr(route, "path", None) for route in router.routes]
+    assert paths.count("/oauth/token") == 1
+
+
+def test_machine_grant_answers_under_the_device_grant_router(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BLOCKING regression: the device flow must not shadow the machine grant.
+
+    The device-grant router builds its own token endpoint, so a machine grant
+    living on a parallel router went silent whenever the device grant was
+    enabled. Folded in as a ``grant_type`` branch, it answers in both mounts.
+    """
+    handler = _handler(monkeypatch)
+    assert handler is not None
+    app = FastAPI()
+    app.include_router(
+        create_device_auth_router(
+            _make_oidc_provider(provider_type="oidc"),
+            _FakeGrantStore(),  # type: ignore[arg-type]
+            handle_client_credentials=handler,
+        )
+    )
+    resp = TestClient(app).post(
+        "/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": _CLIENT_ID,
+            "client_secret": _CLIENT_SECRET,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["scope"] == "sessions"
+
+
+def test_other_grant_types_still_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Adding the machine branch must not shadow the grants already there.
+
+    ``refresh_token`` reaches its own handler (rejected here only because no
+    such token exists), and an unknown grant is still refused.
+    """
+    client = _client(monkeypatch)
+    refresh = client.post(
+        "/oauth/token",
+        data={"grant_type": "refresh_token", "refresh_token": "nope"},
+    )
+    assert refresh.status_code == 400 and refresh.json()["error"] == "invalid_grant"
+
+    unknown = client.post("/oauth/token", data={"grant_type": "password"})
+    assert unknown.status_code == 400 and unknown.json()["error"] == "unsupported_grant_type"
+
+
+def test_machine_grant_does_not_throttle_other_grant_types(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The throttle is scoped to this grant, not hoisted onto the whole route.
+
+    Hoisting it would newly rate-limit login-grant refreshes at the same
+    ceiling — costly behind a shared NAT egress IP, where many hosts renew
+    through one source address.
+    """
+    client = _client(monkeypatch)
+    for _ in range(_TOKEN_RATE_MAX * 2):
+        resp = client.post(
+            "/oauth/token",
+            data={"grant_type": "refresh_token", "refresh_token": "nope"},
+        )
+        assert resp.status_code == 400, resp.text
+
+
+# ── /oauth/token route: error shapes ──────────────────────────────
+
+
+def test_token_wrong_secret_is_invalid_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(monkeypatch)
+    resp = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": _CLIENT_ID,
+            "client_secret": "wrong",
+        },
+    )
+    assert resp.status_code == 401 and resp.json()["error"] == "invalid_client"
+    # Form credentials: no header attempt to challenge.
+    assert "www-authenticate" not in resp.headers
+    assert resp.headers["cache-control"] == "no-store"
+
+
+def test_token_rejected_basic_header_gets_a_challenge(monkeypatch: pytest.MonkeyPatch) -> None:
+    """RFC 6749 §5.2: a 401 that rejected an Authorization header must challenge."""
+    client = _client(monkeypatch)
+    resp = client.post(
+        "/oauth/token",
+        data={"grant_type": "client_credentials"},
+        headers={"Authorization": _basic(_CLIENT_ID, "wrong")},
+    )
+    assert resp.status_code == 401 and resp.json()["error"] == "invalid_client"
+    assert resp.headers["www-authenticate"].startswith("Basic realm=")
+
+
+def test_token_absent_credentials_is_invalid_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client(monkeypatch)
+    resp = client.post("/oauth/token", data={"grant_type": "client_credentials"})
+    assert resp.status_code == 401 and resp.json()["error"] == "invalid_client"
+
+
+def test_token_wrong_client_id_is_invalid_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client(monkeypatch)
+    resp = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": "someone-else",
+            "client_secret": _CLIENT_SECRET,
+        },
+    )
+    assert resp.status_code == 401 and resp.json()["error"] == "invalid_client"
+
+
+def test_sub_promoted_to_admin_stops_minting(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The admin guard is re-run per mint, not only at mount.
+
+    A ``sub`` promoted after startup would otherwise keep minting tokens that
+    inherit /v1/sessions' ``is_admin → LEVEL_OWNER`` override until a restart.
+    RFC 6749 §5.2 puts ``unauthorized_client`` at 400.
+    """
+    store = _FakeStore()
+    client = _client(monkeypatch, store=store)
+    credentials = {
+        "grant_type": "client_credentials",
+        "client_id": _CLIENT_ID,
+        "client_secret": _CLIENT_SECRET,
+    }
+    assert client.post("/oauth/token", data=credentials).status_code == 200
+
+    store.admins.add(_MACHINE_SUB)
+    resp = client.post("/oauth/token", data=credentials)
+    assert resp.status_code == 400 and resp.json()["error"] == "unauthorized_client"
+
+
+def test_store_error_at_mint_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A store that breaks after mount stops new tokens rather than trusting the sub."""
+    store = _FlakyStore()
+    client = _client(monkeypatch, store=store)
+    store.broken = True
+    resp = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": _CLIENT_ID,
+            "client_secret": _CLIENT_SECRET,
+        },
+    )
+    assert resp.status_code == 400 and resp.json()["error"] == "unauthorized_client"
+
+
+def test_store_error_at_mint_is_not_reported_as_an_admin_sub(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The mint refusal, too, distinguishes a store fault from a promoted sub."""
+    store = _FlakyStore()
+    client = _client(monkeypatch, store=store)
+    store.broken = True
+    with caplog.at_level("ERROR"):
+        resp = client.post(
+            "/oauth/token",
+            data={
+                "grant_type": "client_credentials",
+                "client_id": _CLIENT_ID,
+                "client_secret": _CLIENT_SECRET,
+            },
+        )
+    assert resp.status_code == 400
+    refusals = [r.message for r in caplog.records if "refusing to mint" in r.message]
+    assert refusals, "expected a mint refusal to be logged"
+    assert not any("is now an admin" in m for m in refusals)
+    assert any("could not say whether" in m for m in refusals)
+
+
+# ── /oauth/token route: throttle ──────────────────────────────────
+
+
+def test_token_endpoint_is_throttled_per_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The pre-authentication client check is not free to hammer.
+
+    Nothing has authenticated when the secret comparison runs, so the grant
+    carries the same per-IP sliding window the device grant applies to its
+    public authorize endpoint.
+    """
+    client = _client(monkeypatch)
+    wrong = {
+        "grant_type": "client_credentials",
+        "client_id": _CLIENT_ID,
+        "client_secret": "wrong",
+    }
+    for _ in range(_TOKEN_RATE_MAX):
+        assert client.post("/oauth/token", data=wrong).status_code == 401
+    throttled = client.post("/oauth/token", data=wrong)
+    assert throttled.status_code == 429 and throttled.json()["error"] == "slow_down"
+    assert throttled.headers["cache-control"] == "no-store"
+
+
+def test_throttle_gates_ahead_of_the_credential_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Over the ceiling, even a correct credential is refused.
+
+    A limiter that only counted failed authentications would still answer the
+    guess that happened to be right, leaving the guess rate unbounded.
+    """
+    client = _client(monkeypatch)
+    for _ in range(_TOKEN_RATE_MAX):
+        client.post(
+            "/oauth/token",
+            data={
+                "grant_type": "client_credentials",
+                "client_id": _CLIENT_ID,
+                "client_secret": "wrong",
+            },
+        )
+    resp = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": _CLIENT_ID,
+            "client_secret": _CLIENT_SECRET,
+        },
+    )
+    assert resp.status_code == 429 and resp.json()["error"] == "slow_down"
+
+
+# ── _check_cookie: which claims confine a token ───────────────────
+
+
+def _req(path: str, *, bearer: str) -> MagicMock:
+    """Build a minimal mock HTTPConnection carrying a bearer token.
+
+    MagicMock is acceptable here: the claim gate reads only
+    ``request.headers``, ``request.cookies`` and ``request.url.path``, and
+    ``HTTPConnection`` cannot be trivially constructed without a real scope.
+
+    :param path: The request path the allowlist is checked against.
+    :param bearer: The raw JWT to present as ``Authorization: Bearer``.
+    :returns: A mock with ``.headers``, ``.cookies`` and ``.url.path`` set.
+    """
+    mock = MagicMock()
+    mock.cookies = {}
+    mock.headers = {"Authorization": f"Bearer {bearer}"}
+    mock.url.path = path
+    return mock
+
+
+def _machine_token() -> str:
+    """A client-credentials token: ``scope``, no ``grant_id``."""
+    return mint_delegated_token(
+        _MACHINE_SUB,
+        _COOKIE_SECRET,
+        3600,
+        "oidc",
+        grant_id=None,
+        client_id=_CLIENT_ID,
+        jti="jti-machine",
+    )
+
+
+def _device_grant_token(grant_id: str = "device-1") -> str:
+    """A third-party device-grant token: ``scope`` AND ``grant_id``."""
+    return mint_delegated_token(
+        _MACHINE_SUB,
+        _COOKIE_SECRET,
+        3600,
+        "oidc",
+        grant_id=grant_id,
+        client_id="slack",
+        jti="jti-device",
+    )
+
+
+def _login_grant_token(grant_id: str = "login-1") -> str:
+    """A first-party login-grant token: ``grant_id``, NO ``scope``."""
+    return mint_delegated_token(
+        _MACHINE_SUB,
+        _COOKIE_SECRET,
+        3600,
+        "oidc",
+        grant_id=grant_id,
+        client_id=LOGIN_GRANT_CLIENT_ID,
+        jti="jti-login",
+        scope=None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("shape", "token_factory", "allowlisted", "non_allowlisted"),
+    [
+        ("device grant (scope + grant_id)", _device_grant_token, _MACHINE_SUB, None),
+        ("login grant (grant_id, no scope)", _login_grant_token, _MACHINE_SUB, _MACHINE_SUB),
+        ("client credentials (scope, no grant_id)", _machine_token, _MACHINE_SUB, None),
+    ],
+)
+def test_token_authority_table(
+    shape: str,
+    token_factory,
+    allowlisted: str | None,
+    non_allowlisted: str | None,
+) -> None:
+    """Pin all three minted token shapes against the path allowlist together.
+
+    The three rows encode one invariant each, and they have inverted against
+    each other before — a change that confines on ``grant_id``'s ABSENCE
+    rather than on ``scope``'s PRESENCE swaps rows 2 and 3 silently:
+
+    ==========================================  ==============  =============
+    token shape                                 /v1/sessions    /auth/users
+    ==========================================  ==============  =============
+    device grant (``scope`` + ``grant_id``)     allow           deny
+    login grant (``grant_id``, no ``scope``)    allow           allow
+    client creds (``scope``, no ``grant_id``)   allow           deny
+    ==========================================  ==============  =============
+
+    Row 2 is deliberate: a login grant renews the session JWT it replaced and
+    keeps that authority. Rows 1 and 3 are restricted at mint and confined
+    here; row 3 is the whole security argument for the machine grant.
+    """
+    provider = _make_oidc_provider()
+    token = token_factory()
+    assert provider._check_cookie(_req("/v1/sessions", bearer=token)) == allowlisted, shape
+    assert provider._check_cookie(_req("/auth/users", bearer=token)) == non_allowlisted, shape
+
+
+@pytest.mark.parametrize(
+    ("shape", "token_factory", "revocable"),
+    [
+        ("device grant", _device_grant_token, True),
+        ("login grant", _login_grant_token, True),
+        ("client credentials", _machine_token, False),
+    ],
+)
+def test_revocation_denylist_applies_only_to_stored_grants(
+    shape: str, token_factory, revocable: bool
+) -> None:
+    """A ``grant_id``-less token must SKIP the denylist, not fail it.
+
+    The lookup fails closed on an unknown grant, so running it with ``None``
+    for a machine token — which carries no ``grant_id`` — would reject every
+    one of them and silently kill the grant.
+    """
+    provider = _make_oidc_provider()
+    provider.set_grant_revocation_check(lambda grant_id: True)
+    result = provider._check_cookie(_req("/v1/sessions", bearer=token_factory()))
+    assert result == (None if revocable else _MACHINE_SUB), shape
+
+
+def test_no_minted_token_shape_is_ever_cached() -> None:
+    """None of the three shapes may reach the token-keyed credential cache.
+
+    The cache is keyed by token, not path, so a cached entry replayed on
+    another path would skip both the allowlist and the revocation lookup.
+    """
+    for token_factory in (_device_grant_token, _login_grant_token, _machine_token):
+        provider = _make_oidc_provider()
+        provider._check_cookie(_req("/v1/sessions", bearer=token_factory()))
+        assert provider._cookie_cache == {}
+
+
+def test_scope_token_allowed_on_allowlisted_path() -> None:
+    provider = _make_oidc_provider()
+    assert provider._check_cookie(_req("/v1/sessions", bearer=_machine_token())) == _MACHINE_SUB
+    assert (
+        provider._check_cookie(_req("/v1/sessions/abc/events", bearer=_machine_token()))
+        == _MACHINE_SUB
+    )
+
+
+def test_scope_token_rejected_on_non_allowlisted_path() -> None:
+    provider = _make_oidc_provider()
+    assert provider._check_cookie(_req("/auth/users", bearer=_machine_token())) is None
+    assert provider._check_cookie(_req("/v1/me", bearer=_machine_token())) is None
+
+
+def test_scope_token_never_cached_so_no_path_bypass() -> None:
+    """A prior allowed call must NOT let a later disallowed path through.
+
+    The credential cache is keyed by token, not path; caching a scope token
+    would let a replay on a non-allowlisted path skip the allowlist. The
+    scope branch returns before the cache, so every request re-checks.
+    """
+    provider = _make_oidc_provider()
+    token = _machine_token()
+    # Allowed path first — this must not populate the cache.
+    assert provider._check_cookie(_req("/v1/sessions", bearer=token)) == _MACHINE_SUB
+    assert provider._cookie_cache == {}
+    # Same token, disallowed path: still rejected (allowlist re-runs).
+    assert provider._check_cookie(_req("/auth/users", bearer=token)) is None
+    assert provider._cookie_cache == {}
+
+
+def test_plain_session_token_still_cached_and_path_agnostic() -> None:
+    """Regression: a non-scoped session token is cached and works anywhere."""
+    provider = _make_oidc_provider()
+    token = mint_session_token("alice@example.com", _COOKIE_SECRET, 3600, "google")
+    assert provider._check_cookie(_req("/auth/users", bearer=token)) == "alice@example.com"
+    assert len(provider._cookie_cache) == 1
+    # A second call on any path is served identically.
+    assert provider._check_cookie(_req("/v1/me", bearer=token)) == "alice@example.com"
+
+
+def test_grant_id_token_still_hits_revocation_denylist() -> None:
+    """Device tokens (scope + grant_id) still consult the revocation check."""
+    provider = _make_oidc_provider()
+    provider.set_grant_revocation_check(lambda grant_id: grant_id == "revoked-1")
+
+    assert (
+        provider._check_cookie(_req("/v1/sessions", bearer=_device_grant_token("revoked-1")))
+        is None
+    )
+    assert (
+        provider._check_cookie(_req("/v1/sessions", bearer=_device_grant_token("live-1")))
+        == _MACHINE_SUB
+    )
+
+
+def test_non_string_grant_id_is_rejected() -> None:
+    """A malformed ``grant_id`` claim fails closed rather than being ignored."""
+    provider = _make_oidc_provider()
+    payload = {
+        "sub": _MACHINE_SUB,
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 3600,
+        "provider": "oidc",
+        "grant_id": 12345,
+        "scope": "sessions",
+        "act": {"client_id": _CLIENT_ID},
+    }
+    token = jwt.encode(payload, _COOKIE_SECRET, algorithm="HS256")
+    assert provider._check_cookie(_req("/v1/sessions", bearer=token)) is None
+
+
+def test_expired_scope_token_rejected() -> None:
+    provider = _make_oidc_provider()
+    payload = {
+        "sub": _MACHINE_SUB,
+        "iat": int(time.time()) - 7200,
+        "exp": int(time.time()) - 1,
+        "provider": "oidc",
+        "scope": "sessions",
+        "act": {"client_id": _CLIENT_ID},
+    }
+    token = jwt.encode(payload, _COOKIE_SECRET, algorithm="HS256")
+    assert provider._check_cookie(_req("/v1/sessions", bearer=token)) is None

--- a/tests/server/test_oauth_shared.py
+++ b/tests/server/test_oauth_shared.py
@@ -1,0 +1,109 @@
+"""Tests for the helpers both OAuth grant routers share.
+
+:mod:`omnigent.server.routes._oauth` holds the pieces the device grant and the
+client-credentials grant answer with identically: the RFC 6749 §5.1 no-store
+header pair, the error-response factory that carries it, and the per-key
+sliding-window throttle. What is covered here is what a single shared object
+makes possible to get wrong once for both grants — a mutated constant, or an
+RFC 8628 §3.2 response that leaks its ``device_code`` into a cache.
+
+The grant-specific behaviour lives in ``test_device_auth.py`` and
+``test_client_credentials.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from omnigent.server.accounts_config import AccountsConfig
+from omnigent.server.auth import UnifiedAuthProvider
+from omnigent.server.device_grant_store import DeviceGrantStore
+from omnigent.server.routes._oauth import (
+    NO_STORE_HEADERS,
+    SlidingWindowRateLimiter,
+    oauth_error,
+)
+from omnigent.server.routes.device_auth import create_device_auth_router
+
+_COOKIE_SECRET = b"d" * 32
+
+
+# ── The no-store header constant ──────────────────────────────────
+
+
+def test_no_store_headers_are_immutable() -> None:
+    """The documented constant cannot be edited by a caller.
+
+    One mapping is handed to responses from both grant routers, so a mutable
+    one would let any caller silently re-header every later token response in
+    the process.
+    """
+    with pytest.raises(TypeError):
+        NO_STORE_HEADERS["Cache-Control"] = "public"  # type: ignore[index]
+    with pytest.raises(TypeError):
+        NO_STORE_HEADERS["X-Added"] = "1"  # type: ignore[index]
+    assert dict(NO_STORE_HEADERS) == {"Cache-Control": "no-store", "Pragma": "no-cache"}
+
+
+def test_oauth_error_carries_the_no_store_pair_and_merges_extras() -> None:
+    """Extra headers merge over the pair without touching the constant."""
+    response = oauth_error(
+        "invalid_client", status_code=401, headers={"WWW-Authenticate": "Basic"}
+    )
+    assert response.headers["cache-control"] == "no-store"
+    assert response.headers["pragma"] == "no-cache"
+    assert response.headers["www-authenticate"] == "Basic"
+    assert dict(NO_STORE_HEADERS) == {"Cache-Control": "no-store", "Pragma": "no-cache"}
+
+
+# ── The shared throttle ───────────────────────────────────────────
+
+
+def test_sliding_window_allows_up_to_the_ceiling_then_refuses() -> None:
+    limiter = SlidingWindowRateLimiter(3, 60, 10)
+    assert [limiter.allow("ip", 1000.0) for _ in range(4)] == [True, True, True, False]
+    # A key whose hits have aged out is admitted again.
+    assert limiter.allow("ip", 1061.0) is True
+
+
+# ── RFC 8628 §3.2: the device authorize response ──────────────────
+
+
+def _device_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """Mount only the device-grant router, with no client secret configured."""
+    monkeypatch.delenv("OMNIGENT_DEVICE_CLIENT_SECRET", raising=False)
+    provider = UnifiedAuthProvider(
+        source="accounts",
+        accounts_config=AccountsConfig(
+            cookie_secret=_COOKIE_SECRET,
+            session_ttl_hours=8,
+            base_url="http://localhost:8000",
+            init_admin_password=None,
+            invite_ttl_seconds=3600,
+            magic_ttl_seconds=300,
+        ),
+    )
+    store = DeviceGrantStore(f"sqlite:///{tmp_path}/dg.db")
+    app = FastAPI()
+    app.include_router(create_device_auth_router(provider, store))
+    return TestClient(app)
+
+
+def test_device_authorize_response_is_not_cacheable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The authorize 200 carries ``device_code`` + ``user_code``, so no-store.
+
+    RFC 8628 §3.2's body is as sensitive as a token response: the device_code is
+    the bearer credential the client later redeems.
+    """
+    client = _device_app(tmp_path, monkeypatch)
+    resp = client.post("/oauth/device/authorize", json={"client_id": "cli"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["device_code"]
+    assert resp.headers["cache-control"] == "no-store"
+    assert resp.headers["pragma"] == "no-cache"


### PR DESCRIPTION
**Rebased onto `main @ 98d4aa1c9`** in response to review — the route-collision
and confinement fixes below are new since the maintainer's first pass; see
[the review-response comment](https://github.com/omnigent-ai/omnigent/pull/3977#issuecomment-5593758497)
for the full point-by-point.

## Related issue

Closes #3976

## Summary

A headless process cannot authenticate to the server as itself today. Every path that mints a credential assumes a human at a browser: the device grant walks a person through a consent screen, cookie sessions come from an interactive login. So automating anything means either running a browser login for a pseudo-human service account, or handing the process the cookie-signing secret, which is the key to every session on the server.

This adds the standard answer, an OAuth 2.0 client-credentials grant (RFC 6749 §4.4). One confidential client presents an id and secret and receives a short-lived access token representing itself.

It reuses what is already here rather than adding a parallel model: `mint_delegated_token` already produces scope-carrying tokens, `_DELEGATED_ALLOWED_PREFIXES` already fail-closed-confines them off the admin and user-management paths, and `hash_secret` already compares a presented secret against a stored digest.

**Opt-in and default-off**, following the device grant's precedent. The client's env config *is* the opt-in: with none set, `POST /oauth/token` answers exactly as it did before this commit for every other grant type. Nothing about an existing deployment's routed surface changes unless an operator opts in.

## ELI5

A robot needs to log in. Today the only door has a "please click here" button on it, which a robot cannot click, so people either make a fake human account for it or give it the master key. This adds a door for robots: it shows an id and a password and gets a pass that works only on a few specific corridors, never the offices where user accounts are managed. The pass is stamped with the robot's own name, so the logs show the robot did it rather than a person.

## How it works

```
  headless caller                        server
       │                                   │
       │  POST /oauth/token                │
       │  grant_type=client_credentials    │
       │  client_id + client_secret        │
       │─────────────────────────────────► │
       │                          compare secret against
       │                          the stored keyed hash
       │                                   │
       │                          vet the configured sub:
       │                          must NOT be an admin
       │                                   │
       │  ◄─────────────────────────────── │
       │  access_token (scope-carrying)    │
       │                                   │
       │  Authorization: Bearer …          │
       │─────────────────────────────────► │
       │                          fail-closed allowlist:
       │                          /v1/sessions ✓  /auth/users ✗
```

The configured subject must be a **non-admin** principal, vetted at mount and again on every mint. That matters because the allowlist confines the *path*, not the privilege *level* within it: the `is_admin` → `LEVEL_OWNER` override inside `/v1/sessions` keys off the token's identity, so an admin subject would reach every tenant's sessions despite the allowlist. Re-vetting per mint means promoting that principal to admin later stops new tokens rather than waiting for the current one to expire.

`client_credentials` is a third `grant_type` branch inside `create_oauth_token_router`'s existing dispatch, alongside the device code and refresh-token grants — not a second router. It works whether or not the device grant is enabled. Confinement is keyed on the minted token's own `scope` claim being present, not on `grant_id`'s absence, so it stays correct alongside a login-issued refresh grant (`grant_id`, no `scope`), which keeps the full authority it's meant to have.

## Test Plan

```
tests/server/test_client_credentials.py                    ┐
tests/server/test_oauth_shared.py                          ├─ 201 passed
tests/server/integration/test_client_credentials_e2e.py    │
tests/server/test_device_auth.py, test_oidc.py             ┘

ruff check      All checks passed!
ruff format     clean on all touched files
pyrefly         0 errors on all touched files
openapi.json    no drift (these routes never enter the spec)
```

Coverage: config parsing (all-set, all-unset, every partial combination, raw secret pasted where a hash belongs, malformed and uppercase hashes, reserved principal, TTL bounds); secret comparison; the admin-subject refusal at mount and per mint; the fail-closed allowlist including a cache-replay attempt, keyed on `scope` rather than `grant_id` and pinned against all three token shapes (device / client-credentials / login) together so it can't silently invert; the revocation guard on both a grant-derived and a grant-less token; throttling of repeated failed client authentication; the end-to-end path where a minted machine principal creates, operates and deletes its own session; working correctly with the device grant either enabled or disabled; and a half-configured client failing startup.

The confinement fix additionally went through an independent adversarial pass — hand-crafted JWTs over real HTTP, boundary values on both claims, raw-ASGI path traversal, a real (not hand-crafted) login token confirmed to keep full authority — documented in the review-response comment linked above.

The full `tests/server` run is 4431 passed / 10 failed / 8 skipped. The 10 reproduce identically on a clean `main @ 98d4aa1c9` checkout with zero code changes, so they're pre-existing.

## Demo

N/A, no UI surface. The end-to-end integration test drives the whole flow through a production-shaped ASGI app.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

No E2E test: the surface is an HTTP grant with no UI, and the integration test already drives a real ASGI app end to end including session creation and deletion by the minted principal. Manual verification is unchecked because the automated coverage exercises the same paths a manual run would.

Open item from the original review, still worth a maintainer's opinion: the throttle ceiling and the TTL ceiling are independent knobs, and an operator can configure a TTL short enough that the throttle window outlives it. Legal and not obviously wrong, unresolved either way.

(`device_auth.py`'s refactor and the `dependencies=[]` marker from the original two self-disclosed points are now folded into the route-collision fix above and no longer separate asks.)

## Changelog

Adds an opt-in OAuth 2.0 client-credentials grant so a headless client can authenticate as its own non-admin principal, scoped by the existing delegated-token allowlist. Default-off: `POST /oauth/token` answers exactly as before unless a machine client is configured.
