### PR TITLE
chore(web): reject stale lint suppressions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
       - id: web-oxlint
         name: web oxlint
         language: system
-        entry: bash -c 'test -x web/node_modules/.bin/oxlint && cd web && node_modules/.bin/oxlint --deny-warnings .'
+        entry: bash -c 'test -x web/node_modules/.bin/oxlint && cd web && node_modules/.bin/oxlint --deny-warnings --report-unused-disable-directives .'
         files: ^(web/.*\.[cm]?[jt]sx?|web/\.oxlintrc\.json|web/package\.json|pnpm-lock\.yaml)$
         pass_filenames: false
 

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
     "build:embed": "vite build --config vite.embed.config.ts",
     "type-check": "tsc -b",
     "preview": "vite preview",
-    "lint": "oxlint --deny-warnings .",
+    "lint": "oxlint --deny-warnings --report-unused-disable-directives .",
     "lint:fix": "oxlint --fix .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/web/src/components/AgentInfo.tsx
+++ b/web/src/components/AgentInfo.tsx
@@ -408,7 +408,6 @@ function AddPolicyDialog({
                     onChange={(e) => setFilter(e.target.value)}
                     placeholder="Filter policies..."
                     className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-ring"
-                    // eslint-disable-next-line jsx-a11y/no-autofocus
                     autoFocus
                   />
                   <div className="flex max-h-52 flex-col divide-y divide-border overflow-y-auto rounded border border-border">

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -221,7 +221,6 @@ export function shouldEchoSynchronously(byteLength: number, msSinceLastInput: nu
  * synchronous ``writeSync`` method that the public types don't expose
  * (see {@link TerminalSession.writeOutput}).
  */
-// eslint-disable-next-line no-underscore-dangle
 interface TerminalCore {
   _core?: {
     writeSync?: (data: Uint8Array, maxSubsequentCalls?: number) => void;

--- a/web/src/components/scheduled/Label.tsx
+++ b/web/src/components/scheduled/Label.tsx
@@ -7,8 +7,5 @@ import type { ComponentPropsWithoutRef } from "react";
 import { cn } from "@/lib/utils";
 
 export function Label({ className, ...props }: ComponentPropsWithoutRef<"label">) {
-  return (
-    // eslint-disable-next-line jsx-a11y/label-has-associated-control -- callers pass htmlFor
-    <label className={cn("text-sm font-medium leading-none", className)} {...props} />
-  );
+  return <label className={cn("text-sm font-medium leading-none", className)} {...props} />;
 }

--- a/web/src/hooks/useIdleNotifications.ts
+++ b/web/src/hooks/useIdleNotifications.ts
@@ -181,7 +181,6 @@ export function useIdleNotifications(activeConversationId?: string): void {
   useEffect(() => {
     return onNativeNotificationActivated((path) => navigateRef.current(path));
     // navigateRef is stable; the listener is mounted once for the app's life.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Desktop shell only: clicking an `omnigent://.../c/<id>` deep link for a
@@ -191,7 +190,6 @@ export function useIdleNotifications(activeConversationId?: string): void {
   // uses. basename-less `/c/<id>` is rebased under the mount by the router.
   useEffect(() => {
     return onOpenPath((path) => navigateRef.current(path));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Clear any deferred turn-end timers on unmount so a pending cue can't fire
@@ -252,7 +250,6 @@ export function useIdleNotifications(activeConversationId?: string): void {
       window.removeEventListener("keydown", onInteract);
     };
     // pushBadge only touches refs, so the once-mounted listener stays fresh.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Marking a row read/unread in the sidebar rewrites the last-seen map;
@@ -270,7 +267,6 @@ export function useIdleNotifications(activeConversationId?: string): void {
     );
     pushBadge(next, convs);
     // pushBadge and the focus state are refs; rerun only when the map changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [unseenTick]);
 
   useEffect(() => {

--- a/web/src/pages/InboxPage.tsx
+++ b/web/src/pages/InboxPage.tsx
@@ -125,7 +125,6 @@ export function InboxPage() {
   // any snapshot query delivers fresh data (dataUpdatedAt advances),
   // sweep verdicts whose id is still pending on the server — those
   // approvals were consumed and the server re-parked the prompt.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   const snapshotVersionKey = snapshotQueries.map((q) => q.dataUpdatedAt ?? 0).join(",");
   const isFirstRender = useRef(true);
   useEffect(() => {

--- a/web/src/pages/PoliciesPage.tsx
+++ b/web/src/pages/PoliciesPage.tsx
@@ -172,7 +172,6 @@ function AddDefaultPolicyDialog({
                     onChange={(e) => setFilter(e.target.value)}
                     placeholder="Filter policies..."
                     className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-ring"
-                    // eslint-disable-next-line jsx-a11y/no-autofocus
                     autoFocus
                   />
                   <div className="flex max-h-52 flex-col divide-y divide-border overflow-y-auto rounded border border-border">

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -896,7 +896,7 @@ export function AppShell() {
       );
     },
     [setPanelInitialKey, terminalFirst, setSearchParams, conversationId],
-  ); // eslint-disable-line react-hooks/exhaustive-deps
+  );
 
   // Strip the file-viewer URL params (file/diff/comment). Memoized on
   // ``setSearchParams`` so it always closes over react-router's *current*

--- a/web/src/shell/CodeViewer.tsx
+++ b/web/src/shell/CodeViewer.tsx
@@ -175,7 +175,6 @@ const MARKDOWN_COMPONENTS: Components = {
       width: px(width) ?? style?.width,
       height: px(height) ?? style?.height,
     };
-    // eslint-disable-next-line jsx-a11y/alt-text -- alt is forwarded via props
     return <img {...props} style={sized} />;
   },
 };
@@ -537,7 +536,7 @@ export function CodeViewer({
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [panelOpen, isMarkdownEditor, showMonaco, searchOpen, setSearchOpen, searchInputRef]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [panelOpen, isMarkdownEditor, showMonaco, searchOpen, setSearchOpen, searchInputRef]);
 
   // In Monaco mode the custom search bar isn't rendered; the editor mirrors its
   // native find widget to `searchOpen` (open when set, close when cleared). This
@@ -601,7 +600,7 @@ export function CodeViewer({
     };
     container.addEventListener("mouseup", handleMouseUp);
     return () => container.removeEventListener("mouseup", handleMouseUp);
-  }, [rawLines]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [rawLines]);
 
   // Dismiss the floating buttons on any mousedown outside of them, or on any
   // scroll. Both the "Add comment" and "Attach to agent" buttons must be

--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -541,7 +541,7 @@ function FileViewerBody({
   const fileContent = useMemo(() => fileQuery.data?.content ?? "", [fileQuery.data]);
   const { open: openComments, addressed: addressedComments } = useMemo(
     () => classifyAndRemapComments(allComments, fileContent),
-    [allComments, fileContent], // eslint-disable-line react-hooks/exhaustive-deps
+    [allComments, fileContent],
   );
 
   // Apply the linked comment (from ?comment= URL param) once per lifecycle.

--- a/web/src/shell/HtmlCommentViewer.tsx
+++ b/web/src/shell/HtmlCommentViewer.tsx
@@ -233,7 +233,6 @@ export function HtmlCommentViewer({
     <iframe
       ref={iframeRef}
       srcDoc={srcDoc}
-      // oxlint-disable-next-line eslint-plugin-react(iframe-missing-sandbox)
       sandbox={HTML_PREVIEW_SANDBOX}
       title="HTML preview"
       className="w-full h-full border-0"

--- a/web/src/shell/MonacoCodeEditor.tsx
+++ b/web/src/shell/MonacoCodeEditor.tsx
@@ -312,7 +312,7 @@ function MonacoCodeEditorInner({
       // Route ⌘S through the same single-flight + trailing-save engine as
       // auto-save, so a manual save during an in-flight/debounced auto-save can't
       // start an overlapping PUT.
-      // oxlint-disable-next-line eslint(no-bitwise) -- Monaco keybindings are bit-OR'd flags.
+      // Monaco keybindings are bitwise OR'd flags.
       editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
         flushRef.current();
       });

--- a/web/src/shell/PreviewSearchBar.tsx
+++ b/web/src/shell/PreviewSearchBar.tsx
@@ -46,7 +46,6 @@ export function PreviewSearchBar({
     }
     setRanges(findTextRanges(container, query.trim()));
     // contentVersion forces a rebuild after the preview re-renders.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [containerRef, open, query, contentVersion]);
 
   const matchCount = ranges.length;

--- a/web/src/shell/WorkspacePicker.tsx
+++ b/web/src/shell/WorkspacePicker.tsx
@@ -558,8 +558,7 @@ export function WorkspacePicker({
             <FolderPlusIcon className="size-4 shrink-0 text-muted-foreground" />
             <input
               type="text"
-              // eslint-disable-next-line jsx-a11y/no-autofocus -- focus belongs on
-              // the field the user just opened; the picker is already a focus trap.
+              // Focus belongs on the field the user just opened; the picker is already a focus trap.
               autoFocus
               value={newFolderName}
               onChange={(e) => {

--- a/web/src/shell/codeViewerRendering.tsx
+++ b/web/src/shell/codeViewerRendering.tsx
@@ -29,20 +29,15 @@ function splitAtMatches(text: string, query: string): TextSegment[] {
 }
 
 // Shiki encodes font decorations as bit flags on token.fontStyle.
-// oxlint-disable eslint(no-bitwise)
 const SHIKI_ITALIC = 1;
 const SHIKI_BOLD = 2;
 const SHIKI_UNDERLINE = 4;
-// oxlint-enable eslint(no-bitwise)
 
 function buildTokenStyle(token: ThemedToken): CSSProperties {
   return {
     color: token.color,
-    // oxlint-disable-next-line eslint(no-bitwise)
     fontStyle: token.fontStyle && token.fontStyle & SHIKI_ITALIC ? "italic" : undefined,
-    // oxlint-disable-next-line eslint(no-bitwise)
     fontWeight: token.fontStyle && token.fontStyle & SHIKI_BOLD ? "bold" : undefined,
-    // oxlint-disable-next-line eslint(no-bitwise)
     textDecoration: token.fontStyle && token.fontStyle & SHIKI_UNDERLINE ? "underline" : undefined,
     ...(token.htmlStyle as CSSProperties),
   };


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Remove 22 Oxlint/ESLint suppression directives that no longer suppress any diagnostic.
- Enable `--report-unused-disable-directives` in both the web lint script and pre-commit hook.
- Keep all 73 currently active suppression directives unchanged.

## Test Plan

- `pnpm --filter web run lint`
- `pnpm --filter web run type-check`
- `uv run --no-sync pre-commit run --show-diff-on-failure`

## Demo

N/A — lint configuration and comment cleanup only.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

No runtime behavior changes; Oxlint, TSC, and the staged pre-commit suite verify the suppression cleanup and enforcement flag.
