### PR TITLE
feat: name all application database queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,15 @@ Keep comments short and focused on the code, not on the change history.
   issue numbers, or ticket IDs (e.g. `#1646`, `fixes JIRA-123`); the scenario
   should be clear without chasing external links.
 
+## Database query names
+
+Application stores use `make_named_managed_session_maker` and give every
+session a stable semantic operation name. The session-level name must describe
+the caller's intent rather than repeat SQL syntax; use a nested
+`query_name_scope` only when one transaction needs distinct names for important
+subqueries. Because the named session covers implicit flush and commit, don't
+add an explicit `flush()` only to make a query name observable.
+
 ## Framework-owned instructions
 
 Keep runtime lifecycle and metadata instructions separate from portable agent

--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -20,12 +20,16 @@ if TYPE_CHECKING:
     from alembic.config import Config
 from sqlalchemy.orm import Session, sessionmaker
 
+from omnigent.db.query_context import query_name_scope
 from omnigent.entities import NewConversationItem
 
 _logger = logging.getLogger(__name__)
 
 # A callable that returns a context manager yielding a Session.
 ManagedSessionMaker = Callable[[], AbstractContextManager[Session]]
+
+# A callable that requires a semantic query-name suffix for each transaction.
+NamedManagedSessionMaker = Callable[[str], AbstractContextManager[Session]]
 
 # A zero-argument callable returning a fresh database password (e.g. a
 # short-lived Lakebase OAuth token). Invoked once per *new* DBAPI connection.
@@ -344,8 +348,9 @@ def _ensure_conversation_tables(engine: Engine) -> None:
     """Create AP tables (conversations, conversation_items, conversation_labels) if absent."""
     from omnigent.db.db_models import ConversationBase
 
-    ConversationBase.metadata.create_all(bind=engine, checkfirst=True)
-    ensure_fts_table(engine)
+    with query_name_scope("omnigent.database.ensure_conversation_schema"):
+        ConversationBase.metadata.create_all(bind=engine, checkfirst=True)
+        ensure_fts_table(engine)
 
 
 def _build_alembic_config(db_uri: str) -> Config:
@@ -402,18 +407,19 @@ def _run_migrations(engine: Engine, db_uri: str) -> None:
     # Pass a shared connection so Alembic operates within the same
     # engine (required for SQLite in-memory databases, and avoids
     # creating a second connection pool).
-    with engine.begin() as connection:
-        config.attributes["connection"] = connection
-        command.upgrade(config, "head")
-    # Belt-and-suspenders: if a future migration is added but a
-    # caller forgets to wire it into the chain, ``create_all`` will
-    # at least create any missing tables from ORM metadata so the
-    # server still boots. Cannot rescue missing COLUMNS on existing
-    # tables — those need a real migration, which is why the
-    # short-circuit above was removed. Both bases are created because
-    # in single-DB mode this engine hosts the AP tables too.
-    for base in (OmnigentBase, ConversationBase):
-        base.metadata.create_all(bind=engine, checkfirst=True)
+    with query_name_scope("omnigent.database.run_migrations"):
+        with engine.begin() as connection:
+            config.attributes["connection"] = connection
+            command.upgrade(config, "head")
+        # Belt-and-suspenders: if a future migration is added but a
+        # caller forgets to wire it into the chain, ``create_all`` will
+        # at least create any missing tables from ORM metadata so the
+        # server still boots. Cannot rescue missing COLUMNS on existing
+        # tables — those need a real migration, which is why the
+        # short-circuit above was removed. Both bases are created because
+        # in single-DB mode this engine hosts the AP tables too.
+        for base in (OmnigentBase, ConversationBase):
+            base.metadata.create_all(bind=engine, checkfirst=True)
 
 
 def _get_current_db_revision(engine: Engine) -> str | None:
@@ -431,12 +437,13 @@ def _get_current_db_revision(engine: Engine) -> str | None:
     """
     from alembic.runtime.migration import MigrationContext
 
-    inspector = inspect(engine)
-    if "alembic_version" not in inspector.get_table_names():
-        return None
-    with engine.connect() as connection:
-        ctx = MigrationContext.configure(connection)
-        return ctx.get_current_revision()
+    with query_name_scope("omnigent.database.select_current_revision"):
+        inspector = inspect(engine)
+        if "alembic_version" not in inspector.get_table_names():
+            return None
+        with engine.connect() as connection:
+            ctx = MigrationContext.configure(connection)
+            return ctx.get_current_revision()
 
 
 def _get_head_db_revision(db_uri: str) -> str:
@@ -604,6 +611,40 @@ def make_managed_session_maker(
     return managed_session
 
 
+def make_named_managed_session_maker(
+    engine: Engine,
+    *,
+    query_name_prefix: str,
+    immediate: bool = False,
+) -> NamedManagedSessionMaker:
+    """Create managed sessions whose database work always has a semantic name.
+
+    The supplied suffix is joined to ``query_name_prefix`` and remains active
+    through the session's implicit flush and commit. A nested
+    :func:`query_name_scope` can provide a more specific name for one statement.
+
+    :param engine: The SQLAlchemy engine to bind sessions to.
+    :param query_name_prefix: Stable namespace shared by the store's queries,
+        e.g. ``"omnigent.file_store"``.
+    :param immediate: Forwarded to :func:`make_managed_session_maker`.
+    :returns: A callable accepting one semantic query-name suffix per session.
+    """
+    prefix = query_name_prefix.rstrip(".")
+    if not prefix.strip():
+        raise ValueError("query_name_prefix must not be empty")
+
+    managed_session = make_managed_session_maker(engine, immediate=immediate)
+
+    @contextmanager
+    def named_managed_session(query_name: str) -> Iterator[Session]:
+        if not query_name.strip():
+            raise ValueError("query_name must not be empty")
+        with query_name_scope(f"{prefix}.{query_name}"), managed_session() as session:
+            yield session
+
+    return named_managed_session
+
+
 # ── ID generation ──────────────────────────────────────
 
 # Recognised conversation-item types, validated at id generation. The item's
@@ -739,7 +780,7 @@ def ensure_fts_table(engine: Engine) -> None:
         ``conversation_items_fts`` virtual table is created if absent.
     """
     if _supports_fts5(engine.dialect.name):
-        with engine.connect() as conn:
+        with query_name_scope("omnigent.database.ensure_fts_table"), engine.connect() as conn:
             conn.execute(_CREATE_FTS)
             conn.commit()
 

--- a/omnigent/server/accounts_store.py
+++ b/omnigent/server/accounts_store.py
@@ -43,7 +43,7 @@ from omnigent.db.db_models import (
     current_workspace_id,
 )
 from omnigent.db.enum_codecs import decode_account_token_kind, encode_account_token_kind
-from omnigent.db.utils import get_or_create_engine, make_managed_session_maker
+from omnigent.db.utils import get_or_create_engine, make_named_managed_session_maker
 from omnigent.entities import Account, AccountToken
 from omnigent.server.auth import RESERVED_USER_LOCAL, RESERVED_USER_PUBLIC
 
@@ -95,7 +95,10 @@ class SqlAlchemyAccountStore:
     def __init__(self, storage_location: str) -> None:
         self.storage_location = storage_location
         self._engine = get_or_create_engine(storage_location)
-        self._session = make_managed_session_maker(self._engine)
+        self._session = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.account_store",
+        )
         # Immediate session: for the last-admin invariant in delete_user,
         # which must lock the current admin set before counting it. On
         # SQLite, ``BEGIN IMMEDIATE`` acquires the write lock before the
@@ -103,7 +106,11 @@ class SqlAlchemyAccountStore:
         # of reading the same stale admin count. On other dialects this is
         # a no-op — those paths lock explicitly with ``SELECT ... FOR
         # UPDATE`` instead (see ``_supports_for_update``).
-        self._session_immediate = make_managed_session_maker(self._engine, immediate=True)
+        self._session_immediate = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.account_store",
+            immediate=True,
+        )
         self._supports_for_update = self._engine.dialect.name != "sqlite"
 
     # ── User credentials (extends rows in the `users` table) ──────
@@ -132,7 +139,7 @@ class SqlAlchemyAccountStore:
         :raises ValueError: If a user with this id already exists.
         """
         now = int(time.time())
-        with self._session() as session:
+        with self._session("create_user_with_password") as session:
             existing = session.get(SqlUser, (current_workspace_id(), user_id))
             if existing is not None:
                 raise ValueError(f"user {user_id!r} already exists")
@@ -155,7 +162,7 @@ class SqlAlchemyAccountStore:
 
     def get_user(self, user_id: str) -> Account | None:
         """Look up a user by id. Returns ``None`` if missing."""
-        with self._session() as session:
+        with self._session("select_user_by_id") as session:
             row = session.get(SqlUser, (current_workspace_id(), user_id))
             return _to_account(row) if row is not None else None
 
@@ -168,7 +175,7 @@ class SqlAlchemyAccountStore:
         just to gate admin endpoints. The two stores agree by
         construction (single source of truth: the column).
         """
-        with self._session() as session:
+        with self._session("select_user_admin_status") as session:
             row = session.get(SqlUser, (current_workspace_id(), user_id))
             return row is not None and row.is_admin
 
@@ -186,7 +193,7 @@ class SqlAlchemyAccountStore:
         :param user_id: The username to update, e.g. ``"alice"``.
         :param is_admin: The flag value to set.
         """
-        with self._session() as session:
+        with self._session("set_user_admin_status") as session:
             session.execute(
                 update(SqlUser)
                 .where(
@@ -215,7 +222,7 @@ class SqlAlchemyAccountStore:
 
         Result is unordered; UI sorts.
         """
-        with self._session() as session:
+        with self._session("list_users") as session:
             rows = (
                 session.execute(
                     select(SqlUser).where(SqlUser.workspace_id == current_workspace_id())
@@ -270,7 +277,7 @@ class SqlAlchemyAccountStore:
             user exists.
         """
         session_maker = self._session if self._supports_for_update else self._session_immediate
-        with session_maker() as session:
+        with session_maker("delete_user") as session:
             target = session.get(SqlUser, (current_workspace_id(), user_id))
             if target is None:
                 return None
@@ -295,7 +302,7 @@ class SqlAlchemyAccountStore:
         :func:`omnigent.server.passwords.verify_password` — never
         log, return, or store the value elsewhere.
         """
-        with self._session() as session:
+        with self._session("select_password_hash") as session:
             row = session.get(SqlUser, (current_workspace_id(), user_id))
             return row.password_hash if row is not None else None
 
@@ -306,7 +313,7 @@ class SqlAlchemyAccountStore:
         admin-initiated reset. No-op silently if the user does
         not exist (the route should 404 first).
         """
-        with self._session() as session:
+        with self._session("update_password") as session:
             session.execute(
                 update(SqlUser)
                 .where(
@@ -322,7 +329,7 @@ class SqlAlchemyAccountStore:
         :param when_epoch_seconds: Login timestamp. Tests pass a
             fixed value for determinism.
         """
-        with self._session() as session:
+        with self._session("mark_user_logged_in") as session:
             session.execute(
                 update(SqlUser)
                 .where(
@@ -363,7 +370,7 @@ class SqlAlchemyAccountStore:
         """
         if kind not in ("invite", "magic"):
             raise ValueError(f"unknown token kind {kind!r}")
-        with self._session() as session:
+        with self._session("create_account_token") as session:
             row = SqlAccountToken(
                 id=token_id,
                 kind=encode_account_token_kind(kind),
@@ -393,7 +400,7 @@ class SqlAlchemyAccountStore:
         / expired tokens. Caller can't distinguish (intentional —
         opaque-to-bruteforce-guessing).
         """
-        with self._session() as session:
+        with self._session("redeem_account_token") as session:
             result = cast(
                 CursorResult[tuple[object]],
                 session.execute(
@@ -425,7 +432,7 @@ class SqlAlchemyAccountStore:
 
         :returns: The number of rows deleted.
         """
-        with self._session() as session:
+        with self._session("purge_expired_account_tokens") as session:
             result = cast(
                 CursorResult[tuple[object]],
                 session.execute(
@@ -464,7 +471,7 @@ class SqlAlchemyAccountStore:
         :returns: ``True`` if this call redeemed the token, ``False`` if
             it was missing / wrong-kind / already-redeemed / expired.
         """
-        with self._session() as session:
+        with self._session("redeem_oidc_invite") as session:
             result = cast(
                 CursorResult[tuple[object]],
                 session.execute(
@@ -495,7 +502,7 @@ class SqlAlchemyAccountStore:
             ``"contractor@gmail.com"``.
         :returns: ``True`` if a redeemed invite token is bound to it.
         """
-        with self._session() as session:
+        with self._session("select_email_invitation_status") as session:
             return session.execute(
                 select(
                     exists().where(

--- a/omnigent/server/device_grant_store.py
+++ b/omnigent/server/device_grant_store.py
@@ -32,7 +32,7 @@ from sqlalchemy.engine import CursorResult
 
 from omnigent.db.db_models import SqlDeviceGrant, current_workspace_id
 from omnigent.db.enum_codecs import decode_device_grant_status, encode_device_grant_status
-from omnigent.db.utils import get_or_create_engine, make_managed_session_maker
+from omnigent.db.utils import get_or_create_engine, make_named_managed_session_maker
 from omnigent.entities import DeviceGrant
 
 
@@ -85,7 +85,10 @@ class DeviceGrantStore:
     def __init__(self, storage_location: str) -> None:
         self.storage_location = storage_location
         self._engine = get_or_create_engine(storage_location)
-        self._session = make_managed_session_maker(self._engine)
+        self._session = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.device_grant_store",
+        )
 
     def create_grant(
         self,
@@ -113,7 +116,7 @@ class DeviceGrantStore:
         :param expires_at: Unix epoch seconds the device_code expires.
         :returns: The created :class:`DeviceGrant`.
         """
-        with self._session() as session:
+        with self._session("insert_device_grant") as session:
             row = SqlDeviceGrant(
                 id=grant_id,
                 device_code_hash=device_code_hash,
@@ -138,7 +141,7 @@ class DeviceGrantStore:
         Used by the browser consent page to show the initiating client
         before the identity approves. Returns ``None`` if unknown.
         """
-        with self._session() as session:
+        with self._session("select_device_grant_by_user_code") as session:
             row = (
                 session.query(SqlDeviceGrant)
                 .filter(
@@ -151,7 +154,7 @@ class DeviceGrantStore:
 
     def get_by_id(self, grant_id: str) -> DeviceGrant | None:
         """Look up a grant by its id."""
-        with self._session() as session:
+        with self._session("select_device_grant_by_id") as session:
             row = session.get(SqlDeviceGrant, (current_workspace_id(), grant_id))
             return _to_device_grant(row) if row is not None else None
 
@@ -162,7 +165,7 @@ class DeviceGrantStore:
         its ``refresh_token_hash`` cleared to ``NULL``, so a revoked
         token never resolves here. Returns ``None`` if unknown.
         """
-        with self._session() as session:
+        with self._session("select_device_grant_by_refresh_hash") as session:
             row = (
                 session.query(SqlDeviceGrant)
                 .filter(
@@ -197,7 +200,7 @@ class DeviceGrantStore:
         Returns the approved grant, or ``None`` if it was not pending
         (unknown, already decided, or expired).
         """
-        with self._session() as session:
+        with self._session("approve_device_grant") as session:
             result = cast(
                 CursorResult[tuple[object]],
                 session.execute(
@@ -224,7 +227,7 @@ class DeviceGrantStore:
 
     def deny(self, grant_id: str) -> bool:
         """Mark a ``pending`` grant ``denied``. Returns True if it flipped."""
-        with self._session() as session:
+        with self._session("deny_device_grant") as session:
             result = cast(
                 CursorResult[tuple[object]],
                 session.execute(
@@ -261,7 +264,7 @@ class DeviceGrantStore:
             ``"pending"``, ``"denied"``, ``"approved"``, ``"revoked"``,
             ``"redeemed"``. ``grant`` is the row when found.
         """
-        with self._session() as session:
+        with self._session("poll_device_grant") as session:
             row = (
                 session.query(SqlDeviceGrant)
                 .filter(
@@ -309,7 +312,7 @@ class DeviceGrantStore:
         Returns the redeemed grant, or ``None`` if it was not in the
         ``approved`` state (already redeemed, expired, revoked, …).
         """
-        with self._session() as session:
+        with self._session("redeem_device_grant") as session:
             result = cast(
                 CursorResult[tuple[object]],
                 session.execute(
@@ -368,7 +371,7 @@ class DeviceGrantStore:
         stale/mismatched/expired token.
         """
         min_approved_at = now_epoch_seconds - max_lifetime_seconds
-        with self._session() as session:
+        with self._session("rotate_refresh_token") as session:
             result = cast(
                 CursorResult[tuple[object]],
                 session.execute(
@@ -399,7 +402,7 @@ class DeviceGrantStore:
         the grant. Only matches ``redeemed`` (live) grants; a revoked
         grant clears both hashes. Returns ``None`` if unknown.
         """
-        with self._session() as session:
+        with self._session("select_device_grant_by_previous_refresh_hash") as session:
             row = (
                 session.query(SqlDeviceGrant)
                 .filter(
@@ -419,7 +422,7 @@ class DeviceGrantStore:
         ``/oauth/revoke`` and reuse-detection. Access tokens carrying
         this ``grant_id`` are rejected via the revocation denylist.
         """
-        with self._session() as session:
+        with self._session("revoke_device_grant") as session:
             result = cast(
                 CursorResult[tuple[object]],
                 session.execute(
@@ -448,7 +451,7 @@ class DeviceGrantStore:
         Consulted by the auth layer's revocation check for delegated
         access tokens.
         """
-        with self._session() as session:
+        with self._session("select_device_grant_revocation_status") as session:
             row = session.get(SqlDeviceGrant, (current_workspace_id(), grant_id))
             if row is None:
                 return True
@@ -496,7 +499,7 @@ class DeviceGrantStore:
                     SqlDeviceGrant.approved_at <= cutoff,
                 )
             )
-        with self._session() as session:
+        with self._session("purge_expired_device_grants") as session:
             result = cast(
                 CursorResult[tuple[object]],
                 session.execute(

--- a/omnigent/server/identity_migration.py
+++ b/omnigent/server/identity_migration.py
@@ -50,6 +50,7 @@ from omnigent.db.db_models import (
     SqlUser,
     current_workspace_id,
 )
+from omnigent.db.query_context import query_name_scope
 from omnigent.server.auth import _RESERVED_USERS
 
 
@@ -102,7 +103,10 @@ def build_domain_mapping(engine: Engine, domain: str) -> dict[str, str]:
     """
     domain = domain.lstrip("@").strip().lower()
     mapping: dict[str, str] = {}
-    with Session(engine) as session:
+    with (
+        query_name_scope("omnigent.identity_migration.build_domain_mapping"),
+        Session(engine) as session,
+    ):
         ids = (
             session.execute(
                 select(SqlUser.id).where(SqlUser.workspace_id == current_workspace_id())
@@ -151,7 +155,10 @@ def remap_identities(
     """
     report = RemapReport(mapping=dict(mapping))
 
-    with Session(engine) as session:
+    with (
+        query_name_scope("omnigent.identity_migration.remap_identities"),
+        Session(engine) as session,
+    ):
         for old_id, new_id in mapping.items():
             if old_id == new_id:
                 continue

--- a/omnigent/stores/agent_store/sqlalchemy_store.py
+++ b/omnigent/stores/agent_store/sqlalchemy_store.py
@@ -17,7 +17,7 @@ from omnigent.db.enum_codecs import encode_agent_kind
 from omnigent.db.utils import (
     get_or_create_conversation_engine,
     get_or_create_engine,
-    make_managed_session_maker,
+    make_named_managed_session_maker,
     now_epoch,
 )
 from omnigent.entities import Agent, PagedList
@@ -52,14 +52,20 @@ class SqlAlchemyAgentStore(AgentStore):
         super().__init__(storage_location)
         self.conversation_storage_location = conversation_storage_location
         self._engine = get_or_create_engine(storage_location)
-        self._session = make_managed_session_maker(self._engine)
+        self._session = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.agent_store",
+        )
         conv_uri = conversation_storage_location or storage_location
         self._conv_engine = (
             self._engine
             if conv_uri == storage_location
             else get_or_create_conversation_engine(conv_uri)
         )
-        self._conv_session = make_managed_session_maker(self._conv_engine)
+        self._conv_session = make_named_managed_session_maker(
+            self._conv_engine,
+            query_name_prefix="omnigent.agent_store",
+        )
 
     def _session_id_for_agent(self, agent_id: str) -> str | None:
         """
@@ -74,7 +80,7 @@ class SqlAlchemyAgentStore(AgentStore):
         :returns: Owning conversation id, or ``None`` when no
             conversation points at this agent.
         """
-        with self._conv_session() as conv_sess:
+        with self._conv_session("select_session_id_for_agent") as conv_sess:
             return conv_sess.execute(
                 select(SqlConversation.id)
                 .where(
@@ -112,7 +118,7 @@ class SqlAlchemyAgentStore(AgentStore):
             kind=encode_agent_kind("template"),
             description=description,
         )
-        with self._session() as session:
+        with self._session("create_agent") as session:
             # Template names are unique within a workspace. This can't be a
             # partial unique index (MySQL has none), so enforce it here.
             conflict = session.execute(
@@ -139,7 +145,7 @@ class SqlAlchemyAgentStore(AgentStore):
             e.g. ``"agent_abc123"``.
         :returns: The :class:`Agent` if found, otherwise ``None``.
         """
-        with self._session() as session:
+        with self._session("select_agent_by_id") as session:
             row = session.get(SqlAgent, (current_workspace_id(), agent_id))
             if row is None:
                 return None
@@ -162,7 +168,7 @@ class SqlAlchemyAgentStore(AgentStore):
             e.g. ``"code-assistant"``.
         :returns: The :class:`Agent` if found, otherwise ``None``.
         """
-        with self._session() as session:
+        with self._session("select_agent_by_name") as session:
             row = session.execute(
                 select(SqlAgent).where(
                     SqlAgent.workspace_id == current_workspace_id(),
@@ -194,7 +200,7 @@ class SqlAlchemyAgentStore(AgentStore):
         :param order: Sort direction, ``"desc"`` or ``"asc"``.
         :returns: A :class:`PagedList` of :class:`Agent` objects.
         """
-        with self._session() as session:
+        with self._session("list_agents") as session:
             is_desc = order == "desc"
             sort_fn = desc if is_desc else asc
             is_template = SqlAgent.kind == encode_agent_kind("template")
@@ -247,7 +253,7 @@ class SqlAlchemyAgentStore(AgentStore):
         """
         if not agent_ids:
             return {}
-        with self._session() as session:
+        with self._session("select_agent_names") as session:
             rows = session.execute(
                 select(SqlAgent.id, SqlAgent.name).where(
                     SqlAgent.workspace_id == current_workspace_id(),
@@ -272,7 +278,7 @@ class SqlAlchemyAgentStore(AgentStore):
         :returns: The updated :class:`Agent`, or ``None`` if not
             found.
         """
-        with self._session() as session:
+        with self._session("update_agent") as session:
             row = session.get(SqlAgent, (current_workspace_id(), agent_id))
             if not row:
                 return None
@@ -294,7 +300,7 @@ class SqlAlchemyAgentStore(AgentStore):
         :returns: ``True`` if the agent was deleted, ``False`` if
             it did not exist.
         """
-        with self._session() as session:
+        with self._session("delete_agent") as session:
             row = session.get(SqlAgent, (current_workspace_id(), agent_id))
             if not row:
                 return False

--- a/omnigent/stores/comment_store/sqlalchemy_store.py
+++ b/omnigent/stores/comment_store/sqlalchemy_store.py
@@ -10,7 +10,7 @@ from omnigent.db.db_models import SqlComment, current_workspace_id
 from omnigent.db.enum_codecs import decode_comment_status, encode_comment_status
 from omnigent.db.utils import (
     get_or_create_engine,
-    make_managed_session_maker,
+    make_named_managed_session_maker,
     now_epoch_us,
 )
 from omnigent.entities import Comment, CommentsFingerprint
@@ -54,11 +54,14 @@ class SqlAlchemyCommentStore(CommentStore):
         """
         super().__init__(storage_location)
         self._engine = get_or_create_engine(storage_location)
-        self._session = make_managed_session_maker(self._engine)
+        self._session = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.comment_store",
+        )
 
     def get(self, comment_id: str, conversation_id: str) -> Comment | None:
         """Fetch a single comment by id, scoped to a conversation. See base class for contract."""
-        with self._session() as session:
+        with self._session("select_comment_by_id") as session:
             # conversation_id is part of the PK, so the lookup itself enforces
             # the conversation scoping — a wrong conversation simply misses.
             row = session.get(SqlComment, (current_workspace_id(), conversation_id, comment_id))
@@ -95,7 +98,7 @@ class SqlAlchemyCommentStore(CommentStore):
             anchor_content=anchor_content,
             created_by=created_by,
         )
-        with self._session() as session:
+        with self._session("insert_comment") as session:
             session.add(row)
             return _to_entity(row)
 
@@ -114,7 +117,7 @@ class SqlAlchemyCommentStore(CommentStore):
         # created_at is seconds-granular; id breaks same-second ties so the
         # listing has a stable, deterministic order.
         stmt = stmt.order_by(SqlComment.created_at, SqlComment.id)
-        with self._session() as session:
+        with self._session("list_comments") as session:
             rows = list(session.execute(stmt).scalars().all())
             return [_to_entity(r) for r in rows]
 
@@ -127,7 +130,7 @@ class SqlAlchemyCommentStore(CommentStore):
         body: str | None = None,
     ) -> Comment | None:
         """Update a comment's fields, scoped to a conversation. See base class for contract."""
-        with self._session() as session:
+        with self._session("update_comment") as session:
             row = session.get(SqlComment, (current_workspace_id(), conversation_id, comment_id))
             if row is None:
                 return None
@@ -141,7 +144,7 @@ class SqlAlchemyCommentStore(CommentStore):
 
     def delete(self, comment_id: str, conversation_id: str) -> Comment | None:
         """Delete a single comment by id, scoped to a conversation. See base class for contract."""
-        with self._session() as session:
+        with self._session("delete_comment") as session:
             row = session.get(SqlComment, (current_workspace_id(), conversation_id, comment_id))
             if row is None:
                 return None
@@ -167,7 +170,7 @@ class SqlAlchemyCommentStore(CommentStore):
             )
             .group_by(SqlComment.conversation_id)
         )
-        with self._session() as session:
+        with self._session("select_comment_fingerprints") as session:
             return {
                 conversation_id: CommentsFingerprint(count=count, last_updated_at=last_updated)
                 for conversation_id, count, last_updated in session.execute(stmt)
@@ -179,5 +182,5 @@ class SqlAlchemyCommentStore(CommentStore):
             SqlComment.workspace_id == current_workspace_id(),
             SqlComment.conversation_id == conversation_id,
         )
-        with self._session() as session:
+        with self._session("delete_conversation_comments") as session:
             session.execute(stmt)

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -62,7 +62,7 @@ from omnigent.db.utils import (
     get_or_create_conversation_engine,
     get_or_create_engine,
     insert_fts_bulk,
-    make_managed_session_maker,
+    make_named_managed_session_maker,
     now_epoch,
     strip_nul_bytes,
 )
@@ -713,13 +713,20 @@ class SqlAlchemyConversationStore(ConversationStore):
         # Omnigent DB: agents, hosts, policies, files, user_daily_costs,
         # session_permissions, comments, omnigent_conversation_metadata.
         self._engine = get_or_create_engine(storage_location)
-        self._session = make_managed_session_maker(self._engine)
+        self._session = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.conversation_store",
+        )
         # Immediate session: used for read-modify-write operations that must be
         # atomic. On SQLite, ``BEGIN IMMEDIATE`` acquires the write lock before
         # the first read, preventing ``SQLITE_BUSY_SNAPSHOT`` under concurrent
         # writers. On other dialects ``immediate=True`` is a no-op — those paths
         # use ``SELECT … FOR UPDATE`` via ``_supports_for_update`` instead.
-        self._session_immediate = make_managed_session_maker(self._engine, immediate=True)
+        self._session_immediate = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.conversation_store",
+            immediate=True,
+        )
 
         # Agent Platform DB: conversations, conversation_items, conversation_labels.
         # Defaults to the Omnigent DB when not separately configured. Always creates
@@ -731,9 +738,14 @@ class SqlAlchemyConversationStore(ConversationStore):
             if conv_uri == storage_location
             else get_or_create_conversation_engine(conv_uri)
         )
-        self._conv_session = make_managed_session_maker(self._conv_engine)
-        self._conv_session_immediate = make_managed_session_maker(
-            self._conv_engine, immediate=True
+        self._conv_session = make_named_managed_session_maker(
+            self._conv_engine,
+            query_name_prefix="omnigent.conversation_store",
+        )
+        self._conv_session_immediate = make_named_managed_session_maker(
+            self._conv_engine,
+            query_name_prefix="omnigent.conversation_store",
+            immediate=True,
         )
 
         # Dialect-appropriate row-locking flags. Each flag is derived from its
@@ -761,10 +773,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         """
         Fetch the metadata row for a conversation from the Omnigent DB.
         """
-        with (
-            self._session() as meta_sess,
-            query_name_scope("omnigent.conversation_store.select_conversation_metadata_by_id"),
-        ):
+        with self._session("select_conversation_metadata_by_id") as meta_sess:
             return meta_sess.get(
                 SqlConversationMetadata, (current_workspace_id(), conversation_id)
             )
@@ -910,14 +919,11 @@ class SqlAlchemyConversationStore(ConversationStore):
             # Get parent's root from AP, then write AP row and Omnigent meta separately.
             root_id = new_id
             if parent_conversation_id is not None:
-                with self._conv_session() as ap_sess:
-                    with query_name_scope(
-                        "omnigent.conversation_store.select_parent_conversation"
-                    ):
-                        parent_row = ap_sess.get(
-                            SqlConversation,
-                            (current_workspace_id(), parent_conversation_id),
-                        )
+                with self._conv_session("select_parent_conversation") as ap_sess:
+                    parent_row = ap_sess.get(
+                        SqlConversation,
+                        (current_workspace_id(), parent_conversation_id),
+                    )
                     if parent_row is None:
                         raise ConversationNotFoundError(
                             f"parent conversation {parent_conversation_id!r} does not exist"
@@ -925,7 +931,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     root_id = parent_row.root_conversation_id
             if parent_conversation_id is not None and not title:
                 title = f"untitled:{new_id}"
-            with self._conv_session() as ap_sess:
+            with self._conv_session("insert_conversation") as ap_sess:
                 # Application-level (parent, title) uniqueness — there is no DB
                 # unique constraint. Only children are scoped; top-level sessions
                 # (NULL parent) may reuse titles freely. The SELECT seeks this
@@ -963,8 +969,6 @@ class SqlAlchemyConversationStore(ConversationStore):
                     agent_id=agent_id,
                 )
                 ap_sess.add(row)
-                with query_name_scope("omnigent.conversation_store.insert_conversation"):
-                    ap_sess.flush()
             meta = SqlConversationMetadata(
                 id=new_id,
                 kind=encode_conversation_kind(kind),
@@ -977,10 +981,8 @@ class SqlAlchemyConversationStore(ConversationStore):
                     json.dumps(terminal_launch_args) if terminal_launch_args is not None else None
                 ),
             )
-            with self._session() as meta_sess:
+            with self._session("insert_conversation_metadata") as meta_sess:
                 meta_sess.add(meta)
-                with query_name_scope("omnigent.conversation_store.insert_conversation_metadata"):
-                    meta_sess.flush()
             return _to_conversation(row, meta)
         except IntegrityError as exc:
             # Translate a caller-supplied-id PK collision into a clean exception
@@ -1023,9 +1025,8 @@ class SqlAlchemyConversationStore(ConversationStore):
         :returns: The :class:`Conversation` if found, otherwise
             ``None``.
         """
-        with self._conv_session() as session:
-            with query_name_scope("omnigent.conversation_store.select_conversation_by_id"):
-                row = session.get(SqlConversation, (current_workspace_id(), conversation_id))
+        with self._conv_session("select_conversation_by_id") as session:
+            row = session.get(SqlConversation, (current_workspace_id(), conversation_id))
             if row is None:
                 return None
             meta = self._get_meta(session, conversation_id)
@@ -1039,7 +1040,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         """Find the original conversation carrying an import provenance pair."""
         source_label = aliased(SqlConversationLabel)
         external_label = aliased(SqlConversationLabel)
-        with self._conv_session() as session:
+        with self._conv_session("select_imported_conversation") as session:
             conversation_id = session.execute(
                 select(SqlConversation.id)
                 .join(
@@ -1074,7 +1075,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         if not conversation_ids:
             return {}
         unique_ids = list(set(conversation_ids))
-        with self._session() as session:
+        with self._session("select_runner_ids") as session:
             rows = session.execute(
                 select(SqlConversationMetadata.id, SqlConversationMetadata.runner_id).where(
                     SqlConversationMetadata.workspace_id == current_workspace_id(),
@@ -1104,7 +1105,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             return {}
         unique_ids = list(set(conversation_ids))
         # runner_id and host_id are in the Omnigent DB (metadata).
-        with self._session() as session:
+        with self._session("get_session_connectivity") as session:
             meta_rows = session.execute(
                 select(
                     SqlConversationMetadata.id,
@@ -1117,7 +1118,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 )
             ).all()
         # Fork-source label is in the AP DB.
-        with self._conv_session() as ap_sess:
+        with self._conv_session("get_session_connectivity") as ap_sess:
             # One pass over the fork-source connectivity marker, which
             # signals on presence (its value is the source id).
             label_rows = ap_sess.execute(
@@ -1160,7 +1161,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         if not conversation_ids:
             return {}
         unique_ids = list(set(conversation_ids))
-        with self._conv_session() as session:
+        with self._conv_session("get_conversations") as session:
             rows = list(
                 session.execute(
                     select(SqlConversation).where(
@@ -1180,7 +1181,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         meta_rows: list[SqlConversationMetadata] = []
         if rows:
             row_ids = [r.id for r in rows]
-            with self._session() as meta_sess:
+            with self._session("get_conversations") as meta_sess:
                 meta_rows = list(
                     meta_sess.execute(
                         select(SqlConversationMetadata).where(
@@ -1228,7 +1229,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         if not unique_ids:
             return result
 
-        with self._conv_session() as ap_sess:
+        with self._conv_session("list_child_conversation_ids_by_parent") as ap_sess:
             rows = ap_sess.execute(
                 select(SqlConversation.parent_conversation_id, SqlConversation.id)
                 .where(SqlConversation.workspace_id == current_workspace_id())
@@ -1273,7 +1274,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         if not updates:
             return
         stamp = updated_at if updated_at is not None else now_epoch()
-        with self._conv_session() as session:
+        with self._conv_session("set_labels") as session:
             _upsert_labels(session, conversation_id, updates, stamp)
 
     def set_session_state(
@@ -1293,7 +1294,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         """
         import json
 
-        with self._session() as session:
+        with self._session("set_session_state") as session:
             session.execute(
                 update(SqlConversationMetadata)
                 .where(
@@ -1323,7 +1324,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         """
         import json
 
-        with self._session() as session:
+        with self._session("set_session_usage") as session:
             session.execute(
                 update(SqlConversationMetadata)
                 .where(
@@ -1350,7 +1351,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         :returns: ``True`` if a metadata row was updated; ``False`` if the
             conversation has no metadata row.
         """
-        with self._session() as session:
+        with self._session("set_conversation_project") as session:
             result = cast(
                 _RowCountResult,
                 session.execute(
@@ -1395,7 +1396,7 @@ class SqlAlchemyConversationStore(ConversationStore):
 
         from omnigent.stores.conversation_store import apply_session_usage_delta
 
-        with self._session_immediate() as session:
+        with self._session_immediate("increment_session_usage") as session:
             q = select(SqlConversationMetadata).where(
                 SqlConversationMetadata.workspace_id == current_workspace_id(),
                 SqlConversationMetadata.id == conversation_id,
@@ -1437,7 +1438,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         if delta_usd <= 0:
             return
         now = now_epoch()
-        with self._session() as session:
+        with self._session("add_daily_cost") as session:
             dialect = session.bind.dialect.name if session.bind is not None else ""
             if dialect in ("sqlite", "postgresql"):
                 self._upsert_daily_cost_dialect(session, dialect, user_id, day_utc, delta_usd, now)
@@ -1520,7 +1521,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         :returns: The accumulated ``cost_usd``, or ``0.0`` when no row
             exists for ``(user_id, day_utc)``.
         """
-        with self._session() as session:
+        with self._session("get_daily_cost") as session:
             row = session.get(SqlUserDailyCost, (current_workspace_id(), user_id, day_utc))
             return float(row.cost_usd) if row is not None else 0.0
 
@@ -1533,7 +1534,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         a plain ``>=`` on the string column; ``SUM`` returns ``NULL`` for
         an empty range, coalesced to ``0.0``.
         """
-        with self._session() as session:
+        with self._session("sum_daily_cost") as session:
             total = session.execute(
                 select(func.coalesce(func.sum(SqlUserDailyCost.cost_usd), 0.0))
                 .where(SqlUserDailyCost.workspace_id == current_workspace_id())
@@ -1556,7 +1557,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         :returns: ``{"cost_usd": <float>, "ask_approved_usd": <float>}``;
             both ``0.0`` when no row exists for ``(user_id, day_utc)``.
         """
-        with self._session() as session:
+        with self._session("get_daily_cost_state") as session:
             row = session.get(SqlUserDailyCost, (current_workspace_id(), user_id, day_utc))
             if row is None:
                 return {"cost_usd": 0.0, "ask_approved_usd": 0.0}
@@ -1584,7 +1585,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             user approved continuing past, e.g. ``0.05``.
         """
         now = now_epoch()
-        with self._session() as session:
+        with self._session("set_daily_ask_approved") as session:
             dialect = session.bind.dialect.name if session.bind is not None else ""
             if dialect in ("sqlite", "postgresql"):
                 # Typed as Any to sidestep the mypy variance between the
@@ -1653,7 +1654,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         """
         from omnigent.server.auth import RESERVED_USER_PUBLIC
 
-        with self._session() as session:
+        with self._session("select_session_owner") as session:
             return session.execute(
                 select(SqlSessionPermission.user_id)
                 .where(SqlSessionPermission.workspace_id == current_workspace_id())
@@ -1683,7 +1684,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         :returns: A list of matching :class:`ConversationItem`
             objects in relevance order.
         """
-        with self._conv_session() as session:
+        with self._conv_session("search_conversations") as session:
             # Dialect-specific search: the SQLite family (SQLite + D1) has
             # FTS5 virtual tables (MATCH + rank); PostgreSQL doesn't. ILIKE on
             # the JSON data column is a functional fallback there. Proper
@@ -1792,7 +1793,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         :returns: A :class:`PagedList` of
             :class:`ConversationItem` objects.
         """
-        with self._conv_session() as session:
+        with self._conv_session("list_items") as session:
             is_asc = order == "asc"
             sort_fn = asc if is_asc else desc
             # Load only the columns _to_item reads. search_text is a wide Text
@@ -1895,7 +1896,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         if not unique_ids or per_conversation_limit <= 0:
             return result
 
-        with self._conv_session() as session:
+        with self._conv_session("list_latest_message_items_for_conversations") as session:
             ranked = _ranked_latest_message_items(unique_ids)
             rows = session.execute(
                 select(ranked)
@@ -1967,7 +1968,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         now = now_epoch()
         persisted: list[ConversationItem] = []
 
-        with self._conv_session() as session:
+        with self._conv_session("append_conversation_items") as session:
             # Lock the conversation row to serialize position writes.
             # On PostgreSQL this is a row-level FOR UPDATE lock; on
             # SQLite the database-level lock already serializes.
@@ -2094,7 +2095,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         # the AP conversations table and is filtered inline below.
         permission_ids: list[str] | None = None
         if accessible_by is not None or owned_by is not None:
-            with self._session() as meta_sess:
+            with self._session("list_projects") as meta_sess:
                 accessible_set: set[str] | None = None
                 owned_set: set[str] | None = None
                 if accessible_by is not None:
@@ -2122,7 +2123,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     permission_ids = list(
                         accessible_set if accessible_set is not None else owned_set or set()
                     )
-        with self._conv_session() as ap_sess:
+        with self._conv_session("list_projects") as ap_sess:
             # Non-archived conversations, resolved on the AP table.
             non_archived_ids = select(SqlConversation.id).where(
                 SqlConversation.workspace_id == current_workspace_id(),
@@ -2155,7 +2156,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         :param conversation_id: The conversation to update.
         :param key: The label key to remove, e.g. ``"omni_project"``.
         """
-        with self._conv_session() as session:
+        with self._conv_session("delete_label") as session:
             session.execute(
                 delete(SqlConversationLabel).where(
                     SqlConversationLabel.workspace_id == current_workspace_id(),
@@ -2279,7 +2280,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             # (session_permissions), then filter the AP query. accessible_by and
             # owned_by are intersected (both applied) to match the prior
             # behaviour. (ACL pushdown to a single AP query is a follow-up.)
-            with self._session() as meta_sess:
+            with self._session("list_conversations") as meta_sess:
                 accessible_set: set[str] | None = None
                 owned_set: set[str] | None = None
                 if accessible_by is not None:
@@ -2308,7 +2309,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                         accessible_set if accessible_set is not None else owned_set or set()
                     )
 
-        with self._conv_session() as session:
+        with self._conv_session("list_conversations") as session:
             stmt = select(SqlConversation).where(
                 SqlConversation.workspace_id == current_workspace_id()
             )
@@ -2340,7 +2341,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             if agent_name is not None:
                 # Agents live in the Omnigent DB — resolve to IDs first, then
                 # filter on the conversations.agent_id column directly.
-                with self._session() as agent_sess:
+                with self._session("list_conversations") as agent_sess:
                     agent_ids_for_name = list(
                         agent_sess.execute(
                             select(SqlAgent.id).where(
@@ -2400,7 +2401,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                             first_class_stmt = first_class_stmt.where(
                                 SqlConversationMetadata.id.in_(qualifying_ids)
                             )
-                        with self._session() as meta_sess:
+                        with self._session("list_conversations") as meta_sess:
                             first_class_filed = list(meta_sess.execute(first_class_stmt).scalars())
                     stmt = stmt.where(
                         SqlConversation.id.not_in(first_class_filed),
@@ -2436,7 +2437,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                             member_stmt = member_stmt.where(
                                 SqlConversationMetadata.id.in_(qualifying_ids)
                             )
-                        with self._session() as meta_sess:
+                        with self._session("list_conversations") as meta_sess:
                             member_match = list(meta_sess.execute(member_stmt).scalars())
                     stmt = stmt.where(
                         or_(
@@ -2507,7 +2508,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         # Fetch metadata from Omnigent DB and merge.
         meta_by_id: dict[str, SqlConversationMetadata] = {}
         if row_ids:
-            with self._session() as meta_sess:
+            with self._session("list_conversations") as meta_sess:
                 meta_rows = (
                     meta_sess.execute(
                         select(SqlConversationMetadata).where(
@@ -2669,7 +2670,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         now = now_epoch()
         # Two transactions: AP (the conversation row, which carries the agent
         # binding + per-session override blob) and Omnigent (metadata).
-        with self._conv_session() as ap_sess:
+        with self._conv_session("update_conversation") as ap_sess:
             row = ap_sess.get(SqlConversation, (current_workspace_id(), conversation_id))
             if not row:
                 return None
@@ -2716,7 +2717,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 row.updated_at = now
             labels = _fetch_labels(ap_sess, conversation_id)
         if terminal_launch_args is not None:
-            with self._session() as meta_sess:
+            with self._session("update_conversation") as meta_sess:
                 meta = meta_sess.get(
                     SqlConversationMetadata, (current_workspace_id(), conversation_id)
                 )
@@ -2747,7 +2748,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         title: str,
     ) -> Conversation | None:
         """Rename a conversation with an atomic title compare-and-swap."""
-        with self._conv_session() as session:
+        with self._conv_session("rename_conversation_if_title_matches") as session:
             result = cast(
                 _RowCountResult,
                 session.execute(
@@ -2791,7 +2792,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         """
         from sqlalchemy import update
 
-        with self._session() as session:
+        with self._session("set_runner_id") as session:
             stmt = (
                 update(SqlConversationMetadata)
                 .where(
@@ -2819,7 +2820,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             return
         from sqlalchemy import update
 
-        with self._session() as session:
+        with self._session("touch_runner_liveness") as session:
             session.execute(
                 update(SqlConversationMetadata)
                 .where(
@@ -2840,7 +2841,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         """
         from sqlalchemy import update
 
-        with self._session() as session:
+        with self._session("clear_runner_liveness") as session:
             session.execute(
                 update(SqlConversationMetadata)
                 .where(
@@ -2862,7 +2863,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         """
         from sqlalchemy import update
 
-        with self._session() as session:
+        with self._session("set_session_live_status") as session:
             session.execute(
                 update(SqlConversationMetadata)
                 .where(
@@ -2884,7 +2885,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         """
         from sqlalchemy import update
 
-        with self._session() as session:
+        with self._session("set_pending_elicitation_count") as session:
             session.execute(
                 update(SqlConversationMetadata)
                 .where(
@@ -2910,14 +2911,14 @@ class SqlAlchemyConversationStore(ConversationStore):
         :raises ConversationNotFoundError: If no conversation row
             exists for ``conversation_id``.
         """
-        with self._session() as session:
+        with self._session("replace_runner_id") as session:
             meta = session.get(SqlConversationMetadata, (current_workspace_id(), conversation_id))
             if meta is None:
                 raise ConversationNotFoundError(
                     f"conversation {conversation_id!r} does not exist",
                 )
             meta.runner_id = runner_id
-        with self._conv_session() as ap_sess:
+        with self._conv_session("replace_runner_id") as ap_sess:
             ap_row = ap_sess.get(SqlConversation, (current_workspace_id(), conversation_id))
             if ap_row is None:
                 raise ConversationNotFoundError(
@@ -2937,14 +2938,14 @@ class SqlAlchemyConversationStore(ConversationStore):
         :raises ConversationNotFoundError: If no conversation row
             exists for ``conversation_id``.
         """
-        with self._session() as session:
+        with self._session("clear_runner_id") as session:
             meta = session.get(SqlConversationMetadata, (current_workspace_id(), conversation_id))
             if meta is None:
                 raise ConversationNotFoundError(
                     f"conversation {conversation_id!r} does not exist",
                 )
             meta.runner_id = None
-        with self._conv_session() as ap_sess:
+        with self._conv_session("clear_runner_id") as ap_sess:
             ap_row = ap_sess.get(SqlConversation, (current_workspace_id(), conversation_id))
             if ap_row is None:
                 raise ConversationNotFoundError(
@@ -2969,7 +2970,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         :raises ConversationNotFoundError: If no conversation row
             exists for ``conversation_id``.
         """
-        with self._session() as session:
+        with self._session("clear_host_binding") as session:
             meta = session.get(SqlConversationMetadata, (current_workspace_id(), conversation_id))
             if meta is None:
                 raise ConversationNotFoundError(
@@ -2979,7 +2980,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             meta.workspace = None
             meta.git_branch = None
             meta.runner_id = None
-        with self._conv_session() as ap_sess:
+        with self._conv_session("clear_host_binding") as ap_sess:
             ap_row = ap_sess.get(SqlConversation, (current_workspace_id(), conversation_id))
             if ap_row is None:
                 raise ConversationNotFoundError(
@@ -3000,7 +3001,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             ``"runner_token_a1b2c3d4..."``.
         :returns: List of :class:`Conversation` entities.
         """
-        with self._session() as session:
+        with self._session("list_conversations_by_runner_id") as session:
             meta_rows = (
                 session.execute(
                     select(SqlConversationMetadata).where(
@@ -3015,7 +3016,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             return []
         conv_ids = [m.id for m in meta_rows]
         meta_by_id = {m.id: m for m in meta_rows}
-        with self._conv_session() as ap_sess:
+        with self._conv_session("list_conversations_by_runner_id") as ap_sess:
             ap_rows = (
                 ap_sess.execute(
                     select(SqlConversation).where(
@@ -3078,7 +3079,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             ``host_id`` is being set on a row with no ``workspace``
             and the caller did not supply one).
         """
-        with self._session() as session:
+        with self._session("set_host_id") as session:
             meta = session.get(SqlConversationMetadata, (current_workspace_id(), conversation_id))
             if meta is None:
                 raise ConversationNotFoundError(
@@ -3089,7 +3090,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 meta.workspace = workspace
             if git_branch is not None:
                 meta.git_branch = git_branch
-        with self._conv_session() as ap_sess:
+        with self._conv_session("set_host_id") as ap_sess:
             ap_row = ap_sess.get(SqlConversation, (current_workspace_id(), conversation_id))
             if ap_row is None:
                 raise ConversationNotFoundError(
@@ -3122,7 +3123,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         :raises ValueError: If the row already has a different
             ``external_session_id``.
         """
-        with self._session() as session:
+        with self._session("set_external_session_id") as session:
             meta = session.get(SqlConversationMetadata, (current_workspace_id(), conversation_id))
             if meta is None:
                 raise ConversationNotFoundError(
@@ -3138,7 +3139,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             changed = existing != value
             if changed:
                 meta.external_session_id = value
-        with self._conv_session() as ap_sess:
+        with self._conv_session("set_external_session_id") as ap_sess:
             ap_row = ap_sess.get(SqlConversation, (current_workspace_id(), conversation_id))
             if ap_row is None:
                 raise ConversationNotFoundError(
@@ -3258,7 +3259,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         # Get parent root_id from AP first.
         root_conversation_id: str | None = None
         if parent_conversation_id is not None:
-            with self._conv_session() as ap_sess:
+            with self._conv_session("create_session_with_agent") as ap_sess:
                 parent_row = ap_sess.get(
                     SqlConversation, (current_workspace_id(), parent_conversation_id)
                 )
@@ -3277,7 +3278,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             agent_id=agent_id,
             session_overrides=_encode_session_overrides({"reasoning_effort": reasoning_effort}),
         )
-        with self._conv_session() as ap_sess:
+        with self._conv_session("create_session_with_agent") as ap_sess:
             ap_sess.add(conversation_row)
             if labels:
                 _upsert_labels(ap_sess, conversation_id, labels, now)
@@ -3296,7 +3297,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             workspace=workspace,
             terminal_launch_args=terminal_launch_args,
         )
-        with self._session() as session:
+        with self._session("create_session_with_agent") as session:
             session.add(agent_row)
             session.add(meta_row)
             session.flush()
@@ -3455,12 +3456,12 @@ class SqlAlchemyConversationStore(ConversationStore):
 
         # Fetch source metadata (workspace, external_session_id, terminal_launch_args)
         # from the Omnigent DB before opening the AP session.
-        with self._session() as meta_sess:
+        with self._session("fork_conversation") as meta_sess:
             source_meta_ref: SqlConversationMetadata | None = meta_sess.get(
                 SqlConversationMetadata, (current_workspace_id(), source_conversation_id)
             )
 
-        with self._conv_session() as session:
+        with self._conv_session("fork_conversation") as session:
             source = session.get(SqlConversation, (current_workspace_id(), source_conversation_id))
             if source is None:
                 raise LookupError(f"conversation not found: {source_conversation_id!r}")
@@ -3672,7 +3673,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             )
 
         # Write fork metadata (and cloned agent if any) to the Omnigent DB.
-        with self._session() as meta_sess:
+        with self._session("fork_conversation") as meta_sess:
             meta_sess.add(fork_meta)
             if creating_clone and agent_id is not None:
                 assert cloned_agent_name is not None and cloned_agent_bundle_location is not None
@@ -3747,7 +3748,7 @@ class SqlAlchemyConversationStore(ConversationStore):
 
         # AP holds the conversation (agent binding + overrides) + labels;
         # Omnigent holds agent+metadata. Read old_agent_id before overwriting it.
-        with self._conv_session() as ap_sess:
+        with self._conv_session("switch_conversation_agent") as ap_sess:
             row = ap_sess.get(SqlConversation, (current_workspace_id(), conversation_id))
             if row is None:
                 raise LookupError(f"conversation not found: {conversation_id!r}")
@@ -3776,7 +3777,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                 _upsert_labels(ap_sess, conversation_id, upserts, now)
 
         # Update agent + metadata on the Omnigent side.
-        with self._session() as session:
+        with self._session("switch_conversation_agent") as session:
             if old_agent_id is not None:
                 old_agent = session.get(SqlAgent, (current_workspace_id(), old_agent_id))
                 if old_agent is not None and old_agent.kind == encode_agent_kind("session"):
@@ -3826,7 +3827,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         # Omnigent-side rows (metadata/comments/policies/permissions) are cleaned up
         # second. A failure of the second transaction leaves orphaned Omnigent rows
         # for a conversation that no longer exists — an acceptable best-effort tradeoff.
-        with self._conv_session() as ap_sess:
+        with self._conv_session("delete_conversation") as ap_sess:
             row = ap_sess.get(SqlConversation, (current_workspace_id(), conversation_id))
             if not row:
                 return False
@@ -3899,7 +3900,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             )
             ap_sess.delete(row)
 
-        with self._session() as session:
+        with self._session("delete_conversation") as session:
             session.execute(
                 delete(SqlComment).where(
                     SqlComment.workspace_id == current_workspace_id(),

--- a/omnigent/stores/file_store/sqlalchemy_store.py
+++ b/omnigent/stores/file_store/sqlalchemy_store.py
@@ -11,7 +11,7 @@ from omnigent.db.query_context import query_name_scope
 from omnigent.db.utils import (
     generate_file_id,
     get_or_create_engine,
-    make_managed_session_maker,
+    make_named_managed_session_maker,
     now_epoch,
 )
 from omnigent.entities import PagedList, StoredFile
@@ -52,7 +52,10 @@ class SqlAlchemyFileStore(FileStore):
         """
         super().__init__(storage_location)
         self._engine = get_or_create_engine(storage_location)
-        self._session = make_managed_session_maker(self._engine)
+        self._session = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.file_store",
+        )
 
     def create(
         self,
@@ -79,10 +82,8 @@ class SqlAlchemyFileStore(FileStore):
             content_type=content_type,
             session_id=session_id,
         )
-        with self._session() as session:
+        with self._session("insert_file") as session:
             session.add(row)
-            with query_name_scope("omnigent.file_store.insert_file"):
-                session.flush()
             return _to_entity(row)
 
     def get(
@@ -101,9 +102,8 @@ class SqlAlchemyFileStore(FileStore):
         :returns: The :class:`StoredFile` if found, otherwise
             ``None``.
         """
-        with self._session() as session:
-            with query_name_scope("omnigent.file_store.select_file_by_id"):
-                row = session.get(SqlFile, (current_workspace_id(), file_id))
+        with self._session("select_file_by_id") as session:
+            row = session.get(SqlFile, (current_workspace_id(), file_id))
             if row is None:
                 return None
             if session_id is not None and row.session_id != normalize_uuid(session_id):
@@ -134,7 +134,7 @@ class SqlAlchemyFileStore(FileStore):
             files (``session_id IS NULL``).
         :returns: A :class:`PagedList` of :class:`StoredFile`.
         """
-        with self._session() as session:
+        with self._session("list_files") as session:
             is_desc = order == "desc"
             sort_fn = desc if is_desc else asc
             stmt = select(SqlFile).where(SqlFile.workspace_id == current_workspace_id())
@@ -172,8 +172,7 @@ class SqlAlchemyFileStore(FileStore):
                 sort_fn(SqlFile.created_at),
                 sort_fn(SqlFile.id),
             ).limit(limit + 1)
-            with query_name_scope("omnigent.file_store.list_files"):
-                rows = list(session.execute(stmt).scalars().all())
+            rows = list(session.execute(stmt).scalars().all())
             has_more = len(rows) > limit
             if has_more:
                 rows = rows[:limit]
@@ -200,7 +199,7 @@ class SqlAlchemyFileStore(FileStore):
         :param session_id: If set, verify ownership.
         :returns: ``True`` if deleted, ``False`` otherwise.
         """
-        with self._session() as session:
+        with self._session("delete_file") as session:
             with query_name_scope("omnigent.file_store.select_file_by_id"):
                 row = session.get(SqlFile, (current_workspace_id(), file_id))
             if not row:
@@ -208,8 +207,6 @@ class SqlAlchemyFileStore(FileStore):
             if session_id is not None and row.session_id != normalize_uuid(session_id):
                 return False
             session.delete(row)
-            with query_name_scope("omnigent.file_store.delete_file"):
-                session.flush()
             return True
 
     def delete_all_for_session(self, session_id: str) -> builtins.list[str]:
@@ -219,7 +216,7 @@ class SqlAlchemyFileStore(FileStore):
         :param session_id: Owning session/conversation id.
         :returns: List of deleted file ids for artifact cleanup.
         """
-        with self._session() as session:
+        with self._session("delete_session_files") as session:
             stmt = select(SqlFile).where(
                 SqlFile.workspace_id == current_workspace_id(),
                 SqlFile.session_id == session_id,
@@ -229,6 +226,4 @@ class SqlAlchemyFileStore(FileStore):
             ids = [row.id for row in rows]
             for row in rows:
                 session.delete(row)
-            with query_name_scope("omnigent.file_store.delete_session_files"):
-                session.flush()
             return ids

--- a/omnigent/stores/host_store.py
+++ b/omnigent/stores/host_store.py
@@ -28,7 +28,11 @@ from omnigent.db.db_models import (
     current_workspace_id,
 )
 from omnigent.db.enum_codecs import decode_host_status, encode_host_status
-from omnigent.db.utils import get_or_create_engine, make_managed_session_maker, now_epoch
+from omnigent.db.utils import (
+    get_or_create_engine,
+    make_named_managed_session_maker,
+    now_epoch,
+)
 from omnigent.harness_availability import HarnessAvailability, is_harness_availability
 
 # A host is considered live only if its row was touched (connect or
@@ -185,7 +189,10 @@ class HostStore:
             ``"sqlite:///hosts.db"``.
         """
         self._engine: Engine = get_or_create_engine(storage_location)
-        self._session = make_managed_session_maker(self._engine)
+        self._session = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.host_store",
+        )
 
     def upsert_on_connect(
         self,
@@ -240,7 +247,7 @@ class HostStore:
         harnesses_json = (
             json.dumps(configured_harnesses) if configured_harnesses is not None else None
         )
-        with self._session() as session:
+        with self._session("upsert_host_on_connect") as session:
             # Primary lookup: by (workspace_id, host_id) — the new PK.
             row = session.get(SqlHost, (current_workspace_id(), host_id))
             if row is not None:
@@ -483,7 +490,7 @@ class HostStore:
         :param host_id: Host identifier, e.g.
             ``"host_a1b2c3d4..."``.
         """
-        with self._session() as session:
+        with self._session("set_host_offline") as session:
             row = session.execute(
                 select(SqlHost).where(
                     SqlHost.workspace_id == current_workspace_id(), SqlHost.host_id == host_id
@@ -503,7 +510,7 @@ class HostStore:
         :param host_id: Host identifier, e.g. ``"host_a1b2c3d4..."``.
         :param configured_harnesses: Current readiness keyed by harness spelling.
         """
-        with self._session() as session:
+        with self._session("update_harness_readiness") as session:
             session.execute(
                 update(SqlHost)
                 .where(
@@ -534,7 +541,7 @@ class HostStore:
         # Single UPDATE rather than SELECT-then-mutate: this runs every
         # ping interval for every connected host, so the extra read is
         # pure overhead. A missing host simply matches no rows (a no-op).
-        with self._session() as session:
+        with self._session("update_host_heartbeat") as session:
             session.execute(
                 update(SqlHost)
                 .where(
@@ -585,7 +592,7 @@ class HostStore:
             return set()
         unique_ids = list(set(host_ids))
         ref = now_epoch()
-        with self._session() as session:
+        with self._session("select_online_host_ids") as session:
             rows = session.execute(
                 select(SqlHost.host_id, SqlHost.status, SqlHost.updated_at).where(
                     SqlHost.workspace_id == current_workspace_id(),
@@ -610,7 +617,7 @@ class HostStore:
             ``"corey.zumar@databricks.com"``.
         :returns: List of :class:`Host` entities.
         """
-        with self._session() as session:
+        with self._session("list_hosts") as session:
             rows = (
                 session.query(SqlHost)
                 .filter(
@@ -630,7 +637,7 @@ class HostStore:
             ``"host_a1b2c3d4..."``.
         :returns: The :class:`Host` if found, otherwise ``None``.
         """
-        with self._session() as session:
+        with self._session("select_host_by_id") as session:
             row = session.execute(
                 select(SqlHost).where(
                     SqlHost.workspace_id == current_workspace_id(), SqlHost.host_id == host_id
@@ -689,7 +696,7 @@ class HostStore:
         """
         now = now_epoch()
         token_hash = hash_host_launch_token(token)
-        with self._session() as session:
+        with self._session("register_managed_host") as session:
             existing = session.execute(
                 select(SqlHost).where(
                     SqlHost.workspace_id == current_workspace_id(), SqlHost.host_id == host_id
@@ -749,7 +756,7 @@ class HostStore:
             or ``None`` when the host is unknown, the token does not match,
             or the token is expired.
         """
-        with self._session() as session:
+        with self._session("resolve_launch_token") as session:
             row = session.execute(
                 select(SqlHost).where(
                     SqlHost.workspace_id == current_workspace_id(),
@@ -781,7 +788,7 @@ class HostStore:
 
         :param host_id: Host identifier, e.g. ``"host_a1b2c3d4..."``.
         """
-        with self._session() as session:
+        with self._session("delete_host") as session:
             session.execute(
                 update(SqlConversationMetadata)
                 .where(
@@ -810,7 +817,7 @@ class HostStore:
 
         :param host_id: Host identifier, e.g. ``"host_a1b2c3d4..."``.
         """
-        with self._session() as session:
+        with self._session("revoke_launch_token") as session:
             row = session.execute(
                 select(SqlHost).where(
                     SqlHost.workspace_id == current_workspace_id(), SqlHost.host_id == host_id

--- a/omnigent/stores/permission_store/sqlalchemy_store.py
+++ b/omnigent/stores/permission_store/sqlalchemy_store.py
@@ -12,7 +12,7 @@ from sqlalchemy.engine import CursorResult
 from sqlalchemy.sql.dml import Insert
 
 from omnigent.db.db_models import SqlSessionPermission, SqlUser, current_workspace_id
-from omnigent.db.utils import get_or_create_engine, make_managed_session_maker
+from omnigent.db.utils import get_or_create_engine, make_named_managed_session_maker
 from omnigent.entities import Account, ResolvedAccess, SessionPermission
 from omnigent.server.auth import (
     LEVEL_OWNER,
@@ -75,7 +75,10 @@ class SqlAlchemyPermissionStore(PermissionStore):
         """
         super().__init__(storage_location)
         self._engine = get_or_create_engine(storage_location)
-        self._session = make_managed_session_maker(self._engine)
+        self._session = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.permission_store",
+        )
 
     def grant(
         self,
@@ -86,7 +89,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
         can_approve: bool = False,
     ) -> SessionPermission:
         """Upsert a permission grant. See base class for contract."""
-        with self._session() as session:
+        with self._session("grant_permission") as session:
             dialect = self._engine.dialect.name
             values = {
                 "user_id": user_id,
@@ -130,7 +133,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
 
     def revoke(self, user_id: str, conversation_id: str) -> bool:
         """Remove a permission grant. See base class for contract."""
-        with self._session() as session:
+        with self._session("revoke_permission") as session:
             result = cast(
                 CursorResult[tuple[object]],
                 session.execute(
@@ -145,7 +148,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
 
     def get(self, user_id: str, conversation_id: str) -> SessionPermission | None:
         """Look up a single grant. See base class for contract."""
-        with self._session() as session:
+        with self._session("select_permission") as session:
             row = session.get(
                 SqlSessionPermission, (current_workspace_id(), user_id, conversation_id)
             )
@@ -170,7 +173,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
         :returns: The number of grants repointed to *to_user_id*.
         """
         moved = 0
-        with self._session() as session:
+        with self._session("reassign_user_grants") as session:
             # FK target: ensure the destination users.id row exists. Don't
             # downgrade an existing admin flag; only create it if missing.
             if session.get(SqlUser, (current_workspace_id(), to_user_id)) is None:
@@ -234,7 +237,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
         after_user_id: str | None = None,
     ) -> tuple[list[SessionPermission], str | None]:
         """Return grants on a session with cursor pagination. See base class for contract."""
-        with self._session() as session:
+        with self._session("list_session_permissions") as session:
             stmt = (
                 select(SqlSessionPermission)
                 .where(
@@ -260,7 +263,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
         """Return all grants for multiple sessions.  See base class for contract."""
         if not conversation_ids:
             return {}
-        with self._session() as session:
+        with self._session("list_permissions_for_sessions") as session:
             # Convert to entities inside the session so ORM attributes are
             # accessed while the session is still open (avoids DetachedInstanceError).
             entities = [
@@ -281,7 +284,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
 
     def list_for_user(self, user_id: str, *, limit: int = 1000) -> list[SessionPermission]:
         """Return all grants for a user. See base class for contract."""
-        with self._session() as session:
+        with self._session("list_user_permissions") as session:
             rows = (
                 session.execute(
                     select(SqlSessionPermission)
@@ -298,7 +301,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
 
     def ensure_user(self, user_id: str, *, is_admin: bool = False) -> None:
         """Upsert a user row. See base class for contract."""
-        with self._session() as session:
+        with self._session("ensure_user") as session:
             dialect = self._engine.dialect.name
             values = {"id": user_id, "is_admin": is_admin}
             stmt: Insert
@@ -325,7 +328,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
 
     def list_users(self, *, limit: int = 1000) -> list[Account]:
         """List every real user row. See base class for contract."""
-        with self._session() as session:
+        with self._session("list_users") as session:
             rows = (
                 session.execute(
                     select(SqlUser)
@@ -339,13 +342,13 @@ class SqlAlchemyPermissionStore(PermissionStore):
 
     def is_admin(self, user_id: str) -> bool:
         """Check the admin flag. See base class for contract."""
-        with self._session() as session:
+        with self._session("select_user_admin_status") as session:
             row = session.get(SqlUser, (current_workspace_id(), user_id))
             return row is not None and row.is_admin
 
     def set_admin(self, user_id: str, is_admin: bool) -> None:
         """Set the admin flag on an existing user. See base class for contract."""
-        with self._session() as session:
+        with self._session("set_user_admin_status") as session:
             session.execute(
                 update(SqlUser)
                 .where(
@@ -412,7 +415,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
         # paying three separate checkout/BEGIN/COMMIT cycles (which is what
         # calling is_admin + check_access + get_permission_level separately
         # did — see the GET /v1/sessions/{id} snapshot path).
-        with self._session() as session:
+        with self._session("resolve_access") as session:
             user_row = session.get(SqlUser, (current_workspace_id(), user_id))
             user_grant = session.get(
                 SqlSessionPermission, (current_workspace_id(), user_id, conversation_id)
@@ -430,7 +433,7 @@ class SqlAlchemyPermissionStore(PermissionStore):
 
     def has_any_grants(self, conversation_id: str) -> bool:
         """Check for any permission rows. See base class for contract."""
-        with self._session() as session:
+        with self._session("select_user_grant_presence") as session:
             return session.execute(
                 select(
                     exists().where(

--- a/omnigent/stores/policy_store/sqlalchemy_store.py
+++ b/omnigent/stores/policy_store/sqlalchemy_store.py
@@ -22,7 +22,7 @@ from omnigent.db.enum_codecs import (
 )
 from omnigent.db.utils import (
     get_or_create_engine,
-    make_managed_session_maker,
+    make_named_managed_session_maker,
     now_epoch,
 )
 from omnigent.entities import Policy
@@ -72,7 +72,10 @@ class SqlAlchemyPolicyStore(PolicyStore):
         """
         super().__init__(storage_location)
         self._engine = get_or_create_engine(storage_location)
-        self._session = make_managed_session_maker(self._engine)
+        self._session = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.policy_store",
+        )
 
     # ── Session-scoped policy methods ────────────────────────────
 
@@ -106,7 +109,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
             factory_params=json.dumps(factory_params) if factory_params else None,
             enabled=enabled,
         )
-        with self._session() as session:
+        with self._session("insert_policy") as session:
             existing = (
                 session.execute(
                     select(SqlPolicy)
@@ -129,7 +132,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
 
     def get(self, policy_id: str, session_id: str) -> Policy | None:
         """Return the policy if it belongs to the given session."""
-        with self._session() as session:
+        with self._session("select_policy_by_id") as session:
             row = session.get(SqlPolicy, (current_workspace_id(), policy_id))
             if row is None or row.session_id != normalize_uuid(session_id):
                 return None
@@ -145,7 +148,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
         session_id in that key). Without it the planner falls back to a
         full workspace scan.
         """
-        with self._session() as session:
+        with self._session("list_session_policies") as session:
             stmt = (
                 select(SqlPolicy)
                 .where(SqlPolicy.workspace_id == current_workspace_id())
@@ -169,7 +172,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
         Update mutable fields. Returns ``None`` if not found or
         wrong session.
         """
-        with self._session() as session:
+        with self._session("update_policy") as session:
             row = session.get(SqlPolicy, (current_workspace_id(), policy_id))
             if row is None or row.session_id != normalize_uuid(session_id):
                 return None
@@ -212,7 +215,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
 
     def delete(self, policy_id: str, session_id: str) -> bool:
         """Delete a policy. Idempotent: returns ``False`` if not found."""
-        with self._session() as session:
+        with self._session("delete_policy") as session:
             row = session.get(SqlPolicy, (current_workspace_id(), policy_id))
             if row is None or row.session_id != normalize_uuid(session_id):
                 return False
@@ -252,7 +255,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
             enabled=enabled,
             created_by=created_by,
         )
-        with self._session() as session:
+        with self._session("insert_default_policy") as session:
             # Default-name uniqueness is enforced here (no DB constraint):
             # scan for an existing default with the same name digest.
             existing = (
@@ -277,7 +280,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
 
     def get_default(self, policy_id: str) -> Policy | None:
         """Return a default policy by ID (``scope = 'default'``)."""
-        with self._session() as session:
+        with self._session("select_default_policy_by_id") as session:
             row = session.get(SqlPolicy, (current_workspace_id(), policy_id))
             if row is None or row.scope != encode_policy_scope("default"):
                 return None
@@ -285,7 +288,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
 
     def list_defaults(self) -> list[Policy]:
         """List all default policies ordered by ``created_at ASC``."""
-        with self._session() as session:
+        with self._session("list_default_policies") as session:
             stmt = (
                 select(SqlPolicy)
                 .where(SqlPolicy.workspace_id == current_workspace_id())
@@ -307,7 +310,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
         Update mutable fields of a default policy. Returns ``None``
         if not found or not a default policy.
         """
-        with self._session() as session:
+        with self._session("update_default_policy") as session:
             row = session.get(SqlPolicy, (current_workspace_id(), policy_id))
             if row is None or row.scope != encode_policy_scope("default"):
                 return None
@@ -350,7 +353,7 @@ class SqlAlchemyPolicyStore(PolicyStore):
 
     def delete_default(self, policy_id: str) -> bool:
         """Delete a default policy. Idempotent."""
-        with self._session() as session:
+        with self._session("delete_default_policy") as session:
             row = session.get(SqlPolicy, (current_workspace_id(), policy_id))
             if row is None or row.scope != encode_policy_scope("default"):
                 return False

--- a/omnigent/stores/project_store/sqlalchemy_store.py
+++ b/omnigent/stores/project_store/sqlalchemy_store.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 from omnigent.db.db_models import SqlProject, current_workspace_id
 from omnigent.db.utils import (
     get_or_create_engine,
-    make_managed_session_maker,
+    make_named_managed_session_maker,
     now_epoch,
 )
 from omnigent.entities import Project
@@ -118,7 +118,10 @@ class SqlAlchemyProjectStore(ProjectStore):
         """
         super().__init__(storage_location)
         self._engine = get_or_create_engine(storage_location)
-        self._session = make_managed_session_maker(self._engine)
+        self._session = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.project_store",
+        )
 
     def _name_taken(
         self,
@@ -166,7 +169,7 @@ class SqlAlchemyProjectStore(ProjectStore):
         and maps to the same ``ALREADY_EXISTS``; any other integrity failure is
         re-raised untranslated.
         """
-        with self._session() as session:
+        with self._session("insert_project") as session:
             if self._name_taken(session, owner_user_id=owner_user_id, name=name, exclude_id=None):
                 raise OmnigentError(
                     f"A project named {name!r} already exists",
@@ -194,7 +197,7 @@ class SqlAlchemyProjectStore(ProjectStore):
 
     def get(self, project_id: str, *, owner_user_id: str | None) -> Project | None:
         """Return an owned project by id, or ``None`` if not found."""
-        with self._session() as session:
+        with self._session("select_project_by_id") as session:
             row = session.get(SqlProject, (current_workspace_id(), project_id))
             if row is None or row.owner_user_id != owner_user_id:
                 return None
@@ -202,7 +205,7 @@ class SqlAlchemyProjectStore(ProjectStore):
 
     def list(self, *, owner_user_id: str | None) -> list[Project]:
         """List the owner's projects ordered by ``created_at ASC, id ASC``."""
-        with self._session() as session:
+        with self._session("list_projects") as session:
             stmt = (
                 select(SqlProject)
                 .where(SqlProject.workspace_id == current_workspace_id())
@@ -226,7 +229,7 @@ class SqlAlchemyProjectStore(ProjectStore):
         not exist or is not owned by ``owner_user_id``. A ``config`` of ``{}``
         clears the stored defaults (distinct from ``None`` = leave unchanged).
         """
-        with self._session() as session:
+        with self._session("update_project") as session:
             row = session.get(SqlProject, (current_workspace_id(), project_id))
             if row is None or row.owner_user_id != owner_user_id:
                 return None
@@ -263,7 +266,7 @@ class SqlAlchemyProjectStore(ProjectStore):
 
     def delete(self, project_id: str, *, owner_user_id: str | None) -> bool:
         """Delete an owned project. Idempotent; returns ``False`` if not found."""
-        with self._session() as session:
+        with self._session("delete_project") as session:
             row = session.get(SqlProject, (current_workspace_id(), project_id))
             if row is None or row.owner_user_id != owner_user_id:
                 return False

--- a/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
+++ b/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
@@ -23,7 +23,7 @@ from omnigent.db.enum_codecs import (
 )
 from omnigent.db.utils import (
     get_or_create_engine,
-    make_managed_session_maker,
+    make_named_managed_session_maker,
     now_epoch,
 )
 from omnigent.entities import ScheduledTask, ScheduledTaskRun
@@ -108,7 +108,10 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         """
         super().__init__(storage_location)
         self._engine = get_or_create_engine(storage_location)
-        self._session = make_managed_session_maker(self._engine)
+        self._session = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.scheduled_task_store",
+        )
 
     # ── Scheduled tasks ──────────────────────────────────────────
 
@@ -149,14 +152,14 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
             created_at=now_epoch(),
             updated_at=None,
         )
-        with self._session() as session:
+        with self._session("insert_task") as session:
             session.add(row)
             session.flush()
             return _to_entity(row)
 
     def get(self, scheduled_task_id: str) -> ScheduledTask | None:
         """Return a scheduled task by id, or ``None`` if not found."""
-        with self._session() as session:
+        with self._session("select_task_by_id") as session:
             row = session.get(SqlScheduledTask, (current_workspace_id(), scheduled_task_id))
             if row is None:
                 return None
@@ -167,7 +170,7 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
 
         When *owner_user_id* is given, only tasks owned by that user are returned.
         """
-        with self._session() as session:
+        with self._session("list_tasks") as session:
             stmt = (
                 select(SqlScheduledTask)
                 .where(SqlScheduledTask.workspace_id == current_workspace_id())
@@ -180,7 +183,7 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
 
     def list_active(self) -> builtins.list[ScheduledTask]:
         """List active scheduled tasks ordered by ``created_at ASC, id ASC``."""
-        with self._session() as session:
+        with self._session("list_active_tasks") as session:
             stmt = (
                 select(SqlScheduledTask)
                 .where(SqlScheduledTask.workspace_id == current_workspace_id())
@@ -201,7 +204,7 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         active_code = encode_scheduled_task_state("active")
         tasks: list[ScheduledTask] = []
         cursor: tuple[int, int, str] | None = None
-        with self._session() as session:
+        with self._session("list_active_tasks_for_all_workspaces") as session:
             while True:
                 stmt = (
                     select(SqlScheduledTask)
@@ -257,7 +260,7 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         Passing ``rrule`` updates the recurring trigger; ``None``
         leaves it unchanged.
         """
-        with self._session() as session:
+        with self._session("update_task") as session:
             row = session.get(SqlScheduledTask, (current_workspace_id(), scheduled_task_id))
             if row is None:
                 return None
@@ -307,7 +310,7 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
     def delete(self, scheduled_task_id: str) -> bool:
         """Delete a scheduled task and all of its runs. Idempotent: returns ``False`` if not
         found."""
-        with self._session() as session:
+        with self._session("delete_task") as session:
             row = session.get(SqlScheduledTask, (current_workspace_id(), scheduled_task_id))
             if row is None:
                 return False
@@ -347,7 +350,7 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
             error=error,
             error_code=error_code,
         )
-        with self._session() as session:
+        with self._session("insert_task_run") as session:
             session.add(row)
             session.flush()
             return _run_to_entity(row)
@@ -373,7 +376,7 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         :param after_id: Return runs ordered after this run id (exclusive).
         :returns: ``(runs, next_cursor)``.
         """
-        with self._session() as session:
+        with self._session("list_task_runs") as session:
             stmt = (
                 select(SqlScheduledTaskRun)
                 .where(SqlScheduledTaskRun.workspace_id == current_workspace_id())
@@ -421,7 +424,7 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         double-transition (see the interface docstring).
         """
         running_code = encode_scheduled_task_run_status("running")
-        with self._session() as session:
+        with self._session("update_task_run") as session:
             row = session.get(SqlScheduledTaskRun, (current_workspace_id(), run_id))
             if row is None or row.status != running_code:
                 return None
@@ -440,7 +443,7 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         at most one ``running`` run, so ``.first()`` is exact rather than lossy.
         """
         running_code = encode_scheduled_task_run_status("running")
-        with self._session() as session:
+        with self._session("select_running_run_by_conversation") as session:
             stmt = (
                 select(SqlScheduledTaskRun)
                 .where(SqlScheduledTaskRun.workspace_id == current_workspace_id())
@@ -469,7 +472,7 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         if not scheduled_task_ids:
             return []
         running_code = encode_scheduled_task_run_status("running")
-        with self._session() as session:
+        with self._session("list_running_runs_for_tasks") as session:
             stmt = (
                 select(SqlScheduledTaskRun)
                 .where(SqlScheduledTaskRun.workspace_id == current_workspace_id())
@@ -495,7 +498,7 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         """
         if not scheduled_task_ids:
             return {}
-        with self._session() as session:
+        with self._session("list_latest_run_status_for_tasks") as session:
             ranked = (
                 select(
                     SqlScheduledTaskRun.scheduled_task_id.label("task_id"),

--- a/tests/db/test_utils_extended.py
+++ b/tests/db/test_utils_extended.py
@@ -19,9 +19,10 @@ from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import event, text
 
 from omnigent.db.db_models import SqlUser
+from omnigent.db.query_context import current_query_name, query_name_scope
 from omnigent.db.utils import (
     _ITEM_TYPES,
     clear_engine_cache,
@@ -34,6 +35,7 @@ from omnigent.db.utils import (
     get_or_create_engine,
     insert_fts,
     make_managed_session_maker,
+    make_named_managed_session_maker,
     normalize_database_url,
     now_epoch,
     now_epoch_us,
@@ -151,6 +153,64 @@ class TestManagedSessionMaker:
         with managed() as session:
             loaded = session.get(SqlUser, (0, "immediate_test"))
             assert loaded is not None
+
+    def test_named_session_covers_implicit_flush_and_commit(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_named_managed_session_maker(
+            engine,
+            query_name_prefix="omnigent.test_store",
+        )
+        observed_names: list[str | None] = []
+
+        def capture_name(
+            _connection: object,
+            _cursor: object,
+            statement: str,
+            _parameters: object,
+            _context: object,
+            _executemany: bool,
+        ) -> None:
+            if statement.lstrip().upper().startswith("INSERT"):
+                observed_names.append(current_query_name())
+
+        event.listen(engine, "before_cursor_execute", capture_name)
+        try:
+            with managed("insert_user") as session:
+                session.add(SqlUser(id="named_session_test", is_admin=False))
+        finally:
+            event.remove(engine, "before_cursor_execute", capture_name)
+
+        assert observed_names == ["omnigent.test_store.insert_user"]
+        assert current_query_name() is None
+
+    def test_nested_query_name_overrides_and_restores_session_name(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        managed = make_named_managed_session_maker(
+            engine,
+            query_name_prefix="omnigent.test_store",
+        )
+
+        with managed("outer_operation") as session:
+            assert current_query_name() == "omnigent.test_store.outer_operation"
+            with query_name_scope("omnigent.test_store.inner_query"):
+                session.execute(text("SELECT 1"))
+                assert current_query_name() == "omnigent.test_store.inner_query"
+            assert current_query_name() == "omnigent.test_store.outer_operation"
+
+        assert current_query_name() is None
+
+    def test_named_session_rejects_empty_names(self, db_uri: str) -> None:
+        engine = get_or_create_engine(db_uri)
+        with pytest.raises(ValueError, match="query_name_prefix must not be empty"):
+            make_named_managed_session_maker(engine, query_name_prefix=" ")
+
+        managed = make_named_managed_session_maker(
+            engine,
+            query_name_prefix="omnigent.test_store",
+        )
+        with pytest.raises(ValueError, match="query_name must not be empty"):
+            with managed(" "):
+                raise AssertionError("empty query name entered its session")
 
 
 # ── ID generators ─────────────────────────────────────

--- a/tests/stores/test_conversation_labels.py
+++ b/tests/stores/test_conversation_labels.py
@@ -220,7 +220,7 @@ def test_labels_survive_item_compaction_proxy(
     # not reach past the public API.
     from sqlalchemy import delete
 
-    with conversation_store._session() as session:
+    with conversation_store._session("test_setup") as session:
         session.execute(
             delete(SqlConversationItem).where(
                 SqlConversationItem.conversation_id == conv.id,
@@ -261,7 +261,7 @@ async def test_delete_conversation_cascades_to_labels(
 
     from omnigent.db.db_models import SqlConversationLabel
 
-    with conversation_store._session() as session:
+    with conversation_store._session("test_setup") as session:
         count = session.execute(
             select(func.count())
             .select_from(SqlConversationLabel)
@@ -377,7 +377,7 @@ def test_set_labels_honors_caller_timestamp(
     conv = conversation_store.create_conversation()
     caller_stamp = 1_700_000_042  # arbitrary historical epoch
     conversation_store.set_labels(conv.id, {"integrity": "1"}, updated_at=caller_stamp)
-    with conversation_store._session() as session:
+    with conversation_store._session("test_setup") as session:
         row = session.execute(
             select(SqlConversationLabel.updated_at).where(
                 SqlConversationLabel.conversation_id == conv.id,
@@ -424,7 +424,7 @@ def test_upsert_refreshes_timestamp_on_overwrite(
         {"x": "2"},
         updated_at=second_stamp,
     )
-    with conversation_store._session() as session:
+    with conversation_store._session("test_setup") as session:
         stamp = session.execute(
             select(SqlConversationLabel.updated_at).where(
                 SqlConversationLabel.conversation_id == conv.id,

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -751,9 +751,9 @@ def test_position_not_enforced_by_db(
 
     # Neither a same-second nor a later-second duplicate is rejected now: the
     # index is not UNIQUE, and distinct ids keep the PK unique so both persist.
-    with conversation_store._session() as session:
+    with conversation_store._session("test_setup") as session:
         session.add(_duplicate_position_row(existing_created_at))
-    with conversation_store._session() as session:
+    with conversation_store._session("test_setup") as session:
         session.add(_duplicate_position_row(existing_created_at + 1))
 
 
@@ -4533,7 +4533,7 @@ def _stored_next_position(
     """Read the raw ``conversations.next_position`` counter for assertions."""
     from omnigent.db.db_models import SqlConversation
 
-    with conversation_store._session() as session:
+    with conversation_store._session("test_setup") as session:
         row = session.get(SqlConversation, (0, conversation_id))
         assert row is not None
         return row.next_position
@@ -4548,7 +4548,7 @@ def _stored_positions(
 
     from omnigent.db.db_models import SqlConversationItem
 
-    with conversation_store._session() as session:
+    with conversation_store._session("test_setup") as session:
         return sorted(
             session.execute(
                 select(SqlConversationItem.position).where(
@@ -4603,7 +4603,7 @@ def test_append_reads_counter_not_max_scan(
     conv = conversation_store.create_conversation()
     conversation_store.append(conv.id, [_user_message("a"), _user_message("b")])
     # Real max position is 1; jump the counter ahead to 100.
-    with conversation_store._session() as session:
+    with conversation_store._session("test_setup") as session:
         session.get(SqlConversation, (0, conv.id)).next_position = 100
 
     conversation_store.append(conv.id, [_user_message("c")])
@@ -4629,7 +4629,7 @@ def test_append_falls_back_to_scan_when_counter_null(
     if preexisting:
         conversation_store.append(conv.id, [_user_message(f"pre{i}") for i in range(preexisting)])
     # Simulate a pre-counter row: clear the maintained counter.
-    with conversation_store._session() as session:
+    with conversation_store._session("test_setup") as session:
         session.get(SqlConversation, (0, conv.id)).next_position = None
     assert _stored_next_position(conversation_store, conv.id) is None
 
@@ -5179,7 +5179,7 @@ def _stored_item_data(store: SqlAlchemyConversationStore, conversation_id: str) 
 
     from omnigent.db.db_models import SqlConversationItem
 
-    with store._conv_session() as session:
+    with store._conv_session("test_setup") as session:
         return list(
             session.execute(
                 select(SqlConversationItem.data)
@@ -5294,7 +5294,7 @@ def test_item_search_text_seam_redirects_persisted_value(db_uri: str) -> None:
         ],
     )
 
-    with store._conv_session() as session:
+    with store._conv_session("test_setup") as session:
         stored = list(
             session.execute(
                 select(SqlConversationItem.search_text).where(

--- a/tests/stores/test_query_context.py
+++ b/tests/stores/test_query_context.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import ast
 from collections.abc import Iterator
 from contextlib import contextmanager
+from pathlib import Path
 
 import pytest
 from sqlalchemy import Engine, event
@@ -13,6 +15,14 @@ from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
 from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+
+_REPOSITORY_ROOT = Path(__file__).parents[2]
+_APPLICATION_STORE_PATHS = [
+    *_REPOSITORY_ROOT.glob("omnigent/stores/*/sqlalchemy_store.py"),
+    _REPOSITORY_ROOT / "omnigent/stores/host_store.py",
+    _REPOSITORY_ROOT / "omnigent/server/accounts_store.py",
+    _REPOSITORY_ROOT / "omnigent/server/device_grant_store.py",
+]
 
 
 @contextmanager
@@ -62,6 +72,44 @@ def test_query_name_scope_rejects_empty_names() -> None:
     with pytest.raises(ValueError, match="query_name must not be empty"):
         with query_name_scope("  "):
             raise AssertionError("empty query name entered its scope")
+
+
+def test_application_store_sessions_require_literal_query_names() -> None:
+    """New store transactions cannot silently bypass semantic query naming."""
+    unnamed_calls: list[str] = []
+    legacy_makers: list[str] = []
+
+    for path in _APPLICATION_STORE_PATHS:
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if isinstance(node.func, ast.Name) and node.func.id == "make_managed_session_maker":
+                legacy_makers.append(f"{path.relative_to(_REPOSITORY_ROOT)}:{node.lineno}")
+            if (
+                isinstance(node.func, ast.Name)
+                and node.func.id.endswith("session_maker")
+                and not node.args
+            ):
+                unnamed_calls.append(f"{path.relative_to(_REPOSITORY_ROOT)}:{node.lineno}")
+            if not (
+                isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "self"
+                and node.func.attr
+                in {"_session", "_session_immediate", "_conv_session", "_conv_session_immediate"}
+            ):
+                continue
+            if not (
+                len(node.args) == 1
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+                and node.args[0].value.strip()
+            ):
+                unnamed_calls.append(f"{path.relative_to(_REPOSITORY_ROOT)}:{node.lineno}")
+
+    assert legacy_makers == []
+    assert unnamed_calls == []
 
 
 def test_file_store_names_each_application_query(db_uri: str) -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add a query-named managed-session boundary that keeps a semantic operation name active through SQLAlchemy execution, implicit flush, and commit.
- Apply stable names across application stores, account/device-grant persistence, identity migration, and schema/FTS setup. Nested scopes can still give important subqueries a more specific name.
- Document the convention in `AGENTS.md` and add a source guard so new store session call sites cannot omit a literal name.

ELI5: each store operation labels its database work when it opens a transaction, so deferred writes and explicit reads both carry a useful query name.

```text
store operation -> named session -> SQL execute / implicit flush -> commit
                         |
                         +-> optional nested name for a specific subquery
```

## Test Plan

- `uv run --no-sync pytest -q tests/db/test_utils_extended.py tests/stores/test_query_context.py` (36 passed)
- Ran the affected persistence test sweep: the initial run passed 622 tests and found one missed aliased session call in 3 cases; after fixing it, those cases and the source guard passed (8 passed)
- `uv run --no-sync ruff format --check ...`
- `uv run --no-sync ruff check ...`
- `uv run --no-sync pyrefly check` (0 errors)
- `git diff --check`

The repository-wide pre-commit launcher could not install its declared hook environment because `pypi.org` DNS resolution was unavailable; the equivalent project checks above passed.

## Demo

N/A — backend observability change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage verifies implicit flush and commit naming, nested scope restoration, invalid-name handling, and complete named-session coverage across application store modules.

## Changelog

Database operations now expose stable semantic query names for tracing and logging.