### PR TITLE
dev/repro-agent: give Linear tickets a real fetch path + follow linked GitHub issues

### DIFF
--- a/dev/repro-agent/AGENTS.md
+++ b/dev/repro-agent/AGENTS.md
@@ -26,8 +26,27 @@ session and logs are things you *produce*, not inputs:
 - `bug_url` (required) — a link to the bug report: a **GitHub issue URL** or a
   **Linear ticket URL** (e.g. `https://github.com/omnigent-ai/omnigent/issues/1234`
   or `https://linear.app/omnigent/issue/OMNI-1234`). Read the report to get the
-  bug description, steps, and version. Use `gh issue view` for GitHub or your
-  Linear tools for a Linear link.
+  bug description, steps, and version:
+  - **GitHub** → `gh issue view <url> --comments` (the CLI is on the machine).
+  - **Linear** → query the GraphQL API with `sys_os_shell`, using the
+    `LINEAR_API_KEY` from your environment (endpoint
+    `https://api.linear.app/graphql`, header `Authorization: $LINEAR_API_KEY` —
+    **no** `Bearer` prefix). Fetch the ticket by its identifier, e.g.:
+    ```bash
+    curl -s https://api.linear.app/graphql \
+      -H "Authorization: $LINEAR_API_KEY" -H 'Content-Type: application/json' \
+      -d '{"query":"{ issue(id: \"OMNI-1234\") { identifier title description url state { name } comments(first: 50) { nodes { body } } attachments(first: 20) { nodes { url } } } }"}'
+    ```
+    If `LINEAR_API_KEY` is not set (or the fetch fails auth), you cannot read the
+    ticket body — stop with verdict `needs_more_info` naming the missing key
+    rather than guessing the bug from the URL slug.
+  - **Linear → linked GitHub issue.** A Linear ticket often links a GitHub issue
+    (in its `attachments`, description, or comments). If you find one, **always
+    fetch that GitHub issue too** (`gh issue view <url> --comments`) and treat it
+    as authoritative for the journey — the GitHub thread usually carries the
+    concrete repro steps, stack traces, and version that the Linear card only
+    summarizes. Reconcile the two: if they disagree, prefer the GitHub issue for
+    the technical detail and note the discrepancy.
 - `public` (optional, boolean) — when `true`, share this session public-read as
   the first thing you do in preflight (see Preflight). Off by default: locally
   the session is already yours to browse; sharing is for watching a live run or
@@ -67,8 +86,9 @@ Your first turn is a fixed checklist — do all of it before Step 1:
 2. **Confirm the workspace** (see above) and that you can reach the app and your
    tooling with one `sys_os_shell` / tool check: the browser tools
    (`browser_navigate` / `browser_snapshot` / `browser_click` / `browser_type`)
-   for UI journeys, and `sys_session_*` / HTTP for backend journeys. Confirm `gh`
-   is available if `bug_url` is a GitHub issue.
+   for UI journeys, and `sys_session_*` / HTTP for backend journeys. Confirm you
+   can read the report: `gh` is available for a GitHub issue, or `LINEAR_API_KEY`
+   is set for a Linear ticket (if it isn't, stop with `needs_more_info`).
 
 If you cannot reach the app at all, stop and say so. Don't narrate a clean
 preflight.

--- a/dev/repro-agent/AGENTS.md
+++ b/dev/repro-agent/AGENTS.md
@@ -28,18 +28,22 @@ session and logs are things you *produce*, not inputs:
   or `https://linear.app/omnigent/issue/OMNI-1234`). Read the report to get the
   bug description, steps, and version:
   - **GitHub** → `gh issue view <url> --comments` (the CLI is on the machine).
-  - **Linear** → query the GraphQL API with `sys_os_shell`, using the
-    `LINEAR_API_KEY` from your environment (endpoint
-    `https://api.linear.app/graphql`, header `Authorization: $LINEAR_API_KEY` —
-    **no** `Bearer` prefix). Fetch the ticket by its identifier, e.g.:
+  - **Linear** → query the GraphQL API with `sys_os_shell`, using the Linear key
+    from your environment. It arrives as `LINEAR_API_KEY` locally or as
+    `DATABRICKS_LINEAR_API_KEY` under `--server` (the CLI→runner env strip only
+    forwards the `DATABRICKS_`-prefixed name), so read whichever is set. Endpoint
+    `https://api.linear.app/graphql`, header `Authorization: <key>` — **no**
+    `Bearer` prefix. Fetch the ticket by its identifier, e.g.:
     ```bash
+    KEY="${LINEAR_API_KEY:-$DATABRICKS_LINEAR_API_KEY}"
     curl -s https://api.linear.app/graphql \
-      -H "Authorization: $LINEAR_API_KEY" -H 'Content-Type: application/json' \
+      -H "Authorization: $KEY" -H 'Content-Type: application/json' \
       -d '{"query":"{ issue(id: \"OMNI-1234\") { identifier title description url state { name } comments(first: 50) { nodes { body } } attachments(first: 20) { nodes { url } } } }"}'
     ```
-    If `LINEAR_API_KEY` is not set (or the fetch fails auth), you cannot read the
-    ticket body — stop with verdict `needs_more_info` naming the missing key
-    rather than guessing the bug from the URL slug.
+    If neither `LINEAR_API_KEY` nor `DATABRICKS_LINEAR_API_KEY` is set (or the
+    fetch fails auth), you cannot read the ticket body — stop with verdict
+    `needs_more_info` naming the missing key rather than guessing the bug from the
+    URL slug.
   - **Linear → linked GitHub issue.** A Linear ticket often links a GitHub issue
     (in its `attachments`, description, or comments). If you find one, **always
     fetch that GitHub issue too** (`gh issue view <url> --comments`) and treat it
@@ -87,8 +91,9 @@ Your first turn is a fixed checklist — do all of it before Step 1:
    tooling with one `sys_os_shell` / tool check: the browser tools
    (`browser_navigate` / `browser_snapshot` / `browser_click` / `browser_type`)
    for UI journeys, and `sys_session_*` / HTTP for backend journeys. Confirm you
-   can read the report: `gh` is available for a GitHub issue, or `LINEAR_API_KEY`
-   is set for a Linear ticket (if it isn't, stop with `needs_more_info`).
+   can read the report: `gh` is available for a GitHub issue, or a Linear key
+   (`LINEAR_API_KEY` or `DATABRICKS_LINEAR_API_KEY`) is set for a Linear ticket
+   (if it isn't, stop with `needs_more_info`).
 
 If you cannot reach the app at all, stop and say so. Don't narrate a clean
 preflight.

--- a/dev/repro.py
+++ b/dev/repro.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -45,6 +46,35 @@ _AGENT_REL = "dev/repro-agent"
 def _die(msg: str) -> NoReturn:
     print(f"error: {msg}", file=sys.stderr)
     raise SystemExit(1)
+
+
+def _launch_env(bug_url: str) -> dict[str, str]:
+    """Build the child env for ``omnigent run``, forwarding the Linear key.
+
+    Reading a Linear ticket needs ``DATABRICKS_LINEAR_API_KEY`` to reach the
+    agent's shell. Under ``--server`` the daemon→runner hop strips everything
+    not in its allowlist, and the ``DATABRICKS_`` prefix survives only the
+    CLI→daemon hop — so we also name the key in ``OMNIGENT_RUNNER_ENV_PASSTHROUGH``
+    (itself allowlisted), which tells the runner env-build to forward it the rest
+    of the way. Only kicks in for Linear URLs; if the key is unset we warn rather
+    than fail (the agent stops with ``needs_more_info`` and names the missing key).
+    """
+    env = os.environ.copy()
+    if "linear.app" not in bug_url:
+        return env
+    if not env.get("DATABRICKS_LINEAR_API_KEY"):
+        print(
+            "warning: Linear URL but DATABRICKS_LINEAR_API_KEY is not set — the "
+            "agent won't be able to read the ticket (it will stop with "
+            "needs_more_info).",
+            file=sys.stderr,
+        )
+        return env
+    names = [n for n in env.get("OMNIGENT_RUNNER_ENV_PASSTHROUGH", "").split(",") if n.strip()]
+    if "DATABRICKS_LINEAR_API_KEY" not in names:
+        names.append("DATABRICKS_LINEAR_API_KEY")
+    env["OMNIGENT_RUNNER_ENV_PASSTHROUGH"] = ",".join(names)
+    return env
 
 
 def _slug_from_bug_url(bug_url: str) -> str:
@@ -174,10 +204,12 @@ def main() -> None:
     cmd = ["omnigent", "run", _AGENT_REL, "-p", prompt]
     if args.server is not None:
         cmd += ["--server", args.server]
+
+    env = _launch_env(bug_url)
     print(f"→ running: {' '.join(cmd)}")
     print(f"→ cwd:     {worktree}\n")
 
-    result = subprocess.run(cmd, cwd=str(worktree), check=False)
+    result = subprocess.run(cmd, cwd=str(worktree), env=env, check=False)
 
     # Always keep the worktree; the authored test (if any) lives on its branch.
     print(

--- a/dev/repro.py
+++ b/dev/repro.py
@@ -56,17 +56,21 @@ def _launch_env(bug_url: str) -> dict[str, str]:
     not in its allowlist, and the ``DATABRICKS_`` prefix survives only the
     CLI→daemon hop — so we also name the key in ``OMNIGENT_RUNNER_ENV_PASSTHROUGH``
     (itself allowlisted), which tells the runner env-build to forward it the rest
-    of the way. Only kicks in for Linear URLs; if the key is unset we warn rather
-    than fail (the agent stops with ``needs_more_info`` and names the missing key).
+    of the way. Maintainers usually export the plain ``LINEAR_API_KEY`` locally,
+    so mirror that into the ``DATABRICKS_`` name when only the plain one is set.
+    Only kicks in for Linear URLs; if neither is set we warn rather than fail (the
+    agent stops with ``needs_more_info`` and names the missing key).
     """
     env = os.environ.copy()
     if "linear.app" not in bug_url:
         return env
+    if not env.get("DATABRICKS_LINEAR_API_KEY") and env.get("LINEAR_API_KEY"):
+        env["DATABRICKS_LINEAR_API_KEY"] = env["LINEAR_API_KEY"]
     if not env.get("DATABRICKS_LINEAR_API_KEY"):
         print(
-            "warning: Linear URL but DATABRICKS_LINEAR_API_KEY is not set — the "
-            "agent won't be able to read the ticket (it will stop with "
-            "needs_more_info).",
+            "warning: Linear URL but neither LINEAR_API_KEY nor "
+            "DATABRICKS_LINEAR_API_KEY is set — the agent won't be able to read "
+            "the ticket (it will stop with needs_more_info).",
             file=sys.stderr,
         )
         return env


### PR DESCRIPTION
## Summary

The local `dev/repro-agent` reproduced GitHub-issue bugs well but did poorly on
Linear tickets. The cause wasn't that GitHub gives *more* context — it's that
GitHub had a **working** retrieval path (`gh issue view`) while Linear had
**none**: `AGENTS.md` told the agent to use "your Linear tools", but this local
spec wires up no Linear MCP server. So Linear runs couldn't read the ticket body
and fell back to guessing the bug from the URL slug, leaving Step 1 (reconstruct
the journey) — and everything downstream — built on air.

This wires Linear to the same GraphQL path the internal `issue-sync` agent
already uses, and makes the API key actually reach the agent's shell under
`--server`.

### 1. Real Linear fetch path (`AGENTS.md`)

- Endpoint `https://api.linear.app/graphql`, header `Authorization: <key>` (no
  `Bearer`), via `sys_os_shell` `curl`. Fetches title / description / comments /
  attachments.
- **Honest fallback:** if no key is set or auth fails, stop with
  `needs_more_info` naming the missing key instead of guessing from the slug.
- **Follow linked GitHub issues:** a Linear ticket often links a GitHub issue
  (attachments/description/comments). When it does, the agent now **always**
  fetches that GitHub issue too and treats it as authoritative for the technical
  journey (repro steps, stack traces, version) — this is a big part of why
  GitHub-first runs reproduced better.

### 2. Get the key past the `--server` env strip (`dev/repro.py`)

Under `--server`, the CLI → daemon → runner hops strip every env var not
allowlisted, so a bare `LINEAR_API_KEY` never reaches the agent. Three layers:

| Hop | keeps | `DATABRICKS_LINEAR_API_KEY` | bare `LINEAR_API_KEY` |
|---|---|---|---|
| CLI→daemon | allowlist + `DATABRICKS_` prefix | ✅ (prefix) | ❌ |
| daemon→runner | allowlist + `LC_/MLFLOW_/OTEL_/OMNIGENT_OTEL_` + `OMNIGENT_RUNNER_ENV_PASSTHROUGH` names | ❌ prefix alone dies here | ❌ |
| runner→agent (`sandbox: none`) | inherits runner env verbatim | ✅ (whatever hop 2 delivered) | ✅ |

The `DATABRICKS_` prefix survives only the first hop. So when a Linear URL is
passed and `DATABRICKS_LINEAR_API_KEY` is set, `dev/repro.py` now names it in
`OMNIGENT_RUNNER_ENV_PASSTHROUGH` (itself allowlisted) — which tells the
daemon→runner env-build to forward it the rest of the way. `AGENTS.md` reads
whichever name is present (`LINEAR_API_KEY` locally, `DATABRICKS_LINEAR_API_KEY`
under `--server`). If a Linear URL is passed without the key, `dev/repro.py`
warns rather than failing (the agent then stops with `needs_more_info`).

This mirrors exactly how the internal repro workflow already routes the LLM key
through `DATABRICKS_BEARER` for the same reason.

### 3. Companion change (omnigent-internal — not in this repo)

The `repro-agent` CI workflow must set `DATABRICKS_LINEAR_API_KEY: ${{
secrets.LINEAR_API_KEY }}` in the run step, next to the existing
`DATABRICKS_BEARER`. Without it, `--server` Linear runs still can't read the
ticket. Local dev is unaffected — a maintainer just `export LINEAR_API_KEY=...`
and the local daemon path inherits it.

## Test Plan

Docs/prompt + launcher change (not shipped in the wheel). `ruff check` +
`ruff format --check` on `dev/repro.py` pass; `pre-commit` passed. The three env
hops were traced against `cli._build_host_daemon_env`,
`connect._build_runner_env` (allowlist + `OMNIGENT_RUNNER_ENV_PASSTHROUGH`
forwarding), and `os_env.build_helper_env` (`sandbox: none` inherits verbatim).
The Linear GraphQL endpoint + auth-header form match the internal `issue-sync`
agent, which uses the identical pattern against live Linear. `N/A` for automated
tests — this is agent operating guidance + a maintainer launcher script.

## Demo

N/A — no UI / frontend change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Test coverage

- [ ] New tests added
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

Manual verification: agent operating guidance (`AGENTS.md`) + a maintainer-only
launcher (`dev/repro.py`, not packaged). Env-forwarding was verified by tracing
the three allowlist filters in the codebase; the Linear GraphQL call matches the
internal `issue-sync` agent's live-tested pattern. No automated test covers
prompt text or the dev launcher.

This pull request and its description were written by Isaac.
