### PR TITLE
feat(policies): admin gates for permission bypass, modes, and models

### DIFF
--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -1020,6 +1020,12 @@ def _main_evaluate_policy(argv: list[str]) -> int:
     status_model = read_claude_status_model(bridge_dir)
     if status_model:
         context["model"] = status_model
+    # Claude Code stamps its approval mode on every hook payload. Forwarding it
+    # lets a policy gate a session launched with approvals disabled — the flag
+    # itself never reaches the policy layer, only the resulting mode does.
+    permission_mode = payload.get("permission_mode")
+    if isinstance(permission_mode, str) and permission_mode:
+        context["permission_mode"] = permission_mode
 
     def _fail_closed(detail: str | None = None) -> int:
         out = fail_closed_hook_output(hook_event, detail)

--- a/omnigent/policies/builtins/safety.py
+++ b/omnigent/policies/builtins/safety.py
@@ -532,6 +532,209 @@ def enforce_sandbox(
     return evaluate
 
 
+# ── Harness permission-bypass enforcement ──────────────────────────────────
+
+# Per-harness flags that disable the harness's own permission prompting.
+# Matched as substrings so an inline ``FOO=bar claude --flag`` is caught too.
+_PERMISSION_BYPASS_FLAGS: tuple[str, ...] = (
+    "--dangerously-skip-permissions",
+    "--dangerously-bypass-approvals-and-sandbox",
+    "--yolo",
+)
+
+# Scanning is limited to shell-shaped tools so prose and file contents
+# mentioning a flag aren't flagged as launches.
+_SHELL_TOOL_NAMES = frozenset(
+    {"sys_os_shell", "Bash", "Shell", "bash", "terminal", "execute_code", "developer__shell"}
+)
+
+# Argument keys the shell-shaped tools above use to carry the command string.
+_COMMAND_ARG_KEYS = ("command", "cmd", "script", "input")
+
+
+def deny_harness_permission_bypass(
+    extra_flags: list[str] | None = None,
+) -> PolicyCallable:
+    """Factory: block nested harness launches that skip permission prompts.
+
+    An agent with shell access can otherwise start a second agent with
+    approvals disabled, escaping every guardrail on this session in one
+    shell call.
+
+    Matching is case-insensitive on the command string, so a flag
+    assembled at runtime (from a variable) slips through — this is a
+    backstop for a real sandbox, not a replacement.
+
+    :param extra_flags: Additional bypass spellings to block, merged
+        with the built-in set, e.g. ``["--no-confirm"]``. Defaults to
+        ``None``.
+    :returns: A policy callable that DENYs bypass-flag shell calls.
+    """
+    flags = tuple(_PERMISSION_BYPASS_FLAGS) + tuple(extra_flags or ())
+
+    def evaluate(event: PolicyEvent) -> PolicyResponse:
+        """Scan a shell command for permission-bypass flags.
+
+        :param event: Policy event dict.
+        :returns: DENY when a bypass flag is present, ALLOW otherwise.
+        """
+        if event.get("type") != "tool_call":
+            return _ALLOW
+        data = event.get("data")
+        if not isinstance(data, dict):
+            return _ALLOW
+        if data.get("name", "") not in _SHELL_TOOL_NAMES:
+            return _ALLOW
+
+        args = data.get("arguments")
+        if not isinstance(args, dict):
+            return _ALLOW
+
+        for key in _COMMAND_ARG_KEYS:
+            command = args.get(key)
+            if not isinstance(command, str):
+                continue
+            lowered = command.lower()
+            for flag in flags:
+                if flag in lowered:
+                    return {
+                        "result": "DENY",
+                        "reason": (
+                            f"Refusing to launch a nested agent with '{flag}', which "
+                            "disables its permission prompts and bypasses the "
+                            "guardrails on this session. Run the agent without "
+                            "the flag, or ask an administrator to grant an exception."
+                        ),
+                    }
+        return _ALLOW
+
+    return evaluate
+
+
+# ── Harness approval-mode enforcement ──────────────────────────────────────
+
+# The mode a harness reports when launched with a permission-bypass flag
+# (``--dangerously-skip-permissions``): prompting is off entirely. Narrower
+# modes such as ``acceptEdits`` still prompt for shell, so they are not
+# denied by default — pass *denied_modes* to include them.
+_PERMISSIVE_PERMISSION_MODES = frozenset({"bypassPermissions"})
+
+
+def deny_permissive_permission_mode(
+    denied_modes: list[str] | None = None,
+) -> PolicyCallable:
+    """Factory: refuse sessions whose harness has approvals disabled.
+
+    Complements :func:`deny_harness_permission_bypass`, which only catches a
+    *nested* launch: this gates the session the policy is running in, using
+    the approval mode a native hook stamps on the event context.
+
+    Denies on every phase the mode is visible, so the session is blocked at
+    its first gated action rather than only on shell calls. Abstains when the
+    mode is absent — web and API sessions never stamp one, and treating
+    unstamped as bypassed would deny every non-native session.
+
+    :param denied_modes: Modes to refuse, e.g.
+        ``["bypassPermissions", "acceptEdits"]``. Defaults to ``None``
+        (``bypassPermissions`` only).
+    :returns: A policy callable that DENYs permissive-mode sessions.
+    """
+    denied = frozenset(denied_modes) if denied_modes else _PERMISSIVE_PERMISSION_MODES
+
+    def evaluate(event: PolicyEvent) -> PolicyResponse:
+        """Check the session's stamped approval mode.
+
+        :param event: Policy event dict.
+        :returns: DENY for a denied mode, ALLOW otherwise.
+        """
+        context = event.get("context")
+        if not isinstance(context, dict):
+            return _ALLOW
+        mode = context.get("permission_mode")
+        if not isinstance(mode, str) or mode not in denied:
+            return _ALLOW
+        return {
+            "result": "DENY",
+            "reason": (
+                f"This session's harness is running in '{mode}' mode, which "
+                "skips the approval prompts this deployment requires. Restart "
+                "it without the permission-bypass flag."
+            ),
+        }
+
+    return evaluate
+
+
+# ── Model allowlisting ─────────────────────────────────────────────────────
+
+
+def restrict_models(
+    denied_models: list[str] | None = None,
+    allowed_models: list[str] | None = None,
+) -> PolicyCallable:
+    """Factory: restrict which models a session may call.
+
+    Fires on ``llm_request`` and matches ``data["model"]``. Removes a
+    model outright, unlike
+    :func:`omnigent.policies.builtins.routing.deny_trivial_to_expensive_model`,
+    which keeps it available for complex work.
+
+    Matching is exact and case-sensitive — a substring rule would make
+    ``prov/model`` silently gate ``prov/model-mini``. *denied_models* is
+    checked first, so a model on both lists is denied.
+
+    :param denied_models: Model ids to refuse, e.g.
+        ``["provider/expensive-model"]``. Defaults to ``None``.
+    :param allowed_models: When non-empty, the only model ids permitted;
+        anything else is denied. Defaults to ``None`` (no allowlist).
+    :returns: A policy callable that DENYs disallowed models.
+    :raises ValueError: If neither list is supplied, which would make
+        the policy a silent no-op.
+    """
+    denied = frozenset(denied_models or ())
+    allowed = frozenset(allowed_models or ())
+    if not denied and not allowed:
+        raise ValueError(
+            "restrict_models requires denied_models, allowed_models, or both; "
+            "with neither it would allow every model."
+        )
+
+    def evaluate(event: PolicyEvent) -> PolicyResponse:
+        """Check the requested model against the configured lists.
+
+        :param event: Policy event dict.
+        :returns: DENY for a disallowed model, ALLOW otherwise.
+        """
+        if event.get("type") != "llm_request":
+            return _ALLOW
+        data = event.get("data")
+        if not isinstance(data, dict):
+            return _ALLOW
+        model = data.get("model")
+        if not isinstance(model, str) or not model:
+            return _ALLOW
+
+        if model in denied:
+            return {
+                "result": "DENY",
+                "reason": (
+                    f"Model '{model}' is not permitted on this deployment. "
+                    "Choose a different model or contact an administrator."
+                ),
+            }
+        if allowed and model not in allowed:
+            return {
+                "result": "DENY",
+                "reason": (
+                    f"Model '{model}' is not on the approved list for this "
+                    f"deployment. Approved models: {', '.join(sorted(allowed))}."
+                ),
+            }
+        return _ALLOW
+
+    return evaluate
+
+
 # ── PII detection on LLM requests ────────────────────────────────────────────
 
 # Built-in PII categories with their regex patterns. The UI shows
@@ -765,6 +968,77 @@ POLICY_REGISTRY: list[dict[str, object]] = [
                     "items": {"type": "string"},
                     "description": "Env vars to allow through the sandbox "
                     "(null inherits agent's config)",
+                },
+            },
+        },
+    },
+    {
+        "handler": "omnigent.policies.builtins.safety.deny_harness_permission_bypass",
+        "kind": "factory",
+        "name": "Block Nested Permission-Bypass Launches",
+        "description": "Denies shell commands that launch a nested coding agent with a "
+        "flag disabling its permission prompts (--dangerously-skip-permissions, "
+        "--dangerously-bypass-approvals-and-sandbox, --yolo), which would escape this "
+        "session's guardrails. A backstop for a real sandbox, not a replacement.",
+        "params_schema": {
+            "type": "object",
+            "properties": {
+                "extra_flags": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Additional bypass flag spellings to block, "
+                    "merged with the built-in set.",
+                },
+            },
+        },
+    },
+    {
+        "handler": "omnigent.policies.builtins.safety.deny_permissive_permission_mode",
+        "kind": "factory",
+        "name": "Deny Permission-Bypass Sessions",
+        "description": "Denies a session whose own harness was launched with permission "
+        "prompting disabled (bypassPermissions — what --dangerously-skip-permissions "
+        "produces), read from the mode a native hook stamps on the event. Covers the current "
+        "session, where Block Nested Permission-Bypass Launches only covers agents it "
+        "starts. No effect on web / API sessions, which stamp no mode.",
+        "params_schema": {
+            "type": "object",
+            "properties": {
+                "denied_modes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["bypassPermissions", "acceptEdits", "plan", "default"],
+                    },
+                    "uniqueItems": True,
+                    "description": "Approval modes to refuse. Leave empty for "
+                    "bypassPermissions only; add acceptEdits to also block "
+                    "auto-approved file writes.",
+                    "default": ["bypassPermissions"],
+                },
+            },
+        },
+    },
+    {
+        "handler": "omnigent.policies.builtins.safety.restrict_models",
+        "kind": "factory",
+        "name": "Restrict Models",
+        "description": "Allowlists or denylists models by exact id on llm_request. Use to "
+        "keep an expensive tier or unapproved provider off a deployment outright; use "
+        "Deny Trivial To Expensive Model instead to keep it available for complex work.",
+        "params_schema": {
+            "type": "object",
+            "properties": {
+                "denied_models": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Model ids to refuse (checked before the allowlist)",
+                },
+                "allowed_models": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "When set, the only model ids permitted; "
+                    "everything else is denied.",
                 },
             },
         },

--- a/omnigent/policies/function.py
+++ b/omnigent/policies/function.py
@@ -232,6 +232,10 @@ def _build_event(ctx: EvaluationContext) -> PolicyEvent:
             # hook so policies can tailor messages to it. ``None`` when
             # unstamped (web / API).
             "harness": ctx.harness,
+            # The harness's own approval mode (e.g. "bypassPermissions"),
+            # stamped by a native tool hook. ``None`` when unstamped
+            # (web / API) — a gate must not read that as bypassed.
+            "permission_mode": ctx.permission_mode,
             # Conversation labels (engine hot cache), empty when unpopulated.
             "labels": dict(ctx.labels) if ctx.labels is not None else {},
             # Subtree-scoped cumulative cost (this conversation + its

--- a/omnigent/policies/schema.py
+++ b/omnigent/policies/schema.py
@@ -157,6 +157,11 @@ class EventContext(TypedDict, total=False):
         absent on web / API paths. Lets policies tailor messages to how
         the harness exposes model switching (codex-native is
         terminal-only). Read via ``event["context"]["harness"]``.
+    :param permission_mode: The harness's own approval mode, e.g.
+        ``"bypassPermissions"``, stamped by a native tool hook. ``None`` /
+        absent on web / API paths. Lets policies gate a session launched
+        with approvals disabled. Read via
+        ``event["context"]["permission_mode"]``.
     :param labels: Read-only snapshot of the conversation's guardrails
         labels, e.g. ``{"cost_control.plan": "{...}"}``. Populated by
         the server-side engine; empty on paths that don't carry labels
@@ -173,6 +178,7 @@ class EventContext(TypedDict, total=False):
     # unknown model (fail closed).
     model: str | None
     harness: str | None
+    permission_mode: str | None
     labels: dict[str, str]
 
 

--- a/omnigent/policies/types.py
+++ b/omnigent/policies/types.py
@@ -187,6 +187,12 @@ class EvaluationContext:
         (codex-native is terminal-only). Surfaced as
         ``event["context"]["harness"]``. ``None`` on web / API / unstamped
         paths.
+    :param permission_mode: The harness's own approval mode, e.g.
+        ``"bypassPermissions"`` or ``"default"``, stamped by a native tool
+        hook. Lets a policy gate a session whose harness was launched with
+        approvals disabled. Surfaced as
+        ``event["context"]["permission_mode"]``. ``None`` on web / API /
+        unstamped paths.
     :param labels: Read-only snapshot of the conversation's guardrails
         labels, e.g. ``{"cost_control.plan": "{...}"}``. Injected by the
         engine from its label hot cache (the same source ``condition:``
@@ -214,6 +220,7 @@ class EvaluationContext:
     user_daily_cost: dict[str, float | str] | None = None
     model: str | None = None
     harness: str | None = None
+    permission_mode: str | None = None
     labels: dict[str, str] | None = None
     llm_client: PolicyLLMClient | None = None
 

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -6582,6 +6582,15 @@ def _build_evaluation_context(
     hook_harness = (
         supplied_harness if isinstance(supplied_harness, str) and supplied_harness else None
     )
+    # The harness's own approval mode, when a native hook stamped it, so a
+    # policy can gate a session launched with approvals disabled (e.g. Claude
+    # Code's ``bypassPermissions``). Carried through unchanged.
+    supplied_permission_mode = raw_context.get("permission_mode")
+    hook_permission_mode = (
+        supplied_permission_mode
+        if isinstance(supplied_permission_mode, str) and supplied_permission_mode
+        else None
+    )
     structured_data = data if isinstance(data, dict) else {}
     if phase == Phase.TOOL_CALL:
         raw_tool_name = structured_data.get("name")
@@ -6595,6 +6604,7 @@ def _build_evaluation_context(
             actor=actor,
             model=hook_model,
             harness=hook_harness,
+            permission_mode=hook_permission_mode,
         )
     if phase == Phase.TOOL_RESULT:
         tool_result = structured_data.get("result", "")
@@ -6614,6 +6624,7 @@ def _build_evaluation_context(
             actor=actor,
             model=hook_model,
             harness=hook_harness,
+            permission_mode=hook_permission_mode,
         )
     # LLM_REQUEST / LLM_RESPONSE — content is the full request/response dict.
     if phase in (Phase.LLM_REQUEST, Phase.LLM_RESPONSE):
@@ -6623,6 +6634,7 @@ def _build_evaluation_context(
             actor=actor,
             model=hook_model,
             harness=hook_harness,
+            permission_mode=hook_permission_mode,
         )
     # REQUEST / RESPONSE — content is the user/assistant text. The wire ``data``
     # is a dict for the native command hooks (``{"text"|"content": ...}``), but
@@ -6651,6 +6663,7 @@ def _build_evaluation_context(
         actor=actor,
         model=hook_model,
         harness=hook_harness,
+        permission_mode=hook_permission_mode,
     )
 
 

--- a/tests/policies/builtins/test_safety_admin_gates.py
+++ b/tests/policies/builtins/test_safety_admin_gates.py
@@ -1,0 +1,507 @@
+"""
+Tests for the admin-facing safety gates in
+:mod:`omnigent.policies.builtins.safety` — the three factories an operator
+attaches server-wide to bound what a session may do:
+``deny_harness_permission_bypass``, ``restrict_models``, and
+``deny_permissive_permission_mode``.
+
+Layers:
+
+- **Layer 1** — direct callable: bypass-flag detection across harness
+  spellings, casing, env prefixes, and the alternate command-argument keys,
+  with abstention on non-shell tools; model allow/deny matching with
+  deny-first precedence and exact-match semantics; permission-mode gating
+  including abstention on an unstamped mode; and fail-loud factory
+  validation.
+- **Layer 2** — spec resolution through :func:`resolve_function_policy`,
+  proving the DENY decisions thread through the engine boundary.
+- **Layer 3** — registry discovery: each ``POLICY_REGISTRY`` entry is
+  browsable and its schema validates good / bad params.
+
+All three policies are stateless (no ``state_updates``), so there is no
+session_state round-trip layer.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.policies.builtins.safety import (
+    deny_harness_permission_bypass,
+    deny_permissive_permission_mode,
+    restrict_models,
+)
+from omnigent.policies.function import FunctionPolicy, resolve_function_policy
+from omnigent.policies.registry import get_registry, load_registry, validate_factory_params
+from omnigent.policies.schema import PolicyEvent, PolicyResponse
+from omnigent.policies.types import EvaluationContext
+from omnigent.spec.types import FunctionPolicySpec, FunctionRef, Phase, PolicyAction
+from tests.policies.builtins.helpers import tool_call_event as tc
+
+_BYPASS_HANDLER = "omnigent.policies.builtins.safety.deny_harness_permission_bypass"
+_MODELS_HANDLER = "omnigent.policies.builtins.safety.restrict_models"
+_PERM_MODE_HANDLER = "omnigent.policies.builtins.safety.deny_permissive_permission_mode"
+
+
+def _sh(command: str, tool: str = "sys_os_shell", key: str = "command") -> PolicyEvent:
+    """
+    Build a shell-shaped ``tool_call`` event carrying *command*.
+
+    :param command: The shell command string, e.g. ``"claude --yolo"``.
+    :param tool: Shell tool name, e.g. ``"Bash"`` for the Claude Code hook.
+    :param key: Argument key holding the command, e.g. ``"cmd"``.
+    :returns: A ``tool_call`` :class:`PolicyEvent` for a shell tool.
+    """
+    return tc(tool, {key: command})
+
+
+def _llm(model: str) -> PolicyEvent:
+    """
+    Build an ``llm_request`` event targeting *model*.
+
+    :param model: Provider-configured model id, e.g. ``"prov/expensive"``.
+    :returns: An ``llm_request`` :class:`PolicyEvent`.
+    """
+    return {
+        "type": "llm_request",
+        "target": None,
+        "data": {"model": model, "last_user_message": "refactor this"},
+        "context": {"actor": {}, "usage": {}},
+        "session_state": {},
+    }
+
+
+def _action(result: PolicyResponse | None) -> str:
+    """
+    Reduce a policy result to its decision string for terse assertions.
+
+    :param result: The policy response, or ``None`` for an abstention.
+    :returns: The ``result`` field, or ``"ABSTAIN"`` when *result* is
+        ``None``.
+    """
+    if result is None:
+        return "ABSTAIN"
+    return str(result.get("result", "ABSTAIN"))
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Layer 1 — deny_harness_permission_bypass
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "claude --dangerously-skip-permissions",
+        "codex exec --dangerously-bypass-approvals-and-sandbox 'fix it'",
+        "gemini --yolo",
+        "cd /repo && claude --dangerously-skip-permissions -p 'go'",
+    ],
+)
+def test_bypass_flags_are_denied(command: str) -> None:
+    """Each known bypass flag DENYs, including mid-command and chained."""
+    assert _action(deny_harness_permission_bypass()(_sh(command))) == "DENY"
+
+
+def test_bypass_detection_is_case_insensitive() -> None:
+    """An upper-cased flag is still caught.
+
+    Shell flags are case-sensitive to the harness, but a policy that only
+    matched lowercase would be trivially evaded on a case-tolerant wrapper.
+    """
+    policy = deny_harness_permission_bypass()
+    assert _action(policy(_sh("claude --DANGEROUSLY-SKIP-PERMISSIONS"))) == "DENY"
+
+
+def test_bypass_detection_survives_env_prefix() -> None:
+    """An inline ``FOO=bar`` prefix does not hide the flag."""
+    policy = deny_harness_permission_bypass()
+    assert _action(policy(_sh("ANTHROPIC_API_KEY=x claude --dangerously-skip-permissions"))) == (
+        "DENY"
+    )
+
+
+@pytest.mark.parametrize("tool", ["sys_os_shell", "Bash", "Shell", "bash", "developer__shell"])
+def test_bypass_checked_across_harness_shell_tools(tool: str) -> None:
+    """Every harness's shell tool name is scanned, not just the MCP one."""
+    policy = deny_harness_permission_bypass()
+    assert _action(policy(_sh("claude --yolo", tool=tool))) == "DENY"
+
+
+@pytest.mark.parametrize("key", ["command", "cmd", "script", "input"])
+def test_bypass_checked_across_command_arg_keys(key: str) -> None:
+    """The command is found under any of the known argument keys."""
+    policy = deny_harness_permission_bypass()
+    assert _action(policy(_sh("claude --yolo", key=key))) == "DENY"
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["claude -p 'hello'", "ls -la", "git status", "echo dangerously"],
+)
+def test_benign_commands_are_allowed(command: str) -> None:
+    """Ordinary commands pass, including prose containing 'dangerously'."""
+    assert _action(deny_harness_permission_bypass()(_sh(command))) == "ALLOW"
+
+
+def test_abstains_on_non_shell_tools() -> None:
+    """A flag inside a file-read argument is not a launch and is allowed.
+
+    Scanning every tool would flag documentation and test fixtures that
+    merely mention the flag.
+    """
+    policy = deny_harness_permission_bypass()
+    event = tc("Read", {"command": "claude --yolo"})
+    assert _action(policy(event)) == "ALLOW"
+
+
+def test_extra_flags_are_honored() -> None:
+    """Operator-supplied flag spellings extend the built-in set."""
+    policy = deny_harness_permission_bypass(extra_flags=["--no-confirm"])
+    assert _action(policy(_sh("someagent --no-confirm"))) == "DENY"
+
+
+def test_extra_flags_do_not_replace_builtins() -> None:
+    """Supplying ``extra_flags`` keeps the built-in flags active."""
+    policy = deny_harness_permission_bypass(extra_flags=["--no-confirm"])
+    assert _action(policy(_sh("claude --dangerously-skip-permissions"))) == "DENY"
+
+
+def test_bypass_abstains_on_non_tool_call_phases() -> None:
+    """An ``llm_request`` event passes through untouched."""
+    assert _action(deny_harness_permission_bypass()(_llm("prov/model"))) == "ALLOW"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Layer 1 — restrict_models
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_denylisted_model_is_denied() -> None:
+    """A model on the denylist DENYs."""
+    policy = restrict_models(denied_models=["prov/expensive"])
+    assert _action(policy(_llm("prov/expensive"))) == "DENY"
+
+
+def test_model_outside_denylist_is_allowed() -> None:
+    """With only a denylist, everything else passes."""
+    policy = restrict_models(denied_models=["prov/expensive"])
+    assert _action(policy(_llm("prov/cheap"))) == "ALLOW"
+
+
+def test_allowlisted_model_is_allowed() -> None:
+    """A model on the allowlist passes."""
+    assert _action(restrict_models(allowed_models=["prov/ok"])(_llm("prov/ok"))) == "ALLOW"
+
+
+def test_model_outside_allowlist_is_denied() -> None:
+    """With an allowlist set, an unlisted model DENYs."""
+    assert _action(restrict_models(allowed_models=["prov/ok"])(_llm("prov/other"))) == "DENY"
+
+
+def test_denylist_wins_over_allowlist() -> None:
+    """A model on both lists is denied — the safe precedence."""
+    policy = restrict_models(denied_models=["prov/x"], allowed_models=["prov/x", "prov/y"])
+    assert _action(policy(_llm("prov/x"))) == "DENY"
+
+
+def test_model_matching_is_exact_not_substring() -> None:
+    """A versioned variant is not matched by its base name.
+
+    Substring matching would make ``prov/model`` silently gate
+    ``prov/model-mini``; the operator lists ids explicitly instead.
+    """
+    policy = restrict_models(denied_models=["prov/model"])
+    assert _action(policy(_llm("prov/model-mini"))) == "ALLOW"
+
+
+def test_model_matching_is_case_sensitive() -> None:
+    """Model ids are compared verbatim against the provider's spelling."""
+    policy = restrict_models(denied_models=["prov/Model"])
+    assert _action(policy(_llm("prov/model"))) == "ALLOW"
+
+
+def test_deny_reason_lists_approved_models() -> None:
+    """An allowlist denial tells the user which models they may use."""
+    result = restrict_models(allowed_models=["prov/a", "prov/b"])(_llm("prov/z"))
+    assert result is not None
+    reason = str(result.get("reason", ""))
+    assert "prov/a" in reason and "prov/b" in reason
+
+
+def test_restrict_models_abstains_on_tool_calls() -> None:
+    """Tool calls are out of scope for a model gate."""
+    assert _action(restrict_models(denied_models=["prov/x"])(_sh("ls"))) == "ALLOW"
+
+
+def test_empty_model_is_allowed() -> None:
+    """A request with no model id passes rather than failing closed.
+
+    The gate cannot identify an unnamed model; denying here would break
+    providers that omit the field.
+    """
+    policy = restrict_models(allowed_models=["prov/ok"])
+    event: PolicyEvent = {
+        "type": "llm_request",
+        "target": None,
+        "data": {"model": "", "last_user_message": "hi"},
+        "context": {"actor": {}, "usage": {}},
+        "session_state": {},
+    }
+    assert _action(policy(event)) == "ALLOW"
+
+
+def test_restrict_models_requires_at_least_one_list() -> None:
+    """Constructing with neither list fails loud rather than no-opping.
+
+    A silently-permissive security policy is worse than a missing one — the
+    operator believes a gate is active when it is not.
+    """
+    with pytest.raises(ValueError, match="requires denied_models"):
+        restrict_models()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Layer 1 — deny_permissive_permission_mode
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def _mode(mode: str | None, phase: str = "tool_call") -> PolicyEvent:
+    """
+    Build an event whose context carries a stamped approval *mode*.
+
+    :param mode: Harness approval mode, e.g. ``"bypassPermissions"``.
+        ``None`` omits the key, as web / API sessions do.
+    :param phase: Event type, e.g. ``"llm_request"``.
+    :returns: A :class:`PolicyEvent` with the mode on its context.
+    """
+    context: dict[str, object] = {"actor": {}, "usage": {}}
+    if mode is not None:
+        context["permission_mode"] = mode
+    return {
+        "type": phase,
+        "target": None,
+        "data": {"name": "Bash", "arguments": {"command": "ls"}},
+        "context": context,
+        "session_state": {},
+    }
+
+
+def test_bypass_permissions_mode_is_denied() -> None:
+    """``bypassPermissions`` DENYs — the mode a bypass flag produces."""
+    assert _action(deny_permissive_permission_mode()(_mode("bypassPermissions"))) == "DENY"
+
+
+@pytest.mark.parametrize("mode", ["default", "plan", "acceptEdits"])
+def test_prompting_modes_are_allowed(mode: str) -> None:
+    """Modes that still prompt pass by default.
+
+    ``acceptEdits`` auto-approves file writes but still prompts for shell,
+    so it is opt-in via *denied_modes* rather than denied out of the box —
+    blocking it by default would reject a mode many users run day to day.
+    """
+    assert _action(deny_permissive_permission_mode()(_mode(mode))) == "ALLOW"
+
+
+def test_absent_mode_is_allowed() -> None:
+    """An unstamped session passes rather than failing closed.
+
+    Web and API sessions never stamp a mode; treating absent as bypassed
+    would deny every non-native session.
+    """
+    assert _action(deny_permissive_permission_mode()(_mode(None))) == "ALLOW"
+
+
+def test_missing_context_is_allowed() -> None:
+    """An event with no context at all abstains instead of raising."""
+    event: PolicyEvent = {"type": "tool_call", "data": {"name": "Bash", "arguments": {}}}
+    assert _action(deny_permissive_permission_mode()(event)) == "ALLOW"
+
+
+@pytest.mark.parametrize("phase", ["tool_call", "llm_request", "request"])
+def test_mode_gate_fires_on_every_phase(phase: str) -> None:
+    """The gate is phase-agnostic, unlike the tool-scoped gates.
+
+    The mode is a property of the session, not of one action, so the
+    session should be blocked at whichever gate it reaches first.
+    """
+    assert _action(deny_permissive_permission_mode()(_mode("bypassPermissions", phase))) == "DENY"
+
+
+def test_denied_modes_can_widen_the_gate() -> None:
+    """An explicit list replaces the default, so it can add modes."""
+    policy = deny_permissive_permission_mode(
+        denied_modes=["bypassPermissions", "acceptEdits"],
+    )
+    assert _action(policy(_mode("acceptEdits"))) == "DENY"
+    assert _action(policy(_mode("bypassPermissions"))) == "DENY"
+    assert _action(policy(_mode("default"))) == "ALLOW"
+
+
+def test_denied_modes_replaces_rather_than_merges() -> None:
+    """A list omitting the default mode stops denying it.
+
+    The parameter is a replacement, not an addition — an operator who lists
+    only ``acceptEdits`` gets exactly that, so the semantics must be explicit.
+    """
+    policy = deny_permissive_permission_mode(denied_modes=["acceptEdits"])
+    assert _action(policy(_mode("acceptEdits"))) == "DENY"
+    assert _action(policy(_mode("bypassPermissions"))) == "ALLOW"
+
+
+def test_mode_deny_reason_names_the_mode() -> None:
+    """The DENY reason names the offending mode and how to fix it."""
+    result = deny_permissive_permission_mode()(_mode("bypassPermissions"))
+    assert result is not None
+    reason = str(result.get("reason", ""))
+    assert "bypassPermissions" in reason
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Layer 2 — spec resolution through resolve_function_policy
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_resolve_bypass_from_spec_denies() -> None:
+    """deny_harness_permission_bypass DENYs through the engine boundary."""
+    spec = FunctionPolicySpec(
+        name="no-bypass",
+        on=None,
+        function=FunctionRef(path=_BYPASS_HANDLER, arguments={}),
+    )
+    policy: FunctionPolicy = resolve_function_policy(spec)
+    result = await policy.evaluate(
+        EvaluationContext(
+            phase=Phase.TOOL_CALL,
+            tool_name="sys_os_shell",
+            content={
+                "name": "sys_os_shell",
+                "arguments": {"command": "claude --dangerously-skip-permissions"},
+            },
+        ),
+        {},
+    )
+    assert result.action == PolicyAction.DENY
+
+
+@pytest.mark.asyncio
+async def test_resolve_restrict_models_from_spec_denies() -> None:
+    """restrict_models DENYs an llm_request through the engine boundary."""
+    spec = FunctionPolicySpec(
+        name="model-allowlist",
+        on=None,
+        function=FunctionRef(path=_MODELS_HANDLER, arguments={"denied_models": ["prov/x"]}),
+    )
+    policy: FunctionPolicy = resolve_function_policy(spec)
+    result = await policy.evaluate(
+        EvaluationContext(
+            phase=Phase.LLM_REQUEST,
+            tool_name=None,
+            content={"model": "prov/x", "last_user_message": "hi"},
+        ),
+        {},
+    )
+    assert result.action == PolicyAction.DENY
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [("bypassPermissions", PolicyAction.DENY), ("default", PolicyAction.ALLOW)],
+)
+async def test_resolve_permission_mode_from_spec(mode: str, expected: PolicyAction) -> None:
+    """``EvaluationContext.permission_mode`` reaches the callable.
+
+    This is the plumbing assertion: the field has to survive
+    ``EvaluationContext`` → ``event["context"]["permission_mode"]``, or the
+    gate silently allows every session.
+    """
+    spec = FunctionPolicySpec(
+        name="no-bypass-mode",
+        on=None,
+        function=FunctionRef(path=_PERM_MODE_HANDLER, arguments={}),
+    )
+    policy: FunctionPolicy = resolve_function_policy(spec)
+    result = await policy.evaluate(
+        EvaluationContext(
+            phase=Phase.TOOL_CALL,
+            tool_name="Bash",
+            content={"name": "Bash", "arguments": {"command": "ls"}},
+            permission_mode=mode,
+        ),
+        {},
+    )
+    assert result.action == expected
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Layer 3 — registry
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize(
+    "handler",
+    [_BYPASS_HANDLER, _MODELS_HANDLER, _PERM_MODE_HANDLER],
+)
+def test_registry_discovers_admin_gates(handler: str) -> None:
+    """Each gate is browsable via GET /v1/policy-registry with a schema.
+
+    Failure means an admin cannot attach the policy from the UI and its
+    params are never validated on attach.
+    """
+    load_registry()
+    entry = next((e for e in get_registry() if e.handler == handler), None)
+    assert entry is not None, f"{handler} missing from POLICY_REGISTRY"
+    assert entry.kind == "factory"
+    assert entry.params_schema is not None
+
+
+@pytest.mark.parametrize(
+    ("handler", "params"),
+    [
+        (_BYPASS_HANDLER, {"extra_flags": ["--no-confirm"]}),
+        (_MODELS_HANDLER, {"denied_models": ["prov/x"], "allowed_models": ["prov/y"]}),
+        (_PERM_MODE_HANDLER, {"denied_modes": ["bypassPermissions"]}),
+    ],
+)
+def test_registry_accepts_valid_params(handler: str, params: dict[str, object]) -> None:
+    """Well-formed factory params validate clean against the schema."""
+    load_registry()
+    assert validate_factory_params(handler, params) is None
+
+
+def test_permission_mode_schema_default_matches_callable_default() -> None:
+    """The schema's advertised ``denied_modes`` default is the real one.
+
+    The UI pre-fills this value, so a schema listing a mode the callable
+    does not deny would silently widen the gate for anyone who accepts the
+    form's defaults — ``acceptEdits`` is opt-in (it still prompts for shell).
+    """
+    load_registry()
+    entry = next((e for e in get_registry() if e.handler == _PERM_MODE_HANDLER), None)
+    assert entry is not None
+    schema = entry.params_schema
+    assert schema is not None
+    advertised = schema["properties"]["denied_modes"]["default"]  # type: ignore[index]
+
+    policy = deny_permissive_permission_mode()
+    for mode in ["bypassPermissions", "acceptEdits", "plan", "default"]:
+        denied_by_default = _action(policy(_mode(mode))) == "DENY"
+        assert denied_by_default is (mode in advertised), (
+            f"schema default {advertised} disagrees with the callable on '{mode}'"
+        )
+
+
+@pytest.mark.parametrize(
+    ("handler", "params"),
+    [
+        (_BYPASS_HANDLER, {"extra_flags": "--no-confirm"}),
+        (_MODELS_HANDLER, {"denied_models": "prov/x"}),
+        (_PERM_MODE_HANDLER, {"denied_modes": "bypassPermissions"}),
+    ],
+)
+def test_registry_rejects_wrongly_typed_params(handler: str, params: dict[str, object]) -> None:
+    """A wrongly-typed param is rejected before the policy is attached."""
+    load_registry()
+    assert validate_factory_params(handler, params) is not None


### PR DESCRIPTION
## Related issue

N/A

## Summary

Three server-wide policy factories an operator attaches via `default_policies` to bound what a session may do, plus the event plumbing one of them needed.

- **`deny_harness_permission_bypass`** — denies shell commands that launch a *nested* agent with `--dangerously-skip-permissions`, `--dangerously-bypass-approvals-and-sandbox`, or `--yolo`. An agent with shell access can otherwise start a second agent outside the approval path, escaping every other guardrail on the session in one call. This is a backstop for a real sandbox, not a replacement — a flag assembled at runtime still slips through.
- **`deny_permissive_permission_mode`** — denies a session whose *own* harness was launched with prompting disabled. Denies `bypassPermissions` by default; `acceptEdits` still prompts for shell, so it is opt-in via `denied_modes`. Abstains when the mode is absent, since web / API sessions never stamp one and reading unstamped as bypassed would deny every non-native session.
- **`restrict_models`** — allowlist / denylist by exact model id on `llm_request`. Complements `routing.deny_trivial_to_expensive_model`, which keeps an expensive model available for complex work; this removes it outright.

All three are registered in `POLICY_REGISTRY`, so they are browsable via `GET /v1/policy-registry` and their params are schema-validated on attach.

### ELI5

An admin can already sandbox agents. These add three more knobs: don't let an agent spawn another agent with the safety prompts turned off, don't let a session run at all if *its* prompts are off, and restrict which models it may call.

## Test Plan

- `tests/policies/builtins/test_safety_admin_gates.py` — 59 tests across the
  three layers this repo's policy tests use: direct callable, spec resolution
  through `resolve_function_policy` (proving the DENY threads through the engine
  boundary, including that `permission_mode` survives the hop), and registry
  discovery + schema validation of good / bad params.
- Full suite green: `pytest tests/policies/` → 685 passed;
  `+ tests/test_claude_native_hook.py` → 724 passed.
- `pyrefly check` → 0 errors. `ruff check` / `ruff format --check` clean.
- Verified end-to-end on a live server through Claude Code's own `PreToolUse`
  hook protocol: `bypassPermissions` / `acceptEdits` → `permissionDecision:
  "deny"`; `default` / absent → allow.

```
pytest tests/policies/builtins/test_safety_admin_gates.py -q
```

Deployed omnigent locally and curled request to hit these policy checks

## Demo

N/A — no UI change. The new gates surface in the existing policy-registry list.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification drove a live local server through Claude Code's real
`PreToolUse` hook protocol, which covers the one part unit tests can't reach on
their own: that a *real* harness actually stamps `permission_mode` on the
payload. The unit tests cover the gate logic and the `EvaluationContext` → event
hop; the live run confirms the upstream field is really there to be read.

## Changelog

Admins can gate nested permission-bypass launches, sessions whose harness has approvals disabled, and which models a session may call
