### PR TITLE
chore(desktop): bump Electron app version to 0.8.0

### DIFF
--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omnigent-desktop-electron",
   "productName": "Omnigent",
-  "version": "0.6.0",
+  "version": "0.8.0",
   "description": "Omnigent desktop shell (Electron edition) — a thin native wrapper around the server-served web UI.",
   "private": true,
   "main": "src/main.js",


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Bump the Omnigent desktop (Electron) app version from `0.6.0` to `0.8.0` in `web/electron/package.json`, aligning the desktop shell with the `0.8.0` release line.

## Test Plan

- `pre-commit run --files web/electron/package.json` passes (prettier, EOF, whitespace checks).
- Verified `web/electron/package.json` now reports `"version": "0.8.0"`.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Version-string bump only; no logic change. Verified the new value and that pre-commit passes.
