### PR TITLE
test(e2e-ui): de-flake view-mode toggle open in native-parity helpers

### DIFF
--- a/tests/e2e_ui/messages/test_message_render_parity.py
+++ b/tests/e2e_ui/messages/test_message_render_parity.py
@@ -66,6 +66,39 @@ def _send(page: Page, text: str) -> None:
     page.get_by_role("button", name="Send", exact=True).click()
 
 
+# The header Chat/Terminal switcher is a Radix dropdown whose trigger *toggles*
+# on pointer-down. On a busy page (a live terminal stream plus the trigger's own
+# hover-driven tooltip re-rendering onto the same node) a lone click can net back
+# to closed, leaving the menu shut. Reopen until the target item is on screen
+# instead of asserting a single click landed.
+_VIEW_MENU_OPEN_ATTEMPTS = 5
+_VIEW_MENU_OPEN_TIMEOUT_MS = 5_000
+
+
+def _select_view_mode(page: Page, option: str) -> None:
+    """Open the header Chat/Terminal switcher and select *option*.
+
+    Clicks the ``view-mode-toggle`` trigger and waits for the ``option`` radio
+    item; a Radix toggle-trigger click can be swallowed on a busy page, so retry
+    the open before selecting rather than trusting one click.
+
+    :param page: The Playwright page, on the session's chat surface.
+    :param option: The menu item label, e.g. ``"Chat"`` or ``"Terminal"``.
+    """
+    toggle = page.get_by_test_id("view-mode-toggle")
+    expect(toggle).to_be_visible(timeout=30_000)
+    item = page.get_by_role("menuitemradio", name=option)
+    for attempt in range(_VIEW_MENU_OPEN_ATTEMPTS):
+        toggle.click()
+        try:
+            expect(item).to_be_visible(timeout=_VIEW_MENU_OPEN_TIMEOUT_MS)
+            break
+        except AssertionError:
+            if attempt == _VIEW_MENU_OPEN_ATTEMPTS - 1:
+                raise
+    item.click()
+
+
 def _ensure_chat_view(page: Page) -> None:
     """Switch a terminal-first (native) session to its chat bubble view.
 
@@ -76,13 +109,9 @@ def _ensure_chat_view(page: Page) -> None:
 
     :param page: The Playwright page, on the session's chat surface.
     """
-    view_mode = page.get_by_test_id("view-mode-toggle")
-    if view_mode.count() == 0:
+    if page.get_by_test_id("view-mode-toggle").count() == 0:
         return
-    view_mode.click()
-    chat_item = page.get_by_role("menuitemradio", name="Chat")
-    expect(chat_item).to_be_visible(timeout=30_000)
-    chat_item.click()
+    _select_view_mode(page, "Chat")
 
 
 def _turn_prompt(index: int, user_marker: str, assistant_token: str) -> str:

--- a/tests/e2e_ui/messages/test_native_claude_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_claude_render_parity.py
@@ -36,6 +36,7 @@ from .test_message_render_parity import (
     _assert_no_duplicate_render,
     _assert_transcript_parity,
     _ensure_chat_view,
+    _select_view_mode,
     _send,
     _turn_prompt,
 )
@@ -65,12 +66,10 @@ def _open_terminal_view(page: Page) -> None:
 
     :param page: The Playwright page, on the session's chat surface.
     """
-    view_mode = page.get_by_test_id("view-mode-toggle")
-    expect(view_mode).to_be_visible(timeout=_TERMINAL_READY_TIMEOUT_MS)
-    view_mode.click()
-    terminal_item = page.get_by_role("menuitemradio", name="Terminal")
-    expect(terminal_item).to_be_visible(timeout=30_000)
-    terminal_item.click()
+    expect(page.get_by_test_id("view-mode-toggle")).to_be_visible(
+        timeout=_TERMINAL_READY_TIMEOUT_MS
+    )
+    _select_view_mode(page, "Terminal")
 
 
 def _wait_terminal_connected(page: Page) -> None:

--- a/tests/e2e_ui/messages/test_native_codex_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_codex_render_parity.py
@@ -37,6 +37,7 @@ from .test_message_render_parity import (
     _assert_no_duplicate_render,
     _assert_transcript_parity,
     _ensure_chat_view,
+    _select_view_mode,
     _send,
     _turn_prompt,
 )
@@ -67,12 +68,10 @@ def _open_terminal_view(page: Page) -> None:
 
     :param page: The Playwright page, on the session's chat surface.
     """
-    view_mode = page.get_by_test_id("view-mode-toggle")
-    expect(view_mode).to_be_visible(timeout=_TERMINAL_READY_TIMEOUT_MS)
-    view_mode.click()
-    terminal_item = page.get_by_role("menuitemradio", name="Terminal")
-    expect(terminal_item).to_be_visible(timeout=30_000)
-    terminal_item.click()
+    expect(page.get_by_test_id("view-mode-toggle")).to_be_visible(
+        timeout=_TERMINAL_READY_TIMEOUT_MS
+    )
+    _select_view_mode(page, "Terminal")
 
 
 def _wait_terminal_connected(page: Page) -> None:

--- a/tests/e2e_ui/messages/test_native_cursor_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_cursor_render_parity.py
@@ -81,6 +81,7 @@ from .test_message_render_parity import (
     _assert_no_duplicate_render,
     _assert_transcript_parity,
     _ensure_chat_view,
+    _select_view_mode,
     _send,
     _turn_prompt,
 )
@@ -146,12 +147,10 @@ def _open_terminal_view(page: Page) -> None:
 
     :param page: The Playwright page, on the session's chat surface.
     """
-    view_mode = page.get_by_test_id("view-mode-toggle")
-    expect(view_mode).to_be_visible(timeout=_TERMINAL_READY_TIMEOUT_MS)
-    view_mode.click()
-    terminal_item = page.get_by_role("menuitemradio", name="Terminal")
-    expect(terminal_item).to_be_visible(timeout=30_000)
-    terminal_item.click()
+    expect(page.get_by_test_id("view-mode-toggle")).to_be_visible(
+        timeout=_TERMINAL_READY_TIMEOUT_MS
+    )
+    _select_view_mode(page, "Terminal")
 
 
 def _wait_terminal_connected(page: Page) -> None:

--- a/tests/e2e_ui/messages/test_native_goose_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_goose_render_parity.py
@@ -45,6 +45,7 @@ from .test_message_render_parity import (
     _assert_no_duplicate_render,
     _assert_transcript_parity,
     _ensure_chat_view,
+    _select_view_mode,
     _send,
     _turn_prompt,
 )
@@ -93,12 +94,10 @@ pytestmark = pytest.mark.skipif(
 
 def _open_terminal_view(page: Page) -> None:
     """Switch a terminal-first session to its Terminal (TUI) view."""
-    view_mode = page.get_by_test_id("view-mode-toggle")
-    expect(view_mode).to_be_visible(timeout=_TERMINAL_READY_TIMEOUT_MS)
-    view_mode.click()
-    terminal_item = page.get_by_role("menuitemradio", name="Terminal")
-    expect(terminal_item).to_be_visible(timeout=30_000)
-    terminal_item.click()
+    expect(page.get_by_test_id("view-mode-toggle")).to_be_visible(
+        timeout=_TERMINAL_READY_TIMEOUT_MS
+    )
+    _select_view_mode(page, "Terminal")
 
 
 def _wait_terminal_connected(page: Page) -> None:

--- a/tests/e2e_ui/messages/test_native_hermes_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_hermes_render_parity.py
@@ -45,6 +45,7 @@ from .test_message_render_parity import (
     _assert_no_duplicate_render,
     _assert_transcript_parity,
     _ensure_chat_view,
+    _select_view_mode,
     _send,
     _turn_prompt,
 )
@@ -93,12 +94,10 @@ pytestmark = pytest.mark.skipif(
 
 def _open_terminal_view(page: Page) -> None:
     """Switch a terminal-first session to its Terminal (TUI) view."""
-    view_mode = page.get_by_test_id("view-mode-toggle")
-    expect(view_mode).to_be_visible(timeout=_TERMINAL_READY_TIMEOUT_MS)
-    view_mode.click()
-    terminal_item = page.get_by_role("menuitemradio", name="Terminal")
-    expect(terminal_item).to_be_visible(timeout=30_000)
-    terminal_item.click()
+    expect(page.get_by_test_id("view-mode-toggle")).to_be_visible(
+        timeout=_TERMINAL_READY_TIMEOUT_MS
+    )
+    _select_view_mode(page, "Terminal")
 
 
 def _wait_terminal_connected(page: Page) -> None:

--- a/tests/e2e_ui/messages/test_native_kiro_render_parity.py
+++ b/tests/e2e_ui/messages/test_native_kiro_render_parity.py
@@ -43,6 +43,7 @@ from .test_message_render_parity import (
     _assert_no_duplicate_render,
     _assert_transcript_parity,
     _ensure_chat_view,
+    _select_view_mode,
     _send,
     _turn_prompt,
 )
@@ -82,12 +83,10 @@ pytestmark = pytest.mark.skipif(
 
 def _open_terminal_view(page: Page) -> None:
     """Switch a terminal-first session to its Terminal (TUI) view."""
-    view_mode = page.get_by_test_id("view-mode-toggle")
-    expect(view_mode).to_be_visible(timeout=_TERMINAL_READY_TIMEOUT_MS)
-    view_mode.click()
-    terminal_item = page.get_by_role("menuitemradio", name="Terminal")
-    expect(terminal_item).to_be_visible(timeout=30_000)
-    terminal_item.click()
+    expect(page.get_by_test_id("view-mode-toggle")).to_be_visible(
+        timeout=_TERMINAL_READY_TIMEOUT_MS
+    )
+    _select_view_mode(page, "Terminal")
 
 
 def _wait_terminal_connected(page: Page) -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The Chat/Terminal switcher moved into the header (#3931) as a Radix
  `DropdownMenu` whose trigger *toggles* on pointer-down and carries a
  controlled hover tooltip on the same node (`web/src/shell/ViewModeToggle.tsx`).
  On a busy page — a live terminal stream plus that tooltip re-rendering
  during the click — a lone `.click()` occasionally nets the menu back to
  **closed**, so the follow-up `expect(menuitemradio).to_be_visible()` times
  out. That is the flake seen in `test_codex_goal_mode` and the native
  render-parity suites; the failure snapshot shows `tooltip "Terminal view"`
  (rendered only while the menu is closed) with no menu items.
- Add a shared `_select_view_mode(page, option)` helper that reopens the menu
  in a retry loop until the target radio item is actually visible, then selects
  it, instead of trusting one toggle click. Route `_ensure_chat_view` and every
  native-parity `_open_terminal_view` (codex, claude, goose, hermes, cursor,
  kiro) through it.

## Test Plan

- `ruff check` / `ruff format --check` clean; pytest collection succeeds.
- Verifying non-flakiness by dispatching the **Flake stress (E2E UI)** workflow
  (`flake-stress-ui.yml`) against this branch, targeting
  `tests/e2e_ui/chat/test_codex_goal_mode.py::test_codex_goal_mode_with_mocked_responses`.
  Expecting 0/N failures. (Result linked in a comment once the run finishes.)

## Demo

N/A — test-only change; no UI behaviour changes.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

The change is entirely within the e2e_ui Playwright helpers these tests already
use; the same suites that were flaking exercise the fixed path.

This pull request and its description were written by Isaac.
