### PR TITLE
chore(triage): assign every triaged issue an owner; refresh area ownership

### DIFF
--- a/.github/areas.json
+++ b/.github/areas.json
@@ -97,12 +97,9 @@
       "owners": [
         "dhruv0811",
         "TomeHirata",
-        "SabhyaC26",
         "bbqiu",
         "fanzeyi",
-        "aravind-segu"
-      ],
-      "owners_paused": [
+        "aravind-segu",
         "dbczumar"
       ]
     },
@@ -117,9 +114,7 @@
         "dhruv0811",
         "bbqiu",
         "fanzeyi",
-        "aravind-segu"
-      ],
-      "owners_paused": [
+        "aravind-segu",
         "dbczumar"
       ]
     },
@@ -134,9 +129,7 @@
         "dhruv0811",
         "bbqiu",
         "fanzeyi",
-        "aravind-segu"
-      ],
-      "owners_paused": [
+        "aravind-segu",
         "dbczumar"
       ]
     },
@@ -150,12 +143,9 @@
       "owners": [
         "dhruv0811",
         "TomeHirata",
-        "SabhyaC26",
         "bbqiu",
         "fanzeyi",
-        "aravind-segu"
-      ],
-      "owners_paused": [
+        "aravind-segu",
         "dbczumar"
       ]
     },
@@ -167,7 +157,6 @@
         "omnigent/onboarding/"
       ],
       "owners": [
-        "SabhyaC26",
         "dhruv0811",
         "fanzeyi"
       ]
@@ -195,10 +184,7 @@
       ],
       "owners": [
         "TomeHirata",
-        "SabhyaC26",
-        "bbqiu"
-      ],
-      "owners_paused": [
+        "bbqiu",
         "dbczumar"
       ]
     },
@@ -211,8 +197,7 @@
       ],
       "owners": [
         "dhruv0811",
-        "PattaraS",
-        "SabhyaC26"
+        "PattaraS"
       ]
     },
     {
@@ -225,9 +210,7 @@
       "owners": [
         "fanzeyi",
         "dhruv0811",
-        "bbqiu"
-      ],
-      "owners_paused": [
+        "bbqiu",
         "dbczumar"
       ]
     },
@@ -239,10 +222,7 @@
         "omnigent/sandbox/"
       ],
       "owners": [
-        "SabhyaC26",
-        "fanzeyi"
-      ],
-      "owners_paused": [
+        "fanzeyi",
         "dbczumar"
       ]
     },
@@ -258,9 +238,6 @@
         "aravind-segu",
         "fanzeyi",
         "dhruv0811",
-        "SabhyaC26"
-      ],
-      "owners_paused": [
         "dbczumar"
       ]
     },
@@ -276,12 +253,9 @@
         "aravind-segu",
         "fanzeyi",
         "dhruv0811",
-        "SabhyaC26",
         "serena-ruan",
         "daniellok-db",
-        "TomeHirata"
-      ],
-      "owners_paused": [
+        "TomeHirata",
         "dbczumar"
       ]
     },
@@ -297,9 +271,6 @@
         "dhruv0811",
         "aravind-segu",
         "bbqiu",
-        "SabhyaC26"
-      ],
-      "owners_paused": [
         "dbczumar"
       ]
     },
@@ -313,12 +284,9 @@
       "owners": [
         "dhruv0811",
         "TomeHirata",
-        "SabhyaC26",
         "bbqiu",
         "fanzeyi",
-        "aravind-segu"
-      ],
-      "owners_paused": [
+        "aravind-segu",
         "dbczumar"
       ]
     },
@@ -345,9 +313,7 @@
         "dhruv0811",
         "fanzeyi",
         "serena-ruan",
-        "daniellok-db"
-      ],
-      "owners_paused": [
+        "daniellok-db",
         "dbczumar"
       ]
     },
@@ -374,9 +340,6 @@
       "owners": [
         "dhruv0811",
         "PattaraS",
-        "SabhyaC26"
-      ],
-      "owners_paused": [
         "dbczumar"
       ]
     },
@@ -390,12 +353,9 @@
       "owners": [
         "dhruv0811",
         "fanzeyi",
-        "SabhyaC26",
         "TomeHirata",
         "bbqiu",
-        "aravind-segu"
-      ],
-      "owners_paused": [
+        "aravind-segu",
         "dbczumar"
       ]
     },
@@ -410,12 +370,9 @@
       "owners": [
         "dhruv0811",
         "TomeHirata",
-        "SabhyaC26",
         "bbqiu",
         "fanzeyi",
-        "aravind-segu"
-      ],
-      "owners_paused": [
+        "aravind-segu",
         "dbczumar"
       ]
     },
@@ -432,12 +389,9 @@
       "owners": [
         "dhruv0811",
         "TomeHirata",
-        "SabhyaC26",
         "bbqiu",
         "fanzeyi",
-        "aravind-segu"
-      ],
-      "owners_paused": [
+        "aravind-segu",
         "dbczumar"
       ]
     },
@@ -450,10 +404,7 @@
         "omnigent/cursor_native"
       ],
       "owners": [
-        "SabhyaC26",
-        "dhruv0811"
-      ],
-      "owners_paused": [
+        "dhruv0811",
         "dbczumar"
       ]
     },
@@ -468,8 +419,8 @@
         "omnigent/onboarding/gemini_auth.py"
       ],
       "owners": [
-        "SabhyaC26",
-        "TomeHirata"
+        "TomeHirata",
+        "PattaraS"
       ]
     },
     {
@@ -496,7 +447,6 @@
       ],
       "owners": [
         "dhruv0811",
-        "SabhyaC26",
         "TomeHirata"
       ]
     },
@@ -524,7 +474,6 @@
       ],
       "owners": [
         "PattaraS",
-        "SabhyaC26",
         "TomeHirata",
         "dhruv0811"
       ]
@@ -542,9 +491,6 @@
         "dhruv0811",
         "PattaraS",
         "TomeHirata",
-        "SabhyaC26"
-      ],
-      "owners_paused": [
         "dbczumar"
       ]
     },
@@ -557,7 +503,6 @@
         "omnigent/pi_native"
       ],
       "owners": [
-        "SabhyaC26",
         "TomeHirata",
         "dhruv0811"
       ]
@@ -585,7 +530,6 @@
         "omnigent/onboarding/copilot_auth.py"
       ],
       "owners": [
-        "SabhyaC26",
         "PattaraS",
         "TomeHirata",
         "dhruv0811"

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -457,6 +457,7 @@ jobs:
               "ranked_owners": ranked_owners,
               "duplicate_of": dup if isinstance(dup, int) else None,
               "priority": result.get("priority") if result.get("priority") in ALLOWED_PRIORITIES else None,
+              "needs_info": bool(result.get("needs_info")),
               "reasoning": result.get("reasoning", ""),
           }
           pathlib.Path("/tmp/triage_result.json").write_text(json.dumps(output))
@@ -509,12 +510,14 @@ jobs:
             maintainer_assigned=true
           fi
 
-          # Otherwise, assign an owner for P0/P1 issues: the least-loaded area
-          # owner, with LLM rank as a tiebreaker (load primary, rank secondary).
-          # Symmetric with the PR reviewer path. Skipped if the maintainer-author
-          # was already assigned above.
-          priority=$(jq -r '.priority // empty' /tmp/triage_result.json)
-          if [ "$maintainer_assigned" = "false" ] && { [ "$priority" = "P0-critical" ] || [ "$priority" = "P1-high" ]; }; then
+          # Otherwise, assign an owner: the least-loaded area owner, with LLM
+          # rank as a tiebreaker (load primary, rank secondary). Symmetric with
+          # the PR reviewer path. Skipped if the maintainer-author was already
+          # assigned above. Every triaged issue gets an owner — the only issues
+          # left unassigned are needs_info ones (too vague to route until the
+          # reporter adds detail).
+          needs_info=$(jq -r '.needs_info // false' /tmp/triage_result.json)
+          if [ "$maintainer_assigned" = "false" ] && [ "$needs_info" != "true" ]; then
             # Open-issue load per candidate (fewest assigned open issues wins ties).
             # One trusted query; the LLM never sees GH_TOKEN.
             gh issue list --repo "$REPO" --state open --limit 500 \
@@ -526,8 +529,8 @@ jobs:
           owners = json.loads(pathlib.Path("/tmp/owners.json").read_text())
 
           # Candidates: the validated ranked owners (LLM preference order). If the
-          # LLM gave none, fall back to the full owner pool so a P0/P1 is never
-          # left unassigned — load then picks the least-loaded owner.
+          # LLM gave none, fall back to the full owner pool so a triaged issue is
+          # never left unassigned — load then picks the least-loaded owner.
           ranked = triage.get("ranked_owners") or []
           candidates = ranked if ranked else owners
           rank_of = {u: i for i, u in enumerate(ranked)}  # unranked -> +inf below


### PR DESCRIPTION
## Related issue

N/A

## Summary

Two related triage/ownership changes:

- **Issue-triage auto-assignment** (`.github/workflows/issue-triage.yml`): broaden owner assignment from **P0/P1-only** to **every triaged issue except `needs_info`**. The gate now keys off `needs_info` alone, so any bug/enhancement/doc issue with enough info to triage gets a load-balanced area owner (fewest open assigned issues first, LLM rank as tiebreaker), not just high-priority ones. `needs_info` issues stay unassigned until the reporter adds detail; maintainer-authored issues still go to the author. Removes the now-unused `priority`/`type` branch from the shell gate.
- **Area ownership refresh** (`.github/areas.json`):
  - remove `SabhyaC26` from all areas
  - add `PattaraS` to `harness-antigravity` (keeps it at the 2-owner minimum after Sabhya's removal)
  - reactivate `dbczumar` (`owners_paused` → `owners`) across their areas

Note: the workflow only fires on newly opened issues, so this does not retroactively assign the existing backlog.

## Test Plan

- `node --test .github/workflows/areas.test.js` — passes (validates every owner is a maintainer, real `comp:*` labels, 2+ owners/area, path resolution).
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/issue-triage.yml'))"` — YAML valid.
- `pre-commit` (incl. `no-hardcoded-models`) passes on both files.

## Demo

N/A — non-visual (CI workflow + ownership config).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

`areas.json` is covered by the existing `areas.test.js` integrity checks (run above). The `issue-triage.yml` gate has no unit harness; verified manually by tracing the gate logic and validating YAML + pre-commit. Behaviour only triggers on newly opened issues.

This pull request and its description were written by Isaac.