### PR TITLE
Report launch stages on managed-host wake

### DIFF
--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -2545,6 +2545,7 @@ async def resume_managed_host(
     config: ManagedSandboxConfig | None,
     *,
     force: bool = False,
+    on_stage: Callable[[str], None] | None = None,
 ) -> None:
     """
     Wake a dormant managed host so a session bound to it can run again.
@@ -2574,6 +2575,12 @@ async def resume_managed_host(
         the ``sandbox:`` section has been removed since launch.
     :param force: Skip the DB-liveness no-op gate when the caller has local
         evidence that the tunnel is gone.
+    :param on_stage: Progress observer forwarded to the launcher's
+        ``start_host`` (via :func:`_start_sandbox_host`), so a wake reports the
+        launch-pipeline ``"starting"`` stage to the caller's progress surface
+        exactly like a fresh launch (:func:`_arm_and_start_host`) — without it a
+        wake shows a single frozen ``"provisioning"`` band for its whole
+        duration. ``None`` disables progress reporting.
     :raises HTTPException: 502 when the resume or host restart fails.
     """
     if config is None:
@@ -2632,6 +2639,7 @@ async def resume_managed_host(
                 repo_branch=None,
                 repo_name=None,
                 host_config=config.host_config,
+                on_stage=on_stage,
             )
             await _wait_for_host_online(host_store, host.host_id)
         except Exception as exc:

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -3165,10 +3165,24 @@ async def _run_managed_wake(
         tracker.fail(session_id, reason)
         _publish_sandbox_status(session_id, "failed", reason)
         return
+
+    def _on_stage(stage: str) -> None:
+        """Relay the wake's launch-pipeline stage to the session's progress surface.
+
+        Without it the wake shows the single ``"provisioning"`` band that
+        ``_kick_managed_wake`` seeded for its whole duration, even while the host
+        is already re-execing. resume_managed_host may invoke this from the
+        worker thread its ``start_host`` runs on; ``_publish_sandbox_status`` is
+        thread-safe.
+        """
+        _publish_sandbox_status(session_id, stage)
+
     try:
         # Wake the same sandbox in place; resume_managed_host is single-flight
         # per host and a no-op if it's already online.
-        await resume_managed_host(host_id, host_store, sandbox_config, force=True)
+        await resume_managed_host(
+            host_id, host_store, sandbox_config, force=True, on_stage=_on_stage
+        )
         _publish_sandbox_status(session_id, "connecting")
         refreshed = await asyncio.to_thread(conversation_store.get_conversation, session_id)
         if refreshed is None:

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -2304,6 +2304,35 @@ async def test_resume_managed_host_wakes_same_sandbox_and_refreshes_token(db_uri
     assert resolved is not None and resolved.host_id == first.host_id
 
 
+async def test_resume_managed_host_forwards_on_stage(db_uri: str) -> None:
+    """A wake reports launch-pipeline stages through ``on_stage``.
+
+    Parity with the fresh-launch path (``_arm_and_start_host``): base
+    ``start_host`` emits ``"starting"`` before it execs the host, so a wake
+    with an observer must surface at least that stage rather than leaving the
+    caller on a single frozen ``"provisioning"`` band for the whole resume.
+    """
+    host_store = HostStore(db_uri)
+
+    def _register(invocation: HostStartInvocation) -> None:
+        host_store.upsert_on_connect(
+            host_id=invocation.host_id,
+            name=invocation.host_name,
+            user_id=_OWNER,
+        )
+
+    fake = _IsloFakeLauncher(on_host_start=_register, can_resume=True)
+    config = _injected_config(fake)
+    first = await launch_managed_host(config=config, owner=_OWNER, host_store=host_store)
+    host_store.set_offline(first.host_id)
+
+    stages: list[str] = []
+    await resume_managed_host(first.host_id, host_store, config, on_stage=stages.append)
+
+    assert fake.resumed == ["sb-fake-1"]
+    assert "starting" in stages
+
+
 async def test_resume_managed_host_force_wakes_fresh_online_row(db_uri: str) -> None:
     """A local missing-tunnel wake can bypass stale cross-replica DB freshness."""
     host_store = HostStore(db_uri)


### PR DESCRIPTION
## Related issue

N/A

## Summary

A managed-host **wake** (`resume_managed_host` — resuming a dormant resumable sandbox on the next message) never forwarded launch-pipeline stages to the caller, unlike the fresh-launch path (`_arm_and_start_host`), which threads `on_stage` through. So `_run_managed_wake` left the session on the single `"provisioning"` band that `_kick_managed_wake` seeded for the **entire** resume — even while the host was already re-execing and dialing back — and the UI showed a frozen "Provisioning sandbox" band for the whole wake.

- Add an `on_stage` parameter to `resume_managed_host` and forward it to `_start_sandbox_host` (which already accepts it).
- Have `_run_managed_wake` pass a `_publish_sandbox_status` closure, so the wake advances to `"starting"` (emitted by base `start_host`) before `"connecting"`/`"ready"` — matching a fresh launch.

No behavior change when no observer is supplied (`on_stage` defaults to `None`).

## Test Plan

`pytest tests/server/test_managed_hosts.py -k resume_managed_host` — added `test_resume_managed_host_forwards_on_stage` (wake with an observer surfaces `"starting"`); existing resume tests still pass. `ruff check` + `ruff format --check` clean on the changed files.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Changelog

Managed-host wake now reports launch progress ("Starting host") instead of a frozen "Provisioning sandbox" band.
