### PR TITLE
fix(host): retry 401/403 on an already-connected host

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -715,12 +715,18 @@ class HostProcess:
         self._auth_token_factory: Callable[[], str | None] | None = None
         self._auth_token_factory_resolved = False
         # Set on the first accepted WS upgrade. Distinguishes a host that
-        # never authenticated (login redirects turn fatal after
-        # _LOGIN_REDIRECT_FATAL_ATTEMPTS) from a live host hit by a server
-        # restart (login redirects retry forever).
+        # never authenticated (login redirects / 401 / 403 turn fatal) from a
+        # live host hit by a transient failure — a server restart or a dropped
+        # VPN whose proxy answers 401/403 before the request reaches the
+        # server — where the same failures retry forever instead of killing a
+        # host with running sessions.
         self._ever_connected = False
         # Consecutive login-page redirects; reset by a successful upgrade.
         self._login_redirect_streak = 0
+        # Consecutive 401/403 upgrade rejections on an already-connected host;
+        # reset by a successful upgrade. Gates the once-per-episode terminal
+        # notice so a VPN outage doesn't spam stderr on every retry.
+        self._auth_retry_streak = 0
         # Live tunnel connection, set by _serve_frames for the watcher
         # tasks (which outlive any single connection) to report on.
         self._ws: websockets.asyncio.client.ClientConnection | None = None
@@ -1067,6 +1073,31 @@ class HostProcess:
             5xx server bounce) that the reconnect loop should retry.
         """
         if status in _RETRYABLE_UPGRADE_STATUSES or not (400 <= status < 500):
+            return None
+        if status in (401, 403) and self._ever_connected:
+            # A host that already completed an upgrade proved its credentials
+            # and authorization are valid, so a later 401/403 is almost always
+            # a network-path artifact — a dropped VPN whose corporate proxy
+            # answers the upgrade with 401/403 before it reaches the server.
+            # Retry forever (mirrors the login-redirect path) so a live host
+            # with running sessions survives the outage and resumes when the
+            # path recovers, instead of exiting and forcing a manual restart.
+            self._auth_retry_streak += 1
+            cause = (
+                f"Connection refused (HTTP {status}): the host tunnel was "
+                "rejected after it had already connected."
+            )
+            _logger.warning("%s Retrying — check your VPN/network.", cause)
+            if self._auth_retry_streak == 1:
+                # The warning above lands only in the CLI log file; print once
+                # per outage so a foreground `omnigent host` isn't silent.
+                print(
+                    f"⚠ {cause} Retrying — this usually means the VPN or "
+                    "network dropped. It will reconnect automatically once "
+                    "connectivity returns.",
+                    file=sys.stderr,
+                    flush=True,
+                )
             return None
         if status == 401:
             return HostConnectError(
@@ -2312,6 +2343,7 @@ class HostProcess:
         # from here on are server restarts, not an unauthenticated host.
         self._ever_connected = True
         self._login_redirect_streak = 0
+        self._auth_retry_streak = 0
         try:
             await self._serve_frames(ws)
         finally:

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -3322,6 +3322,88 @@ async def test_connected_host_retries_login_redirects_indefinitely(
     assert spy.call_count == 6
 
 
+@pytest.mark.parametrize("status", [401, 403])
+async def test_connected_host_retries_auth_rejection_indefinitely(
+    monkeypatch: pytest.MonkeyPatch, status: int
+) -> None:
+    """401/403 after a successful connect never turns fatal.
+
+    A host that already completed an upgrade proved its credentials and
+    authorization are valid. A later 401/403 is almost always a dropped
+    VPN whose corporate proxy answers the upgrade before it reaches the
+    server — killing the host would drop its live runners and force a
+    manual ``omnigent host`` restart once the VPN reconnects. It must keep
+    retrying past the fresh-host fatal threshold instead.
+    """
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    rejection = _invalid_status(status)
+    # Accepted upgrade first (None), then several rejections (more than the
+    # fresh-host login-redirect fatal threshold of 3 to prove there is no
+    # cap), then a cancel to end the test.
+    spy = _ConnectSpy([None, rejection, rejection, rejection, rejection, asyncio.CancelledError()])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    # Returns normally: if the post-connect rejections were still treated as
+    # fatal this would raise HostConnectError on the first one (call_count 2).
+    await host.run()
+
+    # 6 = accepted connect + 4 retried rejections + the ending cancel.
+    assert spy.call_count == 6
+
+
+@pytest.mark.parametrize("status", [401, 403])
+async def test_connected_host_auth_rejection_prints_notice_once(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    status: int,
+) -> None:
+    """The first auth rejection of an outage warns on stderr, exactly once.
+
+    ``_logger.warning`` goes to the CLI log file, so a foreground
+    ``omnigent host`` would sit silent while it retried a dropped VPN. The
+    terminal notice must name the cause and mention VPN/network, and must
+    print only once per outage (not on every retry) so it doesn't spam
+    stderr while connectivity is down.
+    """
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    rejection = _invalid_status(status)
+    spy = _ConnectSpy([None, rejection, rejection, rejection, asyncio.CancelledError()])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    await host.run()
+
+    err = capsys.readouterr().err
+    # The cause reached the terminal, naming the transient network hint.
+    assert f"HTTP {status}" in err
+    assert "VPN" in err
+    # Printed once for the whole outage, not once per retry — three
+    # consecutive rejections must yield a single notice line.
+    assert err.count(f"HTTP {status}") == 1
+
+
+async def test_fresh_host_still_fails_loud_on_auth_rejection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A never-connected host still fails loud on 401/403.
+
+    The connected-host retry keys on a prior successful upgrade. A host
+    that has NEVER connected and is rejected with 401/403 is genuinely
+    unauthenticated / unauthorized — it must still raise HostConnectError
+    on the first attempt (→ exit 1 with the fix printed), not loop.
+    """
+    spy = _ConnectSpy([_invalid_status(403)])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    with pytest.raises(HostConnectError):
+        await host.run()
+
+    # Exactly one attempt → no silent retry for the fresh-host case.
+    assert spy.call_count == 1
+
+
 @pytest.mark.parametrize(
     "status,expected",
     [


### PR DESCRIPTION
## Related issue

N/A

## Summary

When the VPN drops, a corporate proxy answers the host tunnel's WebSocket upgrade with **403** *before the request ever reaches the Omnigent server*. `_classify_http_status` in `omnigent/host/connect.py` treated 401/403 as permanently fatal, so a live, already-registered host exited with code 1 — forcing the user to re-run `omnigent host` after reconnecting.

- A host that has **already completed an upgrade** proved its credentials and authorization are valid, so a later 401/403 is almost always a transient network-path artifact (dropped VPN), not real deauthorization.
- For a connected host, 401/403 now **retries forever** via the normal reconnect path — mirroring the existing login-redirect design that keys on `_ever_connected` — with a **once-per-outage** stderr notice so a foreground `omnigent host` isn't silent.
- A **fresh, never-connected** host still **fails loud** on the first 401/403 (genuine auth/authorization failure), unchanged.

## Test Plan

- `python -m pytest tests/host/test_connect.py -k "auth_rejection or fails_loud or login_redirect or reconnects_on_transient or permanent_4xx or nonzero_on_fatal" -q` → **21 passed** (6 new cases + all existing fail-loud / transient / login-redirect coverage).
- New tests:
  - `test_connected_host_retries_auth_rejection_indefinitely[401/403]` — connected host retries past the fresh-host fatal threshold.
  - `test_connected_host_auth_rejection_prints_notice_once[401/403]` — terminal notice prints exactly once per outage, names the cause + VPN/network hint.
  - `test_fresh_host_still_fails_loud_on_auth_rejection` — never-connected host still exits on the first rejection.
- `pre-commit run --files omnigent/host/connect.py tests/host/test_connect.py` → all hooks pass.

Manual repro: start `omnigent host <url>` on VPN (it registers), disconnect VPN → previously exited immediately; now prints a one-time `⚠ … HTTP 403 … VPN or network dropped …` notice and keeps retrying; reconnect VPN → host reconnects automatically with no manual restart.

## Demo

before
<img width="682" height="186" alt="image" src="https://github.com/user-attachments/assets/4d0bcaa7-5c04-4491-b80a-8ec3b40e6091" />

after
<img width="933" height="80" alt="image" src="https://github.com/user-attachments/assets/d00810c6-66ba-4853-a278-d6e963d7af63" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests drive the public `run()` / `run_host_process` entry points with a stubbed `websockets.connect` whose handshake raises `InvalidStatus(401/403)`, covering: connected-host retry (no cap), once-per-outage stderr notice, and fresh-host fail-loud. Manual verification: reproduced the VPN-drop path locally against a running host and confirmed it retries and auto-reconnects instead of exiting.

## Changelog

`omnigent host` now survives a dropped VPN — a 401/403 on an already-connected host retries and auto-reconnects instead of exiting
