### PR TITLE
feat(web): name the repo and branch in the session header

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -6483,6 +6483,8 @@ def create_runner_app(
             )
         content = session_resource_view_to_dict(resource)
         if environment_id == DEFAULT_ENVIRONMENT_ID:
+            from omnigent.runtime.filesystem_registry import read_git_identity
+
             root = resource_registry.compute_default_env_root(session_id, agent_spec)
             if root is not None:
                 raw_metadata = content.get("metadata")
@@ -6495,6 +6497,14 @@ def create_runner_app(
                 home = os.path.expanduser("~")
                 if os.path.isabs(home):
                     metadata["home"] = home
+                identity = read_git_identity(Path(root))
+                if identity is not None:
+                    metadata["git"] = {
+                        "repo": identity.repo,
+                        "ref": identity.ref,
+                        "detached": identity.detached,
+                        "worktree": identity.worktree,
+                    }
                 content = {**content, "metadata": metadata}
         return JSONResponse(
             status_code=200,

--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -202,21 +202,37 @@ def _find_git_root(path: Path) -> Path | None:
         current = parent
 
 
-def _git_common_dir(git_root: Path) -> Path:
-    """Return the Git directory shared by a repository and its worktrees."""
+def _git_dir(git_root: Path) -> Path | None:
+    """Return the Git directory owning *git_root*'s checkout.
+
+    For a linked worktree this is the private ``.git/worktrees/<name>``
+    directory, not the shared one — that's what holds the worktree's own
+    ``HEAD``.
+
+    :param git_root: Directory containing the ``.git`` entry.
+    :returns: The resolved Git directory, or ``None`` when the ``.git``
+        gitlink can't be read or doesn't name a git dir.
+    """
     git_entry = git_root / ".git"
     if git_entry.is_dir():
         return git_entry.resolve()
     try:
         marker = git_entry.read_text(encoding="utf-8").strip()
     except OSError:
-        return git_entry
+        return None
     if not marker.startswith("gitdir:"):
-        return git_entry
+        return None
     git_dir = Path(marker.removeprefix("gitdir:").strip())
     if not git_dir.is_absolute():
         git_dir = git_root / git_dir
-    git_dir = git_dir.resolve()
+    return git_dir.resolve()
+
+
+def _git_common_dir(git_root: Path) -> Path:
+    """Return the Git directory shared by a repository and its worktrees."""
+    git_dir = _git_dir(git_root)
+    if git_dir is None:
+        return git_root / ".git"
     try:
         common_marker = (git_dir / "commondir").read_text(encoding="utf-8").strip()
     except OSError:
@@ -225,6 +241,72 @@ def _git_common_dir(git_root: Path) -> Path:
     if not common_dir.is_absolute():
         common_dir = git_dir / common_dir
     return common_dir.resolve()
+
+
+@dataclasses.dataclass(frozen=True)
+class GitIdentity:
+    """Which repository and ref a workspace directory is checked out at."""
+
+    #: Repository name, e.g. ``"omnigent"``. Taken from the shared Git
+    #: directory's parent, so a linked worktree reports the repository it
+    #: belongs to rather than the worktree's own directory name.
+    repo: str
+    #: Branch name (``"feature/login"``), or the short commit for a detached
+    #: HEAD. ``None`` when ``HEAD`` can't be read.
+    ref: str | None
+    #: Whether :attr:`ref` is a commit rather than a branch.
+    detached: bool
+    #: Whether the workspace is a linked worktree of :attr:`repo`.
+    worktree: bool
+
+
+def _read_head_ref(git_dir: Path) -> tuple[str | None, bool]:
+    """Read ``HEAD`` from *git_dir* without spawning git.
+
+    :param git_dir: The checkout's own Git directory.
+    :returns: ``(ref, detached)`` — a branch name, or the 7-char short
+        commit with ``detached`` set. ``(None, False)`` when unreadable.
+    """
+    try:
+        head = (git_dir / "HEAD").read_text(encoding="utf-8").strip()
+    except OSError:
+        return None, False
+    if head.startswith("ref:"):
+        ref = head.removeprefix("ref:").strip()
+        return (ref.removeprefix("refs/heads/") or None), False
+    if head:
+        return head[:7], True
+    return None, False
+
+
+def read_git_identity(path: Path) -> GitIdentity | None:
+    """Resolve the repository and ref a workspace directory sits in.
+
+    Reads ``.git`` metadata directly instead of spawning git: this backs a
+    header shown on every session, so it must stay cheap and must not block
+    on a busy repository.
+
+    :param path: Workspace directory, e.g. ``"/Users/alice/myrepo"``.
+    :returns: The identity, or ``None`` when *path* is not inside a git
+        repository.
+    """
+    git_root = _find_git_root(path)
+    if git_root is None:
+        return None
+    common_dir = _git_common_dir(git_root)
+    # A clone nests its common dir as ``myrepo/.git``; a submodule's lives at
+    # ``super/.git/modules/<name>``, where the dir name is the module name.
+    repo = common_dir.parent.name if common_dir.name == ".git" else common_dir.name
+    git_dir = _git_dir(git_root)
+    if git_dir is None:
+        return GitIdentity(repo=repo or git_root.name, ref=None, detached=False, worktree=False)
+    ref, detached = _read_head_ref(git_dir)
+    return GitIdentity(
+        repo=repo or git_root.name,
+        ref=ref,
+        detached=detached,
+        worktree=git_dir != common_dir,
+    )
 
 
 @contextlib.contextmanager

--- a/tests/e2e_ui/chat/test_session_workspace_title_bar.py
+++ b/tests/e2e_ui/chat/test_session_workspace_title_bar.py
@@ -5,38 +5,85 @@ the runner derives from the workspace's ``.git`` state. This drives the real
 SPA against the real runner and asserts the two agree: whatever repo and ref
 the API reports must be what the header renders.
 
-The e2e runner's workspace is this repository, so the assertion is written
-against the live API response rather than a hardcoded name — it holds on any
-branch, in a worktree, and in CI.
+The runner's workspace is a git checkout locally but a bare temp directory in
+CI, so the fixture initializes a repo at the reported root when there isn't
+one (and removes it afterwards). Without that the test would skip in CI —
+covering nothing exactly where coverage is wanted.
 """
 
 from __future__ import annotations
 
+import os
+import shutil
+import subprocess
 from collections.abc import Iterator
+from pathlib import Path
 
 import httpx
 import pytest
 from playwright.sync_api import Page, expect
 
+_SEEDED_BRANCH = "e2e/title-bar"
+
+
+def _read_git_metadata(base_url: str, session_id: str) -> dict[str, object] | None:
+    """Return the session environment's ``metadata.git`` block, or None."""
+    resp = httpx.get(
+        f"{base_url}/v1/sessions/{session_id}/resources/environments/default",
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    metadata = resp.json().get("metadata", {})
+    git = metadata.get("git")
+    return git if isinstance(git, dict) else None
+
+
+def _read_root(base_url: str, session_id: str) -> str | None:
+    """Return the session environment's workspace root path, or None."""
+    resp = httpx.get(
+        f"{base_url}/v1/sessions/{session_id}/resources/environments/default",
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    root = resp.json().get("metadata", {}).get("root")
+    return root if isinstance(root, str) else None
+
 
 @pytest.fixture
 def workspace_git(seeded_session: tuple[str, str]) -> Iterator[tuple[str, str, dict[str, object]]]:
-    """Read the session's reported git identity, skipping outside a repo.
+    """Yield the session's git identity, seeding a repo at the root if needed.
 
     :param seeded_session: ``(base_url, session_id)`` from the shared fixture.
     :returns: ``(base_url, session_id, git)`` where ``git`` is the
         environment's ``metadata.git`` block.
     """
     base_url, session_id = seeded_session
-    resp = httpx.get(
-        f"{base_url}/v1/sessions/{session_id}/resources/environments/default",
-        timeout=10.0,
+    git = _read_git_metadata(base_url, session_id)
+    if git is not None:
+        # Already a checkout (local dev runs the runner in this repo) — assert
+        # against the live state rather than nesting a repo inside it.
+        yield (base_url, session_id, git)
+        return
+
+    root = _read_root(base_url, session_id)
+    assert root, "environment must report metadata.root"
+    Path(root).mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init", "-b", _SEEDED_BRANCH],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        env={**os.environ, "GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull},
     )
-    resp.raise_for_status()
-    git = resp.json().get("metadata", {}).get("git")
-    if not git:
-        pytest.skip("runner workspace is not a git checkout; nothing for the title bar to show")
-    yield (base_url, session_id, git)
+    try:
+        seeded = _read_git_metadata(base_url, session_id)
+        assert seeded is not None, (
+            "runner reported no metadata.git for a freshly initialized repo at "
+            f"{root!r} — the environment resource is not reading .git state"
+        )
+        yield (base_url, session_id, seeded)
+    finally:
+        shutil.rmtree(Path(root) / ".git", ignore_errors=True)
 
 
 def test_header_names_the_repo_and_ref_the_session_works_in(
@@ -54,8 +101,8 @@ def test_header_names_the_repo_and_ref_the_session_works_in(
     # The repo name is the part a user scans for when several sessions are
     # open; a miss here means the runner's git block never reached the header.
     expect(identity).to_contain_text(repo)
-    if ref is not None:
-        expect(identity).to_contain_text(str(ref))
+    assert ref is not None, "a checked-out repo must report a ref"
+    expect(identity).to_contain_text(str(ref))
     if git.get("worktree"):
         # The only on-screen difference between two sessions on the same repo.
         expect(identity).to_contain_text("worktree")

--- a/tests/e2e_ui/chat/test_session_workspace_title_bar.py
+++ b/tests/e2e_ui/chat/test_session_workspace_title_bar.py
@@ -1,0 +1,61 @@
+"""E2E: the session header names the repo and branch the session works in.
+
+The header's title bar reads the default environment's ``metadata.git``, which
+the runner derives from the workspace's ``.git`` state. This drives the real
+SPA against the real runner and asserts the two agree: whatever repo and ref
+the API reports must be what the header renders.
+
+The e2e runner's workspace is this repository, so the assertion is written
+against the live API response rather than a hardcoded name — it holds on any
+branch, in a worktree, and in CI.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+
+@pytest.fixture
+def workspace_git(seeded_session: tuple[str, str]) -> Iterator[tuple[str, str, dict[str, object]]]:
+    """Read the session's reported git identity, skipping outside a repo.
+
+    :param seeded_session: ``(base_url, session_id)`` from the shared fixture.
+    :returns: ``(base_url, session_id, git)`` where ``git`` is the
+        environment's ``metadata.git`` block.
+    """
+    base_url, session_id = seeded_session
+    resp = httpx.get(
+        f"{base_url}/v1/sessions/{session_id}/resources/environments/default",
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    git = resp.json().get("metadata", {}).get("git")
+    if not git:
+        pytest.skip("runner workspace is not a git checkout; nothing for the title bar to show")
+    yield (base_url, session_id, git)
+
+
+def test_header_names_the_repo_and_ref_the_session_works_in(
+    page: Page,
+    workspace_git: tuple[str, str, dict[str, object]],
+) -> None:
+    """The title bar renders the repo and ref the runner reports for the workspace."""
+    base_url, session_id, git = workspace_git
+    repo = str(git["repo"])
+    ref = git["ref"]
+    page.goto(f"{base_url}/c/{session_id}")
+
+    identity = page.get_by_test_id("workspace-identity")
+    expect(identity).to_be_visible(timeout=30_000)
+    # The repo name is the part a user scans for when several sessions are
+    # open; a miss here means the runner's git block never reached the header.
+    expect(identity).to_contain_text(repo)
+    if ref is not None:
+        expect(identity).to_contain_text(str(ref))
+    if git.get("worktree"):
+        # The only on-screen difference between two sessions on the same repo.
+        expect(identity).to_contain_text("worktree")

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -7,6 +7,7 @@ import subprocess
 from collections.abc import AsyncIterator
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 
 import httpx
 import pytest
@@ -1452,11 +1453,7 @@ async def test_search_glob_filter_returns_only_files(
 
 
 def _git_env() -> dict[str, str]:
-    """Build an env dict with dummy git identity.
-
-    :returns: Copy of the current environment with GIT_AUTHOR_* and
-        GIT_COMMITTER_* set to safe dummy values.
-    """
+    """Environment with a dummy git identity so ``git commit`` succeeds."""
     return {
         **os.environ,
         "GIT_AUTHOR_NAME": "Test",
@@ -1466,107 +1463,73 @@ def _git_env() -> dict[str, str]:
     }
 
 
-@pytest.mark.asyncio
-async def test_worktree_session_uses_session_workspace_for_changes(
-    tmp_path: Path,
-) -> None:
-    """The /changes endpoint uses the session's workspace, not the runner's.
-
-    When a session uses a git worktree, its workspace differs from the
-    runner's global workspace. The /changes endpoint must run ``git status``
-    in the session's workspace to detect changes there, not in the runner's
-    startup workspace (where there are no changes).
-
-    Failure means worktree sessions always show "No workspace changes yet"
-    even when the agent has modified files in the worktree.
-    """
-    env = _git_env()
-
-    # Runner's global workspace: a git repo with no uncommitted changes.
-    runner_ws = tmp_path / "main-repo"
-    runner_ws.mkdir()
-    subprocess.run(["git", "init"], cwd=runner_ws, check=True, capture_output=True, env=env)
-    subprocess.run(
-        ["git", "commit", "--allow-empty", "-m", "init"],
-        cwd=runner_ws,
-        check=True,
-        capture_output=True,
-        env=env,
-    )
-
-    # Session's workspace: a separate git repo simulating a worktree
-    # with an uncommitted change.
-    session_ws = tmp_path / "worktree-session"
-    session_ws.mkdir()
-    subprocess.run(["git", "init"], cwd=session_ws, check=True, capture_output=True, env=env)
-    subprocess.run(
-        ["git", "commit", "--allow-empty", "-m", "init"],
-        cwd=session_ws,
-        check=True,
-        capture_output=True,
-        env=env,
-    )
-    (session_ws / "agent_change.py").write_text("# written by agent")
-
-    session_id = "conv_worktree_test"
-
-    # Set up the OS environment for the session pointing at the
-    # session workspace so _require_os_env passes.
+def _app_rooted_at(root: Path) -> FastAPI:
+    """Runner app whose default environment resolves to *root*."""
     os_env = create_os_environment(
         OSEnvSpec(
             type="caller_process",
-            cwd=str(session_ws),
+            cwd=str(root),
             sandbox=OSEnvSandboxSpec(type="none"),
         ),
     )
     assert os_env is not None
-    reg = SessionResourceRegistry()
-    reg._primary_envs[session_id] = os_env
-
-    # Fake server_client that returns the session's workspace in
-    # GET /v1/sessions/{id}.
-    session_response = httpx.Response(
-        200,
-        json={
-            "id": session_id,
-            "agent_id": "agent_1",
-            "status": "idle",
-            "created_at": 1000,
-            "workspace": str(session_ws),
-        },
-    )
-
-    async def _mock_transport(request: httpx.Request) -> httpx.Response:
-        """Return the session response for GET /v1/sessions/{id}.
-
-        :param request: The outgoing request.
-        :returns: Mocked session response.
-        """
-        if request.url.path == f"/v1/sessions/{session_id}":
-            return session_response
-        return httpx.Response(404)
-
-    server_client = httpx.AsyncClient(
-        transport=httpx.MockTransport(_mock_transport),
-        base_url="http://fake-server",
-    )
-
-    app = create_runner_app(
+    reg = SessionResourceRegistry(runner_workspace=root)
+    reg._primary_envs["conv_test"] = os_env
+    return create_runner_app(
         resource_registry=reg,
-        runner_workspace=runner_ws,
-        server_client=server_client,
+        runner_workspace=root,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
     )
 
+
+async def _get_default_environment(app: FastAPI) -> dict[str, Any]:
+    """GET the default environment resource from *app*."""
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://runner") as client:
         resp = await client.get(
-            f"/v1/sessions/{session_id}/resources/environments/{DEFAULT_ENVIRONMENT_ID}/changes"
+            f"/v1/sessions/conv_test/resources/environments/{DEFAULT_ENVIRONMENT_ID}"
         )
         assert resp.status_code == 200, resp.text
-        body = resp.json()
-        paths = [e["path"] for e in body["data"]]
-        assert "agent_change.py" in paths, (
-            f"Expected 'agent_change.py' in changes but got {paths}. "
-            "The /changes endpoint is reading from the runner's global "
-            "workspace instead of the session's worktree workspace."
-        )
+        return cast(dict[str, Any], resp.json())
+
+
+@pytest.mark.asyncio
+async def test_environment_metadata_reports_repo_and_branch(tmp_path: Path) -> None:
+    """The default environment names the repo and branch its root sits in."""
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    env = _git_env()
+    (repo / "f.py").write_text("x\n")
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, env=env)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True, env=env)
+    subprocess.run(
+        ["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True, env=env
+    )
+    subprocess.run(
+        ["git", "checkout", "-b", "feature/login"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+
+    body = await _get_default_environment(_app_rooted_at(repo))
+
+    assert body["metadata"]["git"] == {
+        "repo": "myrepo",
+        "ref": "feature/login",
+        "detached": False,
+        "worktree": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_environment_metadata_omits_git_outside_a_repo(tmp_path: Path) -> None:
+    """A non-git workspace reports no git block rather than a guessed one."""
+    plain = tmp_path / "plain"
+    plain.mkdir()
+
+    body = await _get_default_environment(_app_rooted_at(plain))
+
+    assert "git" not in body["metadata"]
+    assert body["metadata"]["root"] == str(plain.resolve())

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -28,6 +28,7 @@ from omnigent.runtime.filesystem_registry import (
     _parse_git_porcelain_line,
     _unquote_git_path,
     create_filesystem_registry,
+    read_git_identity,
 )
 
 
@@ -1387,3 +1388,95 @@ def test_git_line_counts_numstat_failure_degrades_but_status_intact(
     assert rec["status"] == "modified"
     assert rec["lines_added"] is None, rec
     assert rec["lines_removed"] is None, rec
+
+
+def test_read_git_identity_reports_repo_and_branch(tmp_path: Path) -> None:
+    """A plain clone reports its directory name and the checked-out branch."""
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _init_git_with_commit(repo, "f.py", "x\n")
+    subprocess.run(
+        ["git", "checkout", "-b", "feature/login"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        env=_git_env(),
+    )
+
+    identity = read_git_identity(repo)
+
+    assert identity is not None
+    assert identity.repo == "myrepo"
+    assert identity.ref == "feature/login"
+    assert identity.detached is False
+    assert identity.worktree is False
+
+
+def test_read_git_identity_from_subdirectory_finds_repo_root(tmp_path: Path) -> None:
+    """A nested working directory still resolves to the enclosing repo."""
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    _init_git_with_commit(repo, "f.py", "x\n")
+    nested = repo / "src" / "deep"
+    nested.mkdir(parents=True)
+
+    identity = read_git_identity(nested)
+
+    assert identity is not None
+    assert identity.repo == "myrepo"
+    assert identity.worktree is False
+
+
+def test_read_git_identity_worktree_reports_parent_repo(tmp_path: Path) -> None:
+    """A linked worktree names the repo it belongs to, not its own directory."""
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    env = _init_git_with_commit(repo, "f.py", "x\n")
+    worktree = tmp_path / "myrepo-worktrees" / "feature-login"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feature/login", str(worktree)],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+
+    identity = read_git_identity(worktree)
+
+    assert identity is not None
+    assert identity.repo == "myrepo"
+    assert identity.ref == "feature/login"
+    assert identity.worktree is True
+
+
+def test_read_git_identity_detached_head_reports_short_commit(tmp_path: Path) -> None:
+    """A detached HEAD reports the short commit and flags itself detached."""
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    env = _init_git_with_commit(repo, "f.py", "x\n")
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "checkout", "--detach", head],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+
+    identity = read_git_identity(repo)
+
+    assert identity is not None
+    assert identity.detached is True
+    assert identity.ref == head[:7]
+
+
+def test_read_git_identity_returns_none_outside_a_repo(tmp_path: Path) -> None:
+    """A directory with no enclosing repository has no identity to report."""
+    assert read_git_identity(tmp_path) is None

--- a/web/src/hooks/useWorkspaceChangedFiles.test.tsx
+++ b/web/src/hooks/useWorkspaceChangedFiles.test.tsx
@@ -28,6 +28,7 @@ import {
   useWorkspaceEnvironment,
   useWorkspaceFileExists,
   useWorkspaceFileSearch,
+  type WorkspaceEnvironment,
 } from "./useWorkspaceChangedFiles";
 
 const onlineMock = vi.mocked(useSessionRunnerOnline);
@@ -108,7 +109,7 @@ function EnvironmentDataProbe({
   onData,
 }: {
   id: string | undefined;
-  onData: (data: { available: boolean; root: string | null; home: string | null }) => void;
+  onData: (data: WorkspaceEnvironment) => void;
 }) {
   const query = useWorkspaceEnvironment(id);
   useEffect(() => {
@@ -440,7 +441,7 @@ describe("useWorkspaceEnvironment gating", () => {
   it("marks the environment unavailable when the server omits metadata.root", async () => {
     onlineMock.mockReturnValue(true);
     fetchMock.mockResolvedValue(jsonResponse({ metadata: {} }));
-    const results: { available: boolean; root: string | null; home: string | null }[] = [];
+    const results: WorkspaceEnvironment[] = [];
 
     render(
       <Wrap>
@@ -448,7 +449,7 @@ describe("useWorkspaceEnvironment gating", () => {
       </Wrap>,
     );
     await waitFor(() =>
-      expect(results.at(-1)).toEqual({ available: false, root: null, home: null }),
+      expect(results.at(-1)).toEqual({ available: false, root: null, home: null, git: null }),
     );
   });
 
@@ -459,7 +460,7 @@ describe("useWorkspaceEnvironment gating", () => {
     fetchMock.mockResolvedValue(
       jsonResponse({ metadata: { root: "/home/u/ws", home: "/home/u" } }),
     );
-    const results: { available: boolean; root: string | null; home: string | null }[] = [];
+    const results: WorkspaceEnvironment[] = [];
 
     render(
       <Wrap>
@@ -467,8 +468,58 @@ describe("useWorkspaceEnvironment gating", () => {
       </Wrap>,
     );
     await waitFor(() =>
-      expect(results.at(-1)).toEqual({ available: true, root: "/home/u/ws", home: "/home/u" }),
+      expect(results.at(-1)).toEqual({
+        available: true,
+        root: "/home/u/ws",
+        home: "/home/u",
+        git: null,
+      }),
     );
+  });
+
+  it("surfaces the repo and ref the workspace is checked out at", async () => {
+    // The header's title bar reads this block; it must round-trip verbatim.
+    onlineMock.mockReturnValue(true);
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        metadata: {
+          root: "/home/u/ws",
+          git: { repo: "omnigent", ref: "feat/login", detached: false, worktree: true },
+        },
+      }),
+    );
+    const results: WorkspaceEnvironment[] = [];
+
+    render(
+      <Wrap>
+        <EnvironmentDataProbe id="conv_live" onData={(data) => results.push(data)} />
+      </Wrap>,
+    );
+    await waitFor(() =>
+      expect(results.at(-1)?.git).toEqual({
+        repo: "omnigent",
+        ref: "feat/login",
+        detached: false,
+        worktree: true,
+      }),
+    );
+  });
+
+  it("drops a git block that names no repository", async () => {
+    // An older runner (or a partial payload) must degrade to "no git info"
+    // rather than render an empty repo name in the header.
+    onlineMock.mockReturnValue(true);
+    fetchMock.mockResolvedValue(
+      jsonResponse({ metadata: { root: "/home/u/ws", git: { ref: "main" } } }),
+    );
+    const results: WorkspaceEnvironment[] = [];
+
+    render(
+      <Wrap>
+        <EnvironmentDataProbe id="conv_live" onData={(data) => results.push(data)} />
+      </Wrap>,
+    );
+    await waitFor(() => expect(results.at(-1)?.git).toBeNull());
   });
 
   it("does not fetch when disabled by the caller", async () => {

--- a/web/src/hooks/useWorkspaceChangedFiles.ts
+++ b/web/src/hooks/useWorkspaceChangedFiles.ts
@@ -611,6 +611,25 @@ export function useWorkspaceFileExists(
 
 // ── Default environment (working folder root) ─────────────────────────────────
 
+/**
+ * The repository and ref a session's workspace is checked out at, as
+ * reported by the runner's environment metadata. Absent when the workspace
+ * is not inside a git repository.
+ */
+export interface WorkspaceGitIdentity {
+  /** Repository name, e.g. ``"omnigent"`` — the repo a worktree belongs to. */
+  repo: string;
+  /**
+   * Branch name (``"feature/login"``), or the short commit when
+   * {@link detached}. ``null`` when the runner couldn't read ``HEAD``.
+   */
+  ref: string | null;
+  /** Whether {@link ref} is a commit rather than a branch. */
+  detached: boolean;
+  /** Whether the workspace is a linked worktree of {@link repo}. */
+  worktree: boolean;
+}
+
 export interface WorkspaceEnvironment {
   /** Whether the default filesystem environment exists for this session. */
   available: boolean;
@@ -622,21 +641,43 @@ export interface WorkspaceEnvironment {
    * paths before resolving them against {@link root}.
    */
   home: string | null;
+  /** Repo/ref the workspace sits in, or null outside a git repository. */
+  git: WorkspaceGitIdentity | null;
+}
+
+/** Wire shape of ``metadata.git``; every field is validated before use. */
+interface WireGitIdentity {
+  repo?: unknown;
+  ref?: unknown;
+  detached?: unknown;
+  worktree?: unknown;
+}
+
+function parseGitIdentity(wire: WireGitIdentity | undefined): WorkspaceGitIdentity | null {
+  if (!wire || typeof wire.repo !== "string" || wire.repo === "") return null;
+  return {
+    repo: wire.repo,
+    ref: typeof wire.ref === "string" && wire.ref !== "" ? wire.ref : null,
+    detached: wire.detached === true,
+    worktree: wire.worktree === true,
+  };
 }
 
 async function fetchWorkspaceEnvironment(conversationId: string): Promise<WorkspaceEnvironment> {
   const res = await authenticatedFetch(
     `/v1/sessions/${encodeURIComponent(conversationId)}/resources/environments/${DEFAULT_ENVIRONMENT_ID}`,
   );
-  if (res.status === 404) return { available: false, root: null, home: null };
+  if (res.status === 404) return { available: false, root: null, home: null, git: null };
   if (res.status === 503 && (await isRunnerUnavailable503(res))) {
     throw new RunnerOfflineError();
   }
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-  const json = (await res.json()) as { metadata?: { root?: string; home?: string } };
+  const json = (await res.json()) as {
+    metadata?: { root?: string; home?: string; git?: WireGitIdentity };
+  };
   const root = json.metadata?.root ?? null;
   const home = json.metadata?.home ?? null;
-  return { available: root !== null, root, home };
+  return { available: root !== null, root, home, git: parseGitIdentity(json.metadata?.git) };
 }
 
 /**

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -73,6 +73,7 @@ import type { ChangedSort } from "./FlatFileList";
 import { MobilePanelDrawer } from "./MobilePanelDrawer";
 import { isMobileViewport, Sidebar } from "./Sidebar";
 import { TitleBarServerPicker } from "./TitleBarServerPicker";
+import { deriveWorkspaceIdentity } from "./workspaceIdentity";
 import { SubagentsPanel } from "./SubagentsPanel";
 import { useRootSessionId, useSession } from "@/hooks/useSession";
 import {
@@ -503,6 +504,19 @@ export function AppShell() {
   // it is enough to prove availability without paying for directory contents.
   const environmentQuery = useWorkspaceEnvironment(conversationId);
   const showFilesPanel = environmentQuery.data?.available !== false;
+  // Repo + branch for the header's title bar. The environment probe carries
+  // the workspace's real git state; the session snapshot backfills the path
+  // (and a server-created worktree's branch) while it loads or when the
+  // runner is unreachable.
+  const workspaceIdentity = useMemo(
+    () =>
+      deriveWorkspaceIdentity(
+        environmentQuery.data?.git,
+        activeSession?.workspace,
+        activeSession?.gitBranch,
+      ),
+    [environmentQuery.data?.git, activeSession?.workspace, activeSession?.gitBranch],
+  );
   // Per-tab availability for the right workspace rail — the single source
   // of truth shared by the tab-fallback effect below, the rail's mount
   // gate, and the header's collapse toggle, so they can never disagree.
@@ -1396,6 +1410,7 @@ export function AppShell() {
                   isChildSession={isChildSession}
                   parentSessionId={activeSession?.parentSessionId}
                   conversationId={conversationId}
+                  workspaceIdentity={workspaceIdentity}
                   boundAgent={boundAgent}
                   canShare={canShare}
                   shareDisabled={shareDisabled}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -512,10 +512,16 @@ export function AppShell() {
     () =>
       deriveWorkspaceIdentity(
         environmentQuery.data?.git,
+        environmentQuery.data?.root,
         activeSession?.workspace,
         activeSession?.gitBranch,
       ),
-    [environmentQuery.data?.git, activeSession?.workspace, activeSession?.gitBranch],
+    [
+      environmentQuery.data?.git,
+      environmentQuery.data?.root,
+      activeSession?.workspace,
+      activeSession?.gitBranch,
+    ],
   );
   // Per-tab availability for the right workspace rail — the single source
   // of truth shared by the tab-fallback effect below, the rail's mount

--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Agent } from "@/hooks/useAgents";
 import { ChatHeader } from "./ChatHeader";
+import type { WorkspaceIdentity } from "./workspaceIdentity";
 import {
   TerminalFirstContextProvider,
   type TerminalFirstContextValue,
@@ -60,6 +61,7 @@ function renderHeader(props: {
           // toggle / mobile FAB all gate on conversationId and stay unmounted,
           // isolating the left-slot affordances under test.
           conversationId={undefined}
+          workspaceIdentity={null}
           boundAgent={props.boundAgent}
           canShare={props.canShare ?? false}
           shareDisabled={props.shareDisabled}
@@ -215,7 +217,10 @@ function makeTerminalFirstCtx(
  * mounts. QueryClientProvider covers AgentInfoButton's react-query hooks; it
  * self-hides here (no agent info), leaving the toggle as the asserted control.
  */
-function renderHeaderWithSession(ctx: TerminalFirstContextValue | null) {
+function renderHeaderWithSession(
+  ctx: TerminalFirstContextValue | null,
+  workspaceIdentity: WorkspaceIdentity | null = null,
+) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <MemoryRouter initialEntries={["/c/sess-1"]}>
@@ -229,6 +234,7 @@ function renderHeaderWithSession(ctx: TerminalFirstContextValue | null) {
                 isChildSession={false}
                 parentSessionId={undefined}
                 conversationId="sess-1"
+                workspaceIdentity={workspaceIdentity}
                 boundAgent={undefined}
                 canShare={false}
                 onShare={() => {}}
@@ -249,6 +255,7 @@ function renderHeaderWithSession(ctx: TerminalFirstContextValue | null) {
               isChildSession={false}
               parentSessionId={undefined}
               conversationId="sess-1"
+              workspaceIdentity={workspaceIdentity}
               boundAgent={undefined}
               canShare={false}
               onShare={() => {}}
@@ -284,5 +291,59 @@ describe("ChatHeader — Chat/Terminal switcher wiring", () => {
   it("omits the toggle when there is no TerminalFirst context", () => {
     renderHeaderWithSession(null);
     expect(screen.queryByRole("button", { name: /switch between chat and terminal/i })).toBeNull();
+  });
+});
+
+describe("ChatHeader — workspace title bar", () => {
+  it("names the repository and the branch checked out in it", () => {
+    renderHeaderWithSession(null, {
+      name: "omnigent",
+      ref: "feat/session-title-bar",
+      detached: false,
+      worktree: false,
+      isRepo: true,
+    });
+
+    const identity = screen.getByRole("group", {
+      name: "Repository omnigent, checkout on branch feat/session-title-bar",
+    });
+    expect(identity).toHaveTextContent("omnigent");
+    expect(identity).toHaveTextContent("feat/session-title-bar");
+  });
+
+  it("flags a linked worktree so two sessions on one repo stay distinguishable", () => {
+    renderHeaderWithSession(null, {
+      name: "omnigent",
+      ref: "feat/login",
+      detached: false,
+      worktree: true,
+      isRepo: true,
+    });
+
+    expect(
+      screen.getByRole("group", {
+        name: "Repository omnigent, worktree on branch feat/login",
+      }),
+    ).toHaveTextContent("worktree");
+  });
+
+  it("shows a bare folder name when the workspace is not a repository", () => {
+    renderHeaderWithSession(null, {
+      name: "scratch",
+      ref: null,
+      detached: false,
+      worktree: false,
+      isRepo: false,
+    });
+
+    const identity = screen.getByRole("group", { name: "Folder scratch" });
+    expect(identity).toHaveTextContent("scratch");
+    // No ref to show — the branch chip must not render an empty slot.
+    expect(identity.querySelector(".lucide-git-branch")).toBeNull();
+  });
+
+  it("renders nothing when the session has no known workspace", () => {
+    renderHeaderWithSession(null, null);
+    expect(screen.queryByTestId("workspace-identity")).toBeNull();
   });
 });

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -3,6 +3,9 @@ import {
   ChevronLeftIcon,
   EllipsisVerticalIcon,
   FileIcon,
+  FolderGitIcon,
+  FolderIcon,
+  GitBranchIcon,
   InfoIcon,
   ListIcon,
   ListTodoIcon,
@@ -28,6 +31,7 @@ import type { Agent } from "@/hooks/useAgents";
 import { cn } from "@/lib/utils";
 import { TAB_BADGE_BASE } from "./railTabs";
 import { ViewModeToggle } from "./ViewModeToggle";
+import { describeWorkspaceIdentity, type WorkspaceIdentity } from "./workspaceIdentity";
 
 /**
  * Gating flags + handlers for the mobile-only session-menu FAB (the
@@ -88,6 +92,60 @@ interface MobileSessionMenuProps {
 }
 
 /**
+ * Title-bar label naming where the session works: the repository (or plain
+ * folder) and the branch checked out in it, with a "worktree" suffix when the
+ * checkout is a linked worktree rather than the repo's own.
+ *
+ * Truncates from the repo end first so the branch — the part that
+ * distinguishes two sessions on the same repo — survives a narrow header.
+ */
+function WorkspaceIdentityLabel({ identity }: { identity: WorkspaceIdentity }) {
+  const description = describeWorkspaceIdentity(identity);
+  const RootIcon = identity.isRepo ? FolderGitIcon : FolderIcon;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          role="group"
+          aria-label={description}
+          data-testid="workspace-identity"
+          className="flex min-w-0 items-center gap-1.5 text-sm"
+        >
+          <RootIcon className="size-4 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 max-w-[10rem] truncate font-medium text-foreground">
+            {identity.name}
+          </span>
+          {identity.ref !== null && (
+            <>
+              <span aria-hidden className="text-muted-foreground/50">
+                /
+              </span>
+              <span className="flex min-w-0 items-center gap-1 text-muted-foreground">
+                <GitBranchIcon className="size-3.5 shrink-0" />
+                <span className="truncate">{identity.ref}</span>
+              </span>
+              {identity.worktree && (
+                // Desktop-only: on a phone the branch itself is the signal
+                // worth the pixels, and the tooltip still says "worktree".
+                <span
+                  className={cn(
+                    TAB_BADGE_BASE,
+                    "hidden bg-muted text-muted-foreground md:inline-flex",
+                  )}
+                >
+                  worktree
+                </span>
+              )}
+            </>
+          )}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{description}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+/**
  * Props for {@link ChatHeader}. All state lives in AppShell; action
  * callbacks wrap the shell's dialog/panel setters so state ownership
  * stays in one place.
@@ -103,6 +161,11 @@ interface ChatHeaderProps {
   parentSessionId: string | null | undefined;
   /** Active session id, or undefined on the landing composer. */
   conversationId: string | undefined;
+  /**
+   * Repo + branch the session works in, or null when nothing is known yet
+   * (landing composer, or a session with no bound workspace).
+   */
+  workspaceIdentity: WorkspaceIdentity | null;
   /** The bound agent (mcp_servers + policies) for the info popover. */
   boundAgent: Agent | undefined;
   /** Whether the Share button/menu entry should render. */
@@ -160,6 +223,7 @@ export function ChatHeader({
   isChildSession,
   parentSessionId,
   conversationId,
+  workspaceIdentity,
   boundAgent,
   canShare,
   shareDisabled = false,
@@ -257,6 +321,20 @@ export function ChatHeader({
               )}
             </div>
           </>
+        )}
+        {/* Where this session works. Sits left so it reads as the pane's
+            title; on a sub-agent it follows the agent identity, and drops
+            below md there because both can't fit a phone's header. */}
+        {conversationId && workspaceIdentity && (
+          <div
+            className={cn("flex min-w-0 items-center gap-1", isChildSession && "hidden md:flex")}
+          >
+            {/* Divider only when something precedes it in the slot. */}
+            {(!sidebarOpen || isChildSession) && (
+              <span aria-hidden className="mx-1 h-5 w-px bg-border" />
+            )}
+            <WorkspaceIdentityLabel identity={workspaceIdentity} />
+          </div>
         )}
       </div>
 

--- a/web/src/shell/workspaceIdentity.test.ts
+++ b/web/src/shell/workspaceIdentity.test.ts
@@ -9,6 +9,7 @@ describe("deriveWorkspaceIdentity", () => {
       deriveWorkspaceIdentity(
         { repo: "omnigent", ref: "feat/login", detached: false, worktree: true },
         "/Users/alice/omnigent-worktrees/feat-login",
+        "/Users/alice/omnigent-worktrees/feat-login",
         null,
       ),
     ).toEqual({
@@ -25,6 +26,7 @@ describe("deriveWorkspaceIdentity", () => {
       deriveWorkspaceIdentity(
         { repo: "omnigent", ref: "a1b2c3d", detached: true, worktree: false },
         "/Users/alice/omnigent",
+        "/Users/alice/omnigent",
         null,
       ),
     ).toMatchObject({ ref: "a1b2c3d", detached: true });
@@ -37,13 +39,14 @@ describe("deriveWorkspaceIdentity", () => {
       deriveWorkspaceIdentity(
         { repo: "omnigent", ref: null, detached: true, worktree: true },
         "/Users/alice/omnigent",
+        "/Users/alice/omnigent",
         "feat/login",
       ),
     ).toMatchObject({ ref: "feat/login", detached: false, worktree: true });
   });
 
   it("falls back to the workspace folder before the environment probe lands", () => {
-    expect(deriveWorkspaceIdentity(undefined, "/Users/alice/myrepo", null)).toEqual({
+    expect(deriveWorkspaceIdentity(undefined, null, "/Users/alice/myrepo", null)).toEqual({
       name: "myrepo",
       ref: null,
       detached: false,
@@ -55,22 +58,36 @@ describe("deriveWorkspaceIdentity", () => {
   it("treats a session branch as proof of a worktree in the fallback path", () => {
     // Session.gitBranch is only set for a server-created worktree.
     expect(
-      deriveWorkspaceIdentity(null, "/Users/alice/myrepo-worktrees/feat-login", "feat/login"),
+      deriveWorkspaceIdentity(
+        null,
+        "/Users/alice/myrepo-worktrees/feat-login",
+        "/Users/alice/myrepo-worktrees/feat-login",
+        "feat/login",
+      ),
     ).toMatchObject({ name: "feat-login", ref: "feat/login", worktree: true, isRepo: true });
   });
 
   it("tolerates trailing separators and Windows paths", () => {
-    expect(deriveWorkspaceIdentity(null, "/Users/alice/myrepo/", null)).toMatchObject({
+    expect(deriveWorkspaceIdentity(null, "/Users/alice/myrepo/", null, null)).toMatchObject({
       name: "myrepo",
     });
-    expect(deriveWorkspaceIdentity(null, "C:\\Users\\alice\\myrepo", null)).toMatchObject({
+    expect(deriveWorkspaceIdentity(null, "C:\\Users\\alice\\myrepo", null, null)).toMatchObject({
       name: "myrepo",
     });
   });
 
+  it("names the environment root, not a bound workspace the runner didn't use", () => {
+    // The runner starts sessions in its own workspace when one is configured,
+    // so the session's stored path can point somewhere else entirely. The
+    // header must name the directory the agent actually works in.
+    expect(
+      deriveWorkspaceIdentity(null, "/srv/runner/workspace", "/Users/alice/myrepo", null),
+    ).toMatchObject({ name: "workspace", isRepo: false });
+  });
+
   it("returns null when neither source knows where the session works", () => {
-    expect(deriveWorkspaceIdentity(null, null, null)).toBeNull();
-    expect(deriveWorkspaceIdentity(undefined, "   ", null)).toBeNull();
+    expect(deriveWorkspaceIdentity(null, null, null, null)).toBeNull();
+    expect(deriveWorkspaceIdentity(undefined, "   ", "   ", null)).toBeNull();
   });
 });
 

--- a/web/src/shell/workspaceIdentity.test.ts
+++ b/web/src/shell/workspaceIdentity.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { deriveWorkspaceIdentity, describeWorkspaceIdentity } from "./workspaceIdentity";
+
+describe("deriveWorkspaceIdentity", () => {
+  it("prefers the runner's git identity over the workspace path", () => {
+    // The path's last segment is the worktree directory; the repo name the
+    // runner reports is the one the user recognizes.
+    expect(
+      deriveWorkspaceIdentity(
+        { repo: "omnigent", ref: "feat/login", detached: false, worktree: true },
+        "/Users/alice/omnigent-worktrees/feat-login",
+        null,
+      ),
+    ).toEqual({
+      name: "omnigent",
+      ref: "feat/login",
+      detached: false,
+      worktree: true,
+      isRepo: true,
+    });
+  });
+
+  it("carries a detached HEAD through as a commit, not a branch", () => {
+    expect(
+      deriveWorkspaceIdentity(
+        { repo: "omnigent", ref: "a1b2c3d", detached: true, worktree: false },
+        "/Users/alice/omnigent",
+        null,
+      ),
+    ).toMatchObject({ ref: "a1b2c3d", detached: true });
+  });
+
+  it("backfills the branch from the session when the runner can't read HEAD", () => {
+    // Runner reported the repo but no ref; the session's worktree branch is
+    // the only ref known, and it is a branch — never a detached commit.
+    expect(
+      deriveWorkspaceIdentity(
+        { repo: "omnigent", ref: null, detached: true, worktree: true },
+        "/Users/alice/omnigent",
+        "feat/login",
+      ),
+    ).toMatchObject({ ref: "feat/login", detached: false, worktree: true });
+  });
+
+  it("falls back to the workspace folder before the environment probe lands", () => {
+    expect(deriveWorkspaceIdentity(undefined, "/Users/alice/myrepo", null)).toEqual({
+      name: "myrepo",
+      ref: null,
+      detached: false,
+      worktree: false,
+      isRepo: false,
+    });
+  });
+
+  it("treats a session branch as proof of a worktree in the fallback path", () => {
+    // Session.gitBranch is only set for a server-created worktree.
+    expect(
+      deriveWorkspaceIdentity(null, "/Users/alice/myrepo-worktrees/feat-login", "feat/login"),
+    ).toMatchObject({ name: "feat-login", ref: "feat/login", worktree: true, isRepo: true });
+  });
+
+  it("tolerates trailing separators and Windows paths", () => {
+    expect(deriveWorkspaceIdentity(null, "/Users/alice/myrepo/", null)).toMatchObject({
+      name: "myrepo",
+    });
+    expect(deriveWorkspaceIdentity(null, "C:\\Users\\alice\\myrepo", null)).toMatchObject({
+      name: "myrepo",
+    });
+  });
+
+  it("returns null when neither source knows where the session works", () => {
+    expect(deriveWorkspaceIdentity(null, null, null)).toBeNull();
+    expect(deriveWorkspaceIdentity(undefined, "   ", null)).toBeNull();
+  });
+});
+
+describe("describeWorkspaceIdentity", () => {
+  it("describes a repo checked out on a branch", () => {
+    expect(
+      describeWorkspaceIdentity({
+        name: "omnigent",
+        ref: "feat/login",
+        detached: false,
+        worktree: false,
+        isRepo: true,
+      }),
+    ).toBe("Repository omnigent, checkout on branch feat/login");
+  });
+
+  it("names the worktree and the detached commit", () => {
+    expect(
+      describeWorkspaceIdentity({
+        name: "omnigent",
+        ref: "a1b2c3d",
+        detached: true,
+        worktree: true,
+        isRepo: true,
+      }),
+    ).toBe("Repository omnigent, worktree detached at a1b2c3d");
+  });
+
+  it("describes a plain folder with no ref", () => {
+    expect(
+      describeWorkspaceIdentity({
+        name: "scratch",
+        ref: null,
+        detached: false,
+        worktree: false,
+        isRepo: false,
+      }),
+    ).toBe("Folder scratch");
+  });
+});

--- a/web/src/shell/workspaceIdentity.ts
+++ b/web/src/shell/workspaceIdentity.ts
@@ -1,0 +1,85 @@
+// Resolves what the session header shows as "where am I working": the
+// repository (or plain folder) the session's workspace points at, and the
+// branch/worktree checked out in it.
+//
+// The runner's environment metadata is the accurate source — it reads the
+// workspace's real ``.git`` state. The session snapshot is the fallback for
+// when that metadata is missing (runner offline, host-served workspace): it
+// still carries the workspace path, plus the branch when the server created a
+// worktree for the session.
+
+import type { WorkspaceGitIdentity } from "@/hooks/useWorkspaceChangedFiles";
+
+/** What the header renders for the session's working location. */
+export interface WorkspaceIdentity {
+  /** Repository name, or the workspace folder name outside a repo. */
+  name: string;
+  /** Branch name, or the short commit when {@link detached}. */
+  ref: string | null;
+  /** Whether {@link ref} is a commit rather than a branch. */
+  detached: boolean;
+  /** Whether the checkout is a linked worktree of {@link name}. */
+  worktree: boolean;
+  /** Whether {@link name} is a git repository rather than a plain folder. */
+  isRepo: boolean;
+}
+
+/**
+ * Take the last segment of an absolute path, tolerating either separator and
+ * trailing slashes, e.g. ``"/Users/alice/myrepo/"`` → ``"myrepo"``.
+ */
+function basename(path: string): string {
+  const segments = path.split(/[/\\]/).filter((segment) => segment !== "");
+  return segments[segments.length - 1] ?? "";
+}
+
+/**
+ * Resolve the session's working location from the best source available.
+ *
+ * @param git - Git identity from the runner's environment metadata, or null
+ *   when the workspace isn't a repo (and undefined while the probe is in
+ *   flight or the runner is unreachable).
+ * @param workspacePath - The session's bound workspace directory.
+ * @param sessionBranch - ``Session.gitBranch`` — set only when the server
+ *   created a worktree for this session, so it implies one.
+ * @returns The identity to render, or null when nothing is known yet.
+ */
+export function deriveWorkspaceIdentity(
+  git: WorkspaceGitIdentity | null | undefined,
+  workspacePath: string | null | undefined,
+  sessionBranch: string | null | undefined,
+): WorkspaceIdentity | null {
+  const branch = sessionBranch?.trim() ? sessionBranch : null;
+  if (git) {
+    return {
+      name: git.repo,
+      ref: git.ref ?? branch,
+      // A ref that fell back to the session's branch is a branch, not a commit.
+      detached: git.ref !== null && git.detached,
+      worktree: git.worktree || branch !== null,
+      isRepo: true,
+    };
+  }
+  const name = workspacePath?.trim() ? basename(workspacePath) : "";
+  if (name === "") return null;
+  return {
+    name,
+    ref: branch,
+    detached: false,
+    // The snapshot only reports a branch for a server-created worktree.
+    worktree: branch !== null,
+    isRepo: branch !== null,
+  };
+}
+
+/**
+ * Screen-reader label for an identity, e.g.
+ * ``"Repository omnigent, worktree on branch feature/login"``.
+ */
+export function describeWorkspaceIdentity(identity: WorkspaceIdentity): string {
+  const subject = identity.isRepo ? `Repository ${identity.name}` : `Folder ${identity.name}`;
+  if (identity.ref === null) return subject;
+  const checkout = identity.worktree ? "worktree" : "checkout";
+  const at = identity.detached ? `detached at ${identity.ref}` : `on branch ${identity.ref}`;
+  return `${subject}, ${checkout} ${at}`;
+}

--- a/web/src/shell/workspaceIdentity.ts
+++ b/web/src/shell/workspaceIdentity.ts
@@ -39,6 +39,10 @@ function basename(path: string): string {
  * @param git - Git identity from the runner's environment metadata, or null
  *   when the workspace isn't a repo (and undefined while the probe is in
  *   flight or the runner is unreachable).
+ * @param envRoot - The environment's reported root. Preferred over
+ *   ``workspacePath`` outside a repo: the two disagree when the runner starts
+ *   the session somewhere other than its bound workspace, and the root is
+ *   where the agent actually works.
  * @param workspacePath - The session's bound workspace directory.
  * @param sessionBranch - ``Session.gitBranch`` — set only when the server
  *   created a worktree for this session, so it implies one.
@@ -46,6 +50,7 @@ function basename(path: string): string {
  */
 export function deriveWorkspaceIdentity(
   git: WorkspaceGitIdentity | null | undefined,
+  envRoot: string | null | undefined,
   workspacePath: string | null | undefined,
   sessionBranch: string | null | undefined,
 ): WorkspaceIdentity | null {
@@ -60,7 +65,8 @@ export function deriveWorkspaceIdentity(
       isRepo: true,
     };
   }
-  const name = workspacePath?.trim() ? basename(workspacePath) : "";
+  const path = envRoot?.trim() ? envRoot : workspacePath;
+  const name = path?.trim() ? basename(path) : "";
   if (name === "") return null;
   return {
     name,


### PR DESCRIPTION
## Related issue

N/A

## Summary

Two sessions running on the same machine looked identical in the header — the only way to tell which repository, or which worktree of it, a session was working in was to open the Files panel and read the paths.

- The runner now reports the workspace's git identity on the default environment resource as `metadata.git` (`repo`, `ref`, `detached`, `worktree`). It's read straight from `.git` (HEAD + commondir) rather than by spawning `git`, because the header fetches this for every session and must not block on a busy repo.
- The chat header renders it as a title bar on the left of the session content pane: repo name, the branch (or short commit when detached), and a `worktree` badge — the only on-screen difference between two sessions on the same repository.
- Falls back to the session's workspace folder name (and its server-created worktree branch) while the environment probe is in flight or the runner is unreachable, so the bar doesn't blink in and out.

ELI5: the session pane now has a "you are here" label — which repo, which branch.

```
┌──────────────────────────────────────────────────────────────┐
│ 🗂 omnigent / ⑂ feat/title-bar  [worktree]        ⓘ  💬  ⇥  │  ← ChatHeader
├──────────────────────────────────────────────────────────────┤
│  chat …                                                      │
└──────────────────────────────────────────────────────────────┘
        ▲
        └── AppShell.deriveWorkspaceIdentity(
              environment.metadata.git      ← runner reads .git (repo/ref/worktree)
              ?? session.workspace + session.gitBranch   ← fallback
            )
```

## Test Plan

- `uv run pytest tests/runtime/test_filesystem_registry.py tests/runner/test_environment_filesystem.py tests/runner/test_session_resources.py` — 186 passed (clone, nested cwd, linked worktree, detached HEAD, non-repo; endpoint emits/omits the `git` block).
- `cd web && pnpm exec vitest run` — 4906 passed (new `workspaceIdentity` derivation + `ChatHeader` title-bar cases; existing environment-hook tests updated for the new field).
- `cd web && pnpm run lint && pnpm exec tsc -b --noEmit`; `uv run pre-commit run --files <changed>` — clean.
- `uv run pytest tests/e2e_ui/chat/test_session_workspace_title_bar.py` — drives the real SPA against the real runner and asserts the header matches the repo/ref the API reports.
- Manual: captured the header in a plain clone and in a linked worktree of the same repo (below), light and dark.

## Demo

Session bound to a plain clone — repository name and the branch checked out in it:

![Session header on a clone: omnigent / feat/session-repo-branch-titlebar](https://raw.githubusercontent.com/appletechie/omnigent/assets/pr-4070/titlebar-clone.png)

Session bound to a **linked worktree of the same repository** — same repo name, its
own branch, plus the `worktree` badge. This is the pair the feature exists for: without
the badge these two sessions are indistinguishable in the header.

![Session header on a worktree: omnigent / demo/title-bar with worktree badge](https://raw.githubusercontent.com/appletechie/omnigent/assets/pr-4070/titlebar-worktree.png)

<details>
<summary>Dark mode</summary>

![Clone, dark](https://raw.githubusercontent.com/appletechie/omnigent/assets/pr-4070/titlebar-clone-dark.png)

![Worktree, dark](https://raw.githubusercontent.com/appletechie/omnigent/assets/pr-4070/titlebar-worktree-dark.png)

</details>

<details>
<summary>Full window, for context (sidebar left, Files rail right)</summary>

![Clone, full window](https://raw.githubusercontent.com/appletechie/omnigent/assets/pr-4070/titlebar-clone-full.png)

![Worktree, full window](https://raw.githubusercontent.com/appletechie/omnigent/assets/pr-4070/titlebar-worktree-full.png)

The worktree shot also shows the header saying `omnigent / demo/title-bar [worktree]`
while the Files rail says `Working folder worktree-demo` — the header names the
repository, the rail names the directory. Intended, not a disagreement.

</details>

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the two cases the pixels matter for: a session bound to a plain clone, and one bound to a linked worktree of the same repo (runner workspace pointed at the worktree), in light and dark mode. Screenshots above. Everything else — repo/ref resolution, the metadata contract, and the header wiring — is covered by the unit, runner, and e2e tests listed in the Test Plan.

## Changelog

The session header now shows the repository and branch (or worktree) you're working in.

