### PR TITLE
fix(lint): suppress pyrefly false-positive on optional nimble-python import

### DIFF
--- a/omnigent/tools/builtins/nimble_research.py
+++ b/omnigent/tools/builtins/nimble_research.py
@@ -529,7 +529,12 @@ def _start_run(
     # Lazy: nimble-python is the optional `nimble` extra, so the base install
     # never needs it. Checked before anything is sent, so nothing is billed.
     try:
-        from nimble_python import APIConnectionError, APIError, APIStatusError, Nimble
+        from nimble_python import (  # pyrefly: ignore[missing-import]
+            APIConnectionError,
+            APIError,
+            APIStatusError,
+            Nimble,
+        )
     except ImportError:
         return (
             None,


### PR DESCRIPTION
## Related issue

N/A

## Summary

`pyrefly` reports `missing-import` on the `nimble_python` import in `nimble_research.py` because `nimble-python` is an optional extra (`pip install 'omnigent[nimble]'`) and isn't present in the base venv. The import is already guarded by `try/except ImportError`, so the error is a false-positive. Added `# pyrefly: ignore[missing-import]` on the import line to silence it without changing runtime behaviour.

## Test Plan

- [x] `pre-commit run --files omnigent/tools/builtins/nimble_research.py` passes (pyrefly + ruff)

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Not applicable

## Coverage notes

Pure lint annotation; no logic changed.