### PR TITLE
fix(web): one host-disconnect UX in the composer badge

### DIFF
--- a/tests/e2e_ui/sessions/test_host_badge.py
+++ b/tests/e2e_ui/sessions/test_host_badge.py
@@ -1,22 +1,31 @@
-"""E2E: the chat header's host badge shows which host a session is bound to.
+"""E2E: the composer's host badge shows which host a session is bound to.
 
-The badge (``ap-web/src/components/HostBadge.tsx``) renders at the top of the
-chat window for a host-bound session: the friendly host name (or a
+The badge (``web/src/components/HostBadge.tsx``) renders in the composer's
+status-line tray for a host-bound session: the friendly host name (or a
 sandbox-provider label) plus a green/red status dot driven by the live host
 ``host_online`` signal. It renders nothing when the session isn't host-bound.
+
+A DISCONNECTED host keeps that exact shape — name + red dot — and becomes
+clickable, opening the reconnect instructions. That one shape is the point: the
+badge must not swap the host's name for generic "Host is offline" copy in some
+disconnect states and keep it in others, which is what it used to do depending
+on whether the runner happened to outlive the host (see the reconnect tests
+below). A dormant *resumable* managed host is the deliberate exception: its
+offline is idle dormancy the next message wakes, so it stays passive.
 
 The harness seeds a normal runner-bound ``hello_world`` session, so the browser
 view is patched into a host-bound shape via route interception (same approach as
 ``test_host_asleep_composer.py``):
 
 - ``GET /v1/sessions/{id}`` (snapshot) → ``host_id`` set so the badge has a host
-  to resolve. ``host_resumable`` + an old ``created_at`` keep an offline host out
-  of the ``host_offline`` reconnect dead-end so the chat view stays normal.
+  to resolve, plus ``host_resumable`` and an old ``created_at`` (past the
+  ``STARTING_GRACE_S`` startup window).
 - ``GET /v1/hosts`` → returns the bound host so the badge resolves its name (or
   the sandbox-provider label). ``HostBadge`` calls this via
   ``useHosts({ includeSandbox: true })``.
-- ``GET /health`` → reports the session's live ``host_online`` so the dot reads
-  online/offline; the open-session poll overrides the WS stream.
+- ``GET /health`` → reports the session's live ``runner_online`` /
+  ``host_online`` so the dot reads online/offline; the open-session poll
+  overrides the WS stream.
 - ``GET /v1/sessions`` (sidebar list) → the session is dropped so the open row
   resolves off-sidebar from the patched snapshot (host-bound).
 - ``WS /v1/sessions/updates`` → blocked so a stream push can't revert liveness to
@@ -27,15 +36,32 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Iterator
 from urllib.parse import urlparse
 
+import pytest
 from playwright.sync_api import Page, Route, expect
 
 _FAKE_HOST_ID = "host_test_badge"
 # Unix seconds well before now so an offline host is outside the startup grace
-# (STARTING_GRACE_S) and reads host_asleep, not `starting` — see
+# (STARTING_GRACE_S) and reads its real liveness, not `starting` — see
 # useSessionLiveness. Harmless for the online case.
 _OLD_CREATED_AT = 1_700_000_000
+
+
+@pytest.fixture(autouse=True)
+def _drop_routes(page: Page) -> Iterator[None]:
+    """Drop this module's route handlers before the page closes.
+
+    Every test here leaves a ``/health`` poll and snapshot refetches in flight.
+    A handler that calls ``route.fetch()`` as the page tears down raises
+    ``TargetClosedError``, which surfaces as an error in the NEXT test's setup.
+
+    :param page: Playwright page fixture.
+    :returns: Iterator yielding once, then unrouting.
+    """
+    yield
+    page.unroute_all(behavior="ignoreErrors")
 
 
 def _patch_host_view(
@@ -44,6 +70,8 @@ def _patch_host_view(
     *,
     host: dict,
     host_online: bool,
+    runner_online: bool = False,
+    host_resumable: bool = True,
 ) -> None:
     """Patch the browser's view of ``session_id`` into a host-bound shape.
 
@@ -55,6 +83,15 @@ def _patch_host_view(
         host (``host_id`` is overwritten to match the patched snapshot).
     :param host_online: Live ``host_online`` the session reports via ``/health``;
         drives the badge's online (green) vs offline (red) dot.
+    :param runner_online: Live ``runner_online`` the session reports via
+        ``/health``. With the host down, ``True`` is the runner-outlives-host
+        case (liveness stays ``online``) and ``False`` is the fully-unreachable
+        one (``host_offline``) — the two states that used to render different
+        host indicators.
+    :param host_resumable: Whether the bound host is a resumable managed host.
+        ``True`` (the default) keeps an offline host out of the ``host_offline``
+        dead-end so the chat view renders normally; ``False`` is a real
+        laptop/external host the user reconnects with ``omnigent host``.
     """
     host = {**host, "host_id": _FAKE_HOST_ID}
 
@@ -66,9 +103,7 @@ def _patch_host_view(
         response = route.fetch()
         payload = response.json()
         payload["host_id"] = _FAKE_HOST_ID
-        # Keep an offline host out of the host_offline reconnect dead-end so the
-        # chat view (and its header) renders normally; harmless when online.
-        payload["host_resumable"] = True
+        payload["host_resumable"] = host_resumable
         payload["created_at"] = _OLD_CREATED_AT
         route.fulfill(
             status=200,
@@ -112,7 +147,7 @@ def _patch_host_view(
             return
         response = route.fetch()
         payload = response.json()
-        live = {"runner_online": False, "host_online": host_online}
+        live = {"runner_online": runner_online, "host_online": host_online}
         if isinstance(payload.get("sessions"), dict):
             payload["sessions"][session_id] = live
         if isinstance(payload.get("session"), dict):
@@ -166,7 +201,12 @@ def test_host_badge_shows_offline_when_host_unreachable(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """A host-bound session whose host is offline shows an offline status.
+    """A dormant resumable managed host shows offline, and stays passive.
+
+    ``host_resumable`` is the one offline host with no reconnect affordance: the
+    sandbox is idle-stopped and the next message wakes it, so ``omnigent host``
+    would be the wrong instruction. Every other offline host is clickable (see
+    the reconnect tests below).
 
     :param page: Playwright page fixture.
     :param seeded_session: ``(base_url, session_id)`` for a real server-backed
@@ -179,6 +219,7 @@ def test_host_badge_shows_offline_when_host_unreachable(
         session_id,
         host={"name": "e2e-host", "owner": "e2e", "status": "offline", "sandbox_provider": None},
         host_online=False,
+        host_resumable=True,
     )
 
     page.goto(f"{base_url}/c/{session_id}")
@@ -187,6 +228,127 @@ def test_host_badge_shows_offline_when_host_unreachable(
     expect(badge).to_be_visible(timeout=15_000)
     expect(badge).to_contain_text("e2e-host")
     expect(badge).to_have_attribute("title", "Host e2e-host, offline", timeout=15_000)
+    assert badge.evaluate("el => el.tagName") != "BUTTON"
+
+
+def test_host_badge_offline_host_keeps_name_while_runner_outlives_it(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A host that drops while its runner keeps streaming is still reconnectable.
+
+    Liveness still calls this session ``online`` (the runner tunnel is up), so
+    the badge used to render a passive name + red dot with no way to act on it.
+    It now carries the same reconnect affordance as any other dropped host.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` for a real server-backed
+        session; the browser view is patched to host-down + runner-up.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    _patch_host_view(
+        page,
+        session_id,
+        host={"name": "e2e-host", "owner": "e2e", "status": "offline", "sandbox_provider": None},
+        host_online=False,
+        runner_online=True,
+        host_resumable=False,
+    )
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    badge = page.get_by_test_id("host-badge")
+    expect(badge).to_be_visible(timeout=15_000)
+    expect(badge).to_contain_text("e2e-host")
+    expect(badge).to_have_attribute(
+        "title", "Host e2e-host, offline — click to reconnect", timeout=15_000
+    )
+    assert badge.evaluate("el => el.tagName") == "BUTTON"
+    # The runner is alive, so the session itself is still usable — the offline
+    # host must not block the composer here.
+    expect(page.get_by_label("Message the agent")).not_to_be_disabled()
+
+
+def test_host_badge_offline_host_keeps_name_when_runner_is_down_too(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A fully unreachable session names its dropped host instead of generic copy.
+
+    This is the ``host_offline`` liveness state, which used to replace the host
+    name with "Host is offline — click to reconnect". The name is what tells the
+    user WHICH machine to go restart, so it stays; the separate band below the
+    composer stays suppressed.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` for a real server-backed
+        session; the browser view is patched to host-down + runner-down.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    _patch_host_view(
+        page,
+        session_id,
+        host={"name": "e2e-host", "owner": "e2e", "status": "offline", "sandbox_provider": None},
+        host_online=False,
+        runner_online=False,
+        host_resumable=False,
+    )
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    badge = page.get_by_test_id("host-badge")
+    expect(badge).to_be_visible(timeout=15_000)
+    expect(badge).to_contain_text("e2e-host")
+    expect(badge).to_have_attribute(
+        "title", "Host e2e-host, offline — click to reconnect", timeout=15_000
+    )
+    assert badge.evaluate("el => el.tagName") == "BUTTON"
+    # The badge owns the affordance; the old band below the composer stays away.
+    expect(page.get_by_test_id("disconnected-indicator")).to_have_count(0)
+
+
+def test_host_badge_click_shows_host_reconnect_instructions(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Clicking the offline host badge opens the host reconnect instructions.
+
+    Driven from the runner-still-up case: liveness reads ``online`` there, so
+    the dialog's state must come from the session's host binding — otherwise it
+    would hand out the local ``omnigent run --resume`` command for a session
+    whose host is what actually needs restarting.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` for a real server-backed
+        session; the browser view is patched to host-down + runner-up.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    _patch_host_view(
+        page,
+        session_id,
+        host={"name": "e2e-host", "owner": "e2e", "status": "offline", "sandbox_provider": None},
+        host_online=False,
+        runner_online=True,
+        host_resumable=False,
+    )
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    badge = page.get_by_test_id("host-badge")
+    expect(badge).to_be_visible(timeout=15_000)
+    badge.click()
+
+    dialog = page.get_by_test_id("reconnect-session-dialog")
+    expect(dialog).to_be_visible(timeout=15_000)
+    expect(dialog).to_contain_text("Host is offline")
+    page.get_by_test_id("reconnect-session-tab-reconnect").click()
+    expect(page.get_by_test_id("reconnect-session-description")).to_contain_text(
+        "This session's host"
+    )
+    expect(page.get_by_test_id("reconnect-session-command")).to_contain_text("omnigent host")
 
 
 def test_host_badge_labels_sandbox_session_by_provider(

--- a/web/src/components/HostBadge.test.tsx
+++ b/web/src/components/HostBadge.test.tsx
@@ -218,29 +218,43 @@ describe("HostBadge", () => {
     expect(screen.getByTestId("host-badge").textContent).toBe("mac-laptop, status unknown");
   });
 
-  it("renders a clickable reconnect affordance in the badge slot when onReconnect is set", () => {
-    // host_offline moves the reconnect prompt up into the host badge: the
-    // passive name + dot is replaced by a button carrying the host-offline
-    // copy, and clicking it opens the reconnect help.
-    useHostsMock.mockReturnValue({
-      data: [
-        {
-          host_id: "host_a1b2",
-          name: "mac-laptop",
-          owner: "alice",
-          status: "offline",
-          sandbox_provider: null,
-        },
-      ],
-    });
+  it("keeps the host name while making an offline host clickable to reconnect", () => {
+    // The one disconnect shape: name + red dot, never swapped for generic
+    // "Host is offline" copy — the user must still read WHICH host dropped —
+    // and clicking it opens the reconnect help.
     useSessionHostOnlineMock.mockReturnValue(false);
     const onReconnect = vi.fn();
     render(<HostBadge sessionId="conv_1" onReconnect={onReconnect} />);
     const badge = screen.getByTestId("host-badge");
     expect(badge.tagName).toBe("BUTTON");
-    expect(badge.textContent).toMatch(/Host is offline/);
+    expect(badge.textContent).toBe("mac-laptop, offline — click to reconnect");
+    expect(badge.getAttribute("title")).toBe("Host mac-laptop, offline — click to reconnect");
     fireEvent.click(badge);
     expect(onReconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays passive for an online host even when onReconnect is set", () => {
+    // onReconnect is wired for every host-bound session; a reachable host has
+    // nothing to reconnect, so the badge must not become a button.
+    render(<HostBadge sessionId="conv_1" onReconnect={vi.fn()} />);
+    const badge = screen.getByTestId("host-badge");
+    expect(badge.tagName).not.toBe("BUTTON");
+    expect(badge.textContent).toBe("mac-laptop, online");
+  });
+
+  it("stays passive for a dormant resumable managed host", () => {
+    // A resumable sandbox host reads offline while idle-stopped, but the next
+    // message wakes it — offering `omnigent host` there would be wrong.
+    useSessionMock.mockReturnValue({
+      session: { hostId: "host_a1b2", hostResumable: true },
+      isLoading: false,
+      error: null,
+    });
+    useSessionHostOnlineMock.mockReturnValue(false);
+    render(<HostBadge sessionId="conv_1" onReconnect={vi.fn()} />);
+    const badge = screen.getByTestId("host-badge");
+    expect(badge.tagName).not.toBe("BUTTON");
+    expect(badge.textContent).toBe("mac-laptop, offline");
   });
 
   it("renders nothing when onReconnect is set but the session isn't host-bound", () => {

--- a/web/src/components/HostBadge.tsx
+++ b/web/src/components/HostBadge.tsx
@@ -1,5 +1,3 @@
-import { MonitorOff as MonitorOffIcon } from "lucide-react";
-
 import { useHosts } from "@/hooks/useHosts";
 import type { Host } from "@/hooks/useHosts";
 import { useSession } from "@/hooks/useSession";
@@ -57,6 +55,8 @@ const STATUS_WORD: Record<HostBadgeStatus, string> = {
   unknown: "status unknown",
 };
 
+const RECONNECT_WORD = "offline — click to reconnect";
+
 /**
  * Host indicator for the open conversation, rendered in the composer's
  * status-line tray, immediately left of the worktree branch
@@ -65,11 +65,17 @@ const STATUS_WORD: Record<HostBadgeStatus, string> = {
  * Shows the friendly host name (or sandbox-provider label) plus a status
  * circle: green online, red offline, neutral while liveness is still unknown.
  *
- * When `onReconnect` is set the session is unreachable because its host is
- * offline (`host_offline` liveness): the badge becomes a clickable "Host is
- * offline — click to reconnect" affordance in the same slot, replacing the
- * passive name + dot. This is what moves the reconnect prompt up beside the
- * host instead of a separate banner below the composer.
+ * The name + dot is the ONLY shape this badge takes — a disconnected host
+ * keeps its name so the user always reads which machine dropped. When the
+ * host tunnel is down and reconnecting is possible, the same name + red dot
+ * becomes a button that opens the reconnect instructions (`onReconnect`).
+ * A dormant resumable managed host is excluded: its "offline" is idle
+ * dormancy the next message wakes, not a disconnect to act on.
+ *
+ * @param sessionId - The open conversation whose host to show.
+ * @param onReconnect - Opens the reconnect help dialog. Wired by the caller
+ *   for every host-bound session; the badge itself decides when a host is
+ *   actually reconnectable.
  */
 export function HostBadge({
   sessionId,
@@ -99,40 +105,50 @@ export function HostBadge({
   const badge = resolveHostBadge({ hostId, host, online });
   if (!badge) return null;
 
-  if (onReconnect) {
-    return (
-      <button
-        type="button"
-        data-testid="host-badge"
-        onClick={onReconnect}
-        className="flex min-w-0 items-center gap-1.5 text-xs text-destructive underline-offset-2 hover:underline"
-        title="Host is offline — click to reconnect"
-      >
-        <span aria-hidden className="size-2 shrink-0 rounded-full bg-destructive" />
-        <MonitorOffIcon className="size-3.5 shrink-0" aria-hidden />
-        <span className="truncate">Host is offline — click to reconnect</span>
-      </button>
-    );
-  }
-
-  return (
-    <div
-      data-testid="host-badge"
-      className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground"
-      title={`Host ${badge.label}, ${STATUS_WORD[badge.status]}`}
-    >
+  // A resumable managed host that reports offline is idle-stopped, not
+  // disconnected — the next message resumes it, and `omnigent host` (what the
+  // reconnect dialog hands out) is the wrong instruction for it.
+  const reconnectable = badge.status === "offline" && !session?.hostResumable && !!onReconnect;
+  const statusWord = reconnectable ? RECONNECT_WORD : STATUS_WORD[badge.status];
+  // The dot is decorative (aria-hidden), so the status would otherwise be
+  // conveyed by color alone. Restate it in sr-only text — read together with
+  // the visible label, a screen reader announces "<host>, <status>". `title`
+  // carries the same text for mouse hover.
+  const content = (
+    <>
       <span
         aria-hidden
         className={cn("size-2 shrink-0 rounded-full", STATUS_DOT_CLASS[badge.status])}
       />
       <span className="truncate">{badge.label}</span>
-      {/* The dot is decorative (aria-hidden), so the status would otherwise be
-          conveyed by color alone. Restate it in sr-only text — read together
-          with the visible label, a screen reader announces "<host>, <status>".
-          `title` carries the same text for mouse hover. No aria-label: on a
-          non-interactive div it's announced unreliably and would only
-          duplicate this text where it is honored. */}
-      <span className="sr-only">, {STATUS_WORD[badge.status]}</span>
+      <span className="sr-only">, {statusWord}</span>
+    </>
+  );
+  const title = `Host ${badge.label}, ${statusWord}`;
+
+  if (reconnectable) {
+    return (
+      <button
+        type="button"
+        data-testid="host-badge"
+        onClick={onReconnect}
+        className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+        title={title}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    // No aria-label: on a non-interactive div it's announced unreliably and
+    // would only duplicate the sr-only text where it is honored.
+    <div
+      data-testid="host-badge"
+      className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground"
+      title={title}
+    >
+      {content}
     </div>
   );
 }

--- a/web/src/pages/ChatPage.statusLine.test.tsx
+++ b/web/src/pages/ChatPage.statusLine.test.tsx
@@ -319,20 +319,30 @@ describe("Composer status line (branch + context ring)", () => {
   });
 
   it("turns the host badge into a clickable reconnect prompt for an offline host", () => {
-    // host_offline surfaces the reconnect affordance in the host badge (in
-    // place of the old banner below the composer): the tray shows even with
-    // no branch/ring, and clicking the badge opens the reconnect help.
+    // An offline host surfaces the reconnect affordance in the host badge (in
+    // place of the old banner below the composer) while keeping the host name:
+    // the tray shows even with no branch/ring, and clicking opens the help.
     bindHost("mac-laptop");
     useSessionHostOnlineMock.mockReturnValue(false);
+    useChatStore.setState({ gitBranch: null, contextWindow: null, tokensUsed: null });
     const onShowReconnectHelp = vi.fn();
-    renderComposer({ hostOffline: true, onShowReconnectHelp });
+    renderComposer({ onShowReconnectHelp });
 
     expect(statusLine()).not.toBeNull();
     const badge = screen.getByTestId("host-badge");
     expect(badge.tagName).toBe("BUTTON");
-    expect(badge).toHaveTextContent(/Host is offline/);
+    expect(badge).toHaveTextContent("mac-laptop");
     badge.click();
     expect(onShowReconnectHelp).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the tray hidden for a session with no host and nothing else to show", () => {
+    // onShowReconnectHelp is now passed for every session, so it must not
+    // resurrect an empty tray on a session with no host badge to hang it on.
+    useChatStore.setState({ gitBranch: null, contextWindow: null, tokensUsed: null });
+    renderComposer({ onShowReconnectHelp: vi.fn() });
+
+    expect(statusLine()).toBeNull();
   });
 
   it("hides the host badge on a sub-agent session", () => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1156,13 +1156,16 @@ export function ChatPage() {
   // the CLI instructions instead so users learn the right entry point.
   if (!urlConvId) return <NewChatLandingScreen />;
 
-  // Pick the reconnect dialog's state from liveness. The dialog only
-  // opens for the two unreachable variants; `host_offline` carries
-  // ownership (a non-owner can't reach the host machine). Any other
-  // liveness defaults to `local_stranded` — harmless since the dialog
-  // stays closed unless an unreachable interaction opened it.
-  const reconnectState = liveness.kind === "host_offline" ? "host_offline" : "local_stranded";
-  const reconnectIsOwner = liveness.kind === "host_offline" ? liveness.isOwner : true;
+  // Pick the reconnect dialog's state from the session's host binding, not
+  // from liveness: the dialog opens both from an unreachable send AND from the
+  // composer's host badge, which offers reconnect whenever the host tunnel is
+  // down — including states liveness still calls reachable (a runner that
+  // outlived its host). A host-bound session always reconnects via
+  // `omnigent host`; only an unbound one relaunches locally. Ownership gates
+  // the host command — a non-owner can't reach that machine.
+  const hostBound = !!(activeSession?.hostId ?? activeConv?.host_id);
+  const reconnectState = hostBound ? "host_offline" : "local_stranded";
+  const reconnectIsOwner = isOwnerLevel(permissionLevel);
 
   return (
     <SessionSharedContext.Provider value={isSessionShared}>
@@ -1882,7 +1885,6 @@ function MainAgentSurface({
           !sandboxLaunching &&
           (liveness.kind === "host_offline" || liveness.kind === "local_stranded")
         }
-        hostOffline={!sandboxLaunching && liveness.kind === "host_offline"}
         onShowReconnectHelp={onShowReconnectHelp}
         costRoutingEligible={costRoutingEligible}
         subAgentLabel={subAgentLabel}
@@ -2759,14 +2761,13 @@ export function ConnectionIndicator({
     return null;
   }
   if (unreachable) {
-    // A `host_offline` session moves the reconnect affordance up into the
-    // composer's host badge (ComposerStatusLine), where the host is already
-    // named — so render nothing here whenever that composer is on screen
-    // (sub-agent sessions included; their badge carries it just like a normal
-    // session's). The composer is hidden only in the terminal-first *terminal*
-    // view (the PTY owns the surface); there the banner still carries the
-    // affordance. `local_stranded` keeps the banner everywhere (no host, hence
-    // no badge).
+    // A host-bound session carries the reconnect affordance in the composer's
+    // host badge (ComposerStatusLine), which names the host that dropped — so
+    // render nothing here whenever that composer is on screen (sub-agent
+    // sessions included; their badge carries it just like a normal session's).
+    // The composer is hidden only in the terminal-first *terminal* view (the
+    // PTY owns the surface); there the banner still carries the affordance.
+    // `local_stranded` keeps the banner everywhere (no host, hence no badge).
     const composerOnScreen = !(terminalFirst?.isTerminalFirst && terminalFirst.view === "terminal");
     if (liveness.kind === "host_offline" && composerOnScreen) {
       return null;
@@ -3512,13 +3513,10 @@ interface ComposerProps {
    */
   unreachable?: boolean;
   /**
-   * The session is host-bound to an offline, non-resumable host
-   * (`host_offline`): the composer's host badge turns into a clickable
-   * "Host is offline — click to reconnect" affordance (see HostBadge's
-   * `onReconnect`), replacing the separate banner below the composer.
+   * Open the reconnect help dialog. Always wired to the status line's host
+   * badge, which turns itself into a clickable reconnect affordance whenever
+   * its bound host is offline and reconnectable.
    */
-  hostOffline?: boolean;
-  /** Open the reconnect help dialog — wired to the host badge when `hostOffline`. */
   onShowReconnectHelp?: () => void;
   /** Session passes `isCostRoutingSession` (polly orchestrator, not a child); see that predicate. */
   costRoutingEligible?: boolean;
@@ -3740,10 +3738,9 @@ function ComposerStatusLine({
   goal: Goal | null;
   isSubAgentSession: boolean;
   /**
-   * When set (`host_offline` liveness), the host badge becomes a clickable
-   * "Host is offline — click to reconnect" affordance. Also forces the tray
-   * to render even when it would otherwise be empty, so the prompt is always
-   * visible for an unreachable host.
+   * Opens the reconnect help dialog, handed to the host badge — which turns
+   * itself into a clickable reconnect affordance when its bound host is
+   * offline and reconnectable.
    */
   onHostReconnect?: () => void;
 }) {
@@ -3773,19 +3770,14 @@ function ComposerStatusLine({
   // contextWindow > 0: the SSE path validates it but the snapshot path doesn't, and 0/0 → "NaN%".
   const showRing =
     !!conversationId && contextWindow != null && contextWindow > 0 && tokensUsed != null;
-  // The offline-host reconnect affordance lives in the host badge, so the tray
-  // must render even when every other slot is empty (an unreachable session
-  // often has no branch/ring yet). Gated by `showHost`: only host-bound
-  // sessions can be `host_offline`, and sub-agents (which hide the badge) are
-  // never host-bound — a stranded child is `local_stranded`, which keeps its
-  // banner elsewhere.
-  const showReconnect = showHost && !!onHostReconnect;
   // A host-bound session shows the badge, so the tray must render for it even
   // with no branch/ring yet — otherwise the host + context footer vanishes for
   // sessions with no worktree branch (e.g. codex) until the ring populates.
+  // This also keeps the offline host's reconnect affordance on screen, since
+  // the badge is where it lives and an unreachable session often has no
+  // branch/ring at all.
   const showHostBadge = showHost && isHostBound;
-  if (!showBranch && !showPlanMode && !showGoal && !showRing && !showReconnect && !showHostBadge)
-    return null;
+  if (!showBranch && !showPlanMode && !showGoal && !showRing && !showHostBadge) return null;
 
   return (
     <div
@@ -3940,7 +3932,6 @@ export function Composer({
   reconnectHint = false,
   sandboxAsleepHint = false,
   unreachable = false,
-  hostOffline = false,
   onShowReconnectHelp,
   costRoutingEligible = false,
   subAgentLabel = null,
@@ -5167,7 +5158,7 @@ export function Composer({
       <ComposerStatusLine
         goal={goal}
         isSubAgentSession={subAgentLabel != null}
-        onHostReconnect={hostOffline ? onShowReconnectHelp : undefined}
+        onHostReconnect={onShowReconnectHelp}
       />
     </form>
   );


### PR DESCRIPTION
## Related issue

N/A

## Summary

A dropped host rendered **two different indicators** in the composer's status line depending on incidental state. The badge read the host tunnel directly (name + red dot), while `ChatPage` passed a *separate* `hostOffline` prop derived from `liveness.kind === "host_offline"` that replaced the host name with generic "Host is offline — click to reconnect" copy.

`host_offline` is far narrower than "the host tunnel is down" (`useSessionLiveness.ts`): it also requires the runner to be down (a live runner short-circuits to `online` first), the 45s startup grace to have lapsed, and the host to be non-resumable. So the same physical event produced different UI:

| host tunnel down, and… | before | after |
|---|---|---|
| runner still alive (host dropped mid-turn) | `● MGCW6F7Y3M` — **not clickable**, no way to act | `● MGCW6F7Y3M` — clickable |
| runner also dead (`host_offline`) | `●⃠ Host is offline — click to reconnect` — **name gone** | `● MGCW6F7Y3M` — clickable |
| dormant resumable managed host | `● MGCW6F7Y3M` — passive | unchanged (passive, by design) |

The badge now owns the decision: **one shape — host name + status dot** — that becomes a button opening the reconnect instructions whenever its bound host is offline and reconnectable. The name is what tells the user *which machine* to go restart, so it never gets thrown away. A dormant **resumable** managed host stays passive on purpose — the next message wakes it, so `omnigent host` would be wrong advice.

The reconnect dialog's state now derives from the session's **host binding** rather than liveness, so a session whose runner outlived its host gets the `omnigent host` command instead of the local `omnigent run --resume` one.

<details>
<summary>ELI5 + signal flow</summary>

Two parts of the UI were each deciding "is the host down?" using different rules, so they disagreed. Now only the badge decides, and everyone else just hands it the "open the reconnect help" callback.

```
                          BEFORE                                 AFTER

  useSessionHostOnline ──► dot color (red)            useSessionHostOnline ─┐
                                                                            ├─► HostBadge
  useSessionLiveness ────► liveness.kind               session.hostResumable ┘     │
         │                      │                                                  │
         └── host_offline? ─────┴──► hostOffline prop ──► ChatPage ── onShowReconnectHelp ──┘
                                          │                             (always wired)
                                          ▼
                                   badge REPLACES the
                                   name with generic copy
```
</details>

## Test Plan

**Automated**

- `tests/e2e_ui/sessions/test_host_badge.py` — 3 new e2e tests covering the states that used to diverge, plus a non-clickability assertion on the resumable case:
  - `test_host_badge_offline_host_keeps_name_while_runner_outlives_it` — host down + runner up (liveness reads `online`)
  - `test_host_badge_offline_host_keeps_name_when_runner_is_down_too` — host down + runner down (`host_offline`); also asserts the old band below the composer stays suppressed
  - `test_host_badge_click_shows_host_reconnect_instructions` — click → dialog hands out `omnigent host`, driven from the runner-still-up case that would previously have produced the local-relaunch command
  - Added an autouse `page.unroute_all(behavior="ignoreErrors")` fixture — these tests leave `/health` polls in flight, and a route callback firing as the page tears down surfaced as a `TargetClosedError` in the *next* test's setup.
  ```
  .venv/bin/python -m pytest tests/e2e_ui/sessions/test_host_badge.py    # 6 passed
  ```
- Unit tests updated in `HostBadge.test.tsx` (name preserved + clickable; online and resumable stay passive) and `ChatPage.statusLine.test.tsx` (tray must not resurrect for a session with no host now that the callback is always passed).
  ```
  pnpm --filter web test        # 274 files, 4893 passed
  pnpm --filter web type-check  # clean
  pre-commit run --files <changed>   # all pass
  ```

**Manual (live server + real host disconnect)**

Ran a dedicated server on its own SQLite DB, connected a real `omnigent host`, created host-bound sessions, then killed the host daemon and drove the page headlessly:

```
phase=online   tag=DIV     text='MGCW6F7Y3M, online'                         dot=rgb(46,166,92)
phase=offline  tag=BUTTON  text='MGCW6F7Y3M, offline — click to reconnect'   dot=rgb(200,50,76)
dialog title='Host is offline'  command='omnigent host \n  --server http://127.0.0.1:8951'
```

## Demo

Captured against a live server with a real `omnigent host` connected and then killed.

**Host online** — passive, green dot, named (`title: "Host corey-macbook, online"`):

![Composer status line with a green dot and the host name corey-macbook](https://raw.githubusercontent.com/omnigent-ai/omnigent/assets/pr-4090-host-badge/composer-online.png)

**Host disconnected** — *same shape*, red dot, now a button (`title: "Host corey-macbook, offline — click to reconnect"`):

![Composer status line with a red dot and the host name corey-macbook still shown](https://raw.githubusercontent.com/omnigent-ai/omnigent/assets/pr-4090-host-badge/composer-offline.png)

**Clicking the badge** — the reconnect instructions, with the host command:

![Host is offline dialog with Reconnect and Clone tabs and the omnigent host command](https://raw.githubusercontent.com/omnigent-ai/omnigent/assets/pr-4090-host-badge/reconnect-dialog.png)

Before this PR the middle state rendered `⊘ Host is offline — click to reconnect` with the host name **replaced** — and in the runner-outlives-host case, no clickable affordance at all, just a passive red dot.

<sub>Screenshots live on the `assets/pr-4090-host-badge` branch so they stay out of this PR's diff — delete that branch after merge.</sub>

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification ran against a live server with a real `omnigent host` connected and then killed — not a mocked liveness signal — asserting the badge's tag, text, title, and computed dot color in both states, and that clicking through yields the `omnigent host` command rather than the local relaunch one. The automated e2e tests patch liveness via route interception because the harness can't hold the transient "runner outlives host" state deterministically.

## Changelog

A disconnected host now always shows its name with a red dot in the composer, and clicking it opens the reconnect instructions
