### PR TITLE
chore(triage): pause aravind-segu as a review owner

### DIFF
--- a/.github/areas.json
+++ b/.github/areas.json
@@ -99,8 +99,10 @@
         "TomeHirata",
         "bbqiu",
         "fanzeyi",
-        "aravind-segu",
         "dbczumar"
+      ],
+      "owners_paused": [
+        "aravind-segu"
       ]
     },
     {
@@ -114,8 +116,10 @@
         "dhruv0811",
         "bbqiu",
         "fanzeyi",
-        "aravind-segu",
         "dbczumar"
+      ],
+      "owners_paused": [
+        "aravind-segu"
       ]
     },
     {
@@ -129,8 +133,10 @@
         "dhruv0811",
         "bbqiu",
         "fanzeyi",
-        "aravind-segu",
         "dbczumar"
+      ],
+      "owners_paused": [
+        "aravind-segu"
       ]
     },
     {
@@ -145,8 +151,10 @@
         "TomeHirata",
         "bbqiu",
         "fanzeyi",
-        "aravind-segu",
         "dbczumar"
+      ],
+      "owners_paused": [
+        "aravind-segu"
       ]
     },
     {
@@ -235,10 +243,12 @@
       ],
       "owners": [
         "bbqiu",
-        "aravind-segu",
         "fanzeyi",
         "dhruv0811",
         "dbczumar"
+      ],
+      "owners_paused": [
+        "aravind-segu"
       ]
     },
     {
@@ -250,13 +260,15 @@
       ],
       "owners": [
         "bbqiu",
-        "aravind-segu",
         "fanzeyi",
         "dhruv0811",
         "serena-ruan",
         "daniellok-db",
         "TomeHirata",
         "dbczumar"
+      ],
+      "owners_paused": [
+        "aravind-segu"
       ]
     },
     {
@@ -269,9 +281,11 @@
       "owners": [
         "fanzeyi",
         "dhruv0811",
-        "aravind-segu",
         "bbqiu",
         "dbczumar"
+      ],
+      "owners_paused": [
+        "aravind-segu"
       ]
     },
     {
@@ -286,8 +300,10 @@
         "TomeHirata",
         "bbqiu",
         "fanzeyi",
-        "aravind-segu",
         "dbczumar"
+      ],
+      "owners_paused": [
+        "aravind-segu"
       ]
     },
     {
@@ -355,8 +371,10 @@
         "fanzeyi",
         "TomeHirata",
         "bbqiu",
-        "aravind-segu",
         "dbczumar"
+      ],
+      "owners_paused": [
+        "aravind-segu"
       ]
     },
     {
@@ -372,8 +390,10 @@
         "TomeHirata",
         "bbqiu",
         "fanzeyi",
-        "aravind-segu",
         "dbczumar"
+      ],
+      "owners_paused": [
+        "aravind-segu"
       ]
     },
     {
@@ -391,8 +411,10 @@
         "TomeHirata",
         "bbqiu",
         "fanzeyi",
-        "aravind-segu",
         "dbczumar"
+      ],
+      "owners_paused": [
+        "aravind-segu"
       ]
     },
     {
@@ -459,9 +481,11 @@
         "omnigent/kimi_native"
       ],
       "owners": [
-        "aravind-segu",
         "dhruv0811",
         "fanzeyi"
+      ],
+      "owners_paused": [
+        "aravind-segu"
       ]
     },
     {


### PR DESCRIPTION
## Related issue

N/A — routing/ownership chore.

## Summary

- Moves `aravind-segu` from `owners` to `owners_paused` in the 12 areas they owned,
  so PR reviewer assignment and issue triage stop routing **new** work to them.
- Existing review requests and assignments are deliberately left in place: this only
  changes future routing, it is not a backlog handoff.
- `owners_paused` is this file's own "benched, not deleted" field. Readers
  (`auto-assign-reviewer.js`, `issue-triage.yml`) build their pool from `owners`
  only, and the 2+ owner integrity check counts paused owners, so no backfill was
  needed and no area is left without an active owner.

## Test Plan

```bash
node .github/workflows/areas.test.js            # all integrity checks pass
node .github/workflows/auto-assign-reviewer.test.js
```

Both pass. Reviewer-logic tests run against the frozen
`auto-assign-reviewer.fixture.json`, so ownership edits here don't churn them.

Verified no area drops to zero active owners.

## Demo

N/A — no user-facing surface.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

`areas.test.js` already enforces the invariants this change could break (owners are
real maintainers, every area keeps 2+ owners counting paused ones). Ran that plus the
reviewer-logic suite locally, and confirmed no area lost its last active owner.

Two notes for reviewers:

- `policies` is now down to a single *active* owner (`TomeHirata`). The integrity
  check passes because paused owners count, but that area is a single point of review.
- Area ownership shifted recently in #4046, which unpaused `dbczumar` into 18 areas.
  Combined with this change, `dbczumar` is the lowest-loaded active owner by a wide
  margin, so they will absorb much of the newly routed work.
