### PR TITLE
fix(claude): send x-databricks-use-coding-agent-mode header to Databricks AI gateway

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -181,6 +181,11 @@ _CLAUDE_CODE_API_KEY_HELPER_TTL_ENV = "CLAUDE_CODE_API_KEY_HELPER_TTL_MS"
 _CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS_ENV = "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"
 _CLAUDE_CODE_USE_GATEWAY_ENV = "CLAUDE_CODE_USE_GATEWAY"
 _CLAUDE_CODE_ENABLE_TOOL_SEARCH_ENV = "ENABLE_TOOL_SEARCH"
+_CLAUDE_CODE_CUSTOM_HEADERS_ENV = "ANTHROPIC_CUSTOM_HEADERS"
+# Claude Code forwards the ANTHROPIC_CUSTOM_HEADERS value verbatim as
+# request headers. The Databricks AI gateway only serves Claude requests
+# in coding-agent mode when this header is present.
+_DATABRICKS_CODING_AGENT_HEADER = "x-databricks-use-coding-agent-mode: true"
 # Claude Code's agent view (the session list opened by `claude agents`, the
 # left-arrow shortcut on an empty prompt, or /background) lets the user hop to
 # other sessions inside the TUI.  Omnigent owns session switching in its own
@@ -1753,6 +1758,7 @@ def _ucode_config_for_profile(
         _UCODE_CLAUDE_BASE_URL_ENV: base_url,
         _CLAUDE_CODE_API_KEY_HELPER_TTL_ENV: str(refresh_interval_ms),
         _CLAUDE_CODE_USE_GATEWAY_ENV: "1",
+        _CLAUDE_CODE_CUSTOM_HEADERS_ENV: _DATABRICKS_CODING_AGENT_HEADER,
     }
     # Pin each Claude Code model-tier alias to the corresponding Databricks
     # gateway model ID so that the /model picker natively shows gateway model

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -89,6 +89,13 @@ logger = logging.getLogger(__name__)
 # producer (Databricks AI gateway or a generic key/gateway provider).
 _GATEWAY_AUTH_REFRESH_MS = 900_000
 
+# Claude Code forwards the ANTHROPIC_CUSTOM_HEADERS value verbatim as
+# request headers. The Databricks AI gateway only serves Claude requests
+# in coding-agent mode when this header is present, so the Databricks
+# gateway env (not the generic-provider gateway env) must carry it.
+_ANTHROPIC_CUSTOM_HEADERS_ENV = "ANTHROPIC_CUSTOM_HEADERS"
+_DATABRICKS_CODING_AGENT_HEADER = "x-databricks-use-coding-agent-mode: true"
+
 # ---------------------------------------------------------------------------
 # TypeAliases for Omnigent JSON-shaped boundary values. The SDK exchanges
 # heterogeneous dicts at the transport and tool boundaries — named aliases
@@ -1014,6 +1021,7 @@ def _resolve_gateway_env(
             auth_refresh_interval_ms or _GATEWAY_AUTH_REFRESH_MS
         ),
         "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+        _ANTHROPIC_CUSTOM_HEADERS_ENV: _DATABRICKS_CODING_AGENT_HEADER,
         _CLAUDE_API_KEY_HELPER_ENV_KEY: auth_command,
     }
 

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -1136,6 +1136,10 @@ class TestResolveGatewayEnv(unittest.TestCase):
                 'databricks auth token --host "https://example.databricks.com"',
                 env["OMNIGENT_CLAUDE_API_KEY_HELPER"],
             )
+            self.assertEqual(
+                env["ANTHROPIC_CUSTOM_HEADERS"],
+                "x-databricks-use-coding-agent-mode: true",
+            )
             self.assertNotIn("ANTHROPIC_AUTH_TOKEN", env)
 
     def test_strips_trailing_slash(self):
@@ -1180,6 +1184,20 @@ class TestResolveGatewayEnv(unittest.TestCase):
             "https://example.databricks.com/ai-gateway/anthropic",
         )
         self.assertEqual(env["OMNIGENT_CLAUDE_API_KEY_HELPER"], "printf token")
+        self.assertEqual(
+            env["ANTHROPIC_CUSTOM_HEADERS"],
+            "x-databricks-use-coding-agent-mode: true",
+        )
+
+    def test_generic_provider_gateway_omits_databricks_header(self):
+        """Non-Databricks gateways must not receive the Databricks mode header."""
+        from omnigent.inner.claude_sdk_executor import _resolve_gateway_env
+
+        env = _resolve_gateway_env(
+            base_url_override="https://mock-llm.example/v1",
+            auth_command_override="printf sk-test",
+        )
+        self.assertNotIn("ANTHROPIC_CUSTOM_HEADERS", env)
 
     def test_host_override_requires_base_url(self):
         from omnigent.inner.claude_sdk_executor import _resolve_gateway_env

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -301,6 +301,7 @@ def test_ucode_config_for_profile_reads_allowlisted_claude_state(
             "ANTHROPIC_BASE_URL": "https://example.databricks.com/ai-gateway/anthropic",
             "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "123456",
             "CLAUDE_CODE_USE_GATEWAY": "1",
+            "ANTHROPIC_CUSTOM_HEADERS": "x-databricks-use-coding-agent-mode: true",
         },
         api_key_helper="printf token",
         model="databricks-claude-opus-test",


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The Databricks AI gateway only serves Claude requests in coding-agent mode when the `x-databricks-use-coding-agent-mode: true` request header is present; omnigent's Claude launches to the gateway did not send it.
- `ClaudeSDKExecutor`'s Databricks gateway env (`_resolve_gateway_env`) and native-claude's ucode launch config now pass `ANTHROPIC_CUSTOM_HEADERS=x-databricks-use-coding-agent-mode: true`, which Claude Code forwards verbatim as request headers (this survives the thinking-display gateway shim, which forwards all request headers).
- Generic-provider gateway envs (non-Databricks `key`/`gateway` providers) deliberately do not receive the header.

## Test Plan

- `uv run pytest tests/test_claude_native.py tests/inner/test_claude_sdk_executor.py -q` — 283 passed.
- Updated the ucode env exact-equality assertion and gateway-env tests to assert the header; added `test_generic_provider_gateway_omits_databricks_header` to pin the Databricks-only scoping.
- `uv run ruff check` and `uv run ruff format --check` on the touched files — clean.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A

## Changelog

Claude sessions routed through the Databricks AI gateway now send the `x-databricks-use-coding-agent-mode` header the gateway requires

Signed-off-by: Zeyi (Rice) Fan <zeyi.f@databricks.com>

Backport of #4082 to `release/v0.8.0`.