### PR TITLE
fix(opencode-native): stop leaking opencode serve processes across teardown paths

### DIFF
--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -1315,14 +1315,20 @@ def create_app(
         _pane_reaper = getattr(app.state, "native_pane_reaper", None)
         if _pane_reaper is not None:
             await _pane_reaper.shutdown()
-        # Close host-spawned codex-native app-servers before the process exits.
-        # Each is spawned in its own session (survives the runner's death), and a
-        # host-initiated stop tears the runner down without a per-session DELETE,
-        # so without this they orphan as lingering ``codex`` processes.
-        from omnigent.runner.native import teardown_all_codex_native_app_servers
+        # Close host-spawned codex-native app-servers and opencode-native
+        # servers before the process exits. A host-initiated stop tears the
+        # runner down without a per-session DELETE, so without this they orphan
+        # as lingering ``codex`` / ``opencode`` processes (codex app-servers in
+        # particular spawn in their own session and survive the runner's death).
+        from omnigent.runner.native import (
+            teardown_all_codex_native_app_servers,
+            teardown_all_opencode_native_servers,
+        )
 
         with contextlib.suppress(Exception):
             await teardown_all_codex_native_app_servers()
+        with contextlib.suppress(Exception):
+            await teardown_all_opencode_native_servers()
         await pm.shutdown()
         await _terminal_registry.shutdown()
         if mcp_manager is not None:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2191,15 +2191,18 @@ def create_runner_app(
                 "session_id": event.session_id,
             },
         )
-        # A codex TUI pane that exits on its own (crash / OOM / host recycle)
-        # never runs the DELETE-session cleanup, so its per-session app-server
-        # + forwarder would linger with no TUI. Tear them down here; no-op for
-        # any session without a registered codex app-server.
-        _teardown_task = asyncio.create_task(
-            _native_runtime.teardown_codex_native_app_server(event.session_id)
-        )
-        _teardown_task.add_done_callback(_background_tasks.discard)
-        _background_tasks.add(_teardown_task)
+        # A codex / opencode TUI pane that exits on its own (crash / OOM /
+        # host recycle) never runs the DELETE-session cleanup, so its
+        # per-session server + forwarder would linger with no TUI. Tear them
+        # down here; each is a no-op for a session without that harness's
+        # registered server.
+        for _teardown in (
+            _native_runtime.teardown_codex_native_app_server,
+            _native_runtime.teardown_opencode_native_server,
+        ):
+            _teardown_task = asyncio.create_task(_teardown(event.session_id))
+            _teardown_task.add_done_callback(_background_tasks.discard)
+            _background_tasks.add(_teardown_task)
         if event.lifecycle != TerminalLifecycle.REQUIRED:
             return
 
@@ -8568,12 +8571,13 @@ def create_runner_app(
             try:
                 await resource_registry.close_terminal(pane.conversation_id, pane.terminal_id)
             finally:
-                # Closing the codex TUI pane leaves its per-session app-server
-                # (and forwarder) running — no-op for other harnesses. Tear it
-                # down in ``finally`` so an idle-reaped codex session can't orphan
-                # a ``codex app-server`` for the runner's lifetime even when the
-                # pane close above partially fails (the very leak this guards).
+                # Closing the codex / opencode TUI pane leaves its per-session
+                # server (and forwarder) running — no-op for other harnesses.
+                # Tear it down in ``finally`` so an idle-reaped session can't
+                # orphan its server for the runner's lifetime even when the pane
+                # close above partially fails (the very leak this guards).
                 await _native_runtime.teardown_codex_native_app_server(pane.conversation_id)
+                await _native_runtime.teardown_opencode_native_server(pane.conversation_id)
                 _publish_terminal_deleted_event(
                     conversation_id=pane.conversation_id,
                     terminal_name=pane.terminal_name,

--- a/omnigent/runner/native/__init__.py
+++ b/omnigent/runner/native/__init__.py
@@ -123,7 +123,9 @@ from omnigent.runner.native.orchestration import (
     _terminal_tmux_pane,
     _unwrap_resolved_spec,
     teardown_all_codex_native_app_servers,
+    teardown_all_opencode_native_servers,
     teardown_codex_native_app_server,
+    teardown_opencode_native_server,
 )
 
 __all__ = [
@@ -249,5 +251,7 @@ __all__ = [
     "_terminal_tmux_pane",
     "_unwrap_resolved_spec",
     "teardown_all_codex_native_app_servers",
+    "teardown_all_opencode_native_servers",
     "teardown_codex_native_app_server",
+    "teardown_opencode_native_server",
 ]

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -246,6 +246,61 @@ async def teardown_all_codex_native_app_servers() -> None:
             await teardown_codex_native_app_server(session_id)
 
 
+async def teardown_opencode_native_server(session_id: str) -> None:
+    """
+    Tear down a host-spawned opencode-native session's ``opencode serve``.
+
+    The opencode counterpart of :func:`teardown_codex_native_app_server`.
+    Only the ``DELETE /v1/sessions`` teardown runs the full native cleanup;
+    the opencode TUI pane can also disappear on its own — the idle pane
+    reaper closes the tmux pane after the idle window, and an unexpected TUI
+    exit (crash / OOM / host recycle) evicts it — neither of which cancels
+    the forwarder. Left alone, the per-session ``opencode serve`` (and its
+    forwarder) survives with no TUI, so a long-lived multi-session runner
+    accumulates orphaned ``opencode`` processes.
+
+    Cancelling the forwarder closes the server via
+    :func:`_supervise_opencode_forwarder`'s own ``finally``; the pop below is
+    the belt-and-suspenders close for the case where no forwarder ever
+    adopted the server. No-op for a session that has no registered opencode
+    server, so this is safe to call from the shared pane-teardown paths
+    regardless of harness.
+
+    :param session_id: Session/conversation id, e.g. ``"conv_abc123"``.
+    :returns: None.
+    """
+    if session_id not in _AUTO_OPENCODE_SERVERS:
+        return
+    await _cancel_auto_forwarder_task(session_id)
+    leftover_server = _AUTO_OPENCODE_SERVERS.pop(session_id, None)
+    if leftover_server is not None:
+        with contextlib.suppress(Exception):
+            await leftover_server.close()
+
+
+async def teardown_all_opencode_native_servers() -> None:
+    """
+    Tear down every host-spawned opencode-native server on this runner.
+
+    The opencode counterpart of
+    :func:`teardown_all_codex_native_app_servers`, called from the runner's
+    shutdown path (``_stop_pm``) so a graceful host or runner stop takes the
+    per-session ``opencode serve`` subprocesses down with it. Per-session
+    teardown normally runs on ``DELETE /v1/sessions``, but a host stop tears
+    the runner down without deleting each session first, so those never fire.
+
+    Iterates a snapshot of the registered session ids and delegates to
+    :func:`teardown_opencode_native_server` (which cancels the forwarder and
+    closes the server). Best-effort and idempotent: a session already torn
+    down is a no-op.
+
+    :returns: None.
+    """
+    for session_id in list(_AUTO_OPENCODE_SERVERS):
+        with contextlib.suppress(Exception):
+            await teardown_opencode_native_server(session_id)
+
+
 def _register_auto_forwarder_task(session_id: str, task: asyncio.Task[object]) -> None:
     """
     Register a session's transcript-forwarder task in the keyed registry.

--- a/tests/runner/test_app_sessions_native_wake_forwarders.py
+++ b/tests/runner/test_app_sessions_native_wake_forwarders.py
@@ -519,6 +519,142 @@ async def test_teardown_all_codex_native_app_servers_closes_every_session() -> N
 
 
 @pytest.mark.asyncio
+async def test_teardown_opencode_native_server_cancels_forwarder_and_closes_server() -> None:
+    """
+    Opencode pane teardown cancels the forwarder and closes the server.
+
+    Opencode mirrors codex: the idle pane reaper and an unexpected TUI exit
+    both close only the tmux pane, so without this helper the per-session
+    ``opencode serve`` (and its forwarder) survives with no TUI, orphaning an
+    ``opencode`` process. Teardown must both cancel the registered forwarder
+    and close the registered server so neither leaks.
+    """
+    session_id = "0bc0de000000000000000000deadbeef"
+    run = _ForwarderRun()
+    closed = False
+
+    async def _parked() -> None:
+        run.task = asyncio.current_task()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            run.cancelled = True
+            raise
+
+    class _FakeServer:
+        async def close(self) -> None:
+            nonlocal closed
+            closed = True
+
+    try:
+        task = asyncio.create_task(_parked())
+        runner_app_mod._register_auto_forwarder_task(session_id, task)
+        runner_app_mod._AUTO_OPENCODE_SERVERS[session_id] = _FakeServer()
+        await asyncio.sleep(0)
+
+        await runner_app_mod.teardown_opencode_native_server(session_id)
+
+        assert task.cancelled(), "forwarder must be finished-cancelled after teardown"
+        assert run.cancelled is True
+        assert closed is True, "registered opencode server must be closed"
+        assert session_id not in runner_app_mod._AUTO_OPENCODE_SERVERS
+        assert session_id not in runner_app_mod._AUTO_FORWARDER_TASKS
+    finally:
+        runner_app_mod._AUTO_FORWARDER_TASKS.pop(session_id, None)
+        runner_app_mod._AUTO_OPENCODE_SERVERS.pop(session_id, None)
+        await _drain_forwarder_runs([run])
+
+
+@pytest.mark.asyncio
+async def test_teardown_opencode_native_server_noop_without_registered_server() -> None:
+    """
+    Teardown is a no-op for a session with no registered opencode server.
+
+    The shared pane-teardown paths fire for every native harness, so calling
+    this for a non-opencode session — or one whose server is already gone —
+    must not touch that session's forwarder or raise.
+    """
+    session_id = "3333333344444444ccccccccdddddddd"
+    run = _ForwarderRun()
+
+    async def _parked() -> None:
+        run.task = asyncio.current_task()
+        await asyncio.Event().wait()
+
+    try:
+        task = asyncio.create_task(_parked())
+        runner_app_mod._register_auto_forwarder_task(session_id, task)
+        await asyncio.sleep(0)
+
+        await runner_app_mod.teardown_opencode_native_server(session_id)
+
+        # No registered opencode server -> the forwarder is left untouched.
+        assert not task.done()
+        assert session_id in runner_app_mod._AUTO_FORWARDER_TASKS
+    finally:
+        runner_app_mod._AUTO_FORWARDER_TASKS.pop(session_id, None)
+        await _drain_forwarder_runs([run])
+
+
+@pytest.mark.asyncio
+async def test_teardown_all_opencode_native_servers_closes_every_session() -> None:
+    """
+    Runner shutdown closes every registered opencode server.
+
+    A host-initiated stop SIGTERMs the runner without a per-session
+    ``DELETE /v1/sessions``, so the shutdown sweep is the only thing that
+    closes the host-spawned ``opencode serve`` subprocesses. Every registered
+    session must be torn down, and the registry left empty.
+    """
+    session_ids = [
+        "dddd0000dddd0000dddd0000dddd0000",
+        "eeee1111eeee1111eeee1111eeee1111",
+        "ffff2222ffff2222ffff2222ffff2222",
+    ]
+    runs = [_ForwarderRun() for _ in session_ids]
+    closed: list[str] = []
+
+    def _make_parked(run: _ForwarderRun) -> Any:
+        async def _parked() -> None:
+            run.task = asyncio.current_task()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                run.cancelled = True
+                raise
+
+        return _parked
+
+    class _FakeServer:
+        def __init__(self, sid: str) -> None:
+            self._sid = sid
+
+        async def close(self) -> None:
+            closed.append(self._sid)
+
+    try:
+        for sid, run in zip(session_ids, runs, strict=True):
+            task = asyncio.create_task(_make_parked(run)())
+            runner_app_mod._register_auto_forwarder_task(sid, task)
+            runner_app_mod._AUTO_OPENCODE_SERVERS[sid] = _FakeServer(sid)
+        await asyncio.sleep(0)
+
+        await runner_app_mod.teardown_all_opencode_native_servers()
+
+        assert sorted(closed) == sorted(session_ids), "every opencode server must be closed"
+        assert all(sid not in runner_app_mod._AUTO_OPENCODE_SERVERS for sid in session_ids)
+        assert all(sid not in runner_app_mod._AUTO_FORWARDER_TASKS for sid in session_ids)
+        assert all(run.cancelled for run in runs), "every forwarder must be cancelled"
+        # Idempotent: a second sweep with an empty registry is a no-op.
+        await runner_app_mod.teardown_all_opencode_native_servers()
+    finally:
+        for sid in session_ids:
+            runner_app_mod._AUTO_FORWARDER_TASKS.pop(sid, None)
+            runner_app_mod._AUTO_OPENCODE_SERVERS.pop(sid, None)
+        await _drain_forwarder_runs(runs)
+
+
+@pytest.mark.asyncio
 async def test_register_auto_forwarder_task_replaces_incumbent_and_survives_stale_evict() -> None:
     """
     Re-registration cancels the incumbent; its done-callback can't evict the successor.


### PR DESCRIPTION
## Related issue

N/A <!-- follow-up to #3925 (codex leak); same shape found in opencode-native -->

## Summary

Follow-up to #3925. Opencode-native has the **same process-leak shape** codex-native did: each session runs a runner-owned `opencode serve` subprocess (tracked in `_AUTO_OPENCODE_SERVERS`) plus the opencode TUI pane. Only the `DELETE /v1/sessions` teardown cancelled the forwarder (whose `finally` closes the server). The other ways the TUI pane goes away left the server orphaned for the runner's lifetime:

- **idle pane reaper** — closed the tmux pane but never touched `_AUTO_OPENCODE_SERVERS`;
- **unexpected TUI exit** (crash / OOM / host recycle) — evicted the pane without cancelling the forwarder;
- **graceful host/runner stop** — tore the runner down without a per-session DELETE, so `_stop_pm` never closed the servers.

This mirrors the codex fix:

- `teardown_opencode_native_server(session_id)` — cancel the session's forwarder (whose `finally` closes the server) and close any leftover registered server. No-op when no opencode server is registered, so it's safe on the shared pane-teardown paths for every harness.
- `teardown_all_opencode_native_servers()` — shutdown sweep for `_stop_pm`.
- Wired into the idle-reaper reap path, the terminal-exit publisher, and `_stop_pm` alongside the existing codex calls.

**No boot-time reconcile** (unlike codex): opencode has no crash-safe process registry, and `opencode serve` is a plain `subprocess.Popen` (not `start_new_session=True`), so it shares the runner's process group and dies with a hard runner death. The graceful-stop + reaper + exit paths cover the observed leak.

## Test Plan

- `pytest tests/runner/test_app_sessions_native_wake_forwarders.py` — 23 passed (incl. 3 new opencode tests: teardown cancels forwarder + closes server; no-op without a registered server; shutdown sweep closes every session + idempotent)
- `pytest tests/terminals/test_pane_reaper.py` — passed
- `pytest tests/runner/test_app_sessions_native_terminals_runtime.py` — 44 passed (3 pre-existing `pi_cwd` failures, unrelated — verified failing on the clean base too)
- `python -c "import omnigent.runner._entry; import omnigent.runner.app"` — clean
- `pre-commit run` on changed files — passed (pyrefly's 2 errors are in untouched files: `routes_core.py`, `nimble_research.py`)

Manual: launch an opencode-native session, then (a) let it idle out (`OMNIGENT_NATIVE_PANE_IDLE_TIMEOUT_S=15`) or kill the TUI pane, and (b) stop the runner gracefully — confirm `pgrep -fl 'opencode serve'` drops to zero instead of accumulating one per session.

## Demo

N/A — non-visual runner-side process-lifecycle fix.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests mirror the codex ones and cover the per-session teardown (cancel-forwarder + close-server; no-op when unregistered) and the shutdown sweep (`teardown_all_opencode_native_servers` closes every session and is idempotent). The reaper / terminal-exit / `_stop_pm` wirings are closure-local and hard to unit-test directly; verified manually by tracing each exit path and by the identical, already-merged codex wiring they sit beside. Existing reaper and native-terminal suites confirm no regression.

## Changelog

Fixed a leak where native OpenCode sub-agents left orphaned `opencode serve` processes after idle reaping, TUI exit, or runner/host shutdown
