### PR TITLE
feat(cli): add --profile to omni run for headless Databricks SP auth

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -6979,6 +6979,19 @@ def attach(
     ),
 )
 @click.option(
+    "--profile",
+    "databricks_profile",
+    default=None,
+    metavar="NAME",
+    help=(
+        "Databricks config profile (~/.databrickscfg) to authenticate a "
+        "remote --server with. Sets DATABRICKS_CONFIG_PROFILE so the SDK "
+        "credential chain (service-principal M2M, PAT, OAuth) resolves that "
+        "profile. Use for headless service-principal access to a Databricks "
+        "App without a prior `omnigent login`."
+    ),
+)
+@click.option(
     "--debug-events",
     "debug_events",
     is_flag=True,
@@ -7013,6 +7026,7 @@ def run(
     ephemeral: bool,
     log: bool,
     server: str | None,
+    databricks_profile: str | None,
     debug_events: bool,
     register_host: bool,
 ) -> None:
@@ -7037,7 +7051,16 @@ def run(
       omnigent run examples/hello_world.yaml --harness codex --model gpt-5.4-mini
       omnigent run --server http://localhost:6767
       omnigent run examples/databricks_coding_agent.yaml --server https://<app>.databricksapps.com
+      omnigent run --server https://<app>.databricksapps.com --profile my-sp -p "hi"
     """
+    # A remote --server authenticated via a named Databricks profile: point the
+    # SDK credential chain (used by every remote-auth path in this process) at
+    # that profile. Explicit here so the profile resolves without a prior
+    # `omnigent login` — the headless service-principal path. Only mutates this
+    # CLI process's env, not the shell. An explicit --profile wins over any
+    # ambient DATABRICKS_CONFIG_PROFILE.
+    if databricks_profile:
+        os.environ["DATABRICKS_CONFIG_PROFILE"] = databricks_profile
     # Apply config defaults for any value the user did not pass explicitly.
     # Explicit CLI args always take precedence; project-local config overrides
     # global config, which provides user-level defaults.

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -3104,6 +3104,85 @@ def test_run_from_openclaw_forwards_server(
     assert run_chat.call_args.kwargs["server_url"] == "https://example.com"
 
 
+def _capture_profile_env_at_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> dict[str, str | None]:
+    """Patch ``run``'s collaborators and capture ``DATABRICKS_CONFIG_PROFILE``.
+
+    Returns a dict whose ``"value"`` key is set to the env var as seen at
+    ``_dispatch_run`` time — i.e. after ``run`` applies ``--profile``.
+    """
+    seen: dict[str, str | None] = {}
+    monkeypatch.setattr("omnigent.cli._load_effective_config", dict)
+
+    def _fake_dispatch(**_: object) -> None:
+        seen["value"] = os.environ.get("DATABRICKS_CONFIG_PROFILE")
+
+    monkeypatch.setattr("omnigent.cli._dispatch_run", _fake_dispatch)
+    return seen
+
+
+def test_run_profile_sets_databricks_config_profile_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--profile`` exports ``DATABRICKS_CONFIG_PROFILE`` for the auth chain.
+
+    The remote-auth paths (``_remote_headers`` / ``_server_auth`` /
+    ``_DatabricksTokenAuth``) resolve credentials through the Databricks SDK's
+    env-based profile selection, so ``run`` must set the env var before
+    dispatch for a headless service-principal ``--server`` login to resolve.
+    """
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    seen = _capture_profile_env_at_dispatch(monkeypatch)
+
+    result = CliRunner().invoke(
+        cli,
+        ["run", "--server", "https://example.com", "--profile", "my-sp", "-p", "hi"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen["value"] == "my-sp"
+
+
+def test_run_profile_wins_over_preset_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit ``--profile`` overrides an ambient ``DATABRICKS_CONFIG_PROFILE``.
+
+    A CLI flag is a stronger signal of intent than an inherited env var; the
+    flag must not be a silent no-op when the env var is already set.
+    """
+    monkeypatch.setenv("DATABRICKS_CONFIG_PROFILE", "preset")
+    seen = _capture_profile_env_at_dispatch(monkeypatch)
+
+    result = CliRunner().invoke(
+        cli,
+        ["run", "--server", "https://example.com", "--profile", "my-sp", "-p", "hi"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen["value"] == "my-sp"
+
+
+def test_run_without_profile_leaves_preset_env_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitting ``--profile`` preserves an ambient ``DATABRICKS_CONFIG_PROFILE``.
+
+    Users who export the env var themselves keep working without the flag.
+    """
+    monkeypatch.setenv("DATABRICKS_CONFIG_PROFILE", "preset")
+    seen = _capture_profile_env_at_dispatch(monkeypatch)
+
+    result = CliRunner().invoke(
+        cli,
+        ["run", "--server", "https://example.com", "-p", "hi"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen["value"] == "preset"
+
+
 def test_materialize_harness_launcher_file_kimi_gets_os_env() -> None:
     """``run --harness kimi`` bakes a caller-process ``os_env`` so the SDK kimi
     operates in the user's current directory, matching claude-sdk.


### PR DESCRIPTION
## Related issue

N/A

## Summary

- `omni run --server <databricks-app-url>` could not authenticate as a **service principal**. The remote-auth paths resolve credentials through the Databricks SDK's default chain, which reads only the `DEFAULT` `~/.databrickscfg` profile. When `DEFAULT` points at a different workspace than the one fronting the app, the minted token is for the *wrong* workspace and the Databricks Apps proxy bounces the request to interactive OIDC (302) instead of admitting it — so headless/CI service-principal access was impossible without a prior browser `omnigent login`.
- Adds a **`--profile NAME`** option to `omni run` that sets `DATABRICKS_CONFIG_PROFILE` for the CLI process, so every remote-auth path (`_remote_headers`, `_server_auth`, `_DatabricksTokenAuth`) resolves the named service-principal profile. An explicit `--profile` **wins over** an ambient `DATABRICKS_CONFIG_PROFILE`; omitting it leaves any preset untouched. The mutation is process-scoped (does not touch the user's shell).
- **Databricks-side prerequisite (not code):** the service principal must have `CAN USE` on the app.

ELI5: `omni run` was always reaching for your "default" Databricks login. This flag lets you say "use *this* service-principal login instead," which is what a robot/CI needs to talk to a deployed omnigent app without a browser.

## Test Plan

- **New unit tests** (`tests/cli/test_cli.py`, all green):
  - `--profile` sets `DATABRICKS_CONFIG_PROFILE` seen at dispatch.
  - explicit `--profile` overrides a preset env var.
  - omitting `--profile` leaves a preset env var untouched.
  ```
  pytest tests/cli/test_cli.py -k "profile_sets_databricks or profile_wins or without_profile_leaves"
  # 3 passed
  ```
- **Live verification** against a real deployed Databricks App (SP granted `CAN USE`):
  - With `--profile <sp>`: `GET /v1/me` → **200**, `user_id` = the SP's client id; `/v1/agents` → 200.
  - Without `--profile` (DEFAULT profile → different workspace): **302** redirect to OIDC.

## Demo

N/A (CLI flag; no UI change)

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the flag→env precedence contract (set / flag-wins / preset-preserved) without network. Manual verification exercised the end-to-end path against a live Databricks App: `--profile <sp>` authenticated the service principal (200) where the default profile was redirected to OIDC (302).

## Changelog

`omnigent run --profile <name>` authenticates a remote `--server` with a named Databricks profile (enables headless service-principal access to a deployed app)

This pull request and its description were written by Isaac.