### PR TITLE
docs(prioritization): issue-prioritization-v2 — severity→score→priority design

### DIFF
--- a/.github/areas.json
+++ b/.github/areas.json
@@ -126,7 +126,7 @@
     {
       "key": "runner",
       "label": "comp:runner",
-      "weight": 1.1,
+      "weight": 1.2,
       "weight_source": "editorial",
       "definition": "The agent runner: the execution engine that drives a turn.",
       "paths": [
@@ -145,7 +145,7 @@
     {
       "key": "runtime",
       "label": "comp:runner",
-      "weight": 1.1,
+      "weight": 1.2,
       "weight_source": "editorial",
       "definition": "The agent runtime and execution scaffolding surrounding the runner.",
       "paths": [
@@ -164,7 +164,7 @@
     {
       "key": "server",
       "label": "comp:server",
-      "weight": 1.1,
+      "weight": 1.2,
       "weight_source": "editorial",
       "definition": "The Omnigent server: HTTP API, session creation and lifecycle, request routing.",
       "paths": [
@@ -249,7 +249,7 @@
     {
       "key": "host",
       "label": "comp:server",
-      "weight": 1.1,
+      "weight": 1.2,
       "weight_source": "editorial",
       "definition": "The host / daemon: the long-running local process that hosts sessions and terminals.",
       "paths": [
@@ -267,7 +267,7 @@
     {
       "key": "sandbox",
       "label": "comp:runner",
-      "weight": 1.1,
+      "weight": 1.2,
       "weight_source": "editorial",
       "definition": "The OS sandbox (bwrap/seatbelt isolation) and egress controls around agent execution.",
       "paths": [
@@ -284,7 +284,7 @@
     {
       "key": "db",
       "label": "comp:server",
-      "weight": 1.1,
+      "weight": 1.2,
       "weight_source": "editorial",
       "definition": "Database and persistence layer for the server.",
       "paths": [

--- a/.github/areas.json
+++ b/.github/areas.json
@@ -17,6 +17,13 @@
     "               comp:policies, comp:harnesses, comp:infra) -- gh cannot add a",
     "               label that does not exist, and there is no label-sync. Several",
     "               areas may share a label (all harness areas share comp:harnesses).",
+    "  weight     - importance multiplier for the composite issue-priority score",
+    "               (designs/prioritization). Discrete bands 1.4/1.1/1.0/0.9. Applies",
+    "               to EVERY area, harness or not -- it is the unified component-weight",
+    "               axis, replacing the harness-only tier. See weight_source.",
+    "  weight_source - 'telemetry' (harness areas, seeded from LJ Sessions by Harness)",
+    "               or 'editorial' (maintainer judgment; no per-component usage signal",
+    "               exists). Refresh telemetry weights periodically.",
     "  definition - prose the LLM reads to route issues/PRs to this area.",
     "  paths      - file-PREFIX list. Matching is filename.startsWith(prefix), and the",
     "               LAST matching area in this array wins per file. So broad prefixes",
@@ -39,6 +46,8 @@
     {
       "key": "repo-automation",
       "label": "comp:infra",
+      "weight": 0.9,
+      "weight_source": "editorial",
       "definition": "Repo automation and CI: GitHub Actions workflows, scripts, Dependabot, issue/PR templates.",
       "paths": [
         ".github/"
@@ -52,6 +61,8 @@
     {
       "key": "web",
       "label": "comp:web-ui",
+      "weight": 1.0,
+      "weight_source": "editorial",
       "definition": "The web frontend (web/) shared by all clients: React UI, components, embed. NOT the desktop or mobile app shells (those are separate areas below).",
       "paths": [
         "web/"
@@ -64,6 +75,8 @@
     {
       "key": "desktop-app",
       "label": "comp:web-ui",
+      "weight": 1.0,
+      "weight_source": "editorial",
       "definition": "The desktop app shell (Electron wrapper around the web UI): main process, packaging, native desktop chrome.",
       "paths": [
         "web/electron/"
@@ -77,6 +90,8 @@
     {
       "key": "mobile-app",
       "label": "comp:web-ui",
+      "weight": 1.0,
+      "weight_source": "editorial",
       "definition": "The mobile app shell (iOS wrapper around the web UI): native mobile integration and packaging.",
       "paths": [
         "web/ios/"
@@ -90,6 +105,8 @@
     {
       "key": "inner",
       "label": "comp:harnesses",
+      "weight": 1.1,
+      "weight_source": "editorial",
       "definition": "Core agent runtime and the harness/executor layer shared by all harnesses (loader, executor base, tool bridge, sandboxes). Harness-specific code has its own areas below.",
       "paths": [
         "omnigent/inner/"
@@ -109,6 +126,8 @@
     {
       "key": "runner",
       "label": "comp:runner",
+      "weight": 1.1,
+      "weight_source": "editorial",
       "definition": "The agent runner: the execution engine that drives a turn.",
       "paths": [
         "omnigent/runner/"
@@ -126,6 +145,8 @@
     {
       "key": "runtime",
       "label": "comp:runner",
+      "weight": 1.1,
+      "weight_source": "editorial",
       "definition": "The agent runtime and execution scaffolding surrounding the runner.",
       "paths": [
         "omnigent/runtime/"
@@ -143,6 +164,8 @@
     {
       "key": "server",
       "label": "comp:server",
+      "weight": 1.1,
+      "weight_source": "editorial",
       "definition": "The Omnigent server: HTTP API, session creation and lifecycle, request routing.",
       "paths": [
         "omnigent/server/"
@@ -162,6 +185,8 @@
     {
       "key": "onboarding",
       "label": "comp:tui",
+      "weight": 1.0,
+      "weight_source": "editorial",
       "definition": "The setup / onboarding flow: first-run setup, provider auth, credential onboarding driven through the CLI.",
       "paths": [
         "omnigent/onboarding/"
@@ -175,6 +200,8 @@
     {
       "key": "policies",
       "label": "comp:policies",
+      "weight": 1.0,
+      "weight_source": "editorial",
       "definition": "Safety policies, guardrails, and policy evaluation/elicitation.",
       "paths": [
         "omnigent/policies/"
@@ -189,6 +216,8 @@
     {
       "key": "spec",
       "label": "comp:repr",
+      "weight": 0.9,
+      "weight_source": "editorial",
       "definition": "Spec and schema layer: representation of agents/sessions and their serialized form.",
       "paths": [
         "omnigent/spec/"
@@ -205,6 +234,8 @@
     {
       "key": "llms",
       "label": "comp:harnesses",
+      "weight": 1.1,
+      "weight_source": "editorial",
       "definition": "LLM provider and model-catalog layer: gateways, provider adapters, model selection.",
       "paths": [
         "omnigent/llms/"
@@ -218,6 +249,8 @@
     {
       "key": "host",
       "label": "comp:server",
+      "weight": 1.1,
+      "weight_source": "editorial",
       "definition": "The host / daemon: the long-running local process that hosts sessions and terminals.",
       "paths": [
         "omnigent/host/"
@@ -234,6 +267,8 @@
     {
       "key": "sandbox",
       "label": "comp:runner",
+      "weight": 1.1,
+      "weight_source": "editorial",
       "definition": "The OS sandbox (bwrap/seatbelt isolation) and egress controls around agent execution.",
       "paths": [
         "omnigent/sandbox/"
@@ -249,6 +284,8 @@
     {
       "key": "db",
       "label": "comp:server",
+      "weight": 1.1,
+      "weight_source": "editorial",
       "definition": "Database and persistence layer for the server.",
       "paths": [
         "omnigent/db/"
@@ -267,6 +304,8 @@
     {
       "key": "stores",
       "label": "comp:repr",
+      "weight": 0.9,
+      "weight_source": "editorial",
       "definition": "Stores: persistence and serialization of sessions, history, and artifacts.",
       "paths": [
         "omnigent/stores/"
@@ -288,6 +327,8 @@
     {
       "key": "terminals",
       "label": "comp:tui",
+      "weight": 1.0,
+      "weight_source": "editorial",
       "definition": "Terminal management: PTY/terminal launch, read, and lifecycle.",
       "paths": [
         "omnigent/terminals/"
@@ -306,6 +347,8 @@
     {
       "key": "tools",
       "label": "comp:harnesses",
+      "weight": 1.1,
+      "weight_source": "editorial",
       "definition": "Built-in tools and the tool-bridge exposed to harnesses.",
       "paths": [
         "omnigent/tools/"
@@ -325,6 +368,8 @@
     {
       "key": "entities",
       "label": "comp:repr",
+      "weight": 0.9,
+      "weight_source": "editorial",
       "definition": "Entity models: the core data model for agents, sessions, and related objects.",
       "paths": [
         "omnigent/entities/"
@@ -337,6 +382,8 @@
     {
       "key": "repl",
       "label": "comp:tui",
+      "weight": 0.9,
+      "weight_source": "editorial",
       "definition": "The interactive REPL and its terminal UI.",
       "paths": [
         "omnigent/repl/"
@@ -354,6 +401,8 @@
     {
       "key": "resources",
       "label": "comp:server",
+      "weight": 1.0,
+      "weight_source": "editorial",
       "definition": "Bundled resources and static assets used by the runtime.",
       "paths": [
         "omnigent/resources/"
@@ -367,6 +416,8 @@
     {
       "key": "deploy",
       "label": "comp:infra",
+      "weight": 0.9,
+      "weight_source": "editorial",
       "definition": "Deploy targets and deployment configuration (Docker, Railway, Render, etc.).",
       "paths": [
         "deploy/"
@@ -383,6 +434,8 @@
     {
       "key": "sdks",
       "label": "comp:server",
+      "weight": 1.0,
+      "weight_source": "editorial",
       "definition": "Python and UI client SDKs.",
       "paths": [
         "sdks/"
@@ -402,6 +455,8 @@
     {
       "key": "harness-claude",
       "label": "comp:harnesses",
+      "weight": 1.4,
+      "weight_source": "telemetry",
       "definition": "The Claude harness family: the Claude SDK executor/harness (claude-sdk) and the native Claude Code terminal integration.",
       "paths": [
         "omnigent/inner/claude_",
@@ -422,6 +477,8 @@
     {
       "key": "harness-codex",
       "label": "comp:harnesses",
+      "weight": 1.4,
+      "weight_source": "telemetry",
       "definition": "The Codex / OpenAI harness family: the OpenAI Agents SDK executor/harness, the open-responses SDK, and the native Codex integration.",
       "paths": [
         "omnigent/inner/codex_",
@@ -444,6 +501,8 @@
     {
       "key": "harness-cursor",
       "label": "comp:harnesses",
+      "weight": 1.1,
+      "weight_source": "telemetry",
       "definition": "The Cursor harness: SDK executor/harness and the native Cursor integration.",
       "paths": [
         "omnigent/inner/cursor_",
@@ -460,6 +519,8 @@
     {
       "key": "harness-antigravity",
       "label": "comp:harnesses",
+      "weight": 1.1,
+      "weight_source": "telemetry",
       "definition": "The Antigravity (Gemini) harness: SDK executor/harness, native integration, and Gemini/Antigravity auth.",
       "paths": [
         "omnigent/inner/antigravity_",
@@ -475,6 +536,8 @@
     {
       "key": "harness-goose",
       "label": "comp:harnesses",
+      "weight": 0.9,
+      "weight_source": "telemetry",
       "definition": "The Goose harness: SDK executor/harness, native TUI/ACP integration, and Goose auth.",
       "paths": [
         "omnigent/inner/goose_",
@@ -489,6 +552,8 @@
     {
       "key": "harness-hermes",
       "label": "comp:harnesses",
+      "weight": 1.1,
+      "weight_source": "telemetry",
       "definition": "The Hermes harness: SDK executor/harness and the native Hermes integration.",
       "paths": [
         "omnigent/inner/hermes_",
@@ -503,6 +568,8 @@
     {
       "key": "harness-kimi",
       "label": "comp:harnesses",
+      "weight": 0.9,
+      "weight_source": "telemetry",
       "definition": "The Kimi harness: SDK executor/harness and the native Kimi integration.",
       "paths": [
         "omnigent/inner/kimi_",
@@ -517,6 +584,8 @@
     {
       "key": "harness-kiro",
       "label": "comp:harnesses",
+      "weight": 0.9,
+      "weight_source": "telemetry",
       "definition": "The Kiro harness: SDK executor/harness and the native Kiro integration.",
       "paths": [
         "omnigent/inner/kiro_",
@@ -532,6 +601,8 @@
     {
       "key": "harness-opencode",
       "label": "comp:harnesses",
+      "weight": 1.1,
+      "weight_source": "telemetry",
       "definition": "The OpenCode harness: SDK executor/harness, native integration, HTTP transport, and OpenCode auth.",
       "paths": [
         "omnigent/inner/opencode_",
@@ -551,6 +622,8 @@
     {
       "key": "harness-pi",
       "label": "comp:harnesses",
+      "weight": 1.1,
+      "weight_source": "telemetry",
       "definition": "The Pi harness: SDK executor/harness and the native Pi integration.",
       "paths": [
         "omnigent/inner/pi_",
@@ -565,6 +638,8 @@
     {
       "key": "harness-qwen",
       "label": "comp:harnesses",
+      "weight": 0.9,
+      "weight_source": "telemetry",
       "definition": "The Qwen harness: SDK executor/harness and the native Qwen integration.",
       "paths": [
         "omnigent/inner/qwen_",
@@ -579,6 +654,8 @@
     {
       "key": "harness-copilot",
       "label": "comp:harnesses",
+      "weight": 1.1,
+      "weight_source": "telemetry",
       "definition": "The GitHub Copilot harness: SDK executor/harness and Copilot auth.",
       "paths": [
         "omnigent/inner/copilot_",

--- a/.github/areas.json
+++ b/.github/areas.json
@@ -18,7 +18,7 @@
     "               label that does not exist, and there is no label-sync. Several",
     "               areas may share a label (all harness areas share comp:harnesses).",
     "  weight     - importance multiplier for the composite issue-priority score",
-    "               (designs/prioritization). Discrete bands 1.4/1.1/1.0/0.9. Applies",
+    "               (designs/prioritization). Discrete bands 1.4/1.2/1.1/1.0/0.9. Applies",
     "               to EVERY area, harness or not -- it is the unified component-weight",
     "               axis, replacing the harness-only tier. See weight_source.",
     "  weight_source - 'telemetry' (harness areas, seeded from LJ Sessions by Harness)",

--- a/.github/workflows/areas.test.js
+++ b/.github/workflows/areas.test.js
@@ -47,7 +47,7 @@ for (const a of areas) {
 
 // Every area has a weight (importance multiplier for the priority score) drawn
 // from the allowed bands, tagged with its source (telemetry vs editorial).
-const ALLOWED_WEIGHTS = new Set([1.4, 1.1, 1.0, 0.9]);
+const ALLOWED_WEIGHTS = new Set([1.4, 1.2, 1.1, 1.0, 0.9]);
 const ALLOWED_WEIGHT_SOURCES = new Set(["telemetry", "editorial"]);
 for (const a of areas) {
   assert(`area ${a.key} weight is an allowed band`, ALLOWED_WEIGHTS.has(a.weight), `${a.weight}`);

--- a/.github/workflows/areas.test.js
+++ b/.github/workflows/areas.test.js
@@ -45,6 +45,19 @@ for (const a of areas) {
   assert(`area ${a.key} has paths`, Array.isArray(a.paths) && a.paths.length > 0);
 }
 
+// Every area has a weight (importance multiplier for the priority score) drawn
+// from the allowed bands, tagged with its source (telemetry vs editorial).
+const ALLOWED_WEIGHTS = new Set([1.4, 1.1, 1.0, 0.9]);
+const ALLOWED_WEIGHT_SOURCES = new Set(["telemetry", "editorial"]);
+for (const a of areas) {
+  assert(`area ${a.key} weight is an allowed band`, ALLOWED_WEIGHTS.has(a.weight), `${a.weight}`);
+  assert(
+    `area ${a.key} weight_source is telemetry|editorial`,
+    ALLOWED_WEIGHT_SOURCES.has(a.weight_source),
+    `${a.weight_source}`,
+  );
+}
+
 // Path resolution (last-match-wins startsWith) sends representative files to the
 // expected area -- especially the web/ carve-out ordering and harness prefixes.
 function resolve(fn) {

--- a/designs/prioritization/issue-prioritization-v2.md
+++ b/designs/prioritization/issue-prioritization-v2.md
@@ -95,7 +95,7 @@ demand is at most a tiebreak**, or the queue will look empty of signal.
 are distinct and it's worth being precise:
 
 1. **Severity** — a graded property of the issue, a function of the axes below
-   (type, blast radius, harness tier, …). Scored `low / medium / high /
+   (type, blast radius, component weight, …). Scored `low / medium / high /
    critical = 10 / 30 / 60 / 100`.
 2. **Score** — severity combined with the mechanical multipliers (reach, tier,
    readiness, dup, demand). This is the **continuous ordering** — it sorts
@@ -118,11 +118,12 @@ lets an issue cross **up** a band:
 | **≥ 25** | **P2-medium** | ordinary graded work |
 | **< 25** | **P3-low** | minor / narrow |
 
-Example: a "high" bug (severity 60) in a tier-1 harness scores 60 × 1.4 = 84 →
-clears **P1**; the same bug on a niche harness scores 60 × 0.9 = 54 → stays
-**P2**. The multiplier moved the label. (Thresholds are tunable constants —
-`P0_MIN`/`P1_MIN`/`P2_MIN` in `score_prototype.py`; the current values give P0 9
-/ P1 58 / P2 206 / P3 87 on the snapshot, a 22% P1-bug share.)
+Example: a "high" bug (severity 60) in a weight-1.4 area scores 60 × 1.4 = 84 →
+clears **P1**; the same bug in a weight-0.9 area scores 60 × 0.9 = 54 → stays
+**P2**. The component weight moved the label. (Thresholds are tunable constants —
+`P0_MIN`/`P1_MIN`/`P2_MIN` in `score_prototype.py`; with the unified component
+weight the snapshot gives P0 15 / P1 68 / P2 208 / P3 69, a 27% P1-bug share —
+see the note under the backfill preview.)
 
 *One consequence worth naming:* because the label comes from the full score,
 non-severity signals **can** tip it — a heavily-reacted FR or a much-duplicated
@@ -212,58 +213,78 @@ open issues — the production backfill uses the LLM grader):
 
 | Priority | Now | Regraded |
 |---|---|---|
-| P0-critical | 3 | 9 |
-| **P1-high** | **128** | **58** |
-| P2-medium | 203 | 206 |
-| P3-low | 15 | 87 |
+| P0-critical | 3 | 15 |
+| **P1-high** | **128** | **68** |
+| P2-medium | 203 | 208 |
+| P3-low | 15 | 69 |
 | (no priority) | 11 | 0 |
 
-**P1 share of open bugs: 60% → 22%** — the inflation drained, and P3 fills out
+**P1 share of open bugs: 60% → 27%** — the inflation drained and P3 fills out
 (score-thresholding sends genuinely-minor items to P3, where the old label
-distribution left it vestigial). What moves, and why:
+distribution left it vestigial). Note 27% sits a bit above the ~20% target: the
+unified component weight lifts core-area (`comp:server`/`comp:runner`, 1.1) bugs
+that were flat 1.0 before, which is the intended effect — if we want a stricter
+P1, the lever is the tunable `P1_MIN` threshold, not re-flattening the weights.
+What moves, and why:
 
 | Change | Count | Example |
 |---|---|---|
-| P1 → P2 | 85 | #3981 desktop rail resize — medium severity, single-platform (score 33) |
-| P2 → P3 | 68 | #4027 "delete button on web UI" — narrow FR (score 22, below the P2 cut) |
-| P2 → P1 | 23 | #3976 headless OAuth2 grant — high-severity FR, broad reach (score 99) |
-| P1 → P3 | 9 | #3980 desktop dialog paint-over — minor, single-platform (score 25) |
-| P2 → P0 | 4 | #2125 multi-host git creds — credential-crossing (score 104) |
+| P1 → P2 | 80 | #3981 desktop rail resize — medium severity, single-platform (score 33) |
+| P2 → P3 | 55 | #4027 "delete button on web UI" — narrow FR (score 22, below the P2 cut) |
+| P2 → P1 | 25 | #3976 headless OAuth2 grant — high-severity FR, broad reach |
+| P2 → P0 | 10 | #2125 multi-host git creds — credential-crossing, weight-1.4 area (score 161) |
+| P1 → P3 | 6 | #3980 desktop dialog paint-over — minor, single-platform (score 25) |
 
 *Caveat:* these per-issue moves use the regex grader, so they inherit its known
 false positives (e.g. #2057/#2054 "sandbox bypass" FRs wrongly reach P0). Read
-the **aggregate shape** (60% → 22%) as the reliable signal and individual rows
+the **aggregate shape** (60% → 27%) as the reliable signal and individual rows
 as illustrative; the LLM backfill corrects the outliers.
 
-### Axis 3 — Harness tier (new, derived)
+### Axis 3 — Component weight (unified; was harness-only)
 
-Harnesses are not equal in strategic weight. Tier is **derived from the
-existing `areas.json` harness areas** (no new hand-labeling). The assignment is
-informed by activity (open issues · reactions), not a guess:
+Not all subsystems are equally important, and importance shouldn't be a
+harness-only concept. An earlier draft had a *harness tier* multiplier that gave
+`comp:harnesses` a 1.4/1.1/0.9 boost and left **every other component at a flat
+1.0** — so a bug in `comp:server` couldn't be weighted above one in `comp:repr`.
+This axis unifies that: **one `weight` per area in `areas.json`, applied to every
+`comp:` label**, harness or not. Harness tier is now just the harness slice of it.
 
-- **Tier 1** — `claude` (128 open / 26 👍), `codex` (95 / 16). Flagship.
-- **Tier 2** — `pi` (41 / 15), `cursor` (37 / 15), `antigravity` (24 / 13),
-  `copilot` (15 / 13), `openai`/`gemini`. **Pi moved up to T2 on the data**
-  (per review: it's the 3rd-most-active harness, above cursor — a T3 default
-  under-weighted it). `opencode` (19 / 3) is the marginal T2/T3 call.
-- **Tier 3** — the low-activity, near-zero-reaction rest: `goose`, `hermes`,
-  `kimi`, `kiro`, `qwen` (each ~10–16 open, 0 👍).
+**One field, two sources.** Each area in `areas.json` carries a `weight` (bands
+**1.4 / 1.1 / 1.0 / 0.9**) and a `weight_source`:
 
-Tier is a maintainer call, not a formula — the counts inform it, and the
-mapping lives in `areas.json` so re-tiering (e.g. finalizing opencode) is a
-one-line edit. Open follow-up flagged in review: confirm the T2 cut in the team
-channel.
+- **Harness weights are telemetry-seeded** (`weight_source: telemetry`) from real
+  usage — the Databricks dashboard's *LJ Sessions by Harness* (sessions + users,
+  last week), aggregating each harness's SDK + native variants. This is a better
+  signal than GitHub issue counts: it measures what people actually run.
+  - **1.4** — `claude`, `codex` (dominant on both users and sessions).
+  - **1.1** — `pi` (clear 3rd), `opencode`, `cursor`, `antigravity`, `hermes`,
+    `copilot`. (Telemetry lifts **hermes** here — GitHub reactions had it near
+    zero, but real session usage puts it mid-pack: a concrete case of usage
+    correcting issue-count.)
+  - **0.9** — `goose`, `kimi`, `kiro`, `qwen` (near-zero usage).
+- **Non-harness weights are editorial** (`weight_source: editorial`) — there is
+  **no per-component usage telemetry** (every session hits the server, so
+  "server usage" isn't a distinguishing signal), so maintainers set these by
+  judgment, honestly labeled as such:
+  - **1.1** — `comp:server`, `comp:runner` core areas (server/host/db,
+    runner/runtime/sandbox) and the shared harness-infra (`inner`/`llms`/`tools`):
+    the execution path a failure blocks everything.
+  - **1.0** — `comp:web-ui`, `comp:policies`, `comp:tui` mainline.
+  - **0.9** — `comp:repr` (spec/stores/entities), `comp:infra`, and low-traffic
+    surfaces (repl).
 
-Tier is a **score multiplier**, and we split the `comp:harnesses` mega-bucket
-(41% of open) with **tier labels — `comp:harness-t1` / `-t2` / `-t3`** — rather
-than per-harness labels (`comp:harness-claude`, …). Tier labels are more
-future-proof: adding a harness or re-tiering one edits `areas.json` (which
-already maps each harness area) and re-runs a backfill, without inventing a new
-label each time a harness ships. The mapping (area → tier) lives in
-`areas.json`, so the tier label and the score multiplier share one source of
-truth. Per-harness *filtering* is still available via the area routing if a
-maintainer wants it, without a label per harness. (Alternative considered and
-rejected in Appendix A.)
+The score reads `weight` for the issue's area (harness issues resolve to the
+specific harness; otherwise the most-important area among the issue's `comp:`
+labels wins). Because it's one `areas.json` field shared with triage + reviewer
+routing, re-weighting is a one-line edit and telemetry can refresh the harness
+bands on a schedule.
+
+**Labels.** The harness view of this weight is still the tier label set
+`comp:harness-t1/-t2/-t3` (future-proof: a new/re-tiered harness is an
+`areas.json` edit, not a new label). Non-harness areas carry their weight in
+`areas.json` without a per-band label — the weight drives the score directly.
+Open follow-up flagged in review: confirm the harness band cut (Pi/opencode) and
+the editorial non-harness weights in the team channel.
 
 ### Component taxonomy — which `comp:` labels to add
 
@@ -310,7 +331,7 @@ valve that lets us be granular without unbounded label growth.
 ```
 base  = severity_weight              # LLM-graded from content (P0/P1/P2/P3-ish, 0–100)
       × reach_multiplier             # all-users/default 1.5 · normal 1.0 · single-platform 0.9
-      × harness_tier_multiplier      # T1 1.4 · T2 1.1 · T3 0.9 · non-harness 1.0
+      × component_weight             # areas.json per-area weight 1.4/1.1/1.0/0.9 (Axis 3)
       × dup_reach                    # +15% per confirmed duplicate, capped +50% (Axis 5)
       × readiness                    # ready-to-work 1.1 · normal 1.0 · needs-info 0.85 (Axis 6)
 
@@ -340,17 +361,18 @@ with linux_bwrap dies at spawn"):
 |---|---|---|
 | severity | 60 (high) | spawn death — a hard failure, no workaround |
 | × reach | × 1.5 | body says it hits every session on the config → broad |
-| × harness_tier | × 1.4 | title says `claude-sdk` → tier-1 |
+| × component_weight | × 1.4 | title says `claude-sdk` → `harness-claude` area, weight 1.4 (Axis 3) |
 | × dup_reach | × 1.0 | no confirmed duplicates (yet) |
 | × readiness | × 1.0 | no explicit repro section matched → no bump |
 | = base | **126** | 60 × 1.5 × 1.4 |
 | × demand (bug) | + 0 | 0 reactions; bugs get only the additive tiebreak |
 | × age | × 1.0 | neutral by default — age never lowers the score |
-| **= score** | **126** | **≥ 100 → P0-critical**; ranks **#3** of 360 (was P1, rank #37) |
+| **= score** | **126** | **≥ 100 → P0-critical**; ranks **#6** of 360 (was P1, rank #37) |
 
-Contrast a vague, low-tier ticket: severity 30 (medium) × reach 0.9
-(single-platform) × tier 0.9 (tier-3 harness) × readiness 1.0 ≈ **24** → **P3**
-(below the 25 cut) — an order of magnitude lower, so it sits deep in the queue.
+Contrast a vague, low-weight ticket: severity 30 (medium) × reach 0.9
+(single-platform) × component_weight 0.9 (e.g. `comp:repr`, or a niche harness)
+× readiness 1.0 ≈ **24** → **P3** (below the 25 cut) — an order of magnitude
+lower, so it sits deep in the queue.
 Same five data points, opposite ends of the queue *and* opposite priority
 labels: that's the score→label derivation doing the work.
 
@@ -627,11 +649,13 @@ each intended as its own follow-up PR (tracked as separate issues).
    rubric (grade FRs across buckets; explicit P0 list; tier-1 floor) + the "P1
    scarcity" guardrail + emit `severity`, `readiness`, and `sub_area` fields.
    Low risk, affects new issues immediately.
-2. **Component labels** — add `comp:harness-t1/-t2/-t3` (map each harness area in
-   `areas.json` to a tier; confirm the T2 cut incl. Pi/opencode in the team
-   channel), plus `comp:sandbox`, `comp:mobile`, `comp:auth`; add the `sub_area`
-   taxonomy for finer routing (SDK/native, UI surface, runner phase, device).
-   Update the classifier allowlist and backfill. See "Component taxonomy."
+2. **Component weight + labels** — the per-area `weight`/`weight_source` fields
+   are already in `areas.json` (harness = telemetry, non-harness = editorial;
+   confirm the harness bands and editorial weights in the team channel). Add the
+   `comp:harness-t1/-t2/-t3` labels (the harness view of the weight), plus
+   `comp:sandbox`, `comp:mobile`, `comp:auth`; add the `sub_area` taxonomy for
+   finer routing (SDK/native, UI surface, runner phase, device). Update the
+   classifier allowlist and backfill. See "Component taxonomy" and Axis 3.
 3. **Template fields** — add Harness (+SDK/native) / Platform-device / Impact /
    Auth-type dropdowns.
 4. **Scoring job** — productionize `score_prototype.py` into a scheduled action
@@ -642,7 +666,8 @@ each intended as its own follow-up PR (tracked as separate issues).
    relabel under the new rubric (see "How regrading works"); preview with
    `score_prototype.py --regrade`. Sets priority only where none exists or the
    bot set the prior value — never over a human edit. Target: P1 back under ~20%
-   of open bugs (regex preview lands it at 22%; the LLM pass should do better).
+   of open bugs (regex preview lands it at 27% with the unified component weight;
+   tune `P1_MIN` and the LLM grader to tighten).
 6. **Consume dedup output** — once [#4037](https://github.com/omnigent-ai/omnigent/pull/4037)
    lands, feed duplicate count into `dup_reach`; wire the unused `good first
    issue` funnel.
@@ -705,217 +730,219 @@ up). The Now→Derived column is the per-issue view of the backfill: the ⚑ row
 are the relabels the one-time regrade would apply.
 
 **Illustrative, not actionable.** This is the *mechanism* running on a
-deliberately-weak grader, so its own failures are visible on purpose: ranks 1–2
+deliberately-weak grader, so its own failures are visible on purpose: ranks 2–3
 (#2057/#2054) are FRs that merely *mention* "sandbox bypass" and are graded
-critical — they sit above the real P0 (#3557, rank 6), so **the very top is
-backwards**; #61 (rank 9) is a *bot* audit issue riding a "security" keyword.
+critical — they sit above the real P0 (#3557, rank 10), so **the very top is
+backwards**; #61 (rank 15) is a *bot* audit issue riding a "security" keyword.
 That's the doc's thesis made concrete: regex can't grade severity. The scaffold
-is sound — strip those artifacts and the genuine tier-1 bugs (#3265, #3557,
-#3270, #3180, #2373) cluster correctly in the top 16. Scores also *tie* in coarse
-bands (many issues share 92/84/…), so within-band order is arbitrary — read this
-as a handful of tiers, not 200 true ranks. Age is now neutral (review point), so
-older issues no longer decay. With the LLM grader plus ≤10% hand-correction (see
-the maintainer guide), this is the shape the production ranking takes.
+is sound — strip those artifacts and the genuine high-weight harness bugs
+(#3265, #3557, #3270, #3180, #2373) cluster correctly near the top. Scores also
+*tie* in coarse bands (many issues share 92/84/…), so within-band order is
+arbitrary — read this as a handful of tiers, not 200 true ranks. Age is neutral
+(review point) and component weight is now unified across all `comp:` (Axis 3),
+so core-area bugs rank above niche ones by the same field harnesses use. With the
+LLM grader plus ≤10% hand-correction (see the maintainer guide), this is the
+shape the production ranking takes.
 
 | # | Score | Sev | Now | Derived | Δrank | Issue |
 |--:|--:|---|---|---|--:|---|
-| 1 | 154 | critical | P2 | P0 ⚑ | +235 | [#2057](https://github.com/omnigent-ai/omnigent/issues/2057) [Feature] Add Codex Auto mode using auto_review instead of jumping to  |
-| 2 | 154 | critical | P2 | P0 ⚑ | +236 | [#2054](https://github.com/omnigent-ai/omnigent/issues/2054) [Feature] Remove duplicate Codex Full access mode and keep Sandbox Byp |
-| 3 | 126 | high | P1 | P0 ⚑ | +34 | [#3265](https://github.com/omnigent-ai/omnigent/issues/3265) claude-sdk agent with linux_bwrap dies at spawn on a runtime bwrap bin |
-| 4 | 115 | high | P2 | P0 ⚑ | +236 | [#2038](https://github.com/omnigent-ai/omnigent/issues/2038) [Feature] No way to deregister/delete an external self-registered host |
-| 5 | 110 | critical | P1 | P0 ⚑ | -1 | [#3983](https://github.com/omnigent-ai/omnigent/issues/3983) [Bug] Smart-routed turns render out of order: reply streams above the  |
-| 6 | 110 | critical | P0 | P0 | -5 | [#3557](https://github.com/omnigent-ai/omnigent/issues/3557) [Bug] Shell-surface policy gates are bypassed by option-taking command |
-| 7 | 110 | critical | P1 | P0 ⚑ | +28 | [#3270](https://github.com/omnigent-ai/omnigent/issues/3270) [Bug] sys_session_create children are absent from both sys_session_lis |
-| 8 | 104 | critical | P2 | P0 ⚑ | +224 | [#2125](https://github.com/omnigent-ai/omnigent/issues/2125) [Feature] Multi-host git credentials for managed sandboxes (GitHub + s |
-| 9 | 100 | critical | P3 | P0 ⚑ | +340 | [#61](https://github.com/omnigent-ai/omnigent/issues/61) 🤖 Code Audit: 21 potential issue(s) found |
-| 10 | 99 | high | P2 | P1 ⚑ | +126 | [#3976](https://github.com/omnigent-ai/omnigent/issues/3976) [Feature] OAuth2 client-credentials grant so a headless process can au |
-| 11 | 99 | high | P2 | P1 ⚑ | +153 | [#3363](https://github.com/omnigent-ai/omnigent/issues/3363) [Feature] Per-project custom instructions (project-scoped context) |
-| 12 | 99 | high | P2 | P1 ⚑ | +165 | [#3164](https://github.com/omnigent-ai/omnigent/issues/3164) [Feature] Optional runtimeClassName on the kubernetes sandbox provider |
-| 13 | 99 | high | P2 | P1 ⚑ | +263 | [#1388](https://github.com/omnigent-ai/omnigent/issues/1388) Make agents a first-class CRUD entity with a dedicated sidebar UI (dec |
-| 14 | 99 | critical | P2 | P1 ⚑ | +301 | [#659](https://github.com/omnigent-ai/omnigent/issues/659) [Feature] add a microvm backend for sandbox |
-| 15 | 92 | high | P1 | P1 | +26 | [#3180](https://github.com/omnigent-ai/omnigent/issues/3180) codex-native: runner never exits on idle timeout — cancelled delta-coa |
-| 16 | 92 | high | P1 | P1 | +66 | [#2373](https://github.com/omnigent-ai/omnigent/issues/2373) [Bug] claude-native: pasted web-UI message loses its Enter, stuck draf |
-| 17 | 92 | high | P1 | P1 | +77 | [#2060](https://github.com/omnigent-ai/omnigent/issues/2060) [Bug] claude-native: first web-UI message silently dropped when Claude |
-| 18 | 92 | high | P1 | P1 | +85 | [#1898](https://github.com/omnigent-ai/omnigent/issues/1898) [Bug] codex-native: cancelling a task awaiting flush() poisons the del |
-| 19 | 92 | high | P2 | P1 ⚑ | +297 | [#654](https://github.com/omnigent-ai/omnigent/issues/654) [Bug] Streaming with codex is hanging and paragraphs are not split. |
-| 20 | 92 | high | P1 | P1 | +107 | [#542](https://github.com/omnigent-ai/omnigent/issues/542) [Bug] AttributeError: 'SubprocessCLITransport' object has no attribute |
-| 21 | 90 | high | P1 | P1 | +31 | [#3001](https://github.com/omnigent-ai/omnigent/issues/3001) [Performance] GET /v1/sessions pre-fetches every accessible conversati |
-| 22 | 89 | high | P2 | P1 ⚑ | +273 | [#1051](https://github.com/omnigent-ai/omnigent/issues/1051) [Feature] Forward OTel exporter knobs to executor subprocess env |
-| 23 | 84 | high | P2 | P1 ⚑ | +131 | [#3558](https://github.com/omnigent-ai/omnigent/issues/3558) claude-sdk: cached client does not rebuild on framework-instruction ch |
-| 24 | 84 | high | P1 | P1 | +29 | [#3000](https://github.com/omnigent-ai/omnigent/issues/3000) claude-native transcript forwarder polls at 4 Hz per session with no i |
-| 25 | 84 | high | P1 | P1 | +37 | [#2748](https://github.com/omnigent-ai/omnigent/issues/2748) Runner idle-shutdown deadlocks forever: codex-forwarder close()/flush( |
-| 26 | 84 | high | P1 | P1 | +41 | [#2575](https://github.com/omnigent-ai/omnigent/issues/2575) pi-native: non-Claude Databricks models (GLM, Gemini, …) hang — provid |
-| 27 | 84 | high | P1 | P1 | +45 | [#2454](https://github.com/omnigent-ai/omnigent/issues/2454) [Bug] Unbounded ~/.omnigent growth: per-session native-harness dirs ar |
-| 28 | 84 | high | P1 | P1 | +52 | [#2421](https://github.com/omnigent-ai/omnigent/issues/2421) [Bug] codex app-server + MCP bridge children leak on ANY unclean runne |
-| 29 | 83 | high | P2 | P1 ⚑ | +276 | [#888](https://github.com/omnigent-ai/omnigent/issues/888) [Feature] Side-by-side multi-session view |
-| 30 | 81 | high | P2 | P1 ⚑ | +107 | [#3970](https://github.com/omnigent-ai/omnigent/issues/3970) pi-native: every turn fails with "Pi model error: 401 Invalid Token" w |
-| 31 | 78 | high | P2 | P1 ⚑ | +303 | [#16](https://github.com/omnigent-ai/omnigent/issues/16) Is native Windows support in scope, or should docs recommend WSL2? |
-| 32 | 76 | high | P2 | P1 ⚑ | +297 | [#151](https://github.com/omnigent-ai/omnigent/issues/151) Native claude_code worker hangs on the one-time Bypass Permissions acc |
-| 33 | 70 | high | P1 | P1 | +5 | [#3261](https://github.com/omnigent-ai/omnigent/issues/3261) [Crash] AttributeError: module 'os' has no attribute 'WNOHANG' |
-| 34 | 66 | high | P2 | P1 ⚑ | +112 | [#3750](https://github.com/omnigent-ai/omnigent/issues/3750) [Crash] PermissionError: [Errno 1] Operation not permitted |
-| 35 | 66 | high | P1 | P1 | -7 | [#3482](https://github.com/omnigent-ai/omnigent/issues/3482) [Crash] ServerError: |
-| 36 | 66 | high | P1 | P1 | -6 | [#3458](https://github.com/omnigent-ai/omnigent/issues/3458) session-updates stream crashes with KeyError when a client watches a c |
-| 37 | 66 | high | P1 | P1 | -5 | [#3359](https://github.com/omnigent-ai/omnigent/issues/3359) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 38 | 66 | high | P2 | P1 ⚑ | +129 | [#3271](https://github.com/omnigent-ai/omnigent/issues/3271) [Feature] Expose per-session context size + last-turn timestamp to age |
-| 39 | 66 | high | P1 | P1 | 0 | [#3251](https://github.com/omnigent-ai/omnigent/issues/3251) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 40 | 66 | high | P2 | P1 ⚑ | +133 | [#3231](https://github.com/omnigent-ai/omnigent/issues/3231) [Crash] OmnigentError: {'error_code': 403, 'message': 'Invalid access  |
-| 41 | 66 | high | P1 | P1 | +4 | [#3052](https://github.com/omnigent-ai/omnigent/issues/3052) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 42 | 66 | high | P1 | P1 | +4 | [#3023](https://github.com/omnigent-ai/omnigent/issues/3023) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 43 | 66 | high | P1 | P1 | +11 | [#2993](https://github.com/omnigent-ai/omnigent/issues/2993) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 44 | 66 | high | P3 | P1 ⚑ | +293 | [#2887](https://github.com/omnigent-ai/omnigent/issues/2887) [Bug] web/package-lock.json is out of sync with package.json; plain `n |
-| 45 | 66 | high | P1 | P1 | +23 | [#2559](https://github.com/omnigent-ai/omnigent/issues/2559) Conversation bricked: Page fails to load when opening markdown file af |
-| 46 | 66 | high | P0 | P1 ⚑ | -44 | [#2355](https://github.com/omnigent-ai/omnigent/issues/2355) [Bug] workspace_id PK-widening migration crashes on populated Postgres |
-| 47 | 66 | high | P3 | P1 ⚑ | +294 | [#2224](https://github.com/omnigent-ai/omnigent/issues/2224) [Bug] get_client model-change check fails for harness="any" |
-| 48 | 66 | high | P1 | P1 | +50 | [#1985](https://github.com/omnigent-ai/omnigent/issues/1985) Headless `omnigent run -p` intermittently hangs forever despite the tu |
-| 49 | 66 | high | P2 | P1 ⚑ | +195 | [#1907](https://github.com/omnigent-ai/omnigent/issues/1907) Sub-agent model_override triggers an unnecessary first-turn harness re |
-| 50 | 66 | high | P1 | P1 | +54 | [#1888](https://github.com/omnigent-ai/omnigent/issues/1888) ansi-to-react default import resolves to the CJS exports object under  |
-| 51 | 66 | high | P2 | P1 ⚑ | +202 | [#1804](https://github.com/omnigent-ai/omnigent/issues/1804) spec parser crashes with TypeError on a null tools.builtins key (and s |
-| 52 | 66 | high | P2 | P1 ⚑ | +237 | [#1076](https://github.com/omnigent-ai/omnigent/issues/1076) Runner-layer Tier-2 escalation: release an unresponsive per-conversati |
-| 53 | 66 | high | P1 | P1 | +68 | [#1026](https://github.com/omnigent-ai/omnigent/issues/1026) Runner orphans tool callbacks with "no active turn context" after mid- |
-| 54 | 65 | high | P2 | P1 ⚑ | +154 | [#2714](https://github.com/omnigent-ai/omnigent/issues/2714) Upgrade openai-agents and remove the temporary openai<2.45 cap |
-| 55 | 65 | high | P1 | P1 | +35 | [#2245](https://github.com/omnigent-ai/omnigent/issues/2245) [Bug] openai-agents harness turn wedges permanently after policy-verdi |
-| 56 | 63 | high | P1 | P1 | +75 | [#108](https://github.com/omnigent-ai/omnigent/issues/108) Cannot install on Linux aarch64 — cel-expr-python has no aarch64 wheel |
-| 57 | 61 | medium | P2 | P1 ⚑ | +211 | [#1596](https://github.com/omnigent-ai/omnigent/issues/1596) Native-CLI harness (claude-native/codex-native) as a named agent's own |
-| 58 | 60 | high | P1 | P1 | -50 | [#3971](https://github.com/omnigent-ai/omnigent/issues/3971) Host runners inherit the daemon's cwd; a deleted launch dir breaks eve |
-| 59 | 60 | high | P1 | P1 | -25 | [#3274](https://github.com/omnigent-ai/omnigent/issues/3274) Sub-agent terminal status rejected with missing_parent_inbox and retri |
-| 60 | 60 | high | P2 | P1 ⚑ | +112 | [#3235](https://github.com/omnigent-ai/omnigent/issues/3235) Flaky E2E UI: test_scheduled_task_create_edit_modal_and_time_picker[ch |
-| 61 | 60 | high | P1 | P1 | -14 | [#3016](https://github.com/omnigent-ai/omnigent/issues/3016) [Bug] A transient session-snapshot failure permanently pins a session  |
-| 62 | 60 | high | P1 | P1 | -14 | [#3012](https://github.com/omnigent-ai/omnigent/issues/3012) Hosts authenticated via `omnigent login` permanently 403 on first reco |
-| 63 | 60 | high | P2 | P1 ⚑ | +155 | [#2428](https://github.com/omnigent-ai/omnigent/issues/2428) sys_session_send to a completed session hangs to ReadTimeout and is si |
-| 64 | 60 | high | P1 | P1 | +27 | [#2241](https://github.com/omnigent-ai/omnigent/issues/2241) Flaky on main: test_interrupt_forwards_to_harness_before_cancelling ti |
-| 65 | 60 | high | P1 | P1 | +31 | [#2051](https://github.com/omnigent-ai/omnigent/issues/2051) [Bug] sys_session_send(session_id=…) completions never drain to sys_re |
-| 66 | 60 | high | P0 | P1 ⚑ | -63 | [#1657](https://github.com/omnigent-ai/omnigent/issues/1657) hermes-native forwarder advances last_id per item, dropping a row's la |
-| 67 | 60 | high | P2 | P1 ⚑ | +247 | [#678](https://github.com/omnigent-ai/omnigent/issues/678) e2e: sub-agent supervisor routing / named-sub-agent auto-wake flakes ( |
-| 68 | 59 | high | P1 | P2 ⚑ | -51 | [#3799](https://github.com/omnigent-ai/omnigent/issues/3799) Android shell cannot sign in to servers behind a front-door auth proxy |
-| 69 | 59 | high | P1 | P2 ⚑ | -49 | [#3730](https://github.com/omnigent-ai/omnigent/issues/3730) [Bug] Android: renderer death terminates the app — OmnigentWebViewClie |
-| 70 | 59 | high | P1 | P2 ⚑ | -48 | [#3701](https://github.com/omnigent-ai/omnigent/issues/3701) [Bug] Desktop app never completes Okta security key / biometric MFA du |
-| 71 | 59 | high | P1 | P2 ⚑ | -38 | [#3299](https://github.com/omnigent-ai/omnigent/issues/3299) [Bug] Harness-credential route times out with a misleading 504 against |
-| 72 | 59 | high | P2 | P2 | +94 | [#3284](https://github.com/omnigent-ai/omnigent/issues/3284) [Crash] DuplicateOptionError: While reading from PosixPath('/Users/*** |
-| 73 | 59 | high | P2 | P2 | +111 | [#3070](https://github.com/omnigent-ai/omnigent/issues/3070) No progress signal on a stuck or interactive harness install |
-| 74 | 59 | high | P1 | P2 ⚑ | -19 | [#2967](https://github.com/omnigent-ai/omnigent/issues/2967) [Bug] A full context window bricks a session with "Prompt is too long" |
-| 75 | 59 | high | P2 | P2 | +141 | [#2480](https://github.com/omnigent-ai/omnigent/issues/2480) [Bug] Postgres-backed local server: bare `No module named 'psycopg'` + |
-| 76 | 59 | high | P1 | P2 ⚑ | +12 | [#2270](https://github.com/omnigent-ai/omnigent/issues/2270) Windows: config list crashes — UnicodeEncodeError on cp1252 (non-UTF8) |
-| 77 | 59 | high | P1 | P2 ⚑ | +12 | [#2269](https://github.com/omnigent-ai/omnigent/issues/2269) Windows: omnigent setup crashes — ModuleNotFoundError: No module named |
-| 78 | 59 | high | P1 | P2 ⚑ | +21 | [#1953](https://github.com/omnigent-ai/omnigent/issues/1953) `omni host` dies permanently when the OIDC session JWT expires — no re |
-| 79 | 59 | high | P1 | P2 ⚑ | +23 | [#1901](https://github.com/omnigent-ai/omnigent/issues/1901) [Bug] kimi/qwen/goose/kiro forwarders blind-retry failed conversation- |
-| 80 | 59 | high | P1 | P2 ⚑ | +25 | [#1881](https://github.com/omnigent-ai/omnigent/issues/1881) [Bug] `omnigent setup` crashes with `ValueError: select() requires at  |
-| 81 | 59 | high | P1 | P2 ⚑ | +27 | [#1827](https://github.com/omnigent-ai/omnigent/issues/1827) [Bug] kimi-native: torn UTF-8 wire read crashes the forwarder; supervi |
-| 82 | 59 | high | P2 | P2 | +185 | [#1600](https://github.com/omnigent-ai/omnigent/issues/1600) Epic: 12-feature contribution (one issue + one PR per feature) |
-| 83 | 59 | high | P2 | P2 | +187 | [#1528](https://github.com/omnigent-ai/omnigent/issues/1528) Idle-session lifecycle UX: reap gracefully, resume seamlessly, surface |
-| 84 | 58 | high | P2 | P2 | +214 | [#1022](https://github.com/omnigent-ai/omnigent/issues/1022) Behind a corporate proxy, the host daemon can't reach the model backen |
-| 85 | 57 | medium | P2 | P2 | +214 | [#1021](https://github.com/omnigent-ai/omnigent/issues/1021) [Feature] GitHub Copilot as provider |
-| 86 | 54 | high | P2 | P2 | +58 | [#3798](https://github.com/omnigent-ai/omnigent/issues/3798) Android shell shows the SPA as if signed in while native login runs in |
-| 87 | 54 | high | P1 | P2 ⚑ | -58 | [#3469](https://github.com/omnigent-ai/omnigent/issues/3469) [Bug] Post-completion compaction spiral: merge-commit diff output trig |
-| 88 | 54 | high | P1 | P2 ⚑ | -23 | [#2629](https://github.com/omnigent-ai/omnigent/issues/2629) web_fetch sub-agent spawn fails with unknown harness 'omnigent' — bare |
-| 89 | 54 | high | P2 | P2 | +166 | [#1778](https://github.com/omnigent-ai/omnigent/issues/1778) opencode-native forwarder loses session content across SSE reconnects  |
-| 90 | 54 | high | P1 | P2 ⚑ | +38 | [#523](https://github.com/omnigent-ai/omnigent/issues/523) REPL pexpect e2e tests starve on boot under full shard load (60s _wait |
-| 91 | 53 | high | P1 | P2 ⚑ | -42 | [#3011](https://github.com/omnigent-ai/omnigent/issues/3011) kiro-native harness: interactive sessions never respond with kiro-cli  |
-| 92 | 53 | high | P1 | P2 ⚑ | -36 | [#2920](https://github.com/omnigent-ai/omnigent/issues/2920) Omnigent server fails to start on native Windows: os.getuid() at impor |
-| 93 | 53 | high | P1 | P2 ⚑ | -36 | [#2919](https://github.com/omnigent-ai/omnigent/issues/2919) omni setup crashes on Windows: ModuleNotFoundError: No module named 't |
-| 94 | 53 | high | P1 | P2 ⚑ | -15 | [#2422](https://github.com/omnigent-ai/omnigent/issues/2422) Windows: five chained defects break the documented degraded-mode subse |
-| 95 | 53 | high | P2 | P2 | +215 | [#762](https://github.com/omnigent-ai/omnigent/issues/762) [Bug] sub agent terminal crashes when cli starts with prompt for input |
-| 96 | 50 | medium | P2 | P2 | +108 | [#2744](https://github.com/omnigent-ai/omnigent/issues/2744) [Bug] codex-native: custom agents time out at launch — native provider |
-| 97 | 46 | medium | P1 | P2 ⚑ | -87 | [#3952](https://github.com/omnigent-ai/omnigent/issues/3952) A stale terminal exit removes the newer Codex resources of the same se |
-| 98 | 46 | medium | P2 | P2 | +93 | [#2984](https://github.com/omnigent-ai/omnigent/issues/2984) [Bug] Codex incorrectly reports `needs-auth` with an authenticated cus |
-| 99 | 46 | medium | P1 | P2 ⚑ | -7 | [#2184](https://github.com/omnigent-ai/omnigent/issues/2184) [Bug] Codex plugin skills are exposed with inconsistent names (`plugin |
-| 100 | 46 | medium | P1 | P2 ⚑ | -7 | [#2071](https://github.com/omnigent-ai/omnigent/issues/2071) [Bug] web_search never advertised to claude-sdk sessions: unprefixed m |
-| 101 | 46 | medium | P2 | P2 | +134 | [#2062](https://github.com/omnigent-ai/omnigent/issues/2062) [Bug] claude-native: per-session model override silently lost when wra |
-| 102 | 46 | medium | P1 | P2 ⚑ | +5 | [#1831](https://github.com/omnigent-ai/omnigent/issues/1831) claude-native workers ignore executor.model pin and per-dispatch args. |
-| 103 | 46 | medium | P1 | P2 ⚑ | +7 | [#1781](https://github.com/omnigent-ai/omnigent/issues/1781) codex harness: ambient DATABRICKS_BEARER/DATABRICKS_TOKEN overrides pr |
-| 104 | 46 | medium | P1 | P2 ⚑ | +15 | [#1128](https://github.com/omnigent-ai/omnigent/issues/1128) [Bug] Claude SDK Appears to Use Opus Instead of Selected Model |
-| 105 | 46 | medium | P1 | P2 ⚑ | +25 | [#241](https://github.com/omnigent-ai/omnigent/issues/241) pi harness: GPT and Gemini dispatches 404 on the Databricks ucode gate |
-| 106 | 46 | medium | P3 | P2 ⚑ | +241 | [#147](https://github.com/omnigent-ai/omnigent/issues/147) Tracking: gradual decomposition of monolith modules (cli.py 9.1KLOC, c |
-| 107 | 42 | medium | P1 | P2 ⚑ | -89 | [#3790](https://github.com/omnigent-ai/omnigent/issues/3790) force_sandbox policy is evaluated but structurally unreachable from cl |
-| 108 | 42 | medium | P2 | P2 | +150 | [#1724](https://github.com/omnigent-ai/omnigent/issues/1724) codex-native harness times out on WSL2 ("Codex TUI never started a thr |
-| 109 | 42 | medium | P1 | P2 ⚑ | -51 | [#2904](https://github.com/omnigent-ai/omnigent/issues/2904) [Bug] claude-native: web-UI chat input fails with "tmux command failed |
-| 110 | 42 | medium | P1 | P2 ⚑ | -29 | [#2397](https://github.com/omnigent-ai/omnigent/issues/2397) [Bug] Codex-native intelligent routing ignores live effort capabilitie |
-| 111 | 42 | medium | P1 | P2 ⚑ | -24 | [#2272](https://github.com/omnigent-ai/omnigent/issues/2272) [Bug] Codex runner can't find OpenRouter secret that exists in keyring |
-| 112 | 42 | medium | P2 | P2 | +192 | [#890](https://github.com/omnigent-ai/omnigent/issues/890) [Bug] omnigent setup fails with npm EACCES when installing the Claude  |
-| 113 | 42 | medium | P1 | P2 ⚑ | +12 | [#668](https://github.com/omnigent-ai/omnigent/issues/668) [Bug] BUG？omni claude times out (60s) on macOS with native Claude Code |
-| 114 | 38 | medium | P1 | P2 ⚑ | -98 | [#3852](https://github.com/omnigent-ai/omnigent/issues/3852) [Bug] Built-in write policies miss Claude Code's `MultiEdit` / `Notebo |
-| 115 | 38 | medium | P2 | P2 | +109 | [#2369](https://github.com/omnigent-ai/omnigent/issues/2369) [Bug] pi harness only lists databricks-claude-sonnet-4-6 |
-| 116 | 38 | medium | P1 | P2 ⚑ | -30 | [#2299](https://github.com/omnigent-ai/omnigent/issues/2299) [Bug] claude-native resume transcripts flatten tool_result image block |
-| 117 | 38 | medium | P2 | P2 | +104 | [#2390](https://github.com/omnigent-ai/omnigent/issues/2390) Builtin policy for per-user sub-agent access control (subagent_access_ |
-| 118 | 38 | medium | P2 | P2 | +206 | [#377](https://github.com/omnigent-ai/omnigent/issues/377) gpt sub-agent fails on startup with missing databricks-sdk dependency |
-| 119 | 38 | medium | P1 | P2 ⚑ | -10 | [#1794](https://github.com/omnigent-ai/omnigent/issues/1794) Bundled Polly: claude-sdk brain "Not logged in" + runaway spawn loop o |
-| 120 | 38 | medium | P1 | P2 ⚑ | -9 | [#1694](https://github.com/omnigent-ai/omnigent/issues/1694) Reliability: parallel code-fix missions fail silently (5s tmux timeout |
-| 121 | 37 | medium | P1 | P2 ⚑ | -79 | [#3101](https://github.com/omnigent-ai/omnigent/issues/3101) Docker/Kubernetes entrypoint never wires project_store — first-class P |
-| 122 | 36 | medium | P2 | P2 | +161 | [#1192](https://github.com/omnigent-ai/omnigent/issues/1192) [Bug] Manual /compact errors "Compaction requires a configured LLM mod |
-| 123 | 36 | medium | P1 | P2 ⚑ | -6 | [#1158](https://github.com/omnigent-ai/omnigent/issues/1158) [Bug] antigravity-native: TUI-typed turns never mirror to the web UI ( |
-| 124 | 36 | medium | P2 | P2 | +161 | [#1157](https://github.com/omnigent-ai/omnigent/issues/1157) [Bug] antigravity-native: no Chat/Terminal toggle — terminal_antigravi |
-| 125 | 36 | feature | P2 | P2 | +188 | [#692](https://github.com/omnigent-ai/omnigent/issues/692) Polly: fan out sub-agent work across multiple concurrent claude profil |
-| 126 | 36 | feature | P2 | P2 | +201 | [#197](https://github.com/omnigent-ai/omnigent/issues/197) Declarative skill sources: pull Claude Code skills + their dependency  |
-| 127 | 35 | medium | P2 | P2 | +110 | [#2055](https://github.com/omnigent-ai/omnigent/issues/2055) [Bug] codex-native harness elicitation: a resolve landing in the betwe |
-| 128 | 35 | medium | P1 | P2 ⚑ | -84 | [#3076](https://github.com/omnigent-ai/omnigent/issues/3076) [Bug] claude-sdk omits ToolSearch, eagerly loading every MCP schema |
-| 129 | 35 | medium | P3 | P2 ⚑ | +210 | [#2800](https://github.com/omnigent-ai/omnigent/issues/2800) [Bug] Top-level custom codex-native agents drop reasoning effort and y |
-| 130 | 35 | medium | P1 | P2 ⚑ | -7 | [#880](https://github.com/omnigent-ai/omnigent/issues/880) [BUG] Native harness (omnigent claude): assistant turns not streamed t |
-| 131 | 33 | medium | P1 | P2 ⚑ | -18 | [#1551](https://github.com/omnigent-ai/omnigent/issues/1551) opencode-native: blocking question tool not surfaced to web (no elicit |
-| 132 | 33 | medium | P2 | P2 | +2 | [#4009](https://github.com/omnigent-ai/omnigent/issues/4009) [Feature] No Go client for the session API, so every Go caller hand-ro |
-| 133 | 33 | medium | P1 | P2 ⚑ | -127 | [#3981](https://github.com/omnigent-ai/omnigent/issues/3981) [Bug] Desktop: Workspace rail resize is unusable on the Browser tab; a |
-| 134 | 33 | medium | P1 | P2 ⚑ | -121 | [#3898](https://github.com/omnigent-ai/omnigent/issues/3898) [Bug] Pack function policies fail server-side input evaluation unless  |
-| 135 | 33 | medium | P1 | P2 ⚑ | -121 | [#3870](https://github.com/omnigent-ai/omnigent/issues/3870) child-session creation returns 500 internal_error, breaking Polly/Debb |
-| 136 | 33 | medium | P2 | P2 | +6 | [#3864](https://github.com/omnigent-ai/omnigent/issues/3864) [Bug] to_api_dict() drops ConversationItem.created_at, so flat items A |
-| 137 | 33 | medium | P1 | P2 ⚑ | -122 | [#3863](https://github.com/omnigent-ai/omnigent/issues/3863) [Bug] Databricks Apps entrypoint never wires project_store — Projects  |
-| 138 | 33 | medium | P2 | P2 | +5 | [#3861](https://github.com/omnigent-ai/omnigent/issues/3861) [Bug] omni host status renders URLs so terminals link the whole status |
-| 139 | 33 | medium | P2 | P2 | +13 | [#3563](https://github.com/omnigent-ai/omnigent/issues/3563) [Bug] Host-bound resume into a deleted workspace: host computes the ex |
-| 140 | 33 | medium | P2 | P2 | +13 | [#3561](https://github.com/omnigent-ai/omnigent/issues/3561) [Bug] `prompt_policy` never sends `_CLASSIFIER_SCHEMA` to the LLM — st |
-| 141 | 33 | medium | P2 | P2 | +14 | [#3550](https://github.com/omnigent-ai/omnigent/issues/3550) [Bug] Missing signing alg's prevent using some OIDC providers |
-| 142 | 33 | medium | P2 | P2 | +18 | [#3435](https://github.com/omnigent-ai/omnigent/issues/3435) [Feature] Admin server-wide usage report (per-user and per-model cost) |
-| 143 | 33 | medium | none | P2 | +210 | [#3402](https://github.com/omnigent-ai/omnigent/issues/3402) [Bug] Label seeding and session-state writes race under concurrent upd |
-| 144 | 33 | medium | P2 | P2 | +18 | [#3368](https://github.com/omnigent-ai/omnigent/issues/3368) Feature: first-class async write-safety (freeze → approve → apply) pri |
-| 145 | 33 | medium | P2 | P2 | +20 | [#3352](https://github.com/omnigent-ai/omnigent/issues/3352) [Feature] OpenClaw onboarding — Option B: chat import (SQLite session  |
-| 146 | 33 | medium | P2 | P2 | +24 | [#3247](https://github.com/omnigent-ai/omnigent/issues/3247) credential_proxy: re-resolve the source on 401 / expiry (short-lived t |
-| 147 | 33 | medium | P1 | P2 ⚑ | -107 | [#3236](https://github.com/omnigent-ai/omnigent/issues/3236) web_search: bare executor.model strings are inferred as provider 'open |
-| 148 | 33 | medium | P2 | P2 | +28 | [#3219](https://github.com/omnigent-ai/omnigent/issues/3219) [Bug] Cmd/Ctrl+Up/Down session traversal stops in an empty focused com |
-| 149 | 33 | medium | P2 | P2 | +43 | [#2921](https://github.com/omnigent-ai/omnigent/issues/2921) Font settings: selected font (incl. Nerd Fonts) never loads — no webfo |
-| 150 | 33 | medium | P1 | P2 ⚑ | -90 | [#2854](https://github.com/omnigent-ai/omnigent/issues/2854) [Bug] Cross-harness `harness_override` is ignored on the `initial_item |
-| 151 | 33 | medium | P2 | P2 | +45 | [#2851](https://github.com/omnigent-ai/omnigent/issues/2851) Policy-supplied targets for ASK approval cards |
-| 152 | 33 | medium | P2 | P2 | +50 | [#2756](https://github.com/omnigent-ai/omnigent/issues/2756) Expose atomic session-event admission to integrations |
-| 153 | 33 | medium | P2 | P2 | +59 | [#2577](https://github.com/omnigent-ai/omnigent/issues/2577) [Feature] Manage OIDC/SSO admins from an id_token claim (IdP group/rol |
-| 154 | 33 | medium | P2 | P2 | +59 | [#2558](https://github.com/omnigent-ai/omnigent/issues/2558) Distribution / Installation / Enterprise Readiness |
-| 155 | 33 | medium | P1 | P2 ⚑ | -85 | [#2539](https://github.com/omnigent-ai/omnigent/issues/2539) Named sys_session_send returns 404 after first child from a bundled se |
-| 156 | 33 | medium | P1 | P2 ⚑ | -85 | [#2524](https://github.com/omnigent-ai/omnigent/issues/2524) [Bug] Registering remote host fails |
-| 157 | 33 | medium | P1 | P2 ⚑ | -84 | [#2444](https://github.com/omnigent-ai/omnigent/issues/2444) Accounts JWT expiry falls through to Databricks auth and breaks persis |
-| 158 | 33 | medium | P2 | P2 | +62 | [#2404](https://github.com/omnigent-ai/omnigent/issues/2404) fix(runtime): orphan sweep can abort startup on unreadable shared-host |
-| 159 | 33 | medium | P2 | P2 | +63 | [#2374](https://github.com/omnigent-ai/omnigent/issues/2374) Proposal: per-turn context_providers to augment system instructions at |
-| 160 | 33 | medium | P1 | P2 ⚑ | -75 | [#2304](https://github.com/omnigent-ai/omnigent/issues/2304) Runner subprocess inherits host daemon cwd, causing os_env cwd resolut |
-| 161 | 33 | medium | P2 | P2 | +73 | [#2070](https://github.com/omnigent-ai/omnigent/issues/2070) [Feature] sys_os_* file tools are hard-confined to the session workspa |
-| 162 | 33 | medium | P2 | P2 | +109 | [#1526](https://github.com/omnigent-ai/omnigent/issues/1526) Refactor: incrementally decompose the 4 god-files (sessions.py, runner |
-| 163 | 33 | medium | P2 | P2 | +111 | [#1411](https://github.com/omnigent-ai/omnigent/issues/1411) Standalone reusable MCP servers: CRUD + connection verify (list tools) |
-| 164 | 33 | medium | P2 | P2 | +126 | [#1075](https://github.com/omnigent-ai/omnigent/issues/1075) [Feature] Support AWS Lambda / Firecracker microVMs as managed sandbox |
-| 165 | 33 | medium | P2 | P2 | +127 | [#1055](https://github.com/omnigent-ai/omnigent/issues/1055) [Test] End-to-end OTel test against a real collector to lock in the BY |
-| 166 | 33 | medium | P2 | P2 | +127 | [#1054](https://github.com/omnigent-ai/omnigent/issues/1054) [Feature] Record gen_ai.retry events on llm_call spans |
-| 167 | 33 | medium | P2 | P2 | +130 | [#1031](https://github.com/omnigent-ai/omnigent/issues/1031) [Feature] Support serving the standalone Web UI under a subpath, e.g.  |
-| 168 | 33 | medium | P2 | P2 | +132 | [#983](https://github.com/omnigent-ai/omnigent/issues/983) Session sharing ergonomics: `sys_session_share` agent tool + `omnigent |
-| 169 | 33 | medium | P2 | P2 | +139 | [#857](https://github.com/omnigent-ai/omnigent/issues/857) [Proposal] Usage-limit detection + on-429 failover across pooled provi |
-| 170 | 33 | medium | P1 | P2 ⚑ | -46 | [#765](https://github.com/omnigent-ai/omnigent/issues/765) Support interactive mid-flight policy ASK (TOOL_CALL/TOOL_RESULT/OUTPU |
-| 171 | 33 | medium | P1 | P2 ⚑ | -45 | [#547](https://github.com/omnigent-ai/omnigent/issues/547) Bug: Polly model switcher sends invalid Cursor SDK model id |
-| 172 | 33 | medium | P1 | P2 ⚑ | -43 | [#522](https://github.com/omnigent-ai/omnigent/issues/522) Implement async-tool completion auto-delivery (SESSION_REARCHITECTURE  |
-| 173 | 33 | medium | P2 | P2 | +145 | [#509](https://github.com/omnigent-ai/omnigent/issues/509) [Feature] Default new-session workspace from selected agent's cwd |
-| 174 | 33 | medium | P2 | P2 | +149 | [#382](https://github.com/omnigent-ai/omnigent/issues/382) Evaluating the same agent across harnesses: no built-in way to compare |
-| 175 | 33 | medium | P1 | P2 ⚑ | -75 | [#1936](https://github.com/omnigent-ai/omnigent/issues/1936) [BUG] copilot harness: 401 Bad credentials when no token is explicitly |
-| 176 | 32 | feature | P2 | P2 | +97 | [#1454](https://github.com/omnigent-ai/omnigent/issues/1454) [Feature] Change permission mode of a running claude-native session fr |
-| 177 | 31 | medium | P1 | P2 ⚑ | -99 | [#2429](https://github.com/omnigent-ai/omnigent/issues/2429) Server (python -m omnigent.cli server) CPU-spins indefinitely with no  |
-| 178 | 31 | medium | P1 | P2 ⚑ | -58 | [#1113](https://github.com/omnigent-ai/omnigent/issues/1113) Native sub-agent/runner failures surface as bare "failed" with no reas |
-| 179 | 31 | feature | P2 | P2 | -1 | [#3150](https://github.com/omnigent-ai/omnigent/issues/3150) [Feature] CLI: cross-harness fork — continue an existing session in a  |
-| 180 | 31 | feature | P2 | P2 | +79 | [#1703](https://github.com/omnigent-ai/omnigent/issues/1703) [Feature] Unify harness naming: bare names (claude, codex, …) are ambi |
-| 181 | 31 | feature | P3 | P2 ⚑ | +161 | [#1678](https://github.com/omnigent-ai/omnigent/issues/1678) tech-debt(codex-native): extract a string-field helper for repeated di |
-| 182 | 31 | feature | P2 | P2 | +137 | [#503](https://github.com/omnigent-ai/omnigent/issues/503) [Feature] Switch Claude Code account per session via isolated profiles |
-| 183 | 30 | feature | P2 | P2 | +42 | [#2303](https://github.com/omnigent-ai/omnigent/issues/2303) [Feature] Support multi-repo workspaces (nested Git repos or multiple  |
-| 184 | 30 | medium | P2 | P2 | -2 | [#3083](https://github.com/omnigent-ai/omnigent/issues/3083) [Bug] Cursor sessions launched from Omnigent Web is losing MCPs |
-| 185 | 30 | medium | P1 | P2 ⚑ | -67 | [#1156](https://github.com/omnigent-ai/omnigent/issues/1156) [Bug] antigravity-native: web/mobile turns never appear in the native  |
-| 186 | 30 | medium | P2 | P2 | -17 | [#3250](https://github.com/omnigent-ai/omnigent/issues/3250) flaky e2e_ui: test_scheduled_task_create_edit_modal_and_time_picker ti |
-| 187 | 30 | medium | P2 | P2 | +11 | [#2848](https://github.com/omnigent-ai/omnigent/issues/2848) Server logs an expected offline-runner resource 503 as ERROR + full tr |
-| 188 | 30 | medium | P2 | P2 | +13 | [#2767](https://github.com/omnigent-ai/omnigent/issues/2767) [Bug] SQLite pool (default 5+10) not sized to the 200-thread limiter → |
-| 189 | 30 | medium | P1 | P2 ⚑ | -106 | [#2357](https://github.com/omnigent-ai/omnigent/issues/2357) [Bug] admin fleet-view calls SqlAlchemyConversationStore.list_conversa |
-| 190 | 30 | medium | P1 | P2 ⚑ | -95 | [#2052](https://github.com/omnigent-ai/omnigent/issues/2052) [Bug] web_fetch's __web_researcher helper sub-agent fails on 0.4.0 (si |
-| 191 | 30 | medium | P1 | P2 ⚑ | -90 | [#1920](https://github.com/omnigent-ai/omnigent/issues/1920) Seeder matching-hash fast path can't self-heal a lost artifact-store b |
-| 192 | 30 | medium | P1 | P2 ⚑ | -86 | [#1857](https://github.com/omnigent-ai/omnigent/issues/1857) Host daemon stays alive but shows offline — server-dropped host tunnel |
-| 193 | 30 | medium | P1 | P2 ⚑ | -81 | [#1686](https://github.com/omnigent-ai/omnigent/issues/1686) xai: reasoning_effort sent to all Grok models returns HTTP 400 on unsu |
-| 194 | 30 | medium | P2 | P2 | +94 | [#1117](https://github.com/omnigent-ai/omnigent/issues/1117) async generator ignored GeneratorExit — orphaned SSE relay task, excep |
-| 195 | 30 | medium | P2 | P2 | +117 | [#725](https://github.com/omnigent-ai/omnigent/issues/725) Changes panel is empty for native-harness and external edits in non-gi |
-| 196 | 30 | medium | P2 | P2 | +134 | [#146](https://github.com/omnigent-ai/omnigent/issues/146) StreamHooks.on_sub_agent_spawned / on_sub_agent_completed are declared |
-| 197 | 30 | medium | P1 | P2 ⚑ | -192 | [#3982](https://github.com/omnigent-ai/omnigent/issues/3982) [Bug] electron-build.yml pnpm filter matches no package: desktop packa |
-| 198 | 30 | medium | P3 | P2 ⚑ | +138 | [#3733](https://github.com/omnigent-ai/omnigent/issues/3733) [Bug] Android: hardcoded 25px switcher height makes the chat scroll-fa |
-| 199 | 30 | medium | P2 | P2 | -52 | [#3732](https://github.com/omnigent-ai/omnigent/issues/3732) [Bug] Android: a Display-size change leaves the server-switcher pill's |
-| 200 | 30 | medium | P2 | P2 | -50 | [#3592](https://github.com/omnigent-ai/omnigent/issues/3592) [Feature] Deterministic long-term memory (automatic recall/retain) — f |
+| 1 | 161 | critical | P2 | P0 ⚑ | +231 | [#2125](https://github.com/omnigent-ai/omnigent/issues/2125) [Feature] Multi-host git credentials for managed sandboxes (GitHub + s |
+| 2 | 154 | critical | P2 | P0 ⚑ | +234 | [#2057](https://github.com/omnigent-ai/omnigent/issues/2057) [Feature] Add Codex Auto mode using auto_review instead of jumping to  |
+| 3 | 154 | critical | P2 | P0 ⚑ | +235 | [#2054](https://github.com/omnigent-ai/omnigent/issues/2054) [Feature] Remove duplicate Codex Full access mode and keep Sandbox Byp |
+| 4 | 139 | high | P2 | P0 ⚑ | +291 | [#1051](https://github.com/omnigent-ai/omnigent/issues/1051) [Feature] Forward OTel exporter knobs to executor subprocess env |
+| 5 | 127 | high | P2 | P0 ⚑ | +235 | [#2038](https://github.com/omnigent-ai/omnigent/issues/2038) [Feature] No way to deregister/delete an external self-registered host |
+| 6 | 126 | high | P1 | P0 ⚑ | +31 | [#3265](https://github.com/omnigent-ai/omnigent/issues/3265) claude-sdk agent with linux_bwrap dies at spawn on a runtime bwrap bin |
+| 7 | 121 | high | P2 | P0 ⚑ | +327 | [#16](https://github.com/omnigent-ai/omnigent/issues/16) Is native Windows support in scope, or should docs recommend WSL2? |
+| 8 | 121 | critical | P1 | P0 ⚑ | -4 | [#3983](https://github.com/omnigent-ai/omnigent/issues/3983) [Bug] Smart-routed turns render out of order: reply streams above the  |
+| 9 | 121 | critical | P1 | P0 ⚑ | +26 | [#3270](https://github.com/omnigent-ai/omnigent/issues/3270) [Bug] sys_session_create children are absent from both sys_session_lis |
+| 10 | 110 | critical | P0 | P0 | -9 | [#3557](https://github.com/omnigent-ai/omnigent/issues/3557) [Bug] Shell-surface policy gates are bypassed by option-taking command |
+| 11 | 109 | high | P2 | P0 ⚑ | +125 | [#3976](https://github.com/omnigent-ai/omnigent/issues/3976) [Feature] OAuth2 client-credentials grant so a headless process can au |
+| 12 | 109 | high | P2 | P0 ⚑ | +152 | [#3363](https://github.com/omnigent-ai/omnigent/issues/3363) [Feature] Per-project custom instructions (project-scoped context) |
+| 13 | 109 | high | P2 | P0 ⚑ | +263 | [#1388](https://github.com/omnigent-ai/omnigent/issues/1388) Make agents a first-class CRUD entity with a dedicated sidebar UI (dec |
+| 14 | 109 | critical | P2 | P0 ⚑ | +301 | [#659](https://github.com/omnigent-ai/omnigent/issues/659) [Feature] add a microvm backend for sandbox |
+| 15 | 100 | critical | P3 | P0 ⚑ | +334 | [#61](https://github.com/omnigent-ai/omnigent/issues/61) 🤖 Code Audit: 21 potential issue(s) found |
+| 16 | 99 | high | P2 | P1 ⚑ | +121 | [#3970](https://github.com/omnigent-ai/omnigent/issues/3970) pi-native: every turn fails with "Pi model error: 401 Invalid Token" w |
+| 17 | 99 | high | P1 | P1 | +35 | [#3001](https://github.com/omnigent-ai/omnigent/issues/3001) [Performance] GET /v1/sessions pre-fetches every accessible conversati |
+| 18 | 92 | high | P1 | P1 | +15 | [#3299](https://github.com/omnigent-ai/omnigent/issues/3299) [Bug] Harness-credential route times out with a misleading 504 against |
+| 19 | 92 | high | P2 | P1 ⚑ | +147 | [#3284](https://github.com/omnigent-ai/omnigent/issues/3284) [Crash] DuplicateOptionError: While reading from PosixPath('/Users/*** |
+| 20 | 92 | high | P1 | P1 | +21 | [#3180](https://github.com/omnigent-ai/omnigent/issues/3180) codex-native: runner never exits on idle timeout — cancelled delta-coa |
+| 21 | 92 | high | P2 | P1 ⚑ | +163 | [#3070](https://github.com/omnigent-ai/omnigent/issues/3070) No progress signal on a stuck or interactive harness install |
+| 22 | 92 | high | P1 | P1 | +33 | [#2967](https://github.com/omnigent-ai/omnigent/issues/2967) [Bug] A full context window bricks a session with "Prompt is too long" |
+| 23 | 92 | high | P1 | P1 | +59 | [#2373](https://github.com/omnigent-ai/omnigent/issues/2373) [Bug] claude-native: pasted web-UI message loses its Enter, stuck draf |
+| 24 | 92 | high | P1 | P1 | +70 | [#2060](https://github.com/omnigent-ai/omnigent/issues/2060) [Bug] claude-native: first web-UI message silently dropped when Claude |
+| 25 | 92 | high | P1 | P1 | +78 | [#1898](https://github.com/omnigent-ai/omnigent/issues/1898) [Bug] codex-native: cancelling a task awaiting flush() poisons the del |
+| 26 | 92 | high | P2 | P1 ⚑ | +244 | [#1528](https://github.com/omnigent-ai/omnigent/issues/1528) Idle-session lifecycle UX: reap gracefully, resume seamlessly, surface |
+| 27 | 92 | high | P2 | P1 ⚑ | +289 | [#654](https://github.com/omnigent-ai/omnigent/issues/654) [Bug] Streaming with codex is hanging and paragraphs are not split. |
+| 28 | 92 | high | P1 | P1 | +99 | [#542](https://github.com/omnigent-ai/omnigent/issues/542) [Bug] AttributeError: 'SubprocessCLITransport' object has no attribute |
+| 29 | 89 | high | P2 | P1 ⚑ | +148 | [#3164](https://github.com/omnigent-ai/omnigent/issues/3164) [Feature] Optional runtimeClassName on the kubernetes sandbox provider |
+| 30 | 84 | high | P2 | P1 ⚑ | +124 | [#3558](https://github.com/omnigent-ai/omnigent/issues/3558) claude-sdk: cached client does not rebuild on framework-instruction ch |
+| 31 | 84 | high | P1 | P1 | +22 | [#3000](https://github.com/omnigent-ai/omnigent/issues/3000) claude-native transcript forwarder polls at 4 Hz per session with no i |
+| 32 | 84 | high | P1 | P1 | +30 | [#2748](https://github.com/omnigent-ai/omnigent/issues/2748) Runner idle-shutdown deadlocks forever: codex-forwarder close()/flush( |
+| 33 | 84 | high | P1 | P1 | +32 | [#2629](https://github.com/omnigent-ai/omnigent/issues/2629) web_fetch sub-agent spawn fails with unknown harness 'omnigent' — bare |
+| 34 | 84 | high | P1 | P1 | +33 | [#2575](https://github.com/omnigent-ai/omnigent/issues/2575) pi-native: non-Claude Databricks models (GLM, Gemini, …) hang — provid |
+| 35 | 84 | high | P1 | P1 | +37 | [#2454](https://github.com/omnigent-ai/omnigent/issues/2454) [Bug] Unbounded ~/.omnigent growth: per-session native-harness dirs ar |
+| 36 | 84 | high | P1 | P1 | +44 | [#2421](https://github.com/omnigent-ai/omnigent/issues/2421) [Bug] codex app-server + MCP bridge children leak on ANY unclean runne |
+| 37 | 84 | high | P1 | P1 | +91 | [#523](https://github.com/omnigent-ai/omnigent/issues/523) REPL pexpect e2e tests starve on boot under full shard load (60s _wait |
+| 38 | 83 | high | P1 | P1 | +18 | [#2920](https://github.com/omnigent-ai/omnigent/issues/2920) Omnigent server fails to start on native Windows: os.getuid() at impor |
+| 39 | 83 | high | P1 | P1 | +18 | [#2919](https://github.com/omnigent-ai/omnigent/issues/2919) omni setup crashes on Windows: ModuleNotFoundError: No module named 't |
+| 40 | 83 | high | P2 | P1 ⚑ | +168 | [#2714](https://github.com/omnigent-ai/omnigent/issues/2714) Upgrade openai-agents and remove the temporary openai<2.45 cap |
+| 41 | 83 | high | P1 | P1 | +38 | [#2422](https://github.com/omnigent-ai/omnigent/issues/2422) Windows: five chained defects break the documented degraded-mode subse |
+| 42 | 83 | high | P1 | P1 | +48 | [#2245](https://github.com/omnigent-ai/omnigent/issues/2245) [Bug] openai-agents harness turn wedges permanently after policy-verdi |
+| 43 | 83 | high | P2 | P1 ⚑ | +267 | [#762](https://github.com/omnigent-ai/omnigent/issues/762) [Bug] sub agent terminal crashes when cli starts with prompt for input |
+| 44 | 83 | high | P2 | P1 ⚑ | +261 | [#888](https://github.com/omnigent-ai/omnigent/issues/888) [Feature] Side-by-side multi-session view |
+| 45 | 77 | high | P1 | P1 | -7 | [#3261](https://github.com/omnigent-ai/omnigent/issues/3261) [Crash] AttributeError: module 'os' has no attribute 'WNOHANG' |
+| 46 | 76 | high | P2 | P1 ⚑ | +283 | [#151](https://github.com/omnigent-ai/omnigent/issues/151) Native claude_code worker hangs on the one-time Bypass Permissions acc |
+| 47 | 73 | high | P1 | P1 | -19 | [#3482](https://github.com/omnigent-ai/omnigent/issues/3482) [Crash] ServerError: |
+| 48 | 73 | high | P1 | P1 | -18 | [#3458](https://github.com/omnigent-ai/omnigent/issues/3458) session-updates stream crashes with KeyError when a client watches a c |
+| 49 | 73 | high | P2 | P1 ⚑ | +118 | [#3271](https://github.com/omnigent-ai/omnigent/issues/3271) [Feature] Expose per-session context size + last-turn timestamp to age |
+| 50 | 73 | high | P2 | P1 ⚑ | +123 | [#3231](https://github.com/omnigent-ai/omnigent/issues/3231) [Crash] OmnigentError: {'error_code': 403, 'message': 'Invalid access  |
+| 51 | 73 | high | P0 | P1 ⚑ | -49 | [#2355](https://github.com/omnigent-ai/omnigent/issues/2355) [Bug] workspace_id PK-widening migration crashes on populated Postgres |
+| 52 | 73 | high | P3 | P1 ⚑ | +289 | [#2224](https://github.com/omnigent-ai/omnigent/issues/2224) [Bug] get_client model-change check fails for harness="any" |
+| 53 | 73 | high | P1 | P1 | +45 | [#1985](https://github.com/omnigent-ai/omnigent/issues/1985) Headless `omnigent run -p` intermittently hangs forever despite the tu |
+| 54 | 73 | high | P2 | P1 ⚑ | +190 | [#1907](https://github.com/omnigent-ai/omnigent/issues/1907) Sub-agent model_override triggers an unnecessary first-turn harness re |
+| 55 | 73 | high | P2 | P1 ⚑ | +198 | [#1804](https://github.com/omnigent-ai/omnigent/issues/1804) spec parser crashes with TypeError on a null tools.builtins key (and s |
+| 56 | 73 | high | P2 | P1 ⚑ | +211 | [#1600](https://github.com/omnigent-ai/omnigent/issues/1600) Epic: 12-feature contribution (one issue + one PR per feature) |
+| 57 | 73 | high | P2 | P1 ⚑ | +232 | [#1076](https://github.com/omnigent-ai/omnigent/issues/1076) Runner-layer Tier-2 escalation: release an unresponsive per-conversati |
+| 58 | 73 | high | P1 | P1 | +63 | [#1026](https://github.com/omnigent-ai/omnigent/issues/1026) Runner orphans tool callbacks with "no active turn context" after mid- |
+| 59 | 66 | high | P1 | P1 | -51 | [#3971](https://github.com/omnigent-ai/omnigent/issues/3971) Host runners inherit the daemon's cwd; a deleted launch dir breaks eve |
+| 60 | 66 | high | P2 | P1 ⚑ | +86 | [#3750](https://github.com/omnigent-ai/omnigent/issues/3750) [Crash] PermissionError: [Errno 1] Operation not permitted |
+| 61 | 66 | high | P1 | P1 | -32 | [#3469](https://github.com/omnigent-ai/omnigent/issues/3469) [Bug] Post-completion compaction spiral: merge-commit diff output trig |
+| 62 | 66 | high | P1 | P1 | -30 | [#3359](https://github.com/omnigent-ai/omnigent/issues/3359) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 63 | 66 | high | P1 | P1 | -29 | [#3274](https://github.com/omnigent-ai/omnigent/issues/3274) Sub-agent terminal status rejected with missing_parent_inbox and retri |
+| 64 | 66 | high | P1 | P1 | -25 | [#3251](https://github.com/omnigent-ai/omnigent/issues/3251) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 65 | 66 | high | P1 | P1 | -20 | [#3052](https://github.com/omnigent-ai/omnigent/issues/3052) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 66 | 66 | high | P1 | P1 | -20 | [#3023](https://github.com/omnigent-ai/omnigent/issues/3023) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 67 | 66 | high | P1 | P1 | -20 | [#3016](https://github.com/omnigent-ai/omnigent/issues/3016) [Bug] A transient session-snapshot failure permanently pins a session  |
+| 68 | 66 | high | P1 | P1 | -20 | [#3012](https://github.com/omnigent-ai/omnigent/issues/3012) Hosts authenticated via `omnigent login` permanently 403 on first reco |
+| 69 | 66 | high | P1 | P1 | -15 | [#2993](https://github.com/omnigent-ai/omnigent/issues/2993) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 70 | 66 | high | P3 | P1 ⚑ | +267 | [#2887](https://github.com/omnigent-ai/omnigent/issues/2887) [Bug] web/package-lock.json is out of sync with package.json; plain `n |
+| 71 | 66 | high | P1 | P1 | -3 | [#2559](https://github.com/omnigent-ai/omnigent/issues/2559) Conversation bricked: Page fails to load when opening markdown file af |
+| 72 | 66 | high | P2 | P1 ⚑ | +146 | [#2428](https://github.com/omnigent-ai/omnigent/issues/2428) sys_session_send to a completed session hangs to ReadTimeout and is si |
+| 73 | 66 | high | P1 | P1 | +18 | [#2241](https://github.com/omnigent-ai/omnigent/issues/2241) Flaky on main: test_interrupt_forwards_to_harness_before_cancelling ti |
+| 74 | 66 | high | P1 | P1 | +22 | [#2051](https://github.com/omnigent-ai/omnigent/issues/2051) [Bug] sys_session_send(session_id=…) completions never drain to sys_re |
+| 75 | 66 | high | P1 | P1 | +29 | [#1888](https://github.com/omnigent-ai/omnigent/issues/1888) ansi-to-react default import resolves to the CJS exports object under  |
+| 76 | 66 | high | P2 | P1 ⚑ | +179 | [#1778](https://github.com/omnigent-ai/omnigent/issues/1778) opencode-native forwarder loses session content across SSE reconnects  |
+| 77 | 66 | high | P0 | P1 ⚑ | -74 | [#1657](https://github.com/omnigent-ai/omnigent/issues/1657) hermes-native forwarder advances last_id per item, dropping a row's la |
+| 78 | 66 | high | P2 | P1 ⚑ | +236 | [#678](https://github.com/omnigent-ai/omnigent/issues/678) e2e: sub-agent supervisor routing / named-sub-agent auto-wake flakes ( |
+| 79 | 65 | high | P2 | P1 ⚑ | +137 | [#2480](https://github.com/omnigent-ai/omnigent/issues/2480) [Bug] Postgres-backed local server: bare `No module named 'psycopg'` + |
+| 80 | 65 | high | P1 | P1 | +19 | [#1953](https://github.com/omnigent-ai/omnigent/issues/1953) `omni host` dies permanently when the OIDC session JWT expires — no re |
+| 81 | 63 | high | P2 | P1 ⚑ | +217 | [#1022](https://github.com/omnigent-ai/omnigent/issues/1022) Behind a corporate proxy, the host daemon can't reach the model backen |
+| 82 | 61 | medium | P2 | P1 ⚑ | +186 | [#1596](https://github.com/omnigent-ai/omnigent/issues/1596) Native-CLI harness (claude-native/codex-native) as a named agent's own |
+| 83 | 60 | high | P2 | P1 ⚑ | +89 | [#3235](https://github.com/omnigent-ai/omnigent/issues/3235) Flaky E2E UI: test_scheduled_task_create_edit_modal_and_time_picker[ch |
+| 84 | 59 | high | P1 | P2 ⚑ | -67 | [#3799](https://github.com/omnigent-ai/omnigent/issues/3799) Android shell cannot sign in to servers behind a front-door auth proxy |
+| 85 | 59 | high | P1 | P2 ⚑ | -65 | [#3730](https://github.com/omnigent-ai/omnigent/issues/3730) [Bug] Android: renderer death terminates the app — OmnigentWebViewClie |
+| 86 | 59 | high | P1 | P2 ⚑ | -64 | [#3701](https://github.com/omnigent-ai/omnigent/issues/3701) [Bug] Desktop app never completes Okta security key / biometric MFA du |
+| 87 | 59 | high | P1 | P2 ⚑ | +1 | [#2270](https://github.com/omnigent-ai/omnigent/issues/2270) Windows: config list crashes — UnicodeEncodeError on cp1252 (non-UTF8) |
+| 88 | 59 | high | P1 | P2 ⚑ | +1 | [#2269](https://github.com/omnigent-ai/omnigent/issues/2269) Windows: omnigent setup crashes — ModuleNotFoundError: No module named |
+| 89 | 59 | high | P1 | P2 ⚑ | +13 | [#1901](https://github.com/omnigent-ai/omnigent/issues/1901) [Bug] kimi/qwen/goose/kiro forwarders blind-retry failed conversation- |
+| 90 | 59 | high | P1 | P2 ⚑ | +15 | [#1881](https://github.com/omnigent-ai/omnigent/issues/1881) [Bug] `omnigent setup` crashes with `ValueError: select() requires at  |
+| 91 | 59 | high | P1 | P2 ⚑ | +17 | [#1827](https://github.com/omnigent-ai/omnigent/issues/1827) [Bug] kimi-native: torn UTF-8 wire read crashes the forwarder; supervi |
+| 92 | 58 | high | P1 | P2 ⚑ | +39 | [#108](https://github.com/omnigent-ai/omnigent/issues/108) Cannot install on Linux aarch64 — cel-expr-python has no aarch64 wheel |
+| 93 | 57 | medium | P2 | P2 | +206 | [#1021](https://github.com/omnigent-ai/omnigent/issues/1021) [Feature] GitHub Copilot as provider |
+| 94 | 54 | medium | P2 | P2 | +230 | [#377](https://github.com/omnigent-ai/omnigent/issues/377) gpt sub-agent fails on startup with missing databricks-sdk dependency |
+| 95 | 54 | high | P2 | P2 | +49 | [#3798](https://github.com/omnigent-ai/omnigent/issues/3798) Android shell shows the SPA as if signed in while native login runs in |
+| 96 | 53 | high | P1 | P2 ⚑ | -47 | [#3011](https://github.com/omnigent-ai/omnigent/issues/3011) kiro-native harness: interactive sessions never respond with kiro-cli  |
+| 97 | 50 | medium | P2 | P2 | +107 | [#2744](https://github.com/omnigent-ai/omnigent/issues/2744) [Bug] codex-native: custom agents time out at launch — native provider |
+| 98 | 46 | medium | P1 | P2 ⚑ | -88 | [#3952](https://github.com/omnigent-ai/omnigent/issues/3952) A stale terminal exit removes the newer Codex resources of the same se |
+| 99 | 46 | medium | P2 | P2 | +51 | [#3592](https://github.com/omnigent-ai/omnigent/issues/3592) [Feature] Deterministic long-term memory (automatic recall/retain) — f |
+| 100 | 46 | medium | P1 | P2 ⚑ | -75 | [#3536](https://github.com/omnigent-ai/omnigent/issues/3536) [Bug] A session's `reasoning_effort` never reaches in-process harnesse |
+| 101 | 46 | medium | P2 | P2 | +60 | [#3369](https://github.com/omnigent-ai/omnigent/issues/3369) Feature: a policy that fences a spawned type: agent worker read-only ( |
+| 102 | 46 | medium | P2 | P2 | +66 | [#3254](https://github.com/omnigent-ai/omnigent/issues/3254) Sub-agent silently stalls after repeated context compactions during re |
+| 103 | 46 | medium | P2 | P2 | +82 | [#3069](https://github.com/omnigent-ai/omnigent/issues/3069) Harness install surfaces opaque failure reasons (npm stderr not captur |
+| 104 | 46 | medium | P2 | P2 | +87 | [#2984](https://github.com/omnigent-ai/omnigent/issues/2984) [Bug] Codex incorrectly reports `needs-auth` with an authenticated cus |
+| 105 | 46 | medium | P3 | P2 ⚑ | +233 | [#2853](https://github.com/omnigent-ai/omnigent/issues/2853) [Bug] Native harnesses silently drop the agent spec `prompt:` at runti |
+| 106 | 46 | medium | P2 | P2 | +94 | [#2815](https://github.com/omnigent-ai/omnigent/issues/2815) [Feature] Distinguish human waits from machine-liveness deadlines |
+| 107 | 46 | medium | P2 | P2 | +100 | [#2719](https://github.com/omnigent-ai/omnigent/issues/2719) [Bug] |
+| 108 | 46 | medium | P2 | P2 | +103 | [#2644](https://github.com/omnigent-ai/omnigent/issues/2644) Design discussion: deterministic verification gates (a PASS/FAIL quali |
+| 109 | 46 | medium | P1 | P2 ⚑ | -17 | [#2184](https://github.com/omnigent-ai/omnigent/issues/2184) [Bug] Codex plugin skills are exposed with inconsistent names (`plugin |
+| 110 | 46 | medium | P1 | P2 ⚑ | -17 | [#2071](https://github.com/omnigent-ai/omnigent/issues/2071) [Bug] web_search never advertised to claude-sdk sessions: unprefixed m |
+| 111 | 46 | medium | P2 | P2 | +124 | [#2062](https://github.com/omnigent-ai/omnigent/issues/2062) [Bug] claude-native: per-session model override silently lost when wra |
+| 112 | 46 | medium | P1 | P2 ⚑ | -5 | [#1831](https://github.com/omnigent-ai/omnigent/issues/1831) claude-native workers ignore executor.model pin and per-dispatch args. |
+| 113 | 46 | medium | P2 | P2 | +141 | [#1789](https://github.com/omnigent-ai/omnigent/issues/1789) Feature: Canvas — agent-authored artifact panel (#2) |
+| 114 | 46 | medium | P1 | P2 ⚑ | -4 | [#1781](https://github.com/omnigent-ai/omnigent/issues/1781) codex harness: ambient DATABRICKS_BEARER/DATABRICKS_TOKEN overrides pr |
+| 115 | 46 | medium | P2 | P2 | +154 | [#1594](https://github.com/omnigent-ai/omnigent/issues/1594) Server-side idempotency for external_conversation_item (safe dedup on  |
+| 116 | 46 | medium | P2 | P2 | +165 | [#1230](https://github.com/omnigent-ai/omnigent/issues/1230) [Feature] Migrate remaining native forwarders to the shared post_sessi |
+| 117 | 46 | medium | P1 | P2 ⚑ | +2 | [#1128](https://github.com/omnigent-ai/omnigent/issues/1128) [Bug] Claude SDK Appears to Use Opus Instead of Selected Model |
+| 118 | 46 | medium | P2 | P2 | +199 | [#548](https://github.com/omnigent-ai/omnigent/issues/548) Recommend missing dependency install suggestions more gracefully in UI |
+| 119 | 46 | medium | P1 | P2 ⚑ | +11 | [#241](https://github.com/omnigent-ai/omnigent/issues/241) pi harness: GPT and Gemini dispatches 404 on the Databricks ucode gate |
+| 120 | 46 | medium | P3 | P2 ⚑ | +227 | [#147](https://github.com/omnigent-ai/omnigent/issues/147) Tracking: gradual decomposition of monolith modules (cli.py 9.1KLOC, c |
+| 121 | 46 | medium | P1 | P2 ⚑ | -1 | [#1113](https://github.com/omnigent-ai/omnigent/issues/1113) Native sub-agent/runner failures surface as bare "failed" with no reas |
+| 122 | 42 | medium | P2 | P2 | +16 | [#3969](https://github.com/omnigent-ai/omnigent/issues/3969) Databricks gateway sessions default to a stale model (opus-4-7) while  |
+| 123 | 42 | medium | P1 | P2 ⚑ | -105 | [#3790](https://github.com/omnigent-ai/omnigent/issues/3790) force_sandbox policy is evaluated but structurally unreachable from cl |
+| 124 | 42 | medium | P1 | P2 ⚑ | -84 | [#3236](https://github.com/omnigent-ai/omnigent/issues/3236) web_search: bare executor.model strings are inferred as provider 'open |
+| 125 | 42 | medium | P1 | P2 ⚑ | -61 | [#2630](https://github.com/omnigent-ai/omnigent/issues/2630) Tool-spawn failure is swallowed — agent answers from training knowledg |
+| 126 | 42 | medium | P2 | P2 | +132 | [#1724](https://github.com/omnigent-ai/omnigent/issues/1724) codex-native harness times out on WSL2 ("Codex TUI never started a thr |
+| 127 | 42 | medium | P1 | P2 ⚑ | -12 | [#1533](https://github.com/omnigent-ai/omnigent/issues/1533) Context-occupancy meter (context_tokens) freezes on failed turns — onl |
+| 128 | 42 | medium | P1 | P2 ⚑ | -70 | [#2904](https://github.com/omnigent-ai/omnigent/issues/2904) [Bug] claude-native: web-UI chat input fails with "tmux command failed |
+| 129 | 42 | medium | P2 | P2 | +65 | [#2880](https://github.com/omnigent-ai/omnigent/issues/2880) [Feature] Add in-session revert mechanism for all interfaces  |
+| 130 | 42 | medium | P1 | P2 ⚑ | -69 | [#2812](https://github.com/omnigent-ai/omnigent/issues/2812) [Bug] serve-mcp stops answering stdio requests during a slow tool call |
+| 131 | 42 | medium | P1 | P2 ⚑ | -50 | [#2397](https://github.com/omnigent-ai/omnigent/issues/2397) [Bug] Codex-native intelligent routing ignores live effort capabilitie |
+| 132 | 42 | medium | P1 | P2 ⚑ | -45 | [#2272](https://github.com/omnigent-ai/omnigent/issues/2272) [Bug] Codex runner can't find OpenRouter secret that exists in keyring |
+| 133 | 42 | medium | P2 | P2 | +171 | [#890](https://github.com/omnigent-ai/omnigent/issues/890) [Bug] omnigent setup fails with npm EACCES when installing the Claude  |
+| 134 | 42 | medium | P1 | P2 ⚑ | -9 | [#668](https://github.com/omnigent-ai/omnigent/issues/668) [Bug] BUG？omni claude times out (60s) on macOS with native Claude Code |
+| 135 | 40 | medium | P1 | P2 ⚑ | -93 | [#3101](https://github.com/omnigent-ai/omnigent/issues/3101) Docker/Kubernetes entrypoint never wires project_store — first-class P |
+| 136 | 39 | medium | P1 | P2 ⚑ | -23 | [#1551](https://github.com/omnigent-ai/omnigent/issues/1551) opencode-native: blocking question tool not surfaced to web (no elicit |
+| 137 | 38 | medium | P2 | P2 | +2 | [#3950](https://github.com/omnigent-ai/omnigent/issues/3950) An agent switch keeps the previous agent's comment-tool relay |
+| 138 | 38 | medium | P1 | P2 ⚑ | -122 | [#3852](https://github.com/omnigent-ai/omnigent/issues/3852) [Bug] Built-in write policies miss Claude Code's `MultiEdit` / `Notebo |
+| 139 | 38 | medium | P1 | P2 ⚑ | -113 | [#3530](https://github.com/omnigent-ai/omnigent/issues/3530) [Bug] An agent spec's `instructions:` has no effect on 13 of 24 harnes |
+| 140 | 38 | medium | P1 | P2 ⚑ | -113 | [#3525](https://github.com/omnigent-ai/omnigent/issues/3525) Sub-agent sessions are launched from the parent agent's bundle root, e |
+| 141 | 38 | medium | P2 | P2 | +83 | [#2369](https://github.com/omnigent-ai/omnigent/issues/2369) [Bug] pi harness only lists databricks-claude-sonnet-4-6 |
+| 142 | 38 | medium | P1 | P2 ⚑ | -56 | [#2299](https://github.com/omnigent-ai/omnigent/issues/2299) [Bug] claude-native resume transcripts flatten tool_result image block |
+| 143 | 38 | medium | P2 | P2 | +78 | [#2390](https://github.com/omnigent-ai/omnigent/issues/2390) Builtin policy for per-user sub-agent access control (subagent_access_ |
+| 144 | 38 | medium | P1 | P2 ⚑ | -35 | [#1794](https://github.com/omnigent-ai/omnigent/issues/1794) Bundled Polly: claude-sdk brain "Not logged in" + runaway spawn loop o |
+| 145 | 38 | medium | P1 | P2 ⚑ | -34 | [#1694](https://github.com/omnigent-ai/omnigent/issues/1694) Reliability: parallel code-fix missions fail silently (5s tmux timeout |
+| 146 | 38 | medium | P2 | P2 | +182 | [#152](https://github.com/omnigent-ai/omnigent/issues/152) Harness availability is reported from binary presence, not from config |
+| 147 | 36 | medium | P2 | P2 | -13 | [#4009](https://github.com/omnigent-ai/omnigent/issues/4009) [Feature] No Go client for the session API, so every Go caller hand-ro |
+| 148 | 36 | medium | P1 | P2 ⚑ | -135 | [#3898](https://github.com/omnigent-ai/omnigent/issues/3898) [Bug] Pack function policies fail server-side input evaluation unless  |
+| 149 | 36 | medium | P1 | P2 ⚑ | -135 | [#3870](https://github.com/omnigent-ai/omnigent/issues/3870) child-session creation returns 500 internal_error, breaking Polly/Debb |
+| 150 | 36 | medium | P2 | P2 | -8 | [#3864](https://github.com/omnigent-ai/omnigent/issues/3864) [Bug] to_api_dict() drops ConversationItem.created_at, so flat items A |
+| 151 | 36 | medium | P1 | P2 ⚑ | -136 | [#3863](https://github.com/omnigent-ai/omnigent/issues/3863) [Bug] Databricks Apps entrypoint never wires project_store — Projects  |
+| 152 | 36 | medium | P2 | P2 | 0 | [#3563](https://github.com/omnigent-ai/omnigent/issues/3563) [Bug] Host-bound resume into a deleted workspace: host computes the ex |
+| 153 | 36 | medium | P2 | P2 | +2 | [#3550](https://github.com/omnigent-ai/omnigent/issues/3550) [Bug] Missing signing alg's prevent using some OIDC providers |
+| 154 | 36 | medium | P2 | P2 | +6 | [#3435](https://github.com/omnigent-ai/omnigent/issues/3435) [Feature] Admin server-wide usage report (per-user and per-model cost) |
+| 155 | 36 | medium | P2 | P2 | +7 | [#3368](https://github.com/omnigent-ai/omnigent/issues/3368) Feature: first-class async write-safety (freeze → approve → apply) pri |
+| 156 | 36 | medium | P2 | P2 | +9 | [#3352](https://github.com/omnigent-ai/omnigent/issues/3352) [Feature] OpenClaw onboarding — Option B: chat import (SQLite session  |
+| 157 | 36 | medium | P2 | P2 | +13 | [#3247](https://github.com/omnigent-ai/omnigent/issues/3247) credential_proxy: re-resolve the source on 401 / expiry (short-lived t |
+| 158 | 36 | medium | P1 | P2 ⚑ | -98 | [#2854](https://github.com/omnigent-ai/omnigent/issues/2854) [Bug] Cross-harness `harness_override` is ignored on the `initial_item |
+| 159 | 36 | medium | P2 | P2 | +37 | [#2851](https://github.com/omnigent-ai/omnigent/issues/2851) Policy-supplied targets for ASK approval cards |
+| 160 | 36 | medium | P2 | P2 | +42 | [#2756](https://github.com/omnigent-ai/omnigent/issues/2756) Expose atomic session-event admission to integrations |
+| 161 | 36 | medium | P2 | P2 | +51 | [#2577](https://github.com/omnigent-ai/omnigent/issues/2577) [Feature] Manage OIDC/SSO admins from an id_token claim (IdP group/rol |
+| 162 | 36 | medium | P1 | P2 ⚑ | -92 | [#2539](https://github.com/omnigent-ai/omnigent/issues/2539) Named sys_session_send returns 404 after first child from a bundled se |
+| 163 | 36 | medium | P1 | P2 ⚑ | -92 | [#2524](https://github.com/omnigent-ai/omnigent/issues/2524) [Bug] Registering remote host fails |
+| 164 | 36 | medium | P1 | P2 ⚑ | -91 | [#2444](https://github.com/omnigent-ai/omnigent/issues/2444) Accounts JWT expiry falls through to Databricks auth and breaks persis |
+| 165 | 36 | medium | P2 | P2 | +55 | [#2404](https://github.com/omnigent-ai/omnigent/issues/2404) fix(runtime): orphan sweep can abort startup on unreadable shared-host |
+| 166 | 36 | medium | P2 | P2 | +56 | [#2374](https://github.com/omnigent-ai/omnigent/issues/2374) Proposal: per-turn context_providers to augment system instructions at |
+| 167 | 36 | medium | P1 | P2 ⚑ | -82 | [#2304](https://github.com/omnigent-ai/omnigent/issues/2304) Runner subprocess inherits host daemon cwd, causing os_env cwd resolut |
+| 168 | 36 | medium | P2 | P2 | +66 | [#2070](https://github.com/omnigent-ai/omnigent/issues/2070) [Feature] sys_os_* file tools are hard-confined to the session workspa |
+| 169 | 36 | medium | P2 | P2 | +83 | [#1816](https://github.com/omnigent-ai/omnigent/issues/1816) `omni run <agent.yaml> --harness opencode` rejects the agent bundle (T |
+| 170 | 36 | medium | P2 | P2 | +101 | [#1526](https://github.com/omnigent-ai/omnigent/issues/1526) Refactor: incrementally decompose the 4 god-files (sessions.py, runner |
+| 171 | 36 | medium | P2 | P2 | +103 | [#1411](https://github.com/omnigent-ai/omnigent/issues/1411) Standalone reusable MCP servers: CRUD + connection verify (list tools) |
+| 172 | 36 | medium | P1 | P2 ⚑ | -55 | [#1158](https://github.com/omnigent-ai/omnigent/issues/1158) [Bug] antigravity-native: TUI-typed turns never mirror to the web UI ( |
+| 173 | 36 | medium | P2 | P2 | +112 | [#1157](https://github.com/omnigent-ai/omnigent/issues/1157) [Bug] antigravity-native: no Chat/Terminal toggle — terminal_antigravi |
+| 174 | 36 | medium | P2 | P2 | +116 | [#1075](https://github.com/omnigent-ai/omnigent/issues/1075) [Feature] Support AWS Lambda / Firecracker microVMs as managed sandbox |
+| 175 | 36 | medium | P2 | P2 | +117 | [#1055](https://github.com/omnigent-ai/omnigent/issues/1055) [Test] End-to-end OTel test against a real collector to lock in the BY |
+| 176 | 36 | medium | P2 | P2 | +117 | [#1054](https://github.com/omnigent-ai/omnigent/issues/1054) [Feature] Record gen_ai.retry events on llm_call spans |
+| 177 | 36 | medium | P2 | P2 | +120 | [#1031](https://github.com/omnigent-ai/omnigent/issues/1031) [Feature] Support serving the standalone Web UI under a subpath, e.g.  |
+| 178 | 36 | medium | P2 | P2 | +122 | [#983](https://github.com/omnigent-ai/omnigent/issues/983) Session sharing ergonomics: `sys_session_share` agent tool + `omnigent |
+| 179 | 36 | medium | P2 | P2 | +129 | [#857](https://github.com/omnigent-ai/omnigent/issues/857) [Proposal] Usage-limit detection + on-429 failover across pooled provi |
+| 180 | 36 | medium | P1 | P2 ⚑ | -56 | [#765](https://github.com/omnigent-ai/omnigent/issues/765) Support interactive mid-flight policy ASK (TOOL_CALL/TOOL_RESULT/OUTPU |
+| 181 | 36 | medium | P1 | P2 ⚑ | -52 | [#522](https://github.com/omnigent-ai/omnigent/issues/522) Implement async-tool completion auto-delivery (SESSION_REARCHITECTURE  |
+| 182 | 36 | medium | P2 | P2 | +136 | [#509](https://github.com/omnigent-ai/omnigent/issues/509) [Feature] Default new-session workspace from selected agent's cwd |
+| 183 | 36 | medium | P2 | P2 | +140 | [#382](https://github.com/omnigent-ai/omnigent/issues/382) Evaluating the same agent across harnesses: no built-in way to compare |
+| 184 | 36 | feature | P2 | P2 | +57 | [#2003](https://github.com/omnigent-ai/omnigent/issues/2003) [Feature] Pluggable terminal multiplexer backend (tmux / herdr / zelli |
+| 185 | 36 | feature | P2 | P2 | +128 | [#692](https://github.com/omnigent-ai/omnigent/issues/692) Polly: fan out sub-agent work across multiple concurrent claude profil |
+| 186 | 36 | feature | P2 | P2 | +141 | [#197](https://github.com/omnigent-ai/omnigent/issues/197) Declarative skill sources: pull Claude Code skills + their dependency  |
+| 187 | 35 | medium | P1 | P2 ⚑ | -124 | [#2702](https://github.com/omnigent-ai/omnigent/issues/2702) Native idle-detection fork+exec's tmux capture-pane at 5 Hz per termin |
+| 188 | 35 | medium | P2 | P2 | +49 | [#2055](https://github.com/omnigent-ai/omnigent/issues/2055) [Bug] codex-native harness elicitation: a resolve landing in the betwe |
+| 189 | 35 | medium | P1 | P2 ⚑ | -145 | [#3076](https://github.com/omnigent-ai/omnigent/issues/3076) [Bug] claude-sdk omits ToolSearch, eagerly loading every MCP schema |
+| 190 | 35 | medium | P3 | P2 ⚑ | +149 | [#2800](https://github.com/omnigent-ai/omnigent/issues/2800) [Bug] Top-level custom codex-native agents drop reasoning effort and y |
+| 191 | 35 | medium | P1 | P2 ⚑ | -68 | [#880](https://github.com/omnigent-ai/omnigent/issues/880) [BUG] Native harness (omnigent claude): assistant turns not streamed t |
+| 192 | 34 | medium | P1 | P2 ⚑ | -114 | [#2429](https://github.com/omnigent-ai/omnigent/issues/2429) Server (python -m omnigent.cli server) CPU-spins indefinitely with no  |
+| 193 | 33 | feature | P2 | P2 | +32 | [#2303](https://github.com/omnigent-ai/omnigent/issues/2303) [Feature] Support multi-repo workspaces (nested Git repos or multiple  |
+| 194 | 33 | medium | P1 | P2 ⚑ | -188 | [#3981](https://github.com/omnigent-ai/omnigent/issues/3981) [Bug] Desktop: Workspace rail resize is unusable on the Browser tab; a |
+| 195 | 33 | medium | P2 | P2 | -52 | [#3861](https://github.com/omnigent-ai/omnigent/issues/3861) [Bug] omni host status renders URLs so terminals link the whole status |
+| 196 | 33 | medium | P2 | P2 | -43 | [#3561](https://github.com/omnigent-ai/omnigent/issues/3561) [Bug] `prompt_policy` never sends `_CLASSIFIER_SCHEMA` to the LLM — st |
+| 197 | 33 | medium | none | P2 | +156 | [#3402](https://github.com/omnigent-ai/omnigent/issues/3402) [Bug] Label seeding and session-state writes race under concurrent upd |
+| 198 | 33 | medium | P2 | P2 | -22 | [#3219](https://github.com/omnigent-ai/omnigent/issues/3219) [Bug] Cmd/Ctrl+Up/Down session traversal stops in an empty focused com |
+| 199 | 33 | medium | P2 | P2 | -7 | [#2921](https://github.com/omnigent-ai/omnigent/issues/2921) Font settings: selected font (incl. Nerd Fonts) never loads — no webfo |
+| 200 | 33 | medium | P2 | P2 | -2 | [#2848](https://github.com/omnigent-ai/omnigent/issues/2848) Server logs an expected offline-runner resource 503 as ERROR + full tr |

--- a/designs/prioritization/issue-prioritization-v2.md
+++ b/designs/prioritization/issue-prioritization-v2.md
@@ -10,7 +10,9 @@ hits, and it doesn't move over time. This proposal keeps the working
 priority rubric (severity graded across all buckets, for FRs too), independent
 scoring axes (severity × reach × harness-tier × readiness + demand, with
 duplicate count as a reach signal), a maintainer-facing ranked view, and
-re-gradable severity as the mechanism to nudge ranking over time.
+re-gradable severity as the mechanism to nudge ranking over time. Because
+priority is now a *computed* label, a firm rule runs through the whole design:
+**a human-set priority always wins — no bot job overwrites it.**
 
 This is an evolution of, not a replacement for,
 [issue-triage-proposal.md](../issue-triage-proposal.md). The intake, the
@@ -194,7 +196,9 @@ no second rubric to keep in sync. It runs in two situations:
 1. **One-time backfill.** Re-run the classifier over the existing open issues
    once, so the backlog reflects the new rubric on day one. This is a labels-only
    pass — same tool-less classifier, same trusted label-application steps as
-   [Stage 2 triage](../issue-triage-proposal.md); nothing new to build.
+   [Stage 2 triage](../issue-triage-proposal.md); nothing new to build. It sets
+   priority only where none exists or where the bot set the prior value, honoring
+   the human-override guard below.
 2. **Ongoing, on demand.** A maintainer who disagrees just changes the label
    (P2 → P1, or the reverse). That *is* the bump mechanism — no separate pin
    lever (see "Ongoing adjustment"). The scheduled re-score reads the updated
@@ -427,6 +431,41 @@ just **re-grading severity** — the same field the classifier already sets:
    #2125) is upstream — grade severity honestly (Axis 2); the score reads
    severity, so fixing severity fixes the order.
 
+#### Human priority always wins — the bot must not overwrite it
+
+Now that priority is a *computed* label, any job that writes it (the one-time
+backfill, the weekly re-score) could clobber a maintainer's deliberate
+`P0 → P2` or `P3 → P1`. That must never happen. The rule:
+
+> **A bot-written priority is a default; a human-written priority is a
+> decision. The bot only ever sets priority on an issue it hasn't set before,
+> and never overwrites a value a human changed.**
+
+Concretely, on top of today's `on: [opened]` triage (which already never
+re-fires on edits), the re-score/backfill jobs must:
+
+- **Detect the human edit.** An issue is "human-owned" for priority if its
+  current `P*` label differs from what the bot last wrote. The cheapest durable
+  record is a hidden marker the bot leaves when it labels — e.g. a
+  `bot-priority:P2` shadow label (or a one-line machine-readable note in a
+  pinned tracking comment). If `current P* != bot-priority:*`, a human moved it
+  → **skip**. (GitHub's issue-events API also records who set a label and
+  whether the actor is the bot, as a fallback signal.)
+- **Only fill, never replace.** If an issue has *no* priority label, the job may
+  set one. If it already has one the bot itself last wrote, the job may update
+  it (the grade legitimately changed). If a human wrote it, the job leaves the
+  label alone and may at most *surface disagreement* — e.g. list "human P2, bot
+  would say P0" in the ranked view for a maintainer to reconsider, without
+  touching the label.
+- **Re-score reads, doesn't write, human-owned rows.** The weekly ranked view
+  sorts by the computed score for visibility, but the *authoritative label* on a
+  human-owned issue is the human's. The score can still order it in the list;
+  it just can't relabel it.
+
+This keeps the automation as a labor-saver, not an authority: the bot triages
+the long tail, humans override the ones that matter, and the override sticks
+across every subsequent re-score.
+
 #### Maintainer guide — hand-correcting the ranking
 
 The goal is a ranking good enough that **hand-correction is the exception, not
@@ -434,9 +473,10 @@ the process** — a working target is **≤10% of issues touched**. If you're
 correcting more than that, the fix isn't more editing, it's tuning the prompt or
 weights (below). Two properties make correction cheap and safe:
 
-- **Corrections are sticky.** Triage runs `on: issues [opened]` only — it never
-  re-fires on edits, so a label you change by hand is never overwritten by the
-  bot. (The weekly re-score only *reads* labels; it doesn't re-grade.)
+- **Corrections are sticky.** Two layers guarantee this: initial triage runs
+  `on: issues [opened]` only (never re-fires on edits), and the re-score/backfill
+  jobs honor the human-override guard above — a priority a human changed is never
+  overwritten, only surfaced as disagreement if the bot would grade it otherwise.
 - **One knob.** You change the **priority label** (the field the classifier
   emits). The score is a pure function of it plus mechanical factors — no
   separate override to learn.
@@ -591,11 +631,13 @@ Two concrete changes:
    Auth-type dropdowns.
 4. **Scoring job** — productionize `score_prototype.py` into a scheduled action
    that reads LLM-graded severity + readiness + dup count and publishes the
-   ranked view.
+   ranked view. **Must implement the human-override guard** (write a
+   `bot-priority:*` shadow label; skip any issue whose `P*` a human changed).
 5. **One-time backfill (regrade)** — re-run the classifier over open issues to
    relabel under the new rubric (see "How regrading works"); preview with
-   `score_prototype.py --regrade`. Target: P1 back under ~20% of open bugs
-   (regex preview lands it at 22%; the LLM pass should do better).
+   `score_prototype.py --regrade`. Sets priority only where none exists or the
+   bot set the prior value — never over a human edit. Target: P1 back under ~20%
+   of open bugs (regex preview lands it at 22%; the LLM pass should do better).
 6. **Consume dedup output** — once [#4037](https://github.com/omnigent-ai/omnigent/pull/4037)
    lands, feed duplicate count into `dup_reach`; wire the unused `good first
    issue` funnel.

--- a/designs/prioritization/issue-prioritization-v2.md
+++ b/designs/prioritization/issue-prioritization-v2.md
@@ -2,35 +2,36 @@
 
 ## Goal
 
-Make the open-issue queue **orderable by real severity**, not by a label that
-has lost its meaning. Today priority is a single collapsed axis (P1 vs P2 as a
-de-facto binary); it neither reflects how bad an issue is nor how many users it
-hits, and it doesn't move over time. This proposal keeps the working
-[triage pipeline](../issue-triage-proposal.md) and adds: a re-calibrated
-priority rubric (severity graded across all buckets, for FRs too), independent
-scoring axes (severity × reach × component-weight × readiness + demand, with
-duplicate count as a reach signal), a maintainer-facing ranked view, and
-re-gradable severity as the mechanism to nudge ranking over time. Because
-priority is now a *computed* label, a firm rule runs through the whole design:
-**a human-set priority always wins — no bot job overwrites it.**
+Currently priorities used in issues are too coarse and sometimes misleading.
+  - Bugs are sorted into P0, P1, P2, P3.
+  - FRs are always P2.
+  - Categories are broad.
+  - Sorting by priority doesn't give a meaningful list when almost everything are P1 and P2.
 
-This is an evolution of, not a replacement for,
-[issue-triage-proposal.md](../issue-triage-proposal.md). The intake, the
-tool-less classifier, and the trusted-step label application all stay.
+We want better prioritization scheme. This is an attempt to come up with a subjectively better
+scheme. It has automations part, a heuristic scoring rule, and it allows users to intervene.
+
+This can be viewed as an important of the existing [triage pipeline](../issue-triage-proposal.md)
+where we add:
+  - More categories and sub-categories,
+  - Separate severities from priorities (one is used for LLM scoring, another is used as final
+    label.),
+  - Add some details for sorting guideline and expose heuristic scores,
+  - Also mention manual intervention.
+
+
+This document only applies to community issues. Issues created by maintainer will be handled
+separately since they are mostly backlogs or require coordination.
 
 ---
 
 ## Evidence: what the data says (snapshot Aug 2026)
 
-725 issues (360 open / 365 closed), PRs excluded. The triage *pipeline* works —
-only 7 open issues are un-triaged, `needs-triage` is effectively empty. The
-problems are all in the *taxonomy and prioritization*, not the plumbing.
+We currently have: 725 issues (360 open / 365 closed).
 
-**1. Type split is clean — leave it alone.** 0 open issues carry both `Bug` and
-`enhancement`; the template auto-labels and the classifier confirms. This axis
-is healthy.
+**1. Issues are splited into `Bug` and `enhancement` (FRs).** This is good, we keep it as-is.
 
-**2. Priority has collapsed into a P1/P2 binary.**
+**2. Most issues are P1 / P2.**
 
 | Priority | Open | Closed | Median days-to-close | Median age (open) |
 |---|---|---|---|---|
@@ -39,366 +40,155 @@ is healthy.
 | **P2-medium** | **204** | 149 | 3.8d | 28.1d |
 | P3-low | 16 | 19 | 3.4d | 30.8d |
 
-- **125 of 207 open *bugs* (60%) are P1-high** (128 open P1 in total, incl. 3
-  non-bugs). "Major feature broken, no workaround" cannot describe 60% of bugs
-  — P1 is inflated to the point of being noise.
-- **P0 (3) and P3 (16) are vestigial.** Four buckets, two used.
-- **Open-issue age is flat across priorities** (P1 20.6d ≈ P2 28d ≈ P3 30d).
-  If P1 were respected as urgent, P1 age would be far lower than P2. It isn't:
-  priority is *not* pulling issues to the front. Close-time looks fine only
-  because the team turns the whole backlog over in days when it engages —
-  attention/recency orders the queue today, not priority.
+- **125 (60%) are P1**. This is too bloat and making P1 less important.
+- **P0 and P3 are only 19 issues combined**. These two are underused, especially P3.
+- **Open-issue age is flat.** Median days-to-close are 20.6d for P1 and 28.1d for P2.
 
-**3. Severity is orthogonal to the type-default — and the current label hides
-it.** Feature requests default to P2 by rule, so a high-value capability gap is
-indistinguishable from a trivial nice-to-have. Grounding example
-([#2125](https://github.com/omnigent-ai/omnigent/issues/2125), multi-host git
-credentials): a real self-hoster blocker, labeled `P2-medium` purely because
-it's an FR. There is no way today for it to outrank a weak P1.
+This reflects indifference between P1 and P2. To distinguish them, we have to re-prioritize so that
+we have less P1. Aim (magic number) is 25%.
 
-**4. `comp:harnesses` is a mega-bucket.** 148 of 360 open (41%). The next
-components are `comp:server` (135), `comp:runner` (109), `comp:web-ui` (99).
-`areas.json` *already* models per-harness areas (`harness-claude`,
-`harness-codex`, …) but they all collapse to the single `comp:harnesses` label,
-so routing knows the sub-area while the label throws it away. Within harnesses,
-title mentions skew hard to **claude (32) and codex (24)**, then kimi /
-antigravity / openai (~6 each) — a natural tier boundary.
+**Propose:** the final shape should have ~ 25% P1 to distinguish itself from P2. When everything is
+P1, nothing is P1. 
 
-**5. Contributor funnel is unused; dedup is now landing.** `good first issue`
-is on **0** open issues. Dedup was previously latent (only 5 ever closed as
-duplicate), but the dedup labeler in
-[#4037](https://github.com/omnigent-ai/omnigent/pull/4037) is putting it in
-place — link + label, closure gated off by default. That changes the plan: we
-should **use duplicate *count* as a scoring signal** (N confirmed dupes = N
-reporters hit it = bigger blast radius), not auto-close — see Axis 5.
+**3. Priority is meaningful only to bugs today.** FRs are P2, so at first glance, all FRs are
+treated equally. For example, ([#2125](https://github.com/omnigent-ai/omnigent/issues/2125), multi-host git
+credentials): a real self-hoster blocker, labeled `P2-medium` purely because it's an FR.
+There is no way today for it to outrank a weak P1.
 
-**6. Most issues are dogfood, by the MAINTAINER file.** Of 360 open issues,
-**36 are authored by a name in `.github/MAINTAINER`** → 324 "community." (The
-`author_association` field is a poor proxy: it marks 4 as MEMBER that aren't
-maintainers, so we key off the MAINTAINER file, which the triage pipeline
-already reads.) Even the 324 read like insider reports ("antigravity-native:
-TUI-typed turns never mirror"). Reactions are sparse — only **25 of 360** open
-issues have any 👍. Implication: **severity must lead the score; external
-demand is at most a tiebreak**, or the queue will look empty of signal.
+**Propose:** Let's have priorities for FRs too. Since we might filter by `bug`/`enhancement` anyway,
+this doesn't takeaway anything mentally.
+
+**4. Buckets are too coarse.** 148 (41%) are `comp:harness`, 135 are `comp:server`, 109 are
+`comp:runner`, etc. 
+
+**Propose:** Let's have more fine-grained buckets. The benefit are two-fold; 1) it gives us a
+better set of keys to filter on, 2) these keys can be feeded into the scoring function, so we have a
+way to tune more important components. For harnesses specifically, we should make sure to
+have tier-based labels. That will help with prioritization.
+
+
+**5. Community inputs should be taken into account.** For example, if multiple issues are filed for
+the same underlying issue, it is a sign that this issue is widespread. We plan to have automation to
+link duplicates and similar issues. So those can be used for clustering and bumping scores. Factors
+such as number of unique users contributed to issues and likes may also be considered.
+
 
 ---
 
 ## Design
 
-### Axis 1 — Type (unchanged)
+We have the following mental model:
+  1. Issues --> LLM + guideline --> Severity (low / medium / high / critical),
+  2. Severity + metadata --> Score (heuristics, mixed between LLM and hand-tuned weights),
+  3. Score --> Priority (deterministic),
+  4. Priority can be re-adjusted by maintainers.
 
-`bug` / `enhancement` / `documentation`. Clean today; no change.
+The core of this is still non-deterministic by nature. But it should give a reasoning as to why we
+might prioritize one issue over another. Number scores give a total ordering. If one want to use
+priorities, then it is also available as a group of scores (100+ = P0, 60+ = P1, 25+ = P2,
+everything else P3.)
 
-### Axis 2 — Re-calibrated priority rubric
+To make the adjustment scope narrows, we will try to adjust only weights of factors.
 
-**Three layers, one flow (resolving the priority-vs-score discussion).** These
-are distinct and it's worth being precise:
+**Do not read too hard into it. This requires tuning over-time and can always be adjusted, but it
+gives something to start with.** 
 
-1. **Severity** — a graded property of the issue, a function of the axes below
-   (type, blast radius, component weight, …). Scored `low / medium / high /
-   critical = 10 / 30 / 60 / 100`.
-2. **Score** — severity combined with the mechanical multipliers (reach,
-   component weight, readiness, dup, demand). This is the **continuous
-   ordering** — it sorts issues *within and across* priority labels, so two
-   issues that share a label aren't stuck equal.
-3. **Priority label (the outcome)** — the human-facing bucket the score lands
-   in, **by fixed score thresholds** (below). This is what maintainers **sort,
-   filter, and action on**; the score is the *reference for why* an issue got
-   that label. The label is derived from the score, not hand-assigned by type.
+### Axis 1 - Type (unchanged)
 
-**Score → priority label.** One derivation, no parallel rubric: the label is
-just which band the final score falls in. The cut-points sit at the severity
-band values, so a *multiplier* (tier / reach / dup / readiness / demand) is what
-lets an issue cross **up** a band:
+`bug` / `enhancement` / `documentation`.
 
-| Score | Priority | Reading |
-|---|---|---|
-| **≥ 100** | **P0-critical** | a critical-severity issue, or one pushed there by reach/tier |
-| **≥ 60** | **P1-high** | high severity, or a medium boosted by a tier-1 harness / broad reach |
-| **≥ 25** | **P2-medium** | ordinary graded work |
-| **< 25** | **P3-low** | minor / narrow |
+### Axis 2 - Severity (new; done by LLMs)
 
-Example: a "high" bug (severity 60) in a weight-1.4 area scores 60 × 1.4 = 84 →
-clears **P1**; the same bug in a weight-0.9 area scores 60 × 0.9 = 54 → stays
-**P2**. The component weight moved the label. (Thresholds are tunable constants —
-`P0_MIN`/`P1_MIN`/`P2_MIN` in `score_prototype.py`; with the unified component
-weight the snapshot gives P0 15 / P1 68 / P2 208 / P3 69, a 27% P1-bug share —
-see the note under the backfill preview.)
+LLM should judge issues by contents and give grades. Grades can be:
+  - Bugs:
+    - **S0**: Should be fixed ASAP, today if possible. This can be widespread real bugs or some
+      serious security bugs,
+    - **S1**: Real bug affecting one or few narrow real use cases; no easy mitigation,
+    - **S2**: Real bug, with easy mitigation,
+    - **S3**: Not sure if it is real or not.
 
-*One consequence worth naming:* because the label comes from the full score,
-non-severity signals **can** tip it — a heavily-reacted FR or a much-duplicated
-bug can cross into P1. That's intended (demand/blast-radius are legitimate
-priority inputs), but it's bounded: demand is capped (Community demand) and a
-single FR can't reach P0 on reactions alone.
+  - Feature Requests:
+    - **S0**: Blocking (potentially) a lot of users from onboarding Omnigent,
+    - **S1**: Must have soon / on our roadmap / will unblock a certain set of users,
+    - **S2**: Nice to have, but won't matter in terms of functionality,
+    - **S3**: Unclear if it's good or not or a very nit papercut.
 
-So: axes → severity → score → priority label. The score exists precisely because
-a label alone can't order issues that share it (Serena/Pat: "two issues of the
-same label are not equally important"); the label exists because people action
-on buckets, not on a float.
+This grade, together with other metadata, will produce scores.
+Issues will be graded once filed. They can be regraded on changes, but regrading will be done
+semi-manually (comments/labels added).
 
-Priority stays a 4-bucket label but gets a **rubric that forces separation**,
-enforced in the classifier prompt (`.github/triage/config.yaml`) and by a
-one-time backfill.
+The LLM prompt maybe tuned. Mentally, these are severities from LLM, so we will take it with a grain
+of salt, but should still give some directional opinions.
 
-| Priority | Definition (severity × reach — applies to bugs AND FRs) |
+Soft nudge (prompt, not a hard rule): a real claude / codex bug is rarely S3 —
+lean S1–S2. We don't force ≥ S1: the 1.4 component weight (Axis 3) already lifts
+their S0/S1 bugs to P0/P1, so a hard floor would double-count and re-inflate P1.
+
+
+### Axis 3 - Component weight
+
+Some components matter more than others. Each area in `areas.json` carries a
+`weight` (used by the scoring function) and a `weight_source` (metadata: how we
+picked it). Bands: **1.4 / 1.2 / 1.1 / 1.0 / 0.9**.
+
+- **Harness weights are telemetry** (`weight_source: telemetry`) — from *LJ
+  Sessions by Harness* (usage, last week), not issue counts. This is where
+  harness "tiering" lives. Subject to change as usage shifts.
+- **Non-harness weights are editorial** (`weight_source: editorial`) — no
+  per-component usage signal (every session hits the server), so maintainers set
+  these by judgment.
+
+**Combining:** an issue with multiple `comp:` labels takes the **max** weight
+(most-important area wins). Harness issues resolve to the specific harness area.
+
+| Component | Weight | Source | Why |
+|---|---|---|---|
+| `comp:harnesses` — claude, codex | 1.4 | telemetry | Top usage. |
+| `comp:harnesses` — cursor, antigravity, hermes, opencode, pi, copilot | 1.1 | telemetry | Mid usage. |
+| `comp:harnesses` — goose, kimi, kiro, qwen | 0.9 | telemetry | Less usage. |
+| `comp:harnesses` — inner, llms, tools (shared) | 1.1 | editorial | Underpins all harnesses. |
+| `comp:server` — server, host, db | 1.2 | editorial | Core path; failures block everything. |
+| `comp:runner` — runner, runtime, sandbox | 1.2 | editorial | Core execution path. |
+| `comp:server` — resources, sdks | 1.0 | editorial | Supporting. |
+| `comp:web-ui`, `comp:policies`, `comp:tui` | 1.0 | editorial | Mainline surfaces. |
+| `comp:repr`, `comp:infra`, tui/repl | 0.9 | editorial | Lower blast radius. |
+
+Open follow-up (review): confirm the harness bands (Pi/opencode) and the
+editorial weights in the team channel.
+
+#### More / finer labels
+
+Today's 8 `comp:` labels are coarse — a few are mega-buckets:
+
+| Label | Open |
 |---|---|
-| **P0-critical** | A concrete, named critical failure (list below), not a vague "bad." |
-| **P1-high** | High severity (bug: crash / hang / permanent breakage, no workaround. FR: a capability whose *absence* blocks a common workflow) **AND** broad reach (default config, all/most users, or a tier-1 harness). Not "a thing I care about." |
-| **P2-medium** | Real bug with a workaround, OR a substantive capability/feature with a moderate reach. |
-| **P3-low** | Genuinely minor: cosmetic, polish, trivial convenience, narrow nice-to-have — bug or FR. |
+| `comp:harnesses` | 148 |
+| `comp:server` | 135 |
+| `comp:runner` | 109 |
+| `comp:web-ui` | 99 |
+| `comp:tui` / `comp:infra` / `comp:policies` / `comp:repr` | 40 / 34 / 21 / 13 |
 
-**P0 is an explicit list, not a judgment call** (per review — even security
-issues have a severity range, so we enumerate rather than blanket-P0 anything
-"security"). An issue is P0 if it is any of:
+We add granularity two ways (both, deliberately):
 
-- **Cannot start / use the product** — server, host, web UI, app, or sessions
-  fail to start or are unusable for a common configuration.
-- **A critical API is broken** — an endpoint the web UI/app depends on (usefully
-  cross-checked against the harness/API benchmark) returns errors or wrong data.
-- **DB migration failure or data loss** — persistence corruption, a migration
-  that bricks existing data.
-- **Security escape** — a sandbox/policy *bypass* or credential-crossing that
-  lets an agent exceed its granted permissions (this is the one severity that
-  ignores reach — a one-user escape is still P0).
+- **New top-level `comp:` label** when a slice is something you'd *filter and
+  prioritize on* (e.g. `comp:sandbox` is security-grade).
+- **A `sub_area` tag** for the rest. `areas.json` already models sub-areas; the
+  classifier emits the matched one as a second-level tag — granularity without
+  minting a GH label per slice (the repo has no label-sync, so the label set
+  stays small).
 
-Grow the list as real P0s surface. Note we **don't run a hosted service**, so
-"all users down" is nearly hypothetical (only something like telemetry crashing
-on every client) — dropped from the definition in favor of the concrete cases
-above.
+**New labels to add:**
 
-**Tier-1 grading heuristic** (per review). Rather than a hard label floor that
-would override the score, this is guidance to the *grader*: a valid,
-reproducible bug in a **tier-1** harness should rarely be graded below `high`
-severity — a flagship harness failing is, by definition, a serious problem. That
-severity (60) × the tier-1 multiplier (1.4) = 84, which clears P1 through the
-normal score→label path. So the heuristic keeps flagship bugs out of P2 *without*
-a second rule: it just tells the grader not to under-call their severity. Tier
-2/3 bugs land P2/P3 unless severity/reach earn more.
+| New label | Carved from | Weight | Why |
+|---|---|---|---|
+| `comp:harness-t1/-t2/-t3` | `comp:harnesses` | 1.4 / 1.1 / 0.9 (telemetry) | Tier is the harness view of the weight; future-proof (add/re-tier = `areas.json` edit, not a new label). `sub_area` also tags SDK vs native. |
+| `comp:sandbox` | `comp:runner` | 1.1 (editorial) | ~29 issues, security-grade, home of P0 #3557. Inherits runner's 1.1; the *security* lift is in the P0 rubric (Axis 2), not the weight — so it isn't double-counted. |
+| `comp:mobile` | `comp:web-ui` | 1.0 (editorial) | ~23 issues; device sub-tags desktop / mobile-iOS / mobile-Android. Inherits web-ui's 1.0. |
+| `comp:auth` | `comp:server` | 1.1 (editorial) | Distinct surface; types local / multi-user / OIDC / OAuth / Databricks. Inherits server-core's 1.1 (a broken login blocks everything). |
 
-**FRs are graded, not defaulted.** The old prompt defaulted every FR to P2;
-that's the "all FRs are equal" trap. An FR gets P1 when its *absence* is a
-high-severity, broad-reach gap (e.g. [#16](https://github.com/omnigent-ai/omnigent/issues/16)
-native Windows — a whole platform can't run; [#2125](https://github.com/omnigent-ai/omnigent/issues/2125)
-multi-host git creds — blocks the common self-hoster setup), and P3 when it's a
-narrow nice-to-have. Bug-vs-FR is the *type* axis; it does not cap priority.
-(Practically, FR reach is still usually narrower than a crash's, so most FRs
-land P2/P3 — but by grading, not by rule.)
 
-Calibration guardrail added to the prompt: **"P1 is a scarcity signal. If more
-than ~20% of open bugs are P1, you are over-grading. A bug affecting one harness
-on one platform with a workaround is P2, not P1."**
 
-#### How regrading works
-
-Regrading assigns an issue's priority *label* by computing its score and
-applying the thresholds above — the same derivation used everywhere, so there's
-no second rubric to keep in sync. It runs in two situations:
-
-1. **One-time backfill.** Re-run the classifier over the existing open issues
-   once, so the backlog reflects the new rubric on day one. This is a labels-only
-   pass — same tool-less classifier, same trusted label-application steps as
-   [Stage 2 triage](../issue-triage-proposal.md); nothing new to build. It sets
-   priority only where none exists or where the bot set the prior value, honoring
-   the human-override guard below.
-2. **Ongoing, on demand.** A maintainer who disagrees just changes the label
-   (P2 → P1, or the reverse). That *is* the bump mechanism — no separate pin
-   lever (see "Ongoing adjustment"). The scheduled re-score reads the updated
-   label the next time it runs.
-
-The mapping is exactly the score → priority table above (`score ≥ 100 → P0`,
-`≥ 60 → P1`, `≥ 25 → P2`, else `P3`); nothing separate to define.
-
-**Backfill preview** (`score_prototype.py --regrade`, regex grader over the 360
-open issues — the production backfill uses the LLM grader):
-
-| Priority | Now | Regraded |
-|---|---|---|
-| P0-critical | 3 | 15 |
-| **P1-high** | **128** | **68** |
-| P2-medium | 203 | 208 |
-| P3-low | 15 | 69 |
-| (no priority) | 11 | 0 |
-
-**P1 share of open bugs: 60% → 27%** — the inflation drained and P3 fills out
-(score-thresholding sends genuinely-minor items to P3, where the old label
-distribution left it vestigial). Note 27% sits a bit above the ~20% target: the
-unified component weight lifts core-area (`comp:server`/`comp:runner`, 1.1) bugs
-that were flat 1.0 before, which is the intended effect — if we want a stricter
-P1, the lever is the tunable `P1_MIN` threshold, not re-flattening the weights.
-What moves, and why:
-
-| Change | Count | Example |
-|---|---|---|
-| P1 → P2 | 80 | #3981 desktop rail resize — medium severity, single-platform (score 33) |
-| P2 → P3 | 55 | #4027 "delete button on web UI" — narrow FR (score 22, below the P2 cut) |
-| P2 → P1 | 25 | #3976 headless OAuth2 grant — high-severity FR, broad reach |
-| P2 → P0 | 10 | #2125 multi-host git creds — credential-crossing, weight-1.4 area (score 161) |
-| P1 → P3 | 6 | #3980 desktop dialog paint-over — minor, single-platform (score 25) |
-
-*Caveat:* these moves use the regex grader, so read the **aggregate shape**
-(60% → 27%) as reliable and individual rows as illustrative — the regex's known
-false positives (see Dry-run) are what the LLM backfill corrects.
-
-### Axis 3 — Component weight (unified; was harness-only)
-
-Not all subsystems are equally important, and importance shouldn't be a
-harness-only concept. An earlier draft had a *harness tier* multiplier that gave
-`comp:harnesses` a 1.4/1.1/0.9 boost and left **every other component at a flat
-1.0** — so a bug in `comp:server` couldn't be weighted above one in `comp:repr`.
-This axis unifies that: **one `weight` per area in `areas.json`, applied to every
-`comp:` label**, harness or not. Harness tier is now just the harness slice of it.
-
-**One field, two sources.** Each area in `areas.json` carries a `weight` (bands
-**1.4 / 1.1 / 1.0 / 0.9**) and a `weight_source`:
-
-- **Harness weights are telemetry-seeded** (`weight_source: telemetry`) from real
-  usage — the Databricks dashboard's *LJ Sessions by Harness* (sessions + users,
-  last week), aggregating each harness's SDK + native variants. This is a better
-  signal than GitHub issue counts: it measures what people actually run.
-  - **1.4** — `claude`, `codex` (dominant on both users and sessions).
-  - **1.1** — `pi` (clear 3rd), `opencode`, `cursor`, `antigravity`, `hermes`,
-    `copilot`. (Telemetry lifts **hermes** here — GitHub reactions had it near
-    zero, but real session usage puts it mid-pack: a concrete case of usage
-    correcting issue-count.)
-  - **0.9** — `goose`, `kimi`, `kiro`, `qwen` (near-zero usage).
-- **Non-harness weights are editorial** (`weight_source: editorial`) — there is
-  **no per-component usage telemetry** (every session hits the server, so
-  "server usage" isn't a distinguishing signal), so maintainers set these by
-  judgment, honestly labeled as such:
-  - **1.1** — `comp:server`, `comp:runner` core areas (server/host/db,
-    runner/runtime/sandbox) and the shared harness-infra (`inner`/`llms`/`tools`):
-    the execution path a failure blocks everything.
-  - **1.0** — `comp:web-ui`, `comp:policies`, `comp:tui` mainline.
-  - **0.9** — `comp:repr` (spec/stores/entities), `comp:infra`, and low-traffic
-    surfaces (repl).
-
-The score reads `weight` for the issue's area (harness issues resolve to the
-specific harness; otherwise the most-important area among the issue's `comp:`
-labels wins). Because it's one `areas.json` field shared with triage + reviewer
-routing, re-weighting is a one-line edit and telemetry can refresh the harness
-bands on a schedule.
-
-**Labels.** The harness view of this weight is still the tier label set
-`comp:harness-t1/-t2/-t3` (future-proof: a new/re-tiered harness is an
-`areas.json` edit, not a new label). Non-harness areas carry their weight in
-`areas.json` without a per-band label — the weight drives the score directly.
-Open follow-up flagged in review: confirm the harness band cut (Pi/opencode) and
-the editorial non-harness weights in the team channel.
-
-### Component taxonomy — which `comp:` labels to add
-
-There are 8 `comp:` labels today, and several are mega-buckets that merge many
-`areas.json` areas. Review consensus (Serena/Pat) is to go **more granular** —
-fine-grained routing helps both prioritization and reviewer assignment. Two ways
-to add granularity, and we use both deliberately:
-
-- **New top-level `comp:` label** when a slice is a distinct discipline you'd
-  *filter and prioritize on* (e.g. `comp:sandbox` is security-grade).
-- **A `sub_area` tag** for finer structure. `areas.json` *already* models these
-  sub-areas (runner vs sandbox, chat vs composer, …); the classifier can emit
-  the matched sub-area as a second-level tag without minting a GH label per
-  slice. This gives Serena's granularity (chat page / composer / settings /
-  file viewer, runner-start / shutdown / server-comms) for routing and metrics
-  **without dozens of flat labels to sync** — the repo has no label-sync, so
-  keeping the label set small matters.
-
-**Top-level labels — recommended set:**
-
-| Label | Open | Action |
-|---|---|---|
-| `comp:harnesses` | 148 | Split by **tier** `-t1/-t2/-t3` (Axis 3); add a `sub_area` for **SDK vs native** and the specific harness (per review — SDK and native are different failure domains). |
-| `comp:runner` | 109 | **Carve out `comp:sandbox`** (~29: bwrap/seatbelt/egress — security-grade, home of P0 #3557). Keep runner sub-areas (start / shutdown / server+terminal comms) as `sub_area`, not labels. |
-| `comp:web-ui` | 99 | **Add `comp:mobile`** with device sub-tags **desktop / mobile-iOS / mobile-Android** (~23 mobile, ~11 desktop). Keep UI surfaces (chat / composer / session-nav / settings / file-viewer / comment-panel) as `sub_area`. |
-| `comp:server` | 135 | Keep the label, **but add `comp:auth`** as its own label (per review — auth is a distinct surface with types: local / multi-user / OIDC / OAuth / Databricks) and mark **web-UI-critical APIs** so a break there grades P0 (Axis 2). Other server sub-areas (host / db) stay `sub_area`. |
-| `comp:tui` · `comp:infra` · `comp:repr` · `comp:policies` | 40 / 34 / 13 / 21 | Keep as-is; use `sub_area` if a slice ever needs filtering. |
-
-**Net new top-level labels:** `comp:sandbox`, `comp:mobile`, `comp:auth`, plus
-the three `comp:harness-t*` tiers. Everything finer rides on `sub_area`.
-
-Naming note: `comp:sandbox` (narrow) over a broad `comp:security` umbrella —
-"security" would swallow the 120 credential/auth issues (now mostly `comp:auth`
-/ server), re-creating a mega-bucket. Sandbox/policy *bypass* severity is handled
-by the P0 rubric (Axis 2), not by an umbrella label.
-
-**Trade-off, stated honestly:** this is more labels than my first draft argued
-for. The review's call is that granularity earns its keep here — it drives
-reviewer routing too, not just the score. The `sub_area` tag is the pressure
-valve that lets us be granular without unbounded label growth.
-
-### Axis 4 — The composite score (the ordering primitive)
-
-```
-base  = severity_weight              # LLM-graded from content (P0/P1/P2/P3-ish, 0–100)
-      × reach_multiplier             # all-users/default 1.5 · normal 1.0 · single-platform 0.9
-      × component_weight             # areas.json per-area weight 1.4/1.1/1.0/0.9 (Axis 3)
-      × dup_reach                    # +15% per confirmed duplicate, capped +50% (Axis 5)
-      × readiness                    # ready-to-work 1.1 · normal 1.0 · needs-info 0.85 (Axis 6)
-
-score = apply_demand(base, type)     # type-dependent — see "Community demand" below
-      × age_factor                   # DEFAULT 1.0 (neutral) — see note below
-```
-
-Every weight is a named constant in one place. The score is the **continuous
-ordering**; the priority label (Axis 2) is the bucket it lands in. Labels stay
-authoritative for filtering, the score decides *what to look at first* within
-and across them.
-
-**On age (open review point).** An earlier draft *decayed* old issues. Review
-pushed back: a real bug we haven't fixed in 30 days isn't *less* important — if
-anything it's a sign we should **escalate**, not bury it. So the default is
-**neutral (age_factor = 1.0)**; age does not lower the score. We surface aging
-instead through the metrics ("priority age separation") and can add an *upward*
-staleness escalation later if we want, rather than a downward decay. (The dry-run
-defaults to neutral age; the old decaying variant is behind a `DECAY_OLD` flag
-in `score_prototype.py` for comparison only.)
-
-**Worked example — one issue, data points → score.** Take
-[#3265](https://github.com/omnigent-ai/omnigent/issues/3265) ("claude-sdk agent
-with linux_bwrap dies at spawn"):
-
-| Factor | Value | Why |
-|---|---|---|
-| severity | 60 (high) | spawn death — a hard failure, no workaround |
-| × reach | × 1.5 | body says it hits every session on the config → broad |
-| × component_weight | × 1.4 | title says `claude-sdk` → `harness-claude` area, weight 1.4 (Axis 3) |
-| × dup_reach | × 1.0 | no confirmed duplicates (yet) |
-| × readiness | × 1.0 | no explicit repro section matched → no bump |
-| = base | **126** | 60 × 1.5 × 1.4 |
-| × demand (bug) | + 0 | 0 reactions; bugs get only the additive tiebreak |
-| × age | × 1.0 | neutral by default — age never lowers the score |
-| **= score** | **126** | **≥ 100 → P0-critical**; ranks **#6** of 360 (was P1, rank #37) |
-
-Contrast a vague, low-weight ticket: severity 30 (medium) × reach 0.9
-(single-platform) × component_weight 0.9 (e.g. `comp:repr`, or a niche harness)
-× readiness 1.0 ≈ **24** → **P3** (below the 25 cut) — an order of magnitude
-lower, so it sits deep in the queue.
-Same five data points, opposite ends of the queue *and* opposite priority
-labels: that's the score→label derivation doing the work.
-
-**Severity is LLM-graded in production, not regex.** The dry-run uses regex only
-so it's reproducible; the real grader is the triage classifier, which reads full
-content at zero extra cost. The regex's own false positives are the argument for
-this — see the Dry-run section.
-
-### Community demand — used, but type-dependent and bounded
-
-Should 👍 feed the score? **Yes, but bounded** — the reaction distribution
-forces it. 93% of open issues (335/360) have zero reactions; the 51 total skew
-hard to FRs (9 of the top 10 reacted are FRs) and are almost all external. So
-reactions are a **demand** signal (a wanted capability), not a **severity** one.
-The model reflects that:
-
-- **Type-dependent.** FRs: a bounded *multiplier* (up to +60%), so a well-liked
-  FR climbs. Bugs: a small additive *tiebreak* (≤15 pts), so a 0-reaction crash
-  still outranks a lightly-liked cosmetic FR. Severity always leads for bugs.
-- **Log-scaled and capped** (`log1p` + hard cap), so one popular FR can't swamp
-  severity. **Comments excluded** — here they're mostly repro back-and-forth, a
-  sign a bug is *harder*, not more wanted.
-
-Without these bounds, a 93%-zero, FR-skewed signal would tilt a dogfood-heavy
-backlog toward features — the exact failure the type-split guards against.
-
-### Axis 5 — Duplicate reach
+### Axis 5 — Duplicate issue
 
 The dedup labeler ([#4037](https://github.com/omnigent-ai/omnigent/pull/4037))
 links and labels duplicates without auto-closing. That gives us a reach signal
@@ -411,179 +201,84 @@ carry dup links.
 
 ### Axis 6 — Readiness
 
-A ticket you can *start on now* — repro steps, a real body — is worth surfacing
-above an equally-severe but vague one. `readiness` is a small multiplier: 1.1
-for a bug with a repro section and a ≥400-char body (or any substantive FR), 1.0
-otherwise. It's deliberately gentle — it breaks near-ties, it never overrides
-severity.
+A ticket you can *start on now* is worth surfacing above an equally-severe but vague one.
+`readiness` is a small multiplier: 1.1 for a bug with a repro section and a ≥400-char body
+(or any substantive FR), 1.0 otherwise. Gentle — it breaks near-ties, never overrides severity.
 
-**`needs-info` vs partial info (review clarification).** These are two different
-states and the design treats them differently:
+**`needs-info` is separate. If it's genuinely incomprehensible, we give *no score*, meaning P3 by
+default. However, if information are partially presented and is comprehensible, then 1.0.
 
-- **`needs-info` = genuinely incomprehensible** — we can't tell what's going on
-  from the description at all. These get **no priority** (Serena's point: don't
-  prioritize or assign a reviewer to something we can't understand); the pending
-  backfill leaves priority unset until the reporter responds. In the score they
-  sit at `readiness = 0.85`, but the more important effect is having no priority
-  label to sort by.
-- **Partial info** — comprehensible, but missing a repro or a demo. These are
-  **not** `needs-info`; we still grade and prioritize them, because a serious bug
-  is worth looking at even without a clean repro (Pat's point). They just don't
-  get the +1.1 readiness bump.
+### Axis 7 - Community demand
 
-Today `needs-info` is on **0** open bugs, so the backfill also gives the
-classifier an explicit reason to apply it — only to the incomprehensible ones.
+Unique user engagement and comments and thumb-up will be counted additively. So they will bump the
+issue but won't have too much weight. Existing issues get at most 15 pts today.
 
-### Surfacing the score — one Databricks job, one scores table
+### Axis 8 - Age factor
 
-The score must be **computed in exactly one place**, or it drifts between
-whatever recomputes it. That place is a scheduled **Databricks notebook job**,
-not a GitHub Action — because the job sits next to both its input (the synced
-issues table) and its output (the dashboard), so there's no cross-system data
-hop and no second implementation of the formula.
+Recent issues (0 - 5 days): 1.0
+5 - 21 days: 1.2 - bump lightly to provide more visibility.
+21+ days: 0.8 - Since they are ignored for awhile. chances are, they are less important. If not, the
+maintainer should bump priority (since priority gives more scores).
 
+
+
+### Scoring function (the ordering primitive)
 ```
-main.team_eng_omnigent.github_issues_bronze   (issues already synced here —
-  │                                             labels, title, body, comments,
-  │                                             reactions in raw_json, created_at)
-  ▼
-[Databricks job: THE one place the score is computed]
-  severity(persisted) × reach × component_weight(areas.json) × dup × readiness
-  │                          + demand ─┐
-  ├──► issue_scores (Delta) ───────────┴──►  dashboard tile: ORDER BY score DESC
-  └──► apply priority/component labels back to GitHub  (needs a write credential)
+base  = severity_weight              # LLM grade, reach folded in (S0/S1/S2/S3 = 100/60/30/10)
+      × component_weight             # areas.json per-area weight 1.4/1.2/1.1/1.0/0.9 (Axis 3)
+      × dup_reach                    # +15% per confirmed duplicate, capped +50% (Axis 5)
+      × readiness                    # ready-to-work 1.1 · normal 1.0 (Axis 6)
+
+score = apply_demand(base, type)     # additive, ≤15 pts (Axis 7)
+      × age_factor                   # 0-5d 1.0 · 5-21d 1.2 · 21d+ 0.8 (Axis 8)
 ```
 
-Concrete facts this rests on (verified against the workspace):
+Every weight is a named constant; the priority label is the band the score lands in
+(`≥100 P0 · ≥60 P1 · ≥25 P2 · else P3`).
 
-- **Reads are tokenless.** Issues are already ingested into
-  `main.team_eng_omnigent.github_issues_bronze` (with a watermark table driving
-  incremental sync). The job reads that table — **no GitHub token needed to
-  score**. `component_weight` comes from `areas.json`; reactions come from
-  `raw_json`.
-- **Only the write-back needs a credential.** Applying the regraded
-  priority/component labels to GitHub needs a write token — now a **Databricks
-  secret** (a scoped PAT or App-installation token), not a CI secret. Clean
-  split: **compute + dashboard = read-only in Databricks; label writes = the one
-  credentialed step.**
-- **Preserve the prompt-injection boundary.** The Action's security posture
-  (LLM has no tools/shell/token; a trusted step validates output against
-  `ALLOWED_COMPONENTS`/`ALLOWED_PRIORITIES` before any write) **must carry over
-  intact**: the notebook cell holding the GitHub token must not be the context
-  that ran the LLM, and every write stays allowlist-gated. A notebook makes it
-  easy to accidentally hand the token to the model's context — so this is a
-  deliberate structure, not a default.
-- **The bot's own writes lag bronze.** Labels the job writes won't appear in
-  bronze until the next ingestion, so the job can't read its last action back
-  from bronze. It keeps its own `issue_bot_state` Delta table (issue → last
-  bot-written priority/severity) — which is exactly the human-override guard's
-  shadow record, so one table serves both idempotency and override detection.
-- **Trigger cadence — the one open decision.** A notebook job is scheduled
-  (cron), not event-driven, so first-touch triage of a *new* issue waits for the
-  next run (+ ingestion lag) instead of firing in minutes. For scoring /
-  re-score / backfill / dashboard that's inherent and fine. If near-real-time
-  first triage matters, the mitigation is a **thin dispatch Action** (`on:
-  issues [opened]` → trigger the Databricks job) that carries *zero* logic — the
-  formula still lives only in the notebook. Flag for the team: accept ~15–30 min
-  cadence, or keep the dispatcher.
+**Worked example — one issue, data points → score.** Take
+[#3265](https://github.com/omnigent-ai/omnigent/issues/3265) ("claude-sdk agent
+with linux_bwrap dies at spawn"):
 
-**Linear.** Issues already sync to Linear on a regular cadence, so Linear is an
-existing surface, not something to build. Scores stay in GitHub + the dashboard;
-we do **not** push scores into Linear (it consumes labels/status, it wouldn't
-compute severity×reach anyway). If a Linear-side priority is ever wanted, it
-reads the same `issue_scores` table — never a second computation.
+| Factor | Value | Why |
+|---|---|---|
+| severity | 60 (S1) | spawn death, no workaround; not widespread enough for S0 |
+| × component_weight | × 1.4 | `claude-sdk` → `harness-claude`, weight 1.4 (Axis 3) |
+| × dup_reach | × 1.0 | no confirmed duplicates |
+| × readiness | × 1.0 | no repro section matched |
+| + demand (bug) | + 0 | 0 reactions |
+| × age | × 1.2 | 10 days old → mid-life visibility bump |
+| **= score** | **101** | 60 × 1.4 × 1.2 → **≥ 100 → P0**; rank **#17** of 360 (was rank #37 by label) |
 
-### Determinism — same inputs, same score
+Contrast a vague, low-weight ticket: severity 30 (S2) × component_weight 0.9
+(e.g. `comp:repr`) × age 0.8 (stale) ≈ **22** → **P3**, near the bottom. Same
+factors, opposite ends of the queue — that's the score→label derivation working.
+
+### Determinism - same inputs, same score
 
 The score is a **pure arithmetic function** of its inputs (multiply/add, no
 randomness), so given identical inputs it is byte-for-byte reproducible across
 runs. Two nuances worth stating plainly:
 
-- **Persisted severity is what guarantees it.** The one non-reproducible input
-  would be re-grading severity with the LLM every run (LLM output isn't stable
-  across samples/model versions — it would shuffle dashboard ranks for no
-  reason). Because severity is **graded once at triage and stored** (Rollout
-  step 1), the re-score job reads a fixed value and never re-invokes the model.
-- **The score still moves over time — by design, bounded.** `dup_reach` and
-  `demand` read *current* duplicate and reaction counts, so a well-liked or
-  much-duplicated issue legitimately rises as signal accrues. That's the
-  intended "ranking evolves" behavior, not nondeterminism. (We deliberately
-  removed the one *unwanted* time-drift, age decay, per review.)
+- **Persisted severity is what guarantees it.** since severity is the only LLM-generated label.
+- **The score still moves over time — by design.** `dup_reach` / `demand` read
+  *current* counts, and `age_factor` (Axis 8) changes as an issue progress. This is intended.
 
-**Tie-breaking is deferred.** Scores cluster in coarse bands (many share
-92/84/…); within a tie the order isn't pinned. That's acceptable for now — the
-bands are what matter. When a stable within-band order is wanted, the ranked
-query adds a deterministic tiebreaker (`ORDER BY score DESC, issue_number`); no
-model or scoring change needed.
+Note: There is no tie-breaking today.
 
-### Ongoing adjustment — re-grade severity, don't add a pin lever
+### Updates
+We will have a schedule job to regrade tickets periodically since metadata can change.
 
-Prioritization is not a one-shot classification, but the adjustment lever is
-just **re-grading severity** — the same field the classifier already sets:
+### Maintainer Intervention
 
-1. **Periodic re-score.** The scheduled job (below) recomputes the score and
-   refreshes the ranked view / `issue_scores` table, reflecting demand/dup
-   changes without re-triaging. **No LLM call** — it reads the *persisted*
-   severity (Rollout step 1) and does pure arithmetic, so a re-run with no data
-   change reproduces the same scores (see "Determinism").
-2. **Re-grade severity to bump.** To move an issue, a maintainer changes its
-   label (P2 → P1) — the one knob they already use. There is deliberately no
-   separate `pin:high`/`pin:low`: it would mean the same thing as changing
-   severity but out of band from it. The real fix for a mis-ranked issue (e.g.
-   #2125) is upstream — grade severity honestly (Axis 2); the score reads
-   severity, so fixing severity fixes the order.
+Since severity is LLM judgement, maintainer may decide to override priority in the issues.
+That's fine and expected. Putting a note here that if there are too many adjustments, we should
+revisit some weights. Bot shouldn't overwrite human judgement.
 
-#### Human priority always wins — the bot must not overwrite it
 
-Now that priority is a *computed* label, a **scheduled** job that writes it (the
-re-score, the one-time backfill) runs every tick — so without a guard it *will*
-clobber a maintainer's deliberate `P0 → P2` or `P3 → P1` on the next run. That
-must never happen. The rule:
+The goal is a ranking good enough that **hand-correction is needed for ≤10% of issues touched**.
+If you're correcting more than that, we should fix prompts or weights.
 
-> **A bot-written priority is a default; a human-written priority is a
-> decision. The bot only ever sets priority on an issue it hasn't set before,
-> and never overwrites a value a human changed.**
-
-Concretely, the job must:
-
-- **Detect the human edit** via the `issue_bot_state` table (the job's record of
-  the priority it last wrote per issue — the same table that makes the job
-  idempotent against bronze's ingestion lag). If the issue's current `P*` label
-  differs from `issue_bot_state`'s last-bot-written value, a human moved it →
-  **skip**. (GitHub's issue-events API, which records whether the label actor
-  was the bot, is a fallback signal.)
-- **Only fill, never replace.** If an issue has *no* priority label, the job may
-  set one. If it already has one the bot itself last wrote, the job may update
-  it (the grade legitimately changed). If a human wrote it, the job leaves the
-  label alone and may at most *surface disagreement* — e.g. list "human P2, bot
-  would say P0" in the ranked view for a maintainer to reconsider, without
-  touching the label.
-- **Re-score reads, doesn't write, human-owned rows.** The weekly ranked view
-  sorts by the computed score for visibility, but the *authoritative label* on a
-  human-owned issue is the human's. The score can still order it in the list;
-  it just can't relabel it.
-
-This keeps the automation as a labor-saver, not an authority: the bot triages
-the long tail, humans override the ones that matter, and the override sticks
-across every subsequent re-score.
-
-#### Maintainer guide — hand-correcting the ranking
-
-The goal is a ranking good enough that **hand-correction is the exception, not
-the process** — a working target is **≤10% of issues touched**. If you're
-correcting more than that, the fix isn't more editing, it's tuning the prompt or
-weights (below). Two properties make correction cheap and safe:
-
-- **Corrections are sticky.** The scheduled job honors the human-override guard
-  above — a priority a human changed is recorded in `issue_bot_state` as
-  human-owned and never overwritten, only surfaced as disagreement if the bot
-  would grade it otherwise.
-- **One knob.** You change the **priority label** (the field the classifier
-  emits). The score is a pure function of it plus mechanical factors — no
-  separate override to learn.
-
-**When to correct** — reach for it only when the *grade* is wrong, not when you
-merely disagree with a neighbor in a tie:
 
 | Symptom | Action |
 |---|---|
@@ -591,178 +286,110 @@ merely disagree with a neighbor in a tie:
 | Right severity, wrong reach (e.g. "affects all users" missed) | Same: bump the label; reach feeds severity's bucket. |
 | A security/sandbox/policy **bypass** graded as ordinary | Set `P0-critical` — bypass is top severity regardless of reach (Axis 2). |
 | Truly incomprehensible | Add `needs-info` and leave priority unset (don't prioritize what we can't understand). Partial-but-serious info: keep prioritizing, skip the label. |
-| You just prefer a different order *within the same grade* | **Don't.** Ties are arbitrary by design; re-grading here is noise. |
 
-**When NOT to correct — fix the system instead.** A hand-edit fixes one issue; a
-prompt fix fixes the class. Escalate from editing to tuning when:
-
-- The **same misgrade recurs** (e.g. every "sandbox bypass" *feature request*
-  gets graded critical — the #2057/#2054 class). Fix the classifier prompt in
-  `.github/triage/config.yaml`, not the issues one by one.
-- You cross the **~10% correction rate** in a re-score cycle. That's the signal
-  the weights (tier multipliers, demand cap, readiness) or the rubric need
-  tuning — re-run `score_prototype.py` against the new weights and eyeball the
-  before→after before shipping.
-- The **`Re-grade rate` metric** (below) trends up. It's the quantitative
-  version of the same signal.
-
-**What this is not:** there is no per-issue score override, no manual score
-number, no pin. Everything flows through the priority label so the ranking stays
-explainable — anyone can re-derive an issue's position from its label + factors,
-and there's no hidden hand-tuning to reverse-engineer later.
 
 ---
 
-## Dry-run: before → after (methodical, on real issues)
+## Dry-run: LLM grader vs. regex, on real issues
 
-`designs/prioritization/score_prototype.py` reads a snapshot of all open issues
-and prints **current-priority ordering vs composite-score ordering**, with a
-rank delta per issue, so we tune weights against real test cases. (Pass
-`--regrade` for the priority-*label* backfill preview shown in Axis 2 instead of
-the score ranking.)
+`score_prototype.py` grades severity with regex so a dry-run is reproducible.
+But regex only keyword-matches — to check the *design*, an LLM (this one) read
+**the 100 oldest open issues**, graded S0–S3 by content, and ran the grades
+through the same scoring machinery (weight × dup × readiness + demand × age).
+**Priority flipped on 49 of 100** — the argument for grading severity with the
+classifier in production.
 
-**Is severity re-graded in these examples?** Yes — the dry-run ignores the
-existing priority label entirely and *re-grades severity from content* (regex
-stand-in for the LLM), so the "After" column is a fresh grade, not a re-sort of
-the old labels. The regex grade distribution across the 360 open issues:
+**Distribution (100 issues):**
 
-| Grade | critical | high | medium | low | (FR default) |
-|---|---|---|---|---|---|
-| Count | 8 | 85 | 183 | 3 | 81 |
+| Priority | regex | LLM |
+|---|--:|--:|
+| P0 | 2 | 1 |
+| P1 | 13 | 13 |
+| P2 | 43 | 65 |
+| P3 | 42 | 21 |
 
-That shape is itself a sanity check: **critical is scarce (8)**, most bugs are
-medium, and `low` is under-detected by regex (only 3) — a real grader would find
-more genuinely-minor issues. It's the inverse of today's inflated-P1 label
-distribution, which is the goal.
+**Confusion — regex (row) → LLM (col):**
 
-Selected results (360 open issues; rank out of 360, lower = higher priority):
+| regex ↓ \ LLM → | P0 | P1 | P2 | P3 |
+|---|--:|--:|--:|--:|
+| **P0** (2) | 1 | 0 | 1 | 0 |
+| **P1** (13) | 0 | 6 | 6 | 1 |
+| **P2** (43) | 0 | 7 | 30 | 6 |
+| **P3** (42) | 0 | 0 | 28 | 14 |
 
-**Severity surfaces real bugs the label buried:**
+**Agree 51 / 100. Of the 49 flips: 35 regex-too-low, 14 regex-too-high.** The
+skew is the tell — regex parks anything without a strong keyword in P3 (and
+defaults FRs low), so **28 of its 42 P3s are really P2** on reading: real
+feature work or bugs-with-a-workaround it couldn't distinguish from noise.
+Agreement concentrates where regex can keyword-match (P2→P2 30, P1→P1 6); it
+mis-parks the extremes.
 
-| Issue | Before | After | Δ | Note |
-|---|---|---|---|---|
-| #3557 policy-gate bypass (P0) | 1 | 10 | −9 | Real P0 stays near top ✅ |
-| #3265 claude-sdk bwrap spawn death (P1) | 37 | 6 | +31 | High-sev, weight-1.4 harness, broad reach ✅ |
-| #3270 sub-agent sessions absent (P1) | 35 | 9 | +26 | ✅ |
-| #2421 codex MCP bridge child leak (P1) | 80 | 36 | +44 | Resource leak, weight-1.4 ✅ |
-| #2454 unbounded ~/.omnigent growth (P1) | 72 | 35 | +37 | ✅ |
+A few concrete flips show *why*, in both directions:
 
-**Community demand lifts wanted FRs — bounded, so bugs stay on top:**
+**Regex over-grades (keyword false positives) → LLM corrects down:**
 
-| Issue | 👍 | Before | After | Δ | Note |
-|---|---|---|---|---|---|
-| #16 native Windows support (FR) | 6 | 334 | 7 | +327 | Whole-platform reach + demand → graded P0 ✅ |
-| #1021 GitHub Copilot as provider (FR) | 10 | 299 | 93 | +206 | Most-reacted FR climbs on demand alone ✅ |
-| #888 side-by-side multi-session (FR) | 2 | 305 | 44 | +261 | ✅ |
+| Issue | regex | LLM | Why regex was wrong |
+|---|---|---|---|
+| #2057 Codex Auto mode (FR) | P0 | **P2** | FR *proposing* a mode; "sandbox bypass" is what it avoids, not a report. |
+| #2054 dedup Codex modes (FR) | P0 | **P3** | Config tidying; same false keyword. |
+| #61 bot "Code Audit" (bug) | P1 | **P3** | Auto-generated list, "verify before acting" — not a confirmed bug. |
+| #2125 multi-host git creds (FR) | P0 | **P1** | Real blocker, but regex hit the literal phrase "PAT is offered", not the risk. |
 
-**Dry-run limits — the evidence that severity must be LLM-graded, not regex.**
-The regex grader mis-scores three ways, and all three are visible near the top,
-which is exactly why production grades with the classifier:
+**Regex under-grades (no way to read impact) → LLM corrects up:**
 
-| Issue | After | Failure |
-|---|---|---|
-| #2057 / #2054 Codex-mode FRs | 2 / 3 | **False positive** — "sandbox bypass" in the FR body trips the critical regex; an LLM reads that they *propose* a mode, not report a bypass. |
-| #61 bot "Code Audit" (P3) | 15 | **False positive** — a bot audit issue mentioning "security". |
-| #2125 multi-host git creds (FR) | 1 | **Lucky match** — body literally says "your GitHub PAT is offered to the self-hosted remote", so the regex hits a credential pattern. Right answer, wrong reason: an LLM would grade it critical because it *understands* the credential-crossing, not on an exact phrase. |
+| Issue | regex | LLM | Why |
+|---|---|---|---|
+| #1021 Copilot provider (FR) | P2 | **P1** | Wanted new provider (10 👍); regex graded the FR "medium". |
+| #2429 server CPU-spin (bug) | P2 | **P1** | 10h spin, no watchdog; "medium" keyword undersold a real reliability bug. |
+| #3790 force_sandbox no-op (bug) | P2 | **P1** | A safety policy silently disabled — security-adjacent; regex saw only "evaluated". |
 
-**Takeaway:** the score *mechanics* order the queue far better than the label;
-the severity *grader* must be the LLM (its regex false positives *and* lucky
-matches both prove it); weights are defensible starting points — tune against
-this table.
+**Regex already right (no flip):** #3557 (P0 policy bypass), #16 (P0, whole
+platform), #3981 (P2, has workaround), #377 (P2, trivial mitigation). Regex is
+fine when the keyword *happens* to match the real severity.
+
+**Takeaway:** once severity is graded honestly, the machinery carries it to a
+sensible priority with no extra tuning (e.g. #2429 crosses P1 on the 1.2 server
+weight). The grader must be the LLM; the weights are a defensible start.
 
 ---
 
 ## Intake: what more to collect
 
-The bug template asks Version + OS but both optional → sparse. Add structured,
-**dropdown** fields (dropdowns beat free-text for scoring signal):
+Today's bug template has Version + OS, both optional → sparse. Add optional
+dropdowns (cheap for the reporter, better signal than free text):
 
-- **Harness** (dropdown: claude / codex / cursor / … / n/a) **+ mode (SDK /
-  native)** — the #1 component, currently buried in prose. Feeds the component
-  weight directly; the SDK-vs-native split feeds `sub_area` (per review).
-- **Platform / device** (dropdown: macOS / Linux / Windows / **desktop /
-  mobile-iOS / mobile-Android** / Docker) — a whole class of bugs is
-  platform-specific (Windows setup crashes, iOS/Android OIDC, Linux aarch64).
-  Feeds reach and the `comp:mobile` device sub-tag.
-- **Impact / reach** (dropdown: all users / most / some / edge) — the reach axis
-  the reporter can often answer better than the grader.
-- **Auth type** (dropdown: local / multi-user / OIDC / OAuth / Databricks /
-  n-a) — shown for auth issues; feeds `comp:auth` (per review).
-
-Keep them optional (the pipeline already triages from description alone) but
-dropdowns cost the reporter nothing and sharpen severity × reach.
-
-### Sandbox / security deserves its own treatment
-
-Sandbox/security is a distinct category, and the data agrees: **63** open issues
-mention sandbox (bwrap/seatbelt/egress), **70** policy/guardrail, **120**
-credential/secret; the top P0 (#3557) is a policy-gate *bypass*. A sandbox escape
-or policy bypass is a **security** severity, not a functional one, and the design
-handles it in two places: the `comp:sandbox` label (Component taxonomy) and the
-P0 rubric's "security escape" row (Axis 2), where *escape / bypass /
-credential-crossing* is top-tier **regardless of reach** — the one place reach
-does not gate priority.
+- **Harness + mode** (claude / codex / … + SDK / native) → component weight + `sub_area`.
+- **Platform / device** (macOS / Linux / Windows / desktop / mobile-iOS / mobile-Android / Docker) → `comp:mobile` sub-tag + reach.
+- **Impact / reach** (all / most / some / edge) → feeds severity (Axis 2).
+- **Auth type** (local / multi-user / OIDC / OAuth / Databricks) → `comp:auth`.
 
 ---
 
 ## Rollout
 
-**Status: mostly design + prototype.** This PR adds the design doc, the dry-run
-prototype, and the per-area `weight`/`weight_source` fields in `areas.json` (with
-a test). It does **not** create any `comp:*` labels or wire `areas.json` into the
-live classifier. The steps below are the implementation plan, each intended as
-its own follow-up PR.
+Nothing here is built yet except the `areas.json` weights (+ test). Action items,
+each its own PR:
 
-1. **Prompt re-calibration + persist severity** (`.github/triage/config.yaml`)
-   — new priority rubric (grade FRs across buckets; explicit P0 list; tier-1
-   floor) + the "P1 scarcity" guardrail + emit `severity`, `readiness`, and
-   `sub_area`. **`severity` is graded once at triage and persisted** (a stored
-   field, not just a transient classification): it's the largest multiplier and
-   the one input the score can't recompute from labels/text alone, so storing it
-   is what makes re-scoring deterministic (see "Determinism"). Low risk, affects
-   new issues immediately.
-2. **Component weight + labels** — the per-area `weight`/`weight_source` fields
-   are already in `areas.json` (harness = telemetry, non-harness = editorial;
-   confirm the harness bands and editorial weights in the team channel). Add the
-   `comp:harness-t1/-t2/-t3` labels (the harness view of the weight), plus
-   `comp:sandbox`, `comp:mobile`, `comp:auth`; add the `sub_area` taxonomy for
-   finer routing (SDK/native, UI surface, runner phase, device). Update the
-   classifier allowlist and backfill. See "Component taxonomy" and Axis 3.
-3. **Template fields** — add Harness (+SDK/native) / Platform-device / Impact /
-   Auth-type dropdowns.
-4. **Scoring & triage job (Databricks notebook, not a GitHub Action)** —
-   productionize `score_prototype.py` as a scheduled Databricks job. It reads
-   the already-synced issues table, computes score + derived priority **in one
-   place**, writes the `issue_scores` table the dashboard reads, and applies the
-   priority/component labels back to GitHub. See "Surfacing the score" below for
-   the data flow, the read-tokenless / write-with-secret split, and the
-   preserved prompt-injection boundary. **Must implement the human-override
-   guard** (an `issue_bot_state` record of what the bot last wrote; skip any
-   issue whose `P*` a human changed).
-5. **One-time backfill (regrade)** — re-run the classifier over open issues to
-   relabel under the new rubric (see "How regrading works"); preview with
-   `score_prototype.py --regrade`. Sets priority only where none exists or the
-   bot set the prior value — never over a human edit. Target: P1 back under ~20%
-   of open bugs (regex preview lands it at 27% with the unified component weight;
-   tune `P1_MIN` and the LLM grader to tighten).
-6. **Consume dedup output** — once [#4037](https://github.com/omnigent-ai/omnigent/pull/4037)
-   lands, feed duplicate count into `dup_reach`; wire the unused `good first
-   issue` funnel.
+- [ ] **Tune the classifier prompt** (`.github/triage/config.yaml`) — S0–S3 rubric,
+  FRs graded, tier-1 nudge, P0 list; emit + **persist** `severity`, `readiness`,
+  `sub_area` (persisted severity is what keeps re-scoring deterministic).
+- [ ] **Create the cron job** — scheduled Databricks notebook: read
+  `github_issues_bronze`, compute score once, write `issue_scores`, apply labels
+  back (with the human-override guard). See "Surfacing the score".
+- [ ] **Add labels** — `severity S0–S3`, `comp:harness-t1/-t2/-t3`, `comp:sandbox`,
+  `comp:mobile`, `comp:auth`; wire the classifier allowlist.
+- [ ] **Add template dropdowns** — Harness+mode / Platform-device / Impact / Auth-type.
+- [ ] **Backfill** — regrade open issues (`--regrade`; preview lands ~23% P1 bugs),
+  filling only bot-owned priorities.
+- [ ] **Plumb scores to the dashboard** — `issue_scores` → a ranked Lakeview tile.
 
 ## Metrics
 
-- **P1 share of open bugs** — target < 20% (today 60%).
-- **Priority age separation** — P1 median age should drop well below P2's
-  (today they're equal — the tell that priority is ignored).
-- **Prioritization efficiency** — of the k issues actually resolved in a period,
-  what fraction of the *achievable* score did we capture? Compute
-  `sum(score of the k resolved) / sum(score of the top-k by score)`. A ratio
-  near 1.0 means the team is working the highest-scored issues; a low ratio
-  means high-score issues are being skipped (either the score is wrong, or
-  attention is going elsewhere). This is the single best signal that the score
-  is *ordering real work*, not just producing a list.
-- **Re-grade rate** — how often maintainers change a severity/priority label
-  after triage (high = the classifier's grading needs tuning).
+- **P1 share of open bugs** — target ~25% (today 60%).
+- **Priority age separation** — P1 median age should drop below P2's (equal today).
+- **Prioritization efficiency** — `sum(score of k resolved) / sum(score of top-k)`;
+  near 1.0 = we're working the highest-scored issues.
+- **Re-grade rate** — how often maintainers change a label post-triage (high = tune the grader).
 
 ---
 
@@ -807,219 +434,218 @@ up). The Now→Derived column is the per-issue view of the backfill: the ⚑ row
 are the relabels the one-time regrade would apply.
 
 **Illustrative, not actionable.** This is the *mechanism* running on a
-deliberately-weak grader, so its own failures are visible on purpose: ranks 2–3
-(#2057/#2054) are FRs that merely *mention* "sandbox bypass" and are graded
-critical — they sit above the real P0 (#3557, rank 10), so **the very top is
-backwards**; #61 (rank 15) is a *bot* audit issue riding a "security" keyword.
-That's the doc's thesis made concrete: regex can't grade severity. The scaffold
-is sound — strip those artifacts and the genuine high-weight harness bugs
-(#3265, #3557, #3270, #3180, #2373) cluster correctly near the top. Scores also
-*tie* in coarse bands (many issues share 92/84/…), so within-band order is
-arbitrary — read this as a handful of tiers, not 200 true ranks. Age is neutral
-(review point) and component weight is now unified across all `comp:` (Axis 3),
-so core-area bugs rank above niche ones by the same field harnesses use. With the
-LLM grader plus ≤10% hand-correction (see the maintainer guide), this is the
-shape the production ranking takes.
+deliberately-weak grader, so its own failures are visible on purpose: ranks 2–5
+(#2125/#2057/#2054) are FRs that hit a critical-regex keyword — they sit above
+the real P0 (#3557, rank 14), so **the very top is backwards**; #61 (rank 33) is
+a *bot* audit issue riding a "security" keyword. That's the doc's thesis made
+concrete: regex can't grade severity. Strip those artifacts and the genuine
+high-weight harness bugs cluster correctly near the top. Scores *tie* in coarse
+bands (many share 84/67/…), so within-band order is arbitrary — read this as a
+handful of tiers, not 200 true ranks. With the LLM grader plus ≤10%
+hand-correction (see the maintainer guide), this is the shape the production
+ranking takes.
 
 | # | Score | Sev | Now | Derived | Δrank | Issue |
 |--:|--:|---|---|---|--:|---|
-| 1 | 161 | critical | P2 | P0 ⚑ | +231 | [#2125](https://github.com/omnigent-ai/omnigent/issues/2125) [Feature] Multi-host git credentials for managed sandboxes (GitHub + s |
-| 2 | 154 | critical | P2 | P0 ⚑ | +234 | [#2057](https://github.com/omnigent-ai/omnigent/issues/2057) [Feature] Add Codex Auto mode using auto_review instead of jumping to  |
-| 3 | 154 | critical | P2 | P0 ⚑ | +235 | [#2054](https://github.com/omnigent-ai/omnigent/issues/2054) [Feature] Remove duplicate Codex Full access mode and keep Sandbox Byp |
-| 4 | 139 | high | P2 | P0 ⚑ | +291 | [#1051](https://github.com/omnigent-ai/omnigent/issues/1051) [Feature] Forward OTel exporter knobs to executor subprocess env |
-| 5 | 127 | high | P2 | P0 ⚑ | +235 | [#2038](https://github.com/omnigent-ai/omnigent/issues/2038) [Feature] No way to deregister/delete an external self-registered host |
-| 6 | 126 | high | P1 | P0 ⚑ | +31 | [#3265](https://github.com/omnigent-ai/omnigent/issues/3265) claude-sdk agent with linux_bwrap dies at spawn on a runtime bwrap bin |
-| 7 | 121 | high | P2 | P0 ⚑ | +327 | [#16](https://github.com/omnigent-ai/omnigent/issues/16) Is native Windows support in scope, or should docs recommend WSL2? |
-| 8 | 121 | critical | P1 | P0 ⚑ | -4 | [#3983](https://github.com/omnigent-ai/omnigent/issues/3983) [Bug] Smart-routed turns render out of order: reply streams above the  |
-| 9 | 121 | critical | P1 | P0 ⚑ | +26 | [#3270](https://github.com/omnigent-ai/omnigent/issues/3270) [Bug] sys_session_create children are absent from both sys_session_lis |
-| 10 | 110 | critical | P0 | P0 | -9 | [#3557](https://github.com/omnigent-ai/omnigent/issues/3557) [Bug] Shell-surface policy gates are bypassed by option-taking command |
-| 11 | 109 | high | P2 | P0 ⚑ | +125 | [#3976](https://github.com/omnigent-ai/omnigent/issues/3976) [Feature] OAuth2 client-credentials grant so a headless process can au |
-| 12 | 109 | high | P2 | P0 ⚑ | +152 | [#3363](https://github.com/omnigent-ai/omnigent/issues/3363) [Feature] Per-project custom instructions (project-scoped context) |
-| 13 | 109 | high | P2 | P0 ⚑ | +263 | [#1388](https://github.com/omnigent-ai/omnigent/issues/1388) Make agents a first-class CRUD entity with a dedicated sidebar UI (dec |
-| 14 | 109 | critical | P2 | P0 ⚑ | +301 | [#659](https://github.com/omnigent-ai/omnigent/issues/659) [Feature] add a microvm backend for sandbox |
-| 15 | 100 | critical | P3 | P0 ⚑ | +334 | [#61](https://github.com/omnigent-ai/omnigent/issues/61) 🤖 Code Audit: 21 potential issue(s) found |
-| 16 | 99 | high | P2 | P1 ⚑ | +121 | [#3970](https://github.com/omnigent-ai/omnigent/issues/3970) pi-native: every turn fails with "Pi model error: 401 Invalid Token" w |
-| 17 | 99 | high | P1 | P1 | +35 | [#3001](https://github.com/omnigent-ai/omnigent/issues/3001) [Performance] GET /v1/sessions pre-fetches every accessible conversati |
-| 18 | 92 | high | P1 | P1 | +15 | [#3299](https://github.com/omnigent-ai/omnigent/issues/3299) [Bug] Harness-credential route times out with a misleading 504 against |
-| 19 | 92 | high | P2 | P1 ⚑ | +147 | [#3284](https://github.com/omnigent-ai/omnigent/issues/3284) [Crash] DuplicateOptionError: While reading from PosixPath('/Users/*** |
-| 20 | 92 | high | P1 | P1 | +21 | [#3180](https://github.com/omnigent-ai/omnigent/issues/3180) codex-native: runner never exits on idle timeout — cancelled delta-coa |
-| 21 | 92 | high | P2 | P1 ⚑ | +163 | [#3070](https://github.com/omnigent-ai/omnigent/issues/3070) No progress signal on a stuck or interactive harness install |
-| 22 | 92 | high | P1 | P1 | +33 | [#2967](https://github.com/omnigent-ai/omnigent/issues/2967) [Bug] A full context window bricks a session with "Prompt is too long" |
-| 23 | 92 | high | P1 | P1 | +59 | [#2373](https://github.com/omnigent-ai/omnigent/issues/2373) [Bug] claude-native: pasted web-UI message loses its Enter, stuck draf |
-| 24 | 92 | high | P1 | P1 | +70 | [#2060](https://github.com/omnigent-ai/omnigent/issues/2060) [Bug] claude-native: first web-UI message silently dropped when Claude |
-| 25 | 92 | high | P1 | P1 | +78 | [#1898](https://github.com/omnigent-ai/omnigent/issues/1898) [Bug] codex-native: cancelling a task awaiting flush() poisons the del |
-| 26 | 92 | high | P2 | P1 ⚑ | +244 | [#1528](https://github.com/omnigent-ai/omnigent/issues/1528) Idle-session lifecycle UX: reap gracefully, resume seamlessly, surface |
-| 27 | 92 | high | P2 | P1 ⚑ | +289 | [#654](https://github.com/omnigent-ai/omnigent/issues/654) [Bug] Streaming with codex is hanging and paragraphs are not split. |
-| 28 | 92 | high | P1 | P1 | +99 | [#542](https://github.com/omnigent-ai/omnigent/issues/542) [Bug] AttributeError: 'SubprocessCLITransport' object has no attribute |
-| 29 | 89 | high | P2 | P1 ⚑ | +148 | [#3164](https://github.com/omnigent-ai/omnigent/issues/3164) [Feature] Optional runtimeClassName on the kubernetes sandbox provider |
-| 30 | 84 | high | P2 | P1 ⚑ | +124 | [#3558](https://github.com/omnigent-ai/omnigent/issues/3558) claude-sdk: cached client does not rebuild on framework-instruction ch |
-| 31 | 84 | high | P1 | P1 | +22 | [#3000](https://github.com/omnigent-ai/omnigent/issues/3000) claude-native transcript forwarder polls at 4 Hz per session with no i |
-| 32 | 84 | high | P1 | P1 | +30 | [#2748](https://github.com/omnigent-ai/omnigent/issues/2748) Runner idle-shutdown deadlocks forever: codex-forwarder close()/flush( |
-| 33 | 84 | high | P1 | P1 | +32 | [#2629](https://github.com/omnigent-ai/omnigent/issues/2629) web_fetch sub-agent spawn fails with unknown harness 'omnigent' — bare |
-| 34 | 84 | high | P1 | P1 | +33 | [#2575](https://github.com/omnigent-ai/omnigent/issues/2575) pi-native: non-Claude Databricks models (GLM, Gemini, …) hang — provid |
-| 35 | 84 | high | P1 | P1 | +37 | [#2454](https://github.com/omnigent-ai/omnigent/issues/2454) [Bug] Unbounded ~/.omnigent growth: per-session native-harness dirs ar |
-| 36 | 84 | high | P1 | P1 | +44 | [#2421](https://github.com/omnigent-ai/omnigent/issues/2421) [Bug] codex app-server + MCP bridge children leak on ANY unclean runne |
-| 37 | 84 | high | P1 | P1 | +91 | [#523](https://github.com/omnigent-ai/omnigent/issues/523) REPL pexpect e2e tests starve on boot under full shard load (60s _wait |
-| 38 | 83 | high | P1 | P1 | +18 | [#2920](https://github.com/omnigent-ai/omnigent/issues/2920) Omnigent server fails to start on native Windows: os.getuid() at impor |
-| 39 | 83 | high | P1 | P1 | +18 | [#2919](https://github.com/omnigent-ai/omnigent/issues/2919) omni setup crashes on Windows: ModuleNotFoundError: No module named 't |
-| 40 | 83 | high | P2 | P1 ⚑ | +168 | [#2714](https://github.com/omnigent-ai/omnigent/issues/2714) Upgrade openai-agents and remove the temporary openai<2.45 cap |
-| 41 | 83 | high | P1 | P1 | +38 | [#2422](https://github.com/omnigent-ai/omnigent/issues/2422) Windows: five chained defects break the documented degraded-mode subse |
-| 42 | 83 | high | P1 | P1 | +48 | [#2245](https://github.com/omnigent-ai/omnigent/issues/2245) [Bug] openai-agents harness turn wedges permanently after policy-verdi |
-| 43 | 83 | high | P2 | P1 ⚑ | +267 | [#762](https://github.com/omnigent-ai/omnigent/issues/762) [Bug] sub agent terminal crashes when cli starts with prompt for input |
-| 44 | 83 | high | P2 | P1 ⚑ | +261 | [#888](https://github.com/omnigent-ai/omnigent/issues/888) [Feature] Side-by-side multi-session view |
-| 45 | 77 | high | P1 | P1 | -7 | [#3261](https://github.com/omnigent-ai/omnigent/issues/3261) [Crash] AttributeError: module 'os' has no attribute 'WNOHANG' |
-| 46 | 76 | high | P2 | P1 ⚑ | +283 | [#151](https://github.com/omnigent-ai/omnigent/issues/151) Native claude_code worker hangs on the one-time Bypass Permissions acc |
-| 47 | 73 | high | P1 | P1 | -19 | [#3482](https://github.com/omnigent-ai/omnigent/issues/3482) [Crash] ServerError: |
-| 48 | 73 | high | P1 | P1 | -18 | [#3458](https://github.com/omnigent-ai/omnigent/issues/3458) session-updates stream crashes with KeyError when a client watches a c |
-| 49 | 73 | high | P2 | P1 ⚑ | +118 | [#3271](https://github.com/omnigent-ai/omnigent/issues/3271) [Feature] Expose per-session context size + last-turn timestamp to age |
-| 50 | 73 | high | P2 | P1 ⚑ | +123 | [#3231](https://github.com/omnigent-ai/omnigent/issues/3231) [Crash] OmnigentError: {'error_code': 403, 'message': 'Invalid access  |
-| 51 | 73 | high | P0 | P1 ⚑ | -49 | [#2355](https://github.com/omnigent-ai/omnigent/issues/2355) [Bug] workspace_id PK-widening migration crashes on populated Postgres |
-| 52 | 73 | high | P3 | P1 ⚑ | +289 | [#2224](https://github.com/omnigent-ai/omnigent/issues/2224) [Bug] get_client model-change check fails for harness="any" |
-| 53 | 73 | high | P1 | P1 | +45 | [#1985](https://github.com/omnigent-ai/omnigent/issues/1985) Headless `omnigent run -p` intermittently hangs forever despite the tu |
-| 54 | 73 | high | P2 | P1 ⚑ | +190 | [#1907](https://github.com/omnigent-ai/omnigent/issues/1907) Sub-agent model_override triggers an unnecessary first-turn harness re |
-| 55 | 73 | high | P2 | P1 ⚑ | +198 | [#1804](https://github.com/omnigent-ai/omnigent/issues/1804) spec parser crashes with TypeError on a null tools.builtins key (and s |
-| 56 | 73 | high | P2 | P1 ⚑ | +211 | [#1600](https://github.com/omnigent-ai/omnigent/issues/1600) Epic: 12-feature contribution (one issue + one PR per feature) |
-| 57 | 73 | high | P2 | P1 ⚑ | +232 | [#1076](https://github.com/omnigent-ai/omnigent/issues/1076) Runner-layer Tier-2 escalation: release an unresponsive per-conversati |
-| 58 | 73 | high | P1 | P1 | +63 | [#1026](https://github.com/omnigent-ai/omnigent/issues/1026) Runner orphans tool callbacks with "no active turn context" after mid- |
-| 59 | 66 | high | P1 | P1 | -51 | [#3971](https://github.com/omnigent-ai/omnigent/issues/3971) Host runners inherit the daemon's cwd; a deleted launch dir breaks eve |
-| 60 | 66 | high | P2 | P1 ⚑ | +86 | [#3750](https://github.com/omnigent-ai/omnigent/issues/3750) [Crash] PermissionError: [Errno 1] Operation not permitted |
-| 61 | 66 | high | P1 | P1 | -32 | [#3469](https://github.com/omnigent-ai/omnigent/issues/3469) [Bug] Post-completion compaction spiral: merge-commit diff output trig |
-| 62 | 66 | high | P1 | P1 | -30 | [#3359](https://github.com/omnigent-ai/omnigent/issues/3359) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 63 | 66 | high | P1 | P1 | -29 | [#3274](https://github.com/omnigent-ai/omnigent/issues/3274) Sub-agent terminal status rejected with missing_parent_inbox and retri |
-| 64 | 66 | high | P1 | P1 | -25 | [#3251](https://github.com/omnigent-ai/omnigent/issues/3251) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 65 | 66 | high | P1 | P1 | -20 | [#3052](https://github.com/omnigent-ai/omnigent/issues/3052) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 66 | 66 | high | P1 | P1 | -20 | [#3023](https://github.com/omnigent-ai/omnigent/issues/3023) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 67 | 66 | high | P1 | P1 | -20 | [#3016](https://github.com/omnigent-ai/omnigent/issues/3016) [Bug] A transient session-snapshot failure permanently pins a session  |
-| 68 | 66 | high | P1 | P1 | -20 | [#3012](https://github.com/omnigent-ai/omnigent/issues/3012) Hosts authenticated via `omnigent login` permanently 403 on first reco |
-| 69 | 66 | high | P1 | P1 | -15 | [#2993](https://github.com/omnigent-ai/omnigent/issues/2993) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 70 | 66 | high | P3 | P1 ⚑ | +267 | [#2887](https://github.com/omnigent-ai/omnigent/issues/2887) [Bug] web/package-lock.json is out of sync with package.json; plain `n |
-| 71 | 66 | high | P1 | P1 | -3 | [#2559](https://github.com/omnigent-ai/omnigent/issues/2559) Conversation bricked: Page fails to load when opening markdown file af |
-| 72 | 66 | high | P2 | P1 ⚑ | +146 | [#2428](https://github.com/omnigent-ai/omnigent/issues/2428) sys_session_send to a completed session hangs to ReadTimeout and is si |
-| 73 | 66 | high | P1 | P1 | +18 | [#2241](https://github.com/omnigent-ai/omnigent/issues/2241) Flaky on main: test_interrupt_forwards_to_harness_before_cancelling ti |
-| 74 | 66 | high | P1 | P1 | +22 | [#2051](https://github.com/omnigent-ai/omnigent/issues/2051) [Bug] sys_session_send(session_id=…) completions never drain to sys_re |
-| 75 | 66 | high | P1 | P1 | +29 | [#1888](https://github.com/omnigent-ai/omnigent/issues/1888) ansi-to-react default import resolves to the CJS exports object under  |
-| 76 | 66 | high | P2 | P1 ⚑ | +179 | [#1778](https://github.com/omnigent-ai/omnigent/issues/1778) opencode-native forwarder loses session content across SSE reconnects  |
-| 77 | 66 | high | P0 | P1 ⚑ | -74 | [#1657](https://github.com/omnigent-ai/omnigent/issues/1657) hermes-native forwarder advances last_id per item, dropping a row's la |
-| 78 | 66 | high | P2 | P1 ⚑ | +236 | [#678](https://github.com/omnigent-ai/omnigent/issues/678) e2e: sub-agent supervisor routing / named-sub-agent auto-wake flakes ( |
-| 79 | 65 | high | P2 | P1 ⚑ | +137 | [#2480](https://github.com/omnigent-ai/omnigent/issues/2480) [Bug] Postgres-backed local server: bare `No module named 'psycopg'` + |
-| 80 | 65 | high | P1 | P1 | +19 | [#1953](https://github.com/omnigent-ai/omnigent/issues/1953) `omni host` dies permanently when the OIDC session JWT expires — no re |
-| 81 | 63 | high | P2 | P1 ⚑ | +217 | [#1022](https://github.com/omnigent-ai/omnigent/issues/1022) Behind a corporate proxy, the host daemon can't reach the model backen |
-| 82 | 61 | medium | P2 | P1 ⚑ | +186 | [#1596](https://github.com/omnigent-ai/omnigent/issues/1596) Native-CLI harness (claude-native/codex-native) as a named agent's own |
-| 83 | 60 | high | P2 | P1 ⚑ | +89 | [#3235](https://github.com/omnigent-ai/omnigent/issues/3235) Flaky E2E UI: test_scheduled_task_create_edit_modal_and_time_picker[ch |
-| 84 | 59 | high | P1 | P2 ⚑ | -67 | [#3799](https://github.com/omnigent-ai/omnigent/issues/3799) Android shell cannot sign in to servers behind a front-door auth proxy |
-| 85 | 59 | high | P1 | P2 ⚑ | -65 | [#3730](https://github.com/omnigent-ai/omnigent/issues/3730) [Bug] Android: renderer death terminates the app — OmnigentWebViewClie |
-| 86 | 59 | high | P1 | P2 ⚑ | -64 | [#3701](https://github.com/omnigent-ai/omnigent/issues/3701) [Bug] Desktop app never completes Okta security key / biometric MFA du |
-| 87 | 59 | high | P1 | P2 ⚑ | +1 | [#2270](https://github.com/omnigent-ai/omnigent/issues/2270) Windows: config list crashes — UnicodeEncodeError on cp1252 (non-UTF8) |
-| 88 | 59 | high | P1 | P2 ⚑ | +1 | [#2269](https://github.com/omnigent-ai/omnigent/issues/2269) Windows: omnigent setup crashes — ModuleNotFoundError: No module named |
-| 89 | 59 | high | P1 | P2 ⚑ | +13 | [#1901](https://github.com/omnigent-ai/omnigent/issues/1901) [Bug] kimi/qwen/goose/kiro forwarders blind-retry failed conversation- |
-| 90 | 59 | high | P1 | P2 ⚑ | +15 | [#1881](https://github.com/omnigent-ai/omnigent/issues/1881) [Bug] `omnigent setup` crashes with `ValueError: select() requires at  |
-| 91 | 59 | high | P1 | P2 ⚑ | +17 | [#1827](https://github.com/omnigent-ai/omnigent/issues/1827) [Bug] kimi-native: torn UTF-8 wire read crashes the forwarder; supervi |
-| 92 | 58 | high | P1 | P2 ⚑ | +39 | [#108](https://github.com/omnigent-ai/omnigent/issues/108) Cannot install on Linux aarch64 — cel-expr-python has no aarch64 wheel |
-| 93 | 57 | medium | P2 | P2 | +206 | [#1021](https://github.com/omnigent-ai/omnigent/issues/1021) [Feature] GitHub Copilot as provider |
-| 94 | 54 | medium | P2 | P2 | +230 | [#377](https://github.com/omnigent-ai/omnigent/issues/377) gpt sub-agent fails on startup with missing databricks-sdk dependency |
-| 95 | 54 | high | P2 | P2 | +49 | [#3798](https://github.com/omnigent-ai/omnigent/issues/3798) Android shell shows the SPA as if signed in while native login runs in |
-| 96 | 53 | high | P1 | P2 ⚑ | -47 | [#3011](https://github.com/omnigent-ai/omnigent/issues/3011) kiro-native harness: interactive sessions never respond with kiro-cli  |
-| 97 | 50 | medium | P2 | P2 | +107 | [#2744](https://github.com/omnigent-ai/omnigent/issues/2744) [Bug] codex-native: custom agents time out at launch — native provider |
-| 98 | 46 | medium | P1 | P2 ⚑ | -88 | [#3952](https://github.com/omnigent-ai/omnigent/issues/3952) A stale terminal exit removes the newer Codex resources of the same se |
-| 99 | 46 | medium | P2 | P2 | +51 | [#3592](https://github.com/omnigent-ai/omnigent/issues/3592) [Feature] Deterministic long-term memory (automatic recall/retain) — f |
-| 100 | 46 | medium | P1 | P2 ⚑ | -75 | [#3536](https://github.com/omnigent-ai/omnigent/issues/3536) [Bug] A session's `reasoning_effort` never reaches in-process harnesse |
-| 101 | 46 | medium | P2 | P2 | +60 | [#3369](https://github.com/omnigent-ai/omnigent/issues/3369) Feature: a policy that fences a spawned type: agent worker read-only ( |
-| 102 | 46 | medium | P2 | P2 | +66 | [#3254](https://github.com/omnigent-ai/omnigent/issues/3254) Sub-agent silently stalls after repeated context compactions during re |
-| 103 | 46 | medium | P2 | P2 | +82 | [#3069](https://github.com/omnigent-ai/omnigent/issues/3069) Harness install surfaces opaque failure reasons (npm stderr not captur |
-| 104 | 46 | medium | P2 | P2 | +87 | [#2984](https://github.com/omnigent-ai/omnigent/issues/2984) [Bug] Codex incorrectly reports `needs-auth` with an authenticated cus |
-| 105 | 46 | medium | P3 | P2 ⚑ | +233 | [#2853](https://github.com/omnigent-ai/omnigent/issues/2853) [Bug] Native harnesses silently drop the agent spec `prompt:` at runti |
-| 106 | 46 | medium | P2 | P2 | +94 | [#2815](https://github.com/omnigent-ai/omnigent/issues/2815) [Feature] Distinguish human waits from machine-liveness deadlines |
-| 107 | 46 | medium | P2 | P2 | +100 | [#2719](https://github.com/omnigent-ai/omnigent/issues/2719) [Bug] |
-| 108 | 46 | medium | P2 | P2 | +103 | [#2644](https://github.com/omnigent-ai/omnigent/issues/2644) Design discussion: deterministic verification gates (a PASS/FAIL quali |
-| 109 | 46 | medium | P1 | P2 ⚑ | -17 | [#2184](https://github.com/omnigent-ai/omnigent/issues/2184) [Bug] Codex plugin skills are exposed with inconsistent names (`plugin |
-| 110 | 46 | medium | P1 | P2 ⚑ | -17 | [#2071](https://github.com/omnigent-ai/omnigent/issues/2071) [Bug] web_search never advertised to claude-sdk sessions: unprefixed m |
-| 111 | 46 | medium | P2 | P2 | +124 | [#2062](https://github.com/omnigent-ai/omnigent/issues/2062) [Bug] claude-native: per-session model override silently lost when wra |
-| 112 | 46 | medium | P1 | P2 ⚑ | -5 | [#1831](https://github.com/omnigent-ai/omnigent/issues/1831) claude-native workers ignore executor.model pin and per-dispatch args. |
-| 113 | 46 | medium | P2 | P2 | +141 | [#1789](https://github.com/omnigent-ai/omnigent/issues/1789) Feature: Canvas — agent-authored artifact panel (#2) |
-| 114 | 46 | medium | P1 | P2 ⚑ | -4 | [#1781](https://github.com/omnigent-ai/omnigent/issues/1781) codex harness: ambient DATABRICKS_BEARER/DATABRICKS_TOKEN overrides pr |
-| 115 | 46 | medium | P2 | P2 | +154 | [#1594](https://github.com/omnigent-ai/omnigent/issues/1594) Server-side idempotency for external_conversation_item (safe dedup on  |
-| 116 | 46 | medium | P2 | P2 | +165 | [#1230](https://github.com/omnigent-ai/omnigent/issues/1230) [Feature] Migrate remaining native forwarders to the shared post_sessi |
-| 117 | 46 | medium | P1 | P2 ⚑ | +2 | [#1128](https://github.com/omnigent-ai/omnigent/issues/1128) [Bug] Claude SDK Appears to Use Opus Instead of Selected Model |
-| 118 | 46 | medium | P2 | P2 | +199 | [#548](https://github.com/omnigent-ai/omnigent/issues/548) Recommend missing dependency install suggestions more gracefully in UI |
-| 119 | 46 | medium | P1 | P2 ⚑ | +11 | [#241](https://github.com/omnigent-ai/omnigent/issues/241) pi harness: GPT and Gemini dispatches 404 on the Databricks ucode gate |
-| 120 | 46 | medium | P3 | P2 ⚑ | +227 | [#147](https://github.com/omnigent-ai/omnigent/issues/147) Tracking: gradual decomposition of monolith modules (cli.py 9.1KLOC, c |
-| 121 | 46 | medium | P1 | P2 ⚑ | -1 | [#1113](https://github.com/omnigent-ai/omnigent/issues/1113) Native sub-agent/runner failures surface as bare "failed" with no reas |
-| 122 | 42 | medium | P2 | P2 | +16 | [#3969](https://github.com/omnigent-ai/omnigent/issues/3969) Databricks gateway sessions default to a stale model (opus-4-7) while  |
-| 123 | 42 | medium | P1 | P2 ⚑ | -105 | [#3790](https://github.com/omnigent-ai/omnigent/issues/3790) force_sandbox policy is evaluated but structurally unreachable from cl |
-| 124 | 42 | medium | P1 | P2 ⚑ | -84 | [#3236](https://github.com/omnigent-ai/omnigent/issues/3236) web_search: bare executor.model strings are inferred as provider 'open |
-| 125 | 42 | medium | P1 | P2 ⚑ | -61 | [#2630](https://github.com/omnigent-ai/omnigent/issues/2630) Tool-spawn failure is swallowed — agent answers from training knowledg |
-| 126 | 42 | medium | P2 | P2 | +132 | [#1724](https://github.com/omnigent-ai/omnigent/issues/1724) codex-native harness times out on WSL2 ("Codex TUI never started a thr |
-| 127 | 42 | medium | P1 | P2 ⚑ | -12 | [#1533](https://github.com/omnigent-ai/omnigent/issues/1533) Context-occupancy meter (context_tokens) freezes on failed turns — onl |
-| 128 | 42 | medium | P1 | P2 ⚑ | -70 | [#2904](https://github.com/omnigent-ai/omnigent/issues/2904) [Bug] claude-native: web-UI chat input fails with "tmux command failed |
-| 129 | 42 | medium | P2 | P2 | +65 | [#2880](https://github.com/omnigent-ai/omnigent/issues/2880) [Feature] Add in-session revert mechanism for all interfaces  |
-| 130 | 42 | medium | P1 | P2 ⚑ | -69 | [#2812](https://github.com/omnigent-ai/omnigent/issues/2812) [Bug] serve-mcp stops answering stdio requests during a slow tool call |
-| 131 | 42 | medium | P1 | P2 ⚑ | -50 | [#2397](https://github.com/omnigent-ai/omnigent/issues/2397) [Bug] Codex-native intelligent routing ignores live effort capabilitie |
-| 132 | 42 | medium | P1 | P2 ⚑ | -45 | [#2272](https://github.com/omnigent-ai/omnigent/issues/2272) [Bug] Codex runner can't find OpenRouter secret that exists in keyring |
-| 133 | 42 | medium | P2 | P2 | +171 | [#890](https://github.com/omnigent-ai/omnigent/issues/890) [Bug] omnigent setup fails with npm EACCES when installing the Claude  |
-| 134 | 42 | medium | P1 | P2 ⚑ | -9 | [#668](https://github.com/omnigent-ai/omnigent/issues/668) [Bug] BUG？omni claude times out (60s) on macOS with native Claude Code |
-| 135 | 40 | medium | P1 | P2 ⚑ | -93 | [#3101](https://github.com/omnigent-ai/omnigent/issues/3101) Docker/Kubernetes entrypoint never wires project_store — first-class P |
-| 136 | 39 | medium | P1 | P2 ⚑ | -23 | [#1551](https://github.com/omnigent-ai/omnigent/issues/1551) opencode-native: blocking question tool not surfaced to web (no elicit |
-| 137 | 38 | medium | P2 | P2 | +2 | [#3950](https://github.com/omnigent-ai/omnigent/issues/3950) An agent switch keeps the previous agent's comment-tool relay |
-| 138 | 38 | medium | P1 | P2 ⚑ | -122 | [#3852](https://github.com/omnigent-ai/omnigent/issues/3852) [Bug] Built-in write policies miss Claude Code's `MultiEdit` / `Notebo |
-| 139 | 38 | medium | P1 | P2 ⚑ | -113 | [#3530](https://github.com/omnigent-ai/omnigent/issues/3530) [Bug] An agent spec's `instructions:` has no effect on 13 of 24 harnes |
-| 140 | 38 | medium | P1 | P2 ⚑ | -113 | [#3525](https://github.com/omnigent-ai/omnigent/issues/3525) Sub-agent sessions are launched from the parent agent's bundle root, e |
-| 141 | 38 | medium | P2 | P2 | +83 | [#2369](https://github.com/omnigent-ai/omnigent/issues/2369) [Bug] pi harness only lists databricks-claude-sonnet-4-6 |
-| 142 | 38 | medium | P1 | P2 ⚑ | -56 | [#2299](https://github.com/omnigent-ai/omnigent/issues/2299) [Bug] claude-native resume transcripts flatten tool_result image block |
-| 143 | 38 | medium | P2 | P2 | +78 | [#2390](https://github.com/omnigent-ai/omnigent/issues/2390) Builtin policy for per-user sub-agent access control (subagent_access_ |
-| 144 | 38 | medium | P1 | P2 ⚑ | -35 | [#1794](https://github.com/omnigent-ai/omnigent/issues/1794) Bundled Polly: claude-sdk brain "Not logged in" + runaway spawn loop o |
-| 145 | 38 | medium | P1 | P2 ⚑ | -34 | [#1694](https://github.com/omnigent-ai/omnigent/issues/1694) Reliability: parallel code-fix missions fail silently (5s tmux timeout |
-| 146 | 38 | medium | P2 | P2 | +182 | [#152](https://github.com/omnigent-ai/omnigent/issues/152) Harness availability is reported from binary presence, not from config |
-| 147 | 36 | medium | P2 | P2 | -13 | [#4009](https://github.com/omnigent-ai/omnigent/issues/4009) [Feature] No Go client for the session API, so every Go caller hand-ro |
-| 148 | 36 | medium | P1 | P2 ⚑ | -135 | [#3898](https://github.com/omnigent-ai/omnigent/issues/3898) [Bug] Pack function policies fail server-side input evaluation unless  |
-| 149 | 36 | medium | P1 | P2 ⚑ | -135 | [#3870](https://github.com/omnigent-ai/omnigent/issues/3870) child-session creation returns 500 internal_error, breaking Polly/Debb |
-| 150 | 36 | medium | P2 | P2 | -8 | [#3864](https://github.com/omnigent-ai/omnigent/issues/3864) [Bug] to_api_dict() drops ConversationItem.created_at, so flat items A |
-| 151 | 36 | medium | P1 | P2 ⚑ | -136 | [#3863](https://github.com/omnigent-ai/omnigent/issues/3863) [Bug] Databricks Apps entrypoint never wires project_store — Projects  |
-| 152 | 36 | medium | P2 | P2 | 0 | [#3563](https://github.com/omnigent-ai/omnigent/issues/3563) [Bug] Host-bound resume into a deleted workspace: host computes the ex |
-| 153 | 36 | medium | P2 | P2 | +2 | [#3550](https://github.com/omnigent-ai/omnigent/issues/3550) [Bug] Missing signing alg's prevent using some OIDC providers |
-| 154 | 36 | medium | P2 | P2 | +6 | [#3435](https://github.com/omnigent-ai/omnigent/issues/3435) [Feature] Admin server-wide usage report (per-user and per-model cost) |
-| 155 | 36 | medium | P2 | P2 | +7 | [#3368](https://github.com/omnigent-ai/omnigent/issues/3368) Feature: first-class async write-safety (freeze → approve → apply) pri |
-| 156 | 36 | medium | P2 | P2 | +9 | [#3352](https://github.com/omnigent-ai/omnigent/issues/3352) [Feature] OpenClaw onboarding — Option B: chat import (SQLite session  |
-| 157 | 36 | medium | P2 | P2 | +13 | [#3247](https://github.com/omnigent-ai/omnigent/issues/3247) credential_proxy: re-resolve the source on 401 / expiry (short-lived t |
-| 158 | 36 | medium | P1 | P2 ⚑ | -98 | [#2854](https://github.com/omnigent-ai/omnigent/issues/2854) [Bug] Cross-harness `harness_override` is ignored on the `initial_item |
-| 159 | 36 | medium | P2 | P2 | +37 | [#2851](https://github.com/omnigent-ai/omnigent/issues/2851) Policy-supplied targets for ASK approval cards |
-| 160 | 36 | medium | P2 | P2 | +42 | [#2756](https://github.com/omnigent-ai/omnigent/issues/2756) Expose atomic session-event admission to integrations |
-| 161 | 36 | medium | P2 | P2 | +51 | [#2577](https://github.com/omnigent-ai/omnigent/issues/2577) [Feature] Manage OIDC/SSO admins from an id_token claim (IdP group/rol |
-| 162 | 36 | medium | P1 | P2 ⚑ | -92 | [#2539](https://github.com/omnigent-ai/omnigent/issues/2539) Named sys_session_send returns 404 after first child from a bundled se |
-| 163 | 36 | medium | P1 | P2 ⚑ | -92 | [#2524](https://github.com/omnigent-ai/omnigent/issues/2524) [Bug] Registering remote host fails |
-| 164 | 36 | medium | P1 | P2 ⚑ | -91 | [#2444](https://github.com/omnigent-ai/omnigent/issues/2444) Accounts JWT expiry falls through to Databricks auth and breaks persis |
-| 165 | 36 | medium | P2 | P2 | +55 | [#2404](https://github.com/omnigent-ai/omnigent/issues/2404) fix(runtime): orphan sweep can abort startup on unreadable shared-host |
-| 166 | 36 | medium | P2 | P2 | +56 | [#2374](https://github.com/omnigent-ai/omnigent/issues/2374) Proposal: per-turn context_providers to augment system instructions at |
-| 167 | 36 | medium | P1 | P2 ⚑ | -82 | [#2304](https://github.com/omnigent-ai/omnigent/issues/2304) Runner subprocess inherits host daemon cwd, causing os_env cwd resolut |
-| 168 | 36 | medium | P2 | P2 | +66 | [#2070](https://github.com/omnigent-ai/omnigent/issues/2070) [Feature] sys_os_* file tools are hard-confined to the session workspa |
-| 169 | 36 | medium | P2 | P2 | +83 | [#1816](https://github.com/omnigent-ai/omnigent/issues/1816) `omni run <agent.yaml> --harness opencode` rejects the agent bundle (T |
-| 170 | 36 | medium | P2 | P2 | +101 | [#1526](https://github.com/omnigent-ai/omnigent/issues/1526) Refactor: incrementally decompose the 4 god-files (sessions.py, runner |
-| 171 | 36 | medium | P2 | P2 | +103 | [#1411](https://github.com/omnigent-ai/omnigent/issues/1411) Standalone reusable MCP servers: CRUD + connection verify (list tools) |
-| 172 | 36 | medium | P1 | P2 ⚑ | -55 | [#1158](https://github.com/omnigent-ai/omnigent/issues/1158) [Bug] antigravity-native: TUI-typed turns never mirror to the web UI ( |
-| 173 | 36 | medium | P2 | P2 | +112 | [#1157](https://github.com/omnigent-ai/omnigent/issues/1157) [Bug] antigravity-native: no Chat/Terminal toggle — terminal_antigravi |
-| 174 | 36 | medium | P2 | P2 | +116 | [#1075](https://github.com/omnigent-ai/omnigent/issues/1075) [Feature] Support AWS Lambda / Firecracker microVMs as managed sandbox |
-| 175 | 36 | medium | P2 | P2 | +117 | [#1055](https://github.com/omnigent-ai/omnigent/issues/1055) [Test] End-to-end OTel test against a real collector to lock in the BY |
-| 176 | 36 | medium | P2 | P2 | +117 | [#1054](https://github.com/omnigent-ai/omnigent/issues/1054) [Feature] Record gen_ai.retry events on llm_call spans |
-| 177 | 36 | medium | P2 | P2 | +120 | [#1031](https://github.com/omnigent-ai/omnigent/issues/1031) [Feature] Support serving the standalone Web UI under a subpath, e.g.  |
-| 178 | 36 | medium | P2 | P2 | +122 | [#983](https://github.com/omnigent-ai/omnigent/issues/983) Session sharing ergonomics: `sys_session_share` agent tool + `omnigent |
-| 179 | 36 | medium | P2 | P2 | +129 | [#857](https://github.com/omnigent-ai/omnigent/issues/857) [Proposal] Usage-limit detection + on-429 failover across pooled provi |
-| 180 | 36 | medium | P1 | P2 ⚑ | -56 | [#765](https://github.com/omnigent-ai/omnigent/issues/765) Support interactive mid-flight policy ASK (TOOL_CALL/TOOL_RESULT/OUTPU |
-| 181 | 36 | medium | P1 | P2 ⚑ | -52 | [#522](https://github.com/omnigent-ai/omnigent/issues/522) Implement async-tool completion auto-delivery (SESSION_REARCHITECTURE  |
-| 182 | 36 | medium | P2 | P2 | +136 | [#509](https://github.com/omnigent-ai/omnigent/issues/509) [Feature] Default new-session workspace from selected agent's cwd |
-| 183 | 36 | medium | P2 | P2 | +140 | [#382](https://github.com/omnigent-ai/omnigent/issues/382) Evaluating the same agent across harnesses: no built-in way to compare |
-| 184 | 36 | feature | P2 | P2 | +57 | [#2003](https://github.com/omnigent-ai/omnigent/issues/2003) [Feature] Pluggable terminal multiplexer backend (tmux / herdr / zelli |
-| 185 | 36 | feature | P2 | P2 | +128 | [#692](https://github.com/omnigent-ai/omnigent/issues/692) Polly: fan out sub-agent work across multiple concurrent claude profil |
-| 186 | 36 | feature | P2 | P2 | +141 | [#197](https://github.com/omnigent-ai/omnigent/issues/197) Declarative skill sources: pull Claude Code skills + their dependency  |
-| 187 | 35 | medium | P1 | P2 ⚑ | -124 | [#2702](https://github.com/omnigent-ai/omnigent/issues/2702) Native idle-detection fork+exec's tmux capture-pane at 5 Hz per termin |
-| 188 | 35 | medium | P2 | P2 | +49 | [#2055](https://github.com/omnigent-ai/omnigent/issues/2055) [Bug] codex-native harness elicitation: a resolve landing in the betwe |
-| 189 | 35 | medium | P1 | P2 ⚑ | -145 | [#3076](https://github.com/omnigent-ai/omnigent/issues/3076) [Bug] claude-sdk omits ToolSearch, eagerly loading every MCP schema |
-| 190 | 35 | medium | P3 | P2 ⚑ | +149 | [#2800](https://github.com/omnigent-ai/omnigent/issues/2800) [Bug] Top-level custom codex-native agents drop reasoning effort and y |
-| 191 | 35 | medium | P1 | P2 ⚑ | -68 | [#880](https://github.com/omnigent-ai/omnigent/issues/880) [BUG] Native harness (omnigent claude): assistant turns not streamed t |
-| 192 | 34 | medium | P1 | P2 ⚑ | -114 | [#2429](https://github.com/omnigent-ai/omnigent/issues/2429) Server (python -m omnigent.cli server) CPU-spins indefinitely with no  |
-| 193 | 33 | feature | P2 | P2 | +32 | [#2303](https://github.com/omnigent-ai/omnigent/issues/2303) [Feature] Support multi-repo workspaces (nested Git repos or multiple  |
-| 194 | 33 | medium | P1 | P2 ⚑ | -188 | [#3981](https://github.com/omnigent-ai/omnigent/issues/3981) [Bug] Desktop: Workspace rail resize is unusable on the Browser tab; a |
-| 195 | 33 | medium | P2 | P2 | -52 | [#3861](https://github.com/omnigent-ai/omnigent/issues/3861) [Bug] omni host status renders URLs so terminals link the whole status |
+| 1 | 158 | critical | P1 | P0 ⚑ | +34 | [#3270](https://github.com/omnigent-ai/omnigent/issues/3270) [Bug] sys_session_create children are absent from both sys_session_lis |
+| 2 | 143 | critical | P2 | P0 ⚑ | +230 | [#2125](https://github.com/omnigent-ai/omnigent/issues/2125) [Feature] Multi-host git credentials for managed sandboxes (GitHub + s |
+| 3 | 132 | critical | P1 | P0 ⚑ | +1 | [#3983](https://github.com/omnigent-ai/omnigent/issues/3983) [Bug] Smart-routed turns render out of order: reply streams above the  |
+| 4 | 123 | critical | P2 | P0 ⚑ | +232 | [#2057](https://github.com/omnigent-ai/omnigent/issues/2057) [Feature] Add Codex Auto mode using auto_review instead of jumping to  |
+| 5 | 123 | critical | P2 | P0 ⚑ | +233 | [#2054](https://github.com/omnigent-ai/omnigent/issues/2054) [Feature] Remove duplicate Codex Full access mode and keep Sandbox Byp |
+| 6 | 111 | high | P1 | P0 ⚑ | +27 | [#3299](https://github.com/omnigent-ai/omnigent/issues/3299) [Bug] Harness-credential route times out with a misleading 504 against |
+| 7 | 111 | high | P2 | P0 ⚑ | +159 | [#3284](https://github.com/omnigent-ai/omnigent/issues/3284) [Crash] DuplicateOptionError: While reading from PosixPath('/Users/*** |
+| 8 | 111 | high | P1 | P0 ⚑ | +33 | [#3180](https://github.com/omnigent-ai/omnigent/issues/3180) codex-native: runner never exits on idle timeout — cancelled delta-coa |
+| 9 | 111 | high | P2 | P0 ⚑ | +175 | [#3070](https://github.com/omnigent-ai/omnigent/issues/3070) No progress signal on a stuck or interactive harness install |
+| 10 | 111 | high | P1 | P0 ⚑ | +45 | [#2967](https://github.com/omnigent-ai/omnigent/issues/2967) [Bug] A full context window bricks a session with "Prompt is too long" |
+| 11 | 111 | high | P1 | P0 ⚑ | +45 | [#2920](https://github.com/omnigent-ai/omnigent/issues/2920) Omnigent server fails to start on native Windows: os.getuid() at impor |
+| 12 | 111 | high | P1 | P0 ⚑ | +45 | [#2919](https://github.com/omnigent-ai/omnigent/issues/2919) omni setup crashes on Windows: ModuleNotFoundError: No module named 't |
+| 13 | 111 | high | P2 | P0 ⚑ | +195 | [#2714](https://github.com/omnigent-ai/omnigent/issues/2714) Upgrade openai-agents and remove the temporary openai<2.45 cap |
+| 14 | 110 | critical | P0 | P0 | -13 | [#3557](https://github.com/omnigent-ai/omnigent/issues/3557) [Bug] Shell-surface policy gates are bypassed by option-taking command |
+| 15 | 108 | high | P2 | P0 ⚑ | +319 | [#16](https://github.com/omnigent-ai/omnigent/issues/16) Is native Windows support in scope, or should docs recommend WSL2? |
+| 16 | 106 | critical | P2 | P0 ⚑ | +299 | [#659](https://github.com/omnigent-ai/omnigent/issues/659) [Feature] add a microvm backend for sandbox |
+| 17 | 101 | high | P1 | P0 ⚑ | +20 | [#3265](https://github.com/omnigent-ai/omnigent/issues/3265) claude-sdk agent with linux_bwrap dies at spawn on a runtime bwrap bin |
+| 18 | 101 | high | P1 | P0 ⚑ | +35 | [#3000](https://github.com/omnigent-ai/omnigent/issues/3000) claude-native transcript forwarder polls at 4 Hz per session with no i |
+| 19 | 101 | high | P1 | P0 ⚑ | +43 | [#2748](https://github.com/omnigent-ai/omnigent/issues/2748) Runner idle-shutdown deadlocks forever: codex-forwarder close()/flush( |
+| 20 | 101 | high | P1 | P0 ⚑ | +45 | [#2629](https://github.com/omnigent-ai/omnigent/issues/2629) web_fetch sub-agent spawn fails with unknown harness 'omnigent' — bare |
+| 21 | 101 | high | P1 | P0 ⚑ | +46 | [#2575](https://github.com/omnigent-ai/omnigent/issues/2575) pi-native: non-Claude Databricks models (GLM, Gemini, …) hang — provid |
+| 22 | 100 | high | P1 | P1 | +16 | [#3261](https://github.com/omnigent-ai/omnigent/issues/3261) [Crash] AttributeError: module 'os' has no attribute 'WNOHANG' |
+| 23 | 95 | high | P1 | P1 | +5 | [#3482](https://github.com/omnigent-ai/omnigent/issues/3482) [Crash] ServerError: |
+| 24 | 95 | high | P1 | P1 | +6 | [#3458](https://github.com/omnigent-ai/omnigent/issues/3458) session-updates stream crashes with KeyError when a client watches a c |
+| 25 | 95 | high | P2 | P1 ⚑ | +139 | [#3363](https://github.com/omnigent-ai/omnigent/issues/3363) [Feature] Per-project custom instructions (project-scoped context) |
+| 26 | 95 | high | P2 | P1 ⚑ | +141 | [#3271](https://github.com/omnigent-ai/omnigent/issues/3271) [Feature] Expose per-session context size + last-turn timestamp to age |
+| 27 | 95 | high | P2 | P1 ⚑ | +146 | [#3231](https://github.com/omnigent-ai/omnigent/issues/3231) [Crash] OmnigentError: {'error_code': 403, 'message': 'Invalid access  |
+| 28 | 86 | high | P1 | P1 | +6 | [#3274](https://github.com/omnigent-ai/omnigent/issues/3274) Sub-agent terminal status rejected with missing_parent_inbox and retri |
+| 29 | 86 | high | P1 | P1 | +18 | [#3016](https://github.com/omnigent-ai/omnigent/issues/3016) [Bug] A transient session-snapshot failure permanently pins a session  |
+| 30 | 86 | high | P1 | P1 | +18 | [#3012](https://github.com/omnigent-ai/omnigent/issues/3012) Hosts authenticated via `omnigent login` permanently 403 on first reco |
+| 31 | 86 | high | P1 | P1 | +21 | [#3001](https://github.com/omnigent-ai/omnigent/issues/3001) [Performance] GET /v1/sessions pre-fetches every accessible conversati |
+| 32 | 84 | high | P2 | P1 ⚑ | +122 | [#3558](https://github.com/omnigent-ai/omnigent/issues/3558) claude-sdk: cached client does not rebuild on framework-instruction ch |
+| 33 | 80 | critical | P3 | P1 ⚑ | +316 | [#61](https://github.com/omnigent-ai/omnigent/issues/61) 🤖 Code Audit: 21 potential issue(s) found |
+| 34 | 79 | high | P2 | P1 ⚑ | +102 | [#3976](https://github.com/omnigent-ai/omnigent/issues/3976) [Feature] OAuth2 client-credentials grant so a headless process can au |
+| 35 | 79 | high | P1 | P1 | -6 | [#3469](https://github.com/omnigent-ai/omnigent/issues/3469) [Bug] Post-completion compaction spiral: merge-commit diff output trig |
+| 36 | 79 | high | P1 | P1 | -4 | [#3359](https://github.com/omnigent-ai/omnigent/issues/3359) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 37 | 79 | high | P1 | P1 | +2 | [#3251](https://github.com/omnigent-ai/omnigent/issues/3251) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 38 | 79 | high | P1 | P1 | +7 | [#3052](https://github.com/omnigent-ai/omnigent/issues/3052) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 39 | 79 | high | P1 | P1 | +7 | [#3023](https://github.com/omnigent-ai/omnigent/issues/3023) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 40 | 79 | high | P1 | P1 | +14 | [#2993](https://github.com/omnigent-ai/omnigent/issues/2993) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 41 | 79 | high | P3 | P1 ⚑ | +296 | [#2887](https://github.com/omnigent-ai/omnigent/issues/2887) [Bug] web/package-lock.json is out of sync with package.json; plain `n |
+| 42 | 79 | high | P1 | P1 | +26 | [#2559](https://github.com/omnigent-ai/omnigent/issues/2559) Conversation bricked: Page fails to load when opening markdown file af |
+| 43 | 74 | high | P1 | P1 | +36 | [#2422](https://github.com/omnigent-ai/omnigent/issues/2422) Windows: five chained defects break the documented degraded-mode subse |
+| 44 | 74 | high | P1 | P1 | +38 | [#2373](https://github.com/omnigent-ai/omnigent/issues/2373) [Bug] claude-native: pasted web-UI message loses its Enter, stuck draf |
+| 45 | 74 | high | P1 | P1 | +45 | [#2245](https://github.com/omnigent-ai/omnigent/issues/2245) [Bug] openai-agents harness turn wedges permanently after policy-verdi |
+| 46 | 74 | high | P1 | P1 | +48 | [#2060](https://github.com/omnigent-ai/omnigent/issues/2060) [Bug] claude-native: first web-UI message silently dropped when Claude |
+| 47 | 74 | high | P1 | P1 | +56 | [#1898](https://github.com/omnigent-ai/omnigent/issues/1898) [Bug] codex-native: cancelling a task awaiting flush() poisons the del |
+| 48 | 74 | high | P2 | P1 ⚑ | +222 | [#1528](https://github.com/omnigent-ai/omnigent/issues/1528) Idle-session lifecycle UX: reap gracefully, resume seamlessly, surface |
+| 49 | 74 | high | P2 | P1 ⚑ | +246 | [#1051](https://github.com/omnigent-ai/omnigent/issues/1051) [Feature] Forward OTel exporter knobs to executor subprocess env |
+| 50 | 74 | high | P2 | P1 ⚑ | +260 | [#762](https://github.com/omnigent-ai/omnigent/issues/762) [Bug] sub agent terminal crashes when cli starts with prompt for input |
+| 51 | 74 | high | P2 | P1 ⚑ | +265 | [#654](https://github.com/omnigent-ai/omnigent/issues/654) [Bug] Streaming with codex is hanging and paragraphs are not split. |
+| 52 | 74 | high | P1 | P1 | +75 | [#542](https://github.com/omnigent-ai/omnigent/issues/542) [Bug] AttributeError: 'SubprocessCLITransport' object has no attribute |
+| 53 | 74 | high | P2 | P1 ⚑ | +187 | [#2038](https://github.com/omnigent-ai/omnigent/issues/2038) [Feature] No way to deregister/delete an external self-registered host |
+| 54 | 72 | high | P1 | P1 | -46 | [#3971](https://github.com/omnigent-ai/omnigent/issues/3971) Host runners inherit the daemon's cwd; a deleted launch dir breaks eve |
+| 55 | 72 | high | P2 | P1 ⚑ | +117 | [#3235](https://github.com/omnigent-ai/omnigent/issues/3235) Flaky E2E UI: test_scheduled_task_create_edit_modal_and_time_picker[ch |
+| 56 | 71 | high | P2 | P1 ⚑ | +121 | [#3164](https://github.com/omnigent-ai/omnigent/issues/3164) [Feature] Optional runtimeClassName on the kubernetes sandbox provider |
+| 57 | 71 | high | P1 | P1 | -8 | [#3011](https://github.com/omnigent-ai/omnigent/issues/3011) kiro-native harness: interactive sessions never respond with kiro-cli  |
+| 58 | 67 | high | P1 | P1 | +14 | [#2454](https://github.com/omnigent-ai/omnigent/issues/2454) [Bug] Unbounded ~/.omnigent growth: per-session native-harness dirs ar |
+| 59 | 67 | high | P1 | P1 | +21 | [#2421](https://github.com/omnigent-ai/omnigent/issues/2421) [Bug] codex app-server + MCP bridge children leak on ANY unclean runne |
+| 60 | 67 | high | P1 | P1 | +68 | [#523](https://github.com/omnigent-ai/omnigent/issues/523) REPL pexpect e2e tests starve on boot under full shard load (60s _wait |
+| 61 | 67 | high | P2 | P1 ⚑ | +268 | [#151](https://github.com/omnigent-ai/omnigent/issues/151) Native claude_code worker hangs on the one-time Bypass Permissions acc |
+| 62 | 66 | high | P2 | P1 ⚑ | +243 | [#888](https://github.com/omnigent-ai/omnigent/issues/888) [Feature] Side-by-side multi-session view |
+| 63 | 66 | high | P2 | P1 ⚑ | +74 | [#3970](https://github.com/omnigent-ai/omnigent/issues/3970) pi-native: every turn fails with "Pi model error: 401 Invalid Token" w |
+| 64 | 66 | high | P1 | P1 | -47 | [#3799](https://github.com/omnigent-ai/omnigent/issues/3799) Android shell cannot sign in to servers behind a front-door auth proxy |
+| 65 | 66 | high | P2 | P1 ⚑ | +81 | [#3750](https://github.com/omnigent-ai/omnigent/issues/3750) [Crash] PermissionError: [Errno 1] Operation not permitted |
+| 66 | 66 | high | P1 | P1 | -46 | [#3730](https://github.com/omnigent-ai/omnigent/issues/3730) [Bug] Android: renderer death terminates the app — OmnigentWebViewClie |
+| 67 | 66 | high | P1 | P1 | -45 | [#3701](https://github.com/omnigent-ai/omnigent/issues/3701) [Bug] Desktop app never completes Okta security key / biometric MFA du |
+| 68 | 63 | high | P2 | P1 ⚑ | +148 | [#2480](https://github.com/omnigent-ai/omnigent/issues/2480) [Bug] Postgres-backed local server: bare `No module named 'psycopg'` + |
+| 69 | 63 | high | P0 | P1 ⚑ | -67 | [#2355](https://github.com/omnigent-ai/omnigent/issues/2355) [Bug] workspace_id PK-widening migration crashes on populated Postgres |
+| 70 | 63 | high | P3 | P1 ⚑ | +271 | [#2224](https://github.com/omnigent-ai/omnigent/issues/2224) [Bug] get_client model-change check fails for harness="any" |
+| 71 | 63 | high | P1 | P1 | +27 | [#1985](https://github.com/omnigent-ai/omnigent/issues/1985) Headless `omnigent run -p` intermittently hangs forever despite the tu |
+| 72 | 63 | high | P1 | P1 | +27 | [#1953](https://github.com/omnigent-ai/omnigent/issues/1953) `omni host` dies permanently when the OIDC session JWT expires — no re |
+| 73 | 63 | high | P2 | P1 ⚑ | +171 | [#1907](https://github.com/omnigent-ai/omnigent/issues/1907) Sub-agent model_override triggers an unnecessary first-turn harness re |
+| 74 | 63 | high | P2 | P1 ⚑ | +179 | [#1804](https://github.com/omnigent-ai/omnigent/issues/1804) spec parser crashes with TypeError on a null tools.builtins key (and s |
+| 75 | 63 | high | P2 | P1 ⚑ | +201 | [#1388](https://github.com/omnigent-ai/omnigent/issues/1388) Make agents a first-class CRUD entity with a dedicated sidebar UI (dec |
+| 76 | 63 | high | P2 | P1 ⚑ | +213 | [#1076](https://github.com/omnigent-ai/omnigent/issues/1076) Runner-layer Tier-2 escalation: release an unresponsive per-conversati |
+| 77 | 63 | high | P1 | P1 | +44 | [#1026](https://github.com/omnigent-ai/omnigent/issues/1026) Runner orphans tool callbacks with "no active turn context" after mid- |
+| 78 | 61 | high | P2 | P1 ⚑ | +220 | [#1022](https://github.com/omnigent-ai/omnigent/issues/1022) Behind a corporate proxy, the host daemon can't reach the model backen |
+| 79 | 60 | medium | P2 | P1 ⚑ | +125 | [#2744](https://github.com/omnigent-ai/omnigent/issues/2744) [Bug] codex-native: custom agents time out at launch — native provider |
+| 80 | 60 | high | P2 | P1 ⚑ | +64 | [#3798](https://github.com/omnigent-ai/omnigent/issues/3798) Android shell shows the SPA as if signed in while native login runs in |
+| 81 | 58 | high | P2 | P2 | +186 | [#1600](https://github.com/omnigent-ai/omnigent/issues/1600) Epic: 12-feature contribution (one issue + one PR per feature) |
+| 82 | 58 | high | P2 | P2 | +136 | [#2428](https://github.com/omnigent-ai/omnigent/issues/2428) sys_session_send to a completed session hangs to ReadTimeout and is si |
+| 83 | 58 | high | P1 | P2 ⚑ | +8 | [#2241](https://github.com/omnigent-ai/omnigent/issues/2241) Flaky on main: test_interrupt_forwards_to_harness_before_cancelling ti |
+| 84 | 58 | high | P1 | P2 ⚑ | +12 | [#2051](https://github.com/omnigent-ai/omnigent/issues/2051) [Bug] sys_session_send(session_id=…) completions never drain to sys_re |
+| 85 | 58 | high | P0 | P2 ⚑ | -82 | [#1657](https://github.com/omnigent-ai/omnigent/issues/1657) hermes-native forwarder advances last_id per item, dropping a row's la |
+| 86 | 58 | high | P2 | P2 | +228 | [#678](https://github.com/omnigent-ai/omnigent/issues/678) e2e: sub-agent supervisor routing / named-sub-agent auto-wake flakes ( |
+| 87 | 55 | medium | P1 | P2 ⚑ | -62 | [#3536](https://github.com/omnigent-ai/omnigent/issues/3536) [Bug] A session's `reasoning_effort` never reaches in-process harnesse |
+| 88 | 55 | medium | P2 | P2 | +73 | [#3369](https://github.com/omnigent-ai/omnigent/issues/3369) Feature: a policy that fences a spawned type: agent worker read-only ( |
+| 89 | 55 | medium | P2 | P2 | +79 | [#3254](https://github.com/omnigent-ai/omnigent/issues/3254) Sub-agent silently stalls after repeated context compactions during re |
+| 90 | 55 | medium | P2 | P2 | +95 | [#3069](https://github.com/omnigent-ai/omnigent/issues/3069) Harness install surfaces opaque failure reasons (npm stderr not captur |
+| 91 | 55 | medium | P2 | P2 | +100 | [#2984](https://github.com/omnigent-ai/omnigent/issues/2984) [Bug] Codex incorrectly reports `needs-auth` with an authenticated cus |
+| 92 | 55 | medium | P1 | P2 ⚑ | -34 | [#2904](https://github.com/omnigent-ai/omnigent/issues/2904) [Bug] claude-native: web-UI chat input fails with "tmux command failed |
+| 93 | 55 | medium | P2 | P2 | +101 | [#2880](https://github.com/omnigent-ai/omnigent/issues/2880) [Feature] Add in-session revert mechanism for all interfaces  |
+| 94 | 55 | medium | P3 | P2 ⚑ | +244 | [#2853](https://github.com/omnigent-ai/omnigent/issues/2853) [Bug] Native harnesses silently drop the agent spec `prompt:` at runti |
+| 95 | 55 | medium | P2 | P2 | +105 | [#2815](https://github.com/omnigent-ai/omnigent/issues/2815) [Feature] Distinguish human waits from machine-liveness deadlines |
+| 96 | 55 | medium | P1 | P2 ⚑ | -35 | [#2812](https://github.com/omnigent-ai/omnigent/issues/2812) [Bug] serve-mcp stops answering stdio requests during a slow tool call |
+| 97 | 55 | medium | P2 | P2 | +110 | [#2719](https://github.com/omnigent-ai/omnigent/issues/2719) [Bug] |
+| 98 | 55 | medium | P2 | P2 | +113 | [#2644](https://github.com/omnigent-ai/omnigent/issues/2644) Design discussion: deterministic verification gates (a PASS/FAIL quali |
+| 99 | 53 | high | P1 | P2 ⚑ | -11 | [#2270](https://github.com/omnigent-ai/omnigent/issues/2270) Windows: config list crashes — UnicodeEncodeError on cp1252 (non-UTF8) |
+| 100 | 53 | high | P1 | P2 ⚑ | -11 | [#2269](https://github.com/omnigent-ai/omnigent/issues/2269) Windows: omnigent setup crashes — ModuleNotFoundError: No module named |
+| 101 | 53 | high | P1 | P2 ⚑ | +3 | [#1888](https://github.com/omnigent-ai/omnigent/issues/1888) ansi-to-react default import resolves to the CJS exports object under  |
+| 102 | 53 | high | P1 | P2 ⚑ | +3 | [#1881](https://github.com/omnigent-ai/omnigent/issues/1881) [Bug] `omnigent setup` crashes with `ValueError: select() requires at  |
+| 103 | 53 | high | P2 | P2 | +152 | [#1778](https://github.com/omnigent-ai/omnigent/issues/1778) opencode-native forwarder loses session content across SSE reconnects  |
+| 104 | 52 | medium | P1 | P2 ⚑ | -62 | [#3101](https://github.com/omnigent-ai/omnigent/issues/3101) Docker/Kubernetes entrypoint never wires project_store — first-class P |
+| 105 | 51 | high | P1 | P2 ⚑ | +26 | [#108](https://github.com/omnigent-ai/omnigent/issues/108) Cannot install on Linux aarch64 — cel-expr-python has no aarch64 wheel |
+| 106 | 50 | medium | P1 | P2 ⚑ | -66 | [#3236](https://github.com/omnigent-ai/omnigent/issues/3236) web_search: bare executor.model strings are inferred as provider 'open |
+| 107 | 50 | medium | P1 | P2 ⚑ | -43 | [#2630](https://github.com/omnigent-ai/omnigent/issues/2630) Tool-spawn failure is swallowed — agent answers from training knowledg |
+| 108 | 49 | medium | P2 | P2 | +160 | [#1596](https://github.com/omnigent-ai/omnigent/issues/1596) Native-CLI harness (claude-native/codex-native) as a named agent's own |
+| 109 | 48 | high | P1 | P2 ⚑ | -7 | [#1901](https://github.com/omnigent-ai/omnigent/issues/1901) [Bug] kimi/qwen/goose/kiro forwarders blind-retry failed conversation- |
+| 110 | 48 | high | P1 | P2 ⚑ | -2 | [#1827](https://github.com/omnigent-ai/omnigent/issues/1827) [Bug] kimi-native: torn UTF-8 wire read crashes the forwarder; supervi |
+| 111 | 48 | medium | P2 | P2 | +46 | [#3531](https://github.com/omnigent-ai/omnigent/issues/3531) SSH_AUTH_SOCK dropped at the host→runner env boundary, breaking ssh-ag |
+| 112 | 48 | medium | P2 | P2 | +48 | [#3435](https://github.com/omnigent-ai/omnigent/issues/3435) [Feature] Admin server-wide usage report (per-user and per-model cost) |
+| 113 | 48 | medium | P2 | P2 | +49 | [#3368](https://github.com/omnigent-ai/omnigent/issues/3368) Feature: first-class async write-safety (freeze → approve → apply) pri |
+| 114 | 48 | medium | P2 | P2 | +51 | [#3352](https://github.com/omnigent-ai/omnigent/issues/3352) [Feature] OpenClaw onboarding — Option B: chat import (SQLite session  |
+| 115 | 48 | medium | P2 | P2 | +55 | [#3247](https://github.com/omnigent-ai/omnigent/issues/3247) credential_proxy: re-resolve the source on 401 / expiry (short-lived t |
+| 116 | 48 | medium | P1 | P2 ⚑ | -56 | [#2854](https://github.com/omnigent-ai/omnigent/issues/2854) [Bug] Cross-harness `harness_override` is ignored on the `initial_item |
+| 117 | 48 | medium | P2 | P2 | +79 | [#2851](https://github.com/omnigent-ai/omnigent/issues/2851) Policy-supplied targets for ASK approval cards |
+| 118 | 48 | medium | P2 | P2 | +84 | [#2756](https://github.com/omnigent-ai/omnigent/issues/2756) Expose atomic session-event admission to integrations |
+| 119 | 48 | medium | P2 | P2 | +93 | [#2577](https://github.com/omnigent-ai/omnigent/issues/2577) [Feature] Manage OIDC/SSO admins from an id_token claim (IdP group/rol |
+| 120 | 48 | medium | P2 | P2 | +94 | [#2542](https://github.com/omnigent-ai/omnigent/issues/2542) [Feature] Ambient-detect a local llama-server, mirroring Ollama detect |
+| 121 | 48 | medium | P1 | P2 ⚑ | -51 | [#2539](https://github.com/omnigent-ai/omnigent/issues/2539) Named sys_session_send returns 404 after first child from a bundled se |
+| 122 | 46 | medium | P1 | P2 ⚑ | -112 | [#3952](https://github.com/omnigent-ai/omnigent/issues/3952) A stale terminal exit removes the newer Codex resources of the same se |
+| 123 | 46 | medium | P2 | P2 | +27 | [#3592](https://github.com/omnigent-ai/omnigent/issues/3592) [Feature] Deterministic long-term memory (automatic recall/retain) — f |
+| 124 | 46 | medium | P1 | P2 ⚑ | -98 | [#3530](https://github.com/omnigent-ai/omnigent/issues/3530) [Bug] An agent spec's `instructions:` has no effect on 13 of 24 harnes |
+| 125 | 46 | medium | P1 | P2 ⚑ | -98 | [#3525](https://github.com/omnigent-ai/omnigent/issues/3525) Sub-agent sessions are launched from the parent agent's bundle root, e |
+| 126 | 46 | medium | P1 | P2 ⚑ | -82 | [#3076](https://github.com/omnigent-ai/omnigent/issues/3076) [Bug] claude-sdk omits ToolSearch, eagerly loading every MCP schema |
+| 127 | 46 | medium | P3 | P2 ⚑ | +212 | [#2800](https://github.com/omnigent-ai/omnigent/issues/2800) [Bug] Top-level custom codex-native agents drop reasoning effort and y |
+| 128 | 45 | medium | P2 | P2 | +171 | [#1021](https://github.com/omnigent-ai/omnigent/issues/1021) [Feature] GitHub Copilot as provider |
+| 129 | 43 | medium | P2 | P2 | +195 | [#377](https://github.com/omnigent-ai/omnigent/issues/377) gpt sub-agent fails on startup with missing databricks-sdk dependency |
+| 130 | 43 | medium | P2 | P2 | +68 | [#2848](https://github.com/omnigent-ai/omnigent/issues/2848) Server logs an expected offline-runner resource 503 as ERROR + full tr |
+| 131 | 43 | medium | P2 | P2 | +70 | [#2767](https://github.com/omnigent-ai/omnigent/issues/2767) [Bug] SQLite pool (default 5+10) not sized to the 200-thread limiter → |
+| 132 | 42 | medium | P2 | P2 | +6 | [#3969](https://github.com/omnigent-ai/omnigent/issues/3969) Databricks gateway sessions default to a stale model (opus-4-7) while  |
+| 133 | 42 | medium | P1 | P2 ⚑ | -115 | [#3790](https://github.com/omnigent-ai/omnigent/issues/3790) force_sandbox policy is evaluated but structurally unreachable from cl |
+| 134 | 42 | medium | P1 | P2 ⚑ | -71 | [#2702](https://github.com/omnigent-ai/omnigent/issues/2702) Native idle-detection fork+exec's tmux capture-pane at 5 Hz per termin |
+| 135 | 40 | medium | P2 | P2 | -1 | [#4009](https://github.com/omnigent-ai/omnigent/issues/4009) [Feature] No Go client for the session API, so every Go caller hand-ro |
+| 136 | 40 | medium | P1 | P2 ⚑ | -123 | [#3898](https://github.com/omnigent-ai/omnigent/issues/3898) [Bug] Pack function policies fail server-side input evaluation unless  |
+| 137 | 40 | medium | P1 | P2 ⚑ | -123 | [#3870](https://github.com/omnigent-ai/omnigent/issues/3870) child-session creation returns 500 internal_error, breaking Polly/Debb |
+| 138 | 40 | medium | P2 | P2 | +4 | [#3864](https://github.com/omnigent-ai/omnigent/issues/3864) [Bug] to_api_dict() drops ConversationItem.created_at, so flat items A |
+| 139 | 40 | medium | P1 | P2 ⚑ | -124 | [#3863](https://github.com/omnigent-ai/omnigent/issues/3863) [Bug] Databricks Apps entrypoint never wires project_store — Projects  |
+| 140 | 40 | medium | P2 | P2 | +12 | [#3563](https://github.com/omnigent-ai/omnigent/issues/3563) [Bug] Host-bound resume into a deleted workspace: host computes the ex |
+| 141 | 40 | medium | P2 | P2 | +14 | [#3550](https://github.com/omnigent-ai/omnigent/issues/3550) [Bug] Missing signing alg's prevent using some OIDC providers |
+| 142 | 40 | medium | P2 | P2 | +16 | [#3449](https://github.com/omnigent-ai/omnigent/issues/3449) [Bug] Item pagination cursor can't use the index, so scroll-back scans |
+| 143 | 40 | medium | none | P2 | +210 | [#3402](https://github.com/omnigent-ai/omnigent/issues/3402) [Bug] Label seeding and session-state writes race under concurrent upd |
+| 144 | 40 | medium | none | P2 | +210 | [#3392](https://github.com/omnigent-ai/omnigent/issues/3392) [Bug] Linux desktop app missing Icon |
+| 145 | 40 | medium | P2 | P2 | +31 | [#3219](https://github.com/omnigent-ai/omnigent/issues/3219) [Bug] Cmd/Ctrl+Up/Down session traversal stops in an empty focused com |
+| 146 | 40 | medium | P1 | P2 ⚑ | -103 | [#3095](https://github.com/omnigent-ai/omnigent/issues/3095) [Bug] Can't uninstall |
+| 147 | 40 | medium | P2 | P2 | +40 | [#3064](https://github.com/omnigent-ai/omnigent/issues/3064) [Bug] Created file links are inaccessible from remote sessions |
+| 148 | 40 | medium | P2 | P2 | +44 | [#2921](https://github.com/omnigent-ai/omnigent/issues/2921) Font settings: selected font (incl. Nerd Fonts) never loads — no webfo |
+| 149 | 40 | medium | P1 | P2 ⚑ | -90 | [#2866](https://github.com/omnigent-ai/omnigent/issues/2866) iOS app: Google OIDC fails with 403 disallowed_useragent in embedded w |
+| 150 | 40 | medium | P1 | P2 ⚑ | -81 | [#2549](https://github.com/omnigent-ai/omnigent/issues/2549) [Bug] iOS Google OIDC fails with disallowed_useragent in WKWebView |
+| 151 | 38 | medium | P2 | P2 | -12 | [#3950](https://github.com/omnigent-ai/omnigent/issues/3950) An agent switch keeps the previous agent's comment-tool relay |
+| 152 | 38 | medium | P1 | P2 ⚑ | -136 | [#3852](https://github.com/omnigent-ai/omnigent/issues/3852) [Bug] Built-in write policies miss Claude Code's `MultiEdit` / `Notebo |
+| 153 | 37 | feature | P2 | P2 | +25 | [#3150](https://github.com/omnigent-ai/omnigent/issues/3150) [Feature] CLI: cross-harness fork — continue an existing session in a  |
+| 154 | 37 | medium | P1 | P2 ⚑ | -73 | [#2397](https://github.com/omnigent-ai/omnigent/issues/2397) [Bug] Codex-native intelligent routing ignores live effort capabilitie |
+| 155 | 37 | medium | P1 | P2 ⚑ | -68 | [#2272](https://github.com/omnigent-ai/omnigent/issues/2272) [Bug] Codex runner can't find OpenRouter secret that exists in keyring |
+| 156 | 37 | medium | P1 | P2 ⚑ | -64 | [#2184](https://github.com/omnigent-ai/omnigent/issues/2184) [Bug] Codex plugin skills are exposed with inconsistent names (`plugin |
+| 157 | 37 | medium | P1 | P2 ⚑ | -64 | [#2071](https://github.com/omnigent-ai/omnigent/issues/2071) [Bug] web_search never advertised to claude-sdk sessions: unprefixed m |
+| 158 | 37 | medium | P2 | P2 | +77 | [#2062](https://github.com/omnigent-ai/omnigent/issues/2062) [Bug] claude-native: per-session model override silently lost when wra |
+| 159 | 37 | medium | P1 | P2 ⚑ | -52 | [#1831](https://github.com/omnigent-ai/omnigent/issues/1831) claude-native workers ignore executor.model pin and per-dispatch args. |
+| 160 | 37 | medium | P2 | P2 | +94 | [#1789](https://github.com/omnigent-ai/omnigent/issues/1789) Feature: Canvas — agent-authored artifact panel (#2) |
+| 161 | 37 | medium | P1 | P2 ⚑ | -51 | [#1781](https://github.com/omnigent-ai/omnigent/issues/1781) codex harness: ambient DATABRICKS_BEARER/DATABRICKS_TOKEN overrides pr |
+| 162 | 37 | medium | P2 | P2 | +107 | [#1594](https://github.com/omnigent-ai/omnigent/issues/1594) Server-side idempotency for external_conversation_item (safe dedup on  |
+| 163 | 37 | medium | P2 | P2 | +118 | [#1230](https://github.com/omnigent-ai/omnigent/issues/1230) [Feature] Migrate remaining native forwarders to the shared post_sessi |
+| 164 | 37 | medium | P1 | P2 ⚑ | -45 | [#1128](https://github.com/omnigent-ai/omnigent/issues/1128) [Bug] Claude SDK Appears to Use Opus Instead of Selected Model |
+| 165 | 37 | medium | P2 | P2 | +139 | [#890](https://github.com/omnigent-ai/omnigent/issues/890) [Bug] omnigent setup fails with npm EACCES when installing the Claude  |
+| 166 | 37 | medium | P1 | P2 ⚑ | -41 | [#668](https://github.com/omnigent-ai/omnigent/issues/668) [Bug] BUG？omni claude times out (60s) on macOS with native Claude Code |
+| 167 | 37 | medium | P2 | P2 | +150 | [#548](https://github.com/omnigent-ai/omnigent/issues/548) Recommend missing dependency install suggestions more gracefully in UI |
+| 168 | 37 | medium | P1 | P2 ⚑ | -38 | [#241](https://github.com/omnigent-ai/omnigent/issues/241) pi harness: GPT and Gemini dispatches 404 on the Databricks ucode gate |
+| 169 | 37 | medium | P3 | P2 ⚑ | +178 | [#147](https://github.com/omnigent-ai/omnigent/issues/147) Tracking: gradual decomposition of monolith modules (cli.py 9.1KLOC, c |
+| 170 | 37 | medium | P1 | P2 ⚑ | -50 | [#1113](https://github.com/omnigent-ai/omnigent/issues/1113) Native sub-agent/runner failures surface as bare "failed" with no reas |
+| 171 | 36 | medium | P2 | P2 | +11 | [#3083](https://github.com/omnigent-ai/omnigent/issues/3083) [Bug] Cursor sessions launched from Omnigent Web is losing MCPs |
+| 172 | 36 | medium | P1 | P2 ⚑ | -141 | [#3424](https://github.com/omnigent-ai/omnigent/issues/3424) [Bug] Per-request pool checkout + pre-ping overhead: ~11 checkouts/req |
+| 173 | 36 | medium | none | P2 | +178 | [#3408](https://github.com/omnigent-ai/omnigent/issues/3408) [Bug] Mac app start locally fails with no such command start |
+| 174 | 36 | medium | P2 | P2 | -5 | [#3250](https://github.com/omnigent-ai/omnigent/issues/3250) flaky e2e_ui: test_scheduled_task_create_edit_modal_and_time_picker ti |
+| 175 | 36 | medium | P1 | P2 ⚑ | -125 | [#3004](https://github.com/omnigent-ai/omnigent/issues/3004) [Performance] Every streamed event re-loads conversation + ACL: 16 que |
+| 176 | 36 | medium | P1 | P2 ⚑ | -125 | [#3003](https://github.com/omnigent-ai/omnigent/issues/3003) [Performance] Policy engine rebuilt per evaluation: 32 queries + two f |
+| 177 | 36 | medium | P2 | P2 | +20 | [#2849](https://github.com/omnigent-ai/omnigent/issues/2849) [Performance] Session switch re-runs a full eager transcript backfill  |
+| 178 | 36 | medium | P2 | P2 | +32 | [#2703](https://github.com/omnigent-ai/omnigent/issues/2703) Runner re-parses agent-bundle YAML per session with pure-Python SafeLo |
+| 179 | 36 | medium | P1 | P2 ⚑ | -113 | [#2592](https://github.com/omnigent-ai/omnigent/issues/2592) [Bug] omni update wipes extras installs: VCS reinstall spec rebuilt fr |
+| 180 | 36 | medium | P2 | P2 | +33 | [#2558](https://github.com/omnigent-ai/omnigent/issues/2558) Distribution / Installation / Enterprise Readiness |
+| 181 | 34 | medium | P1 | P2 ⚑ | -72 | [#1794](https://github.com/omnigent-ai/omnigent/issues/1794) Bundled Polly: claude-sdk brain "Not logged in" + runaway spawn loop o |
+| 182 | 34 | medium | P2 | P2 | +76 | [#1724](https://github.com/omnigent-ai/omnigent/issues/1724) codex-native harness times out on WSL2 ("Codex TUI never started a thr |
+| 183 | 34 | medium | P1 | P2 ⚑ | -72 | [#1694](https://github.com/omnigent-ai/omnigent/issues/1694) Reliability: parallel code-fix missions fail silently (5s tmux timeout |
+| 184 | 34 | medium | P1 | P2 ⚑ | -69 | [#1533](https://github.com/omnigent-ai/omnigent/issues/1533) Context-occupancy meter (context_tokens) freezes on failed turns — onl |
+| 185 | 34 | medium | P2 | P2 | +143 | [#152](https://github.com/omnigent-ai/omnigent/issues/152) Harness availability is reported from binary presence, not from config |
+| 186 | 33 | medium | P1 | P2 ⚑ | -181 | [#3982](https://github.com/omnigent-ai/omnigent/issues/3982) [Bug] electron-build.yml pnpm filter matches no package: desktop packa |
+| 187 | 33 | medium | P1 | P2 ⚑ | -181 | [#3981](https://github.com/omnigent-ai/omnigent/issues/3981) [Bug] Desktop: Workspace rail resize is unusable on the Browser tab; a |
+| 188 | 33 | medium | P1 | P2 ⚑ | -179 | [#3967](https://github.com/omnigent-ai/omnigent/issues/3967) Daemon registry records and host identity should be scoped to the data |
+| 189 | 33 | medium | P1 | P2 ⚑ | -178 | [#3951](https://github.com/omnigent-ai/omnigent/issues/3951) The runner-wide agent spec cache can publish a superseded tool spec |
+| 190 | 33 | medium | P1 | P2 ⚑ | -178 | [#3949](https://github.com/omnigent-ai/omnigent/issues/3949) Session reset does not fence in-flight terminal publication |
+| 191 | 33 | medium | P2 | P2 | -48 | [#3861](https://github.com/omnigent-ai/omnigent/issues/3861) [Bug] omni host status renders URLs so terminals link the whole status |
+| 192 | 33 | medium | P3 | P2 ⚑ | +144 | [#3733](https://github.com/omnigent-ai/omnigent/issues/3733) [Bug] Android: hardcoded 25px switcher height makes the chat scroll-fa |
+| 193 | 33 | medium | P2 | P2 | -46 | [#3732](https://github.com/omnigent-ai/omnigent/issues/3732) [Bug] Android: a Display-size change leaves the server-switcher pill's |
+| 194 | 33 | medium | P2 | P2 | -43 | [#3586](https://github.com/omnigent-ai/omnigent/issues/3586) [Bug] Android: native server-picker pill overlaps the sidebar header c |
+| 195 | 33 | medium | P1 | P2 ⚑ | -171 | [#3578](https://github.com/omnigent-ai/omnigent/issues/3578) [Bug] MacOS Start Locally - "Error: No such command 'start'" |
 | 196 | 33 | medium | P2 | P2 | -43 | [#3561](https://github.com/omnigent-ai/omnigent/issues/3561) [Bug] `prompt_policy` never sends `_CLASSIFIER_SCHEMA` to the LLM — st |
-| 197 | 33 | medium | none | P2 | +156 | [#3402](https://github.com/omnigent-ai/omnigent/issues/3402) [Bug] Label seeding and session-state writes race under concurrent upd |
-| 198 | 33 | medium | P2 | P2 | -22 | [#3219](https://github.com/omnigent-ai/omnigent/issues/3219) [Bug] Cmd/Ctrl+Up/Down session traversal stops in an empty focused com |
-| 199 | 33 | medium | P2 | P2 | -7 | [#2921](https://github.com/omnigent-ai/omnigent/issues/2921) Font settings: selected font (incl. Nerd Fonts) never loads — no webfo |
-| 200 | 33 | medium | P2 | P2 | -2 | [#2848](https://github.com/omnigent-ai/omnigent/issues/2848) Server logs an expected offline-runner resource 503 as ERROR + full tr |
+| 197 | 33 | medium | P2 | P2 | -17 | [#3127](https://github.com/omnigent-ai/omnigent/issues/3127) Desktop app: closed sub-agents stay in the Agents panel with no 'close |
+| 198 | 33 | medium | P2 | P2 | -8 | [#2988](https://github.com/omnigent-ai/omnigent/issues/2988) [Bug] Arrow keys don't work in `omni setup` menus |
+| 199 | 32 | medium | P1 | P2 ⚑ | -121 | [#2429](https://github.com/omnigent-ai/omnigent/issues/2429) Server (python -m omnigent.cli server) CPU-spins indefinitely with no  |
+| 200 | 32 | medium | P1 | P2 ⚑ | -129 | [#2524](https://github.com/omnigent-ai/omnigent/issues/2524) [Bug] Registering remote host fails |
+
+

--- a/designs/prioritization/issue-prioritization-v2.md
+++ b/designs/prioritization/issue-prioritization-v2.md
@@ -88,7 +88,7 @@ might prioritize one issue over another. Number scores give a total ordering. If
 priorities, then it is also available as a group of scores (100+ = P0, 60+ = P1, 25+ = P2,
 everything else P3.)
 
-To make the adjustment scope narrows, we will try to adjust only weights of factors.
+To make the adjustment scope narrow, we will try to adjust only named weights / modules.
 
 **Do not read too hard into it. This requires tuning over-time and can always be adjusted, but it
 gives something to start with.** 
@@ -171,7 +171,7 @@ Today's 8 `comp:` labels are coarse — a few are mega-buckets:
 We add granularity two ways (both, deliberately):
 
 - **New top-level `comp:` label** when a slice is something you'd *filter and
-  prioritize on* (e.g. `comp:sandbox` is security-grade).
+  prioritize on* (e.g. `comp:sandbox`, `comp:db`, `comp:ios`, `comp:android`).
 - **A `sub_area` tag** for the rest. `areas.json` already models sub-areas; the
   classifier emits the matched one as a second-level tag — granularity without
   minting a GH label per slice (the repo has no label-sync, so the label set
@@ -182,9 +182,10 @@ We add granularity two ways (both, deliberately):
 | New label | Carved from | Weight | Why |
 |---|---|---|---|
 | `comp:harness-t1/-t2/-t3` | `comp:harnesses` | 1.4 / 1.1 / 0.9 (telemetry) | Tier is the harness view of the weight; future-proof (add/re-tier = `areas.json` edit, not a new label). `sub_area` also tags SDK vs native. |
-| `comp:sandbox` | `comp:runner` | 1.1 (editorial) | ~29 issues, security-grade, home of P0 #3557. Inherits runner's 1.1; the *security* lift is in the P0 rubric (Axis 2), not the weight — so it isn't double-counted. |
-| `comp:mobile` | `comp:web-ui` | 1.0 (editorial) | ~23 issues; device sub-tags desktop / mobile-iOS / mobile-Android. Inherits web-ui's 1.0. |
-| `comp:auth` | `comp:server` | 1.1 (editorial) | Distinct surface; types local / multi-user / OIDC / OAuth / Databricks. Inherits server-core's 1.1 (a broken login blocks everything). |
+| `comp:sandbox` | `comp:runner` | 1.2 (editorial) | Security-grade execution boundary. Security lift still comes from severity, not the weight. |
+| `comp:db` | `comp:server` | 1.2 (editorial) | Persistent state / migrations / local DB. Already an `areas.json` area; lift to label. |
+| `comp:ios`, `comp:android` | `comp:web-ui` | 1.0 (editorial) | Platform-specific app shells. These should sync from the intake Platform / device dropdown. |
+| `comp:auth` | `comp:server` | 1.2 (editorial) | Login / credentials / OIDC / OAuth / Databricks auth; a broken login blocks everything. |
 
 
 
@@ -199,26 +200,32 @@ The scoring job reads the dup count from the labeler's linked issues; the
 dry-run stubs it (`duplicate_count`, default 0) since the snapshot JSON doesn't
 carry dup links.
 
-### Axis 6 — Readiness
+### Optional module — Readiness
 
 A ticket you can *start on now* is worth surfacing above an equally-severe but vague one.
 `readiness` is a small multiplier: 1.1 for a bug with a repro section and a ≥400-char body
 (or any substantive FR), 1.0 otherwise. Gentle — it breaks near-ties, never overrides severity.
 
-**`needs-info` is separate. If it's genuinely incomprehensible, we give *no score*, meaning P3 by
-default. However, if information are partially presented and is comprehensible, then 1.0.
+Reviewer note: keep this **off in v1** unless the dry-run shows it improves ordering. It should be
+a named module (`ENABLE_READINESS`) so reassignment is one config change.
+
+**`needs-info` is separate.** If it's genuinely incomprehensible, we give *no score*, meaning P3 by
+default. If information is partial but comprehensible, then 1.0.
 
 ### Axis 7 - Community demand
 
 Unique user engagement and comments and thumb-up will be counted additively. So they will bump the
 issue but won't have too much weight. Existing issues get at most 15 pts today.
 
-### Axis 8 - Age factor
+### Optional module — Age factor
 
 Recent issues (0 - 5 days): 1.0
 5 - 21 days: 1.2 - bump lightly to provide more visibility.
 21+ days: 0.8 - Since they are ignored for awhile. chances are, they are less important. If not, the
 maintainer should bump priority (since priority gives more scores).
+
+Reviewer note: keep this **off in v1**. Age is useful as a dashboard slice / metric, but it should
+not decide priority unless we explicitly turn the module on.
 
 
 
@@ -227,14 +234,17 @@ maintainer should bump priority (since priority gives more scores).
 base  = severity_weight              # LLM grade, reach folded in (S0/S1/S2/S3 = 100/60/30/10)
       × component_weight             # areas.json per-area weight 1.4/1.2/1.1/1.0/0.9 (Axis 3)
       × dup_reach                    # +15% per confirmed duplicate, capped +50% (Axis 5)
-      × readiness                    # ready-to-work 1.1 · normal 1.0 (Axis 6)
 
 score = apply_demand(base, type)     # additive, ≤15 pts (Axis 7)
-      × age_factor                   # 0-5d 1.0 · 5-21d 1.2 · 21d+ 0.8 (Axis 8)
+
+# Optional modules, default off in v1:
+score = score × readiness_factor     # if enabled: ready 1.1 · normal 1.0 · needs-info 0.85
+score = score × age_factor           # if enabled: 0-5d 1.0 · 5-21d 1.2 · 21d+ 0.8
 ```
 
-Every weight is a named constant; the priority label is the band the score lands in
-(`≥100 P0 · ≥60 P1 · ≥25 P2 · else P3`).
+Every weight/module is named. Serena's review is right: readiness and age should not be baked into
+the core formula. The priority label is the band the score lands in (`≥100 P0 · ≥60 P1 · ≥25 P2 ·
+else P3`).
 
 **Worked example — one issue, data points → score.** Take
 [#3265](https://github.com/omnigent-ai/omnigent/issues/3265) ("claude-sdk agent
@@ -245,13 +255,12 @@ with linux_bwrap dies at spawn"):
 | severity | 60 (S1) | spawn death, no workaround; not widespread enough for S0 |
 | × component_weight | × 1.4 | `claude-sdk` → `harness-claude`, weight 1.4 (Axis 3) |
 | × dup_reach | × 1.0 | no confirmed duplicates |
-| × readiness | × 1.0 | no repro section matched |
 | + demand (bug) | + 0 | 0 reactions |
-| × age | × 1.2 | 10 days old → mid-life visibility bump |
-| **= score** | **101** | 60 × 1.4 × 1.2 → **≥ 100 → P0**; rank **#17** of 360 (was rank #37 by label) |
+| readiness / age | off | optional modules disabled in v1 |
+| **= score** | **84** | 60 × 1.4 → **≥ 60 → P1** |
 
-Contrast a vague, low-weight ticket: severity 30 (S2) × component_weight 0.9
-(e.g. `comp:repr`) × age 0.8 (stale) ≈ **22** → **P3**, near the bottom. Same
+Contrast a low-severity, low-weight ticket: severity 10 (S3) × component_weight 0.9
+(e.g. `comp:repr`) ≈ **9** → **P3**, near the bottom. Same
 factors, opposite ends of the queue — that's the score→label derivation working.
 
 ### Determinism - same inputs, same score
@@ -262,7 +271,7 @@ runs. Two nuances worth stating plainly:
 
 - **Persisted severity is what guarantees it.** since severity is the only LLM-generated label.
 - **The score still moves over time — by design.** `dup_reach` / `demand` read
-  *current* counts, and `age_factor` (Axis 8) changes as an issue progress. This is intended.
+  *current* counts. If the age module is enabled later, age would move too.
 
 Note: There is no tie-breaking today.
 
@@ -295,7 +304,7 @@ If you're correcting more than that, we should fix prompts or weights.
 `score_prototype.py` grades severity with regex so a dry-run is reproducible.
 But regex only keyword-matches — to check the *design*, an LLM (this one) read
 **the 100 oldest open issues**, graded S0–S3 by content, and ran the grades
-through the same scoring machinery (weight × dup × readiness + demand × age).
+through the same scoring machinery (severity × component × dup, then demand).
 **Priority flipped on 49 of 100** — the argument for grading severity with the
 classifier in production.
 
@@ -359,7 +368,7 @@ Today's bug template has Version + OS, both optional → sparse. Add optional
 dropdowns (cheap for the reporter, better signal than free text):
 
 - **Harness + mode** (claude / codex / … + SDK / native) → component weight + `sub_area`.
-- **Platform / device** (macOS / Linux / Windows / desktop / mobile-iOS / mobile-Android / Docker) → `comp:mobile` sub-tag + reach.
+- **Platform / device** (macOS / Linux / Windows / desktop / iOS / Android / Docker) → `comp:ios` / `comp:android` / platform metadata.
 - **Impact / reach** (all / most / some / edge) → feeds severity (Axis 2).
 - **Auth type** (local / multi-user / OIDC / OAuth / Databricks) → `comp:auth`.
 
@@ -371,15 +380,17 @@ Nothing here is built yet except the `areas.json` weights (+ test). Action items
 each its own PR:
 
 - [ ] **Tune the classifier prompt** (`.github/triage/config.yaml`) — S0–S3 rubric,
-  FRs graded, tier-1 nudge, P0 list; emit + **persist** `severity`, `readiness`,
+  FRs graded, tier-1 nudge, P0 list; emit + **persist** `severity`, `component`,
   `sub_area` (persisted severity is what keeps re-scoring deterministic).
 - [ ] **Create the cron job** — scheduled Databricks notebook: read
   `github_issues_bronze`, compute score once, write `issue_scores`, apply labels
   back (with the human-override guard). See "Surfacing the score".
 - [ ] **Add labels** — `severity S0–S3`, `comp:harness-t1/-t2/-t3`, `comp:sandbox`,
-  `comp:mobile`, `comp:auth`; wire the classifier allowlist.
+  `comp:db`, `comp:ios`, `comp:android`, `comp:auth`; wire the classifier allowlist
+  and then update `areas.json` labels/tests.
 - [ ] **Add template dropdowns** — Harness+mode / Platform-device / Impact / Auth-type.
-- [ ] **Backfill** — regrade open issues (`--regrade`; preview lands ~23% P1 bugs),
+- [ ] **Backfill** — regrade open issues (`--regrade`; preview: P1 bugs 60% → 31%,
+  still above the ~25% target),
   filling only bot-owned priorities.
 - [ ] **Plumb scores to the dashboard** — `issue_scores` → a ranked Lakeview tile.
 
@@ -434,9 +445,9 @@ up). The Now→Derived column is the per-issue view of the backfill: the ⚑ row
 are the relabels the one-time regrade would apply.
 
 **Illustrative, not actionable.** This is the *mechanism* running on a
-deliberately-weak grader, so its own failures are visible on purpose: ranks 2–5
+deliberately-weak grader, so its own failures are visible on purpose: ranks 1–3
 (#2125/#2057/#2054) are FRs that hit a critical-regex keyword — they sit above
-the real P0 (#3557, rank 14), so **the very top is backwards**; #61 (rank 33) is
+the real P0 (#3557, rank 8), so **the very top is backwards**; #61 (rank 9) is
 a *bot* audit issue riding a "security" keyword. That's the doc's thesis made
 concrete: regex can't grade severity. Strip those artifacts and the genuine
 high-weight harness bugs cluster correctly near the top. Scores *tie* in coarse
@@ -447,205 +458,203 @@ ranking takes.
 
 | # | Score | Sev | Now | Derived | Δrank | Issue |
 |--:|--:|---|---|---|--:|---|
-| 1 | 158 | critical | P1 | P0 ⚑ | +34 | [#3270](https://github.com/omnigent-ai/omnigent/issues/3270) [Bug] sys_session_create children are absent from both sys_session_lis |
-| 2 | 143 | critical | P2 | P0 ⚑ | +230 | [#2125](https://github.com/omnigent-ai/omnigent/issues/2125) [Feature] Multi-host git credentials for managed sandboxes (GitHub + s |
-| 3 | 132 | critical | P1 | P0 ⚑ | +1 | [#3983](https://github.com/omnigent-ai/omnigent/issues/3983) [Bug] Smart-routed turns render out of order: reply streams above the  |
-| 4 | 123 | critical | P2 | P0 ⚑ | +232 | [#2057](https://github.com/omnigent-ai/omnigent/issues/2057) [Feature] Add Codex Auto mode using auto_review instead of jumping to  |
-| 5 | 123 | critical | P2 | P0 ⚑ | +233 | [#2054](https://github.com/omnigent-ai/omnigent/issues/2054) [Feature] Remove duplicate Codex Full access mode and keep Sandbox Byp |
-| 6 | 111 | high | P1 | P0 ⚑ | +27 | [#3299](https://github.com/omnigent-ai/omnigent/issues/3299) [Bug] Harness-credential route times out with a misleading 504 against |
-| 7 | 111 | high | P2 | P0 ⚑ | +159 | [#3284](https://github.com/omnigent-ai/omnigent/issues/3284) [Crash] DuplicateOptionError: While reading from PosixPath('/Users/*** |
-| 8 | 111 | high | P1 | P0 ⚑ | +33 | [#3180](https://github.com/omnigent-ai/omnigent/issues/3180) codex-native: runner never exits on idle timeout — cancelled delta-coa |
-| 9 | 111 | high | P2 | P0 ⚑ | +175 | [#3070](https://github.com/omnigent-ai/omnigent/issues/3070) No progress signal on a stuck or interactive harness install |
-| 10 | 111 | high | P1 | P0 ⚑ | +45 | [#2967](https://github.com/omnigent-ai/omnigent/issues/2967) [Bug] A full context window bricks a session with "Prompt is too long" |
-| 11 | 111 | high | P1 | P0 ⚑ | +45 | [#2920](https://github.com/omnigent-ai/omnigent/issues/2920) Omnigent server fails to start on native Windows: os.getuid() at impor |
-| 12 | 111 | high | P1 | P0 ⚑ | +45 | [#2919](https://github.com/omnigent-ai/omnigent/issues/2919) omni setup crashes on Windows: ModuleNotFoundError: No module named 't |
-| 13 | 111 | high | P2 | P0 ⚑ | +195 | [#2714](https://github.com/omnigent-ai/omnigent/issues/2714) Upgrade openai-agents and remove the temporary openai<2.45 cap |
-| 14 | 110 | critical | P0 | P0 | -13 | [#3557](https://github.com/omnigent-ai/omnigent/issues/3557) [Bug] Shell-surface policy gates are bypassed by option-taking command |
-| 15 | 108 | high | P2 | P0 ⚑ | +319 | [#16](https://github.com/omnigent-ai/omnigent/issues/16) Is native Windows support in scope, or should docs recommend WSL2? |
-| 16 | 106 | critical | P2 | P0 ⚑ | +299 | [#659](https://github.com/omnigent-ai/omnigent/issues/659) [Feature] add a microvm backend for sandbox |
-| 17 | 101 | high | P1 | P0 ⚑ | +20 | [#3265](https://github.com/omnigent-ai/omnigent/issues/3265) claude-sdk agent with linux_bwrap dies at spawn on a runtime bwrap bin |
-| 18 | 101 | high | P1 | P0 ⚑ | +35 | [#3000](https://github.com/omnigent-ai/omnigent/issues/3000) claude-native transcript forwarder polls at 4 Hz per session with no i |
-| 19 | 101 | high | P1 | P0 ⚑ | +43 | [#2748](https://github.com/omnigent-ai/omnigent/issues/2748) Runner idle-shutdown deadlocks forever: codex-forwarder close()/flush( |
-| 20 | 101 | high | P1 | P0 ⚑ | +45 | [#2629](https://github.com/omnigent-ai/omnigent/issues/2629) web_fetch sub-agent spawn fails with unknown harness 'omnigent' — bare |
-| 21 | 101 | high | P1 | P0 ⚑ | +46 | [#2575](https://github.com/omnigent-ai/omnigent/issues/2575) pi-native: non-Claude Databricks models (GLM, Gemini, …) hang — provid |
-| 22 | 100 | high | P1 | P1 | +16 | [#3261](https://github.com/omnigent-ai/omnigent/issues/3261) [Crash] AttributeError: module 'os' has no attribute 'WNOHANG' |
-| 23 | 95 | high | P1 | P1 | +5 | [#3482](https://github.com/omnigent-ai/omnigent/issues/3482) [Crash] ServerError: |
-| 24 | 95 | high | P1 | P1 | +6 | [#3458](https://github.com/omnigent-ai/omnigent/issues/3458) session-updates stream crashes with KeyError when a client watches a c |
-| 25 | 95 | high | P2 | P1 ⚑ | +139 | [#3363](https://github.com/omnigent-ai/omnigent/issues/3363) [Feature] Per-project custom instructions (project-scoped context) |
-| 26 | 95 | high | P2 | P1 ⚑ | +141 | [#3271](https://github.com/omnigent-ai/omnigent/issues/3271) [Feature] Expose per-session context size + last-turn timestamp to age |
-| 27 | 95 | high | P2 | P1 ⚑ | +146 | [#3231](https://github.com/omnigent-ai/omnigent/issues/3231) [Crash] OmnigentError: {'error_code': 403, 'message': 'Invalid access  |
-| 28 | 86 | high | P1 | P1 | +6 | [#3274](https://github.com/omnigent-ai/omnigent/issues/3274) Sub-agent terminal status rejected with missing_parent_inbox and retri |
-| 29 | 86 | high | P1 | P1 | +18 | [#3016](https://github.com/omnigent-ai/omnigent/issues/3016) [Bug] A transient session-snapshot failure permanently pins a session  |
-| 30 | 86 | high | P1 | P1 | +18 | [#3012](https://github.com/omnigent-ai/omnigent/issues/3012) Hosts authenticated via `omnigent login` permanently 403 on first reco |
-| 31 | 86 | high | P1 | P1 | +21 | [#3001](https://github.com/omnigent-ai/omnigent/issues/3001) [Performance] GET /v1/sessions pre-fetches every accessible conversati |
-| 32 | 84 | high | P2 | P1 ⚑ | +122 | [#3558](https://github.com/omnigent-ai/omnigent/issues/3558) claude-sdk: cached client does not rebuild on framework-instruction ch |
-| 33 | 80 | critical | P3 | P1 ⚑ | +316 | [#61](https://github.com/omnigent-ai/omnigent/issues/61) 🤖 Code Audit: 21 potential issue(s) found |
-| 34 | 79 | high | P2 | P1 ⚑ | +102 | [#3976](https://github.com/omnigent-ai/omnigent/issues/3976) [Feature] OAuth2 client-credentials grant so a headless process can au |
-| 35 | 79 | high | P1 | P1 | -6 | [#3469](https://github.com/omnigent-ai/omnigent/issues/3469) [Bug] Post-completion compaction spiral: merge-commit diff output trig |
-| 36 | 79 | high | P1 | P1 | -4 | [#3359](https://github.com/omnigent-ai/omnigent/issues/3359) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 37 | 79 | high | P1 | P1 | +2 | [#3251](https://github.com/omnigent-ai/omnigent/issues/3251) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 38 | 79 | high | P1 | P1 | +7 | [#3052](https://github.com/omnigent-ai/omnigent/issues/3052) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 39 | 79 | high | P1 | P1 | +7 | [#3023](https://github.com/omnigent-ai/omnigent/issues/3023) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 40 | 79 | high | P1 | P1 | +14 | [#2993](https://github.com/omnigent-ai/omnigent/issues/2993) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 41 | 79 | high | P3 | P1 ⚑ | +296 | [#2887](https://github.com/omnigent-ai/omnigent/issues/2887) [Bug] web/package-lock.json is out of sync with package.json; plain `n |
-| 42 | 79 | high | P1 | P1 | +26 | [#2559](https://github.com/omnigent-ai/omnigent/issues/2559) Conversation bricked: Page fails to load when opening markdown file af |
-| 43 | 74 | high | P1 | P1 | +36 | [#2422](https://github.com/omnigent-ai/omnigent/issues/2422) Windows: five chained defects break the documented degraded-mode subse |
-| 44 | 74 | high | P1 | P1 | +38 | [#2373](https://github.com/omnigent-ai/omnigent/issues/2373) [Bug] claude-native: pasted web-UI message loses its Enter, stuck draf |
-| 45 | 74 | high | P1 | P1 | +45 | [#2245](https://github.com/omnigent-ai/omnigent/issues/2245) [Bug] openai-agents harness turn wedges permanently after policy-verdi |
-| 46 | 74 | high | P1 | P1 | +48 | [#2060](https://github.com/omnigent-ai/omnigent/issues/2060) [Bug] claude-native: first web-UI message silently dropped when Claude |
-| 47 | 74 | high | P1 | P1 | +56 | [#1898](https://github.com/omnigent-ai/omnigent/issues/1898) [Bug] codex-native: cancelling a task awaiting flush() poisons the del |
-| 48 | 74 | high | P2 | P1 ⚑ | +222 | [#1528](https://github.com/omnigent-ai/omnigent/issues/1528) Idle-session lifecycle UX: reap gracefully, resume seamlessly, surface |
-| 49 | 74 | high | P2 | P1 ⚑ | +246 | [#1051](https://github.com/omnigent-ai/omnigent/issues/1051) [Feature] Forward OTel exporter knobs to executor subprocess env |
-| 50 | 74 | high | P2 | P1 ⚑ | +260 | [#762](https://github.com/omnigent-ai/omnigent/issues/762) [Bug] sub agent terminal crashes when cli starts with prompt for input |
-| 51 | 74 | high | P2 | P1 ⚑ | +265 | [#654](https://github.com/omnigent-ai/omnigent/issues/654) [Bug] Streaming with codex is hanging and paragraphs are not split. |
-| 52 | 74 | high | P1 | P1 | +75 | [#542](https://github.com/omnigent-ai/omnigent/issues/542) [Bug] AttributeError: 'SubprocessCLITransport' object has no attribute |
-| 53 | 74 | high | P2 | P1 ⚑ | +187 | [#2038](https://github.com/omnigent-ai/omnigent/issues/2038) [Feature] No way to deregister/delete an external self-registered host |
-| 54 | 72 | high | P1 | P1 | -46 | [#3971](https://github.com/omnigent-ai/omnigent/issues/3971) Host runners inherit the daemon's cwd; a deleted launch dir breaks eve |
-| 55 | 72 | high | P2 | P1 ⚑ | +117 | [#3235](https://github.com/omnigent-ai/omnigent/issues/3235) Flaky E2E UI: test_scheduled_task_create_edit_modal_and_time_picker[ch |
-| 56 | 71 | high | P2 | P1 ⚑ | +121 | [#3164](https://github.com/omnigent-ai/omnigent/issues/3164) [Feature] Optional runtimeClassName on the kubernetes sandbox provider |
-| 57 | 71 | high | P1 | P1 | -8 | [#3011](https://github.com/omnigent-ai/omnigent/issues/3011) kiro-native harness: interactive sessions never respond with kiro-cli  |
-| 58 | 67 | high | P1 | P1 | +14 | [#2454](https://github.com/omnigent-ai/omnigent/issues/2454) [Bug] Unbounded ~/.omnigent growth: per-session native-harness dirs ar |
-| 59 | 67 | high | P1 | P1 | +21 | [#2421](https://github.com/omnigent-ai/omnigent/issues/2421) [Bug] codex app-server + MCP bridge children leak on ANY unclean runne |
-| 60 | 67 | high | P1 | P1 | +68 | [#523](https://github.com/omnigent-ai/omnigent/issues/523) REPL pexpect e2e tests starve on boot under full shard load (60s _wait |
-| 61 | 67 | high | P2 | P1 ⚑ | +268 | [#151](https://github.com/omnigent-ai/omnigent/issues/151) Native claude_code worker hangs on the one-time Bypass Permissions acc |
-| 62 | 66 | high | P2 | P1 ⚑ | +243 | [#888](https://github.com/omnigent-ai/omnigent/issues/888) [Feature] Side-by-side multi-session view |
-| 63 | 66 | high | P2 | P1 ⚑ | +74 | [#3970](https://github.com/omnigent-ai/omnigent/issues/3970) pi-native: every turn fails with "Pi model error: 401 Invalid Token" w |
-| 64 | 66 | high | P1 | P1 | -47 | [#3799](https://github.com/omnigent-ai/omnigent/issues/3799) Android shell cannot sign in to servers behind a front-door auth proxy |
-| 65 | 66 | high | P2 | P1 ⚑ | +81 | [#3750](https://github.com/omnigent-ai/omnigent/issues/3750) [Crash] PermissionError: [Errno 1] Operation not permitted |
-| 66 | 66 | high | P1 | P1 | -46 | [#3730](https://github.com/omnigent-ai/omnigent/issues/3730) [Bug] Android: renderer death terminates the app — OmnigentWebViewClie |
-| 67 | 66 | high | P1 | P1 | -45 | [#3701](https://github.com/omnigent-ai/omnigent/issues/3701) [Bug] Desktop app never completes Okta security key / biometric MFA du |
-| 68 | 63 | high | P2 | P1 ⚑ | +148 | [#2480](https://github.com/omnigent-ai/omnigent/issues/2480) [Bug] Postgres-backed local server: bare `No module named 'psycopg'` + |
-| 69 | 63 | high | P0 | P1 ⚑ | -67 | [#2355](https://github.com/omnigent-ai/omnigent/issues/2355) [Bug] workspace_id PK-widening migration crashes on populated Postgres |
-| 70 | 63 | high | P3 | P1 ⚑ | +271 | [#2224](https://github.com/omnigent-ai/omnigent/issues/2224) [Bug] get_client model-change check fails for harness="any" |
-| 71 | 63 | high | P1 | P1 | +27 | [#1985](https://github.com/omnigent-ai/omnigent/issues/1985) Headless `omnigent run -p` intermittently hangs forever despite the tu |
-| 72 | 63 | high | P1 | P1 | +27 | [#1953](https://github.com/omnigent-ai/omnigent/issues/1953) `omni host` dies permanently when the OIDC session JWT expires — no re |
-| 73 | 63 | high | P2 | P1 ⚑ | +171 | [#1907](https://github.com/omnigent-ai/omnigent/issues/1907) Sub-agent model_override triggers an unnecessary first-turn harness re |
-| 74 | 63 | high | P2 | P1 ⚑ | +179 | [#1804](https://github.com/omnigent-ai/omnigent/issues/1804) spec parser crashes with TypeError on a null tools.builtins key (and s |
-| 75 | 63 | high | P2 | P1 ⚑ | +201 | [#1388](https://github.com/omnigent-ai/omnigent/issues/1388) Make agents a first-class CRUD entity with a dedicated sidebar UI (dec |
-| 76 | 63 | high | P2 | P1 ⚑ | +213 | [#1076](https://github.com/omnigent-ai/omnigent/issues/1076) Runner-layer Tier-2 escalation: release an unresponsive per-conversati |
-| 77 | 63 | high | P1 | P1 | +44 | [#1026](https://github.com/omnigent-ai/omnigent/issues/1026) Runner orphans tool callbacks with "no active turn context" after mid- |
-| 78 | 61 | high | P2 | P1 ⚑ | +220 | [#1022](https://github.com/omnigent-ai/omnigent/issues/1022) Behind a corporate proxy, the host daemon can't reach the model backen |
-| 79 | 60 | medium | P2 | P1 ⚑ | +125 | [#2744](https://github.com/omnigent-ai/omnigent/issues/2744) [Bug] codex-native: custom agents time out at launch — native provider |
-| 80 | 60 | high | P2 | P1 ⚑ | +64 | [#3798](https://github.com/omnigent-ai/omnigent/issues/3798) Android shell shows the SPA as if signed in while native login runs in |
-| 81 | 58 | high | P2 | P2 | +186 | [#1600](https://github.com/omnigent-ai/omnigent/issues/1600) Epic: 12-feature contribution (one issue + one PR per feature) |
-| 82 | 58 | high | P2 | P2 | +136 | [#2428](https://github.com/omnigent-ai/omnigent/issues/2428) sys_session_send to a completed session hangs to ReadTimeout and is si |
-| 83 | 58 | high | P1 | P2 ⚑ | +8 | [#2241](https://github.com/omnigent-ai/omnigent/issues/2241) Flaky on main: test_interrupt_forwards_to_harness_before_cancelling ti |
-| 84 | 58 | high | P1 | P2 ⚑ | +12 | [#2051](https://github.com/omnigent-ai/omnigent/issues/2051) [Bug] sys_session_send(session_id=…) completions never drain to sys_re |
-| 85 | 58 | high | P0 | P2 ⚑ | -82 | [#1657](https://github.com/omnigent-ai/omnigent/issues/1657) hermes-native forwarder advances last_id per item, dropping a row's la |
-| 86 | 58 | high | P2 | P2 | +228 | [#678](https://github.com/omnigent-ai/omnigent/issues/678) e2e: sub-agent supervisor routing / named-sub-agent auto-wake flakes ( |
-| 87 | 55 | medium | P1 | P2 ⚑ | -62 | [#3536](https://github.com/omnigent-ai/omnigent/issues/3536) [Bug] A session's `reasoning_effort` never reaches in-process harnesse |
-| 88 | 55 | medium | P2 | P2 | +73 | [#3369](https://github.com/omnigent-ai/omnigent/issues/3369) Feature: a policy that fences a spawned type: agent worker read-only ( |
-| 89 | 55 | medium | P2 | P2 | +79 | [#3254](https://github.com/omnigent-ai/omnigent/issues/3254) Sub-agent silently stalls after repeated context compactions during re |
-| 90 | 55 | medium | P2 | P2 | +95 | [#3069](https://github.com/omnigent-ai/omnigent/issues/3069) Harness install surfaces opaque failure reasons (npm stderr not captur |
-| 91 | 55 | medium | P2 | P2 | +100 | [#2984](https://github.com/omnigent-ai/omnigent/issues/2984) [Bug] Codex incorrectly reports `needs-auth` with an authenticated cus |
-| 92 | 55 | medium | P1 | P2 ⚑ | -34 | [#2904](https://github.com/omnigent-ai/omnigent/issues/2904) [Bug] claude-native: web-UI chat input fails with "tmux command failed |
-| 93 | 55 | medium | P2 | P2 | +101 | [#2880](https://github.com/omnigent-ai/omnigent/issues/2880) [Feature] Add in-session revert mechanism for all interfaces  |
-| 94 | 55 | medium | P3 | P2 ⚑ | +244 | [#2853](https://github.com/omnigent-ai/omnigent/issues/2853) [Bug] Native harnesses silently drop the agent spec `prompt:` at runti |
-| 95 | 55 | medium | P2 | P2 | +105 | [#2815](https://github.com/omnigent-ai/omnigent/issues/2815) [Feature] Distinguish human waits from machine-liveness deadlines |
-| 96 | 55 | medium | P1 | P2 ⚑ | -35 | [#2812](https://github.com/omnigent-ai/omnigent/issues/2812) [Bug] serve-mcp stops answering stdio requests during a slow tool call |
-| 97 | 55 | medium | P2 | P2 | +110 | [#2719](https://github.com/omnigent-ai/omnigent/issues/2719) [Bug] |
-| 98 | 55 | medium | P2 | P2 | +113 | [#2644](https://github.com/omnigent-ai/omnigent/issues/2644) Design discussion: deterministic verification gates (a PASS/FAIL quali |
-| 99 | 53 | high | P1 | P2 ⚑ | -11 | [#2270](https://github.com/omnigent-ai/omnigent/issues/2270) Windows: config list crashes — UnicodeEncodeError on cp1252 (non-UTF8) |
-| 100 | 53 | high | P1 | P2 ⚑ | -11 | [#2269](https://github.com/omnigent-ai/omnigent/issues/2269) Windows: omnigent setup crashes — ModuleNotFoundError: No module named |
-| 101 | 53 | high | P1 | P2 ⚑ | +3 | [#1888](https://github.com/omnigent-ai/omnigent/issues/1888) ansi-to-react default import resolves to the CJS exports object under  |
-| 102 | 53 | high | P1 | P2 ⚑ | +3 | [#1881](https://github.com/omnigent-ai/omnigent/issues/1881) [Bug] `omnigent setup` crashes with `ValueError: select() requires at  |
-| 103 | 53 | high | P2 | P2 | +152 | [#1778](https://github.com/omnigent-ai/omnigent/issues/1778) opencode-native forwarder loses session content across SSE reconnects  |
-| 104 | 52 | medium | P1 | P2 ⚑ | -62 | [#3101](https://github.com/omnigent-ai/omnigent/issues/3101) Docker/Kubernetes entrypoint never wires project_store — first-class P |
-| 105 | 51 | high | P1 | P2 ⚑ | +26 | [#108](https://github.com/omnigent-ai/omnigent/issues/108) Cannot install on Linux aarch64 — cel-expr-python has no aarch64 wheel |
-| 106 | 50 | medium | P1 | P2 ⚑ | -66 | [#3236](https://github.com/omnigent-ai/omnigent/issues/3236) web_search: bare executor.model strings are inferred as provider 'open |
-| 107 | 50 | medium | P1 | P2 ⚑ | -43 | [#2630](https://github.com/omnigent-ai/omnigent/issues/2630) Tool-spawn failure is swallowed — agent answers from training knowledg |
-| 108 | 49 | medium | P2 | P2 | +160 | [#1596](https://github.com/omnigent-ai/omnigent/issues/1596) Native-CLI harness (claude-native/codex-native) as a named agent's own |
-| 109 | 48 | high | P1 | P2 ⚑ | -7 | [#1901](https://github.com/omnigent-ai/omnigent/issues/1901) [Bug] kimi/qwen/goose/kiro forwarders blind-retry failed conversation- |
-| 110 | 48 | high | P1 | P2 ⚑ | -2 | [#1827](https://github.com/omnigent-ai/omnigent/issues/1827) [Bug] kimi-native: torn UTF-8 wire read crashes the forwarder; supervi |
-| 111 | 48 | medium | P2 | P2 | +46 | [#3531](https://github.com/omnigent-ai/omnigent/issues/3531) SSH_AUTH_SOCK dropped at the host→runner env boundary, breaking ssh-ag |
-| 112 | 48 | medium | P2 | P2 | +48 | [#3435](https://github.com/omnigent-ai/omnigent/issues/3435) [Feature] Admin server-wide usage report (per-user and per-model cost) |
-| 113 | 48 | medium | P2 | P2 | +49 | [#3368](https://github.com/omnigent-ai/omnigent/issues/3368) Feature: first-class async write-safety (freeze → approve → apply) pri |
-| 114 | 48 | medium | P2 | P2 | +51 | [#3352](https://github.com/omnigent-ai/omnigent/issues/3352) [Feature] OpenClaw onboarding — Option B: chat import (SQLite session  |
-| 115 | 48 | medium | P2 | P2 | +55 | [#3247](https://github.com/omnigent-ai/omnigent/issues/3247) credential_proxy: re-resolve the source on 401 / expiry (short-lived t |
-| 116 | 48 | medium | P1 | P2 ⚑ | -56 | [#2854](https://github.com/omnigent-ai/omnigent/issues/2854) [Bug] Cross-harness `harness_override` is ignored on the `initial_item |
-| 117 | 48 | medium | P2 | P2 | +79 | [#2851](https://github.com/omnigent-ai/omnigent/issues/2851) Policy-supplied targets for ASK approval cards |
-| 118 | 48 | medium | P2 | P2 | +84 | [#2756](https://github.com/omnigent-ai/omnigent/issues/2756) Expose atomic session-event admission to integrations |
-| 119 | 48 | medium | P2 | P2 | +93 | [#2577](https://github.com/omnigent-ai/omnigent/issues/2577) [Feature] Manage OIDC/SSO admins from an id_token claim (IdP group/rol |
-| 120 | 48 | medium | P2 | P2 | +94 | [#2542](https://github.com/omnigent-ai/omnigent/issues/2542) [Feature] Ambient-detect a local llama-server, mirroring Ollama detect |
-| 121 | 48 | medium | P1 | P2 ⚑ | -51 | [#2539](https://github.com/omnigent-ai/omnigent/issues/2539) Named sys_session_send returns 404 after first child from a bundled se |
-| 122 | 46 | medium | P1 | P2 ⚑ | -112 | [#3952](https://github.com/omnigent-ai/omnigent/issues/3952) A stale terminal exit removes the newer Codex resources of the same se |
-| 123 | 46 | medium | P2 | P2 | +27 | [#3592](https://github.com/omnigent-ai/omnigent/issues/3592) [Feature] Deterministic long-term memory (automatic recall/retain) — f |
-| 124 | 46 | medium | P1 | P2 ⚑ | -98 | [#3530](https://github.com/omnigent-ai/omnigent/issues/3530) [Bug] An agent spec's `instructions:` has no effect on 13 of 24 harnes |
-| 125 | 46 | medium | P1 | P2 ⚑ | -98 | [#3525](https://github.com/omnigent-ai/omnigent/issues/3525) Sub-agent sessions are launched from the parent agent's bundle root, e |
-| 126 | 46 | medium | P1 | P2 ⚑ | -82 | [#3076](https://github.com/omnigent-ai/omnigent/issues/3076) [Bug] claude-sdk omits ToolSearch, eagerly loading every MCP schema |
-| 127 | 46 | medium | P3 | P2 ⚑ | +212 | [#2800](https://github.com/omnigent-ai/omnigent/issues/2800) [Bug] Top-level custom codex-native agents drop reasoning effort and y |
-| 128 | 45 | medium | P2 | P2 | +171 | [#1021](https://github.com/omnigent-ai/omnigent/issues/1021) [Feature] GitHub Copilot as provider |
-| 129 | 43 | medium | P2 | P2 | +195 | [#377](https://github.com/omnigent-ai/omnigent/issues/377) gpt sub-agent fails on startup with missing databricks-sdk dependency |
-| 130 | 43 | medium | P2 | P2 | +68 | [#2848](https://github.com/omnigent-ai/omnigent/issues/2848) Server logs an expected offline-runner resource 503 as ERROR + full tr |
-| 131 | 43 | medium | P2 | P2 | +70 | [#2767](https://github.com/omnigent-ai/omnigent/issues/2767) [Bug] SQLite pool (default 5+10) not sized to the 200-thread limiter → |
-| 132 | 42 | medium | P2 | P2 | +6 | [#3969](https://github.com/omnigent-ai/omnigent/issues/3969) Databricks gateway sessions default to a stale model (opus-4-7) while  |
-| 133 | 42 | medium | P1 | P2 ⚑ | -115 | [#3790](https://github.com/omnigent-ai/omnigent/issues/3790) force_sandbox policy is evaluated but structurally unreachable from cl |
-| 134 | 42 | medium | P1 | P2 ⚑ | -71 | [#2702](https://github.com/omnigent-ai/omnigent/issues/2702) Native idle-detection fork+exec's tmux capture-pane at 5 Hz per termin |
-| 135 | 40 | medium | P2 | P2 | -1 | [#4009](https://github.com/omnigent-ai/omnigent/issues/4009) [Feature] No Go client for the session API, so every Go caller hand-ro |
-| 136 | 40 | medium | P1 | P2 ⚑ | -123 | [#3898](https://github.com/omnigent-ai/omnigent/issues/3898) [Bug] Pack function policies fail server-side input evaluation unless  |
-| 137 | 40 | medium | P1 | P2 ⚑ | -123 | [#3870](https://github.com/omnigent-ai/omnigent/issues/3870) child-session creation returns 500 internal_error, breaking Polly/Debb |
-| 138 | 40 | medium | P2 | P2 | +4 | [#3864](https://github.com/omnigent-ai/omnigent/issues/3864) [Bug] to_api_dict() drops ConversationItem.created_at, so flat items A |
-| 139 | 40 | medium | P1 | P2 ⚑ | -124 | [#3863](https://github.com/omnigent-ai/omnigent/issues/3863) [Bug] Databricks Apps entrypoint never wires project_store — Projects  |
-| 140 | 40 | medium | P2 | P2 | +12 | [#3563](https://github.com/omnigent-ai/omnigent/issues/3563) [Bug] Host-bound resume into a deleted workspace: host computes the ex |
-| 141 | 40 | medium | P2 | P2 | +14 | [#3550](https://github.com/omnigent-ai/omnigent/issues/3550) [Bug] Missing signing alg's prevent using some OIDC providers |
-| 142 | 40 | medium | P2 | P2 | +16 | [#3449](https://github.com/omnigent-ai/omnigent/issues/3449) [Bug] Item pagination cursor can't use the index, so scroll-back scans |
-| 143 | 40 | medium | none | P2 | +210 | [#3402](https://github.com/omnigent-ai/omnigent/issues/3402) [Bug] Label seeding and session-state writes race under concurrent upd |
-| 144 | 40 | medium | none | P2 | +210 | [#3392](https://github.com/omnigent-ai/omnigent/issues/3392) [Bug] Linux desktop app missing Icon |
-| 145 | 40 | medium | P2 | P2 | +31 | [#3219](https://github.com/omnigent-ai/omnigent/issues/3219) [Bug] Cmd/Ctrl+Up/Down session traversal stops in an empty focused com |
-| 146 | 40 | medium | P1 | P2 ⚑ | -103 | [#3095](https://github.com/omnigent-ai/omnigent/issues/3095) [Bug] Can't uninstall |
-| 147 | 40 | medium | P2 | P2 | +40 | [#3064](https://github.com/omnigent-ai/omnigent/issues/3064) [Bug] Created file links are inaccessible from remote sessions |
-| 148 | 40 | medium | P2 | P2 | +44 | [#2921](https://github.com/omnigent-ai/omnigent/issues/2921) Font settings: selected font (incl. Nerd Fonts) never loads — no webfo |
-| 149 | 40 | medium | P1 | P2 ⚑ | -90 | [#2866](https://github.com/omnigent-ai/omnigent/issues/2866) iOS app: Google OIDC fails with 403 disallowed_useragent in embedded w |
-| 150 | 40 | medium | P1 | P2 ⚑ | -81 | [#2549](https://github.com/omnigent-ai/omnigent/issues/2549) [Bug] iOS Google OIDC fails with disallowed_useragent in WKWebView |
-| 151 | 38 | medium | P2 | P2 | -12 | [#3950](https://github.com/omnigent-ai/omnigent/issues/3950) An agent switch keeps the previous agent's comment-tool relay |
-| 152 | 38 | medium | P1 | P2 ⚑ | -136 | [#3852](https://github.com/omnigent-ai/omnigent/issues/3852) [Bug] Built-in write policies miss Claude Code's `MultiEdit` / `Notebo |
-| 153 | 37 | feature | P2 | P2 | +25 | [#3150](https://github.com/omnigent-ai/omnigent/issues/3150) [Feature] CLI: cross-harness fork — continue an existing session in a  |
-| 154 | 37 | medium | P1 | P2 ⚑ | -73 | [#2397](https://github.com/omnigent-ai/omnigent/issues/2397) [Bug] Codex-native intelligent routing ignores live effort capabilitie |
-| 155 | 37 | medium | P1 | P2 ⚑ | -68 | [#2272](https://github.com/omnigent-ai/omnigent/issues/2272) [Bug] Codex runner can't find OpenRouter secret that exists in keyring |
-| 156 | 37 | medium | P1 | P2 ⚑ | -64 | [#2184](https://github.com/omnigent-ai/omnigent/issues/2184) [Bug] Codex plugin skills are exposed with inconsistent names (`plugin |
-| 157 | 37 | medium | P1 | P2 ⚑ | -64 | [#2071](https://github.com/omnigent-ai/omnigent/issues/2071) [Bug] web_search never advertised to claude-sdk sessions: unprefixed m |
-| 158 | 37 | medium | P2 | P2 | +77 | [#2062](https://github.com/omnigent-ai/omnigent/issues/2062) [Bug] claude-native: per-session model override silently lost when wra |
-| 159 | 37 | medium | P1 | P2 ⚑ | -52 | [#1831](https://github.com/omnigent-ai/omnigent/issues/1831) claude-native workers ignore executor.model pin and per-dispatch args. |
-| 160 | 37 | medium | P2 | P2 | +94 | [#1789](https://github.com/omnigent-ai/omnigent/issues/1789) Feature: Canvas — agent-authored artifact panel (#2) |
-| 161 | 37 | medium | P1 | P2 ⚑ | -51 | [#1781](https://github.com/omnigent-ai/omnigent/issues/1781) codex harness: ambient DATABRICKS_BEARER/DATABRICKS_TOKEN overrides pr |
-| 162 | 37 | medium | P2 | P2 | +107 | [#1594](https://github.com/omnigent-ai/omnigent/issues/1594) Server-side idempotency for external_conversation_item (safe dedup on  |
-| 163 | 37 | medium | P2 | P2 | +118 | [#1230](https://github.com/omnigent-ai/omnigent/issues/1230) [Feature] Migrate remaining native forwarders to the shared post_sessi |
-| 164 | 37 | medium | P1 | P2 ⚑ | -45 | [#1128](https://github.com/omnigent-ai/omnigent/issues/1128) [Bug] Claude SDK Appears to Use Opus Instead of Selected Model |
-| 165 | 37 | medium | P2 | P2 | +139 | [#890](https://github.com/omnigent-ai/omnigent/issues/890) [Bug] omnigent setup fails with npm EACCES when installing the Claude  |
-| 166 | 37 | medium | P1 | P2 ⚑ | -41 | [#668](https://github.com/omnigent-ai/omnigent/issues/668) [Bug] BUG？omni claude times out (60s) on macOS with native Claude Code |
-| 167 | 37 | medium | P2 | P2 | +150 | [#548](https://github.com/omnigent-ai/omnigent/issues/548) Recommend missing dependency install suggestions more gracefully in UI |
-| 168 | 37 | medium | P1 | P2 ⚑ | -38 | [#241](https://github.com/omnigent-ai/omnigent/issues/241) pi harness: GPT and Gemini dispatches 404 on the Databricks ucode gate |
-| 169 | 37 | medium | P3 | P2 ⚑ | +178 | [#147](https://github.com/omnigent-ai/omnigent/issues/147) Tracking: gradual decomposition of monolith modules (cli.py 9.1KLOC, c |
-| 170 | 37 | medium | P1 | P2 ⚑ | -50 | [#1113](https://github.com/omnigent-ai/omnigent/issues/1113) Native sub-agent/runner failures surface as bare "failed" with no reas |
-| 171 | 36 | medium | P2 | P2 | +11 | [#3083](https://github.com/omnigent-ai/omnigent/issues/3083) [Bug] Cursor sessions launched from Omnigent Web is losing MCPs |
-| 172 | 36 | medium | P1 | P2 ⚑ | -141 | [#3424](https://github.com/omnigent-ai/omnigent/issues/3424) [Bug] Per-request pool checkout + pre-ping overhead: ~11 checkouts/req |
-| 173 | 36 | medium | none | P2 | +178 | [#3408](https://github.com/omnigent-ai/omnigent/issues/3408) [Bug] Mac app start locally fails with no such command start |
-| 174 | 36 | medium | P2 | P2 | -5 | [#3250](https://github.com/omnigent-ai/omnigent/issues/3250) flaky e2e_ui: test_scheduled_task_create_edit_modal_and_time_picker ti |
-| 175 | 36 | medium | P1 | P2 ⚑ | -125 | [#3004](https://github.com/omnigent-ai/omnigent/issues/3004) [Performance] Every streamed event re-loads conversation + ACL: 16 que |
-| 176 | 36 | medium | P1 | P2 ⚑ | -125 | [#3003](https://github.com/omnigent-ai/omnigent/issues/3003) [Performance] Policy engine rebuilt per evaluation: 32 queries + two f |
-| 177 | 36 | medium | P2 | P2 | +20 | [#2849](https://github.com/omnigent-ai/omnigent/issues/2849) [Performance] Session switch re-runs a full eager transcript backfill  |
-| 178 | 36 | medium | P2 | P2 | +32 | [#2703](https://github.com/omnigent-ai/omnigent/issues/2703) Runner re-parses agent-bundle YAML per session with pure-Python SafeLo |
-| 179 | 36 | medium | P1 | P2 ⚑ | -113 | [#2592](https://github.com/omnigent-ai/omnigent/issues/2592) [Bug] omni update wipes extras installs: VCS reinstall spec rebuilt fr |
-| 180 | 36 | medium | P2 | P2 | +33 | [#2558](https://github.com/omnigent-ai/omnigent/issues/2558) Distribution / Installation / Enterprise Readiness |
-| 181 | 34 | medium | P1 | P2 ⚑ | -72 | [#1794](https://github.com/omnigent-ai/omnigent/issues/1794) Bundled Polly: claude-sdk brain "Not logged in" + runaway spawn loop o |
-| 182 | 34 | medium | P2 | P2 | +76 | [#1724](https://github.com/omnigent-ai/omnigent/issues/1724) codex-native harness times out on WSL2 ("Codex TUI never started a thr |
-| 183 | 34 | medium | P1 | P2 ⚑ | -72 | [#1694](https://github.com/omnigent-ai/omnigent/issues/1694) Reliability: parallel code-fix missions fail silently (5s tmux timeout |
-| 184 | 34 | medium | P1 | P2 ⚑ | -69 | [#1533](https://github.com/omnigent-ai/omnigent/issues/1533) Context-occupancy meter (context_tokens) freezes on failed turns — onl |
-| 185 | 34 | medium | P2 | P2 | +143 | [#152](https://github.com/omnigent-ai/omnigent/issues/152) Harness availability is reported from binary presence, not from config |
-| 186 | 33 | medium | P1 | P2 ⚑ | -181 | [#3982](https://github.com/omnigent-ai/omnigent/issues/3982) [Bug] electron-build.yml pnpm filter matches no package: desktop packa |
-| 187 | 33 | medium | P1 | P2 ⚑ | -181 | [#3981](https://github.com/omnigent-ai/omnigent/issues/3981) [Bug] Desktop: Workspace rail resize is unusable on the Browser tab; a |
-| 188 | 33 | medium | P1 | P2 ⚑ | -179 | [#3967](https://github.com/omnigent-ai/omnigent/issues/3967) Daemon registry records and host identity should be scoped to the data |
-| 189 | 33 | medium | P1 | P2 ⚑ | -178 | [#3951](https://github.com/omnigent-ai/omnigent/issues/3951) The runner-wide agent spec cache can publish a superseded tool spec |
-| 190 | 33 | medium | P1 | P2 ⚑ | -178 | [#3949](https://github.com/omnigent-ai/omnigent/issues/3949) Session reset does not fence in-flight terminal publication |
-| 191 | 33 | medium | P2 | P2 | -48 | [#3861](https://github.com/omnigent-ai/omnigent/issues/3861) [Bug] omni host status renders URLs so terminals link the whole status |
-| 192 | 33 | medium | P3 | P2 ⚑ | +144 | [#3733](https://github.com/omnigent-ai/omnigent/issues/3733) [Bug] Android: hardcoded 25px switcher height makes the chat scroll-fa |
-| 193 | 33 | medium | P2 | P2 | -46 | [#3732](https://github.com/omnigent-ai/omnigent/issues/3732) [Bug] Android: a Display-size change leaves the server-switcher pill's |
-| 194 | 33 | medium | P2 | P2 | -43 | [#3586](https://github.com/omnigent-ai/omnigent/issues/3586) [Bug] Android: native server-picker pill overlaps the sidebar header c |
-| 195 | 33 | medium | P1 | P2 ⚑ | -171 | [#3578](https://github.com/omnigent-ai/omnigent/issues/3578) [Bug] MacOS Start Locally - "Error: No such command 'start'" |
-| 196 | 33 | medium | P2 | P2 | -43 | [#3561](https://github.com/omnigent-ai/omnigent/issues/3561) [Bug] `prompt_policy` never sends `_CLASSIFIER_SCHEMA` to the LLM — st |
-| 197 | 33 | medium | P2 | P2 | -17 | [#3127](https://github.com/omnigent-ai/omnigent/issues/3127) Desktop app: closed sub-agents stay in the Agents panel with no 'close |
-| 198 | 33 | medium | P2 | P2 | -8 | [#2988](https://github.com/omnigent-ai/omnigent/issues/2988) [Bug] Arrow keys don't work in `omni setup` menus |
-| 199 | 32 | medium | P1 | P2 ⚑ | -121 | [#2429](https://github.com/omnigent-ai/omnigent/issues/2429) Server (python -m omnigent.cli server) CPU-spins indefinitely with no  |
-| 200 | 32 | medium | P1 | P2 ⚑ | -129 | [#2524](https://github.com/omnigent-ai/omnigent/issues/2524) [Bug] Registering remote host fails |
-
-
+| 1 | 163 | critical | P2 | P0 ⚑ | +231 | [#2125](https://github.com/omnigent-ai/omnigent/issues/2125) [Feature] Multi-host git credentials for managed sandboxes (GitHub + s |
+| 2 | 140 | critical | P2 | P0 ⚑ | +234 | [#2057](https://github.com/omnigent-ai/omnigent/issues/2057) [Feature] Add Codex Auto mode using auto_review instead of jumping to  |
+| 3 | 140 | critical | P2 | P0 ⚑ | +235 | [#2054](https://github.com/omnigent-ai/omnigent/issues/2054) [Feature] Remove duplicate Codex Full access mode and keep Sandbox Byp |
+| 4 | 122 | high | P2 | P0 ⚑ | +330 | [#16](https://github.com/omnigent-ai/omnigent/issues/16) Is native Windows support in scope, or should docs recommend WSL2? |
+| 5 | 120 | critical | P1 | P0 ⚑ | -1 | [#3983](https://github.com/omnigent-ai/omnigent/issues/3983) [Bug] Smart-routed turns render out of order: reply streams above the  |
+| 6 | 120 | critical | P1 | P0 ⚑ | +29 | [#3270](https://github.com/omnigent-ai/omnigent/issues/3270) [Bug] sys_session_create children are absent from both sys_session_lis |
+| 7 | 120 | critical | P2 | P0 ⚑ | +308 | [#659](https://github.com/omnigent-ai/omnigent/issues/659) [Feature] add a microvm backend for sandbox |
+| 8 | 100 | critical | P0 | P0 | -7 | [#3557](https://github.com/omnigent-ai/omnigent/issues/3557) [Bug] Shell-surface policy gates are bypassed by option-taking command |
+| 9 | 100 | critical | P3 | P0 ⚑ | +340 | [#61](https://github.com/omnigent-ai/omnigent/issues/61) 🤖 Code Audit: 21 potential issue(s) found |
+| 10 | 84 | high | P2 | P1 ⚑ | +144 | [#3558](https://github.com/omnigent-ai/omnigent/issues/3558) claude-sdk: cached client does not rebuild on framework-instruction ch |
+| 11 | 84 | high | P1 | P1 | +22 | [#3299](https://github.com/omnigent-ai/omnigent/issues/3299) [Bug] Harness-credential route times out with a misleading 504 against |
+| 12 | 84 | high | P2 | P1 ⚑ | +154 | [#3284](https://github.com/omnigent-ai/omnigent/issues/3284) [Crash] DuplicateOptionError: While reading from PosixPath('/Users/*** |
+| 13 | 84 | high | P1 | P1 | +24 | [#3265](https://github.com/omnigent-ai/omnigent/issues/3265) claude-sdk agent with linux_bwrap dies at spawn on a runtime bwrap bin |
+| 14 | 84 | high | P1 | P1 | +27 | [#3180](https://github.com/omnigent-ai/omnigent/issues/3180) codex-native: runner never exits on idle timeout — cancelled delta-coa |
+| 15 | 84 | high | P2 | P1 ⚑ | +169 | [#3070](https://github.com/omnigent-ai/omnigent/issues/3070) No progress signal on a stuck or interactive harness install |
+| 16 | 84 | high | P1 | P1 | +37 | [#3000](https://github.com/omnigent-ai/omnigent/issues/3000) claude-native transcript forwarder polls at 4 Hz per session with no i |
+| 17 | 84 | high | P1 | P1 | +38 | [#2967](https://github.com/omnigent-ai/omnigent/issues/2967) [Bug] A full context window bricks a session with "Prompt is too long" |
+| 18 | 84 | high | P1 | P1 | +38 | [#2920](https://github.com/omnigent-ai/omnigent/issues/2920) Omnigent server fails to start on native Windows: os.getuid() at impor |
+| 19 | 84 | high | P1 | P1 | +38 | [#2919](https://github.com/omnigent-ai/omnigent/issues/2919) omni setup crashes on Windows: ModuleNotFoundError: No module named 't |
+| 20 | 84 | high | P1 | P1 | +42 | [#2748](https://github.com/omnigent-ai/omnigent/issues/2748) Runner idle-shutdown deadlocks forever: codex-forwarder close()/flush( |
+| 21 | 84 | high | P2 | P1 ⚑ | +187 | [#2714](https://github.com/omnigent-ai/omnigent/issues/2714) Upgrade openai-agents and remove the temporary openai<2.45 cap |
+| 22 | 84 | high | P1 | P1 | +43 | [#2629](https://github.com/omnigent-ai/omnigent/issues/2629) web_fetch sub-agent spawn fails with unknown harness 'omnigent' — bare |
+| 23 | 84 | high | P1 | P1 | +44 | [#2575](https://github.com/omnigent-ai/omnigent/issues/2575) pi-native: non-Claude Databricks models (GLM, Gemini, …) hang — provid |
+| 24 | 84 | high | P1 | P1 | +48 | [#2454](https://github.com/omnigent-ai/omnigent/issues/2454) [Bug] Unbounded ~/.omnigent growth: per-session native-harness dirs ar |
+| 25 | 84 | high | P1 | P1 | +54 | [#2422](https://github.com/omnigent-ai/omnigent/issues/2422) Windows: five chained defects break the documented degraded-mode subse |
+| 26 | 84 | high | P1 | P1 | +54 | [#2421](https://github.com/omnigent-ai/omnigent/issues/2421) [Bug] codex app-server + MCP bridge children leak on ANY unclean runne |
+| 27 | 84 | high | P1 | P1 | +55 | [#2373](https://github.com/omnigent-ai/omnigent/issues/2373) [Bug] claude-native: pasted web-UI message loses its Enter, stuck draf |
+| 28 | 84 | high | P1 | P1 | +62 | [#2245](https://github.com/omnigent-ai/omnigent/issues/2245) [Bug] openai-agents harness turn wedges permanently after policy-verdi |
+| 29 | 84 | high | P1 | P1 | +65 | [#2060](https://github.com/omnigent-ai/omnigent/issues/2060) [Bug] claude-native: first web-UI message silently dropped when Claude |
+| 30 | 84 | high | P1 | P1 | +73 | [#1898](https://github.com/omnigent-ai/omnigent/issues/1898) [Bug] codex-native: cancelling a task awaiting flush() poisons the del |
+| 31 | 84 | high | P2 | P1 ⚑ | +239 | [#1528](https://github.com/omnigent-ai/omnigent/issues/1528) Idle-session lifecycle UX: reap gracefully, resume seamlessly, surface |
+| 32 | 84 | high | P2 | P1 ⚑ | +263 | [#1051](https://github.com/omnigent-ai/omnigent/issues/1051) [Feature] Forward OTel exporter knobs to executor subprocess env |
+| 33 | 84 | high | P2 | P1 ⚑ | +277 | [#762](https://github.com/omnigent-ai/omnigent/issues/762) [Bug] sub agent terminal crashes when cli starts with prompt for input |
+| 34 | 84 | high | P2 | P1 ⚑ | +282 | [#654](https://github.com/omnigent-ai/omnigent/issues/654) [Bug] Streaming with codex is hanging and paragraphs are not split. |
+| 35 | 84 | high | P1 | P1 | +92 | [#542](https://github.com/omnigent-ai/omnigent/issues/542) [Bug] AttributeError: 'SubprocessCLITransport' object has no attribute |
+| 36 | 84 | high | P1 | P1 | +92 | [#523](https://github.com/omnigent-ai/omnigent/issues/523) REPL pexpect e2e tests starve on boot under full shard load (60s _wait |
+| 37 | 84 | high | P2 | P1 ⚑ | +292 | [#151](https://github.com/omnigent-ai/omnigent/issues/151) Native claude_code worker hangs on the one-time Bypass Permissions acc |
+| 38 | 84 | high | P2 | P1 ⚑ | +202 | [#2038](https://github.com/omnigent-ai/omnigent/issues/2038) [Feature] No way to deregister/delete an external self-registered host |
+| 39 | 76 | high | P1 | P1 | -1 | [#3261](https://github.com/omnigent-ai/omnigent/issues/3261) [Crash] AttributeError: module 'os' has no attribute 'WNOHANG' |
+| 40 | 76 | high | P2 | P1 ⚑ | +258 | [#1022](https://github.com/omnigent-ai/omnigent/issues/1022) Behind a corporate proxy, the host daemon can't reach the model backen |
+| 41 | 75 | high | P2 | P1 ⚑ | +264 | [#888](https://github.com/omnigent-ai/omnigent/issues/888) [Feature] Side-by-side multi-session view |
+| 42 | 72 | high | P2 | P1 ⚑ | +94 | [#3976](https://github.com/omnigent-ai/omnigent/issues/3976) [Feature] OAuth2 client-credentials grant so a headless process can au |
+| 43 | 72 | high | P1 | P1 | -35 | [#3971](https://github.com/omnigent-ai/omnigent/issues/3971) Host runners inherit the daemon's cwd; a deleted launch dir breaks eve |
+| 44 | 72 | high | P1 | P1 | -16 | [#3482](https://github.com/omnigent-ai/omnigent/issues/3482) [Crash] ServerError: |
+| 45 | 72 | high | P1 | P1 | -15 | [#3458](https://github.com/omnigent-ai/omnigent/issues/3458) session-updates stream crashes with KeyError when a client watches a c |
+| 46 | 72 | high | P2 | P1 ⚑ | +118 | [#3363](https://github.com/omnigent-ai/omnigent/issues/3363) [Feature] Per-project custom instructions (project-scoped context) |
+| 47 | 72 | high | P1 | P1 | -13 | [#3274](https://github.com/omnigent-ai/omnigent/issues/3274) Sub-agent terminal status rejected with missing_parent_inbox and retri |
+| 48 | 72 | high | P2 | P1 ⚑ | +119 | [#3271](https://github.com/omnigent-ai/omnigent/issues/3271) [Feature] Expose per-session context size + last-turn timestamp to age |
+| 49 | 72 | high | P2 | P1 ⚑ | +124 | [#3231](https://github.com/omnigent-ai/omnigent/issues/3231) [Crash] OmnigentError: {'error_code': 403, 'message': 'Invalid access  |
+| 50 | 72 | high | P1 | P1 | -3 | [#3016](https://github.com/omnigent-ai/omnigent/issues/3016) [Bug] A transient session-snapshot failure permanently pins a session  |
+| 51 | 72 | high | P1 | P1 | -3 | [#3012](https://github.com/omnigent-ai/omnigent/issues/3012) Hosts authenticated via `omnigent login` permanently 403 on first reco |
+| 52 | 72 | high | P1 | P1 | 0 | [#3001](https://github.com/omnigent-ai/omnigent/issues/3001) [Performance] GET /v1/sessions pre-fetches every accessible conversati |
+| 53 | 72 | high | P2 | P1 ⚑ | +163 | [#2480](https://github.com/omnigent-ai/omnigent/issues/2480) [Bug] Postgres-backed local server: bare `No module named 'psycopg'` + |
+| 54 | 72 | high | P2 | P1 ⚑ | +164 | [#2428](https://github.com/omnigent-ai/omnigent/issues/2428) sys_session_send to a completed session hangs to ReadTimeout and is si |
+| 55 | 72 | high | P0 | P1 ⚑ | -53 | [#2355](https://github.com/omnigent-ai/omnigent/issues/2355) [Bug] workspace_id PK-widening migration crashes on populated Postgres |
+| 56 | 72 | high | P1 | P1 | +35 | [#2241](https://github.com/omnigent-ai/omnigent/issues/2241) Flaky on main: test_interrupt_forwards_to_harness_before_cancelling ti |
+| 57 | 72 | high | P3 | P1 ⚑ | +284 | [#2224](https://github.com/omnigent-ai/omnigent/issues/2224) [Bug] get_client model-change check fails for harness="any" |
+| 58 | 72 | high | P1 | P1 | +38 | [#2051](https://github.com/omnigent-ai/omnigent/issues/2051) [Bug] sys_session_send(session_id=…) completions never drain to sys_re |
+| 59 | 72 | high | P1 | P1 | +39 | [#1985](https://github.com/omnigent-ai/omnigent/issues/1985) Headless `omnigent run -p` intermittently hangs forever despite the tu |
+| 60 | 72 | high | P1 | P1 | +39 | [#1953](https://github.com/omnigent-ai/omnigent/issues/1953) `omni host` dies permanently when the OIDC session JWT expires — no re |
+| 61 | 72 | high | P2 | P1 ⚑ | +183 | [#1907](https://github.com/omnigent-ai/omnigent/issues/1907) Sub-agent model_override triggers an unnecessary first-turn harness re |
+| 62 | 72 | high | P2 | P1 ⚑ | +191 | [#1804](https://github.com/omnigent-ai/omnigent/issues/1804) spec parser crashes with TypeError on a null tools.builtins key (and s |
+| 63 | 72 | high | P0 | P1 ⚑ | -60 | [#1657](https://github.com/omnigent-ai/omnigent/issues/1657) hermes-native forwarder advances last_id per item, dropping a row's la |
+| 64 | 72 | high | P2 | P1 ⚑ | +212 | [#1388](https://github.com/omnigent-ai/omnigent/issues/1388) Make agents a first-class CRUD entity with a dedicated sidebar UI (dec |
+| 65 | 72 | high | P2 | P1 ⚑ | +224 | [#1076](https://github.com/omnigent-ai/omnigent/issues/1076) Runner-layer Tier-2 escalation: release an unresponsive per-conversati |
+| 66 | 72 | high | P1 | P1 | +55 | [#1026](https://github.com/omnigent-ai/omnigent/issues/1026) Runner orphans tool callbacks with "no active turn context" after mid- |
+| 67 | 72 | high | P2 | P1 ⚑ | +247 | [#678](https://github.com/omnigent-ai/omnigent/issues/678) e2e: sub-agent supervisor routing / named-sub-agent auto-wake flakes ( |
+| 68 | 66 | high | P2 | P1 ⚑ | +69 | [#3970](https://github.com/omnigent-ai/omnigent/issues/3970) pi-native: every turn fails with "Pi model error: 401 Invalid Token" w |
+| 69 | 66 | high | P1 | P1 | -40 | [#3469](https://github.com/omnigent-ai/omnigent/issues/3469) [Bug] Post-completion compaction spiral: merge-commit diff output trig |
+| 70 | 66 | high | P2 | P1 ⚑ | +185 | [#1778](https://github.com/omnigent-ai/omnigent/issues/1778) opencode-native forwarder loses session content across SSE reconnects  |
+| 71 | 66 | high | P2 | P1 ⚑ | +196 | [#1600](https://github.com/omnigent-ai/omnigent/issues/1600) Epic: 12-feature contribution (one issue + one PR per feature) |
+| 72 | 60 | high | P1 | P1 | -55 | [#3799](https://github.com/omnigent-ai/omnigent/issues/3799) Android shell cannot sign in to servers behind a front-door auth proxy |
+| 73 | 60 | high | P2 | P1 ⚑ | +71 | [#3798](https://github.com/omnigent-ai/omnigent/issues/3798) Android shell shows the SPA as if signed in while native login runs in |
+| 74 | 60 | high | P2 | P1 ⚑ | +72 | [#3750](https://github.com/omnigent-ai/omnigent/issues/3750) [Crash] PermissionError: [Errno 1] Operation not permitted |
+| 75 | 60 | high | P1 | P1 | -55 | [#3730](https://github.com/omnigent-ai/omnigent/issues/3730) [Bug] Android: renderer death terminates the app — OmnigentWebViewClie |
+| 76 | 60 | high | P1 | P1 | -54 | [#3701](https://github.com/omnigent-ai/omnigent/issues/3701) [Bug] Desktop app never completes Okta security key / biometric MFA du |
+| 77 | 60 | high | P1 | P1 | -45 | [#3359](https://github.com/omnigent-ai/omnigent/issues/3359) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 78 | 60 | high | P1 | P1 | -39 | [#3251](https://github.com/omnigent-ai/omnigent/issues/3251) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 79 | 60 | high | P2 | P1 ⚑ | +93 | [#3235](https://github.com/omnigent-ai/omnigent/issues/3235) Flaky E2E UI: test_scheduled_task_create_edit_modal_and_time_picker[ch |
+| 80 | 60 | high | P1 | P1 | -35 | [#3052](https://github.com/omnigent-ai/omnigent/issues/3052) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 81 | 60 | high | P1 | P1 | -35 | [#3023](https://github.com/omnigent-ai/omnigent/issues/3023) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 82 | 60 | high | P1 | P1 | -28 | [#2993](https://github.com/omnigent-ai/omnigent/issues/2993) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 83 | 60 | high | P3 | P1 ⚑ | +254 | [#2887](https://github.com/omnigent-ai/omnigent/issues/2887) [Bug] web/package-lock.json is out of sync with package.json; plain `n |
+| 84 | 60 | high | P1 | P1 | -16 | [#2559](https://github.com/omnigent-ai/omnigent/issues/2559) Conversation bricked: Page fails to load when opening markdown file af |
+| 85 | 60 | high | P1 | P1 | +3 | [#2270](https://github.com/omnigent-ai/omnigent/issues/2270) Windows: config list crashes — UnicodeEncodeError on cp1252 (non-UTF8) |
+| 86 | 60 | high | P1 | P1 | +3 | [#2269](https://github.com/omnigent-ai/omnigent/issues/2269) Windows: omnigent setup crashes — ModuleNotFoundError: No module named |
+| 87 | 60 | high | P1 | P1 | +17 | [#1888](https://github.com/omnigent-ai/omnigent/issues/1888) ansi-to-react default import resolves to the CJS exports object under  |
+| 88 | 60 | high | P1 | P1 | +17 | [#1881](https://github.com/omnigent-ai/omnigent/issues/1881) [Bug] `omnigent setup` crashes with `ValueError: select() requires at  |
+| 89 | 58 | high | P1 | P2 ⚑ | +42 | [#108](https://github.com/omnigent-ai/omnigent/issues/108) Cannot install on Linux aarch64 — cel-expr-python has no aarch64 wheel |
+| 90 | 56 | medium | P2 | P2 | +178 | [#1596](https://github.com/omnigent-ai/omnigent/issues/1596) Native-CLI harness (claude-native/codex-native) as a named agent's own |
+| 91 | 54 | high | P2 | P2 | +86 | [#3164](https://github.com/omnigent-ai/omnigent/issues/3164) [Feature] Optional runtimeClassName on the kubernetes sandbox provider |
+| 92 | 54 | high | P1 | P2 ⚑ | -43 | [#3011](https://github.com/omnigent-ai/omnigent/issues/3011) kiro-native harness: interactive sessions never respond with kiro-cli  |
+| 93 | 54 | high | P1 | P2 ⚑ | +9 | [#1901](https://github.com/omnigent-ai/omnigent/issues/1901) [Bug] kimi/qwen/goose/kiro forwarders blind-retry failed conversation- |
+| 94 | 54 | high | P1 | P2 ⚑ | +14 | [#1827](https://github.com/omnigent-ai/omnigent/issues/1827) [Bug] kimi-native: torn UTF-8 wire read crashes the forwarder; supervi |
+| 95 | 52 | medium | P2 | P2 | +204 | [#1021](https://github.com/omnigent-ai/omnigent/issues/1021) [Feature] GitHub Copilot as provider |
+| 96 | 50 | medium | P2 | P2 | +228 | [#377](https://github.com/omnigent-ai/omnigent/issues/377) gpt sub-agent fails on startup with missing databricks-sdk dependency |
+| 97 | 46 | medium | P2 | P2 | +107 | [#2744](https://github.com/omnigent-ai/omnigent/issues/2744) [Bug] codex-native: custom agents time out at launch — native provider |
+| 98 | 46 | medium | P1 | P2 ⚑ | +22 | [#1113](https://github.com/omnigent-ai/omnigent/issues/1113) Native sub-agent/runner failures surface as bare "failed" with no reas |
+| 99 | 42 | medium | P2 | P2 | +39 | [#3969](https://github.com/omnigent-ai/omnigent/issues/3969) Databricks gateway sessions default to a stale model (opus-4-7) while  |
+| 100 | 42 | medium | P1 | P2 ⚑ | -90 | [#3952](https://github.com/omnigent-ai/omnigent/issues/3952) A stale terminal exit removes the newer Codex resources of the same se |
+| 101 | 42 | medium | P1 | P2 ⚑ | -83 | [#3790](https://github.com/omnigent-ai/omnigent/issues/3790) force_sandbox policy is evaluated but structurally unreachable from cl |
+| 102 | 42 | medium | P2 | P2 | +48 | [#3592](https://github.com/omnigent-ai/omnigent/issues/3592) [Feature] Deterministic long-term memory (automatic recall/retain) — f |
+| 103 | 42 | medium | P1 | P2 ⚑ | -78 | [#3536](https://github.com/omnigent-ai/omnigent/issues/3536) [Bug] A session's `reasoning_effort` never reaches in-process harnesse |
+| 104 | 42 | medium | P2 | P2 | +57 | [#3369](https://github.com/omnigent-ai/omnigent/issues/3369) Feature: a policy that fences a spawned type: agent worker read-only ( |
+| 105 | 42 | medium | P2 | P2 | +63 | [#3254](https://github.com/omnigent-ai/omnigent/issues/3254) Sub-agent silently stalls after repeated context compactions during re |
+| 106 | 42 | medium | P1 | P2 ⚑ | -66 | [#3236](https://github.com/omnigent-ai/omnigent/issues/3236) web_search: bare executor.model strings are inferred as provider 'open |
+| 107 | 42 | medium | P2 | P2 | +78 | [#3069](https://github.com/omnigent-ai/omnigent/issues/3069) Harness install surfaces opaque failure reasons (npm stderr not captur |
+| 108 | 42 | medium | P2 | P2 | +83 | [#2984](https://github.com/omnigent-ai/omnigent/issues/2984) [Bug] Codex incorrectly reports `needs-auth` with an authenticated cus |
+| 109 | 42 | medium | P1 | P2 ⚑ | -51 | [#2904](https://github.com/omnigent-ai/omnigent/issues/2904) [Bug] claude-native: web-UI chat input fails with "tmux command failed |
+| 110 | 42 | medium | P2 | P2 | +84 | [#2880](https://github.com/omnigent-ai/omnigent/issues/2880) [Feature] Add in-session revert mechanism for all interfaces  |
+| 111 | 42 | medium | P3 | P2 ⚑ | +227 | [#2853](https://github.com/omnigent-ai/omnigent/issues/2853) [Bug] Native harnesses silently drop the agent spec `prompt:` at runti |
+| 112 | 42 | medium | P2 | P2 | +88 | [#2815](https://github.com/omnigent-ai/omnigent/issues/2815) [Feature] Distinguish human waits from machine-liveness deadlines |
+| 113 | 42 | medium | P1 | P2 ⚑ | -52 | [#2812](https://github.com/omnigent-ai/omnigent/issues/2812) [Bug] serve-mcp stops answering stdio requests during a slow tool call |
+| 114 | 42 | medium | P2 | P2 | +93 | [#2719](https://github.com/omnigent-ai/omnigent/issues/2719) [Bug] |
+| 115 | 42 | medium | P2 | P2 | +96 | [#2644](https://github.com/omnigent-ai/omnigent/issues/2644) Design discussion: deterministic verification gates (a PASS/FAIL quali |
+| 116 | 42 | medium | P1 | P2 ⚑ | -52 | [#2630](https://github.com/omnigent-ai/omnigent/issues/2630) Tool-spawn failure is swallowed — agent answers from training knowledg |
+| 117 | 42 | medium | P1 | P2 ⚑ | -36 | [#2397](https://github.com/omnigent-ai/omnigent/issues/2397) [Bug] Codex-native intelligent routing ignores live effort capabilitie |
+| 118 | 42 | medium | P1 | P2 ⚑ | -31 | [#2272](https://github.com/omnigent-ai/omnigent/issues/2272) [Bug] Codex runner can't find OpenRouter secret that exists in keyring |
+| 119 | 42 | medium | P1 | P2 ⚑ | -27 | [#2184](https://github.com/omnigent-ai/omnigent/issues/2184) [Bug] Codex plugin skills are exposed with inconsistent names (`plugin |
+| 120 | 42 | medium | P1 | P2 ⚑ | -27 | [#2071](https://github.com/omnigent-ai/omnigent/issues/2071) [Bug] web_search never advertised to claude-sdk sessions: unprefixed m |
+| 121 | 42 | medium | P2 | P2 | +114 | [#2062](https://github.com/omnigent-ai/omnigent/issues/2062) [Bug] claude-native: per-session model override silently lost when wra |
+| 122 | 42 | medium | P1 | P2 ⚑ | -15 | [#1831](https://github.com/omnigent-ai/omnigent/issues/1831) claude-native workers ignore executor.model pin and per-dispatch args. |
+| 123 | 42 | medium | P1 | P2 ⚑ | -14 | [#1794](https://github.com/omnigent-ai/omnigent/issues/1794) Bundled Polly: claude-sdk brain "Not logged in" + runaway spawn loop o |
+| 124 | 42 | medium | P2 | P2 | +130 | [#1789](https://github.com/omnigent-ai/omnigent/issues/1789) Feature: Canvas — agent-authored artifact panel (#2) |
+| 125 | 42 | medium | P1 | P2 ⚑ | -15 | [#1781](https://github.com/omnigent-ai/omnigent/issues/1781) codex harness: ambient DATABRICKS_BEARER/DATABRICKS_TOKEN overrides pr |
+| 126 | 42 | medium | P2 | P2 | +132 | [#1724](https://github.com/omnigent-ai/omnigent/issues/1724) codex-native harness times out on WSL2 ("Codex TUI never started a thr |
+| 127 | 42 | medium | P1 | P2 ⚑ | -16 | [#1694](https://github.com/omnigent-ai/omnigent/issues/1694) Reliability: parallel code-fix missions fail silently (5s tmux timeout |
+| 128 | 42 | medium | P2 | P2 | +141 | [#1594](https://github.com/omnigent-ai/omnigent/issues/1594) Server-side idempotency for external_conversation_item (safe dedup on  |
+| 129 | 42 | medium | P1 | P2 ⚑ | -14 | [#1533](https://github.com/omnigent-ai/omnigent/issues/1533) Context-occupancy meter (context_tokens) freezes on failed turns — onl |
+| 130 | 42 | medium | P2 | P2 | +151 | [#1230](https://github.com/omnigent-ai/omnigent/issues/1230) [Feature] Migrate remaining native forwarders to the shared post_sessi |
+| 131 | 42 | medium | P1 | P2 ⚑ | -12 | [#1128](https://github.com/omnigent-ai/omnigent/issues/1128) [Bug] Claude SDK Appears to Use Opus Instead of Selected Model |
+| 132 | 42 | medium | P2 | P2 | +172 | [#890](https://github.com/omnigent-ai/omnigent/issues/890) [Bug] omnigent setup fails with npm EACCES when installing the Claude  |
+| 133 | 42 | medium | P1 | P2 ⚑ | -8 | [#668](https://github.com/omnigent-ai/omnigent/issues/668) [Bug] BUG？omni claude times out (60s) on macOS with native Claude Code |
+| 134 | 42 | medium | P2 | P2 | +183 | [#548](https://github.com/omnigent-ai/omnigent/issues/548) Recommend missing dependency install suggestions more gracefully in UI |
+| 135 | 42 | medium | P1 | P2 ⚑ | -5 | [#241](https://github.com/omnigent-ai/omnigent/issues/241) pi harness: GPT and Gemini dispatches 404 on the Databricks ucode gate |
+| 136 | 42 | medium | P2 | P2 | +192 | [#152](https://github.com/omnigent-ai/omnigent/issues/152) Harness availability is reported from binary presence, not from config |
+| 137 | 42 | medium | P3 | P2 ⚑ | +210 | [#147](https://github.com/omnigent-ai/omnigent/issues/147) Tracking: gradual decomposition of monolith modules (cli.py 9.1KLOC, c |
+| 138 | 40 | medium | P1 | P2 ⚑ | -96 | [#3101](https://github.com/omnigent-ai/omnigent/issues/3101) Docker/Kubernetes entrypoint never wires project_store — first-class P |
+| 139 | 40 | medium | P1 | P2 ⚑ | -61 | [#2429](https://github.com/omnigent-ai/omnigent/issues/2429) Server (python -m omnigent.cli server) CPU-spins indefinitely with no  |
+| 140 | 39 | medium | P1 | P2 ⚑ | -27 | [#1551](https://github.com/omnigent-ai/omnigent/issues/1551) opencode-native: blocking question tool not surfaced to web (no elicit |
+| 141 | 36 | medium | P2 | P2 | -7 | [#4009](https://github.com/omnigent-ai/omnigent/issues/4009) [Feature] No Go client for the session API, so every Go caller hand-ro |
+| 142 | 36 | medium | P1 | P2 ⚑ | -129 | [#3898](https://github.com/omnigent-ai/omnigent/issues/3898) [Bug] Pack function policies fail server-side input evaluation unless  |
+| 143 | 36 | medium | P1 | P2 ⚑ | -129 | [#3870](https://github.com/omnigent-ai/omnigent/issues/3870) child-session creation returns 500 internal_error, breaking Polly/Debb |
+| 144 | 36 | medium | P2 | P2 | -2 | [#3864](https://github.com/omnigent-ai/omnigent/issues/3864) [Bug] to_api_dict() drops ConversationItem.created_at, so flat items A |
+| 145 | 36 | medium | P1 | P2 ⚑ | -130 | [#3863](https://github.com/omnigent-ai/omnigent/issues/3863) [Bug] Databricks Apps entrypoint never wires project_store — Projects  |
+| 146 | 36 | medium | P2 | P2 | +6 | [#3563](https://github.com/omnigent-ai/omnigent/issues/3563) [Bug] Host-bound resume into a deleted workspace: host computes the ex |
+| 147 | 36 | medium | P2 | P2 | +8 | [#3550](https://github.com/omnigent-ai/omnigent/issues/3550) [Bug] Missing signing alg's prevent using some OIDC providers |
+| 148 | 36 | medium | P2 | P2 | +9 | [#3531](https://github.com/omnigent-ai/omnigent/issues/3531) SSH_AUTH_SOCK dropped at the host→runner env boundary, breaking ssh-ag |
+| 149 | 36 | medium | P2 | P2 | +11 | [#3435](https://github.com/omnigent-ai/omnigent/issues/3435) [Feature] Admin server-wide usage report (per-user and per-model cost) |
+| 150 | 36 | medium | P2 | P2 | +12 | [#3368](https://github.com/omnigent-ai/omnigent/issues/3368) Feature: first-class async write-safety (freeze → approve → apply) pri |
+| 151 | 36 | medium | P2 | P2 | +14 | [#3352](https://github.com/omnigent-ai/omnigent/issues/3352) [Feature] OpenClaw onboarding — Option B: chat import (SQLite session  |
+| 152 | 36 | medium | P2 | P2 | +18 | [#3247](https://github.com/omnigent-ai/omnigent/issues/3247) credential_proxy: re-resolve the source on 401 / expiry (short-lived t |
+| 153 | 36 | medium | P1 | P2 ⚑ | -93 | [#2854](https://github.com/omnigent-ai/omnigent/issues/2854) [Bug] Cross-harness `harness_override` is ignored on the `initial_item |
+| 154 | 36 | medium | P2 | P2 | +42 | [#2851](https://github.com/omnigent-ai/omnigent/issues/2851) Policy-supplied targets for ASK approval cards |
+| 155 | 36 | medium | P2 | P2 | +43 | [#2848](https://github.com/omnigent-ai/omnigent/issues/2848) Server logs an expected offline-runner resource 503 as ERROR + full tr |
+| 156 | 36 | medium | P2 | P2 | +45 | [#2767](https://github.com/omnigent-ai/omnigent/issues/2767) [Bug] SQLite pool (default 5+10) not sized to the 200-thread limiter → |
+| 157 | 36 | medium | P2 | P2 | +45 | [#2756](https://github.com/omnigent-ai/omnigent/issues/2756) Expose atomic session-event admission to integrations |
+| 158 | 36 | medium | P2 | P2 | +54 | [#2577](https://github.com/omnigent-ai/omnigent/issues/2577) [Feature] Manage OIDC/SSO admins from an id_token claim (IdP group/rol |
+| 159 | 36 | medium | P2 | P2 | +55 | [#2542](https://github.com/omnigent-ai/omnigent/issues/2542) [Feature] Ambient-detect a local llama-server, mirroring Ollama detect |
+| 160 | 36 | medium | P1 | P2 ⚑ | -90 | [#2539](https://github.com/omnigent-ai/omnigent/issues/2539) Named sys_session_send returns 404 after first child from a bundled se |
+| 161 | 36 | medium | P1 | P2 ⚑ | -90 | [#2524](https://github.com/omnigent-ai/omnigent/issues/2524) [Bug] Registering remote host fails |
+| 162 | 36 | medium | P1 | P2 ⚑ | -89 | [#2444](https://github.com/omnigent-ai/omnigent/issues/2444) Accounts JWT expiry falls through to Databricks auth and breaks persis |
+| 163 | 36 | medium | P1 | P2 ⚑ | -89 | [#2437](https://github.com/omnigent-ai/omnigent/issues/2437) [Bug] Remote URL chat cannot create a fresh registered-agent session |
+| 164 | 36 | medium | P2 | P2 | +55 | [#2423](https://github.com/omnigent-ai/omnigent/issues/2423) Web UI: new-session picker offers agents that cannot launch on the tar |
+| 165 | 36 | medium | P2 | P2 | +55 | [#2404](https://github.com/omnigent-ai/omnigent/issues/2404) fix(runtime): orphan sweep can abort startup on unreadable shared-host |
+| 166 | 36 | medium | P2 | P2 | +56 | [#2374](https://github.com/omnigent-ai/omnigent/issues/2374) Proposal: per-turn context_providers to augment system instructions at |
+| 167 | 36 | medium | P1 | P2 ⚑ | -84 | [#2357](https://github.com/omnigent-ai/omnigent/issues/2357) [Bug] admin fleet-view calls SqlAlchemyConversationStore.list_conversa |
+| 168 | 36 | medium | P1 | P2 ⚑ | -83 | [#2304](https://github.com/omnigent-ai/omnigent/issues/2304) Runner subprocess inherits host daemon cwd, causing os_env cwd resolut |
+| 169 | 36 | medium | P2 | P2 | +64 | [#2080](https://github.com/omnigent-ai/omnigent/issues/2080) feat(runner): sys_session_create cannot set a per-session model — no w |
+| 170 | 36 | medium | P2 | P2 | +64 | [#2070](https://github.com/omnigent-ai/omnigent/issues/2070) [Feature] sys_os_* file tools are hard-confined to the session workspa |
+| 171 | 36 | medium | P1 | P2 ⚑ | -76 | [#2052](https://github.com/omnigent-ai/omnigent/issues/2052) [Bug] web_fetch's __web_researcher helper sub-agent fails on 0.4.0 (si |
+| 172 | 36 | medium | P1 | P2 ⚑ | -75 | [#2039](https://github.com/omnigent-ai/omnigent/issues/2039) [Bug] omni host treats a transient 4xx during a server restart as perm |
+| 173 | 36 | medium | P1 | P2 ⚑ | -72 | [#1920](https://github.com/omnigent-ai/omnigent/issues/1920) Seeder matching-hash fast path can't self-heal a lost artifact-store b |
+| 174 | 36 | medium | P1 | P2 ⚑ | -68 | [#1857](https://github.com/omnigent-ai/omnigent/issues/1857) Host daemon stays alive but shows offline — server-dropped host tunnel |
+| 175 | 36 | medium | P2 | P2 | +81 | [#1751](https://github.com/omnigent-ai/omnigent/issues/1751) Feature: Web Push / PWA (#8) |
+| 176 | 36 | medium | P1 | P2 ⚑ | -64 | [#1686](https://github.com/omnigent-ai/omnigent/issues/1686) xai: reasoning_effort sent to all Grok models returns HTTP 400 on unsu |
+| 177 | 36 | medium | P2 | P2 | +94 | [#1526](https://github.com/omnigent-ai/omnigent/issues/1526) Refactor: incrementally decompose the 4 god-files (sessions.py, runner |
+| 178 | 36 | medium | P2 | P2 | +96 | [#1411](https://github.com/omnigent-ai/omnigent/issues/1411) Standalone reusable MCP servers: CRUD + connection verify (list tools) |
+| 179 | 36 | medium | P2 | P2 | +109 | [#1117](https://github.com/omnigent-ai/omnigent/issues/1117) async generator ignored GeneratorExit — orphaned SSE relay task, excep |
+| 180 | 36 | medium | P2 | P2 | +110 | [#1075](https://github.com/omnigent-ai/omnigent/issues/1075) [Feature] Support AWS Lambda / Firecracker microVMs as managed sandbox |
+| 181 | 36 | medium | P2 | P2 | +111 | [#1055](https://github.com/omnigent-ai/omnigent/issues/1055) [Test] End-to-end OTel test against a real collector to lock in the BY |
+| 182 | 36 | medium | P2 | P2 | +111 | [#1054](https://github.com/omnigent-ai/omnigent/issues/1054) [Feature] Record gen_ai.retry events on llm_call spans |
+| 183 | 36 | medium | P2 | P2 | +114 | [#1031](https://github.com/omnigent-ai/omnigent/issues/1031) [Feature] Support serving the standalone Web UI under a subpath, e.g.  |
+| 184 | 36 | medium | P2 | P2 | +116 | [#983](https://github.com/omnigent-ai/omnigent/issues/983) Session sharing ergonomics: `sys_session_share` agent tool + `omnigent |
+| 185 | 36 | medium | P2 | P2 | +123 | [#857](https://github.com/omnigent-ai/omnigent/issues/857) [Proposal] Usage-limit detection + on-429 failover across pooled provi |
+| 186 | 36 | medium | P1 | P2 ⚑ | -62 | [#765](https://github.com/omnigent-ai/omnigent/issues/765) Support interactive mid-flight policy ASK (TOOL_CALL/TOOL_RESULT/OUTPU |
+| 187 | 36 | medium | P2 | P2 | +125 | [#725](https://github.com/omnigent-ai/omnigent/issues/725) Changes panel is empty for native-harness and external edits in non-gi |
+| 188 | 36 | medium | P1 | P2 ⚑ | -59 | [#522](https://github.com/omnigent-ai/omnigent/issues/522) Implement async-tool completion auto-delivery (SESSION_REARCHITECTURE  |
+| 189 | 36 | medium | P2 | P2 | +129 | [#509](https://github.com/omnigent-ai/omnigent/issues/509) [Feature] Default new-session workspace from selected agent's cwd |
+| 190 | 36 | medium | P2 | P2 | +133 | [#382](https://github.com/omnigent-ai/omnigent/issues/382) Evaluating the same agent across harnesses: no built-in way to compare |
+| 191 | 36 | medium | P2 | P2 | +139 | [#146](https://github.com/omnigent-ai/omnigent/issues/146) StreamHooks.on_sub_agent_spawned / on_sub_agent_completed are declared |
+| 192 | 35 | medium | P2 | P2 | -53 | [#3950](https://github.com/omnigent-ai/omnigent/issues/3950) An agent switch keeps the previous agent's comment-tool relay |
+| 193 | 35 | medium | P1 | P2 ⚑ | -177 | [#3852](https://github.com/omnigent-ai/omnigent/issues/3852) [Bug] Built-in write policies miss Claude Code's `MultiEdit` / `Notebo |
+| 194 | 35 | medium | P1 | P2 ⚑ | -168 | [#3530](https://github.com/omnigent-ai/omnigent/issues/3530) [Bug] An agent spec's `instructions:` has no effect on 13 of 24 harnes |
+| 195 | 35 | medium | P1 | P2 ⚑ | -168 | [#3525](https://github.com/omnigent-ai/omnigent/issues/3525) Sub-agent sessions are launched from the parent agent's bundle root, e |
+| 196 | 35 | medium | P1 | P2 ⚑ | -152 | [#3076](https://github.com/omnigent-ai/omnigent/issues/3076) [Bug] claude-sdk omits ToolSearch, eagerly loading every MCP schema |
+| 197 | 35 | medium | P3 | P2 ⚑ | +142 | [#2800](https://github.com/omnigent-ai/omnigent/issues/2800) [Bug] Top-level custom codex-native agents drop reasoning effort and y |
+| 198 | 35 | medium | P1 | P2 ⚑ | -135 | [#2702](https://github.com/omnigent-ai/omnigent/issues/2702) Native idle-detection fork+exec's tmux capture-pane at 5 Hz per termin |
+| 199 | 35 | medium | P2 | P2 | +25 | [#2369](https://github.com/omnigent-ai/omnigent/issues/2369) [Bug] pi harness only lists databricks-claude-sonnet-4-6 |
+| 200 | 35 | medium | P1 | P2 ⚑ | -114 | [#2299](https://github.com/omnigent-ai/omnigent/issues/2299) [Bug] claude-native resume transcripts flatten tool_result image block |

--- a/designs/prioritization/issue-prioritization-v2.md
+++ b/designs/prioritization/issue-prioritization-v2.md
@@ -8,7 +8,7 @@ de-facto binary); it neither reflects how bad an issue is nor how many users it
 hits, and it doesn't move over time. This proposal keeps the working
 [triage pipeline](../issue-triage-proposal.md) and adds: a re-calibrated
 priority rubric (severity graded across all buckets, for FRs too), independent
-scoring axes (severity × reach × harness-tier × readiness + demand, with
+scoring axes (severity × reach × component-weight × readiness + demand, with
 duplicate count as a reach signal), a maintainer-facing ranked view, and
 re-gradable severity as the mechanism to nudge ranking over time. Because
 priority is now a *computed* label, a firm rule runs through the whole design:
@@ -97,10 +97,10 @@ are distinct and it's worth being precise:
 1. **Severity** — a graded property of the issue, a function of the axes below
    (type, blast radius, component weight, …). Scored `low / medium / high /
    critical = 10 / 30 / 60 / 100`.
-2. **Score** — severity combined with the mechanical multipliers (reach, tier,
-   readiness, dup, demand). This is the **continuous ordering** — it sorts
-   issues *within and across* priority labels, so two issues that share a label
-   aren't stuck equal.
+2. **Score** — severity combined with the mechanical multipliers (reach,
+   component weight, readiness, dup, demand). This is the **continuous
+   ordering** — it sorts issues *within and across* priority labels, so two
+   issues that share a label aren't stuck equal.
 3. **Priority label (the outcome)** — the human-facing bucket the score lands
    in, **by fixed score thresholds** (below). This is what maintainers **sort,
    filter, and action on**; the score is the *reference for why* an issue got
@@ -235,10 +235,9 @@ What moves, and why:
 | P2 → P0 | 10 | #2125 multi-host git creds — credential-crossing, weight-1.4 area (score 161) |
 | P1 → P3 | 6 | #3980 desktop dialog paint-over — minor, single-platform (score 25) |
 
-*Caveat:* these per-issue moves use the regex grader, so they inherit its known
-false positives (e.g. #2057/#2054 "sandbox bypass" FRs wrongly reach P0). Read
-the **aggregate shape** (60% → 27%) as the reliable signal and individual rows
-as illustrative; the LLM backfill corrects the outliers.
+*Caveat:* these moves use the regex grader, so read the **aggregate shape**
+(60% → 27%) as reliable and individual rows as illustrative — the regex's known
+false positives (see Dry-run) are what the LLM backfill corrects.
 
 ### Axis 3 — Component weight (unified; was harness-only)
 
@@ -376,12 +375,10 @@ lower, so it sits deep in the queue.
 Same five data points, opposite ends of the queue *and* opposite priority
 labels: that's the score→label derivation doing the work.
 
-**Why severity is LLM-graded, not label-derived:** the dry-run
-(`score_prototype.py`) grades severity with regex for reproducibility, and it
-demonstrates *why regex isn't enough in production* — "sandbox **bypass**" in an
-FR title falsely scored two Codex-mode FRs (#2057, #2054) as critical, and a bot
-"Code Audit" issue (#61) too. The production grader is the triage classifier,
-which reads full content and already runs per issue at zero extra cost.
+**Severity is LLM-graded in production, not regex.** The dry-run uses regex only
+so it's reproducible; the real grader is the triage classifier, which reads full
+content at zero extra cost. The regex's own false positives are the argument for
+this — see the Dry-run section.
 
 ### Community demand — used, but type-dependent and bounded
 
@@ -562,37 +559,34 @@ Selected results (360 open issues; rank out of 360, lower = higher priority):
 
 | Issue | Before | After | Δ | Note |
 |---|---|---|---|---|
-| #3557 policy-gate bypass (P0) | 1 | 6 | −5 | Real P0 stays near top ✅ |
-| #3265 claude-sdk bwrap spawn death (P1) | 37 | 3 | +34 | High-sev, tier-1 harness, has repro ✅ |
-| #3270 sub-agent sessions absent (P1) | 35 | 7 | +28 | ✅ |
-| #2421 codex MCP bridge child leak (P1) | 80 | 27 | +53 | Resource leak, tier-1 ✅ |
-| #2454 unbounded ~/.omnigent growth (P1) | 72 | 26 | +46 | ✅ |
+| #3557 policy-gate bypass (P0) | 1 | 10 | −9 | Real P0 stays near top ✅ |
+| #3265 claude-sdk bwrap spawn death (P1) | 37 | 6 | +31 | High-sev, weight-1.4 harness, broad reach ✅ |
+| #3270 sub-agent sessions absent (P1) | 35 | 9 | +26 | ✅ |
+| #2421 codex MCP bridge child leak (P1) | 80 | 36 | +44 | Resource leak, weight-1.4 ✅ |
+| #2454 unbounded ~/.omnigent growth (P1) | 72 | 35 | +37 | ✅ |
 
 **Community demand lifts wanted FRs — bounded, so bugs stay on top:**
 
 | Issue | 👍 | Before | After | Δ | Note |
 |---|---|---|---|---|---|
-| #1021 GitHub Copilot as provider (FR) | 10 | 299 | 92 | +207 | Most-wanted FR climbs; demand alone pushed it up ✅ |
-| #16 native Windows support (FR) | 6 | 334 | 32 | +302 | High demand + graded P1 (whole platform) ✅ |
-| #888 side-by-side multi-session (FR) | 2 | 305 | 30 | +275 | ✅ |
+| #16 native Windows support (FR) | 6 | 334 | 7 | +327 | Whole-platform reach + demand → graded P0 ✅ |
+| #1021 GitHub Copilot as provider (FR) | 10 | 299 | 93 | +206 | Most-reacted FR climbs on demand alone ✅ |
+| #888 side-by-side multi-session (FR) | 2 | 305 | 44 | +261 | ✅ |
 
-**Dry-run limits — the evidence that severity must be LLM-graded, not regex:**
+**Dry-run limits — the evidence that severity must be LLM-graded, not regex.**
+The regex grader mis-scores three ways, and all three are visible near the top,
+which is exactly why production grades with the classifier:
 
-| Issue | Before | After | Note |
-|---|---|---|---|
-| #2057 / #2054 Codex-mode FRs | 236/238 | 1/2 | **False positive** — "sandbox bypass" in the FR body tripped the critical regex. An LLM reads that it's *proposing* a mode, not reporting a bypass. |
-| #61 bot "Code Audit" (P3) | 349 | 19 | **False positive** — a bot audit issue mentioning "security". LLM grader avoids. |
-| #2125 multi-host git creds (P2, FR) | 232 | 8 | **Lucky match** — the body literally says "your GitHub PAT is offered to the self-hosted remote", so the regex hits a credential-leak pattern and scores it critical. Right answer, wrong reason: it's an exact-phrase fluke, not comprehension. An LLM would grade it high because it *understands* the credential-crossing risk. |
+| Issue | After | Failure |
+|---|---|---|
+| #2057 / #2054 Codex-mode FRs | 2 / 3 | **False positive** — "sandbox bypass" in the FR body trips the critical regex; an LLM reads that they *propose* a mode, not report a bypass. |
+| #61 bot "Code Audit" (P3) | 15 | **False positive** — a bot audit issue mentioning "security". |
+| #2125 multi-host git creds (FR) | 1 | **Lucky match** — body literally says "your GitHub PAT is offered to the self-hosted remote", so the regex hits a credential pattern. Right answer, wrong reason: an LLM would grade it critical because it *understands* the credential-crossing, not on an exact phrase. |
 
-#2125 makes the point either way: the earlier draft's regex *missed* it (false
-negative); a one-word regex tweak now *over-*hits it. Both are the same lesson —
-regex can't reason about severity, so production must grade with the LLM.
-
-**Takeaways for the real build:**
-- The score *mechanics* order the queue far better than the priority label.
-- The severity *grader* must be the LLM, not regex — the dry-run's false
-  positives *and* its lucky matches are both the proof.
-- Weights are defensible starting points; tune against this before→after table.
+**Takeaway:** the score *mechanics* order the queue far better than the label;
+the severity *grader* must be the LLM (its regex false positives *and* lucky
+matches both prove it); weights are defensible starting points — tune against
+this table.
 
 ---
 
@@ -602,8 +596,8 @@ The bug template asks Version + OS but both optional → sparse. Add structured,
 **dropdown** fields (dropdowns beat free-text for scoring signal):
 
 - **Harness** (dropdown: claude / codex / cursor / … / n/a) **+ mode (SDK /
-  native)** — the #1 component, currently buried in prose. Feeds tier directly;
-  the SDK-vs-native split feeds `sub_area` (per review).
+  native)** — the #1 component, currently buried in prose. Feeds the component
+  weight directly; the SDK-vs-native split feeds `sub_area` (per review).
 - **Platform / device** (dropdown: macOS / Linux / Windows / **desktop /
   mobile-iOS / mobile-Android** / Docker) — a whole class of bugs is
   platform-specific (Windows setup crashes, iOS/Android OIDC, Linux aarch64).
@@ -618,32 +612,24 @@ dropdowns cost the reporter nothing and sharpen severity × reach.
 
 ### Sandbox / security deserves its own treatment
 
-You flagged sandboxing as its own category — the data agrees. Across open
-issues: **63 mention sandbox** (bwrap/seatbelt/egress), **70 policy/guardrail**,
-**120 credential/secret**. The top P0
-([#3557](https://github.com/omnigent-ai/omnigent/issues/3557)) is a
-shell-surface policy-gate *bypass*; #2125 is a credential-crossing risk. These
-aren't ordinary bugs — a sandbox escape or policy bypass is a **security
-severity**, not a functional one.
-
-Two concrete changes:
-
-- **Component:** promote `sandbox` to its own `comp:sandbox` label (today it
-  collapses into `comp:runner`); `policies` already has `comp:policies`. See
-  "Component taxonomy" above for the full rationale.
-- **Severity:** the rubric's P0 row explicitly names "security/policy/sandbox
-  bypass," and the grader should treat *escape / bypass / credential-crossing*
-  as top-tier severity regardless of reach — a one-user sandbox escape is still
-  P0. This is the one place reach does **not** gate priority.
+Sandbox/security is a distinct category, and the data agrees: **63** open issues
+mention sandbox (bwrap/seatbelt/egress), **70** policy/guardrail, **120**
+credential/secret; the top P0 (#3557) is a policy-gate *bypass*. A sandbox escape
+or policy bypass is a **security** severity, not a functional one, and the design
+handles it in two places: the `comp:sandbox` label (Component taxonomy) and the
+P0 rubric's "security escape" row (Axis 2), where *escape / bypass /
+credential-crossing* is top-tier **regardless of reach** — the one place reach
+does not gate priority.
 
 ---
 
 ## Rollout
 
-**Status: none of this is built yet.** This PR is the design + a dry-run
-prototype only — no labels are created, `areas.json` is unchanged, and the
-classifier config is untouched. The steps below are the implementation plan,
-each intended as its own follow-up PR (tracked as separate issues).
+**Status: mostly design + prototype.** This PR adds the design doc, the dry-run
+prototype, and the per-area `weight`/`weight_source` fields in `areas.json` (with
+a test). It does **not** create any `comp:*` labels or wire `areas.json` into the
+live classifier. The steps below are the implementation plan, each intended as
+its own follow-up PR.
 
 1. **Prompt re-calibration** (`.github/triage/config.yaml`) — new priority
    rubric (grade FRs across buckets; explicit P0 list; tier-1 floor) + the "P1

--- a/designs/prioritization/issue-prioritization-v2.md
+++ b/designs/prioritization/issue-prioritization-v2.md
@@ -114,6 +114,58 @@ Calibration guardrail added to the prompt: **"P1 is a scarcity signal. If more
 than ~20% of open bugs are P1, you are over-grading. A bug affecting one harness
 on one platform with a workaround is P2, not P1."**
 
+#### How regrading works
+
+Regrading maps an issue to a priority *bucket* from `severity × reach` — a
+pure label change, independent of the score. It runs in two situations:
+
+1. **One-time backfill.** Re-run the classifier over the existing open issues
+   once, so the backlog reflects the new rubric on day one. This is a labels-only
+   pass — same tool-less classifier, same trusted label-application steps as
+   [Stage 2 triage](../issue-triage-proposal.md); nothing new to build.
+2. **Ongoing, on demand.** A maintainer who disagrees just changes the label
+   (P2 → P1, or the reverse). That *is* the bump mechanism — no separate pin
+   lever (see "Ongoing adjustment"). The scheduled re-score reads the updated
+   label the next time it runs.
+
+The mapping is mechanical once severity and reach are graded:
+
+| Graded severity | + reach | → priority |
+|---|---|---|
+| critical (security / data-loss / all-users-down) | any | **P0** |
+| high (crash / hang / no-workaround; FR: blocks common workflow) | broad / normal | **P1** |
+| high | single-platform | **P2** |
+| medium | broad | **P1** |
+| medium | normal / narrow | **P2** |
+| low / narrow FR | — | **P3** |
+
+**Backfill preview** (`score_prototype.py --regrade`, regex grader over the 360
+open issues — the production backfill uses the LLM grader):
+
+| Priority | Now | Regraded |
+|---|---|---|
+| P0-critical | 3 | 8 |
+| **P1-high** | **128** | **65** |
+| P2-medium | 203 | 273 |
+| P3-low | 15 | 14 |
+| (no priority) | 11 | 0 |
+
+**P1 share of open bugs: 60% → 25%** — the inflation drained, the P1/P2 binary
+un-collapsed. What moves, and why:
+
+| Change | Count | Example |
+|---|---|---|
+| P1 → P2 | 87 | #3980 desktop dialog paint-over — medium severity, single-platform (not "all users, no workaround") |
+| P2 → P1 | 24 | #3976 headless OAuth2 grant — high-severity FR, broad reach (was defaulted to P2) |
+| P2 → P3 | 10 | #3074 OS-native directory picker — narrow nice-to-have FR |
+| P3 → P2 | 12 | under-graded items pulled up |
+| P2 → P0 | 4 | #659 microvm sandbox backend — security-tier |
+
+*Caveat:* these per-issue moves use the regex grader, so they inherit its known
+false positives (e.g. #2057/#2054 "sandbox bypass" FRs wrongly reach P0). Read
+the **aggregate shape** (60% → 25%) as the reliable signal and individual rows
+as illustrative; the LLM backfill corrects the outliers.
+
 ### Axis 3 — Harness tier (new, derived)
 
 Harnesses are not equal in strategic weight. Tier is **derived from the
@@ -263,7 +315,9 @@ severity; fixing severity fixes the score.
 
 `designs/prioritization/score_prototype.py` reads a snapshot of all open issues
 and prints **current-priority ordering vs composite-score ordering**, with a
-rank delta per issue, so we tune weights against real test cases.
+rank delta per issue, so we tune weights against real test cases. (Pass
+`--regrade` for the priority-*label* backfill preview shown in Axis 2 instead of
+the score ranking.)
 
 **Is severity re-graded in these examples?** Yes — the dry-run ignores the
 existing priority label entirely and *re-grades severity from content* (regex
@@ -369,8 +423,10 @@ Two concrete changes:
 4. **Scoring job** — productionize `score_prototype.py` into a scheduled action
    that reads LLM-graded severity + readiness + dup count and publishes the
    ranked view.
-5. **One-time backfill** — re-run triage over the 128 open P1s to demote the
-   mislabeled ones (target: P1 back under ~20% of open bugs).
+5. **One-time backfill (regrade)** — re-run the classifier over open issues to
+   relabel under the new rubric (see "How regrading works"); preview with
+   `score_prototype.py --regrade`. Target: P1 back under ~20% of open bugs
+   (regex preview lands it at 25%; the LLM pass should do better).
 6. **Consume dedup output** — once [#4037](https://github.com/omnigent-ai/omnigent/pull/4037)
    lands, feed duplicate count into `dup_reach`; wire the unused `good first
    issue` funnel.

--- a/designs/prioritization/issue-prioritization-v2.md
+++ b/designs/prioritization/issue-prioritization-v2.md
@@ -214,8 +214,9 @@ default. If information is partial but comprehensible, then 1.0.
 
 ### Axis 7 - Community demand
 
-Unique user engagement and comments and thumb-up will be counted additively. So they will bump the
-issue but won't have too much weight. Existing issues get at most 15 pts today.
+GitHub `+1` reactions add a small, linear bonus: `15 × min(upvotes, 12) / 12`.
+The same rule applies to every issue type, so demand can add at most 15 points.
+Comments are excluded because they mostly measure debugging activity, not demand.
 
 ### Optional module — Age factor
 
@@ -235,7 +236,7 @@ base  = severity_weight              # LLM grade, reach folded in (S0/S1/S2/S3 =
       × component_weight             # areas.json per-area weight 1.4/1.2/1.1/1.0/0.9 (Axis 3)
       × dup_reach                    # +15% per confirmed duplicate, capped +50% (Axis 5)
 
-score = apply_demand(base, type)     # additive, ≤15 pts (Axis 7)
+score = base + demand_points         # 15 × min(upvotes, 12) / 12 (Axis 7)
 
 # Optional modules, default off in v1:
 score = score × readiness_factor     # if enabled: ready 1.1 · normal 1.0 · needs-info 0.85
@@ -307,6 +308,9 @@ But regex only keyword-matches — to check the *design*, an LLM (this one) read
 through the same scoring machinery (severity × component × dup, then demand).
 **Priority flipped on 49 of 100** — the argument for grading severity with the
 classifier in production.
+
+`score_prototype.py` is retained as historical scratch paper; the formula above
+and the production scoring config are canonical.
 
 **Distribution (100 issues):**
 

--- a/designs/prioritization/issue-prioritization-v2.md
+++ b/designs/prioritization/issue-prioritization-v2.md
@@ -261,36 +261,21 @@ which reads full content and already runs per issue at zero extra cost.
 
 ### Community demand — used, but type-dependent and bounded
 
-Should 👍 / engagement feed the score? **Yes, but carefully**, because of what
-the reaction distribution actually looks like on this repo:
+Should 👍 feed the score? **Yes, but bounded** — the reaction distribution
+forces it. 93% of open issues (335/360) have zero reactions; the 51 total skew
+hard to FRs (9 of the top 10 reacted are FRs) and are almost all external. So
+reactions are a **demand** signal (a wanted capability), not a **severity** one.
+The model reflects that:
 
-- **93% of open issues (335/360) have zero reactions**; 51 reactions total
-  across the whole backlog, with a tiny head (one issue at 10, one at 6, a
-  handful at 2–4).
-- **Reactions skew hard to feature requests** — 9 of the top 10 reacted issues
-  are FRs — and are almost entirely external (50 of 51 from NONE/CONTRIBUTOR,
-  ~0 from maintainers). So reactions are a **demand** signal (a wanted
-  capability), not a **severity** signal (bugs are reported once, rarely
-  upvoted).
+- **Type-dependent.** FRs: a bounded *multiplier* (up to +60%), so a well-liked
+  FR climbs. Bugs: a small additive *tiebreak* (≤15 pts), so a 0-reaction crash
+  still outranks a lightly-liked cosmetic FR. Severity always leads for bugs.
+- **Log-scaled and capped** (`log1p` + hard cap), so one popular FR can't swamp
+  severity. **Comments excluded** — here they're mostly repro back-and-forth, a
+  sign a bug is *harder*, not more wanted.
 
-Consequences baked into the model:
-
-1. **Type-dependent.** For **feature requests**, demand is a bounded
-   *multiplier* (up to +60%), so a well-liked FR climbs above unwanted ones.
-   For **bugs**, demand is only a small additive *tiebreak* (≤15 pts), so a
-   0-reaction crash still outranks a lightly-liked cosmetic FR. Severity always
-   leads for bugs.
-2. **Log-scaled and capped.** With a backlog max of ~10 reactions, a linear
-   term would let one popular FR swamp severity; `log1p` + a hard cap keeps
-   demand a nudge, not a driver.
-3. **Comments are excluded.** On this repo, bug comment volume is mostly repro
-   back-and-forth — a bug with more comments is often *harder*, not more wanted
-   — so comments would reward contentious issues rather than important ones.
-
-**Caveat this guards against:** because reactions are 93%-zero and tilt toward
-external FRs, over-weighting demand would systematically bias a
-dogfood-bug-heavy backlog toward features. Bounding it (and splitting by type)
-keeps severity as the driver.
+Without these bounds, a 93%-zero, FR-skewed signal would tilt a dogfood-heavy
+backlog toward features — the exact failure the type-split guards against.
 
 ### Axis 5 — Duplicate reach
 
@@ -320,22 +305,16 @@ existing fields; the production grader can set it directly.
 Prioritization is not a one-shot classification, but the adjustment lever is
 just **re-grading severity** — the same field the classifier already sets:
 
-1. **Periodic re-score.** A scheduled job (weekly) recomputes the score for all
-   open issues and posts/updates a single **ranked view** (a pinned issue or a
-   generated `PRIORITY-QUEUE.md`), so demand/age/dup changes are reflected
-   without re-triaging. Cheap: no LLM call needed for re-score if severity is
-   cached as a field at triage time.
-2. **Re-grade severity to bump.** To push an issue up or down, a maintainer
-   changes its priority/severity label (P2 → P1) — exactly what you asked: "I
-   can bump P2 → P1 or vice versa." No separate `pin:high` / `pin:low` lever.
-   A dedicated pin was in the previous draft; it's dropped as over-engineering
-   — a second override that means the same thing as changing severity, but out
-   of band from it. One knob, and it's the one maintainers already use.
-
-The earlier draft leaned on `pin` to rescue "high-severity P2s" like #2125. The
-better fix is upstream: grade severity honestly in the first place (Axis 2) so
-#2125 lands where it belongs, and re-grade if it's wrong. The score reads
-severity; fixing severity fixes the score.
+1. **Periodic re-score.** A scheduled (weekly) job recomputes the score and
+   posts/updates a single **ranked view** (a pinned issue or generated
+   `PRIORITY-QUEUE.md`), reflecting demand/age/dup changes without re-triaging.
+   No LLM call needed if severity is cached as a field at triage time.
+2. **Re-grade severity to bump.** To move an issue, a maintainer changes its
+   label (P2 → P1) — the one knob they already use. There is deliberately no
+   separate `pin:high`/`pin:low`: it would mean the same thing as changing
+   severity but out of band from it. The real fix for a mis-ranked issue (e.g.
+   #2125) is upstream — grade severity honestly (Axis 2); the score reads
+   severity, so fixing severity fixes the order.
 
 ---
 
@@ -506,3 +485,216 @@ adds three labels instead of eleven and doesn't grow with the harness count.
 - **Auto-closing duplicates.** The dedup labeler
   ([#4037](https://github.com/omnigent-ai/omnigent/pull/4037)) links without
   closing; we keep dupes open and use their *count* as a reach signal (Axis 5).
+
+## Appendix C — Full ranking snapshot (top 200 of 360 open)
+
+Generated from today's snapshot with `score_prototype.py --markdown 200`
+(regex severity grader — the same stand-in used throughout; production uses
+the LLM grader). Columns: **Score** = composite score; **Sev** = re-graded
+severity; **Now** = current priority label; **Δrank** = movement vs the
+current priority-label ordering (positive = moved up). Regenerate any time to
+refresh. Read this as illustrative ordering — the regex grader's known false
+positives (e.g. #2057/#2054) are visible near the top.
+
+| # | Score | Sev | Now | Δrank | Issue |
+|--:|--:|---|---|--:|---|
+| 1 | 154 | critical | P2-medium | +235 | [#2057](https://github.com/omnigent-ai/omnigent/issues/2057) [Feature] Add Codex Auto mode using auto_review instead of jumping to  |
+| 2 | 154 | critical | P2-medium | +236 | [#2054](https://github.com/omnigent-ai/omnigent/issues/2054) [Feature] Remove duplicate Codex Full access mode and keep Sandbox Byp |
+| 3 | 126 | high | P1-high | +34 | [#3265](https://github.com/omnigent-ai/omnigent/issues/3265) claude-sdk agent with linux_bwrap dies at spawn on a runtime bwrap bin |
+| 4 | 115 | high | P2-medium | +236 | [#2038](https://github.com/omnigent-ai/omnigent/issues/2038) [Feature] No way to deregister/delete an external self-registered host |
+| 5 | 110 | critical | P1-high | -1 | [#3983](https://github.com/omnigent-ai/omnigent/issues/3983) [Bug] Smart-routed turns render out of order: reply streams above the  |
+| 6 | 110 | critical | P0-critical | -5 | [#3557](https://github.com/omnigent-ai/omnigent/issues/3557) [Bug] Shell-surface policy gates are bypassed by option-taking command |
+| 7 | 110 | critical | P1-high | +28 | [#3270](https://github.com/omnigent-ai/omnigent/issues/3270) [Bug] sys_session_create children are absent from both sys_session_lis |
+| 8 | 104 | critical | P2-medium | +224 | [#2125](https://github.com/omnigent-ai/omnigent/issues/2125) [Feature] Multi-host git credentials for managed sandboxes (GitHub + s |
+| 9 | 99 | high | P2-medium | +127 | [#3976](https://github.com/omnigent-ai/omnigent/issues/3976) [Feature] OAuth2 client-credentials grant so a headless process can au |
+| 10 | 99 | high | P2-medium | +154 | [#3363](https://github.com/omnigent-ai/omnigent/issues/3363) [Feature] Per-project custom instructions (project-scoped context) |
+| 11 | 99 | high | P2-medium | +166 | [#3164](https://github.com/omnigent-ai/omnigent/issues/3164) [Feature] Optional runtimeClassName on the kubernetes sandbox provider |
+| 12 | 95 | high | P2-medium | +264 | [#1388](https://github.com/omnigent-ai/omnigent/issues/1388) Make agents a first-class CRUD entity with a dedicated sidebar UI (dec |
+| 13 | 92 | high | P1-high | +28 | [#3180](https://github.com/omnigent-ai/omnigent/issues/3180) codex-native: runner never exits on idle timeout — cancelled delta-coa |
+| 14 | 92 | high | P1-high | +68 | [#2373](https://github.com/omnigent-ai/omnigent/issues/2373) [Bug] claude-native: pasted web-UI message loses its Enter, stuck draf |
+| 15 | 92 | high | P1-high | +79 | [#2060](https://github.com/omnigent-ai/omnigent/issues/2060) [Bug] claude-native: first web-UI message silently dropped when Claude |
+| 16 | 91 | high | P1-high | +87 | [#1898](https://github.com/omnigent-ai/omnigent/issues/1898) [Bug] codex-native: cancelling a task awaiting flush() poisons the del |
+| 17 | 91 | critical | P2-medium | +298 | [#659](https://github.com/omnigent-ai/omnigent/issues/659) [Feature] add a microvm backend for sandbox |
+| 18 | 90 | high | P1-high | +34 | [#3001](https://github.com/omnigent-ai/omnigent/issues/3001) [Performance] GET /v1/sessions pre-fetches every accessible conversati |
+| 19 | 90 | critical | P3-low | +330 | [#61](https://github.com/omnigent-ai/omnigent/issues/61) 🤖 Code Audit: 21 potential issue(s) found |
+| 20 | 85 | high | P2-medium | +296 | [#654](https://github.com/omnigent-ai/omnigent/issues/654) [Bug] Streaming with codex is hanging and paragraphs are not split. |
+| 21 | 84 | high | P1-high | +106 | [#542](https://github.com/omnigent-ai/omnigent/issues/542) [Bug] AttributeError: 'SubprocessCLITransport' object has no attribute |
+| 22 | 84 | high | P2-medium | +132 | [#3558](https://github.com/omnigent-ai/omnigent/issues/3558) claude-sdk: cached client does not rebuild on framework-instruction ch |
+| 23 | 84 | high | P1-high | +30 | [#3000](https://github.com/omnigent-ai/omnigent/issues/3000) claude-native transcript forwarder polls at 4 Hz per session with no i |
+| 24 | 84 | high | P1-high | +38 | [#2748](https://github.com/omnigent-ai/omnigent/issues/2748) Runner idle-shutdown deadlocks forever: codex-forwarder close()/flush( |
+| 25 | 84 | high | P1-high | +42 | [#2575](https://github.com/omnigent-ai/omnigent/issues/2575) pi-native: non-Claude Databricks models (GLM, Gemini, …) hang — provid |
+| 26 | 84 | high | P1-high | +46 | [#2454](https://github.com/omnigent-ai/omnigent/issues/2454) [Bug] Unbounded ~/.omnigent growth: per-session native-harness dirs ar |
+| 27 | 84 | high | P1-high | +53 | [#2421](https://github.com/omnigent-ai/omnigent/issues/2421) [Bug] codex app-server + MCP bridge children leak on ANY unclean runne |
+| 28 | 84 | high | P2-medium | +267 | [#1051](https://github.com/omnigent-ai/omnigent/issues/1051) [Feature] Forward OTel exporter knobs to executor subprocess env |
+| 29 | 81 | high | P2-medium | +108 | [#3970](https://github.com/omnigent-ai/omnigent/issues/3970) pi-native: every turn fails with "Pi model error: 401 Invalid Token" w |
+| 30 | 77 | high | P2-medium | +275 | [#888](https://github.com/omnigent-ai/omnigent/issues/888) [Feature] Side-by-side multi-session view |
+| 31 | 70 | high | P1-high | +7 | [#3261](https://github.com/omnigent-ai/omnigent/issues/3261) [Crash] AttributeError: module 'os' has no attribute 'WNOHANG' |
+| 32 | 69 | high | P2-medium | +302 | [#16](https://github.com/omnigent-ai/omnigent/issues/16) Is native Windows support in scope, or should docs recommend WSL2? |
+| 33 | 68 | high | P2-medium | +296 | [#151](https://github.com/omnigent-ai/omnigent/issues/151) Native claude_code worker hangs on the one-time Bypass Permissions acc |
+| 34 | 66 | high | P2-medium | +112 | [#3750](https://github.com/omnigent-ai/omnigent/issues/3750) [Crash] PermissionError: [Errno 1] Operation not permitted |
+| 35 | 66 | high | P1-high | -7 | [#3482](https://github.com/omnigent-ai/omnigent/issues/3482) [Crash] ServerError: |
+| 36 | 66 | high | P1-high | -6 | [#3458](https://github.com/omnigent-ai/omnigent/issues/3458) session-updates stream crashes with KeyError when a client watches a c |
+| 37 | 66 | high | P1-high | -5 | [#3359](https://github.com/omnigent-ai/omnigent/issues/3359) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 38 | 66 | high | P2-medium | +129 | [#3271](https://github.com/omnigent-ai/omnigent/issues/3271) [Feature] Expose per-session context size + last-turn timestamp to age |
+| 39 | 66 | high | P1-high | 0 | [#3251](https://github.com/omnigent-ai/omnigent/issues/3251) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 40 | 66 | high | P2-medium | +133 | [#3231](https://github.com/omnigent-ai/omnigent/issues/3231) [Crash] OmnigentError: {'error_code': 403, 'message': 'Invalid access  |
+| 41 | 66 | high | P1-high | +4 | [#3052](https://github.com/omnigent-ai/omnigent/issues/3052) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 42 | 66 | high | P1-high | +4 | [#3023](https://github.com/omnigent-ai/omnigent/issues/3023) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 43 | 66 | high | P1-high | +11 | [#2993](https://github.com/omnigent-ai/omnigent/issues/2993) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 44 | 66 | high | P3-low | +293 | [#2887](https://github.com/omnigent-ai/omnigent/issues/2887) [Bug] web/package-lock.json is out of sync with package.json; plain `n |
+| 45 | 66 | high | P1-high | +23 | [#2559](https://github.com/omnigent-ai/omnigent/issues/2559) Conversation bricked: Page fails to load when opening markdown file af |
+| 46 | 66 | high | P0-critical | -44 | [#2355](https://github.com/omnigent-ai/omnigent/issues/2355) [Bug] workspace_id PK-widening migration crashes on populated Postgres |
+| 47 | 66 | high | P3-low | +294 | [#2224](https://github.com/omnigent-ai/omnigent/issues/2224) [Bug] get_client model-change check fails for harness="any" |
+| 48 | 66 | high | P1-high | +50 | [#1985](https://github.com/omnigent-ai/omnigent/issues/1985) Headless `omnigent run -p` intermittently hangs forever despite the tu |
+| 49 | 65 | high | P2-medium | +159 | [#2714](https://github.com/omnigent-ai/omnigent/issues/2714) Upgrade openai-agents and remove the temporary openai<2.45 cap |
+| 50 | 65 | high | P1-high | +40 | [#2245](https://github.com/omnigent-ai/omnigent/issues/2245) [Bug] openai-agents harness turn wedges permanently after policy-verdi |
+| 51 | 65 | high | P2-medium | +193 | [#1907](https://github.com/omnigent-ai/omnigent/issues/1907) Sub-agent model_override triggers an unnecessary first-turn harness re |
+| 52 | 65 | high | P1-high | +52 | [#1888](https://github.com/omnigent-ai/omnigent/issues/1888) ansi-to-react default import resolves to the CJS exports object under  |
+| 53 | 65 | high | P2-medium | +200 | [#1804](https://github.com/omnigent-ai/omnigent/issues/1804) spec parser crashes with TypeError on a null tools.builtins key (and s |
+| 54 | 62 | high | P2-medium | +235 | [#1076](https://github.com/omnigent-ai/omnigent/issues/1076) Runner-layer Tier-2 escalation: release an unresponsive per-conversati |
+| 55 | 62 | high | P1-high | +66 | [#1026](https://github.com/omnigent-ai/omnigent/issues/1026) Runner orphans tool callbacks with "no active turn context" after mid- |
+| 56 | 60 | high | P1-high | -48 | [#3971](https://github.com/omnigent-ai/omnigent/issues/3971) Host runners inherit the daemon's cwd; a deleted launch dir breaks eve |
+| 57 | 60 | high | P1-high | -23 | [#3274](https://github.com/omnigent-ai/omnigent/issues/3274) Sub-agent terminal status rejected with missing_parent_inbox and retri |
+| 58 | 60 | high | P2-medium | +114 | [#3235](https://github.com/omnigent-ai/omnigent/issues/3235) Flaky E2E UI: test_scheduled_task_create_edit_modal_and_time_picker[ch |
+| 59 | 60 | high | P1-high | -12 | [#3016](https://github.com/omnigent-ai/omnigent/issues/3016) [Bug] A transient session-snapshot failure permanently pins a session  |
+| 60 | 60 | high | P1-high | -12 | [#3012](https://github.com/omnigent-ai/omnigent/issues/3012) Hosts authenticated via `omnigent login` permanently 403 on first reco |
+| 61 | 60 | high | P2-medium | +157 | [#2428](https://github.com/omnigent-ai/omnigent/issues/2428) sys_session_send to a completed session hangs to ReadTimeout and is si |
+| 62 | 60 | high | P1-high | +29 | [#2241](https://github.com/omnigent-ai/omnigent/issues/2241) Flaky on main: test_interrupt_forwards_to_harness_before_cancelling ti |
+| 63 | 60 | high | P1-high | +33 | [#2051](https://github.com/omnigent-ai/omnigent/issues/2051) [Bug] sys_session_send(session_id=…) completions never drain to sys_re |
+| 64 | 59 | medium | P2-medium | +204 | [#1596](https://github.com/omnigent-ai/omnigent/issues/1596) Native-CLI harness (claude-native/codex-native) as a named agent's own |
+| 65 | 59 | high | P1-high | -48 | [#3799](https://github.com/omnigent-ai/omnigent/issues/3799) Android shell cannot sign in to servers behind a front-door auth proxy |
+| 66 | 59 | high | P1-high | -46 | [#3730](https://github.com/omnigent-ai/omnigent/issues/3730) [Bug] Android: renderer death terminates the app — OmnigentWebViewClie |
+| 67 | 59 | high | P1-high | -45 | [#3701](https://github.com/omnigent-ai/omnigent/issues/3701) [Bug] Desktop app never completes Okta security key / biometric MFA du |
+| 68 | 59 | high | P1-high | -35 | [#3299](https://github.com/omnigent-ai/omnigent/issues/3299) [Bug] Harness-credential route times out with a misleading 504 against |
+| 69 | 59 | high | P2-medium | +97 | [#3284](https://github.com/omnigent-ai/omnigent/issues/3284) [Crash] DuplicateOptionError: While reading from PosixPath('/Users/*** |
+| 70 | 59 | high | P2-medium | +114 | [#3070](https://github.com/omnigent-ai/omnigent/issues/3070) No progress signal on a stuck or interactive harness install |
+| 71 | 59 | high | P1-high | -16 | [#2967](https://github.com/omnigent-ai/omnigent/issues/2967) [Bug] A full context window bricks a session with "Prompt is too long" |
+| 72 | 59 | high | P2-medium | +144 | [#2480](https://github.com/omnigent-ai/omnigent/issues/2480) [Bug] Postgres-backed local server: bare `No module named 'psycopg'` + |
+| 73 | 59 | high | P1-high | +15 | [#2270](https://github.com/omnigent-ai/omnigent/issues/2270) Windows: config list crashes — UnicodeEncodeError on cp1252 (non-UTF8) |
+| 74 | 59 | high | P1-high | +15 | [#2269](https://github.com/omnigent-ai/omnigent/issues/2269) Windows: omnigent setup crashes — ModuleNotFoundError: No module named |
+| 75 | 59 | high | P1-high | +24 | [#1953](https://github.com/omnigent-ai/omnigent/issues/1953) `omni host` dies permanently when the OIDC session JWT expires — no re |
+| 76 | 59 | high | P1-high | +26 | [#1901](https://github.com/omnigent-ai/omnigent/issues/1901) [Bug] kimi/qwen/goose/kiro forwarders blind-retry failed conversation- |
+| 77 | 59 | high | P1-high | +28 | [#1881](https://github.com/omnigent-ai/omnigent/issues/1881) [Bug] `omnigent setup` crashes with `ValueError: select() requires at  |
+| 78 | 58 | high | P0-critical | -75 | [#1657](https://github.com/omnigent-ai/omnigent/issues/1657) hermes-native forwarder advances last_id per item, dropping a row's la |
+| 79 | 58 | high | P1-high | +29 | [#1827](https://github.com/omnigent-ai/omnigent/issues/1827) [Bug] kimi-native: torn UTF-8 wire read crashes the forwarder; supervi |
+| 80 | 58 | high | P2-medium | +187 | [#1600](https://github.com/omnigent-ai/omnigent/issues/1600) Epic: 12-feature contribution (one issue + one PR per feature) |
+| 81 | 57 | high | P2-medium | +189 | [#1528](https://github.com/omnigent-ai/omnigent/issues/1528) Idle-session lifecycle UX: reap gracefully, resume seamlessly, surface |
+| 82 | 57 | high | P1-high | +49 | [#108](https://github.com/omnigent-ai/omnigent/issues/108) Cannot install on Linux aarch64 — cel-expr-python has no aarch64 wheel |
+| 83 | 55 | high | P2-medium | +231 | [#678](https://github.com/omnigent-ai/omnigent/issues/678) e2e: sub-agent supervisor routing / named-sub-agent auto-wake flakes ( |
+| 84 | 55 | high | P2-medium | +214 | [#1022](https://github.com/omnigent-ai/omnigent/issues/1022) Behind a corporate proxy, the host daemon can't reach the model backen |
+| 85 | 54 | high | P2-medium | +59 | [#3798](https://github.com/omnigent-ai/omnigent/issues/3798) Android shell shows the SPA as if signed in while native login runs in |
+| 86 | 54 | high | P1-high | -57 | [#3469](https://github.com/omnigent-ai/omnigent/issues/3469) [Bug] Post-completion compaction spiral: merge-commit diff output trig |
+| 87 | 54 | high | P1-high | -22 | [#2629](https://github.com/omnigent-ai/omnigent/issues/2629) web_fetch sub-agent spawn fails with unknown harness 'omnigent' — bare |
+| 88 | 53 | high | P1-high | -39 | [#3011](https://github.com/omnigent-ai/omnigent/issues/3011) kiro-native harness: interactive sessions never respond with kiro-cli  |
+| 89 | 53 | high | P1-high | -33 | [#2920](https://github.com/omnigent-ai/omnigent/issues/2920) Omnigent server fails to start on native Windows: os.getuid() at impor |
+| 90 | 53 | high | P1-high | -33 | [#2919](https://github.com/omnigent-ai/omnigent/issues/2919) omni setup crashes on Windows: ModuleNotFoundError: No module named 't |
+| 91 | 53 | high | P1-high | -12 | [#2422](https://github.com/omnigent-ai/omnigent/issues/2422) Windows: five chained defects break the documented degraded-mode subse |
+| 92 | 53 | medium | P2-medium | +207 | [#1021](https://github.com/omnigent-ai/omnigent/issues/1021) [Feature] GitHub Copilot as provider |
+| 93 | 53 | high | P2-medium | +162 | [#1778](https://github.com/omnigent-ai/omnigent/issues/1778) opencode-native forwarder loses session content across SSE reconnects  |
+| 94 | 50 | medium | P2-medium | +110 | [#2744](https://github.com/omnigent-ai/omnigent/issues/2744) [Bug] codex-native: custom agents time out at launch — native provider |
+| 95 | 49 | high | P1-high | +33 | [#523](https://github.com/omnigent-ai/omnigent/issues/523) REPL pexpect e2e tests starve on boot under full shard load (60s _wait |
+| 96 | 49 | high | P2-medium | +214 | [#762](https://github.com/omnigent-ai/omnigent/issues/762) [Bug] sub agent terminal crashes when cli starts with prompt for input |
+| 97 | 46 | medium | P1-high | -87 | [#3952](https://github.com/omnigent-ai/omnigent/issues/3952) A stale terminal exit removes the newer Codex resources of the same se |
+| 98 | 46 | medium | P2-medium | +93 | [#2984](https://github.com/omnigent-ai/omnigent/issues/2984) [Bug] Codex incorrectly reports `needs-auth` with an authenticated cus |
+| 99 | 46 | medium | P1-high | -7 | [#2184](https://github.com/omnigent-ai/omnigent/issues/2184) [Bug] Codex plugin skills are exposed with inconsistent names (`plugin |
+| 100 | 46 | medium | P1-high | -7 | [#2071](https://github.com/omnigent-ai/omnigent/issues/2071) [Bug] web_search never advertised to claude-sdk sessions: unprefixed m |
+| 101 | 46 | medium | P2-medium | +134 | [#2062](https://github.com/omnigent-ai/omnigent/issues/2062) [Bug] claude-native: per-session model override silently lost when wra |
+| 102 | 45 | medium | P1-high | +5 | [#1831](https://github.com/omnigent-ai/omnigent/issues/1831) claude-native workers ignore executor.model pin and per-dispatch args. |
+| 103 | 45 | medium | P1-high | +7 | [#1781](https://github.com/omnigent-ai/omnigent/issues/1781) codex harness: ambient DATABRICKS_BEARER/DATABRICKS_TOKEN overrides pr |
+| 104 | 44 | medium | P1-high | +15 | [#1128](https://github.com/omnigent-ai/omnigent/issues/1128) [Bug] Claude SDK Appears to Use Opus Instead of Selected Model |
+| 105 | 42 | medium | P1-high | -87 | [#3790](https://github.com/omnigent-ai/omnigent/issues/3790) force_sandbox policy is evaluated but structurally unreachable from cl |
+| 106 | 42 | medium | P1-high | +24 | [#241](https://github.com/omnigent-ai/omnigent/issues/241) pi harness: GPT and Gemini dispatches 404 on the Databricks ucode gate |
+| 107 | 42 | medium | P3-low | +240 | [#147](https://github.com/omnigent-ai/omnigent/issues/147) Tracking: gradual decomposition of monolith modules (cli.py 9.1KLOC, c |
+| 108 | 42 | medium | P1-high | -50 | [#2904](https://github.com/omnigent-ai/omnigent/issues/2904) [Bug] claude-native: web-UI chat input fails with "tmux command failed |
+| 109 | 42 | medium | P1-high | -28 | [#2397](https://github.com/omnigent-ai/omnigent/issues/2397) [Bug] Codex-native intelligent routing ignores live effort capabilitie |
+| 110 | 42 | medium | P1-high | -23 | [#2272](https://github.com/omnigent-ai/omnigent/issues/2272) [Bug] Codex runner can't find OpenRouter secret that exists in keyring |
+| 111 | 41 | medium | P2-medium | +147 | [#1724](https://github.com/omnigent-ai/omnigent/issues/1724) codex-native harness times out on WSL2 ("Codex TUI never started a thr |
+| 112 | 39 | medium | P2-medium | +192 | [#890](https://github.com/omnigent-ai/omnigent/issues/890) [Bug] omnigent setup fails with npm EACCES when installing the Claude  |
+| 113 | 38 | medium | P1-high | -97 | [#3852](https://github.com/omnigent-ai/omnigent/issues/3852) [Bug] Built-in write policies miss Claude Code's `MultiEdit` / `Notebo |
+| 114 | 38 | medium | P2-medium | +110 | [#2369](https://github.com/omnigent-ai/omnigent/issues/2369) [Bug] pi harness only lists databricks-claude-sonnet-4-6 |
+| 115 | 38 | medium | P1-high | -29 | [#2299](https://github.com/omnigent-ai/omnigent/issues/2299) [Bug] claude-native resume transcripts flatten tool_result image block |
+| 116 | 38 | medium | P2-medium | +105 | [#2390](https://github.com/omnigent-ai/omnigent/issues/2390) Builtin policy for per-user sub-agent access control (subagent_access_ |
+| 117 | 38 | medium | P1-high | +8 | [#668](https://github.com/omnigent-ai/omnigent/issues/668) [Bug] BUG？omni claude times out (60s) on macOS with native Claude Code |
+| 118 | 37 | medium | P1-high | -9 | [#1794](https://github.com/omnigent-ai/omnigent/issues/1794) Bundled Polly: claude-sdk brain "Not logged in" + runaway spawn loop o |
+| 119 | 37 | medium | P1-high | -77 | [#3101](https://github.com/omnigent-ai/omnigent/issues/3101) Docker/Kubernetes entrypoint never wires project_store — first-class P |
+| 120 | 37 | medium | P1-high | -9 | [#1694](https://github.com/omnigent-ai/omnigent/issues/1694) Reliability: parallel code-fix missions fail silently (5s tmux timeout |
+| 121 | 35 | medium | P2-medium | +116 | [#2055](https://github.com/omnigent-ai/omnigent/issues/2055) [Bug] codex-native harness elicitation: a resolve landing in the betwe |
+| 122 | 35 | medium | P1-high | -78 | [#3076](https://github.com/omnigent-ai/omnigent/issues/3076) [Bug] claude-sdk omits ToolSearch, eagerly loading every MCP schema |
+| 123 | 35 | medium | P3-low | +216 | [#2800](https://github.com/omnigent-ai/omnigent/issues/2800) [Bug] Top-level custom codex-native agents drop reasoning effort and y |
+| 124 | 34 | medium | P2-medium | +159 | [#1192](https://github.com/omnigent-ai/omnigent/issues/1192) [Bug] Manual /compact errors "Compaction requires a configured LLM mod |
+| 125 | 34 | medium | P1-high | -8 | [#1158](https://github.com/omnigent-ai/omnigent/issues/1158) [Bug] antigravity-native: TUI-typed turns never mirror to the web UI ( |
+| 126 | 34 | medium | P2-medium | +159 | [#1157](https://github.com/omnigent-ai/omnigent/issues/1157) [Bug] antigravity-native: no Chat/Terminal toggle — terminal_antigravi |
+| 127 | 34 | medium | P2-medium | +197 | [#377](https://github.com/omnigent-ai/omnigent/issues/377) gpt sub-agent fails on startup with missing databricks-sdk dependency |
+| 128 | 33 | medium | P2-medium | +6 | [#4009](https://github.com/omnigent-ai/omnigent/issues/4009) [Feature] No Go client for the session API, so every Go caller hand-ro |
+| 129 | 33 | medium | P1-high | -123 | [#3981](https://github.com/omnigent-ai/omnigent/issues/3981) [Bug] Desktop: Workspace rail resize is unusable on the Browser tab; a |
+| 130 | 33 | medium | P1-high | -117 | [#3898](https://github.com/omnigent-ai/omnigent/issues/3898) [Bug] Pack function policies fail server-side input evaluation unless  |
+| 131 | 33 | medium | P1-high | -117 | [#3870](https://github.com/omnigent-ai/omnigent/issues/3870) child-session creation returns 500 internal_error, breaking Polly/Debb |
+| 132 | 33 | medium | P2-medium | +10 | [#3864](https://github.com/omnigent-ai/omnigent/issues/3864) [Bug] to_api_dict() drops ConversationItem.created_at, so flat items A |
+| 133 | 33 | medium | P1-high | -118 | [#3863](https://github.com/omnigent-ai/omnigent/issues/3863) [Bug] Databricks Apps entrypoint never wires project_store — Projects  |
+| 134 | 33 | medium | P2-medium | +9 | [#3861](https://github.com/omnigent-ai/omnigent/issues/3861) [Bug] omni host status renders URLs so terminals link the whole status |
+| 135 | 33 | medium | P2-medium | +17 | [#3563](https://github.com/omnigent-ai/omnigent/issues/3563) [Bug] Host-bound resume into a deleted workspace: host computes the ex |
+| 136 | 33 | medium | P2-medium | +17 | [#3561](https://github.com/omnigent-ai/omnigent/issues/3561) [Bug] `prompt_policy` never sends `_CLASSIFIER_SCHEMA` to the LLM — st |
+| 137 | 33 | medium | P2-medium | +18 | [#3550](https://github.com/omnigent-ai/omnigent/issues/3550) [Bug] Missing signing alg's prevent using some OIDC providers |
+| 138 | 33 | medium | P2-medium | +22 | [#3435](https://github.com/omnigent-ai/omnigent/issues/3435) [Feature] Admin server-wide usage report (per-user and per-model cost) |
+| 139 | 33 | medium | none | +214 | [#3402](https://github.com/omnigent-ai/omnigent/issues/3402) [Bug] Label seeding and session-state writes race under concurrent upd |
+| 140 | 33 | medium | P2-medium | +22 | [#3368](https://github.com/omnigent-ai/omnigent/issues/3368) Feature: first-class async write-safety (freeze → approve → apply) pri |
+| 141 | 33 | medium | P2-medium | +24 | [#3352](https://github.com/omnigent-ai/omnigent/issues/3352) [Feature] OpenClaw onboarding — Option B: chat import (SQLite session  |
+| 142 | 33 | medium | P2-medium | +28 | [#3247](https://github.com/omnigent-ai/omnigent/issues/3247) credential_proxy: re-resolve the source on 401 / expiry (short-lived t |
+| 143 | 33 | medium | P1-high | -103 | [#3236](https://github.com/omnigent-ai/omnigent/issues/3236) web_search: bare executor.model strings are inferred as provider 'open |
+| 144 | 33 | medium | P2-medium | +32 | [#3219](https://github.com/omnigent-ai/omnigent/issues/3219) [Bug] Cmd/Ctrl+Up/Down session traversal stops in an empty focused com |
+| 145 | 33 | medium | P2-medium | +47 | [#2921](https://github.com/omnigent-ai/omnigent/issues/2921) Font settings: selected font (incl. Nerd Fonts) never loads — no webfo |
+| 146 | 33 | medium | P1-high | -86 | [#2854](https://github.com/omnigent-ai/omnigent/issues/2854) [Bug] Cross-harness `harness_override` is ignored on the `initial_item |
+| 147 | 33 | medium | P2-medium | +49 | [#2851](https://github.com/omnigent-ai/omnigent/issues/2851) Policy-supplied targets for ASK approval cards |
+| 148 | 33 | medium | P2-medium | +54 | [#2756](https://github.com/omnigent-ai/omnigent/issues/2756) Expose atomic session-event admission to integrations |
+| 149 | 33 | medium | P2-medium | +63 | [#2577](https://github.com/omnigent-ai/omnigent/issues/2577) [Feature] Manage OIDC/SSO admins from an id_token claim (IdP group/rol |
+| 150 | 33 | medium | P2-medium | +63 | [#2558](https://github.com/omnigent-ai/omnigent/issues/2558) Distribution / Installation / Enterprise Readiness |
+| 151 | 33 | medium | P1-high | -81 | [#2539](https://github.com/omnigent-ai/omnigent/issues/2539) Named sys_session_send returns 404 after first child from a bundled se |
+| 152 | 33 | medium | P1-high | -81 | [#2524](https://github.com/omnigent-ai/omnigent/issues/2524) [Bug] Registering remote host fails |
+| 153 | 33 | medium | P1-high | -80 | [#2444](https://github.com/omnigent-ai/omnigent/issues/2444) Accounts JWT expiry falls through to Databricks auth and breaks persis |
+| 154 | 33 | medium | P2-medium | +66 | [#2404](https://github.com/omnigent-ai/omnigent/issues/2404) fix(runtime): orphan sweep can abort startup on unreadable shared-host |
+| 155 | 33 | medium | P2-medium | +67 | [#2374](https://github.com/omnigent-ai/omnigent/issues/2374) Proposal: per-turn context_providers to augment system instructions at |
+| 156 | 33 | medium | P1-high | -71 | [#2304](https://github.com/omnigent-ai/omnigent/issues/2304) Runner subprocess inherits host daemon cwd, causing os_env cwd resolut |
+| 157 | 33 | medium | P2-medium | +77 | [#2070](https://github.com/omnigent-ai/omnigent/issues/2070) [Feature] sys_os_* file tools are hard-confined to the session workspa |
+| 158 | 33 | feature | P2-medium | +155 | [#692](https://github.com/omnigent-ai/omnigent/issues/692) Polly: fan out sub-agent work across multiple concurrent claude profil |
+| 159 | 32 | medium | P1-high | -59 | [#1936](https://github.com/omnigent-ai/omnigent/issues/1936) [BUG] copilot harness: 401 Bad credentials when no token is explicitly |
+| 160 | 32 | medium | P1-high | -47 | [#1551](https://github.com/omnigent-ai/omnigent/issues/1551) opencode-native: blocking question tool not surfaced to web (no elicit |
+| 161 | 32 | feature | P2-medium | +166 | [#197](https://github.com/omnigent-ai/omnigent/issues/197) Declarative skill sources: pull Claude Code skills + their dependency  |
+| 162 | 32 | medium | P1-high | -39 | [#880](https://github.com/omnigent-ai/omnigent/issues/880) [BUG] Native harness (omnigent claude): assistant turns not streamed t |
+| 163 | 32 | medium | P2-medium | +108 | [#1526](https://github.com/omnigent-ai/omnigent/issues/1526) Refactor: incrementally decompose the 4 god-files (sessions.py, runner |
+| 164 | 32 | medium | P2-medium | +110 | [#1411](https://github.com/omnigent-ai/omnigent/issues/1411) Standalone reusable MCP servers: CRUD + connection verify (list tools) |
+| 165 | 31 | medium | P2-medium | +125 | [#1075](https://github.com/omnigent-ai/omnigent/issues/1075) [Feature] Support AWS Lambda / Firecracker microVMs as managed sandbox |
+| 166 | 31 | medium | P2-medium | +126 | [#1055](https://github.com/omnigent-ai/omnigent/issues/1055) [Test] End-to-end OTel test against a real collector to lock in the BY |
+| 167 | 31 | medium | P2-medium | +126 | [#1054](https://github.com/omnigent-ai/omnigent/issues/1054) [Feature] Record gen_ai.retry events on llm_call spans |
+| 168 | 31 | medium | P1-high | -90 | [#2429](https://github.com/omnigent-ai/omnigent/issues/2429) Server (python -m omnigent.cli server) CPU-spins indefinitely with no  |
+| 169 | 31 | medium | P2-medium | +128 | [#1031](https://github.com/omnigent-ai/omnigent/issues/1031) [Feature] Support serving the standalone Web UI under a subpath, e.g.  |
+| 170 | 31 | medium | P2-medium | +130 | [#983](https://github.com/omnigent-ai/omnigent/issues/983) Session sharing ergonomics: `sys_session_share` agent tool + `omnigent |
+| 171 | 31 | feature | P2-medium | +102 | [#1454](https://github.com/omnigent-ai/omnigent/issues/1454) [Feature] Change permission mode of a running claude-native session fr |
+| 172 | 31 | feature | P2-medium | +6 | [#3150](https://github.com/omnigent-ai/omnigent/issues/3150) [Feature] CLI: cross-harness fork — continue an existing session in a  |
+| 173 | 30 | medium | P2-medium | +135 | [#857](https://github.com/omnigent-ai/omnigent/issues/857) [Proposal] Usage-limit detection + on-429 failover across pooled provi |
+| 174 | 30 | medium | P1-high | -50 | [#765](https://github.com/omnigent-ai/omnigent/issues/765) Support interactive mid-flight policy ASK (TOOL_CALL/TOOL_RESULT/OUTPU |
+| 175 | 30 | feature | P2-medium | +50 | [#2303](https://github.com/omnigent-ai/omnigent/issues/2303) [Feature] Support multi-repo workspaces (nested Git repos or multiple  |
+| 176 | 30 | medium | P2-medium | +6 | [#3083](https://github.com/omnigent-ai/omnigent/issues/3083) [Bug] Cursor sessions launched from Omnigent Web is losing MCPs |
+| 177 | 30 | medium | P1-high | -51 | [#547](https://github.com/omnigent-ai/omnigent/issues/547) Bug: Polly model switcher sends invalid Cursor SDK model id |
+| 178 | 30 | medium | P1-high | -49 | [#522](https://github.com/omnigent-ai/omnigent/issues/522) Implement async-tool completion auto-delivery (SESSION_REARCHITECTURE  |
+| 179 | 30 | feature | P2-medium | +80 | [#1703](https://github.com/omnigent-ai/omnigent/issues/1703) [Feature] Unify harness naming: bare names (claude, codex, …) are ambi |
+| 180 | 30 | medium | P2-medium | +138 | [#509](https://github.com/omnigent-ai/omnigent/issues/509) [Feature] Default new-session workspace from selected agent's cwd |
+| 181 | 30 | feature | P3-low | +161 | [#1678](https://github.com/omnigent-ai/omnigent/issues/1678) tech-debt(codex-native): extract a string-field helper for repeated di |
+| 182 | 30 | medium | P2-medium | -13 | [#3250](https://github.com/omnigent-ai/omnigent/issues/3250) flaky e2e_ui: test_scheduled_task_create_edit_modal_and_time_picker ti |
+| 183 | 30 | medium | P2-medium | +15 | [#2848](https://github.com/omnigent-ai/omnigent/issues/2848) Server logs an expected offline-runner resource 503 as ERROR + full tr |
+| 184 | 30 | medium | P2-medium | +17 | [#2767](https://github.com/omnigent-ai/omnigent/issues/2767) [Bug] SQLite pool (default 5+10) not sized to the 200-thread limiter → |
+| 185 | 30 | medium | P1-high | -102 | [#2357](https://github.com/omnigent-ai/omnigent/issues/2357) [Bug] admin fleet-view calls SqlAlchemyConversationStore.list_conversa |
+| 186 | 30 | medium | P1-high | -91 | [#2052](https://github.com/omnigent-ai/omnigent/issues/2052) [Bug] web_fetch's __web_researcher helper sub-agent fails on 0.4.0 (si |
+| 187 | 30 | medium | P2-medium | +136 | [#382](https://github.com/omnigent-ai/omnigent/issues/382) Evaluating the same agent across harnesses: no built-in way to compare |
+| 188 | 30 | medium | P1-high | -87 | [#1920](https://github.com/omnigent-ai/omnigent/issues/1920) Seeder matching-hash fast path can't self-heal a lost artifact-store b |
+| 189 | 30 | medium | P1-high | -184 | [#3982](https://github.com/omnigent-ai/omnigent/issues/3982) [Bug] electron-build.yml pnpm filter matches no package: desktop packa |
+| 190 | 30 | medium | P3-low | +146 | [#3733](https://github.com/omnigent-ai/omnigent/issues/3733) [Bug] Android: hardcoded 25px switcher height makes the chat scroll-fa |
+| 191 | 30 | medium | P2-medium | -44 | [#3732](https://github.com/omnigent-ai/omnigent/issues/3732) [Bug] Android: a Display-size change leaves the server-switcher pill's |
+| 192 | 30 | medium | P2-medium | -42 | [#3592](https://github.com/omnigent-ai/omnigent/issues/3592) [Feature] Deterministic long-term memory (automatic recall/retain) — f |
+| 193 | 30 | medium | P2-medium | -42 | [#3586](https://github.com/omnigent-ai/omnigent/issues/3586) [Bug] Android: native server-picker pill overlaps the sidebar header c |
+| 194 | 30 | medium | P1-high | -170 | [#3578](https://github.com/omnigent-ai/omnigent/issues/3578) [Bug] MacOS Start Locally - "Error: No such command 'start'" |
+| 195 | 30 | medium | P1-high | -170 | [#3536](https://github.com/omnigent-ai/omnigent/issues/3536) [Bug] A session's `reasoning_effort` never reaches in-process harnesse |
+| 196 | 30 | medium | P2-medium | -39 | [#3531](https://github.com/omnigent-ai/omnigent/issues/3531) SSH_AUTH_SOCK dropped at the host→runner env boundary, breaking ssh-ag |
+| 197 | 30 | medium | none | +157 | [#3392](https://github.com/omnigent-ai/omnigent/issues/3392) [Bug] Linux desktop app missing Icon |
+| 198 | 30 | medium | P2-medium | -37 | [#3369](https://github.com/omnigent-ai/omnigent/issues/3369) Feature: a policy that fences a spawned type: agent worker read-only ( |
+| 199 | 30 | medium | P2-medium | -31 | [#3254](https://github.com/omnigent-ai/omnigent/issues/3254) Sub-agent silently stalls after repeated context compactions during re |
+| 200 | 30 | medium | P1-high | -157 | [#3095](https://github.com/omnigent-ai/omnigent/issues/3095) [Bug] Can't uninstall |

--- a/designs/prioritization/issue-prioritization-v2.md
+++ b/designs/prioritization/issue-prioritization-v2.md
@@ -89,17 +89,61 @@ demand is at most a tiebreak**, or the queue will look empty of signal.
 
 ### Axis 2 — Re-calibrated priority rubric
 
+**Three layers, one flow (resolving the priority-vs-score discussion).** These
+are distinct and it's worth being precise:
+
+1. **Severity** — a graded property of the issue, a function of the axes below
+   (type, blast radius, harness tier, …). Scored `low / medium / high /
+   critical = 10 / 30 / 60 / 100`.
+2. **Score** — severity combined with the mechanical multipliers (reach, tier,
+   readiness, dup, demand). This is the **continuous ordering** — it sorts
+   issues *within and across* priority labels, so two issues that share a label
+   aren't stuck equal.
+3. **Priority label (the outcome)** — the human-facing bucket the score lands
+   in. This is what maintainers **sort, filter, and action on**; the score is
+   the *reference for why* an issue got that label. The label is derived, not
+   hand-assigned by type.
+
+So: axes → severity → score → priority label. The score exists precisely because
+a label alone can't order issues that share it (Serena/Pat: "two issues of the
+same label are not equally important"); the label exists because people action
+on buckets, not on a float.
+
 Priority stays a 4-bucket label but gets a **rubric that forces separation**,
 enforced in the classifier prompt (`.github/triage/config.yaml`) and by a
-one-time backfill. The key change: **priority is a function of severity × reach,
-graded from content — not a type-default.**
+one-time backfill.
 
 | Priority | Definition (severity × reach — applies to bugs AND FRs) |
 |---|---|
-| **P0-critical** | Security/policy/sandbox bypass, data loss, or all-users-down. Rare by construction. |
+| **P0-critical** | A concrete, named critical failure (list below), not a vague "bad." |
 | **P1-high** | High severity (bug: crash / hang / permanent breakage, no workaround. FR: a capability whose *absence* blocks a common workflow) **AND** broad reach (default config, all/most users, or a tier-1 harness). Not "a thing I care about." |
 | **P2-medium** | Real bug with a workaround, OR a substantive capability/feature with a moderate reach. |
 | **P3-low** | Genuinely minor: cosmetic, polish, trivial convenience, narrow nice-to-have — bug or FR. |
+
+**P0 is an explicit list, not a judgment call** (per review — even security
+issues have a severity range, so we enumerate rather than blanket-P0 anything
+"security"). An issue is P0 if it is any of:
+
+- **Cannot start / use the product** — server, host, web UI, app, or sessions
+  fail to start or are unusable for a common configuration.
+- **A critical API is broken** — an endpoint the web UI/app depends on (usefully
+  cross-checked against the harness/API benchmark) returns errors or wrong data.
+- **DB migration failure or data loss** — persistence corruption, a migration
+  that bricks existing data.
+- **Security escape** — a sandbox/policy *bypass* or credential-crossing that
+  lets an agent exceed its granted permissions (this is the one severity that
+  ignores reach — a one-user escape is still P0).
+
+Grow the list as real P0s surface. Note we **don't run a hosted service**, so
+"all users down" is nearly hypothetical (only something like telemetry crashing
+on every client) — dropped from the definition in favor of the concrete cases
+above.
+
+**A simple tier→priority floor** (per review, as a sanity check on the graded
+score): a *valid bug* in a **tier-1** harness is **at least P1**; a valid bug in
+tier-2/3 is normally P2/P3 unless its severity/reach pushes it up. The score
+does the fine ordering; this floor keeps the classifier from under-grading a
+flagship-harness bug.
 
 **FRs are graded, not defaulted.** The old prompt defaulted every FR to P2;
 that's the "all FRs are equal" trap. An FR gets P1 when its *absence* is a
@@ -169,11 +213,21 @@ as illustrative; the LLM backfill corrects the outliers.
 ### Axis 3 — Harness tier (new, derived)
 
 Harnesses are not equal in strategic weight. Tier is **derived from the
-existing `areas.json` harness areas** (no new hand-labeling):
+existing `areas.json` harness areas** (no new hand-labeling). The assignment is
+informed by activity (open issues · reactions), not a guess:
 
-- **Tier 1** — `claude`, `codex` (flagship; ~38% of harness issues).
-- **Tier 2** — `cursor`, `antigravity`, `copilot`, `gemini`/`openai`.
-- **Tier 3** — everything else (goose, hermes, kimi, kiro, opencode, pi, qwen).
+- **Tier 1** — `claude` (128 open / 26 👍), `codex` (95 / 16). Flagship.
+- **Tier 2** — `pi` (41 / 15), `cursor` (37 / 15), `antigravity` (24 / 13),
+  `copilot` (15 / 13), `openai`/`gemini`. **Pi moved up to T2 on the data**
+  (per review: it's the 3rd-most-active harness, above cursor — a T3 default
+  under-weighted it). `opencode` (19 / 3) is the marginal T2/T3 call.
+- **Tier 3** — the low-activity, near-zero-reaction rest: `goose`, `hermes`,
+  `kimi`, `kiro`, `qwen` (each ~10–16 open, 0 👍).
+
+Tier is a maintainer call, not a formula — the counts inform it, and the
+mapping lives in `areas.json` so re-tiering (e.g. finalizing opencode) is a
+one-line edit. Open follow-up flagged in review: confirm the T2 cut in the team
+channel.
 
 Tier is a **score multiplier**, and we split the `comp:harnesses` mega-bucket
 (41% of open) with **tier labels — `comp:harness-t1` / `-t2` / `-t3`** — rather
@@ -188,31 +242,43 @@ rejected in Appendix A.)
 
 ### Component taxonomy — which `comp:` labels to add
 
-There are 8 `comp:` labels today, and several are mega-buckets because each
-merges multiple `areas.json` areas. The bar for a new label is deliberately
-high: **split only when you'd actually filter on it, or when it changes how the
-issue is graded** — every split costs new labels + an `areas.json` mapping + a
-classifier-allowlist update + a one-time backfill, and the repo has *no
-label-sync* by design. By that test:
+There are 8 `comp:` labels today, and several are mega-buckets that merge many
+`areas.json` areas. Review consensus (Serena/Pat) is to go **more granular** —
+fine-grained routing helps both prioritization and reviewer assignment. Two ways
+to add granularity, and we use both deliberately:
 
-| Label | Open | Recommendation |
+- **New top-level `comp:` label** when a slice is a distinct discipline you'd
+  *filter and prioritize on* (e.g. `comp:sandbox` is security-grade).
+- **A `sub_area` tag** for finer structure. `areas.json` *already* models these
+  sub-areas (runner vs sandbox, chat vs composer, …); the classifier can emit
+  the matched sub-area as a second-level tag without minting a GH label per
+  slice. This gives Serena's granularity (chat page / composer / settings /
+  file viewer, runner-start / shutdown / server-comms) for routing and metrics
+  **without dozens of flat labels to sync** — the repo has no label-sync, so
+  keeping the label set small matters.
+
+**Top-level labels — recommended set:**
+
+| Label | Open | Action |
 |---|---|---|
-| `comp:harnesses` | 148 | Split by **tier** — `-t1/-t2/-t3` (Axis 3). |
-| `comp:runner` | 109 | **Carve out `comp:sandbox`** (~29 of the 109 are sandbox/isolation: bwrap/seatbelt/egress). Distinct discipline, security-grade severity, home of the top P0 (#3557). Makes the security surface *filterable*, not just score-boosted. |
-| `comp:web-ui` | 99 | **Add `comp:mobile`** (~23: iOS/Android OIDC, renderer death, iPad layout) — a different failure domain and reporter set from browser-web (~55). Defer `comp:desktop`/electron (~11): borderline, revisit if it grows. |
-| `comp:server` | 135 | **Leave as-is.** Its sub-buckets (host 55, db 36, sdk 65) overlap heavily on the same session/API issues; splitting would just multi-label without aiding prioritization. |
-| `comp:tui` · `comp:infra` · `comp:repr` · `comp:policies` | 40 / 34 / 13 / 21 | **Leave as-is** — small enough to prioritize within; splitting adds labels without payoff. `comp:policies` already isolates the guardrail surface. |
+| `comp:harnesses` | 148 | Split by **tier** `-t1/-t2/-t3` (Axis 3); add a `sub_area` for **SDK vs native** and the specific harness (per review — SDK and native are different failure domains). |
+| `comp:runner` | 109 | **Carve out `comp:sandbox`** (~29: bwrap/seatbelt/egress — security-grade, home of P0 #3557). Keep runner sub-areas (start / shutdown / server+terminal comms) as `sub_area`, not labels. |
+| `comp:web-ui` | 99 | **Add `comp:mobile`** with device sub-tags **desktop / mobile-iOS / mobile-Android** (~23 mobile, ~11 desktop). Keep UI surfaces (chat / composer / session-nav / settings / file-viewer / comment-panel) as `sub_area`. |
+| `comp:server` | 135 | Keep the label, **but add `comp:auth`** as its own label (per review — auth is a distinct surface with types: local / multi-user / OIDC / OAuth / Databricks) and mark **web-UI-critical APIs** so a break there grades P0 (Axis 2). Other server sub-areas (host / db) stay `sub_area`. |
+| `comp:tui` · `comp:infra` · `comp:repr` · `comp:policies` | 40 / 34 / 13 / 21 | Keep as-is; use `sub_area` if a slice ever needs filtering. |
 
-Net new labels: **`comp:sandbox`** and **`comp:mobile`** (plus the three harness
-tier labels). Everything else stays. `sandbox` and `policies` remain
-first-class (see Sandbox / security below); we're promoting `sandbox` from an
-area that collapses into `comp:runner` to its own label, not inventing a new
-concept.
+**Net new top-level labels:** `comp:sandbox`, `comp:mobile`, `comp:auth`, plus
+the three `comp:harness-t*` tiers. Everything finer rides on `sub_area`.
 
-Naming note: `comp:sandbox` (narrow) is preferred over a broad `comp:security`
-umbrella — "security" would pull in the 120 credential/auth issues that mostly
-belong to `comp:server`/onboarding, re-creating a mega-bucket. Sandbox/policy
-*bypass* severity is handled by the rubric (Axis 2), not by an umbrella label.
+Naming note: `comp:sandbox` (narrow) over a broad `comp:security` umbrella —
+"security" would swallow the 120 credential/auth issues (now mostly `comp:auth`
+/ server), re-creating a mega-bucket. Sandbox/policy *bypass* severity is handled
+by the P0 rubric (Axis 2), not by an umbrella label.
+
+**Trade-off, stated honestly:** this is more labels than my first draft argued
+for. The review's call is that granularity earns its keep here — it drives
+reviewer routing too, not just the score. The `sub_area` tag is the pressure
+valve that lets us be granular without unbounded label growth.
 
 ### Axis 4 — The composite score (the ordering primitive)
 
@@ -224,12 +290,22 @@ base  = severity_weight              # LLM-graded from content (P0/P1/P2/P3-ish,
       × readiness                    # ready-to-work 1.1 · normal 1.0 · needs-info 0.85 (Axis 6)
 
 score = apply_demand(base, type)     # type-dependent — see "Community demand" below
-      × recency_factor               # 1.0 fresh; gentle decay past ~30d (tunable)
+      × age_factor                   # DEFAULT 1.0 (neutral) — see note below
 ```
 
-Every weight is a named constant in one place. The score is **advisory
-ordering** layered on top of the labels; labels stay authoritative for
-filtering, the score decides *what to look at first*.
+Every weight is a named constant in one place. The score is the **continuous
+ordering**; the priority label (Axis 2) is the bucket it lands in. Labels stay
+authoritative for filtering, the score decides *what to look at first* within
+and across them.
+
+**On age (open review point).** An earlier draft *decayed* old issues. Review
+pushed back: a real bug we haven't fixed in 30 days isn't *less* important — if
+anything it's a sign we should **escalate**, not bury it. So the default is
+**neutral (age_factor = 1.0)**; age does not lower the score. We surface aging
+instead through the metrics ("priority age separation") and can add an *upward*
+staleness escalation later if we want, rather than a downward decay. (The dry-run
+defaults to neutral age; the old decaying variant is behind a `DECAY_OLD` flag
+in `score_prototype.py` for comparison only.)
 
 **Worked example — one issue, data points → score.** Take
 [#3265](https://github.com/omnigent-ai/omnigent/issues/3265) ("claude-sdk agent
@@ -244,7 +320,7 @@ with linux_bwrap dies at spawn"):
 | × readiness | × 1.1 | 400+ char body with repro steps → ready to work |
 | = base | **92.4** | |
 | × demand (bug) | + 0 | 0 reactions; bugs get only the additive tiebreak |
-| × recency | × 1.0 | 10 days old, under the 30-day decay threshold |
+| × age | × 1.0 | neutral by default — age never lowers the score |
 | **= score** | **≈ 92** | ranks **#3** of 360 (was #37 by priority label) |
 
 Contrast a vague, low-tier ticket: severity 30 (medium) × reach 0.9
@@ -292,13 +368,26 @@ carry dup links.
 
 A ticket you can *start on now* — repro steps, a real body — is worth surfacing
 above an equally-severe but vague one. `readiness` is a small multiplier: 1.1
-for a bug with a repro section and a ≥400-char body (or any substantive FR),
-0.85 for anything labeled `needs-info` (explicitly blocked on the reporter),
-1.0 otherwise. It's deliberately gentle — it breaks near-ties, it never
-overrides severity. On the current backlog it bumps 272 issues, penalizes only
-the 4 `needs-info` ones (today `needs-info` is applied to **0** open bugs, so
-this also gives the classifier a reason to use it). Cheap to compute from
-existing fields; the production grader can set it directly.
+for a bug with a repro section and a ≥400-char body (or any substantive FR), 1.0
+otherwise. It's deliberately gentle — it breaks near-ties, it never overrides
+severity.
+
+**`needs-info` vs partial info (review clarification).** These are two different
+states and the design treats them differently:
+
+- **`needs-info` = genuinely incomprehensible** — we can't tell what's going on
+  from the description at all. These get **no priority** (Serena's point: don't
+  prioritize or assign a reviewer to something we can't understand); the pending
+  backfill leaves priority unset until the reporter responds. In the score they
+  sit at `readiness = 0.85`, but the more important effect is having no priority
+  label to sort by.
+- **Partial info** — comprehensible, but missing a repro or a demo. These are
+  **not** `needs-info`; we still grade and prioritize them, because a serious bug
+  is worth looking at even without a clean repro (Pat's point). They just don't
+  get the +1.1 readiness bump.
+
+Today `needs-info` is on **0** open bugs, so the backfill also gives the
+classifier an explicit reason to apply it — only to the incomprehensible ones.
 
 ### Ongoing adjustment — re-grade severity, don't add a pin lever
 
@@ -338,7 +427,7 @@ merely disagree with a neighbor in a tie:
 | Grader misread severity (a real P1 sitting at P2, or vice versa) | Change the priority label. Done — it sticks. |
 | Right severity, wrong reach (e.g. "affects all users" missed) | Same: bump the label; reach feeds severity's bucket. |
 | A security/sandbox/policy **bypass** graded as ordinary | Set `P0-critical` — bypass is top severity regardless of reach (Axis 2). |
-| Blocked on the reporter | Add `needs-info` (drops readiness ×0.85); don't fight the score. |
+| Truly incomprehensible | Add `needs-info` and leave priority unset (don't prioritize what we can't understand). Partial-but-serious info: keep prioritizing, skip the label. |
 | You just prefer a different order *within the same grade* | **Don't.** Ties are arbitrary by design; re-grading here is noise. |
 
 **When NOT to correct — fix the system instead.** A hand-edit fixes one issue; a
@@ -428,13 +517,17 @@ regex can't reason about severity, so production must grade with the LLM.
 The bug template asks Version + OS but both optional → sparse. Add structured,
 **dropdown** fields (dropdowns beat free-text for scoring signal):
 
-- **Harness** (dropdown: claude / codex / cursor / … / n/a) — the #1 component,
-  currently buried in prose. Feeds tier directly.
-- **Platform / device** (dropdown: macOS / Linux / Windows / iOS / Android /
-  Docker) — a whole class of bugs is platform-specific (Windows setup crashes,
-  iOS/Android OIDC, Linux aarch64). Feeds reach.
+- **Harness** (dropdown: claude / codex / cursor / … / n/a) **+ mode (SDK /
+  native)** — the #1 component, currently buried in prose. Feeds tier directly;
+  the SDK-vs-native split feeds `sub_area` (per review).
+- **Platform / device** (dropdown: macOS / Linux / Windows / **desktop /
+  mobile-iOS / mobile-Android** / Docker) — a whole class of bugs is
+  platform-specific (Windows setup crashes, iOS/Android OIDC, Linux aarch64).
+  Feeds reach and the `comp:mobile` device sub-tag.
 - **Impact / reach** (dropdown: all users / most / some / edge) — the reach axis
   the reporter can often answer better than the grader.
+- **Auth type** (dropdown: local / multi-user / OIDC / OAuth / Databricks /
+  n-a) — shown for auth issues; feeds `comp:auth` (per review).
 
 Keep them optional (the pipeline already triages from description alone) but
 dropdowns cost the reporter nothing and sharpen severity × reach.
@@ -464,14 +557,16 @@ Two concrete changes:
 ## Rollout
 
 1. **Prompt re-calibration** (`.github/triage/config.yaml`) — new priority
-   rubric (grade FRs across buckets; security/sandbox → P0) + the "P1 scarcity"
-   guardrail + emit `severity` and `readiness` fields. Low risk, affects new
-   issues immediately.
-2. **Component labels** — add `comp:harness-t1/-t2/-t3` (map each harness area
-   in `areas.json` to a tier), plus `comp:sandbox` and `comp:mobile`; update the
-   classifier allowlist and backfill existing `comp:harnesses` / `comp:runner` /
-   `comp:web-ui` issues into the new labels. See "Component taxonomy."
-3. **Template fields** — add Harness / Platform / Impact dropdowns.
+   rubric (grade FRs across buckets; explicit P0 list; tier-1 floor) + the "P1
+   scarcity" guardrail + emit `severity`, `readiness`, and `sub_area` fields.
+   Low risk, affects new issues immediately.
+2. **Component labels** — add `comp:harness-t1/-t2/-t3` (map each harness area in
+   `areas.json` to a tier; confirm the T2 cut incl. Pi/opencode in the team
+   channel), plus `comp:sandbox`, `comp:mobile`, `comp:auth`; add the `sub_area`
+   taxonomy for finer routing (SDK/native, UI surface, runner phase, device).
+   Update the classifier allowlist and backfill. See "Component taxonomy."
+3. **Template fields** — add Harness (+SDK/native) / Platform-device / Impact /
+   Auth-type dropdowns.
 4. **Scoring job** — productionize `score_prototype.py` into a scheduled action
    that reads LLM-graded severity + readiness + dup count and publishes the
    ranked view.
@@ -541,13 +636,14 @@ current priority-label ordering (positive = moved up).
 deliberately-weak grader, so its own failures are visible on purpose: ranks 1–2
 (#2057/#2054) are FRs that merely *mention* "sandbox bypass" and are graded
 critical — they sit above the real P0 (#3557, rank 6), so **the very top is
-backwards**; #61 (rank 19) is a *bot* audit issue. That's the doc's thesis made
-concrete: regex can't grade severity. The scaffold is sound — strip those
-artifacts and the genuine tier-1 bugs (#3265, #3557, #3270, #3180, #2373)
-cluster correctly in the top 15. Scores also *tie* in coarse bands (nine issues
-share 99/92), so within-band order is arbitrary — read this as ~8 tiers, not 200
-ranks. With the LLM grader plus ≤10% hand-correction (see the maintainer guide),
-this is the shape the production ranking takes.
+backwards**; #61 (rank 9) is a *bot* audit issue riding a "security" keyword.
+That's the doc's thesis made concrete: regex can't grade severity. The scaffold
+is sound — strip those artifacts and the genuine tier-1 bugs (#3265, #3557,
+#3270, #3180, #2373) cluster correctly in the top 16. Scores also *tie* in coarse
+bands (many issues share 92/84/…), so within-band order is arbitrary — read this
+as a handful of tiers, not 200 true ranks. Age is now neutral (review point), so
+older issues no longer decay. With the LLM grader plus ≤10% hand-correction (see
+the maintainer guide), this is the shape the production ranking takes.
 
 | # | Score | Sev | Now | Δrank | Issue |
 |--:|--:|---|---|--:|---|
@@ -559,31 +655,31 @@ this is the shape the production ranking takes.
 | 6 | 110 | critical | P0-critical | -5 | [#3557](https://github.com/omnigent-ai/omnigent/issues/3557) [Bug] Shell-surface policy gates are bypassed by option-taking command |
 | 7 | 110 | critical | P1-high | +28 | [#3270](https://github.com/omnigent-ai/omnigent/issues/3270) [Bug] sys_session_create children are absent from both sys_session_lis |
 | 8 | 104 | critical | P2-medium | +224 | [#2125](https://github.com/omnigent-ai/omnigent/issues/2125) [Feature] Multi-host git credentials for managed sandboxes (GitHub + s |
-| 9 | 99 | high | P2-medium | +127 | [#3976](https://github.com/omnigent-ai/omnigent/issues/3976) [Feature] OAuth2 client-credentials grant so a headless process can au |
-| 10 | 99 | high | P2-medium | +154 | [#3363](https://github.com/omnigent-ai/omnigent/issues/3363) [Feature] Per-project custom instructions (project-scoped context) |
-| 11 | 99 | high | P2-medium | +166 | [#3164](https://github.com/omnigent-ai/omnigent/issues/3164) [Feature] Optional runtimeClassName on the kubernetes sandbox provider |
-| 12 | 95 | high | P2-medium | +264 | [#1388](https://github.com/omnigent-ai/omnigent/issues/1388) Make agents a first-class CRUD entity with a dedicated sidebar UI (dec |
-| 13 | 92 | high | P1-high | +28 | [#3180](https://github.com/omnigent-ai/omnigent/issues/3180) codex-native: runner never exits on idle timeout — cancelled delta-coa |
-| 14 | 92 | high | P1-high | +68 | [#2373](https://github.com/omnigent-ai/omnigent/issues/2373) [Bug] claude-native: pasted web-UI message loses its Enter, stuck draf |
-| 15 | 92 | high | P1-high | +79 | [#2060](https://github.com/omnigent-ai/omnigent/issues/2060) [Bug] claude-native: first web-UI message silently dropped when Claude |
-| 16 | 91 | high | P1-high | +87 | [#1898](https://github.com/omnigent-ai/omnigent/issues/1898) [Bug] codex-native: cancelling a task awaiting flush() poisons the del |
-| 17 | 91 | critical | P2-medium | +298 | [#659](https://github.com/omnigent-ai/omnigent/issues/659) [Feature] add a microvm backend for sandbox |
-| 18 | 90 | high | P1-high | +34 | [#3001](https://github.com/omnigent-ai/omnigent/issues/3001) [Performance] GET /v1/sessions pre-fetches every accessible conversati |
-| 19 | 90 | critical | P3-low | +330 | [#61](https://github.com/omnigent-ai/omnigent/issues/61) 🤖 Code Audit: 21 potential issue(s) found |
-| 20 | 85 | high | P2-medium | +296 | [#654](https://github.com/omnigent-ai/omnigent/issues/654) [Bug] Streaming with codex is hanging and paragraphs are not split. |
-| 21 | 84 | high | P1-high | +106 | [#542](https://github.com/omnigent-ai/omnigent/issues/542) [Bug] AttributeError: 'SubprocessCLITransport' object has no attribute |
-| 22 | 84 | high | P2-medium | +132 | [#3558](https://github.com/omnigent-ai/omnigent/issues/3558) claude-sdk: cached client does not rebuild on framework-instruction ch |
-| 23 | 84 | high | P1-high | +30 | [#3000](https://github.com/omnigent-ai/omnigent/issues/3000) claude-native transcript forwarder polls at 4 Hz per session with no i |
-| 24 | 84 | high | P1-high | +38 | [#2748](https://github.com/omnigent-ai/omnigent/issues/2748) Runner idle-shutdown deadlocks forever: codex-forwarder close()/flush( |
-| 25 | 84 | high | P1-high | +42 | [#2575](https://github.com/omnigent-ai/omnigent/issues/2575) pi-native: non-Claude Databricks models (GLM, Gemini, …) hang — provid |
-| 26 | 84 | high | P1-high | +46 | [#2454](https://github.com/omnigent-ai/omnigent/issues/2454) [Bug] Unbounded ~/.omnigent growth: per-session native-harness dirs ar |
-| 27 | 84 | high | P1-high | +53 | [#2421](https://github.com/omnigent-ai/omnigent/issues/2421) [Bug] codex app-server + MCP bridge children leak on ANY unclean runne |
-| 28 | 84 | high | P2-medium | +267 | [#1051](https://github.com/omnigent-ai/omnigent/issues/1051) [Feature] Forward OTel exporter knobs to executor subprocess env |
-| 29 | 81 | high | P2-medium | +108 | [#3970](https://github.com/omnigent-ai/omnigent/issues/3970) pi-native: every turn fails with "Pi model error: 401 Invalid Token" w |
-| 30 | 77 | high | P2-medium | +275 | [#888](https://github.com/omnigent-ai/omnigent/issues/888) [Feature] Side-by-side multi-session view |
-| 31 | 70 | high | P1-high | +7 | [#3261](https://github.com/omnigent-ai/omnigent/issues/3261) [Crash] AttributeError: module 'os' has no attribute 'WNOHANG' |
-| 32 | 69 | high | P2-medium | +302 | [#16](https://github.com/omnigent-ai/omnigent/issues/16) Is native Windows support in scope, or should docs recommend WSL2? |
-| 33 | 68 | high | P2-medium | +296 | [#151](https://github.com/omnigent-ai/omnigent/issues/151) Native claude_code worker hangs on the one-time Bypass Permissions acc |
+| 9 | 100 | critical | P3-low | +340 | [#61](https://github.com/omnigent-ai/omnigent/issues/61) 🤖 Code Audit: 21 potential issue(s) found |
+| 10 | 99 | high | P2-medium | +126 | [#3976](https://github.com/omnigent-ai/omnigent/issues/3976) [Feature] OAuth2 client-credentials grant so a headless process can au |
+| 11 | 99 | high | P2-medium | +153 | [#3363](https://github.com/omnigent-ai/omnigent/issues/3363) [Feature] Per-project custom instructions (project-scoped context) |
+| 12 | 99 | high | P2-medium | +165 | [#3164](https://github.com/omnigent-ai/omnigent/issues/3164) [Feature] Optional runtimeClassName on the kubernetes sandbox provider |
+| 13 | 99 | high | P2-medium | +263 | [#1388](https://github.com/omnigent-ai/omnigent/issues/1388) Make agents a first-class CRUD entity with a dedicated sidebar UI (dec |
+| 14 | 99 | critical | P2-medium | +301 | [#659](https://github.com/omnigent-ai/omnigent/issues/659) [Feature] add a microvm backend for sandbox |
+| 15 | 92 | high | P1-high | +26 | [#3180](https://github.com/omnigent-ai/omnigent/issues/3180) codex-native: runner never exits on idle timeout — cancelled delta-coa |
+| 16 | 92 | high | P1-high | +66 | [#2373](https://github.com/omnigent-ai/omnigent/issues/2373) [Bug] claude-native: pasted web-UI message loses its Enter, stuck draf |
+| 17 | 92 | high | P1-high | +77 | [#2060](https://github.com/omnigent-ai/omnigent/issues/2060) [Bug] claude-native: first web-UI message silently dropped when Claude |
+| 18 | 92 | high | P1-high | +85 | [#1898](https://github.com/omnigent-ai/omnigent/issues/1898) [Bug] codex-native: cancelling a task awaiting flush() poisons the del |
+| 19 | 92 | high | P2-medium | +297 | [#654](https://github.com/omnigent-ai/omnigent/issues/654) [Bug] Streaming with codex is hanging and paragraphs are not split. |
+| 20 | 92 | high | P1-high | +107 | [#542](https://github.com/omnigent-ai/omnigent/issues/542) [Bug] AttributeError: 'SubprocessCLITransport' object has no attribute |
+| 21 | 90 | high | P1-high | +31 | [#3001](https://github.com/omnigent-ai/omnigent/issues/3001) [Performance] GET /v1/sessions pre-fetches every accessible conversati |
+| 22 | 89 | high | P2-medium | +273 | [#1051](https://github.com/omnigent-ai/omnigent/issues/1051) [Feature] Forward OTel exporter knobs to executor subprocess env |
+| 23 | 84 | high | P2-medium | +131 | [#3558](https://github.com/omnigent-ai/omnigent/issues/3558) claude-sdk: cached client does not rebuild on framework-instruction ch |
+| 24 | 84 | high | P1-high | +29 | [#3000](https://github.com/omnigent-ai/omnigent/issues/3000) claude-native transcript forwarder polls at 4 Hz per session with no i |
+| 25 | 84 | high | P1-high | +37 | [#2748](https://github.com/omnigent-ai/omnigent/issues/2748) Runner idle-shutdown deadlocks forever: codex-forwarder close()/flush( |
+| 26 | 84 | high | P1-high | +41 | [#2575](https://github.com/omnigent-ai/omnigent/issues/2575) pi-native: non-Claude Databricks models (GLM, Gemini, …) hang — provid |
+| 27 | 84 | high | P1-high | +45 | [#2454](https://github.com/omnigent-ai/omnigent/issues/2454) [Bug] Unbounded ~/.omnigent growth: per-session native-harness dirs ar |
+| 28 | 84 | high | P1-high | +52 | [#2421](https://github.com/omnigent-ai/omnigent/issues/2421) [Bug] codex app-server + MCP bridge children leak on ANY unclean runne |
+| 29 | 83 | high | P2-medium | +276 | [#888](https://github.com/omnigent-ai/omnigent/issues/888) [Feature] Side-by-side multi-session view |
+| 30 | 81 | high | P2-medium | +107 | [#3970](https://github.com/omnigent-ai/omnigent/issues/3970) pi-native: every turn fails with "Pi model error: 401 Invalid Token" w |
+| 31 | 78 | high | P2-medium | +303 | [#16](https://github.com/omnigent-ai/omnigent/issues/16) Is native Windows support in scope, or should docs recommend WSL2? |
+| 32 | 76 | high | P2-medium | +297 | [#151](https://github.com/omnigent-ai/omnigent/issues/151) Native claude_code worker hangs on the one-time Bypass Permissions acc |
+| 33 | 70 | high | P1-high | +5 | [#3261](https://github.com/omnigent-ai/omnigent/issues/3261) [Crash] AttributeError: module 'os' has no attribute 'WNOHANG' |
 | 34 | 66 | high | P2-medium | +112 | [#3750](https://github.com/omnigent-ai/omnigent/issues/3750) [Crash] PermissionError: [Errno 1] Operation not permitted |
 | 35 | 66 | high | P1-high | -7 | [#3482](https://github.com/omnigent-ai/omnigent/issues/3482) [Crash] ServerError: |
 | 36 | 66 | high | P1-high | -6 | [#3458](https://github.com/omnigent-ai/omnigent/issues/3458) session-updates stream crashes with KeyError when a client watches a c |
@@ -599,155 +695,155 @@ this is the shape the production ranking takes.
 | 46 | 66 | high | P0-critical | -44 | [#2355](https://github.com/omnigent-ai/omnigent/issues/2355) [Bug] workspace_id PK-widening migration crashes on populated Postgres |
 | 47 | 66 | high | P3-low | +294 | [#2224](https://github.com/omnigent-ai/omnigent/issues/2224) [Bug] get_client model-change check fails for harness="any" |
 | 48 | 66 | high | P1-high | +50 | [#1985](https://github.com/omnigent-ai/omnigent/issues/1985) Headless `omnigent run -p` intermittently hangs forever despite the tu |
-| 49 | 65 | high | P2-medium | +159 | [#2714](https://github.com/omnigent-ai/omnigent/issues/2714) Upgrade openai-agents and remove the temporary openai<2.45 cap |
-| 50 | 65 | high | P1-high | +40 | [#2245](https://github.com/omnigent-ai/omnigent/issues/2245) [Bug] openai-agents harness turn wedges permanently after policy-verdi |
-| 51 | 65 | high | P2-medium | +193 | [#1907](https://github.com/omnigent-ai/omnigent/issues/1907) Sub-agent model_override triggers an unnecessary first-turn harness re |
-| 52 | 65 | high | P1-high | +52 | [#1888](https://github.com/omnigent-ai/omnigent/issues/1888) ansi-to-react default import resolves to the CJS exports object under  |
-| 53 | 65 | high | P2-medium | +200 | [#1804](https://github.com/omnigent-ai/omnigent/issues/1804) spec parser crashes with TypeError on a null tools.builtins key (and s |
-| 54 | 62 | high | P2-medium | +235 | [#1076](https://github.com/omnigent-ai/omnigent/issues/1076) Runner-layer Tier-2 escalation: release an unresponsive per-conversati |
-| 55 | 62 | high | P1-high | +66 | [#1026](https://github.com/omnigent-ai/omnigent/issues/1026) Runner orphans tool callbacks with "no active turn context" after mid- |
-| 56 | 60 | high | P1-high | -48 | [#3971](https://github.com/omnigent-ai/omnigent/issues/3971) Host runners inherit the daemon's cwd; a deleted launch dir breaks eve |
-| 57 | 60 | high | P1-high | -23 | [#3274](https://github.com/omnigent-ai/omnigent/issues/3274) Sub-agent terminal status rejected with missing_parent_inbox and retri |
-| 58 | 60 | high | P2-medium | +114 | [#3235](https://github.com/omnigent-ai/omnigent/issues/3235) Flaky E2E UI: test_scheduled_task_create_edit_modal_and_time_picker[ch |
-| 59 | 60 | high | P1-high | -12 | [#3016](https://github.com/omnigent-ai/omnigent/issues/3016) [Bug] A transient session-snapshot failure permanently pins a session  |
-| 60 | 60 | high | P1-high | -12 | [#3012](https://github.com/omnigent-ai/omnigent/issues/3012) Hosts authenticated via `omnigent login` permanently 403 on first reco |
-| 61 | 60 | high | P2-medium | +157 | [#2428](https://github.com/omnigent-ai/omnigent/issues/2428) sys_session_send to a completed session hangs to ReadTimeout and is si |
-| 62 | 60 | high | P1-high | +29 | [#2241](https://github.com/omnigent-ai/omnigent/issues/2241) Flaky on main: test_interrupt_forwards_to_harness_before_cancelling ti |
-| 63 | 60 | high | P1-high | +33 | [#2051](https://github.com/omnigent-ai/omnigent/issues/2051) [Bug] sys_session_send(session_id=…) completions never drain to sys_re |
-| 64 | 59 | medium | P2-medium | +204 | [#1596](https://github.com/omnigent-ai/omnigent/issues/1596) Native-CLI harness (claude-native/codex-native) as a named agent's own |
-| 65 | 59 | high | P1-high | -48 | [#3799](https://github.com/omnigent-ai/omnigent/issues/3799) Android shell cannot sign in to servers behind a front-door auth proxy |
-| 66 | 59 | high | P1-high | -46 | [#3730](https://github.com/omnigent-ai/omnigent/issues/3730) [Bug] Android: renderer death terminates the app — OmnigentWebViewClie |
-| 67 | 59 | high | P1-high | -45 | [#3701](https://github.com/omnigent-ai/omnigent/issues/3701) [Bug] Desktop app never completes Okta security key / biometric MFA du |
-| 68 | 59 | high | P1-high | -35 | [#3299](https://github.com/omnigent-ai/omnigent/issues/3299) [Bug] Harness-credential route times out with a misleading 504 against |
-| 69 | 59 | high | P2-medium | +97 | [#3284](https://github.com/omnigent-ai/omnigent/issues/3284) [Crash] DuplicateOptionError: While reading from PosixPath('/Users/*** |
-| 70 | 59 | high | P2-medium | +114 | [#3070](https://github.com/omnigent-ai/omnigent/issues/3070) No progress signal on a stuck or interactive harness install |
-| 71 | 59 | high | P1-high | -16 | [#2967](https://github.com/omnigent-ai/omnigent/issues/2967) [Bug] A full context window bricks a session with "Prompt is too long" |
-| 72 | 59 | high | P2-medium | +144 | [#2480](https://github.com/omnigent-ai/omnigent/issues/2480) [Bug] Postgres-backed local server: bare `No module named 'psycopg'` + |
-| 73 | 59 | high | P1-high | +15 | [#2270](https://github.com/omnigent-ai/omnigent/issues/2270) Windows: config list crashes — UnicodeEncodeError on cp1252 (non-UTF8) |
-| 74 | 59 | high | P1-high | +15 | [#2269](https://github.com/omnigent-ai/omnigent/issues/2269) Windows: omnigent setup crashes — ModuleNotFoundError: No module named |
-| 75 | 59 | high | P1-high | +24 | [#1953](https://github.com/omnigent-ai/omnigent/issues/1953) `omni host` dies permanently when the OIDC session JWT expires — no re |
-| 76 | 59 | high | P1-high | +26 | [#1901](https://github.com/omnigent-ai/omnigent/issues/1901) [Bug] kimi/qwen/goose/kiro forwarders blind-retry failed conversation- |
-| 77 | 59 | high | P1-high | +28 | [#1881](https://github.com/omnigent-ai/omnigent/issues/1881) [Bug] `omnigent setup` crashes with `ValueError: select() requires at  |
-| 78 | 58 | high | P0-critical | -75 | [#1657](https://github.com/omnigent-ai/omnigent/issues/1657) hermes-native forwarder advances last_id per item, dropping a row's la |
-| 79 | 58 | high | P1-high | +29 | [#1827](https://github.com/omnigent-ai/omnigent/issues/1827) [Bug] kimi-native: torn UTF-8 wire read crashes the forwarder; supervi |
-| 80 | 58 | high | P2-medium | +187 | [#1600](https://github.com/omnigent-ai/omnigent/issues/1600) Epic: 12-feature contribution (one issue + one PR per feature) |
-| 81 | 57 | high | P2-medium | +189 | [#1528](https://github.com/omnigent-ai/omnigent/issues/1528) Idle-session lifecycle UX: reap gracefully, resume seamlessly, surface |
-| 82 | 57 | high | P1-high | +49 | [#108](https://github.com/omnigent-ai/omnigent/issues/108) Cannot install on Linux aarch64 — cel-expr-python has no aarch64 wheel |
-| 83 | 55 | high | P2-medium | +231 | [#678](https://github.com/omnigent-ai/omnigent/issues/678) e2e: sub-agent supervisor routing / named-sub-agent auto-wake flakes ( |
-| 84 | 55 | high | P2-medium | +214 | [#1022](https://github.com/omnigent-ai/omnigent/issues/1022) Behind a corporate proxy, the host daemon can't reach the model backen |
-| 85 | 54 | high | P2-medium | +59 | [#3798](https://github.com/omnigent-ai/omnigent/issues/3798) Android shell shows the SPA as if signed in while native login runs in |
-| 86 | 54 | high | P1-high | -57 | [#3469](https://github.com/omnigent-ai/omnigent/issues/3469) [Bug] Post-completion compaction spiral: merge-commit diff output trig |
-| 87 | 54 | high | P1-high | -22 | [#2629](https://github.com/omnigent-ai/omnigent/issues/2629) web_fetch sub-agent spawn fails with unknown harness 'omnigent' — bare |
-| 88 | 53 | high | P1-high | -39 | [#3011](https://github.com/omnigent-ai/omnigent/issues/3011) kiro-native harness: interactive sessions never respond with kiro-cli  |
-| 89 | 53 | high | P1-high | -33 | [#2920](https://github.com/omnigent-ai/omnigent/issues/2920) Omnigent server fails to start on native Windows: os.getuid() at impor |
-| 90 | 53 | high | P1-high | -33 | [#2919](https://github.com/omnigent-ai/omnigent/issues/2919) omni setup crashes on Windows: ModuleNotFoundError: No module named 't |
-| 91 | 53 | high | P1-high | -12 | [#2422](https://github.com/omnigent-ai/omnigent/issues/2422) Windows: five chained defects break the documented degraded-mode subse |
-| 92 | 53 | medium | P2-medium | +207 | [#1021](https://github.com/omnigent-ai/omnigent/issues/1021) [Feature] GitHub Copilot as provider |
-| 93 | 53 | high | P2-medium | +162 | [#1778](https://github.com/omnigent-ai/omnigent/issues/1778) opencode-native forwarder loses session content across SSE reconnects  |
-| 94 | 50 | medium | P2-medium | +110 | [#2744](https://github.com/omnigent-ai/omnigent/issues/2744) [Bug] codex-native: custom agents time out at launch — native provider |
-| 95 | 49 | high | P1-high | +33 | [#523](https://github.com/omnigent-ai/omnigent/issues/523) REPL pexpect e2e tests starve on boot under full shard load (60s _wait |
-| 96 | 49 | high | P2-medium | +214 | [#762](https://github.com/omnigent-ai/omnigent/issues/762) [Bug] sub agent terminal crashes when cli starts with prompt for input |
+| 49 | 66 | high | P2-medium | +195 | [#1907](https://github.com/omnigent-ai/omnigent/issues/1907) Sub-agent model_override triggers an unnecessary first-turn harness re |
+| 50 | 66 | high | P1-high | +54 | [#1888](https://github.com/omnigent-ai/omnigent/issues/1888) ansi-to-react default import resolves to the CJS exports object under  |
+| 51 | 66 | high | P2-medium | +202 | [#1804](https://github.com/omnigent-ai/omnigent/issues/1804) spec parser crashes with TypeError on a null tools.builtins key (and s |
+| 52 | 66 | high | P2-medium | +237 | [#1076](https://github.com/omnigent-ai/omnigent/issues/1076) Runner-layer Tier-2 escalation: release an unresponsive per-conversati |
+| 53 | 66 | high | P1-high | +68 | [#1026](https://github.com/omnigent-ai/omnigent/issues/1026) Runner orphans tool callbacks with "no active turn context" after mid- |
+| 54 | 65 | high | P2-medium | +154 | [#2714](https://github.com/omnigent-ai/omnigent/issues/2714) Upgrade openai-agents and remove the temporary openai<2.45 cap |
+| 55 | 65 | high | P1-high | +35 | [#2245](https://github.com/omnigent-ai/omnigent/issues/2245) [Bug] openai-agents harness turn wedges permanently after policy-verdi |
+| 56 | 63 | high | P1-high | +75 | [#108](https://github.com/omnigent-ai/omnigent/issues/108) Cannot install on Linux aarch64 — cel-expr-python has no aarch64 wheel |
+| 57 | 61 | medium | P2-medium | +211 | [#1596](https://github.com/omnigent-ai/omnigent/issues/1596) Native-CLI harness (claude-native/codex-native) as a named agent's own |
+| 58 | 60 | high | P1-high | -50 | [#3971](https://github.com/omnigent-ai/omnigent/issues/3971) Host runners inherit the daemon's cwd; a deleted launch dir breaks eve |
+| 59 | 60 | high | P1-high | -25 | [#3274](https://github.com/omnigent-ai/omnigent/issues/3274) Sub-agent terminal status rejected with missing_parent_inbox and retri |
+| 60 | 60 | high | P2-medium | +112 | [#3235](https://github.com/omnigent-ai/omnigent/issues/3235) Flaky E2E UI: test_scheduled_task_create_edit_modal_and_time_picker[ch |
+| 61 | 60 | high | P1-high | -14 | [#3016](https://github.com/omnigent-ai/omnigent/issues/3016) [Bug] A transient session-snapshot failure permanently pins a session  |
+| 62 | 60 | high | P1-high | -14 | [#3012](https://github.com/omnigent-ai/omnigent/issues/3012) Hosts authenticated via `omnigent login` permanently 403 on first reco |
+| 63 | 60 | high | P2-medium | +155 | [#2428](https://github.com/omnigent-ai/omnigent/issues/2428) sys_session_send to a completed session hangs to ReadTimeout and is si |
+| 64 | 60 | high | P1-high | +27 | [#2241](https://github.com/omnigent-ai/omnigent/issues/2241) Flaky on main: test_interrupt_forwards_to_harness_before_cancelling ti |
+| 65 | 60 | high | P1-high | +31 | [#2051](https://github.com/omnigent-ai/omnigent/issues/2051) [Bug] sys_session_send(session_id=…) completions never drain to sys_re |
+| 66 | 60 | high | P0-critical | -63 | [#1657](https://github.com/omnigent-ai/omnigent/issues/1657) hermes-native forwarder advances last_id per item, dropping a row's la |
+| 67 | 60 | high | P2-medium | +247 | [#678](https://github.com/omnigent-ai/omnigent/issues/678) e2e: sub-agent supervisor routing / named-sub-agent auto-wake flakes ( |
+| 68 | 59 | high | P1-high | -51 | [#3799](https://github.com/omnigent-ai/omnigent/issues/3799) Android shell cannot sign in to servers behind a front-door auth proxy |
+| 69 | 59 | high | P1-high | -49 | [#3730](https://github.com/omnigent-ai/omnigent/issues/3730) [Bug] Android: renderer death terminates the app — OmnigentWebViewClie |
+| 70 | 59 | high | P1-high | -48 | [#3701](https://github.com/omnigent-ai/omnigent/issues/3701) [Bug] Desktop app never completes Okta security key / biometric MFA du |
+| 71 | 59 | high | P1-high | -38 | [#3299](https://github.com/omnigent-ai/omnigent/issues/3299) [Bug] Harness-credential route times out with a misleading 504 against |
+| 72 | 59 | high | P2-medium | +94 | [#3284](https://github.com/omnigent-ai/omnigent/issues/3284) [Crash] DuplicateOptionError: While reading from PosixPath('/Users/*** |
+| 73 | 59 | high | P2-medium | +111 | [#3070](https://github.com/omnigent-ai/omnigent/issues/3070) No progress signal on a stuck or interactive harness install |
+| 74 | 59 | high | P1-high | -19 | [#2967](https://github.com/omnigent-ai/omnigent/issues/2967) [Bug] A full context window bricks a session with "Prompt is too long" |
+| 75 | 59 | high | P2-medium | +141 | [#2480](https://github.com/omnigent-ai/omnigent/issues/2480) [Bug] Postgres-backed local server: bare `No module named 'psycopg'` + |
+| 76 | 59 | high | P1-high | +12 | [#2270](https://github.com/omnigent-ai/omnigent/issues/2270) Windows: config list crashes — UnicodeEncodeError on cp1252 (non-UTF8) |
+| 77 | 59 | high | P1-high | +12 | [#2269](https://github.com/omnigent-ai/omnigent/issues/2269) Windows: omnigent setup crashes — ModuleNotFoundError: No module named |
+| 78 | 59 | high | P1-high | +21 | [#1953](https://github.com/omnigent-ai/omnigent/issues/1953) `omni host` dies permanently when the OIDC session JWT expires — no re |
+| 79 | 59 | high | P1-high | +23 | [#1901](https://github.com/omnigent-ai/omnigent/issues/1901) [Bug] kimi/qwen/goose/kiro forwarders blind-retry failed conversation- |
+| 80 | 59 | high | P1-high | +25 | [#1881](https://github.com/omnigent-ai/omnigent/issues/1881) [Bug] `omnigent setup` crashes with `ValueError: select() requires at  |
+| 81 | 59 | high | P1-high | +27 | [#1827](https://github.com/omnigent-ai/omnigent/issues/1827) [Bug] kimi-native: torn UTF-8 wire read crashes the forwarder; supervi |
+| 82 | 59 | high | P2-medium | +185 | [#1600](https://github.com/omnigent-ai/omnigent/issues/1600) Epic: 12-feature contribution (one issue + one PR per feature) |
+| 83 | 59 | high | P2-medium | +187 | [#1528](https://github.com/omnigent-ai/omnigent/issues/1528) Idle-session lifecycle UX: reap gracefully, resume seamlessly, surface |
+| 84 | 58 | high | P2-medium | +214 | [#1022](https://github.com/omnigent-ai/omnigent/issues/1022) Behind a corporate proxy, the host daemon can't reach the model backen |
+| 85 | 57 | medium | P2-medium | +214 | [#1021](https://github.com/omnigent-ai/omnigent/issues/1021) [Feature] GitHub Copilot as provider |
+| 86 | 54 | high | P2-medium | +58 | [#3798](https://github.com/omnigent-ai/omnigent/issues/3798) Android shell shows the SPA as if signed in while native login runs in |
+| 87 | 54 | high | P1-high | -58 | [#3469](https://github.com/omnigent-ai/omnigent/issues/3469) [Bug] Post-completion compaction spiral: merge-commit diff output trig |
+| 88 | 54 | high | P1-high | -23 | [#2629](https://github.com/omnigent-ai/omnigent/issues/2629) web_fetch sub-agent spawn fails with unknown harness 'omnigent' — bare |
+| 89 | 54 | high | P2-medium | +166 | [#1778](https://github.com/omnigent-ai/omnigent/issues/1778) opencode-native forwarder loses session content across SSE reconnects  |
+| 90 | 54 | high | P1-high | +38 | [#523](https://github.com/omnigent-ai/omnigent/issues/523) REPL pexpect e2e tests starve on boot under full shard load (60s _wait |
+| 91 | 53 | high | P1-high | -42 | [#3011](https://github.com/omnigent-ai/omnigent/issues/3011) kiro-native harness: interactive sessions never respond with kiro-cli  |
+| 92 | 53 | high | P1-high | -36 | [#2920](https://github.com/omnigent-ai/omnigent/issues/2920) Omnigent server fails to start on native Windows: os.getuid() at impor |
+| 93 | 53 | high | P1-high | -36 | [#2919](https://github.com/omnigent-ai/omnigent/issues/2919) omni setup crashes on Windows: ModuleNotFoundError: No module named 't |
+| 94 | 53 | high | P1-high | -15 | [#2422](https://github.com/omnigent-ai/omnigent/issues/2422) Windows: five chained defects break the documented degraded-mode subse |
+| 95 | 53 | high | P2-medium | +215 | [#762](https://github.com/omnigent-ai/omnigent/issues/762) [Bug] sub agent terminal crashes when cli starts with prompt for input |
+| 96 | 50 | medium | P2-medium | +108 | [#2744](https://github.com/omnigent-ai/omnigent/issues/2744) [Bug] codex-native: custom agents time out at launch — native provider |
 | 97 | 46 | medium | P1-high | -87 | [#3952](https://github.com/omnigent-ai/omnigent/issues/3952) A stale terminal exit removes the newer Codex resources of the same se |
 | 98 | 46 | medium | P2-medium | +93 | [#2984](https://github.com/omnigent-ai/omnigent/issues/2984) [Bug] Codex incorrectly reports `needs-auth` with an authenticated cus |
 | 99 | 46 | medium | P1-high | -7 | [#2184](https://github.com/omnigent-ai/omnigent/issues/2184) [Bug] Codex plugin skills are exposed with inconsistent names (`plugin |
 | 100 | 46 | medium | P1-high | -7 | [#2071](https://github.com/omnigent-ai/omnigent/issues/2071) [Bug] web_search never advertised to claude-sdk sessions: unprefixed m |
 | 101 | 46 | medium | P2-medium | +134 | [#2062](https://github.com/omnigent-ai/omnigent/issues/2062) [Bug] claude-native: per-session model override silently lost when wra |
-| 102 | 45 | medium | P1-high | +5 | [#1831](https://github.com/omnigent-ai/omnigent/issues/1831) claude-native workers ignore executor.model pin and per-dispatch args. |
-| 103 | 45 | medium | P1-high | +7 | [#1781](https://github.com/omnigent-ai/omnigent/issues/1781) codex harness: ambient DATABRICKS_BEARER/DATABRICKS_TOKEN overrides pr |
-| 104 | 44 | medium | P1-high | +15 | [#1128](https://github.com/omnigent-ai/omnigent/issues/1128) [Bug] Claude SDK Appears to Use Opus Instead of Selected Model |
-| 105 | 42 | medium | P1-high | -87 | [#3790](https://github.com/omnigent-ai/omnigent/issues/3790) force_sandbox policy is evaluated but structurally unreachable from cl |
-| 106 | 42 | medium | P1-high | +24 | [#241](https://github.com/omnigent-ai/omnigent/issues/241) pi harness: GPT and Gemini dispatches 404 on the Databricks ucode gate |
-| 107 | 42 | medium | P3-low | +240 | [#147](https://github.com/omnigent-ai/omnigent/issues/147) Tracking: gradual decomposition of monolith modules (cli.py 9.1KLOC, c |
-| 108 | 42 | medium | P1-high | -50 | [#2904](https://github.com/omnigent-ai/omnigent/issues/2904) [Bug] claude-native: web-UI chat input fails with "tmux command failed |
-| 109 | 42 | medium | P1-high | -28 | [#2397](https://github.com/omnigent-ai/omnigent/issues/2397) [Bug] Codex-native intelligent routing ignores live effort capabilitie |
-| 110 | 42 | medium | P1-high | -23 | [#2272](https://github.com/omnigent-ai/omnigent/issues/2272) [Bug] Codex runner can't find OpenRouter secret that exists in keyring |
-| 111 | 41 | medium | P2-medium | +147 | [#1724](https://github.com/omnigent-ai/omnigent/issues/1724) codex-native harness times out on WSL2 ("Codex TUI never started a thr |
-| 112 | 39 | medium | P2-medium | +192 | [#890](https://github.com/omnigent-ai/omnigent/issues/890) [Bug] omnigent setup fails with npm EACCES when installing the Claude  |
-| 113 | 38 | medium | P1-high | -97 | [#3852](https://github.com/omnigent-ai/omnigent/issues/3852) [Bug] Built-in write policies miss Claude Code's `MultiEdit` / `Notebo |
-| 114 | 38 | medium | P2-medium | +110 | [#2369](https://github.com/omnigent-ai/omnigent/issues/2369) [Bug] pi harness only lists databricks-claude-sonnet-4-6 |
-| 115 | 38 | medium | P1-high | -29 | [#2299](https://github.com/omnigent-ai/omnigent/issues/2299) [Bug] claude-native resume transcripts flatten tool_result image block |
-| 116 | 38 | medium | P2-medium | +105 | [#2390](https://github.com/omnigent-ai/omnigent/issues/2390) Builtin policy for per-user sub-agent access control (subagent_access_ |
-| 117 | 38 | medium | P1-high | +8 | [#668](https://github.com/omnigent-ai/omnigent/issues/668) [Bug] BUG？omni claude times out (60s) on macOS with native Claude Code |
-| 118 | 37 | medium | P1-high | -9 | [#1794](https://github.com/omnigent-ai/omnigent/issues/1794) Bundled Polly: claude-sdk brain "Not logged in" + runaway spawn loop o |
-| 119 | 37 | medium | P1-high | -77 | [#3101](https://github.com/omnigent-ai/omnigent/issues/3101) Docker/Kubernetes entrypoint never wires project_store — first-class P |
-| 120 | 37 | medium | P1-high | -9 | [#1694](https://github.com/omnigent-ai/omnigent/issues/1694) Reliability: parallel code-fix missions fail silently (5s tmux timeout |
-| 121 | 35 | medium | P2-medium | +116 | [#2055](https://github.com/omnigent-ai/omnigent/issues/2055) [Bug] codex-native harness elicitation: a resolve landing in the betwe |
-| 122 | 35 | medium | P1-high | -78 | [#3076](https://github.com/omnigent-ai/omnigent/issues/3076) [Bug] claude-sdk omits ToolSearch, eagerly loading every MCP schema |
-| 123 | 35 | medium | P3-low | +216 | [#2800](https://github.com/omnigent-ai/omnigent/issues/2800) [Bug] Top-level custom codex-native agents drop reasoning effort and y |
-| 124 | 34 | medium | P2-medium | +159 | [#1192](https://github.com/omnigent-ai/omnigent/issues/1192) [Bug] Manual /compact errors "Compaction requires a configured LLM mod |
-| 125 | 34 | medium | P1-high | -8 | [#1158](https://github.com/omnigent-ai/omnigent/issues/1158) [Bug] antigravity-native: TUI-typed turns never mirror to the web UI ( |
-| 126 | 34 | medium | P2-medium | +159 | [#1157](https://github.com/omnigent-ai/omnigent/issues/1157) [Bug] antigravity-native: no Chat/Terminal toggle — terminal_antigravi |
-| 127 | 34 | medium | P2-medium | +197 | [#377](https://github.com/omnigent-ai/omnigent/issues/377) gpt sub-agent fails on startup with missing databricks-sdk dependency |
-| 128 | 33 | medium | P2-medium | +6 | [#4009](https://github.com/omnigent-ai/omnigent/issues/4009) [Feature] No Go client for the session API, so every Go caller hand-ro |
-| 129 | 33 | medium | P1-high | -123 | [#3981](https://github.com/omnigent-ai/omnigent/issues/3981) [Bug] Desktop: Workspace rail resize is unusable on the Browser tab; a |
-| 130 | 33 | medium | P1-high | -117 | [#3898](https://github.com/omnigent-ai/omnigent/issues/3898) [Bug] Pack function policies fail server-side input evaluation unless  |
-| 131 | 33 | medium | P1-high | -117 | [#3870](https://github.com/omnigent-ai/omnigent/issues/3870) child-session creation returns 500 internal_error, breaking Polly/Debb |
-| 132 | 33 | medium | P2-medium | +10 | [#3864](https://github.com/omnigent-ai/omnigent/issues/3864) [Bug] to_api_dict() drops ConversationItem.created_at, so flat items A |
-| 133 | 33 | medium | P1-high | -118 | [#3863](https://github.com/omnigent-ai/omnigent/issues/3863) [Bug] Databricks Apps entrypoint never wires project_store — Projects  |
-| 134 | 33 | medium | P2-medium | +9 | [#3861](https://github.com/omnigent-ai/omnigent/issues/3861) [Bug] omni host status renders URLs so terminals link the whole status |
-| 135 | 33 | medium | P2-medium | +17 | [#3563](https://github.com/omnigent-ai/omnigent/issues/3563) [Bug] Host-bound resume into a deleted workspace: host computes the ex |
-| 136 | 33 | medium | P2-medium | +17 | [#3561](https://github.com/omnigent-ai/omnigent/issues/3561) [Bug] `prompt_policy` never sends `_CLASSIFIER_SCHEMA` to the LLM — st |
-| 137 | 33 | medium | P2-medium | +18 | [#3550](https://github.com/omnigent-ai/omnigent/issues/3550) [Bug] Missing signing alg's prevent using some OIDC providers |
-| 138 | 33 | medium | P2-medium | +22 | [#3435](https://github.com/omnigent-ai/omnigent/issues/3435) [Feature] Admin server-wide usage report (per-user and per-model cost) |
-| 139 | 33 | medium | none | +214 | [#3402](https://github.com/omnigent-ai/omnigent/issues/3402) [Bug] Label seeding and session-state writes race under concurrent upd |
-| 140 | 33 | medium | P2-medium | +22 | [#3368](https://github.com/omnigent-ai/omnigent/issues/3368) Feature: first-class async write-safety (freeze → approve → apply) pri |
-| 141 | 33 | medium | P2-medium | +24 | [#3352](https://github.com/omnigent-ai/omnigent/issues/3352) [Feature] OpenClaw onboarding — Option B: chat import (SQLite session  |
-| 142 | 33 | medium | P2-medium | +28 | [#3247](https://github.com/omnigent-ai/omnigent/issues/3247) credential_proxy: re-resolve the source on 401 / expiry (short-lived t |
-| 143 | 33 | medium | P1-high | -103 | [#3236](https://github.com/omnigent-ai/omnigent/issues/3236) web_search: bare executor.model strings are inferred as provider 'open |
-| 144 | 33 | medium | P2-medium | +32 | [#3219](https://github.com/omnigent-ai/omnigent/issues/3219) [Bug] Cmd/Ctrl+Up/Down session traversal stops in an empty focused com |
-| 145 | 33 | medium | P2-medium | +47 | [#2921](https://github.com/omnigent-ai/omnigent/issues/2921) Font settings: selected font (incl. Nerd Fonts) never loads — no webfo |
-| 146 | 33 | medium | P1-high | -86 | [#2854](https://github.com/omnigent-ai/omnigent/issues/2854) [Bug] Cross-harness `harness_override` is ignored on the `initial_item |
-| 147 | 33 | medium | P2-medium | +49 | [#2851](https://github.com/omnigent-ai/omnigent/issues/2851) Policy-supplied targets for ASK approval cards |
-| 148 | 33 | medium | P2-medium | +54 | [#2756](https://github.com/omnigent-ai/omnigent/issues/2756) Expose atomic session-event admission to integrations |
-| 149 | 33 | medium | P2-medium | +63 | [#2577](https://github.com/omnigent-ai/omnigent/issues/2577) [Feature] Manage OIDC/SSO admins from an id_token claim (IdP group/rol |
-| 150 | 33 | medium | P2-medium | +63 | [#2558](https://github.com/omnigent-ai/omnigent/issues/2558) Distribution / Installation / Enterprise Readiness |
-| 151 | 33 | medium | P1-high | -81 | [#2539](https://github.com/omnigent-ai/omnigent/issues/2539) Named sys_session_send returns 404 after first child from a bundled se |
-| 152 | 33 | medium | P1-high | -81 | [#2524](https://github.com/omnigent-ai/omnigent/issues/2524) [Bug] Registering remote host fails |
-| 153 | 33 | medium | P1-high | -80 | [#2444](https://github.com/omnigent-ai/omnigent/issues/2444) Accounts JWT expiry falls through to Databricks auth and breaks persis |
-| 154 | 33 | medium | P2-medium | +66 | [#2404](https://github.com/omnigent-ai/omnigent/issues/2404) fix(runtime): orphan sweep can abort startup on unreadable shared-host |
-| 155 | 33 | medium | P2-medium | +67 | [#2374](https://github.com/omnigent-ai/omnigent/issues/2374) Proposal: per-turn context_providers to augment system instructions at |
-| 156 | 33 | medium | P1-high | -71 | [#2304](https://github.com/omnigent-ai/omnigent/issues/2304) Runner subprocess inherits host daemon cwd, causing os_env cwd resolut |
-| 157 | 33 | medium | P2-medium | +77 | [#2070](https://github.com/omnigent-ai/omnigent/issues/2070) [Feature] sys_os_* file tools are hard-confined to the session workspa |
-| 158 | 33 | feature | P2-medium | +155 | [#692](https://github.com/omnigent-ai/omnigent/issues/692) Polly: fan out sub-agent work across multiple concurrent claude profil |
-| 159 | 32 | medium | P1-high | -59 | [#1936](https://github.com/omnigent-ai/omnigent/issues/1936) [BUG] copilot harness: 401 Bad credentials when no token is explicitly |
-| 160 | 32 | medium | P1-high | -47 | [#1551](https://github.com/omnigent-ai/omnigent/issues/1551) opencode-native: blocking question tool not surfaced to web (no elicit |
-| 161 | 32 | feature | P2-medium | +166 | [#197](https://github.com/omnigent-ai/omnigent/issues/197) Declarative skill sources: pull Claude Code skills + their dependency  |
-| 162 | 32 | medium | P1-high | -39 | [#880](https://github.com/omnigent-ai/omnigent/issues/880) [BUG] Native harness (omnigent claude): assistant turns not streamed t |
-| 163 | 32 | medium | P2-medium | +108 | [#1526](https://github.com/omnigent-ai/omnigent/issues/1526) Refactor: incrementally decompose the 4 god-files (sessions.py, runner |
-| 164 | 32 | medium | P2-medium | +110 | [#1411](https://github.com/omnigent-ai/omnigent/issues/1411) Standalone reusable MCP servers: CRUD + connection verify (list tools) |
-| 165 | 31 | medium | P2-medium | +125 | [#1075](https://github.com/omnigent-ai/omnigent/issues/1075) [Feature] Support AWS Lambda / Firecracker microVMs as managed sandbox |
-| 166 | 31 | medium | P2-medium | +126 | [#1055](https://github.com/omnigent-ai/omnigent/issues/1055) [Test] End-to-end OTel test against a real collector to lock in the BY |
-| 167 | 31 | medium | P2-medium | +126 | [#1054](https://github.com/omnigent-ai/omnigent/issues/1054) [Feature] Record gen_ai.retry events on llm_call spans |
-| 168 | 31 | medium | P1-high | -90 | [#2429](https://github.com/omnigent-ai/omnigent/issues/2429) Server (python -m omnigent.cli server) CPU-spins indefinitely with no  |
-| 169 | 31 | medium | P2-medium | +128 | [#1031](https://github.com/omnigent-ai/omnigent/issues/1031) [Feature] Support serving the standalone Web UI under a subpath, e.g.  |
-| 170 | 31 | medium | P2-medium | +130 | [#983](https://github.com/omnigent-ai/omnigent/issues/983) Session sharing ergonomics: `sys_session_share` agent tool + `omnigent |
-| 171 | 31 | feature | P2-medium | +102 | [#1454](https://github.com/omnigent-ai/omnigent/issues/1454) [Feature] Change permission mode of a running claude-native session fr |
-| 172 | 31 | feature | P2-medium | +6 | [#3150](https://github.com/omnigent-ai/omnigent/issues/3150) [Feature] CLI: cross-harness fork — continue an existing session in a  |
-| 173 | 30 | medium | P2-medium | +135 | [#857](https://github.com/omnigent-ai/omnigent/issues/857) [Proposal] Usage-limit detection + on-429 failover across pooled provi |
-| 174 | 30 | medium | P1-high | -50 | [#765](https://github.com/omnigent-ai/omnigent/issues/765) Support interactive mid-flight policy ASK (TOOL_CALL/TOOL_RESULT/OUTPU |
-| 175 | 30 | feature | P2-medium | +50 | [#2303](https://github.com/omnigent-ai/omnigent/issues/2303) [Feature] Support multi-repo workspaces (nested Git repos or multiple  |
-| 176 | 30 | medium | P2-medium | +6 | [#3083](https://github.com/omnigent-ai/omnigent/issues/3083) [Bug] Cursor sessions launched from Omnigent Web is losing MCPs |
-| 177 | 30 | medium | P1-high | -51 | [#547](https://github.com/omnigent-ai/omnigent/issues/547) Bug: Polly model switcher sends invalid Cursor SDK model id |
-| 178 | 30 | medium | P1-high | -49 | [#522](https://github.com/omnigent-ai/omnigent/issues/522) Implement async-tool completion auto-delivery (SESSION_REARCHITECTURE  |
-| 179 | 30 | feature | P2-medium | +80 | [#1703](https://github.com/omnigent-ai/omnigent/issues/1703) [Feature] Unify harness naming: bare names (claude, codex, …) are ambi |
-| 180 | 30 | medium | P2-medium | +138 | [#509](https://github.com/omnigent-ai/omnigent/issues/509) [Feature] Default new-session workspace from selected agent's cwd |
-| 181 | 30 | feature | P3-low | +161 | [#1678](https://github.com/omnigent-ai/omnigent/issues/1678) tech-debt(codex-native): extract a string-field helper for repeated di |
-| 182 | 30 | medium | P2-medium | -13 | [#3250](https://github.com/omnigent-ai/omnigent/issues/3250) flaky e2e_ui: test_scheduled_task_create_edit_modal_and_time_picker ti |
-| 183 | 30 | medium | P2-medium | +15 | [#2848](https://github.com/omnigent-ai/omnigent/issues/2848) Server logs an expected offline-runner resource 503 as ERROR + full tr |
-| 184 | 30 | medium | P2-medium | +17 | [#2767](https://github.com/omnigent-ai/omnigent/issues/2767) [Bug] SQLite pool (default 5+10) not sized to the 200-thread limiter → |
-| 185 | 30 | medium | P1-high | -102 | [#2357](https://github.com/omnigent-ai/omnigent/issues/2357) [Bug] admin fleet-view calls SqlAlchemyConversationStore.list_conversa |
-| 186 | 30 | medium | P1-high | -91 | [#2052](https://github.com/omnigent-ai/omnigent/issues/2052) [Bug] web_fetch's __web_researcher helper sub-agent fails on 0.4.0 (si |
-| 187 | 30 | medium | P2-medium | +136 | [#382](https://github.com/omnigent-ai/omnigent/issues/382) Evaluating the same agent across harnesses: no built-in way to compare |
-| 188 | 30 | medium | P1-high | -87 | [#1920](https://github.com/omnigent-ai/omnigent/issues/1920) Seeder matching-hash fast path can't self-heal a lost artifact-store b |
-| 189 | 30 | medium | P1-high | -184 | [#3982](https://github.com/omnigent-ai/omnigent/issues/3982) [Bug] electron-build.yml pnpm filter matches no package: desktop packa |
-| 190 | 30 | medium | P3-low | +146 | [#3733](https://github.com/omnigent-ai/omnigent/issues/3733) [Bug] Android: hardcoded 25px switcher height makes the chat scroll-fa |
-| 191 | 30 | medium | P2-medium | -44 | [#3732](https://github.com/omnigent-ai/omnigent/issues/3732) [Bug] Android: a Display-size change leaves the server-switcher pill's |
-| 192 | 30 | medium | P2-medium | -42 | [#3592](https://github.com/omnigent-ai/omnigent/issues/3592) [Feature] Deterministic long-term memory (automatic recall/retain) — f |
-| 193 | 30 | medium | P2-medium | -42 | [#3586](https://github.com/omnigent-ai/omnigent/issues/3586) [Bug] Android: native server-picker pill overlaps the sidebar header c |
-| 194 | 30 | medium | P1-high | -170 | [#3578](https://github.com/omnigent-ai/omnigent/issues/3578) [Bug] MacOS Start Locally - "Error: No such command 'start'" |
-| 195 | 30 | medium | P1-high | -170 | [#3536](https://github.com/omnigent-ai/omnigent/issues/3536) [Bug] A session's `reasoning_effort` never reaches in-process harnesse |
-| 196 | 30 | medium | P2-medium | -39 | [#3531](https://github.com/omnigent-ai/omnigent/issues/3531) SSH_AUTH_SOCK dropped at the host→runner env boundary, breaking ssh-ag |
-| 197 | 30 | medium | none | +157 | [#3392](https://github.com/omnigent-ai/omnigent/issues/3392) [Bug] Linux desktop app missing Icon |
-| 198 | 30 | medium | P2-medium | -37 | [#3369](https://github.com/omnigent-ai/omnigent/issues/3369) Feature: a policy that fences a spawned type: agent worker read-only ( |
-| 199 | 30 | medium | P2-medium | -31 | [#3254](https://github.com/omnigent-ai/omnigent/issues/3254) Sub-agent silently stalls after repeated context compactions during re |
-| 200 | 30 | medium | P1-high | -157 | [#3095](https://github.com/omnigent-ai/omnigent/issues/3095) [Bug] Can't uninstall |
+| 102 | 46 | medium | P1-high | +5 | [#1831](https://github.com/omnigent-ai/omnigent/issues/1831) claude-native workers ignore executor.model pin and per-dispatch args. |
+| 103 | 46 | medium | P1-high | +7 | [#1781](https://github.com/omnigent-ai/omnigent/issues/1781) codex harness: ambient DATABRICKS_BEARER/DATABRICKS_TOKEN overrides pr |
+| 104 | 46 | medium | P1-high | +15 | [#1128](https://github.com/omnigent-ai/omnigent/issues/1128) [Bug] Claude SDK Appears to Use Opus Instead of Selected Model |
+| 105 | 46 | medium | P1-high | +25 | [#241](https://github.com/omnigent-ai/omnigent/issues/241) pi harness: GPT and Gemini dispatches 404 on the Databricks ucode gate |
+| 106 | 46 | medium | P3-low | +241 | [#147](https://github.com/omnigent-ai/omnigent/issues/147) Tracking: gradual decomposition of monolith modules (cli.py 9.1KLOC, c |
+| 107 | 42 | medium | P1-high | -89 | [#3790](https://github.com/omnigent-ai/omnigent/issues/3790) force_sandbox policy is evaluated but structurally unreachable from cl |
+| 108 | 42 | medium | P2-medium | +150 | [#1724](https://github.com/omnigent-ai/omnigent/issues/1724) codex-native harness times out on WSL2 ("Codex TUI never started a thr |
+| 109 | 42 | medium | P1-high | -51 | [#2904](https://github.com/omnigent-ai/omnigent/issues/2904) [Bug] claude-native: web-UI chat input fails with "tmux command failed |
+| 110 | 42 | medium | P1-high | -29 | [#2397](https://github.com/omnigent-ai/omnigent/issues/2397) [Bug] Codex-native intelligent routing ignores live effort capabilitie |
+| 111 | 42 | medium | P1-high | -24 | [#2272](https://github.com/omnigent-ai/omnigent/issues/2272) [Bug] Codex runner can't find OpenRouter secret that exists in keyring |
+| 112 | 42 | medium | P2-medium | +192 | [#890](https://github.com/omnigent-ai/omnigent/issues/890) [Bug] omnigent setup fails with npm EACCES when installing the Claude  |
+| 113 | 42 | medium | P1-high | +12 | [#668](https://github.com/omnigent-ai/omnigent/issues/668) [Bug] BUG？omni claude times out (60s) on macOS with native Claude Code |
+| 114 | 38 | medium | P1-high | -98 | [#3852](https://github.com/omnigent-ai/omnigent/issues/3852) [Bug] Built-in write policies miss Claude Code's `MultiEdit` / `Notebo |
+| 115 | 38 | medium | P2-medium | +109 | [#2369](https://github.com/omnigent-ai/omnigent/issues/2369) [Bug] pi harness only lists databricks-claude-sonnet-4-6 |
+| 116 | 38 | medium | P1-high | -30 | [#2299](https://github.com/omnigent-ai/omnigent/issues/2299) [Bug] claude-native resume transcripts flatten tool_result image block |
+| 117 | 38 | medium | P2-medium | +104 | [#2390](https://github.com/omnigent-ai/omnigent/issues/2390) Builtin policy for per-user sub-agent access control (subagent_access_ |
+| 118 | 38 | medium | P2-medium | +206 | [#377](https://github.com/omnigent-ai/omnigent/issues/377) gpt sub-agent fails on startup with missing databricks-sdk dependency |
+| 119 | 38 | medium | P1-high | -10 | [#1794](https://github.com/omnigent-ai/omnigent/issues/1794) Bundled Polly: claude-sdk brain "Not logged in" + runaway spawn loop o |
+| 120 | 38 | medium | P1-high | -9 | [#1694](https://github.com/omnigent-ai/omnigent/issues/1694) Reliability: parallel code-fix missions fail silently (5s tmux timeout |
+| 121 | 37 | medium | P1-high | -79 | [#3101](https://github.com/omnigent-ai/omnigent/issues/3101) Docker/Kubernetes entrypoint never wires project_store — first-class P |
+| 122 | 36 | medium | P2-medium | +161 | [#1192](https://github.com/omnigent-ai/omnigent/issues/1192) [Bug] Manual /compact errors "Compaction requires a configured LLM mod |
+| 123 | 36 | medium | P1-high | -6 | [#1158](https://github.com/omnigent-ai/omnigent/issues/1158) [Bug] antigravity-native: TUI-typed turns never mirror to the web UI ( |
+| 124 | 36 | medium | P2-medium | +161 | [#1157](https://github.com/omnigent-ai/omnigent/issues/1157) [Bug] antigravity-native: no Chat/Terminal toggle — terminal_antigravi |
+| 125 | 36 | feature | P2-medium | +188 | [#692](https://github.com/omnigent-ai/omnigent/issues/692) Polly: fan out sub-agent work across multiple concurrent claude profil |
+| 126 | 36 | feature | P2-medium | +201 | [#197](https://github.com/omnigent-ai/omnigent/issues/197) Declarative skill sources: pull Claude Code skills + their dependency  |
+| 127 | 35 | medium | P2-medium | +110 | [#2055](https://github.com/omnigent-ai/omnigent/issues/2055) [Bug] codex-native harness elicitation: a resolve landing in the betwe |
+| 128 | 35 | medium | P1-high | -84 | [#3076](https://github.com/omnigent-ai/omnigent/issues/3076) [Bug] claude-sdk omits ToolSearch, eagerly loading every MCP schema |
+| 129 | 35 | medium | P3-low | +210 | [#2800](https://github.com/omnigent-ai/omnigent/issues/2800) [Bug] Top-level custom codex-native agents drop reasoning effort and y |
+| 130 | 35 | medium | P1-high | -7 | [#880](https://github.com/omnigent-ai/omnigent/issues/880) [BUG] Native harness (omnigent claude): assistant turns not streamed t |
+| 131 | 33 | medium | P1-high | -18 | [#1551](https://github.com/omnigent-ai/omnigent/issues/1551) opencode-native: blocking question tool not surfaced to web (no elicit |
+| 132 | 33 | medium | P2-medium | +2 | [#4009](https://github.com/omnigent-ai/omnigent/issues/4009) [Feature] No Go client for the session API, so every Go caller hand-ro |
+| 133 | 33 | medium | P1-high | -127 | [#3981](https://github.com/omnigent-ai/omnigent/issues/3981) [Bug] Desktop: Workspace rail resize is unusable on the Browser tab; a |
+| 134 | 33 | medium | P1-high | -121 | [#3898](https://github.com/omnigent-ai/omnigent/issues/3898) [Bug] Pack function policies fail server-side input evaluation unless  |
+| 135 | 33 | medium | P1-high | -121 | [#3870](https://github.com/omnigent-ai/omnigent/issues/3870) child-session creation returns 500 internal_error, breaking Polly/Debb |
+| 136 | 33 | medium | P2-medium | +6 | [#3864](https://github.com/omnigent-ai/omnigent/issues/3864) [Bug] to_api_dict() drops ConversationItem.created_at, so flat items A |
+| 137 | 33 | medium | P1-high | -122 | [#3863](https://github.com/omnigent-ai/omnigent/issues/3863) [Bug] Databricks Apps entrypoint never wires project_store — Projects  |
+| 138 | 33 | medium | P2-medium | +5 | [#3861](https://github.com/omnigent-ai/omnigent/issues/3861) [Bug] omni host status renders URLs so terminals link the whole status |
+| 139 | 33 | medium | P2-medium | +13 | [#3563](https://github.com/omnigent-ai/omnigent/issues/3563) [Bug] Host-bound resume into a deleted workspace: host computes the ex |
+| 140 | 33 | medium | P2-medium | +13 | [#3561](https://github.com/omnigent-ai/omnigent/issues/3561) [Bug] `prompt_policy` never sends `_CLASSIFIER_SCHEMA` to the LLM — st |
+| 141 | 33 | medium | P2-medium | +14 | [#3550](https://github.com/omnigent-ai/omnigent/issues/3550) [Bug] Missing signing alg's prevent using some OIDC providers |
+| 142 | 33 | medium | P2-medium | +18 | [#3435](https://github.com/omnigent-ai/omnigent/issues/3435) [Feature] Admin server-wide usage report (per-user and per-model cost) |
+| 143 | 33 | medium | none | +210 | [#3402](https://github.com/omnigent-ai/omnigent/issues/3402) [Bug] Label seeding and session-state writes race under concurrent upd |
+| 144 | 33 | medium | P2-medium | +18 | [#3368](https://github.com/omnigent-ai/omnigent/issues/3368) Feature: first-class async write-safety (freeze → approve → apply) pri |
+| 145 | 33 | medium | P2-medium | +20 | [#3352](https://github.com/omnigent-ai/omnigent/issues/3352) [Feature] OpenClaw onboarding — Option B: chat import (SQLite session  |
+| 146 | 33 | medium | P2-medium | +24 | [#3247](https://github.com/omnigent-ai/omnigent/issues/3247) credential_proxy: re-resolve the source on 401 / expiry (short-lived t |
+| 147 | 33 | medium | P1-high | -107 | [#3236](https://github.com/omnigent-ai/omnigent/issues/3236) web_search: bare executor.model strings are inferred as provider 'open |
+| 148 | 33 | medium | P2-medium | +28 | [#3219](https://github.com/omnigent-ai/omnigent/issues/3219) [Bug] Cmd/Ctrl+Up/Down session traversal stops in an empty focused com |
+| 149 | 33 | medium | P2-medium | +43 | [#2921](https://github.com/omnigent-ai/omnigent/issues/2921) Font settings: selected font (incl. Nerd Fonts) never loads — no webfo |
+| 150 | 33 | medium | P1-high | -90 | [#2854](https://github.com/omnigent-ai/omnigent/issues/2854) [Bug] Cross-harness `harness_override` is ignored on the `initial_item |
+| 151 | 33 | medium | P2-medium | +45 | [#2851](https://github.com/omnigent-ai/omnigent/issues/2851) Policy-supplied targets for ASK approval cards |
+| 152 | 33 | medium | P2-medium | +50 | [#2756](https://github.com/omnigent-ai/omnigent/issues/2756) Expose atomic session-event admission to integrations |
+| 153 | 33 | medium | P2-medium | +59 | [#2577](https://github.com/omnigent-ai/omnigent/issues/2577) [Feature] Manage OIDC/SSO admins from an id_token claim (IdP group/rol |
+| 154 | 33 | medium | P2-medium | +59 | [#2558](https://github.com/omnigent-ai/omnigent/issues/2558) Distribution / Installation / Enterprise Readiness |
+| 155 | 33 | medium | P1-high | -85 | [#2539](https://github.com/omnigent-ai/omnigent/issues/2539) Named sys_session_send returns 404 after first child from a bundled se |
+| 156 | 33 | medium | P1-high | -85 | [#2524](https://github.com/omnigent-ai/omnigent/issues/2524) [Bug] Registering remote host fails |
+| 157 | 33 | medium | P1-high | -84 | [#2444](https://github.com/omnigent-ai/omnigent/issues/2444) Accounts JWT expiry falls through to Databricks auth and breaks persis |
+| 158 | 33 | medium | P2-medium | +62 | [#2404](https://github.com/omnigent-ai/omnigent/issues/2404) fix(runtime): orphan sweep can abort startup on unreadable shared-host |
+| 159 | 33 | medium | P2-medium | +63 | [#2374](https://github.com/omnigent-ai/omnigent/issues/2374) Proposal: per-turn context_providers to augment system instructions at |
+| 160 | 33 | medium | P1-high | -75 | [#2304](https://github.com/omnigent-ai/omnigent/issues/2304) Runner subprocess inherits host daemon cwd, causing os_env cwd resolut |
+| 161 | 33 | medium | P2-medium | +73 | [#2070](https://github.com/omnigent-ai/omnigent/issues/2070) [Feature] sys_os_* file tools are hard-confined to the session workspa |
+| 162 | 33 | medium | P2-medium | +109 | [#1526](https://github.com/omnigent-ai/omnigent/issues/1526) Refactor: incrementally decompose the 4 god-files (sessions.py, runner |
+| 163 | 33 | medium | P2-medium | +111 | [#1411](https://github.com/omnigent-ai/omnigent/issues/1411) Standalone reusable MCP servers: CRUD + connection verify (list tools) |
+| 164 | 33 | medium | P2-medium | +126 | [#1075](https://github.com/omnigent-ai/omnigent/issues/1075) [Feature] Support AWS Lambda / Firecracker microVMs as managed sandbox |
+| 165 | 33 | medium | P2-medium | +127 | [#1055](https://github.com/omnigent-ai/omnigent/issues/1055) [Test] End-to-end OTel test against a real collector to lock in the BY |
+| 166 | 33 | medium | P2-medium | +127 | [#1054](https://github.com/omnigent-ai/omnigent/issues/1054) [Feature] Record gen_ai.retry events on llm_call spans |
+| 167 | 33 | medium | P2-medium | +130 | [#1031](https://github.com/omnigent-ai/omnigent/issues/1031) [Feature] Support serving the standalone Web UI under a subpath, e.g.  |
+| 168 | 33 | medium | P2-medium | +132 | [#983](https://github.com/omnigent-ai/omnigent/issues/983) Session sharing ergonomics: `sys_session_share` agent tool + `omnigent |
+| 169 | 33 | medium | P2-medium | +139 | [#857](https://github.com/omnigent-ai/omnigent/issues/857) [Proposal] Usage-limit detection + on-429 failover across pooled provi |
+| 170 | 33 | medium | P1-high | -46 | [#765](https://github.com/omnigent-ai/omnigent/issues/765) Support interactive mid-flight policy ASK (TOOL_CALL/TOOL_RESULT/OUTPU |
+| 171 | 33 | medium | P1-high | -45 | [#547](https://github.com/omnigent-ai/omnigent/issues/547) Bug: Polly model switcher sends invalid Cursor SDK model id |
+| 172 | 33 | medium | P1-high | -43 | [#522](https://github.com/omnigent-ai/omnigent/issues/522) Implement async-tool completion auto-delivery (SESSION_REARCHITECTURE  |
+| 173 | 33 | medium | P2-medium | +145 | [#509](https://github.com/omnigent-ai/omnigent/issues/509) [Feature] Default new-session workspace from selected agent's cwd |
+| 174 | 33 | medium | P2-medium | +149 | [#382](https://github.com/omnigent-ai/omnigent/issues/382) Evaluating the same agent across harnesses: no built-in way to compare |
+| 175 | 33 | medium | P1-high | -75 | [#1936](https://github.com/omnigent-ai/omnigent/issues/1936) [BUG] copilot harness: 401 Bad credentials when no token is explicitly |
+| 176 | 32 | feature | P2-medium | +97 | [#1454](https://github.com/omnigent-ai/omnigent/issues/1454) [Feature] Change permission mode of a running claude-native session fr |
+| 177 | 31 | medium | P1-high | -99 | [#2429](https://github.com/omnigent-ai/omnigent/issues/2429) Server (python -m omnigent.cli server) CPU-spins indefinitely with no  |
+| 178 | 31 | medium | P1-high | -58 | [#1113](https://github.com/omnigent-ai/omnigent/issues/1113) Native sub-agent/runner failures surface as bare "failed" with no reas |
+| 179 | 31 | feature | P2-medium | -1 | [#3150](https://github.com/omnigent-ai/omnigent/issues/3150) [Feature] CLI: cross-harness fork — continue an existing session in a  |
+| 180 | 31 | feature | P2-medium | +79 | [#1703](https://github.com/omnigent-ai/omnigent/issues/1703) [Feature] Unify harness naming: bare names (claude, codex, …) are ambi |
+| 181 | 31 | feature | P3-low | +161 | [#1678](https://github.com/omnigent-ai/omnigent/issues/1678) tech-debt(codex-native): extract a string-field helper for repeated di |
+| 182 | 31 | feature | P2-medium | +137 | [#503](https://github.com/omnigent-ai/omnigent/issues/503) [Feature] Switch Claude Code account per session via isolated profiles |
+| 183 | 30 | feature | P2-medium | +42 | [#2303](https://github.com/omnigent-ai/omnigent/issues/2303) [Feature] Support multi-repo workspaces (nested Git repos or multiple  |
+| 184 | 30 | medium | P2-medium | -2 | [#3083](https://github.com/omnigent-ai/omnigent/issues/3083) [Bug] Cursor sessions launched from Omnigent Web is losing MCPs |
+| 185 | 30 | medium | P1-high | -67 | [#1156](https://github.com/omnigent-ai/omnigent/issues/1156) [Bug] antigravity-native: web/mobile turns never appear in the native  |
+| 186 | 30 | medium | P2-medium | -17 | [#3250](https://github.com/omnigent-ai/omnigent/issues/3250) flaky e2e_ui: test_scheduled_task_create_edit_modal_and_time_picker ti |
+| 187 | 30 | medium | P2-medium | +11 | [#2848](https://github.com/omnigent-ai/omnigent/issues/2848) Server logs an expected offline-runner resource 503 as ERROR + full tr |
+| 188 | 30 | medium | P2-medium | +13 | [#2767](https://github.com/omnigent-ai/omnigent/issues/2767) [Bug] SQLite pool (default 5+10) not sized to the 200-thread limiter → |
+| 189 | 30 | medium | P1-high | -106 | [#2357](https://github.com/omnigent-ai/omnigent/issues/2357) [Bug] admin fleet-view calls SqlAlchemyConversationStore.list_conversa |
+| 190 | 30 | medium | P1-high | -95 | [#2052](https://github.com/omnigent-ai/omnigent/issues/2052) [Bug] web_fetch's __web_researcher helper sub-agent fails on 0.4.0 (si |
+| 191 | 30 | medium | P1-high | -90 | [#1920](https://github.com/omnigent-ai/omnigent/issues/1920) Seeder matching-hash fast path can't self-heal a lost artifact-store b |
+| 192 | 30 | medium | P1-high | -86 | [#1857](https://github.com/omnigent-ai/omnigent/issues/1857) Host daemon stays alive but shows offline — server-dropped host tunnel |
+| 193 | 30 | medium | P1-high | -81 | [#1686](https://github.com/omnigent-ai/omnigent/issues/1686) xai: reasoning_effort sent to all Grok models returns HTTP 400 on unsu |
+| 194 | 30 | medium | P2-medium | +94 | [#1117](https://github.com/omnigent-ai/omnigent/issues/1117) async generator ignored GeneratorExit — orphaned SSE relay task, excep |
+| 195 | 30 | medium | P2-medium | +117 | [#725](https://github.com/omnigent-ai/omnigent/issues/725) Changes panel is empty for native-harness and external edits in non-gi |
+| 196 | 30 | medium | P2-medium | +134 | [#146](https://github.com/omnigent-ai/omnigent/issues/146) StreamHooks.on_sub_agent_spawned / on_sub_agent_completed are declared |
+| 197 | 30 | medium | P1-high | -192 | [#3982](https://github.com/omnigent-ai/omnigent/issues/3982) [Bug] electron-build.yml pnpm filter matches no package: desktop packa |
+| 198 | 30 | medium | P3-low | +138 | [#3733](https://github.com/omnigent-ai/omnigent/issues/3733) [Bug] Android: hardcoded 25px switcher height makes the chat scroll-fa |
+| 199 | 30 | medium | P2-medium | -52 | [#3732](https://github.com/omnigent-ai/omnigent/issues/3732) [Bug] Android: a Display-size change leaves the server-switcher pill's |
+| 200 | 30 | medium | P2-medium | -50 | [#3592](https://github.com/omnigent-ai/omnigent/issues/3592) [Feature] Deterministic long-term memory (automatic recall/retain) — f |

--- a/designs/prioritization/issue-prioritization-v2.md
+++ b/designs/prioritization/issue-prioritization-v2.md
@@ -100,9 +100,33 @@ are distinct and it's worth being precise:
    issues *within and across* priority labels, so two issues that share a label
    aren't stuck equal.
 3. **Priority label (the outcome)** — the human-facing bucket the score lands
-   in. This is what maintainers **sort, filter, and action on**; the score is
-   the *reference for why* an issue got that label. The label is derived, not
-   hand-assigned by type.
+   in, **by fixed score thresholds** (below). This is what maintainers **sort,
+   filter, and action on**; the score is the *reference for why* an issue got
+   that label. The label is derived from the score, not hand-assigned by type.
+
+**Score → priority label.** One derivation, no parallel rubric: the label is
+just which band the final score falls in. The cut-points sit at the severity
+band values, so a *multiplier* (tier / reach / dup / readiness / demand) is what
+lets an issue cross **up** a band:
+
+| Score | Priority | Reading |
+|---|---|---|
+| **≥ 100** | **P0-critical** | a critical-severity issue, or one pushed there by reach/tier |
+| **≥ 60** | **P1-high** | high severity, or a medium boosted by a tier-1 harness / broad reach |
+| **≥ 25** | **P2-medium** | ordinary graded work |
+| **< 25** | **P3-low** | minor / narrow |
+
+Example: a "high" bug (severity 60) in a tier-1 harness scores 60 × 1.4 = 84 →
+clears **P1**; the same bug on a niche harness scores 60 × 0.9 = 54 → stays
+**P2**. The multiplier moved the label. (Thresholds are tunable constants —
+`P0_MIN`/`P1_MIN`/`P2_MIN` in `score_prototype.py`; the current values give P0 9
+/ P1 58 / P2 206 / P3 87 on the snapshot, a 22% P1-bug share.)
+
+*One consequence worth naming:* because the label comes from the full score,
+non-severity signals **can** tip it — a heavily-reacted FR or a much-duplicated
+bug can cross into P1. That's intended (demand/blast-radius are legitimate
+priority inputs), but it's bounded: demand is capped (Community demand) and a
+single FR can't reach P0 on reactions alone.
 
 So: axes → severity → score → priority label. The score exists precisely because
 a label alone can't order issues that share it (Serena/Pat: "two issues of the
@@ -139,11 +163,14 @@ Grow the list as real P0s surface. Note we **don't run a hosted service**, so
 on every client) — dropped from the definition in favor of the concrete cases
 above.
 
-**A simple tier→priority floor** (per review, as a sanity check on the graded
-score): a *valid bug* in a **tier-1** harness is **at least P1**; a valid bug in
-tier-2/3 is normally P2/P3 unless its severity/reach pushes it up. The score
-does the fine ordering; this floor keeps the classifier from under-grading a
-flagship-harness bug.
+**Tier-1 grading heuristic** (per review). Rather than a hard label floor that
+would override the score, this is guidance to the *grader*: a valid,
+reproducible bug in a **tier-1** harness should rarely be graded below `high`
+severity — a flagship harness failing is, by definition, a serious problem. That
+severity (60) × the tier-1 multiplier (1.4) = 84, which clears P1 through the
+normal score→label path. So the heuristic keeps flagship bugs out of P2 *without*
+a second rule: it just tells the grader not to under-call their severity. Tier
+2/3 bugs land P2/P3 unless severity/reach earn more.
 
 **FRs are graded, not defaulted.** The old prompt defaulted every FR to P2;
 that's the "all FRs are equal" trap. An FR gets P1 when its *absence* is a
@@ -160,8 +187,9 @@ on one platform with a workaround is P2, not P1."**
 
 #### How regrading works
 
-Regrading maps an issue to a priority *bucket* from `severity × reach` — a
-pure label change, independent of the score. It runs in two situations:
+Regrading assigns an issue's priority *label* by computing its score and
+applying the thresholds above — the same derivation used everywhere, so there's
+no second rubric to keep in sync. It runs in two situations:
 
 1. **One-time backfill.** Re-run the classifier over the existing open issues
    once, so the backlog reflects the new rubric on day one. This is a labels-only
@@ -172,42 +200,35 @@ pure label change, independent of the score. It runs in two situations:
    lever (see "Ongoing adjustment"). The scheduled re-score reads the updated
    label the next time it runs.
 
-The mapping is mechanical once severity and reach are graded:
-
-| Graded severity | + reach | → priority |
-|---|---|---|
-| critical (security / data-loss / all-users-down) | any | **P0** |
-| high (crash / hang / no-workaround; FR: blocks common workflow) | broad / normal | **P1** |
-| high | single-platform | **P2** |
-| medium | broad | **P1** |
-| medium | normal / narrow | **P2** |
-| low / narrow FR | — | **P3** |
+The mapping is exactly the score → priority table above (`score ≥ 100 → P0`,
+`≥ 60 → P1`, `≥ 25 → P2`, else `P3`); nothing separate to define.
 
 **Backfill preview** (`score_prototype.py --regrade`, regex grader over the 360
 open issues — the production backfill uses the LLM grader):
 
 | Priority | Now | Regraded |
 |---|---|---|
-| P0-critical | 3 | 8 |
-| **P1-high** | **128** | **65** |
-| P2-medium | 203 | 273 |
-| P3-low | 15 | 14 |
+| P0-critical | 3 | 9 |
+| **P1-high** | **128** | **58** |
+| P2-medium | 203 | 206 |
+| P3-low | 15 | 87 |
 | (no priority) | 11 | 0 |
 
-**P1 share of open bugs: 60% → 25%** — the inflation drained, the P1/P2 binary
-un-collapsed. What moves, and why:
+**P1 share of open bugs: 60% → 22%** — the inflation drained, and P3 fills out
+(score-thresholding sends genuinely-minor items to P3, where the old label
+distribution left it vestigial). What moves, and why:
 
 | Change | Count | Example |
 |---|---|---|
-| P1 → P2 | 87 | #3980 desktop dialog paint-over — medium severity, single-platform (not "all users, no workaround") |
-| P2 → P1 | 24 | #3976 headless OAuth2 grant — high-severity FR, broad reach (was defaulted to P2) |
-| P2 → P3 | 10 | #3074 OS-native directory picker — narrow nice-to-have FR |
-| P3 → P2 | 12 | under-graded items pulled up |
-| P2 → P0 | 4 | #659 microvm sandbox backend — security-tier |
+| P1 → P2 | 85 | #3981 desktop rail resize — medium severity, single-platform (score 33) |
+| P2 → P3 | 68 | #4027 "delete button on web UI" — narrow FR (score 22, below the P2 cut) |
+| P2 → P1 | 23 | #3976 headless OAuth2 grant — high-severity FR, broad reach (score 99) |
+| P1 → P3 | 9 | #3980 desktop dialog paint-over — minor, single-platform (score 25) |
+| P2 → P0 | 4 | #2125 multi-host git creds — credential-crossing (score 104) |
 
 *Caveat:* these per-issue moves use the regex grader, so they inherit its known
 false positives (e.g. #2057/#2054 "sandbox bypass" FRs wrongly reach P0). Read
-the **aggregate shape** (60% → 25%) as the reliable signal and individual rows
+the **aggregate shape** (60% → 22%) as the reliable signal and individual rows
 as illustrative; the LLM backfill corrects the outliers.
 
 ### Axis 3 — Harness tier (new, derived)
@@ -313,20 +334,21 @@ with linux_bwrap dies at spawn"):
 
 | Factor | Value | Why |
 |---|---|---|
-| severity | 60 (high) | body matches "cannot start" / spawn death — a hard failure, no workaround |
-| × reach | × 1.0 | affects the linux_bwrap sandbox config, not literally all users |
+| severity | 60 (high) | spawn death — a hard failure, no workaround |
+| × reach | × 1.5 | body says it hits every session on the config → broad |
 | × harness_tier | × 1.4 | title says `claude-sdk` → tier-1 |
 | × dup_reach | × 1.0 | no confirmed duplicates (yet) |
-| × readiness | × 1.1 | 400+ char body with repro steps → ready to work |
-| = base | **92.4** | |
+| × readiness | × 1.0 | no explicit repro section matched → no bump |
+| = base | **126** | 60 × 1.5 × 1.4 |
 | × demand (bug) | + 0 | 0 reactions; bugs get only the additive tiebreak |
 | × age | × 1.0 | neutral by default — age never lowers the score |
-| **= score** | **≈ 92** | ranks **#3** of 360 (was #37 by priority label) |
+| **= score** | **126** | **≥ 100 → P0-critical**; ranks **#3** of 360 (was P1, rank #37) |
 
 Contrast a vague, low-tier ticket: severity 30 (medium) × reach 0.9
-(single-platform) × tier 0.9 (tier-3 harness) × readiness 1.0 ≈ **24** — an
-order of magnitude lower, so it sits deep in the queue. That gap is the point:
-the score turns four cheap data points into an order.
+(single-platform) × tier 0.9 (tier-3 harness) × readiness 1.0 ≈ **24** → **P3**
+(below the 25 cut) — an order of magnitude lower, so it sits deep in the queue.
+Same five data points, opposite ends of the queue *and* opposite priority
+labels: that's the score→label derivation doing the work.
 
 **Why severity is LLM-graded, not label-derived:** the dry-run
 (`score_prototype.py`) grades severity with regex for reproducibility, and it
@@ -573,7 +595,7 @@ Two concrete changes:
 5. **One-time backfill (regrade)** — re-run the classifier over open issues to
    relabel under the new rubric (see "How regrading works"); preview with
    `score_prototype.py --regrade`. Target: P1 back under ~20% of open bugs
-   (regex preview lands it at 25%; the LLM pass should do better).
+   (regex preview lands it at 22%; the LLM pass should do better).
 6. **Consume dedup output** — once [#4037](https://github.com/omnigent-ai/omnigent/pull/4037)
    lands, feed duplicate count into `dup_reach`; wire the unused `good first
    issue` funnel.

--- a/designs/prioritization/issue-prioritization-v2.md
+++ b/designs/prioritization/issue-prioritization-v2.md
@@ -186,6 +186,34 @@ truth. Per-harness *filtering* is still available via the area routing if a
 maintainer wants it, without a label per harness. (Alternative considered and
 rejected in Appendix A.)
 
+### Component taxonomy — which `comp:` labels to add
+
+There are 8 `comp:` labels today, and several are mega-buckets because each
+merges multiple `areas.json` areas. The bar for a new label is deliberately
+high: **split only when you'd actually filter on it, or when it changes how the
+issue is graded** — every split costs new labels + an `areas.json` mapping + a
+classifier-allowlist update + a one-time backfill, and the repo has *no
+label-sync* by design. By that test:
+
+| Label | Open | Recommendation |
+|---|---|---|
+| `comp:harnesses` | 148 | Split by **tier** — `-t1/-t2/-t3` (Axis 3). |
+| `comp:runner` | 109 | **Carve out `comp:sandbox`** (~29 of the 109 are sandbox/isolation: bwrap/seatbelt/egress). Distinct discipline, security-grade severity, home of the top P0 (#3557). Makes the security surface *filterable*, not just score-boosted. |
+| `comp:web-ui` | 99 | **Add `comp:mobile`** (~23: iOS/Android OIDC, renderer death, iPad layout) — a different failure domain and reporter set from browser-web (~55). Defer `comp:desktop`/electron (~11): borderline, revisit if it grows. |
+| `comp:server` | 135 | **Leave as-is.** Its sub-buckets (host 55, db 36, sdk 65) overlap heavily on the same session/API issues; splitting would just multi-label without aiding prioritization. |
+| `comp:tui` · `comp:infra` · `comp:repr` · `comp:policies` | 40 / 34 / 13 / 21 | **Leave as-is** — small enough to prioritize within; splitting adds labels without payoff. `comp:policies` already isolates the guardrail surface. |
+
+Net new labels: **`comp:sandbox`** and **`comp:mobile`** (plus the three harness
+tier labels). Everything else stays. `sandbox` and `policies` remain
+first-class (see Sandbox / security below); we're promoting `sandbox` from an
+area that collapses into `comp:runner` to its own label, not inventing a new
+concept.
+
+Naming note: `comp:sandbox` (narrow) is preferred over a broad `comp:security`
+umbrella — "security" would pull in the 120 credential/auth issues that mostly
+belong to `comp:server`/onboarding, re-creating a mega-bucket. Sandbox/policy
+*bypass* severity is handled by the rubric (Axis 2), not by an umbrella label.
+
 ### Axis 4 — The composite score (the ordering primitive)
 
 ```
@@ -401,9 +429,9 @@ severity**, not a functional one.
 
 Two concrete changes:
 
-- **Component:** `sandbox` and `policies` are already distinct areas in
-  `areas.json` (mapping to `comp:runner` / `comp:policies`). Keep them
-  first-class; don't fold them into the harness buckets.
+- **Component:** promote `sandbox` to its own `comp:sandbox` label (today it
+  collapses into `comp:runner`); `policies` already has `comp:policies`. See
+  "Component taxonomy" above for the full rationale.
 - **Severity:** the rubric's P0 row explicitly names "security/policy/sandbox
   bypass," and the grader should treat *escape / bypass / credential-crossing*
   as top-tier severity regardless of reach — a one-user sandbox escape is still
@@ -417,8 +445,10 @@ Two concrete changes:
    rubric (grade FRs across buckets; security/sandbox → P0) + the "P1 scarcity"
    guardrail + emit `severity` and `readiness` fields. Low risk, affects new
    issues immediately.
-2. **Harness tier labels** — add `comp:harness-t1/-t2/-t3`, map each harness
-   area in `areas.json` to a tier, backfill existing `comp:harnesses` issues.
+2. **Component labels** — add `comp:harness-t1/-t2/-t3` (map each harness area
+   in `areas.json` to a tier), plus `comp:sandbox` and `comp:mobile`; update the
+   classifier allowlist and backfill existing `comp:harnesses` / `comp:runner` /
+   `comp:web-ui` issues into the new labels. See "Component taxonomy."
 3. **Template fields** — add Harness / Platform / Impact dropdowns.
 4. **Scoring job** — productionize `score_prototype.py` into a scheduled action
    that reads LLM-graded severity + readiness + dup count and publishes the

--- a/designs/prioritization/issue-prioritization-v2.md
+++ b/designs/prioritization/issue-prioritization-v2.md
@@ -316,6 +316,49 @@ just **re-grading severity** — the same field the classifier already sets:
    #2125) is upstream — grade severity honestly (Axis 2); the score reads
    severity, so fixing severity fixes the order.
 
+#### Maintainer guide — hand-correcting the ranking
+
+The goal is a ranking good enough that **hand-correction is the exception, not
+the process** — a working target is **≤10% of issues touched**. If you're
+correcting more than that, the fix isn't more editing, it's tuning the prompt or
+weights (below). Two properties make correction cheap and safe:
+
+- **Corrections are sticky.** Triage runs `on: issues [opened]` only — it never
+  re-fires on edits, so a label you change by hand is never overwritten by the
+  bot. (The weekly re-score only *reads* labels; it doesn't re-grade.)
+- **One knob.** You change the **priority label** (the field the classifier
+  emits). The score is a pure function of it plus mechanical factors — no
+  separate override to learn.
+
+**When to correct** — reach for it only when the *grade* is wrong, not when you
+merely disagree with a neighbor in a tie:
+
+| Symptom | Action |
+|---|---|
+| Grader misread severity (a real P1 sitting at P2, or vice versa) | Change the priority label. Done — it sticks. |
+| Right severity, wrong reach (e.g. "affects all users" missed) | Same: bump the label; reach feeds severity's bucket. |
+| A security/sandbox/policy **bypass** graded as ordinary | Set `P0-critical` — bypass is top severity regardless of reach (Axis 2). |
+| Blocked on the reporter | Add `needs-info` (drops readiness ×0.85); don't fight the score. |
+| You just prefer a different order *within the same grade* | **Don't.** Ties are arbitrary by design; re-grading here is noise. |
+
+**When NOT to correct — fix the system instead.** A hand-edit fixes one issue; a
+prompt fix fixes the class. Escalate from editing to tuning when:
+
+- The **same misgrade recurs** (e.g. every "sandbox bypass" *feature request*
+  gets graded critical — the #2057/#2054 class). Fix the classifier prompt in
+  `.github/triage/config.yaml`, not the issues one by one.
+- You cross the **~10% correction rate** in a re-score cycle. That's the signal
+  the weights (tier multipliers, demand cap, readiness) or the rubric need
+  tuning — re-run `score_prototype.py` against the new weights and eyeball the
+  before→after before shipping.
+- The **`Re-grade rate` metric** (below) trends up. It's the quantitative
+  version of the same signal.
+
+**What this is not:** there is no per-issue score override, no manual score
+number, no pin. Everything flows through the priority label so the ranking stays
+explainable — anyone can re-derive an issue's position from its label + factors,
+and there's no hidden hand-tuning to reverse-engineer later.
+
 ---
 
 ## Dry-run: before → after (methodical, on real issues)
@@ -492,9 +535,19 @@ Generated from today's snapshot with `score_prototype.py --markdown 200`
 (regex severity grader — the same stand-in used throughout; production uses
 the LLM grader). Columns: **Score** = composite score; **Sev** = re-graded
 severity; **Now** = current priority label; **Δrank** = movement vs the
-current priority-label ordering (positive = moved up). Regenerate any time to
-refresh. Read this as illustrative ordering — the regex grader's known false
-positives (e.g. #2057/#2054) are visible near the top.
+current priority-label ordering (positive = moved up).
+
+**Illustrative, not actionable.** This is the *mechanism* running on a
+deliberately-weak grader, so its own failures are visible on purpose: ranks 1–2
+(#2057/#2054) are FRs that merely *mention* "sandbox bypass" and are graded
+critical — they sit above the real P0 (#3557, rank 6), so **the very top is
+backwards**; #61 (rank 19) is a *bot* audit issue. That's the doc's thesis made
+concrete: regex can't grade severity. The scaffold is sound — strip those
+artifacts and the genuine tier-1 bugs (#3265, #3557, #3270, #3180, #2373)
+cluster correctly in the top 15. Scores also *tie* in coarse bands (nine issues
+share 99/92), so within-band order is arbitrary — read this as ~8 tiers, not 200
+ranks. With the LLM grader plus ≤10% hand-correction (see the maintainer guide),
+this is the shape the production ranking takes.
 
 | # | Score | Sev | Now | Δrank | Issue |
 |--:|--:|---|---|--:|---|

--- a/designs/prioritization/issue-prioritization-v2.md
+++ b/designs/prioritization/issue-prioritization-v2.md
@@ -1,0 +1,304 @@
+# Issue Prioritization v2 for omnigent
+
+## Goal
+
+Make the open-issue queue **orderable by real severity**, not by a label that
+has lost its meaning. Today priority is a single collapsed axis (P1 vs P2 as a
+de-facto binary); it neither reflects how bad an issue is nor how many users it
+hits, and it doesn't move over time. This proposal keeps the working
+[triage pipeline](../issue-triage-proposal.md) and adds: a re-calibrated
+priority rubric, independent scoring axes (severity × reach × harness-tier +
+demand), a maintainer-facing ranked view, and a lightweight way to nudge
+ranking over time.
+
+This is an evolution of, not a replacement for,
+[issue-triage-proposal.md](../issue-triage-proposal.md). The intake, the
+tool-less classifier, and the trusted-step label application all stay.
+
+---
+
+## Evidence: what the data says (snapshot Aug 2026)
+
+725 issues (360 open / 365 closed), PRs excluded. The triage *pipeline* works —
+only 7 open issues are un-triaged, `needs-triage` is effectively empty. The
+problems are all in the *taxonomy and prioritization*, not the plumbing.
+
+**1. Type split is clean — leave it alone.** 0 open issues carry both `Bug` and
+`enhancement`; the template auto-labels and the classifier confirms. This axis
+is healthy.
+
+**2. Priority has collapsed into a P1/P2 binary.**
+
+| Priority | Open | Closed | Median days-to-close | Median age (open) |
+|---|---|---|---|---|
+| P0-critical | 3 | 12 | 2.7d | 25d |
+| **P1-high** | **128** | 139 | 1.9d | 20.6d |
+| **P2-medium** | **204** | 149 | 3.8d | 28.1d |
+| P3-low | 16 | 19 | 3.4d | 30.8d |
+
+- **125 of 207 open bugs (60%) are P1-high.** "Major feature broken, no
+  workaround" cannot describe 60% of bugs — P1 is inflated to the point of
+  being noise.
+- **P0 (3) and P3 (16) are vestigial.** Four buckets, two used.
+- **Open-issue age is flat across priorities** (P1 20.6d ≈ P2 28d ≈ P3 30d).
+  If P1 were respected as urgent, P1 age would be far lower than P2. It isn't:
+  priority is *not* pulling issues to the front. Close-time looks fine only
+  because the team turns the whole backlog over in days when it engages —
+  attention/recency orders the queue today, not priority.
+
+**3. Severity is orthogonal to the type-default — and the current label hides
+it.** Feature requests default to P2 by rule, so a high-value capability gap is
+indistinguishable from a trivial nice-to-have. Grounding example
+([#2125](https://github.com/omnigent-ai/omnigent/issues/2125), multi-host git
+credentials): a real self-hoster blocker, labeled `P2-medium` purely because
+it's an FR. There is no way today for it to outrank a weak P1.
+
+**4. `comp:harnesses` is a mega-bucket.** 148 of 360 open (41%). The next
+components are `comp:server` (135), `comp:runner` (109), `comp:web-ui` (99).
+`areas.json` *already* models per-harness areas (`harness-claude`,
+`harness-codex`, …) but they all collapse to the single `comp:harnesses` label,
+so routing knows the sub-area while the label throws it away. Within harnesses,
+title mentions skew hard to **claude (32) and codex (24)**, then kimi /
+antigravity / openai (~6 each) — a natural tier boundary.
+
+**5. Contributor + dedup funnels are unused vs. the design.**
+`good first issue` is on **0** open issues; only **5** issues ever closed as
+duplicate (0 currently labeled) — yet the triage design calls dedup the
+"highest-ROI automation." Both are latent, not wired.
+
+**6. "Community volume" is mostly internal dogfood.** 320 of 360 open issues
+are NONE/CONTRIBUTOR-authored, but the bug titles read like insider reports
+("antigravity-native: TUI-typed turns never mirror"). Reactions are sparse —
+only **25 of 360** open issues have any 👍. Implication: **severity must lead
+the score; external demand is at most a tiebreak**, or the queue will look
+empty of signal.
+
+---
+
+## Design
+
+### Axis 1 — Type (unchanged)
+
+`bug` / `enhancement` / `documentation`. Clean today; no change.
+
+### Axis 2 — Re-calibrated priority rubric
+
+Priority stays a 4-bucket label but gets a **rubric that forces separation**,
+enforced in the classifier prompt (`.github/triage/config.yaml`) and by a
+one-time backfill. The key change: **priority is a function of severity × reach,
+graded from content — not a type-default.**
+
+| Priority | Definition (must satisfy BOTH severity and reach) |
+|---|---|
+| **P0-critical** | Security/policy bypass, data loss, or all-users-down. Rare by construction. |
+| **P1-high** | High severity (crash / hang / permanent breakage / no workaround) **AND** broad reach (default config, all/most users, or a tier-1 harness). Not "a bug I care about." |
+| **P2-medium** | Real bug with a workaround, OR a substantive capability/feature. **Default for FRs**, but a P2 can outrank a P1 in the *score* (below) when its severity/demand is high — the label is a bucket, the score is the order. |
+| **P3-low** | Genuinely minor: cosmetic, polish, trivial convenience, narrow nice-to-have. |
+
+Calibration guardrail added to the prompt: **"P1 is a scarcity signal. If more
+than ~20% of open bugs are P1, you are over-grading. A bug affecting one harness
+on one platform with a workaround is P2, not P1."**
+
+### Axis 3 — Harness tier (new, derived)
+
+Harnesses are not equal in strategic weight. Tier is **derived from the
+existing `areas.json` harness areas** (no new hand-labeling):
+
+- **Tier 1** — `claude`, `codex` (flagship; ~38% of harness issues).
+- **Tier 2** — `cursor`, `antigravity`, `copilot`, `gemini`/`openai`.
+- **Tier 3** — everything else (goose, hermes, kimi, kiro, opencode, pi, qwen).
+
+Tier is a **score multiplier**, not a visible label, so it can be re-weighted
+without relabeling. Optionally surface as `tier:1|2|3` labels later if
+maintainers want to filter on it.
+
+**Recommended, not required:** split `comp:harnesses` into per-harness labels
+so the 41% bucket becomes filterable. This is a bigger change (new labels + a
+label-sync step, which the repo deliberately avoids today) — see Appendix A. If
+we don't split, tier-as-multiplier still recovers most of the value.
+
+### Axis 4 — The composite score (the ordering primitive)
+
+```
+base  = severity_weight              # LLM-graded from content (P0/P1/P2/P3-ish, 0–100)
+      × reach_multiplier             # all-users/default 1.5 · normal 1.0 · single-platform 0.9
+      × harness_tier_multiplier      # T1 1.4 · T2 1.1 · T3 0.9 · non-harness 1.0
+
+score = apply_demand(base, type)     # type-dependent — see "Community demand" below
+      × recency_factor               # 1.0 fresh; gentle decay past ~30d (tunable)
+      + manual_pin                   # maintainer override (see "eyeball" below)
+```
+
+Every weight is a named constant in one place. The score is **advisory
+ordering** layered on top of the labels; labels stay authoritative for
+filtering, the score decides *what to look at first*.
+
+**Why severity is LLM-graded, not label-derived:** the dry-run
+(`score_prototype.py`) grades severity with regex for reproducibility, and it
+demonstrates *why regex isn't enough in production* — "sandbox **bypass**" in an
+FR title falsely scored two Codex-mode FRs (#2057, #2054) as critical, and a bot
+"Code Audit" issue (#61) too. The production grader is the triage classifier,
+which reads full content and already runs per issue at zero extra cost.
+
+### Community demand — used, but type-dependent and bounded
+
+Should 👍 / engagement feed the score? **Yes, but carefully**, because of what
+the reaction distribution actually looks like on this repo:
+
+- **93% of open issues (335/360) have zero reactions**; 51 reactions total
+  across the whole backlog, with a tiny head (one issue at 10, one at 6, a
+  handful at 2–4).
+- **Reactions skew hard to feature requests** — 9 of the top 10 reacted issues
+  are FRs — and are almost entirely external (50 of 51 from NONE/CONTRIBUTOR,
+  ~0 from maintainers). So reactions are a **demand** signal (a wanted
+  capability), not a **severity** signal (bugs are reported once, rarely
+  upvoted).
+
+Consequences baked into the model:
+
+1. **Type-dependent.** For **feature requests**, demand is a bounded
+   *multiplier* (up to +60%), so a well-liked FR climbs above unwanted ones.
+   For **bugs**, demand is only a small additive *tiebreak* (≤15 pts), so a
+   0-reaction crash still outranks a lightly-liked cosmetic FR. Severity always
+   leads for bugs.
+2. **Log-scaled and capped.** With a backlog max of ~10 reactions, a linear
+   term would let one popular FR swamp severity; `log1p` + a hard cap keeps
+   demand a nudge, not a driver.
+3. **Comments are excluded.** On this repo, bug comment volume is mostly repro
+   back-and-forth — a bug with more comments is often *harder*, not more wanted
+   — so comments would reward contentious issues rather than important ones.
+
+**Caveat this guards against:** because reactions are 93%-zero and tilt toward
+external FRs, over-weighting demand would systematically bias a
+dogfood-bug-heavy backlog toward features. Bounding it (and splitting by type)
+keeps severity as the driver.
+
+### Ongoing adjustment — the "eyeball / upgrade over time" mechanism
+
+Prioritization is not a one-shot classification. Three cheap levers:
+
+1. **Periodic re-score.** A scheduled job (weekly) recomputes the score for all
+   open issues and posts/updates a single **ranked view** (a pinned issue or a
+   generated `PRIORITY-QUEUE.md`), so demand/age changes are reflected without
+   re-triaging. Cheap: no LLM call needed for re-score if severity is cached as
+   a label/field at triage time.
+2. **Manual pin / nudge.** Maintainers add `pin:high` / `pin:low` (or 👍 on a
+   tracking comment) to force an issue up or down; `manual_pin` in the score
+   honors it. This is the direct answer to "#2125 is a high-severity P2" — a
+   maintainer bumps it once and it sticks.
+3. **Severity is re-gradable.** Because severity is a field, not baked into the
+   priority bucket, re-triage (`/retriage` slash command or label toggle) can
+   revise it as understanding of an issue evolves.
+
+---
+
+## Dry-run: before → after (methodical, on real issues)
+
+`designs/prioritization/score_prototype.py` reads a snapshot of all open issues
+and prints **current-priority ordering vs composite-score ordering**, with a
+rank delta per issue, so we tune weights against real test cases.
+
+Selected results (360 open issues; rank out of 360, lower = higher priority):
+
+**Severity surfaces real bugs the label buried:**
+
+| Issue | Before | After | Δ | Note |
+|---|---|---|---|---|
+| #3557 policy-gate bypass (P0) | 1 | 6 | −5 | Real P0 stays near top ✅ |
+| #3265 claude-sdk bwrap spawn death (P1) | 37 | 3 | +34 | High-sev, tier-1 harness ✅ |
+| #3270 sub-agent sessions absent (P1) | 35 | 7 | +28 | ✅ |
+| #2421 codex MCP bridge child leak (P1) | 80 | 20 | +60 | Resource leak, tier-1 ✅ |
+| #2454 unbounded ~/.omnigent growth (P1) | 72 | 19 | +53 | ✅ |
+
+**Community demand lifts wanted FRs — bounded, so bugs stay on top:**
+
+| Issue | 👍 | Before | After | Δ | Note |
+|---|---|---|---|---|---|
+| #1021 GitHub Copilot as provider (FR) | 10 | 299 | 93 | +206 | Most-wanted FR climbs; demand pushed score 31→48 ✅ |
+| #16 native Windows support (FR) | 6 | 334 | 32 | +302 | High demand + broad reach ✅ |
+| #888 side-by-side multi-session (FR) | 2 | 305 | 29 | +276 | ✅ |
+
+**Dry-run limits — the evidence that severity must be LLM-graded, not regex:**
+
+| Issue | Before | After | Note |
+|---|---|---|---|
+| #2057 / #2054 Codex-mode FRs | 236/238 | 1/2 | **False positive** — "sandbox bypass" tripped the critical regex. LLM grader avoids. |
+| #61 bot "Code Audit" (P3) | 349 | 12 | **False positive** — audit issue mentioning security. LLM grader avoids. |
+| #2125 multi-host git creds (P2, FR) | 232 | 324 | **False negative** — a real capability gap, but no severity keyword and only 1 👍, so it *sinks*. The LLM grader (or a `pin:high`) is exactly what rescues it. |
+
+#2125 is the clearest case for the whole design: a regex/label view can't see
+it's important, so it needs either content-grading (LLM) or the manual-pin
+lever — which is why both are in the model.
+
+**Takeaways for the real build:**
+- The score *mechanics* order the queue far better than the priority label.
+- The severity *grader* must be the LLM, not regex — the dry-run's own false
+  positives are the proof.
+- Weights are defensible starting points; tune against this before→after table.
+
+---
+
+## Intake: what more to collect
+
+The bug template asks Version + OS but both optional → sparse. Add structured,
+**dropdown** fields (dropdowns beat free-text for scoring signal):
+
+- **Harness** (dropdown: claude / codex / cursor / … / n/a) — the #1 component,
+  currently buried in prose. Feeds tier directly.
+- **Platform / device** (dropdown: macOS / Linux / Windows / iOS / Android /
+  Docker) — a whole class of bugs is platform-specific (Windows setup crashes,
+  iOS/Android OIDC, Linux aarch64). Feeds reach.
+- **Impact / reach** (dropdown: all users / most / some / edge) — the reach axis
+  the reporter can often answer better than the grader.
+
+Keep them optional (the pipeline already triages from description alone) but
+dropdowns cost the reporter nothing and sharpen severity × reach.
+
+---
+
+## Rollout
+
+1. **Prompt re-calibration** (`.github/triage/config.yaml`) — new priority
+   rubric + the "P1 scarcity" guardrail + emit a `severity` field. Low risk,
+   affects new issues immediately.
+2. **Template fields** — add Harness / Platform / Impact dropdowns.
+3. **Scoring job** — productionize `score_prototype.py` into a scheduled action
+   that reads the LLM-graded severity and publishes the ranked view.
+4. **One-time backfill** — re-run triage over the 128 open P1s to demote the
+   mislabeled ones (target: P1 back under ~20% of open bugs).
+5. **Wire the latent funnels** — actually apply `good first issue`; revisit why
+   dedup fires so rarely.
+
+## Metrics
+
+- **P1 share of open bugs** — target < 20% (today 60%).
+- **Priority age separation** — P1 median age should drop well below P2's
+  (today they're equal — the tell that priority is ignored).
+- **Score→action correlation** — are top-scored issues the ones getting closed?
+- **Manual-pin rate** — how often maintainers override the score (high = weights
+  need tuning).
+
+---
+
+## Appendix A — Should we split `comp:harnesses`?
+
+**For:** it's 41% of open issues; `areas.json` already knows the sub-area;
+per-harness labels make the biggest bucket filterable and feed tier without
+title-keyword guessing.
+
+**Against:** the repo intentionally has *no label-sync* (`areas.json` notes
+`gh` can't add a nonexistent label), and 8 areas share `comp:harnesses` today.
+Splitting means ~11 new `harness:*` labels + a sync step + updating the
+classifier allowlist.
+
+**Recommendation:** defer the label split; ship tier-as-multiplier first (gets
+most of the value with no new labels). Split only if maintainers want to *filter*
+by harness, not just *order* by it.
+
+## Appendix B — Rejected: keep priority as the only axis
+
+Considered leaving priority as the single lever and just re-calibrating the
+rubric. Rejected because it can't express "high-severity P2" (#2125) — a bucket
+label can't encode within-bucket ordering, and maintainers demonstrably need to
+re-rank over time. The score exists precisely to order *within and across*
+buckets.

--- a/designs/prioritization/issue-prioritization-v2.md
+++ b/designs/prioritization/issue-prioritization-v2.md
@@ -7,9 +7,10 @@ has lost its meaning. Today priority is a single collapsed axis (P1 vs P2 as a
 de-facto binary); it neither reflects how bad an issue is nor how many users it
 hits, and it doesn't move over time. This proposal keeps the working
 [triage pipeline](../issue-triage-proposal.md) and adds: a re-calibrated
-priority rubric, independent scoring axes (severity × reach × harness-tier +
-demand), a maintainer-facing ranked view, and a lightweight way to nudge
-ranking over time.
+priority rubric (severity graded across all buckets, for FRs too), independent
+scoring axes (severity × reach × harness-tier × readiness + demand, with
+duplicate count as a reach signal), a maintainer-facing ranked view, and
+re-gradable severity as the mechanism to nudge ranking over time.
 
 This is an evolution of, not a replacement for,
 [issue-triage-proposal.md](../issue-triage-proposal.md). The intake, the
@@ -36,9 +37,9 @@ is healthy.
 | **P2-medium** | **204** | 149 | 3.8d | 28.1d |
 | P3-low | 16 | 19 | 3.4d | 30.8d |
 
-- **125 of 207 open bugs (60%) are P1-high.** "Major feature broken, no
-  workaround" cannot describe 60% of bugs — P1 is inflated to the point of
-  being noise.
+- **125 of 207 open *bugs* (60%) are P1-high** (128 open P1 in total, incl. 3
+  non-bugs). "Major feature broken, no workaround" cannot describe 60% of bugs
+  — P1 is inflated to the point of being noise.
 - **P0 (3) and P3 (16) are vestigial.** Four buckets, two used.
 - **Open-issue age is flat across priorities** (P1 20.6d ≈ P2 28d ≈ P3 30d).
   If P1 were respected as urgent, P1 age would be far lower than P2. It isn't:
@@ -61,17 +62,22 @@ so routing knows the sub-area while the label throws it away. Within harnesses,
 title mentions skew hard to **claude (32) and codex (24)**, then kimi /
 antigravity / openai (~6 each) — a natural tier boundary.
 
-**5. Contributor + dedup funnels are unused vs. the design.**
-`good first issue` is on **0** open issues; only **5** issues ever closed as
-duplicate (0 currently labeled) — yet the triage design calls dedup the
-"highest-ROI automation." Both are latent, not wired.
+**5. Contributor funnel is unused; dedup is now landing.** `good first issue`
+is on **0** open issues. Dedup was previously latent (only 5 ever closed as
+duplicate), but the dedup labeler in
+[#4037](https://github.com/omnigent-ai/omnigent/pull/4037) is putting it in
+place — link + label, closure gated off by default. That changes the plan: we
+should **use duplicate *count* as a scoring signal** (N confirmed dupes = N
+reporters hit it = bigger blast radius), not auto-close — see Axis 5.
 
-**6. "Community volume" is mostly internal dogfood.** 320 of 360 open issues
-are NONE/CONTRIBUTOR-authored, but the bug titles read like insider reports
-("antigravity-native: TUI-typed turns never mirror"). Reactions are sparse —
-only **25 of 360** open issues have any 👍. Implication: **severity must lead
-the score; external demand is at most a tiebreak**, or the queue will look
-empty of signal.
+**6. Most issues are dogfood, by the MAINTAINER file.** Of 360 open issues,
+**36 are authored by a name in `.github/MAINTAINER`** → 324 "community." (The
+`author_association` field is a poor proxy: it marks 4 as MEMBER that aren't
+maintainers, so we key off the MAINTAINER file, which the triage pipeline
+already reads.) Even the 324 read like insider reports ("antigravity-native:
+TUI-typed turns never mirror"). Reactions are sparse — only **25 of 360** open
+issues have any 👍. Implication: **severity must lead the score; external
+demand is at most a tiebreak**, or the queue will look empty of signal.
 
 ---
 
@@ -88,12 +94,21 @@ enforced in the classifier prompt (`.github/triage/config.yaml`) and by a
 one-time backfill. The key change: **priority is a function of severity × reach,
 graded from content — not a type-default.**
 
-| Priority | Definition (must satisfy BOTH severity and reach) |
+| Priority | Definition (severity × reach — applies to bugs AND FRs) |
 |---|---|
-| **P0-critical** | Security/policy bypass, data loss, or all-users-down. Rare by construction. |
-| **P1-high** | High severity (crash / hang / permanent breakage / no workaround) **AND** broad reach (default config, all/most users, or a tier-1 harness). Not "a bug I care about." |
-| **P2-medium** | Real bug with a workaround, OR a substantive capability/feature. **Default for FRs**, but a P2 can outrank a P1 in the *score* (below) when its severity/demand is high — the label is a bucket, the score is the order. |
-| **P3-low** | Genuinely minor: cosmetic, polish, trivial convenience, narrow nice-to-have. |
+| **P0-critical** | Security/policy/sandbox bypass, data loss, or all-users-down. Rare by construction. |
+| **P1-high** | High severity (bug: crash / hang / permanent breakage, no workaround. FR: a capability whose *absence* blocks a common workflow) **AND** broad reach (default config, all/most users, or a tier-1 harness). Not "a thing I care about." |
+| **P2-medium** | Real bug with a workaround, OR a substantive capability/feature with a moderate reach. |
+| **P3-low** | Genuinely minor: cosmetic, polish, trivial convenience, narrow nice-to-have — bug or FR. |
+
+**FRs are graded, not defaulted.** The old prompt defaulted every FR to P2;
+that's the "all FRs are equal" trap. An FR gets P1 when its *absence* is a
+high-severity, broad-reach gap (e.g. [#16](https://github.com/omnigent-ai/omnigent/issues/16)
+native Windows — a whole platform can't run; [#2125](https://github.com/omnigent-ai/omnigent/issues/2125)
+multi-host git creds — blocks the common self-hoster setup), and P3 when it's a
+narrow nice-to-have. Bug-vs-FR is the *type* axis; it does not cap priority.
+(Practically, FR reach is still usually narrower than a crash's, so most FRs
+land P2/P3 — but by grading, not by rule.)
 
 Calibration guardrail added to the prompt: **"P1 is a scarcity signal. If more
 than ~20% of open bugs are P1, you are over-grading. A bug affecting one harness
@@ -108,14 +123,16 @@ existing `areas.json` harness areas** (no new hand-labeling):
 - **Tier 2** — `cursor`, `antigravity`, `copilot`, `gemini`/`openai`.
 - **Tier 3** — everything else (goose, hermes, kimi, kiro, opencode, pi, qwen).
 
-Tier is a **score multiplier**, not a visible label, so it can be re-weighted
-without relabeling. Optionally surface as `tier:1|2|3` labels later if
-maintainers want to filter on it.
-
-**Recommended, not required:** split `comp:harnesses` into per-harness labels
-so the 41% bucket becomes filterable. This is a bigger change (new labels + a
-label-sync step, which the repo deliberately avoids today) — see Appendix A. If
-we don't split, tier-as-multiplier still recovers most of the value.
+Tier is a **score multiplier**, and we split the `comp:harnesses` mega-bucket
+(41% of open) with **tier labels — `comp:harness-t1` / `-t2` / `-t3`** — rather
+than per-harness labels (`comp:harness-claude`, …). Tier labels are more
+future-proof: adding a harness or re-tiering one edits `areas.json` (which
+already maps each harness area) and re-runs a backfill, without inventing a new
+label each time a harness ships. The mapping (area → tier) lives in
+`areas.json`, so the tier label and the score multiplier share one source of
+truth. Per-harness *filtering* is still available via the area routing if a
+maintainer wants it, without a label per harness. (Alternative considered and
+rejected in Appendix A.)
 
 ### Axis 4 — The composite score (the ordering primitive)
 
@@ -123,15 +140,37 @@ we don't split, tier-as-multiplier still recovers most of the value.
 base  = severity_weight              # LLM-graded from content (P0/P1/P2/P3-ish, 0–100)
       × reach_multiplier             # all-users/default 1.5 · normal 1.0 · single-platform 0.9
       × harness_tier_multiplier      # T1 1.4 · T2 1.1 · T3 0.9 · non-harness 1.0
+      × dup_reach                    # +15% per confirmed duplicate, capped +50% (Axis 5)
+      × readiness                    # ready-to-work 1.1 · normal 1.0 · needs-info 0.85 (Axis 6)
 
 score = apply_demand(base, type)     # type-dependent — see "Community demand" below
       × recency_factor               # 1.0 fresh; gentle decay past ~30d (tunable)
-      + manual_pin                   # maintainer override (see "eyeball" below)
 ```
 
 Every weight is a named constant in one place. The score is **advisory
 ordering** layered on top of the labels; labels stay authoritative for
 filtering, the score decides *what to look at first*.
+
+**Worked example — one issue, data points → score.** Take
+[#3265](https://github.com/omnigent-ai/omnigent/issues/3265) ("claude-sdk agent
+with linux_bwrap dies at spawn"):
+
+| Factor | Value | Why |
+|---|---|---|
+| severity | 60 (high) | body matches "cannot start" / spawn death — a hard failure, no workaround |
+| × reach | × 1.0 | affects the linux_bwrap sandbox config, not literally all users |
+| × harness_tier | × 1.4 | title says `claude-sdk` → tier-1 |
+| × dup_reach | × 1.0 | no confirmed duplicates (yet) |
+| × readiness | × 1.1 | 400+ char body with repro steps → ready to work |
+| = base | **92.4** | |
+| × demand (bug) | + 0 | 0 reactions; bugs get only the additive tiebreak |
+| × recency | × 1.0 | 10 days old, under the 30-day decay threshold |
+| **= score** | **≈ 92** | ranks **#3** of 360 (was #37 by priority label) |
+
+Contrast a vague, low-tier ticket: severity 30 (medium) × reach 0.9
+(single-platform) × tier 0.9 (tier-3 harness) × readiness 1.0 ≈ **24** — an
+order of magnitude lower, so it sits deep in the queue. That gap is the point:
+the score turns four cheap data points into an order.
 
 **Why severity is LLM-graded, not label-derived:** the dry-run
 (`score_prototype.py`) grades severity with regex for reproducibility, and it
@@ -173,22 +212,50 @@ external FRs, over-weighting demand would systematically bias a
 dogfood-bug-heavy backlog toward features. Bounding it (and splitting by type)
 keeps severity as the driver.
 
-### Ongoing adjustment — the "eyeball / upgrade over time" mechanism
+### Axis 5 — Duplicate reach
 
-Prioritization is not a one-shot classification. Three cheap levers:
+The dedup labeler ([#4037](https://github.com/omnigent-ai/omnigent/pull/4037))
+links and labels duplicates without auto-closing. That gives us a reach signal
+for free: **N confirmed duplicates means N reporters hit the same issue.**
+`dup_reach` bumps the score +15% per confirmed duplicate, capped at +50%, so a
+frequently-reduplicated bug rises without letting a pile-on dominate severity.
+The scoring job reads the dup count from the labeler's linked issues; the
+dry-run stubs it (`duplicate_count`, default 0) since the snapshot JSON doesn't
+carry dup links.
+
+### Axis 6 — Readiness
+
+A ticket you can *start on now* — repro steps, a real body — is worth surfacing
+above an equally-severe but vague one. `readiness` is a small multiplier: 1.1
+for a bug with a repro section and a ≥400-char body (or any substantive FR),
+0.85 for anything labeled `needs-info` (explicitly blocked on the reporter),
+1.0 otherwise. It's deliberately gentle — it breaks near-ties, it never
+overrides severity. On the current backlog it bumps 272 issues, penalizes only
+the 4 `needs-info` ones (today `needs-info` is applied to **0** open bugs, so
+this also gives the classifier a reason to use it). Cheap to compute from
+existing fields; the production grader can set it directly.
+
+### Ongoing adjustment — re-grade severity, don't add a pin lever
+
+Prioritization is not a one-shot classification, but the adjustment lever is
+just **re-grading severity** — the same field the classifier already sets:
 
 1. **Periodic re-score.** A scheduled job (weekly) recomputes the score for all
    open issues and posts/updates a single **ranked view** (a pinned issue or a
-   generated `PRIORITY-QUEUE.md`), so demand/age changes are reflected without
-   re-triaging. Cheap: no LLM call needed for re-score if severity is cached as
-   a label/field at triage time.
-2. **Manual pin / nudge.** Maintainers add `pin:high` / `pin:low` (or 👍 on a
-   tracking comment) to force an issue up or down; `manual_pin` in the score
-   honors it. This is the direct answer to "#2125 is a high-severity P2" — a
-   maintainer bumps it once and it sticks.
-3. **Severity is re-gradable.** Because severity is a field, not baked into the
-   priority bucket, re-triage (`/retriage` slash command or label toggle) can
-   revise it as understanding of an issue evolves.
+   generated `PRIORITY-QUEUE.md`), so demand/age/dup changes are reflected
+   without re-triaging. Cheap: no LLM call needed for re-score if severity is
+   cached as a field at triage time.
+2. **Re-grade severity to bump.** To push an issue up or down, a maintainer
+   changes its priority/severity label (P2 → P1) — exactly what you asked: "I
+   can bump P2 → P1 or vice versa." No separate `pin:high` / `pin:low` lever.
+   A dedicated pin was in the previous draft; it's dropped as over-engineering
+   — a second override that means the same thing as changing severity, but out
+   of band from it. One knob, and it's the one maintainers already use.
+
+The earlier draft leaned on `pin` to rescue "high-severity P2s" like #2125. The
+better fix is upstream: grade severity honestly in the first place (Axis 2) so
+#2125 lands where it belongs, and re-grade if it's wrong. The score reads
+severity; fixing severity fixes the score.
 
 ---
 
@@ -198,6 +265,20 @@ Prioritization is not a one-shot classification. Three cheap levers:
 and prints **current-priority ordering vs composite-score ordering**, with a
 rank delta per issue, so we tune weights against real test cases.
 
+**Is severity re-graded in these examples?** Yes — the dry-run ignores the
+existing priority label entirely and *re-grades severity from content* (regex
+stand-in for the LLM), so the "After" column is a fresh grade, not a re-sort of
+the old labels. The regex grade distribution across the 360 open issues:
+
+| Grade | critical | high | medium | low | (FR default) |
+|---|---|---|---|---|---|
+| Count | 8 | 85 | 183 | 3 | 81 |
+
+That shape is itself a sanity check: **critical is scarce (8)**, most bugs are
+medium, and `low` is under-detected by regex (only 3) — a real grader would find
+more genuinely-minor issues. It's the inverse of today's inflated-P1 label
+distribution, which is the goal.
+
 Selected results (360 open issues; rank out of 360, lower = higher priority):
 
 **Severity surfaces real bugs the label buried:**
@@ -205,35 +286,35 @@ Selected results (360 open issues; rank out of 360, lower = higher priority):
 | Issue | Before | After | Δ | Note |
 |---|---|---|---|---|
 | #3557 policy-gate bypass (P0) | 1 | 6 | −5 | Real P0 stays near top ✅ |
-| #3265 claude-sdk bwrap spawn death (P1) | 37 | 3 | +34 | High-sev, tier-1 harness ✅ |
+| #3265 claude-sdk bwrap spawn death (P1) | 37 | 3 | +34 | High-sev, tier-1 harness, has repro ✅ |
 | #3270 sub-agent sessions absent (P1) | 35 | 7 | +28 | ✅ |
-| #2421 codex MCP bridge child leak (P1) | 80 | 20 | +60 | Resource leak, tier-1 ✅ |
-| #2454 unbounded ~/.omnigent growth (P1) | 72 | 19 | +53 | ✅ |
+| #2421 codex MCP bridge child leak (P1) | 80 | 27 | +53 | Resource leak, tier-1 ✅ |
+| #2454 unbounded ~/.omnigent growth (P1) | 72 | 26 | +46 | ✅ |
 
 **Community demand lifts wanted FRs — bounded, so bugs stay on top:**
 
 | Issue | 👍 | Before | After | Δ | Note |
 |---|---|---|---|---|---|
-| #1021 GitHub Copilot as provider (FR) | 10 | 299 | 93 | +206 | Most-wanted FR climbs; demand pushed score 31→48 ✅ |
-| #16 native Windows support (FR) | 6 | 334 | 32 | +302 | High demand + broad reach ✅ |
-| #888 side-by-side multi-session (FR) | 2 | 305 | 29 | +276 | ✅ |
+| #1021 GitHub Copilot as provider (FR) | 10 | 299 | 92 | +207 | Most-wanted FR climbs; demand alone pushed it up ✅ |
+| #16 native Windows support (FR) | 6 | 334 | 32 | +302 | High demand + graded P1 (whole platform) ✅ |
+| #888 side-by-side multi-session (FR) | 2 | 305 | 30 | +275 | ✅ |
 
 **Dry-run limits — the evidence that severity must be LLM-graded, not regex:**
 
 | Issue | Before | After | Note |
 |---|---|---|---|
-| #2057 / #2054 Codex-mode FRs | 236/238 | 1/2 | **False positive** — "sandbox bypass" tripped the critical regex. LLM grader avoids. |
-| #61 bot "Code Audit" (P3) | 349 | 12 | **False positive** — audit issue mentioning security. LLM grader avoids. |
-| #2125 multi-host git creds (P2, FR) | 232 | 324 | **False negative** — a real capability gap, but no severity keyword and only 1 👍, so it *sinks*. The LLM grader (or a `pin:high`) is exactly what rescues it. |
+| #2057 / #2054 Codex-mode FRs | 236/238 | 1/2 | **False positive** — "sandbox bypass" in the FR body tripped the critical regex. An LLM reads that it's *proposing* a mode, not reporting a bypass. |
+| #61 bot "Code Audit" (P3) | 349 | 19 | **False positive** — a bot audit issue mentioning "security". LLM grader avoids. |
+| #2125 multi-host git creds (P2, FR) | 232 | 8 | **Lucky match** — the body literally says "your GitHub PAT is offered to the self-hosted remote", so the regex hits a credential-leak pattern and scores it critical. Right answer, wrong reason: it's an exact-phrase fluke, not comprehension. An LLM would grade it high because it *understands* the credential-crossing risk. |
 
-#2125 is the clearest case for the whole design: a regex/label view can't see
-it's important, so it needs either content-grading (LLM) or the manual-pin
-lever — which is why both are in the model.
+#2125 makes the point either way: the earlier draft's regex *missed* it (false
+negative); a one-word regex tweak now *over-*hits it. Both are the same lesson —
+regex can't reason about severity, so production must grade with the LLM.
 
 **Takeaways for the real build:**
 - The score *mechanics* order the queue far better than the priority label.
-- The severity *grader* must be the LLM, not regex — the dry-run's own false
-  positives are the proof.
+- The severity *grader* must be the LLM, not regex — the dry-run's false
+  positives *and* its lucky matches are both the proof.
 - Weights are defensible starting points; tune against this before→after table.
 
 ---
@@ -254,51 +335,88 @@ The bug template asks Version + OS but both optional → sparse. Add structured,
 Keep them optional (the pipeline already triages from description alone) but
 dropdowns cost the reporter nothing and sharpen severity × reach.
 
+### Sandbox / security deserves its own treatment
+
+You flagged sandboxing as its own category — the data agrees. Across open
+issues: **63 mention sandbox** (bwrap/seatbelt/egress), **70 policy/guardrail**,
+**120 credential/secret**. The top P0
+([#3557](https://github.com/omnigent-ai/omnigent/issues/3557)) is a
+shell-surface policy-gate *bypass*; #2125 is a credential-crossing risk. These
+aren't ordinary bugs — a sandbox escape or policy bypass is a **security
+severity**, not a functional one.
+
+Two concrete changes:
+
+- **Component:** `sandbox` and `policies` are already distinct areas in
+  `areas.json` (mapping to `comp:runner` / `comp:policies`). Keep them
+  first-class; don't fold them into the harness buckets.
+- **Severity:** the rubric's P0 row explicitly names "security/policy/sandbox
+  bypass," and the grader should treat *escape / bypass / credential-crossing*
+  as top-tier severity regardless of reach — a one-user sandbox escape is still
+  P0. This is the one place reach does **not** gate priority.
+
 ---
 
 ## Rollout
 
 1. **Prompt re-calibration** (`.github/triage/config.yaml`) — new priority
-   rubric + the "P1 scarcity" guardrail + emit a `severity` field. Low risk,
-   affects new issues immediately.
-2. **Template fields** — add Harness / Platform / Impact dropdowns.
-3. **Scoring job** — productionize `score_prototype.py` into a scheduled action
-   that reads the LLM-graded severity and publishes the ranked view.
-4. **One-time backfill** — re-run triage over the 128 open P1s to demote the
+   rubric (grade FRs across buckets; security/sandbox → P0) + the "P1 scarcity"
+   guardrail + emit `severity` and `readiness` fields. Low risk, affects new
+   issues immediately.
+2. **Harness tier labels** — add `comp:harness-t1/-t2/-t3`, map each harness
+   area in `areas.json` to a tier, backfill existing `comp:harnesses` issues.
+3. **Template fields** — add Harness / Platform / Impact dropdowns.
+4. **Scoring job** — productionize `score_prototype.py` into a scheduled action
+   that reads LLM-graded severity + readiness + dup count and publishes the
+   ranked view.
+5. **One-time backfill** — re-run triage over the 128 open P1s to demote the
    mislabeled ones (target: P1 back under ~20% of open bugs).
-5. **Wire the latent funnels** — actually apply `good first issue`; revisit why
-   dedup fires so rarely.
+6. **Consume dedup output** — once [#4037](https://github.com/omnigent-ai/omnigent/pull/4037)
+   lands, feed duplicate count into `dup_reach`; wire the unused `good first
+   issue` funnel.
 
 ## Metrics
 
 - **P1 share of open bugs** — target < 20% (today 60%).
 - **Priority age separation** — P1 median age should drop well below P2's
   (today they're equal — the tell that priority is ignored).
-- **Score→action correlation** — are top-scored issues the ones getting closed?
-- **Manual-pin rate** — how often maintainers override the score (high = weights
-  need tuning).
+- **Prioritization efficiency** — of the k issues actually resolved in a period,
+  what fraction of the *achievable* score did we capture? Compute
+  `sum(score of the k resolved) / sum(score of the top-k by score)`. A ratio
+  near 1.0 means the team is working the highest-scored issues; a low ratio
+  means high-score issues are being skipped (either the score is wrong, or
+  attention is going elsewhere). This is the single best signal that the score
+  is *ordering real work*, not just producing a list.
+- **Re-grade rate** — how often maintainers change a severity/priority label
+  after triage (high = the classifier's grading needs tuning).
 
 ---
 
-## Appendix A — Should we split `comp:harnesses`?
+## Appendix A — Splitting `comp:harnesses`: tier labels vs per-harness labels
 
-**For:** it's 41% of open issues; `areas.json` already knows the sub-area;
-per-harness labels make the biggest bucket filterable and feed tier without
-title-keyword guessing.
+`comp:harnesses` is 41% of open issues and needs splitting. Two options:
 
-**Against:** the repo intentionally has *no label-sync* (`areas.json` notes
-`gh` can't add a nonexistent label), and 8 areas share `comp:harnesses` today.
-Splitting means ~11 new `harness:*` labels + a sync step + updating the
-classifier allowlist.
+- **Per-harness** (`comp:harness-claude`, `comp:harness-codex`, …) — one label
+  per harness (~11 today). Maximally granular, but every new harness needs a
+  new label, and re-tiering means re-teaching everyone which harnesses are
+  "important."
+- **Tier** (`comp:harness-t1/-t2/-t3`) — three stable labels; the harness→tier
+  mapping lives in `areas.json`. **Chosen.** Future-proof: shipping a harness or
+  re-tiering one is an `areas.json` edit + backfill, no new label. Per-harness
+  *filtering* is still possible through area routing when someone needs it.
 
-**Recommendation:** defer the label split; ship tier-as-multiplier first (gets
-most of the value with no new labels). Split only if maintainers want to *filter*
-by harness, not just *order* by it.
+Both need the same one-time backfill of existing `comp:harnesses` issues; tier
+adds three labels instead of eleven and doesn't grow with the harness count.
 
-## Appendix B — Rejected: keep priority as the only axis
+## Appendix B — Rejected alternatives
 
-Considered leaving priority as the single lever and just re-calibrating the
-rubric. Rejected because it can't express "high-severity P2" (#2125) — a bucket
-label can't encode within-bucket ordering, and maintainers demonstrably need to
-re-rank over time. The score exists precisely to order *within and across*
-buckets.
+- **Keep priority as the only axis.** Can't express a high-severity item stuck
+  in a low bucket (#2125), and a single bucket label can't encode ordering
+  within a bucket. The score exists to order within and across buckets.
+- **A separate `pin:high` / `pin:low` override** (in an earlier draft). Dropped:
+  it's a second knob that means the same thing as changing severity but sits out
+  of band from it. Maintainers re-grade severity to bump — one knob, the one
+  they already use.
+- **Auto-closing duplicates.** The dedup labeler
+  ([#4037](https://github.com/omnigent-ai/omnigent/pull/4037)) links without
+  closing; we keep dupes open and use their *count* as a reach signal (Axis 5).

--- a/designs/prioritization/issue-prioritization-v2.md
+++ b/designs/prioritization/issue-prioritization-v2.md
@@ -618,6 +618,11 @@ Two concrete changes:
 
 ## Rollout
 
+**Status: none of this is built yet.** This PR is the design + a dry-run
+prototype only — no labels are created, `areas.json` is unchanged, and the
+classifier config is untouched. The steps below are the implementation plan,
+each intended as its own follow-up PR (tracked as separate issues).
+
 1. **Prompt re-calibration** (`.github/triage/config.yaml`) — new priority
    rubric (grade FRs across buckets; explicit P0 list; tier-1 floor) + the "P1
    scarcity" guardrail + emit `severity`, `readiness`, and `sub_area` fields.

--- a/designs/prioritization/issue-prioritization-v2.md
+++ b/designs/prioritization/issue-prioritization-v2.md
@@ -434,15 +434,98 @@ states and the design treats them differently:
 Today `needs-info` is on **0** open bugs, so the backfill also gives the
 classifier an explicit reason to apply it — only to the incomprehensible ones.
 
+### Surfacing the score — one Databricks job, one scores table
+
+The score must be **computed in exactly one place**, or it drifts between
+whatever recomputes it. That place is a scheduled **Databricks notebook job**,
+not a GitHub Action — because the job sits next to both its input (the synced
+issues table) and its output (the dashboard), so there's no cross-system data
+hop and no second implementation of the formula.
+
+```
+main.team_eng_omnigent.github_issues_bronze   (issues already synced here —
+  │                                             labels, title, body, comments,
+  │                                             reactions in raw_json, created_at)
+  ▼
+[Databricks job: THE one place the score is computed]
+  severity(persisted) × reach × component_weight(areas.json) × dup × readiness
+  │                          + demand ─┐
+  ├──► issue_scores (Delta) ───────────┴──►  dashboard tile: ORDER BY score DESC
+  └──► apply priority/component labels back to GitHub  (needs a write credential)
+```
+
+Concrete facts this rests on (verified against the workspace):
+
+- **Reads are tokenless.** Issues are already ingested into
+  `main.team_eng_omnigent.github_issues_bronze` (with a watermark table driving
+  incremental sync). The job reads that table — **no GitHub token needed to
+  score**. `component_weight` comes from `areas.json`; reactions come from
+  `raw_json`.
+- **Only the write-back needs a credential.** Applying the regraded
+  priority/component labels to GitHub needs a write token — now a **Databricks
+  secret** (a scoped PAT or App-installation token), not a CI secret. Clean
+  split: **compute + dashboard = read-only in Databricks; label writes = the one
+  credentialed step.**
+- **Preserve the prompt-injection boundary.** The Action's security posture
+  (LLM has no tools/shell/token; a trusted step validates output against
+  `ALLOWED_COMPONENTS`/`ALLOWED_PRIORITIES` before any write) **must carry over
+  intact**: the notebook cell holding the GitHub token must not be the context
+  that ran the LLM, and every write stays allowlist-gated. A notebook makes it
+  easy to accidentally hand the token to the model's context — so this is a
+  deliberate structure, not a default.
+- **The bot's own writes lag bronze.** Labels the job writes won't appear in
+  bronze until the next ingestion, so the job can't read its last action back
+  from bronze. It keeps its own `issue_bot_state` Delta table (issue → last
+  bot-written priority/severity) — which is exactly the human-override guard's
+  shadow record, so one table serves both idempotency and override detection.
+- **Trigger cadence — the one open decision.** A notebook job is scheduled
+  (cron), not event-driven, so first-touch triage of a *new* issue waits for the
+  next run (+ ingestion lag) instead of firing in minutes. For scoring /
+  re-score / backfill / dashboard that's inherent and fine. If near-real-time
+  first triage matters, the mitigation is a **thin dispatch Action** (`on:
+  issues [opened]` → trigger the Databricks job) that carries *zero* logic — the
+  formula still lives only in the notebook. Flag for the team: accept ~15–30 min
+  cadence, or keep the dispatcher.
+
+**Linear.** Issues already sync to Linear on a regular cadence, so Linear is an
+existing surface, not something to build. Scores stay in GitHub + the dashboard;
+we do **not** push scores into Linear (it consumes labels/status, it wouldn't
+compute severity×reach anyway). If a Linear-side priority is ever wanted, it
+reads the same `issue_scores` table — never a second computation.
+
+### Determinism — same inputs, same score
+
+The score is a **pure arithmetic function** of its inputs (multiply/add, no
+randomness), so given identical inputs it is byte-for-byte reproducible across
+runs. Two nuances worth stating plainly:
+
+- **Persisted severity is what guarantees it.** The one non-reproducible input
+  would be re-grading severity with the LLM every run (LLM output isn't stable
+  across samples/model versions — it would shuffle dashboard ranks for no
+  reason). Because severity is **graded once at triage and stored** (Rollout
+  step 1), the re-score job reads a fixed value and never re-invokes the model.
+- **The score still moves over time — by design, bounded.** `dup_reach` and
+  `demand` read *current* duplicate and reaction counts, so a well-liked or
+  much-duplicated issue legitimately rises as signal accrues. That's the
+  intended "ranking evolves" behavior, not nondeterminism. (We deliberately
+  removed the one *unwanted* time-drift, age decay, per review.)
+
+**Tie-breaking is deferred.** Scores cluster in coarse bands (many share
+92/84/…); within a tie the order isn't pinned. That's acceptable for now — the
+bands are what matter. When a stable within-band order is wanted, the ranked
+query adds a deterministic tiebreaker (`ORDER BY score DESC, issue_number`); no
+model or scoring change needed.
+
 ### Ongoing adjustment — re-grade severity, don't add a pin lever
 
 Prioritization is not a one-shot classification, but the adjustment lever is
 just **re-grading severity** — the same field the classifier already sets:
 
-1. **Periodic re-score.** A scheduled (weekly) job recomputes the score and
-   posts/updates a single **ranked view** (a pinned issue or generated
-   `PRIORITY-QUEUE.md`), reflecting demand/age/dup changes without re-triaging.
-   No LLM call needed if severity is cached as a field at triage time.
+1. **Periodic re-score.** The scheduled job (below) recomputes the score and
+   refreshes the ranked view / `issue_scores` table, reflecting demand/dup
+   changes without re-triaging. **No LLM call** — it reads the *persisted*
+   severity (Rollout step 1) and does pure arithmetic, so a re-run with no data
+   change reproduces the same scores (see "Determinism").
 2. **Re-grade severity to bump.** To move an issue, a maintainer changes its
    label (P2 → P1) — the one knob they already use. There is deliberately no
    separate `pin:high`/`pin:low`: it would mean the same thing as changing
@@ -452,24 +535,23 @@ just **re-grading severity** — the same field the classifier already sets:
 
 #### Human priority always wins — the bot must not overwrite it
 
-Now that priority is a *computed* label, any job that writes it (the one-time
-backfill, the weekly re-score) could clobber a maintainer's deliberate
-`P0 → P2` or `P3 → P1`. That must never happen. The rule:
+Now that priority is a *computed* label, a **scheduled** job that writes it (the
+re-score, the one-time backfill) runs every tick — so without a guard it *will*
+clobber a maintainer's deliberate `P0 → P2` or `P3 → P1` on the next run. That
+must never happen. The rule:
 
 > **A bot-written priority is a default; a human-written priority is a
 > decision. The bot only ever sets priority on an issue it hasn't set before,
 > and never overwrites a value a human changed.**
 
-Concretely, on top of today's `on: [opened]` triage (which already never
-re-fires on edits), the re-score/backfill jobs must:
+Concretely, the job must:
 
-- **Detect the human edit.** An issue is "human-owned" for priority if its
-  current `P*` label differs from what the bot last wrote. The cheapest durable
-  record is a hidden marker the bot leaves when it labels — e.g. a
-  `bot-priority:P2` shadow label (or a one-line machine-readable note in a
-  pinned tracking comment). If `current P* != bot-priority:*`, a human moved it
-  → **skip**. (GitHub's issue-events API also records who set a label and
-  whether the actor is the bot, as a fallback signal.)
+- **Detect the human edit** via the `issue_bot_state` table (the job's record of
+  the priority it last wrote per issue — the same table that makes the job
+  idempotent against bronze's ingestion lag). If the issue's current `P*` label
+  differs from `issue_bot_state`'s last-bot-written value, a human moved it →
+  **skip**. (GitHub's issue-events API, which records whether the label actor
+  was the bot, is a fallback signal.)
 - **Only fill, never replace.** If an issue has *no* priority label, the job may
   set one. If it already has one the bot itself last wrote, the job may update
   it (the grade legitimately changed). If a human wrote it, the job leaves the
@@ -492,10 +574,10 @@ the process** — a working target is **≤10% of issues touched**. If you're
 correcting more than that, the fix isn't more editing, it's tuning the prompt or
 weights (below). Two properties make correction cheap and safe:
 
-- **Corrections are sticky.** Two layers guarantee this: initial triage runs
-  `on: issues [opened]` only (never re-fires on edits), and the re-score/backfill
-  jobs honor the human-override guard above — a priority a human changed is never
-  overwritten, only surfaced as disagreement if the bot would grade it otherwise.
+- **Corrections are sticky.** The scheduled job honors the human-override guard
+  above — a priority a human changed is recorded in `issue_bot_state` as
+  human-owned and never overwritten, only surfaced as disagreement if the bot
+  would grade it otherwise.
 - **One knob.** You change the **priority label** (the field the classifier
   emits). The score is a pure function of it plus mechanical factors — no
   separate override to learn.
@@ -631,10 +713,14 @@ a test). It does **not** create any `comp:*` labels or wire `areas.json` into th
 live classifier. The steps below are the implementation plan, each intended as
 its own follow-up PR.
 
-1. **Prompt re-calibration** (`.github/triage/config.yaml`) — new priority
-   rubric (grade FRs across buckets; explicit P0 list; tier-1 floor) + the "P1
-   scarcity" guardrail + emit `severity`, `readiness`, and `sub_area` fields.
-   Low risk, affects new issues immediately.
+1. **Prompt re-calibration + persist severity** (`.github/triage/config.yaml`)
+   — new priority rubric (grade FRs across buckets; explicit P0 list; tier-1
+   floor) + the "P1 scarcity" guardrail + emit `severity`, `readiness`, and
+   `sub_area`. **`severity` is graded once at triage and persisted** (a stored
+   field, not just a transient classification): it's the largest multiplier and
+   the one input the score can't recompute from labels/text alone, so storing it
+   is what makes re-scoring deterministic (see "Determinism"). Low risk, affects
+   new issues immediately.
 2. **Component weight + labels** — the per-area `weight`/`weight_source` fields
    are already in `areas.json` (harness = telemetry, non-harness = editorial;
    confirm the harness bands and editorial weights in the team channel). Add the
@@ -644,10 +730,15 @@ its own follow-up PR.
    classifier allowlist and backfill. See "Component taxonomy" and Axis 3.
 3. **Template fields** — add Harness (+SDK/native) / Platform-device / Impact /
    Auth-type dropdowns.
-4. **Scoring job** — productionize `score_prototype.py` into a scheduled action
-   that reads LLM-graded severity + readiness + dup count and publishes the
-   ranked view. **Must implement the human-override guard** (write a
-   `bot-priority:*` shadow label; skip any issue whose `P*` a human changed).
+4. **Scoring & triage job (Databricks notebook, not a GitHub Action)** —
+   productionize `score_prototype.py` as a scheduled Databricks job. It reads
+   the already-synced issues table, computes score + derived priority **in one
+   place**, writes the `issue_scores` table the dashboard reads, and applies the
+   priority/component labels back to GitHub. See "Surfacing the score" below for
+   the data flow, the read-tokenless / write-with-secret split, and the
+   preserved prompt-injection boundary. **Must implement the human-override
+   guard** (an `issue_bot_state` record of what the bot last wrote; skip any
+   issue whose `P*` a human changed).
 5. **One-time backfill (regrade)** — re-run the classifier over open issues to
    relabel under the new rubric (see "How regrading works"); preview with
    `score_prototype.py --regrade`. Sets priority only where none exists or the

--- a/designs/prioritization/issue-prioritization-v2.md
+++ b/designs/prioritization/issue-prioritization-v2.md
@@ -648,11 +648,14 @@ adds three labels instead of eleven and doesn't grow with the harness count.
 
 ## Appendix C — Full ranking snapshot (top 200 of 360 open)
 
-Generated from today's snapshot with `score_prototype.py --markdown 200`
-(regex severity grader — the same stand-in used throughout; production uses
-the LLM grader). Columns: **Score** = composite score; **Sev** = re-graded
-severity; **Now** = current priority label; **Δrank** = movement vs the
-current priority-label ordering (positive = moved up).
+Generated from the snapshot with `score_prototype.py --markdown 200` (regex
+severity grader — the same stand-in used throughout; production uses the LLM
+grader). Columns: **Score** = composite score; **Sev** = re-graded severity;
+**Now** = current priority label; **Derived** = the priority the score→label
+thresholds (Axis 2) assign, with **⚑** marking a change from today's label;
+**Δrank** = movement vs the current priority-label ordering (positive = moved
+up). The Now→Derived column is the per-issue view of the backfill: the ⚑ rows
+are the relabels the one-time regrade would apply.
 
 **Illustrative, not actionable.** This is the *mechanism* running on a
 deliberately-weak grader, so its own failures are visible on purpose: ranks 1–2
@@ -667,205 +670,205 @@ as a handful of tiers, not 200 true ranks. Age is now neutral (review point), so
 older issues no longer decay. With the LLM grader plus ≤10% hand-correction (see
 the maintainer guide), this is the shape the production ranking takes.
 
-| # | Score | Sev | Now | Δrank | Issue |
-|--:|--:|---|---|--:|---|
-| 1 | 154 | critical | P2-medium | +235 | [#2057](https://github.com/omnigent-ai/omnigent/issues/2057) [Feature] Add Codex Auto mode using auto_review instead of jumping to  |
-| 2 | 154 | critical | P2-medium | +236 | [#2054](https://github.com/omnigent-ai/omnigent/issues/2054) [Feature] Remove duplicate Codex Full access mode and keep Sandbox Byp |
-| 3 | 126 | high | P1-high | +34 | [#3265](https://github.com/omnigent-ai/omnigent/issues/3265) claude-sdk agent with linux_bwrap dies at spawn on a runtime bwrap bin |
-| 4 | 115 | high | P2-medium | +236 | [#2038](https://github.com/omnigent-ai/omnigent/issues/2038) [Feature] No way to deregister/delete an external self-registered host |
-| 5 | 110 | critical | P1-high | -1 | [#3983](https://github.com/omnigent-ai/omnigent/issues/3983) [Bug] Smart-routed turns render out of order: reply streams above the  |
-| 6 | 110 | critical | P0-critical | -5 | [#3557](https://github.com/omnigent-ai/omnigent/issues/3557) [Bug] Shell-surface policy gates are bypassed by option-taking command |
-| 7 | 110 | critical | P1-high | +28 | [#3270](https://github.com/omnigent-ai/omnigent/issues/3270) [Bug] sys_session_create children are absent from both sys_session_lis |
-| 8 | 104 | critical | P2-medium | +224 | [#2125](https://github.com/omnigent-ai/omnigent/issues/2125) [Feature] Multi-host git credentials for managed sandboxes (GitHub + s |
-| 9 | 100 | critical | P3-low | +340 | [#61](https://github.com/omnigent-ai/omnigent/issues/61) 🤖 Code Audit: 21 potential issue(s) found |
-| 10 | 99 | high | P2-medium | +126 | [#3976](https://github.com/omnigent-ai/omnigent/issues/3976) [Feature] OAuth2 client-credentials grant so a headless process can au |
-| 11 | 99 | high | P2-medium | +153 | [#3363](https://github.com/omnigent-ai/omnigent/issues/3363) [Feature] Per-project custom instructions (project-scoped context) |
-| 12 | 99 | high | P2-medium | +165 | [#3164](https://github.com/omnigent-ai/omnigent/issues/3164) [Feature] Optional runtimeClassName on the kubernetes sandbox provider |
-| 13 | 99 | high | P2-medium | +263 | [#1388](https://github.com/omnigent-ai/omnigent/issues/1388) Make agents a first-class CRUD entity with a dedicated sidebar UI (dec |
-| 14 | 99 | critical | P2-medium | +301 | [#659](https://github.com/omnigent-ai/omnigent/issues/659) [Feature] add a microvm backend for sandbox |
-| 15 | 92 | high | P1-high | +26 | [#3180](https://github.com/omnigent-ai/omnigent/issues/3180) codex-native: runner never exits on idle timeout — cancelled delta-coa |
-| 16 | 92 | high | P1-high | +66 | [#2373](https://github.com/omnigent-ai/omnigent/issues/2373) [Bug] claude-native: pasted web-UI message loses its Enter, stuck draf |
-| 17 | 92 | high | P1-high | +77 | [#2060](https://github.com/omnigent-ai/omnigent/issues/2060) [Bug] claude-native: first web-UI message silently dropped when Claude |
-| 18 | 92 | high | P1-high | +85 | [#1898](https://github.com/omnigent-ai/omnigent/issues/1898) [Bug] codex-native: cancelling a task awaiting flush() poisons the del |
-| 19 | 92 | high | P2-medium | +297 | [#654](https://github.com/omnigent-ai/omnigent/issues/654) [Bug] Streaming with codex is hanging and paragraphs are not split. |
-| 20 | 92 | high | P1-high | +107 | [#542](https://github.com/omnigent-ai/omnigent/issues/542) [Bug] AttributeError: 'SubprocessCLITransport' object has no attribute |
-| 21 | 90 | high | P1-high | +31 | [#3001](https://github.com/omnigent-ai/omnigent/issues/3001) [Performance] GET /v1/sessions pre-fetches every accessible conversati |
-| 22 | 89 | high | P2-medium | +273 | [#1051](https://github.com/omnigent-ai/omnigent/issues/1051) [Feature] Forward OTel exporter knobs to executor subprocess env |
-| 23 | 84 | high | P2-medium | +131 | [#3558](https://github.com/omnigent-ai/omnigent/issues/3558) claude-sdk: cached client does not rebuild on framework-instruction ch |
-| 24 | 84 | high | P1-high | +29 | [#3000](https://github.com/omnigent-ai/omnigent/issues/3000) claude-native transcript forwarder polls at 4 Hz per session with no i |
-| 25 | 84 | high | P1-high | +37 | [#2748](https://github.com/omnigent-ai/omnigent/issues/2748) Runner idle-shutdown deadlocks forever: codex-forwarder close()/flush( |
-| 26 | 84 | high | P1-high | +41 | [#2575](https://github.com/omnigent-ai/omnigent/issues/2575) pi-native: non-Claude Databricks models (GLM, Gemini, …) hang — provid |
-| 27 | 84 | high | P1-high | +45 | [#2454](https://github.com/omnigent-ai/omnigent/issues/2454) [Bug] Unbounded ~/.omnigent growth: per-session native-harness dirs ar |
-| 28 | 84 | high | P1-high | +52 | [#2421](https://github.com/omnigent-ai/omnigent/issues/2421) [Bug] codex app-server + MCP bridge children leak on ANY unclean runne |
-| 29 | 83 | high | P2-medium | +276 | [#888](https://github.com/omnigent-ai/omnigent/issues/888) [Feature] Side-by-side multi-session view |
-| 30 | 81 | high | P2-medium | +107 | [#3970](https://github.com/omnigent-ai/omnigent/issues/3970) pi-native: every turn fails with "Pi model error: 401 Invalid Token" w |
-| 31 | 78 | high | P2-medium | +303 | [#16](https://github.com/omnigent-ai/omnigent/issues/16) Is native Windows support in scope, or should docs recommend WSL2? |
-| 32 | 76 | high | P2-medium | +297 | [#151](https://github.com/omnigent-ai/omnigent/issues/151) Native claude_code worker hangs on the one-time Bypass Permissions acc |
-| 33 | 70 | high | P1-high | +5 | [#3261](https://github.com/omnigent-ai/omnigent/issues/3261) [Crash] AttributeError: module 'os' has no attribute 'WNOHANG' |
-| 34 | 66 | high | P2-medium | +112 | [#3750](https://github.com/omnigent-ai/omnigent/issues/3750) [Crash] PermissionError: [Errno 1] Operation not permitted |
-| 35 | 66 | high | P1-high | -7 | [#3482](https://github.com/omnigent-ai/omnigent/issues/3482) [Crash] ServerError: |
-| 36 | 66 | high | P1-high | -6 | [#3458](https://github.com/omnigent-ai/omnigent/issues/3458) session-updates stream crashes with KeyError when a client watches a c |
-| 37 | 66 | high | P1-high | -5 | [#3359](https://github.com/omnigent-ai/omnigent/issues/3359) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 38 | 66 | high | P2-medium | +129 | [#3271](https://github.com/omnigent-ai/omnigent/issues/3271) [Feature] Expose per-session context size + last-turn timestamp to age |
-| 39 | 66 | high | P1-high | 0 | [#3251](https://github.com/omnigent-ai/omnigent/issues/3251) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 40 | 66 | high | P2-medium | +133 | [#3231](https://github.com/omnigent-ai/omnigent/issues/3231) [Crash] OmnigentError: {'error_code': 403, 'message': 'Invalid access  |
-| 41 | 66 | high | P1-high | +4 | [#3052](https://github.com/omnigent-ai/omnigent/issues/3052) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 42 | 66 | high | P1-high | +4 | [#3023](https://github.com/omnigent-ai/omnigent/issues/3023) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 43 | 66 | high | P1-high | +11 | [#2993](https://github.com/omnigent-ai/omnigent/issues/2993) [Crash] ModuleNotFoundError: No module named 'termios' |
-| 44 | 66 | high | P3-low | +293 | [#2887](https://github.com/omnigent-ai/omnigent/issues/2887) [Bug] web/package-lock.json is out of sync with package.json; plain `n |
-| 45 | 66 | high | P1-high | +23 | [#2559](https://github.com/omnigent-ai/omnigent/issues/2559) Conversation bricked: Page fails to load when opening markdown file af |
-| 46 | 66 | high | P0-critical | -44 | [#2355](https://github.com/omnigent-ai/omnigent/issues/2355) [Bug] workspace_id PK-widening migration crashes on populated Postgres |
-| 47 | 66 | high | P3-low | +294 | [#2224](https://github.com/omnigent-ai/omnigent/issues/2224) [Bug] get_client model-change check fails for harness="any" |
-| 48 | 66 | high | P1-high | +50 | [#1985](https://github.com/omnigent-ai/omnigent/issues/1985) Headless `omnigent run -p` intermittently hangs forever despite the tu |
-| 49 | 66 | high | P2-medium | +195 | [#1907](https://github.com/omnigent-ai/omnigent/issues/1907) Sub-agent model_override triggers an unnecessary first-turn harness re |
-| 50 | 66 | high | P1-high | +54 | [#1888](https://github.com/omnigent-ai/omnigent/issues/1888) ansi-to-react default import resolves to the CJS exports object under  |
-| 51 | 66 | high | P2-medium | +202 | [#1804](https://github.com/omnigent-ai/omnigent/issues/1804) spec parser crashes with TypeError on a null tools.builtins key (and s |
-| 52 | 66 | high | P2-medium | +237 | [#1076](https://github.com/omnigent-ai/omnigent/issues/1076) Runner-layer Tier-2 escalation: release an unresponsive per-conversati |
-| 53 | 66 | high | P1-high | +68 | [#1026](https://github.com/omnigent-ai/omnigent/issues/1026) Runner orphans tool callbacks with "no active turn context" after mid- |
-| 54 | 65 | high | P2-medium | +154 | [#2714](https://github.com/omnigent-ai/omnigent/issues/2714) Upgrade openai-agents and remove the temporary openai<2.45 cap |
-| 55 | 65 | high | P1-high | +35 | [#2245](https://github.com/omnigent-ai/omnigent/issues/2245) [Bug] openai-agents harness turn wedges permanently after policy-verdi |
-| 56 | 63 | high | P1-high | +75 | [#108](https://github.com/omnigent-ai/omnigent/issues/108) Cannot install on Linux aarch64 — cel-expr-python has no aarch64 wheel |
-| 57 | 61 | medium | P2-medium | +211 | [#1596](https://github.com/omnigent-ai/omnigent/issues/1596) Native-CLI harness (claude-native/codex-native) as a named agent's own |
-| 58 | 60 | high | P1-high | -50 | [#3971](https://github.com/omnigent-ai/omnigent/issues/3971) Host runners inherit the daemon's cwd; a deleted launch dir breaks eve |
-| 59 | 60 | high | P1-high | -25 | [#3274](https://github.com/omnigent-ai/omnigent/issues/3274) Sub-agent terminal status rejected with missing_parent_inbox and retri |
-| 60 | 60 | high | P2-medium | +112 | [#3235](https://github.com/omnigent-ai/omnigent/issues/3235) Flaky E2E UI: test_scheduled_task_create_edit_modal_and_time_picker[ch |
-| 61 | 60 | high | P1-high | -14 | [#3016](https://github.com/omnigent-ai/omnigent/issues/3016) [Bug] A transient session-snapshot failure permanently pins a session  |
-| 62 | 60 | high | P1-high | -14 | [#3012](https://github.com/omnigent-ai/omnigent/issues/3012) Hosts authenticated via `omnigent login` permanently 403 on first reco |
-| 63 | 60 | high | P2-medium | +155 | [#2428](https://github.com/omnigent-ai/omnigent/issues/2428) sys_session_send to a completed session hangs to ReadTimeout and is si |
-| 64 | 60 | high | P1-high | +27 | [#2241](https://github.com/omnigent-ai/omnigent/issues/2241) Flaky on main: test_interrupt_forwards_to_harness_before_cancelling ti |
-| 65 | 60 | high | P1-high | +31 | [#2051](https://github.com/omnigent-ai/omnigent/issues/2051) [Bug] sys_session_send(session_id=…) completions never drain to sys_re |
-| 66 | 60 | high | P0-critical | -63 | [#1657](https://github.com/omnigent-ai/omnigent/issues/1657) hermes-native forwarder advances last_id per item, dropping a row's la |
-| 67 | 60 | high | P2-medium | +247 | [#678](https://github.com/omnigent-ai/omnigent/issues/678) e2e: sub-agent supervisor routing / named-sub-agent auto-wake flakes ( |
-| 68 | 59 | high | P1-high | -51 | [#3799](https://github.com/omnigent-ai/omnigent/issues/3799) Android shell cannot sign in to servers behind a front-door auth proxy |
-| 69 | 59 | high | P1-high | -49 | [#3730](https://github.com/omnigent-ai/omnigent/issues/3730) [Bug] Android: renderer death terminates the app — OmnigentWebViewClie |
-| 70 | 59 | high | P1-high | -48 | [#3701](https://github.com/omnigent-ai/omnigent/issues/3701) [Bug] Desktop app never completes Okta security key / biometric MFA du |
-| 71 | 59 | high | P1-high | -38 | [#3299](https://github.com/omnigent-ai/omnigent/issues/3299) [Bug] Harness-credential route times out with a misleading 504 against |
-| 72 | 59 | high | P2-medium | +94 | [#3284](https://github.com/omnigent-ai/omnigent/issues/3284) [Crash] DuplicateOptionError: While reading from PosixPath('/Users/*** |
-| 73 | 59 | high | P2-medium | +111 | [#3070](https://github.com/omnigent-ai/omnigent/issues/3070) No progress signal on a stuck or interactive harness install |
-| 74 | 59 | high | P1-high | -19 | [#2967](https://github.com/omnigent-ai/omnigent/issues/2967) [Bug] A full context window bricks a session with "Prompt is too long" |
-| 75 | 59 | high | P2-medium | +141 | [#2480](https://github.com/omnigent-ai/omnigent/issues/2480) [Bug] Postgres-backed local server: bare `No module named 'psycopg'` + |
-| 76 | 59 | high | P1-high | +12 | [#2270](https://github.com/omnigent-ai/omnigent/issues/2270) Windows: config list crashes — UnicodeEncodeError on cp1252 (non-UTF8) |
-| 77 | 59 | high | P1-high | +12 | [#2269](https://github.com/omnigent-ai/omnigent/issues/2269) Windows: omnigent setup crashes — ModuleNotFoundError: No module named |
-| 78 | 59 | high | P1-high | +21 | [#1953](https://github.com/omnigent-ai/omnigent/issues/1953) `omni host` dies permanently when the OIDC session JWT expires — no re |
-| 79 | 59 | high | P1-high | +23 | [#1901](https://github.com/omnigent-ai/omnigent/issues/1901) [Bug] kimi/qwen/goose/kiro forwarders blind-retry failed conversation- |
-| 80 | 59 | high | P1-high | +25 | [#1881](https://github.com/omnigent-ai/omnigent/issues/1881) [Bug] `omnigent setup` crashes with `ValueError: select() requires at  |
-| 81 | 59 | high | P1-high | +27 | [#1827](https://github.com/omnigent-ai/omnigent/issues/1827) [Bug] kimi-native: torn UTF-8 wire read crashes the forwarder; supervi |
-| 82 | 59 | high | P2-medium | +185 | [#1600](https://github.com/omnigent-ai/omnigent/issues/1600) Epic: 12-feature contribution (one issue + one PR per feature) |
-| 83 | 59 | high | P2-medium | +187 | [#1528](https://github.com/omnigent-ai/omnigent/issues/1528) Idle-session lifecycle UX: reap gracefully, resume seamlessly, surface |
-| 84 | 58 | high | P2-medium | +214 | [#1022](https://github.com/omnigent-ai/omnigent/issues/1022) Behind a corporate proxy, the host daemon can't reach the model backen |
-| 85 | 57 | medium | P2-medium | +214 | [#1021](https://github.com/omnigent-ai/omnigent/issues/1021) [Feature] GitHub Copilot as provider |
-| 86 | 54 | high | P2-medium | +58 | [#3798](https://github.com/omnigent-ai/omnigent/issues/3798) Android shell shows the SPA as if signed in while native login runs in |
-| 87 | 54 | high | P1-high | -58 | [#3469](https://github.com/omnigent-ai/omnigent/issues/3469) [Bug] Post-completion compaction spiral: merge-commit diff output trig |
-| 88 | 54 | high | P1-high | -23 | [#2629](https://github.com/omnigent-ai/omnigent/issues/2629) web_fetch sub-agent spawn fails with unknown harness 'omnigent' — bare |
-| 89 | 54 | high | P2-medium | +166 | [#1778](https://github.com/omnigent-ai/omnigent/issues/1778) opencode-native forwarder loses session content across SSE reconnects  |
-| 90 | 54 | high | P1-high | +38 | [#523](https://github.com/omnigent-ai/omnigent/issues/523) REPL pexpect e2e tests starve on boot under full shard load (60s _wait |
-| 91 | 53 | high | P1-high | -42 | [#3011](https://github.com/omnigent-ai/omnigent/issues/3011) kiro-native harness: interactive sessions never respond with kiro-cli  |
-| 92 | 53 | high | P1-high | -36 | [#2920](https://github.com/omnigent-ai/omnigent/issues/2920) Omnigent server fails to start on native Windows: os.getuid() at impor |
-| 93 | 53 | high | P1-high | -36 | [#2919](https://github.com/omnigent-ai/omnigent/issues/2919) omni setup crashes on Windows: ModuleNotFoundError: No module named 't |
-| 94 | 53 | high | P1-high | -15 | [#2422](https://github.com/omnigent-ai/omnigent/issues/2422) Windows: five chained defects break the documented degraded-mode subse |
-| 95 | 53 | high | P2-medium | +215 | [#762](https://github.com/omnigent-ai/omnigent/issues/762) [Bug] sub agent terminal crashes when cli starts with prompt for input |
-| 96 | 50 | medium | P2-medium | +108 | [#2744](https://github.com/omnigent-ai/omnigent/issues/2744) [Bug] codex-native: custom agents time out at launch — native provider |
-| 97 | 46 | medium | P1-high | -87 | [#3952](https://github.com/omnigent-ai/omnigent/issues/3952) A stale terminal exit removes the newer Codex resources of the same se |
-| 98 | 46 | medium | P2-medium | +93 | [#2984](https://github.com/omnigent-ai/omnigent/issues/2984) [Bug] Codex incorrectly reports `needs-auth` with an authenticated cus |
-| 99 | 46 | medium | P1-high | -7 | [#2184](https://github.com/omnigent-ai/omnigent/issues/2184) [Bug] Codex plugin skills are exposed with inconsistent names (`plugin |
-| 100 | 46 | medium | P1-high | -7 | [#2071](https://github.com/omnigent-ai/omnigent/issues/2071) [Bug] web_search never advertised to claude-sdk sessions: unprefixed m |
-| 101 | 46 | medium | P2-medium | +134 | [#2062](https://github.com/omnigent-ai/omnigent/issues/2062) [Bug] claude-native: per-session model override silently lost when wra |
-| 102 | 46 | medium | P1-high | +5 | [#1831](https://github.com/omnigent-ai/omnigent/issues/1831) claude-native workers ignore executor.model pin and per-dispatch args. |
-| 103 | 46 | medium | P1-high | +7 | [#1781](https://github.com/omnigent-ai/omnigent/issues/1781) codex harness: ambient DATABRICKS_BEARER/DATABRICKS_TOKEN overrides pr |
-| 104 | 46 | medium | P1-high | +15 | [#1128](https://github.com/omnigent-ai/omnigent/issues/1128) [Bug] Claude SDK Appears to Use Opus Instead of Selected Model |
-| 105 | 46 | medium | P1-high | +25 | [#241](https://github.com/omnigent-ai/omnigent/issues/241) pi harness: GPT and Gemini dispatches 404 on the Databricks ucode gate |
-| 106 | 46 | medium | P3-low | +241 | [#147](https://github.com/omnigent-ai/omnigent/issues/147) Tracking: gradual decomposition of monolith modules (cli.py 9.1KLOC, c |
-| 107 | 42 | medium | P1-high | -89 | [#3790](https://github.com/omnigent-ai/omnigent/issues/3790) force_sandbox policy is evaluated but structurally unreachable from cl |
-| 108 | 42 | medium | P2-medium | +150 | [#1724](https://github.com/omnigent-ai/omnigent/issues/1724) codex-native harness times out on WSL2 ("Codex TUI never started a thr |
-| 109 | 42 | medium | P1-high | -51 | [#2904](https://github.com/omnigent-ai/omnigent/issues/2904) [Bug] claude-native: web-UI chat input fails with "tmux command failed |
-| 110 | 42 | medium | P1-high | -29 | [#2397](https://github.com/omnigent-ai/omnigent/issues/2397) [Bug] Codex-native intelligent routing ignores live effort capabilitie |
-| 111 | 42 | medium | P1-high | -24 | [#2272](https://github.com/omnigent-ai/omnigent/issues/2272) [Bug] Codex runner can't find OpenRouter secret that exists in keyring |
-| 112 | 42 | medium | P2-medium | +192 | [#890](https://github.com/omnigent-ai/omnigent/issues/890) [Bug] omnigent setup fails with npm EACCES when installing the Claude  |
-| 113 | 42 | medium | P1-high | +12 | [#668](https://github.com/omnigent-ai/omnigent/issues/668) [Bug] BUG？omni claude times out (60s) on macOS with native Claude Code |
-| 114 | 38 | medium | P1-high | -98 | [#3852](https://github.com/omnigent-ai/omnigent/issues/3852) [Bug] Built-in write policies miss Claude Code's `MultiEdit` / `Notebo |
-| 115 | 38 | medium | P2-medium | +109 | [#2369](https://github.com/omnigent-ai/omnigent/issues/2369) [Bug] pi harness only lists databricks-claude-sonnet-4-6 |
-| 116 | 38 | medium | P1-high | -30 | [#2299](https://github.com/omnigent-ai/omnigent/issues/2299) [Bug] claude-native resume transcripts flatten tool_result image block |
-| 117 | 38 | medium | P2-medium | +104 | [#2390](https://github.com/omnigent-ai/omnigent/issues/2390) Builtin policy for per-user sub-agent access control (subagent_access_ |
-| 118 | 38 | medium | P2-medium | +206 | [#377](https://github.com/omnigent-ai/omnigent/issues/377) gpt sub-agent fails on startup with missing databricks-sdk dependency |
-| 119 | 38 | medium | P1-high | -10 | [#1794](https://github.com/omnigent-ai/omnigent/issues/1794) Bundled Polly: claude-sdk brain "Not logged in" + runaway spawn loop o |
-| 120 | 38 | medium | P1-high | -9 | [#1694](https://github.com/omnigent-ai/omnigent/issues/1694) Reliability: parallel code-fix missions fail silently (5s tmux timeout |
-| 121 | 37 | medium | P1-high | -79 | [#3101](https://github.com/omnigent-ai/omnigent/issues/3101) Docker/Kubernetes entrypoint never wires project_store — first-class P |
-| 122 | 36 | medium | P2-medium | +161 | [#1192](https://github.com/omnigent-ai/omnigent/issues/1192) [Bug] Manual /compact errors "Compaction requires a configured LLM mod |
-| 123 | 36 | medium | P1-high | -6 | [#1158](https://github.com/omnigent-ai/omnigent/issues/1158) [Bug] antigravity-native: TUI-typed turns never mirror to the web UI ( |
-| 124 | 36 | medium | P2-medium | +161 | [#1157](https://github.com/omnigent-ai/omnigent/issues/1157) [Bug] antigravity-native: no Chat/Terminal toggle — terminal_antigravi |
-| 125 | 36 | feature | P2-medium | +188 | [#692](https://github.com/omnigent-ai/omnigent/issues/692) Polly: fan out sub-agent work across multiple concurrent claude profil |
-| 126 | 36 | feature | P2-medium | +201 | [#197](https://github.com/omnigent-ai/omnigent/issues/197) Declarative skill sources: pull Claude Code skills + their dependency  |
-| 127 | 35 | medium | P2-medium | +110 | [#2055](https://github.com/omnigent-ai/omnigent/issues/2055) [Bug] codex-native harness elicitation: a resolve landing in the betwe |
-| 128 | 35 | medium | P1-high | -84 | [#3076](https://github.com/omnigent-ai/omnigent/issues/3076) [Bug] claude-sdk omits ToolSearch, eagerly loading every MCP schema |
-| 129 | 35 | medium | P3-low | +210 | [#2800](https://github.com/omnigent-ai/omnigent/issues/2800) [Bug] Top-level custom codex-native agents drop reasoning effort and y |
-| 130 | 35 | medium | P1-high | -7 | [#880](https://github.com/omnigent-ai/omnigent/issues/880) [BUG] Native harness (omnigent claude): assistant turns not streamed t |
-| 131 | 33 | medium | P1-high | -18 | [#1551](https://github.com/omnigent-ai/omnigent/issues/1551) opencode-native: blocking question tool not surfaced to web (no elicit |
-| 132 | 33 | medium | P2-medium | +2 | [#4009](https://github.com/omnigent-ai/omnigent/issues/4009) [Feature] No Go client for the session API, so every Go caller hand-ro |
-| 133 | 33 | medium | P1-high | -127 | [#3981](https://github.com/omnigent-ai/omnigent/issues/3981) [Bug] Desktop: Workspace rail resize is unusable on the Browser tab; a |
-| 134 | 33 | medium | P1-high | -121 | [#3898](https://github.com/omnigent-ai/omnigent/issues/3898) [Bug] Pack function policies fail server-side input evaluation unless  |
-| 135 | 33 | medium | P1-high | -121 | [#3870](https://github.com/omnigent-ai/omnigent/issues/3870) child-session creation returns 500 internal_error, breaking Polly/Debb |
-| 136 | 33 | medium | P2-medium | +6 | [#3864](https://github.com/omnigent-ai/omnigent/issues/3864) [Bug] to_api_dict() drops ConversationItem.created_at, so flat items A |
-| 137 | 33 | medium | P1-high | -122 | [#3863](https://github.com/omnigent-ai/omnigent/issues/3863) [Bug] Databricks Apps entrypoint never wires project_store — Projects  |
-| 138 | 33 | medium | P2-medium | +5 | [#3861](https://github.com/omnigent-ai/omnigent/issues/3861) [Bug] omni host status renders URLs so terminals link the whole status |
-| 139 | 33 | medium | P2-medium | +13 | [#3563](https://github.com/omnigent-ai/omnigent/issues/3563) [Bug] Host-bound resume into a deleted workspace: host computes the ex |
-| 140 | 33 | medium | P2-medium | +13 | [#3561](https://github.com/omnigent-ai/omnigent/issues/3561) [Bug] `prompt_policy` never sends `_CLASSIFIER_SCHEMA` to the LLM — st |
-| 141 | 33 | medium | P2-medium | +14 | [#3550](https://github.com/omnigent-ai/omnigent/issues/3550) [Bug] Missing signing alg's prevent using some OIDC providers |
-| 142 | 33 | medium | P2-medium | +18 | [#3435](https://github.com/omnigent-ai/omnigent/issues/3435) [Feature] Admin server-wide usage report (per-user and per-model cost) |
-| 143 | 33 | medium | none | +210 | [#3402](https://github.com/omnigent-ai/omnigent/issues/3402) [Bug] Label seeding and session-state writes race under concurrent upd |
-| 144 | 33 | medium | P2-medium | +18 | [#3368](https://github.com/omnigent-ai/omnigent/issues/3368) Feature: first-class async write-safety (freeze → approve → apply) pri |
-| 145 | 33 | medium | P2-medium | +20 | [#3352](https://github.com/omnigent-ai/omnigent/issues/3352) [Feature] OpenClaw onboarding — Option B: chat import (SQLite session  |
-| 146 | 33 | medium | P2-medium | +24 | [#3247](https://github.com/omnigent-ai/omnigent/issues/3247) credential_proxy: re-resolve the source on 401 / expiry (short-lived t |
-| 147 | 33 | medium | P1-high | -107 | [#3236](https://github.com/omnigent-ai/omnigent/issues/3236) web_search: bare executor.model strings are inferred as provider 'open |
-| 148 | 33 | medium | P2-medium | +28 | [#3219](https://github.com/omnigent-ai/omnigent/issues/3219) [Bug] Cmd/Ctrl+Up/Down session traversal stops in an empty focused com |
-| 149 | 33 | medium | P2-medium | +43 | [#2921](https://github.com/omnigent-ai/omnigent/issues/2921) Font settings: selected font (incl. Nerd Fonts) never loads — no webfo |
-| 150 | 33 | medium | P1-high | -90 | [#2854](https://github.com/omnigent-ai/omnigent/issues/2854) [Bug] Cross-harness `harness_override` is ignored on the `initial_item |
-| 151 | 33 | medium | P2-medium | +45 | [#2851](https://github.com/omnigent-ai/omnigent/issues/2851) Policy-supplied targets for ASK approval cards |
-| 152 | 33 | medium | P2-medium | +50 | [#2756](https://github.com/omnigent-ai/omnigent/issues/2756) Expose atomic session-event admission to integrations |
-| 153 | 33 | medium | P2-medium | +59 | [#2577](https://github.com/omnigent-ai/omnigent/issues/2577) [Feature] Manage OIDC/SSO admins from an id_token claim (IdP group/rol |
-| 154 | 33 | medium | P2-medium | +59 | [#2558](https://github.com/omnigent-ai/omnigent/issues/2558) Distribution / Installation / Enterprise Readiness |
-| 155 | 33 | medium | P1-high | -85 | [#2539](https://github.com/omnigent-ai/omnigent/issues/2539) Named sys_session_send returns 404 after first child from a bundled se |
-| 156 | 33 | medium | P1-high | -85 | [#2524](https://github.com/omnigent-ai/omnigent/issues/2524) [Bug] Registering remote host fails |
-| 157 | 33 | medium | P1-high | -84 | [#2444](https://github.com/omnigent-ai/omnigent/issues/2444) Accounts JWT expiry falls through to Databricks auth and breaks persis |
-| 158 | 33 | medium | P2-medium | +62 | [#2404](https://github.com/omnigent-ai/omnigent/issues/2404) fix(runtime): orphan sweep can abort startup on unreadable shared-host |
-| 159 | 33 | medium | P2-medium | +63 | [#2374](https://github.com/omnigent-ai/omnigent/issues/2374) Proposal: per-turn context_providers to augment system instructions at |
-| 160 | 33 | medium | P1-high | -75 | [#2304](https://github.com/omnigent-ai/omnigent/issues/2304) Runner subprocess inherits host daemon cwd, causing os_env cwd resolut |
-| 161 | 33 | medium | P2-medium | +73 | [#2070](https://github.com/omnigent-ai/omnigent/issues/2070) [Feature] sys_os_* file tools are hard-confined to the session workspa |
-| 162 | 33 | medium | P2-medium | +109 | [#1526](https://github.com/omnigent-ai/omnigent/issues/1526) Refactor: incrementally decompose the 4 god-files (sessions.py, runner |
-| 163 | 33 | medium | P2-medium | +111 | [#1411](https://github.com/omnigent-ai/omnigent/issues/1411) Standalone reusable MCP servers: CRUD + connection verify (list tools) |
-| 164 | 33 | medium | P2-medium | +126 | [#1075](https://github.com/omnigent-ai/omnigent/issues/1075) [Feature] Support AWS Lambda / Firecracker microVMs as managed sandbox |
-| 165 | 33 | medium | P2-medium | +127 | [#1055](https://github.com/omnigent-ai/omnigent/issues/1055) [Test] End-to-end OTel test against a real collector to lock in the BY |
-| 166 | 33 | medium | P2-medium | +127 | [#1054](https://github.com/omnigent-ai/omnigent/issues/1054) [Feature] Record gen_ai.retry events on llm_call spans |
-| 167 | 33 | medium | P2-medium | +130 | [#1031](https://github.com/omnigent-ai/omnigent/issues/1031) [Feature] Support serving the standalone Web UI under a subpath, e.g.  |
-| 168 | 33 | medium | P2-medium | +132 | [#983](https://github.com/omnigent-ai/omnigent/issues/983) Session sharing ergonomics: `sys_session_share` agent tool + `omnigent |
-| 169 | 33 | medium | P2-medium | +139 | [#857](https://github.com/omnigent-ai/omnigent/issues/857) [Proposal] Usage-limit detection + on-429 failover across pooled provi |
-| 170 | 33 | medium | P1-high | -46 | [#765](https://github.com/omnigent-ai/omnigent/issues/765) Support interactive mid-flight policy ASK (TOOL_CALL/TOOL_RESULT/OUTPU |
-| 171 | 33 | medium | P1-high | -45 | [#547](https://github.com/omnigent-ai/omnigent/issues/547) Bug: Polly model switcher sends invalid Cursor SDK model id |
-| 172 | 33 | medium | P1-high | -43 | [#522](https://github.com/omnigent-ai/omnigent/issues/522) Implement async-tool completion auto-delivery (SESSION_REARCHITECTURE  |
-| 173 | 33 | medium | P2-medium | +145 | [#509](https://github.com/omnigent-ai/omnigent/issues/509) [Feature] Default new-session workspace from selected agent's cwd |
-| 174 | 33 | medium | P2-medium | +149 | [#382](https://github.com/omnigent-ai/omnigent/issues/382) Evaluating the same agent across harnesses: no built-in way to compare |
-| 175 | 33 | medium | P1-high | -75 | [#1936](https://github.com/omnigent-ai/omnigent/issues/1936) [BUG] copilot harness: 401 Bad credentials when no token is explicitly |
-| 176 | 32 | feature | P2-medium | +97 | [#1454](https://github.com/omnigent-ai/omnigent/issues/1454) [Feature] Change permission mode of a running claude-native session fr |
-| 177 | 31 | medium | P1-high | -99 | [#2429](https://github.com/omnigent-ai/omnigent/issues/2429) Server (python -m omnigent.cli server) CPU-spins indefinitely with no  |
-| 178 | 31 | medium | P1-high | -58 | [#1113](https://github.com/omnigent-ai/omnigent/issues/1113) Native sub-agent/runner failures surface as bare "failed" with no reas |
-| 179 | 31 | feature | P2-medium | -1 | [#3150](https://github.com/omnigent-ai/omnigent/issues/3150) [Feature] CLI: cross-harness fork — continue an existing session in a  |
-| 180 | 31 | feature | P2-medium | +79 | [#1703](https://github.com/omnigent-ai/omnigent/issues/1703) [Feature] Unify harness naming: bare names (claude, codex, …) are ambi |
-| 181 | 31 | feature | P3-low | +161 | [#1678](https://github.com/omnigent-ai/omnigent/issues/1678) tech-debt(codex-native): extract a string-field helper for repeated di |
-| 182 | 31 | feature | P2-medium | +137 | [#503](https://github.com/omnigent-ai/omnigent/issues/503) [Feature] Switch Claude Code account per session via isolated profiles |
-| 183 | 30 | feature | P2-medium | +42 | [#2303](https://github.com/omnigent-ai/omnigent/issues/2303) [Feature] Support multi-repo workspaces (nested Git repos or multiple  |
-| 184 | 30 | medium | P2-medium | -2 | [#3083](https://github.com/omnigent-ai/omnigent/issues/3083) [Bug] Cursor sessions launched from Omnigent Web is losing MCPs |
-| 185 | 30 | medium | P1-high | -67 | [#1156](https://github.com/omnigent-ai/omnigent/issues/1156) [Bug] antigravity-native: web/mobile turns never appear in the native  |
-| 186 | 30 | medium | P2-medium | -17 | [#3250](https://github.com/omnigent-ai/omnigent/issues/3250) flaky e2e_ui: test_scheduled_task_create_edit_modal_and_time_picker ti |
-| 187 | 30 | medium | P2-medium | +11 | [#2848](https://github.com/omnigent-ai/omnigent/issues/2848) Server logs an expected offline-runner resource 503 as ERROR + full tr |
-| 188 | 30 | medium | P2-medium | +13 | [#2767](https://github.com/omnigent-ai/omnigent/issues/2767) [Bug] SQLite pool (default 5+10) not sized to the 200-thread limiter → |
-| 189 | 30 | medium | P1-high | -106 | [#2357](https://github.com/omnigent-ai/omnigent/issues/2357) [Bug] admin fleet-view calls SqlAlchemyConversationStore.list_conversa |
-| 190 | 30 | medium | P1-high | -95 | [#2052](https://github.com/omnigent-ai/omnigent/issues/2052) [Bug] web_fetch's __web_researcher helper sub-agent fails on 0.4.0 (si |
-| 191 | 30 | medium | P1-high | -90 | [#1920](https://github.com/omnigent-ai/omnigent/issues/1920) Seeder matching-hash fast path can't self-heal a lost artifact-store b |
-| 192 | 30 | medium | P1-high | -86 | [#1857](https://github.com/omnigent-ai/omnigent/issues/1857) Host daemon stays alive but shows offline — server-dropped host tunnel |
-| 193 | 30 | medium | P1-high | -81 | [#1686](https://github.com/omnigent-ai/omnigent/issues/1686) xai: reasoning_effort sent to all Grok models returns HTTP 400 on unsu |
-| 194 | 30 | medium | P2-medium | +94 | [#1117](https://github.com/omnigent-ai/omnigent/issues/1117) async generator ignored GeneratorExit — orphaned SSE relay task, excep |
-| 195 | 30 | medium | P2-medium | +117 | [#725](https://github.com/omnigent-ai/omnigent/issues/725) Changes panel is empty for native-harness and external edits in non-gi |
-| 196 | 30 | medium | P2-medium | +134 | [#146](https://github.com/omnigent-ai/omnigent/issues/146) StreamHooks.on_sub_agent_spawned / on_sub_agent_completed are declared |
-| 197 | 30 | medium | P1-high | -192 | [#3982](https://github.com/omnigent-ai/omnigent/issues/3982) [Bug] electron-build.yml pnpm filter matches no package: desktop packa |
-| 198 | 30 | medium | P3-low | +138 | [#3733](https://github.com/omnigent-ai/omnigent/issues/3733) [Bug] Android: hardcoded 25px switcher height makes the chat scroll-fa |
-| 199 | 30 | medium | P2-medium | -52 | [#3732](https://github.com/omnigent-ai/omnigent/issues/3732) [Bug] Android: a Display-size change leaves the server-switcher pill's |
-| 200 | 30 | medium | P2-medium | -50 | [#3592](https://github.com/omnigent-ai/omnigent/issues/3592) [Feature] Deterministic long-term memory (automatic recall/retain) — f |
+| # | Score | Sev | Now | Derived | Δrank | Issue |
+|--:|--:|---|---|---|--:|---|
+| 1 | 154 | critical | P2 | P0 ⚑ | +235 | [#2057](https://github.com/omnigent-ai/omnigent/issues/2057) [Feature] Add Codex Auto mode using auto_review instead of jumping to  |
+| 2 | 154 | critical | P2 | P0 ⚑ | +236 | [#2054](https://github.com/omnigent-ai/omnigent/issues/2054) [Feature] Remove duplicate Codex Full access mode and keep Sandbox Byp |
+| 3 | 126 | high | P1 | P0 ⚑ | +34 | [#3265](https://github.com/omnigent-ai/omnigent/issues/3265) claude-sdk agent with linux_bwrap dies at spawn on a runtime bwrap bin |
+| 4 | 115 | high | P2 | P0 ⚑ | +236 | [#2038](https://github.com/omnigent-ai/omnigent/issues/2038) [Feature] No way to deregister/delete an external self-registered host |
+| 5 | 110 | critical | P1 | P0 ⚑ | -1 | [#3983](https://github.com/omnigent-ai/omnigent/issues/3983) [Bug] Smart-routed turns render out of order: reply streams above the  |
+| 6 | 110 | critical | P0 | P0 | -5 | [#3557](https://github.com/omnigent-ai/omnigent/issues/3557) [Bug] Shell-surface policy gates are bypassed by option-taking command |
+| 7 | 110 | critical | P1 | P0 ⚑ | +28 | [#3270](https://github.com/omnigent-ai/omnigent/issues/3270) [Bug] sys_session_create children are absent from both sys_session_lis |
+| 8 | 104 | critical | P2 | P0 ⚑ | +224 | [#2125](https://github.com/omnigent-ai/omnigent/issues/2125) [Feature] Multi-host git credentials for managed sandboxes (GitHub + s |
+| 9 | 100 | critical | P3 | P0 ⚑ | +340 | [#61](https://github.com/omnigent-ai/omnigent/issues/61) 🤖 Code Audit: 21 potential issue(s) found |
+| 10 | 99 | high | P2 | P1 ⚑ | +126 | [#3976](https://github.com/omnigent-ai/omnigent/issues/3976) [Feature] OAuth2 client-credentials grant so a headless process can au |
+| 11 | 99 | high | P2 | P1 ⚑ | +153 | [#3363](https://github.com/omnigent-ai/omnigent/issues/3363) [Feature] Per-project custom instructions (project-scoped context) |
+| 12 | 99 | high | P2 | P1 ⚑ | +165 | [#3164](https://github.com/omnigent-ai/omnigent/issues/3164) [Feature] Optional runtimeClassName on the kubernetes sandbox provider |
+| 13 | 99 | high | P2 | P1 ⚑ | +263 | [#1388](https://github.com/omnigent-ai/omnigent/issues/1388) Make agents a first-class CRUD entity with a dedicated sidebar UI (dec |
+| 14 | 99 | critical | P2 | P1 ⚑ | +301 | [#659](https://github.com/omnigent-ai/omnigent/issues/659) [Feature] add a microvm backend for sandbox |
+| 15 | 92 | high | P1 | P1 | +26 | [#3180](https://github.com/omnigent-ai/omnigent/issues/3180) codex-native: runner never exits on idle timeout — cancelled delta-coa |
+| 16 | 92 | high | P1 | P1 | +66 | [#2373](https://github.com/omnigent-ai/omnigent/issues/2373) [Bug] claude-native: pasted web-UI message loses its Enter, stuck draf |
+| 17 | 92 | high | P1 | P1 | +77 | [#2060](https://github.com/omnigent-ai/omnigent/issues/2060) [Bug] claude-native: first web-UI message silently dropped when Claude |
+| 18 | 92 | high | P1 | P1 | +85 | [#1898](https://github.com/omnigent-ai/omnigent/issues/1898) [Bug] codex-native: cancelling a task awaiting flush() poisons the del |
+| 19 | 92 | high | P2 | P1 ⚑ | +297 | [#654](https://github.com/omnigent-ai/omnigent/issues/654) [Bug] Streaming with codex is hanging and paragraphs are not split. |
+| 20 | 92 | high | P1 | P1 | +107 | [#542](https://github.com/omnigent-ai/omnigent/issues/542) [Bug] AttributeError: 'SubprocessCLITransport' object has no attribute |
+| 21 | 90 | high | P1 | P1 | +31 | [#3001](https://github.com/omnigent-ai/omnigent/issues/3001) [Performance] GET /v1/sessions pre-fetches every accessible conversati |
+| 22 | 89 | high | P2 | P1 ⚑ | +273 | [#1051](https://github.com/omnigent-ai/omnigent/issues/1051) [Feature] Forward OTel exporter knobs to executor subprocess env |
+| 23 | 84 | high | P2 | P1 ⚑ | +131 | [#3558](https://github.com/omnigent-ai/omnigent/issues/3558) claude-sdk: cached client does not rebuild on framework-instruction ch |
+| 24 | 84 | high | P1 | P1 | +29 | [#3000](https://github.com/omnigent-ai/omnigent/issues/3000) claude-native transcript forwarder polls at 4 Hz per session with no i |
+| 25 | 84 | high | P1 | P1 | +37 | [#2748](https://github.com/omnigent-ai/omnigent/issues/2748) Runner idle-shutdown deadlocks forever: codex-forwarder close()/flush( |
+| 26 | 84 | high | P1 | P1 | +41 | [#2575](https://github.com/omnigent-ai/omnigent/issues/2575) pi-native: non-Claude Databricks models (GLM, Gemini, …) hang — provid |
+| 27 | 84 | high | P1 | P1 | +45 | [#2454](https://github.com/omnigent-ai/omnigent/issues/2454) [Bug] Unbounded ~/.omnigent growth: per-session native-harness dirs ar |
+| 28 | 84 | high | P1 | P1 | +52 | [#2421](https://github.com/omnigent-ai/omnigent/issues/2421) [Bug] codex app-server + MCP bridge children leak on ANY unclean runne |
+| 29 | 83 | high | P2 | P1 ⚑ | +276 | [#888](https://github.com/omnigent-ai/omnigent/issues/888) [Feature] Side-by-side multi-session view |
+| 30 | 81 | high | P2 | P1 ⚑ | +107 | [#3970](https://github.com/omnigent-ai/omnigent/issues/3970) pi-native: every turn fails with "Pi model error: 401 Invalid Token" w |
+| 31 | 78 | high | P2 | P1 ⚑ | +303 | [#16](https://github.com/omnigent-ai/omnigent/issues/16) Is native Windows support in scope, or should docs recommend WSL2? |
+| 32 | 76 | high | P2 | P1 ⚑ | +297 | [#151](https://github.com/omnigent-ai/omnigent/issues/151) Native claude_code worker hangs on the one-time Bypass Permissions acc |
+| 33 | 70 | high | P1 | P1 | +5 | [#3261](https://github.com/omnigent-ai/omnigent/issues/3261) [Crash] AttributeError: module 'os' has no attribute 'WNOHANG' |
+| 34 | 66 | high | P2 | P1 ⚑ | +112 | [#3750](https://github.com/omnigent-ai/omnigent/issues/3750) [Crash] PermissionError: [Errno 1] Operation not permitted |
+| 35 | 66 | high | P1 | P1 | -7 | [#3482](https://github.com/omnigent-ai/omnigent/issues/3482) [Crash] ServerError: |
+| 36 | 66 | high | P1 | P1 | -6 | [#3458](https://github.com/omnigent-ai/omnigent/issues/3458) session-updates stream crashes with KeyError when a client watches a c |
+| 37 | 66 | high | P1 | P1 | -5 | [#3359](https://github.com/omnigent-ai/omnigent/issues/3359) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 38 | 66 | high | P2 | P1 ⚑ | +129 | [#3271](https://github.com/omnigent-ai/omnigent/issues/3271) [Feature] Expose per-session context size + last-turn timestamp to age |
+| 39 | 66 | high | P1 | P1 | 0 | [#3251](https://github.com/omnigent-ai/omnigent/issues/3251) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 40 | 66 | high | P2 | P1 ⚑ | +133 | [#3231](https://github.com/omnigent-ai/omnigent/issues/3231) [Crash] OmnigentError: {'error_code': 403, 'message': 'Invalid access  |
+| 41 | 66 | high | P1 | P1 | +4 | [#3052](https://github.com/omnigent-ai/omnigent/issues/3052) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 42 | 66 | high | P1 | P1 | +4 | [#3023](https://github.com/omnigent-ai/omnigent/issues/3023) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 43 | 66 | high | P1 | P1 | +11 | [#2993](https://github.com/omnigent-ai/omnigent/issues/2993) [Crash] ModuleNotFoundError: No module named 'termios' |
+| 44 | 66 | high | P3 | P1 ⚑ | +293 | [#2887](https://github.com/omnigent-ai/omnigent/issues/2887) [Bug] web/package-lock.json is out of sync with package.json; plain `n |
+| 45 | 66 | high | P1 | P1 | +23 | [#2559](https://github.com/omnigent-ai/omnigent/issues/2559) Conversation bricked: Page fails to load when opening markdown file af |
+| 46 | 66 | high | P0 | P1 ⚑ | -44 | [#2355](https://github.com/omnigent-ai/omnigent/issues/2355) [Bug] workspace_id PK-widening migration crashes on populated Postgres |
+| 47 | 66 | high | P3 | P1 ⚑ | +294 | [#2224](https://github.com/omnigent-ai/omnigent/issues/2224) [Bug] get_client model-change check fails for harness="any" |
+| 48 | 66 | high | P1 | P1 | +50 | [#1985](https://github.com/omnigent-ai/omnigent/issues/1985) Headless `omnigent run -p` intermittently hangs forever despite the tu |
+| 49 | 66 | high | P2 | P1 ⚑ | +195 | [#1907](https://github.com/omnigent-ai/omnigent/issues/1907) Sub-agent model_override triggers an unnecessary first-turn harness re |
+| 50 | 66 | high | P1 | P1 | +54 | [#1888](https://github.com/omnigent-ai/omnigent/issues/1888) ansi-to-react default import resolves to the CJS exports object under  |
+| 51 | 66 | high | P2 | P1 ⚑ | +202 | [#1804](https://github.com/omnigent-ai/omnigent/issues/1804) spec parser crashes with TypeError on a null tools.builtins key (and s |
+| 52 | 66 | high | P2 | P1 ⚑ | +237 | [#1076](https://github.com/omnigent-ai/omnigent/issues/1076) Runner-layer Tier-2 escalation: release an unresponsive per-conversati |
+| 53 | 66 | high | P1 | P1 | +68 | [#1026](https://github.com/omnigent-ai/omnigent/issues/1026) Runner orphans tool callbacks with "no active turn context" after mid- |
+| 54 | 65 | high | P2 | P1 ⚑ | +154 | [#2714](https://github.com/omnigent-ai/omnigent/issues/2714) Upgrade openai-agents and remove the temporary openai<2.45 cap |
+| 55 | 65 | high | P1 | P1 | +35 | [#2245](https://github.com/omnigent-ai/omnigent/issues/2245) [Bug] openai-agents harness turn wedges permanently after policy-verdi |
+| 56 | 63 | high | P1 | P1 | +75 | [#108](https://github.com/omnigent-ai/omnigent/issues/108) Cannot install on Linux aarch64 — cel-expr-python has no aarch64 wheel |
+| 57 | 61 | medium | P2 | P1 ⚑ | +211 | [#1596](https://github.com/omnigent-ai/omnigent/issues/1596) Native-CLI harness (claude-native/codex-native) as a named agent's own |
+| 58 | 60 | high | P1 | P1 | -50 | [#3971](https://github.com/omnigent-ai/omnigent/issues/3971) Host runners inherit the daemon's cwd; a deleted launch dir breaks eve |
+| 59 | 60 | high | P1 | P1 | -25 | [#3274](https://github.com/omnigent-ai/omnigent/issues/3274) Sub-agent terminal status rejected with missing_parent_inbox and retri |
+| 60 | 60 | high | P2 | P1 ⚑ | +112 | [#3235](https://github.com/omnigent-ai/omnigent/issues/3235) Flaky E2E UI: test_scheduled_task_create_edit_modal_and_time_picker[ch |
+| 61 | 60 | high | P1 | P1 | -14 | [#3016](https://github.com/omnigent-ai/omnigent/issues/3016) [Bug] A transient session-snapshot failure permanently pins a session  |
+| 62 | 60 | high | P1 | P1 | -14 | [#3012](https://github.com/omnigent-ai/omnigent/issues/3012) Hosts authenticated via `omnigent login` permanently 403 on first reco |
+| 63 | 60 | high | P2 | P1 ⚑ | +155 | [#2428](https://github.com/omnigent-ai/omnigent/issues/2428) sys_session_send to a completed session hangs to ReadTimeout and is si |
+| 64 | 60 | high | P1 | P1 | +27 | [#2241](https://github.com/omnigent-ai/omnigent/issues/2241) Flaky on main: test_interrupt_forwards_to_harness_before_cancelling ti |
+| 65 | 60 | high | P1 | P1 | +31 | [#2051](https://github.com/omnigent-ai/omnigent/issues/2051) [Bug] sys_session_send(session_id=…) completions never drain to sys_re |
+| 66 | 60 | high | P0 | P1 ⚑ | -63 | [#1657](https://github.com/omnigent-ai/omnigent/issues/1657) hermes-native forwarder advances last_id per item, dropping a row's la |
+| 67 | 60 | high | P2 | P1 ⚑ | +247 | [#678](https://github.com/omnigent-ai/omnigent/issues/678) e2e: sub-agent supervisor routing / named-sub-agent auto-wake flakes ( |
+| 68 | 59 | high | P1 | P2 ⚑ | -51 | [#3799](https://github.com/omnigent-ai/omnigent/issues/3799) Android shell cannot sign in to servers behind a front-door auth proxy |
+| 69 | 59 | high | P1 | P2 ⚑ | -49 | [#3730](https://github.com/omnigent-ai/omnigent/issues/3730) [Bug] Android: renderer death terminates the app — OmnigentWebViewClie |
+| 70 | 59 | high | P1 | P2 ⚑ | -48 | [#3701](https://github.com/omnigent-ai/omnigent/issues/3701) [Bug] Desktop app never completes Okta security key / biometric MFA du |
+| 71 | 59 | high | P1 | P2 ⚑ | -38 | [#3299](https://github.com/omnigent-ai/omnigent/issues/3299) [Bug] Harness-credential route times out with a misleading 504 against |
+| 72 | 59 | high | P2 | P2 | +94 | [#3284](https://github.com/omnigent-ai/omnigent/issues/3284) [Crash] DuplicateOptionError: While reading from PosixPath('/Users/*** |
+| 73 | 59 | high | P2 | P2 | +111 | [#3070](https://github.com/omnigent-ai/omnigent/issues/3070) No progress signal on a stuck or interactive harness install |
+| 74 | 59 | high | P1 | P2 ⚑ | -19 | [#2967](https://github.com/omnigent-ai/omnigent/issues/2967) [Bug] A full context window bricks a session with "Prompt is too long" |
+| 75 | 59 | high | P2 | P2 | +141 | [#2480](https://github.com/omnigent-ai/omnigent/issues/2480) [Bug] Postgres-backed local server: bare `No module named 'psycopg'` + |
+| 76 | 59 | high | P1 | P2 ⚑ | +12 | [#2270](https://github.com/omnigent-ai/omnigent/issues/2270) Windows: config list crashes — UnicodeEncodeError on cp1252 (non-UTF8) |
+| 77 | 59 | high | P1 | P2 ⚑ | +12 | [#2269](https://github.com/omnigent-ai/omnigent/issues/2269) Windows: omnigent setup crashes — ModuleNotFoundError: No module named |
+| 78 | 59 | high | P1 | P2 ⚑ | +21 | [#1953](https://github.com/omnigent-ai/omnigent/issues/1953) `omni host` dies permanently when the OIDC session JWT expires — no re |
+| 79 | 59 | high | P1 | P2 ⚑ | +23 | [#1901](https://github.com/omnigent-ai/omnigent/issues/1901) [Bug] kimi/qwen/goose/kiro forwarders blind-retry failed conversation- |
+| 80 | 59 | high | P1 | P2 ⚑ | +25 | [#1881](https://github.com/omnigent-ai/omnigent/issues/1881) [Bug] `omnigent setup` crashes with `ValueError: select() requires at  |
+| 81 | 59 | high | P1 | P2 ⚑ | +27 | [#1827](https://github.com/omnigent-ai/omnigent/issues/1827) [Bug] kimi-native: torn UTF-8 wire read crashes the forwarder; supervi |
+| 82 | 59 | high | P2 | P2 | +185 | [#1600](https://github.com/omnigent-ai/omnigent/issues/1600) Epic: 12-feature contribution (one issue + one PR per feature) |
+| 83 | 59 | high | P2 | P2 | +187 | [#1528](https://github.com/omnigent-ai/omnigent/issues/1528) Idle-session lifecycle UX: reap gracefully, resume seamlessly, surface |
+| 84 | 58 | high | P2 | P2 | +214 | [#1022](https://github.com/omnigent-ai/omnigent/issues/1022) Behind a corporate proxy, the host daemon can't reach the model backen |
+| 85 | 57 | medium | P2 | P2 | +214 | [#1021](https://github.com/omnigent-ai/omnigent/issues/1021) [Feature] GitHub Copilot as provider |
+| 86 | 54 | high | P2 | P2 | +58 | [#3798](https://github.com/omnigent-ai/omnigent/issues/3798) Android shell shows the SPA as if signed in while native login runs in |
+| 87 | 54 | high | P1 | P2 ⚑ | -58 | [#3469](https://github.com/omnigent-ai/omnigent/issues/3469) [Bug] Post-completion compaction spiral: merge-commit diff output trig |
+| 88 | 54 | high | P1 | P2 ⚑ | -23 | [#2629](https://github.com/omnigent-ai/omnigent/issues/2629) web_fetch sub-agent spawn fails with unknown harness 'omnigent' — bare |
+| 89 | 54 | high | P2 | P2 | +166 | [#1778](https://github.com/omnigent-ai/omnigent/issues/1778) opencode-native forwarder loses session content across SSE reconnects  |
+| 90 | 54 | high | P1 | P2 ⚑ | +38 | [#523](https://github.com/omnigent-ai/omnigent/issues/523) REPL pexpect e2e tests starve on boot under full shard load (60s _wait |
+| 91 | 53 | high | P1 | P2 ⚑ | -42 | [#3011](https://github.com/omnigent-ai/omnigent/issues/3011) kiro-native harness: interactive sessions never respond with kiro-cli  |
+| 92 | 53 | high | P1 | P2 ⚑ | -36 | [#2920](https://github.com/omnigent-ai/omnigent/issues/2920) Omnigent server fails to start on native Windows: os.getuid() at impor |
+| 93 | 53 | high | P1 | P2 ⚑ | -36 | [#2919](https://github.com/omnigent-ai/omnigent/issues/2919) omni setup crashes on Windows: ModuleNotFoundError: No module named 't |
+| 94 | 53 | high | P1 | P2 ⚑ | -15 | [#2422](https://github.com/omnigent-ai/omnigent/issues/2422) Windows: five chained defects break the documented degraded-mode subse |
+| 95 | 53 | high | P2 | P2 | +215 | [#762](https://github.com/omnigent-ai/omnigent/issues/762) [Bug] sub agent terminal crashes when cli starts with prompt for input |
+| 96 | 50 | medium | P2 | P2 | +108 | [#2744](https://github.com/omnigent-ai/omnigent/issues/2744) [Bug] codex-native: custom agents time out at launch — native provider |
+| 97 | 46 | medium | P1 | P2 ⚑ | -87 | [#3952](https://github.com/omnigent-ai/omnigent/issues/3952) A stale terminal exit removes the newer Codex resources of the same se |
+| 98 | 46 | medium | P2 | P2 | +93 | [#2984](https://github.com/omnigent-ai/omnigent/issues/2984) [Bug] Codex incorrectly reports `needs-auth` with an authenticated cus |
+| 99 | 46 | medium | P1 | P2 ⚑ | -7 | [#2184](https://github.com/omnigent-ai/omnigent/issues/2184) [Bug] Codex plugin skills are exposed with inconsistent names (`plugin |
+| 100 | 46 | medium | P1 | P2 ⚑ | -7 | [#2071](https://github.com/omnigent-ai/omnigent/issues/2071) [Bug] web_search never advertised to claude-sdk sessions: unprefixed m |
+| 101 | 46 | medium | P2 | P2 | +134 | [#2062](https://github.com/omnigent-ai/omnigent/issues/2062) [Bug] claude-native: per-session model override silently lost when wra |
+| 102 | 46 | medium | P1 | P2 ⚑ | +5 | [#1831](https://github.com/omnigent-ai/omnigent/issues/1831) claude-native workers ignore executor.model pin and per-dispatch args. |
+| 103 | 46 | medium | P1 | P2 ⚑ | +7 | [#1781](https://github.com/omnigent-ai/omnigent/issues/1781) codex harness: ambient DATABRICKS_BEARER/DATABRICKS_TOKEN overrides pr |
+| 104 | 46 | medium | P1 | P2 ⚑ | +15 | [#1128](https://github.com/omnigent-ai/omnigent/issues/1128) [Bug] Claude SDK Appears to Use Opus Instead of Selected Model |
+| 105 | 46 | medium | P1 | P2 ⚑ | +25 | [#241](https://github.com/omnigent-ai/omnigent/issues/241) pi harness: GPT and Gemini dispatches 404 on the Databricks ucode gate |
+| 106 | 46 | medium | P3 | P2 ⚑ | +241 | [#147](https://github.com/omnigent-ai/omnigent/issues/147) Tracking: gradual decomposition of monolith modules (cli.py 9.1KLOC, c |
+| 107 | 42 | medium | P1 | P2 ⚑ | -89 | [#3790](https://github.com/omnigent-ai/omnigent/issues/3790) force_sandbox policy is evaluated but structurally unreachable from cl |
+| 108 | 42 | medium | P2 | P2 | +150 | [#1724](https://github.com/omnigent-ai/omnigent/issues/1724) codex-native harness times out on WSL2 ("Codex TUI never started a thr |
+| 109 | 42 | medium | P1 | P2 ⚑ | -51 | [#2904](https://github.com/omnigent-ai/omnigent/issues/2904) [Bug] claude-native: web-UI chat input fails with "tmux command failed |
+| 110 | 42 | medium | P1 | P2 ⚑ | -29 | [#2397](https://github.com/omnigent-ai/omnigent/issues/2397) [Bug] Codex-native intelligent routing ignores live effort capabilitie |
+| 111 | 42 | medium | P1 | P2 ⚑ | -24 | [#2272](https://github.com/omnigent-ai/omnigent/issues/2272) [Bug] Codex runner can't find OpenRouter secret that exists in keyring |
+| 112 | 42 | medium | P2 | P2 | +192 | [#890](https://github.com/omnigent-ai/omnigent/issues/890) [Bug] omnigent setup fails with npm EACCES when installing the Claude  |
+| 113 | 42 | medium | P1 | P2 ⚑ | +12 | [#668](https://github.com/omnigent-ai/omnigent/issues/668) [Bug] BUG？omni claude times out (60s) on macOS with native Claude Code |
+| 114 | 38 | medium | P1 | P2 ⚑ | -98 | [#3852](https://github.com/omnigent-ai/omnigent/issues/3852) [Bug] Built-in write policies miss Claude Code's `MultiEdit` / `Notebo |
+| 115 | 38 | medium | P2 | P2 | +109 | [#2369](https://github.com/omnigent-ai/omnigent/issues/2369) [Bug] pi harness only lists databricks-claude-sonnet-4-6 |
+| 116 | 38 | medium | P1 | P2 ⚑ | -30 | [#2299](https://github.com/omnigent-ai/omnigent/issues/2299) [Bug] claude-native resume transcripts flatten tool_result image block |
+| 117 | 38 | medium | P2 | P2 | +104 | [#2390](https://github.com/omnigent-ai/omnigent/issues/2390) Builtin policy for per-user sub-agent access control (subagent_access_ |
+| 118 | 38 | medium | P2 | P2 | +206 | [#377](https://github.com/omnigent-ai/omnigent/issues/377) gpt sub-agent fails on startup with missing databricks-sdk dependency |
+| 119 | 38 | medium | P1 | P2 ⚑ | -10 | [#1794](https://github.com/omnigent-ai/omnigent/issues/1794) Bundled Polly: claude-sdk brain "Not logged in" + runaway spawn loop o |
+| 120 | 38 | medium | P1 | P2 ⚑ | -9 | [#1694](https://github.com/omnigent-ai/omnigent/issues/1694) Reliability: parallel code-fix missions fail silently (5s tmux timeout |
+| 121 | 37 | medium | P1 | P2 ⚑ | -79 | [#3101](https://github.com/omnigent-ai/omnigent/issues/3101) Docker/Kubernetes entrypoint never wires project_store — first-class P |
+| 122 | 36 | medium | P2 | P2 | +161 | [#1192](https://github.com/omnigent-ai/omnigent/issues/1192) [Bug] Manual /compact errors "Compaction requires a configured LLM mod |
+| 123 | 36 | medium | P1 | P2 ⚑ | -6 | [#1158](https://github.com/omnigent-ai/omnigent/issues/1158) [Bug] antigravity-native: TUI-typed turns never mirror to the web UI ( |
+| 124 | 36 | medium | P2 | P2 | +161 | [#1157](https://github.com/omnigent-ai/omnigent/issues/1157) [Bug] antigravity-native: no Chat/Terminal toggle — terminal_antigravi |
+| 125 | 36 | feature | P2 | P2 | +188 | [#692](https://github.com/omnigent-ai/omnigent/issues/692) Polly: fan out sub-agent work across multiple concurrent claude profil |
+| 126 | 36 | feature | P2 | P2 | +201 | [#197](https://github.com/omnigent-ai/omnigent/issues/197) Declarative skill sources: pull Claude Code skills + their dependency  |
+| 127 | 35 | medium | P2 | P2 | +110 | [#2055](https://github.com/omnigent-ai/omnigent/issues/2055) [Bug] codex-native harness elicitation: a resolve landing in the betwe |
+| 128 | 35 | medium | P1 | P2 ⚑ | -84 | [#3076](https://github.com/omnigent-ai/omnigent/issues/3076) [Bug] claude-sdk omits ToolSearch, eagerly loading every MCP schema |
+| 129 | 35 | medium | P3 | P2 ⚑ | +210 | [#2800](https://github.com/omnigent-ai/omnigent/issues/2800) [Bug] Top-level custom codex-native agents drop reasoning effort and y |
+| 130 | 35 | medium | P1 | P2 ⚑ | -7 | [#880](https://github.com/omnigent-ai/omnigent/issues/880) [BUG] Native harness (omnigent claude): assistant turns not streamed t |
+| 131 | 33 | medium | P1 | P2 ⚑ | -18 | [#1551](https://github.com/omnigent-ai/omnigent/issues/1551) opencode-native: blocking question tool not surfaced to web (no elicit |
+| 132 | 33 | medium | P2 | P2 | +2 | [#4009](https://github.com/omnigent-ai/omnigent/issues/4009) [Feature] No Go client for the session API, so every Go caller hand-ro |
+| 133 | 33 | medium | P1 | P2 ⚑ | -127 | [#3981](https://github.com/omnigent-ai/omnigent/issues/3981) [Bug] Desktop: Workspace rail resize is unusable on the Browser tab; a |
+| 134 | 33 | medium | P1 | P2 ⚑ | -121 | [#3898](https://github.com/omnigent-ai/omnigent/issues/3898) [Bug] Pack function policies fail server-side input evaluation unless  |
+| 135 | 33 | medium | P1 | P2 ⚑ | -121 | [#3870](https://github.com/omnigent-ai/omnigent/issues/3870) child-session creation returns 500 internal_error, breaking Polly/Debb |
+| 136 | 33 | medium | P2 | P2 | +6 | [#3864](https://github.com/omnigent-ai/omnigent/issues/3864) [Bug] to_api_dict() drops ConversationItem.created_at, so flat items A |
+| 137 | 33 | medium | P1 | P2 ⚑ | -122 | [#3863](https://github.com/omnigent-ai/omnigent/issues/3863) [Bug] Databricks Apps entrypoint never wires project_store — Projects  |
+| 138 | 33 | medium | P2 | P2 | +5 | [#3861](https://github.com/omnigent-ai/omnigent/issues/3861) [Bug] omni host status renders URLs so terminals link the whole status |
+| 139 | 33 | medium | P2 | P2 | +13 | [#3563](https://github.com/omnigent-ai/omnigent/issues/3563) [Bug] Host-bound resume into a deleted workspace: host computes the ex |
+| 140 | 33 | medium | P2 | P2 | +13 | [#3561](https://github.com/omnigent-ai/omnigent/issues/3561) [Bug] `prompt_policy` never sends `_CLASSIFIER_SCHEMA` to the LLM — st |
+| 141 | 33 | medium | P2 | P2 | +14 | [#3550](https://github.com/omnigent-ai/omnigent/issues/3550) [Bug] Missing signing alg's prevent using some OIDC providers |
+| 142 | 33 | medium | P2 | P2 | +18 | [#3435](https://github.com/omnigent-ai/omnigent/issues/3435) [Feature] Admin server-wide usage report (per-user and per-model cost) |
+| 143 | 33 | medium | none | P2 | +210 | [#3402](https://github.com/omnigent-ai/omnigent/issues/3402) [Bug] Label seeding and session-state writes race under concurrent upd |
+| 144 | 33 | medium | P2 | P2 | +18 | [#3368](https://github.com/omnigent-ai/omnigent/issues/3368) Feature: first-class async write-safety (freeze → approve → apply) pri |
+| 145 | 33 | medium | P2 | P2 | +20 | [#3352](https://github.com/omnigent-ai/omnigent/issues/3352) [Feature] OpenClaw onboarding — Option B: chat import (SQLite session  |
+| 146 | 33 | medium | P2 | P2 | +24 | [#3247](https://github.com/omnigent-ai/omnigent/issues/3247) credential_proxy: re-resolve the source on 401 / expiry (short-lived t |
+| 147 | 33 | medium | P1 | P2 ⚑ | -107 | [#3236](https://github.com/omnigent-ai/omnigent/issues/3236) web_search: bare executor.model strings are inferred as provider 'open |
+| 148 | 33 | medium | P2 | P2 | +28 | [#3219](https://github.com/omnigent-ai/omnigent/issues/3219) [Bug] Cmd/Ctrl+Up/Down session traversal stops in an empty focused com |
+| 149 | 33 | medium | P2 | P2 | +43 | [#2921](https://github.com/omnigent-ai/omnigent/issues/2921) Font settings: selected font (incl. Nerd Fonts) never loads — no webfo |
+| 150 | 33 | medium | P1 | P2 ⚑ | -90 | [#2854](https://github.com/omnigent-ai/omnigent/issues/2854) [Bug] Cross-harness `harness_override` is ignored on the `initial_item |
+| 151 | 33 | medium | P2 | P2 | +45 | [#2851](https://github.com/omnigent-ai/omnigent/issues/2851) Policy-supplied targets for ASK approval cards |
+| 152 | 33 | medium | P2 | P2 | +50 | [#2756](https://github.com/omnigent-ai/omnigent/issues/2756) Expose atomic session-event admission to integrations |
+| 153 | 33 | medium | P2 | P2 | +59 | [#2577](https://github.com/omnigent-ai/omnigent/issues/2577) [Feature] Manage OIDC/SSO admins from an id_token claim (IdP group/rol |
+| 154 | 33 | medium | P2 | P2 | +59 | [#2558](https://github.com/omnigent-ai/omnigent/issues/2558) Distribution / Installation / Enterprise Readiness |
+| 155 | 33 | medium | P1 | P2 ⚑ | -85 | [#2539](https://github.com/omnigent-ai/omnigent/issues/2539) Named sys_session_send returns 404 after first child from a bundled se |
+| 156 | 33 | medium | P1 | P2 ⚑ | -85 | [#2524](https://github.com/omnigent-ai/omnigent/issues/2524) [Bug] Registering remote host fails |
+| 157 | 33 | medium | P1 | P2 ⚑ | -84 | [#2444](https://github.com/omnigent-ai/omnigent/issues/2444) Accounts JWT expiry falls through to Databricks auth and breaks persis |
+| 158 | 33 | medium | P2 | P2 | +62 | [#2404](https://github.com/omnigent-ai/omnigent/issues/2404) fix(runtime): orphan sweep can abort startup on unreadable shared-host |
+| 159 | 33 | medium | P2 | P2 | +63 | [#2374](https://github.com/omnigent-ai/omnigent/issues/2374) Proposal: per-turn context_providers to augment system instructions at |
+| 160 | 33 | medium | P1 | P2 ⚑ | -75 | [#2304](https://github.com/omnigent-ai/omnigent/issues/2304) Runner subprocess inherits host daemon cwd, causing os_env cwd resolut |
+| 161 | 33 | medium | P2 | P2 | +73 | [#2070](https://github.com/omnigent-ai/omnigent/issues/2070) [Feature] sys_os_* file tools are hard-confined to the session workspa |
+| 162 | 33 | medium | P2 | P2 | +109 | [#1526](https://github.com/omnigent-ai/omnigent/issues/1526) Refactor: incrementally decompose the 4 god-files (sessions.py, runner |
+| 163 | 33 | medium | P2 | P2 | +111 | [#1411](https://github.com/omnigent-ai/omnigent/issues/1411) Standalone reusable MCP servers: CRUD + connection verify (list tools) |
+| 164 | 33 | medium | P2 | P2 | +126 | [#1075](https://github.com/omnigent-ai/omnigent/issues/1075) [Feature] Support AWS Lambda / Firecracker microVMs as managed sandbox |
+| 165 | 33 | medium | P2 | P2 | +127 | [#1055](https://github.com/omnigent-ai/omnigent/issues/1055) [Test] End-to-end OTel test against a real collector to lock in the BY |
+| 166 | 33 | medium | P2 | P2 | +127 | [#1054](https://github.com/omnigent-ai/omnigent/issues/1054) [Feature] Record gen_ai.retry events on llm_call spans |
+| 167 | 33 | medium | P2 | P2 | +130 | [#1031](https://github.com/omnigent-ai/omnigent/issues/1031) [Feature] Support serving the standalone Web UI under a subpath, e.g.  |
+| 168 | 33 | medium | P2 | P2 | +132 | [#983](https://github.com/omnigent-ai/omnigent/issues/983) Session sharing ergonomics: `sys_session_share` agent tool + `omnigent |
+| 169 | 33 | medium | P2 | P2 | +139 | [#857](https://github.com/omnigent-ai/omnigent/issues/857) [Proposal] Usage-limit detection + on-429 failover across pooled provi |
+| 170 | 33 | medium | P1 | P2 ⚑ | -46 | [#765](https://github.com/omnigent-ai/omnigent/issues/765) Support interactive mid-flight policy ASK (TOOL_CALL/TOOL_RESULT/OUTPU |
+| 171 | 33 | medium | P1 | P2 ⚑ | -45 | [#547](https://github.com/omnigent-ai/omnigent/issues/547) Bug: Polly model switcher sends invalid Cursor SDK model id |
+| 172 | 33 | medium | P1 | P2 ⚑ | -43 | [#522](https://github.com/omnigent-ai/omnigent/issues/522) Implement async-tool completion auto-delivery (SESSION_REARCHITECTURE  |
+| 173 | 33 | medium | P2 | P2 | +145 | [#509](https://github.com/omnigent-ai/omnigent/issues/509) [Feature] Default new-session workspace from selected agent's cwd |
+| 174 | 33 | medium | P2 | P2 | +149 | [#382](https://github.com/omnigent-ai/omnigent/issues/382) Evaluating the same agent across harnesses: no built-in way to compare |
+| 175 | 33 | medium | P1 | P2 ⚑ | -75 | [#1936](https://github.com/omnigent-ai/omnigent/issues/1936) [BUG] copilot harness: 401 Bad credentials when no token is explicitly |
+| 176 | 32 | feature | P2 | P2 | +97 | [#1454](https://github.com/omnigent-ai/omnigent/issues/1454) [Feature] Change permission mode of a running claude-native session fr |
+| 177 | 31 | medium | P1 | P2 ⚑ | -99 | [#2429](https://github.com/omnigent-ai/omnigent/issues/2429) Server (python -m omnigent.cli server) CPU-spins indefinitely with no  |
+| 178 | 31 | medium | P1 | P2 ⚑ | -58 | [#1113](https://github.com/omnigent-ai/omnigent/issues/1113) Native sub-agent/runner failures surface as bare "failed" with no reas |
+| 179 | 31 | feature | P2 | P2 | -1 | [#3150](https://github.com/omnigent-ai/omnigent/issues/3150) [Feature] CLI: cross-harness fork — continue an existing session in a  |
+| 180 | 31 | feature | P2 | P2 | +79 | [#1703](https://github.com/omnigent-ai/omnigent/issues/1703) [Feature] Unify harness naming: bare names (claude, codex, …) are ambi |
+| 181 | 31 | feature | P3 | P2 ⚑ | +161 | [#1678](https://github.com/omnigent-ai/omnigent/issues/1678) tech-debt(codex-native): extract a string-field helper for repeated di |
+| 182 | 31 | feature | P2 | P2 | +137 | [#503](https://github.com/omnigent-ai/omnigent/issues/503) [Feature] Switch Claude Code account per session via isolated profiles |
+| 183 | 30 | feature | P2 | P2 | +42 | [#2303](https://github.com/omnigent-ai/omnigent/issues/2303) [Feature] Support multi-repo workspaces (nested Git repos or multiple  |
+| 184 | 30 | medium | P2 | P2 | -2 | [#3083](https://github.com/omnigent-ai/omnigent/issues/3083) [Bug] Cursor sessions launched from Omnigent Web is losing MCPs |
+| 185 | 30 | medium | P1 | P2 ⚑ | -67 | [#1156](https://github.com/omnigent-ai/omnigent/issues/1156) [Bug] antigravity-native: web/mobile turns never appear in the native  |
+| 186 | 30 | medium | P2 | P2 | -17 | [#3250](https://github.com/omnigent-ai/omnigent/issues/3250) flaky e2e_ui: test_scheduled_task_create_edit_modal_and_time_picker ti |
+| 187 | 30 | medium | P2 | P2 | +11 | [#2848](https://github.com/omnigent-ai/omnigent/issues/2848) Server logs an expected offline-runner resource 503 as ERROR + full tr |
+| 188 | 30 | medium | P2 | P2 | +13 | [#2767](https://github.com/omnigent-ai/omnigent/issues/2767) [Bug] SQLite pool (default 5+10) not sized to the 200-thread limiter → |
+| 189 | 30 | medium | P1 | P2 ⚑ | -106 | [#2357](https://github.com/omnigent-ai/omnigent/issues/2357) [Bug] admin fleet-view calls SqlAlchemyConversationStore.list_conversa |
+| 190 | 30 | medium | P1 | P2 ⚑ | -95 | [#2052](https://github.com/omnigent-ai/omnigent/issues/2052) [Bug] web_fetch's __web_researcher helper sub-agent fails on 0.4.0 (si |
+| 191 | 30 | medium | P1 | P2 ⚑ | -90 | [#1920](https://github.com/omnigent-ai/omnigent/issues/1920) Seeder matching-hash fast path can't self-heal a lost artifact-store b |
+| 192 | 30 | medium | P1 | P2 ⚑ | -86 | [#1857](https://github.com/omnigent-ai/omnigent/issues/1857) Host daemon stays alive but shows offline — server-dropped host tunnel |
+| 193 | 30 | medium | P1 | P2 ⚑ | -81 | [#1686](https://github.com/omnigent-ai/omnigent/issues/1686) xai: reasoning_effort sent to all Grok models returns HTTP 400 on unsu |
+| 194 | 30 | medium | P2 | P2 | +94 | [#1117](https://github.com/omnigent-ai/omnigent/issues/1117) async generator ignored GeneratorExit — orphaned SSE relay task, excep |
+| 195 | 30 | medium | P2 | P2 | +117 | [#725](https://github.com/omnigent-ai/omnigent/issues/725) Changes panel is empty for native-harness and external edits in non-gi |
+| 196 | 30 | medium | P2 | P2 | +134 | [#146](https://github.com/omnigent-ai/omnigent/issues/146) StreamHooks.on_sub_agent_spawned / on_sub_agent_completed are declared |
+| 197 | 30 | medium | P1 | P2 ⚑ | -192 | [#3982](https://github.com/omnigent-ai/omnigent/issues/3982) [Bug] electron-build.yml pnpm filter matches no package: desktop packa |
+| 198 | 30 | medium | P3 | P2 ⚑ | +138 | [#3733](https://github.com/omnigent-ai/omnigent/issues/3733) [Bug] Android: hardcoded 25px switcher height makes the chat scroll-fa |
+| 199 | 30 | medium | P2 | P2 | -52 | [#3732](https://github.com/omnigent-ai/omnigent/issues/3732) [Bug] Android: a Display-size change leaves the server-switcher pill's |
+| 200 | 30 | medium | P2 | P2 | -50 | [#3592](https://github.com/omnigent-ai/omnigent/issues/3592) [Feature] Deterministic long-term memory (automatic recall/retain) — f |

--- a/designs/prioritization/score_prototype.py
+++ b/designs/prioritization/score_prototype.py
@@ -289,6 +289,25 @@ def print_regrade(opn):
         print(f"  {v:>4}  {k}")
 
 
+def print_markdown(opn, limit=200):
+    """Emit a GitHub-markdown ranking table (for the design-doc appendix)."""
+    before = sorted(opn, key=current_rank_key)
+    after = sorted(opn, key=lambda i: score(i)[0], reverse=True)
+    before_rank = {i["number"]: n for n, i in enumerate(before)}
+
+    print("| # | Score | Sev | Now | Δrank | Issue |")
+    print("|--:|--:|---|---|--:|---|")
+    for n, i in enumerate(after[:limit]):
+        sc, sn = score(i)
+        b = before_rank[i["number"]]
+        delta = b - n
+        arrow = f"+{delta}" if delta > 0 else str(delta)
+        title = i["title"].replace("|", "\\|")[:70]
+        num = i["number"]
+        link = f"[#{num}](https://github.com/omnigent-ai/omnigent/issues/{num})"
+        print(f"| {n + 1} | {sc:.0f} | {sn} | {current_prio(i)} | {arrow} | {link} {title} |")
+
+
 def main():
     args = [a for a in sys.argv[1:] if not a.startswith("--")]
     flags = {a for a in sys.argv[1:] if a.startswith("--")}
@@ -299,6 +318,9 @@ def main():
 
     if "--regrade" in flags:
         print_regrade(opn)  # priority-label backfill preview
+    elif "--markdown" in flags:
+        limit = next((int(a) for a in args[1:] if a.isdigit()), 200)
+        print_markdown(opn, limit)  # markdown table for the doc appendix
     else:
         print_score_ranking(opn)  # composite-score before->after (default)
 

--- a/designs/prioritization/score_prototype.py
+++ b/designs/prioritization/score_prototype.py
@@ -203,6 +203,19 @@ def dup_reach(i):
     return 1.0 + min(0.5, 0.15 * n)  # +15% per dup, capped at +50%
 
 
+# Age is NEUTRAL by default (design review: an unfixed old bug isn't less
+# important — if anything it should escalate, not decay). Set DECAY_OLD=True
+# only to reproduce the earlier decaying variant for comparison.
+DECAY_OLD = False
+
+
+def age_factor(i):
+    if not DECAY_OLD:
+        return 1.0
+    a = age_days(i)
+    return 1.0 if a < 30 else max(0.7, 1.0 - (a - 30) / 200)
+
+
 def score(i):
     sname, sw = severity(i)
     s = sw * reach(i) * tier_mult(i) * dup_reach(i) * readiness(i)
@@ -211,8 +224,7 @@ def score(i):
         s *= 1.0 + FR_DEMAND_MAX * d  # demand LEADS for feature requests
     else:
         s += BUG_DEMAND_MAX * d  # demand is only a tiebreak for bugs
-    a = age_days(i)
-    s *= 1.0 if a < 30 else max(0.7, 1.0 - (a - 30) / 200)  # gentle decay for very old
+    s *= age_factor(i)
     return s, sname
 
 

--- a/designs/prioritization/score_prototype.py
+++ b/designs/prioritization/score_prototype.py
@@ -106,7 +106,7 @@ SEVERITY = {
 PRIOS = ("P0-critical", "P1-high", "P2-medium", "P3-low")
 
 # Component importance is one unified axis: a per-area `weight` read from
-# .github/areas.json (bands 1.4/1.1/1.0/0.9), applied to EVERY comp: label —
+# .github/areas.json (bands 1.4/1.2/1.1/1.0/0.9), applied to EVERY comp: label —
 # not the old harness-only tier. Harness weights are telemetry-seeded (session
 # usage); non-harness are editorial. See areas.json `weight` / `weight_source`.
 _AREAS_PATH = os.path.join(os.path.dirname(__file__), "..", "..", ".github", "areas.json")
@@ -191,6 +191,12 @@ DEMAND_CAP = 12  # log input cap so one popular FR can't swamp severity
 FR_DEMAND_MAX = 0.6  # +60% at most for the most-wanted FR
 BUG_DEMAND_MAX = 15  # small flat additive tiebreak for bugs
 
+# Optional modules. Reviewer feedback is to ship the first implementation with
+# readiness and age disabled, but keep them isolated so we can tune/re-enable by
+# changing one constant rather than rewriting the formula.
+ENABLE_READINESS = False
+ENABLE_AGE_FACTOR = False
+
 
 def _demand_signal(i):
     """0..1 normalized, log-scaled reaction intensity."""
@@ -202,9 +208,8 @@ def age_days(i):
     return (NOW - parse(i["created_at"])).total_seconds() / 86400
 
 
-# Readiness: an actionable ticket (repro steps, a real body) is worth surfacing
-# above a vague one at the same severity — you can start on it now. A small
-# multiplier so it only breaks near-ties, never overrides severity.
+# Readiness: optional near-tie module for actionable tickets (repro steps, a
+# real body). Disabled by default in this prototype per reviewer feedback.
 _REPRO = re.compile(r"steps to reproduce|reproduc|to reproduce", re.I)
 READINESS_MIN, READINESS_MAX = 0.85, 1.1
 
@@ -226,11 +231,9 @@ def dup_reach(i):
     return 1.0 + min(0.5, 0.15 * n)  # +15% per dup, capped at +50%
 
 
-# Age factor (Axis 8): fresh issues are neutral, mid-life issues get a light
-# visibility bump, and long-ignored issues decay (if they mattered, a maintainer
-# bumps priority, which adds far more than this shaves). Age is measured against
-# the snapshot's newest issue (set in main()), not wall-clock, so a stale
-# snapshot doesn't push every row into the old bucket.
+# Age factor: optional visibility/decay module. Disabled by default in this
+# prototype per reviewer feedback. Age is measured against the snapshot's newest
+# issue when enabled, so a stale snapshot doesn't push every row into old-age.
 def age_factor(i):
     a = age_days(i)
     if a <= 5:
@@ -246,13 +249,15 @@ def score(i):
     # multiplier: in production the LLM grades a widespread failure higher. The
     # regex stand-in can't make that judgment, so broad-reach issues are
     # under-graded here — one more reason production severity must be LLM-graded.
-    s = sw * area_weight(i) * dup_reach(i) * readiness(i)
+    readiness_factor = readiness(i) if ENABLE_READINESS else 1.0
+    s = sw * area_weight(i) * dup_reach(i) * readiness_factor
     d = _demand_signal(i)
     if "enhancement" in labels(i):
         s *= 1.0 + FR_DEMAND_MAX * d  # demand LEADS for feature requests
     else:
         s += BUG_DEMAND_MAX * d  # demand is only a tiebreak for bugs
-    s *= age_factor(i)
+    if ENABLE_AGE_FACTOR:
+        s *= age_factor(i)
     return s, sname
 
 
@@ -265,10 +270,10 @@ def current_rank_key(i):
 
 # Score → priority label: a single derivation (design decision). The cut-points
 # sit at the severity band values (100 = critical, 60 = high, 25 ≈ medium), so a
-# multiplier (tier/reach/dup/readiness/demand) is what lets an issue cross UP a
+# multiplier (component/dup/demand) is what lets an issue cross UP a
 # band — e.g. a "high" (60) bug in a tier-1 harness (×1.4 = 84) clears P1, while
 # the same bug on a niche harness (×0.9 = 54) stays P2. On today's snapshot this
-# yields P0 9 / P1 58 / P2 206 / P3 87, and a 24% P1 share of open bugs.
+# Re-run this script after changing weights; the appendix is generated from it.
 P0_MIN, P1_MIN, P2_MIN = 100, 60, 25
 
 
@@ -369,9 +374,7 @@ def main():
         data = json.load(f)
     opn = [i for i in data if i.get("pull_request") is None and i["state"] == "open"]
 
-    # Anchor age to the snapshot's newest issue, not wall-clock: the age factor
-    # (Axis 8) is meaningless if a stale snapshot dumps every issue in the 21d+
-    # bucket. In production the job runs live, so wall-clock is correct there.
+    # Keep age deterministic for optional ENABLE_AGE_FACTOR sensitivity runs.
     global NOW
     NOW = max(parse(i["created_at"]) for i in opn)
 

--- a/designs/prioritization/score_prototype.py
+++ b/designs/prioritization/score_prototype.py
@@ -235,25 +235,31 @@ def current_rank_key(i):
     return (p, -parse(i["created_at"]).timestamp())
 
 
-def regrade(i):
-    """Map an issue to a priority BUCKET from severity × reach (Axis 2 rubric).
+# Score → priority label: a single derivation (design decision). The cut-points
+# sit at the severity band values (100 = critical, 60 = high, 25 ≈ medium), so a
+# multiplier (tier/reach/dup/readiness/demand) is what lets an issue cross UP a
+# band — e.g. a "high" (60) bug in a tier-1 harness (×1.4 = 84) clears P1, while
+# the same bug on a niche harness (×0.9 = 54) stays P2. On today's snapshot this
+# yields P0 9 / P1 58 / P2 206 / P3 87, and a 24% P1 share of open bugs.
+P0_MIN, P1_MIN, P2_MIN = 100, 60, 25
 
-    This is the backfill output — a priority *label*, not a score. Applies to
-    bugs and FRs alike; type does not cap priority. In production the LLM grades
-    severity/reach; here we reuse the regex severity()/reach() so the backfill
-    preview is reproducible (and carries the same known false positives).
-    """
-    sname, _ = severity(i)
-    r = reach(i)  # 1.5 broad · 1.0 normal · 0.9 single-platform
-    if sname == "critical":  # security/data-loss/all-users-down
+
+def priority_from_score(i):
+    """The priority LABEL, derived from the final score (one system, no parallel
+    rubric). This is both the backfill output and how the classifier's grade
+    becomes a bucket in production."""
+    s = score(i)[0]
+    if s >= P0_MIN:
         return "P0-critical"
-    if sname == "high":  # high severity: broad reach -> P1, narrow -> P2
-        return "P1-high" if r >= 1.0 else "P2-medium"
-    if sname == "medium":  # medium only reaches P1 when reach is broad
-        return "P1-high" if r >= 1.5 else "P2-medium"
-    if sname == "low":
-        return "P3-low"
-    return "P2-medium" if r >= 1.0 else "P3-low"  # FR default: reach decides
+    if s >= P1_MIN:
+        return "P1-high"
+    if s >= P2_MIN:
+        return "P2-medium"
+    return "P3-low"
+
+
+# Back-compat alias for the --regrade path / any external callers.
+regrade = priority_from_score
 
 
 def current_prio(i):

--- a/designs/prioritization/score_prototype.py
+++ b/designs/prioritization/score_prototype.py
@@ -155,23 +155,6 @@ def severity(i):
     return ("medium", 25) if "Bug" in labels(i) else ("feature", 20)
 
 
-_BROAD_REACH = re.compile(
-    r"\ball (?:users|sessions|platforms)|every (?:user|session|request)"
-    r"|any harness|default config"
-)
-
-
-def reach(i):
-    text = (i["title"] + " " + (i.get("body") or ""))[:1500].lower()
-    if _BROAD_REACH.search(text):
-        return 1.5
-    if re.search(
-        r"\bwindows|\bios\b|\bandroid|\blinux|\baarch64|\bmacos|\belectron|\bself.host", text
-    ):
-        return 0.9  # platform-specific: real, but narrower blast radius
-    return 1.0
-
-
 def area_weight(i):
     """Unified component-importance multiplier from areas.json `weight`.
 
@@ -243,22 +226,27 @@ def dup_reach(i):
     return 1.0 + min(0.5, 0.15 * n)  # +15% per dup, capped at +50%
 
 
-# Age is NEUTRAL by default (design review: an unfixed old bug isn't less
-# important — if anything it should escalate, not decay). Set DECAY_OLD=True
-# only to reproduce the earlier decaying variant for comparison.
-DECAY_OLD = False
-
-
+# Age factor (Axis 8): fresh issues are neutral, mid-life issues get a light
+# visibility bump, and long-ignored issues decay (if they mattered, a maintainer
+# bumps priority, which adds far more than this shaves). Age is measured against
+# the snapshot's newest issue (set in main()), not wall-clock, so a stale
+# snapshot doesn't push every row into the old bucket.
 def age_factor(i):
-    if not DECAY_OLD:
-        return 1.0
     a = age_days(i)
-    return 1.0 if a < 30 else max(0.7, 1.0 - (a - 30) / 200)
+    if a <= 5:
+        return 1.0
+    if a <= 21:
+        return 1.2
+    return 0.8
 
 
 def score(i):
     sname, sw = severity(i)
-    s = sw * reach(i) * area_weight(i) * dup_reach(i) * readiness(i)
+    # Reach (blast radius) is folded INTO the severity grade, not a separate
+    # multiplier: in production the LLM grades a widespread failure higher. The
+    # regex stand-in can't make that judgment, so broad-reach issues are
+    # under-graded here — one more reason production severity must be LLM-graded.
+    s = sw * area_weight(i) * dup_reach(i) * readiness(i)
     d = _demand_signal(i)
     if "enhancement" in labels(i):
         s *= 1.0 + FR_DEMAND_MAX * d  # demand LEADS for feature requests
@@ -380,6 +368,12 @@ def main():
     with open(path) as f:
         data = json.load(f)
     opn = [i for i in data if i.get("pull_request") is None and i["state"] == "open"]
+
+    # Anchor age to the snapshot's newest issue, not wall-clock: the age factor
+    # (Axis 8) is meaningless if a stale snapshot dumps every issue in the 21d+
+    # bucket. In production the job runs live, so wall-clock is correct there.
+    global NOW
+    NOW = max(parse(i["created_at"]) for i in opn)
 
     if "--regrade" in flags:
         print_regrade(opn)  # priority-label backfill preview

--- a/designs/prioritization/score_prototype.py
+++ b/designs/prioritization/score_prototype.py
@@ -313,8 +313,8 @@ def print_markdown(opn, limit=200):
     after = sorted(opn, key=lambda i: score(i)[0], reverse=True)
     before_rank = {i["number"]: n for n, i in enumerate(before)}
 
-    print("| # | Score | Sev | Now | Δrank | Issue |")
-    print("|--:|--:|---|---|--:|---|")
+    print("| # | Score | Sev | Now | Derived | Δrank | Issue |")
+    print("|--:|--:|---|---|---|--:|---|")
     for n, i in enumerate(after[:limit]):
         sc, sn = score(i)
         b = before_rank[i["number"]]
@@ -323,7 +323,14 @@ def print_markdown(opn, limit=200):
         title = i["title"].replace("|", "\\|")[:70]
         num = i["number"]
         link = f"[#{num}](https://github.com/omnigent-ai/omnigent/issues/{num})"
-        print(f"| {n + 1} | {sc:.0f} | {sn} | {current_prio(i)} | {arrow} | {link} {title} |")
+        derived = priority_from_score(i).replace("-critical", "").replace("-high", "")
+        derived = derived.replace("-medium", "").replace("-low", "")
+        now = current_prio(i).replace("-critical", "").replace("-high", "")
+        now = now.replace("-medium", "").replace("-low", "")
+        moved = " ⚑" if now != derived and now != "none" else ""
+        print(
+            f"| {n + 1} | {sc:.0f} | {sn} | {now} | {derived}{moved} | {arrow} | {link} {title} |"
+        )
 
 
 def main():

--- a/designs/prioritization/score_prototype.py
+++ b/designs/prioritization/score_prototype.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Dry-run prototype for issue-prioritization-v2 scoring.
+
+Reads a snapshot of all open issues and produces a BEFORE (current priority
+label ordering) vs AFTER (composite score ordering) comparison, so we can
+eyeball which issues move and tune the weights against real test cases.
+
+The severity heuristic here is a *stand-in* for the production design, where
+severity is graded by the triage classifier LLM (which reads full issue
+content). Regex is used only so the dry-run is reproducible and inspectable.
+
+Usage:
+    # refresh the snapshot (external org -> ghx from gh-profiles)
+    GH_HOST=github.com ghx api --paginate \
+      "repos/omnigent-ai/omnigent/issues?state=all&per_page=100" > /tmp/all_issues_raw.json
+    python3 designs/prioritization/score_prototype.py /tmp/all_issues_raw.json
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import math
+import re
+import sys
+
+NOW = datetime.datetime.now(datetime.timezone.utc)
+
+# ── Tunable weights ──────────────────────────────────────────────────────
+# Severity tiers are checked most-severe first; first match wins. Kept narrow
+# so a stray "credential" mention doesn't inflate everything to critical.
+SEVERITY = {
+    "critical": (
+        100,
+        [
+            r"\bdata ?loss\b",
+            r"\bvulnerab",
+            r"\bCVE-\d",
+            r"\bRCE\b",
+            r"\bexfiltrat",
+            r"\bpolicy (?:gate|bypass)",
+            r"\bsandbox (?:escape|bypass)",
+            r"\bgates? (?:are )?bypass",
+            r"\bcorrupt(?:s|ion|ed)\b",
+            r"\bPAT is offered",
+            r"\bleak(?:s|ed) (?:the |a )?(?:secret|token|credential)",
+        ],
+    ),
+    "high": (
+        60,
+        [
+            r"\bcrash",
+            r"\bdeadlock",
+            r"\bhangs?\b",
+            r"\bbricks?\b",
+            r"\bpermanently\b",
+            r"\bnever (?:recover|complete|exit|return)",
+            r"\bcannot (?:install|start|log ?in|sign ?in|uninstall)",
+            r"\bfails? to start\b",
+            r"\bwedge",
+            r"\binfinite\b",
+            r"\bunbounded\b",
+            r"\bstarv(?:e|ation)",
+            r"\bevery (?:user|session|request)\b",
+            r"\ball (?:users|sessions)\b",
+        ],
+    ),
+    "medium": (
+        30,
+        [
+            r"\berror",
+            r"\bfails?\b",
+            r"\btimeout|\btimes? out",
+            r"\b(?:404|401|403|500)\b",
+            r"\bwrong\b",
+            r"\bignore[sd]?\b",
+            r"\bmissing\b",
+            r"\bincorrect",
+            r"\bregression",
+            r"\bswallow",
+            r"\bsilent",
+        ],
+    ),
+    "low": (
+        10,
+        [
+            r"\bcosmetic",
+            r"\bpolish",
+            r"\btypo",
+            r"\bnit\b",
+            r"\bmisalign|\balignment\b",
+            r"\btooltip",
+            r"\brename\b",
+            r"\bnice.to.have",
+            r"\bminor\b",
+            r"\brenders? und",
+        ],
+    ),
+}
+
+TIER1 = ["claude", "codex"]
+TIER2 = ["cursor", "antigravity", "copilot", "gemini", "openai"]
+PRIOS = ("P0-critical", "P1-high", "P2-medium", "P3-low")
+
+
+def labels(i):
+    return {lab["name"] for lab in i["labels"]}
+
+
+def parse(s):
+    return datetime.datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+def severity(i):
+    text = (i["title"] + " " + (i.get("body") or ""))[:2000].lower()
+    for name, (w, pats) in SEVERITY.items():
+        if any(re.search(p, text) for p in pats):
+            return name, w
+    return ("medium", 25) if "Bug" in labels(i) else ("feature", 20)
+
+
+_BROAD_REACH = re.compile(
+    r"\ball (?:users|sessions|platforms)|every (?:user|session|request)"
+    r"|any harness|default config"
+)
+
+
+def reach(i):
+    text = (i["title"] + " " + (i.get("body") or ""))[:1500].lower()
+    if _BROAD_REACH.search(text):
+        return 1.5
+    if re.search(
+        r"\bwindows|\bios\b|\bandroid|\blinux|\baarch64|\bmacos|\belectron|\bself.host", text
+    ):
+        return 0.9  # platform-specific: real, but narrower blast radius
+    return 1.0
+
+
+def tier_mult(i):
+    if "comp:harnesses" not in labels(i):
+        return 1.0
+    t = i["title"].lower()
+    if any(k in t for k in TIER1):
+        return 1.4
+    if any(k in t for k in TIER2):
+        return 1.1
+    return 0.9
+
+
+# Demand handling is type-dependent, grounded in the reaction distribution:
+# 93% of open issues have 0 reactions, and the reacted ones skew heavily to
+# feature requests. So reactions are a *demand* signal (a wanted capability),
+# not a *severity* signal — a bug's importance comes from content, not upvotes.
+#   - Feature requests: demand is a bounded MULTIPLIER, so a well-liked FR
+#     climbs above unwanted ones.
+#   - Bugs: demand is a small additive TIEBREAK only, so a 0-reaction crash
+#     still outranks a lightly-liked cosmetic FR.
+# Comments are deliberately excluded: on this repo they're mostly repro
+# back-and-forth (a bug with more comments is often harder, not more wanted).
+DEMAND_CAP = 12  # log input cap so one popular FR can't swamp severity
+FR_DEMAND_MAX = 0.6  # +60% at most for the most-wanted FR
+BUG_DEMAND_MAX = 15  # small flat additive tiebreak for bugs
+
+
+def _demand_signal(i):
+    """0..1 normalized, log-scaled reaction intensity."""
+    r = min(i.get("reactions", {}).get("total_count", 0), DEMAND_CAP)
+    return math.log1p(r) / math.log1p(DEMAND_CAP)
+
+
+def age_days(i):
+    return (NOW - parse(i["created_at"])).total_seconds() / 86400
+
+
+def score(i):
+    sname, sw = severity(i)
+    s = sw * reach(i) * tier_mult(i)
+    d = _demand_signal(i)
+    if "enhancement" in labels(i):
+        s *= 1.0 + FR_DEMAND_MAX * d  # demand LEADS for feature requests
+    else:
+        s += BUG_DEMAND_MAX * d  # demand is only a tiebreak for bugs
+    a = age_days(i)
+    s *= 1.0 if a < 30 else max(0.7, 1.0 - (a - 30) / 200)  # gentle decay for very old
+    return s, sname
+
+
+def current_rank_key(i):
+    """BEFORE ordering: priority label, then recency (how the queue reads today)."""
+    lab = labels(i)
+    p = next((n for n, name in enumerate(PRIOS) if name in lab), len(PRIOS))
+    return (p, -parse(i["created_at"]).timestamp())
+
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else "/tmp/all_issues_raw.json"
+    with open(path) as f:
+        data = json.load(f)
+    opn = [i for i in data if i.get("pull_request") is None and i["state"] == "open"]
+
+    before = sorted(opn, key=current_rank_key)
+    after = sorted(opn, key=lambda i: score(i)[0], reverse=True)
+    before_rank = {i["number"]: n for n, i in enumerate(before)}
+
+    print(f"# {len(opn)} open issues — BEFORE (priority label) vs AFTER (composite score)\n")
+    print(f"{'AFTER':>5} {'BEFORE':>6} {'Δ':>5}  {'score':>6} {'severity':9} {'prio':11} issue")
+    for n, i in enumerate(after):
+        sc, sn = score(i)
+        pr = next((p for p in PRIOS if p in labels(i)), "none")
+        b = before_rank[i["number"]]
+        delta = b - n  # positive = moved UP vs current ordering
+        arrow = f"+{delta}" if delta > 0 else str(delta)
+        title = i["title"][:48]
+        print(f"{n + 1:>5} {b + 1:>6} {arrow:>5}  {sc:6.0f} {sn:9} {pr:11} #{i['number']} {title}")
+
+
+if __name__ == "__main__":
+    main()

--- a/designs/prioritization/score_prototype.py
+++ b/designs/prioritization/score_prototype.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import datetime
 import json
 import math
+import os
 import re
 import sys
 
@@ -102,9 +103,37 @@ SEVERITY = {
     ),
 }
 
-TIER1 = ["claude", "codex"]
-TIER2 = ["cursor", "antigravity", "copilot", "gemini", "openai"]
 PRIOS = ("P0-critical", "P1-high", "P2-medium", "P3-low")
+
+# Component importance is one unified axis: a per-area `weight` read from
+# .github/areas.json (bands 1.4/1.1/1.0/0.9), applied to EVERY comp: label —
+# not the old harness-only tier. Harness weights are telemetry-seeded (session
+# usage); non-harness are editorial. See areas.json `weight` / `weight_source`.
+_AREAS_PATH = os.path.join(os.path.dirname(__file__), "..", "..", ".github", "areas.json")
+
+
+def _load_area_weights():
+    """Return (label_weight, harness_area_weights):
+    - label_weight[comp:label] = max weight among areas sharing that label
+      (the fallback when we can't pin the exact sub-area).
+    - harness_area_weights = [(keyword, weight)] for harness-* areas, so a
+      harness issue resolves to its specific harness by a title keyword."""
+    try:
+        with open(_AREAS_PATH) as f:
+            areas = json.load(f)["areas"]
+    except (OSError, KeyError):
+        return {}, []
+    label_weight = {}
+    harness = []
+    for a in areas:
+        w = a.get("weight", 1.0)
+        label_weight[a["label"]] = max(label_weight.get(a["label"], 0.0), w)
+        if a["key"].startswith("harness-"):
+            harness.append((a["key"][len("harness-") :], w))
+    return label_weight, harness
+
+
+_LABEL_WEIGHT, _HARNESS_WEIGHTS = _load_area_weights()
 
 
 def labels(i):
@@ -143,15 +172,26 @@ def reach(i):
     return 1.0
 
 
-def tier_mult(i):
-    if "comp:harnesses" not in labels(i):
+def area_weight(i):
+    """Unified component-importance multiplier from areas.json `weight`.
+
+    Applies to every comp: label (not harness-only). For a harness issue we
+    resolve the specific harness by a title keyword → that harness area's
+    weight; otherwise we use the max weight among areas sharing the comp: label.
+    No comp: label → 1.0 (neutral)."""
+    labs = labels(i)
+    comps = [x for x in labs if x.startswith("comp:")]
+    if not comps:
         return 1.0
-    t = i["title"].lower()
-    if any(k in t for k in TIER1):
-        return 1.4
-    if any(k in t for k in TIER2):
-        return 1.1
-    return 0.9
+    if "comp:harnesses" in comps:
+        t = i["title"].lower()
+        for keyword, w in _HARNESS_WEIGHTS:
+            if keyword in t:
+                return w
+        # harness issue we can't pin to a specific harness: shared-infra weight
+        # (inner/llms/tools) is captured by the label max below.
+    # Most-important area wins among the issue's comp labels.
+    return max((_LABEL_WEIGHT.get(c, 1.0) for c in comps), default=1.0)
 
 
 # Demand handling is type-dependent, grounded in the reaction distribution:
@@ -218,7 +258,7 @@ def age_factor(i):
 
 def score(i):
     sname, sw = severity(i)
-    s = sw * reach(i) * tier_mult(i) * dup_reach(i) * readiness(i)
+    s = sw * reach(i) * area_weight(i) * dup_reach(i) * readiness(i)
     d = _demand_signal(i)
     if "enhancement" in labels(i):
         s *= 1.0 + FR_DEMAND_MAX * d  # demand LEADS for feature requests

--- a/designs/prioritization/score_prototype.py
+++ b/designs/prioritization/score_prototype.py
@@ -14,6 +14,8 @@ Usage:
     GH_HOST=github.com ghx api --paginate \
       "repos/omnigent-ai/omnigent/issues?state=all&per_page=100" > /tmp/all_issues_raw.json
     python3 designs/prioritization/score_prototype.py /tmp/all_issues_raw.json
+    # priority-LABEL backfill preview (current vs regraded bucket, no scores):
+    python3 designs/prioritization/score_prototype.py /tmp/all_issues_raw.json --regrade
 """
 
 from __future__ import annotations
@@ -221,12 +223,32 @@ def current_rank_key(i):
     return (p, -parse(i["created_at"]).timestamp())
 
 
-def main():
-    path = sys.argv[1] if len(sys.argv) > 1 else "/tmp/all_issues_raw.json"
-    with open(path) as f:
-        data = json.load(f)
-    opn = [i for i in data if i.get("pull_request") is None and i["state"] == "open"]
+def regrade(i):
+    """Map an issue to a priority BUCKET from severity × reach (Axis 2 rubric).
 
+    This is the backfill output — a priority *label*, not a score. Applies to
+    bugs and FRs alike; type does not cap priority. In production the LLM grades
+    severity/reach; here we reuse the regex severity()/reach() so the backfill
+    preview is reproducible (and carries the same known false positives).
+    """
+    sname, _ = severity(i)
+    r = reach(i)  # 1.5 broad · 1.0 normal · 0.9 single-platform
+    if sname == "critical":  # security/data-loss/all-users-down
+        return "P0-critical"
+    if sname == "high":  # high severity: broad reach -> P1, narrow -> P2
+        return "P1-high" if r >= 1.0 else "P2-medium"
+    if sname == "medium":  # medium only reaches P1 when reach is broad
+        return "P1-high" if r >= 1.5 else "P2-medium"
+    if sname == "low":
+        return "P3-low"
+    return "P2-medium" if r >= 1.0 else "P3-low"  # FR default: reach decides
+
+
+def current_prio(i):
+    return next((p for p in PRIOS if p in labels(i)), "none")
+
+
+def print_score_ranking(opn):
     before = sorted(opn, key=current_rank_key)
     after = sorted(opn, key=lambda i: score(i)[0], reverse=True)
     before_rank = {i["number"]: n for n, i in enumerate(before)}
@@ -235,12 +257,50 @@ def main():
     print(f"{'AFTER':>5} {'BEFORE':>6} {'Δ':>5}  {'score':>6} {'severity':9} {'prio':11} issue")
     for n, i in enumerate(after):
         sc, sn = score(i)
-        pr = next((p for p in PRIOS if p in labels(i)), "none")
+        pr = current_prio(i)
         b = before_rank[i["number"]]
         delta = b - n  # positive = moved UP vs current ordering
         arrow = f"+{delta}" if delta > 0 else str(delta)
         title = i["title"][:48]
         print(f"{n + 1:>5} {b + 1:>6} {arrow:>5}  {sc:6.0f} {sn:9} {pr:11} #{i['number']} {title}")
+
+
+def print_regrade(opn):
+    """Backfill preview: current priority LABEL vs regraded label (no scores)."""
+    import collections
+
+    cur = collections.Counter(current_prio(i) for i in opn)
+    new = collections.Counter(regrade(i) for i in opn)
+    print(f"# {len(opn)} open issues — priority LABEL regrade (backfill preview)\n")
+    print(f"{'priority':12} {'now':>5} {'regraded':>9}")
+    for p in (*PRIOS, "none"):
+        print(f"{p:12} {cur.get(p, 0):>5} {new.get(p, 0):>9}")
+
+    bugs = [i for i in opn if "Bug" in labels(i)]
+    p1_now = sum(current_prio(i) == "P1-high" for i in bugs)
+    p1_new = sum(regrade(i) == "P1-high" for i in bugs)
+    print(f"\nP1 share of open bugs: {p1_now}/{len(bugs)} -> {p1_new}/{len(bugs)}")
+
+    moves = collections.Counter(
+        f"{current_prio(i)} -> {regrade(i)}" for i in opn if current_prio(i) != regrade(i)
+    )
+    print("\nchanged labels (count):")
+    for k, v in moves.most_common():
+        print(f"  {v:>4}  {k}")
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    flags = {a for a in sys.argv[1:] if a.startswith("--")}
+    path = args[0] if args else "/tmp/all_issues_raw.json"
+    with open(path) as f:
+        data = json.load(f)
+    opn = [i for i in data if i.get("pull_request") is None and i["state"] == "open"]
+
+    if "--regrade" in flags:
+        print_regrade(opn)  # priority-label backfill preview
+    else:
+        print_score_ranking(opn)  # composite-score before->after (default)
 
 
 if __name__ == "__main__":

--- a/designs/prioritization/score_prototype.py
+++ b/designs/prioritization/score_prototype.py
@@ -30,19 +30,21 @@ NOW = datetime.datetime.now(datetime.timezone.utc)
 # Severity tiers are checked most-severe first; first match wins. Kept narrow
 # so a stray "credential" mention doesn't inflate everything to critical.
 SEVERITY = {
+    # NOTE: `severity()` lowercases the text before matching, so every pattern
+    # here MUST be lowercase — an uppercase literal can never match.
     "critical": (
         100,
         [
             r"\bdata ?loss\b",
             r"\bvulnerab",
-            r"\bCVE-\d",
-            r"\bRCE\b",
+            r"\bcve-\d",
+            r"\brce\b",
             r"\bexfiltrat",
             r"\bpolicy (?:gate|bypass)",
             r"\bsandbox (?:escape|bypass)",
             r"\bgates? (?:are )?bypass",
             r"\bcorrupt(?:s|ion|ed)\b",
-            r"\bPAT is offered",
+            r"\bpat is offered",
             r"\bleak(?:s|ed) (?:the |a )?(?:secret|token|credential)",
         ],
     ),
@@ -116,6 +118,9 @@ def severity(i):
     for name, (w, pats) in SEVERITY.items():
         if any(re.search(p, text) for p in pats):
             return name, w
+    # Fallbacks for issues that hit no keyword. An un-keyworded bug scores 25 —
+    # just below an explicit "medium" (30) so known-medium bugs sort above
+    # unknown ones; an un-keyworded FR scores 20 (see FR grading note in doc).
     return ("medium", 25) if "Bug" in labels(i) else ("feature", 20)
 
 
@@ -172,9 +177,33 @@ def age_days(i):
     return (NOW - parse(i["created_at"])).total_seconds() / 86400
 
 
+# Readiness: an actionable ticket (repro steps, a real body) is worth surfacing
+# above a vague one at the same severity — you can start on it now. A small
+# multiplier so it only breaks near-ties, never overrides severity.
+_REPRO = re.compile(r"steps to reproduce|reproduc|to reproduce", re.I)
+READINESS_MIN, READINESS_MAX = 0.85, 1.1
+
+
+def readiness(i):
+    if "needs-info" in labels(i):
+        return READINESS_MIN  # explicitly blocked on the reporter
+    body = i.get("body") or ""
+    ready = len(body) >= 400 and (_REPRO.search(body) or "enhancement" in labels(i))
+    return READINESS_MAX if ready else 1.0
+
+
+# Duplicate blast-radius: N confirmed duplicates of an issue means N reporters
+# hit it — a reach signal. Snapshot JSON doesn't carry dup links, so this reads
+# an optional `duplicate_count` the production job would populate from the
+# dedup labeler (see PR #4037). Defaults to no-op on the dry-run data.
+def dup_reach(i):
+    n = i.get("duplicate_count", 0)
+    return 1.0 + min(0.5, 0.15 * n)  # +15% per dup, capped at +50%
+
+
 def score(i):
     sname, sw = severity(i)
-    s = sw * reach(i) * tier_mult(i)
+    s = sw * reach(i) * tier_mult(i) * dup_reach(i) * readiness(i)
     d = _demand_signal(i)
     if "enhancement" in labels(i):
         s *= 1.0 + FR_DEMAND_MAX * d  # demand LEADS for feature requests


### PR DESCRIPTION
## Related issue

N/A — design doc + prototype.

## Summary

Priority on the open-issue queue has lost its meaning. On the backlog (360 open / 365 closed):

- **P1 is inflated** — 125 of 207 open bugs (60%) are `P1-high`; `P0` (3) and `P3` (16) are vestigial. It's collapsed into a P1/P2 binary.
- **Priority doesn't order the queue** — open-issue *age* is flat across priorities (P1 ≈ P2 ≈ P3 ≈ 20–30d); attention/recency orders it today, not priority.
- **FRs are all P2** — a real capability gap (e.g. #2125) is indistinguishable from a trivial nice-to-have.

This PR is the **design + a runnable prototype** (nothing wired into the live classifier yet). The model:

```
Issue → LLM grades Severity (S0–S3) → × weights → Score → Priority (thresholds) → maintainer can override
```

- **Severity (Axis 2)** — an LLM grades S0–S3 from issue *content*; **reach is folded into the grade** (no separate multiplier), and it must not re-encode factors weighted elsewhere.
- **Component weight (Axis 3)** — one per-area `weight` in `areas.json` applied to every `comp:` (not harness-only). Harness weights are **telemetry-seeded** (LJ Sessions by Harness); non-harness are editorial. Adds finer labels (`comp:harness-t1/-t2/-t3`, `comp:sandbox`, `comp:mobile`, `comp:auth`) + a `sub_area` tag.
- **Score** = `severity × component_weight × dup_reach × readiness + demand × age_factor`, then bucketed by fixed thresholds (`≥100 P0 · ≥60 P1 · ≥25 P2 · else P3`). Age (Axis 8) is a light mid-life bump / long-tail decay; demand is a bounded additive nudge.
- **Priority is the output, a maintainer edit always wins** — a scheduled Databricks job computes the score in one place, writes an `issue_scores` table for the dashboard, and applies labels back, never overwriting a human-set priority.

**Files:**
- `designs/prioritization/issue-prioritization-v2.md` — the design.
- `designs/prioritization/score_prototype.py` — reproducible dry-run (regex severity stand-in).
- `.github/areas.json` (+ `areas.test.js`) — the per-area `weight`/`weight_source` fields. This is the only runtime-adjacent change; labels + classifier wiring are rollout follow-ups.

## Test Plan

**LLM-vs-regex dry-run (in the doc):** I (an LLM) read the 100 oldest open issues, graded S0–S3 by content, and ran the grades through the scoring machinery. **49/100 flipped priority vs. the regex stand-in** (35 regex-too-low, 14 too-high) — the evidence that production severity must be LLM-graded, not keyword-matched. Distribution + confusion matrix are in the doc's Dry-run section.

**Reproducible prototype:**
```bash
GH_HOST=github.com ghx api --paginate \
  "repos/omnigent-ai/omnigent/issues?state=all&per_page=100" > /tmp/all_issues_raw.json
python3 designs/prioritization/score_prototype.py /tmp/all_issues_raw.json            # score ranking
python3 designs/prioritization/score_prototype.py /tmp/all_issues_raw.json --regrade  # priority-label backfill preview (P1-bug 60% → 23%)
python3 designs/prioritization/score_prototype.py /tmp/all_issues_raw.json --markdown 200  # Appendix C table
```

Checks: `uvx ruff check` / `ruff format --check` clean; `node .github/workflows/areas.test.js` passes (weights validated); `areas.json` valid JSON.

## Demo

N/A — docs + analysis script, no UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Design doc + a dry-run script + the `areas.json` weight fields. The one testable change — the new `weight`/`weight_source` fields — is covered by `.github/workflows/areas.test.js` (asserts every area has an allowed-band weight and a valid source). The prototype is a reproducible analysis tool, verified manually against a live snapshot (see Test Plan). Nothing is wired into the runtime/classifier yet; that lands with the rollout PRs (prompt tuning, cron job, labels, template, backfill, dashboard).

This pull request and its description were written by Isaac.
