### PR TITLE
fix(setup): don't hang on corepack's pnpm download prompt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,12 @@ class _GenerateBuildInfo(build_py):
           a silent API-only install that surfaces later as "the web
           UI doesn't load".
 
+        The pnpm commands run with ``COREPACK_ENABLE_DOWNLOAD_PROMPT=0``
+        and no stdin: corepack (whether reached via its ``pnpm`` shim or
+        as ``corepack pnpm``) otherwise blocks on an interactive
+        confirmation before downloading the pinned pnpm, which a
+        non-interactive install can never answer.
+
         :raises SystemExit: If Node.js < 22 (or absent), pnpm is not
             on PATH (and corepack can't supply it), or the web UI
             build fails, and no skip condition applies.
@@ -192,22 +198,32 @@ class _GenerateBuildInfo(build_py):
                 "without the web UI (API-only server), set "
                 "OMNIGENT_SKIP_WEB_UI=true."
             )
+        # A ``pnpm`` on PATH is often a corepack shim, which asks "Do you
+        # want to continue? [Y/n]" before fetching the pinned pnpm. That
+        # prompt is invisible under a build backend, so the install looks
+        # hung; "0" downloads without asking (shims default it to "1").
+        env = {**os.environ, "COREPACK_ENABLE_DOWNLOAD_PROMPT": "0"}
         try:
             # Workspace root, not ``web/``: the lockfile and workspace
             # manifest live at the repo root. ``--frozen-lockfile``
             # matches CI and guarantees the build is reproducible from
-            # the committed ``pnpm-lock.yaml``.
+            # the committed ``pnpm-lock.yaml``. No stdin, so nothing in
+            # the toolchain can block on input we can never deliver.
             subprocess.run(
                 [*pnpm_cmd, "install", "--frozen-lockfile", "--filter", "web"],
                 cwd=root,
                 check=True,
                 timeout=600,
+                stdin=subprocess.DEVNULL,
+                env=env,
             )
             subprocess.run(
                 [*pnpm_cmd, "--filter", "web", "run", "build"],
                 cwd=root,
                 check=True,
                 timeout=600,
+                stdin=subprocess.DEVNULL,
+                env=env,
             )
         except (subprocess.SubprocessError, OSError) as exc:
             raise SystemExit(

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -696,12 +696,24 @@ def built_spa(request: pytest.FixtureRequest) -> None:
         # pnpm frozen-lockfile uses the root workspace lockfile, which
         # keeps the pinned tree matching CI and avoids re-resolving the
         # React peer conflicts that used to require --legacy-peer-deps.
+        # COREPACK_ENABLE_DOWNLOAD_PROMPT=0 keeps a corepack `pnpm` shim
+        # from blocking on its download confirmation under captured
+        # pytest output, which reads as a hung test run.
+        env = {**os.environ, "COREPACK_ENABLE_DOWNLOAD_PROMPT": "0"}
         subprocess.run(
             ["pnpm", "install", "--frozen-lockfile", "--filter", "web"],
             cwd=_REPO_ROOT,
             check=True,
+            stdin=subprocess.DEVNULL,
+            env=env,
         )
-        subprocess.run(["pnpm", "--filter", "web", "run", "build"], cwd=_REPO_ROOT, check=True)
+        subprocess.run(
+            ["pnpm", "--filter", "web", "run", "build"],
+            cwd=_REPO_ROOT,
+            check=True,
+            stdin=subprocess.DEVNULL,
+            env=env,
+        )
 
     _assert_pwa_build(_BUILD_OUTPUT)
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- After the switch to corepack/pnpm, `pip install .` / `uv sync` could hang
  indefinitely for users who have a corepack `pnpm` shim on PATH but have
  never downloaded pnpm. Corepack prints `! Corepack is about to download
  .../pnpm-11.15.1.tgz` and then blocks on `? Do you want to continue? [Y/n]`.
  Build backends capture output, so the prompt is invisible and the install
  just sits there until the 600s timeout.
- The trigger is the shim, not the `corepack pnpm` fallback: corepack's
  `dist/pnpm.js` does `COREPACK_ENABLE_DOWNLOAD_PROMPT ??= '1'` while explicit
  `dist/corepack.js` uses `'0'`. `shutil.which("pnpm")` finds the shim, so the
  prompting path is the one that looked fine. CI is unaffected because corepack
  skips the prompt when `$CI` is set.
- Run both pnpm commands in `setup.py` with
  `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` (download without asking) and
  `stdin=DEVNULL` so nothing else in the toolchain can block on input we can
  never deliver. Applied the same fix to `tests/e2e_ui/conftest.py`, which had
  the identical latent hang under captured pytest output.

## Test Plan

Reproduced the hang and verified the fix against the pinned `pnpm@11.15.1`,
handing the child a real TTY via `pty.openpty()` and an empty `COREPACK_HOME`:

```
BEFORE (shim default prompt=1, TTY stdin): HUNG (timeout)
        err='! Corepack is about to download .../pnpm-11.15.1.tgz\n? Do yo'
AFTER  (prompt=0 + stdin=DEVNULL):         proceeds straight to download
```

End-to-end check of the install path:

```bash
rm -rf ~/.cache/node/corepack "$COREPACK_HOME"
corepack enable                 # pnpm shim on PATH, pnpm not yet fetched
rm -rf omnigent/server/static/web-ui
pip install .                   # previously stalled with no output
```

`ruff check` / `ruff format --check` clean on both files.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified manually: the failure only reproduces with a corepack `pnpm` shim, an
unpopulated `COREPACK_HOME`, and a TTY on stdin, so an automated test would
have to stand up a pty plus a registry fetch inside the build backend. Covered
instead by the pty-based before/after check in the Test Plan.

## Changelog

`pip install` / `uv sync` no longer hangs when pnpm is provided by a corepack
shim that has not downloaded pnpm yet.


