### PR TITLE
docs(release): scrub the private secure-release repo name from the public repo

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,9 +1,9 @@
 # Create a GitHub Release entry (the `…/releases` page) when a version tag is
 # pushed. This is METADATA ONLY — it does NOT build or publish any installable
-# artifact. PyPI publishing lives in the central secure-release repo
-# (databricks/secure-public-registry-releases-eng → `omnigent` workflow), on
-# hardened runners with OIDC Trusted Publishing and a mandatory dependency
-# scan. Keeping those concerns separate is deliberate (see the maintainer release runbook):
+# artifact. PyPI publishing lives in a Databricks-internal secure-release repo
+# (its `omnigent` workflow), on hardened runners with OIDC Trusted Publishing
+# and a mandatory dependency scan. Keeping those concerns separate is
+# deliberate (see the maintainer release runbook):
 #
 #   * This job runs NO project or third-party code — no build, no `pip
 #     install`/`npm ci`, no tests. Its only action is SHA-pinned

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -645,11 +645,14 @@ jobs:
           {
             echo "## Next steps"
             echo ""
-            echo "1. Dispatch the secure-release repo on this tag:"
+            # Run summaries are world-readable on a public repo, so the
+            # secure-release repo is a placeholder here; the runbook names it.
+            echo "1. Dispatch the secure-release repo on this tag. Substitute the repo"
+            echo "   name from the maintainer release runbook, then run:"
             echo '   ```'
-            echo "   gh workflow run omnigent.yml --repo databricks/secure-public-registry-releases-eng \\"
+            echo "   gh workflow run omnigent.yml --repo <secure-release-repo> \\"
             echo "     -f ref=${TAG} -f destination=pypi -f dry-run=true    # gates rehearsal"
-            echo "   gh workflow run omnigent.yml --repo databricks/secure-public-registry-releases-eng \\"
+            echo "   gh workflow run omnigent.yml --repo <secure-release-repo> \\"
             echo "     -f ref=${TAG} -f destination=pypi -f dry-run=false   # real publish"
             echo '   ```'
             if [ "$PRERELEASE" = "true" ]; then

--- a/.github/workflows/vscode-extension-release.yml
+++ b/.github/workflows/vscode-extension-release.yml
@@ -9,8 +9,8 @@
 # match the input), so the tag and the packaged version can't diverge.
 #
 # This produces the ARTIFACT ONLY — it does NOT publish to the VS Code
-# Marketplace or Open VSX. That runs from the central secure-release repo
-# (databricks/secure-public-registry-releases-eng), on hardened runners, where
+# Marketplace or Open VSX. That runs from a Databricks-internal secure-release
+# repo, on hardened runners, where
 # a workflow downloads this `.vsix`, verifies its `.sha256`, scans it, and
 # publishes. Keeping the two halves separate is deliberate: this job only
 # builds and uploads; the secured half holds the marketplace tokens and scan

--- a/designs/RELEASE-AUTOMATION.md
+++ b/designs/RELEASE-AUTOMATION.md
@@ -27,7 +27,7 @@ suggests. Per release step:
 | Bump main to next `.dev0` | human CLI (or `bump-version.yml` post-release) | 🟡 semi |
 | Draft GH release (prerelease flag for rc, rerun-safe) | `github-release.yml` on tag push | ✅ |
 | CHANGELOG PR + LLM-curated draft notes | `draft-release-notes.yml` via `workflow_run` (final tags only) | ✅ |
-| Secure-repo gates + PyPI publish | manual `gh workflow run omnigent.yml` ×2–3 (dry-run, [test-pypi], pypi) in `databricks/secure-public-registry-releases-eng` | ❌ manual dispatches |
+| Secure-repo gates + PyPI publish | manual `gh workflow run omnigent.yml` ×2–3 (dry-run, [test-pypi], pypi) in the internal secure-release repo | ❌ manual dispatches |
 | Post-publish validation (clean venv install + `--version`) | human CLI recipe | ❌ manual |
 | Publish GH release as Latest | human UI click | ❌ manual (and API publish does **not** set `make_latest` unless told to) |
 | Site release post + `X.Y-docs → main` PR | `publish-changelog.yml` on `release: published` | ✅ |

--- a/editors/vscode/PUBLISHING.md
+++ b/editors/vscode/PUBLISHING.md
@@ -10,18 +10,14 @@ The work splits into two halves:
 
 - **This repo** builds a SHA256-verified `.vsix` and attaches it to a GitHub
 release. No marketplace tokens live here.
-- **The secure-release repo**
-([`databricks/secure-public-registry-releases-eng`](https://github.com/databricks/secure-public-registry-releases-eng))
-downloads that `.vsix`, verifies the checksum, scans it (`databricks/gh-action-scan`),
-and publishes to the VS Code Marketplace and Open VSX. It holds the tokens and
-the approval gate.
+- **A Databricks-internal secure-release repo** downloads that `.vsix`, verifies
+the checksum, scans it, and publishes to the VS Code Marketplace and Open VSX.
+It holds the tokens and the approval gate.
 
-Two existing workflows in the secure repo are the reference:
-[`databricks-vscode.yml`](https://github.com/databricks/secure-public-registry-releases-eng/blob/main/.github/workflows/databricks-vscode.yml)
-(the extension publish flow to adapt) and
-[`omnigent.yml`](https://github.com/databricks/secure-public-registry-releases-eng/blob/main/.github/workflows/omnigent.yml)
-(omnigent's PyPI release, which already checks out `omnigent-ai/omnigent`
-cross-org). Both require SAML SSO to view.
+Two existing workflows in the secure repo are the reference: the Databricks VS
+Code extension publish flow (the one to adapt) and omnigent's PyPI release
+(which already checks out `omnigent-ai/omnigent` cross-org). Maintainers: the
+repo name and workflow paths are in the maintainer release runbook.
 
 ## Steps to release
 
@@ -83,7 +79,7 @@ The one-time setup that makes this possible is tracked below.
 | 3   | Verify the build: `pnpm install --frozen-lockfile && pnpm run build && pnpm run package` → valid `.vsix`                                                                                                                                                                                                                                                                 | local / CI                                                                                                                                                                  | — (done)            |
 | 4   | Release-PR workflow bumps version + CHANGELOG; a manually-dispatched release workflow builds the `.vsix` and attaches it (+`.sha256`) to a draft GitHub release                                                                                                                                                                                | `.github/workflows/vscode-release-pr.yml`, `vscode-extension-release.yml`                                                                                                   | — (done)            |
 | 5   | Ask DECO to register `omnigent-vscode` under the `databricks` publisher + add dedicated `OMNI_VSCE_TOKEN` / `OMNI_OVSX_PAT` secrets (and an `omnigent-vscode-marketplace` environment for the reviewer gate)                                                                                                                                    | Slack `#dev-ecosystem-discuss` ([https://databricks.slack.com/archives/C01KSAWFXG8/p1782971196701749](https://databricks.slack.com/archives/C01KSAWFXG8/p1782971196701749)) | human approval      |
-| 6   | Add an `omnigent-vscode.yml` publish workflow in the secure repo, adapting the existing [`databricks-vscode.yml`](https://github.com/databricks/secure-public-registry-releases-eng/blob/main/.github/workflows/databricks-vscode.yml) (SAML SSO required) — it already does download → scan → `vsce publish` + `ovsx publish` in one workflow | `secure-public-registry-releases-eng`                                                                                                                                       | DECO grant (step 5) |
+| 6   | Add an `omnigent-vscode.yml` publish workflow in the secure repo, adapting the existing Databricks VS Code extension workflow — it already does download → scan → `vsce publish` + `ovsx publish` in one workflow | the internal secure-release repo                                                                                                                                            | DECO grant (step 5) |
 | 7   | Populate the dedicated `OMNI_VSCE_TOKEN` + `OMNI_OVSX_PAT` secrets; register rows in `go/npp-release-status`; get sign-off in `#unblock-releases-public`                                                                                                                                                                                       | secure repo + Slack                                                                                                                                                         | steps 5–6           |
 
 


### PR DESCRIPTION
## Related issue

N/A — follow-up to a team thread on distributing release knowledge (Corey / Rice / me).

## Summary

The private Databricks secure-release repo was named in **9 places**: three
workflow header comments, the `release.yml` run summary, a design-doc table row,
and four direct links into the private repo's file tree from
`editors/vscode/PUBLISHING.md`. None of it resolves for anyone outside
Databricks.

**`release.yml`** printed the name into its run summary on *every* release.
Public run summaries are world-readable, so a repo variable would leak it just
the same. The summary now prints the full command with `<secure-release-repo>` as
the only placeholder, so a release manager still gets something to paste and fill
in:

```
1. Dispatch the secure-release repo on this tag. Substitute the repo
   name from the maintainer release runbook, then run:
   ```
   gh workflow run omnigent.yml --repo <secure-release-repo> \
     -f ref=v0.6.0rc1 -f destination=pypi -f dry-run=true    # gates rehearsal
   gh workflow run omnigent.yml --repo <secure-release-repo> \
     -f ref=v0.6.0rc1 -f destination=pypi -f dry-run=false   # real publish
   ```
```

The rest is a straight substitution to "a Databricks-internal secure-release
repo". `PUBLISHING.md` keeps the build half and defers the repo name and workflow
paths to the runbook (omnigent-ai/omnigent-internal#31, corrected by #32), which now carries them.

**No behaviour change** — no trigger, input, permission, or step logic is
touched. The only executable change is the summary `echo` block.

## Test Plan

- `git grep secure-public-registry` → **0 hits** across the tree.
- Extracted the modified `Next steps` run block from the workflow YAML and
  **executed it**, asserting the rendered summary contains the placeholder and
  not the private name.
- All 3 touched workflows parse (`yaml.safe_load`); `bash -n` clean on the
  extracted run block.
- Confirmed the internal runbook retains every scrubbed detail (secure-repo
  reference workflows, the scan action, the setup tracking links).

## Demo

N/A — non-visual. Rendered summary shown above.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Comments and one run-summary `echo`; no code path to unit-test. Verified by
extracting the run block from the YAML and executing it, checking the output for
the placeholder and the absence of the private repo name.
