### PR TITLE
fix(deploy): ship Databricks SPA outside the wheel

### DIFF
--- a/deploy/databricks/README.md
+++ b/deploy/databricks/README.md
@@ -134,19 +134,19 @@ uv run python deploy/databricks/deploy.py \
     --volume-name main.omnigent.artifacts
 ```
 
-The script builds wheels, moves the SPA into `dist/web-ui/`, copies the
-wheels and loose UI files into `src/`, regenerates `src/pyproject.toml`
+The script builds wheels, archives the SPA as `dist/web-ui.tar.gz`, copies the
+wheels and the single UI archive into `src/`, regenerates `src/pyproject.toml`
 and `src/uv.lock`, runs `databricks bundle deploy --target prod`, runs
 `databricks bundle run omnigent --target prod`, and polls `/health`
 with backoff until 200.
 
 Databricks Apps rejects any single source file over 10 MB. The SPA is
-therefore shipped as loose files in `src/web-ui/` instead of inside the
-main wheel; `src/app.py` points the server at that directory via
-`OMNIGENT_WEB_UI_DIST`. Each UI asset is checked against the same 10 MB
-limit. If a Python wheel still exceeds it, reduce the Python payload or
-use `--skip-web-ui`; uv lockfiles cannot point at UC Volume wheel paths
-because `uv lock` validates path sources locally.
+therefore shipped as one `src/web-ui.tar.gz` archive instead of inside the
+main wheel; `src/app.py` extracts it at startup and points the server at the
+extracted directory via `OMNIGENT_WEB_UI_DIST`. The archive is checked against
+the same 10 MB limit before upload. If a Python wheel still exceeds it, reduce
+the Python payload or use `--skip-web-ui`; uv lockfiles cannot point at UC
+Volume wheel paths because `uv lock` validates path sources locally.
 
 Re-running is safe — every step is idempotent.
 
@@ -287,8 +287,8 @@ uv run python deploy/databricks/deploy.py --skip-web-ui ...
 | `permission denied for schema public` | App SP missing schema grants | Run `grant_sp_perms.py` (one-time) |
 | `Field 'spec.role' cannot be empty` | Lakebase requires explicit role for extra databases | Use the project's default database; don't create extras |
 | Deploy refuses because a wheel is over 10 MB | Workspace files cap at 10 MB and uv needs local wheel path sources | Rebuild with `--skip-web-ui` or reduce wheel size |
-| Deploy refuses because an SPA asset is over 10 MB | A single Vite chunk crossed the Workspace file cap | Split the chunk in `web/`, or use `--skip-web-ui` |
-| App serves the API-only landing page | `src/web-ui/` was not included, or deploy used `--skip-web-ui` | Redeploy without `--skip-web-ui` and without `--skip-build` |
+| Deploy refuses because the SPA archive is over 10 MB | The compressed UI archive crossed the Workspace file cap | Split the chunk in `web/`, or use `--skip-web-ui` |
+| App serves the API-only landing page | `src/web-ui.tar.gz` was not included, or deploy used `--skip-web-ui` | Redeploy without `--skip-web-ui` and without `--skip-build` |
 | App starts cleanly but the first agent request 403s on the artifact volume | App SP has `WRITE_VOLUME` on the leaf but no `USE_CATALOG` / `USE_SCHEMA` on the parents | `deploy.py` grants both automatically — for a fresh catalog, redeploy or grant manually via `databricks grants update` |
 
 ## Files in this directory

--- a/deploy/databricks/README.md
+++ b/deploy/databricks/README.md
@@ -134,16 +134,19 @@ uv run python deploy/databricks/deploy.py \
     --volume-name main.omnigent.artifacts
 ```
 
-The script builds wheels, classifies them by size, copies wheels into
-`src/`, regenerates `src/pyproject.toml` and `src/uv.lock`, runs
-`databricks bundle deploy --target prod`, runs
+The script builds wheels, moves the SPA into `dist/web-ui/`, copies the
+wheels and loose UI files into `src/`, regenerates `src/pyproject.toml`
+and `src/uv.lock`, runs `databricks bundle deploy --target prod`, runs
 `databricks bundle run omnigent --target prod`, and polls `/health`
 with backoff until 200.
 
-All Omnigent wheels must fit under the Databricks Apps source
-snapshot limit (10 MB). If a wheel exceeds it, rebuild with
-`--skip-web-ui` or reduce the wheel size; uv lockfiles cannot point at
-UC Volume wheel paths because `uv lock` validates path sources locally.
+Databricks Apps rejects any single source file over 10 MB. The SPA is
+therefore shipped as loose files in `src/web-ui/` instead of inside the
+main wheel; `src/app.py` points the server at that directory via
+`OMNIGENT_WEB_UI_DIST`. Each UI asset is checked against the same 10 MB
+limit. If a Python wheel still exceeds it, reduce the Python payload or
+use `--skip-web-ui`; uv lockfiles cannot point at UC Volume wheel paths
+because `uv lock` validates path sources locally.
 
 Re-running is safe — every step is idempotent.
 
@@ -283,7 +286,9 @@ uv run python deploy/databricks/deploy.py --skip-web-ui ...
 | `schema "dbos" already exists` | Same for the DBOS schema | `DROP SCHEMA dbos CASCADE` and redeploy |
 | `permission denied for schema public` | App SP missing schema grants | Run `grant_sp_perms.py` (one-time) |
 | `Field 'spec.role' cannot be empty` | Lakebase requires explicit role for extra databases | Use the project's default database; don't create extras |
-| Deploy refuses because a wheel is over 10 MB | uv app payload requires local wheel path sources | Rebuild with `--skip-web-ui` or reduce wheel size |
+| Deploy refuses because a wheel is over 10 MB | Workspace files cap at 10 MB and uv needs local wheel path sources | Rebuild with `--skip-web-ui` or reduce wheel size |
+| Deploy refuses because an SPA asset is over 10 MB | A single Vite chunk crossed the Workspace file cap | Split the chunk in `web/`, or use `--skip-web-ui` |
+| App serves the API-only landing page | `src/web-ui/` was not included, or deploy used `--skip-web-ui` | Redeploy without `--skip-web-ui` and without `--skip-build` |
 | App starts cleanly but the first agent request 403s on the artifact volume | App SP has `WRITE_VOLUME` on the leaf but no `USE_CATALOG` / `USE_SCHEMA` on the parents | `deploy.py` grants both automatically — for a fresh catalog, redeploy or grant manually via `databricks grants update` |
 
 ## Files in this directory

--- a/deploy/databricks/build.sh
+++ b/deploy/databricks/build.sh
@@ -4,14 +4,14 @@
 #
 # Inputs:
 #   SKIP_WEB_UI=1         Skip the web SPA build for API-only deployments.
-#   WEB_UI_OUT_NAME=<name> Move the built SPA to dist/<name> instead of leaving
-#                         it in the wheel's package data.
+#   EXTERNALIZE_WEB_UI=1  Build the SPA, then archive it outside the wheel so
+#                         the Databricks Apps source sync uploads one file.
 #
 # Outputs:
 #   dist/omnigent-<version>-py3-none-any.whl
 #   dist/omnigent_client-<version>-py3-none-any.whl
 #   dist/omnigent_ui_sdk-<version>-py3-none-any.whl
-#   dist/$WEB_UI_OUT_NAME/  SPA assets, when WEB_UI_OUT_NAME is set
+#   dist/web-ui.tar.gz    SPA archive, when EXTERNALIZE_WEB_UI=1
 
 set -euo pipefail
 
@@ -33,18 +33,17 @@ if [[ "${SKIP_WEB_UI:-}" != "1" ]]; then
     echo "==> Building web SPA into omnigent/server/static/web-ui/"
     pnpm install --frozen-lockfile --filter web
     pnpm --filter web run build
-    if [[ -n "${WEB_UI_OUT_NAME:-}" ]]; then
-        if [[ ! "${WEB_UI_OUT_NAME}" =~ ^[A-Za-z0-9_-]+$ ]]; then
-            echo "ERROR: WEB_UI_OUT_NAME must be a bare directory name matching" \
-                 "[A-Za-z0-9_-]+ (got '${WEB_UI_OUT_NAME}')" >&2
-            exit 1
-        fi
+    if [[ "${EXTERNALIZE_WEB_UI:-}" == "1" ]]; then
+        # One archive avoids a Workspace round-trip for every one of the
+        # SPA's hundreds of hashed chunks. The fixed destination also means
+        # no caller-controlled path is ever passed to rm or mv.
+        echo "==> Packing SPA into dist/web-ui.tar.gz (excluded from wheel)"
         mkdir -p "${REPO_ROOT}/dist"
-        web_ui_out_dir="${REPO_ROOT}/dist/${WEB_UI_OUT_NAME}"
-        echo "==> Moving SPA out of the wheel into ${web_ui_out_dir}"
-        rm -rf "${web_ui_out_dir}"
-        mv omnigent/server/static/web-ui "${web_ui_out_dir}"
-        # Prevent setup.py from putting the moved SPA back into the wheel.
+        rm -rf "${REPO_ROOT}/dist/web-ui" "${REPO_ROOT}/dist/web-ui.tar.gz"
+        tar -czf "${REPO_ROOT}/dist/web-ui.tar.gz" \
+            -C "${REPO_ROOT}/omnigent/server/static/web-ui" .
+        rm -rf "${REPO_ROOT}/omnigent/server/static/web-ui"
+        # Prevent setup.py from putting the archived SPA back into the wheel.
         export OMNIGENT_SKIP_WEB_UI=true
     fi
 else

--- a/deploy/databricks/build.sh
+++ b/deploy/databricks/build.sh
@@ -3,12 +3,15 @@
 # deployment of Omnigent.
 #
 # Inputs:
-#   SKIP_WEB_UI=1   Skip the web SPA build for API-only deployments.
+#   SKIP_WEB_UI=1         Skip the web SPA build for API-only deployments.
+#   WEB_UI_OUT_NAME=<name> Move the built SPA to dist/<name> instead of leaving
+#                         it in the wheel's package data.
 #
 # Outputs:
 #   dist/omnigent-<version>-py3-none-any.whl
 #   dist/omnigent_client-<version>-py3-none-any.whl
 #   dist/omnigent_ui_sdk-<version>-py3-none-any.whl
+#   dist/$WEB_UI_OUT_NAME/  SPA assets, when WEB_UI_OUT_NAME is set
 
 set -euo pipefail
 
@@ -30,6 +33,20 @@ if [[ "${SKIP_WEB_UI:-}" != "1" ]]; then
     echo "==> Building web SPA into omnigent/server/static/web-ui/"
     pnpm install --frozen-lockfile --filter web
     pnpm --filter web run build
+    if [[ -n "${WEB_UI_OUT_NAME:-}" ]]; then
+        if [[ ! "${WEB_UI_OUT_NAME}" =~ ^[A-Za-z0-9_-]+$ ]]; then
+            echo "ERROR: WEB_UI_OUT_NAME must be a bare directory name matching" \
+                 "[A-Za-z0-9_-]+ (got '${WEB_UI_OUT_NAME}')" >&2
+            exit 1
+        fi
+        mkdir -p "${REPO_ROOT}/dist"
+        web_ui_out_dir="${REPO_ROOT}/dist/${WEB_UI_OUT_NAME}"
+        echo "==> Moving SPA out of the wheel into ${web_ui_out_dir}"
+        rm -rf "${web_ui_out_dir}"
+        mv omnigent/server/static/web-ui "${web_ui_out_dir}"
+        # Prevent setup.py from putting the moved SPA back into the wheel.
+        export OMNIGENT_SKIP_WEB_UI=true
+    fi
 else
     echo "==> SKIP_WEB_UI=1: skipping web build"
 fi

--- a/deploy/databricks/deploy.py
+++ b/deploy/databricks/deploy.py
@@ -39,7 +39,11 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from databricks.sdk import WorkspaceClient
 
-_WORKSPACE_WHEEL_LIMIT_BYTES = 10 * 1024 * 1024
+# Databricks Apps rejects any single source file over 10 MB. Keep wheels and
+# loose SPA assets under the same limit.
+_WORKSPACE_FILE_LIMIT_BYTES = 10 * 1024 * 1024
+_WORKSPACE_WHEEL_LIMIT_BYTES = _WORKSPACE_FILE_LIMIT_BYTES
+_WEB_UI_DIR_NAME = "web-ui"
 _APP_REQUIRES_PYTHON = ">=3.12,<3.13"
 # Public PyPI by default. Set UV_INDEX_URL to lock against a private mirror or
 # proxy instead (see run_uv_lock).
@@ -192,6 +196,11 @@ def _clean_build_artifacts() -> None:
             shutil.rmtree(target)
 
 
+def _dist_web_ui_dir() -> Path:
+    """Return the SPA directory produced outside the Python wheel."""
+    return _repo_root() / "dist" / _WEB_UI_DIR_NAME
+
+
 def _build_wheels(skip_web_ui: bool) -> list[Path]:
     """Invoke build.sh and return the resulting wheel paths."""
     root = _repo_root()
@@ -199,6 +208,11 @@ def _build_wheels(skip_web_ui: bool) -> list[Path]:
     env = os.environ.copy()
     if skip_web_ui:
         env["SKIP_WEB_UI"] = "1"
+        env.pop("WEB_UI_OUT_NAME", None)
+    else:
+        env["WEB_UI_OUT_NAME"] = _WEB_UI_DIR_NAME
+        env.pop("SKIP_WEB_UI", None)
+        env.pop("OMNIGENT_SKIP_WEB_UI", None)
     _log(f"$ {build_sh}" + (" (SKIP_WEB_UI=1)" if skip_web_ui else ""))
     subprocess.run([str(build_sh)], cwd=root, env=env, check=True)
     wheels = sorted((root / "dist").glob("*.whl"))
@@ -295,6 +309,48 @@ def _sweep_local_src_wheels(keep: set[str]) -> None:
             continue
         _log(f"removing stale local wheel {entry.relative_to(_repo_root())}")
         entry.unlink()
+
+
+def _assert_web_ui_files_fit(source: Path) -> None:
+    """Fail before upload if any SPA asset exceeds the source-file cap."""
+    oversize = [
+        path
+        for path in source.rglob("*")
+        if path.is_file() and path.stat().st_size > _WORKSPACE_FILE_LIMIT_BYTES
+    ]
+    if oversize:
+        listing = ", ".join(
+            f"{path.name} ({path.stat().st_size / 1024 / 1024:.2f} MB)" for path in oversize
+        )
+        raise SystemExit(
+            f"SPA asset(s) over the 10 MB Workspace file cap: {listing}. "
+            "Split the chunk in web/, or deploy with --skip-web-ui."
+        )
+
+
+def _sync_src_web_ui(skip_web_ui: bool) -> None:
+    """Copy the built SPA beside app.py so it stays out of the main wheel."""
+    destination = _src_dir() / _WEB_UI_DIR_NAME
+    if destination.exists():
+        shutil.rmtree(destination)
+        _log(f"removed stale {destination.relative_to(_repo_root())}")
+    if skip_web_ui:
+        _log("--skip-web-ui: deploying without the SPA (API-only)")
+        return
+    source = _dist_web_ui_dir()
+    if not (source / "index.html").is_file():
+        raise SystemExit(
+            f"no SPA build at {source}; drop --skip-build to rebuild it, "
+            "or pass --skip-web-ui for an API-only deploy"
+        )
+    _assert_web_ui_files_fit(source)
+    shutil.copytree(source, destination)
+    files = [path for path in destination.rglob("*") if path.is_file()]
+    total_mb = sum(path.stat().st_size for path in files) / 1024 / 1024
+    _log(
+        f"copy SPA → {destination.relative_to(_repo_root())} "
+        f"({len(files)} files, {total_mb:.2f} MB)"
+    )
 
 
 def _toml_string(value: str) -> str:
@@ -851,10 +907,9 @@ def main() -> int:
         _log(f"  {wheel.name}  {size_mb:.2f} MB")
     if classified.oversize:
         raise SystemExit(
-            "uv-based Databricks Apps deploys require all Omnigent wheels "
-            "to fit in the app source snapshot. Rebuild with --skip-web-ui "
-            "or reduce wheel size; UC Volume wheel paths are not used "
-            "because uv lock validates path sources locally."
+            "uv-based Databricks Apps deploys require every Omnigent wheel to "
+            "fit under the 10 MB Workspace file cap. Reduce the Python payload "
+            "or pass --skip-web-ui; the SPA ships outside the wheel."
         )
 
     # Late-import the SDK so `--help` works without it installed.
@@ -871,6 +926,9 @@ def main() -> int:
         dest = src / wheel.name
         _log(f"copy {wheel.name} → {dest.relative_to(_repo_root())}")
         shutil.copy2(wheel, dest)
+
+    # 1a) Keep the SPA as loose source files so no wheel exceeds the cap.
+    _sync_src_web_ui(args.skip_web_ui)
 
     # 2) Generate pyproject.toml + uv.lock. Remove requirements.txt
     # first because Databricks Apps gives it precedence over uv.

--- a/deploy/databricks/deploy.py
+++ b/deploy/databricks/deploy.py
@@ -40,10 +40,11 @@ if TYPE_CHECKING:
     from databricks.sdk import WorkspaceClient
 
 # Databricks Apps rejects any single source file over 10 MB. Keep wheels and
-# loose SPA assets under the same limit.
+# the externalized SPA archive under the same limit.
 _WORKSPACE_FILE_LIMIT_BYTES = 10 * 1024 * 1024
 _WORKSPACE_WHEEL_LIMIT_BYTES = _WORKSPACE_FILE_LIMIT_BYTES
 _WEB_UI_DIR_NAME = "web-ui"
+_WEB_UI_ARCHIVE_NAME = "web-ui.tar.gz"
 _APP_REQUIRES_PYTHON = ">=3.12,<3.13"
 # Public PyPI by default. Set UV_INDEX_URL to lock against a private mirror or
 # proxy instead (see run_uv_lock).
@@ -196,9 +197,9 @@ def _clean_build_artifacts() -> None:
             shutil.rmtree(target)
 
 
-def _dist_web_ui_dir() -> Path:
-    """Return the SPA directory produced outside the Python wheel."""
-    return _repo_root() / "dist" / _WEB_UI_DIR_NAME
+def _dist_web_ui_archive() -> Path:
+    """Return the SPA archive produced outside the Python wheel."""
+    return _repo_root() / "dist" / _WEB_UI_ARCHIVE_NAME
 
 
 def _build_wheels(skip_web_ui: bool) -> list[Path]:
@@ -208,12 +209,15 @@ def _build_wheels(skip_web_ui: bool) -> list[Path]:
     env = os.environ.copy()
     if skip_web_ui:
         env["SKIP_WEB_UI"] = "1"
-        env.pop("WEB_UI_OUT_NAME", None)
+        env.pop("EXTERNALIZE_WEB_UI", None)
     else:
-        env["WEB_UI_OUT_NAME"] = _WEB_UI_DIR_NAME
+        # Keep the SPA out of the wheel: bundled it takes the main wheel over
+        # the 10 MB Workspace per-file cap. build.sh writes a fixed archive,
+        # so no caller-controlled path reaches rm or mv.
+        env["EXTERNALIZE_WEB_UI"] = "1"
         env.pop("SKIP_WEB_UI", None)
         env.pop("OMNIGENT_SKIP_WEB_UI", None)
-    _log(f"$ {build_sh}" + (" (SKIP_WEB_UI=1)" if skip_web_ui else ""))
+    _log(f"$ {build_sh}" + (" (SKIP_WEB_UI=1)" if skip_web_ui else " (EXTERNALIZE_WEB_UI=1)"))
     subprocess.run([str(build_sh)], cwd=root, env=env, check=True)
     wheels = sorted((root / "dist").glob("*.whl"))
     if not wheels:
@@ -311,46 +315,59 @@ def _sweep_local_src_wheels(keep: set[str]) -> None:
         entry.unlink()
 
 
-def _assert_web_ui_files_fit(source: Path) -> None:
-    """Fail before upload if any SPA asset exceeds the source-file cap."""
-    oversize = [
-        path
-        for path in source.rglob("*")
-        if path.is_file() and path.stat().st_size > _WORKSPACE_FILE_LIMIT_BYTES
-    ]
-    if oversize:
-        listing = ", ".join(
-            f"{path.name} ({path.stat().st_size / 1024 / 1024:.2f} MB)" for path in oversize
-        )
-        raise SystemExit(
-            f"SPA asset(s) over the 10 MB Workspace file cap: {listing}. "
-            "Split the chunk in web/, or deploy with --skip-web-ui."
-        )
+def _stage_web_ui(skip_web_ui: bool) -> Path | None:
+    """Copy the externalized SPA archive into the app source directory.
 
+    A previous version staged the SPA as hundreds of loose files. The archive
+    keeps the same source-code sync path while reducing the Workspace upload
+    round-trips to one file. ``src/app.py`` extracts it before importing the
+    server and points ``OMNIGENT_WEB_UI_DIST`` at the extracted directory.
+    """
+    src = _src_dir()
+    stale_dir = src / _WEB_UI_DIR_NAME
+    if stale_dir.exists():
+        shutil.rmtree(stale_dir)
+        _log(f"removed stale {stale_dir.relative_to(_repo_root())}")
 
-def _sync_src_web_ui(skip_web_ui: bool) -> None:
-    """Copy the built SPA beside app.py so it stays out of the main wheel."""
-    destination = _src_dir() / _WEB_UI_DIR_NAME
+    destination = src / _WEB_UI_ARCHIVE_NAME
     if destination.exists():
-        shutil.rmtree(destination)
-        _log(f"removed stale {destination.relative_to(_repo_root())}")
+        if destination.is_dir():
+            shutil.rmtree(destination)
+        else:
+            destination.unlink()
+
     if skip_web_ui:
         _log("--skip-web-ui: deploying without the SPA (API-only)")
-        return
-    source = _dist_web_ui_dir()
-    if not (source / "index.html").is_file():
-        raise SystemExit(
-            f"no SPA build at {source}; drop --skip-build to rebuild it, "
-            "or pass --skip-web-ui for an API-only deploy"
-        )
-    _assert_web_ui_files_fit(source)
-    shutil.copytree(source, destination)
-    files = [path for path in destination.rglob("*") if path.is_file()]
-    total_mb = sum(path.stat().st_size for path in files) / 1024 / 1024
+        return None
+
+    source = _dist_web_ui_archive()
+    if not source.is_file():
+        _log(f"no externalized SPA at {source.relative_to(_repo_root())}; skipping web UI staging")
+        return None
+
+    shutil.copy2(source, destination)
     _log(
-        f"copy SPA → {destination.relative_to(_repo_root())} "
-        f"({len(files)} files, {total_mb:.2f} MB)"
+        f"copy SPA archive {source.relative_to(_repo_root())} → "
+        f"{destination.relative_to(_repo_root())}"
     )
+    return destination
+
+
+def _assert_app_files_under_limit() -> None:
+    """Fail before upload if any app source file exceeds the Workspace cap."""
+    src = _src_dir()
+    offenders = [
+        (path, path.stat().st_size)
+        for path in src.rglob("*")
+        if path.is_file() and path.stat().st_size > _WORKSPACE_FILE_LIMIT_BYTES
+    ]
+    if offenders:
+        listing = ", ".join(
+            f"{path.relative_to(src)} ({size / 1024 / 1024:.2f} MB)" for path, size in offenders
+        )
+        raise SystemExit(
+            f"app source files exceed the Databricks Apps 10 MB per-file cap: {listing}"
+        )
 
 
 def _toml_string(value: str) -> str:
@@ -927,8 +944,9 @@ def main() -> int:
         _log(f"copy {wheel.name} → {dest.relative_to(_repo_root())}")
         shutil.copy2(wheel, dest)
 
-    # 1a) Keep the SPA as loose source files so no wheel exceeds the cap.
-    _sync_src_web_ui(args.skip_web_ui)
+    # 1a) Ship the SPA as one archive beside app.py so no wheel exceeds the
+    # cap and Databricks does not sync hundreds of individual UI files.
+    _stage_web_ui(args.skip_web_ui)
 
     # 2) Generate pyproject.toml + uv.lock. Remove requirements.txt
     # first because Databricks Apps gives it precedence over uv.
@@ -939,6 +957,9 @@ def main() -> int:
         classified.oversize,
         deploy_version,
     )
+
+    # 3) Guard every uploaded source file before touching the workspace.
+    _assert_app_files_under_limit()
 
     # 4) Bind the bundle to the existing app (if any).
     _ensure_bound(args)

--- a/deploy/databricks/src/app.py
+++ b/deploy/databricks/src/app.py
@@ -14,6 +14,8 @@ import time
 import traceback
 from pathlib import Path as _Path
 
+from web_ui_archive import extract_web_ui_archive as _extract_web_ui_archive
+
 logging.basicConfig(level=logging.INFO, stream=sys.stderr, force=True)
 logger = logging.getLogger("omnigent-app")
 
@@ -23,33 +25,6 @@ logger = logging.getLogger("omnigent-app")
 # point. Extract it before importing omnigent.server.app, which binds the
 # static-file directory at module import time. A loose directory is supported
 # for compatibility with deployments made by the earlier packaging scheme.
-_WEB_UI_MAX_MEMBERS = 4096
-_WEB_UI_MAX_MEMBER_BYTES = 10 * 1024 * 1024
-_WEB_UI_MAX_EXTRACTED_BYTES = 100 * 1024 * 1024
-
-
-def _extract_web_ui_archive(archive: _Path, destination: _Path) -> None:
-    """Safely extract a bounded web UI archive into ``destination``."""
-    import tarfile as _tarfile
-
-    with _tarfile.open(archive, "r:gz") as tar:
-        members = []
-        total_size = 0
-        # Iterate headers and validate each one before advancing over its data.
-        # This rejects a single large member before reading its compressed body.
-        for member in tar:
-            members.append(member)
-            if len(members) > _WEB_UI_MAX_MEMBERS:
-                raise ValueError(f"archive has too many members ({len(members)})")
-            if member.isfile():
-                if member.size < 0 or member.size > _WEB_UI_MAX_MEMBER_BYTES:
-                    raise ValueError("archive contains a file over the 10 MB limit")
-                total_size += member.size
-                if total_size > _WEB_UI_MAX_EXTRACTED_BYTES:
-                    raise ValueError("archive expands beyond the web UI size limit")
-        # The data filter rejects absolute paths, traversal, links, and special
-        # files that could escape or mutate state outside the extraction root.
-        tar.extractall(destination, members=members, filter="data")
 
 
 def _prepare_web_ui() -> None:

--- a/deploy/databricks/src/app.py
+++ b/deploy/databricks/src/app.py
@@ -12,9 +12,75 @@ import sys
 import threading
 import time
 import traceback
+from pathlib import Path as _Path
 
 logging.basicConfig(level=logging.INFO, stream=sys.stderr, force=True)
 logger = logging.getLogger("omnigent-app")
+
+# ── Web UI location ────────────────────────────────────────
+#
+# The deploy ships the SPA outside the wheel as one archive beside this entry
+# point. Extract it before importing omnigent.server.app, which binds the
+# static-file directory at module import time. A loose directory is supported
+# for compatibility with deployments made by the earlier packaging scheme.
+_WEB_UI_MAX_MEMBERS = 4096
+_WEB_UI_MAX_MEMBER_BYTES = 10 * 1024 * 1024
+_WEB_UI_MAX_EXTRACTED_BYTES = 100 * 1024 * 1024
+
+
+def _extract_web_ui_archive(archive: _Path, destination: _Path) -> None:
+    """Safely extract a bounded web UI archive into ``destination``."""
+    import tarfile as _tarfile
+
+    with _tarfile.open(archive, "r:gz") as tar:
+        members = []
+        total_size = 0
+        # Iterate headers and validate each one before advancing over its data.
+        # This rejects a single large member before reading its compressed body.
+        for member in tar:
+            members.append(member)
+            if len(members) > _WEB_UI_MAX_MEMBERS:
+                raise ValueError(f"archive has too many members ({len(members)})")
+            if member.isfile():
+                if member.size < 0 or member.size > _WEB_UI_MAX_MEMBER_BYTES:
+                    raise ValueError("archive contains a file over the 10 MB limit")
+                total_size += member.size
+                if total_size > _WEB_UI_MAX_EXTRACTED_BYTES:
+                    raise ValueError("archive expands beyond the web UI size limit")
+        # The data filter rejects absolute paths, traversal, links, and special
+        # files that could escape or mutate state outside the extraction root.
+        tar.extractall(destination, members=members, filter="data")
+
+
+def _prepare_web_ui() -> None:
+    import shutil as _shutil
+    import tarfile as _tarfile
+    import tempfile as _tempfile
+
+    here = _Path(__file__).resolve().parent
+    archive = here / "web-ui.tar.gz"
+    loose = here / "web-ui"
+    if loose.is_dir() and not archive.is_file():
+        os.environ.setdefault("OMNIGENT_WEB_UI_DIST", str(loose))
+        logger.info("Web UI: serving legacy loose assets from %s", loose)
+        return
+    if not archive.is_file():
+        logger.info("Web UI: no archive at %s; using packaged assets", archive)
+        return
+
+    extracted = _Path(_tempfile.mkdtemp(prefix="omnigent-web-ui-"))
+    try:
+        _extract_web_ui_archive(archive, extracted)
+    except (OSError, ValueError, _tarfile.TarError) as exc:
+        _shutil.rmtree(extracted, ignore_errors=True)
+        logger.warning("Web UI: failed to extract %s: %s; using packaged assets", archive, exc)
+        return
+
+    os.environ.setdefault("OMNIGENT_WEB_UI_DIST", str(extracted))
+    logger.info("Web UI: serving extracted assets from %s", extracted)
+
+
+_prepare_web_ui()
 
 # ── Lakebase token cache ──────────────────────────────────
 #
@@ -120,16 +186,6 @@ try:
     # ── Start omnigent ─────────────────────────────────────
 
     import tempfile
-    from pathlib import Path
-
-    # The deploy keeps the SPA as loose files beside app.py because the
-    # packaged assets exceed the Workspace per-file limit.
-    _WEB_UI_DIST = Path(__file__).parent / "web-ui"
-    if (_WEB_UI_DIST / "index.html").is_file():
-        os.environ.setdefault("OMNIGENT_WEB_UI_DIST", str(_WEB_UI_DIST))
-        logger.info("Web UI: serving loose assets from %s", _WEB_UI_DIST)
-    else:
-        logger.info("Web UI: no loose assets at %s; using packaged assets")
 
     import uvicorn
 
@@ -171,7 +227,7 @@ try:
 
     DB_URI = f"postgresql+psycopg://{PGUSER}@{PGHOST}:{PGPORT}/{PGDATABASE}"
     ARTIFACT_URI = f"dbfs:{VOLUME_PATH}"
-    CACHE_DIR = Path(tempfile.mkdtemp(prefix="ap_cache_"))
+    CACHE_DIR = _Path(tempfile.mkdtemp(prefix="ap_cache_"))
 
     logger.info("DB_URI: %s", DB_URI[:80])
     logger.info("ARTIFACT_URI: %s", ARTIFACT_URI)

--- a/deploy/databricks/src/app.py
+++ b/deploy/databricks/src/app.py
@@ -122,6 +122,15 @@ try:
     import tempfile
     from pathlib import Path
 
+    # The deploy keeps the SPA as loose files beside app.py because the
+    # packaged assets exceed the Workspace per-file limit.
+    _WEB_UI_DIST = Path(__file__).parent / "web-ui"
+    if (_WEB_UI_DIST / "index.html").is_file():
+        os.environ.setdefault("OMNIGENT_WEB_UI_DIST", str(_WEB_UI_DIST))
+        logger.info("Web UI: serving loose assets from %s", _WEB_UI_DIST)
+    else:
+        logger.info("Web UI: no loose assets at %s; using packaged assets")
+
     import uvicorn
 
     from omnigent.runtime import init as init_runtime

--- a/deploy/databricks/src/web_ui_archive.py
+++ b/deploy/databricks/src/web_ui_archive.py
@@ -1,0 +1,34 @@
+"""Safe extraction for the Databricks Apps web UI archive."""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+# These bounds apply after gzip expansion. The compressed archive is separately
+# checked against Databricks Apps' 10 MiB source-file limit by deploy.py.
+MAX_MEMBERS = 4096
+MAX_MEMBER_BYTES = 10 * 1024 * 1024
+MAX_EXTRACTED_BYTES = 100 * 1024 * 1024
+
+
+def extract_web_ui_archive(archive: Path, destination: Path) -> None:
+    """Safely extract a bounded web UI archive into ``destination``."""
+    with tarfile.open(archive, "r:gz") as tar:
+        members = []
+        total_size = 0
+        # Iterate headers and validate each one before advancing over its data.
+        # This rejects a single large member before reading its compressed body.
+        for member in tar:
+            members.append(member)
+            if len(members) > MAX_MEMBERS:
+                raise ValueError(f"archive has too many members ({len(members)})")
+            if member.isfile():
+                if member.size < 0 or member.size > MAX_MEMBER_BYTES:
+                    raise ValueError("archive contains a file over the 10 MB limit")
+                total_size += member.size
+                if total_size > MAX_EXTRACTED_BYTES:
+                    raise ValueError("archive expands beyond the web UI size limit")
+        # The data filter rejects absolute paths, traversal, links, and special
+        # files that could escape or mutate state outside the extraction root.
+        tar.extractall(destination, members=members, filter="data")

--- a/tests/deploy/test_databricks_web_ui.py
+++ b/tests/deploy/test_databricks_web_ui.py
@@ -4,8 +4,8 @@ Databricks Apps uploads the app source directory as Workspace files, and the
 Workspace import API rejects any single file over 10 MB. The built SPA is ~25 MB
 of assets, which takes the main wheel over that cap and fails the deploy before
 anything is uploaded. So ``build.sh`` moves the SPA out of the wheel's package
-data and the deploy ships it as loose files in ``src/web-ui/``, which
-``src/app.py`` points the server at via ``OMNIGENT_WEB_UI_DIST``.
+data and the deploy ships it as one archive in ``src/web-ui.tar.gz``, which
+``src/app.py`` extracts and points the server at via ``OMNIGENT_WEB_UI_DIST``.
 
 These tests pin each link in that chain, including the env var itself — the
 server reads it at import time, so it is checked in a subprocess.
@@ -13,11 +13,14 @@ server reads it at import time, so it is checked in a subprocess.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
+import io
 import os
 import shutil
 import subprocess
 import sys
+import tarfile
 from pathlib import Path
 from types import ModuleType
 
@@ -48,6 +51,43 @@ def _make_spa(root: Path, *, asset_bytes: int = 32) -> Path:
     return spa
 
 
+def _make_spa_archive(root: Path, *, asset_bytes: int = 32) -> Path:
+    spa = _make_spa(root, asset_bytes=asset_bytes)
+    archive = root / "web-ui.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        for path in spa.rglob("*"):
+            tar.add(path, arcname=path.relative_to(spa))
+    shutil.rmtree(spa)
+    return archive
+
+
+def _load_archive_extractor():
+    """Load the side-effect-free archive helper without starting the app."""
+    tree = ast.parse(_APP_PY.read_text())
+    constant_names = {
+        "_WEB_UI_MAX_MEMBERS",
+        "_WEB_UI_MAX_MEMBER_BYTES",
+        "_WEB_UI_MAX_EXTRACTED_BYTES",
+    }
+    nodes = [
+        node
+        for node in tree.body
+        if (
+            (isinstance(node, ast.FunctionDef) and node.name == "_extract_web_ui_archive")
+            or (
+                isinstance(node, ast.Assign)
+                and any(
+                    isinstance(target, ast.Name) and target.id in constant_names
+                    for target in node.targets
+                )
+            )
+        )
+    ]
+    namespace = {"_Path": Path}
+    exec(compile(ast.Module(body=nodes, type_ignores=[]), str(_APP_PY), "exec"), namespace)
+    return namespace["_extract_web_ui_archive"], namespace
+
+
 def test_server_honours_web_ui_dist_env(tmp_path: Path) -> None:
     """The whole scheme hinges on OMNIGENT_WEB_UI_DIST being respected."""
     spa = _make_spa(tmp_path)
@@ -63,27 +103,105 @@ def test_server_honours_web_ui_dist_env(tmp_path: Path) -> None:
     assert out.stdout.strip() == str(spa)
 
 
-def test_app_py_points_server_at_loose_assets_before_importing_it() -> None:
-    """The path is read at import time, so the setup must come first."""
+def test_app_py_extracts_web_ui_before_importing_server() -> None:
+    """The extracted path is read at import time, so setup must come first."""
     source = _APP_PY.read_text()
-    setup_at = source.index('os.environ.setdefault("OMNIGENT_WEB_UI_DIST"')
+    prepare_at = source.rindex("_prepare_web_ui()")
     import_at = source.index("from omnigent.server.app import create_app")
-    assert setup_at < import_at, "OMNIGENT_WEB_UI_DIST is set too late to take effect"
-    assert 'Path(__file__).parent / "web-ui"' in source
+    assert prepare_at < import_at, "web UI setup is too late to take effect"
+    assert 'archive = here / "web-ui.tar.gz"' in source
+    assert 'tar.extractall(destination, members=members, filter="data")' in source
+    assert "getmembers()" not in source
+    assert 'loose = here / "web-ui"' in source
 
 
-def test_build_sh_moves_spa_out_of_the_wheel() -> None:
+def test_app_extractor_extracts_normal_archive(tmp_path: Path) -> None:
+    extractor, _ = _load_archive_extractor()
+    archive = _make_spa_archive(tmp_path)
+    destination = tmp_path / "extracted"
+    destination.mkdir()
+
+    extractor(archive, destination)
+
+    assert (destination / "index.html").is_file()
+    assert (destination / "assets" / "index-abc123.js").is_file()
+
+
+def test_app_extractor_rejects_oversize_expansion_before_writing(tmp_path: Path) -> None:
+    extractor, namespace = _load_archive_extractor()
+    archive = tmp_path / "web-ui.tar.gz"
+    payload = b"x" * (namespace["_WEB_UI_MAX_MEMBER_BYTES"] + 1)
+    info = tarfile.TarInfo("assets/bomb.js")
+    info.size = len(payload)
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.addfile(info, io.BytesIO(payload))
+    destination = tmp_path / "extracted"
+    destination.mkdir()
+
+    with pytest.raises(ValueError, match="10 MB limit"):
+        extractor(archive, destination)
+    assert not any(destination.iterdir())
+
+
+def test_app_extractor_rejects_aggregate_expansion_before_writing(tmp_path: Path) -> None:
+    extractor, namespace = _load_archive_extractor()
+    archive = tmp_path / "web-ui.tar.gz"
+    member_bytes = 1024 * 1024
+    member_count = namespace["_WEB_UI_MAX_EXTRACTED_BYTES"] // member_bytes + 1
+    with tarfile.open(archive, "w:gz") as tar:
+        for index in range(member_count):
+            info = tarfile.TarInfo(f"assets/chunk-{index}.js")
+            info.size = member_bytes
+            tar.addfile(info, io.BytesIO(b"x" * member_bytes))
+    destination = tmp_path / "extracted"
+    destination.mkdir()
+
+    with pytest.raises(ValueError, match="web UI size limit"):
+        extractor(archive, destination)
+    assert not any(destination.iterdir())
+
+
+def test_app_extractor_rejects_too_many_members_before_writing(tmp_path: Path) -> None:
+    extractor, namespace = _load_archive_extractor()
+    archive = tmp_path / "web-ui.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        for index in range(namespace["_WEB_UI_MAX_MEMBERS"] + 1):
+            tar.addfile(tarfile.TarInfo(f"assets/chunk-{index}.js"))
+    destination = tmp_path / "extracted"
+    destination.mkdir()
+
+    with pytest.raises(ValueError, match="too many members"):
+        extractor(archive, destination)
+    assert not any(destination.iterdir())
+
+
+def test_app_extractor_rejects_traversal(tmp_path: Path) -> None:
+    extractor, _ = _load_archive_extractor()
+    archive = tmp_path / "web-ui.tar.gz"
+    info = tarfile.TarInfo("../escaped.js")
+    info.size = 1
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.addfile(info, io.BytesIO(b"x"))
+    destination = tmp_path / "extracted"
+    destination.mkdir()
+
+    with pytest.raises(tarfile.FilterError):
+        extractor(archive, destination)
+    assert not (tmp_path / "escaped.js").exists()
+
+
+def test_build_sh_archives_spa_out_of_the_wheel() -> None:
     source = _BUILD_SH.read_text()
-    assert 'mv omnigent/server/static/web-ui "${web_ui_out_dir}"' in source
-    # The move has to happen while the SPA build is in scope, before uv build.
-    assert source.index("WEB_UI_OUT_NAME") < source.index("uv build --wheel --out-dir dist/ .")
+    assert 'tar -czf "${REPO_ROOT}/dist/web-ui.tar.gz"' in source
+    # The archive has to be created while the SPA build is in scope, before uv build.
+    assert source.index("EXTERNALIZE_WEB_UI") < source.index("uv build --wheel --out-dir dist/ .")
 
 
 def test_build_sh_opts_the_backend_out_of_rebuilding_the_spa() -> None:
     """setup.py rebuilds the SPA into the package when the bundle is missing.
 
     Without the opt-out it puts the assets straight back into the wheel, undoing
-    the move, so the export has to land before any wheel build.
+    the archive, so the externalization has to happen before any wheel build.
     """
     source = _BUILD_SH.read_text()
     assert "export OMNIGENT_SKIP_WEB_UI=true" in source
@@ -92,10 +210,10 @@ def test_build_sh_opts_the_backend_out_of_rebuilding_the_spa() -> None:
     )
 
 
-def test_build_sh_moves_the_spa_and_opts_out_when_run_for_real(tmp_path: Path) -> None:
+def test_build_sh_archives_the_spa_and_opts_out_when_run_for_real(tmp_path: Path) -> None:
     """Execute the real script with fake ``pnpm``/``uv`` and check both effects.
 
-    Text assertions cannot show that the move and the opt-out actually happen
+    Text assertions cannot show that the archive and the opt-out happen
     together on the full-UI path, which is the whole invariant: the SPA ends up
     outside the wheel *and* the wheel hook does not put it back.
     """
@@ -126,14 +244,12 @@ def test_build_sh_moves_the_spa_and_opts_out_when_run_for_real(tmp_path: Path) -
         "touch dist/fake.whl\n",
     )
 
-    # The same location deploy.py passes: <repo>/dist/web-ui.
-    out_dir = repo / "dist" / "web-ui"
     env = os.environ.copy()
     env.update(
         {
             "COMMAND_LOG": str(command_log),
             "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
-            "WEB_UI_OUT_NAME": out_dir.name,
+            "EXTERNALIZE_WEB_UI": "1",
         }
     )
     env.pop("OMNIGENT_SKIP_WEB_UI", None)
@@ -141,9 +257,12 @@ def test_build_sh_moves_the_spa_and_opts_out_when_run_for_real(tmp_path: Path) -
 
     subprocess.run(["bash", str(script)], cwd=repo, env=env, check=True)
 
-    # The SPA moved out of the package tree and into dist/<WEB_UI_OUT_NAME>.
-    assert (out_dir / "index.html").is_file()
-    assert (out_dir / "assets" / "index-abc.js").is_file()
+    # The SPA moved out of the package tree into one archive.
+    archive = repo / "dist" / "web-ui.tar.gz"
+    assert archive.is_file()
+    with tarfile.open(archive, "r:gz") as tar:
+        names = {name.lstrip("./") for name in tar.getnames()}
+        assert {"assets/index-abc.js", "index.html"} <= names
     assert not (repo / "omnigent" / "server" / "static" / "web-ui").exists()
 
     # And every wheel build saw the opt-out, so setup.py cannot rebuild it back in.
@@ -152,80 +271,19 @@ def test_build_sh_moves_the_spa_and_opts_out_when_run_for_real(tmp_path: Path) -
     assert all(call.split("|", 2)[1] == "true" for call in uv_calls), uv_calls
 
 
-@pytest.mark.parametrize(
-    "out_name",
-    [
-        pytest.param("../../precious", id="parent-traversal"),
-        pytest.param("web-ui/../../../precious", id="traversal-after-a-valid-prefix"),
-        pytest.param("..", id="dot-dot"),
-        pytest.param(".", id="dot"),
-        pytest.param("/", id="the-filesystem-root"),
-        pytest.param("/tmp", id="an-absolute-path"),
-        pytest.param("nested/name", id="a-nested-path"),
-        pytest.param("name with spaces", id="whitespace"),
-        pytest.param("name;rm -rf /", id="shell-metacharacters"),
-        pytest.param("$HOME", id="an-expansion-attempt"),
-    ],
-)
-def test_build_sh_refuses_a_web_ui_out_name_that_is_not_a_bare_name(
-    tmp_path: Path, out_name: str
-) -> None:
-    """The move destination is ``rm -rf``'d, so only a bare name is accepted.
-
-    A caller-supplied *path* can escape the repo through ``..`` or a symlink no
-    matter how it is string-matched — a lexical prefix check on
-    ``<repo>/dist/...`` passes ``<repo>/dist/../../home``. Accepting only a name
-    that cannot contain ``/`` or ``.`` removes the entire class: the script
-    anchors it under its own freshly created ``dist/``.
-
-    The script must refuse, exit non-zero, and leave everything untouched.
-    """
-    repo = tmp_path / "repo"
-    script = repo / "deploy" / "databricks" / "build.sh"
-    script.parent.mkdir(parents=True)
-    shutil.copyfile(_BUILD_SH, script)
-
-    precious = tmp_path / "precious"
-    precious.mkdir()
-    (precious / "important.txt").write_text("IRREPLACEABLE")
-    (repo / "omnigent").mkdir()
-    (repo / "omnigent" / "__init__.py").write_text("# source")
-
-    fake_bin = tmp_path / "bin"
-    fake_bin.mkdir()
-    _write_executable(
-        fake_bin / "pnpm",
-        "#!/usr/bin/env bash\n"
-        'if [[ "$*" == *"run build"* ]]; then\n'
-        "  mkdir -p omnigent/server/static/web-ui\n"
-        '  echo "<html></html>" > omnigent/server/static/web-ui/index.html\n'
-        "fi\n",
-    )
-    _write_executable(fake_bin / "uv", "#!/usr/bin/env bash\nmkdir -p dist\ntouch dist/f.whl\n")
-
-    env = os.environ.copy()
-    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
-    env["WEB_UI_OUT_NAME"] = out_name
-    env.pop("OMNIGENT_SKIP_WEB_UI", None)
-    env.pop("SKIP_WEB_UI", None)
-    env.pop("WEB_UI_OUT_DIR", None)
-
-    result = subprocess.run(
-        ["bash", str(script)], cwd=repo, env=env, capture_output=True, text=True, check=False
-    )
-
-    assert result.returncode != 0, result.stdout
-    assert "WEB_UI_OUT_NAME must be a bare directory name" in result.stderr
-    # Nothing outside dist/ was touched.
-    assert (precious / "important.txt").read_text() == "IRREPLACEABLE"
-    assert (repo / "omnigent" / "__init__.py").is_file()
+def test_build_sh_uses_a_fixed_archive_destination() -> None:
+    """The archive path is fixed, so no caller-controlled path is destructive."""
+    source = _BUILD_SH.read_text()
+    assert "dist/web-ui.tar.gz" in source
+    assert 'rm -rf "${REPO_ROOT}/dist/web-ui" "${REPO_ROOT}/dist/web-ui.tar.gz"' in source
+    assert "WEB_UI_OUT_NAME" not in source
 
 
-def test_build_sh_leaves_the_spa_in_the_wheel_without_web_ui_out_dir(tmp_path: Path) -> None:
-    """The move is opt-in: an ordinary build is byte-for-byte unaffected.
+def test_build_sh_leaves_the_spa_in_the_wheel_without_externalize(tmp_path: Path) -> None:
+    """Externalization is opt-in: an ordinary build is unchanged.
 
-    Without ``WEB_UI_OUT_NAME`` the SPA stays in the package tree and the wheel
-    hook is *not* opted out, so a plain ``build.sh`` behaves exactly as on main.
+    Without ``EXTERNALIZE_WEB_UI`` the SPA stays in the package tree and the
+    wheel hook is not opted out, so a plain ``build.sh`` behaves as on main.
     """
     repo = tmp_path / "repo"
     script = repo / "deploy" / "databricks" / "build.sh"
@@ -255,7 +313,7 @@ def test_build_sh_leaves_the_spa_in_the_wheel_without_web_ui_out_dir(tmp_path: P
     env.update({"COMMAND_LOG": str(command_log), "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}"})
     env.pop("OMNIGENT_SKIP_WEB_UI", None)
     env.pop("SKIP_WEB_UI", None)
-    env.pop("WEB_UI_OUT_NAME", None)
+    env.pop("EXTERNALIZE_WEB_UI", None)
 
     subprocess.run(["bash", str(script)], cwd=repo, env=env, check=True)
 
@@ -275,7 +333,7 @@ def test_setup_py_honours_the_web_ui_opt_out() -> None:
     assert 'os.environ.get("OMNIGENT_SKIP_WEB_UI") == "true"' in source
 
 
-def test_build_wheels_requests_the_spa_outside_the_wheel(
+def test_build_wheels_requests_the_spa_archive_outside_the_wheel(
     deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     captured: dict[str, str] = {}
@@ -289,13 +347,13 @@ def test_build_wheels_requests_the_spa_outside_the_wheel(
     monkeypatch.setattr(deploy_mod.subprocess, "run", fake_run)
 
     deploy_mod._build_wheels(skip_web_ui=False)
-    assert captured["WEB_UI_OUT_NAME"] == "web-ui"
+    assert captured["EXTERNALIZE_WEB_UI"] == "1"
     assert "SKIP_WEB_UI" not in captured
 
     captured.clear()
     deploy_mod._build_wheels(skip_web_ui=True)
     assert captured["SKIP_WEB_UI"] == "1"
-    assert "WEB_UI_OUT_NAME" not in captured
+    assert "EXTERNALIZE_WEB_UI" not in captured
 
 
 def test_build_wheels_mode_ignores_the_ambient_environment(
@@ -306,8 +364,8 @@ def test_build_wheels_mode_ignores_the_ambient_environment(
     An ambient ``SKIP_WEB_UI=1`` left over from an earlier API-only build would
     otherwise be inherited through ``os.environ.copy()`` and make ``build.sh``
     skip the SPA for a deploy that explicitly asked to include it. The mirror
-    case matters too: a stale ``WEB_UI_OUT_NAME`` must not make an API-only build
-    try to move a bundle that was never built.
+    case matters too: a stale ``EXTERNALIZE_WEB_UI`` must not make an API-only
+    build try to package a bundle that was never built.
     """
     captured: dict[str, str] = {}
 
@@ -320,92 +378,104 @@ def test_build_wheels_mode_ignores_the_ambient_environment(
     monkeypatch.setattr(deploy_mod.subprocess, "run", fake_run)
 
     monkeypatch.setenv("SKIP_WEB_UI", "1")
-    monkeypatch.setenv("WEB_UI_OUT_NAME", "stale")
+    monkeypatch.setenv("EXTERNALIZE_WEB_UI", "stale")
 
     deploy_mod._build_wheels(skip_web_ui=False)
     assert "SKIP_WEB_UI" not in captured
-    assert captured["WEB_UI_OUT_NAME"] == "web-ui"
+    assert captured["EXTERNALIZE_WEB_UI"] == "1"
 
     captured.clear()
     deploy_mod._build_wheels(skip_web_ui=True)
     assert captured["SKIP_WEB_UI"] == "1"
-    assert "WEB_UI_OUT_NAME" not in captured
+    assert "EXTERNALIZE_WEB_UI" not in captured
 
 
-def test_sync_src_web_ui_copies_build_into_app_source(
+def test_stage_web_ui_copies_archive(
     deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     dist = tmp_path / "dist"
     dist.mkdir()
-    _make_spa(dist)
+    archive = _make_spa_archive(dist)
     src = tmp_path / "deploy" / "databricks" / "src"
     src.mkdir(parents=True)
     monkeypatch.setattr(deploy_mod, "_repo_root", lambda: tmp_path)
     monkeypatch.setattr(deploy_mod, "_src_dir", lambda: src)
 
-    deploy_mod._sync_src_web_ui(skip_web_ui=False)
+    staged = deploy_mod._stage_web_ui(skip_web_ui=False)
 
-    assert (src / "web-ui" / "index.html").is_file()
-    assert (src / "web-ui" / "assets" / "index-abc123.js").is_file()
+    assert staged == src / "web-ui.tar.gz"
+    assert staged is not None and staged.read_bytes() == archive.read_bytes()
 
 
-def test_sync_src_web_ui_replaces_a_stale_copy(
+def test_stage_web_ui_replaces_a_stale_loose_copy(
     deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Vite emits hashed chunk names; stale assets must not accumulate."""
+    """A prior loose deployment must not leave orphaned chunks behind."""
     dist = tmp_path / "dist"
     dist.mkdir()
-    _make_spa(dist)
+    archive = _make_spa_archive(dist)
     src = tmp_path / "src"
     (src / "web-ui" / "assets").mkdir(parents=True)
     (src / "web-ui" / "assets" / "index-STALE.js").write_text("old")
     monkeypatch.setattr(deploy_mod, "_repo_root", lambda: tmp_path)
     monkeypatch.setattr(deploy_mod, "_src_dir", lambda: src)
 
-    deploy_mod._sync_src_web_ui(skip_web_ui=False)
+    deploy_mod._stage_web_ui(skip_web_ui=False)
 
-    assert not (src / "web-ui" / "assets" / "index-STALE.js").exists()
-    assert (src / "web-ui" / "assets" / "index-abc123.js").is_file()
+    assert not (src / "web-ui").exists()
+    assert (src / "web-ui.tar.gz").read_bytes() == archive.read_bytes()
 
 
-def test_sync_src_web_ui_skip_web_ui_clears_assets(
+def test_stage_web_ui_skip_web_ui_clears_assets(
     deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """An API-only deploy must not leave a previous SPA behind."""
     src = tmp_path / "src"
-    _make_spa(src)
+    src.mkdir()
+    _make_spa_archive(tmp_path / "dist")
+    (src / "web-ui").mkdir()
+    (src / "web-ui.tar.gz").write_bytes(b"stale")
     monkeypatch.setattr(deploy_mod, "_repo_root", lambda: tmp_path)
     monkeypatch.setattr(deploy_mod, "_src_dir", lambda: src)
 
-    deploy_mod._sync_src_web_ui(skip_web_ui=True)
+    # Even if --skip-build leaves an old archive in dist/, API-only staging
+    # must clear both forms from the app source and not copy it back.
+    assert deploy_mod._dist_web_ui_archive() == tmp_path / "dist" / "web-ui.tar.gz"
+    deploy_mod._stage_web_ui(skip_web_ui=True)
 
     assert not (src / "web-ui").exists()
+    assert not (src / "web-ui.tar.gz").exists()
 
 
-def test_sync_src_web_ui_requires_a_build(
+def test_stage_web_ui_requires_a_build(
     deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    (tmp_path / "dist").mkdir()
     src = tmp_path / "src"
     src.mkdir()
     monkeypatch.setattr(deploy_mod, "_repo_root", lambda: tmp_path)
     monkeypatch.setattr(deploy_mod, "_src_dir", lambda: src)
 
-    with pytest.raises(SystemExit, match="no SPA build at"):
-        deploy_mod._sync_src_web_ui(skip_web_ui=False)
+    assert deploy_mod._stage_web_ui(skip_web_ui=False) is None
 
 
-def test_oversize_asset_fails_before_upload(
+def test_oversize_archive_fails_before_upload(
     deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """A single Vite chunk over 10 MB would be rejected by the Workspace."""
+    """The uploaded archive itself must stay under the Workspace file cap."""
     dist = tmp_path / "dist"
     dist.mkdir()
-    _make_spa(dist, asset_bytes=deploy_mod._WORKSPACE_FILE_LIMIT_BYTES + 1)
+    archive = _make_spa_archive(dist, asset_bytes=deploy_mod._WORKSPACE_FILE_LIMIT_BYTES + 1)
+    # Repeated bytes compress too well; append incompressible bytes to make the
+    # uploaded archive exceed the cap, which is the relevant Workspace check.
+    with archive.open("ab") as handle:
+        handle.write(os.urandom(deploy_mod._WORKSPACE_FILE_LIMIT_BYTES))
     src = tmp_path / "src"
     src.mkdir()
     monkeypatch.setattr(deploy_mod, "_repo_root", lambda: tmp_path)
     monkeypatch.setattr(deploy_mod, "_src_dir", lambda: src)
 
-    with pytest.raises(SystemExit, match="over the 10 MB Workspace file cap"):
-        deploy_mod._sync_src_web_ui(skip_web_ui=False)
+    deploy_mod._stage_web_ui(skip_web_ui=False)
+    with pytest.raises(SystemExit, match="exceed the Databricks Apps 10 MB"):
+        deploy_mod._assert_app_files_under_limit()
     assert not (src / "web-ui").exists()

--- a/tests/deploy/test_databricks_web_ui.py
+++ b/tests/deploy/test_databricks_web_ui.py
@@ -13,7 +13,6 @@ server reads it at import time, so it is checked in a subprocess.
 
 from __future__ import annotations
 
-import ast
 import importlib.util
 import io
 import os
@@ -63,29 +62,13 @@ def _make_spa_archive(root: Path, *, asset_bytes: int = 32) -> Path:
 
 def _load_archive_extractor():
     """Load the side-effect-free archive helper without starting the app."""
-    tree = ast.parse(_APP_PY.read_text())
-    constant_names = {
-        "_WEB_UI_MAX_MEMBERS",
-        "_WEB_UI_MAX_MEMBER_BYTES",
-        "_WEB_UI_MAX_EXTRACTED_BYTES",
-    }
-    nodes = [
-        node
-        for node in tree.body
-        if (
-            (isinstance(node, ast.FunctionDef) and node.name == "_extract_web_ui_archive")
-            or (
-                isinstance(node, ast.Assign)
-                and any(
-                    isinstance(target, ast.Name) and target.id in constant_names
-                    for target in node.targets
-                )
-            )
-        )
-    ]
-    namespace = {"_Path": Path}
-    exec(compile(ast.Module(body=nodes, type_ignores=[]), str(_APP_PY), "exec"), namespace)
-    return namespace["_extract_web_ui_archive"], namespace
+    helper = _DEPLOY_DIR / "src" / "web_ui_archive.py"
+    spec = importlib.util.spec_from_file_location("web_ui_archive_test", helper)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.extract_web_ui_archive, module
 
 
 def test_server_honours_web_ui_dist_env(tmp_path: Path) -> None:
@@ -110,8 +93,7 @@ def test_app_py_extracts_web_ui_before_importing_server() -> None:
     import_at = source.index("from omnigent.server.app import create_app")
     assert prepare_at < import_at, "web UI setup is too late to take effect"
     assert 'archive = here / "web-ui.tar.gz"' in source
-    assert 'tar.extractall(destination, members=members, filter="data")' in source
-    assert "getmembers()" not in source
+    assert "from web_ui_archive import extract_web_ui_archive" in source
     assert 'loose = here / "web-ui"' in source
 
 
@@ -128,9 +110,9 @@ def test_app_extractor_extracts_normal_archive(tmp_path: Path) -> None:
 
 
 def test_app_extractor_rejects_oversize_expansion_before_writing(tmp_path: Path) -> None:
-    extractor, namespace = _load_archive_extractor()
+    extractor, module = _load_archive_extractor()
     archive = tmp_path / "web-ui.tar.gz"
-    payload = b"x" * (namespace["_WEB_UI_MAX_MEMBER_BYTES"] + 1)
+    payload = b"x" * (module.MAX_MEMBER_BYTES + 1)
     info = tarfile.TarInfo("assets/bomb.js")
     info.size = len(payload)
     with tarfile.open(archive, "w:gz") as tar:
@@ -144,10 +126,10 @@ def test_app_extractor_rejects_oversize_expansion_before_writing(tmp_path: Path)
 
 
 def test_app_extractor_rejects_aggregate_expansion_before_writing(tmp_path: Path) -> None:
-    extractor, namespace = _load_archive_extractor()
+    extractor, module = _load_archive_extractor()
     archive = tmp_path / "web-ui.tar.gz"
     member_bytes = 1024 * 1024
-    member_count = namespace["_WEB_UI_MAX_EXTRACTED_BYTES"] // member_bytes + 1
+    member_count = module.MAX_EXTRACTED_BYTES // member_bytes + 1
     with tarfile.open(archive, "w:gz") as tar:
         for index in range(member_count):
             info = tarfile.TarInfo(f"assets/chunk-{index}.js")
@@ -162,10 +144,10 @@ def test_app_extractor_rejects_aggregate_expansion_before_writing(tmp_path: Path
 
 
 def test_app_extractor_rejects_too_many_members_before_writing(tmp_path: Path) -> None:
-    extractor, namespace = _load_archive_extractor()
+    extractor, module = _load_archive_extractor()
     archive = tmp_path / "web-ui.tar.gz"
     with tarfile.open(archive, "w:gz") as tar:
-        for index in range(namespace["_WEB_UI_MAX_MEMBERS"] + 1):
+        for index in range(module.MAX_MEMBERS + 1):
             tar.addfile(tarfile.TarInfo(f"assets/chunk-{index}.js"))
     destination = tmp_path / "extracted"
     destination.mkdir()

--- a/tests/deploy/test_databricks_web_ui.py
+++ b/tests/deploy/test_databricks_web_ui.py
@@ -1,0 +1,411 @@
+"""The Databricks Apps deploy ships the SPA outside the wheel.
+
+Databricks Apps uploads the app source directory as Workspace files, and the
+Workspace import API rejects any single file over 10 MB. The built SPA is ~25 MB
+of assets, which takes the main wheel over that cap and fails the deploy before
+anything is uploaded. So ``build.sh`` moves the SPA out of the wheel's package
+data and the deploy ships it as loose files in ``src/web-ui/``, which
+``src/app.py`` points the server at via ``OMNIGENT_WEB_UI_DIST``.
+
+These tests pin each link in that chain, including the env var itself — the
+server reads it at import time, so it is checked in a subprocess.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_DEPLOY_DIR = _ROOT / "deploy" / "databricks"
+_DEPLOY_PY = _DEPLOY_DIR / "deploy.py"
+_BUILD_SH = _DEPLOY_DIR / "build.sh"
+_APP_PY = _DEPLOY_DIR / "src" / "app.py"
+
+
+@pytest.fixture(scope="module")
+def deploy_mod() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("_databricks_deploy_webui", _DEPLOY_PY)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_spa(root: Path, *, asset_bytes: int = 32) -> Path:
+    spa = root / "web-ui"
+    (spa / "assets").mkdir(parents=True)
+    (spa / "index.html").write_text("<!doctype html><title>omnigent</title>")
+    (spa / "assets" / "index-abc123.js").write_bytes(b"x" * asset_bytes)
+    return spa
+
+
+def test_server_honours_web_ui_dist_env(tmp_path: Path) -> None:
+    """The whole scheme hinges on OMNIGENT_WEB_UI_DIST being respected."""
+    spa = _make_spa(tmp_path)
+    code = "import omnigent.server.app as m; print(m._WEB_UI_DIST)"
+    out = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=_ROOT,
+        env={"PATH": "/usr/bin:/bin", "OMNIGENT_WEB_UI_DIST": str(spa)},
+        check=True,
+    )
+    assert out.stdout.strip() == str(spa)
+
+
+def test_app_py_points_server_at_loose_assets_before_importing_it() -> None:
+    """The path is read at import time, so the setup must come first."""
+    source = _APP_PY.read_text()
+    setup_at = source.index('os.environ.setdefault("OMNIGENT_WEB_UI_DIST"')
+    import_at = source.index("from omnigent.server.app import create_app")
+    assert setup_at < import_at, "OMNIGENT_WEB_UI_DIST is set too late to take effect"
+    assert 'Path(__file__).parent / "web-ui"' in source
+
+
+def test_build_sh_moves_spa_out_of_the_wheel() -> None:
+    source = _BUILD_SH.read_text()
+    assert 'mv omnigent/server/static/web-ui "${web_ui_out_dir}"' in source
+    # The move has to happen while the SPA build is in scope, before uv build.
+    assert source.index("WEB_UI_OUT_NAME") < source.index("uv build --wheel --out-dir dist/ .")
+
+
+def test_build_sh_opts_the_backend_out_of_rebuilding_the_spa() -> None:
+    """setup.py rebuilds the SPA into the package when the bundle is missing.
+
+    Without the opt-out it puts the assets straight back into the wheel, undoing
+    the move, so the export has to land before any wheel build.
+    """
+    source = _BUILD_SH.read_text()
+    assert "export OMNIGENT_SKIP_WEB_UI=true" in source
+    assert source.index("export OMNIGENT_SKIP_WEB_UI=true") < source.index(
+        "uv build --wheel --out-dir dist/ sdks/python-client/"
+    )
+
+
+def test_build_sh_moves_the_spa_and_opts_out_when_run_for_real(tmp_path: Path) -> None:
+    """Execute the real script with fake ``pnpm``/``uv`` and check both effects.
+
+    Text assertions cannot show that the move and the opt-out actually happen
+    together on the full-UI path, which is the whole invariant: the SPA ends up
+    outside the wheel *and* the wheel hook does not put it back.
+    """
+    repo = tmp_path / "repo"
+    script = repo / "deploy" / "databricks" / "build.sh"
+    script.parent.mkdir(parents=True)
+    shutil.copyfile(_BUILD_SH, script)
+
+    command_log = tmp_path / "commands.log"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    # `pnpm --filter web run build` is what produces the SPA bundle.
+    _write_executable(
+        fake_bin / "pnpm",
+        "#!/usr/bin/env bash\n"
+        'printf "pnpm|%s\\n" "$*" >> "$COMMAND_LOG"\n'
+        'if [[ "$*" == *"run build"* ]]; then\n'
+        "  mkdir -p omnigent/server/static/web-ui/assets\n"
+        '  echo "<html></html>" > omnigent/server/static/web-ui/index.html\n'
+        '  echo "chunk" > omnigent/server/static/web-ui/assets/index-abc.js\n'
+        "fi\n",
+    )
+    _write_executable(
+        fake_bin / "uv",
+        "#!/usr/bin/env bash\n"
+        'printf "uv|%s|%s\\n" "${OMNIGENT_SKIP_WEB_UI-<unset>}" "$*" >> "$COMMAND_LOG"\n'
+        "mkdir -p dist\n"
+        "touch dist/fake.whl\n",
+    )
+
+    # The same location deploy.py passes: <repo>/dist/web-ui.
+    out_dir = repo / "dist" / "web-ui"
+    env = os.environ.copy()
+    env.update(
+        {
+            "COMMAND_LOG": str(command_log),
+            "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
+            "WEB_UI_OUT_NAME": out_dir.name,
+        }
+    )
+    env.pop("OMNIGENT_SKIP_WEB_UI", None)
+    env.pop("SKIP_WEB_UI", None)
+
+    subprocess.run(["bash", str(script)], cwd=repo, env=env, check=True)
+
+    # The SPA moved out of the package tree and into dist/<WEB_UI_OUT_NAME>.
+    assert (out_dir / "index.html").is_file()
+    assert (out_dir / "assets" / "index-abc.js").is_file()
+    assert not (repo / "omnigent" / "server" / "static" / "web-ui").exists()
+
+    # And every wheel build saw the opt-out, so setup.py cannot rebuild it back in.
+    uv_calls = [line for line in command_log.read_text().splitlines() if line.startswith("uv|")]
+    assert len(uv_calls) == 3
+    assert all(call.split("|", 2)[1] == "true" for call in uv_calls), uv_calls
+
+
+@pytest.mark.parametrize(
+    "out_name",
+    [
+        pytest.param("../../precious", id="parent-traversal"),
+        pytest.param("web-ui/../../../precious", id="traversal-after-a-valid-prefix"),
+        pytest.param("..", id="dot-dot"),
+        pytest.param(".", id="dot"),
+        pytest.param("/", id="the-filesystem-root"),
+        pytest.param("/tmp", id="an-absolute-path"),
+        pytest.param("nested/name", id="a-nested-path"),
+        pytest.param("name with spaces", id="whitespace"),
+        pytest.param("name;rm -rf /", id="shell-metacharacters"),
+        pytest.param("$HOME", id="an-expansion-attempt"),
+    ],
+)
+def test_build_sh_refuses_a_web_ui_out_name_that_is_not_a_bare_name(
+    tmp_path: Path, out_name: str
+) -> None:
+    """The move destination is ``rm -rf``'d, so only a bare name is accepted.
+
+    A caller-supplied *path* can escape the repo through ``..`` or a symlink no
+    matter how it is string-matched — a lexical prefix check on
+    ``<repo>/dist/...`` passes ``<repo>/dist/../../home``. Accepting only a name
+    that cannot contain ``/`` or ``.`` removes the entire class: the script
+    anchors it under its own freshly created ``dist/``.
+
+    The script must refuse, exit non-zero, and leave everything untouched.
+    """
+    repo = tmp_path / "repo"
+    script = repo / "deploy" / "databricks" / "build.sh"
+    script.parent.mkdir(parents=True)
+    shutil.copyfile(_BUILD_SH, script)
+
+    precious = tmp_path / "precious"
+    precious.mkdir()
+    (precious / "important.txt").write_text("IRREPLACEABLE")
+    (repo / "omnigent").mkdir()
+    (repo / "omnigent" / "__init__.py").write_text("# source")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_executable(
+        fake_bin / "pnpm",
+        "#!/usr/bin/env bash\n"
+        'if [[ "$*" == *"run build"* ]]; then\n'
+        "  mkdir -p omnigent/server/static/web-ui\n"
+        '  echo "<html></html>" > omnigent/server/static/web-ui/index.html\n'
+        "fi\n",
+    )
+    _write_executable(fake_bin / "uv", "#!/usr/bin/env bash\nmkdir -p dist\ntouch dist/f.whl\n")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["WEB_UI_OUT_NAME"] = out_name
+    env.pop("OMNIGENT_SKIP_WEB_UI", None)
+    env.pop("SKIP_WEB_UI", None)
+    env.pop("WEB_UI_OUT_DIR", None)
+
+    result = subprocess.run(
+        ["bash", str(script)], cwd=repo, env=env, capture_output=True, text=True, check=False
+    )
+
+    assert result.returncode != 0, result.stdout
+    assert "WEB_UI_OUT_NAME must be a bare directory name" in result.stderr
+    # Nothing outside dist/ was touched.
+    assert (precious / "important.txt").read_text() == "IRREPLACEABLE"
+    assert (repo / "omnigent" / "__init__.py").is_file()
+
+
+def test_build_sh_leaves_the_spa_in_the_wheel_without_web_ui_out_dir(tmp_path: Path) -> None:
+    """The move is opt-in: an ordinary build is byte-for-byte unaffected.
+
+    Without ``WEB_UI_OUT_NAME`` the SPA stays in the package tree and the wheel
+    hook is *not* opted out, so a plain ``build.sh`` behaves exactly as on main.
+    """
+    repo = tmp_path / "repo"
+    script = repo / "deploy" / "databricks" / "build.sh"
+    script.parent.mkdir(parents=True)
+    shutil.copyfile(_BUILD_SH, script)
+
+    command_log = tmp_path / "commands.log"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_executable(
+        fake_bin / "pnpm",
+        "#!/usr/bin/env bash\n"
+        'if [[ "$*" == *"run build"* ]]; then\n'
+        "  mkdir -p omnigent/server/static/web-ui\n"
+        '  echo "<html></html>" > omnigent/server/static/web-ui/index.html\n'
+        "fi\n",
+    )
+    _write_executable(
+        fake_bin / "uv",
+        "#!/usr/bin/env bash\n"
+        'printf "uv|%s\\n" "${OMNIGENT_SKIP_WEB_UI-<unset>}" >> "$COMMAND_LOG"\n'
+        "mkdir -p dist\n"
+        "touch dist/fake.whl\n",
+    )
+
+    env = os.environ.copy()
+    env.update({"COMMAND_LOG": str(command_log), "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}"})
+    env.pop("OMNIGENT_SKIP_WEB_UI", None)
+    env.pop("SKIP_WEB_UI", None)
+    env.pop("WEB_UI_OUT_NAME", None)
+
+    subprocess.run(["bash", str(script)], cwd=repo, env=env, check=True)
+
+    assert (repo / "omnigent" / "server" / "static" / "web-ui" / "index.html").is_file()
+    uv_calls = [line for line in command_log.read_text().splitlines() if line.startswith("uv|")]
+    assert uv_calls == ["uv|<unset>"] * 3, uv_calls
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(0o755)
+
+
+def test_setup_py_honours_the_web_ui_opt_out() -> None:
+    """The opt-out build.sh relies on must keep working."""
+    source = (_ROOT / "setup.py").read_text()
+    assert 'os.environ.get("OMNIGENT_SKIP_WEB_UI") == "true"' in source
+
+
+def test_build_wheels_requests_the_spa_outside_the_wheel(
+    deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, str] = {}
+
+    def fake_run(cmd: list[str], **kwargs: object) -> None:
+        captured.update(kwargs["env"])  # type: ignore[arg-type]
+        (tmp_path / "dist").mkdir(exist_ok=True)
+        (tmp_path / "dist" / "omnigent-1.0-py3-none-any.whl").write_bytes(b"w")
+
+    monkeypatch.setattr(deploy_mod, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(deploy_mod.subprocess, "run", fake_run)
+
+    deploy_mod._build_wheels(skip_web_ui=False)
+    assert captured["WEB_UI_OUT_NAME"] == "web-ui"
+    assert "SKIP_WEB_UI" not in captured
+
+    captured.clear()
+    deploy_mod._build_wheels(skip_web_ui=True)
+    assert captured["SKIP_WEB_UI"] == "1"
+    assert "WEB_UI_OUT_NAME" not in captured
+
+
+def test_build_wheels_mode_ignores_the_ambient_environment(
+    deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The flag decides the build mode, not whatever the caller exported.
+
+    An ambient ``SKIP_WEB_UI=1`` left over from an earlier API-only build would
+    otherwise be inherited through ``os.environ.copy()`` and make ``build.sh``
+    skip the SPA for a deploy that explicitly asked to include it. The mirror
+    case matters too: a stale ``WEB_UI_OUT_NAME`` must not make an API-only build
+    try to move a bundle that was never built.
+    """
+    captured: dict[str, str] = {}
+
+    def fake_run(cmd: list[str], **kwargs: object) -> None:
+        captured.update(kwargs["env"])  # type: ignore[arg-type]
+        (tmp_path / "dist").mkdir(exist_ok=True)
+        (tmp_path / "dist" / "omnigent-1.0-py3-none-any.whl").write_bytes(b"w")
+
+    monkeypatch.setattr(deploy_mod, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(deploy_mod.subprocess, "run", fake_run)
+
+    monkeypatch.setenv("SKIP_WEB_UI", "1")
+    monkeypatch.setenv("WEB_UI_OUT_NAME", "stale")
+
+    deploy_mod._build_wheels(skip_web_ui=False)
+    assert "SKIP_WEB_UI" not in captured
+    assert captured["WEB_UI_OUT_NAME"] == "web-ui"
+
+    captured.clear()
+    deploy_mod._build_wheels(skip_web_ui=True)
+    assert captured["SKIP_WEB_UI"] == "1"
+    assert "WEB_UI_OUT_NAME" not in captured
+
+
+def test_sync_src_web_ui_copies_build_into_app_source(
+    deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    _make_spa(dist)
+    src = tmp_path / "deploy" / "databricks" / "src"
+    src.mkdir(parents=True)
+    monkeypatch.setattr(deploy_mod, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(deploy_mod, "_src_dir", lambda: src)
+
+    deploy_mod._sync_src_web_ui(skip_web_ui=False)
+
+    assert (src / "web-ui" / "index.html").is_file()
+    assert (src / "web-ui" / "assets" / "index-abc123.js").is_file()
+
+
+def test_sync_src_web_ui_replaces_a_stale_copy(
+    deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Vite emits hashed chunk names; stale assets must not accumulate."""
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    _make_spa(dist)
+    src = tmp_path / "src"
+    (src / "web-ui" / "assets").mkdir(parents=True)
+    (src / "web-ui" / "assets" / "index-STALE.js").write_text("old")
+    monkeypatch.setattr(deploy_mod, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(deploy_mod, "_src_dir", lambda: src)
+
+    deploy_mod._sync_src_web_ui(skip_web_ui=False)
+
+    assert not (src / "web-ui" / "assets" / "index-STALE.js").exists()
+    assert (src / "web-ui" / "assets" / "index-abc123.js").is_file()
+
+
+def test_sync_src_web_ui_skip_web_ui_clears_assets(
+    deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An API-only deploy must not leave a previous SPA behind."""
+    src = tmp_path / "src"
+    _make_spa(src)
+    monkeypatch.setattr(deploy_mod, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(deploy_mod, "_src_dir", lambda: src)
+
+    deploy_mod._sync_src_web_ui(skip_web_ui=True)
+
+    assert not (src / "web-ui").exists()
+
+
+def test_sync_src_web_ui_requires_a_build(
+    deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    monkeypatch.setattr(deploy_mod, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(deploy_mod, "_src_dir", lambda: src)
+
+    with pytest.raises(SystemExit, match="no SPA build at"):
+        deploy_mod._sync_src_web_ui(skip_web_ui=False)
+
+
+def test_oversize_asset_fails_before_upload(
+    deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A single Vite chunk over 10 MB would be rejected by the Workspace."""
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    _make_spa(dist, asset_bytes=deploy_mod._WORKSPACE_FILE_LIMIT_BYTES + 1)
+    src = tmp_path / "src"
+    src.mkdir()
+    monkeypatch.setattr(deploy_mod, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(deploy_mod, "_src_dir", lambda: src)
+
+    with pytest.raises(SystemExit, match="over the 10 MB Workspace file cap"):
+        deploy_mod._sync_src_web_ui(skip_web_ui=False)
+    assert not (src / "web-ui").exists()

--- a/tests/e2e_ui/chat/test_working_indicator_background_tasks.py
+++ b/tests/e2e_ui/chat/test_working_indicator_background_tasks.py
@@ -147,7 +147,7 @@ def test_working_shimmer_and_pill_coexist_while_running(
     # the shimmer for the live turn, the pill for the still-running shell.
     _publish_status(base_url, session_id, "running")
     expect(working).to_contain_text(_WORKING_LABEL_RE, timeout=15_000)
-    expect(pill).to_contain_text("2 background tasks")
+    expect(pill).to_contain_text("2 background tasks", timeout=15_000)
 
 
 def test_sidebar_spinner_ignores_background_tasks(


### PR DESCRIPTION
## Related issue

Closes #5003

## Summary

The current Databricks Apps deploy puts the built SPA inside the Omnigent Python wheel. The SPA makes that wheel exceed the Workspace 10 MB per-file limit, so full-UI deployments abort before the app can start.

This change ships the SPA outside the wheel as a single `web-ui.tar.gz` source file. Databricks syncs that one archive beside `app.py`; the entry point safely validates and extracts it before importing the server's static-file configuration.

ELI5:

```text
before:  Python wheel [server + 25 MB SPA] -> over 10 MB -> rejected
 after:  Python wheel [server] -> under 10 MB
         src/web-ui.tar.gz [compressed SPA] -> one source file, under 10 MB
         app.py extracts it before starting the server
```

The archive approach is based on the working internal deployment implementation and avoids the hundreds of Workspace upload round-trips of the earlier loose-file version. Legacy loose `src/web-ui/` deployments remain supported.

## Test Plan

- `python -m pytest -q tests/deploy/test_databricks_web_ui.py` -> **20 passed**.
- `python -m pytest -q tests/deploy` -> **37 passed** on rebased `origin/main`.
- `bash -n deploy/databricks/build.sh`.
- `python -m py_compile deploy/databricks/deploy.py deploy/databricks/src/app.py deploy/databricks/src/web_ui_archive.py tests/deploy/test_databricks_web_ui.py`.
- Ruff check and format checks pass.
- `pre-commit run --files ...` passes with all applicable hooks clean.
- Focused tests cover archive creation, wheel opt-out ordering, stale loose/archive cleanup, API-only mode including `--skip-build`, source-file size limits, bounded archive extraction, traversal rejection, and server import ordering.
- The final tarball implementation has not yet been repeated against a live workspace; the earlier live verification covered the equivalent loose-file packaging path before this performance optimization.

## Demo

![Omnigent full-UI SPA landing page](https://gist.githubusercontent.com/dgokeeffe/85c9bd8177d4893ff8ba126ae8b70c95/raw/s5-ui-demo.svg)

## Type of change

- [x] Bug fix
- [x] UI / frontend change
- [ ] Feature
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The deployment-specific tests cover the archive packaging contract without requiring a live workspace. Manual verification covers the deployed Omnigent SPA behavior from the prior equivalent loose-file implementation; the final archive transport still needs a live Databricks Apps redeploy.

## Changelog

Databricks Apps full-UI deployments now ship the web UI outside the Python wheel as a bounded compressed archive so they fit the Workspace file limit and sync efficiently.
