### PR TITLE
perf(host): skip host-status HTTP call for dead daemon processes

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -7585,6 +7585,10 @@ def _add_daemon_host_status(
 
     :param payload: Payload from :func:`_base_daemon_status_payload`.
     """
+    # A dead process cannot have an online tunnel — skip the round-trip.
+    if payload.get("process") != "online":
+        payload["host_status"] = "offline"
+        return
     base_url = payload.get("server_url")
     host_id = payload.get("host_id")
     if not isinstance(base_url, str):

--- a/tests/host/test_cli_host.py
+++ b/tests/host/test_cli_host.py
@@ -15,7 +15,7 @@ import psutil
 import pytest
 from click.testing import CliRunner
 
-from omnigent.cli import _ensure_host_daemon, _host_daemon_alive, cli
+from omnigent.cli import _add_daemon_host_status, _ensure_host_daemon, _host_daemon_alive, cli
 from omnigent.host.local_server import LocalServerStartup
 
 
@@ -576,3 +576,34 @@ def test_host_stop_treats_zombie_daemon_as_dead(
         "stale daemon record survived stop — a subsequent host start "
         "would be blocked by an 'already running' conflict"
     )
+
+
+def test_add_daemon_host_status_skips_http_for_dead_process() -> None:
+    """Dead processes must not trigger a network round-trip.
+
+    ``_add_daemon_host_status`` is called for every daemon record, including
+    the many stale records accumulated over development sessions. Before this
+    fix each dead record caused a ``GET /v1/hosts/{id}`` call that hit
+    ConnectError or a remote timeout, making ``omni host status`` slow.
+    A dead process cannot have an online tunnel, so the correct answer is
+    ``host_status = "offline"`` with no HTTP request made.
+    """
+    http_calls: list[str] = []
+
+    def _fake_http(*args: object, **kwargs: object) -> object:
+        http_calls.append(str(kwargs))
+        raise AssertionError("HTTP must not be called for a dead process")
+
+    payload = {
+        "process": "offline",
+        "server_url": "https://example.com",
+        "host_id": "host_abc123",
+        "host_status": None,
+        "error": None,
+    }
+    with patch("omnigent.cli._host_http_json", _fake_http):
+        _add_daemon_host_status(payload)
+
+    assert payload["host_status"] == "offline"
+    assert payload["error"] is None
+    assert http_calls == [], "No HTTP calls expected for a dead process"


### PR DESCRIPTION
## Related issue

N/A

## Summary

`omni host status` makes a `GET /v1/hosts/{id}` request for every daemon record to fetch the server-side host status. Over time, dev workstations accumulate many stale daemon records (39 measured) — one per `omnigent host` invocation that wasn't explicitly stopped. Every stale record triggered a sequential HTTP round-trip, even though a dead process can't have an online tunnel.

- In `_add_daemon_host_status`, check `payload["process"]` before issuing the request. If the local process is not `"online"`, set `host_status = "offline"` and return immediately — no network call.
- Cuts `omni host status` from ~14 s to ~5 s on a workstation with many stale records (remaining time is Python startup + HTTP calls for the 2 live daemons).

## Test Plan

- [x] Added `test_add_daemon_host_status_skips_http_for_dead_process`: patches `_host_http_json` to assert-fail if called, builds a payload with `process=offline`, calls `_add_daemon_host_status`, asserts `host_status=offline` with no HTTP call made.
- [x] All existing tests in `tests/host/test_cli_host.py` pass.
- [x] Manually timed `omni host status` before/after: 13.8 s → 4.7 s.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

## Changelog

`omni host status` is significantly faster when stale daemon records have accumulated.