### PR TITLE
fix(harness): raise idle watchdog default to 600s so long compaction survives

### DIFF
--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -104,8 +104,14 @@ _POLICY_EVAL_TIMEOUT_S = 86400.0
 # ``run_turn`` becomes ``response.failed`` (vs heartbeating forever).
 # Every non-heartbeat ``ctx.emit`` resets the deadline (see
 # ``_guarded_run_turn``), so a long-but-active turn is never killed.
+# The window must clear the longest single progress-free ``await`` a
+# healthy turn can make — notably context compaction, whose summarizing
+# LLM call runs as one long ``await`` emitting no non-heartbeat events
+# (see ``runtime/compaction.py``). On a near-full context that call can
+# exceed the old 240s cap, tripping the watchdog and wedging the session
+# in a "Prompt is too long" → compaction → 240s-timeout loop.
 # Env var name kept for the ops knob; ``<= 0`` disables.
-_TURN_IDLE_TIMEOUT_S = float(os.environ.get("HARNESS_TURN_TIMEOUT_S", "240"))
+_TURN_IDLE_TIMEOUT_S = float(os.environ.get("HARNESS_TURN_TIMEOUT_S", "600"))
 
 # Absolute per-turn ceiling: a hard cap on TOTAL turn duration, backstop
 # to the idle watchdog above. The idle watchdog never trips a turn that


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The per-turn **idle watchdog** fails a turn that emits no non-heartbeat events for its window (default 240s). It resets on every real progress event, so it's meant to catch a *wedged* turn — not a slow-but-healthy one.
- Context **compaction**'s summarizing LLM call (`runtime/compaction.py` → `summarize_history`) runs as a single long `await` that emits nothing until it returns. On a near-full context that call can take longer than 240s, so the idle watchdog trips it.
- This wedges the session in a loop reported in Slack: `Prompt is too long` → auto-compaction → `turn exceeded the 240s harness idle watchdog (run_turn emitted no events for 240s; likely a wedged LLM or tool call)` → retry re-triggers the same slow compaction → repeat.
- Fix: raise the idle watchdog **default** from `240s` to `600s` in `omnigent/runtime/harnesses/_scaffold.py`, giving a healthy long compaction room to finish. The `HARNESS_TURN_TIMEOUT_S` env knob and the absolute per-turn ceiling (`HARNESS_TURN_ABSOLUTE_TIMEOUT_S`, 3600s) are unchanged.

## Test Plan

- `pytest tests/runtime/harnesses/test_scaffold.py -k "watchdog or idle or wedged or busy or absolute or heartbeat"` — 6 passed. These drive the watchdog via `HARNESS_TURN_TIMEOUT_S` overrides, so they're independent of the default and confirm idle/absolute/heartbeat behavior still holds.
- No test asserts the `240` default; the only other `240` literals in the tree are unrelated (MCP startup settle, pi-native park timeout).

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Behavior is unchanged except for the default window length. Existing scaffold watchdog tests exercise idle-timeout, absolute-cap, and heartbeat-ignoring paths via explicit `HARNESS_TURN_TIMEOUT_S` overrides, so they cover the mechanism regardless of the default. I ran that subset locally (6 passed). No new test is added because the change is a single default constant with no new branch.

## Changelog

Long context compaction no longer fails with a 240s idle-watchdog timeout on near-full sessions

---

This pull request and its description were written by Isaac.
