### PR TITLE
test(vscode): update Vitest mock typing

### DIFF
--- a/editors/vscode/src/panel/EditorPanelController.test.ts
+++ b/editors/vscode/src/panel/EditorPanelController.test.ts
@@ -4,6 +4,7 @@
  * the iframe render path is taken (the only path in this build).
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Mock } from "vitest";
 import * as vscode from "vscode";
 import { EditorPanelController } from "./EditorPanelController";
 import type { ServerTarget } from "../config";
@@ -43,12 +44,12 @@ function makeController() {
 
 describe("EditorPanelController", () => {
   let fake: ReturnType<typeof makeFakePanel>;
-  let createSpy: ReturnType<typeof vi.fn<unknown[], unknown>>;
+  let createSpy: Mock<() => ReturnType<typeof makeFakePanel>["panel"]>;
 
   beforeEach(() => {
     fake = makeFakePanel();
     const win = vscode.window as unknown as Record<string, unknown>;
-    createSpy = vi.fn<unknown[], unknown>(() => fake.panel);
+    createSpy = vi.fn(() => fake.panel);
     win.createWebviewPanel = createSpy;
   });
 


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Update the VS Code extension's panel test to use Vitest 3's single function-signature mock generic.
- Clear the extension's three remaining TypeScript errors without changing test behavior.
- Establish a clean VS Code TSC baseline for a follow-up enforcement PR.

## Test Plan

- `pnpm --dir editors/vscode run type-check`
- `pnpm --dir editors/vscode run test` (55 tests passed)
- `pnpm --dir editors/vscode run build`
- `uv run --no-sync pre-commit run --show-diff-on-failure`

## Demo

N/A — test typing cleanup only.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The updated mock is exercised by all five `EditorPanelController` tests; the complete extension suite passes.
