### PR TITLE
feat(web): show harness icons on Agents graph-view nodes

### DIFF
--- a/web/src/components/AgentCard.tsx
+++ b/web/src/components/AgentCard.tsx
@@ -1,64 +1,7 @@
-import { BotIcon } from "lucide-react";
-import { AntigravityIcon } from "@/components/icons/AntigravityIcon";
-import { ClaudeIcon } from "@/components/icons/ClaudeIcon";
-import { CodexIcon } from "@/components/icons/CodexIcon";
-import { CursorIcon } from "@/components/icons/CursorIcon";
-import { GooseIcon } from "@/components/icons/GooseIcon";
-import { HermesIcon } from "@/components/icons/HermesIcon";
-import { KimiIcon } from "@/components/icons/KimiIcon";
-import { KiroIcon } from "@/components/icons/KiroIcon";
-import { NessieIcon } from "@/components/icons/NessieIcon";
-import { OpenCodeIcon } from "@/components/icons/OpenCodeIcon";
-import { PiIcon } from "@/components/icons/PiIcon";
-import type { ComponentType, SVGProps } from "react";
 import type { AvailableAgent } from "@/hooks/useAvailableAgents";
-import { nativeCodingAgentForAvailableAgent } from "@/lib/nativeCodingAgents";
+import { iconForSessionAgent } from "@/shell/subagentIcons";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { AgentHoverCard } from "@/components/AgentHoverCard";
-
-/**
- * Pick the glyph for a catalog agent.
- *
- * Named agents win first (nessie runs on the claude-sdk harness, so a
- * harness check would mislabel it with the Claude glyph), then harness/kind
- * so any Claude-, Codex-, Cursor-, pi-, or Goose-backed agent (native TUI or
- * headless) gets the right glyph regardless of its registered name, then a
- * generic bot (qwen falls back to bot for now).
- *
- * @param agent - The catalog entry to render.
- * @returns The icon component to render for the agent.
- */
-function iconForAgent(agent: AvailableAgent): ComponentType<SVGProps<SVGSVGElement>> {
-  if (agent.name === "nessie") return NessieIcon;
-  const nativeAgent = nativeCodingAgentForAvailableAgent(agent);
-  if (nativeAgent?.iconKind === "claude") return ClaudeIcon;
-  if (nativeAgent?.iconKind === "codex") return CodexIcon;
-  if (nativeAgent?.iconKind === "opencode") return OpenCodeIcon;
-  if (nativeAgent?.iconKind === "pi") return PiIcon;
-  if (nativeAgent?.iconKind === "cursor") return CursorIcon;
-  if (nativeAgent?.iconKind === "kiro") return KiroIcon;
-  if (nativeAgent?.iconKind === "goose") return GooseIcon;
-  if (nativeAgent?.iconKind === "kimi") return KimiIcon;
-  if (nativeAgent?.iconKind === "antigravity") return AntigravityIcon;
-  if (nativeAgent?.iconKind === "hermes") return HermesIcon;
-  // A null harness (spec couldn't load) flows through to the bot fallback.
-  if (agent.harness?.includes("codex")) return CodexIcon;
-  if (agent.harness?.includes("claude")) return ClaudeIcon;
-  // Both the SDK "cursor" harness and "cursor-native" get the Cursor glyph.
-  if (agent.harness?.includes("cursor")) return CursorIcon;
-  if (agent.harness?.includes("hermes")) return HermesIcon;
-  if (agent.harness?.includes("kiro")) return KiroIcon;
-  if (agent.harness?.includes("goose")) return GooseIcon;
-  // Both the SDK "kimi"/"kimi-code" harness and "kimi-native" get the Kimi glyph.
-  if (agent.harness?.includes("kimi")) return KimiIcon;
-  // qwen falls back to generic BotIcon for now; see docs/QWEN_FOLLOWUPS.md
-  // Exact match — a substring check would false-match e.g. "openapi".
-  if (agent.harness === "pi") return PiIcon;
-  // Both the native (`antigravity-native`) and SDK (`antigravity`) harnesses
-  // share the Antigravity glyph.
-  if (agent.harness?.includes("antigravity")) return AntigravityIcon;
-  return BotIcon;
-}
 
 /**
  * Selectable card for one available agent.
@@ -94,7 +37,8 @@ export function AgentCard({
   compact?: boolean;
   hover?: boolean;
 }) {
-  const Icon = iconForAgent(agent);
+  // Catalog agents carry no wrapper label — name + harness are the signals.
+  const Icon = iconForSessionAgent({ agentName: agent.name, harness: agent.harness });
   const card = (
     <button
       type="button"

--- a/web/src/shell/AgentGraphNode.test.tsx
+++ b/web/src/shell/AgentGraphNode.test.tsx
@@ -1,0 +1,196 @@
+// Proves every graph-view node carries its harness/role glyph — the same one
+// the list view shows — for BOTH the root node and child nodes.
+//
+// Node data comes from the real ``buildGraphLayout`` so the test covers the
+// whole path (raw session/child fields → layout → glyph), not just the
+// component in isolation. @xyflow/react is stubbed: importing its barrel (and
+// CSS bundle) exhausts the jsdom worker, and the node only needs <Handle>.
+
+import type { ChildSessionInfo } from "@/hooks/useChildSessions";
+import type { Node, NodeProps } from "@xyflow/react";
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@xyflow/react", () => ({
+  Handle: () => null,
+  Position: { Top: "top", Bottom: "bottom" },
+}));
+
+vi.mock("@/components/icons/ClaudeIcon", () => ({
+  ClaudeIcon: (props: Record<string, unknown>) => <svg {...props} data-icon="claude" />,
+}));
+vi.mock("@/components/icons/CodexIcon", () => ({
+  CodexIcon: (props: Record<string, unknown>) => <svg {...props} data-icon="codex" />,
+}));
+vi.mock("@/components/icons/OpenCodeIcon", () => ({
+  OpenCodeIcon: (props: Record<string, unknown>) => <svg {...props} data-icon="opencode" />,
+}));
+vi.mock("@/components/icons/PiIcon", () => ({
+  PiIcon: (props: Record<string, unknown>) => <svg {...props} data-icon="pi" />,
+}));
+vi.mock("@/components/icons/OttoIcon", () => ({
+  OttoIcon: (props: Record<string, unknown>) => <svg {...props} data-icon="otto" />,
+}));
+vi.mock("@/components/icons/NessieIcon", () => ({
+  NessieIcon: (props: Record<string, unknown>) => <svg {...props} data-icon="nessie" />,
+}));
+
+import { AgentGraphNode } from "./AgentGraphNode";
+import { buildGraphLayout, type AgentNodeData, type TreeRoot } from "./subagentGraphLayout";
+
+function childInfo(overrides: Partial<ChildSessionInfo> & { id: string }): ChildSessionInfo {
+  return {
+    title: null,
+    tool: null,
+    session_name: null,
+    current_task_status: null,
+    busy: false,
+    last_message_preview: null,
+    pending_elicitations_count: 0,
+    ...overrides,
+  };
+}
+
+/**
+ * Lay out a root + its children, then render each node through the real
+ * component. Returns a lookup from session id to that node's element.
+ */
+function renderGraphNodes(
+  root: Partial<TreeRoot> = {},
+  children: ChildSessionInfo[] = [],
+): (sessionId: string) => HTMLElement {
+  const childrenMap = new Map<string, ChildSessionInfo[]>([["conv_root", children]]);
+  const { nodes } = buildGraphLayout(
+    {
+      id: "conv_root",
+      label: "main",
+      activity: "idle",
+      statusLabel: "Idle",
+      preview: null,
+      ...root,
+    },
+    childrenMap,
+    "conv_root",
+  );
+
+  const { container } = render(
+    <>
+      {nodes.map((node) => (
+        <div key={node.id} data-session-id={node.data.sessionId}>
+          <AgentGraphNode {...({ data: node.data } as unknown as NodeProps<Node<AgentNodeData>>)} />
+        </div>
+      ))}
+    </>,
+  );
+
+  return (sessionId: string) => {
+    const el = container.querySelector<HTMLElement>(`[data-session-id="${sessionId}"]`);
+    if (!el) throw new Error(`No graph node for ${sessionId}`);
+    return el;
+  };
+}
+
+afterEach(cleanup);
+
+describe("AgentGraphNode icons", () => {
+  it("renders the harness glyph on the ROOT node", () => {
+    const at = renderGraphNodes({ wrapper: "claude-code-native-ui" });
+
+    expect(at("conv_root").querySelector('[data-icon="claude"]')).not.toBeNull();
+  });
+
+  it("renders the harness glyph on CHILD nodes", () => {
+    const at = renderGraphNodes({}, [
+      childInfo({
+        id: "conv_codex",
+        session_name: "auth-refactor",
+        tool: "codex",
+        labels: { "omnigent.wrapper": "codex-native-ui" },
+      }),
+      childInfo({
+        id: "conv_opencode",
+        session_name: "port-auth",
+        tool: "opencode",
+        labels: { "omnigent.wrapper": "opencode-native-ui" },
+      }),
+    ]);
+
+    expect(at("conv_codex").querySelector('[data-icon="codex"]')).not.toBeNull();
+    expect(at("conv_opencode").querySelector('[data-icon="opencode"]')).not.toBeNull();
+  });
+
+  it("resolves the root's glyph from its harness when it has no wrapper label", () => {
+    const at = renderGraphNodes({ harness: "claude-sdk" });
+
+    expect(at("conv_root").querySelector('[data-icon="claude"]')).not.toBeNull();
+  });
+
+  it("gives the root the nessie glyph by agent name", () => {
+    // nessie runs on claude-sdk, so a harness-first check would mislabel it.
+    const at = renderGraphNodes({ agentName: "nessie", harness: "claude-sdk" });
+
+    expect(at("conv_root").querySelector('[data-icon="nessie"]')).not.toBeNull();
+  });
+
+  it("falls back to the generic bot on an unrecognized root", () => {
+    const at = renderGraphNodes({ wrapper: "some-other-wrapper" });
+
+    const root = at("conv_root");
+    expect(root.querySelector(".lucide-bot")).not.toBeNull();
+    expect(root.querySelector('[data-icon="claude"]')).toBeNull();
+  });
+
+  it("gives child nodes role icons, and Otto when the type is unusable", () => {
+    const at = renderGraphNodes({}, [
+      childInfo({ id: "conv_explore", session_name: "find-bug", tool: "Explore" }),
+      childInfo({ id: "conv_generic", session_name: "misc", tool: "general-purpose" }),
+    ]);
+
+    expect(at("conv_explore").querySelector(".lucide-search")).not.toBeNull();
+    expect(at("conv_generic").querySelector('[data-icon="otto"]')).not.toBeNull();
+  });
+
+  it("gives native sub-agent children role icons, not the brand logo", () => {
+    // Mirrors the list view: a native session's sub-agents are all the same
+    // brand, so `…-subagent` wrappers read by role instead.
+    const at = renderGraphNodes({}, [
+      childInfo({
+        id: "conv_sub",
+        session_name: "find-bug",
+        tool: "Explore",
+        labels: { "omnigent.wrapper": "claude-code-native-ui-subagent" },
+      }),
+    ]);
+
+    const sub = at("conv_sub");
+    expect(sub.querySelector(".lucide-search")).not.toBeNull();
+    expect(sub.querySelector('[data-icon="claude"]')).toBeNull();
+  });
+
+  it("does not infer a brand logo from a child's tool name alone", () => {
+    const at = renderGraphNodes({}, [
+      childInfo({ id: "conv_custom", session_name: "custom-review", tool: "codex" }),
+    ]);
+
+    expect(at("conv_custom").querySelector('[data-icon="codex"]')).toBeNull();
+  });
+
+  it("hides the decorative icon from the accessibility tree", () => {
+    // The node's text label carries the name, so the glyph must not be
+    // announced — same treatment as the list view's connector glyph.
+    const at = renderGraphNodes({ wrapper: "claude-code-native-ui" });
+
+    expect(at("conv_root").querySelector('[data-icon="claude"]')).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+  });
+
+  it("still renders the label and status dot alongside the icon", () => {
+    // Guards against the icon displacing what the node already showed.
+    const at = renderGraphNodes({ label: "main", wrapper: "claude-code-native-ui" });
+
+    expect(at("conv_root")).toHaveTextContent("main");
+  });
+});

--- a/web/src/shell/AgentGraphNode.tsx
+++ b/web/src/shell/AgentGraphNode.tsx
@@ -1,0 +1,91 @@
+// One node of the Agents-pane graph view. Split out of SubagentsGraphView so
+// it can be rendered in tests without importing ReactFlow's barrel + CSS
+// bundle, which exhausts the jsdom worker.
+
+import type { NodeProps, Node } from "@xyflow/react";
+import { Handle, Position } from "@xyflow/react";
+import { RunningDot } from "@/components/RunningDot";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { NODE_WIDTH, type AgentActivity, type AgentNodeData } from "./subagentGraphLayout";
+import { AGENT_ICON_CLASS, iconForChildAgent, iconForSessionAgent } from "./subagentIcons";
+import { activityDotClassName } from "./subagentStatus";
+
+// Per-activity node border + background tint. The status DOT color is NOT
+// defined here — it comes from the shared ``activityDotClassName`` so the
+// graph dot always matches the list dot (the source of truth).
+const ACTIVITY_TINT: Record<AgentActivity, { border: string; bg: string }> = {
+  working: { border: "border-brand-accent", bg: "bg-brand-accent/5" },
+  awaiting: { border: "border-warning", bg: "bg-warning/5" },
+  failed: { border: "border-destructive", bg: "bg-destructive/5" },
+  launching: { border: "border-muted-foreground/40", bg: "bg-muted/30" },
+  disconnected: { border: "border-muted-foreground/30", bg: "bg-card" },
+  done: { border: "border-muted-foreground/30", bg: "bg-card" },
+  idle: { border: "border-muted-foreground/30", bg: "bg-card" },
+  other: { border: "border-muted-foreground/30", bg: "bg-card" },
+};
+
+function NodeStatusDot({ activity }: { activity: AgentActivity }) {
+  if (activity === "working") return <RunningDot />;
+  if (activity === "awaiting") {
+    return (
+      <Badge className="border-transparent bg-warning/15 text-warning text-[9px] px-1 py-0">
+        !
+      </Badge>
+    );
+  }
+  return (
+    <span
+      className={cn("inline-block size-2 shrink-0 rounded-full", activityDotClassName(activity))}
+    />
+  );
+}
+
+export function AgentGraphNode({ data }: NodeProps<Node<AgentNodeData>>) {
+  const { label, activity, statusLabel, isActive, preview, wrapper, tool, agentName, harness } =
+    data;
+  const tint = ACTIVITY_TINT[activity];
+  // Same glyph the list view shows for this agent: the root reads as a whole
+  // session (brand → nessie → bot), children as sub-agents (brand → role →
+  // Otto). Decorative — the node label beside it carries the name.
+  const Icon = data.isRoot
+    ? iconForSessionAgent({ wrapper, agentName, harness })
+    : iconForChildAgent({ wrapper, tool });
+
+  return (
+    <>
+      <Handle
+        type="target"
+        position={Position.Top}
+        className="!bg-muted-foreground/40 !w-1.5 !h-1.5 !border-0"
+      />
+      <div
+        className={cn(
+          "rounded-lg border px-3 py-2 shadow-sm transition-colors hover:shadow-md cursor-pointer",
+          tint.border,
+          tint.bg,
+          isActive && "ring-2 ring-ring ring-offset-1 ring-offset-background",
+        )}
+        style={{ width: NODE_WIDTH }}
+      >
+        <div className="flex items-center gap-1.5">
+          <Icon aria-hidden="true" className={AGENT_ICON_CLASS} />
+          <span className="truncate text-xs font-medium leading-tight">{label}</span>
+          <span className="flex-1" />
+          <NodeStatusDot activity={activity} />
+        </div>
+        {preview && (
+          <p className="mt-1 truncate text-[10px] leading-tight text-muted-foreground">{preview}</p>
+        )}
+        {!["idle", "done"].includes(activity) && (
+          <p className="mt-0.5 text-[10px] text-muted-foreground">{statusLabel}</p>
+        )}
+      </div>
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className="!bg-muted-foreground/40 !w-1.5 !h-1.5 !border-0"
+      />
+    </>
+  );
+}

--- a/web/src/shell/SubagentsGraphView.test.tsx
+++ b/web/src/shell/SubagentsGraphView.test.tsx
@@ -11,6 +11,7 @@ import {
   computeSubtreeWidths,
   layoutTree,
   type TreeNode,
+  type TreeRoot,
 } from "./subagentGraphLayout";
 import { activityDotClassName, childStatus, sessionStatus } from "./subagentStatus";
 import { SubagentsPanel } from "./SubagentsPanel";
@@ -126,7 +127,24 @@ function leaf(id: string, overrides: Partial<TreeNode> = {}): TreeNode {
     activity: "idle",
     statusLabel: "Idle",
     preview: null,
+    wrapper: null,
+    tool: null,
+    agentName: null,
+    harness: null,
     children: [],
+    ...overrides,
+  };
+}
+
+/** The root descriptor ``buildTree`` takes, with the identity fields
+ *  defaulted so each test names only what it exercises. */
+function treeRoot(overrides: Partial<TreeRoot> = {}): TreeRoot {
+  return {
+    id: "root",
+    label: "main",
+    activity: "idle",
+    statusLabel: "Idle",
+    preview: null,
     ...overrides,
   };
 }
@@ -492,13 +510,17 @@ describe("layoutTree", () => {
 
 describe("buildTree", () => {
   it("creates a leaf when no children exist in the map", () => {
-    const tree = buildTree("root", "main", "idle", "Idle", null, new Map(), 0);
+    const tree = buildTree(treeRoot({ activity: "idle", statusLabel: "Idle" }), new Map(), 0);
     expect(tree).toEqual({
       id: "root",
       label: "main",
       activity: "idle",
       statusLabel: "Idle",
       preview: null,
+      wrapper: null,
+      tool: null,
+      agentName: null,
+      harness: null,
       children: [],
     });
   });
@@ -516,7 +538,7 @@ describe("buildTree", () => {
     ]);
     map.set("c1", [childInfo({ id: "c1a", session_name: "search", tool: "Explore" })]);
 
-    const tree = buildTree("root", "main", "working", "Working", null, map, 0);
+    const tree = buildTree(treeRoot({ activity: "working", statusLabel: "Working" }), map, 0);
 
     expect(tree.children).toHaveLength(2);
     expect(tree.children[0].id).toBe("c1");
@@ -536,7 +558,7 @@ describe("buildTree", () => {
     map.set("c2", [childInfo({ id: "c3", tool: "c" })]);
     map.set("c3", [childInfo({ id: "c4", tool: "d" })]);
 
-    const tree = buildTree("root", "main", "idle", "Idle", null, map, 0);
+    const tree = buildTree(treeRoot({ activity: "idle", statusLabel: "Idle" }), map, 0);
 
     expect(tree.children).toHaveLength(1);
     expect(tree.children[0].children).toHaveLength(1);
@@ -553,7 +575,7 @@ describe("buildTree", () => {
       childInfo({ id: "c4" }),
     ]);
 
-    const tree = buildTree("root", "main", "idle", "Idle", null, map, 0);
+    const tree = buildTree(treeRoot({ activity: "idle", statusLabel: "Idle" }), map, 0);
 
     expect(tree.children[0].label).toBe("named");
     expect(tree.children[1].label).toBe("titled");
@@ -567,7 +589,7 @@ describe("buildTree", () => {
       childInfo({ id: "c1", tool: "a", last_message_preview: "Searching for auth..." }),
     ]);
 
-    const tree = buildTree("root", "main", "idle", "Idle", null, map, 0);
+    const tree = buildTree(treeRoot({ activity: "idle", statusLabel: "Idle" }), map, 0);
 
     expect(tree.children[0].preview).toBe("Searching for auth...");
   });

--- a/web/src/shell/SubagentsGraphView.tsx
+++ b/web/src/shell/SubagentsGraphView.tsx
@@ -1,94 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { NodeTypes, NodeProps, Node } from "@xyflow/react";
-import { ReactFlow, Background, Position, Handle, useReactFlow } from "@xyflow/react";
+import type { NodeTypes, Node } from "@xyflow/react";
+import { ReactFlow, Background, useReactFlow } from "@xyflow/react";
 import { useLocation, useNavigate } from "@/lib/routing";
-import { RunningDot } from "@/components/RunningDot";
-import { Badge } from "@/components/ui/badge";
 import { ZoomInIcon, ZoomOutIcon, Maximize2Icon } from "lucide-react";
 import { MAX_TREE_DEPTH, useChildSessions, type ChildSessionInfo } from "@/hooks/useChildSessions";
 import { useSession } from "@/hooks/useSession";
-import { cn } from "@/lib/utils";
 import { nativeCodingAgentForWrapper, WRAPPER_LABEL_KEY } from "@/lib/nativeCodingAgents";
-import {
-  buildGraphLayout,
-  NODE_WIDTH,
-  type AgentActivity,
-  type AgentNodeData,
-} from "./subagentGraphLayout";
-import { activityDotClassName, sessionStatus } from "./subagentStatus";
+import { AgentGraphNode } from "./AgentGraphNode";
+import { buildGraphLayout, type AgentNodeData } from "./subagentGraphLayout";
+import { sessionStatus } from "./subagentStatus";
 
 import "@xyflow/react/dist/style.css";
-
-// Per-activity node border + background tint. The status DOT color is NOT
-// defined here — it comes from the shared ``activityDotClassName`` so the
-// graph dot always matches the list dot (the source of truth).
-const ACTIVITY_TINT: Record<AgentActivity, { border: string; bg: string }> = {
-  working: { border: "border-brand-accent", bg: "bg-brand-accent/5" },
-  awaiting: { border: "border-warning", bg: "bg-warning/5" },
-  failed: { border: "border-destructive", bg: "bg-destructive/5" },
-  launching: { border: "border-muted-foreground/40", bg: "bg-muted/30" },
-  disconnected: { border: "border-muted-foreground/30", bg: "bg-card" },
-  done: { border: "border-muted-foreground/30", bg: "bg-card" },
-  idle: { border: "border-muted-foreground/30", bg: "bg-card" },
-  other: { border: "border-muted-foreground/30", bg: "bg-card" },
-};
-
-function NodeStatusDot({ activity }: { activity: AgentActivity }) {
-  if (activity === "working") return <RunningDot />;
-  if (activity === "awaiting") {
-    return (
-      <Badge className="border-transparent bg-warning/15 text-warning text-[9px] px-1 py-0">
-        !
-      </Badge>
-    );
-  }
-  return (
-    <span
-      className={cn("inline-block size-2 shrink-0 rounded-full", activityDotClassName(activity))}
-    />
-  );
-}
-
-function AgentNodeComponent({ data }: NodeProps<Node<AgentNodeData>>) {
-  const { label, activity, statusLabel, isActive, preview } = data;
-  const tint = ACTIVITY_TINT[activity];
-
-  return (
-    <>
-      <Handle
-        type="target"
-        position={Position.Top}
-        className="!bg-muted-foreground/40 !w-1.5 !h-1.5 !border-0"
-      />
-      <div
-        className={cn(
-          "rounded-lg border px-3 py-2 shadow-sm transition-colors hover:shadow-md cursor-pointer",
-          tint.border,
-          tint.bg,
-          isActive && "ring-2 ring-ring ring-offset-1 ring-offset-background",
-        )}
-        style={{ width: NODE_WIDTH }}
-      >
-        <div className="flex items-center gap-1.5">
-          <span className="truncate text-xs font-medium leading-tight">{label}</span>
-          <span className="flex-1" />
-          <NodeStatusDot activity={activity} />
-        </div>
-        {preview && (
-          <p className="mt-1 truncate text-[10px] leading-tight text-muted-foreground">{preview}</p>
-        )}
-        {!["idle", "done"].includes(activity) && (
-          <p className="mt-0.5 text-[10px] text-muted-foreground">{statusLabel}</p>
-        )}
-      </div>
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        className="!bg-muted-foreground/40 !w-1.5 !h-1.5 !border-0"
-      />
-    </>
-  );
-}
 
 function ZoomControls() {
   const { zoomIn, zoomOut, fitView } = useReactFlow();
@@ -124,7 +46,7 @@ function ZoomControls() {
   );
 }
 
-const nodeTypes: NodeTypes = { agent: AgentNodeComponent };
+const nodeTypes: NodeTypes = { agent: AgentGraphNode };
 
 function ChildCollector({
   parentId,
@@ -195,18 +117,36 @@ export function SubagentsGraphView({ conversationId, rootSessionId }: SubagentsG
   const rootActivity = rootStatus.activity;
   const rootStatusLabel = rootStatus.label;
 
+  const rootAgentName = session?.agentName ?? null;
+  const rootHarness = session?.harness ?? null;
+
   const { nodes: layoutNodes, edges: layoutEdges } = useMemo(
     () =>
       buildGraphLayout(
-        rootSessionId,
-        rootLabel,
-        rootActivity,
-        rootStatusLabel,
-        null,
+        {
+          id: rootSessionId,
+          label: rootLabel,
+          activity: rootActivity,
+          statusLabel: rootStatusLabel,
+          preview: null,
+          wrapper: wrapper ?? null,
+          agentName: rootAgentName,
+          harness: rootHarness,
+        },
         childrenMap,
         conversationId,
       ),
-    [rootSessionId, rootLabel, rootActivity, rootStatusLabel, childrenMap, conversationId],
+    [
+      rootSessionId,
+      rootLabel,
+      rootActivity,
+      rootStatusLabel,
+      wrapper,
+      rootAgentName,
+      rootHarness,
+      childrenMap,
+      conversationId,
+    ],
   );
 
   const navigate = useNavigate();

--- a/web/src/shell/SubagentsPanel.test.tsx
+++ b/web/src/shell/SubagentsPanel.test.tsx
@@ -15,7 +15,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { OttoIcon } from "@/components/icons/OttoIcon";
 import { type ChildSessionInfo, useChildSessions } from "@/hooks/useChildSessions";
 import { useSession } from "@/hooks/useSession";
-import { iconForAgentType, SubagentsPanel } from "./SubagentsPanel";
+import { iconForAgentType } from "./subagentIcons";
+import { SubagentsPanel } from "./SubagentsPanel";
 
 vi.mock("@/hooks/useChildSessions", async (importOriginal) => ({
   // Keep the real module (MAX_TREE_DEPTH and friends) — only the

--- a/web/src/shell/SubagentsPanel.tsx
+++ b/web/src/shell/SubagentsPanel.tsx
@@ -15,37 +15,16 @@
 // click opens it in a new tab, matching the sidebar's behavior.
 
 import { lazy, Suspense, useState } from "react";
-import type { ComponentType, SVGProps } from "react";
 import {
-  BookOpenIcon,
-  BotIcon,
-  Code2Icon,
-  CompassIcon,
   ChevronDownIcon,
   ChevronRightIcon,
   CornerDownRightIcon,
-  FileTextIcon,
-  FlaskConicalIcon,
   ListIcon,
   NetworkIcon,
   PlusIcon,
-  ScanSearchIcon,
-  SearchIcon,
 } from "lucide-react";
 import { Link, useLocation } from "@/lib/routing";
 import { Badge } from "@/components/ui/badge";
-import { AntigravityIcon } from "@/components/icons/AntigravityIcon";
-import { ClaudeIcon } from "@/components/icons/ClaudeIcon";
-import { CodexIcon } from "@/components/icons/CodexIcon";
-import { CursorIcon } from "@/components/icons/CursorIcon";
-import { GooseIcon } from "@/components/icons/GooseIcon";
-import { HermesIcon } from "@/components/icons/HermesIcon";
-import { KimiIcon } from "@/components/icons/KimiIcon";
-import { KiroIcon } from "@/components/icons/KiroIcon";
-import { NessieIcon } from "@/components/icons/NessieIcon";
-import { OpenCodeIcon } from "@/components/icons/OpenCodeIcon";
-import { OttoIcon } from "@/components/icons/OttoIcon";
-import { PiIcon } from "@/components/icons/PiIcon";
 import { Button } from "@/components/ui/button";
 import { RunningDot } from "@/components/RunningDot";
 import { MAX_TREE_DEPTH, useChildSessions, type ChildSessionInfo } from "@/hooks/useChildSessions";
@@ -57,6 +36,7 @@ const SubagentsGraphView = lazy(() =>
   import("./SubagentsGraphView").then((m) => ({ default: m.SubagentsGraphView })),
 );
 import { nativeCodingAgentForWrapper, WRAPPER_LABEL_KEY } from "@/lib/nativeCodingAgents";
+import { AGENT_ICON_CLASS, iconForChildAgent, iconForSessionAgent } from "./subagentIcons";
 import {
   activityDotClassName,
   childStatus,
@@ -75,9 +55,6 @@ import { AddAgentDialog } from "./AddAgentDialog";
 const SESSION_SCOPED_PARAMS = ["file", "diff", "comment", "view"] as const;
 const CODEX_NATIVE_SUBAGENT_WRAPPER = "codex-native-ui-subagent";
 const OPENCODE_NATIVE_SUBAGENT_WRAPPER = "opencode-native-ui-subagent";
-// Pi children are scaffold (no wrapper label); the spawn title's agent-type head (``tool``) is the signal.
-const PI_AGENT_NAME = "pi";
-type AgentRowIcon = ComponentType<SVGProps<SVGSVGElement>>;
 
 /**
  * Build a rail-link search string from the current URL, dropping the
@@ -253,71 +230,6 @@ const SETTLED_STATE: Record<AgentActivity, boolean> = {
 };
 
 /**
- * Map a sub-agent type label to a category icon so a mix of agents reads by
- * role at a glance (Claude Code spawns many same-type "Explore" agents — the
- * icon distinguishes roles; the preview line below distinguishes instances).
- * Category icons are monochrome — the row applies the muted color; the
- * fallback is the full-color Otto (starfish) mascot.
- *
- * @param tool - The agent type, e.g. ``"Explore"`` or ``"researcher"``;
- *   ``null`` when the child carries no type.
- * @returns An SVG icon component.
- */
-export function iconForAgentType(tool: string | null): AgentRowIcon {
-  const t = (tool ?? "").toLowerCase();
-  if (t.includes("explore")) return SearchIcon;
-  if (t.includes("research")) return BookOpenIcon;
-  if (t.includes("plan") || t.includes("architect")) return CompassIcon;
-  if (t.includes("review")) return ScanSearchIcon;
-  if (t.includes("test")) return FlaskConicalIcon;
-  if (t.includes("doc") || t.includes("writ")) return FileTextIcon;
-  if (
-    t.includes("code") ||
-    t.includes("eng") ||
-    t.includes("dev") ||
-    t.includes("front") ||
-    t.includes("back")
-  ) {
-    return Code2Icon;
-  }
-  return OttoIcon;
-}
-
-/**
- * Pick a brand glyph for coding child sessions when the summary carries
- * enough identity metadata. Native children identify via their wrapper
- * label (authoritative — a custom scaffold agent merely *named* "codex"
- * must not get the Codex logo). Pi children are scaffold sessions with
- * no wrapper label, so the exact agent name ``"pi"`` is the signal.
- *
- * Only full native sessions get the brand glyph. *Sub-agent* wrapper
- * children (``…-subagent``) deliberately fall through to the role icons
- * (and the Otto fallback) — a native session's sub-agents are all the
- * same brand, so repeating the logo down the tree says nothing, while
- * role icons distinguish what each one is doing.
- *
- * @param child - One child-session summary from the poll or stream.
- * @returns The Claude/Codex/pi glyph component, or ``null`` for generic agents.
- */
-function brandChildIcon(child: ChildSessionInfo): AgentRowIcon | null {
-  const wrapper = child.labels?.[WRAPPER_LABEL_KEY];
-  const nativeAgent = nativeCodingAgentForWrapper(wrapper);
-  if (nativeAgent?.iconKind === "claude") return ClaudeIcon;
-  if (nativeAgent?.iconKind === "codex") return CodexIcon;
-  if (nativeAgent?.iconKind === "opencode") return OpenCodeIcon;
-  if (nativeAgent?.iconKind === "pi") return PiIcon;
-  if (nativeAgent?.iconKind === "cursor") return CursorIcon;
-  if (nativeAgent?.iconKind === "kiro") return KiroIcon;
-  if (nativeAgent?.iconKind === "antigravity") return AntigravityIcon;
-  if (nativeAgent?.iconKind === "goose") return GooseIcon;
-  if (nativeAgent?.iconKind === "kimi") return KimiIcon;
-  if (nativeAgent?.iconKind === "hermes") return HermesIcon;
-  // Exact match — substring checks would false-match names like "pipeline".
-  if (child.tool === PI_AGENT_NAME) return PiIcon;
-  return null;
-}
-
-/**
  * Indicator + optional label shared by the main and child rows. The working
  * state reuses the sidebar's RunningDot in the same grey tone, so
  * "active" reads identically across the app; other states are a single
@@ -478,32 +390,6 @@ function mainMessagePreview(items: SessionItem[] | undefined): string | null {
   return null;
 }
 
-/**
- * Resolve a session's brand icon from its native-wrapper ``iconKind``
- * (authoritative for native-terminal sessions) with a harness-substring
- * fallback for plain SDK sessions that carry no wrapper label — e.g.
- * ``omni --harness kimi``, whose ``harness: "kimi"`` would otherwise fall
- * through to the generic bot. Mirrors ``iconForAgent`` in ``AgentCard.tsx``.
- */
-function iconForWrapperOrHarness(
-  iconKind: string | undefined,
-  harness: string | null | undefined,
-  isNessie: boolean,
-): AgentRowIcon {
-  if (iconKind === "claude" || harness?.includes("claude")) return ClaudeIcon;
-  if (iconKind === "codex" || harness?.includes("codex")) return CodexIcon;
-  if (iconKind === "opencode" || harness?.includes("opencode")) return OpenCodeIcon;
-  if (iconKind === "cursor" || harness?.includes("cursor")) return CursorIcon;
-  if (iconKind === "kiro" || harness?.includes("kiro")) return KiroIcon;
-  if (iconKind === "goose" || harness?.includes("goose")) return GooseIcon;
-  if (iconKind === "kimi" || harness?.includes("kimi")) return KimiIcon;
-  if (iconKind === "antigravity" || harness?.includes("antigravity")) return AntigravityIcon;
-  // Exact match — a substring check would false-match e.g. "openapi".
-  if (iconKind === "pi" || harness === "pi") return PiIcon;
-  if (isNessie) return NessieIcon;
-  return BotIcon;
-}
-
 function MainRow({ rootSessionId, isActive }: { rootSessionId: string; isActive: boolean }) {
   const { session } = useSession(rootSessionId);
   const search = railLinkSearch(useLocation().search);
@@ -512,7 +398,11 @@ function MainRow({ rootSessionId, isActive }: { rootSessionId: string; isActive:
   const wrapper = session?.labels?.[WRAPPER_LABEL_KEY];
   const nativeAgent = nativeCodingAgentForWrapper(wrapper);
   const isNessie = session?.agentName === "nessie";
-  const Icon = iconForWrapperOrHarness(nativeAgent?.iconKind, session?.harness, isNessie);
+  const Icon = iconForSessionAgent({
+    wrapper,
+    agentName: session?.agentName,
+    harness: session?.harness,
+  });
   // Native wrappers show the product name (mirroring the sidebar) instead
   // of the spec's YAML name (e.g. "claude-native-ui"); other agents show
   // their agent name, with "main" only while the session loads or when it
@@ -539,7 +429,7 @@ function MainRow({ rootSessionId, isActive }: { rootSessionId: string; isActive:
         )}
       >
         <div className="flex w-full items-center gap-1">
-          <Icon className="size-3.5 shrink-0 text-muted-foreground" />
+          <Icon className={AGENT_ICON_CLASS} />
           <span className="shrink-0 truncate text-xs font-medium">{label}</span>
           <span className="flex-1" />
           <StatusIndicator {...sessionStatus(session?.status, session?.lastTaskError)} />
@@ -587,7 +477,7 @@ function SubagentRow({
   const collapsed = collapsedRows[child.id] ?? false;
   const status = childStatus(child);
   const search = railLinkSearch(useLocation().search);
-  const Icon = brandChildIcon(child) ?? iconForAgentType(child.tool);
+  const Icon = iconForChildAgent(child);
   const primary = childPrimaryLabel(child);
   const isActive = conversationId === child.id;
   // De-emphasize settled rows (done/idle) so working/failed agents dominate
@@ -646,7 +536,7 @@ function SubagentRow({
                 className="-ml-3 size-3 shrink-0 text-muted-foreground/60"
               />
             )}
-            <Icon className="size-3.5 shrink-0 text-muted-foreground" />
+            <Icon className={AGENT_ICON_CLASS} />
             <span className="shrink-0 truncate text-xs font-medium">{primary}</span>
             <span className="flex-1" />
             <StatusIndicator {...status} />

--- a/web/src/shell/subagentGraphLayout.ts
+++ b/web/src/shell/subagentGraphLayout.ts
@@ -1,20 +1,37 @@
 import type { ChildSessionInfo } from "@/hooks/useChildSessions";
 import { MAX_TREE_DEPTH } from "@/hooks/useChildSessions";
+import { WRAPPER_LABEL_KEY } from "@/lib/nativeCodingAgents";
 import { childStatus, type AgentActivity } from "./subagentStatus";
 
 export type { AgentActivity };
 
-export interface AgentNodeData {
+// Raw identity fields the node component resolves into a harness/role glyph.
+// Kept as plain strings so this module stays free of React and icon imports.
+export interface AgentIconFields {
+  /** ``omnigent.wrapper`` label, when the session carries one. */
+  wrapper: string | null;
+  /** Sub-agent type, e.g. ``"Explore"``; ``null`` on the root node. */
+  tool: string | null;
+  /** Agent name — resolves the root's nessie glyph. ``null`` on children. */
+  agentName: string | null;
+  /** Resolved harness, for SDK sessions carrying no wrapper label. */
+  harness: string | null;
+}
+
+export interface AgentNodeData extends AgentIconFields {
   label: string;
   activity: AgentActivity;
   statusLabel: string;
   sessionId: string;
   isActive: boolean;
   preview: string | null;
+  /** True for the root node, which resolves its glyph as a whole session
+   *  (brand → nessie → bot) rather than as a typed sub-agent. */
+  isRoot: boolean;
   [key: string]: unknown;
 }
 
-export interface TreeNode {
+export interface TreeNode extends AgentIconFields {
   id: string;
   label: string;
   activity: AgentActivity;
@@ -79,7 +96,7 @@ export function layoutTree(
   const nodes: LayoutNode[] = [];
   const edges: LayoutEdge[] = [];
 
-  function place(node: TreeNode, x: number, y: number) {
+  function place(node: TreeNode, x: number, y: number, isRoot: boolean) {
     nodes.push({
       id: node.id,
       type: "agent",
@@ -91,6 +108,11 @@ export function layoutTree(
         sessionId: node.id,
         isActive: node.id === activeId,
         preview: node.preview,
+        wrapper: node.wrapper,
+        tool: node.tool,
+        agentName: node.agentName,
+        harness: node.harness,
+        isRoot,
       },
     });
 
@@ -119,33 +141,44 @@ export function layoutTree(
         },
       });
 
-      place(child, childCenterX, childY);
+      place(child, childCenterX, childY, false);
       childX += childWidth + HORIZONTAL_GAP;
     }
   }
 
-  place(root, 0, 0);
+  place(root, 0, 0, true);
   return { nodes, edges };
 }
 
+/** The subtree root's own fields. Grouped rather than passed positionally —
+ *  the identity fields the node icons need would otherwise push this to ten
+ *  positional arguments. */
+export interface TreeRoot extends Partial<AgentIconFields> {
+  id: string;
+  label: string;
+  activity: AgentActivity;
+  statusLabel: string;
+  preview: string | null;
+}
+
 export function buildTree(
-  rootId: string,
-  rootLabel: string,
-  rootActivity: AgentActivity,
-  rootStatusLabel: string,
-  rootPreview: string | null,
+  root: TreeRoot,
   childrenMap: Map<string, ChildSessionInfo[]>,
   depth: number,
   visited = new Set<string>(),
 ): TreeNode {
-  visited.add(rootId);
-  const children = childrenMap.get(rootId) ?? [];
+  visited.add(root.id);
+  const children = childrenMap.get(root.id) ?? [];
   return {
-    id: rootId,
-    label: rootLabel,
-    activity: rootActivity,
-    statusLabel: rootStatusLabel,
-    preview: rootPreview,
+    id: root.id,
+    label: root.label,
+    activity: root.activity,
+    statusLabel: root.statusLabel,
+    preview: root.preview,
+    wrapper: root.wrapper ?? null,
+    tool: root.tool ?? null,
+    agentName: root.agentName ?? null,
+    harness: root.harness ?? null,
     children:
       depth >= MAX_TREE_DEPTH
         ? []
@@ -155,11 +188,15 @@ export function buildTree(
               const status = childActivity(child);
               const label = child.session_name ?? child.title ?? child.tool ?? child.id;
               return buildTree(
-                child.id,
-                label,
-                status.activity,
-                status.label,
-                child.last_message_preview,
+                {
+                  id: child.id,
+                  label,
+                  activity: status.activity,
+                  statusLabel: status.label,
+                  preview: child.last_message_preview,
+                  wrapper: child.labels?.[WRAPPER_LABEL_KEY] ?? null,
+                  tool: child.tool,
+                },
                 childrenMap,
                 depth + 1,
                 visited,
@@ -169,22 +206,9 @@ export function buildTree(
 }
 
 export function buildGraphLayout(
-  rootId: string,
-  rootLabel: string,
-  rootActivity: AgentActivity,
-  rootStatusLabel: string,
-  rootPreview: string | null,
+  root: TreeRoot,
   childrenMap: Map<string, ChildSessionInfo[]>,
   activeId: string,
 ): { nodes: LayoutNode[]; edges: LayoutEdge[] } {
-  const tree = buildTree(
-    rootId,
-    rootLabel,
-    rootActivity,
-    rootStatusLabel,
-    rootPreview,
-    childrenMap,
-    0,
-  );
-  return layoutTree(tree, activeId);
+  return layoutTree(buildTree(root, childrenMap, 0), activeId);
 }

--- a/web/src/shell/subagentIcons.test.tsx
+++ b/web/src/shell/subagentIcons.test.tsx
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  BookOpenIcon,
+  BotIcon,
+  Code2Icon,
+  CompassIcon,
+  FileTextIcon,
+  FlaskConicalIcon,
+  ScanSearchIcon,
+  SearchIcon,
+} from "lucide-react";
+
+// Stub the brand logos so jsdom doesn't resolve @lobehub/ui's runtime
+// tooltip imports; the identity comparisons below don't need real SVGs.
+vi.mock("@/components/icons/ClaudeIcon", () => ({ ClaudeIcon: () => null }));
+vi.mock("@/components/icons/CodexIcon", () => ({ CodexIcon: () => null }));
+vi.mock("@/components/icons/OpenCodeIcon", () => ({ OpenCodeIcon: () => null }));
+vi.mock("@/components/icons/CursorIcon", () => ({ CursorIcon: () => null }));
+vi.mock("@/components/icons/KiroIcon", () => ({ KiroIcon: () => null }));
+vi.mock("@/components/icons/GooseIcon", () => ({ GooseIcon: () => null }));
+vi.mock("@/components/icons/KimiIcon", () => ({ KimiIcon: () => null }));
+vi.mock("@/components/icons/HermesIcon", () => ({ HermesIcon: () => null }));
+vi.mock("@/components/icons/AntigravityIcon", () => ({ AntigravityIcon: () => null }));
+vi.mock("@/components/icons/NessieIcon", () => ({ NessieIcon: () => null }));
+vi.mock("@/components/icons/PiIcon", () => ({ PiIcon: () => null }));
+vi.mock("@/components/icons/OttoIcon", () => ({ OttoIcon: () => null }));
+
+import { AntigravityIcon } from "@/components/icons/AntigravityIcon";
+import { ClaudeIcon } from "@/components/icons/ClaudeIcon";
+import { CodexIcon } from "@/components/icons/CodexIcon";
+import { CursorIcon } from "@/components/icons/CursorIcon";
+import { GooseIcon } from "@/components/icons/GooseIcon";
+import { HermesIcon } from "@/components/icons/HermesIcon";
+import { KimiIcon } from "@/components/icons/KimiIcon";
+import { KiroIcon } from "@/components/icons/KiroIcon";
+import { NessieIcon } from "@/components/icons/NessieIcon";
+import { OpenCodeIcon } from "@/components/icons/OpenCodeIcon";
+import { OttoIcon } from "@/components/icons/OttoIcon";
+import { PiIcon } from "@/components/icons/PiIcon";
+import {
+  iconForAgentType,
+  iconForChildAgent,
+  iconForSessionAgent,
+  type AgentRowIcon,
+} from "./subagentIcons";
+
+// ===========================================================================
+// Tier 2: role icons from the sub-agent type
+// ===========================================================================
+
+describe("iconForAgentType", () => {
+  // Order-sensitive cases (review before code, doc before writ) are covered
+  // by the multi-keyword entries below.
+  const CASES: [string | null, AgentRowIcon][] = [
+    ["Explore", SearchIcon],
+    ["deep-researcher", BookOpenIcon],
+    ["planner", CompassIcon],
+    ["architect", CompassIcon],
+    ["code-reviewer", ScanSearchIcon],
+    ["pr-test-analyzer", FlaskConicalIcon],
+    ["frontend_engineer", Code2Icon],
+    ["documentation", FileTextIcon],
+    ["technical-writer", FileTextIcon],
+    ["general-purpose", OttoIcon],
+    [null, OttoIcon],
+  ];
+
+  it.each(CASES)("maps %s to its category icon", (tool, expected) => {
+    expect(iconForAgentType(tool)).toBe(expected);
+  });
+
+  it("falls back to Otto for an undefined type", () => {
+    expect(iconForAgentType(undefined)).toBe(OttoIcon);
+  });
+});
+
+// ===========================================================================
+// Child rows: brand → role → Otto
+// ===========================================================================
+
+describe("iconForChildAgent", () => {
+  const WRAPPER_BRANDS: [string, AgentRowIcon][] = [
+    ["claude-code-native-ui", ClaudeIcon],
+    ["codex-native-ui", CodexIcon],
+    ["opencode-native-ui", OpenCodeIcon],
+    ["cursor-native-ui", CursorIcon],
+    ["kiro-native-ui", KiroIcon],
+    ["pi-native-ui", PiIcon],
+    ["goose-native-ui", GooseIcon],
+    ["kimi-native-ui", KimiIcon],
+    ["hermes-native-ui", HermesIcon],
+    ["antigravity-native-ui", AntigravityIcon],
+  ];
+
+  it.each(WRAPPER_BRANDS)("gives %s children its brand glyph", (wrapper, expected) => {
+    expect(iconForChildAgent({ wrapper, tool: "Explore" })).toBe(expected);
+  });
+
+  it("reads the wrapper off raw session labels too", () => {
+    expect(iconForChildAgent({ labels: { "omnigent.wrapper": "codex-native-ui" } })).toBe(
+      CodexIcon,
+    );
+  });
+
+  // Tier 3 of the deliberate design rule: a native session's sub-agents are
+  // all the same brand, so `…-subagent` wrappers read by ROLE, not brand.
+  it.each(WRAPPER_BRANDS.map(([wrapper]) => wrapper))(
+    "falls through to role icons for the %s-subagent wrapper",
+    (wrapper) => {
+      expect(iconForChildAgent({ wrapper: `${wrapper}-subagent`, tool: "Explore" })).toBe(
+        SearchIcon,
+      );
+    },
+  );
+
+  it("gives -subagent children with no usable type the Otto fallback", () => {
+    expect(iconForChildAgent({ wrapper: "claude-code-native-ui-subagent", tool: "claude" })).toBe(
+      OttoIcon,
+    );
+  });
+
+  it("does not infer a brand from the tool name alone", () => {
+    // A custom scaffold agent merely NAMED "codex" must not borrow the logo.
+    // It reads as a role instead ("codex" contains "code" → Code2Icon).
+    expect(iconForChildAgent({ tool: "codex" })).toBe(Code2Icon);
+    expect(iconForChildAgent({ tool: "claude" })).toBe(OttoIcon);
+  });
+
+  it("uses the pi glyph for pi children, matched by exact tool name", () => {
+    expect(iconForChildAgent({ tool: "pi" })).toBe(PiIcon);
+  });
+
+  it("does not match pi as a substring of a longer tool name", () => {
+    expect(iconForChildAgent({ tool: "pipeline" })).not.toBe(PiIcon);
+  });
+
+  it("falls back to a role icon for an unknown wrapper", () => {
+    expect(iconForChildAgent({ wrapper: "some-other-wrapper", tool: "reviewer" })).toBe(
+      ScanSearchIcon,
+    );
+  });
+
+  it("falls back to Otto when there is no wrapper and no usable type", () => {
+    expect(iconForChildAgent({})).toBe(OttoIcon);
+  });
+
+  it("gives qwen children a role icon — it has no brand glyph yet", () => {
+    expect(iconForChildAgent({ wrapper: "qwen-native-ui", tool: "Explore" })).toBe(SearchIcon);
+  });
+});
+
+// ===========================================================================
+// Root / catalog rows: brand → nessie → bot (no role tier)
+// ===========================================================================
+
+describe("iconForSessionAgent", () => {
+  it.each([
+    ["claude-code-native-ui", ClaudeIcon],
+    ["codex-native-ui", CodexIcon],
+    ["opencode-native-ui", OpenCodeIcon],
+    ["hermes-native-ui", HermesIcon],
+  ] as [string, AgentRowIcon][])("resolves the %s wrapper to its glyph", (wrapper, expected) => {
+    expect(iconForSessionAgent({ wrapper })).toBe(expected);
+  });
+
+  it.each([
+    ["claude-sdk", ClaudeIcon],
+    ["codex-native", CodexIcon],
+    ["opencode", OpenCodeIcon],
+    ["cursor", CursorIcon],
+    ["kimi-code", KimiIcon],
+    ["hermes", HermesIcon],
+    ["antigravity", AntigravityIcon],
+    ["goose", GooseIcon],
+    ["kiro", KiroIcon],
+  ] as [string, AgentRowIcon][])(
+    "falls back to the %s harness when there is no wrapper label",
+    (harness, expected) => {
+      expect(iconForSessionAgent({ harness })).toBe(expected);
+    },
+  );
+
+  it("matches the pi harness exactly, not as a substring", () => {
+    expect(iconForSessionAgent({ harness: "pi" })).toBe(PiIcon);
+    expect(iconForSessionAgent({ harness: "openapi" })).toBe(BotIcon);
+  });
+
+  it("resolves nessie by name even on the claude-sdk harness", () => {
+    // A harness-first check would hand nessie the Claude glyph.
+    expect(iconForSessionAgent({ agentName: "nessie", harness: "claude-sdk" })).toBe(NessieIcon);
+  });
+
+  it("resolves nessie by name when the harness is null", () => {
+    expect(iconForSessionAgent({ agentName: "nessie", harness: null })).toBe(NessieIcon);
+  });
+
+  it("resolves a native agent name when no wrapper or harness is present", () => {
+    expect(iconForSessionAgent({ agentName: "codex-native-ui" })).toBe(CodexIcon);
+  });
+
+  // Tier 1 of the fallback contract: root rows with nothing recognizable
+  // get the generic bot, NOT Otto — they are sessions, not typed sub-agents.
+  it("falls back to the generic bot for an unknown wrapper and harness", () => {
+    expect(iconForSessionAgent({ wrapper: "some-other-wrapper", harness: "mystery" })).toBe(
+      BotIcon,
+    );
+  });
+
+  it("falls back to the generic bot when every signal is absent", () => {
+    expect(iconForSessionAgent({})).toBe(BotIcon);
+  });
+
+  it("falls back to the generic bot for qwen, which has no brand glyph yet", () => {
+    expect(iconForSessionAgent({ wrapper: "qwen-native-ui" })).toBe(BotIcon);
+  });
+});

--- a/web/src/shell/subagentIcons.tsx
+++ b/web/src/shell/subagentIcons.tsx
@@ -1,0 +1,220 @@
+// Canonical agent-icon resolution shared by the Agents rail's list view
+// (SubagentsPanel), its graph view (SubagentsGraphView), and the agent
+// catalog cards (AgentCard), so the three never drift. Mirrors the split in
+// ``subagentStatus.ts``: one module owns the mapping, every view reads it.
+//
+// Three tiers, in order:
+//   1. Brand glyph — a native wrapper label, agent name, or harness
+//      identifies the harness running the session (Claude, Codex, pi, …).
+//   2. Role icon — no brand match, so the sub-agent *type* (``tool``)
+//      picks a category glyph (Explore → magnifier, reviewer → scan, …).
+//   3. Fallback — Otto for typed sub-agent children, ``BotIcon`` for root
+//      and catalog rows, which are whole sessions with no role to read.
+
+import type { ComponentType, SVGProps } from "react";
+import {
+  BookOpenIcon,
+  BotIcon,
+  Code2Icon,
+  CompassIcon,
+  FileTextIcon,
+  FlaskConicalIcon,
+  ScanSearchIcon,
+  SearchIcon,
+} from "lucide-react";
+import { AntigravityIcon } from "@/components/icons/AntigravityIcon";
+import { ClaudeIcon } from "@/components/icons/ClaudeIcon";
+import { CodexIcon } from "@/components/icons/CodexIcon";
+import { CursorIcon } from "@/components/icons/CursorIcon";
+import { GooseIcon } from "@/components/icons/GooseIcon";
+import { HermesIcon } from "@/components/icons/HermesIcon";
+import { KimiIcon } from "@/components/icons/KimiIcon";
+import { KiroIcon } from "@/components/icons/KiroIcon";
+import { NessieIcon } from "@/components/icons/NessieIcon";
+import { OpenCodeIcon } from "@/components/icons/OpenCodeIcon";
+import { OttoIcon } from "@/components/icons/OttoIcon";
+import { PiIcon } from "@/components/icons/PiIcon";
+import {
+  nativeCodingAgentForAgentName,
+  nativeCodingAgentForHarness,
+  nativeCodingAgentForWrapper,
+  WRAPPER_LABEL_KEY,
+  type NativeCodingAgentIconKind,
+} from "@/lib/nativeCodingAgents";
+
+export type AgentRowIcon = ComponentType<SVGProps<SVGSVGElement>>;
+
+/** Classes every agent icon in the Agents rail renders with, so the list
+ *  and graph views size and tint the glyph identically. */
+export const AGENT_ICON_CLASS = "size-3.5 shrink-0 text-muted-foreground";
+
+// Brand glyph per ``iconKind``. ``qwen`` is absent on purpose — it has no
+// brand mark yet, so it falls through to the bot / role icons.
+const BRAND_ICONS: Partial<Record<NativeCodingAgentIconKind, AgentRowIcon>> = {
+  claude: ClaudeIcon,
+  codex: CodexIcon,
+  opencode: OpenCodeIcon,
+  pi: PiIcon,
+  cursor: CursorIcon,
+  kiro: KiroIcon,
+  antigravity: AntigravityIcon,
+  goose: GooseIcon,
+  kimi: KimiIcon,
+  hermes: HermesIcon,
+};
+
+// Harness spellings matched as substrings so both forms of a harness
+// (``claude-native`` and ``claude-sdk``) land on the same glyph. ``pi`` is
+// excluded — it is matched exactly, since a substring check would
+// false-match names like "openapi".
+const HARNESS_SUBSTRINGS: readonly NativeCodingAgentIconKind[] = [
+  "claude",
+  "codex",
+  "opencode",
+  "cursor",
+  "kiro",
+  "goose",
+  "kimi",
+  "antigravity",
+  "hermes",
+];
+
+// Wrapper suffix marking a *sub-agent* of a native session rather than the
+// native session itself. These deliberately get role icons: a native
+// session's sub-agents are all the same brand, so repeating the logo down
+// the tree says nothing, while role icons distinguish what each is doing.
+const NATIVE_SUBAGENT_WRAPPER_SUFFIX = "-subagent";
+
+// Nessie runs on the claude-sdk harness, so it is matched by name before
+// any harness check — otherwise it would wear the Claude glyph.
+const NESSIE_AGENT_NAME = "nessie";
+
+// Pi scaffold children carry no wrapper label, so the spawn title's
+// agent-type head (``tool``) is the only identity signal.
+const PI_AGENT_NAME = "pi";
+
+function brandForIconKind(kind: NativeCodingAgentIconKind | undefined): AgentRowIcon | null {
+  return (kind && BRAND_ICONS[kind]) ?? null;
+}
+
+/**
+ * Resolve a brand glyph from a native wrapper label, agent name, or harness.
+ *
+ * The wrapper label and agent name are authoritative exact lookups — a
+ * custom scaffold agent merely *named* "codex" must not borrow the Codex
+ * logo. The harness substring pass then covers plain SDK sessions that
+ * carry no wrapper label, e.g. ``omni --harness kimi``.
+ *
+ * @param source - Whichever identity signals the caller has.
+ * @returns The brand glyph, or ``null`` when nothing matches.
+ */
+export function brandIconFor({
+  wrapper,
+  agentName,
+  harness,
+}: {
+  wrapper?: string | null;
+  agentName?: string | null;
+  harness?: string | null;
+}): AgentRowIcon | null {
+  const byWrapper = brandForIconKind(nativeCodingAgentForWrapper(wrapper)?.iconKind);
+  if (byWrapper) return byWrapper;
+  const byName = brandForIconKind(nativeCodingAgentForAgentName(agentName)?.iconKind);
+  if (byName) return byName;
+  const byHarness = brandForIconKind(nativeCodingAgentForHarness(harness)?.iconKind);
+  if (byHarness) return byHarness;
+  if (harness) {
+    for (const kind of HARNESS_SUBSTRINGS) {
+      if (harness.includes(kind)) return BRAND_ICONS[kind] ?? null;
+    }
+    // Exact match — a substring check would false-match e.g. "openapi".
+    if (harness === PI_AGENT_NAME) return PiIcon;
+  }
+  return null;
+}
+
+/**
+ * Map a sub-agent type label to a category icon so a mix of agents reads by
+ * role at a glance (Claude Code spawns many same-type "Explore" agents — the
+ * icon distinguishes roles; the preview line below distinguishes instances).
+ * Category icons are monochrome — the caller applies the muted color; the
+ * fallback is the full-color Otto (starfish) mascot.
+ *
+ * @param tool - The agent type, e.g. ``"Explore"`` or ``"researcher"``;
+ *   ``null`` when the child carries no type.
+ * @returns An SVG icon component.
+ */
+export function iconForAgentType(tool: string | null | undefined): AgentRowIcon {
+  const t = (tool ?? "").toLowerCase();
+  if (t.includes("explore")) return SearchIcon;
+  if (t.includes("research")) return BookOpenIcon;
+  if (t.includes("plan") || t.includes("architect")) return CompassIcon;
+  if (t.includes("review")) return ScanSearchIcon;
+  if (t.includes("test")) return FlaskConicalIcon;
+  if (t.includes("doc") || t.includes("writ")) return FileTextIcon;
+  if (
+    t.includes("code") ||
+    t.includes("eng") ||
+    t.includes("dev") ||
+    t.includes("front") ||
+    t.includes("back")
+  ) {
+    return Code2Icon;
+  }
+  return OttoIcon;
+}
+
+/**
+ * Icon for one child (sub-agent) row: brand glyph when the child is a full
+ * native session, else a role icon from its type, else Otto.
+ *
+ * A child's ``tool`` is a sub-agent *type*, never a harness, so it is not
+ * substring-matched against brand names — only the exact ``"pi"`` scaffold
+ * name is, since pi children carry no wrapper label.
+ *
+ * @param child - The child's identity fields, as raw labels or a
+ *   pre-extracted ``wrapper``.
+ * @returns The glyph to render on the row.
+ */
+export function iconForChildAgent(child: {
+  labels?: Record<string, string> | null;
+  wrapper?: string | null;
+  tool?: string | null;
+}): AgentRowIcon {
+  const wrapper = child.wrapper ?? child.labels?.[WRAPPER_LABEL_KEY];
+  // Sub-agents of a native session read by role, not by brand. Redundant
+  // with the wrapper lookup missing today, but states the rule where the
+  // decision is made rather than leaving it to a map miss.
+  if (wrapper?.endsWith(NATIVE_SUBAGENT_WRAPPER_SUFFIX)) return iconForAgentType(child.tool);
+  const brand = brandIconFor({ wrapper });
+  if (brand) return brand;
+  // Exact match — substring checks would false-match names like "pipeline".
+  if (child.tool === PI_AGENT_NAME) return PiIcon;
+  return iconForAgentType(child.tool);
+}
+
+/**
+ * Icon for a root or catalog row, which represents a whole session rather
+ * than a typed sub-agent: brand glyph, then the nessie mascot, then a
+ * generic bot — there is no role ``tool`` to fall back on.
+ *
+ * @param session - The session's wrapper label, agent name, and harness.
+ * @returns The glyph to render.
+ */
+export function iconForSessionAgent({
+  wrapper,
+  agentName,
+  harness,
+}: {
+  wrapper?: string | null;
+  agentName?: string | null;
+  harness?: string | null;
+}): AgentRowIcon {
+  // Exact wrapper / agent-name lookups first, then nessie by name, then
+  // the fuzzy harness pass — nessie is on claude-sdk, so a harness-first
+  // check would hand it the Claude glyph.
+  const exact = brandIconFor({ wrapper, agentName });
+  if (exact) return exact;
+  if (agentName === NESSIE_AGENT_NAME) return NessieIcon;
+  return brandIconFor({ harness }) ?? BotIcon;
+}


### PR DESCRIPTION
## Related issue

N/A — no existing issue for this.

Adjacent open work: **PR #3143** (`fix(web): filter closed sub-agents from Agents panel`) touches the same Agents panel and is the one real conflict surface — it filters the child list that feeds both views, while this PR changes how each row/node resolves its icon. Issues #1231 (Session Profile) and #3874 (Session Bundles) are neighbours, not overlaps.

## Summary

The Agents pane's **tree view** has always shown which harness is running each task — a Claude, Codex, Cursor, … glyph per row, with role icons for sub-agents. The **graph view** rendered the same sessions as bare labels, so at a glance you couldn't tell a Claude node from a Codex one.

- **Graph nodes now carry the same glyph as the tree**, on both the root node and child nodes. No server/API change was needed: the graph already fetched the same `ChildSessionInfo` objects via `useChildSessions`; it just dropped `labels` and `tool` when flattening into `TreeNode`. Those now ride through as raw strings and resolve at render time.
- **One shared resolver.** Icon resolution lived in three near-duplicate cascades (`SubagentsPanel`'s child + root resolvers, and `AgentCard`'s). Lifted into `web/src/shell/subagentIcons.tsx` — the same split `subagentStatus.ts` already uses — and consumed from all three original call sites plus the new graph one. The duplicates are deleted.
- **Graph node split out** into `AgentGraphNode.tsx`, so it can be rendered in tests without `@xyflow/react`'s barrel + CSS bundle (which exhausts the jsdom worker — the existing test file mocks the whole component out for exactly this reason). `subagentGraphLayout.ts` stays pure: no React, no `@xyflow/react`, no icon imports, so its 20+ unit tests keep passing.

The three fallback tiers are preserved exactly, including the deliberate rule that `…-subagent` wrappers **fall through to role icons** rather than repeating a native session's logo down the tree:

```
root / catalog row:   brand glyph → nessie (by name) → BotIcon
child row:            brand glyph → role icon (from `tool`) → OttoIcon
`…-subagent` wrapper: (skips brand) → role icon → OttoIcon
```

### Two drift fixes, called out explicitly

Unifying the three copies exposed two spots where they had silently diverged. Both were **missing** brand glyphs, not wrong ones:

| Case | Before | After |
|---|---|---|
| Root row, `hermes-native-ui` session | generic `BotIcon` | Hermes glyph |
| Agent card, SDK `--harness opencode` | generic `BotIcon` | OpenCode glyph |

Neither was a deliberate semantic (unlike the `-subagent` rule, which is documented and tested). The alternative — encoding per-call-site exclusions like `const ROOT_SKIP = new Set(["hermes"])` — would bake the inconsistency in as intentional-looking code. **No case that previously showed a brand glyph changes.**

## Test Plan

All commands run from the worktree; the web workspace is pnpm-based and CI pins **Node 22** (`.github/actions/setup-pnpm`):

```
pnpm install --frozen-lockfile --filter web   # matches .github/workflows/lint.yml
cd web
./node_modules/.bin/tsc -b        # PASS
npm run lint                      # PASS (oxlint --deny-warnings)
./node_modules/.bin/vitest run    # 276 files passed | 1 skipped
                                  # 4960 tests passed | 3 expected fail | 1 skipped
npm run build                     # PASS (built in 1.61s)
```

`pre-commit run --files <the 10 changed files>` — all hooks pass (prettier, oxlint, TypeScript type check, whitespace/EOL/merge-conflict/large-file checks).

New tests:

- `web/src/shell/subagentIcons.test.tsx` — 60 cases over the shared resolver: every wrapper→brand pair, the harness-substring fallback, `pi` matched exactly (and *not* as a substring of `openapi`/`pipeline`), nessie-by-name winning over its `claude-sdk` harness, **all three fallback tiers**, and the `-subagent` fall-through asserted across every native wrapper.
- `web/src/shell/AgentGraphNode.test.tsx` — 10 cases asserting the icon renders **on both a root node and child nodes**. Node data comes from the real `buildGraphLayout`, so these cover the whole path (raw session/child fields → layout → glyph), not the component in isolation.

The existing `-subagent` fall-through test at `SubagentsPanel.test.tsx` stays green and its semantic is unchanged.

`pnpm-lock.yaml` and `uv.lock` are untouched — no dependency changes.

## Demo

Graph view, before and after. Same fabricated tree in both: a Claude Code root, a Codex child (`auth-refactor`), a Cursor child (`port-tests`), two role-icon children (`find-the-bug` → magnifier, `check-diff` → scan), and under the Codex node a `…-subagent` child (`trace-call`) that correctly shows a **role** icon rather than a repeated brand logo.

**Before** — every node is a bare label:

![graph view before](https://raw.githubusercontent.com/btli/omnigent/demo-assets-graph-icons/graph-before.png)

**After** — each node carries its harness / role glyph:

![graph view after](https://raw.githubusercontent.com/btli/omnigent/demo-assets-graph-icons/graph-after.png)

**After (dark mode)** — the glyphs tint via `text-muted-foreground`, so they read in both themes:

![graph view after, dark mode](https://raw.githubusercontent.com/btli/omnigent/demo-assets-graph-icons/graph-after-dark.png)

Icons use the tree view's exact classes (`size-3.5 shrink-0 text-muted-foreground`) and sit immediately before the label. `NODE_WIDTH` is unchanged at 180 — a 14px icon + 6px gap fits, and the label was already `truncate`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage is the 70 new unit tests above, plus the existing Agents-panel suite guarding the tree view and the layout module against regression.

Manual verification: rendered the real `AgentGraphNode` + `buildGraphLayout` in a browser against a fabricated multi-harness tree (the screenshots above), in both light and dark mode, confirming the root node and every child node resolve the expected glyph and that the `-subagent` child falls through to a role icon. Accessibility: the glyph is decorative next to a visible text label, so it is rendered `aria-hidden="true"` — matching how the tree view already hides its decorative connector glyph — and this is asserted in `AgentGraphNode.test.tsx`.

Not covered by e2e: an `e2e_ui` journey asserting glyphs in a live browser. The graph view has no existing e2e coverage to extend, and the icon path is fully exercised by the unit tests from raw session fields through layout to the rendered glyph.

## Changelog

The Agents pane's graph view now shows each agent's harness icon, so you can tell at a glance which tool is running which task.
