### PR TITLE
fix(host): recover from workspace-missing runner launch failures

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -29,6 +29,7 @@ from omnigent.harness_aliases import canonicalize_harness
 from omnigent.harness_availability import HARNESS_BINARY_MISSING, HarnessAvailability
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE,
+    WORKSPACE_MISSING_ERROR_CODE,
     HostCreateDirFrame,
     HostCreateDirResultFrame,
     HostCreateWorktreeFrame,
@@ -1141,6 +1142,7 @@ class HostProcess:
                 request_id=frame.request_id,
                 status="failed",
                 error=f"workspace path does not exist: {workspace}",
+                error_code=WORKSPACE_MISSING_ERROR_CODE,
             )
 
         runner_id = token_bound_runner_id(frame.binding_token)

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -33,6 +33,11 @@ from omnigent.json_types import JsonObject as _JsonObject
 # ``ErrorCode.HARNESS_NOT_CONFIGURED``), and tests.
 HARNESS_NOT_CONFIGURED_ERROR_CODE = "harness_not_configured"
 
+# when the host refuses a launch because the session's workspace directory
+# does not exist on the host (e.g. the worktree was deleted). Shared by the
+# daemon (producer) and server (consumer) so both can handle it structurally.
+WORKSPACE_MISSING_ERROR_CODE = "workspace_missing"
+
 
 class HostFrameKind(str, Enum):
     """All host frame kinds; the value is the JSON wire string."""

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -43,6 +43,9 @@ from omnigent.errors import ElicitationDeclinedError, ErrorCode, OmnigentError
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE as _HARNESS_NOT_CONFIGURED_ERROR_CODE,
 )
+from omnigent.host.frames import (
+    WORKSPACE_MISSING_ERROR_CODE as _WORKSPACE_MISSING_ERROR_CODE,
+)
 from omnigent.llms.context_window import resolve_effective_context_window
 from omnigent.native_coding_agents import (
     native_coding_agent_for_agent_name,
@@ -2684,10 +2687,25 @@ async def ensure_runner_connected(
                 host_registry,
                 host_conn,
             )
-            # A harness-not-configured refusal is a real host-side error, but
-            # out of band there's no turn to persist it against — leave the
-            # binding and let the caller surface the transport failure.
-            if launch_attempt.error_code != _HARNESS_NOT_CONFIGURED_ERROR_CODE:
+            # A harness-not-configured or workspace-missing refusal means the
+            # runner will never appear — don't set relaunched_runner_id or the
+            # caller will wait out the full connect timeout for nothing.
+            # Record the refusal message in runner_exit_reports so the
+            # runner_failed_to_start error surfaces the actionable cause
+            # rather than the generic "may have failed to start" fallback.
+            _fatal_refusal = launch_attempt.error_code in (
+                _HARNESS_NOT_CONFIGURED_ERROR_CODE,
+                _WORKSPACE_MISSING_ERROR_CODE,
+            )
+            if _fatal_refusal and launch_attempt.error is not None:
+                _rer = getattr(app_state, "runner_exit_reports", None)
+                if _rer is not None:
+                    _rer.record(
+                        launch_attempt.runner_id,
+                        launch_attempt.error,
+                        owner=None,
+                    )
+            if not _fatal_refusal:
                 relaunched_runner_id = launch_attempt.runner_id
         elif await _maybe_relaunch_managed_sandbox(
             session_id=session_id,

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -25,6 +25,9 @@ from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE as _HARNESS_NOT_CONFIGURED_ERROR_CODE,
 )
+from omnigent.host.frames import (
+    WORKSPACE_MISSING_ERROR_CODE as _WORKSPACE_MISSING_ERROR_CODE,
+)
 from omnigent.runner.identity import RUNNER_TUNNEL_TOKEN_HEADER, token_bound_runner_id
 from omnigent.runner.routing import RunnerRouter
 from omnigent.runtime import (
@@ -1163,6 +1166,31 @@ def register_events_routes(
                             body,
                             conversation_store,
                             launch_attempt.error,
+                            runner_router,
+                            created_by=created_by,
+                        )
+                        return {"queued": True, "item_id": item_id}
+                    if launch_attempt.error_code == _WORKSPACE_MISSING_ERROR_CODE:
+                        # The host refused: the workspace directory no longer
+                        # exists (e.g. the worktree was deleted). Consume the
+                        # message and persist an actionable error banner so the
+                        # user knows to start a new session with a valid
+                        # workspace — instead of timing out into a generic
+                        # RUNNER_UNAVAILABLE.
+                        item_id = await _persist_native_terminal_failure(
+                            session_id,
+                            conv,
+                            body,
+                            conversation_store,
+                            ErrorData(
+                                source="execution",
+                                code="runner_failed_to_start",
+                                message=(
+                                    launch_attempt.error
+                                    or "The session workspace no longer exists on the host. "
+                                    "Start a new session with a valid workspace."
+                                ),
+                            ),
                             runner_router,
                             created_by=created_by,
                         )

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -636,6 +636,9 @@ async def test_handle_launch_fails_for_bad_workspace() -> None:
     assert "does not exist" in (result.error or ""), (
         f"Error should mention path doesn't exist, got: {result.error!r}"
     )
+    assert result.error_code == "workspace_missing", (
+        f"Should carry workspace_missing error_code, got: {result.error_code!r}"
+    )
     assert result.runner_id is None
 
 

--- a/tests/server/integration/test_session_host_launch.py
+++ b/tests/server/integration/test_session_host_launch.py
@@ -493,6 +493,7 @@ async def test_inline_launch_failure_still_returns_bound_session(
 _HARNESS_REFUSAL = (
     "harness 'codex' is not configured on host 'laptop' — run `omnigent setup` on that machine"
 )
+_WORKSPACE_MISSING_ERROR = "workspace path does not exist: /deleted/worktree"
 
 
 async def test_inline_create_harness_not_configured_stays_lenient(
@@ -1793,3 +1794,91 @@ async def test_offline_runner_no_host_still_returns_503(
     finally:
         set_runner_router(prior_router)
     assert resp.status_code == 503, resp.text
+
+
+async def test_message_relaunch_workspace_missing_persists_error_turn(
+    client: httpx.AsyncClient,
+    app: FastAPI,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Workspace-missing refusal at relaunch persists user msg + error turn.
+
+    When the session workspace has been deleted on the host (e.g. the
+    worktree was pruned), the host returns ``workspace_missing`` and the
+    runner will never appear. The server must:
+    - NOT wait out the full connect timeout (which would hang every message);
+    - Persist the user message together with a ``runner_failed_to_start``
+      error item carrying the host's actionable "workspace does not exist"
+      message instead of the generic fallback.
+
+    Mutation check: drop the ``_WORKSPACE_MISSING_ERROR_CODE`` branch in
+    ``_ensure_runner_relay_ready`` and the message 503s with
+    ``runner_unavailable`` and no error item is written.
+    """
+    from omnigent.runtime import set_runner_client
+    from omnigent.server.routes import sessions as sessions_module
+
+    monkeypatch.setattr(sessions_module, "_HOST_BOUND_RUNNER_CONNECT_GRACE_S", 0.0)
+
+    comm = await _connect_host(app)
+    agent = await create_test_agent(
+        client,
+        executor={"type": "omnigent", "config": {"harness": "claude-native"}},
+    )
+    create_responder = asyncio.create_task(_serve_one_launch(comm, launch_status="launched"))
+    create_resp = await client.post(
+        "/v1/sessions",
+        json={"agent_id": agent["id"], "host_id": _HOST_ID, "workspace": _WORKSPACE},
+    )
+    await create_responder
+    assert create_resp.status_code == 201, create_resp.text
+    session_id = create_resp.json()["id"]
+
+    set_runner_client(None)
+    relaunch_responder = asyncio.create_task(
+        _serve_one_launch(
+            comm,
+            launch_status="failed",
+            launch_error=_WORKSPACE_MISSING_ERROR,
+            launch_error_code="workspace_missing",
+        )
+    )
+    try:
+        msg_resp = await client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={
+                "type": "message",
+                "data": {"role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+            },
+        )
+    finally:
+        await relaunch_responder
+        set_runner_client(None)
+
+    assert msg_resp.status_code == 202, (
+        f"expected 202, got {msg_resp.status_code}: {msg_resp.text}"
+    )
+
+    items = await client.get(f"/v1/sessions/{session_id}/items")
+    assert items.status_code == 200, items.text
+    data = items.json()["data"]
+    user_texts = [
+        part.get("text", "")
+        for item in data
+        if item.get("type") == "message"
+        for part in item.get("content", [])
+    ]
+    assert "hello" in user_texts, f"user message should be persisted, got {user_texts!r}"
+    error_items = [item for item in data if item.get("type") == "error"]
+    assert len(error_items) == 1, (
+        f"expected exactly one error item for the workspace-missing refusal, got {error_items!r}"
+    )
+    assert error_items[0]["code"] == "runner_failed_to_start"
+    assert "does not exist" in error_items[0]["message"], (
+        f"error message should mention workspace does not exist, got {error_items[0]['message']!r}"
+    )
+
+    conv = SqlAlchemyConversationStore(db_uri).get_conversation(session_id)
+    assert conv is not None
+    assert conv.host_id == _HOST_ID


### PR DESCRIPTION
## Summary

When a session's workspace directory is deleted on the host (e.g. a worktree is pruned), users see a confusing generic `runner_failed_to_start` error after waiting out the full connect timeout. The root cause: the host returns a failed result with no `error_code`, so the server can't distinguish a workspace-missing failure from other failures.

- Add `WORKSPACE_MISSING_ERROR_CODE = "workspace_missing"` to `host/frames.py`
- Host sets this code when `workspace.is_dir()` fails at launch time
- `routes_events.py` handles `workspace_missing` the same way as `harness_not_configured`: immediately consume the user message and persist a `runner_failed_to_start` error item carrying the host's "workspace path does not exist: ..." message — no more waiting out the full connect timeout
- `_ensure_runner_relay_ready` in `orchestration.py` also skips the connect-timeout wait for `workspace_missing`, and records the refusal in `runner_exit_reports` so snapshot-based UI renders also show the actionable message

The user-visible error changes from:
> "The runner for this session is not available — it may have failed to start. See the host logs."

To:
> "workspace path does not exist: /Users/.../omnigent-worktrees/my-branch"

Which tells them exactly why and implicitly points to starting a new session with a valid workspace.

## Test Plan

- `test_handle_launch_fails_for_bad_workspace`: updated to assert `error_code == "workspace_missing"`
- `test_message_relaunch_workspace_missing_persists_error_turn`: new integration test — workspace-missing refusal at relaunch persists user message + `runner_failed_to_start` error item with actionable message; does not 503

```
python -m pytest tests/host/test_connect.py::test_handle_launch_fails_for_bad_workspace tests/server/integration/test_session_host_launch.py::test_message_relaunch_workspace_missing_persists_error_turn -v
# 2 passed
python -m pytest tests/server/integration/test_session_host_launch.py tests/server/integration/test_sessions_archive.py tests/host/test_connect.py -q
# 129 passed
```

## Demo

N/A — error message improvement, no UI change.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Test coverage
- [x] New tests added