### PR TITLE
fix: run conversation deletion off event loop

### DIFF
--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import Any, Protocol, cast
@@ -3870,6 +3871,10 @@ class SqlAlchemyConversationStore(ConversationStore):
         return conv
 
     async def delete_conversation(self, conversation_id: str) -> bool:
+        """Delete a conversation subtree without blocking the event loop."""
+        return await asyncio.to_thread(self._delete_conversation_sync, conversation_id)
+
+    def _delete_conversation_sync(self, conversation_id: str) -> bool:
         """
         Delete a conversation and all of its descendants, cleaning up
         every related row explicitly (no DB-level CASCADE).

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
+import threading
+
 import pytest
 from sqlalchemy import event, text
 
@@ -1649,6 +1652,28 @@ async def test_delete_conversation(
     assert conversation_store.get_conversation(conv.id) is None
     assert conversation_store.list_items(conv.id).data == []
     assert await conversation_store.delete_conversation(conv.id) is False
+
+
+@pytest.mark.asyncio
+async def test_delete_conversation_does_not_block_event_loop(
+    conversation_store: SqlAlchemyConversationStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_delete(_conversation_id: str) -> bool:
+        started.set()
+        return release.wait(timeout=1)
+
+    monkeypatch.setattr(conversation_store, "_delete_conversation_sync", blocking_delete)
+    delete_task = asyncio.create_task(conversation_store.delete_conversation("conv_test"))
+    try:
+        assert await asyncio.to_thread(started.wait, 1)
+        assert not delete_task.done()
+    finally:
+        release.set()
+    assert await delete_task is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

N/A (reported directly)

## Summary

- Offloads `SqlAlchemyConversationStore.delete_conversation` to a worker thread so its recursive CTE and cross-database deletes cannot block the server event loop.
- Keeps the existing delete transaction body unchanged behind a synchronous helper and adds a regression test that proves the loop advances while that body is blocked.

ELI5: the server now hands the slow database cleanup to a worker instead of making every live request wait behind it.

`async request -> asyncio.to_thread -> existing recursive delete`

## Test Plan

- `pytest -q tests/stores/test_conversation_store.py tests/stores/test_conversation_store_split_db.py -k 'delete_conversation'` — 7 passed.
- Ruff check and format-check on both changed files.
- Pyrefly on the changed store implementation — 0 errors.
- Live Browser verification against a local server + connected host: created a real Claude workflow, sent `Reply with exactly DELETE-E2E-READY. Do not use tools.`, and received `DELETE-E2E-READY`.
- Seeded that live parent with 6,000 recursive sub-agent conversations and 6,000 item/FTS rows, then deleted it through the UI. The 4.739-second delete removed all conversation, metadata, item, and FTS rows while 800/800 health probes and 400/400 concurrent session-list requests succeeded (health max 63 ms; session-list max 12 ms).

## Demo

N/A — backend concurrency fix; verified through the live UI and Browser workflow above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification used the current branch's live backend, a real connected local host, and the Browser UI. The recursive delete ran long enough to expose the original freeze while concurrent probes verified that the event loop remained responsive.

## Changelog

Deleting large agent conversation trees no longer freezes other server activity.
