### PR TITLE
refactor(harness): declarative catalog makes an ACP CLI harness one table row

### DIFF
--- a/.claude/skills/harness-integration-guide/SKILL.md
+++ b/.claude/skills/harness-integration-guide/SKILL.md
@@ -115,6 +115,19 @@ All capabilities are **required** for a complete harness integration:
 - [ ] Unit tests cover tool bridging, auth, model routing
 - [ ] Mock LLM tests cover the happy path without real API calls
 
+### Shortcut: ACP CLI harnesses are one catalog row
+
+If the vendor CLI speaks the Agent Client Protocol on stdio (the
+`goose acp` / `qwen --acp` family), do NOT write a new inner module, registry
+entries, or a spawn-env builder. Add one row to `ACP_CLI_HARNESSES` in
+`omnigent/acp_cli_harnesses.py` (label, binary, ACP argv, aliases, install
+hint or npm package, vendor login command) plus docs. Validity, module
+routing, picker label, capabilities, install spec, readiness, setup steps,
+spawn env, and the live e2e-matrix exclusion all derive from the row;
+`tests/test_acp_cli_harnesses.py` asserts the wiring per row automatically.
+These rows run through `omnigent/inner/acp_harness.py` and `AcpExecutor`, own
+their auth and model selection, and reject `/model` overrides up front.
+
 ---
 
 ## Part 2 — Native harnesses

--- a/omnigent/acp_cli_harnesses.py
+++ b/omnigent/acp_cli_harnesses.py
@@ -1,0 +1,75 @@
+"""Declarative catalog of builtin ACP CLI harnesses.
+
+One row here is one first-class harness backed by a vendor CLI that speaks the
+Agent Client Protocol on stdio (the ``goose acp`` / ``qwen --acp`` family).
+Rows are pure data; every registration a row needs derives from this table:
+
+- registry entries (validity, module routing, aliases, picker label,
+  capabilities, install spec, install keys): ``omnigent/harness_plugins.py``
+- readiness: the generic install-key gate in
+  ``omnigent/onboarding/harness_readiness.py`` (binary on PATH)
+- setup steps and one-click installability:
+  ``omnigent/onboarding/harness_install.py``
+- spawn env: :func:`omnigent.runtime.workflow._build_acp_cli_spawn_env`
+- dispatch: ``_build_spawn_env_from_spec`` in ``omnigent/runner/app.py``
+- live e2e matrix exclusion:
+  ``tests/e2e/omnigent/test_run_harness_without_agent_e2e.py``
+
+Every row runs through the shared generic wrap
+(``omnigent/inner/acp_harness.py``) and :class:`~omnigent.inner.acp_executor.
+AcpExecutor` — the same code path a user-configured ``acp:<slug>`` agent uses.
+To promote a new ACP-speaking vendor CLI to a builtin harness, add one row and
+its docs; do not add a new inner module, registry entries, or a per-harness
+spawn-env builder. Rows own their auth and model selection (``OWN_AUTH``): no
+Omnigent credential or model override is wired, so a ``/model`` pick is
+rejected up front rather than silently dropped.
+
+This module stays import-light (stdlib + :mod:`omnigent.harness_install_spec`)
+so the registry, onboarding, and runner layers can all read it without cycles.
+"""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+
+from omnigent.harness_install_spec import HarnessInstallSpec
+
+
+@dataclass(frozen=True)
+class AcpCliHarness:
+    """One builtin ACP CLI harness, declared as pure data.
+
+    :param install: Install + auth metadata (display label, binary, optional
+        npm package or install hint, vendor login command). The ``binary`` is
+        also the readiness gate and the spawn command's argv[0].
+    :param args: Argv appended after the binary to start the CLI's ACP stdio
+        server, e.g. ``("--acp",)`` or ``("agent", "stdio")``.
+    :param aliases: Accepted alternate spellings, canonicalized to the row key.
+    """
+
+    install: HarnessInstallSpec
+    args: tuple[str, ...]
+    aliases: tuple[str, ...] = ()
+
+    @property
+    def label(self) -> str:
+        """Picker/display label, e.g. ``"Grok Build"``."""
+        return self.install.display
+
+    @property
+    def binary(self) -> str:
+        """The vendor CLI binary name, e.g. ``"grok"``."""
+        return self.install.binary
+
+    @property
+    def login_command(self) -> str | None:
+        """The vendor login command to show in setup steps, or ``None``."""
+        if self.install.login_args is None:
+            return None
+        return shlex.join([self.binary, *self.install.login_args])
+
+
+# Keyed by canonical harness id. Keep keys sorted; each row's registrations
+# derive from here (see the module docstring for the full list).
+ACP_CLI_HARNESSES: dict[str, AcpCliHarness] = {}

--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -30,6 +30,7 @@ from omnigent._wrapper_labels import (
     UI_MODE_TERMINAL_VALUE,
     WRAPPER_LABEL_KEY,
 )
+from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
 from omnigent.harness_capabilities import (
     AuthModel,
     EffortFamily,
@@ -642,6 +643,11 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
     ),
 }
 
+# Builtin ACP CLI harnesses (omnigent/acp_cli_harnesses.py) run through the
+# same generic wrap as the "acp" harness, so they share its declared profile.
+for _acp_cli_name in ACP_CLI_HARNESSES:
+    _BUILTIN_CAPABILITIES[_acp_cli_name] = _BUILTIN_CAPABILITIES["acp"]
+
 
 _BUILTIN_CONTRIBUTION = HarnessContribution(
     name="omnigent",
@@ -672,8 +678,13 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
             "qwen",
             "qwen-native",
         }
+        # Builtin ACP CLI harnesses derive from the declarative catalog; a new
+        # vendor CLI is one row there, not another entry in each set below.
+        | set(ACP_CLI_HARNESSES)
     ),
     harness_modules={
+        # Every catalog row runs the shared generic ACP wrap.
+        **dict.fromkeys(ACP_CLI_HARNESSES, "omnigent.inner.acp_harness"),
         "acp": "omnigent.inner.acp_harness",
         "antigravity": "omnigent.inner.antigravity_harness",
         "antigravity-native": "omnigent.inner.antigravity_native_harness",
@@ -699,6 +710,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         "qwen-native": "omnigent.inner.qwen_native_harness",
     },
     aliases={
+        **{alias: name for name, row in ACP_CLI_HARNESSES.items() for alias in row.aliases},
         "agy": "antigravity",
         "claude": "claude-sdk",
         "github-copilot": "copilot",
@@ -756,6 +768,14 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         HERMES_NATIVE_CODING_AGENT,
     ),
     native_providers=_BUILTIN_NATIVE_PROVIDERS,
+    # Catalog rows gate readiness on their vendor binary; the install spec also
+    # feeds setup steps and (for npm rows) the one-click install path.
+    install_specs={name: row.install for name, row in ACP_CLI_HARNESSES.items()},
+    harness_install_keys={
+        spelling: name
+        for name, row in ACP_CLI_HARNESSES.items()
+        for spelling in (name, *row.aliases)
+    },
     model_env_keys={
         "acp": "HARNESS_ACP_MODEL",
         "antigravity": "HARNESS_ANTIGRAVITY_MODEL",
@@ -794,6 +814,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         # stays a valid harness for YAML specs (and the credential-free
         # integration mock LLM), but is no longer offered as a UI pick.
         "pi": "Pi",
+        **{name: row.label for name, row in ACP_CLI_HARNESSES.items()},
     },
     capabilities=_BUILTIN_CAPABILITIES,
 )

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -47,6 +47,7 @@ from typing import NamedTuple
 from packaging.version import InvalidVersion, Version
 
 from omnigent._platform import resolve_cli_binary
+from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
 from omnigent.harness_install_spec import HarnessInstallSpec, SetupStep
 from omnigent.onboarding.provider_config import ANTHROPIC_FAMILY, GEMINI_FAMILY, OPENAI_FAMILY
 from omnigent.opencode_native_client import (
@@ -360,6 +361,14 @@ _UI_INSTALLABLE_HARNESS_TO_KEY: dict[str, str] = {
     QWEN_KEY: QWEN_KEY,
 }
 
+# Builtin ACP CLI harnesses (omnigent/acp_cli_harnesses.py) with an npm package
+# are one-click installable; rows shipping via curl/shell installers stay out,
+# like cursor/kimi above.
+for _acp_name, _acp_row in ACP_CLI_HARNESSES.items():
+    if _acp_row.install.package is not None:
+        for _acp_spelling in (_acp_name, *_acp_row.aliases):
+            _UI_INSTALLABLE_HARNESS_TO_KEY[_acp_spelling] = _acp_name
+
 
 # Family keys the UI may install, derived once from the allowlist so the
 # executor-spelling fallback in ``ui_install_key`` can't admit a non-installable
@@ -510,6 +519,20 @@ _UI_AUTH_STEP_BY_KEY: dict[str, SetupStep] = {
         status_key=None,
     ),
 }
+
+# Builtin ACP CLI harnesses own their credentials (vendor CLI login), so each
+# row with a login command gets a run-on-host auth step, untracked like qwen's.
+for _acp_name, _acp_row in ACP_CLI_HARNESSES.items():
+    _acp_login = _acp_row.login_command
+    if _acp_login is not None:
+        _UI_AUTH_STEP_BY_KEY[_acp_name] = SetupStep(
+            kind="auth",
+            title=f"Sign in to {_acp_row.label}",
+            detail=f"{_acp_row.label} manages its own credentials; sign in on the host.",
+            action="command",
+            command=_acp_login,
+            status_key=None,
+        )
 
 
 def ui_setup_steps(harness: str) -> list[SetupStep]:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -40,6 +40,7 @@ import httpx
 from fastapi import FastAPI, HTTPException, Query, Request, WebSocket
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
+from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
 from omnigent.entities.session_resources import (
     DEFAULT_ENVIRONMENT_ID,
     SessionResourceView,
@@ -8719,6 +8720,7 @@ def _build_spawn_env_from_spec(
             )
     try:
         from omnigent.runtime.workflow import (
+            _build_acp_cli_spawn_env,
             _build_acp_spawn_env,
             _build_antigravity_spawn_env,
             _build_claude_sdk_spawn_env,
@@ -8754,6 +8756,12 @@ def _build_spawn_env_from_spec(
             env = _build_acp_spawn_env(effective_spec, cwd=cwd, workdir=workdir)
         elif harness == "copilot":
             env = _build_copilot_spawn_env(effective_spec, cwd=cwd, workdir=workdir)
+        elif harness in ACP_CLI_HARNESSES:
+            # Builtin ACP CLI harnesses (one catalog row each) share a single
+            # builder; the row supplies the command, label, and install info.
+            env = _build_acp_cli_spawn_env(
+                effective_spec, harness=harness, cwd=cwd, workdir=workdir
+            )
         else:
             builder_path = spawn_env_builders().get(harness)
             if builder_path is not None:

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -1514,6 +1514,57 @@ def _build_goose_spawn_env(
     return env
 
 
+def _build_acp_cli_spawn_env(
+    spec: AgentSpec,
+    *,
+    harness: str,
+    cwd: Path | None = None,
+    workdir: Path | None = None,
+) -> dict[str, str]:
+    """Build the generic-ACP env for one builtin ACP CLI harness (catalog row).
+
+    Rows in :data:`omnigent.acp_cli_harnesses.ACP_CLI_HARNESSES` all run the
+    shared ``omnigent/inner/acp_harness.py`` wrap; this maps a row + spec to
+    the ``HARNESS_ACP_*`` vars it reads. Like goose/acp, a vendor ACP CLI owns
+    its own auth and model, so no provider/gateway credential and no model var
+    is wired. The binary resolves via the ``OMNIGENT_<NAME>_PATH`` env
+    override, then the config ``harness.<name>.command`` path, then PATH plus
+    the common global install dirs.
+
+    :param spec: The agent spec.
+    :param harness: The catalog row key, e.g. ``"grok"``.
+    :param workdir: Accepted for signature parity with the other builders; the
+        ACP wrap consumes no bundle dir.
+    :returns: A dict of ``HARNESS_ACP_*`` env-var overrides for the spawn.
+    """
+    from omnigent._platform import resolve_cli_binary
+    from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
+    from omnigent.harness_startup_config import (
+        config_harness_path_override,
+        resolve_harness_path,
+    )
+
+    row = ACP_CLI_HARNESSES[harness]
+    executable = (
+        resolve_harness_path(harness)
+        or config_harness_path_override(harness, load_config())
+        or resolve_cli_binary(row.binary)
+        or row.binary
+    )
+    env = {
+        "HARNESS_ACP_COMMAND": shlex.join([executable, *row.args]),
+        "HARNESS_ACP_NAME": row.label,
+    }
+    # Session workspace (selected working folder). ``None`` lets the wrap fall
+    # back to OMNIGENT_RUNNER_WORKSPACE — see HARNESS_ACP_CWD.
+    if cwd is not None:
+        env["HARNESS_ACP_CWD"] = str(cwd)
+    os_env_payload = _serialize_os_env(spec.os_env)
+    if os_env_payload is not None:
+        env["HARNESS_ACP_OS_ENV"] = os_env_payload
+    return env
+
+
 def _build_acp_spawn_env(
     spec: AgentSpec,
     *,

--- a/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
+++ b/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import pytest
 
+from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
 from omnigent.runtime.harnesses import _HARNESS_MODULES
 from omnigent.spec._omnigent_compat import OMNIGENT_HARNESSES
 from tests.e2e._harness_probes import (
@@ -225,6 +226,12 @@ def test_run_harness_live_matrix_covers_registered_coding_harnesses() -> None:
     ``omnigent run --harness hermes-native``, AND it wraps the ``hermes`` CLI
     binary. Its coverage is the dedicated hermes-native bridge/executor/forwarder/
     approval-mirror unit tests.
+
+    Builtin ACP CLI harnesses (every row of ``ACP_CLI_HARNESSES``) are excluded
+    for the same reason as ``goose``: each wraps an own-auth vendor CLI, so its
+    spawn env carries no gateway/profile probe vars for this matrix to drive.
+    Their shared wiring is covered by ``tests/test_acp_cli_harnesses.py`` and
+    the ``tests/inner/test_acp_executor.py`` suite.
     """
     expected_live_harnesses = set(OMNIGENT_HARNESSES).intersection(_HARNESS_MODULES) - {
         "acp",
@@ -246,5 +253,6 @@ def test_run_harness_live_matrix_covers_registered_coding_harnesses() -> None:
         "kimi-native",
         "hermes",
         "hermes-native",
+        *ACP_CLI_HARNESSES,
     }
     assert {probe.harness for probe in HARNESS_PROBES} == expected_live_harnesses

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -9,6 +9,7 @@ import pytest
 import yaml
 
 import omnigent.onboarding.harness_install as hi
+from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
 from omnigent.harness_availability import HARNESS_VERSION_TOO_LOW
 from omnigent.onboarding.harness_readiness import (
     configured_harness_map,
@@ -131,6 +132,13 @@ def test_sdk_and_unknown_harnesses_are_never_gated(
         "goose-native",
         "native-goose",
         "hermes",
+        # Builtin ACP CLI harnesses gate on their vendor binary; every catalog
+        # row (and alias) joins automatically.
+        *sorted(
+            spelling
+            for name, row in ACP_CLI_HARNESSES.items()
+            for spelling in (name, *row.aliases)
+        ),
     ],
 )
 def test_cli_harness_configured_only_when_binary_installed(
@@ -341,6 +349,13 @@ def test_configured_harness_map_covers_all_spellings(
         # Generic ACP harness — config-gated (≥1 agent in the acp: block), no CLI
         # binary of its own; the acp:<slug> picks are config-derived, not keyed here.
         "acp",
+        # Builtin ACP CLI harnesses: every catalog row + alias, derived so a new
+        # row never needs to touch this list.
+        *(
+            spelling
+            for name, row in ACP_CLI_HARNESSES.items()
+            for spelling in (name, *row.aliases)
+        ),
     }
     assert set(result) == expected_keys
 
@@ -385,6 +400,7 @@ def test_configured_harness_map_gates_only_cli_harnesses(
         "native-goose",
         "qwen",
         "hermes",
+        *sorted(ACP_CLI_HARNESSES),
     ):
         assert result[cli] is not True, f"{cli} should be gated on its CLI binary"
     # Auth-aware harnesses (codex, claude, opencode, cursor, pi) carry a

--- a/tests/test_acp_cli_harnesses.py
+++ b/tests/test_acp_cli_harnesses.py
@@ -1,0 +1,170 @@
+"""The declarative builtin ACP CLI harness catalog (omnigent/acp_cli_harnesses.py).
+
+Two halves:
+
+- Mechanism tests drive a fake catalog row through the shared spawn-env builder
+  and the runner dispatch, so the machinery stays covered even while the
+  catalog is small.
+- Per-row tests parametrize over the real catalog and assert every derived
+  registration a row relies on, so adding a row is one dict entry and this
+  module proves the wiring end to end.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import shlex
+from pathlib import Path
+
+import pytest
+
+from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES, AcpCliHarness
+from omnigent.harness_aliases import canonicalize_harness
+from omnigent.harness_install_spec import HarnessInstallSpec
+from omnigent.harness_plugins import (
+    harness_capabilities,
+    harness_install_keys,
+    harness_labels,
+    harness_modules,
+    install_specs,
+    valid_harnesses,
+)
+from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+from omnigent.onboarding.harness_install import ui_setup_steps
+from omnigent.runtime.workflow import _build_acp_cli_spawn_env
+from omnigent.spec.types import AgentSpec, ExecutorSpec
+
+_FAKE_ROW = AcpCliHarness(
+    install=HarnessInstallSpec(
+        "Fake CLI",
+        "fakecli",
+        None,
+        login_args=("login", "--device"),
+        install_hint="curl -fsSL https://fake.example/install.sh | bash",
+    ),
+    args=("agent", "stdio"),
+    aliases=("fake-cli",),
+)
+
+
+def _spec(harness: str, os_env: OSEnvSpec | None = None) -> AgentSpec:
+    return AgentSpec(
+        spec_version=1,
+        name=f"test-{harness}",
+        instructions="Test agent.",
+        executor=ExecutorSpec(type="omnigent", config={"harness": harness}),
+        os_env=os_env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mechanism (fake row)
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_env_forwards_cwd_sandbox_and_quotes_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shared builder forwards session cwd + os_env and shell-quotes argv0.
+
+    These are exactly the fields a hand-rolled thin wrap historically dropped
+    (a spec sandbox silently ignored, the session folder falling back to the
+    runner workspace), so the catalog path must prove them.
+    """
+    monkeypatch.setitem(ACP_CLI_HARNESSES, "fakecli", _FAKE_ROW)
+    monkeypatch.delenv("OMNIGENT_FAKECLI_PATH", raising=False)
+    # A resolved binary path containing a space must survive the round-trip
+    # through the shlex-split command string.
+    monkeypatch.setattr(
+        "omnigent._platform.resolve_cli_binary",
+        lambda name, **k: "/opt/fake cli/fakecli" if name == "fakecli" else None,
+    )
+    os_env = OSEnvSpec(
+        type="caller_process",
+        cwd=None,
+        sandbox=OSEnvSandboxSpec(type="omnibox"),
+        fork=False,
+    )
+    env = _build_acp_cli_spawn_env(
+        _spec("fakecli", os_env=os_env), harness="fakecli", cwd=Path("/work/space")
+    )
+
+    assert shlex.split(env["HARNESS_ACP_COMMAND"]) == [
+        "/opt/fake cli/fakecli",
+        "agent",
+        "stdio",
+    ]
+    assert env["HARNESS_ACP_NAME"] == "Fake CLI"
+    assert env["HARNESS_ACP_CWD"] == "/work/space"
+    assert json.loads(env["HARNESS_ACP_OS_ENV"]) == dataclasses.asdict(os_env)
+    # Rows own their model selection: no model var may ride along.
+    assert "HARNESS_ACP_MODEL" not in env
+
+
+def test_spawn_env_honors_path_override_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(ACP_CLI_HARNESSES, "fakecli", _FAKE_ROW)
+    monkeypatch.setenv("OMNIGENT_FAKECLI_PATH", "/custom/fakecli")
+    env = _build_acp_cli_spawn_env(_spec("fakecli"), harness="fakecli")
+    assert shlex.split(env["HARNESS_ACP_COMMAND"])[0] == "/custom/fakecli"
+    # No session cwd and no os_env on the spec: neither var may be emitted, so
+    # the wrap falls back to OMNIGENT_RUNNER_WORKSPACE / its own default.
+    assert "HARNESS_ACP_CWD" not in env
+    assert "HARNESS_ACP_OS_ENV" not in env
+
+
+def test_runner_dispatch_routes_catalog_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_build_spawn_env_from_spec picks up any catalog row without new wiring."""
+    from omnigent.runner.app import _build_spawn_env_from_spec
+
+    monkeypatch.setitem(ACP_CLI_HARNESSES, "fakecli", _FAKE_ROW)
+    monkeypatch.delenv("OMNIGENT_FAKECLI_PATH", raising=False)
+    env = _build_spawn_env_from_spec(_spec("fakecli"), "fakecli")
+    assert env is not None
+    assert env["HARNESS_ACP_NAME"] == "Fake CLI"
+    assert shlex.split(env["HARNESS_ACP_COMMAND"])[-2:] == ["agent", "stdio"]
+
+
+def test_fake_row_login_command() -> None:
+    assert _FAKE_ROW.login_command == "fakecli login --device"
+    assert _FAKE_ROW.label == "Fake CLI"
+    assert _FAKE_ROW.binary == "fakecli"
+
+
+# ---------------------------------------------------------------------------
+# Per-row registration (parametrized over the real catalog)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", sorted(ACP_CLI_HARNESSES))
+def test_catalog_row_is_fully_registered(name: str) -> None:
+    """One catalog row must yield every registration a harness needs."""
+    row = ACP_CLI_HARNESSES[name]
+
+    assert name in valid_harnesses()
+    assert harness_modules()[name] == "omnigent.inner.acp_harness"
+    assert harness_labels()[name] == row.label
+    # Same declared profile as the generic "acp" harness they run through.
+    assert harness_capabilities()[name] == harness_capabilities()["acp"]
+    assert install_specs()[name] == row.install
+    for spelling in (name, *row.aliases):
+        assert harness_install_keys()[spelling] == name
+    for alias in row.aliases:
+        assert canonicalize_harness(alias) == name
+    # The setup checklist must exist, and rows with a vendor login must show it.
+    steps = ui_setup_steps(name)
+    assert steps
+    if row.login_command is not None and row.install.package is not None:
+        assert any(step.command == row.login_command for step in steps)
+
+
+@pytest.mark.parametrize("name", sorted(ACP_CLI_HARNESSES))
+def test_catalog_row_spawn_env_builds(name: str) -> None:
+    """The shared builder produces a launchable command for every real row."""
+    row = ACP_CLI_HARNESSES[name]
+    env = _build_acp_cli_spawn_env(_spec(name), harness=name)
+    argv = shlex.split(env["HARNESS_ACP_COMMAND"])
+    assert argv[0], "argv[0] must resolve to a non-empty binary"
+    if row.args:
+        assert argv[-len(row.args) :] == list(row.args)
+    assert env["HARNESS_ACP_NAME"] == row.label


### PR DESCRIPTION
## Related issue

N/A (registration-sprawl refactor; unblocks #3075 and #3560, which each become one catalog row)

## Summary

Promoting an ACP-speaking vendor CLI to a first-class harness has meant editing 6+ registration points (capabilities, valid set, module map, aliases, labels, install spec, readiness, setup steps, a per-harness spawn-env builder, the live e2e-matrix exclusion) plus copying a near-identical thin inner module. The two in-flight ACP harness PRs (#3075 Grok Build, #3560 Qoder) each re-derived all of this by hand, and one shipped without its spawn-env builder, which silently dropped the session working folder and the spec sandbox.

This PR adds a declarative catalog, `omnigent/acp_cli_harnesses.py`: one `AcpCliHarness` row per vendor CLI (label, binary, ACP argv, aliases, install/login metadata). Every registration derives from the row, so a new ACP CLI harness is one dict entry plus docs.

**ELI5:** vendor CLIs that speak ACP all run through the same generic executor anyway; the only real differences are the command line and the install/login instructions. So those differences become a table row, and the code that used to be copied per harness now reads the table.

```mermaid
flowchart LR
  R[ACP_CLI_HARNESSES row] --> P[harness_plugins: validity, module, alias, label, caps, install]
  R --> O[onboarding: readiness gate, setup steps, one-click install]
  R --> W[workflow: shared _build_acp_cli_spawn_env]
  W --> A[inner/acp_harness.py + AcpExecutor]
```

- The shared spawn-env builder forwards the session cwd and the serialized `os_env`/sandbox, shell-quotes the resolved binary path, and wires no model var (rows own model selection, so `/model` is rejected up front instead of accepted-and-dropped).
- Readiness rides the existing contribution install-key gate; no new readiness branches.
- The runner dispatch gains one membership check that covers every current and future row.
- The catalog ships empty. The first rows land in #3075 (Grok Build) and #3560 (Qoder / Qoder CN), which shrink to a row + docs each.
- `.claude/skills/harness-integration-guide` now documents the one-row path.

## Test Plan

- `pytest tests/test_acp_cli_harnesses.py tests/test_harness_plugins.py tests/test_harness_capabilities.py tests/onboarding/test_harness_readiness.py tests/onboarding/test_harness_install.py` — 192 passed, 2 skipped (the per-row parametrized tests, which skip while the catalog is empty).
- `pytest tests/e2e/omnigent/test_run_harness_without_agent_e2e.py::test_run_harness_live_matrix_covers_registered_coding_harnesses` — passes; the exclusion set now extends from the catalog.
- New `tests/test_acp_cli_harnesses.py` drives a fake catalog row through the shared builder and the runner dispatch: cwd + sandbox forwarding, argv quoting for paths with spaces, `OMNIGENT_<NAME>_PATH` override, and no model env var. Per-row tests assert full registration for every real row as rows land.
- `pre-commit run --all-files` — clean (includes pyrefly).

## Demo

N/A — backend refactor with no visible change (the catalog is empty until #3075/#3560 land their rows).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The e2e change is to the registry-coverage guard test (it derives the live-matrix exclusion from the catalog); no live-credential path changes. The registration/readiness/setup-step surfaces are covered by the existing suites, which now also run over derived entries.

This pull request and its description were written by Isaac.
