### PR TITLE
chore(lint): enforce VS Code type checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,12 +82,12 @@ jobs:
       - name: Set up pnpm
         uses: ./.github/actions/setup-pnpm
 
-      - name: Install web dependencies
-        # Pin the npm registry to the npmjs default; limit to the web package
-        # so Electron's large native devDependencies are not fetched.
+      - name: Install TypeScript dependencies
+        # Pin the npm registry to the npmjs default; limit installs to packages
+        # checked here so Electron's large native devDependencies are not fetched.
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
-        run: pnpm install --frozen-lockfile --filter web
+        run: pnpm install --frozen-lockfile --filter web --filter omnigent-vscode
 
       # The pnpm equivalent of the `uv sync --locked` gate above.
       # `pnpm install --frozen-lockfile` only checks the lockfile is CONSISTENT

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,6 +74,13 @@ repos:
         files: ^(web/.*\.[cm]?[jt]sx?|web/tsconfig(?:\.[^.]+)?\.json|web/package\.json|pnpm-(?:lock|workspace)\.yaml)$
         pass_filenames: false
 
+      - id: vscode-tsc
+        name: VS Code extension TypeScript type check
+        language: system
+        entry: bash -c 'test -x editors/vscode/node_modules/.bin/tsc && cd editors/vscode && node_modules/.bin/tsc --noEmit'
+        files: ^(editors/vscode/.*\.[cm]?[jt]sx?|editors/vscode/tsconfig\.json|editors/vscode/package\.json|pnpm-(?:lock|workspace)\.yaml)$
+        pass_filenames: false
+
       # Android Kotlin formatting + linting via ktlint (config:
       # web/android/.editorconfig). The wrapper no-ops when ktlint is absent,
       # so local machines without ktlint installed skip cleanly. CI installs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,12 @@ When touching `web/`:
 cd web && pnpm install && pnpm run lint && pnpm run type-check && pnpm run build
 ```
 
+When touching `editors/vscode/`:
+
+```bash
+cd editors/vscode && pnpm install && pnpm run type-check && pnpm run test && pnpm run build
+```
+
 ## Running locally
 
 Start with the smallest relevant automated test described in [Tests](#tests).

--- a/justfile
+++ b/justfile
@@ -99,9 +99,10 @@ typecheck-python: _ensure-uv
 
 [group('lint')]
 lint-ts:
-    pnpm install --frozen-lockfile --filter web
+    pnpm install --frozen-lockfile --filter web --filter omnigent-vscode
     pnpm --filter web run lint
     pnpm --filter web run type-check
+    pnpm --filter omnigent-vscode run type-check
 
 # --- Lockfile maintenance ---
 


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Add the VS Code extension's clean TSC baseline to pre-commit and required lint CI.
- Install only the web and VS Code workspace dependencies in lint CI, continuing to exclude Electron's large dependency set.
- Extend `just lint-ts` and contributor documentation to cover both TypeScript projects.

## Test Plan

- `pnpm install --frozen-lockfile --filter web --filter omnigent-vscode`
- `pnpm --filter web run type-check`
- `pnpm --filter omnigent-vscode run type-check`
- `uv run --no-sync pre-commit run vscode-tsc --all-files`
- `uv run --no-sync pre-commit run --show-diff-on-failure`

## Demo

N/A — CI, pre-commit, and documentation changes only.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified both filtered dependency installation and the new pre-commit hook against the clean VS Code TSC baseline. `just lint-ts` could not be invoked because `just` is not installed locally; each command in the recipe was run directly.
