### PR TITLE
feat(memory): automatic long-term memory via the memory: spec block

### DIFF
--- a/examples/remy_auto/config.yaml
+++ b/examples/remy_auto/config.yaml
@@ -1,0 +1,50 @@
+# Remy Auto — an assistant that remembers, automatically.
+#
+# This is the runtime-`memory:`-block counterpart to the `remy` example. Where
+# `remy` declares the hindsight_* TOOLS and a prompt instructing the model to
+# call them, Remy Auto has NO memory tools and a NEUTRAL prompt. Recall and
+# retain are handled deterministically by the runtime: before each turn the
+# runner recalls relevant memories and injects them; after each turn it retains
+# the user's message. The model is never asked to manage memory.
+#
+# So if Remy Auto answers, in a fresh session, a question about something you
+# told it in an earlier session, that is the automatic `memory:` layer working
+# — not the model choosing to call a tool.
+#
+# Setup:
+#   pip install 'omnigent[hindsight]'
+#   export HINDSIGHT_API_KEY=hsk_...        # https://ui.hindsight.vectorize.io
+#
+# Usage:
+#   omnigent run examples/remy_auto
+#
+# Runs on the Claude Agent SDK harness, so configure a Claude provider first
+# (e.g. `omnigent setup`, or export ANTHROPIC_API_KEY).
+
+spec_version: 1
+name: remy-auto
+description: >-
+  A helpful assistant with automatic long-term memory. Remy Auto recalls what it
+  already knows before each turn and retains what you tell it — with no memory
+  tools and no memory instructions, entirely via the runtime `memory:` block,
+  powered by Hindsight.
+
+executor:
+  type: omnigent
+  config:
+    harness: claude-sdk
+
+# Deliberately neutral: the model is NOT told to save or recall anything. Any
+# cross-session memory you observe is the `memory:` block below, not the prompt.
+prompt: |
+  You are a helpful, concise assistant.
+
+# Automatic long-term memory. bank_id pins a stable, human-readable bank so every
+# session shares one memory store (omit it and the bank defaults to the agent
+# id). Setting enabled turns on both auto_recall and auto_retain.
+memory:
+  enabled: true
+  provider: hindsight        # memory backend (default & only value today)
+  api_key: ${HINDSIGHT_API_KEY}
+  bank_id: remy-auto
+  budget: mid

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5794,6 +5794,40 @@ def create_runner_app(
             _content_summary[:20],
         )
 
+        # Automatic long-term memory (opt-in via the spec ``memory:`` block).
+        # Recall runs before the model sees the turn and augments the system
+        # prompt; retain persists the user's turn. Both are best effort and
+        # never block or fail the turn — recall is time-bounded and retain
+        # runs in the background (see omnigent/runtime/memory.py). Runs here,
+        # at the shared dispatch chokepoint, so every harness gets the same
+        # behaviour without per-runtime wiring.
+        _mem_cfg = cached_spec.memory if cached_spec is not None else None
+        if _mem_cfg is not None and _mem_cfg.enabled:
+            from omnigent.runtime import memory as auto_memory
+
+            _mem_bank = auto_memory.resolve_bank(_mem_cfg, msg_body.get("agent_id"), conv)
+            _mem_query = auto_memory.extract_latest_user_text(harness_body.get("content"))
+            if _mem_bank and _mem_query:
+                if _mem_cfg.auto_recall:
+                    _recalled = await auto_memory.recall_instructions(
+                        _mem_cfg, _mem_bank, _mem_query
+                    )
+                    if _recalled:
+                        if is_native_harness(harness_name):
+                            # Native harnesses ignore per-turn instructions
+                            # (system prompt is fixed at spawn); the user
+                            # message content is the only per-turn channel to
+                            # the model, so inject the recalled memory there.
+                            harness_body["content"] = auto_memory.prepend_memory_to_content(
+                                harness_body.get("content"), _recalled
+                            )
+                        else:
+                            instructions = (
+                                f"{instructions}\n\n{_recalled}" if instructions else _recalled
+                            )
+                if _mem_cfg.auto_retain:
+                    auto_memory.schedule_retain(_mem_cfg, _mem_bank, _mem_query)
+
         if instructions:
             harness_body["instructions"] = instructions
 

--- a/omnigent/runtime/memory.py
+++ b/omnigent/runtime/memory.py
@@ -1,0 +1,329 @@
+"""Automatic long-term memory for the turn lifecycle.
+
+Deterministic recall/retain wired into the runner's turn dispatch and driven
+by the agent spec's ``memory:`` block (:class:`~omnigent.spec.types.MemoryConfig`).
+This is the *non-tool* path: unlike the ``hindsight_*`` built-in tools, the
+model does not have to elect to call anything for memory to work.
+
+- **Recall** runs before the model sees the turn and returns a block of relevant
+  memories. The runner injects it as a system prompt for executor harnesses, or
+  prepends it to the user message for native harnesses (which fix their system
+  prompt at spawn) — see :func:`prepend_memory_to_content`.
+- **Retain** persists the user's turn after dispatch.
+
+``memory:`` is a generic feature; the backend is selected by
+``MemoryConfig.provider`` and dispatched through the :data:`_BACKENDS` registry
+(mirroring the ``web_search`` tool's ``_Backend`` idiom). Hindsight is the
+default and, today, only backend; its ``hindsight_client`` SDK is an optional
+dependency (``omnigent[hindsight]``) imported lazily so this module loads even
+when memory is unconfigured.
+
+Both phases are best effort — a slow or unreachable backend must never fail or
+stall a turn, so every call is guarded and recall is time-bounded.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from hindsight_client import Hindsight
+
+    from omnigent.spec.types import MemoryConfig
+
+_logger = logging.getLogger(__name__)
+
+_DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
+
+# Background retain tasks, kept referenced so the event loop does not GC them
+# mid-flight (asyncio holds only a weak reference to a bare task). Each task
+# removes itself on completion via the done callback below.
+_RETAIN_TASKS: set[asyncio.Task[None]] = set()
+
+# Banks ensured-to-exist this process, so retain does not issue a redundant
+# create_bank on every turn. Module-level to mirror the ``hindsight_*`` tools'
+# cache and share the effect across sessions.
+_CREATED_BANKS: set[str] = set()
+
+
+def resolve_bank(
+    cfg: MemoryConfig,
+    agent_id: object,
+    conversation_id: object,
+) -> str | None:
+    """Resolve the memory bank: config ``bank_id`` → agent id → conversation id.
+
+    Matches the ``hindsight_*`` tools' rule so tool-based and automatic memory
+    share a bank. Returns the first non-empty *string* candidate; empty strings
+    and non-string values (the runner threads these from loosely-typed request
+    dicts) fall through rather than resolving to an empty bank that would
+    silently co-mingle every agent's memory.
+
+    :param cfg: The agent's memory configuration.
+    :param agent_id: The run's agent id, if any.
+    :param conversation_id: The run's conversation id, if any.
+    :returns: The resolved bank id, or ``None`` when none could be determined.
+    """
+    for candidate in (cfg.bank_id, agent_id, conversation_id):
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return None
+
+
+# Fallback HTTP timeout for the retain path, whose fact-extraction call can
+# legitimately run longer than a recall. Recall passes its own (shorter)
+# ``recall_timeout`` instead — see ``_hindsight_recall``.
+_DEFAULT_CLIENT_TIMEOUT = 30.0
+
+
+def _build_client(cfg: MemoryConfig, *, timeout: float = _DEFAULT_CLIENT_TIMEOUT) -> Hindsight:
+    """Construct a Hindsight client from *cfg* (lazy SDK import).
+
+    :param timeout: HTTP timeout in seconds. Recall passes ``cfg.recall_timeout``
+        so the blocking SDK call unwinds close to when the turn stops waiting on
+        it (``asyncio.wait_for``) — otherwise a timed-out recall would keep a
+        worker thread busy for the full default timeout under a slow backend.
+    """
+    import hindsight_client
+
+    return hindsight_client.Hindsight(
+        base_url=cfg.api_url or _DEFAULT_API_URL,
+        api_key=cfg.api_key,
+        timeout=timeout,
+    )
+
+
+def _close_client(client: Hindsight) -> None:
+    """Best-effort close of a per-call client to free its HTTP session.
+
+    A fresh client is built per recall/retain, so it must be closed or the
+    long-lived runner leaks an ``aiohttp`` session/connector each turn.
+    """
+    close = getattr(client, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception as e:
+            _logger.debug("Hindsight client close failed: %s", e)
+
+
+def extract_latest_user_text(content: object) -> str | None:
+    """Pull the most recent user message's text from harness content items.
+
+    ``content`` is the list assembled for ``harness_body["content"]``: message
+    items carry a ``role`` and either a plain-string ``content`` or a list of
+    blocks each with a ``text`` field. Keys on ``role == "user"`` (not the
+    optional ``type`` field), mirroring the native executors' own
+    ``_latest_user_text`` so both the persisted-history shape
+    (``{"type": "message", "role": ...}``) and the inbound-turn shape
+    (``{"role": ...}``) are handled. Returns the concatenated text of the last
+    user message, or ``None`` when no user text is present. Defensive against
+    unexpected shapes so a malformed item can never raise into the turn path.
+
+    :param content: The harness content items (expected ``list[dict]``).
+    :returns: The latest user message text, or ``None``.
+    """
+    if not isinstance(content, list):
+        return None
+    for item in reversed(content):
+        if not isinstance(item, dict) or item.get("role") != "user":
+            continue
+        blocks = item.get("content")
+        if isinstance(blocks, str):
+            return blocks.strip() or None
+        if not isinstance(blocks, list):
+            continue
+        parts: list[str] = []
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+            text = block.get("text")
+            if isinstance(text, str) and text.strip():
+                parts.append(text.strip())
+        if parts:
+            return "\n".join(parts)
+    return None
+
+
+# Content block type carrying recalled memory injected into a native turn's
+# user message. Native harnesses fix the system prompt at spawn, so the user
+# message content is the only per-turn channel that reaches the model. The
+# native prompt builder accepts both ``input_text`` and ``text``; ``input_text``
+# matches how user turns are otherwise encoded (see entities/conversation.py).
+_MEMORY_BLOCK_TYPE = "input_text"
+
+
+def prepend_memory_to_content(content: object, memory_block: str) -> object:
+    """Prepend recalled *memory_block* to the latest user message in *content*.
+
+    Used for native harnesses, whose per-turn system prompt is fixed at spawn —
+    the user message content is the only channel that reaches the model each
+    turn (executor harnesses instead take an injected system prompt). Returns a
+    new content list with the memory as a leading block on the most recent user
+    message. Returns *content* unchanged when its shape is unrecognised, so a
+    malformed turn simply proceeds without injected memory.
+
+    :param content: The harness content items (expected ``list[dict]``).
+    :param memory_block: The formatted memory text to inject.
+    :returns: A new content list, or *content* unchanged.
+    """
+    if not isinstance(content, list):
+        return content
+    block = {"type": _MEMORY_BLOCK_TYPE, "text": memory_block}
+    new_content = list(content)
+    for idx in range(len(new_content) - 1, -1, -1):
+        item = new_content[idx]
+        if not isinstance(item, dict) or item.get("role") != "user":
+            continue
+        blocks = item.get("content")
+        if isinstance(blocks, str):
+            new_blocks: list[object] = [block, {"type": _MEMORY_BLOCK_TYPE, "text": blocks}]
+        elif isinstance(blocks, list):
+            new_blocks = [block, *blocks]
+        else:
+            return content
+        new_content[idx] = {**item, "content": new_blocks}
+        return new_content
+    return content
+
+
+def _hindsight_recall(cfg: MemoryConfig, bank: str, query: str) -> list[str]:
+    """Blocking Hindsight recall; run off-loop via :func:`asyncio.to_thread`."""
+    client = _build_client(cfg, timeout=cfg.recall_timeout)
+    try:
+        response = client.recall(
+            bank_id=bank,
+            query=query,
+            budget=cfg.budget,
+            max_tokens=cfg.max_tokens,
+        )
+        return [r.text for r in (response.results or []) if getattr(r, "text", None)]
+    finally:
+        _close_client(client)
+
+
+def _hindsight_retain(cfg: MemoryConfig, bank: str, content: str) -> None:
+    """Blocking Hindsight retain; run off-loop via :func:`asyncio.to_thread`."""
+    client = _build_client(cfg)
+    try:
+        if bank not in _CREATED_BANKS:
+            try:
+                client.create_bank(bank_id=bank, name=bank)
+            except Exception as e:
+                # Bank likely already exists; a real auth/network failure
+                # surfaces on the retain call below.
+                _logger.debug("create_bank(%r) failed (assuming it exists): %s", bank, e)
+            _CREATED_BANKS.add(bank)
+        client.retain(bank_id=bank, content=content)
+    finally:
+        _close_client(client)
+
+
+@dataclass(frozen=True)
+class _MemoryBackend:
+    """A selectable memory backend in the :data:`_BACKENDS` registry.
+
+    Mirrors the ``web_search`` tool's ``_Backend`` idiom: the generic ``memory:``
+    feature dispatches recall/retain to the backend named by
+    ``MemoryConfig.provider``. Both callables are blocking and are run off the
+    event loop via :func:`asyncio.to_thread`.
+
+    :param recall: ``(cfg, bank, query) -> list[str]`` of recalled memory texts.
+    :param retain: ``(cfg, bank, content) -> None`` persisting the user's turn.
+    """
+
+    recall: Callable[[MemoryConfig, str, str], list[str]]
+    retain: Callable[[MemoryConfig, str, str], None]
+
+
+# Backend registry keyed by ``MemoryConfig.provider``. Keep in sync with
+# ``_MEMORY_PROVIDERS`` in ``omnigent/spec/parser.py`` — the parser validates the
+# provider name at load time, so a missing entry here would be a bug, not user
+# error. Hindsight is the default and, today, only backend.
+_BACKENDS: dict[str, _MemoryBackend] = {
+    "hindsight": _MemoryBackend(recall=_hindsight_recall, retain=_hindsight_retain),
+}
+
+
+def _backend_for(cfg: MemoryConfig) -> _MemoryBackend | None:
+    """Return the backend for ``cfg.provider``, or ``None`` if unregistered."""
+    return _BACKENDS.get(cfg.provider)
+
+
+async def recall_instructions(cfg: MemoryConfig, bank: str, query: str) -> str | None:
+    """Recall memories for *query* and format them as a system-prompt block.
+
+    Returns ``None`` (never raises) on timeout, backend error, or no hits, so
+    the turn always proceeds. Bounded by ``cfg.recall_timeout`` so a stalled
+    backend adds at most that many seconds to a turn.
+
+    :param cfg: The agent's memory configuration.
+    :param bank: The resolved memory bank.
+    :param query: The recall query (typically the latest user message).
+    :returns: A ready-to-inject instructions block, or ``None``.
+    """
+    backend = _backend_for(cfg)
+    if backend is None:
+        _logger.warning("Unknown memory provider %r; skipping recall.", cfg.provider)
+        return None
+    try:
+        memories = await asyncio.wait_for(
+            asyncio.to_thread(backend.recall, cfg, bank, query),
+            timeout=cfg.recall_timeout,
+        )
+    except TimeoutError:
+        _logger.warning(
+            "Memory recall timed out after %ss (provider=%s, bank=%s); "
+            "dispatching without memory.",
+            cfg.recall_timeout,
+            cfg.provider,
+            bank,
+        )
+        return None
+    except Exception as e:
+        _logger.warning("Memory recall failed (provider=%s, bank=%s): %s", cfg.provider, bank, e)
+        return None
+    if not memories:
+        return None
+    body = "\n".join(f"- {m}" for m in memories)
+    return (
+        "## Relevant long-term memory\n"
+        "The following facts were recalled from earlier sessions and may be "
+        "relevant to this turn. Treat them as background you already know; do "
+        "not mention that they came from memory unless asked.\n"
+        f"{body}"
+    )
+
+
+def schedule_retain(cfg: MemoryConfig, bank: str, content: str) -> None:
+    """Persist *content* to memory in the background (fire-and-forget).
+
+    Retain triggers server-side fact extraction and can be slow, so it must
+    not block the turn. Runs on a worker thread; failures are logged, never
+    raised. The task is tracked to survive garbage collection and cleared on
+    completion.
+
+    :param cfg: The agent's memory configuration.
+    :param bank: The resolved memory bank.
+    :param content: The text to persist (typically the user's turn).
+    """
+    backend = _backend_for(cfg)
+    if backend is None:
+        _logger.warning("Unknown memory provider %r; skipping retain.", cfg.provider)
+        return
+
+    async def _run() -> None:
+        try:
+            await asyncio.to_thread(backend.retain, cfg, bank, content)
+        except Exception as e:
+            _logger.warning(
+                "Memory retain failed (provider=%s, bank=%s): %s", cfg.provider, bank, e
+            )
+
+    task = asyncio.create_task(_run())
+    _RETAIN_TASKS.add(task)
+    task.add_done_callback(_RETAIN_TASKS.discard)

--- a/omnigent/spec/AGENTSPEC.md
+++ b/omnigent/spec/AGENTSPEC.md
@@ -174,6 +174,49 @@ tools:
 
 ---
 
+## Memory — `memory:`
+
+Automatic long-term memory. `memory:` is a generic feature; the backend is chosen by
+`provider` (default and, today, only value `hindsight`, backed by
+[Hindsight](https://github.com/vectorize-io/hindsight)), so the feature name stays
+independent of any one integration. This is the deterministic counterpart to the
+`hindsight_*` built-in tools: instead of relying on the model to *call* a tool, the
+runtime recalls relevant memories and injects them before each turn, and persists the
+user's turn afterward. It works across every harness because it runs at the shared
+turn-dispatch point, not in a harness-specific hook: executor harnesses (`claude-sdk`,
+`llm`) receive recalled memory as an injected system prompt, while native harnesses —
+whose system prompt is fixed at spawn — receive it prepended to the turn's user message.
+
+```yaml
+memory:
+  enabled: true                 # master switch (default false → no auto memory)
+  api_key: ${HINDSIGHT_API_KEY} # required when enabled
+  # --- all optional below ---
+  provider: hindsight           # memory backend (default & only value: hindsight)
+  api_url: https://api.hindsight.vectorize.io   # default: the provider's default endpoint
+  bank_id: my-agent             # default: agent id, then conversation id
+  auto_recall: true             # inject recalled memories into the prompt (default true)
+  auto_retain: true             # persist the user's turn (default true)
+  budget: mid                   # recall depth: low | mid | high (default mid)
+  max_tokens: 4096              # max recalled memory injected per turn
+  recall_timeout: 10.0          # seconds before a slow recall is skipped for the turn
+```
+
+Both phases are **best effort**: recall is time-bounded (`recall_timeout`) and retain
+runs in the background, so a slow or unreachable backend never blocks or fails a turn.
+The bank resolves the same way as the `hindsight_*` tools (`bank_id` → agent id →
+conversation id), so declaring both shares one bank. Setting `enabled: true` turns on
+both `auto_recall` and `auto_retain` unless either is individually set to `false`.
+
+`auto_retain` persists **the user's turn only** — not the assistant's response. Recall
+is therefore built from what users tell the agent (plus Hindsight's server-side fact
+extraction), not from the model's own answers. If you want the agent to store its
+conclusions too, keep the `hindsight_retain` tool available alongside this block.
+
+The `hindsight-client` SDK ships in the `omnigent[hindsight]` extra.
+
+---
+
 ## Instructions
 
 Free-form text injected into the system prompt. Defines personality,
@@ -404,9 +447,6 @@ The validator (`validator.py`) enforces:
 
 - **Builtin tools: `search.web`, `code.execute`, `memory.*`** — standardized
   runtime-provided tools. Interfaces and availability will be defined soon.
-
-- **Memory policy declarations** — a `memory:` block for consent hints and
-  scope declarations. Memory is purely a tool concern in v1.
 
 - **`when:` routing hints on sub-agents** — declarative hints in `tools.agents`
   entries describing when to call each sub-agent. Skill content handles routing

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -40,6 +40,7 @@ from omnigent.spec.types import (
     LLMConfig,
     LocalToolInfo,
     MCPServerConfig,
+    MemoryConfig,
     ModalityConfig,
     Phase,
     PhaseSelector,
@@ -53,6 +54,17 @@ from omnigent.spec.types import (
 )
 
 _log = logging.getLogger(__name__)
+
+# Valid recall/reflect budget levels for the ``memory:`` block, matching
+# the ``hindsight_*`` built-in tools' accepted values.
+_MEMORY_BUDGETS = frozenset({"low", "mid", "high"})
+
+# Selectable backends for the ``memory:`` block's ``provider`` key. The block
+# is a generic memory *feature*; the backend is chosen here (Hindsight is the
+# default and, today, only value) so the feature stays independent of any one
+# integration. Mirrors the runtime backend registry in
+# ``omnigent/runtime/memory.py`` — keep the two in sync when adding a backend.
+_MEMORY_PROVIDERS = frozenset({"hindsight"})
 
 # Context files scanned in priority order when ``instructions:`` is absent.
 # First file found wins (no merge).
@@ -238,6 +250,7 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
         )
     compaction = _parse_compaction(raw.get("compaction"))
     guardrails = _parse_guardrails(raw.get("guardrails"), expand_env=expand_env)
+    memory = _parse_memory(raw.get("memory"), expand_env=expand_env)
     os_env = _parse_os_env(raw.get("os_env"))
     terminals = _parse_terminals(raw.get("terminals"))
     params = raw.get("params", {})
@@ -296,6 +309,7 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
         executor=executor,
         compaction=compaction,
         guardrails=guardrails,
+        memory=memory,
         params=params,
         instructions=instructions,
         skills=skills,
@@ -2022,6 +2036,94 @@ def _parse_compaction(
         recent_window=_parse_int_field(
             raw.get("recent_window", 5),
             "compaction.recent_window",
+        ),
+    )
+
+
+def _parse_memory(
+    raw: dict[str, object] | None,
+    *,
+    expand_env: bool = True,
+) -> MemoryConfig | None:
+    """
+    Parse the ``memory:`` block from config.yaml into a
+    :class:`MemoryConfig`.
+
+    Returns ``None`` when the block is absent — the runtime does no
+    automatic recall/retain in that case. When present but
+    ``enabled: false``, a populated (disabled) config is still returned
+    so the runtime's own opt-in check is the single source of truth.
+
+    ``api_key`` / ``api_url`` are env-expanded (like other secret-bearing
+    blocks) so ``${HINDSIGHT_API_KEY}`` resolves at parse time. When
+    ``enabled`` is true, ``api_key`` is required — a missing key is a
+    load-time error rather than a per-turn failure.
+
+    :param raw: The ``memory:`` mapping from config.yaml, or ``None``
+        when the block was absent. Example:
+        ``{"enabled": True, "api_key": "${HINDSIGHT_API_KEY}",
+        "bank_id": "acme", "budget": "high"}``.
+    :param expand_env: Whether to expand ``${VAR}`` references in
+        ``api_key`` / ``api_url``. Disabled for scaffolding/validation.
+    :returns: A populated :class:`MemoryConfig`, or ``None`` when *raw*
+        is ``None``.
+    :raises OmnigentError: If *raw* is not a mapping, a field has the
+        wrong type, or ``enabled`` is true without an ``api_key``.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise OmnigentError(
+            f"memory: must be a mapping, got {type(raw).__name__}",
+            code=ErrorCode.INVALID_INPUT,
+        )
+
+    secrets = {
+        key: value for key in ("api_key", "api_url") if isinstance(value := raw.get(key), str)
+    }
+    if expand_env and secrets:
+        secrets = expand_env_vars(secrets)
+
+    enabled = bool(raw.get("enabled", False))
+    provider = raw.get("provider", "hindsight")
+    if not isinstance(provider, str) or provider not in _MEMORY_PROVIDERS:
+        raise OmnigentError(
+            f"memory.provider must be one of {sorted(_MEMORY_PROVIDERS)}, got {provider!r}",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    budget = raw.get("budget", "mid")
+    if not isinstance(budget, str) or budget not in _MEMORY_BUDGETS:
+        raise OmnigentError(
+            f"memory.budget must be one of {sorted(_MEMORY_BUDGETS)}, got {budget!r}",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    bank_id = raw.get("bank_id")
+    if bank_id is not None and not isinstance(bank_id, str):
+        raise OmnigentError(
+            f"memory.bank_id must be a string, got {type(bank_id).__name__}",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    api_key = secrets.get("api_key")
+    if enabled and not api_key:
+        raise OmnigentError(
+            "memory.api_key is required when memory.enabled is true "
+            "(e.g. api_key: ${HINDSIGHT_API_KEY}).",
+            code=ErrorCode.INVALID_INPUT,
+        )
+
+    return MemoryConfig(
+        enabled=enabled,
+        auto_recall=bool(raw.get("auto_recall", True)),
+        auto_retain=bool(raw.get("auto_retain", True)),
+        provider=provider,
+        api_key=api_key,
+        api_url=secrets.get("api_url"),
+        bank_id=bank_id,
+        budget=budget,
+        max_tokens=_parse_int_field(raw.get("max_tokens", 4096), "memory.max_tokens"),
+        recall_timeout=_parse_float_field(
+            raw.get("recall_timeout", 10.0),
+            "memory.recall_timeout",
         ),
     )
 

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -652,6 +652,69 @@ class CompactionConfig:
 
 
 @dataclass
+class MemoryConfig:
+    """
+    Automatic long-term memory configuration.
+
+    Parsed from the top-level ``memory:`` block in config.yaml. Unlike
+    the ``hindsight_*`` built-in tools (which the model must *choose* to
+    call), this block wires memory into the turn lifecycle
+    deterministically: recalled context is injected before the model
+    sees the turn, and the user's turn is persisted after dispatch —
+    neither depends on the model electing to call a tool.
+
+    ``memory:`` is the generic *feature*; the *backend* is selected by
+    ``provider`` (default and, today, only value ``hindsight``), so the
+    feature name stays independent of any one integration. The Hindsight
+    backend shares the same ``hindsight-client`` SDK and bank-resolution
+    rule as the ``hindsight_*`` tools, so tool-based and automatic memory
+    share a bank.
+
+    The block is **opt-in**: an agent with no ``memory:`` block gets
+    ``None`` here and the runtime skips the whole layer. Setting
+    ``enabled: true`` turns on both ``auto_recall`` and ``auto_retain``
+    unless either is individually disabled.
+
+    :param enabled: Master switch. ``False`` (the default) means the
+        runtime does no automatic recall or retain, even if the other
+        fields are set.
+    :param auto_recall: When enabled, recall relevant memories before
+        each turn and inject them. Defaults to ``True``.
+    :param auto_retain: When enabled, persist the user's turn to
+        long-term memory after dispatch. Defaults to ``True``.
+    :param provider: Memory backend to use. Defaults to ``"hindsight"``,
+        currently the only supported value; the field exists so the
+        generic ``memory:`` feature can gain other backends without a
+        spec change.
+    :param api_key: Backend API key (for Hindsight, typically
+        ``${HINDSIGHT_API_KEY}`` in YAML, expanded at parse time).
+        Required when ``enabled``.
+    :param api_url: Backend API base URL. ``None`` uses the provider
+        default (Hindsight Cloud for the ``hindsight`` provider).
+    :param bank_id: Memory bank to read/write. ``None`` falls back to the
+        run's ``agent_id`` then ``conversation_id`` (matching the
+        ``hindsight_*`` tools), so a single block isolates memory per
+        agent out of the box.
+    :param budget: Recall budget level — ``low`` / ``mid`` / ``high``.
+    :param max_tokens: Max tokens of recalled memory injected per turn.
+    :param recall_timeout: Seconds to wait for a recall before giving up
+        and dispatching the turn without injected memory. Bounds the
+        latency a slow or unreachable backend can add to a turn.
+    """
+
+    enabled: bool = False
+    auto_recall: bool = True
+    auto_retain: bool = True
+    provider: str = "hindsight"
+    api_key: str | None = None
+    api_url: str | None = None
+    bank_id: str | None = None
+    budget: str = "mid"
+    max_tokens: int = 4096
+    recall_timeout: float = 10.0
+
+
+@dataclass
 class LLMConfig:  # type: ignore[explicit-any]  # extra: dict[str, Any] field (see below)
     """
     LLM configuration block from config.yaml.
@@ -1441,6 +1504,17 @@ class AgentSpec:  # type: ignore[explicit-any]  # params: dict[str, Any] field (
         ``guardrails:`` block — runtime builds a no-op engine
         with zero policies and an empty label cache. See
         POLICIES.md §3, §4.
+    :param memory: Automatic long-term memory configuration from the
+        top-level ``memory:`` block (a generic feature whose backend is
+        chosen by ``provider``, default ``hindsight``).
+        ``None`` only when the block is **absent**; a present block
+        always parses to a populated :class:`MemoryConfig` (even with
+        ``enabled: false``), so callers gate on ``memory.enabled``, not
+        ``memory is None``. When enabled, recalled memories are injected
+        before each turn and the user's turn is persisted after
+        dispatch; otherwise the runtime does no automatic recall/retain
+        and memory is available only through the ``hindsight_*`` built-in
+        tools if declared.
     :param async_enabled: Whether the LLM-callable async-dispatch
         builtins (``sys_call_async``, ``sys_read_inbox``,
         ``sys_cancel_async``) are registered. YAML key is
@@ -1560,6 +1634,7 @@ class AgentSpec:  # type: ignore[explicit-any]  # params: dict[str, Any] field (
     executor: ExecutorSpec = field(default_factory=ExecutorSpec)
     compaction: CompactionConfig | None = None
     guardrails: GuardrailsSpec | None = None
+    memory: MemoryConfig | None = None
     async_enabled: bool = True
     os_env: OSEnvSpec | None = None
     terminals: dict[str, TerminalEnvSpec] | None = None

--- a/omnigent/spec/validator.py
+++ b/omnigent/spec/validator.py
@@ -92,6 +92,7 @@ def validate(spec: AgentSpec) -> ValidationResult:
     _validate_local_tools(spec, result)
     _validate_sub_agents(spec, result)
     _validate_compaction(spec, result)
+    _validate_memory(spec, result)
     _validate_os_env(spec, result)
     return result
 
@@ -468,6 +469,30 @@ def _validate_compaction(spec: AgentSpec, result: ValidationResult) -> None:
         result.add(
             "compaction.recent_window",
             f"must be non-negative, got {spec.compaction.recent_window}",
+        )
+
+
+def _validate_memory(spec: AgentSpec, result: ValidationResult) -> None:
+    """
+    Validate the automatic-memory configuration if present.
+
+    Budget and the enabled/api_key requirement are enforced at parse
+    time; this covers the numeric bounds a mapping-shape check can't.
+
+    :param spec: The agent spec to check.
+    :param result: Accumulator for any validation errors found.
+    """
+    if spec.memory is None:
+        return
+    if spec.memory.max_tokens <= 0:
+        result.add(
+            "memory.max_tokens",
+            f"must be positive, got {spec.memory.max_tokens}",
+        )
+    if spec.memory.recall_timeout <= 0:
+        result.add(
+            "memory.recall_timeout",
+            f"must be positive, got {spec.memory.recall_timeout}",
         )
 
 

--- a/tests/e2e/omnigent/test_example_remy_auto.py
+++ b/tests/e2e/omnigent/test_example_remy_auto.py
@@ -1,0 +1,75 @@
+"""Structural test for the Remy Auto automatic-memory example (examples/remy_auto).
+
+Remy Auto is the runtime-``memory:``-block counterpart to ``remy``: same
+"assistant that remembers", but recall/retain are automatic (handled by the
+runner) instead of exposed as ``hindsight_*`` tools the model must call. Pure
+spec-load -- no LLM, no credentials, no Hindsight API key required.
+
+What breaks if this fails:
+- the ``memory:`` block is dropped or disabled (Remy Auto stops remembering),
+- ``auto_recall`` / ``auto_retain`` are silently flipped off,
+- the shared bank_id changes (memory splits across runs),
+- a ``hindsight_*`` tool leaks back in (this example is deliberately tool-free —
+  its whole point is that memory needs no tools),
+- the harness changes away from claude-sdk, or the agent is pinned to a model
+  (re-coupling it to one provider).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.spec import load
+from omnigent.spec.types import AgentSpec
+
+# tests/e2e/omnigent/test_example_remy_auto.py -> repo root is 3 parents up.
+_REMY_AUTO_BUNDLE = Path(__file__).resolve().parents[3] / "examples" / "remy_auto"
+
+
+@pytest.fixture(scope="module")
+def remy_auto_spec() -> AgentSpec:
+    """Load and validate the remy_auto bundle once for the module.
+
+    expand_env=False so the structural tests run without a live HINDSIGHT_API_KEY;
+    the ``${HINDSIGHT_API_KEY}`` reference is preserved verbatim.
+    """
+    return load(_REMY_AUTO_BUNDLE, expand_env=False)
+
+
+def test_remy_auto_name_and_harness(remy_auto_spec: AgentSpec) -> None:
+    """Remy Auto runs on the claude-sdk harness with no model pinned."""
+    assert remy_auto_spec.name == "remy-auto"
+    assert remy_auto_spec.executor.config.get("harness") == "claude-sdk"
+    assert remy_auto_spec.executor.model is None
+
+
+def test_remy_auto_memory_block_enabled(remy_auto_spec: AgentSpec) -> None:
+    """The automatic memory layer is configured and both phases are on."""
+    memory = remy_auto_spec.memory
+    assert memory is not None, "Remy Auto must declare a memory: block"
+    assert memory.enabled is True
+    assert memory.auto_recall is True
+    assert memory.auto_retain is True
+    assert memory.bank_id == "remy-auto"
+    assert memory.provider == "hindsight"
+
+
+def test_remy_auto_api_key_uses_env_reference(remy_auto_spec: AgentSpec) -> None:
+    """The example must not hardcode a key -- it references the env var."""
+    assert remy_auto_spec.memory is not None
+    assert remy_auto_spec.memory.api_key == "${HINDSIGHT_API_KEY}"
+
+
+def test_remy_auto_has_no_memory_tools(remy_auto_spec: AgentSpec) -> None:
+    """The whole point: automatic memory needs no hindsight_* tools declared."""
+    names = {b.name for b in remy_auto_spec.tools.builtins}
+    assert not (names & {"hindsight_recall", "hindsight_retain", "hindsight_reflect"}), (
+        f"remy_auto must declare no Hindsight tools; got {names}"
+    )
+
+
+def test_remy_auto_has_no_sub_agents(remy_auto_spec: AgentSpec) -> None:
+    """Remy Auto is a single agent -- no sub-agents."""
+    assert remy_auto_spec.sub_agents == []

--- a/tests/inner/test_claude_native_memory_injection.py
+++ b/tests/inner/test_claude_native_memory_injection.py
@@ -1,0 +1,73 @@
+"""Integration: automatic-recall content survives the real native executor.
+
+The runner injects recalled memory into a native turn by prepending an
+``input_text`` block to the user message (native harnesses fix the system
+prompt at spawn, so content is the only per-turn channel). This test drives the
+*real* :class:`ClaudeNativeExecutor.run_turn` — the strictest native consumer,
+which extracts ``input_text`` blocks only — and asserts the recalled memory
+reaches the text typed into Claude's pane, ahead of the user's own message.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from omnigent.inner import claude_native_executor
+from omnigent.inner.claude_native_executor import ClaudeNativeExecutor
+from omnigent.runtime.memory import prepend_memory_to_content
+
+
+@pytest.mark.asyncio
+async def test_recalled_memory_reaches_claude_native_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    bridge_dir = tmp_path / "bridge"
+    sent: list[str] = []
+
+    def fake_inject_user_message(
+        bridge_dir_arg: Path,
+        *,
+        content: str,
+        timeout_s: float = 30.0,
+    ) -> None:
+        del bridge_dir_arg, timeout_s
+        sent.append(content)
+
+    monkeypatch.setattr(
+        claude_native_executor,
+        "inject_user_message",
+        fake_inject_user_message,
+    )
+
+    # Shape the runner produces for a native turn: a user message whose content
+    # is a list of input_text blocks.
+    content: list[dict[str, Any]] = [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "what do you know about me?"}],
+        }
+    ]
+    memory_block = "## Relevant long-term memory\n- The user prefers tea over coffee."
+    injected = prepend_memory_to_content(content, memory_block)
+
+    executor = ClaudeNativeExecutor(bridge_dir)
+    _ = [
+        event
+        async for event in executor.run_turn(
+            messages=injected,  # type: ignore[arg-type]
+            tools=[],
+            system_prompt="ignored",
+        )
+    ]
+
+    assert len(sent) == 1
+    prompt = sent[0]
+    assert "prefers tea over coffee" in prompt
+    assert "what do you know about me?" in prompt
+    # Recalled memory precedes the user's own message text.
+    assert prompt.index("prefers tea over coffee") < prompt.index("what do you know about me?")

--- a/tests/runtime/test_memory.py
+++ b/tests/runtime/test_memory.py
@@ -1,0 +1,272 @@
+"""Unit tests for omnigent.runtime.memory (automatic long-term memory)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from omnigent.runtime import memory as auto_memory
+from omnigent.spec.types import MemoryConfig
+
+
+def _cfg(**overrides: Any) -> MemoryConfig:
+    base: dict[str, Any] = {"enabled": True, "api_key": "k"}
+    base.update(overrides)
+    return MemoryConfig(**base)
+
+
+class _FakeResult:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _FakeRecallResponse:
+    def __init__(self, texts: list[str]) -> None:
+        self.results = [_FakeResult(t) for t in texts]
+
+
+class _FakeClient:
+    """Records calls and returns canned recall results."""
+
+    def __init__(self, *, recall_texts: list[str] | None = None) -> None:
+        self._recall_texts = recall_texts or []
+        self.retained: list[str] = []
+        self.created_banks: list[str] = []
+
+    def create_bank(self, *, bank_id: str, name: str) -> None:
+        self.created_banks.append(bank_id)
+
+    def recall(self, **kwargs: Any) -> _FakeRecallResponse:
+        return _FakeRecallResponse(self._recall_texts)
+
+    def retain(self, *, bank_id: str, content: str) -> None:
+        self.retained.append(content)
+
+
+# --- extract_latest_user_text ------------------------------------------------
+
+
+def test_extract_from_block_list() -> None:
+    content = [
+        {"type": "message", "role": "user", "content": [{"type": "text", "text": "hello"}]},
+    ]
+    assert auto_memory.extract_latest_user_text(content) == "hello"
+
+
+def test_extract_picks_last_user_message() -> None:
+    content = [
+        {"type": "message", "role": "user", "content": [{"type": "text", "text": "first"}]},
+        {"type": "message", "role": "assistant", "content": [{"type": "text", "text": "reply"}]},
+        {"type": "message", "role": "user", "content": [{"type": "text", "text": "second"}]},
+    ]
+    assert auto_memory.extract_latest_user_text(content) == "second"
+
+
+def test_extract_from_plain_string_content() -> None:
+    content = [{"type": "message", "role": "user", "content": "  plain  "}]
+    assert auto_memory.extract_latest_user_text(content) == "plain"
+
+
+def test_extract_joins_multiple_text_blocks() -> None:
+    content = [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}],
+        }
+    ]
+    assert auto_memory.extract_latest_user_text(content) == "a\nb"
+
+
+def test_extract_no_user_message_returns_none() -> None:
+    content = [
+        {"type": "message", "role": "assistant", "content": [{"type": "text", "text": "x"}]}
+    ]
+    assert auto_memory.extract_latest_user_text(content) is None
+
+
+def test_extract_non_list_returns_none() -> None:
+    assert auto_memory.extract_latest_user_text(None) is None
+    assert auto_memory.extract_latest_user_text("not a list") is None
+
+
+def test_extract_bare_role_shape_without_type() -> None:
+    # Inbound-turn items may omit the ``type`` field (executor message shape).
+    content = [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}]
+    assert auto_memory.extract_latest_user_text(content) == "hi"
+
+
+# --- prepend_memory_to_content -----------------------------------------------
+
+
+def test_prepend_memory_to_block_list() -> None:
+    content = [
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+    ]
+    result = auto_memory.prepend_memory_to_content(content, "MEM")
+    assert isinstance(result, list)
+    blocks = result[0]["content"]
+    assert blocks[0] == {"type": "input_text", "text": "MEM"}
+    assert blocks[1] == {"type": "input_text", "text": "hi"}
+
+
+def test_prepend_memory_targets_latest_user_message() -> None:
+    content = [
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "old"}]},
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "new"}]},
+    ]
+    result = auto_memory.prepend_memory_to_content(content, "MEM")
+    assert result[0]["content"][0]["text"] == "old"  # untouched
+    assert result[1]["content"][0]["text"] == "MEM"
+    assert result[1]["content"][1]["text"] == "new"
+
+
+def test_prepend_memory_to_string_content() -> None:
+    content = [{"type": "message", "role": "user", "content": "plain"}]
+    result = auto_memory.prepend_memory_to_content(content, "MEM")
+    blocks = result[0]["content"]
+    assert blocks[0] == {"type": "input_text", "text": "MEM"}
+    assert blocks[1] == {"type": "input_text", "text": "plain"}
+
+
+def test_prepend_memory_does_not_mutate_input() -> None:
+    content = [
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]}
+    ]
+    auto_memory.prepend_memory_to_content(content, "MEM")
+    assert content[0]["content"] == [{"type": "input_text", "text": "hi"}]
+
+
+def test_prepend_memory_unrecognised_shape_returns_unchanged() -> None:
+    assert auto_memory.prepend_memory_to_content(None, "MEM") is None
+    no_user = [{"type": "message", "role": "assistant", "content": []}]
+    assert auto_memory.prepend_memory_to_content(no_user, "MEM") is no_user
+
+
+def test_prepend_memory_bare_role_shape_without_type() -> None:
+    # Inbound-turn items may omit the ``type`` field (executor message shape).
+    content = [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}]
+    result = auto_memory.prepend_memory_to_content(content, "MEM")
+    assert result[0]["content"][0] == {"type": "input_text", "text": "MEM"}
+
+
+# --- resolve_bank ------------------------------------------------------------
+
+
+def test_resolve_bank_prefers_config() -> None:
+    assert auto_memory.resolve_bank(_cfg(bank_id="cfg"), "agent", "conv") == "cfg"
+
+
+def test_resolve_bank_falls_back_to_agent_then_conversation() -> None:
+    assert auto_memory.resolve_bank(_cfg(), "agent", "conv") == "agent"
+    assert auto_memory.resolve_bank(_cfg(), "", "conv") == "conv"
+
+
+def test_resolve_bank_none_when_nothing() -> None:
+    assert auto_memory.resolve_bank(_cfg(), "", "") is None
+    assert auto_memory.resolve_bank(_cfg(), None, None) is None
+
+
+# --- recall_instructions -----------------------------------------------------
+
+
+async def test_recall_formats_block(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _FakeClient(recall_texts=["likes tea", "based in NYC"])
+    monkeypatch.setattr(auto_memory, "_build_client", lambda cfg, **_: client)
+    block = await auto_memory.recall_instructions(_cfg(), "bank", "query")
+    assert block is not None
+    assert "- likes tea" in block
+    assert "- based in NYC" in block
+    assert "long-term memory" in block.lower()
+
+
+async def test_recall_empty_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        auto_memory, "_build_client", lambda cfg, **_: _FakeClient(recall_texts=[])
+    )
+    assert await auto_memory.recall_instructions(_cfg(), "bank", "query") is None
+
+
+async def test_recall_backend_error_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(cfg: MemoryConfig, **_: object) -> Any:
+        raise RuntimeError("backend down")
+
+    monkeypatch.setattr(auto_memory, "_build_client", _boom)
+    assert await auto_memory.recall_instructions(_cfg(), "bank", "query") is None
+
+
+async def test_recall_times_out_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _slow_recall(cfg: MemoryConfig, bank: str, query: str) -> list[str]:
+        import time
+
+        time.sleep(0.5)
+        return ["late"]
+
+    backend = auto_memory._MemoryBackend(recall=_slow_recall, retain=lambda *_: None)
+    monkeypatch.setattr(auto_memory, "_backend_for", lambda cfg: backend)
+    result = await auto_memory.recall_instructions(_cfg(recall_timeout=0.05), "bank", "query")
+    assert result is None
+
+
+async def test_recall_client_uses_recall_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Recall builds its client with recall_timeout so a timed-out call unwinds
+    promptly instead of pinning a worker thread for the default 30s."""
+    seen: dict[str, object] = {}
+
+    def _capture(cfg: MemoryConfig, **kwargs: object) -> _FakeClient:
+        seen["timeout"] = kwargs.get("timeout")
+        return _FakeClient(recall_texts=["x"])
+
+    monkeypatch.setattr(auto_memory, "_build_client", _capture)
+    await auto_memory.recall_instructions(_cfg(recall_timeout=3.5), "bank", "q")
+    assert seen["timeout"] == 3.5
+
+
+# --- provider dispatch -------------------------------------------------------
+
+
+def test_backend_for_hindsight() -> None:
+    assert auto_memory._backend_for(_cfg(provider="hindsight")) is not None
+
+
+def test_backend_for_unknown_returns_none() -> None:
+    assert auto_memory._backend_for(_cfg(provider="nope")) is None
+
+
+async def test_recall_unknown_provider_returns_none() -> None:
+    # Provider is validated at parse time; the runtime still guards defensively.
+    assert await auto_memory.recall_instructions(_cfg(provider="nope"), "bank", "q") is None
+
+
+async def test_schedule_retain_unknown_provider_noop() -> None:
+    auto_memory.schedule_retain(_cfg(provider="nope"), "bank", "content")
+    await _drain_retain_tasks()  # must not raise or schedule work
+
+
+# --- schedule_retain ---------------------------------------------------------
+
+
+async def _drain_retain_tasks() -> None:
+    for task in list(auto_memory._RETAIN_TASKS):
+        await task
+
+
+async def test_schedule_retain_persists(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _FakeClient()
+    monkeypatch.setattr(auto_memory, "_build_client", lambda cfg, **_: client)
+    monkeypatch.setattr(auto_memory, "_CREATED_BANKS", set())
+    auto_memory.schedule_retain(_cfg(), "bank", "remember this")
+    await _drain_retain_tasks()
+    assert client.retained == ["remember this"]
+    assert client.created_banks == ["bank"]
+
+
+async def test_schedule_retain_swallows_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(cfg: MemoryConfig, **_: object) -> Any:
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(auto_memory, "_build_client", _boom)
+    auto_memory.schedule_retain(_cfg(), "bank", "content")
+    # Must not raise into the caller even though retain failed.
+    await _drain_retain_tasks()

--- a/tests/spec/test_parser_memory.py
+++ b/tests/spec/test_parser_memory.py
@@ -1,0 +1,135 @@
+"""Tests for parsing the ``memory:`` block (omnigent.spec.parser)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from omnigent.errors import OmnigentError
+from omnigent.spec.parser import parse
+from omnigent.spec.validator import validate
+
+
+def _write(tmp_path: Path, memory: object) -> Path:
+    config: dict[str, object] = {"spec_version": 1, "name": "mem-agent"}
+    if memory is not None:
+        config["memory"] = memory
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    return tmp_path
+
+
+def test_memory_absent_is_none(tmp_path: Path) -> None:
+    spec = parse(_write(tmp_path, None))
+    assert spec.memory is None
+
+
+def test_memory_disabled_needs_no_api_key(tmp_path: Path) -> None:
+    spec = parse(_write(tmp_path, {"enabled": False}))
+    assert spec.memory is not None
+    assert spec.memory.enabled is False
+    # Auto flags still default on so flipping ``enabled`` later is enough.
+    assert spec.memory.auto_recall is True
+    assert spec.memory.auto_retain is True
+    assert spec.memory.api_key is None
+
+
+def test_memory_enabled_parses_all_fields(tmp_path: Path) -> None:
+    spec = parse(
+        _write(
+            tmp_path,
+            {
+                "enabled": True,
+                "api_key": "secret-key",
+                "api_url": "https://example.test",
+                "bank_id": "acme",
+                "budget": "high",
+                "max_tokens": 2048,
+                "recall_timeout": 3.5,
+                "auto_retain": False,
+            },
+        )
+    )
+    assert spec.memory is not None
+    mem = spec.memory
+    assert mem.enabled is True
+    assert mem.api_key == "secret-key"
+    assert mem.api_url == "https://example.test"
+    assert mem.bank_id == "acme"
+    assert mem.budget == "high"
+    assert mem.max_tokens == 2048
+    assert mem.recall_timeout == 3.5
+    assert mem.auto_recall is True
+    assert mem.auto_retain is False
+    assert mem.provider == "hindsight"  # default when unspecified
+
+
+def test_memory_api_key_env_expanded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HINDSIGHT_API_KEY", "from-env")
+    spec = parse(_write(tmp_path, {"enabled": True, "api_key": "${HINDSIGHT_API_KEY}"}))
+    assert spec.memory is not None
+    assert spec.memory.api_key == "from-env"
+
+
+def test_memory_api_key_unset_env_fails_loud(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("HINDSIGHT_API_KEY", raising=False)
+    with pytest.raises(OmnigentError, match=r"HINDSIGHT_API_KEY"):
+        parse(_write(tmp_path, {"enabled": True, "api_key": "${HINDSIGHT_API_KEY}"}))
+
+
+def test_memory_enabled_without_api_key_raises(tmp_path: Path) -> None:
+    with pytest.raises(OmnigentError, match=r"memory.api_key is required"):
+        parse(_write(tmp_path, {"enabled": True}))
+
+
+def test_memory_invalid_budget_raises(tmp_path: Path) -> None:
+    with pytest.raises(OmnigentError, match=r"memory.budget must be one of"):
+        parse(_write(tmp_path, {"enabled": True, "api_key": "k", "budget": "turbo"}))
+
+
+def test_memory_non_mapping_raises(tmp_path: Path) -> None:
+    with pytest.raises(OmnigentError, match=r"memory: must be a mapping"):
+        parse(_write(tmp_path, ["not", "a", "mapping"]))
+
+
+def test_memory_rejects_boolean_max_tokens(tmp_path: Path) -> None:
+    with pytest.raises(OmnigentError, match=r"memory.max_tokens must be an integer"):
+        parse(_write(tmp_path, {"enabled": True, "api_key": "k", "max_tokens": True}))
+
+
+def test_memory_rejects_non_string_bank_id(tmp_path: Path) -> None:
+    with pytest.raises(OmnigentError, match=r"memory.bank_id must be a string"):
+        parse(_write(tmp_path, {"enabled": True, "api_key": "k", "bank_id": 123}))
+
+
+def test_memory_explicit_provider_hindsight(tmp_path: Path) -> None:
+    spec = parse(_write(tmp_path, {"enabled": True, "api_key": "k", "provider": "hindsight"}))
+    assert spec.memory is not None
+    assert spec.memory.provider == "hindsight"
+
+
+def test_memory_rejects_unknown_provider(tmp_path: Path) -> None:
+    with pytest.raises(OmnigentError, match=r"memory.provider must be one of"):
+        parse(_write(tmp_path, {"enabled": True, "api_key": "k", "provider": "goodmemory"}))
+
+
+def test_memory_rejects_non_string_provider(tmp_path: Path) -> None:
+    with pytest.raises(OmnigentError, match=r"memory.provider must be one of"):
+        parse(_write(tmp_path, {"enabled": True, "api_key": "k", "provider": 123}))
+
+
+def test_validate_rejects_non_positive_bounds(tmp_path: Path) -> None:
+    spec = parse(
+        _write(
+            tmp_path,
+            {"enabled": True, "api_key": "k", "max_tokens": 0, "recall_timeout": 0.0},
+        )
+    )
+    result = validate(spec)
+    assert not result.valid
+    paths = {error.path for error in result.errors}
+    assert "memory.max_tokens" in paths
+    assert "memory.recall_timeout" in paths


### PR DESCRIPTION
Follow-up to #526 (Hindsight memory tools). Closes #3592.

The `hindsight_*` tools are **model-dependent** — memory only happens when the model chooses to call one. This adds an **opt-in, deterministic** layer: an agent-spec `memory:` block that recalls before every turn and retains after it, with no reliance on the model.

```yaml
memory:
  enabled: true
  api_key: ${HINDSIGHT_API_KEY}
  # optional: bank_id, budget, max_tokens, recall_timeout, auto_recall, auto_retain
```

## Design

Wired at the shared runner turn-dispatch seam (`_run_turn_bg_setup_and_stream`), not per-runtime hooks, so it covers every harness:

- **Recall** → injected as the system prompt for executor harnesses (`claude-sdk` / `llm`); prepended to the user message for native harnesses (which fix their system prompt at spawn).
- **Retain** → persists the user's turn in the background after dispatch.

Best-effort throughout: recall is time-bounded and retain is fire-and-forget, so a slow or unreachable backend never blocks or fails a turn. Reuses the `omnigent[hindsight]` extra and the tools' bank-resolution rule (`bank_id` → agent id → conversation id), so tool-based and automatic memory share one bank.

## What's included

- `MemoryConfig` + parser/validator for the `memory:` block
- `omnigent/runtime/memory.py` — recall/retain helpers (non-fatal, latency-bounded, per-call client closed to avoid leaking sessions)
- runner wiring in `_run_turn_bg_setup_and_stream`
- `examples/remy_auto` — a tool-free automatic-memory example agent
- tests: parser, runtime helpers, a **real-`ClaudeNativeExecutor` injection** test, and a structural example test

## Testing

Full memory suite green (`ruff` + `pyrefly` clean). Verified end-to-end against live Hindsight (retain → fresh-session recall) on `claude-sdk` and via the real native executor, and validated in a clean-room Docker build.
