### PR TITLE
feat(ci): let PR authors reopen closed PRs with /reopen

### DIFF
--- a/.github/workflows/duplicate-prs.js
+++ b/.github/workflows/duplicate-prs.js
@@ -13,7 +13,8 @@ const DAYS_TO_CONSIDER = 14;
 const DUPLICATE_LABEL = "duplicate";
 
 const duplicateMessage = (author, issueNumber, keeperPR) =>
-  `@${author} This PR appears to reference the same issue (#${issueNumber}) as #${keeperPR} (opened earlier). Closing as a duplicate.`;
+  `@${author} This PR appears to reference the same issue (#${issueNumber}) as #${keeperPR} (opened earlier). Closing as a duplicate. ` +
+  `If that's wrong, comment \`/reopen\` and this PR will be reopened.`;
 
 // Maintainer duplicates are flagged but not auto-closed -- a softer, no-action
 // heads-up so the maintainer can decide what to do.

--- a/.github/workflows/reopen-notice-test.yml
+++ b/.github/workflows/reopen-notice-test.yml
@@ -1,0 +1,31 @@
+name: Reopen Notice Test
+
+# Offline unit test for the close-notice logic: runs reopen-notice.test.js
+# (mocked GitHub client, no network). Triggers only when the script or its test
+# change. Runs on `pull_request` (PR head checkout) so it tests the PR's own
+# version. No secrets, no network.
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/reopen-notice.js
+      - .github/workflows/reopen-notice.test.js
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reopen-notice-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run reopen-notice unit test
+        run: node .github/workflows/reopen-notice.test.js

--- a/.github/workflows/reopen-notice.js
+++ b/.github/workflows/reopen-notice.js
@@ -1,0 +1,58 @@
+// Tell the author how to reopen, on every close that leaves `/reopen` usable.
+//
+// Bot closers post their own tailored notice (see duplicate-prs.js), and GitHub
+// suppresses the `closed` event for GITHUB_TOKEN-driven closes anyway, so in
+// practice this covers human closes: a maintainer closing a community PR, or an
+// author closing their own. Merges are not closes. A maintainer's close is
+// deliberate, so the author is pointed at the maintainer rather than at
+// `/reopen`, which would refuse them anyway.
+//
+// Posts at most once per PR: a PR closed, reopened, and closed again does not
+// re-notify.
+
+const MARKER = "<!-- reopen-notice -->";
+
+const authorClosed = () =>
+  `${MARKER}\nClosed. If you want to pick this back up, comment \`/reopen\` — ` +
+  `GitHub only lets maintainers press the Reopen button, so this command does it for you. ` +
+  `It needs the source branch to still exist.`;
+
+const maintainerClosed = (author) =>
+  `${MARKER}\n@${author} this PR was closed by a maintainer. If you think that was a mistake, ` +
+  `reply here and ask them to reopen it — \`/reopen\` only undoes automated closes. ` +
+  `See [CONTRIBUTING.md](https://github.com/omnigent-ai/omnigent/blob/main/CONTRIBUTING.md#reopening-a-closed-pr).`;
+
+module.exports = async ({ github, context, core }) => {
+  const { owner, repo } = context.repo;
+  const pr = context.payload.pull_request;
+
+  if (pr.merged) {
+    core.info(`PR #${pr.number} was merged, not closed; nothing to say.`);
+    return;
+  }
+
+  const closer = context.payload.sender.login;
+  if (closer.endsWith("[bot]")) {
+    core.info(`PR #${pr.number} closed by ${closer}, which posts its own notice.`);
+    return;
+  }
+
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: pr.number,
+    per_page: 100,
+  });
+  if (comments.some((c) => c.body?.includes(MARKER))) {
+    core.info(`PR #${pr.number} already has the reopen notice.`);
+    return;
+  }
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: pr.number,
+    body: closer === pr.user.login ? authorClosed() : maintainerClosed(pr.user.login),
+  });
+  core.info(`Posted reopen notice on #${pr.number} (closed by ${closer}).`);
+};

--- a/.github/workflows/reopen-notice.test.js
+++ b/.github/workflows/reopen-notice.test.js
@@ -1,0 +1,57 @@
+// Local unit test for reopen-notice.js -- mocks the GitHub client and runs the
+// real decision logic. No network.
+
+const assert = require("assert");
+const path = require("path");
+const script = require(path.resolve(".github/workflows/reopen-notice.js"));
+
+// Run the script against a scenario; returns the comments it posted.
+async function run({ author = "ext", closer = "maintainer1", merged = false, existing = [] }) {
+  const comments = [];
+  const github = {
+    paginate: async () => existing.map((body) => ({ body })),
+    rest: {
+      issues: {
+        listComments: "listComments",
+        createComment: async ({ body }) => comments.push(body),
+      },
+    },
+  };
+  const context = {
+    repo: { owner: "omnigent-ai", repo: "omnigent" },
+    payload: {
+      pull_request: { number: 7, merged, user: { login: author } },
+      sender: { login: closer },
+    },
+  };
+  await script({ github, context, core: { info: () => {} } });
+  return comments;
+}
+
+(async () => {
+  // Maintainer closed a community PR: point the author at the maintainer, and
+  // do NOT advertise /reopen (it would refuse them).
+  let c = await run({});
+  assert.strictEqual(c.length, 1);
+  assert.match(c[0], /closed by a maintainer/);
+  assert.doesNotMatch(c[0], /comment `\/reopen`/);
+
+  // Author closed their own PR: advertise /reopen, since it works for them.
+  c = await run({ closer: "ext" });
+  assert.match(c[0], /`\/reopen`/);
+
+  // Merged: not a close, say nothing.
+  assert.deepStrictEqual(await run({ merged: true }), []);
+
+  // Bot closer: it posts its own tailored notice, so stay quiet.
+  assert.deepStrictEqual(await run({ closer: "github-actions[bot]" }), []);
+
+  // Already notified (close -> reopen -> close): do not repeat.
+  assert.deepStrictEqual(await run({ existing: ["<!-- reopen-notice -->\nClosed."] }), []);
+
+  // An unrelated comment does not count as the notice.
+  c = await run({ existing: ["lgtm"] });
+  assert.strictEqual(c.length, 1);
+
+  console.log("reopen-notice.test.js: all assertions passed");
+})();

--- a/.github/workflows/reopen-notice.yml
+++ b/.github/workflows/reopen-notice.yml
@@ -1,0 +1,45 @@
+name: Reopen notice on PR close
+
+# When a PR is closed without merging, comment telling the author how to get it
+# back (`/reopen`, handled by reopen-pr.yml). Logic + safety notes live in
+# reopen-notice.js (offline unit test: reopen-notice.test.js).
+#
+# `pull_request` (not _target) is enough: this reads only event metadata and the
+# comment list, never PR code, and the default GITHUB_TOKEN on a fork PR still
+# grants issues: write for commenting on the base repo.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reopen-notice-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  notice:
+    if: github.repository == 'omnigent-ai/omnigent' && !github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      # Job-level permissions REPLACE the workflow-level block, so restate read.
+      contents: read
+      issues: write # post the notice
+    steps:
+      # Trusted default branch, .github only (the script). Never PR head.
+      - name: Check out .github
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: .github
+          persist-credentials: false
+      - name: Comment with the reopen instructions
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          retries: 3
+          script: |
+            const script = require('./.github/workflows/reopen-notice.js');
+            await script({ github, context, core });

--- a/.github/workflows/reopen-notice.yml
+++ b/.github/workflows/reopen-notice.yml
@@ -4,12 +4,14 @@ name: Reopen notice on PR close
 # back (`/reopen`, handled by reopen-pr.yml). Logic + safety notes live in
 # reopen-notice.js (offline unit test: reopen-notice.test.js).
 #
-# `pull_request` (not _target) is enough: this reads only event metadata and the
-# comment list, never PR code, and the default GITHUB_TOKEN on a fork PR still
-# grants issues: write for commenting on the base repo.
+# `pull_request_target`, because a fork PR's `pull_request` token is read-only no
+# matter what `permissions:` asks for -- commenting would 403 on exactly the fork
+# PRs this notice exists for. `_target` runs in the base-repo context with a
+# grantable token; safe here since the job reads only event metadata and the
+# comment list, checks out the default branch's `.github`, and runs no PR code.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 permissions:

--- a/.github/workflows/reopen-pr-test.yml
+++ b/.github/workflows/reopen-pr-test.yml
@@ -1,0 +1,31 @@
+name: Reopen PR Test
+
+# Offline unit test for the /reopen logic: runs reopen-pr.test.js (mocked GitHub
+# client, no network). Triggers only when the script or its test change. Runs on
+# `pull_request` (PR head checkout) so it tests the PR's own version. No secrets,
+# no network.
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/reopen-pr.js
+      - .github/workflows/reopen-pr.test.js
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reopen-pr-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run /reopen unit test
+        run: node .github/workflows/reopen-pr.test.js

--- a/.github/workflows/reopen-pr.js
+++ b/.github/workflows/reopen-pr.js
@@ -1,0 +1,92 @@
+// Reopen a bot-closed PR when its author comments `/reopen`.
+//
+// Why this exists: reopening a PR needs Triage+ on the base repo, so a fork
+// contributor (Read only) cannot undo a bot close themselves -- their only
+// option today is opening a fresh PR. This lets them ask the bot, which does
+// have the permission, to do it.
+//
+// Only the PR author may use it, and only on a PR a bot closed (never one a
+// maintainer closed deliberately, and never a merged one). Reopening also
+// requires the head branch to still exist; if it is gone, say so instead of
+// failing silently.
+
+const BOT_CLOSERS = ["github-actions[bot]"];
+
+const notAuthor = () =>
+  "Only the PR author can use `/reopen`. A maintainer can reopen this PR directly.";
+
+const closedByHuman = (login) =>
+  `This PR was closed by @${login}, not automatically, so \`/reopen\` does not apply. ` +
+  `Please reply here and ask them to reopen it.`;
+
+const branchGone = (ref) =>
+  `Cannot reopen: the source branch \`${ref}\` no longer exists. ` +
+  `Push it again and open a fresh PR referencing this one.`;
+
+const reopened = () => "Reopened. Thanks for following up!";
+
+// The actor that performed the most recent close. Null when nothing closed it.
+async function lastCloser({ github, owner, repo, number }) {
+  const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
+    owner,
+    repo,
+    issue_number: number,
+    per_page: 100,
+  });
+  const closes = events.filter((e) => e.event === "closed");
+  return closes.length ? closes[closes.length - 1].actor?.login ?? null : null;
+}
+
+module.exports = async ({ github, context, core }) => {
+  const { owner, repo } = context.repo;
+  const number = context.payload.issue.number;
+  const commenter = context.payload.comment.user.login;
+
+  const comment = async (body) =>
+    github.rest.issues.createComment({ owner, repo, issue_number: number, body });
+
+  const pr = (await github.rest.pulls.get({ owner, repo, pull_number: number })).data;
+
+  if (pr.merged) {
+    core.info(`PR #${number} is merged; ignoring.`);
+    return;
+  }
+  if (pr.state === "open") {
+    core.info(`PR #${number} is already open; ignoring.`);
+    return;
+  }
+  if (commenter !== pr.user.login) {
+    await comment(notAuthor());
+    return;
+  }
+
+  const closer = await lastCloser({ github, owner, repo, number });
+  if (closer && !BOT_CLOSERS.includes(closer)) {
+    await comment(closedByHuman(closer));
+    return;
+  }
+
+  // A fork whose branch (or whole repo) is gone leaves head.repo null or the
+  // ref unresolvable -- GitHub then refuses the reopen.
+  if (!pr.head.repo) {
+    await comment(branchGone(pr.head.ref));
+    return;
+  }
+  try {
+    await github.rest.repos.getBranch({
+      owner: pr.head.repo.owner.login,
+      repo: pr.head.repo.name,
+      branch: pr.head.ref,
+    });
+  } catch (err) {
+    if (err.status === 404) {
+      await comment(branchGone(pr.head.ref));
+      return;
+    }
+    throw err;
+  }
+
+  await github.rest.pulls.update({ owner, repo, pull_number: number, state: "open" });
+  await comment(reopened());
+  core.info(`Reopened PR #${number} for @${commenter}.`);
+};

--- a/.github/workflows/reopen-pr.js
+++ b/.github/workflows/reopen-pr.js
@@ -5,17 +5,18 @@
 // option today is opening a fresh PR. This lets them ask the bot, which does
 // have the permission, to do it.
 //
-// Only the PR author may use it, and only on a PR a bot closed (never one a
-// maintainer closed deliberately, and never a merged one). Reopening also
-// requires the head branch to still exist; if it is gone, say so instead of
-// failing silently.
+// Only the PR author may use it, and only when the close was automated or their
+// own (a Read-only author cannot reopen even their own close). A close by a
+// maintainer stands -- that was a decision, not a mechanism. Merged PRs are
+// ignored. Reopening also requires the head branch to still exist; if it is
+// gone, say so instead of failing silently.
 
 const BOT_CLOSERS = ["github-actions[bot]"];
 
 const notAuthor = () =>
   "Only the PR author can use `/reopen`. A maintainer can reopen this PR directly.";
 
-const closedByHuman = (login) =>
+const closedByMaintainer = (login) =>
   `This PR was closed by @${login}, not automatically, so \`/reopen\` does not apply. ` +
   `Please reply here and ask them to reopen it.`;
 
@@ -61,8 +62,8 @@ module.exports = async ({ github, context, core }) => {
   }
 
   const closer = await lastCloser({ github, owner, repo, number });
-  if (closer && !BOT_CLOSERS.includes(closer)) {
-    await comment(closedByHuman(closer));
+  if (closer && !BOT_CLOSERS.includes(closer) && closer !== pr.user.login) {
+    await comment(closedByMaintainer(closer));
     return;
   }
 

--- a/.github/workflows/reopen-pr.js
+++ b/.github/workflows/reopen-pr.js
@@ -11,7 +11,15 @@
 // ignored. Reopening also requires the head branch to still exist; if it is
 // gone, say so instead of failing silently.
 
-const BOT_CLOSERS = ["github-actions[bot]"];
+// Any bot close is undoable. Matched by suffix rather than an allowlist so a
+// close from a GitHub App (its own `[bot]` login) isn't mistaken for a
+// maintainer's deliberate close, which `/reopen` would then refuse.
+const isBotCloser = (login) => login.endsWith("[bot]");
+
+// `/reopen` as a command: first non-space token on a line. The workflow `if:`
+// only prefilters on the substring, so "see /reopened elsewhere" reaches here
+// and must not trigger.
+const COMMAND = /^[ \t]*\/reopen[ \t]*$/m;
 
 const notAuthor = () =>
   "Only the PR author can use `/reopen`. A maintainer can reopen this PR directly.";
@@ -43,6 +51,11 @@ module.exports = async ({ github, context, core }) => {
   const number = context.payload.issue.number;
   const commenter = context.payload.comment.user.login;
 
+  if (!COMMAND.test(context.payload.comment.body ?? "")) {
+    core.info(`Comment on #${number} mentions /reopen but not as a command; ignoring.`);
+    return;
+  }
+
   const comment = async (body) =>
     github.rest.issues.createComment({ owner, repo, issue_number: number, body });
 
@@ -62,7 +75,9 @@ module.exports = async ({ github, context, core }) => {
   }
 
   const closer = await lastCloser({ github, owner, repo, number });
-  if (closer && !BOT_CLOSERS.includes(closer) && closer !== pr.user.login) {
+  // A null closer (closed with no `closed` timeline event) falls through to the
+  // reopen: there's no maintainer decision on record to preserve.
+  if (closer && !isBotCloser(closer) && closer !== pr.user.login) {
     await comment(closedByMaintainer(closer));
     return;
   }

--- a/.github/workflows/reopen-pr.test.js
+++ b/.github/workflows/reopen-pr.test.js
@@ -1,0 +1,84 @@
+// Local unit test for reopen-pr.js -- mocks the GitHub client and runs the real
+// decision logic. No network.
+
+const assert = require("assert");
+const path = require("path");
+const script = require(path.resolve(".github/workflows/reopen-pr.js"));
+
+// Run the script against a scenario; returns the side effects.
+async function run({
+  commenter = "ext",
+  author = "ext",
+  state = "closed",
+  merged = false,
+  closer = "github-actions[bot]",
+  headRepo = { owner: { login: "ext" }, name: "omnigent" },
+  branchExists = true,
+}) {
+  const reopens = [];
+  const comments = [];
+  const github = {
+    paginate: async () => (closer ? [{ event: "closed", actor: { login: closer } }] : []),
+    rest: {
+      issues: {
+        listEventsForTimeline: "listEventsForTimeline",
+        createComment: async ({ body }) => comments.push(body),
+      },
+      pulls: {
+        get: async () => ({ data: { state, merged, user: { login: author }, head: { ref: "feat", repo: headRepo } } }),
+        update: async ({ pull_number, state }) => reopens.push({ pull_number, state }),
+      },
+      repos: {
+        getBranch: async () => {
+          if (!branchExists) {
+            const err = new Error("Branch not found");
+            err.status = 404;
+            throw err;
+          }
+          return { data: {} };
+        },
+      },
+    },
+  };
+  const context = {
+    repo: { owner: "omnigent-ai", repo: "omnigent" },
+    payload: { issue: { number: 7, pull_request: {} }, comment: { user: { login: commenter } } },
+  };
+  await script({ github, context, core: { info: () => {} } });
+  return { reopens, comments };
+}
+
+(async () => {
+  // Author reopening a bot-closed PR: reopened, with confirmation.
+  let r = await run({});
+  assert.deepStrictEqual(r.reopens, [{ pull_number: 7, state: "open" }]);
+  assert.match(r.comments[0], /Reopened/);
+
+  // Someone other than the author: refused, no reopen.
+  r = await run({ commenter: "stranger" });
+  assert.deepStrictEqual(r.reopens, []);
+  assert.match(r.comments[0], /Only the PR author/);
+
+  // Closed by a human maintainer: refused, names them.
+  r = await run({ closer: "maintainer1" });
+  assert.deepStrictEqual(r.reopens, []);
+  assert.match(r.comments[0], /closed by @maintainer1/);
+
+  // Head branch deleted: explains instead of failing.
+  r = await run({ branchExists: false });
+  assert.deepStrictEqual(r.reopens, []);
+  assert.match(r.comments[0], /no longer exists/);
+
+  // Whole fork gone (head.repo null): same explanation.
+  r = await run({ headRepo: null });
+  assert.deepStrictEqual(r.reopens, []);
+  assert.match(r.comments[0], /no longer exists/);
+
+  // Already open, and merged: both silently ignored.
+  r = await run({ state: "open" });
+  assert.deepStrictEqual([r.reopens, r.comments], [[], []]);
+  r = await run({ merged: true, state: "closed" });
+  assert.deepStrictEqual([r.reopens, r.comments], [[], []]);
+
+  console.log("reopen-pr.test.js: all assertions passed");
+})();

--- a/.github/workflows/reopen-pr.test.js
+++ b/.github/workflows/reopen-pr.test.js
@@ -59,10 +59,16 @@ async function run({
   assert.deepStrictEqual(r.reopens, []);
   assert.match(r.comments[0], /Only the PR author/);
 
-  // Closed by a human maintainer: refused, names them.
+  // Closed by a maintainer: refused, names them.
   r = await run({ closer: "maintainer1" });
   assert.deepStrictEqual(r.reopens, []);
   assert.match(r.comments[0], /closed by @maintainer1/);
+
+  // Author closed it themselves: reopened (Read-only authors can't undo even
+  // their own close).
+  r = await run({ closer: "ext" });
+  assert.deepStrictEqual(r.reopens, [{ pull_number: 7, state: "open" }]);
+  assert.match(r.comments[0], /Reopened/);
 
   // Head branch deleted: explains instead of failing.
   r = await run({ branchExists: false });

--- a/.github/workflows/reopen-pr.test.js
+++ b/.github/workflows/reopen-pr.test.js
@@ -14,6 +14,7 @@ async function run({
   closer = "github-actions[bot]",
   headRepo = { owner: { login: "ext" }, name: "omnigent" },
   branchExists = true,
+  body = "/reopen",
 }) {
   const reopens = [];
   const comments = [];
@@ -42,7 +43,10 @@ async function run({
   };
   const context = {
     repo: { owner: "omnigent-ai", repo: "omnigent" },
-    payload: { issue: { number: 7, pull_request: {} }, comment: { user: { login: commenter } } },
+    payload: {
+      issue: { number: 7, pull_request: {} },
+      comment: { user: { login: commenter }, body },
+    },
   };
   await script({ github, context, core: { info: () => {} } });
   return { reopens, comments };
@@ -64,6 +68,16 @@ async function run({
   assert.deepStrictEqual(r.reopens, []);
   assert.match(r.comments[0], /closed by @maintainer1/);
 
+  // Closed by a GitHub App bot (not github-actions): still an automated close,
+  // so it reopens -- suffix match, not an allowlist.
+  r = await run({ closer: "omnigent-ci[bot]" });
+  assert.deepStrictEqual(r.reopens, [{ pull_number: 7, state: "open" }]);
+  assert.match(r.comments[0], /Reopened/);
+
+  // No `closed` event on record: nothing to preserve, so reopen.
+  r = await run({ closer: null });
+  assert.deepStrictEqual(r.reopens, [{ pull_number: 7, state: "open" }]);
+
   // Author closed it themselves: reopened (Read-only authors can't undo even
   // their own close).
   r = await run({ closer: "ext" });
@@ -79,6 +93,13 @@ async function run({
   r = await run({ headRepo: null });
   assert.deepStrictEqual(r.reopens, []);
   assert.match(r.comments[0], /no longer exists/);
+
+  // `/reopen` must be a command, not a mention: prose about it does nothing,
+  // but a trailing newline or leading indent still counts.
+  r = await run({ body: "see /reopened elsewhere" });
+  assert.deepStrictEqual([r.reopens, r.comments], [[], []]);
+  r = await run({ body: "  /reopen\n\nthanks!" });
+  assert.deepStrictEqual(r.reopens, [{ pull_number: 7, state: "open" }]);
 
   // Already open, and merged: both silently ignored.
   r = await run({ state: "open" });

--- a/.github/workflows/reopen-pr.yml
+++ b/.github/workflows/reopen-pr.yml
@@ -24,7 +24,7 @@ jobs:
     if: >-
       github.repository == 'omnigent-ai/omnigent'
       && github.event.issue.pull_request
-      && startsWith(github.event.comment.body, '/reopen')
+      && contains(github.event.comment.body, '/reopen')
       && !endsWith(github.event.comment.user.login, '[bot]')
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/reopen-pr.yml
+++ b/.github/workflows/reopen-pr.yml
@@ -1,0 +1,50 @@
+name: Reopen PR on /reopen comment
+
+# A PR author comments `/reopen` to undo an automated close. Reopening needs
+# Triage+ on the base repo, which fork contributors don't have, so the bot does
+# it for them. All logic + safety notes live in reopen-pr.js (offline unit test:
+# reopen-pr.test.js).
+#
+# Runs on the trusted default branch with the repo GITHUB_TOKEN; it reads no
+# PR-authored code, only the issues/PRs API.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reopen-pr-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  reopen:
+    if: >-
+      github.repository == 'omnigent-ai/omnigent'
+      && github.event.issue.pull_request
+      && startsWith(github.event.comment.body, '/reopen')
+      && !endsWith(github.event.comment.user.login, '[bot]')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      # Job-level permissions REPLACE the workflow-level block, so restate read.
+      contents: read
+      pull-requests: write # reopen the PR
+      issues: write # post the outcome comment
+    steps:
+      # Trusted default branch, .github only (the script). Never PR head.
+      - name: Check out .github
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: .github
+          persist-credentials: false
+      - name: Reopen if eligible
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          retries: 3
+          script: |
+            const script = require('./.github/workflows/reopen-pr.js');
+            await script({ github, context, core });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,3 +185,15 @@ Frontend changes follow the same expectation with a different toolchain:
   "UI / frontend change" box and attach a **video or images** in the `Demo`
   section showing the new behaviour, so reviewers can see it without checking
   out the branch.
+
+### Reopening a closed PR
+
+If automation closed your PR (as a duplicate, for example) and you think that
+was wrong, comment `/reopen` on it and a bot will reopen it for you. GitHub only
+lets maintainers press the Reopen button, so this command is how you do it
+yourself — you can also use it on a PR you closed by hand.
+
+Only the PR author can use it, and it won't override a maintainer who closed
+your PR deliberately; ask them in a comment instead. It also needs your source
+branch to still exist — if you deleted it, push it again and open a fresh PR
+linking the old one.


### PR DESCRIPTION
## Related issue

N/A (tracked internally as OMNI-2314; no GitHub issue)

## Summary

A closed PR is currently a dead end for a community contributor. Reopening a PR
requires Triage or higher on the base repo, and fork contributors have Read, so
when automation closes a PR (as a duplicate, say) the author cannot undo it —
their only option is filing a fresh PR. No bot-closed PR in this repo has ever
been reopened.

- **`/reopen`** — the author comments it, and the bot (which does have the
  permission) reopens the PR for them.
- **A comment on close** telling the author how to get the PR back, so the
  instructions are where they will actually be seen rather than in docs.
- **`CONTRIBUTING.md`** documents the command, who may use it, and its limits.

`/reopen` only undoes closes it should: the commenter must be the PR author, and
the last close must have been the bot or the author themselves (a Read-only
author cannot reopen even their own close). A maintainer's close is a decision,
not a mechanism, so it stands — that case points the author at the maintainer
instead. Merged and already-open PRs are ignored. A deleted head branch makes
reopening impossible for anyone, so it gets an explanation rather than a silent
failure.

The close notice is tailored to who closed it for the same reason: advertising
`/reopen` on a maintainer close would tell contributors to run a command that
then refuses them. A hidden marker keeps close → reopen → close from
re-notifying.

One constraint shaped the split into two workflows: GitHub suppresses workflow
runs for events emitted by `GITHUB_TOKEN`, and `closed` is one of the
non-triggering `pull_request` types, so a single on-close workflow cannot cover
our own bot's closes. Bot closers therefore carry the notice inline
(`duplicate-prs.js`), and the event-driven workflow covers human closes.

```
PR closed ──┬── merged ──────────────────→ nothing (not a close)
            ├── by our bot ──────────────→ closer's own comment: "/reopen"
            ├── by the author ───────────→ notice: "/reopen" (works for them)
            └── by a maintainer ─────────→ notice: "ask them" + CONTRIBUTING link

/reopen ────┬── not the author ──────────→ refused
            ├── closed by a maintainer ──→ refused, names them
            ├── branch gone ─────────────→ explained
            └── otherwise ───────────────→ reopened + confirmation
```

Both workflows follow the pattern already used by `review-sla.yml`: checkout of
the trusted default branch's `.github` only, never PR head, no PR-authored code
executed, and least-privilege scopes.

## Test Plan

Offline unit tests, mocked GitHub client, no network:

```bash
node .github/workflows/reopen-pr.test.js       # 8 cases
node .github/workflows/reopen-notice.test.js   # 6 cases
```

Both pass. Each covers the refusal paths, not just the happy path: non-author,
maintainer close, deleted branch, vanished fork, merged, already-open, and the
already-notified case. `duplicate-prs.test.js` still passes after its message
change. `pre-commit run` is clean on every touched file.

The behaviour needs a live PR close to exercise end to end, so post-merge:
close a throwaway fork PR as its author (expect the `/reopen` notice, then
`/reopen` reopens it); close one as a maintainer (expect the "ask them" variant,
and `/reopen` from the author refuses); merge anything (expect no notice).
Existing bot-closed PRs with live branches — #3916, #3188 — accept `/reopen`
immediately, though they will not retroactively receive the notice comment.

## Demo

N/A (no UI change)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Both scripts have offline unit tests covering every decision branch, run in CI
by `reopen-pr-test.yml` and `reopen-notice-test.yml` when the scripts change.

Manual verification so far covers what can be checked without a live close: both
test suites and `duplicate-prs.test.js` pass locally, `pre-commit` is clean, and
the root cause was confirmed against the live repo — every bot-closed PR sampled
still has its head branch, and none has ever been reopened, so the blocker is
permissions rather than deleted branches. The GitHub-side behaviour (event
delivery, the reopen API call, comment rendering) can only be exercised by
closing a real PR, which is the post-merge check listed in the Test Plan.

## Changelog

Comment `/reopen` on a closed pull request to reopen it yourself
