### PR TITLE
fix(claude-sdk): recover sessions after user interrupt

### DIFF
--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -2862,7 +2862,8 @@ class ClaudeSDKExecutor(Executor):
             self._evict_client_on_cancel(session_key)
             raise
         except Exception as exc:  # noqa: BLE001 — top-level executor error boundary; records crash and surfaces to caller
-            self._crashed_sessions[session_key] = str(exc)
+            if session_key in self._clients:
+                self._crashed_sessions[session_key] = str(exc)
             await self._close_live_client(session_key)
             stderr_text = "\n".join(stderr_lines) if stderr_lines else "(no stderr captured)"
             diagnostics_text = (

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -2299,6 +2299,83 @@ class TestStreamEventStreaming(unittest.TestCase):
 
         _run(_t())
 
+    def test_interrupt_teardown_does_not_mark_session_crashed(self):
+        """A user Stop must not poison later turns when teardown kills the CLI."""
+        from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+
+        clients = []
+        response_started = asyncio.Event()
+        process_terminated = asyncio.Event()
+
+        class _ResultMessage:
+            def __init__(self, session_id, result):
+                self.session_id = session_id
+                self.result = result
+                self.is_error = None
+                self.usage = None
+
+        class _FakeSDK:
+            AssistantMessage = type("AssistantMessage", (), {})
+            UserMessage = type("UserMessage", (), {})
+            SystemMessage = type("SystemMessage", (), {})
+            ResultMessage = _ResultMessage
+            StreamEvent = type("StreamEvent", (), {})
+            ClaudeAgentOptions = type(
+                "ClaudeAgentOptions",
+                (),
+                {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
+            )
+
+            class ClaudeSDKClient:
+                def __init__(self, options):
+                    self.options = options
+                    self.index = len(clients)
+                    clients.append(self)
+
+                async def connect(self):
+                    return None
+
+                async def query(self, prompt, session_id="default"):
+                    return None
+
+                async def receive_response(self):
+                    if self.index == 0:
+                        response_started.set()
+                        await process_terminated.wait()
+                        raise RuntimeError("ProcessError: command exited after SIGTERM")
+                    yield _ResultMessage("claude-session-a", "recovered")
+
+                async def interrupt(self):
+                    return None
+
+        async def _t():
+            executor = ClaudeSDKExecutor()
+            messages = [{"role": "user", "content": "hello", "session_id": "session-a"}]
+
+            async def _consume_turn():
+                return [event async for event in executor.run_turn(messages, [], "")]
+
+            async def _terminate(_client):
+                process_terminated.set()
+
+            with (
+                patch("omnigent.inner.claude_sdk_executor._ensure_sdk", return_value=_FakeSDK),
+                patch.object(executor, "_force_close_client", side_effect=_terminate),
+            ):
+                interrupted_turn = asyncio.create_task(_consume_turn())
+                await asyncio.wait_for(response_started.wait(), timeout=5)
+                self.assertTrue(await executor.interrupt_session("session-a"))
+                await interrupted_turn
+
+                self.assertNotIn("session-a", executor._crashed_sessions)
+                events = [event async for event in executor.run_turn(messages, [], "")]
+
+            self.assertEqual(len(clients), 2)
+            self.assertIsInstance(events[-1], TurnComplete)
+            self.assertEqual(events[-1].response, "recovered")
+
+        _run(_t())
+
     def test_close_disconnects_all_live_clients(self):
         from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor, _ClaudeClientState
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Keep intentional Claude SDK interrupt teardown from marking the session as crashed when the terminated CLI reports `ProcessError`.
- Add a regression test proving a stopped turn can be followed by a successful turn in the same Omnigent session.

ELI5: Stop removes the active client on purpose. If that client then reports that it was terminated, Omnigent now recognizes the termination as part of Stop instead of treating the conversation as permanently broken.

```text
Stop -> remove client -> CLI exits with SIGTERM -> do not set crash marker
                                                -> next turn creates a client -> succeeds
```

## Test Plan

- `python -m pytest tests/inner/test_claude_sdk_executor.py` (121 passed)
- Ruff checks for both changed Python files passed.
- Pyrefly passed.
- Live E2E with a local Omnigent server and host in the Browser: started a `sleep 30` command, clicked Interrupt, observed the Claude runner report `ProcessError` with exit code 143, then sent a follow-up in the same session and received `SECOND_OK`.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regression test deterministically reproduces interrupt teardown followed by a process error and asserts that a second turn recovers. Manual verification exercised the same sequence through the live Browser UI against a local Omnigent server and host.

## Changelog

Stopping a Claude SDK turn no longer prevents follow-up messages in the same session.
