### PR TITLE
feat(ci): flag PRs that link no issue (dry run)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,8 +17,8 @@ gives this PR the issue's priority in the review queue. If an older, still-open
 community PR already closes the same issue, the newer one may be auto-closed as
 a duplicate (maintainer PRs are exempt).
 
-No associated issue? Either check `Refactor / chore`, `Docs`, or `Test / CI`
-under *Type of change* below, or replace the line below with `no-issue`.
+If this is either a `Refactor / chore`, `Docs`, or `Test / CI` *Type of change* 
+below, then no issue is required to be associated. 
 -->
 
 Closes #

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,10 +12,13 @@ For AI-written descriptions:
 
 <!--
 Link the issue this PR addresses with a closing keyword so GitHub auto-links it
-(and closes it on merge): e.g. `Closes #123`. One issue per PR. If an older,
-still-open community PR already closes the same issue, the newer one may be
-auto-closed as a duplicate (maintainer PRs are exempt). Use `N/A` for
-chores/docs with no associated issue.
+(and closes it on merge): e.g. `Closes #123`. One issue per PR. Linking also
+gives this PR the issue's priority in the review queue. If an older, still-open
+community PR already closes the same issue, the newer one may be auto-closed as
+a duplicate (maintainer PRs are exempt).
+
+No associated issue? Either check `Refactor / chore`, `Docs`, or `Test / CI`
+under *Type of change* below, or replace the line below with `no-issue`.
 -->
 
 Closes #

--- a/.github/workflows/demo-check.yml
+++ b/.github/workflows/demo-check.yml
@@ -1,11 +1,17 @@
-name: Demo Check
+name: PR Hygiene
 
-# Scan open contributor PRs every hour and comment on any that check the
-# "UI / frontend change" box but have no demo (screenshot / video) in the Demo
-# section. Maintainer PRs and drafts are skipped. PRs already labeled
-# `needs-demo` are skipped on subsequent runs to avoid duplicate comments.
-# Never checks out or runs PR code -- it reads PR metadata via the API using
-# only the default-branch script. See demo-check.js.
+# Hourly sweep over recently-opened PRs. Two independent checks share the run:
+#
+#   1. Demo check -- comment on PRs that check "Bug fix" / "Feature" /
+#      "UI / frontend change" but provide no demo (screenshot / video).
+#      See demo-check.js.
+#   2. Issue-link check -- flag PRs that link no issue. Dry-run by default
+#      (writes the verdict list to the step summary and changes nothing);
+#      set ENFORCE to "true" to comment + label. See pr-issue-link.js.
+#
+# Both skip drafts and PRs they've already flagged (the label is the dedupe).
+# Neither ever closes anything. Never checks out or runs PR code -- they read
+# PR metadata via the API using only the default-branch script.
 
 on:
   schedule:
@@ -38,9 +44,24 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           sparse-checkout: .github
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+      - name: Demo check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           retries: 3
           script: |
             const script = require(".github/workflows/demo-check.js");
+            await script({ context, github, core });
+      # Dry run: resolves every verdict into the step summary without
+      # commenting or labeling. Flip ENFORCE to "true" once the verdict list
+      # has been reviewed; LIMIT caps how many PRs one run may flag.
+      - name: Issue-link check
+        if: always()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          ENFORCE: "false"
+          LIMIT: "25"
+        with:
+          retries: 3
+          script: |
+            const script = require(".github/workflows/pr-issue-link.js");
             await script({ context, github, core });

--- a/.github/workflows/demo-check.yml
+++ b/.github/workflows/demo-check.yml
@@ -5,9 +5,10 @@ name: PR Hygiene
 #   1. Demo check -- comment on PRs that check "Bug fix" / "Feature" /
 #      "UI / frontend change" but provide no demo (screenshot / video).
 #      See demo-check.js.
-#   2. Issue-link check -- flag PRs that link no issue. Dry-run by default
-#      (writes the verdict list to the step summary and changes nothing);
-#      set ENFORCE to "true" to comment + label. See pr-issue-link.js.
+#   2. Issue-link check -- flag PRs that link no issue. Forward-only (nothing
+#      opened before its effective date is considered, so the backlog is
+#      untouched) and dry-run by default: it writes the verdict list to the step
+#      summary and changes nothing until ENFORCE is "true". See pr-issue-link.js.
 #
 # Both skip drafts and PRs they've already flagged (the label is the dedupe).
 # Neither ever closes anything. Never checks out or runs PR code -- they read
@@ -52,8 +53,9 @@ jobs:
             const script = require(".github/workflows/demo-check.js");
             await script({ context, github, core });
       # Dry run: resolves every verdict into the step summary without
-      # commenting or labeling. Flip ENFORCE to "true" once the verdict list
-      # has been reviewed; LIMIT caps how many PRs one run may flag.
+      # commenting or labeling. Flip ENFORCE to "true" once the verdict list has
+      # been reviewed; LIMIT then caps how many PRs one run may flag (it does not
+      # truncate a dry run, whose job is to show the complete list).
       - name: Issue-link check
         if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0

--- a/.github/workflows/demo-check.yml
+++ b/.github/workflows/demo-check.yml
@@ -5,7 +5,7 @@ name: PR Hygiene
 #   1. Demo check -- comment on PRs that check "Bug fix" / "Feature" /
 #      "UI / frontend change" but provide no demo (screenshot / video).
 #      See demo-check.js.
-#   2. Issue-link check -- flag PRs that link no issue. Forward-only (nothing
+#   2. Issue-link check -- comment on PRs that link no issue. Forward-only (nothing
 #      opened before its effective date is considered, so the backlog is
 #      untouched) and dry-run by default: it writes the verdict list to the step
 #      summary and changes nothing until ENFORCE is "true". See pr-issue-link.js.

--- a/.github/workflows/demo-check.yml
+++ b/.github/workflows/demo-check.yml
@@ -10,7 +10,8 @@ name: PR Hygiene
 #      untouched) and dry-run by default: it writes the verdict list to the step
 #      summary and changes nothing until ENFORCE is "true". See pr-issue-link.js.
 #
-# Both skip drafts and PRs they've already flagged (the label is the dedupe).
+# Both skip drafts and PRs they've already flagged -- the demo check dedupes on
+# its `needs-demo` label, the issue-link check on a marker in its own comment.
 # Neither ever closes anything. Never checks out or runs PR code -- they read
 # PR metadata via the API using only the default-branch script.
 

--- a/.github/workflows/pr-issue-link-test.yml
+++ b/.github/workflows/pr-issue-link-test.yml
@@ -1,0 +1,31 @@
+name: PR Issue-Link Test
+
+# Offline unit test for the issue-link check: runs pr-issue-link.test.js (mocked
+# GitHub client, no network). Triggers only when the script or its test change.
+# Runs on `pull_request` (PR head checkout) so it tests the PR's own version.
+# No secrets, no network.
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/pr-issue-link.js
+      - .github/workflows/pr-issue-link.test.js
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-issue-link-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run issue-link unit test
+        run: node .github/workflows/pr-issue-link.test.js

--- a/.github/workflows/pr-issue-link.js
+++ b/.github/workflows/pr-issue-link.js
@@ -1,0 +1,246 @@
+// Scan PRs opened in the last 24 hours and flag any that don't link an issue.
+// Runs hourly from the demo-check sweep; the 24-hour window ensures every new PR
+// is checked even if it was opened just before a cron tick. Flagged PRs get one
+// comment plus the `missing-issue-link` label, which also dedupes subsequent
+// runs. Nothing is ever closed -- the label is the signal a future merge gate or
+// closer can read (Prow's model: plugins label, only the merge queue blocks).
+//
+// ENFORCE=false (the default) is a dry run: it resolves every verdict and writes
+// them to the step summary without commenting or labeling.
+//
+// Exemptions, in the order applied:
+//   - bots (release automation can't file issues; our CI bots author as
+//     CONTRIBUTOR, not MEMBER, so association checks miss them)
+//   - drafts
+//   - an affirmatively checked `Refactor / chore`, `Docs`, or `Test / CI` box.
+//     Note this requires a DECLARATION: an empty or deleted template does NOT
+//     exempt, or removing the template would become the way to skip the rule.
+//   - trivial changes (<= 9 changed lines, the same threshold pr-size.js uses
+//     for size/XS) -- Spark's "trivial changes ... do not require a JIRA"
+//   - reverts
+//   - `no-issue` on a line of its own in the body (an escape hatch a first-time
+//     contributor can use; they cannot apply labels)
+//   - `skip-issue-check` label (maintainer override)
+//
+// Maintainer PRs are flagged too: the label is advisory while nothing closes,
+// and maintainer PRs are the majority of unlinked ones.
+
+const MS_PER_HOUR = 60 * 60 * 1000;
+const HOURS_TO_SCAN = 24;
+const LABEL = "missing-issue-link";
+const OVERRIDE_LABEL = "skip-issue-check";
+// Same threshold pr-size.js uses for size/XS.
+const TRIVIAL_LINES = 9;
+
+// Change types that describe work with no user-visible behaviour, and so no
+// tracking issue. Must match the "Type of change" boxes in
+// .github/pull_request_template.md.
+const DECLARED_EXEMPT_TYPE = /- \[[xX]\]\s*(?:Refactor \/ chore|Docs|Test \/ CI)\b/;
+// `no-issue` alone on a line (mirrors Prow's `releasenote: none` escape hatch).
+const OPT_OUT = /^[ \t>]*no-issue[ \t]*$/im;
+
+const QUERY = `
+  query($cursor: String, $searchQuery: String!) {
+    rateLimit { remaining resetAt }
+    search(query: $searchQuery, type: ISSUE, first: 50, after: $cursor) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        ... on PullRequest {
+          number
+          title
+          isDraft
+          additions
+          deletions
+          author { login __typename }
+          labels(first: 30) { nodes { name } }
+          body
+        }
+      }
+    }
+  }
+`;
+
+// Resolved per PR rather than in the batch search above: the search connection
+// under-reports closingIssuesReferences, and a false "unlinked" verdict is the
+// one mistake that reaches a contributor.
+const LINK_QUERY = `
+  query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        closingIssuesReferences(first: 1) { totalCount }
+      }
+    }
+  }
+`;
+
+function isBot(pr) {
+  const author = pr.author || {};
+  return author.__typename === "Bot" || (author.login || "").endsWith("[bot]");
+}
+
+// Returns the reason this PR is exempt, or null when the rule applies.
+// Order matters only for which reason gets reported.
+function exemptReason(pr) {
+  const body = pr.body ?? "";
+  const labels = pr.labels?.nodes?.map((l) => l.name) ?? [];
+  if (isBot(pr)) return "bot";
+  if (pr.isDraft) return "draft";
+  if (labels.includes(OVERRIDE_LABEL)) return `${OVERRIDE_LABEL} label`;
+  if (DECLARED_EXEMPT_TYPE.test(body)) return "declared chore/docs/test";
+  if ((pr.additions ?? 0) + (pr.deletions ?? 0) <= TRIVIAL_LINES) return "trivial";
+  if (/^\s*revert\b/i.test(pr.title ?? "")) return "revert";
+  if (OPT_OUT.test(body)) return "no-issue opt-out";
+  return null;
+}
+
+const message = (author) =>
+  `@${author} This PR doesn't link an issue.
+
+Please edit the description to link the issue this PR addresses with a closing keyword, e.g. \`Closes #123\`, or link it from the **Development** section of the sidebar. Linking gives the PR the issue's priority in our review queue, and closes the issue automatically on merge.
+
+If this change genuinely has no associated issue:
+
+- Check **Refactor / chore**, **Docs**, or **Test / CI** under *Type of change* if that's what it is, or
+- Put \`no-issue\` on its own line in the description.
+
+_No action is taken beyond this comment._`;
+
+module.exports = async ({ context, github, core }) => {
+  const { owner, repo } = context.repo;
+  // Default to a dry run: enforcement is opt-in via the workflow env.
+  const enforce = process.env.ENFORCE === "true";
+  const limit = Number(process.env.LIMIT || 0) || Infinity;
+
+  try {
+    if (enforce) {
+      try {
+        await github.rest.issues.createLabel({
+          owner,
+          repo,
+          name: LABEL,
+          color: "d93f0b",
+          description: "PR does not link an issue",
+        });
+      } catch (err) {
+        // 422 = already exists; anything else is unexpected.
+        if (err.status !== 422) {
+          core.warning(`Could not create label '${LABEL}': ${err.message}`);
+        }
+      }
+    }
+
+    const cutoff = new Date(Date.now() - HOURS_TO_SCAN * MS_PER_HOUR);
+    const cutoffString = cutoff.toISOString().replace(/\.\d{3}Z$/, "Z");
+    const searchQuery = `repo:${owner}/${repo} is:pr is:open created:>${cutoffString}`;
+    console.log(`Scanning PRs: ${searchQuery} (enforce=${enforce})`);
+
+    let cursor = null;
+    let hasNextPage = true;
+    const allPRs = [];
+    while (hasNextPage) {
+      const response = await github.graphql(QUERY, { cursor, searchQuery });
+      const { remaining, resetAt } = response.rateLimit;
+      console.log(`Rate limit: ${remaining} remaining, resets at ${resetAt}`);
+      const { nodes, pageInfo } = response.search;
+      hasNextPage = pageInfo.hasNextPage;
+      cursor = pageInfo.endCursor;
+      allPRs.push(...nodes);
+    }
+    console.log(`Found ${allPRs.length} open PRs from the last ${HOURS_TO_SCAN} hours`);
+
+    const verdicts = [];
+    let flagged = 0;
+
+    for (const pr of allPRs) {
+      const labels = pr.labels?.nodes?.map((l) => l.name) ?? [];
+      // Already flagged: the label is the dedupe, so never comment twice.
+      if (labels.includes(LABEL)) {
+        verdicts.push({ pr: pr.number, verdict: "skip", reason: "already flagged" });
+        continue;
+      }
+
+      const exempt = exemptReason(pr);
+      if (exempt) {
+        verdicts.push({ pr: pr.number, verdict: "exempt", reason: exempt });
+        continue;
+      }
+
+      // Authoritative link check: covers closing keywords, cross-repo refs,
+      // full issue URLs, and issues linked from the sidebar (which a body
+      // regex cannot see and which fires no webhook).
+      let linkCount;
+      try {
+        const resp = await github.graphql(LINK_QUERY, { owner, repo, number: pr.number });
+        linkCount = resp.repository.pullRequest.closingIssuesReferences.totalCount;
+      } catch (err) {
+        // Fail closed: an unverifiable PR is left alone rather than flagged.
+        core.warning(`Could not resolve links for #${pr.number}: ${err.message}`);
+        verdicts.push({ pr: pr.number, verdict: "skip", reason: "link lookup failed" });
+        continue;
+      }
+      if (linkCount > 0) {
+        verdicts.push({ pr: pr.number, verdict: "ok", reason: `${linkCount} linked` });
+        continue;
+      }
+
+      if (flagged >= limit) {
+        verdicts.push({ pr: pr.number, verdict: "deferred", reason: "run limit reached" });
+        continue;
+      }
+
+      const author = pr.author?.login ?? "contributor";
+      verdicts.push({ pr: pr.number, verdict: "FLAG", reason: `@${author}` });
+      flagged++;
+
+      if (!enforce) continue;
+
+      // Comment before labeling: if the comment fails the PR stays unlabeled
+      // and is retried next run. Labeling first would permanently suppress it.
+      await github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: pr.number,
+        body: message(author),
+      });
+      await github.rest.issues.addLabels({
+        owner,
+        repo,
+        issue_number: pr.number,
+        labels: [LABEL],
+      });
+    }
+
+    const counts = verdicts.reduce((acc, v) => {
+      acc[v.verdict] = (acc[v.verdict] || 0) + 1;
+      return acc;
+    }, {});
+    const summary = Object.entries(counts).map(([k, n]) => `${k}=${n}`).join(" ");
+    console.log(`Done (enforce=${enforce}). ${summary}`);
+
+    // The full verdict list, so a dry run can be reviewed before enforcing.
+    if (core.summary) {
+      core.summary
+        .addHeading(`Issue-link check ${enforce ? "(enforcing)" : "(dry run — nothing changed)"}`, 3)
+        .addRaw(`\n${summary}\n\n`)
+        .addTable([
+          [
+            { data: "PR", header: true },
+            { data: "Verdict", header: true },
+            { data: "Reason", header: true },
+          ],
+          ...verdicts.map((v) => [`#${v.pr}`, v.verdict, v.reason]),
+        ]);
+      await core.summary.write();
+    }
+  } catch (error) {
+    if (error.status === 429 || error.message?.includes("rate limit")) {
+      console.log("Rate limit hit. Exiting gracefully.");
+      return;
+    }
+    throw error;
+  }
+};
+
+// Exported for the offline unit test.
+module.exports.exemptReason = exemptReason;
+module.exports.LABEL = LABEL;

--- a/.github/workflows/pr-issue-link.js
+++ b/.github/workflows/pr-issue-link.js
@@ -5,6 +5,9 @@
 // runs. Nothing is ever closed -- the label is the signal a future merge gate or
 // closer can read (Prow's model: plugins label, only the merge queue blocks).
 //
+// Forward-only: nothing opened before EFFECTIVE_FROM is ever considered, so the
+// existing backlog is untouched no matter how the scan window is set.
+//
 // ENFORCE=false (the default) is a dry run: it resolves every verdict and writes
 // them to the step summary without commenting or labeling.
 //
@@ -12,11 +15,13 @@
 //   - bots (release automation can't file issues; our CI bots author as
 //     CONTRIBUTOR, not MEMBER, so association checks miss them)
 //   - drafts
-//   - an affirmatively checked `Refactor / chore`, `Docs`, or `Test / CI` box.
-//     Note this requires a DECLARATION: an empty or deleted template does NOT
-//     exempt, or removing the template would become the way to skip the rule.
-//   - trivial changes (<= 9 changed lines, the same threshold pr-size.js uses
-//     for size/XS) -- Spark's "trivial changes ... do not require a JIRA"
+//   - an affirmatively checked `Refactor / chore`, `Docs`, or `Test / CI` box,
+//     with no `Bug fix` / `Feature` / `UI` box also checked. Note this requires a
+//     DECLARATION: an empty or deleted template does NOT exempt, or removing the
+//     template would become the way to skip the rule.
+//   - trivial changes (<= 9 changed lines, the size/XS cutoff) -- Spark's
+//     "trivial changes ... do not require a JIRA". Counts raw additions +
+//     deletions, so unlike size/XS it does not exclude regenerated lockfiles.
 //   - reverts
 //   - `no-issue` on a line of its own in the body (an escape hatch a first-time
 //     contributor can use; they cannot apply labels)
@@ -27,6 +32,10 @@
 
 const MS_PER_HOUR = 60 * 60 * 1000;
 const HOURS_TO_SCAN = 24;
+// The rule applies going forward only. PRs opened before this date are the
+// backlog's problem, cleared by hand, and must never be flagged -- so the floor
+// is a constant here rather than something a wider scan window could reach past.
+const EFFECTIVE_FROM = "2026-08-05T00:00:00Z";
 const LABEL = "missing-issue-link";
 const OVERRIDE_LABEL = "skip-issue-check";
 // Same threshold pr-size.js uses for size/XS.
@@ -38,6 +47,9 @@ const MAINTAINER_ASSOCIATIONS = ["MEMBER", "OWNER", "COLLABORATOR"];
 // tracking issue. Must match the "Type of change" boxes in
 // .github/pull_request_template.md.
 const DECLARED_EXEMPT_TYPE = /- \[[xX]\]\s*(?:Refactor \/ chore|Docs|Test \/ CI)\b/;
+// Types that always want an issue. Checked alongside an exempt type, these win:
+// otherwise ticking `Test / CI` next to `Bug fix` is a free opt-out.
+const DECLARED_TRACKED_TYPE = /- \[[xX]\]\s*(?:Bug fix|Feature|UI \/ frontend change)\b/;
 // `no-issue` alone on a line (mirrors Prow's `releasenote: none` escape hatch).
 const OPT_OUT = /^[ \t>]*no-issue[ \t]*$/im;
 
@@ -92,7 +104,9 @@ function exemptReason(pr, maintainers = new Set()) {
   if (MAINTAINER_ASSOCIATIONS.includes(pr.authorAssociation)) return "maintainer";
   if (maintainers.has((pr.author?.login ?? "").toLowerCase())) return "maintainer";
   if (labels.includes(OVERRIDE_LABEL)) return `${OVERRIDE_LABEL} label`;
-  if (DECLARED_EXEMPT_TYPE.test(body)) return "declared chore/docs/test";
+  if (DECLARED_EXEMPT_TYPE.test(body) && !DECLARED_TRACKED_TYPE.test(body)) {
+    return "declared chore/docs/test";
+  }
   if ((pr.additions ?? 0) + (pr.deletions ?? 0) <= TRIVIAL_LINES) return "trivial";
   if (/^\s*revert\b/i.test(pr.title ?? "")) return "revert";
   if (OPT_OUT.test(body)) return "no-issue opt-out";
@@ -115,7 +129,9 @@ module.exports = async ({ context, github, core }) => {
   const { owner, repo } = context.repo;
   // Default to a dry run: enforcement is opt-in via the workflow env.
   const enforce = process.env.ENFORCE === "true";
-  const limit = Number(process.env.LIMIT || 0) || Infinity;
+  // Unset means unlimited; an explicit LIMIT=0 means flag nothing.
+  const parsedLimit = Number(process.env.LIMIT);
+  const limit = Number.isFinite(parsedLimit) && process.env.LIMIT !== "" ? parsedLimit : Infinity;
 
   try {
     // Load maintainers from the API, not the checked-out tree, so a PR can't
@@ -155,7 +171,11 @@ module.exports = async ({ context, github, core }) => {
       }
     }
 
-    const cutoff = new Date(Date.now() - HOURS_TO_SCAN * MS_PER_HOUR);
+    const windowStart = new Date(Date.now() - HOURS_TO_SCAN * MS_PER_HOUR);
+    // Never look further back than the effective date, whichever is later.
+    const cutoff = new Date(
+      Math.max(windowStart.getTime(), new Date(EFFECTIVE_FROM).getTime())
+    );
     const cutoffString = cutoff.toISOString().replace(/\.\d{3}Z$/, "Z");
     const searchQuery = `repo:${owner}/${repo} is:pr is:open created:>${cutoffString}`;
     console.log(`Scanning PRs: ${searchQuery} (enforce=${enforce})`);
@@ -209,16 +229,22 @@ module.exports = async ({ context, github, core }) => {
         continue;
       }
 
+      const author = pr.author?.login ?? "contributor";
+
+      // A dry run enumerates every verdict -- that's its whole point, so LIMIT
+      // (which bounds how many contributors one enforcing run may touch) must
+      // not truncate the list an operator reviews before enabling.
+      if (!enforce) {
+        verdicts.push({ pr: pr.number, verdict: "FLAG", reason: `@${author}` });
+        continue;
+      }
+
       if (flagged >= limit) {
         verdicts.push({ pr: pr.number, verdict: "deferred", reason: "run limit reached" });
         continue;
       }
-
-      const author = pr.author?.login ?? "contributor";
       verdicts.push({ pr: pr.number, verdict: "FLAG", reason: `@${author}` });
       flagged++;
-
-      if (!enforce) continue;
 
       // Comment before labeling: if the comment fails the PR stays unlabeled
       // and is retried next run. Labeling first would permanently suppress it.
@@ -270,3 +296,4 @@ module.exports = async ({ context, github, core }) => {
 // Exported for the offline unit test.
 module.exports.exemptReason = exemptReason;
 module.exports.LABEL = LABEL;
+module.exports.EFFECTIVE_FROM = EFFECTIVE_FROM;

--- a/.github/workflows/pr-issue-link.js
+++ b/.github/workflows/pr-issue-link.js
@@ -1,9 +1,8 @@
 // Scan PRs opened in the last 24 hours and flag any that don't link an issue.
 // Runs hourly from the demo-check sweep; the 24-hour window ensures every new PR
-// is checked even if it was opened just before a cron tick. Flagged PRs get one
-// comment plus the `missing-issue-link` label, which also dedupes subsequent
-// runs. Nothing is ever closed -- the label is the signal a future merge gate or
-// closer can read (Prow's model: plugins label, only the merge queue blocks).
+// is checked even if it was opened just before a cron tick. A flagged PR gets one
+// comment and nothing else: no label (it would only add noise to the queue
+// maintainers filter) and no close.
 //
 // Forward-only: nothing opened before EFFECTIVE_FROM is ever considered, so the
 // existing backlog is untouched no matter how the scan window is set.
@@ -36,7 +35,10 @@ const HOURS_TO_SCAN = 24;
 // backlog's problem, cleared by hand, and must never be flagged -- so the floor
 // is a constant here rather than something a wider scan window could reach past.
 const EFFECTIVE_FROM = "2026-08-05T00:00:00Z";
-const LABEL = "missing-issue-link";
+// Dedupe on a hidden marker in the bot's own comment rather than a label: the
+// nudge is a one-shot message, and a label on top of it would add queue noise
+// maintainers have to filter past (same approach as reopen-notice.js).
+const MARKER = "<!-- pr-issue-link -->";
 const OVERRIDE_LABEL = "skip-issue-check";
 // Same threshold pr-size.js uses for size/XS.
 const TRIVIAL_LINES = 9;
@@ -154,23 +156,6 @@ module.exports = async ({ context, github, core }) => {
       core.warning(`Could not load .github/MAINTAINER: ${err.message}`);
     }
 
-    if (enforce) {
-      try {
-        await github.rest.issues.createLabel({
-          owner,
-          repo,
-          name: LABEL,
-          color: "d93f0b",
-          description: "PR does not link an issue",
-        });
-      } catch (err) {
-        // 422 = already exists; anything else is unexpected.
-        if (err.status !== 422) {
-          core.warning(`Could not create label '${LABEL}': ${err.message}`);
-        }
-      }
-    }
-
     const windowStart = new Date(Date.now() - HOURS_TO_SCAN * MS_PER_HOUR);
     // Never look further back than the effective date, whichever is later.
     const cutoff = new Date(
@@ -198,13 +183,6 @@ module.exports = async ({ context, github, core }) => {
     let flagged = 0;
 
     for (const pr of allPRs) {
-      const labels = pr.labels?.nodes?.map((l) => l.name) ?? [];
-      // Already flagged: the label is the dedupe, so never comment twice.
-      if (labels.includes(LABEL)) {
-        verdicts.push({ pr: pr.number, verdict: "skip", reason: "already flagged" });
-        continue;
-      }
-
       const exempt = exemptReason(pr, maintainers);
       if (exempt) {
         verdicts.push({ pr: pr.number, verdict: "exempt", reason: exempt });
@@ -243,22 +221,27 @@ module.exports = async ({ context, github, core }) => {
         verdicts.push({ pr: pr.number, verdict: "deferred", reason: "run limit reached" });
         continue;
       }
+
+      // Only PRs about to be nudged pay for the comment lookup. Checked here
+      // rather than up front so the dry run doesn't spend a request per PR.
+      const comments = await github.paginate(github.rest.issues.listComments, {
+        owner,
+        repo,
+        issue_number: pr.number,
+        per_page: 100,
+      });
+      if (comments.some((c) => c.body?.includes(MARKER))) {
+        verdicts.push({ pr: pr.number, verdict: "skip", reason: "already nudged" });
+        continue;
+      }
+
       verdicts.push({ pr: pr.number, verdict: "FLAG", reason: `@${author}` });
       flagged++;
-
-      // Comment before labeling: if the comment fails the PR stays unlabeled
-      // and is retried next run. Labeling first would permanently suppress it.
       await github.rest.issues.createComment({
         owner,
         repo,
         issue_number: pr.number,
-        body: message(author),
-      });
-      await github.rest.issues.addLabels({
-        owner,
-        repo,
-        issue_number: pr.number,
-        labels: [LABEL],
+        body: `${MARKER}\n${message(author)}`,
       });
     }
 
@@ -295,5 +278,5 @@ module.exports = async ({ context, github, core }) => {
 
 // Exported for the offline unit test.
 module.exports.exemptReason = exemptReason;
-module.exports.LABEL = LABEL;
+module.exports.MARKER = MARKER;
 module.exports.EFFECTIVE_FROM = EFFECTIVE_FROM;

--- a/.github/workflows/pr-issue-link.js
+++ b/.github/workflows/pr-issue-link.js
@@ -22,9 +22,9 @@
 //     "trivial changes ... do not require a JIRA". Counts raw additions +
 //     deletions, so unlike size/XS it does not exclude regenerated lockfiles.
 //   - reverts
-//   - `no-issue` on a line of its own in the body (an escape hatch a first-time
-//     contributor can use; they cannot apply labels)
-//   - `skip-issue-check` label (maintainer override)
+//   - `skip-issue-check` label (maintainer override -- deliberately the only
+//     unconditional opt-out, and it needs write access. A self-service escape
+//     hatch would make the rule optional for exactly the PRs it targets.)
 //   - maintainers, by authorAssociation OR the .github/MAINTAINER file. Both are
 //     needed: a maintainer whose org membership is private reads as CONTRIBUTOR,
 //     and a maintainer may hold write access without being listed in the file.
@@ -52,8 +52,6 @@ const DECLARED_EXEMPT_TYPE = /- \[[xX]\]\s*(?:Refactor \/ chore|Docs|Test \/ CI)
 // Types that always want an issue. Checked alongside an exempt type, these win:
 // otherwise ticking `Test / CI` next to `Bug fix` is a free opt-out.
 const DECLARED_TRACKED_TYPE = /- \[[xX]\]\s*(?:Bug fix|Feature|UI \/ frontend change)\b/;
-// `no-issue` alone on a line (mirrors Prow's `releasenote: none` escape hatch).
-const OPT_OUT = /^[ \t>]*no-issue[ \t]*$/im;
 
 const QUERY = `
   query($cursor: String, $searchQuery: String!) {
@@ -111,7 +109,6 @@ function exemptReason(pr, maintainers = new Set()) {
   }
   if ((pr.additions ?? 0) + (pr.deletions ?? 0) <= TRIVIAL_LINES) return "trivial";
   if (/^\s*revert\b/i.test(pr.title ?? "")) return "revert";
-  if (OPT_OUT.test(body)) return "no-issue opt-out";
   return null;
 }
 
@@ -120,10 +117,7 @@ const message = (author) =>
 
 Please edit the description to link the issue this PR addresses with a closing keyword, e.g. \`Closes #123\`, or link it from the **Development** section of the sidebar. Linking gives the PR the issue's priority in our review queue, and closes the issue automatically on merge.
 
-If this change genuinely has no associated issue:
-
-- Check **Refactor / chore**, **Docs**, or **Test / CI** under *Type of change* if that's what it is, or
-- Put \`no-issue\` on its own line in the description.
+If this change genuinely has no associated issue, check **Refactor / chore**, **Docs**, or **Test / CI** under *Type of change* — those types don't need one. Anything else should have an issue so it can be prioritized; open one if it doesn't exist yet.
 
 _No action is taken beyond this comment._`;
 

--- a/.github/workflows/pr-issue-link.js
+++ b/.github/workflows/pr-issue-link.js
@@ -21,9 +21,9 @@
 //   - `no-issue` on a line of its own in the body (an escape hatch a first-time
 //     contributor can use; they cannot apply labels)
 //   - `skip-issue-check` label (maintainer override)
-//
-// Maintainer PRs are flagged too: the label is advisory while nothing closes,
-// and maintainer PRs are the majority of unlinked ones.
+//   - maintainers, by authorAssociation OR the .github/MAINTAINER file. Both are
+//     needed: a maintainer whose org membership is private reads as CONTRIBUTOR,
+//     and a maintainer may hold write access without being listed in the file.
 
 const MS_PER_HOUR = 60 * 60 * 1000;
 const HOURS_TO_SCAN = 24;
@@ -31,6 +31,8 @@ const LABEL = "missing-issue-link";
 const OVERRIDE_LABEL = "skip-issue-check";
 // Same threshold pr-size.js uses for size/XS.
 const TRIVIAL_LINES = 9;
+
+const MAINTAINER_ASSOCIATIONS = ["MEMBER", "OWNER", "COLLABORATOR"];
 
 // Change types that describe work with no user-visible behaviour, and so no
 // tracking issue. Must match the "Type of change" boxes in
@@ -51,6 +53,7 @@ const QUERY = `
           isDraft
           additions
           deletions
+          authorAssociation
           author { login __typename }
           labels(first: 30) { nodes { name } }
           body
@@ -79,12 +82,15 @@ function isBot(pr) {
 }
 
 // Returns the reason this PR is exempt, or null when the rule applies.
+// `maintainers` is the lowercased login set from .github/MAINTAINER.
 // Order matters only for which reason gets reported.
-function exemptReason(pr) {
+function exemptReason(pr, maintainers = new Set()) {
   const body = pr.body ?? "";
   const labels = pr.labels?.nodes?.map((l) => l.name) ?? [];
   if (isBot(pr)) return "bot";
   if (pr.isDraft) return "draft";
+  if (MAINTAINER_ASSOCIATIONS.includes(pr.authorAssociation)) return "maintainer";
+  if (maintainers.has((pr.author?.login ?? "").toLowerCase())) return "maintainer";
   if (labels.includes(OVERRIDE_LABEL)) return `${OVERRIDE_LABEL} label`;
   if (DECLARED_EXEMPT_TYPE.test(body)) return "declared chore/docs/test";
   if ((pr.additions ?? 0) + (pr.deletions ?? 0) <= TRIVIAL_LINES) return "trivial";
@@ -112,6 +118,26 @@ module.exports = async ({ context, github, core }) => {
   const limit = Number(process.env.LIMIT || 0) || Infinity;
 
   try {
+    // Load maintainers from the API, not the checked-out tree, so a PR can't
+    // self-grant by editing the file (same approach as demo-check.js).
+    const maintainers = new Set();
+    try {
+      const resp = await github.rest.repos.getContent({
+        owner,
+        repo,
+        path: ".github/MAINTAINER",
+        ref: "main",
+      });
+      Buffer.from(resp.data.content, "base64")
+        .toString("utf8")
+        .split("\n")
+        .map((l) => l.replace(/#.*$/, "").trim().toLowerCase())
+        .filter(Boolean)
+        .forEach((m) => maintainers.add(m));
+    } catch (err) {
+      core.warning(`Could not load .github/MAINTAINER: ${err.message}`);
+    }
+
     if (enforce) {
       try {
         await github.rest.issues.createLabel({
@@ -159,7 +185,7 @@ module.exports = async ({ context, github, core }) => {
         continue;
       }
 
-      const exempt = exemptReason(pr);
+      const exempt = exemptReason(pr, maintainers);
       if (exempt) {
         verdicts.push({ pr: pr.number, verdict: "exempt", reason: exempt });
         continue;

--- a/.github/workflows/pr-issue-link.js
+++ b/.github/workflows/pr-issue-link.js
@@ -125,9 +125,18 @@ module.exports = async ({ context, github, core }) => {
   const { owner, repo } = context.repo;
   // Default to a dry run: enforcement is opt-in via the workflow env.
   const enforce = process.env.ENFORCE === "true";
-  // Unset means unlimited; an explicit LIMIT=0 means flag nothing.
-  const parsedLimit = Number(process.env.LIMIT);
-  const limit = Number.isFinite(parsedLimit) && process.env.LIMIT !== "" ? parsedLimit : Infinity;
+  // Unset means unlimited; an explicit LIMIT=0 means flag nothing. A malformed
+  // value flags nothing rather than everything -- this bounds how many
+  // contributors one run may comment on, so the safe default is the low one.
+  const rawLimit = process.env.LIMIT;
+  let limit = Infinity;
+  if (rawLimit !== undefined && rawLimit !== "") {
+    limit = Number(rawLimit);
+    if (!Number.isFinite(limit)) {
+      core.warning(`LIMIT=${rawLimit} is not a number; flagging nothing this run.`);
+      limit = 0;
+    }
+  }
 
   try {
     // Load maintainers from the API, not the checked-out tree, so a PR can't
@@ -138,7 +147,7 @@ module.exports = async ({ context, github, core }) => {
         owner,
         repo,
         path: ".github/MAINTAINER",
-        ref: "main",
+        ref: context.payload.repository?.default_branch ?? "main",
       });
       Buffer.from(resp.data.content, "base64")
         .toString("utf8")

--- a/.github/workflows/pr-issue-link.test.js
+++ b/.github/workflows/pr-issue-link.test.js
@@ -1,0 +1,189 @@
+// Local unit test for pr-issue-link.js -- mocks the GitHub client and runs the
+// real decision logic. No network. Covers the exemption predicates, the
+// authoritative per-PR link lookup, dedupe, and that a dry run touches nothing.
+
+const assert = require("assert");
+const path = require("path");
+const script = require(path.resolve(".github/workflows/pr-issue-link.js"));
+
+// A PR node shaped like the GraphQL search response.
+function pr({
+  number,
+  body = "",
+  title = "feat: thing",
+  author = "ext",
+  bot = false,
+  draft = false,
+  additions = 100,
+  deletions = 0,
+  labels = [],
+}) {
+  return {
+    number,
+    title,
+    isDraft: draft,
+    additions,
+    deletions,
+    author: { login: author, __typename: bot ? "Bot" : "User" },
+    labels: { nodes: labels.map((name) => ({ name })) },
+    body,
+  };
+}
+
+// Run the script over PR nodes. `linked` maps PR number -> closing-issue count.
+// `env` overrides process.env for the run.
+async function run(nodes, { linked = {}, env = {}, linkError = false } = {}) {
+  const commented = [];
+  const labeled = [];
+  let searchCalls = 0;
+  const github = {
+    graphql: async (query, vars) => {
+      if (query.includes("pullRequest(number:")) {
+        if (linkError) throw new Error("boom");
+        return {
+          repository: {
+            pullRequest: {
+              closingIssuesReferences: { totalCount: linked[vars.number] ?? 0 },
+            },
+          },
+        };
+      }
+      const done = searchCalls++ > 0;
+      return {
+        rateLimit: { remaining: 4999, resetAt: "n/a" },
+        search: {
+          pageInfo: { hasNextPage: !done, endCursor: "c" },
+          nodes: done ? [] : nodes,
+        },
+      };
+    },
+    rest: {
+      issues: {
+        createLabel: async () => {},
+        createComment: async ({ issue_number, body }) => commented.push({ issue_number, body }),
+        addLabels: async ({ issue_number, labels: ls }) => labeled.push({ issue_number, labels: ls }),
+      },
+    },
+  };
+  const warnings = [];
+  const core = { warning: (m) => warnings.push(m), summary: null };
+  const saved = { ...process.env };
+  Object.assign(process.env, env);
+  try {
+    await script({ context: { repo: { owner: "o", repo: "r" } }, github, core });
+  } finally {
+    for (const k of Object.keys(env)) delete process.env[k];
+    Object.assign(process.env, saved);
+  }
+  return { commented, labeled, warnings };
+}
+
+const ENFORCE = { ENFORCE: "true" };
+
+// ---- exemption predicates (pure) ----
+const { exemptReason } = script;
+
+assert.strictEqual(exemptReason(pr({ number: 1 })), null, "plain unlinked PR is not exempt");
+assert.strictEqual(exemptReason(pr({ number: 2, bot: true })), "bot");
+assert.strictEqual(exemptReason(pr({ number: 3, draft: true })), "draft");
+assert.strictEqual(
+  exemptReason(pr({ number: 4, labels: ["skip-issue-check"] })),
+  "skip-issue-check label"
+);
+assert.strictEqual(
+  exemptReason(pr({ number: 5, additions: 4, deletions: 5 })),
+  "trivial",
+  "<= 9 changed lines is trivial"
+);
+assert.strictEqual(
+  exemptReason(pr({ number: 6, additions: 6, deletions: 5 })),
+  null,
+  "10 changed lines is not trivial"
+);
+assert.strictEqual(exemptReason(pr({ number: 7, title: "Revert \"feat: x\"" })), "revert");
+assert.strictEqual(exemptReason(pr({ number: 8, body: "blah\nno-issue\nblah" })), "no-issue opt-out");
+
+// Declared exempt types, matching the real template's checkbox labels.
+for (const type of ["Refactor / chore", "Docs", "Test / CI"]) {
+  assert.strictEqual(
+    exemptReason(pr({ number: 9, body: `## Type of change\n\n- [x] ${type}\n` })),
+    "declared chore/docs/test",
+    `${type} checked is exempt`
+  );
+}
+// The whole point of the gate: silence must NOT exempt.
+assert.strictEqual(
+  exemptReason(
+    pr({
+      number: 10,
+      body: "## Type of change\n\n- [ ] Bug fix\n- [ ] Refactor / chore\n- [ ] Docs\n- [ ] Test / CI\n",
+    })
+  ),
+  null,
+  "unchecked boxes do not exempt"
+);
+assert.strictEqual(
+  exemptReason(pr({ number: 11, body: "no template at all" })),
+  null,
+  "a deleted template does not exempt"
+);
+assert.strictEqual(
+  exemptReason(pr({ number: 12, body: "## Type of change\n\n- [x] Bug fix\n- [ ] Docs\n" })),
+  null,
+  "a declared Bug fix is not exempt"
+);
+
+// ---- end-to-end behaviour ----
+(async () => {
+  // Dry run (the default) must not comment or label.
+  {
+    const { commented, labeled } = await run([pr({ number: 20 })]);
+    assert.strictEqual(commented.length, 0, "dry run must not comment");
+    assert.strictEqual(labeled.length, 0, "dry run must not label");
+  }
+
+  // Enforcing: an unlinked, non-exempt PR gets one comment + the label.
+  {
+    const { commented, labeled } = await run([pr({ number: 21, author: "alice" })], { env: ENFORCE });
+    assert.strictEqual(commented.length, 1);
+    assert.strictEqual(commented[0].issue_number, 21);
+    assert.match(commented[0].body, /@alice/);
+    assert.match(commented[0].body, /Closes #123/);
+    assert.deepStrictEqual(labeled, [{ issue_number: 21, labels: [script.LABEL] }]);
+  }
+
+  // A linked PR is left alone even when enforcing.
+  {
+    const { commented, labeled } = await run([pr({ number: 22 })], {
+      linked: { 22: 1 },
+      env: ENFORCE,
+    });
+    assert.strictEqual(commented.length, 0, "linked PR must not be flagged");
+    assert.strictEqual(labeled.length, 0);
+  }
+
+  // Already-labeled PRs are never commented on twice.
+  {
+    const { commented } = await run([pr({ number: 23, labels: [script.LABEL] })], { env: ENFORCE });
+    assert.strictEqual(commented.length, 0, "label dedupes repeat runs");
+  }
+
+  // A failed link lookup must fail closed (skip), never flag.
+  {
+    const { commented, warnings } = await run([pr({ number: 24 })], {
+      env: ENFORCE,
+      linkError: true,
+    });
+    assert.strictEqual(commented.length, 0, "unverifiable PR must not be flagged");
+    assert.ok(warnings.some((w) => /Could not resolve links for #24/.test(w)));
+  }
+
+  // LIMIT caps how many PRs a single run touches.
+  {
+    const nodes = [25, 26, 27].map((number) => pr({ number }));
+    const { commented } = await run(nodes, { env: { ...ENFORCE, LIMIT: "2" } });
+    assert.strictEqual(commented.length, 2, "LIMIT caps flags per run");
+  }
+
+  console.log("pr-issue-link.test.js: all assertions passed");
+})();

--- a/.github/workflows/pr-issue-link.test.js
+++ b/.github/workflows/pr-issue-link.test.js
@@ -34,7 +34,10 @@ function pr({
 
 // Run the script over PR nodes. `linked` maps PR number -> closing-issue count.
 // `env` overrides process.env for the run.
-async function run(nodes, { linked = {}, env = {}, linkError = false, maintainers = [] } = {}) {
+async function run(
+  nodes,
+  { linked = {}, env = {}, linkError = false, maintainers = [], existingComments = {} } = {}
+) {
   const commented = [];
   const labeled = [];
   const queries = [];
@@ -62,6 +65,8 @@ async function run(nodes, { linked = {}, env = {}, linkError = false, maintainer
         },
       };
     },
+    paginate: async (_fn, { issue_number }) =>
+      (existingComments[issue_number] ?? []).map((body) => ({ body })),
     rest: {
       repos: {
         getContent: async () => ({
@@ -69,7 +74,7 @@ async function run(nodes, { linked = {}, env = {}, linkError = false, maintainer
         }),
       },
       issues: {
-        createLabel: async () => {},
+        listComments: "listComments",
         createComment: async ({ issue_number, body }) => commented.push({ issue_number, body }),
         addLabels: async ({ issue_number, labels: ls }) => labeled.push({ issue_number, labels: ls }),
       },
@@ -204,14 +209,15 @@ for (const tracked of ["Bug fix", "Feature", "UI / frontend change"]) {
     assert.strictEqual(labeled.length, 0, "dry run must not label");
   }
 
-  // Enforcing: an unlinked, non-exempt PR gets one comment + the label.
+  // Enforcing: an unlinked, non-exempt PR gets exactly one comment and no label.
   {
     const { commented, labeled } = await run([pr({ number: 21, author: "alice" })], { env: ENFORCE });
     assert.strictEqual(commented.length, 1);
     assert.strictEqual(commented[0].issue_number, 21);
     assert.match(commented[0].body, /@alice/);
     assert.match(commented[0].body, /Closes #123/);
-    assert.deepStrictEqual(labeled, [{ issue_number: 21, labels: [script.LABEL] }]);
+    assert.ok(commented[0].body.startsWith(script.MARKER), "comment carries the dedupe marker");
+    assert.deepStrictEqual(labeled, [], "no label is applied");
   }
 
   // A linked PR is left alone even when enforcing.
@@ -224,10 +230,23 @@ for (const tracked of ["Bug fix", "Feature", "UI / frontend change"]) {
     assert.strictEqual(labeled.length, 0);
   }
 
-  // Already-labeled PRs are never commented on twice.
+  // An already-nudged PR is never commented on twice: the hidden marker in the
+  // bot's own earlier comment is the dedupe.
   {
-    const { commented } = await run([pr({ number: 23, labels: [script.LABEL] })], { env: ENFORCE });
-    assert.strictEqual(commented.length, 0, "label dedupes repeat runs");
+    const { commented } = await run([pr({ number: 23 })], {
+      env: ENFORCE,
+      existingComments: { 23: [`${script.MARKER}\nplease link an issue`] },
+    });
+    assert.strictEqual(commented.length, 0, "marker dedupes repeat runs");
+  }
+
+  // An unrelated human comment must not be mistaken for the nudge.
+  {
+    const { commented } = await run([pr({ number: 231 })], {
+      env: ENFORCE,
+      existingComments: { 231: ["lgtm"] },
+    });
+    assert.strictEqual(commented.length, 1, "only the marker suppresses the nudge");
   }
 
   // A failed link lookup must fail closed (skip), never flag.

--- a/.github/workflows/pr-issue-link.test.js
+++ b/.github/workflows/pr-issue-link.test.js
@@ -37,10 +37,12 @@ function pr({
 async function run(nodes, { linked = {}, env = {}, linkError = false, maintainers = [] } = {}) {
   const commented = [];
   const labeled = [];
+  const queries = [];
   let searchCalls = 0;
   const github = {
     repos: {},
     graphql: async (query, vars) => {
+      if (vars.searchQuery) queries.push(vars.searchQuery);
       if (query.includes("pullRequest(number:")) {
         if (linkError) throw new Error("boom");
         return {
@@ -74,7 +76,19 @@ async function run(nodes, { linked = {}, env = {}, linkError = false, maintainer
     },
   };
   const warnings = [];
-  const core = { warning: (m) => warnings.push(m), summary: null };
+  // Capture the step-summary table rows so the dry-run verdict list can be
+  // asserted on (the rows are `[#N, verdict, reason]` after the header).
+  const rows = [];
+  const summary = {
+    addHeading: () => summary,
+    addRaw: () => summary,
+    addTable: (table) => {
+      rows.push(...table.slice(1));
+      return summary;
+    },
+    write: async () => {},
+  };
+  const core = { warning: (m) => warnings.push(m), summary };
   const saved = { ...process.env };
   Object.assign(process.env, env);
   try {
@@ -83,7 +97,7 @@ async function run(nodes, { linked = {}, env = {}, linkError = false, maintainer
     for (const k of Object.keys(env)) delete process.env[k];
     Object.assign(process.env, saved);
   }
-  return { commented, labeled, warnings };
+  return { commented, labeled, warnings, rows, queries };
 }
 
 const ENFORCE = { ENFORCE: "true" };
@@ -161,9 +175,28 @@ assert.strictEqual(
   null,
   "a declared Bug fix is not exempt"
 );
+// Ticking an exempt box alongside a tracked one must not buy an opt-out.
+for (const tracked of ["Bug fix", "Feature", "UI / frontend change"]) {
+  assert.strictEqual(
+    exemptReason(
+      pr({ number: 13, body: `## Type of change\n\n- [x] ${tracked}\n- [x] Test / CI\n` })
+    ),
+    null,
+    `${tracked} + Test / CI is not exempt`
+  );
+}
 
 // ---- end-to-end behaviour ----
 (async () => {
+  // Forward-only: the search must never reach past the effective date, so the
+  // pre-existing backlog can't be flagged.
+  {
+    const { queries } = await run([pr({ number: 19 })]);
+    const floor = new Date(script.EFFECTIVE_FROM).getTime();
+    const asked = new Date(/created:>(\S+)/.exec(queries[0])[1]).getTime();
+    assert.ok(asked >= floor, "scan cutoff never predates the effective date");
+  }
+
   // Dry run (the default) must not comment or label.
   {
     const { commented, labeled } = await run([pr({ number: 20 })]);
@@ -210,8 +243,31 @@ assert.strictEqual(
   // LIMIT caps how many PRs a single run touches.
   {
     const nodes = [25, 26, 27].map((number) => pr({ number }));
-    const { commented } = await run(nodes, { env: { ...ENFORCE, LIMIT: "2" } });
+    const { commented, rows } = await run(nodes, { env: { ...ENFORCE, LIMIT: "2" } });
     assert.strictEqual(commented.length, 2, "LIMIT caps flags per run");
+    assert.ok(
+      rows.some((r) => r[1] === "deferred"),
+      "the PR past the cap is reported as deferred"
+    );
+  }
+
+  // LIMIT must NOT truncate a dry run: reviewing the full list before enabling
+  // is the entire point of the dry run.
+  {
+    const nodes = [40, 41, 42].map((number) => pr({ number }));
+    const { commented, rows } = await run(nodes, { env: { LIMIT: "1" } });
+    assert.strictEqual(commented.length, 0, "dry run still touches nothing");
+    assert.strictEqual(
+      rows.filter((r) => r[1] === "FLAG").length,
+      3,
+      "dry run enumerates every flaggable PR regardless of LIMIT"
+    );
+  }
+
+  // An explicit LIMIT=0 means flag nothing (not unlimited).
+  {
+    const { commented } = await run([pr({ number: 43 })], { env: { ...ENFORCE, LIMIT: "0" } });
+    assert.strictEqual(commented.length, 0, "LIMIT=0 flags nothing");
   }
 
   // Maintainer PRs are never commented on, by either signal.

--- a/.github/workflows/pr-issue-link.test.js
+++ b/.github/workflows/pr-issue-link.test.js
@@ -97,7 +97,11 @@ async function run(
   const saved = { ...process.env };
   Object.assign(process.env, env);
   try {
-    await script({ context: { repo: { owner: "o", repo: "r" } }, github, core });
+    await script({
+      context: { repo: { owner: "o", repo: "r" }, payload: { repository: { default_branch: "main" } } },
+      github,
+      core,
+    });
   } finally {
     for (const k of Object.keys(env)) delete process.env[k];
     Object.assign(process.env, saved);
@@ -288,6 +292,15 @@ for (const tracked of ["Bug fix", "Feature", "UI / frontend change"]) {
   {
     const { commented } = await run([pr({ number: 43 })], { env: { ...ENFORCE, LIMIT: "0" } });
     assert.strictEqual(commented.length, 0, "LIMIT=0 flags nothing");
+  }
+
+  // A malformed LIMIT must fail toward flagging nothing, not everything.
+  {
+    const { commented, warnings } = await run([pr({ number: 44 })], {
+      env: { ...ENFORCE, LIMIT: "abc" },
+    });
+    assert.strictEqual(commented.length, 0, "malformed LIMIT flags nothing");
+    assert.ok(warnings.some((w) => /not a number/.test(w)), "and says so");
   }
 
   // Maintainer PRs are never commented on, by either signal.

--- a/.github/workflows/pr-issue-link.test.js
+++ b/.github/workflows/pr-issue-link.test.js
@@ -149,7 +149,8 @@ assert.strictEqual(
   "10 changed lines is not trivial"
 );
 assert.strictEqual(exemptReason(pr({ number: 7, title: "Revert \"feat: x\"" })), "revert");
-assert.strictEqual(exemptReason(pr({ number: 8, body: "blah\nno-issue\nblah" })), "no-issue opt-out");
+// There is no self-service opt-out: writing `no-issue` in the body does nothing.
+assert.strictEqual(exemptReason(pr({ number: 8, body: "blah\nno-issue\nblah" })), null);
 
 // Declared exempt types, matching the real template's checkbox labels.
 for (const type of ["Refactor / chore", "Docs", "Test / CI"]) {

--- a/.github/workflows/pr-issue-link.test.js
+++ b/.github/workflows/pr-issue-link.test.js
@@ -12,6 +12,7 @@ function pr({
   body = "",
   title = "feat: thing",
   author = "ext",
+  assoc = "CONTRIBUTOR",
   bot = false,
   draft = false,
   additions = 100,
@@ -24,6 +25,7 @@ function pr({
     isDraft: draft,
     additions,
     deletions,
+    authorAssociation: assoc,
     author: { login: author, __typename: bot ? "Bot" : "User" },
     labels: { nodes: labels.map((name) => ({ name })) },
     body,
@@ -32,11 +34,12 @@ function pr({
 
 // Run the script over PR nodes. `linked` maps PR number -> closing-issue count.
 // `env` overrides process.env for the run.
-async function run(nodes, { linked = {}, env = {}, linkError = false } = {}) {
+async function run(nodes, { linked = {}, env = {}, linkError = false, maintainers = [] } = {}) {
   const commented = [];
   const labeled = [];
   let searchCalls = 0;
   const github = {
+    repos: {},
     graphql: async (query, vars) => {
       if (query.includes("pullRequest(number:")) {
         if (linkError) throw new Error("boom");
@@ -58,6 +61,11 @@ async function run(nodes, { linked = {}, env = {}, linkError = false } = {}) {
       };
     },
     rest: {
+      repos: {
+        getContent: async () => ({
+          data: { content: Buffer.from(maintainers.join("\n"), "utf8").toString("base64") },
+        }),
+      },
       issues: {
         createLabel: async () => {},
         createComment: async ({ issue_number, body }) => commented.push({ issue_number, body }),
@@ -86,6 +94,27 @@ const { exemptReason } = script;
 assert.strictEqual(exemptReason(pr({ number: 1 })), null, "plain unlinked PR is not exempt");
 assert.strictEqual(exemptReason(pr({ number: 2, bot: true })), "bot");
 assert.strictEqual(exemptReason(pr({ number: 3, draft: true })), "draft");
+
+// Maintainers are exempt via EITHER signal. Both are needed: a maintainer with
+// private org membership reads as CONTRIBUTOR, and a maintainer with write
+// access may not be listed in .github/MAINTAINER.
+for (const assoc of ["MEMBER", "OWNER", "COLLABORATOR"]) {
+  assert.strictEqual(
+    exemptReason(pr({ number: 30, assoc })),
+    "maintainer",
+    `${assoc} is exempt by association`
+  );
+}
+assert.strictEqual(
+  exemptReason(pr({ number: 31, author: "Maintainer-Person", assoc: "CONTRIBUTOR" }), new Set(["maintainer-person"])),
+  "maintainer",
+  "MAINTAINER file catches a private-membership maintainer (case-insensitive)"
+);
+assert.strictEqual(
+  exemptReason(pr({ number: 32, author: "outsider" }), new Set(["maintainer-person"])),
+  null,
+  "a non-maintainer is still enforced"
+);
 assert.strictEqual(
   exemptReason(pr({ number: 4, labels: ["skip-issue-check"] })),
   "skip-issue-check label"
@@ -183,6 +212,31 @@ assert.strictEqual(
     const nodes = [25, 26, 27].map((number) => pr({ number }));
     const { commented } = await run(nodes, { env: { ...ENFORCE, LIMIT: "2" } });
     assert.strictEqual(commented.length, 2, "LIMIT caps flags per run");
+  }
+
+  // Maintainer PRs are never commented on, by either signal.
+  {
+    const { commented } = await run(
+      [
+        pr({ number: 28, assoc: "MEMBER" }),
+        pr({ number: 29, author: "listed-maintainer" }),
+        pr({ number: 30, author: "outsider" }),
+      ],
+      { env: ENFORCE, maintainers: ["listed-maintainer", "# a comment"] }
+    );
+    assert.deepStrictEqual(
+      commented.map((c) => c.issue_number),
+      [30],
+      "only the non-maintainer is commented on"
+    );
+  }
+
+  // A missing MAINTAINER file must not crash the run (association still applies).
+  {
+    const github_err = { env: ENFORCE };
+    const { commented, warnings } = await run([pr({ number: 31, assoc: "MEMBER" })], github_err);
+    assert.strictEqual(commented.length, 0, "MEMBER stays exempt without the file");
+    assert.ok(!warnings.some((w) => /throw/i.test(w)));
   }
 
   console.log("pr-issue-link.test.js: all assertions passed");


### PR DESCRIPTION
## Related issue

Tracked internally as OMNI-2311 (part of OMNI-2214, "Better review process"). No
public issue; this PR declares **Refactor / chore** and **Test / CI** below, which
is the exemption the check itself honors.

## Summary

Linking a PR to an issue is what gives it a priority in the review queue, but
**329 of 480 open PRs link nothing**, so most of the queue arrives unsorted.

- Adds an hourly issue-link check to the PR-hygiene sweep. A PR with no linked
  issue gets **one comment and nothing else** — no label, and nothing is ever
  closed. Dedupe is a hidden marker in the bot's own comment
  (`<!-- pr-issue-link -->`), the same approach `reopen-notice.js` uses, so the
  nudge stays a one-shot message rather than adding a label maintainers have to
  filter past.
- **Ships as a dry run.** `ENFORCE` defaults to `"false"`, which resolves every
  verdict into the step summary while changing nothing, so the full list can be
  reviewed before a single contributor is commented on. `LIMIT` bounds how many
  PRs one run may flag **once enforcement is on**; it deliberately does not
  truncate a dry run, whose purpose is to show the complete list.
- **Forward-only.** `EFFECTIVE_FROM` is a hard floor the scan cutoff cannot
  predate, so the existing backlog is untouched no matter how the scan window is
  configured. The 24-hour window alone made this incidental; the constant makes it
  a property of the rule.
- Reuses the existing hourly sweep rather than adding a workflow, so there are no
  new permissions, no `pull_request_target`, and no fork-secret path. The workflow
  is renamed **PR Hygiene** now that it carries two checks.

**Exemptions**, in the order evaluated: bots, drafts, maintainers, the
`skip-issue-check` label, an affirmatively checked `Refactor / chore` / `Docs` /
`Test / CI` box with no `Bug fix` / `Feature` / `UI` box also checked, trivial
changes (≤ 9 lines, the `size/XS` threshold), and reverts. Order only decides
which reason gets reported; every path exempts.

There is deliberately **no self-service opt-out**. An earlier revision honored a
`no-issue` line in the body; it was removed, because a rule anyone can skip by
typing one line is not a rule — and it was available to exactly the PRs this
check targets. The only unconditional bypass is `skip-issue-check`, which needs
write access. A test asserts a `no-issue` body line does nothing, so the hatch
cannot quietly return.

Three choices were made against measurements rather than by taste:

- **The chore exemption requires a declaration.** Exempting on the *absence* of a
  checked box would have made deleting the template the cheapest way to skip the
  rule — that measured at **105 PRs versus 23 genuine chore declarations**.
- **A tracked type beats an exempt one.** Ticking `Test / CI` beside `Bug fix`
  would otherwise have been a free opt-out.
- **Maintainers are exempt on either signal** (`authorAssociation` or
  `.github/MAINTAINER`). Both are needed: association catches 79 of the flagged
  PRs and the file catches 75, because one maintainer is `MEMBER` but unlisted;
  conversely a maintainer with private org membership reads as `CONTRIBUTOR`. The
  file is read from the API, not the checked-out tree, so a PR cannot self-grant
  by editing it.

Link status is resolved **per PR** via `closingIssuesReferences` rather than a
body regex, so sidebar links, cross-repo refs (`Fixes owner/repo#N`), and full
issue URLs all count. Those are forms a keyword regex misses, and two of them
appear in our own backlog (#3577, #997). A failed lookup **fails closed** and
leaves the PR alone.

## Test Plan

- `node .github/workflows/pr-issue-link.test.js` — offline, mocked GitHub client,
  no network. Covers every exemption predicate, the per-PR link lookup, the
  comment-marker dedupe (and that an unrelated human comment does not suppress
  the nudge), the effective-date floor, `LIMIT` under enforcement plus `LIMIT=0`
  and a malformed `LIMIT` both flagging nothing, that a dry run enumerates every
  verdict regardless of `LIMIT`, that a dry run performs no writes, that a failed
  link lookup does not flag, and that a missing `MAINTAINER` file degrades to
  association-only instead of crashing. A `pr-issue-link-test.yml` runs it on any
  PR touching the script or its test.
- `pre-commit run --files ...` — clean.
- **Executed the real script against this repo in dry-run mode** (60-day window,
  live GitHub client), with the mocked write methods rigged to throw if called, so
  "nothing was touched" is proven rather than assumed. That run predates the
  label removal, so its verdict counts describe the same decision logic minus the
  labeling step:

  | Verdict | Count |
  | --- | --- |
  | FLAG (would comment) | 149 |
  | ok (issue linked) | 121 |
  | exempt | 210 |
  | skip / lookup failure | 0 |

  Exempt breakdown: maintainer 112, draft 48, declared chore/docs/test 46, bot 3,
  trivial 1. The 149 span 81 distinct authors, 49 of whom have exactly one.
  Verified zero maintainer logins remain in the flagged set. Note the window used
  there was widened deliberately for measurement; the shipped check is bounded by
  `EFFECTIVE_FROM`, so it will never reach those PRs.

## Demo

N/A — no user-visible change. The only contributor-facing surface is the PR
template wording, and the bot comment, which is disabled in this PR.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the live dry run described in the Test Plan: the committed
script was executed against this repository with a real GitHub client and write
methods that throw, producing the verdict table above without commenting on any
PR. Enforcement is off in this PR, so the only behaviour that reaches contributors
today is the template wording.
