### PR TITLE
fix(web): stop rendering shell-style env vars in prose as LaTeX math

### DIFF
--- a/web/src/components/ai-elements/mathMarkdown.test.ts
+++ b/web/src/components/ai-elements/mathMarkdown.test.ts
@@ -30,6 +30,12 @@ describe("normalizeExplicitMathDelimiters — dollar handling", () => {
     );
   });
 
+  it("escapes a single-char braced reference but not a bare single char", () => {
+    // Braces disambiguate `${A}` as a variable; bare `$A …` stays inline math.
+    expect(normalizeExplicitMathDelimiters("value ${A} here")).toBe("value \\${A} here");
+    expect(normalizeExplicitMathDelimiters("the $A + B$ span")).toBe("the $A + B$ span");
+  });
+
   it("leaves genuine inline math intact", () => {
     expect(normalizeExplicitMathDelimiters("the value $x + y$ holds")).toBe(
       "the value $x + y$ holds",

--- a/web/src/components/ai-elements/mathMarkdown.test.ts
+++ b/web/src/components/ai-elements/mathMarkdown.test.ts
@@ -36,6 +36,12 @@ describe("normalizeExplicitMathDelimiters — dollar handling", () => {
     expect(normalizeExplicitMathDelimiters("the $A + B$ span")).toBe("the $A + B$ span");
   });
 
+  it("does not match a SCREAMING_CASE prefix of a mixed-case token", () => {
+    // `$FOO` is a prefix of `$FOOBar`; matching it would escape the opener and
+    // strand the closing `$`, breaking the surrounding inline math span.
+    expect(normalizeExplicitMathDelimiters("the $FOOBar$ span")).toBe("the $FOOBar$ span");
+  });
+
   it("leaves genuine inline math intact", () => {
     expect(normalizeExplicitMathDelimiters("the value $x + y$ holds")).toBe(
       "the value $x + y$ holds",

--- a/web/src/components/ai-elements/mathMarkdown.test.ts
+++ b/web/src/components/ai-elements/mathMarkdown.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { normalizeExplicitMathDelimiters } from "./mathMarkdown";
+
+describe("normalizeExplicitMathDelimiters — dollar handling", () => {
+  it("converts TeX delimiters to dollars outside code", () => {
+    expect(normalizeExplicitMathDelimiters("area is \\(a^2\\)")).toBe("area is $a^2$");
+    expect(normalizeExplicitMathDelimiters("\\[a+b\\]")).toBe("$$a+b$$");
+  });
+
+  it("escapes currency so prose doesn't render as math", () => {
+    expect(normalizeExplicitMathDelimiters("it costs $5 or $10")).toBe("it costs \\$5 or \\$10");
+  });
+
+  it("escapes shell-style env-var references so they read as literal text", () => {
+    expect(normalizeExplicitMathDelimiters("Set $LLM_API_KEY")).toBe("Set \\$LLM_API_KEY");
+    expect(
+      normalizeExplicitMathDelimiters(
+        "Unresolved environment variable '$LLM_API_KEY' referenced by 'env:LLM_API_KEY'. " +
+          "Set $LLM_API_KEY or $OMNIGENT_LLM_API_KEY in the environment.",
+      ),
+    ).toBe(
+      "Unresolved environment variable '\\$LLM_API_KEY' referenced by 'env:LLM_API_KEY'. " +
+        "Set \\$LLM_API_KEY or \\$OMNIGENT_LLM_API_KEY in the environment.",
+    );
+  });
+
+  it("escapes braced env-var references", () => {
+    expect(normalizeExplicitMathDelimiters("use ${OMNIGENT_LLM_API_KEY} here")).toBe(
+      "use \\${OMNIGENT_LLM_API_KEY} here",
+    );
+  });
+
+  it("leaves genuine inline math intact", () => {
+    expect(normalizeExplicitMathDelimiters("the value $x + y$ holds")).toBe(
+      "the value $x + y$ holds",
+    );
+  });
+
+  it("leaves dollars inside inline code verbatim", () => {
+    expect(normalizeExplicitMathDelimiters("`$LLM_API_KEY`")).toBe("`$LLM_API_KEY`");
+  });
+});

--- a/web/src/components/ai-elements/mathMarkdown.ts
+++ b/web/src/components/ai-elements/mathMarkdown.ts
@@ -3,8 +3,13 @@
 // convention), so it's treated as literal text rather than a math opener. The
 // braces already disambiguate `${A}`, so a single char is enough there; the
 // bare form requires 2+ chars so a lone `$X …` still reads as inline math.
+// The bare form also demands a full-token boundary (`(?![A-Za-z0-9_])`) so a
+// mixed token like `$FOOBar$` isn't matched by its uppercase prefix — the
+// lookahead rejects any continuing identifier char so greedy backtracking
+// can't settle on `$FOO`; escaping only the opener would strand the closing
+// `$` and break genuine inline math.
 // Anchored at the `$`, which the caller has already matched.
-const SHELL_VAR_RE = /^\$(?:\{[A-Z_][A-Z0-9_]*\}|[A-Z_][A-Z0-9_]+)/;
+const SHELL_VAR_RE = /^\$(?:\{[A-Z_][A-Z0-9_]*\}|[A-Z_][A-Z0-9_]+(?![A-Za-z0-9_]))/;
 
 // Optional 1–3 space indent + a fence run, per CommonMark. Matching the full
 // run (not just the first three chars) also keeps a ````-fenced block from

--- a/web/src/components/ai-elements/mathMarkdown.ts
+++ b/web/src/components/ai-elements/mathMarkdown.ts
@@ -1,7 +1,9 @@
 // A lone `$` reads as a shell-style variable reference — `$VAR_NAME` or
-// `${VAR_NAME}` — when followed by a SCREAMING_CASE identifier of 2+ chars (an
-// env-var convention), so it's treated as literal text rather than a math
-// opener. Anchored at the `$`, which the caller has already matched.
+// `${VAR_NAME}` — when followed by a SCREAMING_CASE identifier (an env-var
+// convention), so it's treated as literal text rather than a math opener. The
+// braces already disambiguate `${A}`, so a single char is enough there; the
+// bare form requires 2+ chars so a lone `$X …` still reads as inline math.
+// Anchored at the `$`, which the caller has already matched.
 const SHELL_VAR_RE = /^\$(?:\{[A-Z_][A-Z0-9_]*\}|[A-Z_][A-Z0-9_]+)/;
 
 // Optional 1–3 space indent + a fence run, per CommonMark. Matching the full

--- a/web/src/components/ai-elements/mathMarkdown.ts
+++ b/web/src/components/ai-elements/mathMarkdown.ts
@@ -1,3 +1,9 @@
+// A lone `$` reads as a shell-style variable reference — `$VAR_NAME` or
+// `${VAR_NAME}` — when followed by a SCREAMING_CASE identifier of 2+ chars (an
+// env-var convention), so it's treated as literal text rather than a math
+// opener. Anchored at the `$`, which the caller has already matched.
+const SHELL_VAR_RE = /^\$(?:\{[A-Z_][A-Z0-9_]*\}|[A-Z_][A-Z0-9_]+)/;
+
 // Optional 1–3 space indent + a fence run, per CommonMark. Matching the full
 // run (not just the first three chars) also keeps a ````-fenced block from
 // leaking its fourth backtick into inline-code tracking.
@@ -15,11 +21,14 @@ const FENCE_RE = /^ {0,3}(`{3,}|~{3,})/;
  * - A literal `\\` or `\$` is copied verbatim so its trailing `\[`/`\(` isn't
  *   read as an explicit delimiter and an escaped dollar isn't re-toggled.
  *
- * A single `$` immediately before a digit reads as currency ($5), not an inline
- * math opener, so it's escaped and doesn't flip the math span — otherwise, with
- * single-dollar math enabled, prose like "it costs $5 or $10" renders as a
- * garbled formula. (Genuine inline math that starts with a digit, e.g. `$3x$`,
- * is the rare casualty; digit-led currency in prose is far more common.)
+ * A single `$` reads as literal prose rather than an inline-math opener when it
+ * looks like currency ($5) or a shell-style variable reference ($LLM_API_KEY,
+ * ${OMNIGENT_LLM_API_KEY}), so it's escaped and doesn't flip the math span.
+ * Otherwise, with single-dollar math enabled, prose like "it costs $5 or $10"
+ * or an error such as "Unresolved variable '$LLM_API_KEY' … Set $LLM_API_KEY"
+ * renders as a garbled formula. (Genuine inline math that starts with a digit
+ * (`$3x$`) or a SCREAMING_CASE identifier (`$N_A$`) is the rare casualty;
+ * currency and env-var references in prose are far more common.)
  */
 export function normalizeExplicitMathDelimiters(text: string): string {
   let result = "";
@@ -83,8 +92,9 @@ export function normalizeExplicitMathDelimiters(text: string): string {
     if (char === "$") {
       let run = 1;
       while (text[i + run] === "$") run += 1;
-      const isCurrency = run === 1 && !inMath && /\d/.test(text[i + 1] ?? "");
-      if (isCurrency) {
+      const isLiteralDollar =
+        run === 1 && !inMath && (/\d/.test(text[i + 1] ?? "") || SHELL_VAR_RE.test(text.slice(i)));
+      if (isLiteralDollar) {
         result += "\\$";
         continue;
       }


### PR DESCRIPTION
## Related issue

N/A

## Summary

Error messages that reference environment variables — e.g. `Error: turn setup failed: Unresolved environment variable '$LLM_API_KEY' referenced by 'env:LLM_API_KEY'. Set $LLM_API_KEY or $OMNIGENT_LLM_API_KEY in the environment.` — render through the assistant markdown renderer, which has single-dollar math enabled (`singleDollarTextMath: true`). The paired `$` tokens collapsed into a garbled inline LaTeX formula (see before image).

`normalizeExplicitMathDelimiters` already escaped a lone `$` before a digit (currency, e.g. `$5`) so prose doesn't flip the math span. This extends that heuristic to also escape shell-style variable references — `$VAR_NAME` and `${VAR_NAME}` in SCREAMING_CASE — so they stay literal text.

## Test Plan

- Added `web/src/components/ai-elements/mathMarkdown.test.ts` covering currency, `$LLM_API_KEY`, `${OMNIGENT_LLM_API_KEY}`, the exact error string, genuine inline math (`$x + y$` preserved), and inline-code verbatim.
- `cd web && npm test` — full suite green (4884 passed).
- `cd web && npm run build` — succeeds.

## Demo

**Before:** `$LLM_API_KEY ... $ ... $` rendered as an italic LaTeX formula (as in the reported screenshot).

**After:** the `$LLM_API_KEY` / `$OMNIGENT_LLM_API_KEY` tokens render as literal text.

N/A (text-rendering fix; covered by unit tests).

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — unit tests cover the escaping logic directly.

## Changelog

Error messages that mention environment variables like `$LLM_API_KEY` no longer render as garbled math

This pull request and its description were written by Isaac.