### PR TITLE
chore(web): require explicit returns

### DIFF
--- a/web/src/shell/CommentsPanel.tsx
+++ b/web/src/shell/CommentsPanel.tsx
@@ -114,11 +114,10 @@ export function CommentsPanel({
     const isExisting = comments.some(
       (c) => c.start_index === activeSelectionStart && c.end_index === activeSelectionEnd,
     );
-    if (!isExisting) {
-      // rAF ensures the textarea has been rendered before we try to focus it.
-      const id = requestAnimationFrame(() => addCommentTextareaRef.current?.focus());
-      return () => cancelAnimationFrame(id);
-    }
+    if (isExisting) return undefined;
+    // rAF ensures the textarea has been rendered before we try to focus it.
+    const id = requestAnimationFrame(() => addCommentTextareaRef.current?.focus());
+    return () => cancelAnimationFrame(id);
   }, [activeSelectionStart, activeSelectionEnd, comments]);
 
   // Selecting a highlighted range in the file activates its comment; if that

--- a/web/src/shell/MarkdownSearchBar.tsx
+++ b/web/src/shell/MarkdownSearchBar.tsx
@@ -88,10 +88,9 @@ export function MarkdownSearchBar({
 
   // Focus the input when the bar opens.
   useEffect(() => {
-    if (open) {
-      const id = setTimeout(() => inputRef.current?.focus(), 0);
-      return () => clearTimeout(id);
-    }
+    if (!open) return undefined;
+    const id = setTimeout(() => inputRef.current?.focus(), 0);
+    return () => clearTimeout(id);
   }, [open, inputRef]);
 
   const goNext = useCallback(() => {

--- a/web/src/shell/MonacoCodeEditor.tsx
+++ b/web/src/shell/MonacoCodeEditor.tsx
@@ -420,10 +420,12 @@ function MonacoCodeEditorInner({
     else status = "idle";
     onSaveStatusChangeRef.current?.(status);
     // "Saved" is transient: clear it back to idle so the chip doesn't linger.
-    if (status === "saved") {
-      const t = window.setTimeout(() => onSaveStatusChangeRef.current?.("idle"), SAVED_BADGE_MS);
-      return () => window.clearTimeout(t);
-    }
+    if (status !== "saved") return undefined;
+    const timeout = window.setTimeout(
+      () => onSaveStatusChangeRef.current?.("idle"),
+      SAVED_BADGE_MS,
+    );
+    return () => window.clearTimeout(timeout);
   }, [writePending, writeError, writeSuccess, saveDisabled, isDirty]);
 
   // Clear the toolbar chip when this editor goes away (file switch / mode change

--- a/web/src/shell/PreviewSearchBar.tsx
+++ b/web/src/shell/PreviewSearchBar.tsx
@@ -91,10 +91,9 @@ export function PreviewSearchBar({
 
   // Focus the input when the bar opens.
   useEffect(() => {
-    if (open) {
-      const id = setTimeout(() => inputRef.current?.focus(), 0);
-      return () => clearTimeout(id);
-    }
+    if (!open) return undefined;
+    const id = setTimeout(() => inputRef.current?.focus(), 0);
+    return () => clearTimeout(id);
   }, [open, inputRef]);
 
   const goNext = useCallback(() => {

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -3001,13 +3001,12 @@ function ConversationRow({
   useEffect(() => {
     const was = wasDraggingRef.current;
     wasDraggingRef.current = isDragging;
-    if (was && !isDragging) {
-      justDraggedRef.current = true;
-      const timer = setTimeout(() => {
-        justDraggedRef.current = false;
-      }, 0);
-      return () => clearTimeout(timer);
-    }
+    if (!was || isDragging) return undefined;
+    justDraggedRef.current = true;
+    const timer = setTimeout(() => {
+      justDraggedRef.current = false;
+    }, 0);
+    return () => clearTimeout(timer);
   }, [isDragging]);
   // Merge the drag node ref with the row ref used for scroll-into-view.
   const setRowRef = useCallback(

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -17,6 +17,7 @@
     "jsx": "react-jsx",
 
     /* Linting */
+    "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitOverride": true,

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -16,6 +16,7 @@
     "noEmit": true,
 
     /* Linting */
+    "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitOverride": true,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -315,6 +315,7 @@ export default defineConfig({
           if (normalized.includes("/shiki") || normalized.includes("/@shikijs/")) {
             return "shiki";
           }
+          return undefined;
         },
       },
     },


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Enable TypeScript `noImplicitReturns` for both web compiler projects.
- Make six conditional callback return paths explicit without changing runtime behavior.
- Prevent future functions from accidentally falling through without returning a value.

## Test Plan

- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `pnpm --filter web exec prettier --check src/shell/CommentsPanel.tsx src/shell/MarkdownSearchBar.tsx src/shell/MonacoCodeEditor.tsx src/shell/PreviewSearchBar.tsx src/shell/Sidebar.tsx vite.config.ts tsconfig.app.json tsconfig.node.json`
- `pnpm --filter web exec vitest run src/shell/CommentsPanel.test.tsx src/shell/MarkdownSearchBar.test.tsx src/shell/MonacoCodeEditor.autosave.test.tsx src/shell/PreviewSearchBar.test.tsx src/shell/Sidebar.test.tsx` (111 tests passed)
- `uv run --no-sync pre-commit run --show-diff-on-failure`

## Demo

N/A — compiler enforcement and behavior-preserving cleanup only.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The affected React effect cleanup paths are covered by the existing component and autosave tests listed above.
