### PR TITLE
docs(changelog): v0.8.1 ships the switcher revert, not nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ website under `/releases`.
 
 ## [v0.8.1] — 2026-08-03
 
-_No user-facing changes._
+- [UI] Reverted the v0.8.0 "Chat/Terminal switcher in the header" change; the
+  switcher returns to its previous location. (#3931)
 
 ## [v0.8.0] — 2026-08-03
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The auto-generated v0.8.1 CHANGELOG entry says *no user-facing changes*, but the release's entire purpose is the revert of the Chat/Terminal switcher header move (#3931). The curation maps commits to merged PRs in the tag range, and a cherry-picked revert whose PR (#4000) is still open on main is invisible to it.
- Replaces the placeholder with the real entry.

## Test Plan

Docs-only; rendered locally.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

This pull request and its description were written by Isaac.