### PR TITLE
fix(ci): normalize uv.lock to canonical form after every CI uv lock

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -84,7 +84,12 @@ jobs:
             python scripts/update_versions.py "$MODE" --new-version "$NEW_VERSION"
 
       - name: Regenerate lockfile
-        run: uv lock
+        run: |
+          uv lock
+          # uv may emit non-canonical lockfile fields (e.g. size on file
+          # entries); normalize like the pre-commit fixer, then hard-verify.
+          python3 scripts/normalize_uv_lock_registry.py uv.lock || true
+          python3 scripts/normalize_uv_lock_registry.py --check uv.lock
 
       - name: Verify all locations agree
         run: uv run --no-project --python 3.12 --with packaging python scripts/update_versions.py check

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -229,6 +229,10 @@ jobs:
           uv run --no-project --python 3.12 --with packaging \
             python scripts/update_versions.py pre-release --new-version "$VERSION"
           uv lock
+          # uv may emit non-canonical lockfile fields (e.g. size on file
+          # entries); normalize like the pre-commit fixer, then hard-verify.
+          python3 scripts/normalize_uv_lock_registry.py uv.lock || true
+          python3 scripts/normalize_uv_lock_registry.py --check uv.lock
           uv run --no-project --python 3.12 --with packaging \
             python scripts/update_versions.py check --expect "$VERSION"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -600,6 +600,10 @@ jobs:
             uv run --no-project --python 3.12 --with packaging \
               python scripts/update_versions.py pre-release --new-version "$VERSION"
             uv lock
+            # uv may emit non-canonical lockfile fields (e.g. size on file
+            # entries); normalize like the pre-commit fixer, then hard-verify.
+            python3 scripts/normalize_uv_lock_registry.py uv.lock || true
+            python3 scripts/normalize_uv_lock_registry.py --check uv.lock
           fi
           uv run --no-project --python 3.12 --with packaging \
             python scripts/update_versions.py check --expect "$VERSION"


### PR DESCRIPTION
## Related issue

N/A

## Summary

- All three CI paths that regenerate `uv.lock` (release cut, main bump, nightly cut) commit uv's raw output. The runner's current uv writes `size =` fields on every file entry, which the repo's canonical lockfile form (`scripts/normalize_uv_lock_registry.py`, enforced by the `normalize-uv-lock-registry` pre-commit hook) forbids.
- Live impact today: the v0.8.0 release commit carried 2,885 size fields, so the `release/v0.8.0` branch-push lint run failed ("1 non-canonical entry(s) … size field on 2885 file entries") — and a red branch head would make the next cut from that branch (0.8.1, rc2, …) fail `release.yml`'s green-CI gate.
- Fix: after each CI `uv lock`, run the normalizer (a pre-commit-style fixer that exits non-zero when it rewrites, so that exit is tolerated), then hard-verify with `--check` so a genuinely broken lockfile still fails the step. Same three-line pattern in `release.yml`, `bump-version.yml`, `nightly-release.yml`.

## Test Plan

- Reproduced the exact failure locally: took the v0.8.0 tag's `uv.lock` (pre-deletion), ran `normalize_uv_lock_registry.py --check` → fails with the same message; ran the fixer → exits 1 and strips all 2,885 size fields; `--check` then passes.
- Verified the script is stdlib-only (`re`/`sys`/`pathlib`), so bare `python3` on the runner needs no setup step.
- `pre-commit run` on all three workflow files: clean.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Manual verification completed
- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Workflows have no test harness; the normalizer itself is already covered by the pre-commit hook contract, and the next release cut's branch-push lint run is the end-to-end check this change exists to turn green.

This pull request and its description were written by Isaac.
