### PR TITLE
fix(desktop): suppress native browser view for every dialog overlay (Fixes #3980)

### DIFF
--- a/web/electron/src/browserIpc.js
+++ b/web/electron/src/browserIpc.js
@@ -315,6 +315,16 @@ function registerBrowserIpc({ ipcMain, isPinnedOriginSender, getRegistryForEvent
     return { ok: r.ok, error: r.error };
   });
 
+  // Hide/restore the active view while a DOM overlay (share dialog, etc.) is
+  // open in the renderer. The native view paints above ALL renderer DOM, so
+  // overlays must suppress it to appear on top; hidden (not detached) so the
+  // page keeps running and reappears instantly on overlay close.
+  ipcMain.handle("omnigent:browser-set-overlay-suppressed", (event, args) => {
+    const g = gateRegistry(event);
+    if (g.error) return { ok: false, error: g.error };
+    return g.registry.setOverlaySuppressed(!!args?.suppressed);
+  });
+
   // Reposition the active conversation's view to freshly-measured bounds.
   ipcMain.handle("omnigent:browser-resize", (event, args) => {
     const g = gateRegistry(event);

--- a/web/electron/src/browserViewRegistry.js
+++ b/web/electron/src/browserViewRegistry.js
@@ -33,6 +33,22 @@ function createBrowserViewRegistry({
 } = {}) {
   const entries = new Map(); // conversationId -> BrowserViewEntry
   let activeConversationId = null;
+  // While true, the active view stays hidden (not detached): the native view
+  // paints ABOVE every DOM element, so an open renderer overlay (share dialog,
+  // etc.) would otherwise render underneath the page. Applied to whichever
+  // entry is (or becomes) active until cleared.
+  let overlaySuppressed = false;
+
+  /** Hide/show a view in place — never throws, no-op on stubs without setVisible. */
+  function setViewVisible(entry, visible) {
+    const view = entry && entry.view;
+    if (!view || typeof view.setVisible !== "function") return;
+    try {
+      view.setVisible(visible);
+    } catch {
+      /* destroyed */
+    }
+  }
 
   function makeEntry(conversationId, view) {
     const entry = {
@@ -176,6 +192,7 @@ function createBrowserViewRegistry({
       } catch {
         /* host gone */
       }
+      setViewVisible(entry, !overlaySuppressed);
     }
     // Signal the renderer a view now exists. On a fresh conversation the view is
     // created detached (no host-active-changed fires), so without this the pane
@@ -256,8 +273,26 @@ function createBrowserViewRegistry({
     } catch {
       /* host gone */
     }
+    // Re-apply visibility on every attach: setVisible(false) persists on the
+    // view across detach/attach, so a swap while an overlay is open must stay
+    // hidden, and a normal swap must undo any earlier suppression.
+    setViewVisible(next, !overlaySuppressed);
     next.boundsController.resync();
     sendToRenderer("browser-host-active-changed", { conversationId });
+    return { ok: true };
+  }
+
+  // Hide (suppressed=true) or restore (false) the active view while a DOM
+  // overlay is open in the renderer. Hidden, not detached: the page keeps
+  // running and the pane's bounds loop stays wired, so closing the overlay
+  // restores it instantly. The flag outlives the current active entry — a view
+  // activated while suppressed attaches hidden.
+  function setOverlaySuppressed(suppressed) {
+    overlaySuppressed = !!suppressed;
+    if (activeConversationId !== null) {
+      const entry = entries.get(activeConversationId);
+      if (entry) setViewVisible(entry, !overlaySuppressed);
+    }
     return { ok: true };
   }
 
@@ -316,10 +351,12 @@ function createBrowserViewRegistry({
     getOrCreate,
     openOrNavigate,
     setActive,
+    setOverlaySuppressed,
     close,
     closeAll,
     // Introspection
     activeConversationId: () => activeConversationId,
+    overlaySuppressed: () => overlaySuppressed,
     size: () => entries.size,
     has: (conversationId) => entries.has(conversationId),
     forEach: (fn) => entries.forEach(fn),

--- a/web/electron/src/preload.js
+++ b/web/electron/src/preload.js
@@ -196,6 +196,13 @@ contextBridge.exposeInMainWorld("omnigentDesktop", {
   browserSetActive: (conversationId) =>
     ipcRenderer.invoke("omnigent:browser-set-active", { conversationId }),
   /**
+   * Hide (true) / restore (false) the active view while a DOM overlay
+   * (dialog/modal) is open — the native view otherwise paints above it.
+   * @param {boolean} suppressed
+   */
+  browserSetOverlaySuppressed: (suppressed) =>
+    ipcRenderer.invoke("omnigent:browser-set-overlay-suppressed", { suppressed }),
+  /**
    * Reposition the conversation's view to freshly-measured placeholder bounds.
    * @param {string} conversationId
    * @param {{x:number,y:number,width:number,height:number,devicePixelRatio?:number}} bounds

--- a/web/electron/test/browserViewRegistry.test.js
+++ b/web/electron/test/browserViewRegistry.test.js
@@ -332,3 +332,95 @@ describe("browserViewRegistry — child window.open is denied (S3)", () => {
     assert.deepEqual(windowOpen("https://example.com/ok"), { action: "deny" });
   });
 });
+
+describe("browserViewRegistry — overlay suppression (modal above the native view)", () => {
+  // The native WebContentsView paints above ALL renderer DOM, so an open
+  // modal (e.g. the share dialog) must hide the view for its lifetime. These
+  // tests drive setOverlaySuppressed with setVisible-recording stub views.
+  function makeVisibilityRegistry() {
+    const attached = [];
+    const makeStubView = () => {
+      let visible = true;
+      return {
+        setVisible(v) {
+          visible = v;
+        },
+        getVisible: () => visible,
+      };
+    };
+    const registry = createBrowserViewRegistry({
+      WebContentsViewCtor: () => makeStubView(),
+      createBoundsController: () => ({ setRendererBounds() {}, resync() {}, clear() {} }),
+      attachToHost() {},
+      detachFromHost() {},
+      sendToRenderer() {},
+    });
+    // Helper: create a view so setActive has something to toggle.
+    registry.openOrNavigate("conv_1", "https://example.com");
+    return registry;
+  }
+
+  it("setOverlaySuppressed(true) hides the active view", () => {
+    const registry = makeVisibilityRegistry();
+    registry.setActive("conv_1");
+    const entry = registry.get("conv_1");
+    assert.equal(entry.view.getVisible(), true);
+
+    registry.setOverlaySuppressed(true);
+    assert.equal(entry.view.getVisible(), false);
+  });
+
+  it("setOverlaySuppressed(false) restores the active view", () => {
+    const registry = makeVisibilityRegistry();
+    registry.setActive("conv_1");
+    const entry = registry.get("conv_1");
+    registry.setOverlaySuppressed(true);
+    assert.equal(entry.view.getVisible(), false);
+
+    registry.setOverlaySuppressed(false);
+    assert.equal(entry.view.getVisible(), true);
+  });
+
+  it("a view activated while suppressed attaches hidden", () => {
+    const registry = makeVisibilityRegistry();
+    registry.setOverlaySuppressed(true);
+
+    registry.setActive("conv_1");
+    const entry = registry.get("conv_1");
+    assert.equal(entry.view.getVisible(), false);
+  });
+
+  it("suppressed flag outlives a swap — new active view inherits hidden state", () => {
+    const registry = makeVisibilityRegistry();
+    registry.openOrNavigate("conv_2", "https://example.org");
+    registry.setActive("conv_1");
+    registry.setOverlaySuppressed(true);
+
+    // Swap to conv_2 while suppressed
+    registry.setActive("conv_2");
+    const entry = registry.get("conv_2");
+    assert.equal(entry.view.getVisible(), false);
+
+    // Restore
+    registry.setOverlaySuppressed(false);
+    assert.equal(entry.view.getVisible(), true);
+  });
+
+  it("setOverlaySuppressed(false) is a no-op on a view that was never hidden", () => {
+    const registry = makeVisibilityRegistry();
+    registry.setActive("conv_1");
+    const entry = registry.get("conv_1");
+
+    registry.setOverlaySuppressed(false);
+    assert.equal(entry.view.getVisible(), true);
+  });
+
+  it("overlaySuppressed() introspection reflects the current state", () => {
+    const registry = makeVisibilityRegistry();
+    assert.equal(registry.overlaySuppressed(), false);
+    registry.setOverlaySuppressed(true);
+    assert.equal(registry.overlaySuppressed(), true);
+    registry.setOverlaySuppressed(false);
+    assert.equal(registry.overlaySuppressed(), false);
+  });
+});

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -6,6 +6,7 @@ import { isIOSShell } from "@/lib/nativeBridge";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { XIcon } from "lucide-react";
+import { useSuppressBrowserView } from "@/hooks/useSuppressBrowserView";
 
 function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
@@ -33,6 +34,14 @@ function DialogOverlay({
   className,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  // The embedded browser's native WebContentsView paints above ALL renderer
+  // DOM — no z-index can put a modal over it. Suppress the view (hide it in
+  // place) for the overlay's lifetime so the dialog appears on top. Mounted
+  // only while the dialog is open (Radix portals the overlay content), so
+  // `true` is the correct active signal: mount → suppress, unmount → restore.
+  // Ref-counted: overlapping overlays keep the view hidden until the last one
+  // closes. No-op outside Electron / on shells without the browser bridge.
+  useSuppressBrowserView(true);
   return (
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"

--- a/web/src/hooks/useSuppressBrowserView.test.tsx
+++ b/web/src/hooks/useSuppressBrowserView.test.tsx
@@ -1,0 +1,83 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// supportsBrowser gates the hook; force it true so it reaches the bridge.
+vi.mock("@/lib/nativeBridge", () => ({
+  supportsBrowser: () => true,
+}));
+
+import { useSuppressBrowserView } from "./useSuppressBrowserView";
+
+/** Install a `window.omnigentDesktop` bridge; returns the suppression mock. */
+function installBridge() {
+  const browserSetOverlaySuppressed = vi.fn().mockResolvedValue({ ok: true });
+  (window as unknown as { omnigentDesktop?: unknown }).omnigentDesktop = {
+    browserSetOverlaySuppressed,
+  };
+  return browserSetOverlaySuppressed;
+}
+
+afterEach(() => {
+  delete (window as unknown as { omnigentDesktop?: unknown }).omnigentDesktop;
+});
+
+describe("useSuppressBrowserView", () => {
+  it("hides the native view while active and restores it on close", () => {
+    const suppress = installBridge();
+    const { rerender } = renderHook(({ open }) => useSuppressBrowserView(open), {
+      initialProps: { open: false },
+    });
+    expect(suppress).not.toHaveBeenCalled();
+
+    // Overlay opens (e.g. the share dialog) → the view must hide, or the
+    // native page paints over the modal.
+    rerender({ open: true });
+    expect(suppress).toHaveBeenCalledTimes(1);
+    expect(suppress).toHaveBeenLastCalledWith(true);
+
+    // Overlay closes → the view comes back.
+    rerender({ open: false });
+    expect(suppress).toHaveBeenCalledTimes(2);
+    expect(suppress).toHaveBeenLastCalledWith(false);
+  });
+
+  it("restores the view on unmount while still active", () => {
+    const suppress = installBridge();
+    const { unmount } = renderHook(() => useSuppressBrowserView(true));
+    expect(suppress).toHaveBeenLastCalledWith(true);
+    unmount();
+    expect(suppress).toHaveBeenLastCalledWith(false);
+  });
+
+  it("never calls the bridge while inactive", () => {
+    const suppress = installBridge();
+    const { unmount } = renderHook(() => useSuppressBrowserView(false));
+    unmount();
+    expect(suppress).not.toHaveBeenCalled();
+  });
+
+  it("keeps the view hidden until the LAST overlapping overlay closes", () => {
+    const suppress = installBridge();
+    const first = renderHook(() => useSuppressBrowserView(true));
+    const second = renderHook(() => useSuppressBrowserView(true));
+    // Only the first open crosses the 0→1 boundary.
+    expect(suppress).toHaveBeenCalledTimes(1);
+    expect(suppress).toHaveBeenLastCalledWith(true);
+
+    first.unmount();
+    // One overlay still open — the view must stay hidden.
+    expect(suppress).toHaveBeenCalledTimes(1);
+
+    second.unmount();
+    expect(suppress).toHaveBeenCalledTimes(2);
+    expect(suppress).toHaveBeenLastCalledWith(false);
+  });
+
+  it("no-ops on shells that predate browserSetOverlaySuppressed", () => {
+    (window as unknown as { omnigentDesktop?: unknown }).omnigentDesktop = {};
+    expect(() => {
+      const { unmount } = renderHook(() => useSuppressBrowserView(true));
+      unmount();
+    }).not.toThrow();
+  });
+});

--- a/web/src/hooks/useSuppressBrowserView.ts
+++ b/web/src/hooks/useSuppressBrowserView.ts
@@ -1,0 +1,39 @@
+/** Hide the embedded browser's native WebContentsView while a DOM overlay
+ *  (dialog/modal) is open. The native view paints ABOVE every DOM element —
+ *  no z-index can put a modal over it — so overlays that must appear on top
+ *  suppress it for their open lifetime. Ref-counted across instances so
+ *  overlapping overlays don't unhide the view early; no-op outside Electron
+ *  and on desktop shells that predate the browser bridge. */
+import { useEffect } from "react";
+import { supportsBrowser } from "@/lib/nativeBridge";
+
+/** Slice of `window.omnigentDesktop` this hook calls. Typed locally (like
+ *  BrowserPane) so the hook doesn't depend on the full nativeBridge type;
+ *  optional because an older shell may predate the method. */
+interface OverlayBridge {
+  browserSetOverlaySuppressed?: (suppressed: boolean) => Promise<{ ok: boolean; error?: string }>;
+}
+
+function getBridge(): OverlayBridge | null {
+  if (!supportsBrowser()) return null;
+  const w = window as unknown as { omnigentDesktop?: OverlayBridge };
+  return w.omnigentDesktop ?? null;
+}
+
+// Count of currently-open overlays across all hook instances. The view is
+// hidden while the count is > 0 and restored only when it returns to 0.
+let openOverlays = 0;
+
+export function useSuppressBrowserView(active: boolean) {
+  useEffect(() => {
+    if (!active) return;
+    const bridge = getBridge();
+    if (!bridge?.browserSetOverlaySuppressed) return;
+    openOverlays += 1;
+    if (openOverlays === 1) void bridge.browserSetOverlaySuppressed(true);
+    return () => {
+      openOverlays -= 1;
+      if (openOverlays === 0) void getBridge()?.browserSetOverlaySuppressed?.(false);
+    };
+  }, [active]);
+}


### PR DESCRIPTION
## Problem

The embedded Browser tab's native WebContentsView paints above ALL renderer DOM — no z-index or portal can put a modal over it. Opening a fork dialog, command palette, agent info, keyboard shortcuts, or any other overlay while the Browser tab is active renders the dialog *underneath* the browser page. You can hear yourself clicking a dialog you cannot see.

## Background

PR #3491 introduced the right mechanism (`setOverlaySuppressed` in the view registry + `useSuppressBrowserView` hook) but wired it only to the Share dialog. The fork dialog, command palette, agent info, keyboard shortcuts, and ~20 other overlay surfaces all remained unwired.

## Approach

Rather than adding one `useSuppressBrowserView(xOpen)` per dialog (which is fragile and easy to miss on new dialogs), this PR drives suppression from the shared `DialogOverlay` component. Every Radix dialog uses this component, so **all** dialogs get the fix for free.

### Non-dialog overlays (lightbox, toasts) that don't use the Radix Dialog component remain unwired — they can be handled case by case in follow-up PRs.

## Changes

- **`web/src/hooks/useSuppressBrowserView.ts`** (new) — Ref-counted hook; hides the native view while any overlay is open, restores it only when the last overlay closes. No-op outside Electron.
- **`web/src/components/ui/dialog.tsx`** — Wire `useSuppressBrowserView(true)` to `DialogOverlay`. Since it mounts only when the dialog is open, mount → suppress, unmount → restore.
- **`web/electron/src/browserViewRegistry.js`** — Add `setOverlaySuppressed` method. Hides the active view in place (not detached, so the page keeps running) via `view.setVisible()`. Flag outlives view swaps so a suppressed state persists across tab switches.
- **`web/electron/src/browserIpc.js`** — Register `omnigent:browser-set-overlay-suppressed` IPC handler.
- **`web/electron/src/preload.js`** — Expose `browserSetOverlaySuppressed` on the context bridge.
- **`web/electron/test/browserViewRegistry.test.js`** — 6 new tests covering hide/restore, suppressed-state inheritance, swaps, and introspection.
- **`web/src/hooks/useSuppressBrowserView.test.tsx`** (new) — 5 new tests covering open/close, unmount, no-op, ref-counting, and fallback shells.

Closes #3980