### PR TITLE
Fix cancelled ingest waiters wedging sessions

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1980,9 +1980,7 @@ def create_runner_app(
     _active_turns: dict[str, asyncio.Task[None] | None] = {}
     _native_pane_status: dict[str, str] = {}
     _session_message_buffers: dict[str, list[_JsonObject]] = {}
-    _ingest_next_seq: dict[str, int] = {}
-    _ingest_now_serving: dict[str, int] = {}
-    _ingest_cond: dict[str, asyncio.Condition] = {}
+    _ingest_locks: dict[str, asyncio.Lock] = {}
     _interrupted_sessions: set[str] = set()
     app.state.interrupted_sessions = _interrupted_sessions
     _background_tasks: set[asyncio.Task[object]] = set()
@@ -3304,9 +3302,7 @@ def create_runner_app(
         _session_message_buffers.pop(session_id, None)
         _live_response_id.pop(session_id, None)
         _native_pane_status.pop(session_id, None)
-        _ingest_next_seq.pop(session_id, None)
-        _ingest_now_serving.pop(session_id, None)
-        _ingest_cond.pop(session_id, None)
+        _ingest_locks.pop(session_id, None)
         _codex_terminal_ensure_locks.pop(session_id, None)
         _claude_terminal_ensure_locks.pop(session_id, None)
         _pi_terminal_ensure_locks.pop(session_id, None)
@@ -4937,16 +4933,8 @@ def create_runner_app(
         session_id: str,
     ) -> None:
 
-        _seq = _ingest_next_seq.get(session_id, 0)
-        _ingest_next_seq[session_id] = _seq + 1
-        _cond = _ingest_cond.get(session_id)
-        if _cond is None:
-            _cond = asyncio.Condition()
-            _ingest_cond[session_id] = _cond
-        async with _cond:
-            while _ingest_now_serving.get(session_id, 0) != _seq:
-                await _cond.wait()
-        try:
+        _ingest_lock = _ingest_locks.setdefault(session_id, asyncio.Lock())
+        async with _ingest_lock:
             if session_id in _active_turns:
                 return
 
@@ -4992,10 +4980,6 @@ def create_runner_app(
                 _background_tasks.discard,
             )
             _background_tasks.add(_turn_task)
-        finally:
-            async with _cond:
-                _ingest_now_serving[session_id] = _seq + 1
-                _cond.notify_all()
 
     async def _post_subagent_wake_notice(
         parent_id: str, notice: str, child_id: str, created_by: str | None
@@ -6206,16 +6190,8 @@ def create_runner_app(
             if _is_native_harness(conversation_id):
                 resource_registry.note_session_turn_started(conversation_id)
 
-            _seq = _ingest_next_seq.get(conversation_id, 0)
-            _ingest_next_seq[conversation_id] = _seq + 1
-            _cond = _ingest_cond.get(conversation_id)
-            if _cond is None:
-                _cond = asyncio.Condition()
-                _ingest_cond[conversation_id] = _cond
-            async with _cond:
-                while _ingest_now_serving.get(conversation_id, 0) != _seq:
-                    await _cond.wait()
-            try:
+            _ingest_lock = _ingest_locks.setdefault(conversation_id, asyncio.Lock())
+            async with _ingest_lock:
                 _raw_content = message_body.get("content")
                 if isinstance(_raw_content, list):
                     message_body["content"] = await _resolve_forwarded_message_content(
@@ -6333,10 +6309,6 @@ def create_runner_app(
                         "detail": "Turn started.",
                     },
                 )
-            finally:
-                async with _cond:
-                    _ingest_now_serving[conversation_id] = _seq + 1
-                    _cond.notify_all()
 
         if body_type == "interrupt":
             _harness = _session_harness_name(conversation_id)

--- a/tests/runner/test_app_sessions_native_workflow_messages.py
+++ b/tests/runner/test_app_sessions_native_workflow_messages.py
@@ -873,6 +873,65 @@ async def test_forwarded_model_override_reaches_the_harness() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cancelled_ingest_waiter_does_not_block_later_messages() -> None:
+    """Cancelling a queued message must not strand its ingest ticket."""
+    hc = _ScriptedHarnessClient(
+        [
+            _sse({"type": "response.created", "response": {"id": "resp_1"}}),
+            _sse({"type": "response.completed", "response": {"id": "resp_1"}}),
+        ]
+    )
+    server = _GatedFileServerClient()
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(hc),  # type: ignore[arg-type]
+        server_client=server,  # type: ignore[arg-type]
+    )
+    session_id = "ea532aed7642ec833ab31a5649c3495b"
+
+    async with _runner_client(app) as client:
+        first = asyncio.create_task(
+            client.post(
+                f"/v1/sessions/{session_id}/events",
+                json={
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_image",
+                            "file_id": "c531a3c97ad5fca15709d73d1f734a0c",
+                            "filename": "a.png",
+                        }
+                    ],
+                },
+            )
+        )
+        await asyncio.wait_for(server.meta_fetch_started.wait(), timeout=5.0)
+
+        cancelled = asyncio.create_task(
+            client.post(
+                f"/v1/sessions/{session_id}/events",
+                json={"type": "message", "content": [{"type": "input_text", "text": "drop"}]},
+            )
+        )
+        await asyncio.sleep(0.05)
+        cancelled.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await cancelled
+
+        server.release.set()
+        assert (await asyncio.wait_for(first, timeout=5.0)).status_code == 202
+        response = await asyncio.wait_for(
+            client.post(
+                f"/v1/sessions/{session_id}/events",
+                json={"type": "message", "content": [{"type": "input_text", "text": "next"}]},
+            ),
+            timeout=1.0,
+        )
+
+    assert response.status_code == 202
+
+
+@pytest.mark.asyncio
 async def test_buffered_continuation_skips_transient_idle() -> None:
     """End-of-turn `idle` is suppressed when a buffered message will start a new turn."""
     import asyncio as _aio


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Replace the runner's custom ticket/condition ingest gate with a per-session FIFO `asyncio.Lock`, so cancelled waiters are removed instead of permanently blocking the queue.
- Apply the same gate to direct message intake and buffered-turn continuation, with a regression test for the cancelled-waiter sequence.

**ELI5:** A cancelled request used to keep its number in line forever. The standard lock drops cancelled waiters, so the next message can move forward.

```mermaid
flowchart LR
    A[Active ingest] --> B[Cancelled waiter]
    B --> C[Later message]
    B -. removed from lock queue .-> C
```

## Test Plan

- `pytest -q tests/runner/test_app_sessions_native_workflow_messages.py` — 25 passed.
- `pre-commit run --files omnigent/runner/app.py tests/runner/test_app_sessions_native_workflow_messages.py` — all applicable hooks passed, including Ruff and Pyrefly.
- Started a disposable live server and host from this branch, then used the in-app Browser UI to launch a host-backed Codex runner. Sent a command containing `sleep 3`, queued a follow-up during the active turn, and sent another message afterward; the session returned `LIVE_READY`, `FIRST_DONE`, `SECOND_DONE`, and `THIRD_DONE` without wedging.

## Demo

N/A — backend concurrency fix with no visual change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new regression cancels a waiter parked behind a slow ingest and verifies the next message completes. The existing ordering test confirms FIFO delivery is preserved. Manual verification exercised the full browser → server → host → runner path.

## Changelog

Sessions continue accepting messages when a queued wake request is cancelled.
