### PR TITLE
feat(telemetry): accept "default" omnigent_version in remote config

### DIFF
--- a/omnigent/telemetry/client.py
+++ b/omnigent/telemetry/client.py
@@ -187,7 +187,7 @@ def _fetch_remote_config() -> TelemetryConfig | None:
             return None
         cfg: dict[object, object] = raw_config
 
-        if cfg.get("omnigent_version") != VERSION:
+        if cfg.get("omnigent_version") not in (VERSION, "default"):
             _logger.debug("Telemetry config version mismatch; disabling telemetry")
             return None
         if cfg.get("disable_telemetry") is True:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -298,6 +298,23 @@ def test_fetch_remote_config_respects_rollout_percentage_boundaries(
     assert (result is not None) is included
 
 
+def test_fetch_remote_config_accepts_default_version() -> None:
+    """A config with omnigent_version='default' is accepted for any client version."""
+    import omnigent.telemetry.client as _mod
+
+    config = {
+        "omnigent_version": "default",
+        "ingestion_url": "https://telemetry.example.test",
+        "rollout_percentage": 100,
+    }
+    with patch("urllib.request.urlopen") as urlopen:
+        response = urlopen.return_value.__enter__.return_value
+        response.read.return_value = json.dumps(config).encode("utf-8")
+        result = _mod._fetch_remote_config()
+
+    assert result is not None
+
+
 # ── get_installation_id ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Related issue

N/A — companion to omnigent-ai/omnigent-telemetry#15

## Summary

- [omnigent-ai/omnigent-telemetry#15](https://github.com/omnigent-ai/omnigent-telemetry/pull/15) adds a CloudFront fallback (`default.json`, `omnigent_version: "default"`) for versions without an explicit config file.
- Without this change the version check in `_fetch_remote_config` always rejects the default payload and silently disables telemetry for those versions.
- Accept `"default"` as a valid `omnigent_version` so the default config is honoured.

## Test Plan

- New unit test `test_fetch_remote_config_accepts_default_version` verifies a config with `omnigent_version: "default"` is accepted.
- Existing rollout-percentage tests still pass.

```
python -m pytest tests/test_telemetry.py::test_fetch_remote_config_accepts_default_version tests/test_telemetry.py::test_fetch_remote_config_respects_rollout_percentage_boundaries -x -q
```

## Demo

N/A

## Type of change

- [x] Bug fix

## Test coverage

- [x] Unit tests added / updated

## Coverage notes

N/A