### PR TITLE
fix(web): remount terminal view when switching same-vendor sessions

### DIFF
--- a/web/src/shell/MainTerminalView.test.tsx
+++ b/web/src/shell/MainTerminalView.test.tsx
@@ -1,11 +1,17 @@
 import type * as UseTerminalsModule from "@/hooks/useTerminals";
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type TerminalInfo, useTerminals } from "@/hooks/useTerminals";
 import { MainTerminalView } from "./MainTerminalView";
 import type { TerminalFirstContextValue } from "./TerminalFirstContext";
 import { TerminalFirstContextProvider } from "./TerminalFirstContext";
+
+// Monotonic per-mount id. A fresh value on `data-instance` means React
+// remounted the TerminalView (new xterm + WebSocket) rather than reusing
+// the existing one — the signal the stale-scrollback regression test needs.
+let terminalMountSeq = 0;
 
 vi.mock("@/components/blocks/TerminalView", () => ({
   TerminalView: ({
@@ -16,14 +22,20 @@ vi.mock("@/components/blocks/TerminalView", () => ({
     sessionId: string;
     terminalId: string;
     readOnly?: boolean;
-  }) => (
-    <div
-      data-testid="terminal-view"
-      data-session-id={sessionId}
-      data-terminal-id={terminalId}
-      data-read-only={String(readOnly ?? false)}
-    />
-  ),
+  }) => {
+    // useRef initializer runs once per mount, so the id is stable across
+    // re-renders of the same instance and only changes on a remount.
+    const instance = useRef(++terminalMountSeq);
+    return (
+      <div
+        data-testid="terminal-view"
+        data-session-id={sessionId}
+        data-terminal-id={terminalId}
+        data-read-only={String(readOnly ?? false)}
+        data-instance={String(instance.current)}
+      />
+    );
+  },
 }));
 
 vi.mock("@/hooks/useTerminals", async (importOriginal) => ({
@@ -84,19 +96,21 @@ function renderView({
   isNativeWrapper = false,
   initialTerminalKey = null,
   readOnly = false,
+  conversationId = "conv_sdk",
   setView,
 }: {
   terminals: TerminalInfo[];
   isNativeWrapper?: boolean;
   initialTerminalKey?: string | null;
   readOnly?: boolean;
+  conversationId?: string;
   setView?: (view: "chat" | "terminal") => void;
 }) {
   useTerminalsMock.mockReturnValue({ terminals, isLoading: false, error: null });
   return render(
     <TerminalFirstContextProvider value={makeCtx(isNativeWrapper, setView)}>
       <MainTerminalView
-        conversationId="conv_sdk"
+        conversationId={conversationId}
         initialTerminalKey={initialTerminalKey}
         readOnly={readOnly}
       />
@@ -203,6 +217,38 @@ describe("MainTerminalView — native wrapper sessions", () => {
     expect(screen.queryByText("claude")).toBeNull();
     expect(screen.queryByText("bash")).toBeNull();
     expect(screen.queryByTestId("new-shell-button")).toBeNull();
+  });
+
+  it("remounts the terminal when switching between two same-vendor sessions", () => {
+    // Two claude-native sessions share the same agent-terminal id
+    // (`terminal_claude_main`). ChatPage stays mounted across a session
+    // switch and only feeds MainTerminalView a new conversationId, so the
+    // terminal must remount off the session — otherwise the pane keeps the
+    // previous session's scrollback until the new WS repaints.
+    const claudePane: TerminalInfo = {
+      id: "terminal_claude_main",
+      name: "claude",
+      session: "main",
+      running: true,
+    };
+    const { rerender } = renderView({
+      terminals: [claudePane],
+      isNativeWrapper: true,
+      conversationId: "conv_a",
+    });
+    const first = screen.getByTestId("terminal-view").getAttribute("data-instance");
+
+    rerender(
+      <TerminalFirstContextProvider value={makeCtx(true)}>
+        <MainTerminalView conversationId="conv_b" initialTerminalKey={null} readOnly={false} />
+      </TerminalFirstContextProvider>,
+    );
+
+    const view = screen.getByTestId("terminal-view");
+    expect(view).toHaveAttribute("data-session-id", "conv_b");
+    // A new instance id proves the mount was torn down and rebuilt for the
+    // new session rather than reused with stale scrollback.
+    expect(view.getAttribute("data-instance")).not.toBe(first);
   });
 
   it("renders a rail-opened shell chrome-free with the close X", () => {

--- a/web/src/shell/MainTerminalView.test.tsx
+++ b/web/src/shell/MainTerminalView.test.tsx
@@ -23,9 +23,11 @@ vi.mock("@/components/blocks/TerminalView", () => ({
     terminalId: string;
     readOnly?: boolean;
   }) => {
-    // useRef initializer runs once per mount, so the id is stable across
-    // re-renders of the same instance and only changes on a remount.
-    const instance = useRef(++terminalMountSeq);
+    // Assign once per mount (useRef(arg) evaluates arg every render but keeps
+    // the first value), so the id is stable across re-renders and only changes
+    // on a remount.
+    const instance = useRef<number | null>(null);
+    if (instance.current === null) instance.current = ++terminalMountSeq;
     return (
       <div
         data-testid="terminal-view"

--- a/web/src/shell/MainTerminalView.tsx
+++ b/web/src/shell/MainTerminalView.tsx
@@ -160,7 +160,13 @@ export function MainTerminalView({
             )}
             <div className="min-h-0 flex-1">
               {activeTerminal && (
-                <div key={activeTerminal.id} className="flex h-full flex-col">
+                // Scope the key to the session: agent terminals share a fixed
+                // id across same-shape sessions (e.g. `terminal_claude_main`),
+                // so id alone reuses the xterm mount and shows stale scrollback.
+                <div
+                  key={`${conversationId}:${activeTerminal.id}`}
+                  className="flex h-full flex-col"
+                >
                   <TerminalView
                     sessionId={conversationId}
                     terminalId={activeTerminal.id}

--- a/web/src/shell/TerminalsPanel.test.tsx
+++ b/web/src/shell/TerminalsPanel.test.tsx
@@ -1,9 +1,15 @@
 import type * as UseTerminalsModule from "@/hooks/useTerminals";
 
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type TerminalInfo, useTerminals } from "@/hooks/useTerminals";
 import { TerminalsPanel } from "./TerminalsPanel";
+
+// Monotonic per-mount id. A fresh `data-instance` means React remounted
+// the TerminalView (new xterm + WebSocket) rather than reusing it — the
+// signal the stale-scrollback regression test needs.
+let terminalMountSeq = 0;
 
 vi.mock("@/components/blocks/TerminalView", () => ({
   TerminalView: ({
@@ -14,14 +20,20 @@ vi.mock("@/components/blocks/TerminalView", () => ({
     sessionId: string;
     terminalId: string;
     readOnly?: boolean;
-  }) => (
-    <div
-      data-testid="terminal-view"
-      data-session-id={sessionId}
-      data-terminal-id={terminalId}
-      data-read-only={String(readOnly ?? false)}
-    />
-  ),
+  }) => {
+    // useRef initializer runs once per mount, so the id is stable across
+    // re-renders and only changes on a remount.
+    const instance = useRef(++terminalMountSeq);
+    return (
+      <div
+        data-testid="terminal-view"
+        data-session-id={sessionId}
+        data-terminal-id={terminalId}
+        data-read-only={String(readOnly ?? false)}
+        data-instance={String(instance.current)}
+      />
+    );
+  },
 }));
 
 vi.mock("@/hooks/useTerminals", async (importOriginal) => ({
@@ -166,6 +178,42 @@ describe("TerminalsPanel navigation", () => {
     // A non-owner sees the shell but cannot type — the shared PTY runs
     // as the owner, so keystrokes can't be attributed per-user.
     expect(screen.getByTestId("terminal-view")).toHaveAttribute("data-read-only", "true");
+  });
+
+  it("remounts the terminal when switching sessions with the same terminal id", () => {
+    // Two sessions of the same shape share a terminal id (e.g. every
+    // native session's agent pane). The panel stays mounted across a
+    // session switch, so keying the xterm wrapper on the id alone would
+    // reuse the mount and keep the previous session's scrollback until
+    // the new WS repaints. The wrapper key is scoped to the session id.
+    const terminals = [makeTerminal("terminal_claude_main", "claude", "main")];
+    const { rerender } = renderPanel({
+      initialTerminalKey: "terminal:terminal_claude_main",
+      terminals,
+    });
+    act(() => {
+      vi.advanceTimersByTime(180);
+    });
+    const first = screen.getByTestId("terminal-view").getAttribute("data-instance");
+
+    rerender(
+      <TerminalsPanel
+        open
+        conversationId="conv_other"
+        initialTerminalKey="terminal:terminal_claude_main"
+        readOnly={false}
+        onClose={vi.fn()}
+      />,
+    );
+    act(() => {
+      vi.advanceTimersByTime(180);
+    });
+
+    const view = screen.getByTestId("terminal-view");
+    expect(view).toHaveAttribute("data-session-id", "conv_other");
+    // A new instance id proves a clean remount, not a reused mount with
+    // stale scrollback.
+    expect(view.getAttribute("data-instance")).not.toBe(first);
   });
 
   it("defers mounting TerminalView until the panel is expanded", () => {

--- a/web/src/shell/TerminalsPanel.test.tsx
+++ b/web/src/shell/TerminalsPanel.test.tsx
@@ -21,9 +21,11 @@ vi.mock("@/components/blocks/TerminalView", () => ({
     terminalId: string;
     readOnly?: boolean;
   }) => {
-    // useRef initializer runs once per mount, so the id is stable across
-    // re-renders and only changes on a remount.
-    const instance = useRef(++terminalMountSeq);
+    // Assign once per mount (useRef(arg) evaluates arg every render but keeps
+    // the first value), so the id is stable across re-renders and only changes
+    // on a remount.
+    const instance = useRef<number | null>(null);
+    if (instance.current === null) instance.current = ++terminalMountSeq;
     return (
       <div
         data-testid="terminal-view"

--- a/web/src/shell/TerminalsPanel.tsx
+++ b/web/src/shell/TerminalsPanel.tsx
@@ -235,7 +235,10 @@ export function TerminalsPanel({
         {/* xterm — only rendered when a terminal is selected */}
         <div className={cn("min-h-0 min-w-0 flex-1", !activeTerminal && "hidden")}>
           {expanded && activeTerminal ? (
-            <div key={activeTerminal.id} className="flex h-full flex-col">
+            // Scope the key to the session: agent terminals share a fixed id
+            // across same-shape sessions (e.g. `terminal_claude_main`), so id
+            // alone reuses the xterm mount and shows stale scrollback.
+            <div key={`${conversationId}:${activeTerminal.id}`} className="flex h-full flex-col">
               <TerminalView
                 sessionId={conversationId}
                 terminalId={activeTerminal.id}


### PR DESCRIPTION
## Related issue

N/A

## Summary

Switching between two sessions that are both in **Terminal** view drew the previous session's terminal history; it only corrected after a manual page refresh.

Root cause: two sessions of the same shape share a fixed agent-terminal id (every claude-native session's `terminal_claude_main`, every SDK session's `terminal_tui_main`, etc.). `ChatPage` stays mounted across a session switch and only feeds `MainTerminalView` / `TerminalsPanel` a new `conversationId`, so keying the xterm wrapper on the terminal id alone let React reuse the existing mount — the pane kept the prior session's 20k-line scrollback until the new WebSocket reconnected and tmux repainted.

Fix: scope the wrapper `key` to `${conversationId}:${terminalId}` in both surfaces, forcing a clean remount (fresh xterm + WebSocket, no stale buffer) on a session switch. Long-standing latent bug, present since the initial commit — not a recent regression.

## Test Plan

- Added regression tests to `MainTerminalView.test.tsx` and `TerminalsPanel.test.tsx`: a mount-counter on the mocked `TerminalView` asserts the instance is torn down and rebuilt when `conversationId` changes while the terminal id stays the same. Verified both tests **fail without the fix** and pass with it.
- Full web suite green (`npm test`): 4880 passed, 3 expected-fail, 1 skipped.
- `npm run build` and `tsc -b` clean.
- Manually verified in the running app: two claude-native sessions in Terminal view, switching back and forth now shows each session's own terminal immediately with no stale history and no refresh needed.

## Demo

Before: Two CC sessions share the same terminal

https://github.com/user-attachments/assets/40d1bec8-d0cb-4770-9612-b308860228ae

After: Each CC session shows its own terminal

https://github.com/user-attachments/assets/7a621ac6-e7d8-41ef-b6a8-aa7423dbc6a8

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran two claude-native sessions in Terminal view in the local dev app and confirmed switching between them no longer shows the other session's scrollback (previously required a refresh). Automated regression tests cover the remount-on-session-switch behavior for both the main terminal view and the terminals panel.

## Changelog

Switching between two terminal-view sessions no longer shows the previous session's stale terminal history

This pull request and its description were written by Isaac.
