### PR TITLE
chore(lint): enforce web TypeScript checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-# Runs the project's pre-commit hooks (ruff, Pyrefly, TypeScript lint, custom
+# Runs the project's pre-commit hooks (ruff, Pyrefly, TypeScript lint/type-check, custom
 # anti-pattern grep hooks, etc.) on every non-draft PR and on push to main.
 # Surfaces as the `Pre-commit checks` check, a REQUIRED gate entry in
 # merge-ready.yml. Draft PRs are skipped; `ready_for_review` refires so the

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,13 @@ repos:
         files: ^(web/.*\.[cm]?[jt]sx?|web/\.oxlintrc\.json|web/package\.json|pnpm-lock\.yaml)$
         pass_filenames: false
 
+      - id: web-tsc
+        name: web TypeScript type check
+        language: system
+        entry: pnpm --filter web run type-check
+        files: ^(web/.*\.[cm]?[jt]sx?|web/tsconfig(?:\.[^.]+)?\.json|web/package\.json|pnpm-(?:lock|workspace)\.yaml)$
+        pass_filenames: false
+
       # Android Kotlin formatting + linting via ktlint (config:
       # web/android/.editorconfig). The wrapper no-ops when ktlint is absent,
       # so local machines without ktlint installed skip cleanly. CI installs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
       - id: web-tsc
         name: web TypeScript type check
         language: system
-        entry: pnpm --filter web run type-check
+        entry: bash -c 'test -x web/node_modules/.bin/tsc && cd web && node_modules/.bin/tsc -b'
         files: ^(web/.*\.[cm]?[jt]sx?|web/tsconfig(?:\.[^.]+)?\.json|web/package\.json|pnpm-(?:lock|workspace)\.yaml)$
         pass_filenames: false
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ uv run pre-commit run --all-files
 When touching `web/`:
 
 ```bash
-cd web && pnpm install && pnpm run lint && pnpm run build
+cd web && pnpm install && pnpm run lint && pnpm run type-check && pnpm run build
 ```
 
 ## Running locally

--- a/justfile
+++ b/justfile
@@ -101,6 +101,7 @@ typecheck-python: _ensure-uv
 lint-ts:
     pnpm install --frozen-lockfile --filter web
     pnpm --filter web run lint
+    pnpm --filter web run type-check
 
 # --- Lockfile maintenance ---
 

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -6,6 +6,7 @@
     "module": "esnext",
     "types": ["vite/client"],
     "skipLibCheck": true,
+    "strict": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",
@@ -18,6 +19,8 @@
     /* Linting */
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noUncheckedSideEffectImports": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
 

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -6,6 +6,7 @@
     "module": "esnext",
     "types": ["node"],
     "skipLibCheck": true,
+    "strict": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",
@@ -17,6 +18,8 @@
     /* Linting */
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noUncheckedSideEffectImports": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add the existing web `tsc -b` command to pre-commit, which also makes it part of the required `Pre-commit checks` CI gate.
- Enable TypeScript `strict`, `noImplicitOverride`, and `noUncheckedSideEffectImports` in both web projects; the current baseline already passes all three.
- Keep `just lint-ts` and the contributor workflow aligned with the enforced checks.

## Test Plan

- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `uv run --no-sync pre-commit run web-tsc --all-files`
- `uv run --no-sync pre-commit run --show-diff-on-failure`

## Demo

N/A — non-visual lint and type-checking change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified the stricter compiler settings against the complete web TypeScript project and exercised the exact pre-commit hook used by CI.
