### PR TITLE
Expose semantic database query names

### DIFF
--- a/omnigent/db/__init__.py
+++ b/omnigent/db/__init__.py
@@ -13,6 +13,7 @@ from omnigent.db.db_models import (
     current_workspace_id,
     workspace_scope,
 )
+from omnigent.db.query_context import current_query_name, query_name_scope
 
 __all__ = [
     "DEFAULT_WORKSPACE_ID",
@@ -24,6 +25,8 @@ __all__ = [
     "SqlFile",
     "SqlSessionPermission",
     "SqlUser",
+    "current_query_name",
     "current_workspace_id",
+    "query_name_scope",
     "workspace_scope",
 ]

--- a/omnigent/db/query_context.py
+++ b/omnigent/db/query_context.py
@@ -1,0 +1,34 @@
+"""Context-local names for database query observability."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+_current_query_name: ContextVar[str | None] = ContextVar("omnigent_query_name", default=None)
+
+
+def current_query_name() -> str | None:
+    """Return the semantic name of the query currently being executed, if any.
+
+    Database instrumentation can read this value without coupling application
+    stores to a particular query-comment format, tracer, or logger.
+    """
+    return _current_query_name.get()
+
+
+@contextmanager
+def query_name_scope(query_name: str) -> Iterator[None]:
+    """Bind ``query_name`` while one logical database query executes.
+
+    Nested scopes restore their parent's name, including when query execution
+    raises. The scope itself does not modify SQL or emit telemetry.
+    """
+    if not query_name.strip():
+        raise ValueError("query_name must not be empty")
+    token = _current_query_name.set(query_name)
+    try:
+        yield
+    finally:
+        _current_query_name.reset(token)

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -50,6 +50,7 @@ from omnigent.db.enum_codecs import (
     encode_item_type,
     encode_session_live_status,
 )
+from omnigent.db.query_context import query_name_scope
 from omnigent.db.utils import (
     _supports_fts5,
     build_search_snippet,
@@ -483,16 +484,17 @@ def _fetch_labels(
     :returns: Mapping from label key to value (string-typed).
         Empty dict when no rows match.
     """
-    rows = (
-        session.execute(
-            select(SqlConversationLabel.key, SqlConversationLabel.value).where(
-                SqlConversationLabel.workspace_id == current_workspace_id(),
-                SqlConversationLabel.conversation_id == conversation_id,
+    with query_name_scope("omnigent.conversation_store.select_conversation_labels"):
+        rows = (
+            session.execute(
+                select(SqlConversationLabel.key, SqlConversationLabel.value).where(
+                    SqlConversationLabel.workspace_id == current_workspace_id(),
+                    SqlConversationLabel.conversation_id == conversation_id,
+                )
             )
+            .tuples()
+            .all()
         )
-        .tuples()
-        .all()
-    )
     return dict(rows)
 
 
@@ -759,7 +761,10 @@ class SqlAlchemyConversationStore(ConversationStore):
         """
         Fetch the metadata row for a conversation from the Omnigent DB.
         """
-        with self._session() as meta_sess:
+        with (
+            self._session() as meta_sess,
+            query_name_scope("omnigent.conversation_store.select_conversation_metadata_by_id"),
+        ):
             return meta_sess.get(
                 SqlConversationMetadata, (current_workspace_id(), conversation_id)
             )
@@ -906,9 +911,13 @@ class SqlAlchemyConversationStore(ConversationStore):
             root_id = new_id
             if parent_conversation_id is not None:
                 with self._conv_session() as ap_sess:
-                    parent_row = ap_sess.get(
-                        SqlConversation, (current_workspace_id(), parent_conversation_id)
-                    )
+                    with query_name_scope(
+                        "omnigent.conversation_store.select_parent_conversation"
+                    ):
+                        parent_row = ap_sess.get(
+                            SqlConversation,
+                            (current_workspace_id(), parent_conversation_id),
+                        )
                     if parent_row is None:
                         raise ConversationNotFoundError(
                             f"parent conversation {parent_conversation_id!r} does not exist"
@@ -927,15 +936,18 @@ class SqlAlchemyConversationStore(ConversationStore):
                 # the runner's find-or-create pre-check, so this fires only on a
                 # genuine collision).
                 if parent_conversation_id is not None:
-                    duplicate = ap_sess.execute(
-                        select(SqlConversation.id)
-                        .where(
-                            SqlConversation.workspace_id == current_workspace_id(),
-                            SqlConversation.parent_conversation_id == parent_conversation_id,
-                            SqlConversation.title == (title or ""),
-                        )
-                        .limit(1)
-                    ).first()
+                    with query_name_scope(
+                        "omnigent.conversation_store.select_duplicate_child_title"
+                    ):
+                        duplicate = ap_sess.execute(
+                            select(SqlConversation.id)
+                            .where(
+                                SqlConversation.workspace_id == current_workspace_id(),
+                                SqlConversation.parent_conversation_id == parent_conversation_id,
+                                SqlConversation.title == (title or ""),
+                            )
+                            .limit(1)
+                        ).first()
                     if duplicate is not None:
                         raise NameAlreadyExistsError(
                             f"sub-agent name already exists under parent "
@@ -951,6 +963,8 @@ class SqlAlchemyConversationStore(ConversationStore):
                     agent_id=agent_id,
                 )
                 ap_sess.add(row)
+                with query_name_scope("omnigent.conversation_store.insert_conversation"):
+                    ap_sess.flush()
             meta = SqlConversationMetadata(
                 id=new_id,
                 kind=encode_conversation_kind(kind),
@@ -965,6 +979,8 @@ class SqlAlchemyConversationStore(ConversationStore):
             )
             with self._session() as meta_sess:
                 meta_sess.add(meta)
+                with query_name_scope("omnigent.conversation_store.insert_conversation_metadata"):
+                    meta_sess.flush()
             return _to_conversation(row, meta)
         except IntegrityError as exc:
             # Translate a caller-supplied-id PK collision into a clean exception
@@ -1008,7 +1024,8 @@ class SqlAlchemyConversationStore(ConversationStore):
             ``None``.
         """
         with self._conv_session() as session:
-            row = session.get(SqlConversation, (current_workspace_id(), conversation_id))
+            with query_name_scope("omnigent.conversation_store.select_conversation_by_id"):
+                row = session.get(SqlConversation, (current_workspace_id(), conversation_id))
             if row is None:
                 return None
             meta = self._get_meta(session, conversation_id)

--- a/omnigent/stores/file_store/sqlalchemy_store.py
+++ b/omnigent/stores/file_store/sqlalchemy_store.py
@@ -7,6 +7,7 @@ import builtins
 from sqlalchemy import and_, asc, desc, or_, select
 
 from omnigent.db.db_models import SqlFile, current_workspace_id, normalize_uuid
+from omnigent.db.query_context import query_name_scope
 from omnigent.db.utils import (
     generate_file_id,
     get_or_create_engine,
@@ -80,6 +81,8 @@ class SqlAlchemyFileStore(FileStore):
         )
         with self._session() as session:
             session.add(row)
+            with query_name_scope("omnigent.file_store.insert_file"):
+                session.flush()
             return _to_entity(row)
 
     def get(
@@ -99,7 +102,8 @@ class SqlAlchemyFileStore(FileStore):
             ``None``.
         """
         with self._session() as session:
-            row = session.get(SqlFile, (current_workspace_id(), file_id))
+            with query_name_scope("omnigent.file_store.select_file_by_id"):
+                row = session.get(SqlFile, (current_workspace_id(), file_id))
             if row is None:
                 return None
             if session_id is not None and row.session_id != normalize_uuid(session_id):
@@ -168,7 +172,8 @@ class SqlAlchemyFileStore(FileStore):
                 sort_fn(SqlFile.created_at),
                 sort_fn(SqlFile.id),
             ).limit(limit + 1)
-            rows = list(session.execute(stmt).scalars().all())
+            with query_name_scope("omnigent.file_store.list_files"):
+                rows = list(session.execute(stmt).scalars().all())
             has_more = len(rows) > limit
             if has_more:
                 rows = rows[:limit]
@@ -196,12 +201,15 @@ class SqlAlchemyFileStore(FileStore):
         :returns: ``True`` if deleted, ``False`` otherwise.
         """
         with self._session() as session:
-            row = session.get(SqlFile, (current_workspace_id(), file_id))
+            with query_name_scope("omnigent.file_store.select_file_by_id"):
+                row = session.get(SqlFile, (current_workspace_id(), file_id))
             if not row:
                 return False
             if session_id is not None and row.session_id != normalize_uuid(session_id):
                 return False
             session.delete(row)
+            with query_name_scope("omnigent.file_store.delete_file"):
+                session.flush()
             return True
 
     def delete_all_for_session(self, session_id: str) -> builtins.list[str]:
@@ -216,8 +224,11 @@ class SqlAlchemyFileStore(FileStore):
                 SqlFile.workspace_id == current_workspace_id(),
                 SqlFile.session_id == session_id,
             )
-            rows = list(session.execute(stmt).scalars().all())
+            with query_name_scope("omnigent.file_store.list_session_files_for_delete"):
+                rows = list(session.execute(stmt).scalars().all())
             ids = [row.id for row in rows]
             for row in rows:
                 session.delete(row)
+            with query_name_scope("omnigent.file_store.delete_session_files"):
+                session.flush()
             return ids

--- a/tests/stores/test_query_context.py
+++ b/tests/stores/test_query_context.py
@@ -1,0 +1,132 @@
+"""Tests for semantic database query names."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import Engine, event
+
+from omnigent.db import current_query_name, query_name_scope
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+
+
+@contextmanager
+def _capture_application_query_names(*engines: Engine) -> Iterator[list[str | None]]:
+    """Capture names visible while application DML executes on ``engines``."""
+    query_names: list[str | None] = []
+
+    def capture_query_name(
+        _connection: object,
+        _cursor: object,
+        statement: str,
+        _parameters: object,
+        _context: object,
+        _executemany: bool,
+    ) -> None:
+        command = statement.lstrip().partition(" ")[0].upper()
+        if command in {"SELECT", "INSERT", "UPDATE", "DELETE"}:
+            query_names.append(current_query_name())
+
+    unique_engines = list(dict.fromkeys(engines))
+    for engine in unique_engines:
+        event.listen(engine, "before_cursor_execute", capture_query_name)
+    try:
+        yield query_names
+    finally:
+        for engine in unique_engines:
+            event.remove(engine, "before_cursor_execute", capture_query_name)
+
+
+def test_query_name_scope_restores_nested_and_failed_scopes() -> None:
+    """Nested and failed queries cannot leak their names to later work."""
+    assert current_query_name() is None
+
+    with query_name_scope("outer.query"):
+        assert current_query_name() == "outer.query"
+        with pytest.raises(RuntimeError, match="failed query"):
+            with query_name_scope("inner.query"):
+                assert current_query_name() == "inner.query"
+                raise RuntimeError("failed query")
+        assert current_query_name() == "outer.query"
+
+    assert current_query_name() is None
+
+
+def test_query_name_scope_rejects_empty_names() -> None:
+    """An empty identifier fails before any query can inherit it."""
+    with pytest.raises(ValueError, match="query_name must not be empty"):
+        with query_name_scope("  "):
+            raise AssertionError("empty query name entered its scope")
+
+
+def test_file_store_names_each_application_query(db_uri: str) -> None:
+    """Every query in a file-store lifecycle exposes its stable semantic name."""
+    file_store = SqlAlchemyFileStore(db_uri)
+
+    with _capture_application_query_names(file_store._engine) as query_names:
+        file = file_store.create("report.txt", 10, session_id="94c349190e241f85a984b3df8f129696")
+        assert query_names == ["omnigent.file_store.insert_file"]
+
+        query_names.clear()
+        file_store.get(file.id)
+        assert query_names == ["omnigent.file_store.select_file_by_id"]
+
+        query_names.clear()
+        file_store.list(session_id="94c349190e241f85a984b3df8f129696")
+        assert query_names == ["omnigent.file_store.list_files"]
+
+        query_names.clear()
+        file_store.delete(file.id)
+        assert query_names == [
+            "omnigent.file_store.select_file_by_id",
+            "omnigent.file_store.delete_file",
+        ]
+
+        file_store.create("old.txt", 1, session_id="94c349190e241f85a984b3df8f129696")
+        query_names.clear()
+        file_store.delete_all_for_session("94c349190e241f85a984b3df8f129696")
+        assert query_names == [
+            "omnigent.file_store.list_session_files_for_delete",
+            "omnigent.file_store.delete_session_files",
+        ]
+
+
+def test_conversation_store_names_create_and_get_queries(
+    split_db_conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Conversation creation and lookup name queries across both databases."""
+    store = split_db_conversation_store
+
+    with _capture_application_query_names(store._engine, store._conv_engine) as query_names:
+        parent = store.create_conversation(title="parent")
+        assert query_names == [
+            "omnigent.conversation_store.insert_conversation",
+            "omnigent.conversation_store.insert_conversation_metadata",
+        ]
+
+        query_names.clear()
+        child = store.create_conversation(
+            title="child",
+            parent_conversation_id=parent.id,
+        )
+        assert query_names == [
+            "omnigent.conversation_store.select_parent_conversation",
+            "omnigent.conversation_store.select_duplicate_child_title",
+            "omnigent.conversation_store.insert_conversation",
+            "omnigent.conversation_store.insert_conversation_metadata",
+        ]
+
+        query_names.clear()
+        fetched = store.get_conversation(child.id)
+        assert fetched is not None
+        assert fetched.id == child.id
+        assert query_names == [
+            "omnigent.conversation_store.select_conversation_by_id",
+            "omnigent.conversation_store.select_conversation_metadata_by_id",
+            "omnigent.conversation_store.select_conversation_labels",
+        ]


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Expose a context-local semantic name for the database query currently executing, without coupling stores to a query-comment format or telemetry backend.
- Name every application DML statement in the SQLAlchemy file-store lifecycle and in conversation create/get paths, including split-database execution.

## Test Plan

Added listener-based unit coverage that rejects empty names and verifies exact names for every DML statement exercised by FileStore CRUD and ConversationStore create/get. The existing file, conversation, and split-database conversation suites pass (225 tests), and the relevant Ruff, Pyrefly, and test-quality hooks pass.

## Demo

N/A; this is a backend observability API.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The listener tests exclude managed-session setup SQL and prove that inserts and deletes execute during their own named flush scopes.

## Changelog

Database observability integrations can identify semantic FileStore and ConversationStore queries.
