### PR TITLE
ci(nightly): watch nightly-release in the failure monitor; document the lane

### DIFF
--- a/.github/workflows/nightly-failure-monitor.yml
+++ b/.github/workflows/nightly-failure-monitor.yml
@@ -7,10 +7,13 @@ name: Nightly Failure Monitor
 # the maintainer; it comments-and-closes that issue when a later nightly is
 # green. A single flake (one red run) is ignored -- the real-LLM legs are
 # 429-sensitive -- so only a sustained break pages.
+#
+# Nightly Release is watched for the same reason: it is fully unattended, so a
+# broken cut blocks nobody and consumers just silently stop getting new builds.
 
 on:
   workflow_run:
-    workflows: ["E2E Tests", "E2E UI Tests"]
+    workflows: ["E2E Tests", "E2E UI Tests", "Nightly Release"]
     types: [completed]
 
 permissions:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -168,6 +168,35 @@ does not change for a patch, and a patch never needs a new branch.
 
 ---
 
+## Nightly builds
+
+`nightly-release.yml` runs at 04:30 UTC: it finds the newest commit on `main`
+with green CI, stamps the lockstep version to `X.Y.Z.devYYYYMMDD` (today's UTC
+date on main's `X.Y.Z.dev0` line), commits that stamp detached (`main` never
+moves and no release branch is created), and pushes only the tag. Quiet nights
+and same-day re-runs no-op. The tag push publishes the immutable Docker image
+tag; no GitHub release, changelog, or homebrew automation fires for dev tags,
+and a default `pip install omnigent` never resolves them.
+
+Nightlies do not go to PyPI. Consumers install straight from the tag with uv
+(requires git, uv, Node 22+, and pnpm):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/omnigent-ai/omnigent/main/scripts/update_nightly.sh | bash
+```
+
+The script is idempotent (cron-safe) and pins all three lockstep packages to
+one tagged commit; `omnigent --version` prints that commit. An existing
+install moves onto (or along) the channel with `omni upgrade --nightly`.
+
+A bad nightly needs no recovery: fix `main` and the next night's tag
+supersedes it. For an ad-hoc cut, dispatch `nightly-release.yml` (dry-run by
+default; `-f dry_run=false` cuts for real, and it no-ops when today's tag
+already exists). Sustained failures of the cut file a tracking issue via
+`nightly-failure-monitor.yml`.
+
+---
+
 ## One-time setup (repo admin)
 
 - **`publish-release` environment** on `omnigent-ai/omnigent` with required


### PR DESCRIPTION
## Related issue

N/A

## Summary

Follow-up to #3475 (nightly builds), closing its two operational gaps:

- **Failure monitoring**: `nightly-release.yml` is fully unattended, so a broken cut blocks nobody and consumers just silently stop getting new builds. This adds "Nightly Release" to `nightly-failure-monitor.yml`'s watch list. The existing semantics apply unchanged: only scheduled runs on `main` count, two consecutive failures file/update one tracking issue, and a later green run closes it. Quiet nights (plan runs, cut skipped) conclude `success`, so they correctly close any open issue.
- **Runbook**: RELEASING.md had nothing on the nightly lane. New "Nightly builds" section covers what the workflow does (tag-only, detached stamp, main never moves), how consumers install and update from tags (`scripts/update_nightly.sh`, `omni upgrade --nightly`, no PyPI involved), and recovery (none needed: fix `main`, the next tag supersedes).

## Test Plan

- The monitor change cannot be exercised from a PR: `workflow_run` triggers always execute the default-branch copy of the workflow. Verified by inspection that the script's filters accept the new workflow's runs: scheduled nightly cuts fire with `event=schedule` on `main`, failures conclude `failure` (counted), and skip-nights conclude `success` (closes the issue). Manual dispatches are ignored by the existing `event !== 'schedule'` guard.
- Docs claims match shipped behavior; the consumer flow was verified in a clean environment (isolated `uv tool install` from a git ref resolves all three lockstep packages to one commit, `omnigent --version` prints that commit, and `omni upgrade --nightly` reports the no-tags case with an actionable message).
- `pre-commit` clean on both files.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The monitor is config plus a github-script step with no test harness, and `workflow_run` triggers only run from the default branch, so the first scheduled nightly after merge is the live check. Verification here is the filter-semantics inspection and the clean-room consumer-flow run described above.

This pull request and its description were written by Isaac.
