### PR TITLE
fix(claude-native): apply web plan verdicts to the TUI plan dialog

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -2744,6 +2744,52 @@ def inject_interrupt(
     _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Escape")
 
 
+# Option-1 label in Claude Code's plan-review dialog: proof that dialog is
+# what's on screen before a verdict is keyed into it.
+_PLAN_DIALOG_MARKER = "Yes, and use auto mode"
+
+_PLAN_VERDICT_KEYS = {"auto": "1", "manual": "2", "reject": "Escape"}
+
+
+def inject_plan_verdict(
+    bridge_dir: Path,
+    *,
+    verdict: str,
+    timeout_s: float = _TMUX_READY_TIMEOUT_S,
+) -> bool:
+    """
+    Answer Claude Code's plan-review dialog by keystroke.
+
+    Claude Code ignores a ``PermissionRequest`` hook's ``allow`` for
+    ``ExitPlanMode`` — that dialog is answerable only from the TUI — so a
+    web-UI plan verdict has to be keyed in the way a local user would.
+    Every other gated tool honors the hook decision instead.
+
+    The pane check is the only guard available (the verdict carries no tool
+    identity), and it doubles as the "already answered in the terminal" case.
+
+    :param bridge_dir: Bridge directory path, e.g.
+        ``/tmp/omnigent/claude-native/<digest>``.
+    :param verdict: ``"auto"`` (approve + auto mode), ``"manual"``
+        (approve, keep approving edits), or ``"reject"``.
+    :param timeout_s: Seconds to wait for ``tmux.json``, e.g. ``1.0``.
+    :returns: ``True`` when the keystroke was sent, ``False`` when the
+        plan dialog was not showing.
+    :raises ValueError: If *verdict* is not a known option.
+    :raises RuntimeError: If the tmux target is not advertised in time,
+        or if the ``tmux send-keys`` invocation fails.
+    """
+    key = _PLAN_VERDICT_KEYS.get(verdict)
+    if key is None:
+        raise ValueError(f"unknown plan verdict {verdict!r}")
+    info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
+    if _PLAN_DIALOG_MARKER not in _capture_pane(info["socket_path"], info["tmux_target"]):
+        return False
+    # No ``-l``: tmux must read ``Escape`` as a key name, not literal text.
+    _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], key)
+    return True
+
+
 def kill_session(
     bridge_dir: Path,
     *,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -4037,6 +4037,54 @@ def create_runner_app(
             )
         return Response(status_code=204)
 
+    async def _apply_claude_native_plan_verdict(
+        conv_id: str,
+        data: Mapping[str, object],
+    ) -> None:
+        """
+        Key a web-UI plan verdict into Claude Code's plan-review dialog.
+
+        Claude Code ignores a ``PermissionRequest`` hook's ``allow`` for
+        ``ExitPlanMode``, so a plan approved in the web UI never reaches the
+        pane and the session stays parked on the TUI dialog. Best-effort:
+        :func:`inject_plan_verdict` no-ops unless that dialog is on screen,
+        so a non-plan verdict (or one already answered in the terminal)
+        presses nothing.
+
+        :param conv_id: Session/conversation identifier, e.g.
+            ``"conv_abc123"``.
+        :param data: The approval payload, e.g.
+            ``{"elicitation_id": "elicit_claude_ab12", "action": "accept",
+            "content": {"allow_all_edits": True}}``.
+        :returns: None.
+        """
+        from omnigent.claude_native_bridge import (
+            bridge_dir_for_bridge_id,
+            inject_plan_verdict,
+        )
+
+        content = data.get("content")
+        if data.get("action") != "accept":
+            verdict = "reject"
+        elif isinstance(content, dict) and content.get("allow_all_edits") is True:
+            verdict = "auto"
+        else:
+            verdict = "manual"
+        try:
+            bridge_id = await _claude_native_bridge_id_for_session(
+                server_client=server_client,
+                session_id=conv_id,
+            )
+            # Short timeout: a missing tmux.json means no pane to answer.
+            await asyncio.to_thread(
+                inject_plan_verdict,
+                bridge_dir_for_bridge_id(bridge_id),
+                verdict=verdict,
+                timeout_s=1.0,
+            )
+        except Exception:  # noqa: BLE001 — best-effort; TUI can still answer
+            _logger.debug("claude-native plan verdict not applied", exc_info=True)
+
     async def _handle_cursor_native_model_change(
         conv_id: str,
         model: str | None,
@@ -6272,6 +6320,8 @@ def create_runner_app(
             _data = body.get("data") or body
             _elicit_action = _data.get("action", "")
             pending_approvals.resolve(_data.get("elicitation_id", ""), _elicit_action == "accept")
+            if _session_harness_name(conversation_id) == "claude-native":
+                await _apply_claude_native_plan_verdict(conversation_id, _data)
             if _elicit_action == "decline":
                 try:
                     _int_client = await process_manager.get_client(conversation_id, "any")


### PR DESCRIPTION
## Related issue

Closes #4064

## Summary

Approving a plan from the web UI did nothing for claude-native sessions. The card showed as approved but the plan never ran; answering in the terminal view was the only way through.

Claude Code ignores a `PermissionRequest` hook's `allow` for `ExitPlanMode`. That dialog only accepts a TUI answer, so the `setMode` decision the server builds in `routes_hooks.py` never took effect. Side effect: Claude's `auto` mode was unreachable from the web UI, since the plan card is the only surface that offers it.

This keys the verdict into the pane instead, the way a local user would: `1` for accept-with-auto-mode, `2` for accept, `Escape` for reject. It rides the approval event the server already forwards to the runner, so there is no new event type, no server plumbing, and no schema change.

ELI5: the web UI was mailing its answer to an address Claude doesn't read. Now it presses the button on the screen instead.

```
web click -> resolve endpoint -> approval event -> runner
                                                    |
                                    pane shows plan dialog?
                                       /                \
                                     yes                 no
                                      |                   |
                            send key 1 / 2 / Esc        no-op
```

The pane check is the only guard available, since the verdict carries no tool identity. It doubles as the "already answered in the terminal" case.

## Test Plan

Ran against a live local server with a real claude-native session.

1. Session with `--permission-mode plan`, asked for a one-line plan, waited 20s, then approved from the web UI with `allow_all_edits`. Plan ran, file written, pane status line flipped to `auto mode on`. Fails on `main`: dialog stays open, mode stays `plan`, no file.
2. Guard: resolved a non-plan elicitation id and confirmed the pane was byte-identical afterwards (no stray keystroke).
3. Regression: edit approval in `default` mode still works through the hook decision. One approval with `allow_all_edits` created both files, so the `acceptEdits` switch is intact.
4. Helper logic: `auto` maps to `1`, `manual` to `2`, `reject` to `Escape`; no-dialog returns `False` and sends nothing; unknown verdict raises `ValueError`.

## Demo

Before (broken on `main`) and after (this branch):

Before - https://drive.google.com/file/d/1jJeuE0GCYbJJ1Zr8rIBjsU0I7CLvcvcT/view?usp=sharing
After - https://drive.google.com/file/d/1V1_P9w4WfMzOw3VHRrpgbpY8hQuWiw9A/view?usp=sharing

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified manually end to end against a live server and a real `claude` TUI, covering the fix, the no-op guard, and the edit-approval regression (steps above).

No automated test yet: the behaviour needs a real `claude` binary driving a tmux pane, which the existing suites don't stand up for claude-native approvals. Happy to add an `e2e_ui` test if a reviewer wants one, or a unit test around `inject_plan_verdict` with the tmux calls mocked (the mapping and guard assertions from step 4 port directly).

One known coupling: the fix depends on the plan dialog's option order (`1` = auto, `2` = manual). If a future Claude Code release reorders them, the marker check makes it a no-op rather than a wrong keypress, but it would silently stop working.

## Changelog

Approving a plan from the web UI now works for Claude Code sessions, including "Yes, and use auto mode"
