### PR TITLE
fix(logging): preserve exception tracebacks

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -307,7 +307,7 @@ def _client_safe_error_detail(exc: BaseException, *, context: str) -> str:
         e.g. ``"harness spawn"``. Appears only in the server log.
     :returns: A fixed, non-sensitive string safe to return to clients.
     """
-    _logger.warning("%s failed: %s", context, exc, exc_info=True)
+    _logger.warning("%s failed: %s", context, exc, exc_info=exc)
     return "Request failed on the runner; see runner logs for details."
 
 

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -5244,7 +5244,7 @@ def _native_terminal_start_error_payload(exc: BaseException, runtime_name: str) 
         JSON error responses. The message is a fixed, client-safe string;
         the raw cause is logged for operators, not surfaced to the caller.
     """
-    _logger.warning("Native %s terminal start failed: %s", runtime_name, exc, exc_info=True)
+    _logger.warning("Native %s terminal start failed: %s", runtime_name, exc, exc_info=exc)
     if IS_WINDOWS:
         # Native terminals are tmux/PTY-based and disabled on Windows by design.
         # Give the client an actionable message instead of "see runner logs".

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1337,7 +1337,7 @@ def create_app(
         :returns: A JSON response with the error code and message.
         """
         if exc.http_status >= 500:
-            _logger.error("Internal error: %s", exc.message, exc_info=True)
+            _logger.error("Internal error: %s", exc.message, exc_info=exc)
         elif exc.http_status == 400 and request.url.path.endswith("/policies/evaluate"):
             _logger.warning(
                 "Policy evaluate rejected 400 on %s: %s", request.url.path, exc.message
@@ -1375,7 +1375,7 @@ def create_app(
                 status_code=404,
                 content={"error": {"code": ErrorCode.NOT_FOUND, "message": "Not found."}},
             )
-        _logger.error("Database error: %s", exc, exc_info=True)
+        _logger.error("Database error: %s", exc, exc_info=exc)
         return JSONResponse(
             status_code=500,
             content={
@@ -1400,7 +1400,7 @@ def create_app(
         :param exc: The unhandled exception.
         :returns: A 500 JSON response with ``internal_error`` code.
         """
-        _logger.error("Unhandled exception: %s", exc, exc_info=True)
+        _logger.error("Unhandled exception: %s", exc, exc_info=exc)
         return JSONResponse(
             status_code=500,
             content={

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -486,9 +486,10 @@ extend-exclude = [
 # ``RET``      — flake8-return (consistent return statements)
 # ``C4``       — flake8-comprehensions (cleaner list/dict/set comprehensions)
 # ``PIE``      — flake8-pie (misc correctness + style)
+# ``LOG``      — flake8-logging (correct exception and logger usage)
 # ``RUF``      — ruff-specific (sorted ``__all__``, dangling asyncio
 #                tasks, unused noqa, ...)
-select = ["E", "F", "I", "UP", "ARG", "BLE", "B", "SIM", "RET", "C4", "PIE", "RUF"]
+select = ["E", "F", "I", "UP", "ARG", "BLE", "B", "SIM", "RET", "C4", "PIE", "LOG", "RUF"]
 ignore = [
     # ARG003 (unused class-method args): too noisy on ABC-subclass signatures
     # where the arg is required by the interface contract.


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Enable Ruff's `LOG` rules for correct logger and exception usage.
- Replace five `exc_info=True` calls made outside exception handlers with `exc_info=exc`.
- Preserve the supplied traceback instead of emitting the misleading `NoneType: None` text.

## Test Plan

- `uv run --no-sync ruff check omnigent tests integrations scripts`
- `uv run --no-sync pytest -q tests/runner/test_runner_dispatch.py::test_runner_post_returns_503_when_spec_resolver_fails tests/runner/test_app_sessions_native_terminals_autocreate.py::test_publish_native_terminal_start_error_emits_failed_status_only tests/server/test_app.py` (38 tests passed)
- `uv run --no-sync pre-commit run --show-diff-on-failure`

## Demo

N/A — server-side logging correctness and lint enforcement only.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing runner tests exercise both logging helpers and assert that the raw exception remains available to operators while client responses stay generic.
