### PR TITLE
fix(web): don't show the previous session's model in the composer

### DIFF
--- a/tests/e2e_ui/chat/test_claude_model_picker.py
+++ b/tests/e2e_ui/chat/test_claude_model_picker.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 from playwright.sync_api import Page, Route, expect
 
 from omnigent.claude_native import ClaudeNativeUcodeConfig, claude_native_model_options
+from tests.e2e_ui.conftest import seed_committed_turn
 
 _EXPECTED_ROWS = [
     ("opus", "Opus 4.10"),
@@ -425,6 +426,187 @@ def test_claude_native_unpinned_gateway_catalog_offers_only_the_routable_default
     expect(rows.first).to_have_attribute("data-model-id", default_model)
     expect(rows.first).to_have_attribute("data-active", "true")
     _screenshot(page, "unpinned-gateway-picker")
+
+
+_CODEX_MODEL_ID = "gpt-5.5"
+_CODEX_MODEL_LABEL = "Codex Pretty 5.5"
+_CODEX_MODEL_OPTIONS = [
+    {
+        "id": _CODEX_MODEL_ID,
+        "model": "databricks-gpt-5-5",
+        "displayName": _CODEX_MODEL_LABEL,
+        "isDefault": True,
+    }
+]
+_CLAUDE_LLM_MODEL = "system.ai.claude-sonnet-5"
+# Long enough that the stale-label window is unmissable, short enough to keep
+# the test quick. Only the switch back to the Claude session is delayed.
+_SNAPSHOT_DELAY_MS = 2_000
+
+# Records every distinct composer model label the page ever paints, tagged with
+# the session route it was painted under. A transient wrong label is invisible
+# to `expect()` (which retries until it passes), so the assertion runs against
+# this log rather than a point-in-time read.
+_LABEL_RECORDER = """
+(() => {
+  window.__modelLabelLog = [];
+  const record = () => {
+    const el = document.querySelector('[data-testid="composer-model-effort-label"]');
+    const entry = { path: location.pathname, text: el ? el.textContent.trim() : "" };
+    const log = window.__modelLabelLog;
+    const last = log[log.length - 1];
+    if (!last || last.path !== entry.path || last.text !== entry.text) log.push(entry);
+  };
+  new MutationObserver(record).observe(document, {
+    subtree: true,
+    childList: true,
+    characterData: true,
+  });
+})()
+"""
+
+# Holds the incoming session's snapshot GET so the pre-bind window — where the
+# store has dropped the outgoing session's model fields but not yet hydrated the
+# incoming one's — lasts long enough to observe. Armed via `__delaySnapshot`
+# right before the switch so the first visit stays fast.
+_SNAPSHOT_DELAY = """
+(() => {
+  const sessionId = __SESSION_ID__;
+  const delayMs = __DELAY_MS__;
+  const originalFetch = window.fetch.bind(window);
+  window.fetch = async (input, init) => {
+    const url = typeof input === "string" ? input : input.url;
+    if (
+      window.__delaySnapshot &&
+      new URL(url, window.location.origin).pathname === `/v1/sessions/${sessionId}`
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    return originalFetch(input, init);
+  };
+})()
+"""
+
+
+def _patch_native_session_pair(page: Page, codex_session_id: str, claude_session_id: str) -> None:
+    """Patch two session snapshots at once: one codex-native, one claude-native.
+
+    The sibling single-session helpers each own a ``**/v1/sessions/**`` route
+    and ``continue_()`` past the ids they don't serve, so two of them can't be
+    composed (the first matching handler wins and goes straight to the
+    network). This serves both ids from one handler instead.
+
+    :param page: Playwright page before navigation.
+    :param codex_session_id: Session id to shape as codex-native, pinned to
+        ``gpt-5.5`` via ``model_override`` so binding it leaves that model as
+        the cross-session sticky pick.
+    :param claude_session_id: Session id to shape as claude-native, bound to
+        Sonnet 5 with no override of its own.
+    """
+
+    def _handle(route: Route) -> None:
+        request = route.request
+        path = urlparse(request.url).path
+        if request.method != "GET" or path not in (
+            f"/v1/sessions/{codex_session_id}",
+            f"/v1/sessions/{claude_session_id}",
+        ):
+            route.continue_()
+            return
+
+        response = route.fetch()
+        payload = response.json()
+        if path == f"/v1/sessions/{codex_session_id}":
+            wrapper, harness = "codex-native-ui", "codex"
+            payload["llm_model"] = _CODEX_MODEL_ID
+            payload["model_override"] = _CODEX_MODEL_ID
+            payload["model_options"] = _CODEX_MODEL_OPTIONS
+        else:
+            wrapper, harness = "claude-code-native-ui", "claude"
+            payload["llm_model"] = _CLAUDE_LLM_MODEL
+            payload["model_options"] = _MODEL_OPTIONS
+        payload["labels"] = {**payload.get("labels", {}), "omnigent.wrapper": wrapper}
+        payload["harness"] = harness
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    page.route("**/v1/sessions/**", _handle)
+
+
+def test_composer_model_label_never_shows_the_previous_sessions_model(
+    page: Page,
+    seeded_session_pair: tuple[str, str, str],
+) -> None:
+    """Switching Codex → Claude must not paint Codex's model on the way in.
+
+    Failure mode this catches: ``switchTo`` clears the session-scoped model
+    fields (``sessionModelOverride`` / ``llmModel`` / ``codexModelOptions``) but
+    deliberately keeps ``selectedModel``, the cross-session sticky pick. The
+    native picker kind flips to Claude immediately (the session query and the
+    sidebar row are already cached), so for the whole snapshot round trip the
+    composer resolves the sticky and reads ``gpt-5.5`` on a Claude session
+    before correcting itself to Sonnet 5.
+
+    :param page: Playwright page fixture.
+    :param seeded_session_pair: ``(base_url, codex_session, claude_session)``
+        for two real server-backed sessions; both snapshots are patched into
+        native shapes as seen by the browser.
+    """
+    base_url, codex_session, claude_session = seeded_session_pair
+    # Both sessions need a committed transcript: the store caches (and repaints
+    # from) only non-empty ones, and an empty session falls back to the hydrate
+    # placeholder, which hides the composer instead of painting a stale label.
+    for session_id in (codex_session, claude_session):
+        seed_committed_turn(session_id, prompt="ping", reply="pong")
+    _patch_native_session_pair(page, codex_session, claude_session)
+    page.add_init_script(_LABEL_RECORDER)
+    page.add_init_script(
+        _SNAPSHOT_DELAY.replace("__SESSION_ID__", json.dumps(claude_session)).replace(
+            "__DELAY_MS__", str(_SNAPSHOT_DELAY_MS)
+        )
+    )
+
+    label = page.get_by_test_id("composer-model-effort-label")
+
+    # Visit the Claude session first so the return trip is the real-world
+    # switch-back: its snapshot query and transcript are cached, so the
+    # composer stays mounted (no hydrate placeholder) and paints through the
+    # window instead of being replaced by a spinner.
+    page.goto(f"{base_url}/c/{claude_session}")
+    expect(label).to_contain_text("Sonnet 5", timeout=15_000)
+
+    # Open the Codex session — binding it makes gpt-5.5 the sticky pick.
+    page.locator(f'a[href="/c/{codex_session}"]').click()
+    page.wait_for_url(re.compile(rf"/c/{re.escape(codex_session)}"))
+    expect(label).to_contain_text(_CODEX_MODEL_LABEL, timeout=15_000)
+
+    # Switch back to Claude with its snapshot held, and watch every label the
+    # composer paints under the Claude route.
+    page.evaluate("window.__delaySnapshot = true")
+    page.evaluate("window.__modelLabelLog = []")
+    page.locator(f'a[href="/c/{claude_session}"]').click()
+    page.wait_for_url(re.compile(rf"/c/{re.escape(claude_session)}"))
+    expect(label).to_contain_text("Sonnet 5", timeout=15_000)
+
+    log = page.evaluate("window.__modelLabelLog")
+    claude_labels = [e["text"] for e in log if e["path"] == f"/c/{claude_session}"]
+    # Guard against a no-op run: the held snapshot must have produced at least
+    # one pre-bind paint before the settled Sonnet 5 label.
+    assert len(claude_labels) > 1, (
+        f"the delayed-bind window was never observed (labels: {claude_labels}); "
+        "the snapshot delay did not take effect, so this run proves nothing"
+    )
+    leaked = [
+        text for text in claude_labels if _CODEX_MODEL_ID in text or _CODEX_MODEL_LABEL in text
+    ]
+    assert not leaked, (
+        f"the Codex session's model leaked into the Claude session's composer: {leaked} "
+        f"(full label sequence under the Claude route: {claude_labels}). The composer must "
+        "never surface another session's sticky model while the snapshot is in flight."
+    )
 
 
 def test_claude_native_picker_prefers_session_override_over_sticky_model(

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -909,6 +909,35 @@ describe("Composer model/effort label", () => {
     // the leaked model was suppressed.
     expect(label()).toHaveTextContent("High");
   });
+
+  it("does not leak the cross-session sticky model on a native session before its catalog lands", () => {
+    // The Codex→Claude switch repro: `switchTo` clears the session-scoped model
+    // fields but keeps the sticky, so mid-switch a claude-native session has an
+    // empty catalog and the `gpt-5.5` the outgoing Codex session left behind.
+    // The label must wait for a model this session vouches for rather than
+    // paint the previous session's pick for the whole bind round trip.
+    useChatStore.setState({
+      selectedModel: "gpt-5.5", // outgoing Codex session's pick — must not surface
+      sessionModelOverride: null,
+      selectedEffort: "high",
+      llmModel: null,
+      codexModelOptions: [], // cleared by `switchTo`, refilled when the snapshot lands
+    });
+    renderWithTooltips(
+      <Composer
+        {...composerProps({
+          agents: [{ id: "a1", name: "claude" }],
+          selectedAgentId: "a1",
+          modelPickerKind: "claude",
+          showModels: true,
+          codexModelOptions: [],
+        })}
+      />,
+    );
+    expect(label()).not.toHaveTextContent("gpt-5.5");
+    // The real effort still renders — only the leaked model was suppressed.
+    expect(label()).toHaveTextContent("High");
+  });
 });
 
 describe("Composer effort slash-command visibility", () => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -5981,23 +5981,35 @@ function useResolvedComposerModel(
   // the live ``setModel``; a TUI ``/model`` pick posts external_model_change),
   // so like cursor/kiro/opencode the live model is the session override, never
   // the cross-session sticky ``selectedModel``.
+  // The sticky is this session's model only when the session itself advertises
+  // it. `switchTo` clears the session-scoped fields but deliberately keeps
+  // `selectedModel`, so until the incoming snapshot lands the catalog is empty
+  // and the sticky still holds the OUTGOING session's pick — surfacing it paints
+  // e.g. a Codex gpt-5.5 on a Claude session for the whole bind round trip.
+  // Gating on the session's own catalog mirrors the compatibility rule bindStream
+  // applies a moment later, so the label never advertises a model this session
+  // would reject. Post-bind this is a no-op: the store only ever leaves a
+  // catalog-compatible sticky (or the override) in `selectedModel`.
+  const sessionStickyModel =
+    findNativeModelOption(codexModelOptions, selectedModel) !== null ? selectedModel : null;
   const pickerSelectedModel =
     modelPickerKind === "cursor" ||
     modelPickerKind === "kiro" ||
     modelPickerKind === "opencode" ||
     modelPickerKind === "pi"
       ? sessionModelOverride
-      : (sessionModelOverride ?? selectedModel);
+      : (sessionModelOverride ?? sessionStickyModel);
   // SDK/bundle agents (no native picker) never have the cross-session sticky
   // applied to them, so their live model is the session's own — the applied
   // override or the bound default — never `selectedModel` (a pick carried over
   // from an unrelated session, e.g. a gpt-5.5 left from a Codex session showing
-  // on a Claude-SDK agent like Polly). claude-/codex-native keep `selectedModel`:
-  // there the sticky IS the applied model.
+  // on a Claude-SDK agent like Polly). claude-/codex-native keep the sticky —
+  // there it IS the applied model — but only once this session's catalog vouches
+  // for it (see `sessionStickyModel`).
   const nonNativeModel =
     modelPickerKind === null
       ? (sessionModelOverride ?? llmModel)
-      : (sessionModelOverride ?? selectedModel ?? llmModel);
+      : (sessionModelOverride ?? sessionStickyModel ?? llmModel);
   const effectiveModel = nativeVendorOwnsModel
     ? modelPickerKind === "cursor" || modelPickerKind === "kiro"
       ? // cursor mirrors its live TUI model into ``model_override``; kiro sets it


### PR DESCRIPTION
## Related issue

N/A

## Summary

Switching from a Codex session to a Claude Code session briefly painted the
Codex model (`gpt-5.5`) in the Claude session's composer, then corrected itself
to the Claude model a moment later.

`switchTo` clears the session-scoped model fields (`sessionModelOverride`,
`llmModel`, `codexModelOptions`) but deliberately keeps `selectedModel`, the
cross-session sticky pick, so a CLI-created new chat inherits the user's last
choice. Meanwhile the native picker kind flips to Claude instantly — the session
query and sidebar row are already cached — so for the whole snapshot round trip
the composer resolved `sessionModelOverride ?? selectedModel ?? llmModel` to the
*outgoing* session's model and rendered it on the incoming session.

The fix only surfaces the sticky once the session's own catalog vouches for it.
Pre-bind the catalog is empty, so the label waits instead of advertising a model
this session would reject. Post-bind it is a no-op: the store only ever leaves a
catalog-compatible sticky (or the override) in `selectedModel`. This mirrors the
compatibility rule `bindStream` applies a moment later, so it fixes the general
case rather than just codex→claude.

## Test Plan

New E2E test, written before the fix and confirmed to reproduce it:
`tests/e2e_ui/chat/test_claude_model_picker.py::test_composer_model_label_never_shows_the_previous_sessions_model`

A transient wrong value is invisible to `expect()` (which retries until it
passes), so the test installs a `MutationObserver` that logs every distinct
label the composer paints tagged with the session route, holds the incoming
snapshot with a browser-side `fetch` delay, and asserts over the log filtered to
the Claude route. It also asserts the delayed window was actually observed, so a
delay that stopped working fails loudly instead of passing vacuously.

```
# reproduces against unfixed code, passes with the fix (3/3 repeat runs, ~10s)
pytest tests/e2e_ui/chat/test_claude_model_picker.py -k previous_sessions_model

# full model-picker suites
pytest tests/e2e_ui/chat/test_claude_model_picker.py tests/e2e_ui/chat/test_codex_model_metadata.py   # 9 passed

# web unit tests
pnpm --filter web run test    # 4891 passed
```

The unit test went into the existing `ChatPage.composer.test.tsx` group that
already covers this bug class for cursor and SDK/bundle sessions — the
claude-/codex-native case was the gap. Verified it fails without the fix.

Also verified manually against a live local server with two real native sessions
(see Demo).

## Demo

Recorded on a local server with two **real** native sessions — one launched via
`omnigent codex`, one via `omnigent claude`, each with a committed transcript.
The trace below is every distinct label the composer painted under the Claude
session's route while switching back into it.

**Before**

```
1. claude session label: 'Opus xHigh'
2. codex session label:  'GPT-5.5 xhigh'
3. back on claude:       'Opus xHigh'

every label painted under the Claude route during the switch:
   ['gpt-5.5 xHigh', 'Opus xHigh']          <-- Codex model on a Claude session

RESULT: LEAKED codex model -> ['gpt-5.5 xHigh']
```

**After**

```
1. claude session label: 'Opus xHigh'
2. codex session label:  'GPT-5.5 xhigh'
3. back on claude:       'Opus xHigh'

every label painted under the Claude route during the switch:
   ['xHigh', 'Opus xHigh']                  <-- effort only, then the real model

RESULT: clean — no codex model ever painted
```

The label is briefly effort-only rather than showing a wrong model — a
deliberate trade, since the complaint was the label asserting something false.
In normal use that window is a few hundred ms.

Behaviour after the fix, for a Claude/Codex session's composer label:

| Case | What renders |
| --- | --- |
| Session has its own model pinned | the pin |
| No pin; the sticky is a model this session offers | the sticky (unchanged) |
| No pin; the sticky isn't offered here | the model the session launched with |
| The switching window, before the snapshot lands | effort only, then the real model |

Only the last row changes. Cursor / Kiro / OpenCode / Pi and SDK-bundle agents
never consulted the sticky for this label, so they are untouched.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification ran the real user flow against a local server with two real
native sessions (`omnigent codex` and `omnigent claude`, each with a committed
transcript): open Claude → switch to Codex → switch back to Claude, recording
every label painted. A/B'd by reverting the one-line change and rebuilding the
SPA, which reproduced the reported flash exactly; restoring it cleared it. The
Demo section above is that run's output.

## Changelog

The composer no longer briefly shows the previous session's model when you switch between Codex and Claude Code sessions
