### PR TITLE
dev/repro: add --public flag to share the reproduction session at start

### DIFF
--- a/dev/repro-agent/AGENTS.md
+++ b/dev/repro-agent/AGENTS.md
@@ -28,6 +28,10 @@ session and logs are things you *produce*, not inputs:
   or `https://linear.app/omnigent/issue/OMNI-1234`). Read the report to get the
   bug description, steps, and version. Use `gh issue view` for GitHub or your
   Linear tools for a Linear link.
+- `public` (optional, boolean) — when `true`, share this session public-read as
+  the first thing you do in preflight (see Preflight). Off by default: locally
+  the session is already yours to browse; sharing is for watching a live run or
+  reproducing against a shared server.
 
 You always reproduce against the app you are connected to — the running build
 (latest `main`) — never an older checkout. So the reported version is context for
@@ -51,12 +55,23 @@ your omnigent checkout.)
 
 ## Preflight (first turn)
 
-After confirming the workspace above, confirm you can reach the app and your
-tooling with one `sys_os_shell` / tool check: the browser tools
-(`browser_navigate` / `browser_snapshot` / `browser_click` / `browser_type`) for
-UI journeys, and `sys_session_*` / HTTP for backend journeys. Confirm `gh` is
-available if `bug_url` is a GitHub issue. If you cannot reach the app at all,
-stop and say so. Don't narrate a clean preflight.
+Your first turn is a fixed checklist — do all of it before Step 1:
+
+1. **Share the session if `public: true`.** If — and only if — the input
+   contains `public: true`, call `sys_session_share` with no `session_id`
+   (shares the calling session), `user_id: "__public__"`, `level: "read"` **as
+   the first thing you do this turn**, so the session is browsable live while you
+   work. If it returns `access_denied` (public sharing disabled server-side),
+   note that and carry on — it is not a reproduction failure. When `public` is
+   absent or false (the default), skip this — do not call `sys_session_share`.
+2. **Confirm the workspace** (see above) and that you can reach the app and your
+   tooling with one `sys_os_shell` / tool check: the browser tools
+   (`browser_navigate` / `browser_snapshot` / `browser_click` / `browser_type`)
+   for UI journeys, and `sys_session_*` / HTTP for backend journeys. Confirm `gh`
+   is available if `bug_url` is a GitHub issue.
+
+If you cannot reach the app at all, stop and say so. Don't narrate a clean
+preflight.
 
 ## Step 1 — Reconstruct the user journey
 

--- a/dev/repro-agent/README.md
+++ b/dev/repro-agent/README.md
@@ -43,7 +43,12 @@ checkout, and runs the agent from there.
 python dev/repro.py                     # prompts for the bug URL
 python dev/repro.py https://github.com/omnigent-ai/omnigent/issues/1234
 python dev/repro.py OMNI-1234 --server http://localhost:6767
+python dev/repro.py <bug_url> --public  # share the session public-read at start
 ```
+
+`--public` shares the session read-only (anyone who can reach the server) right
+after it starts — useful for watching a live run or reproducing against a shared
+`--server`. Off by default.
 
 It always keeps the worktree and prints its path + branch at the end; remove it
 with `git worktree remove <path>` when done.

--- a/dev/repro-agent/config.yaml
+++ b/dev/repro-agent/config.yaml
@@ -54,6 +54,14 @@ executor:
 # The full operating procedure lives in AGENTS.md, read at startup.
 instructions: AGENTS.md
 
+# Grant sys_session_share authority to grant the __public__ sentinel (anonymous
+# read-only). Locally your session is already yours to browse, so sharing is
+# opt-in: the agent only shares when invoked with `public: true` (the
+# `dev/repro.py --public` flag). Useful when watching a live run or reproducing
+# against a shared --server. Still gated by the server's own public-sharing
+# switch.
+agent_session_sharing: public
+
 async: true
 cancellable: true
 

--- a/dev/repro.py
+++ b/dev/repro.py
@@ -21,6 +21,7 @@ Usage (from the repo root):
   python dev/repro.py                     # prompts for the bug URL
   python dev/repro.py https://github.com/omnigent-ai/omnigent/issues/1234
   python dev/repro.py OMNI-1234 --server http://localhost:6767
+  python dev/repro.py <bug_url> --public  # share the session public-read at start
 
 Reproducing runs against whatever server ``omnigent run`` uses (the local server
 it spins up by default, or the one you pass with ``--server``).
@@ -109,6 +110,13 @@ def _parse_args() -> argparse.Namespace:
         help="Omnigent server URL to reproduce against. Omit to use the local "
         "server omnigent run spins up.",
     )
+    p.add_argument(
+        "--public",
+        action="store_true",
+        help="Share the reproduction session public-read (anyone who can reach "
+        "the server) right after it starts. Off by default — useful when "
+        "watching a live run or reproducing against a shared --server.",
+    )
     return p.parse_args()
 
 
@@ -127,9 +135,13 @@ def main() -> None:
     if not bug_url:
         _die("no bug URL given")
 
-    # The agent's input contract is just the bug URL; it always reproduces
-    # against the running build (latest main), so there's no version to pass.
-    prompt = json.dumps({"bug_url": bug_url})
+    # The agent's input contract is the bug URL (it always reproduces against the
+    # running build, so there's no version to pass), plus an optional `public`
+    # flag telling it to share the session public-read right after it starts.
+    payload: dict[str, object] = {"bug_url": bug_url}
+    if args.public:
+        payload["public"] = True
+    prompt = json.dumps(payload)
 
     # Create the isolated worktree off the CURRENT checkout's HEAD. We resolve
     # HEAD to a concrete commit and pass it as the base, because create_worktree


### PR DESCRIPTION
## Related issue

N/A

## Summary

Adds an opt-in `--public` flag to the `dev/repro.py` driver so a reproduction
session can be shared read-only (anyone who can reach the server) at the start
of the run — useful when watching a live run or reproducing against a shared
`--server`. Off by default, since a local session is already yours to browse.

- `dev/repro.py`: add `--public`; include `"public": true` in the agent's input
  contract payload when set.
- `dev/repro-agent/config.yaml`: re-add `agent_session_sharing: public` to grant
  the `__public__` capability (opt-in, only exercised via the flag).
- `dev/repro-agent/AGENTS.md`: document the `public` input and make sharing the
  first preflight action.
- `dev/repro-agent/README.md`: document the flag.

## Test Plan

Ran `dev/repro.py --public` against a local server and inspected the session:

```bash
python dev/repro.py https://github.com/omnigent-ai/omnigent/issues/3987 \
  --server http://localhost:6767 --public
```

- The flag flows through: `--public` sets `"public": true` in the payload; with
  it omitted the payload is just `{"bug_url": ...}` (verified `--help` + the
  payload builder).
- Config loads with `agent_session_sharing: public`; pre-commit (ruff) passes.

**Known limitation (prompt-only):** sharing currently relies on the agent
honoring the `public: true` instruction, and in local testing the claude-sdk
agent did not reliably call `sys_session_share` at start — it tends to go
straight into preflight/reproduction. So `--public` is best-effort as shipped.
A follow-up should make `dev/repro.py` perform the share deterministically
(issue the public-read grant itself once the session id is known) rather than
depending on the agent's prompt-following.

## Demo

N/A — dev-only tooling / agent instructions.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified the flag plumbing (payload, `--help`, config load, ruff) and
attempted an end-to-end `--public` run against a local server. Dev-only tooling,
so no automated test target. See the known-limitation note above: the
prompt-driven share is not yet reliable and a deterministic follow-up is
recommended.