### PR TITLE
fix(ci): normalize uv.lock after /regen resolutions

### DIFF
--- a/.github/workflows/oss-regen-on-comment.yml
+++ b/.github/workflows/oss-regen-on-comment.yml
@@ -4,8 +4,8 @@
 # oss-regenerate-and-smoke.yml (standalone rolling PR on dispatch).
 #
 # Two forms:
-#   /regen                      re-resolve, preserving existing pins.
-#   /regen upgrade <pkg> [pkg]  additionally force uv to take the newest allowed
+#   /regen                      re-resolve BOTH lockfiles, preserving existing pins.
+#   /regen upgrade <pkg> [pkg]  uv.lock ONLY: force uv to take the newest allowed
 #                               version of each named package (uv lock
 #                               --upgrade-package). Use for a transitive pip
 #                               security bump Dependabot can't land on this uv
@@ -193,8 +193,13 @@ jobs:
           # entries); normalize like the pre-commit fixer, then hard-verify.
           python3 scripts/normalize_uv_lock_registry.py uv.lock || true
           python3 scripts/normalize_uv_lock_registry.py --check uv.lock
-          rm -f pnpm-lock.yaml
-          pnpm install --lockfile-only
+          # `/regen upgrade <py pkgs>` is a targeted Python bump: leave the npm
+          # lockfile alone so the PR diff stays reviewable. Plain `/regen`
+          # refreshes both lockfiles, as before.
+          if [ "$REGEN_MODE" != "upgrade" ]; then
+            rm -f pnpm-lock.yaml
+            pnpm install --lockfile-only
+          fi
 
       # Mint the App token only AFTER `uv lock` so untrusted PR build backends
       # never see it. Skipped when the App isn't configured (push then falls back

--- a/.github/workflows/oss-regen-on-comment.yml
+++ b/.github/workflows/oss-regen-on-comment.yml
@@ -189,6 +189,10 @@ jobs:
           else
             uv lock
           fi
+          # uv may emit non-canonical lockfile fields (e.g. size on file
+          # entries); normalize like the pre-commit fixer, then hard-verify.
+          python3 scripts/normalize_uv_lock_registry.py uv.lock || true
+          python3 scripts/normalize_uv_lock_registry.py --check uv.lock
           rm -f pnpm-lock.yaml
           pnpm install --lockfile-only
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- `oss-regen-on-comment.yml` was the one lock-writing CI path left out of the normalize-then-verify treatment (release.yml / bump-version.yml / nightly-release.yml got it earlier today): its `uv lock --upgrade-package` runs re-add `size =` fields, which the canonical lockfile form forbids.
- Live impact tonight: two `/regen` runs on the 0.9.0.dev0 bump PR ballooned its lockfile diff by ~3k lines of formatting noise and turned the pre-commit lint red; the branch needed a manual normalize commit.
- Same three lines as the other workflows: run the fixer (tolerating its rewrote-something exit), then hard-verify with `--check`.
- Second fix, same root complaint: `/regen upgrade <py pkgs>` also deleted and re-resolved `pnpm-lock.yaml` from scratch, burying a ~100-line Python dependency fix under thousands of lines of npm churn on the bump PR. Upgrade mode now touches only `uv.lock`; plain `/regen` still refreshes both lockfiles.

## Test Plan

- Reproduced on the live bump PR branch: fixer stripped 3,132 size fields, `--check` then passes, resolved versions unchanged.
- `pre-commit run` on the workflow file: clean.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Workflows have no test harness; the fixer's behavior was exercised for real on the bump PR branch tonight, and the next `/regen` on any PR is the end-to-end check.

This pull request and its description were written by Isaac.
