### PR TITLE
refactor(db): rename projects.owner_user_id to user_id; drop the name UNIQUE index; compress config

### DIFF
--- a/designs/PROJECTS_PRD.md
+++ b/designs/PROJECTS_PRD.md
@@ -174,8 +174,8 @@ class SqlProject(OmnigentBase):
         # returns a stable order (e.g. created_at / name); the client may
         # re-order locally.
         Index("ix_projects_owner", "workspace_id", "user_id", "id"),
-        # Per-owner name uniqueness (§7.1); app validates too.
-        Index("uq_projects_owner_name", "workspace_id", "user_id", "name", unique=True),
+        # Per-owner name uniqueness (§7.1) is a store-level check
+        # (`_name_taken`), not a unique index — see the table below.
     )
 ```
 
@@ -195,7 +195,7 @@ Index("ix_conversation_metadata_project_id", "workspace_id", "project_id", "id")
 |---|---|---|
 | `id` type | `String(64)`, `proj_`-prefixed | Reads as a sibling of `conv_…` ids; lives in the metadata String column. Newest tables use `Uuid16` — diverge here for readability + column symmetry. |
 | Membership location | `project_id` on `omnigent_conversation_metadata` | Metadata already holds host/workspace/runner; `list_conversations` can filter it inline. |
-| Name uniqueness | per-`(workspace, owner)` unique index | Matches §7.1; case-sensitivity still open (Q3). |
+| Name uniqueness | store-level check, **no** unique index | Matches §7.1; case-sensitivity still open (Q3). The unique index shipped in Phase 1a and was dropped in `d5e6f7a8b9c0`: it never held for single-user mode (NULL owner, and SQL treats NULLs as distinct), and `name` is mutable, so it was maintained on every rename. Concurrent creates/renames to one name can now both land. |
 | Ownership | `user_id` **column on the row** | See "Where ownership lives" below — differs from sessions on purpose. |
 | Ordering | **no `position` column** | Reorder is deferred and client-only (§7.2); no server state until proven needed. |
 | Deferred columns | default host/workspace/harness/model, memory/context refs | Added in Phase 2/3, not now. |
@@ -449,9 +449,11 @@ Shipped: the project **container** — create, list, rename, and delete empty
 projects. Session→project membership landed separately in Phase 1b (below).
 - ✅ **`projects` table** — `SqlProject` (`db_models.py`): `id` (Uuid16),
   `name`, `user_id`, `created_at`, `updated_at`. Owner-scoped index; a
-  UNIQUE index on `(workspace_id, user_id, name)` enforces per-owner name
+  UNIQUE index on `(workspace_id, user_id, name)` enforced per-owner name
   uniqueness at the DB layer for non-NULL owners (the store's `_name_taken`
-  check guards NULL-owner / single-user rows, which SQL treats as distinct).
+  check guarded NULL-owner / single-user rows, which SQL treats as distinct).
+  That index was later dropped in `d5e6f7a8b9c0`, leaving `_name_taken` the
+  sole guard for every owner.
   (No `config` column in Phase 1a — deferred so we didn't ship an unused
   column; added in Phase 2 via migration `b3c4d5e6f7a8`, see the TODO below.)
 - ✅ **Migration** `b1c2d3e4f5a6` — creates the `projects` table only;
@@ -459,7 +461,8 @@ projects. Session→project membership landed separately in Phase 1b (below).
 - ✅ **Entity** — `Project` (`entities/project.py`).
 - ✅ **Store** — `ProjectStore` + `SqlAlchemyProjectStore` (create/get/list/
   update/delete, owner-scoped; `IntegrityError` → `ALREADY_EXISTS` as the DB
-  backstop for the uniqueness race).
+  backstop for the uniqueness race — removed with the index in
+  `d5e6f7a8b9c0`).
 - ✅ **API** — `POST/GET/PATCH/DELETE /v1/projects` (`routes/projects.py`),
   request/response schemas, wired into `create_app` + CLI; `openapi.json`
   regenerated. Every handler is owner-scoped (projects are owner-private).

--- a/designs/PROJECTS_PRD.md
+++ b/designs/PROJECTS_PRD.md
@@ -163,7 +163,7 @@ class SqlProject(OmnigentBase):
     # permission table the way session ownership is. Correct here precisely
     # because projects have no ACL and are owner-private (§9) — see the
     # "Where ownership lives" note below. None in single-user/OSS mode.
-    owner_user_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    user_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     created_at: Mapped[int] = mapped_column(Integer, nullable=False)
     updated_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
     # No `position` column: ordering is deferred and, when added, will be a
@@ -173,9 +173,9 @@ class SqlProject(OmnigentBase):
         # "list my projects": prefix scan on (workspace_id, owner). Server
         # returns a stable order (e.g. created_at / name); the client may
         # re-order locally.
-        Index("ix_projects_owner", "workspace_id", "owner_user_id", "id"),
+        Index("ix_projects_owner", "workspace_id", "user_id", "id"),
         # Per-owner name uniqueness (§7.1); app validates too.
-        Index("uq_projects_owner_name", "workspace_id", "owner_user_id", "name", unique=True),
+        Index("uq_projects_owner_name", "workspace_id", "user_id", "name", unique=True),
     )
 ```
 
@@ -196,7 +196,7 @@ Index("ix_conversation_metadata_project_id", "workspace_id", "project_id", "id")
 | `id` type | `String(64)`, `proj_`-prefixed | Reads as a sibling of `conv_…` ids; lives in the metadata String column. Newest tables use `Uuid16` — diverge here for readability + column symmetry. |
 | Membership location | `project_id` on `omnigent_conversation_metadata` | Metadata already holds host/workspace/runner; `list_conversations` can filter it inline. |
 | Name uniqueness | per-`(workspace, owner)` unique index | Matches §7.1; case-sensitivity still open (Q3). |
-| Ownership | `owner_user_id` **column on the row** | See "Where ownership lives" below — differs from sessions on purpose. |
+| Ownership | `user_id` **column on the row** | See "Where ownership lives" below — differs from sessions on purpose. |
 | Ordering | **no `position` column** | Reorder is deferred and client-only (§7.2); no server state until proven needed. |
 | Deferred columns | default host/workspace/harness/model, memory/context refs | Added in Phase 2/3, not now. |
 
@@ -209,12 +209,12 @@ shareable:
   `list_projects(owned_by=...)`). This is required *because sessions are shared*:
   ownership is just the top row among many `(user, level)` grants.
 - **`scheduled_tasks`** — a personal, non-shareable artifact with no ACL — instead
-  stamps `owner_user_id` directly on the row (`db_models.py:1298`), indexed
-  `(workspace_id, owner_user_id, id)`.
+  stamps `user_id` directly on the row (`db_models.py:1298`), indexed
+  `(workspace_id, user_id, id)`.
 
 Projects follow `scheduled_tasks`, not sessions, **because §9 gives them no
 project-level ACL** — they're owner-private, single-owner, never granted to
-anyone else. With no `project_permissions` table to derive from, `owner_user_id`
+anyone else. With no `project_permissions` table to derive from, `user_id`
 on the row is the correct and consistent choice. (The v1 label-based
 `list_projects` derives ownership from `session_permissions` only because a label
 has no row of its own to stamp — the first-class table removes that constraint.)
@@ -448,8 +448,8 @@ Tracks what has actually landed vs. what remains. Updated as work ships.
 Shipped: the project **container** — create, list, rename, and delete empty
 projects. Session→project membership landed separately in Phase 1b (below).
 - ✅ **`projects` table** — `SqlProject` (`db_models.py`): `id` (Uuid16),
-  `name`, `owner_user_id`, `created_at`, `updated_at`. Owner-scoped index; a
-  UNIQUE index on `(workspace_id, owner_user_id, name)` enforces per-owner name
+  `name`, `user_id`, `created_at`, `updated_at`. Owner-scoped index; a
+  UNIQUE index on `(workspace_id, user_id, name)` enforces per-owner name
   uniqueness at the DB layer for non-NULL owners (the store's `_name_taken`
   check guards NULL-owner / single-user rows, which SQL treats as distinct).
   (No `config` column in Phase 1a — deferred so we didn't ship an unused

--- a/dev/benchmarks/omnigent/seed.py
+++ b/dev/benchmarks/omnigent/seed.py
@@ -341,7 +341,7 @@ def _seed_via_store(
     # see them. Created before the sessions so membership can be set inline.
     projects_store = SqlAlchemyProjectStore(conv.storage_location)
     for project_id, name in project_specs:
-        projects_store.create(project_id, name, owner_user_id=_PROJECT_OWNER)
+        projects_store.create(project_id, name, user_id=_PROJECT_OWNER)
 
     last_sid = ""
     for s in range(sessions):
@@ -569,7 +569,7 @@ def _seed_via_core(
                         "workspace_id": ws,
                         "id": project_id,
                         "name": name,
-                        "owner_user_id": _PROJECT_OWNER,
+                        "user_id": _PROJECT_OWNER,
                         "created_at": project_now,
                         "updated_at": None,
                     }

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -681,15 +681,15 @@ class SqlProject(OmnigentBase):
     membership lives on ``omnigent_conversation_metadata.project_id``, not
     here; there is no DB foreign key (Rule R032).
 
-    Ownership is stamped on the row via ``owner_user_id`` (like
-    ``scheduled_tasks``), not derived from a permission table the way session
-    ownership is — projects have no ACL of their own and are never shared.
+    Ownership is stamped on the row via ``user_id`` (like ``scheduled_tasks``),
+    not derived from a permission table the way session ownership is — projects
+    have no ACL of their own and are never shared.
 
     :param id: Uuid16 primary key (bare 32-char hex in Python).
     :param name: Human-readable project name; unique per owner (enforced in
-        the store, since ``owner_user_id`` is NULL in single-user mode and a DB
+        the store, since ``user_id`` is NULL in single-user mode and a DB
         unique index treats NULLs as distinct).
-    :param owner_user_id: Owning user, or ``None`` in single-user mode.
+    :param user_id: Owning user, or ``None`` in single-user mode.
     :param created_at: Unix epoch seconds at row creation.
     :param updated_at: Unix epoch seconds of the last write, or ``None``.
     """
@@ -706,7 +706,9 @@ class SqlProject(OmnigentBase):
     )
     id: Mapped[str] = mapped_column(Uuid16(), primary_key=True)
     name: Mapped[str] = mapped_column(String(256), nullable=False)
-    owner_user_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    # Owning user identity. String(128) matches session_permissions.user_id and
+    # every other user-identity column in this schema.
+    user_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     created_at: Mapped[int] = mapped_column(Integer, nullable=False)
     updated_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
     # Default session settings as a compact JSON object (host/workspace/harness/
@@ -718,26 +720,26 @@ class SqlProject(OmnigentBase):
     config: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     __table_args__ = (
-        # "list my projects" — prefix scan on (workspace_id, owner_user_id) with
+        # "list my projects" — prefix scan on (workspace_id, user_id) with
         # created_at in the key so the ORDER BY created_at, id is served by the
         # index (no filesort). Server returns a stable order; reorder, if ever
         # added, is a client-only concern, so there is no ``position`` column.
         Index(
-            "ix_projects_owner_user_id",
+            "ix_projects_user_id",
             "workspace_id",
-            "owner_user_id",
+            "user_id",
             "created_at",
             "id",
         ),
         # Enforces per-owner name uniqueness at the DB layer for NON-NULL owners
         # (closing the store's check-then-insert race under concurrency). SQL
-        # treats NULLs as distinct, so single-user rows (owner_user_id IS NULL)
+        # treats NULLs as distinct, so single-user rows (user_id IS NULL)
         # can still collide on name — the store's _name_taken check covers that
         # case. Also backs the get-by-name lookup.
         Index(
             "ix_projects_name",
             "workspace_id",
-            "owner_user_id",
+            "user_id",
             "name",
             unique=True,
         ),

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -686,9 +686,9 @@ class SqlProject(OmnigentBase):
     have no ACL of their own and are never shared.
 
     :param id: Uuid16 primary key (bare 32-char hex in Python).
-    :param name: Human-readable project name; unique per owner (enforced in
-        the store, since ``user_id`` is NULL in single-user mode and a DB
-        unique index treats NULLs as distinct).
+    :param name: Human-readable project name; unique per owner, enforced in the
+        store (``_name_taken``) rather than by a DB constraint — see
+        ``__table_args__``.
     :param user_id: Owning user, or ``None`` in single-user mode.
     :param created_at: Unix epoch seconds at row creation.
     :param updated_at: Unix epoch seconds of the last write, or ``None``.
@@ -716,32 +716,36 @@ class SqlProject(OmnigentBase):
     # keys are an opaque, client-owned vocabulary: the value is read and written
     # whole with the row and never filtered in SQL, so new keys need no schema
     # change. Stored values are hints the new-chat dialog pre-fills and the user
-    # can always override.
-    config: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # can always override. Opaque and never SQL-filtered — stored compressed
+    # (CompressedText).
+    config: Mapped[str | None] = mapped_column(CompressedText, nullable=True)
 
     __table_args__ = (
         # "list my projects" — prefix scan on (workspace_id, user_id) with
         # created_at in the key so the ORDER BY created_at, id is served by the
         # index (no filesort). Server returns a stable order; reorder, if ever
         # added, is a client-only concern, so there is no ``position`` column.
+        #
+        # Also covers the two name lookups via its (workspace_id, user_id)
+        # prefix: the store's ``_name_taken`` probe and the ``?project=<name>``
+        # member join. Both then filter ``name`` over the owner's handful of
+        # rows, so neither needs a name-leading index of its own.
+        #
+        # There is deliberately NO unique index on (workspace_id, user_id, name).
+        # Per-owner name uniqueness is a store-level check (``_name_taken``), not
+        # a DB constraint: it never held for single-user mode anyway (``user_id``
+        # is NULL there and SQL treats NULLs as distinct), and ``name`` is
+        # mutable, so a unique key over it is maintained on every rename. The
+        # cost is that two concurrent creates/renames to the same name can both
+        # land; the member join already tolerates duplicate names by
+        # construction, since it unions first-class members with label-projects
+        # matched on the same string.
         Index(
             "ix_projects_user_id",
             "workspace_id",
             "user_id",
             "created_at",
             "id",
-        ),
-        # Enforces per-owner name uniqueness at the DB layer for NON-NULL owners
-        # (closing the store's check-then-insert race under concurrency). SQL
-        # treats NULLs as distinct, so single-user rows (user_id IS NULL)
-        # can still collide on name — the store's _name_taken check covers that
-        # case. Also backs the get-by-name lookup.
-        Index(
-            "ix_projects_name",
-            "workspace_id",
-            "user_id",
-            "name",
-            unique=True,
         ),
     )
 

--- a/omnigent/db/migrations/versions/d5e6f7a8b9c0_rename_projects_owner_user_id.py
+++ b/omnigent/db/migrations/versions/d5e6f7a8b9c0_rename_projects_owner_user_id.py
@@ -1,0 +1,104 @@
+"""Rename ``projects.owner_user_id`` to ``user_id``
+
+Revision ID: d5e6f7a8b9c0
+Revises: c4d5e6f7a8b9
+Create Date: 2026-08-04 00:00:00.000000
+
+Finishes the unification started in b3c1a2d4e5f6, which renamed
+``hosts.owner`` and ``scheduled_tasks.owner_user_id`` to the schema-wide
+``user_id`` convention. ``projects`` already existed at that point
+(b1c2d3e4f5a6, five days earlier) but was left out, so it is the last column
+still diverging. This brings it in line with ``session_permissions.user_id``,
+``account_tokens.user_id``, ``device_grants.user_id``, ``hosts.user_id``, and
+``scheduled_tasks.user_id``.
+
+Type is unchanged (``VARCHAR(128)``, nullable). Both indexes covering the
+column are recreated: ``ix_projects_owner_user_id`` → ``ix_projects_user_id``
+(matching the ``ix_scheduled_tasks_user_id`` precedent) and ``ix_projects_name``
+keeps its name, since it is named for the ``name`` column that makes it unique —
+``_is_name_conflict`` in the project store matches on that index name.
+
+The rename is not wire-visible: ``owner_user_id`` was never part of the
+``ProjectObject`` response, so no client contract changes.
+
+Dialect strategy
+----------------
+- **SQLite**: cannot rename a column in place; ``batch_alter_table`` with
+  ``recreate="always"`` rebuilds the table with the new column name.
+- **PostgreSQL / MySQL**: native ``ALTER TABLE ... RENAME COLUMN``
+  (``recreate="auto"``), no copy.
+
+As in b3c1a2d4e5f6, the dependent indexes are dropped before the rename and
+recreated after: a single batch that both renames a column and drops an index
+referencing it trips Alembic's batch reflection, which maps the reflected index
+onto the not-yet-renamed column.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d5e6f7a8b9c0"
+down_revision: str | None = "c4d5e6f7a8b9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_sqlite() -> bool:
+    return op.get_bind().dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    """Rename ``projects.owner_user_id`` → ``user_id``."""
+    recreate: Literal["always", "auto"] = "always" if _is_sqlite() else "auto"
+
+    op.drop_index("ix_projects_name", table_name="projects")
+    op.drop_index("ix_projects_owner_user_id", table_name="projects")
+    with op.batch_alter_table("projects", recreate=recreate) as batch_op:
+        batch_op.alter_column(
+            "owner_user_id",
+            new_column_name="user_id",
+            existing_type=sa.String(128),
+            existing_nullable=True,
+        )
+    op.create_index(
+        "ix_projects_user_id",
+        "projects",
+        ["workspace_id", "user_id", "created_at", "id"],
+    )
+    op.create_index(
+        "ix_projects_name",
+        "projects",
+        ["workspace_id", "user_id", "name"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    """Restore the ``owner_user_id`` column name."""
+    recreate: Literal["always", "auto"] = "always" if _is_sqlite() else "auto"
+
+    op.drop_index("ix_projects_name", table_name="projects")
+    op.drop_index("ix_projects_user_id", table_name="projects")
+    with op.batch_alter_table("projects", recreate=recreate) as batch_op:
+        batch_op.alter_column(
+            "user_id",
+            new_column_name="owner_user_id",
+            existing_type=sa.String(128),
+            existing_nullable=True,
+        )
+    op.create_index(
+        "ix_projects_owner_user_id",
+        "projects",
+        ["workspace_id", "owner_user_id", "created_at", "id"],
+    )
+    op.create_index(
+        "ix_projects_name",
+        "projects",
+        ["workspace_id", "owner_user_id", "name"],
+        unique=True,
+    )

--- a/omnigent/db/migrations/versions/d5e6f7a8b9c0_rename_projects_owner_user_id.py
+++ b/omnigent/db/migrations/versions/d5e6f7a8b9c0_rename_projects_owner_user_id.py
@@ -1,4 +1,4 @@
-"""Rename ``projects.owner_user_id`` to ``user_id``
+"""Rename ``projects.owner_user_id`` to ``user_id``; drop the name UNIQUE index
 
 Revision ID: d5e6f7a8b9c0
 Revises: c4d5e6f7a8b9
@@ -12,14 +12,30 @@ still diverging. This brings it in line with ``session_permissions.user_id``,
 ``account_tokens.user_id``, ``device_grants.user_id``, ``hosts.user_id``, and
 ``scheduled_tasks.user_id``.
 
-Type is unchanged (``VARCHAR(128)``, nullable). Both indexes covering the
-column are recreated: ``ix_projects_owner_user_id`` → ``ix_projects_user_id``
-(matching the ``ix_scheduled_tasks_user_id`` precedent) and ``ix_projects_name``
-keeps its name, since it is named for the ``name`` column that makes it unique —
-``_is_name_conflict`` in the project store matches on that index name.
+Type is unchanged (``VARCHAR(128)``, nullable). ``ix_projects_owner_user_id``
+becomes ``ix_projects_user_id``, matching the ``ix_scheduled_tasks_user_id``
+precedent.
 
-The rename is not wire-visible: ``owner_user_id`` was never part of the
-``ProjectObject`` response, so no client contract changes.
+``ix_projects_name`` — UNIQUE over (workspace_id, owner, name) — is **dropped,
+not renamed**. It backed only the store's two ``_name_taken`` probes, which now
+stand alone as the sole uniqueness check:
+
+- It never held for single-user mode, where the owner column is NULL and SQL
+  treats NULLs as distinct, so that deployment has always allowed duplicates.
+- ``name`` is mutable (``update`` renames it), so a unique key over it is
+  maintained on every rename.
+- The ``?project=<name>`` member join tolerates duplicate names by
+  construction: it unions first-class members with ``omni_project``
+  label-projects matched on the same string, so name-collision merging is
+  already its defined behaviour.
+
+The cost is that two concurrent creates or renames to the same name can both
+land. ``ix_projects_user_id`` still covers both probes via its
+(workspace_id, user_id) prefix, then filters ``name`` over the owner's handful
+of rows.
+
+Neither change is wire-visible: the owner column was never part of the
+``ProjectObject`` response, and dropping an index changes no response shape.
 
 Dialect strategy
 ----------------
@@ -28,10 +44,10 @@ Dialect strategy
 - **PostgreSQL / MySQL**: native ``ALTER TABLE ... RENAME COLUMN``
   (``recreate="auto"``), no copy.
 
-As in b3c1a2d4e5f6, the dependent indexes are dropped before the rename and
-recreated after: a single batch that both renames a column and drops an index
-referencing it trips Alembic's batch reflection, which maps the reflected index
-onto the not-yet-renamed column.
+As in b3c1a2d4e5f6, the dependent indexes are dropped before the rename: a
+single batch that both renames a column and drops an index referencing it trips
+Alembic's batch reflection, which maps the reflected index onto the
+not-yet-renamed column.
 """
 
 from __future__ import annotations
@@ -53,9 +69,10 @@ def _is_sqlite() -> bool:
 
 
 def upgrade() -> None:
-    """Rename ``projects.owner_user_id`` → ``user_id``."""
+    """Rename the owner column and drop ``ix_projects_name``."""
     recreate: Literal["always", "auto"] = "always" if _is_sqlite() else "auto"
 
+    # Dropped for good, not recreated below — see the module docstring.
     op.drop_index("ix_projects_name", table_name="projects")
     op.drop_index("ix_projects_owner_user_id", table_name="projects")
     with op.batch_alter_table("projects", recreate=recreate) as batch_op:
@@ -70,19 +87,17 @@ def upgrade() -> None:
         "projects",
         ["workspace_id", "user_id", "created_at", "id"],
     )
-    op.create_index(
-        "ix_projects_name",
-        "projects",
-        ["workspace_id", "user_id", "name"],
-        unique=True,
-    )
 
 
 def downgrade() -> None:
-    """Restore the ``owner_user_id`` column name."""
+    """Restore the ``owner_user_id`` column name and the UNIQUE name index.
+
+    Recreating ``ix_projects_name`` can fail if duplicate names accumulated
+    while the constraint was absent — deliberately, so the downgrade surfaces
+    the conflict rather than silently discarding a row.
+    """
     recreate: Literal["always", "auto"] = "always" if _is_sqlite() else "auto"
 
-    op.drop_index("ix_projects_name", table_name="projects")
     op.drop_index("ix_projects_user_id", table_name="projects")
     with op.batch_alter_table("projects", recreate=recreate) as batch_op:
         batch_op.alter_column(

--- a/omnigent/db/migrations/versions/e6f7a8b9c0d1_compress_projects_config.py
+++ b/omnigent/db/migrations/versions/e6f7a8b9c0d1_compress_projects_config.py
@@ -1,0 +1,114 @@
+"""Store ``projects.config`` as compressed BLOB/BYTEA
+
+Revision ID: e6f7a8b9c0d1
+Revises: d5e6f7a8b9c0
+Create Date: 2026-08-05 00:00:00.000000
+
+Finishes the sweep of z9a2b3c4d5e6, which converted the then-remaining opaque
+``TEXT`` columns (``policies.handler`` / ``factory_params``,
+``hosts.configured_harnesses``) to a binary column so the application layer can
+store them zstd-compressed (``omnigent/db/compression.py``). ``projects.config``
+landed four days earlier (b1c2d3e4f5a6) and was missed, leaving it the last
+plain-``TEXT`` column outside ``conversation_items``.
+
+``config`` qualifies on the same terms: it holds a machine-generated JSON object
+of default session settings, is read and written whole with the row, and is never
+filtered, ordered, or pattern-matched in SQL. Compressing it also gives a uniform
+on-disk size across backends — MySQL's InnoDB does not compress ``TEXT``/``BLOB``
+by default and SQLite never does, so without client-side compression the column
+would sit uncompressed there while PostgreSQL (TOAST) compressed it.
+
+The Python type stays ``str | None``, so the store, entity, and routes are
+unchanged.
+
+Existing rows need no backfill on upgrade: they become their raw UTF-8 bytes,
+and the codec recognises unframed values and reads them back unchanged,
+re-framing each on its next write. Downgrade decompresses every row back to
+plaintext before restoring the ``TEXT`` type.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+import zstandard
+from alembic import op
+
+revision: str = "e6f7a8b9c0d1"
+down_revision: str | None = "d5e6f7a8b9c0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _alter_type(to_binary: bool) -> None:
+    """Change ``projects.config``'s SQL type in both directions.
+
+    Uses batch mode on every dialect: SQLite cannot alter a column type in
+    place (``recreate="always"`` rebuilds the table), and routing all dialects
+    through ``batch_op`` keeps the change off the bare ``op`` proxy, which the
+    SQLite-safety guard forbids for ``alter_column``.
+
+    :param to_binary: ``True`` for ``TEXT`` → ``LargeBinary`` (upgrade),
+        ``False`` for the reverse (downgrade).
+    """
+    sqlite = op.get_bind().dialect.name == "sqlite"
+    old_type = sa.Text() if to_binary else sa.LargeBinary()
+    new_type = sa.LargeBinary() if to_binary else sa.Text()
+    # PostgreSQL cannot implicitly cast between text and bytea, so spell the
+    # conversion out. Ignored by other dialects.
+    cast = "convert_to(config, 'UTF8')" if to_binary else "convert_from(config, 'UTF8')"
+    with op.batch_alter_table("projects", recreate="always" if sqlite else "auto") as batch:
+        batch.alter_column(
+            "config",
+            existing_type=old_type,
+            type_=new_type,
+            existing_nullable=True,
+            postgresql_using=cast,
+        )
+
+
+def upgrade() -> None:
+    """``TEXT`` → ``LargeBinary``. Existing rows keep their raw UTF-8 bytes."""
+    _alter_type(to_binary=True)
+
+
+def _decode(value: object) -> str:
+    """Reverse the compression frame written by ``omnigent/db/compression.py``.
+
+    Inlined so the downgrade stays correct against this migration's on-disk
+    format regardless of later codec changes.
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, memoryview):
+        data = value.tobytes()
+    elif isinstance(value, bytes):
+        data = value
+    elif isinstance(value, bytearray):
+        data = bytes(value)
+    else:
+        raise TypeError(f"expected binary compressed text, got {type(value).__name__}")
+    if not data or data[0] != 0x00:
+        return data.decode("utf-8")  # legacy unframed text
+    codec, payload = data[1], data[2:]
+    if codec == 0x01:  # zstd
+        decompressed: bytes = zstandard.ZstdDecompressor().decompress(payload)
+        return decompressed.decode("utf-8")
+    return payload.decode("utf-8")  # framed, uncompressed
+
+
+def downgrade() -> None:
+    """Decompress every value, then restore the ``TEXT`` type."""
+    bind = op.get_bind()
+    on_sqlite = bind.dialect.name == "sqlite"
+    # Rewrite each value as raw UTF-8 plaintext (bytes on PostgreSQL/MySQL, str
+    # on dynamically-typed SQLite) so the binary → text conversion sees valid
+    # UTF-8. Untyped text() SQL bypasses the column's binary type processor.
+    select_sql = "SELECT workspace_id, id AS k, config AS v FROM projects WHERE config IS NOT NULL"
+    update_sql = "UPDATE projects SET config = :v WHERE workspace_id = :ws AND id = :k"
+    for workspace_id, row_key, value in bind.execute(sa.text(select_sql)).fetchall():
+        plain = _decode(value)
+        stored = plain if on_sqlite else plain.encode("utf-8")
+        bind.execute(sa.text(update_sql), {"v": stored, "ws": workspace_id, "k": row_key})
+    _alter_type(to_binary=False)

--- a/omnigent/entities/project.py
+++ b/omnigent/entities/project.py
@@ -20,7 +20,7 @@ class Project:
 
     :param id: UUID primary key (bare 32-char hex string, no dashes).
     :param name: Human-readable project name, unique per owner.
-    :param owner_user_id: User the project belongs to, e.g.
+    :param user_id: User the project belongs to, e.g.
         ``"alice@example.com"``. ``None`` in single-user mode. Ownership is
         stamped on the row (not derived from a permission table) because
         projects are owner-private and carry no ACL of their own.
@@ -36,7 +36,7 @@ class Project:
 
     id: str
     name: str
-    owner_user_id: str | None
+    user_id: str | None
     created_at: int
     updated_at: int | None = None
     config: dict[str, Any] = field(default_factory=dict)

--- a/omnigent/server/routes/projects.py
+++ b/omnigent/server/routes/projects.py
@@ -92,7 +92,7 @@ def create_projects_router(
         :raises OmnigentError: 401 if unauthenticated in multi-user mode.
         """
         user_id = require_user(request, auth_provider)
-        projects = await asyncio.to_thread(project_store.list, owner_user_id=user_id)
+        projects = await asyncio.to_thread(project_store.list, user_id=user_id)
         return {"object": "list", "data": [_to_response(p) for p in projects]}
 
     @router.get("/projects/{project_id}")
@@ -106,7 +106,7 @@ def create_projects_router(
             owned by the caller.
         """
         user_id = require_user(request, auth_provider)
-        project = await asyncio.to_thread(project_store.get, project_id, owner_user_id=user_id)
+        project = await asyncio.to_thread(project_store.get, project_id, user_id=user_id)
         if project is None:
             raise OmnigentError("Project not found", code=ErrorCode.NOT_FOUND)
         return _to_response(project)
@@ -131,7 +131,7 @@ def create_projects_router(
         project = await asyncio.to_thread(
             project_store.update,
             project_id,
-            owner_user_id=user_id,
+            user_id=user_id,
             name=body.name,
             config=body.config,
         )
@@ -153,7 +153,7 @@ def create_projects_router(
             owned by the caller.
         """
         user_id = require_user(request, auth_provider)
-        deleted = await asyncio.to_thread(project_store.delete, project_id, owner_user_id=user_id)
+        deleted = await asyncio.to_thread(project_store.delete, project_id, user_id=user_id)
         if not deleted:
             raise OmnigentError("Project not found", code=ErrorCode.NOT_FOUND)
         return {"id": project_id, "object": "project.deleted", "deleted": True}

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -633,7 +633,7 @@ def register_core_routes(
             # First-class first so its id wins when a name exists in both.
             by_name: dict[str, SessionProjectSummary] = {}
             if project_store is not None:
-                for proj in project_store.list(owner_user_id=user_id):
+                for proj in project_store.list(user_id=user_id):
                     by_name[proj.name] = SessionProjectSummary(id=proj.id, name=proj.name)
             # Legacy path: label-derived projects (id=None unless already first-class).
             for name in conversation_store.list_projects(owned_by=user_id):
@@ -1893,7 +1893,7 @@ def register_core_routes(
                         code=ErrorCode.INVALID_INPUT,
                     )
                 owned = await asyncio.to_thread(
-                    project_store.get, target_project_id, owner_user_id=user_id
+                    project_store.get, target_project_id, user_id=user_id
                 )
                 if owned is None:
                     raise OmnigentError("Project not found", code=ErrorCode.NOT_FOUND)
@@ -2092,9 +2092,7 @@ def register_core_routes(
         # unfiled (a foreign project id would show in no folder view).
         fork_project_id = None
         if source.project_id is not None and project_store is not None:
-            owned = await asyncio.to_thread(
-                project_store.get, source.project_id, owner_user_id=user_id
-            )
+            owned = await asyncio.to_thread(project_store.get, source.project_id, user_id=user_id)
             if owned is not None:
                 fork_project_id = source.project_id
 

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -2420,7 +2420,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                         .where(
                             SqlConversationMetadata.workspace_id == current_workspace_id(),
                             SqlProject.workspace_id == current_workspace_id(),
-                            SqlProject.owner_user_id == owned_by,
+                            SqlProject.user_id == owned_by,
                             SqlProject.name == project,
                         )
                     )

--- a/omnigent/stores/project_store/__init__.py
+++ b/omnigent/stores/project_store/__init__.py
@@ -7,7 +7,7 @@ metadata row (``project_id``) and is managed by the conversation store, not
 here.
 
 Projects have no ACL of their own (PRD §9): every method is scoped by
-``owner_user_id`` so a caller only ever sees and mutates their own projects.
+``user_id`` so a caller only ever sees and mutates their own projects.
 """
 
 from __future__ import annotations
@@ -23,7 +23,7 @@ class ProjectStore(ABC):
     Abstract base for project persistence.
 
     Manages the lifecycle of projects (CRUD). All reads and writes are scoped
-    by ``owner_user_id`` because projects are owner-private.
+    by ``user_id`` because projects are owner-private.
     """
 
     def __init__(self, storage_location: str) -> None:
@@ -40,7 +40,7 @@ class ProjectStore(ABC):
         self,
         project_id: str,
         name: str,
-        owner_user_id: str | None,
+        user_id: str | None,
         config: dict[str, Any] | None = None,
     ) -> Project:
         """
@@ -49,7 +49,7 @@ class ProjectStore(ABC):
         :param project_id: Pre-generated unique project id (a UUID string).
         :param name: Human-readable project name. Trimmed, non-empty, unique
             among the owner's projects.
-        :param owner_user_id: Owning user, or ``None`` in single-user mode.
+        :param user_id: Owning user, or ``None`` in single-user mode.
         :param config: Optional default session settings (opaque JSON object);
             ``None`` or empty stores no defaults.
         :returns: The newly created :class:`Project`.
@@ -59,23 +59,23 @@ class ProjectStore(ABC):
         ...
 
     @abstractmethod
-    def get(self, project_id: str, *, owner_user_id: str | None) -> Project | None:
+    def get(self, project_id: str, *, user_id: str | None) -> Project | None:
         """
         Return an owned project by id, or ``None`` if not found.
 
         :param project_id: Opaque project identifier.
-        :param owner_user_id: The requesting owner; a project owned by someone
+        :param user_id: The requesting owner; a project owned by someone
             else is treated as not found.
         :returns: The :class:`Project` if found and owned, else ``None``.
         """
         ...
 
     @abstractmethod
-    def list(self, *, owner_user_id: str | None) -> list[Project]:
+    def list(self, *, user_id: str | None) -> list[Project]:
         """
         List the owner's projects ordered by ``created_at ASC, id ASC``.
 
-        :param owner_user_id: The owner whose projects to return.
+        :param user_id: The owner whose projects to return.
         :returns: List of :class:`Project` instances.
         """
         ...
@@ -85,7 +85,7 @@ class ProjectStore(ABC):
         self,
         project_id: str,
         *,
-        owner_user_id: str | None,
+        user_id: str | None,
         name: str | None = None,
         config: dict[str, Any] | None = None,
     ) -> Project | None:
@@ -93,10 +93,10 @@ class ProjectStore(ABC):
         Update mutable fields of an owned project.
 
         ``None`` leaves a field unchanged. Returns ``None`` if the project does
-        not exist or is not owned by ``owner_user_id``.
+        not exist or is not owned by ``user_id``.
 
         :param project_id: Opaque project identifier.
-        :param owner_user_id: The requesting owner.
+        :param user_id: The requesting owner.
         :param name: New name, or ``None`` to leave unchanged. Trimmed,
             non-empty, unique among the owner's projects.
         :param config: New config object to replace the stored one, or ``None``
@@ -108,7 +108,7 @@ class ProjectStore(ABC):
         ...
 
     @abstractmethod
-    def delete(self, project_id: str, *, owner_user_id: str | None) -> bool:
+    def delete(self, project_id: str, *, user_id: str | None) -> bool:
         """
         Delete an owned project. Idempotent.
 
@@ -116,7 +116,7 @@ class ProjectStore(ABC):
         (clearing ``project_id``) is the caller's responsibility.
 
         :param project_id: Opaque project identifier.
-        :param owner_user_id: The requesting owner.
+        :param user_id: The requesting owner.
         :returns: ``True`` if removed; ``False`` if not found / not owned.
         """
         ...

--- a/omnigent/stores/project_store/sqlalchemy_store.py
+++ b/omnigent/stores/project_store/sqlalchemy_store.py
@@ -6,7 +6,6 @@ import json
 from typing import Any
 
 from sqlalchemy import asc, select
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from omnigent.db.db_models import SqlProject, current_workspace_id
@@ -66,20 +65,6 @@ def _decode_config(raw: str | None) -> dict[str, Any]:
     return decoded if isinstance(decoded, dict) else {}
 
 
-def _is_name_conflict(exc: IntegrityError) -> bool:
-    """Return whether ``exc`` is the per-owner name-UNIQUE index violation.
-
-    Only that constraint should translate to ``ALREADY_EXISTS`` — any other
-    integrity failure (unexpected PK collision, NOT NULL, etc.) must surface
-    as itself rather than a misleading "already exists". Drivers name the hit
-    constraint differently: Postgres reports the index name (``ix_projects_name``)
-    while SQLite lists the columns (``...user_id, projects.name``). Match either
-    signature, keyed on the ``name`` column that is unique to this index.
-    """
-    message = str(exc.orig)
-    return "ix_projects_name" in message or "projects.name" in message
-
-
 def _to_entity(row: SqlProject) -> Project:
     """
     Convert a :class:`SqlProject` ORM row to a :class:`Project`.
@@ -133,9 +118,10 @@ class SqlAlchemyProjectStore(ProjectStore):
     ) -> bool:
         """Return whether ``user_id`` already has a project named ``name``.
 
-        Enforces per-owner name uniqueness in the store because a DB unique
-        index cannot: ``user_id`` is NULL in single-user mode and SQL treats
-        NULLs as distinct, so null-owner rows would never collide.
+        The sole enforcement point for per-owner name uniqueness: there is no
+        unique index behind it (see ``SqlProject.__table_args__``). Being a
+        check-then-write, it cannot close the concurrency window — two
+        simultaneous creates or renames to the same name can both land.
 
         :param session: The active SQLAlchemy session.
         :param user_id: The owner scope.
@@ -161,13 +147,10 @@ class SqlAlchemyProjectStore(ProjectStore):
     ) -> Project:
         """Insert a new, empty project.
 
-        Name uniqueness has two layers: the ``_name_taken`` pre-check gives a
-        friendly error (and is the only guard for NULL owners, which SQL treats
-        as distinct), while the ``ix_projects_name`` UNIQUE index enforces it at
-        the DB layer for non-NULL owners — catching a concurrent create that
-        slips past the check. That index violation surfaces as ``IntegrityError``
-        and maps to the same ``ALREADY_EXISTS``; any other integrity failure is
-        re-raised untranslated.
+        Rejects a name the owner already uses via the ``_name_taken`` pre-check.
+        That check is the only guard — no unique index backs it — so a
+        concurrent create of the same name can slip through; see
+        ``SqlProject.__table_args__`` for why that is acceptable.
         """
         with self._session("insert_project") as session:
             if self._name_taken(session, user_id=user_id, name=name, exclude_id=None):
@@ -184,15 +167,7 @@ class SqlAlchemyProjectStore(ProjectStore):
                 config=_encode_config(config),
             )
             session.add(row)
-            try:
-                session.flush()
-            except IntegrityError as exc:
-                if not _is_name_conflict(exc):
-                    raise
-                raise OmnigentError(
-                    f"A project named {name!r} already exists",
-                    code=ErrorCode.ALREADY_EXISTS,
-                ) from exc
+            session.flush()
             return _to_entity(row)
 
     def get(self, project_id: str, *, user_id: str | None) -> Project | None:
@@ -228,6 +203,10 @@ class SqlAlchemyProjectStore(ProjectStore):
         ``None`` leaves a field unchanged. Returns ``None`` if the project does
         not exist or is not owned by ``user_id``. A ``config`` of ``{}`` clears
         the stored defaults (distinct from ``None`` = leave unchanged).
+
+        A rename re-checks ``_name_taken``, which — as on ``create`` — is the
+        only uniqueness guard, so concurrent renames to the same name can both
+        land.
         """
         with self._session("update_project") as session:
             row = session.get(SqlProject, (current_workspace_id(), project_id))
@@ -249,17 +228,7 @@ class SqlAlchemyProjectStore(ProjectStore):
                     changed = True
             if changed:
                 row.updated_at = now_epoch()
-            try:
-                session.flush()
-            except IntegrityError as exc:
-                # A concurrent rename raced past _name_taken and hit the UNIQUE
-                # index (non-NULL owners); anything else is a real error.
-                if not _is_name_conflict(exc):
-                    raise
-                raise OmnigentError(
-                    f"A project named {name!r} already exists",
-                    code=ErrorCode.ALREADY_EXISTS,
-                ) from exc
+            session.flush()
             return _to_entity(row)
 
     def delete(self, project_id: str, *, user_id: str | None) -> bool:

--- a/omnigent/stores/project_store/sqlalchemy_store.py
+++ b/omnigent/stores/project_store/sqlalchemy_store.py
@@ -73,8 +73,8 @@ def _is_name_conflict(exc: IntegrityError) -> bool:
     integrity failure (unexpected PK collision, NOT NULL, etc.) must surface
     as itself rather than a misleading "already exists". Drivers name the hit
     constraint differently: Postgres reports the index name (``ix_projects_name``)
-    while SQLite lists the columns (``...owner_user_id, projects.name``). Match
-    either signature, keyed on the ``name`` column that is unique to this index.
+    while SQLite lists the columns (``...user_id, projects.name``). Match either
+    signature, keyed on the ``name`` column that is unique to this index.
     """
     message = str(exc.orig)
     return "ix_projects_name" in message or "projects.name" in message
@@ -90,7 +90,7 @@ def _to_entity(row: SqlProject) -> Project:
     return Project(
         id=row.id,
         name=row.name,
-        owner_user_id=row.owner_user_id,
+        user_id=row.user_id,
         created_at=row.created_at,
         updated_at=row.updated_at,
         config=_decode_config(row.config),
@@ -102,7 +102,7 @@ class SqlAlchemyProjectStore(ProjectStore):
     SQLAlchemy-backed implementation of :class:`ProjectStore`.
 
     Persists projects in a relational database via the SQLAlchemy ORM. Every
-    query is scoped by ``workspace_id`` (tenant partition) and ``owner_user_id``
+    query is scoped by ``workspace_id`` (tenant partition) and ``user_id``
     (projects are owner-private).
     """
 
@@ -127,25 +127,25 @@ class SqlAlchemyProjectStore(ProjectStore):
         self,
         session: Session,
         *,
-        owner_user_id: str | None,
+        user_id: str | None,
         name: str,
         exclude_id: str | None,
     ) -> bool:
-        """Return whether ``owner_user_id`` already has a project named ``name``.
+        """Return whether ``user_id`` already has a project named ``name``.
 
         Enforces per-owner name uniqueness in the store because a DB unique
-        index cannot: ``owner_user_id`` is NULL in single-user mode and SQL
-        treats NULLs as distinct, so null-owner rows would never collide.
+        index cannot: ``user_id`` is NULL in single-user mode and SQL treats
+        NULLs as distinct, so null-owner rows would never collide.
 
         :param session: The active SQLAlchemy session.
-        :param owner_user_id: The owner scope.
+        :param user_id: The owner scope.
         :param name: The candidate name.
         :param exclude_id: A project id to exclude (the row being renamed).
         :returns: ``True`` if another of the owner's projects has this name.
         """
         stmt = select(SqlProject.id).where(
             SqlProject.workspace_id == current_workspace_id(),
-            SqlProject.owner_user_id == owner_user_id,
+            SqlProject.user_id == user_id,
             SqlProject.name == name,
         )
         if exclude_id is not None:
@@ -156,7 +156,7 @@ class SqlAlchemyProjectStore(ProjectStore):
         self,
         project_id: str,
         name: str,
-        owner_user_id: str | None,
+        user_id: str | None,
         config: dict[str, Any] | None = None,
     ) -> Project:
         """Insert a new, empty project.
@@ -170,7 +170,7 @@ class SqlAlchemyProjectStore(ProjectStore):
         re-raised untranslated.
         """
         with self._session("insert_project") as session:
-            if self._name_taken(session, owner_user_id=owner_user_id, name=name, exclude_id=None):
+            if self._name_taken(session, user_id=user_id, name=name, exclude_id=None):
                 raise OmnigentError(
                     f"A project named {name!r} already exists",
                     code=ErrorCode.ALREADY_EXISTS,
@@ -178,7 +178,7 @@ class SqlAlchemyProjectStore(ProjectStore):
             row = SqlProject(
                 id=project_id,
                 name=name,
-                owner_user_id=owner_user_id,
+                user_id=user_id,
                 created_at=now_epoch(),
                 updated_at=None,
                 config=_encode_config(config),
@@ -195,21 +195,21 @@ class SqlAlchemyProjectStore(ProjectStore):
                 ) from exc
             return _to_entity(row)
 
-    def get(self, project_id: str, *, owner_user_id: str | None) -> Project | None:
+    def get(self, project_id: str, *, user_id: str | None) -> Project | None:
         """Return an owned project by id, or ``None`` if not found."""
         with self._session("select_project_by_id") as session:
             row = session.get(SqlProject, (current_workspace_id(), project_id))
-            if row is None or row.owner_user_id != owner_user_id:
+            if row is None or row.user_id != user_id:
                 return None
             return _to_entity(row)
 
-    def list(self, *, owner_user_id: str | None) -> list[Project]:
+    def list(self, *, user_id: str | None) -> list[Project]:
         """List the owner's projects ordered by ``created_at ASC, id ASC``."""
         with self._session("list_projects") as session:
             stmt = (
                 select(SqlProject)
                 .where(SqlProject.workspace_id == current_workspace_id())
-                .where(SqlProject.owner_user_id == owner_user_id)
+                .where(SqlProject.user_id == user_id)
                 .order_by(asc(SqlProject.created_at), asc(SqlProject.id))
             )
             rows = session.execute(stmt).scalars().all()
@@ -219,25 +219,23 @@ class SqlAlchemyProjectStore(ProjectStore):
         self,
         project_id: str,
         *,
-        owner_user_id: str | None,
+        user_id: str | None,
         name: str | None = None,
         config: dict[str, Any] | None = None,
     ) -> Project | None:
         """Update mutable fields of an owned project.
 
         ``None`` leaves a field unchanged. Returns ``None`` if the project does
-        not exist or is not owned by ``owner_user_id``. A ``config`` of ``{}``
-        clears the stored defaults (distinct from ``None`` = leave unchanged).
+        not exist or is not owned by ``user_id``. A ``config`` of ``{}`` clears
+        the stored defaults (distinct from ``None`` = leave unchanged).
         """
         with self._session("update_project") as session:
             row = session.get(SqlProject, (current_workspace_id(), project_id))
-            if row is None or row.owner_user_id != owner_user_id:
+            if row is None or row.user_id != user_id:
                 return None
             changed = False
             if name is not None and row.name != name:
-                if self._name_taken(
-                    session, owner_user_id=owner_user_id, name=name, exclude_id=project_id
-                ):
+                if self._name_taken(session, user_id=user_id, name=name, exclude_id=project_id):
                     raise OmnigentError(
                         f"A project named {name!r} already exists",
                         code=ErrorCode.ALREADY_EXISTS,
@@ -264,11 +262,11 @@ class SqlAlchemyProjectStore(ProjectStore):
                 ) from exc
             return _to_entity(row)
 
-    def delete(self, project_id: str, *, owner_user_id: str | None) -> bool:
+    def delete(self, project_id: str, *, user_id: str | None) -> bool:
         """Delete an owned project. Idempotent; returns ``False`` if not found."""
         with self._session("delete_project") as session:
             row = session.get(SqlProject, (current_workspace_id(), project_id))
-            if row is None or row.owner_user_id != owner_user_id:
+            if row is None or row.user_id != user_id:
                 return False
             session.delete(row)
             return True

--- a/tests/benchmarks/test_benchmark_smoke.py
+++ b/tests/benchmarks/test_benchmark_smoke.py
@@ -586,7 +586,7 @@ def test_seed_creates_listable_corpus(tmp_path: Path) -> None:
     assert len(conv.list_items(listing.data[0].id, limit=100).data) == 4
 
     # Projects were seeded (owner-scoped to "local") and sessions filed into them.
-    projects = SqlAlchemyProjectStore(db_uri).list(owner_user_id=RESERVED_USER_LOCAL)
+    projects = SqlAlchemyProjectStore(db_uri).list(user_id=RESERVED_USER_LOCAL)
     assert len(projects) == 2
     # 3 of 6 sessions filed (0.5), listable via the owner-scoped ?project= filter.
     filed = conv.list_conversations(

--- a/tests/benchmarks/test_seed_fast_path.py
+++ b/tests/benchmarks/test_seed_fast_path.py
@@ -70,7 +70,7 @@ def _item_data_ordered(engine):
 def _projects_ordered(engine):
     """(id, name, owner) for every project, sorted — project ids are deterministic."""
     with engine.connect() as conn:
-        rows = conn.execute(text("SELECT id, name, owner_user_id FROM projects")).all()
+        rows = conn.execute(text("SELECT id, name, user_id FROM projects")).all()
     return sorted((pid, name, owner) for pid, name, owner in rows)
 
 
@@ -127,7 +127,7 @@ def test_seed_fast_path_row_counts_and_read_path(tmp_path: Path) -> None:
             )
         ).scalar_one()
         assert filed == 30
-        owners = conn.execute(text("SELECT DISTINCT owner_user_id FROM projects")).all()
+        owners = conn.execute(text("SELECT DISTINCT user_id FROM projects")).all()
         assert owners == [(RESERVED_USER_LOCAL,)]
         # Round-robin: each of the 5 projects holds 30/5 = 6 sessions.
         per_project = conn.execute(

--- a/tests/db/test_migration_projects_user_id.py
+++ b/tests/db/test_migration_projects_user_id.py
@@ -1,0 +1,133 @@
+"""Tests for the projects user_id rename (d5e6f7a8b9c0).
+
+Verifies that after upgrade ``projects.owner_user_id`` is ``projects.user_id``
+behind ``ix_projects_user_id`` and the ``ix_projects_name`` unique index, and
+that downgrade restores the original column and index names with row data
+intact.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy.engine import Engine
+
+from omnigent.db.utils import (
+    _build_alembic_config,
+    clear_engine_cache,
+    get_or_create_engine,
+)
+
+# One step below d5e6f7a8b9c0 — the revision its downgrade lands on.
+_PREVIOUS_HEAD = "c4d5e6f7a8b9"
+
+_PROJECT_ID = "beefbeefbeefbeefbeefbeefbeefbeef"
+
+
+@pytest.fixture
+def db_engine(tmp_path: Path) -> Iterator[Engine]:
+    """Fresh SQLite database at head."""
+    db_path = tmp_path / "test.db"
+    uri = f"sqlite:///{db_path}"
+    engine = get_or_create_engine(uri)
+    try:
+        yield engine
+    finally:
+        clear_engine_cache()
+
+
+def test_projects_user_id_column_at_head(db_engine: Engine) -> None:
+    """After upgrade projects exposes ``user_id``, not ``owner_user_id``."""
+    cols = {c["name"] for c in sa.inspect(db_engine).get_columns("projects")}
+    assert "user_id" in cols, f"Expected projects.user_id; found {cols}"
+    assert "owner_user_id" not in cols, f"projects.owner_user_id should be gone; found {cols}"
+
+
+def test_projects_indexes_at_head(db_engine: Engine) -> None:
+    """The owner-scope index is renamed and both indexes cover ``user_id``."""
+    indexes = {i["name"]: i for i in sa.inspect(db_engine).get_indexes("projects")}
+    assert "ix_projects_user_id" in indexes, f"Expected ix_projects_user_id; found {set(indexes)}"
+    assert "ix_projects_owner_user_id" not in indexes, (
+        f"ix_projects_owner_user_id should be gone; found {set(indexes)}"
+    )
+    # created_at trails the equality columns so "list my projects" sorts from
+    # the index; id completes the key.
+    assert indexes["ix_projects_user_id"]["column_names"] == [
+        "workspace_id",
+        "user_id",
+        "created_at",
+        "id",
+    ]
+    # ix_projects_name keeps its name (the store's _is_name_conflict matches on
+    # it) but now covers user_id, and must still be UNIQUE.
+    name_idx = indexes["ix_projects_name"]
+    assert name_idx["unique"], "ix_projects_name must stay UNIQUE"
+    assert name_idx["column_names"] == ["workspace_id", "user_id", "name"]
+
+
+def test_downgrade_restores_owner_user_id(tmp_path: Path) -> None:
+    """Downgrade one step restores ``owner_user_id`` with data intact.
+
+    Insert a project at head (``user_id``), downgrade (which renames the column
+    back), and confirm the old column/index names are restored and the identity
+    value survived. A final re-upgrade proves the rename is replayable.
+    """
+    db_path = tmp_path / "downgrade.db"
+    uri = f"sqlite:///{db_path}"
+    engine = get_or_create_engine(uri)
+
+    with engine.connect() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO projects (workspace_id, id, name, user_id, created_at, updated_at) "
+                f"VALUES (0, X'{_PROJECT_ID}', 'launch', 'alice@example.com', 1700000000, NULL)"
+            )
+        )
+        conn.commit()
+
+    config = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.downgrade(config, _PREVIOUS_HEAD)
+
+    inspector = sa.inspect(engine)
+    cols = {c["name"] for c in inspector.get_columns("projects")}
+    assert "owner_user_id" in cols and "user_id" not in cols, (
+        f"projects.owner_user_id must be restored and user_id gone; found {cols}"
+    )
+    idx = {i["name"] for i in inspector.get_indexes("projects")}
+    assert "ix_projects_owner_user_id" in idx, (
+        f"ix_projects_owner_user_id must be restored; found {idx}"
+    )
+    assert "ix_projects_user_id" not in idx
+
+    with engine.connect() as conn:
+        owner = conn.execute(
+            sa.text(f"SELECT owner_user_id FROM projects WHERE id = X'{_PROJECT_ID}'")
+        ).scalar_one_or_none()
+    assert owner == "alice@example.com", f"owner value must survive downgrade; got {owner!r}"
+
+    # Re-upgrade to head: user_id is back and the value survives both hops.
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.upgrade(config, "head")
+
+    inspector = sa.inspect(engine)
+    cols = {c["name"] for c in inspector.get_columns("projects")}
+    assert "user_id" in cols and "owner_user_id" not in cols, (
+        f"projects.user_id must be restored on re-upgrade; found {cols}"
+    )
+    with engine.connect() as conn:
+        user_id = conn.execute(
+            sa.text(f"SELECT user_id FROM projects WHERE id = X'{_PROJECT_ID}'")
+        ).scalar_one_or_none()
+    assert user_id == "alice@example.com", (
+        f"user_id value must survive the full round-trip; got {user_id!r}"
+    )
+
+    engine.dispose()
+    clear_engine_cache()

--- a/tests/db/test_migration_projects_user_id.py
+++ b/tests/db/test_migration_projects_user_id.py
@@ -1,9 +1,11 @@
-"""Tests for the projects user_id rename (d5e6f7a8b9c0).
+"""Tests for the projects schema changes in d5e6f7a8b9c0 and e6f7a8b9c0d1.
 
-Verifies that after upgrade ``projects.owner_user_id`` is ``projects.user_id``
-behind ``ix_projects_user_id`` and the ``ix_projects_name`` unique index, and
-that downgrade restores the original column and index names with row data
-intact.
+d5e6f7a8b9c0 renames ``projects.owner_user_id`` to ``user_id`` behind
+``ix_projects_user_id`` and drops the ``ix_projects_name`` UNIQUE index (name
+uniqueness moves wholly into the store). e6f7a8b9c0d1 then converts
+``projects.config`` from ``TEXT`` to a compressed binary column.
+
+Both downgrades are exercised for round-trip data integrity.
 """
 
 from __future__ import annotations
@@ -22,8 +24,11 @@ from omnigent.db.utils import (
     get_or_create_engine,
 )
 
-# One step below d5e6f7a8b9c0 — the revision its downgrade lands on.
+# One step below d5e6f7a8b9c0 — where a full downgrade of both revisions lands.
 _PREVIOUS_HEAD = "c4d5e6f7a8b9"
+
+# One step below e6f7a8b9c0d1 — i.e. d5e6f7a8b9c0, config still ``TEXT``.
+_BEFORE_COMPRESSED_CONFIG = "d5e6f7a8b9c0"
 
 _PROJECT_ID = "beefbeefbeefbeefbeefbeefbeefbeef"
 
@@ -48,7 +53,7 @@ def test_projects_user_id_column_at_head(db_engine: Engine) -> None:
 
 
 def test_projects_indexes_at_head(db_engine: Engine) -> None:
-    """The owner-scope index is renamed and both indexes cover ``user_id``."""
+    """The owner-scope index is renamed; the UNIQUE name index is gone."""
     indexes = {i["name"]: i for i in sa.inspect(db_engine).get_indexes("projects")}
     assert "ix_projects_user_id" in indexes, f"Expected ix_projects_user_id; found {set(indexes)}"
     assert "ix_projects_owner_user_id" not in indexes, (
@@ -62,11 +67,12 @@ def test_projects_indexes_at_head(db_engine: Engine) -> None:
         "created_at",
         "id",
     ]
-    # ix_projects_name keeps its name (the store's _is_name_conflict matches on
-    # it) but now covers user_id, and must still be UNIQUE.
-    name_idx = indexes["ix_projects_name"]
-    assert name_idx["unique"], "ix_projects_name must stay UNIQUE"
-    assert name_idx["column_names"] == ["workspace_id", "user_id", "name"]
+    # Per-owner name uniqueness moved wholly into the store (_name_taken), so no
+    # unique index remains — leaving this the table's only secondary index.
+    assert "ix_projects_name" not in indexes, (
+        f"ix_projects_name should be dropped; found {set(indexes)}"
+    )
+    assert set(indexes) == {"ix_projects_user_id"}, f"Unexpected extra indexes: {set(indexes)}"
 
 
 def test_downgrade_restores_owner_user_id(tmp_path: Path) -> None:
@@ -99,11 +105,18 @@ def test_downgrade_restores_owner_user_id(tmp_path: Path) -> None:
     assert "owner_user_id" in cols and "user_id" not in cols, (
         f"projects.owner_user_id must be restored and user_id gone; found {cols}"
     )
-    idx = {i["name"] for i in inspector.get_indexes("projects")}
-    assert "ix_projects_owner_user_id" in idx, (
-        f"ix_projects_owner_user_id must be restored; found {idx}"
+    indexes = {i["name"]: i for i in inspector.get_indexes("projects")}
+    assert "ix_projects_owner_user_id" in indexes, (
+        f"ix_projects_owner_user_id must be restored; found {set(indexes)}"
     )
-    assert "ix_projects_user_id" not in idx
+    assert "ix_projects_user_id" not in indexes
+    # The downgrade also restores the UNIQUE name index it dropped.
+    assert indexes["ix_projects_name"]["unique"], "ix_projects_name must be restored as UNIQUE"
+    assert indexes["ix_projects_name"]["column_names"] == [
+        "workspace_id",
+        "owner_user_id",
+        "name",
+    ]
 
     with engine.connect() as conn:
         owner = conn.execute(
@@ -128,6 +141,119 @@ def test_downgrade_restores_owner_user_id(tmp_path: Path) -> None:
     assert user_id == "alice@example.com", (
         f"user_id value must survive the full round-trip; got {user_id!r}"
     )
+
+    engine.dispose()
+    clear_engine_cache()
+
+
+def test_config_is_binary_at_head(db_engine: Engine) -> None:
+    """``projects.config`` is a binary column at head, not ``TEXT``.
+
+    e6f7a8b9c0d1 converts it so the value is stored zstd-compressed by
+    ``omnigent.db.compression``, whose framed bytes can contain NUL and would be
+    rejected by a ``TEXT`` column on PostgreSQL.
+    """
+    types = {c["name"]: c["type"] for c in sa.inspect(db_engine).get_columns("projects")}
+    assert isinstance(types["config"], sa.LargeBinary), (
+        f"projects.config should be binary at head, got {types['config']!r}"
+    )
+
+
+def test_config_round_trips_through_the_compressed_column(db_engine: Engine) -> None:
+    """A framed value written at head decodes back to its plaintext.
+
+    Writes through the ORM type (which compresses) and reads back through it,
+    so the column's codec is exercised end to end rather than assumed.
+    """
+    from omnigent.db.db_models import SqlProject
+
+    # Long enough to exceed the codec's compress threshold, so the stored bytes
+    # are a real zstd frame rather than the raw passthrough.
+    payload = '{"harness": "claude", "model": "opus", "note": "' + ("x" * 512) + '"}'
+
+    with db_engine.begin() as conn:
+        conn.execute(
+            sa.insert(SqlProject.__table__).values(
+                workspace_id=0,
+                id=_PROJECT_ID,
+                name="launch",
+                user_id="alice@example.com",
+                created_at=1700000000,
+                updated_at=None,
+                config=payload,
+            )
+        )
+
+    with db_engine.connect() as conn:
+        # Through the typed column: decompressed back to the original str.
+        decoded = conn.execute(
+            sa.select(SqlProject.__table__.c.config).where(
+                SqlProject.__table__.c.id == _PROJECT_ID
+            )
+        ).scalar_one()
+        assert decoded == payload, "config must round-trip through the compressed column"
+
+        # Raw bytes: framed (leading NUL sentinel) and smaller than the input,
+        # proving compression actually happened on disk.
+        raw = conn.execute(
+            sa.text(f"SELECT config FROM projects WHERE id = X'{_PROJECT_ID}'")
+        ).scalar_one()
+    stored = raw.tobytes() if isinstance(raw, memoryview) else raw
+    assert isinstance(stored, bytes), f"expected bytes on disk, got {type(stored).__name__}"
+    assert stored[0] == 0x00, "stored value should carry the compression frame sentinel"
+    assert len(stored) < len(payload.encode("utf-8")), "payload should be compressed on disk"
+
+
+def test_downgrade_restores_plaintext_config(tmp_path: Path) -> None:
+    """Downgrading e6f7a8b9c0d1 decompresses config back to readable ``TEXT``.
+
+    The downgrade must rewrite each row before flipping the type, or the value
+    would be left as unreadable compressed bytes in a text column.
+    """
+    uri = f"sqlite:///{tmp_path / 'config_downgrade.db'}"
+    engine = get_or_create_engine(uri)
+    payload = '{"harness": "codex", "pad": "' + ("y" * 512) + '"}'
+
+    from omnigent.db.db_models import SqlProject
+
+    with engine.begin() as conn:
+        conn.execute(
+            sa.insert(SqlProject.__table__).values(
+                workspace_id=0,
+                id=_PROJECT_ID,
+                name="launch",
+                user_id="alice@example.com",
+                created_at=1700000000,
+                updated_at=None,
+                config=payload,
+            )
+        )
+
+    config = _build_alembic_config(uri)
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.downgrade(config, _BEFORE_COMPRESSED_CONFIG)
+
+    # Read with untyped SQL so no codec is applied: the value must already be
+    # plaintext on disk.
+    with engine.connect() as conn:
+        stored = conn.execute(
+            sa.text(f"SELECT config FROM projects WHERE id = X'{_PROJECT_ID}'")
+        ).scalar_one()
+    plain = stored.decode("utf-8") if isinstance(stored, bytes) else stored
+    assert plain == payload, f"config must be plaintext after downgrade; got {plain!r:.80}"
+
+    # Re-upgrade: the value survives both hops.
+    with engine.begin() as conn:
+        config.attributes["connection"] = conn
+        command.upgrade(config, "head")
+    with engine.connect() as conn:
+        decoded = conn.execute(
+            sa.select(SqlProject.__table__.c.config).where(
+                SqlProject.__table__.c.id == _PROJECT_ID
+            )
+        ).scalar_one()
+    assert decoded == payload, "config must survive the full down/up round-trip"
 
     engine.dispose()
     clear_engine_cache()

--- a/tests/db/test_migration_workspace.py
+++ b/tests/db/test_migration_workspace.py
@@ -399,6 +399,9 @@ def test_compressed_columns_are_binary_at_head(db_engine: Engine) -> None:
         ],
         "comments": ["body", "anchor_content"],
         "agents": ["description"],
+        "policies": ["handler", "factory_params"],
+        "hosts": ["configured_harnesses"],
+        "projects": ["config"],
     }
     for table, columns in expected.items():
         types = {c["name"]: c["type"] for c in inspector.get_columns(table)}

--- a/tests/entities/test_project.py
+++ b/tests/entities/test_project.py
@@ -11,13 +11,13 @@ def test_project_construction() -> None:
     proj = Project(
         id="a" * 32,
         name="My Project",
-        owner_user_id="alice@example.com",
+        user_id="alice@example.com",
         created_at=1700000000,
         updated_at=1700001000,
     )
     assert proj.id == "a" * 32
     assert proj.name == "My Project"
-    assert proj.owner_user_id == "alice@example.com"
+    assert proj.user_id == "alice@example.com"
     assert proj.created_at == 1700000000
     assert proj.updated_at == 1700001000
 
@@ -27,21 +27,21 @@ def test_project_updated_at_defaults_to_none() -> None:
     proj = Project(
         id="b" * 32,
         name="Fresh",
-        owner_user_id="alice@example.com",
+        user_id="alice@example.com",
         created_at=1700000000,
     )
     assert proj.updated_at is None
 
 
 def test_project_owner_none_in_single_user_mode() -> None:
-    """Single-user / OSS mode leaves ``owner_user_id`` as ``None``."""
+    """Single-user / OSS mode leaves ``user_id`` as ``None``."""
     proj = Project(
         id="c" * 32,
         name="Solo",
-        owner_user_id=None,
+        user_id=None,
         created_at=1700000000,
     )
-    assert proj.owner_user_id is None
+    assert proj.user_id is None
 
 
 def test_project_config_defaults_to_empty_dict() -> None:
@@ -50,8 +50,8 @@ def test_project_config_defaults_to_empty_dict() -> None:
     Uses the default_factory, so two instances get independent dicts (no shared
     mutable default).
     """
-    a = Project(id="d" * 32, name="A", owner_user_id=None, created_at=1)
-    b = Project(id="e" * 32, name="B", owner_user_id=None, created_at=1)
+    a = Project(id="d" * 32, name="A", user_id=None, created_at=1)
+    b = Project(id="e" * 32, name="B", user_id=None, created_at=1)
     assert a.config == {}
     a.config["host_id"] = "x"
     assert b.config == {}  # not shared across instances
@@ -62,7 +62,7 @@ def test_project_carries_config() -> None:
     proj = Project(
         id="f" * 32,
         name="Configured",
-        owner_user_id=None,
+        user_id=None,
         created_at=1,
         config={"host_id": "h", "workspace": "/w"},
     )
@@ -71,13 +71,13 @@ def test_project_carries_config() -> None:
 
 def test_project_equality() -> None:
     """Dataclasses support value-based equality."""
-    a = Project(id="x" * 32, name="P", owner_user_id="u", created_at=1)
-    b = Project(id="x" * 32, name="P", owner_user_id="u", created_at=1)
+    a = Project(id="x" * 32, name="P", user_id="u", created_at=1)
+    b = Project(id="x" * 32, name="P", user_id="u", created_at=1)
     assert a == b
 
 
 def test_project_inequality_by_owner() -> None:
     """Two owners' identically named projects are distinct values."""
-    a = Project(id="x" * 32, name="P", owner_user_id="alice", created_at=1)
-    b = Project(id="x" * 32, name="P", owner_user_id="bob", created_at=1)
+    a = Project(id="x" * 32, name="P", user_id="alice", created_at=1)
+    b = Project(id="x" * 32, name="P", user_id="bob", created_at=1)
     assert a != b

--- a/tests/stores/test_project_store.py
+++ b/tests/stores/test_project_store.py
@@ -151,10 +151,10 @@ def test_same_name_allowed_across_owners(store: SqlAlchemyProjectStore) -> None:
 
 
 def test_duplicate_name_rejected_for_null_owner(store: SqlAlchemyProjectStore) -> None:
-    """Single-user mode (NULL owner) still enforces name uniqueness.
+    """Single-user mode (NULL owner) enforces name uniqueness in the store.
 
-    The DB UNIQUE index can't do this (SQL treats NULLs as distinct), so the
-    store's ``_name_taken`` check is the sole guard for NULL owners.
+    ``_name_taken`` is the sole guard for every owner, NULL included — no unique
+    index backs it.
     """
     store.create(_uid("p1"), "Solo", None)
     with pytest.raises(OmnigentError) as exc:
@@ -162,29 +162,32 @@ def test_duplicate_name_rejected_for_null_owner(store: SqlAlchemyProjectStore) -
     assert exc.value.code == ErrorCode.ALREADY_EXISTS
 
 
-def test_duplicate_name_rejected_at_db_layer_for_named_owner(
+def test_duplicate_name_lands_when_precheck_is_bypassed(
     store: SqlAlchemyProjectStore,
 ) -> None:
-    """The UNIQUE index enforces per-owner uniqueness even if the store's
-    ``_name_taken`` pre-check is bypassed — the DB is the race backstop.
+    """A duplicate name is accepted once ``_name_taken`` is bypassed.
+
+    No unique index covers (workspace_id, user_id, name), so the pre-check is
+    the only guard and a concurrent create racing past it lands. Pins that
+    accepted cost: both rows exist, each addressable by its own id.
 
     Monkeypatching ``_name_taken`` to always-miss simulates two concurrent
-    creates both passing the check; the second must still fail via the index's
-    ``IntegrityError``, mapped to ``ALREADY_EXISTS``.
+    creates both passing the check.
     """
     store.create(_uid("p1"), "Dup", "alice@example.com")
     store._name_taken = lambda *a, **k: False  # type: ignore[method-assign]
-    with pytest.raises(OmnigentError) as exc:
-        store.create(_uid("p2"), "Dup", "alice@example.com")
-    assert exc.value.code == ErrorCode.ALREADY_EXISTS
+    store.create(_uid("p2"), "Dup", "alice@example.com")
+
+    assert [p.name for p in store.list(user_id="alice@example.com")] == ["Dup", "Dup"]
+    assert store.get(_uid("p1"), user_id="alice@example.com") is not None
+    assert store.get(_uid("p2"), user_id="alice@example.com") is not None
 
 
-def test_non_name_integrity_error_is_not_masked(store: SqlAlchemyProjectStore) -> None:
-    """An integrity failure that isn't the name index re-raises untranslated.
+def test_primary_key_collision_is_not_masked(store: SqlAlchemyProjectStore) -> None:
+    """Reusing an id surfaces as ``IntegrityError``, not ``ALREADY_EXISTS``.
 
-    Reusing an existing id hits the primary-key constraint, not
-    ``ix_projects_name``; that must surface as ``IntegrityError`` rather than a
-    misleading ``ALREADY_EXISTS`` name collision.
+    The PK is the only remaining constraint on this table, and the store must
+    not dress its violation up as a name collision.
     """
     store.create(_uid("p1"), "Original", "alice@example.com")
     store._name_taken = lambda *a, **k: False  # type: ignore[method-assign]

--- a/tests/stores/test_project_store.py
+++ b/tests/stores/test_project_store.py
@@ -41,7 +41,7 @@ def test_create_returns_project(store: SqlAlchemyProjectStore) -> None:
     project = store.create(_uid("p1"), "My Project", "alice@example.com")
     assert project.id == _uid("p1")
     assert project.name == "My Project"
-    assert project.owner_user_id == "alice@example.com"
+    assert project.user_id == "alice@example.com"
     assert project.created_at > 0
     assert project.updated_at is None
 
@@ -49,20 +49,20 @@ def test_create_returns_project(store: SqlAlchemyProjectStore) -> None:
 def test_get_returns_created_project(store: SqlAlchemyProjectStore) -> None:
     """``get`` reads back a created project for its owner."""
     store.create(_uid("p1"), "My Project", "alice@example.com")
-    got = store.get(_uid("p1"), owner_user_id="alice@example.com")
+    got = store.get(_uid("p1"), user_id="alice@example.com")
     assert got is not None
     assert got.name == "My Project"
 
 
 def test_get_missing_returns_none(store: SqlAlchemyProjectStore) -> None:
     """``get`` returns ``None`` for an unknown id."""
-    assert store.get(_uid("nope"), owner_user_id="alice@example.com") is None
+    assert store.get(_uid("nope"), user_id="alice@example.com") is None
 
 
 def test_get_scoped_to_owner(store: SqlAlchemyProjectStore) -> None:
     """A project owned by someone else reads back as not found."""
     store.create(_uid("p1"), "Alice Project", "alice@example.com")
-    assert store.get(_uid("p1"), owner_user_id="bob@example.com") is None
+    assert store.get(_uid("p1"), user_id="bob@example.com") is None
 
 
 # ── list ──────────────────────────────────────────────────────────────────
@@ -76,7 +76,7 @@ def test_list_orders_by_created_at_then_id(store: SqlAlchemyProjectStore) -> Non
     """
     store.create(_uid("p1"), "First", "alice@example.com")
     store.create(_uid("p2"), "Second", "alice@example.com")
-    listed = store.list(owner_user_id="alice@example.com")
+    listed = store.list(user_id="alice@example.com")
     assert {p.name for p in listed} == {"First", "Second"}
     # Whatever the tie order, it is ascending by (created_at, id).
     keys = [(p.created_at, p.id) for p in listed]
@@ -87,13 +87,13 @@ def test_list_scoped_to_owner(store: SqlAlchemyProjectStore) -> None:
     """``list`` only returns the requesting owner's projects."""
     store.create(_uid("p1"), "Alice Project", "alice@example.com")
     store.create(_uid("p2"), "Bob Project", "bob@example.com")
-    alice = store.list(owner_user_id="alice@example.com")
+    alice = store.list(user_id="alice@example.com")
     assert [p.name for p in alice] == ["Alice Project"]
 
 
 def test_list_empty(store: SqlAlchemyProjectStore) -> None:
     """``list`` returns an empty list when the owner has no projects."""
-    assert store.list(owner_user_id="alice@example.com") == []
+    assert store.list(user_id="alice@example.com") == []
 
 
 # ── single-user (None owner) vs multi-user isolation ────────────────────────
@@ -102,7 +102,7 @@ def test_list_empty(store: SqlAlchemyProjectStore) -> None:
 def test_none_owner_and_named_owner_are_isolated(store: SqlAlchemyProjectStore) -> None:
     """The single-user ``None`` owner is a distinct scope from any named user.
 
-    A project created in single-user mode (``owner_user_id=None``) must not be
+    A project created in single-user mode (``user_id=None``) must not be
     visible to a named multi-user identity, and vice versa — the same DB can
     hold both without cross-leaking.
     """
@@ -110,26 +110,26 @@ def test_none_owner_and_named_owner_are_isolated(store: SqlAlchemyProjectStore) 
     store.create(_uid("alice"), "Alice Project", "alice@example.com")
 
     # Each scope lists only its own.
-    assert [p.name for p in store.list(owner_user_id=None)] == ["Solo Project"]
-    assert [p.name for p in store.list(owner_user_id="alice@example.com")] == ["Alice Project"]
+    assert [p.name for p in store.list(user_id=None)] == ["Solo Project"]
+    assert [p.name for p in store.list(user_id="alice@example.com")] == ["Alice Project"]
 
 
 def test_named_owner_cannot_get_none_owner_project(store: SqlAlchemyProjectStore) -> None:
     """A ``None``-owner project is not found for a named user (and vice versa)."""
     store.create(_uid("solo"), "Solo", None)
-    assert store.get(_uid("solo"), owner_user_id="alice@example.com") is None
-    assert store.get(_uid("solo"), owner_user_id=None) is not None
+    assert store.get(_uid("solo"), user_id="alice@example.com") is None
+    assert store.get(_uid("solo"), user_id=None) is not None
 
 
 def test_named_owner_cannot_mutate_none_owner_project(store: SqlAlchemyProjectStore) -> None:
     """update / delete on a ``None``-owner project are no-ops for a named user."""
     store.create(_uid("solo"), "Solo", None)
-    updated = store.update(_uid("solo"), owner_user_id="alice@example.com", name="Hacked")
+    updated = store.update(_uid("solo"), user_id="alice@example.com", name="Hacked")
     assert updated is None
-    deleted = store.delete(_uid("solo"), owner_user_id="alice@example.com")
+    deleted = store.delete(_uid("solo"), user_id="alice@example.com")
     assert deleted is False
     # Untouched for the real (None) owner.
-    assert store.get(_uid("solo"), owner_user_id=None).name == "Solo"
+    assert store.get(_uid("solo"), user_id=None).name == "Solo"
 
 
 # ── name uniqueness ────────────────────────────────────────────────────────
@@ -199,22 +199,22 @@ def test_create_defaults_to_empty_config(store: SqlAlchemyProjectStore) -> None:
     """A project created without config reads back an empty dict (SQL NULL)."""
     project = store.create(_uid("p1"), "No Config", "alice@example.com")
     assert project.config == {}
-    assert store.get(_uid("p1"), owner_user_id="alice@example.com").config == {}
+    assert store.get(_uid("p1"), user_id="alice@example.com").config == {}
 
 
 def test_create_persists_config(store: SqlAlchemyProjectStore) -> None:
     """A config passed to ``create`` round-trips through ``get``/``list``."""
     cfg = {"host_id": "host_abc", "workspace": "/work/repo", "model": "claude-opus-4-8"}
     store.create(_uid("p1"), "Configured", "alice@example.com", cfg)
-    assert store.get(_uid("p1"), owner_user_id="alice@example.com").config == cfg
-    assert store.list(owner_user_id="alice@example.com")[0].config == cfg
+    assert store.get(_uid("p1"), user_id="alice@example.com").config == cfg
+    assert store.list(user_id="alice@example.com")[0].config == cfg
 
 
 def test_update_replaces_config_and_stamps_updated_at(store: SqlAlchemyProjectStore) -> None:
     """Passing a new ``config`` replaces the stored one and stamps updated_at."""
     store.create(_uid("p1"), "P", "alice@example.com", {"host_id": "old"})
     updated = store.update(
-        _uid("p1"), owner_user_id="alice@example.com", config={"host_id": "new", "model": "m"}
+        _uid("p1"), user_id="alice@example.com", config={"host_id": "new", "model": "m"}
     )
     assert updated is not None
     assert updated.config == {"host_id": "new", "model": "m"}
@@ -225,7 +225,7 @@ def test_update_config_none_leaves_it_unchanged(store: SqlAlchemyProjectStore) -
     """``config=None`` (the default) leaves the stored config untouched."""
     store.create(_uid("p1"), "P", "alice@example.com", {"host_id": "keep"})
     # Rename only — config omitted — must not wipe the stored defaults.
-    updated = store.update(_uid("p1"), owner_user_id="alice@example.com", name="Renamed")
+    updated = store.update(_uid("p1"), user_id="alice@example.com", name="Renamed")
     assert updated is not None
     assert updated.config == {"host_id": "keep"}
 
@@ -233,7 +233,7 @@ def test_update_config_none_leaves_it_unchanged(store: SqlAlchemyProjectStore) -
 def test_update_empty_config_clears_defaults(store: SqlAlchemyProjectStore) -> None:
     """An explicit ``config={}`` clears the stored defaults (distinct from None)."""
     store.create(_uid("p1"), "P", "alice@example.com", {"host_id": "drop"})
-    updated = store.update(_uid("p1"), owner_user_id="alice@example.com", config={})
+    updated = store.update(_uid("p1"), user_id="alice@example.com", config={})
     assert updated is not None
     assert updated.config == {}
     assert updated.updated_at is not None
@@ -242,7 +242,7 @@ def test_update_empty_config_clears_defaults(store: SqlAlchemyProjectStore) -> N
 def test_update_same_config_is_noop(store: SqlAlchemyProjectStore) -> None:
     """Re-setting the identical config changes nothing, leaving updated_at None."""
     store.create(_uid("p1"), "P", "alice@example.com", {"host_id": "x"})
-    updated = store.update(_uid("p1"), owner_user_id="alice@example.com", config={"host_id": "x"})
+    updated = store.update(_uid("p1"), user_id="alice@example.com", config={"host_id": "x"})
     assert updated is not None
     assert updated.updated_at is None
 
@@ -264,10 +264,10 @@ def test_update_rejects_oversized_config(store: SqlAlchemyProjectStore) -> None:
     store.create(_uid("p1"), "P", "alice@example.com", {"host_id": "keep"})
     huge = {"blob": "x" * (64 * 1024 + 1)}
     with pytest.raises(OmnigentError) as exc:
-        store.update(_uid("p1"), owner_user_id="alice@example.com", config=huge)
+        store.update(_uid("p1"), user_id="alice@example.com", config=huge)
     assert exc.value.code == ErrorCode.INVALID_INPUT
     # The prior config is untouched (the encode guard fires before any write).
-    assert store.get(_uid("p1"), owner_user_id="alice@example.com").config == {"host_id": "keep"}
+    assert store.get(_uid("p1"), user_id="alice@example.com").config == {"host_id": "keep"}
 
 
 def test_decode_coerces_non_object_blob_to_empty(store: SqlAlchemyProjectStore) -> None:
@@ -285,7 +285,7 @@ def test_decode_coerces_non_object_blob_to_empty(store: SqlAlchemyProjectStore) 
             sa_text("UPDATE projects SET config = :c WHERE id = :i"),
             {"c": '"just a string"', "i": _uid("p1")},
         )
-    got = store.get(_uid("p1"), owner_user_id="alice@example.com")
+    got = store.get(_uid("p1"), user_id="alice@example.com")
     assert got is not None
     assert got.config == {}
 
@@ -296,7 +296,7 @@ def test_decode_coerces_non_object_blob_to_empty(store: SqlAlchemyProjectStore) 
 def test_update_renames_and_stamps_updated_at(store: SqlAlchemyProjectStore) -> None:
     """Renaming changes ``name`` and sets ``updated_at``."""
     store.create(_uid("p1"), "Old", "alice@example.com")
-    updated = store.update(_uid("p1"), owner_user_id="alice@example.com", name="New")
+    updated = store.update(_uid("p1"), user_id="alice@example.com", name="New")
     assert updated is not None
     assert updated.name == "New"
     assert updated.updated_at is not None
@@ -305,24 +305,24 @@ def test_update_renames_and_stamps_updated_at(store: SqlAlchemyProjectStore) -> 
 def test_update_noop_leaves_updated_at_none(store: SqlAlchemyProjectStore) -> None:
     """An update that changes nothing leaves ``updated_at`` untouched."""
     store.create(_uid("p1"), "Same", "alice@example.com")
-    updated = store.update(_uid("p1"), owner_user_id="alice@example.com", name="Same")
+    updated = store.update(_uid("p1"), user_id="alice@example.com", name="Same")
     assert updated is not None
     assert updated.updated_at is None
 
 
 def test_update_missing_returns_none(store: SqlAlchemyProjectStore) -> None:
     """Updating an unknown project returns ``None``."""
-    updated = store.update(_uid("nope"), owner_user_id="alice@example.com", name="X")
+    updated = store.update(_uid("nope"), user_id="alice@example.com", name="X")
     assert updated is None
 
 
 def test_update_scoped_to_owner(store: SqlAlchemyProjectStore) -> None:
     """A non-owner cannot rename another user's project."""
     store.create(_uid("p1"), "Alice Project", "alice@example.com")
-    updated = store.update(_uid("p1"), owner_user_id="bob@example.com", name="Hacked")
+    updated = store.update(_uid("p1"), user_id="bob@example.com", name="Hacked")
     assert updated is None
     # Unchanged for the real owner.
-    assert store.get(_uid("p1"), owner_user_id="alice@example.com").name == "Alice Project"
+    assert store.get(_uid("p1"), user_id="alice@example.com").name == "Alice Project"
 
 
 def test_update_rejects_duplicate_name(store: SqlAlchemyProjectStore) -> None:
@@ -330,7 +330,7 @@ def test_update_rejects_duplicate_name(store: SqlAlchemyProjectStore) -> None:
     store.create(_uid("p1"), "First", "alice@example.com")
     store.create(_uid("p2"), "Second", "alice@example.com")
     with pytest.raises(OmnigentError) as exc:
-        store.update(_uid("p2"), owner_user_id="alice@example.com", name="First")
+        store.update(_uid("p2"), user_id="alice@example.com", name="First")
     assert exc.value.code == ErrorCode.ALREADY_EXISTS
 
 
@@ -340,16 +340,16 @@ def test_update_rejects_duplicate_name(store: SqlAlchemyProjectStore) -> None:
 def test_delete_removes_project(store: SqlAlchemyProjectStore) -> None:
     """``delete`` removes the project and is idempotent."""
     store.create(_uid("p1"), "Doomed", "alice@example.com")
-    deleted = store.delete(_uid("p1"), owner_user_id="alice@example.com")
+    deleted = store.delete(_uid("p1"), user_id="alice@example.com")
     assert deleted is True
-    assert store.get(_uid("p1"), owner_user_id="alice@example.com") is None
-    deleted_again = store.delete(_uid("p1"), owner_user_id="alice@example.com")
+    assert store.get(_uid("p1"), user_id="alice@example.com") is None
+    deleted_again = store.delete(_uid("p1"), user_id="alice@example.com")
     assert deleted_again is False
 
 
 def test_delete_scoped_to_owner(store: SqlAlchemyProjectStore) -> None:
     """A non-owner cannot delete another user's project."""
     store.create(_uid("p1"), "Alice Project", "alice@example.com")
-    deleted = store.delete(_uid("p1"), owner_user_id="bob@example.com")
+    deleted = store.delete(_uid("p1"), user_id="bob@example.com")
     assert deleted is False
-    assert store.get(_uid("p1"), owner_user_id="alice@example.com") is not None
+    assert store.get(_uid("p1"), user_id="alice@example.com") is not None

--- a/web/src/lib/projectsApi.ts
+++ b/web/src/lib/projectsApi.ts
@@ -41,7 +41,7 @@ export interface Project {
   id: string;
   name: string;
   /** Owner user id; `null` in single-user / OSS mode. */
-  owner_user_id?: string | null;
+  user_id?: string | null;
   created_at?: number;
   updated_at?: number | null;
   /** Stored default session settings; `{}` when the project has none. */


### PR DESCRIPTION
## Related issue

N/A — schema-convention cleanup with no associated issue.

## Summary

Three changes to the `projects` table, each finishing a sweep that missed this table. (2) and (3) come from schema review on the managed mirror of this schema, [databricks-eng/universe#2369565](https://github.com/databricks-eng/universe/pull/2369565), which follows this PR.

### 1. Rename `owner_user_id` → `user_id`

Migration `b3c1a2d4e5f6` unified the session-owner identity columns on the schema-wide `user_id` convention, converting `hosts.owner` and `scheduled_tasks.owner_user_id`. The `projects` table shipped five days earlier (`b1c2d3e4f5a6`) and was missed, so it is the last column still diverging from `session_permissions.user_id`, `account_tokens.user_id`, `device_grants.user_id`, `hosts.user_id`, and `scheduled_tasks.user_id`.

### 2. Drop the `ix_projects_name` UNIQUE index

Folded into the same migration, which already dropped and recreated this index. It backed only the store's two `_name_taken` probes, which now stand alone as the sole per-owner uniqueness check:

- **It never held for single-user mode** — the owner column is NULL there and SQL treats NULLs as distinct, so that deployment (the default local one) has always allowed duplicate names.
- **`name` is mutable** — `update()` renames it, so a unique key over it was maintained on every rename.
- **The `?project=<name>` member join tolerates duplicates by construction** — it unions first-class members with `omni_project` label-projects matched on the same string, so name-collision merging is already its defined behaviour.

The cost is that two concurrent creates or renames to the same name can both land. `ix_projects_user_id` still covers both probes via its `(workspace_id, user_id)` prefix, then filters `name` over the owner's handful of rows, so neither query is left unindexed. `_is_name_conflict` and both now-unreachable `IntegrityError` handlers are removed rather than left as dead protection.

### 3. Store `config` as a compressed BLOB/BYTEA

New migration `e6f7a8b9c0d1`, finishing the sweep of `z9a2b3c4d5e6` (#2939), which converted the then-remaining opaque `TEXT` columns to `CompressedText`. `projects.config` shipped four days earlier and was missed, leaving it the last plain-`TEXT` column outside `conversation_items`. It qualifies on the same terms: machine-generated JSON, read and written whole with the row, never filtered or ordered in SQL. The Python type stays `str | None`, so the store, entity, and routes are unchanged.

- Renames `projects.owner_user_id` → `user_id` (type unchanged: `VARCHAR(128)`, nullable), along with the `Project` entity field and the `ProjectStore` keyword argument.
- `ix_projects_owner_user_id` → `ix_projects_user_id`, matching the `ix_scheduled_tasks_user_id` precedent. `ix_projects_name` is **dropped**, leaving `ix_projects_user_id` as the table's only secondary index.
- Not wire-visible: `owner_user_id` was never part of the `ProjectObject` response, so no client contract changes. The `web/src/lib/projectsApi.ts` field the server never populated is renamed for consistency.

Out of scope on purpose: `scheduled_tasks`' remaining `list(owner_user_id=...)` keyword argument, the Slack integration, and `designs/DEVICE_AUTH.md` — different tables/subsystems.

### Migration ordering

`d5e6f7a8b9c0` revises head `c4d5e6f7a8b9` and follows `b3c1a2d4e5f6`'s dialect strategy: SQLite cannot rename a column in place, so `batch_alter_table(recreate="always")` rebuilds the table, while PostgreSQL/MySQL use native `ALTER TABLE ... RENAME COLUMN` (`recreate="auto"`).

The dependent indexes are dropped *before* the rename and recreated *after* — as in the precedent, a single batch that both renames a column and drops an index referencing it trips Alembic's batch reflection, which maps the reflected index onto the not-yet-renamed column.

```
drop ix_projects_name           (gone for good)
drop ix_projects_owner_user_id ──→ rename column ──→ create ix_projects_user_id
                                     (batched)
```

`e6f7a8b9c0d1` then revises `d5e6f7a8b9c0`, flipping `config` from `TEXT` to `LargeBinary` through the same batch/`postgresql_using` pattern as `z9a2b3c4d5e6`. No backfill on upgrade: existing rows become their raw UTF-8 bytes, and the codec reads unframed values unchanged, re-framing each on its next write. The downgrade decompresses every row before restoring `TEXT`.

## Test Plan

`tests/db/test_migration_projects_user_id.py` covers both migrations (6 tests):
- column is `user_id` at head, `owner_user_id` gone
- `ix_projects_user_id` has the right column order (`workspace_id, user_id, created_at, id`), `ix_projects_name` is gone, and it is the table's *only* secondary index
- downgrade → re-upgrade round-trip: old column name and the restored UNIQUE index come back, and the identity value survives both hops
- `config` is `LargeBinary` at head
- `config` round-trips a >512-byte payload through the ORM type, and the bytes on disk carry the frame sentinel and are smaller than the input — so compression demonstrably happened rather than being assumed
- downgrading `e6f7a8b9c0d1` leaves readable plaintext on disk (read with untyped SQL, so no codec is applied), then re-upgrades intact

Two existing tests in `tests/stores/test_project_store.py` changed with the constraint:
`test_duplicate_name_rejected_at_db_layer_for_named_owner` asserted the DB rejects a duplicate once `_name_taken` is bypassed — that is no longer true, so it is replaced by `test_duplicate_name_lands_when_precheck_is_bypassed`, which pins the newly accepted cost (both rows exist, each addressable by its own id). `test_non_name_integrity_error_is_not_masked` is renamed to `test_primary_key_collision_is_not_masked`, since the PK is now the only constraint it can be testing.

`tests/db/test_migration_workspace.py::test_compressed_columns_are_binary_at_head` gains `projects.config` — and also `policies.handler` / `factory_params` and `hosts.configured_harnesses`, which `z9a2b3c4d5e6` converted but never added to that table-driven check.

```bash
# both migrations
pytest tests/db/test_migration_projects_user_id.py -q           # 6 passed

# full migration chain replays with both new revisions at head
pytest tests/db/ -q                                             # 364 passed

# project store / entity / routes
pytest tests/stores/test_project_store.py tests/entities/test_project.py \
       tests/server/routes/test_projects_crud.py \
       tests/server/routes/test_sessions_project_membership.py \
       tests/server/routes/test_sessions_shared_projects.py -q   # 76 passed
```

`ruff format --check` and `ruff check` are clean across the tree (`ruff check` caught the now-unused `IntegrityError` import, since `_is_name_conflict` is gone). Also asserted at runtime that the model columns, index definitions, entity fields, and all five store method signatures expose `user_id` and no longer accept `owner_user_id`.

Two pre-commit hooks could not run locally and are left to CI: `pyrefly` is not installed in this environment, and the `web/*` hooks (prettier / oxlint / tsc) need a JS toolchain — so the one-line TypeScript edit is not `tsc`-verified locally.

## Demo

N/A — no user-visible change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The rename is covered automatically: the existing project store, entity, CRUD-route, and membership suites all exercise the renamed field and keyword argument, so they would fail on any missed call site. The `config` type change is likewise covered by every existing config test, since the ORM type is transparent — `str` in, `str` out. The migration test adds what those don't reach: the index shapes, the compression actually landing on disk, and both downgrade round-trips.

Manual verification was a runtime introspection check (model columns, index columns/uniqueness, entity dataclass fields, and the `create`/`get`/`list`/`update`/`delete` signatures) confirming `user_id` is present and `owner_user_id` is absent everywhere. This guards against a stale reference in a path no test imports — `dev/benchmarks/omnigent/seed.py` writes the column by name in a raw bulk insert, which type checking alone would not catch.

