### PR TITLE
docs: use non-matching placeholder DSNs in docstrings to quiet secret scanners

### DIFF
--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -21,7 +21,7 @@ module importable for testing / tooling without a live database.
 Configuration is via environment variables:
 
   DATABASE_URL          Required. SQLAlchemy URL. Both PaaS-style URLs
-                        (``postgresql://user:pw@host:5432/db``,
+                        (``postgresql://<user>:<password>@host:5432/db``,
                         ``postgres://...``) and the explicit psycopg3
                         form (``postgresql+psycopg://...``) are accepted;
                         the prefix is normalized automatically.

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -9071,7 +9071,7 @@ def debug_db_upgrade(url: str) -> None:
 
     URL is a SQLAlchemy database URL, e.g.
     ``sqlite:////absolute/path/to/chat.db`` or
-    ``postgresql://user:pass@host/dbname``.
+    ``postgresql://<user>:<password>@host/dbname``.
 
     \b
     IMPORTANT: schema migrations can be slow and are not guaranteed
@@ -9141,7 +9141,7 @@ def debug_migrate_accounts_to_oidc(
 
     URL is a SQLAlchemy database URL, e.g.
     ``sqlite:////absolute/path/to/chat.db`` or
-    ``postgresql://user:pass@host/dbname``.
+    ``postgresql://<user>:<password>@host/dbname``.
 
     \b
     Examples:

--- a/omnigent/db/utils.py
+++ b/omnigent/db/utils.py
@@ -222,7 +222,7 @@ def _create_engine(db_uri: str) -> Engine:
 
     :param db_uri: SQLAlchemy database connection string, e.g.
         ``"sqlite:///mydb.db"`` or
-        ``"postgresql://user:pass@host/dbname"``.
+        ``"postgresql://<user>:<password>@host/dbname"``.
     :returns: A configured :class:`~sqlalchemy.engine.Engine`.
     """
     is_sqlite = db_uri.startswith("sqlite")
@@ -303,7 +303,7 @@ def get_or_create_engine(db_uri: str) -> Engine:
 
     :param db_uri: SQLAlchemy database connection string, e.g.
         ``"sqlite:///mydb.db"`` or
-        ``"postgresql://user:pass@host/dbname"``.
+        ``"postgresql://<user>:<password>@host/dbname"``.
     :returns: A :class:`~sqlalchemy.engine.Engine` for the given URI.
     :raises RuntimeError: If automatic schema migration fails.
     """

--- a/omnigent/stores/agent_store/sqlalchemy_store.py
+++ b/omnigent/stores/agent_store/sqlalchemy_store.py
@@ -42,7 +42,7 @@ class SqlAlchemyAgentStore(AgentStore):
 
         :param storage_location: SQLAlchemy database URI for the Omnigent DB,
             e.g. ``"sqlite:///agents.db"`` or
-            ``"postgresql://user:pass@host/db"``.
+            ``"postgresql://<user>:<password>@host/db"``.
         :param conversation_storage_location: Optional URI for the Agent
             Platform DB. The ``conversations`` table lives there, and
             resolving a session-scoped agent's ``session_id`` requires a

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -704,7 +704,7 @@ class SqlAlchemyConversationStore(ConversationStore):
 
         :param storage_location: SQLAlchemy database URI for the Omnigent DB,
             e.g. ``"sqlite:///omnigent.db"`` or
-            ``"postgresql://user:pass@host/db"``.
+            ``"postgresql://<user>:<password>@host/db"``.
         :param conversation_storage_location: SQLAlchemy database URI for the Agent
             Platform DB (conversations, items, labels). Defaults to
             ``storage_location`` when ``None`` (single-DB mode).


### PR DESCRIPTION
## Related issue

N/A — chore prompted by recurring secret-scanner false positives.

## Summary

The example Postgres URLs in six docstrings/comments are placeholders, but
gitleaks' `postgres-connection-string` rule matches the `scheme://name:secret@host`
*shape* and can't distinguish a placeholder from a live DSN. So they surface as
permanent false positives in GitGuardian digests.

Switching the examples to angle-bracket placeholders sidesteps the rule — `<` and
`>` fall outside its username/password character classes — and reads more clearly
as a placeholder anyway:

```diff
-    ``postgresql://user:pass@host/dbname``.
+    ``postgresql://<user>:<password>@host/dbname``.
```

Files touched: `omnigent/cli.py`, `omnigent/db/utils.py`,
`omnigent/stores/agent_store/sqlalchemy_store.py`,
`omnigent/stores/conversation_store/sqlalchemy_store.py`,
`deploy/docker/entrypoint.py`.

**Scope, deliberately narrow:**

- **Docstrings and comments only.** No behaviour change.
- **Test files are left alone.** Their URLs are live inputs and expected values,
  and one case exists specifically to prove percent-encoded credentials survive
  the prefix rewrite — rewriting it would defeat the test. Those ~15 remaining
  findings are best marked false-positive in the scanner rather than edited.

To be clear about what this does *not* fix: the findings also live in git history
(a June commit), and history-based scans will keep reporting them until they're
allowlisted or the history is rewritten. This only cleans the current tree, which
is what a scan of `main` reports on.

## Test Plan

- Ran the **real** gitleaks 8.16.2 binary with the same `gitleaks.toml` the
  Databricks hook uses: `postgres-connection-string` findings in tracked source
  went **6 → 0** (remaining hits are `.venv/` third-party and `tests/`).
- Verified the replacement form against the rule's regex directly. Note
  `USER:PASSWORD` does **not** work — the rule is case-insensitive — whereas the
  angle-bracket form does.
- **Proved docs-only:** parsed each touched file before/after, stripped all
  docstrings, and compared ASTs — byte-identical in all five.
- Ran `tests/db/test_utils.py`, `test_utils_extended.py`,
  `test_normalize_database_url.py`, `test_docker_entrypoint_import.py`:
  **72 passed, 3 failed**. The 3 failures are `ModuleNotFoundError: No module
  named 'psycopg'` and reproduce identically on unmodified `main` (verified by
  stashing) — pre-existing, missing optional driver, unrelated.

## Demo

N/A — non-visual.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Comment/docstring text only, so there is no behaviour to unit-test. Verified by
AST comparison (docstrings stripped → byte-identical) plus a real gitleaks run
showing 6 → 0 findings in tracked source, and by running the test files covering
the touched modules.
