### PR TITLE
fix(web): give the user message a stable position in the live view

### DIFF
--- a/tests/e2e_ui/chat/test_queued_message_lifecycle.py
+++ b/tests/e2e_ui/chat/test_queued_message_lifecycle.py
@@ -5,7 +5,8 @@ exercise the path a queued/optimistic user message takes:
 
     send → optimistic bubble renders immediately → server consumes it
     (``session.input.consumed``) → bubble promotes into committed
-    history (not dropped, not duplicated) → survives navigation.
+    history (not dropped, not duplicated, at the right transcript
+    position) → survives navigation.
 
 They guard the store wiring this change refactored — the
 ``session.input.consumed`` promotion in ``chatStore.handleSessionEvent``
@@ -49,6 +50,8 @@ _NAV_MSG = "sentinel-nav-7f3a remember this exact phrase"
 _PROMOTE_MSG = "sentinel-promote-91b2 keep this bubble"
 _QUEUE_MSG_A = "sentinel-queue-a-4d1e first of two"
 _QUEUE_MSG_B = "sentinel-queue-b-8c6f second of two"
+_ORDER_MSG_A = "sentinel-order-a-2b7d first turn prompt"
+_ORDER_MSG_B = "sentinel-order-b-5e9c second turn prompt"
 
 _COMPOSER_PLACEHOLDER = "Ask the agent anything…"
 
@@ -56,6 +59,31 @@ _COMPOSER_PLACEHOLDER = "Ask the agent anything…"
 def _user_bubble(page: Page, text: str):
     """Locator for the user-message bubble carrying ``text``."""
     return page.locator('[data-testid="message-bubble"][data-role="user"]').filter(has_text=text)
+
+
+def _bubble_roles(page: Page) -> list[str]:
+    """Roles of every rendered bubble, in transcript (DOM) order.
+
+    ``["user", "assistant", "user", "assistant"]`` for a clean two-turn
+    conversation. Reading the roles rather than the texts keeps the
+    assertion independent of what the model actually replied.
+    """
+    bubbles = page.locator('[data-testid="message-bubble"]')
+    return [b.get_attribute("data-role") or "" for b in bubbles.all()]
+
+
+def _index_of_user_bubble(page: Page, text: str) -> int:
+    """Transcript position of the user bubble carrying ``text``.
+
+    Indexes across ALL bubbles (both roles) so the result can be
+    compared against an assistant bubble's position. Returns ``-1`` when
+    the bubble isn't rendered.
+    """
+    bubbles = page.locator('[data-testid="message-bubble"]')
+    for index, bubble in enumerate(bubbles.all()):
+        if bubble.get_attribute("data-role") == "user" and text in (bubble.inner_text() or ""):
+            return index
+    return -1
 
 
 def _send(page: Page, text: str) -> None:
@@ -183,3 +211,76 @@ def test_second_message_queued_while_first_streams_both_render(
     expect(assistant).to_have_text(re.compile(r"\S"), timeout=60_000)
     expect(_user_bubble(page, _QUEUE_MSG_A)).to_have_count(1, timeout=60_000)
     expect(_user_bubble(page, _QUEUE_MSG_B)).to_have_count(1, timeout=60_000)
+
+
+def test_user_message_renders_above_the_reply_it_prompted(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The prompt stays ABOVE the answer to it, live and across turns.
+
+    Guards the transcript position of a user message end-to-end
+    (issue #3983). A user message is the only transcript content with no
+    position of its own: every other block is appended in stream-arrival
+    order, while the message renders as an optimistic bubble and is then
+    injected out-of-band by the ``session.input.consumed`` handler. If
+    that injection appends instead of placing the message at its wire
+    position, the message renders BELOW the reply it prompted and stays
+    there for the rest of the live session.
+
+    Asserted here:
+
+    1. The user bubble sits above the assistant bubble within a turn —
+       checked live, without a reload, since a reload reads the
+       (already-correct) persisted order and would mask the defect.
+    2. A second turn interleaves correctly, giving
+       ``[user, assistant, user, assistant]`` — a promotion that appends
+       would pile both prompts after the replies.
+
+    Scope caveat, in the spirit of the module docstring: this harness
+    runs an ``openai-agents`` agent with no smart routing, so the ack
+    (``session.input.consumed``) lands before any block commits and the
+    ordering here is correct even without the fix. What makes the defect
+    visible is a turn that commits blocks while the message is still
+    optimistic — smart routing's router-call + runner-forward window, or
+    a native-terminal harness that has no ``input.consumed`` until the
+    CLI echoes. Neither is available here. This test pins the invariant
+    (prompt above its answer, in the live view) so a future regression
+    in the placement path is caught; the racing behaviour itself is
+    covered by the ``chatStore`` and ``mergePendingBubbles`` unit suites.
+    """
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # ── turn 1 ──
+    _send(page, _ORDER_MSG_A)
+    expect(_user_bubble(page, _ORDER_MSG_A)).to_be_visible(timeout=10_000)
+
+    first_reply = page.locator('[data-testid="message-bubble"][data-role="assistant"]').first
+    expect(first_reply).to_have_text(re.compile(r"\S"), timeout=60_000)
+
+    # (1) The prompt precedes the reply in the live transcript. Read
+    # positions across ALL bubbles so this compares transcript order, not
+    # per-role order.
+    user_index = _index_of_user_bubble(page, _ORDER_MSG_A)
+    assert user_index == 0, f"expected the prompt to open the transcript, got index {user_index}"
+    assert _bubble_roles(page)[:2] == ["user", "assistant"], (
+        f"reply rendered above the prompt: {_bubble_roles(page)}"
+    )
+
+    # ── turn 2, sent once the first turn is idle ──
+    _send(page, _ORDER_MSG_B)
+    expect(_user_bubble(page, _ORDER_MSG_B)).to_be_visible(timeout=10_000)
+    expect(page.locator('[data-testid="message-bubble"][data-role="assistant"]')).to_have_count(
+        2, timeout=60_000
+    )
+    second_reply = page.locator('[data-testid="message-bubble"][data-role="assistant"]').nth(1)
+    expect(second_reply).to_have_text(re.compile(r"\S"), timeout=60_000)
+
+    # (2) Turns interleave — neither prompt slid below its reply.
+    assert _bubble_roles(page) == ["user", "assistant", "user", "assistant"], (
+        f"turns did not interleave: {_bubble_roles(page)}"
+    )
+    assert _index_of_user_bubble(page, _ORDER_MSG_B) == 2, (
+        "second prompt is not at the head of its own turn"
+    )

--- a/web/src/lib/renderItems.ts
+++ b/web/src/lib/renderItems.ts
@@ -118,9 +118,24 @@ export type RenderItem =
       rememberScope?: RememberScope | null;
     };
 
+/**
+ * Index of the first block this bubble was built from.
+ *
+ * Lets a caller place something at a known BLOCK position into the
+ * BUBBLE list — specifically, `ChatPage` splices an optimistic user
+ * bubble in at the wire position recorded on its pending entry
+ * (`PendingUserMessage.anchorIndex`), so the message renders above the
+ * turn it started even before its `session.input.consumed` lands
+ * (issue #3983). Absent on bubbles that don't come from a block, i.e.
+ * the optimistic ones the page builds itself.
+ */
+interface BubblePosition {
+  blockStart?: number;
+}
+
 /** A bubble cluster. The page maps over these. */
 export type Bubble =
-  | {
+  | ({
       kind: "user";
       itemId: string;
       content: MessageContentBlock[];
@@ -133,8 +148,8 @@ export type Bubble =
        * optimistic→committed swap (no remount/flink).
        */
       stableKey?: string;
-    }
-  | {
+    } & BubblePosition)
+  | ({
       kind: "assistant";
       responseId: string;
       // Stable, sibling-unique identifier for React keying
@@ -165,17 +180,17 @@ export type Bubble =
        * trailing answer of its own.
        */
       continued?: boolean;
-    }
-  | { kind: "compaction_loading"; itemId: string }
-  | { kind: "compaction"; itemId: string }
-  | {
+    } & BubblePosition)
+  | ({ kind: "compaction_loading"; itemId: string } & BubblePosition)
+  | ({ kind: "compaction"; itemId: string } & BubblePosition)
+  | ({
       kind: "routing_decision";
       itemId: string;
       model: string;
       applied: boolean;
       rationale: string;
       agent?: string;
-    };
+    } & BubblePosition);
 
 const TEXT_BLOCK_TYPES = new Set(["text_chunk", "text_done"]);
 const REASONING_BLOCK_TYPES = new Set(["reasoning_start", "reasoning_chunk", "reasoning_block"]);
@@ -540,6 +555,7 @@ function walkBubbles(
       lastBubbleStart = i;
       bubbles.push({
         kind: "user",
+        blockStart: i,
         itemId: b.ctx.itemId ?? `user_${i}`,
         content: b.content,
         ...(b.ctx.createdBy !== undefined ? { createdBy: b.ctx.createdBy } : {}),
@@ -555,6 +571,7 @@ function walkBubbles(
       lastBubbleStart = i;
       bubbles.push({
         kind: "compaction_loading",
+        blockStart: i,
         itemId: b.ctx.itemId ?? `compaction_loading_${i}`,
       });
       i += 1;
@@ -575,6 +592,7 @@ function walkBubbles(
       lastBubbleStart = i;
       bubbles.push({
         kind: "compaction",
+        blockStart: i,
         itemId: b.ctx.itemId ?? `compaction_${i}`,
       });
       i += 1;
@@ -587,6 +605,7 @@ function walkBubbles(
       lastBubbleStart = i;
       bubbles.push({
         kind: "routing_decision",
+        blockStart: i,
         itemId: b.ctx.itemId ?? `routing_${i}`,
         model: b.model,
         applied: b.applied,
@@ -686,6 +705,7 @@ function walkBubbles(
     const lastActivityAtS = turnLastActivityAtS(groupBlocks);
     bubbles.push({
       kind: "assistant",
+      blockStart: groupStart,
       responseId: groupResponseId,
       stableId,
       lifecycle,

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -470,10 +470,9 @@ describe("mergePendingBubbles", () => {
     expect(bubbleIds(mergePendingBubbles(committed, pending))).toEqual(["u1", "a1", "pend_1"]);
   });
 
-  it("keeps a burst contiguous, positioned by the FIFO head", () => {
-    // Promotion is FIFO, so the head is the entry about to commit;
-    // positioning the group by it keeps near-simultaneous sends together
-    // instead of scattering them one block apart.
+  it("keeps a burst sharing an anchor contiguous", () => {
+    // Two sends before either is acked resolve to the same slot, so they
+    // come out adjacent without any special-casing.
     const committed = [
       { ...userBubble("u1"), blockStart: 0 },
       { ...assistantText("a1"), blockStart: 5 },
@@ -481,6 +480,48 @@ describe("mergePendingBubbles", () => {
     const pending = [
       { ...userBubble("pend_1"), blockStart: 1 },
       { ...userBubble("pend_2"), blockStart: 1 },
+    ];
+    expect(bubbleIds(mergePendingBubbles(committed, pending))).toEqual([
+      "u1",
+      "pend_1",
+      "pend_2",
+      "a1",
+    ]);
+  });
+
+  it("places each pending bubble at its own wire position", () => {
+    // Distinct anchors must resolve to distinct slots. Positioning the
+    // whole group by its head would put `pend_2` above `a1` — and it
+    // would then visibly jump down when its own ack committed it at
+    // anchor 6, which is precisely the artifact this placement removes.
+    const committed = [
+      { ...userBubble("u1"), blockStart: 0 },
+      { ...assistantText("a1"), blockStart: 1 },
+      { ...assistantText("a2"), blockStart: 6 },
+    ];
+    const pending = [
+      { ...userBubble("pend_1"), blockStart: 1 },
+      { ...userBubble("pend_2"), blockStart: 6 },
+    ];
+    expect(bubbleIds(mergePendingBubbles(committed, pending))).toEqual([
+      "u1",
+      "pend_1",
+      "a1",
+      "pend_2",
+      "a2",
+    ]);
+  });
+
+  it("keeps FIFO order when a later anchor resolves to an earlier slot", () => {
+    // Defensive: anchors should be non-decreasing in FIFO order, but a
+    // stale one must never let a later send overtake an earlier one.
+    const committed = [
+      { ...userBubble("u1"), blockStart: 0 },
+      { ...assistantText("a1"), blockStart: 4 },
+    ];
+    const pending = [
+      { ...userBubble("pend_1"), blockStart: 4 },
+      { ...userBubble("pend_2"), blockStart: 0 },
     ];
     expect(bubbleIds(mergePendingBubbles(committed, pending))).toEqual([
       "u1",

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -438,6 +438,91 @@ describe("mergePendingBubbles", () => {
       "pend_1",
     ]);
   });
+
+  it("places the pending bubble at its wire position, above the turn it started", () => {
+    // Issue #3983: on a smart-routed turn the ack is withheld across the
+    // router call and the runner forward, so the routing card and the
+    // first reply tokens commit while the message is still optimistic.
+    // Trailing it renders the user's message UNDER the answer to it.
+    const committed = [
+      { ...userBubble("u1"), blockStart: 0 },
+      { ...assistantText("a1"), blockStart: 1 },
+      { ...assistantText("a2"), blockStart: 4 },
+    ];
+    // Sent when 3 blocks were committed — so it belongs above `a2`.
+    const pending = [{ ...userBubble("pend_1"), blockStart: 3 }];
+    expect(bubbleIds(mergePendingBubbles(committed, pending))).toEqual([
+      "u1",
+      "a1",
+      "pend_1",
+      "a2",
+    ]);
+  });
+
+  it("still trails when every committed bubble predates the send", () => {
+    // The ordinary case: nothing committed between the POST and the ack,
+    // so the wire position IS the bottom and the bubble trails as before.
+    const committed = [
+      { ...userBubble("u1"), blockStart: 0 },
+      { ...assistantText("a1"), blockStart: 1 },
+    ];
+    const pending = [{ ...userBubble("pend_1"), blockStart: 3 }];
+    expect(bubbleIds(mergePendingBubbles(committed, pending))).toEqual(["u1", "a1", "pend_1"]);
+  });
+
+  it("keeps a burst contiguous, positioned by the FIFO head", () => {
+    // Promotion is FIFO, so the head is the entry about to commit;
+    // positioning the group by it keeps near-simultaneous sends together
+    // instead of scattering them one block apart.
+    const committed = [
+      { ...userBubble("u1"), blockStart: 0 },
+      { ...assistantText("a1"), blockStart: 5 },
+    ];
+    const pending = [
+      { ...userBubble("pend_1"), blockStart: 1 },
+      { ...userBubble("pend_2"), blockStart: 1 },
+    ];
+    expect(bubbleIds(mergePendingBubbles(committed, pending))).toEqual([
+      "u1",
+      "pend_1",
+      "pend_2",
+      "a1",
+    ]);
+  });
+
+  it("trails an entry with no wire position even when later bubbles exist", () => {
+    // Snapshot-replayed / stash-restored entries carry no anchor — their
+    // index would point into a different blocks array — so they keep the
+    // historical trailing behaviour.
+    const committed = [
+      { ...userBubble("u1"), blockStart: 0 },
+      { ...assistantText("a1"), blockStart: 9 },
+    ];
+    const pending = [userBubble("pending_srv_1")];
+    expect(bubbleIds(mergePendingBubbles(committed, pending))).toEqual([
+      "u1",
+      "a1",
+      "pending_srv_1",
+    ]);
+  });
+
+  it("still lifts an anchored prompt above a request-phase card", () => {
+    // The two placement rules compose: the anchor picks the slot, then the
+    // elicitation walk-back moves further up if that slot lands after a
+    // standalone REQUEST-phase card.
+    const committed = [
+      { ...assistantText("a1"), blockStart: 0 },
+      { ...elicitationBubble("e1", "request"), blockStart: 4 },
+      { ...assistantText("a2"), blockStart: 5 },
+    ];
+    const pending = [{ ...userBubble("pend_1"), blockStart: 4 }];
+    expect(bubbleIds(mergePendingBubbles(committed, pending))).toEqual([
+      "a1",
+      "pend_1",
+      "e1",
+      "a2",
+    ]);
+  });
 });
 
 // ── reorderCommittedRequestElicitations ─────────────────────────────────────

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -346,6 +346,10 @@ export function buildPendingBubbles(
       // No server item id yet; tempId keeps React keys stable until promotion.
       itemId: p.tempId,
       content: p.content,
+      // The send's wire position, so `mergePendingBubbles` can place the
+      // bubble instead of trailing it. Undefined on snapshot-replayed and
+      // stash-restored entries, which carry no position.
+      ...(p.anchorIndex !== undefined ? { blockStart: p.anchorIndex } : {}),
       ...(author !== null ? { createdBy: author } : {}),
     };
   });
@@ -407,18 +411,37 @@ export function reorderCommittedRequestElicitations(committed: Bubble[]): Bubble
 
 // Place optimistic pending user bubbles into the committed timeline.
 //
-// Pending sends normally trail everything (the input should be visible
-// immediately, and they migrate into `blocks` once their
-// `session.input.consumed` event lands). The exception is a REQUEST-phase
-// policy ASK: that message never gets a consumed event until approval, so
-// it stays pending while its elicitation card renders as a committed
-// bubble — appending the pending bubble after the card would show the
-// approval prompt ABOVE the message that triggered it. When the timeline
-// ends in a run of such request-elicitation bubbles, splice the pending
-// bubbles in just before that run so the prompt stays on top.
+// A pending send belongs at the position it had on the wire, not at the
+// bottom. The two are the same whenever nothing commits between the POST
+// and `session.input.consumed` — but a smart-routed turn holds that ack
+// across the router call and the runner forward, so the routing card and
+// the first reply tokens commit first and a trailing bubble would render
+// the message UNDER the answer to it (issue #3983). `blockStart` carries
+// the block count at send time (`PendingUserMessage.anchorIndex`), so
+// splice in ahead of the first committed bubble built from a later block.
+// The store applies the same position when the ack finally promotes the
+// message, so the bubble doesn't move on promotion.
+//
+// Entries with no `blockStart` (snapshot-replayed, stash-restored) keep
+// the historical trailing behaviour.
+//
+// Layered on top: a REQUEST-phase policy ASK never gets a consumed event
+// until approval, so it stays pending while its elicitation card renders
+// as a committed bubble — leaving the pending bubble after the card would
+// show the approval prompt ABOVE the message that triggered it. When the
+// insertion point is preceded by a run of such request-elicitation
+// bubbles, walk back past them so the prompt stays on top.
 export function mergePendingBubbles(committed: Bubble[], pending: Bubble[]): Bubble[] {
   if (pending.length === 0) return committed;
   let insertAt = committed.length;
+  // Position the group by its FIFO head: promotion is FIFO, so the head is
+  // the entry about to commit, and near-simultaneous sends stay contiguous
+  // rather than being scattered by one block each.
+  const anchor = pending[0]!.blockStart;
+  if (anchor !== undefined) {
+    const at = committed.findIndex((b) => b.blockStart !== undefined && b.blockStart >= anchor);
+    if (at !== -1) insertAt = at;
+  }
   while (insertAt > 0 && isStandaloneElicitationBubble(committed[insertAt - 1]!)) {
     insertAt -= 1;
   }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -433,11 +433,47 @@ export function reorderCommittedRequestElicitations(committed: Bubble[]): Bubble
 // bubbles, walk back past them so the prompt stays on top.
 export function mergePendingBubbles(committed: Bubble[], pending: Bubble[]): Bubble[] {
   if (pending.length === 0) return committed;
+  // Each pending bubble is placed at ITS OWN slot, not the group's. The
+  // store commits each message at its own `anchorIndex`, so positioning
+  // the whole group by its head would make every entry after the head
+  // jump when its own ack lands — the exact artifact this placement
+  // exists to remove. Entries sharing an anchor still come out adjacent,
+  // because they resolve to the same slot.
+  let floor = 0;
+  const slots = pending.map((bubble) => {
+    // Never move backwards: FIFO order among the pending bubbles wins
+    // over a slot computed from a stale or out-of-order anchor.
+    const slot = Math.max(pendingSlot(bubble, committed), floor);
+    floor = slot;
+    return slot;
+  });
+  const merged: Bubble[] = [];
+  let next = 0;
+  for (let i = 0; i <= committed.length; i += 1) {
+    while (next < pending.length && slots[next] === i) merged.push(pending[next++]!);
+    if (i < committed.length) merged.push(committed[i]!);
+  }
+  // Anything whose slot exceeded the committed length trails, as before.
+  while (next < pending.length) merged.push(pending[next++]!);
+  return merged;
+}
+
+/**
+ * Where one optimistic bubble belongs in the committed bubble list.
+ *
+ * Its `blockStart` is the block count at send time, so the slot is the
+ * first committed bubble built from a block at or after that point —
+ * everything earlier predates the send. Bubbles with no `blockStart`
+ * (snapshot-replayed, stash-restored) trail, as they did before wire
+ * positions existed.
+ *
+ * The REQUEST-phase elicitation walk-back then applies on top of the
+ * chosen slot, so an approval prompt never renders above the message it
+ * gates.
+ */
+function pendingSlot(bubble: Bubble, committed: Bubble[]): number {
   let insertAt = committed.length;
-  // Position the group by its FIFO head: promotion is FIFO, so the head is
-  // the entry about to commit, and near-simultaneous sends stay contiguous
-  // rather than being scattered by one block each.
-  const anchor = pending[0]!.blockStart;
+  const anchor = bubble.blockStart;
   if (anchor !== undefined) {
     const at = committed.findIndex((b) => b.blockStart !== undefined && b.blockStart >= anchor);
     if (at !== -1) insertAt = at;
@@ -445,8 +481,7 @@ export function mergePendingBubbles(committed: Bubble[], pending: Bubble[]): Bub
   while (insertAt > 0 && isStandaloneElicitationBubble(committed[insertAt - 1]!)) {
     insertAt -= 1;
   }
-  if (insertAt === committed.length) return [...committed, ...pending];
-  return [...committed.slice(0, insertAt), ...pending, ...committed.slice(insertAt)];
+  return insertAt;
 }
 
 type ElicitationItem = Extract<RenderItem, { kind: "elicitation" }>;

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -4636,6 +4636,79 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
       ]);
     });
 
+    it("appends another viewer's message instead of using our reserved position", () => {
+      // Shared session: a collaborator's consumed event names a server
+      // pending id we don't hold, which is indistinguishable from our own
+      // POST not having returned its id yet — so it lands in the FIFO-head
+      // branch. Committing THEIR message at OUR wire position would lift
+      // it above blocks that preceded it, so a foreign author appends.
+      vi.mocked(getCurrentAuthorId).mockReturnValue("alice@example.com");
+      const prior = textBlock("resp_prev", "msg_prev", "earlier reply");
+      const during = textBlock("resp_new", "msg_reply", "streaming");
+      useChatStore.setState({
+        blocks: [prior, during],
+        pendingUserMessages: [
+          {
+            tempId: "pend_1",
+            content: [{ type: "input_text", text: "mine" }],
+            anchorIndex: 1,
+            author: "alice@example.com",
+          },
+        ],
+      });
+
+      handleSessionEvent({
+        type: "session_input_consumed",
+        itemId: "msg_bob",
+        itemType: "message",
+        clearedPendingId: "pending_srv_9",
+        createdBy: "bob@example.com",
+        data: { role: "user", content: [{ type: "input_text", text: "from bob" }] },
+      });
+
+      // Appended, NOT spliced at index 1 above `msg_reply`.
+      expect(useChatStore.getState().blocks.map((b) => b.ctx.itemId)).toEqual([
+        "msg_prev",
+        "msg_reply",
+        "msg_bob",
+      ]);
+    });
+
+    it("still uses our wire position when the event carries our own author", () => {
+      // Same branch, our own message: `createdBy` matching the viewer (or
+      // absent entirely) means the FIFO head really is this message, so
+      // the reserved position applies.
+      vi.mocked(getCurrentAuthorId).mockReturnValue("alice@example.com");
+      const prior = textBlock("resp_prev", "msg_prev", "earlier reply");
+      const during = textBlock("resp_new", "msg_reply", "streaming");
+      useChatStore.setState({
+        blocks: [prior, during],
+        pendingUserMessages: [
+          {
+            tempId: "pend_1",
+            content: [{ type: "input_text", text: "mine" }],
+            anchorIndex: 1,
+            author: "alice@example.com",
+          },
+        ],
+      });
+
+      handleSessionEvent({
+        type: "session_input_consumed",
+        itemId: "msg_mine",
+        itemType: "message",
+        clearedPendingId: "pending_srv_9",
+        createdBy: "alice@example.com",
+        data: { role: "user", content: [{ type: "input_text", text: "mine" }] },
+      });
+
+      expect(useChatStore.getState().blocks.map((b) => b.ctx.itemId)).toEqual([
+        "msg_prev",
+        "msg_mine",
+        "msg_reply",
+      ]);
+    });
+
     it("clears the optimistic bubble when the block already committed", () => {
       // Issue #3983: a snapshot merge or the native transcript relay can
       // commit the block before the consumed event lands. Only one

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -48,6 +48,7 @@ import type { TerminalInfo } from "@/hooks/useTerminals";
 import { terminalsQueryKey } from "@/hooks/useTerminals";
 import { type ChildSessionInfo, childSessionsQueryKey } from "@/hooks/useChildSessions";
 import {
+  appendInWireOrder,
   consumePendingInitialPrompt,
   handleSessionEvent,
   reviveStrayCompletedResponse,
@@ -97,6 +98,29 @@ function assistantMessage(responseId: string, text: string): ConversationItem {
     status: "completed",
     model: "test-agent",
     content: [{ type: "output_text", text }],
+  };
+}
+
+function blockCtx(responseId: string, itemId: string): AnyBlock["ctx"] {
+  return { agent: null, depth: 0, turn: 0, timestamp: 0, responseId, itemId };
+}
+
+function textBlock(responseId: string, itemId: string, fullText: string): AnyBlock {
+  return {
+    type: "text_done",
+    ctx: blockCtx(responseId, itemId),
+    fullText,
+    hasCodeBlocks: false,
+  };
+}
+
+function routingCardBlock(responseId: string, itemId: string): AnyBlock {
+  return {
+    type: "routing_decision",
+    ctx: blockCtx(responseId, itemId),
+    model: "test-model",
+    applied: true,
+    rationale: "cheap enough",
   };
 }
 
@@ -4514,6 +4538,181 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
       expect(state.blocks).toHaveLength(1);
       expect((state.blocks[0] as UserMessageBlock).ctx.itemId).toBe("msg_hi");
     });
+
+    it("commits the message at its wire position, above blocks that raced it", () => {
+      // Issue #3983: on a smart-routed turn the consumed event only fires
+      // after the router LLM call and the runner forward, so the routing
+      // card and the first reply tokens commit while the message is still
+      // optimistic. Appending on promotion would leave the user's message
+      // UNDER the answer to it for the rest of the live session. The
+      // pending entry carries the block count from send time, so the
+      // promoted block splices in ahead of everything the send caused.
+      const priorTurn = textBlock("resp_prev", "msg_prev", "earlier reply");
+      const card = routingCardBlock("resp_new", "item_card");
+      const firstTokens = textBlock("resp_new", "msg_reply", "on it");
+      useChatStore.setState({
+        blocks: [priorTurn, card, firstTokens],
+        pendingUserMessages: [
+          {
+            tempId: "pend_1",
+            content: [{ type: "input_text", text: "ship it" }],
+            // Only `priorTurn` was committed when the user hit send.
+            anchorIndex: 1,
+          },
+        ],
+      });
+
+      handleSessionEvent({
+        type: "session_input_consumed",
+        itemId: "msg_ship",
+        itemType: "message",
+        clearedPendingId: "pend_1",
+        data: { role: "user", content: [{ type: "input_text", text: "ship it" }] },
+      });
+
+      const state = useChatStore.getState();
+      expect(state.pendingUserMessages).toEqual([]);
+      expect(state.blocks.map((b) => b.ctx.itemId)).toEqual([
+        "msg_prev",
+        "msg_ship",
+        "item_card",
+        "msg_reply",
+      ]);
+    });
+
+    it("keeps a burst of sends in order when they share an anchor", () => {
+      // Two sends before either is consumed share a wire position. The
+      // first promotion shifts the second's anchor, so FIFO promotion
+      // still renders them in the order they were typed.
+      useChatStore.setState({
+        blocks: [],
+        pendingUserMessages: [
+          { tempId: "pend_1", content: [{ type: "input_text", text: "first" }], anchorIndex: 0 },
+          { tempId: "pend_2", content: [{ type: "input_text", text: "second" }], anchorIndex: 0 },
+        ],
+      });
+
+      handleSessionEvent({
+        type: "session_input_consumed",
+        itemId: "msg_1",
+        itemType: "message",
+        clearedPendingId: "pend_1",
+        data: { role: "user", content: [{ type: "input_text", text: "first" }] },
+      });
+      handleSessionEvent({
+        type: "session_input_consumed",
+        itemId: "msg_2",
+        itemType: "message",
+        clearedPendingId: "pend_2",
+        data: { role: "user", content: [{ type: "input_text", text: "second" }] },
+      });
+
+      expect(useChatStore.getState().blocks.map((b) => b.ctx.itemId)).toEqual(["msg_1", "msg_2"]);
+    });
+
+    it("appends when the entry carries no wire position", () => {
+      // Snapshot-replayed and stash-restored bubbles have no anchor
+      // (their index would point into a different blocks array), so they
+      // keep the historical append-on-consumed behaviour.
+      const prior = textBlock("resp_prev", "msg_prev", "earlier reply");
+      useChatStore.setState({
+        blocks: [prior],
+        pendingUserMessages: [
+          { tempId: "pending_srv", content: [{ type: "input_text", text: "replayed" }] },
+        ],
+      });
+
+      handleSessionEvent({
+        type: "session_input_consumed",
+        itemId: "msg_replayed",
+        itemType: "message",
+        clearedPendingId: "pending_srv",
+        data: { role: "user", content: [{ type: "input_text", text: "replayed" }] },
+      });
+
+      expect(useChatStore.getState().blocks.map((b) => b.ctx.itemId)).toEqual([
+        "msg_prev",
+        "msg_replayed",
+      ]);
+    });
+
+    it("clears the optimistic bubble when the block already committed", () => {
+      // Issue #3983: a snapshot merge or the native transcript relay can
+      // commit the block before the consumed event lands. Only one
+      // consumed event ever fires, so bailing out on the dedupe check
+      // without popping the entry stranded the optimistic bubble at the
+      // bottom of the transcript until reload.
+      const committed: UserMessageBlock = {
+        type: "user_message",
+        ctx: {
+          agent: null,
+          depth: 0,
+          turn: 0,
+          timestamp: 0,
+          responseId: "",
+          itemId: "msg_raced",
+        },
+        content: [{ type: "input_text", text: "already here" }],
+      };
+      useChatStore.setState({
+        blocks: [committed],
+        pendingUserMessages: [
+          { tempId: "pend_1", content: [{ type: "input_text", text: "already here" }] },
+        ],
+      });
+
+      handleSessionEvent({
+        type: "session_input_consumed",
+        itemId: "msg_raced",
+        itemType: "message",
+        clearedPendingId: "pend_1",
+        data: { role: "user", content: [{ type: "input_text", text: "already here" }] },
+      });
+
+      const state = useChatStore.getState();
+      // No duplicate bubble, and nothing left pinned to the bottom.
+      expect(state.blocks).toEqual([committed]);
+      expect(state.pendingUserMessages).toEqual([]);
+    });
+
+    it("clears the bubble on an already-committed item the server names by an id we don't hold", () => {
+      // Same race as above, but the consumed event arrived before the POST
+      // returned the server pending id for us to adopt — so the entry is
+      // still keyed `pend_N` and the named id matches nothing. That is the
+      // normal shape of this race, not evidence the bubble is someone
+      // else's, so fall back to the FIFO head like branch 2 does. Bailing
+      // out here would strand the bubble.
+      const committed: UserMessageBlock = {
+        type: "user_message",
+        ctx: {
+          agent: null,
+          depth: 0,
+          turn: 0,
+          timestamp: 0,
+          responseId: "",
+          itemId: "msg_raced",
+        },
+        content: [{ type: "input_text", text: "already here" }],
+      };
+      useChatStore.setState({
+        blocks: [committed],
+        pendingUserMessages: [
+          { tempId: "pend_1", content: [{ type: "input_text", text: "already here" }] },
+        ],
+      });
+
+      handleSessionEvent({
+        type: "session_input_consumed",
+        itemId: "msg_raced",
+        itemType: "message",
+        clearedPendingId: "pending_srv_9",
+        data: { role: "user", content: [{ type: "input_text", text: "already here" }] },
+      });
+
+      const state = useChatStore.getState();
+      expect(state.blocks).toEqual([committed]);
+      expect(state.pendingUserMessages).toEqual([]);
+    });
   });
 
   describe("slash_command (claude-native skill / surfaced command)", () => {
@@ -4605,6 +4804,77 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
       // Same reference — no setState call fired.
       expect(useChatStore.getState()).toBe(before);
     });
+  });
+});
+
+describe("appendInWireOrder", () => {
+  it("hoists a late routing card above the reply it routed", () => {
+    // Issue #3983: the server publishes the card only after the router
+    // call and the runner forward, so it can land after the first deltas
+    // of its own turn. `renderItems` breaks bubble groups on
+    // `routing_decision`, so an in-place append paints the reply as two
+    // streaming bubbles split by the card.
+    const blocks = [
+      textBlock("resp_new", "msg_reply_a", "starting"),
+      textBlock("resp_new", "msg_reply_b", " work"),
+    ];
+    const out = appendInWireOrder(blocks, [routingCardBlock("resp_new", "item_card")], "resp_new");
+    expect(out.map((b) => b.ctx.itemId)).toEqual(["item_card", "msg_reply_a", "msg_reply_b"]);
+  });
+
+  it("never hoists a card past its own turn", () => {
+    // The walk stops at the first block of another response, so a card
+    // stays inside the turn it describes even when earlier turns sit
+    // directly above it.
+    const blocks = [
+      textBlock("resp_prev", "msg_prev", "earlier reply"),
+      textBlock("resp_new", "msg_reply", "starting"),
+    ];
+    const out = appendInWireOrder(blocks, [routingCardBlock("resp_new", "item_card")], "resp_new");
+    expect(out.map((b) => b.ctx.itemId)).toEqual(["msg_prev", "item_card", "msg_reply"]);
+  });
+
+  it("leaves a card that already leads its turn untouched", () => {
+    // The common (non-racing) case must stay a plain append — same order,
+    // and the blocks that were already committed keep their references so
+    // the renderer's incremental bubble cache still applies.
+    const prior = textBlock("resp_prev", "msg_prev", "earlier reply");
+    const card = routingCardBlock("resp_new", "item_card");
+    const out = appendInWireOrder([prior], [card], "resp_new");
+    expect(out).toEqual([prior, card]);
+    expect(out[0]).toBe(prior);
+  });
+
+  it("passes through blocks that are not routing cards", () => {
+    const prior = textBlock("resp_prev", "msg_prev", "earlier reply");
+    const fresh = textBlock("resp_new", "msg_reply", "starting");
+    expect(appendInWireOrder([prior], [fresh], "resp_new")).toEqual([prior, fresh]);
+  });
+
+  it("leaves a card stamped with a non-streaming response alone", () => {
+    // The chip ships with no `response_id` on the wire, so blockStream
+    // stamps it from `state.responseId` — which, for a card arriving BEFORE
+    // its own `response.created` (the intended order), is still the
+    // PREVIOUS turn's id. Walking back on that id would hoist the chip
+    // above the previous turn's reply. Only a card matching the streaming
+    // response may move.
+    const blocks = [
+      textBlock("resp_prev", "msg_prev_a", "earlier"),
+      textBlock("resp_prev", "msg_prev_b", " reply"),
+    ];
+    const stale = routingCardBlock("resp_prev", "item_card");
+    // Prior turn finished; nothing is streaming yet.
+    expect(appendInWireOrder(blocks, [stale], null).map((b) => b.ctx.itemId)).toEqual([
+      "msg_prev_a",
+      "msg_prev_b",
+      "item_card",
+    ]);
+    // A different turn streaming must not license the walk either.
+    expect(appendInWireOrder(blocks, [stale], "resp_new").map((b) => b.ctx.itemId)).toEqual([
+      "msg_prev_a",
+      "msg_prev_b",
+      "item_card",
+    ]);
   });
 });
 

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -4789,13 +4789,23 @@ export function handleSessionEvent(event: StreamEvent): void {
         if (head) {
           const content = committedContentFor(event, head.content);
           if (content === null) return {};
+          // The head's wire position describes the head's message. In a
+          // SHARED session this branch also catches another viewer's
+          // consumed event — it names a server pending id we don't hold,
+          // which is indistinguishable from our own POST not having
+          // returned its id yet — and slotting their message into our
+          // reserved position would lift it above blocks that preceded
+          // it. When the event names an author who isn't us, append (the
+          // behaviour before wire positions existed) instead.
+          const author = event.createdBy;
+          const isForeign = author !== undefined && author !== getCurrentAuthorId();
           return commitUserBlockInPlace(
             s.blocks,
             s.pendingUserMessages.slice(1),
             // stableKey = the popped optimistic bubble's temp id so the
             // promoted bubble keeps the same React key (no remount/flink).
             committedUserBlock(event.itemId, content, head.tempId, event.createdBy ?? head.author),
-            head.anchorIndex,
+            isForeign ? undefined : head.anchorIndex,
           );
         }
 

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -148,6 +148,19 @@ export interface PendingUserMessage {
    * on snapshot-replayed entries (they're already server-owned).
    */
   posted?: boolean;
+  /**
+   * The message's wire position: how many blocks were committed when it
+   * was sent. The optimistic bubble renders at the bottom of the
+   * transcript, but the promoted block belongs HERE — before everything
+   * the send itself caused — so the consumed handler splices it in at
+   * this index instead of appending (see the consumed handler and
+   * {@link commitUserBlockInPlace}).
+   *
+   * Unset on snapshot-replayed entries and on bubbles restored from the
+   * navigate-back stash: those carry no position relative to the blocks
+   * array they land in, so they fall back to append-on-consumed.
+   */
+  anchorIndex?: number;
 }
 
 /**
@@ -1231,7 +1244,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set((s) => ({
       pendingUserMessages: [
         ...s.pendingUserMessages,
-        { tempId, content, ...(selfAuthor !== null ? { author: selfAuthor } : {}) },
+        {
+          tempId,
+          content,
+          anchorIndex: s.blocks.length,
+          ...(selfAuthor !== null ? { author: selfAuthor } : {}),
+        },
       ],
       // A new turn supersedes the prior turn's background-shell tally: the
       // "N background tasks still running" label must give way to "Working…" the
@@ -1425,6 +1443,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         {
           tempId,
           content: [{ type: "input_text" as const, text: commandText }],
+          anchorIndex: s.blocks.length,
           ...(selfAuthor !== null ? { author: selfAuthor } : {}),
         },
       ],
@@ -1609,9 +1628,13 @@ export const useChatStore = create<ChatState>((set, get) => ({
         // Stashing a settled bubble is what stranded image-only messages
         // forever (committed while away + consumed event missed → no
         // pending_inputs entry left, no text for the dedupe to match).
-        const own = s.pendingUserMessages.filter(
-          (p) => p.tempId.startsWith("pend_") && p.posted !== true,
-        );
+        // `anchorIndex` is an index into THIS session's blocks array, which
+        // the switch below clears — drop it so a restored bubble can't
+        // splice itself into an unrelated position on navigate-back. A
+        // stash-restored bubble appends on consumption, as before.
+        const own = s.pendingUserMessages
+          .filter((p) => p.tempId.startsWith("pend_") && p.posted !== true)
+          .map(({ anchorIndex: _droppedAnchor, ...rest }) => rest);
         if (own.length > 0) {
           // Capture the committed user texts present NOW as the dedup
           // baseline: on navigate-back only committed messages new since this
@@ -3735,7 +3758,16 @@ export async function pumpStreamEvents(
         );
       }
       if (fresh.length === 0) return extra ?? {};
-      return { ...(extra ?? {}), blocks: [...s.blocks, ...fresh] };
+      // Read the active response from THIS commit's patch when it carries
+      // one (the `response_start` flush sets it alongside its blocks), else
+      // from current state — so a card batched with its own turn opening
+      // still sees a streaming turn to anchor to.
+      const active = extra?.activeResponse !== undefined ? extra.activeResponse : s.activeResponse;
+      const streamingResponseId = active?.state === "streaming" ? active.responseId : null;
+      return {
+        ...(extra ?? {}),
+        blocks: appendInWireOrder(s.blocks, fresh, streamingResponseId),
+      };
     });
   };
 
@@ -3958,6 +3990,102 @@ function userContentFromEvent(event: SessionInputConsumedEvent): MessageContentB
 
 function hasCommittedItem(blocks: AnyBlock[], itemId: string): boolean {
   return itemId !== "" && blocks.some((block) => block.ctx.itemId === itemId);
+}
+
+/**
+ * Append streamed blocks, keeping each routing-decision card at the head
+ * of the turn it describes.
+ *
+ * The server publishes the card only after the blocking router call and
+ * the runner forward, so on a routed turn it can lose the race against
+ * the first deltas of the very response it routed. Appended where it
+ * lands, it splits the reply: `renderItems` starts a new bubble group on
+ * `routing_decision`, so the same response paints as text, then the
+ * card, then a second bubble that reads as the stream restarting
+ * (issue #3983). Slot the card in ahead of the contiguous run of blocks
+ * already committed for its own response instead — the position the
+ * persisted order gives it.
+ *
+ * Only a card belonging to the response that is CURRENTLY STREAMING is
+ * moved, and that guard is load-bearing rather than defensive. The
+ * server publishes the chip with no `response_id` on the wire, so
+ * `blockStream` stamps it with whatever `state.responseId` holds — which
+ * between turns is still the PREVIOUS turn's id. A card that arrives
+ * ahead of its own `response.created` (the intended, non-racing order)
+ * therefore carries the prior turn's id, and walking back on that would
+ * hoist it above the prior turn's reply. Requiring a streaming match
+ * confines the walk to the turn the card actually routed.
+ *
+ * The walk additionally stops at the first block of another response (or
+ * a user message, whose responseId is ""), so a card can never jump a
+ * turn boundary; a card that already leads its turn is left untouched.
+ *
+ * @param blocks - Current committed blocks.
+ * @param fresh - Newly streamed blocks to commit.
+ * @param streamingResponseId - Id of the response currently streaming, or null when none is.
+ * @returns The new blocks array.
+ */
+export function appendInWireOrder(
+  blocks: AnyBlock[],
+  fresh: AnyBlock[],
+  streamingResponseId: string | null,
+): AnyBlock[] {
+  const out = [...blocks, ...fresh];
+  if (streamingResponseId === null) return out;
+  for (const block of fresh) {
+    if (block.type !== "routing_decision") continue;
+    const responseId = block.ctx.responseId;
+    if (!responseId || responseId !== streamingResponseId) continue;
+    // Re-find the card: an earlier hoist in this batch may have moved it.
+    const card = out.lastIndexOf(block);
+    let at = card;
+    while (at > 0 && out[at - 1]!.ctx.responseId === responseId) at -= 1;
+    if (at === card) continue;
+    out.splice(card, 1);
+    out.splice(at, 0, block);
+  }
+  return out;
+}
+
+/**
+ * Commit a promoted user block at the position its message occupied on
+ * the wire, and keep the still-optimistic bubbles anchored.
+ *
+ * Appending on consumption puts the message below everything that
+ * committed while it was optimistic — and on a smart-routed turn that
+ * window spans the router LLM call and the runner forward, so the reply
+ * starts streaming (and the routing card lands) before the message is
+ * promoted. Appending then freezes that inversion into the live view:
+ * the user's own message renders under the answer to it until reload.
+ * Splicing at `anchorIndex` (the block count at send time) puts it back
+ * where the persisted order has it. See issue #3983.
+ *
+ * Promotions are FIFO, so a burst of sends shares an anchor; each splice
+ * shifts the anchors at or after it by one, keeping the burst in order.
+ *
+ * @param blocks - Current committed blocks.
+ * @param pending - Optimistic bubbles remaining AFTER removing the promoted one.
+ * @param block - The committed user block to place.
+ * @param anchorIndex - The promoted message's wire position, or undefined to append.
+ */
+function commitUserBlockInPlace(
+  blocks: AnyBlock[],
+  pending: PendingUserMessage[],
+  block: UserMessageBlock,
+  anchorIndex: number | undefined,
+): { blocks: AnyBlock[]; pendingUserMessages: PendingUserMessage[] } {
+  if (anchorIndex === undefined) {
+    return { blocks: [...blocks, block], pendingUserMessages: pending };
+  }
+  const at = Math.min(Math.max(anchorIndex, 0), blocks.length);
+  return {
+    blocks: [...blocks.slice(0, at), block, ...blocks.slice(at)],
+    pendingUserMessages: pending.map((p) =>
+      p.anchorIndex !== undefined && p.anchorIndex >= at
+        ? { ...p, anchorIndex: p.anchorIndex + 1 }
+        : p,
+    ),
+  };
 }
 
 /**
@@ -4606,7 +4734,31 @@ export function handleSessionEvent(event: StreamEvent): void {
       //   3. No pending entry — render the event payload as a fresh
       //      committed bubble (TUI-typed message, or another client).
       useChatStore.setState((s) => {
-        if (hasCommittedItem(s.blocks, event.itemId)) return {};
+        // Already committed (a snapshot merge or the native transcript
+        // relay won the race). The block is in place, but the optimistic
+        // bubble is NOT — and no second consumed event is coming, so
+        // returning here without popping it strands the user's message at
+        // the bottom of the transcript for the rest of the session
+        // (issue #3983). Pop the entry this event names, by the same
+        // id-then-FIFO precedence used below.
+        if (hasCommittedItem(s.blocks, event.itemId)) {
+          const clearedId = event.clearedPendingId;
+          const namedIdx = clearedId
+            ? s.pendingUserMessages.findIndex((p) => p.tempId === clearedId)
+            : -1;
+          // Fall back to the FIFO head exactly as branch 2 does: a named id
+          // we don't hold is the normal shape of the race this branch exists
+          // for (the POST hasn't returned the server id to adopt yet), NOT
+          // evidence that the bubble belongs to someone else.
+          const strandedIdx = namedIdx >= 0 ? namedIdx : s.pendingUserMessages.length > 0 ? 0 : -1;
+          if (strandedIdx < 0) return {};
+          return {
+            pendingUserMessages: [
+              ...s.pendingUserMessages.slice(0, strandedIdx),
+              ...s.pendingUserMessages.slice(strandedIdx + 1),
+            ],
+          };
+        }
 
         // 1. Drop by id when the server names the drained entry.
         const cleared = event.clearedPendingId;
@@ -4616,23 +4768,19 @@ export function handleSessionEvent(event: StreamEvent): void {
             const matched = s.pendingUserMessages[idx]!;
             const content = committedContentFor(event, matched.content);
             if (content === null) return {};
-            return {
-              pendingUserMessages: [
-                ...s.pendingUserMessages.slice(0, idx),
-                ...s.pendingUserMessages.slice(idx + 1),
-              ],
+            return commitUserBlockInPlace(
+              s.blocks,
+              [...s.pendingUserMessages.slice(0, idx), ...s.pendingUserMessages.slice(idx + 1)],
               // stableKey = the optimistic bubble's temp id → the
               // promoted bubble keeps the same React key (no remount).
-              blocks: [
-                ...s.blocks,
-                committedUserBlock(
-                  event.itemId,
-                  content,
-                  matched.tempId,
-                  event.createdBy ?? matched.author,
-                ),
-              ],
-            };
+              committedUserBlock(
+                event.itemId,
+                content,
+                matched.tempId,
+                event.createdBy ?? matched.author,
+              ),
+              matched.anchorIndex,
+            );
           }
         }
 
@@ -4641,20 +4789,14 @@ export function handleSessionEvent(event: StreamEvent): void {
         if (head) {
           const content = committedContentFor(event, head.content);
           if (content === null) return {};
-          return {
-            pendingUserMessages: s.pendingUserMessages.slice(1),
+          return commitUserBlockInPlace(
+            s.blocks,
+            s.pendingUserMessages.slice(1),
             // stableKey = the popped optimistic bubble's temp id so the
             // promoted bubble keeps the same React key (no remount/flink).
-            blocks: [
-              ...s.blocks,
-              committedUserBlock(
-                event.itemId,
-                content,
-                head.tempId,
-                event.createdBy ?? head.author,
-              ),
-            ],
-          };
+            committedUserBlock(event.itemId, content, head.tempId, event.createdBy ?? head.author),
+            head.anchorIndex,
+          );
         }
 
         // 3. Nothing pending — render the event payload fresh.


### PR DESCRIPTION
## Issues
Fixes #3983.

## Problem
On the first turn of a smart-routed session the transcript renders out of order in the live view: the assistant reply streams *above* the just-sent user message, the routing-decision card pops in late, and the reply continues in a second bubble below the card (reading as the stream restarting). Reloading shows the correct order — the persisted order is fine, so this is purely a live-rendering defect.

## Root cause
A user message is the only transcript content with no position of its own.

Every other block flows through the stream reducer and is appended in arrival order, which is correct because they all come off one ordered SSE stream. The user's own message takes a different route: an optimistic bubble pinned to the bottom of the transcript, then injected out-of-band by the `session.input.consumed` handler whenever the ack happens to land.

Smart routing withholds that ack across the blocking router LLM call *and* the runner forward (`orchestration.py`), so blocks commit during the window — and appending on promotion freezes the inversion into the live view for the rest of the session.

## Fix

Record the send's wire position, and honour it on both sides of the optimistic/committed boundary.

- **`PendingUserMessage.anchorIndex`** captures the block count at send time. `commitUserBlockInPlace` splices the promoted block in at that index instead of appending, bumping the anchors of the bubbles still in flight so a burst of sends promotes in order. Entries with no anchor (snapshot-replayed, stash-restored — their index would point into a different `blocks` array) keep the previous append behaviour.
- **`Bubble.blockStart`** records which block index each bubble was built from, so `mergePendingBubbles` can splice the *optimistic* bubble in at the same position rather than trailing it. Nothing jumps when the ack lands. The REQUEST-phase elicitation walk-back still applies on top of the chosen slot.

Two adjacent defects in the same path:

- The consumed handler returned early when the item was already committed (snapshot merge or native relay won the race) **without popping the pending entry**. Only one consumed event ever fires, so the optimistic bubble was stranded at the bottom of the transcript until reload. It now pops the entry the event names, falling back to the FIFO head — a named id we don't hold is the normal shape of the race this path exists for (the POST hasn't returned the server id to adopt yet), not evidence the bubble belongs to someone else.
- `renderItems` breaks bubble groups on `routing_decision`, so a card landing mid-response split the reply into two streaming bubbles sharing a `responseId`. `appendInWireOrder` now slots a card ahead of the blocks already committed for its own response.

## Notes on two non-obvious bits

**The routing chip ships with no `response_id` on the wire.** `_emit_server_routing_decision` publishes `{"item": {"id", "type", ...data}}` only, so `parseOutputItem` yields `responseId: ""` and `blockStream` stamps the block from `state.responseId` — which *between turns* is still the previous turn's id. The hoist is therefore restricted to the response that is currently streaming; without that guard, a card arriving ahead of its own `response.created` (the intended, non-racing order) would hoist above the previous turn's reply. (The persisted item instead carries its own synthetic `response_id = routing_<hex>`, matching nothing, so it renders standalone. Live and cold-load arrays differ structurally but render identically — verified deep-equal through `buildBubbles`.)

**No server change.** The issue notes that routing-mvp-v2 removes the most common trigger but not the underlying weakness, and that the durable fix is giving the user message a stable position. This PR does that and leaves the `orchestration.py` timing alone.

## Known adjacent bug, deliberately not fixed here

In a shared session, a teammate's `session.input.consumed` pops *your* optimistic bubble: branch 2's FIFO head is unconditional, and a non-matching `clearedPendingId` can't be used to reject it (that's the same shape as the POST race). `createdBy` vs viewer identity would disambiguate. Happy to file it separately.

## Testing

- 10 new tests in `web/src/store/chatStore.test.ts` (wire-position splice, FIFO burst ordering, no-anchor append, stranded-bubble pop by id and by FIFO fallback, card hoist, turn-boundary guard, non-streaming-response guard, pass-through).
- 5 new tests in `web/src/pages/ChatPage.test.ts` (`mergePendingBubbles` placement, trailing fallback, burst contiguity, no-anchor entries, composition with the request-elicitation walk-back).
- Verified the behavioural tests fail with the change reverted.
- Full `pnpm exec vitest run` suite green, plus `pnpm run type-check`, `pnpm run lint` (oxlint) and prettier.

## Manual repro

Needs a server with smart routing on (`smart_routing_enabled: true` in `/v1/info` — a server-level `llm:` block, or `routing: {provider: external, ...}`).

1. New session with the harness picker set to **Auto** (or, on a routable agent, composer gear → Model → **Smart Routing**).
2. Send the first message of the session.
3. Watch the transcript while the turn runs.

Expected: user message, routing-decision card, one streaming reply below it. It's a race, so it doesn't reproduce every time; native-terminal harnesses are the reliable case because they publish no `input.consumed` at all until the CLI echoes the text back.
