### PR TITLE
fix(native harnesses): keep provider auth out of process arguments

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -174,6 +174,7 @@ _DRAFT_NEEDLE_MAX_CHARS = 24
 # surfaces in the web UI error banner instead of only in the terminal.
 _TERMINAL_FAILURE_TAIL_LINES = 12
 _TERMINAL_FAILURE_TAIL_CHARS = 800
+_INVOCATION_SETTINGS_FILE = "claude-settings.json"
 
 ToolExecutor = Callable[[str, _JsonObject], Awaitable[object]]
 
@@ -1425,6 +1426,9 @@ def augment_claude_args(
     """
     Return Claude CLI args with Omnigent MCP/hook/skill injection.
 
+    Invocation settings are written into the owner-only bridge directory so
+    credential-bearing ``apiKeyHelper`` commands never appear in child argv.
+
     :param claude_args: User-provided Claude Code args, e.g.
         ``("--resume", "abc")``.
     :param bridge_dir: Bridge directory path.
@@ -1472,12 +1476,14 @@ def augment_claude_args(
     )
     args = _merge_disallowed_tools(list(claude_args), _OMNIGENT_DISALLOWED_TOOLS)
     args = _merge_allowed_tools(args, allowed_tools)
+    settings_path = bridge_dir / _INVOCATION_SETTINGS_FILE
+    _write_json_file(settings_path, hook_settings)
     args.extend(
         [
             "--mcp-config",
             json.dumps(mcp_config, separators=(",", ":")),
             "--settings",
-            json.dumps(hook_settings, separators=(",", ":")),
+            str(settings_path),
         ]
     )
     if append_system_prompt:

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -49,6 +49,7 @@ from omnigent.inner.codex_executor import (
     _find_codex_cli,
     _populate_codex_home_config,
     _provider_codex_config_overrides,
+    materialize_codex_provider_config,
 )
 from omnigent.inner.databricks_executor import _databricks_gateway_host
 
@@ -715,6 +716,19 @@ async def _wait_for_discovery_listener(
     raise TimeoutError("Timed out waiting for Codex model discovery app-server")
 
 
+def _build_native_codex_app_server_argv(
+    *,
+    tagged_argv0: str,
+    listen_url: str,
+    config_overrides: Sequence[str],
+) -> list[str]:
+    """Build argv for the native Codex app-server subprocess."""
+    argv = [tagged_argv0, "app-server", "--listen", listen_url]
+    for override in config_overrides:
+        argv.extend(["-c", override])
+    return argv
+
+
 @dataclass
 class CodexNativeAppServer:
     """
@@ -808,6 +822,10 @@ class CodexNativeAppServer:
             self.codex_home,
             self.developer_instructions,
         )
+        self.config_overrides = materialize_codex_provider_config(
+            self.codex_home,
+            self.config_overrides,
+        )
         # Native policy enforcement needs codex's hook-trust protocol
         # (``currentHash`` / ``trustStatus`` in ``hooks/list``), added in
         # codex 0.129. Below that the hook can never be trusted, so
@@ -848,14 +866,11 @@ class CodexNativeAppServer:
             f"{Path(self.codex_path).name} "
             f"{codex_native_session_tag_cmdline_arg(self.process_registry_tag)}"
         )
-        argv = [
-            tagged_argv0,
-            "app-server",
-            "--listen",
-            resolved_listen,
-        ]
-        for override in self.config_overrides:
-            argv.extend(["-c", override])
+        argv = _build_native_codex_app_server_argv(
+            tagged_argv0=tagged_argv0,
+            listen_url=resolved_listen,
+            config_overrides=self.config_overrides,
+        )
         proc_env = {**self.env, "CODEX_HOME": str(self.codex_home)}
         self.process_owner_lock = acquire_codex_native_process_owner_lock()
         try:
@@ -2217,6 +2232,10 @@ def build_codex_remote_args(
     """
     override_args: list[str] = []
     for override in config_overrides:
+        if override.lstrip().startswith("model_providers."):
+            raise ValueError(
+                "Codex remote provider definitions must be materialized in CODEX_HOME"
+            )
         override_args.extend(["-c", override])
     if bypass_sandbox:
         # Strip the conflicting granular flags, then prepend one canonical

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -16,7 +16,7 @@ import re
 import shutil
 import tempfile
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Mapping, MutableMapping
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
@@ -120,6 +120,7 @@ _CODEX_HOME_COPY_FILES = ("config.toml",)
 # shared cache exactly as they would without the private home.
 _CODEX_HOME_SYMLINK_DIRS = (Path("plugins") / "cache",)
 _CODEX_MINIMAL_CONFIG_ENV = "HARNESS_CODEX_MINIMAL_CONFIG"
+_CODEX_PROVIDER_CONFIG_PREFIX = "model_providers."
 
 # Environment variables explicitly excluded from the codex subprocess even
 # when their prefix is in the allowlist. ``OPENAI_API_KEY`` is stripped so
@@ -791,6 +792,69 @@ def _populate_codex_home_config(
             _normalize_copied_codex_effort(dest_path)
 
 
+def materialize_codex_provider_config(
+    codex_home: Path,
+    config_overrides: Iterable[str],
+) -> list[str]:
+    """Move generated provider definitions into a private Codex config.
+
+    Codex accepts provider tables through ``-c``/``--config``, but those
+    tables can contain static credentials or credential-bearing auth
+    commands. Persist them in the session-owned ``config.toml`` instead so
+    process arguments contain only non-secret routing and behavior overrides.
+
+    :param codex_home: Private session ``CODEX_HOME`` directory.
+    :param config_overrides: Pending Codex config override strings.
+    :returns: Overrides safe to retain in subprocess arguments.
+    """
+    codex_home.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(codex_home, 0o700)
+    config_path = codex_home / "config.toml"
+
+    provider_overrides: list[str] = []
+    argv_overrides: list[str] = []
+    for override in config_overrides:
+        if override.lstrip().startswith(_CODEX_PROVIDER_CONFIG_PREFIX):
+            provider_overrides.append(override)
+        else:
+            argv_overrides.append(override)
+    if not provider_overrides:
+        if config_path.is_file() and not config_path.is_symlink():
+            os.chmod(config_path, 0o600)
+        return argv_overrides
+
+    import tomlkit
+
+    existing = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
+    document = tomlkit.parse(existing) if existing else tomlkit.document()
+    providers = document.get("model_providers")
+    if providers is None:
+        document["model_providers"] = tomlkit.table()
+        providers = document["model_providers"]
+    if not isinstance(providers, MutableMapping):
+        raise ValueError("Codex model_providers config must be a TOML table")
+
+    for override in provider_overrides:
+        fragment = tomlkit.parse(override)
+        generated = fragment.get("model_providers")
+        if not isinstance(generated, MutableMapping) or not generated:
+            raise ValueError("Codex provider override must define model_providers")
+        for provider_name, provider_config in generated.items():
+            providers[provider_name] = provider_config
+
+    fd, tmp_name = tempfile.mkstemp(prefix="config.toml.", dir=str(codex_home))
+    try:
+        os.chmod(tmp_name, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(tomlkit.dumps(document))
+        os.replace(tmp_name, config_path)
+        os.chmod(config_path, 0o600)
+    finally:
+        with suppress(FileNotFoundError):
+            os.unlink(tmp_name)
+    return argv_overrides
+
+
 # Top-level ``model_reasoning_effort = "<value>"`` assignment, tolerating
 # leading whitespace and a trailing comment. Only applied to lines *before*
 # the first table header so keys inside ``[profiles.*]`` etc. are never
@@ -1367,6 +1431,10 @@ class _CodexAppServerSession:
         _populate_codex_home_config(
             self._codex_home_dir,
             _codex_home_config_source_from_env(),
+        )
+        self._codex_config_overrides = materialize_codex_provider_config(
+            self._codex_home_dir,
+            self._codex_config_overrides,
         )
         # Override CODEX_HOME so Codex stores its data (including conversation
         # history) in a private temp directory rather than the user's ~/.codex/.

--- a/omnigent/runner/background_titles/codex_native.py
+++ b/omnigent/runner/background_titles/codex_native.py
@@ -27,6 +27,7 @@ async def generate_background_title(context: BackgroundTitleContext) -> str | No
     from omnigent.inner.codex_executor import (
         _codex_home_config_source_from_env,
         _populate_codex_home_config,
+        materialize_codex_provider_config,
     )
     from omnigent.runner.native.orchestration import _codex_native_model_from_spec
 
@@ -51,6 +52,10 @@ async def generate_background_title(context: BackgroundTitleContext) -> str | No
             profile=launch.profile,
             bridge_dir=temp_root / "bridge",
             extra_config_overrides=launch.config_overrides,
+        )
+        native_server.config_overrides = materialize_codex_provider_config(
+            codex_home,
+            native_server.config_overrides,
         )
         output_path = temp_root / "title.txt"
         args = [

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import contextlib
 import json
+import stat
 import tempfile
 import unittest
 from dataclasses import dataclass
@@ -23,6 +24,7 @@ from omnigent.inner.codex_executor import (
     _dynamic_tool_result_payload,
     _goal_objective_from_content,
     _prompt_for_turn,
+    _provider_codex_config_overrides,
     _to_codex_input_items,
 )
 from omnigent.inner.executor import (
@@ -2352,6 +2354,76 @@ def test_populate_codex_skills_from_bundle_none_leaves_no_dir(tmp_path: Path) ->
     populate_codex_skills_from_bundle(codex_home, bundle, "none")
 
     assert not (codex_home / "skills").exists()
+
+
+@pytest.mark.parametrize(
+    "auth_command",
+    [
+        "printf %s sk-sentinel-do-not-use",
+        "credential-helper --token sk-sentinel-do-not-use",
+    ],
+)
+async def test_embedded_codex_materializes_provider_auth_outside_argv(
+    tmp_path: Path,
+    auth_command: str,
+) -> None:
+    """Embedded Codex keeps provider credentials only in private config."""
+    import tomllib
+
+    captured_argv: list[str] = []
+    captured_env: dict[str, str] = {}
+    process = _FakeProcess()
+
+    async def _fake_create_subprocess_exec(*args: str, **kwargs: Any) -> _FakeProcess:
+        captured_argv.extend(args)
+        captured_env.update(kwargs["env"])
+        return process
+
+    source_home = tmp_path / "source-codex-home"
+    source_home.mkdir()
+    overrides = _provider_codex_config_overrides(
+        model="test-model",
+        base_url="https://provider.invalid/v1",
+        auth_command=auth_command,
+        wire_api="responses",
+    )
+    session = _CodexAppServerSession(
+        codex_path="/test/codex",
+        cwd=str(tmp_path),
+        env={},
+        tool_executor=None,
+        codex_config_overrides=overrides,
+    )
+    session._request = AsyncMock(return_value={"result": {}})
+
+    with (
+        patch(
+            "omnigent.inner.codex_executor._create_subprocess_exec",
+            new=_fake_create_subprocess_exec,
+        ),
+        patch(
+            "omnigent.inner.codex_executor._codex_home_config_source_from_env",
+            return_value=source_home,
+        ),
+    ):
+        await session.start()
+        codex_home = Path(captured_env["CODEX_HOME"])
+        config_path = codex_home / "config.toml"
+        config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+
+        assert all("sk-sentinel-do-not-use" not in arg for arg in captured_argv)
+        assert 'model_provider="omnigent_provider"' in captured_argv
+        assert 'model="test-model"' in captured_argv
+        assert config["model_providers"]["omnigent_provider"]["auth"]["args"] == [
+            "-c",
+            auth_command,
+        ]
+        assert config["model_providers"]["omnigent_provider"]["wire_api"] == "responses"
+        assert stat.S_IMODE(codex_home.stat().st_mode) == 0o700
+        assert stat.S_IMODE(config_path.stat().st_mode) == 0o600
+        await session.close()
+
+    assert not codex_home.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -69,6 +69,11 @@ from tests.runner.conftest import (
 from tests.runner.helpers import NullServerClient
 
 
+def _load_claude_invocation_settings(args: list[str]) -> dict[str, Any]:
+    settings_path = Path(args[args.index("--settings") + 1])
+    return json.loads(settings_path.read_text(encoding="utf-8"))
+
+
 def test_read_relay_policy_config_returns_coords_from_tool_relay_json(
     tmp_path: Path,
 ) -> None:
@@ -976,7 +981,7 @@ async def test_auto_create_claude_terminal_injects_ucode_gateway_config(
     gateway_env = {"ANTHROPIC_BASE_URL": "https://gw.example/anthropic"}
     ucode = ClaudeNativeUcodeConfig(
         env=dict(gateway_env),
-        api_key_helper="databricks auth token --fake-helper",
+        api_key_helper="printf %s sk-sentinel-do-not-use",
         model="databricks-claude-opus-4-7",
     )
     # The runner imports ``_ucode_config_for_profile`` from
@@ -1043,9 +1048,10 @@ async def test_auto_create_claude_terminal_injects_ucode_gateway_config(
     # The gateway default model is applied (no per-session override here).
     assert "--model" in spec.args
     assert spec.args[spec.args.index("--model") + 1] == "databricks-claude-opus-4-7"
-    # The apiKeyHelper threaded into the Claude settings augment so the
-    # gateway token command is registered.
-    assert "databricks auth token --fake-helper" in " ".join(spec.args)
+    # The apiKeyHelper is registered in private settings, not subprocess argv.
+    assert all("sk-sentinel-do-not-use" not in arg for arg in spec.args)
+    settings = _load_claude_invocation_settings(spec.args)
+    assert settings["apiKeyHelper"] == "printf %s sk-sentinel-do-not-use"
     assert recorded_configs == {"13efa494411f3ae60211e6be5635062a": ucode}
 
     await fake_client.aclose()
@@ -2677,7 +2683,7 @@ async def test_auto_create_claude_terminal_registers_permission_hook(
     assert spec.keep_alive_after_exit is True
     args = spec.args
     assert "--append-system-prompt" not in args
-    settings = json.loads(args[args.index("--settings") + 1])
+    settings = _load_claude_invocation_settings(args)
     assert "PermissionRequest" in settings["hooks"]
     permission_hook = settings["hooks"]["PermissionRequest"][0]["hooks"][0]
     assert permission_hook["type"] == "command"

--- a/tests/runner/test_background_session_title.py
+++ b/tests/runner/test_background_session_title.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import stat
 import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -14,6 +15,7 @@ import pytest
 
 from omnigent.codex_native_app_server import NativeCodexLaunch
 from omnigent.harness_plugins import BackgroundTitleGeneratorSpec
+from omnigent.inner.codex_executor import _provider_codex_config_overrides
 from omnigent.runner import create_runner_app
 from omnigent.runner.background_titles import BackgroundTitleContext
 from omnigent.runner.background_titles import claude_native as claude_native_titles
@@ -559,7 +561,10 @@ async def test_codex_native_title_uses_ephemeral_tool_free_exec(
             output_path = Path(args[args.index("--output-last-message") + 1])
             codex_home = Path(captured["kwargs"]["env"]["CODEX_HOME"])
             captured["auth_text"] = (codex_home / "auth.json").read_text()
-            captured["config_text"] = (codex_home / "config.toml").read_text()
+            config_path = codex_home / "config.toml"
+            captured["config_text"] = config_path.read_text()
+            captured["codex_home_mode"] = stat.S_IMODE(codex_home.stat().st_mode)
+            captured["config_mode"] = stat.S_IMODE(config_path.stat().st_mode)
             captured["agents_exists"] = (codex_home / "AGENTS.md").exists()
             output_path.write_text("Debug authentication timeout\n")
             return b"", b"ignored warning"
@@ -592,9 +597,15 @@ async def test_codex_native_title_uses_ephemeral_tool_free_exec(
     (source_home / "AGENTS.md").write_text("Do unrelated work")
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", create_subprocess_exec)
+    provider_overrides = _provider_codex_config_overrides(
+        model="gpt-5.4-mini",
+        base_url="https://provider.invalid/v1",
+        auth_command="printf %s sk-sentinel-do-not-use",
+        wire_api="responses",
+    )
     monkeypatch.setattr(
         "omnigent.codex_native_app_server.resolve_native_codex_launch",
-        lambda *, model: NativeCodexLaunch([], model, None),
+        lambda *, model: NativeCodexLaunch(provider_overrides, model, None),
     )
     monkeypatch.setattr(
         "omnigent.codex_native_app_server._find_codex_cli",
@@ -625,6 +636,7 @@ async def test_codex_native_title_uses_ephemeral_tool_free_exec(
     assert args[args.index("--model") + 1] == "gpt-5.4-mini"
     assert "features.shell_tool=false" in args
     assert 'web_search="disabled"' in args
+    assert all("sk-sentinel-do-not-use" not in arg for arg in args)
     assert "omnigent-codex-title-" in captured["kwargs"]["cwd"]
     codex_home = Path(captured["kwargs"]["env"]["CODEX_HOME"])
     assert codex_home != source_home
@@ -636,6 +648,10 @@ async def test_codex_native_title_uses_ephemeral_tool_free_exec(
     assert "unrelated_top_level" not in config_text
     assert "mcp_servers" not in config_text
     assert "[features]" not in config_text
+    assert "sk-sentinel-do-not-use" in config_text
+    assert "omnigent_provider" in config_text
+    assert captured["codex_home_mode"] == 0o700
+    assert captured["config_mode"] == 0o600
     assert captured["agents_exists"] is False
 
 

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -44,6 +44,18 @@ def _stub_catalog_default(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+def _test_bridge_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    bridge_root = tmp_path / "claude-native"
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", bridge_root)
+    return bridge_root / "session"
+
+
+def _load_invocation_settings(args: list[str]) -> dict[str, Any]:
+    settings_path = Path(args[args.index("--settings") + 1])
+    return json.loads(settings_path.read_text(encoding="utf-8"))
+
+
 def test_claude_terminal_request_pins_launch_cwd(tmp_path, monkeypatch) -> None:
     """
     The terminal launch body pins ``cwd`` to the user's launch dir.
@@ -63,10 +75,11 @@ def test_claude_terminal_request_pins_launch_cwd(tmp_path, monkeypatch) -> None:
     Channels flag is not snuck in.
     """
     monkeypatch.chdir(tmp_path)
+    bridge_dir = _test_bridge_dir(tmp_path, monkeypatch)
     body = claude_native._claude_terminal_request(
         ("--resume", "claude-session", "-p", "hi"),
         command="claude",
-        bridge_dir=Path("/tmp/omnigent-test-bridge"),
+        bridge_dir=bridge_dir,
     )
 
     assert body["terminal"] == "claude"
@@ -100,13 +113,13 @@ def test_claude_terminal_request_pins_launch_cwd(tmp_path, monkeypatch) -> None:
         "omnigent.claude_native_bridge",
         "serve-mcp",
         "--bridge-dir",
-        "/tmp/omnigent-test-bridge",
+        str(bridge_dir),
     ]
     # The experimental Claude Channels flag is blocked at the org
     # policy layer — the wrapper must not pass it. Web-UI input now
     # goes through tmux send-keys.
     assert "--dangerously-load-development-channels" not in args
-    settings = json.loads(args[args.index("--settings") + 1])
+    settings = _load_invocation_settings(args)
     assert sorted(settings["hooks"]) == [
         "MessageDisplay",
         "PostToolUse",
@@ -127,7 +140,7 @@ def test_claude_terminal_request_default_launch_is_unwrapped(tmp_path, monkeypat
     body = claude_native._claude_terminal_request(
         ("--resume", "s"),
         command="claude",
-        bridge_dir=Path("/tmp/omnigent-test-bridge"),
+        bridge_dir=_test_bridge_dir(tmp_path, monkeypatch),
     )
     spec = body["spec"]
     assert spec["command"] == "claude"
@@ -158,7 +171,7 @@ def test_claude_terminal_request_launcher_plugin_wraps(tmp_path, monkeypatch) ->
     body = claude_native._claude_terminal_request(
         ("--resume", "s"),
         command="claude",
-        bridge_dir=Path("/tmp/omnigent-test-bridge"),
+        bridge_dir=_test_bridge_dir(tmp_path, monkeypatch),
     )
     spec = body["spec"]
     assert spec["command"] == "isaac"
@@ -170,7 +183,7 @@ def test_claude_terminal_request_launcher_plugin_wraps(tmp_path, monkeypatch) ->
     assert "--settings" in spec["args"]
 
 
-def test_claude_terminal_request_injects_claude_config() -> None:
+def test_claude_terminal_request_injects_claude_config(tmp_path, monkeypatch) -> None:
     """
     Ucode config reaches the terminal env, settings, and model argv.
 
@@ -185,14 +198,14 @@ def test_claude_terminal_request_injects_claude_config() -> None:
             "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "900000",
             "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
         },
-        api_key_helper="printf token",
+        api_key_helper="printf %s sk-sentinel-do-not-use",
         model="databricks-claude-opus-test",
     )
 
     body = claude_native._claude_terminal_request(
         ("--print", "hi"),
         command="claude",
-        bridge_dir=Path("/tmp/omnigent-test-bridge"),
+        bridge_dir=_test_bridge_dir(tmp_path, monkeypatch),
         claude_config=config,
     )
 
@@ -217,12 +230,13 @@ def test_claude_terminal_request_injects_claude_config() -> None:
         "--model",
         "databricks-claude-opus-test",
     ]
-    settings = json.loads(args[args.index("--settings") + 1])
-    assert settings["apiKeyHelper"] == "printf token"
+    settings = _load_invocation_settings(args)
+    assert all("sk-sentinel-do-not-use" not in arg for arg in args)
+    assert settings["apiKeyHelper"] == "printf %s sk-sentinel-do-not-use"
     assert "hooks" in settings
 
 
-def test_claude_terminal_request_preserves_user_model_arg() -> None:
+def test_claude_terminal_request_preserves_user_model_arg(tmp_path, monkeypatch) -> None:
     """
     User-selected Claude model wins over the ucode default.
 
@@ -239,7 +253,7 @@ def test_claude_terminal_request_preserves_user_model_arg() -> None:
     body = claude_native._claude_terminal_request(
         ("--model", "user-model", "--print", "hi"),
         command="claude",
-        bridge_dir=Path("/tmp/omnigent-test-bridge"),
+        bridge_dir=_test_bridge_dir(tmp_path, monkeypatch),
         claude_config=config,
     )
 

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -64,6 +64,11 @@ def _trust_tmp_bridge_parent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path)
 
 
+def _load_invocation_settings(args: list[str]) -> dict[str, Any]:
+    settings_path = Path(args[args.index("--settings") + 1])
+    return json.loads(settings_path.read_text(encoding="utf-8"))
+
+
 @pytest.fixture
 def subprocess_bridge_root() -> Iterator[Path]:
     """
@@ -2175,7 +2180,7 @@ def test_augment_claude_args_injects_mcp_and_hooks(tmp_path: Path) -> None:
     # capability is blocked at the org level. The wrapper must not
     # pass the development-channels flag.
     assert "--dangerously-load-development-channels" not in args
-    settings = json.loads(args[args.index("--settings") + 1])
+    settings = _load_invocation_settings(args)
     assert "omnigent.claude_native_hook" in settings["hooks"]["Stop"][0]["hooks"][0]["command"]
     # ``PreCompact`` must be wired so the forwarder can surface
     # ``response.compaction.in_progress`` while Claude compacts in the
@@ -2192,6 +2197,34 @@ def test_augment_claude_args_injects_mcp_and_hooks(tmp_path: Path) -> None:
     # through the standard PermissionRequest elicitation card, so the
     # wrapper must not inject a ``--disallowedTools`` flag of its own.
     assert "--disallowedTools" not in args
+
+
+@pytest.mark.parametrize(
+    "api_key_helper",
+    (
+        "printf %s sk-sentinel-do-not-use",
+        "credential-helper --token sk-sentinel-do-not-use",
+    ),
+)
+def test_augment_claude_args_materializes_api_key_helper(
+    tmp_path: Path,
+    api_key_helper: str,
+) -> None:
+    bridge_dir = tmp_path / "session"
+
+    args = augment_claude_args(
+        (),
+        bridge_dir=bridge_dir,
+        api_key_helper=api_key_helper,
+    )
+
+    settings_path = Path(args[args.index("--settings") + 1])
+    settings = _load_invocation_settings(args)
+    assert all("sk-sentinel-do-not-use" not in arg for arg in args)
+    assert settings["apiKeyHelper"] == api_key_helper
+    assert settings_path.parent == bridge_dir
+    assert bridge_dir.stat().st_mode & 0o777 == 0o700
+    assert settings_path.stat().st_mode & 0o777 == 0o600
 
 
 def test_augment_claude_args_mirrors_launch_overrides_into_settings(
@@ -2213,7 +2246,7 @@ def test_augment_claude_args_mirrors_launch_overrides_into_settings(
         python_executable="/venv/bin/python",
     )
 
-    settings = json.loads(args[args.index("--settings") + 1])
+    settings = _load_invocation_settings(args)
     assert settings["model"] == "claude-fable-5"
     assert settings["permissions"] == {"defaultMode": "auto"}
     assert settings["effortLevel"] == "xhigh"
@@ -2229,7 +2262,7 @@ def test_augment_claude_args_mirrors_joined_model_arg_into_settings(
         python_executable="/venv/bin/python",
     )
 
-    settings = json.loads(args[args.index("--settings") + 1])
+    settings = _load_invocation_settings(args)
     assert settings["model"] == "claude-sonnet-5"
     assert "permissions" not in settings
     assert "effortLevel" not in settings
@@ -2256,7 +2289,7 @@ def test_augment_claude_args_uses_last_repeated_launch_override(
         python_executable="/venv/bin/python",
     )
 
-    settings = json.loads(args[args.index("--settings") + 1])
+    settings = _load_invocation_settings(args)
     assert settings["model"] == "claude-new"
     assert settings["permissions"] == {"defaultMode": "auto"}
     assert settings["effortLevel"] == "high"
@@ -2389,7 +2422,7 @@ def test_augment_claude_args_omits_permission_hook_without_omnigent_server(
         bridge_dir=tmp_path,
         python_executable="/venv/bin/python",
     )
-    settings = json.loads(args[args.index("--settings") + 1])
+    settings = _load_invocation_settings(args)
     assert "PermissionRequest" not in settings["hooks"]
 
 
@@ -2412,7 +2445,7 @@ def test_augment_claude_args_registers_permission_command_hook(
         ap_server_url="http://127.0.0.1:8787/",
         ap_auth_headers={"Authorization": "Bearer xyz"},
     )
-    settings = json.loads(args[args.index("--settings") + 1])
+    settings = _load_invocation_settings(args)
     permission = settings["hooks"]["PermissionRequest"]
     assert len(permission) == 1
     hooks = permission[0]["hooks"]
@@ -2463,7 +2496,7 @@ def test_augment_claude_args_registers_user_prompt_submit_policy_hook(
         ap_server_url="http://127.0.0.1:8787/",
         ap_auth_headers={"Authorization": "Bearer xyz"},
     )
-    settings = json.loads(args[args.index("--settings") + 1])
+    settings = _load_invocation_settings(args)
     entries = settings["hooks"]["UserPromptSubmit"]
     commands = [h["command"] for entry in entries for h in entry["hooks"]]
     # The forwarder status hook stays; the policy hook is appended.
@@ -2491,7 +2524,7 @@ def test_augment_claude_args_omits_user_prompt_submit_policy_hook_without_server
         bridge_dir=tmp_path,
         python_executable="/venv/bin/python",
     )
-    settings = json.loads(args[args.index("--settings") + 1])
+    settings = _load_invocation_settings(args)
     entries = settings["hooks"]["UserPromptSubmit"]
     commands = [h["command"] for entry in entries for h in entry["hooks"]]
     assert all("evaluate-policy" not in command for command in commands)
@@ -2512,7 +2545,7 @@ def test_augment_claude_args_keeps_permission_hook_without_launch_session_id(
         bridge_dir=tmp_path,
         ap_server_url="http://127.0.0.1:8787",
     )
-    settings = json.loads(args[args.index("--settings") + 1])
+    settings = _load_invocation_settings(args)
     assert settings["hooks"]["PermissionRequest"][0]["hooks"][0]["type"] == "command"
     session_start_command = settings["hooks"]["SessionStart"][0]["hooks"][0]["command"]
     assert "--conversation-url" not in session_start_command

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import stat
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -18,6 +19,7 @@ except ImportError:  # pragma: no cover - Python < 3.11
 from omnigent.codex_native_app_server import (
     _POLICY_HOOK_TIMEOUT_SECONDS,
     CodexNativeAppServer,
+    _build_native_codex_app_server_argv,
     _codex_policy_hooks_settings,
     _hooks_list_diagnostics,
     _model_discovery_cache,
@@ -28,7 +30,10 @@ from omnigent.codex_native_app_server import (
     trust_native_policy_hooks,
 )
 from omnigent.codex_native_hook import _EVALUATE_POLICY_TIMEOUT_S
-from omnigent.inner.codex_executor import _populate_codex_home_config
+from omnigent.inner.codex_executor import (
+    _populate_codex_home_config,
+    _provider_codex_config_overrides,
+)
 
 
 async def test_discover_codex_model_options_strips_secrets_and_stops_process(
@@ -619,6 +624,8 @@ async def test_start_writes_fresh_mcp_config_without_leading_blanks(
 
     rendered = (codex_home / "config.toml").read_text(encoding="utf-8")
     assert rendered.startswith("[mcp_servers.omnigent]\n")
+    assert stat.S_IMODE(codex_home.stat().st_mode) == 0o700
+    assert stat.S_IMODE((codex_home / "config.toml").stat().st_mode) == 0o600
     parsed = tomllib.loads(rendered)
     assert parsed["mcp_servers"]["omnigent"] == {
         "command": "/new/python",
@@ -634,6 +641,92 @@ async def test_start_writes_fresh_mcp_config_without_leading_blanks(
             "sys_session_rename": {"approval_mode": "approve"},
         },
     }
+
+
+async def test_native_codex_materializes_provider_auth_for_app_server_and_tui(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Native app-server and remote TUI argv contain no provider secret."""
+    from omnigent import codex_native_app_server
+
+    source_home = tmp_path / "source-codex-home"
+    source_home.mkdir()
+    (source_home / "config.toml").write_text(
+        'model_providers = { existing = { name = "Existing", '
+        'base_url = "https://existing.invalid/v1", wire_api = "responses" } }\n',
+        encoding="utf-8",
+    )
+    codex_home = tmp_path / "codex-home"
+    bridge_dir = tmp_path / "bridge"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(source_home))
+    _disable_codex_startup_rpc(monkeypatch)
+
+    server = _test_app_server(tmp_path, codex_home, bridge_dir, workspace)
+    server.config_overrides = [
+        *_provider_codex_config_overrides(
+            model="test-model",
+            base_url="https://provider.invalid/v1",
+            auth_command="credential-helper --token sk-sentinel-do-not-use",
+            wire_api="responses",
+        ),
+        'approval_policy="never"',
+        'sandbox_mode="danger-full-access"',
+    ]
+    await server.start()
+    await server.close()
+
+    app_server_argv = _build_native_codex_app_server_argv(
+        tagged_argv0="codex session-tag",
+        listen_url="ws://127.0.0.1:9876",
+        config_overrides=server.config_overrides,
+    )
+    remote_argv = codex_native_app_server.build_codex_remote_args(
+        codex_args=(),
+        thread_id=None,
+        remote_url="ws://127.0.0.1:9876",
+        config_overrides=tuple(server.config_overrides),
+    )
+    assert all("sk-sentinel-do-not-use" not in arg for arg in app_server_argv)
+    assert all("sk-sentinel-do-not-use" not in arg for arg in remote_argv)
+    assert 'model_provider="omnigent_provider"' in app_server_argv
+    assert 'model_provider="omnigent_provider"' in remote_argv
+    assert 'approval_policy="never"' in app_server_argv
+    assert 'sandbox_mode="danger-full-access"' in app_server_argv
+
+    config_path = codex_home / "config.toml"
+    config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    provider = config["model_providers"]["omnigent_provider"]
+    assert config["model_providers"]["existing"]["name"] == "Existing"
+    assert provider["base_url"] == "https://provider.invalid/v1"
+    assert provider["auth"]["args"] == [
+        "-c",
+        "credential-helper --token sk-sentinel-do-not-use",
+    ]
+    assert provider["wire_api"] == "responses"
+    assert stat.S_IMODE(codex_home.stat().st_mode) == 0o700
+    assert stat.S_IMODE(config_path.stat().st_mode) == 0o600
+
+
+def test_remote_codex_rejects_unmaterialized_provider_config() -> None:
+    """Remote TUI construction fails closed on provider table overrides."""
+    from omnigent import codex_native_app_server
+
+    provider_override = _provider_codex_config_overrides(
+        model=None,
+        base_url="https://provider.invalid/v1",
+        auth_command="printf %s sk-sentinel-do-not-use",
+        wire_api="responses",
+    )[-1]
+
+    with pytest.raises(ValueError, match="must be materialized"):
+        codex_native_app_server.build_codex_remote_args(
+            codex_args=(),
+            thread_id=None,
+            remote_url="ws://127.0.0.1:9876",
+            config_overrides=(provider_override,),
+        )
 
 
 async def test_untrusted_hook_is_trusted_via_batchwrite() -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Move generated Codex provider definitions from child-process `-c` arguments into each session's private `$CODEX_HOME/config.toml`.
- Move native Claude invocation settings, including credential-bearing `apiKeyHelper` commands, from inline `--settings` JSON into the session's private bridge directory.
- Enforce owner-only directories and files while preserving provider/model routing, hooks, wire behavior, sandbox settings, approval settings, launcher wrapping, and remote-TUI behavior.

**ELI5:** instead of putting provider credentials on command-line notes that local process inspection can read, Omnigent puts them in locked per-session files and passes only those file paths or non-sensitive routing switches.

```text
Before:
  Codex  -> -c model_providers.<name>={...auth...}
  Claude -> --settings '{"apiKeyHelper":"...auth..."}'
                                      |
                                      +-> credential-bearing argv

After:
  Codex  -> private CODEX_HOME/config.toml (0600)
  Claude -> private bridge/claude-settings.json (0600)
                         inside owner-only directories (0700)
                                      |
                                      +-> credentials stay out of argv
```

## Test Plan

- `( set +u; uv run --frozen --extra dev pytest -q tests/inner/test_codex_executor.py tests/test_codex_native_app_server.py tests/test_codex_native.py tests/test_native_codex_provider.py tests/runner/test_background_session_title.py )` — 381 passed.
- `( set +u; uv run --frozen --extra dev pytest -q tests/test_claude_native_bridge.py tests/test_claude_native.py -k 'not test_relay_close_keeps_advertisement_owned_by_newer_relay' )` — 346 passed; the excluded pre-existing macOS `/tmp` symlink-path test is unrelated to this diff.
- `( set +u; NPM_CONFIG_REGISTRY=https://npm-proxy.cloud.databricks.com/ uv run --frozen --extra dev pre-commit run --from-ref origin/main --to-ref HEAD )`
- Verified static-key and custom-auth-command routing, owner-only permissions, provider/model precedence, hooks and launch settings, and absence of credential-bearing configuration from subprocess argv without network access or external credentials.

## Demo

N/A — non-visual subprocess configuration hardening.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Process-level smoke tests used real Codex and Claude binaries. Codex kept provider authentication out of both wrapper and native subprocess argv; Claude started interactively with two observed processes and kept its sentinel only in private settings. Both paths enforced `0600` files under `0700` directories.

## Changelog

Native Codex and Claude provider credentials are kept out of child process arguments.