### PR TITLE
chore(ci): pause Discord watch rotation schedules

### DIFF
--- a/.github/workflows/discord-watch-rotation-maintain.yml
+++ b/.github/workflows/discord-watch-rotation-maintain.yml
@@ -3,9 +3,11 @@ name: Discord watch rotation - maintain schedule
 # Monthly housekeeping for rotation_schedule.json: prune elapsed dates and
 # extend the horizon ~3 months out. Opens a PR rather than pushing to main, so
 # the change is reviewable and no write to a protected branch is needed.
+# Schedule paused: runs only on manual dispatch for now.
+# To resume, restore the `schedule:` block below.
+#   schedule:
+#     - cron: "0 8 1 * *" # 08:00 UTC on the 1st of each month
 on:
-  schedule:
-    - cron: "0 8 1 * *" # 08:00 UTC on the 1st of each month
   workflow_dispatch: {} # manual "Run workflow" button
 
 # Needs to push a branch and open a PR; no other write scope.

--- a/.github/workflows/discord-watch-rotation.yml
+++ b/.github/workflows/discord-watch-rotation.yml
@@ -1,13 +1,14 @@
 name: Discord watch rotation
 
-# Wakes up only at the UTC times that are ~08:00 in an assignee's timezone.
+# Schedule paused: the rotation ping only runs on manual dispatch for now.
+# To resume, restore the `schedule:` block below.
+#   schedule:
+#     - cron: "0 0 * * *" # 08:00 Asia/Singapore (UTC+8, no daylight saving)
+#     - cron: "0 15 * * *" # 08:00 SF in summer (PDT); 07:00 in winter (PST)
 # Note: a single fixed UTC time can't track San Francisco's daylight saving,
 # so the SF ping lands at 08:00 in summer (PDT) and 07:00 in winter (PST).
 on:
-  schedule:
-    - cron: "0 0 * * *" # 08:00 Asia/Singapore (UTC+8, no daylight saving)
-    - cron: "0 15 * * *" # 08:00 SF in summer (PDT); 07:00 in winter (PST)
-  workflow_dispatch: {} # manual "Run workflow" button for testing
+  workflow_dispatch: {} # manual "Run workflow" button
 
 # Only needs to check out the repo; nothing is written back.
 permissions:


### PR DESCRIPTION
## Related issue

N/A

## Summary

Pause both Discord watch rotation workflows by removing their `cron` schedule
triggers, so neither fires automatically for now.

- `discord-watch-rotation.yml` — dropped the two daily ping crons (08:00 SG / 08:00 SF).
- `discord-watch-rotation-maintain.yml` — dropped the monthly schedule-maintenance cron.
- Kept `workflow_dispatch` on both so they can still be run manually, and left the
  original crons commented out so the schedules can be restored later.

## Test Plan

No behavioral code — YAML-only change. Verified the workflows still parse (pre-commit
`check yaml syntax` passed) and that each retains a valid `workflow_dispatch` trigger.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

CI-config-only change removing scheduled triggers; no automated test coverage applies.
The trigger change only takes effect once merged to the default branch (`main`).

This pull request and its description were written by Isaac.