### PR TITLE
fix(datetime): make timezone handling explicit

### DIFF
--- a/.github/scripts/rotation_maintain.py
+++ b/.github/scripts/rotation_maintain.py
@@ -94,7 +94,7 @@ def main() -> int:
     parser.add_argument(
         "--today",
         type=datetime.date.fromisoformat,
-        default=datetime.date.today(),
+        default=datetime.datetime.now(datetime.timezone.utc).astimezone().date(),
         help="override today's date (ISO), for testing",
     )
     args = parser.parse_args()

--- a/dev/loadtest/run.py
+++ b/dev/loadtest/run.py
@@ -96,7 +96,7 @@ def _resolve_out_dir(out_dir: str | None) -> Path:
     if out_dir:
         out = Path(out_dir)
     else:
-        stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+        stamp = datetime.datetime.now(datetime.timezone.utc).astimezone().strftime("%Y%m%d-%H%M%S")
         out = _RESULTS_ROOT / f"omnigent_load_test-{stamp}"
     out.mkdir(parents=True, exist_ok=True)
     return out

--- a/omnigent/process_logging.py
+++ b/omnigent/process_logging.py
@@ -8,7 +8,7 @@ import os
 import sys
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import BinaryIO, TextIO, TypedDict
 
@@ -174,7 +174,7 @@ def process_log_dir(destination: str, *, root: str | Path | None = None) -> Path
 
 
 def _timestamp() -> str:
-    return datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+    return datetime.now(timezone.utc).astimezone().strftime("%Y%m%d-%H%M%S-%f")
 
 
 def create_process_log_path(

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -5304,7 +5304,7 @@ async def _cmd_switch(
     host: TerminalHost,
     fmt: RichBlockFormatter,
 ) -> None:
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     from rich.table import Table
     from rich.text import Text
@@ -5319,7 +5319,11 @@ async def _cmd_switch(
             table.add_column("Status", style="dim")
             table.add_column("Created", style="dim")
             for i, s in enumerate(sessions_list, 1):
-                when = datetime.fromtimestamp(s.created_at).strftime("%b %d %H:%M")
+                when = (
+                    datetime.fromtimestamp(s.created_at, tz=timezone.utc)
+                    .astimezone()
+                    .strftime("%b %d %H:%M")
+                )
                 table.add_row(str(i), s.id, s.title or "(untitled)", s.status, when)
             host.output(table)
             host.output(

--- a/omnigent/repl/_resume_picker.py
+++ b/omnigent/repl/_resume_picker.py
@@ -28,7 +28,7 @@ import sys
 import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, TextIO
 
@@ -1659,7 +1659,7 @@ def _format_when(created_at: int) -> str:
         return f"{delta // 3600}h ago"
     if delta < 7 * 86400:
         return f"{delta // 86400}d ago"
-    return datetime.fromtimestamp(created_at).strftime("%b %d %H:%M")
+    return datetime.fromtimestamp(created_at, tz=timezone.utc).astimezone().strftime("%b %d %H:%M")
 
 
 def _read_line_choice(in_: TextIO) -> str | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -489,10 +489,11 @@ extend-exclude = [
 # ``RET``      — flake8-return (consistent return statements)
 # ``C4``       — flake8-comprehensions (cleaner list/dict/set comprehensions)
 # ``PIE``      — flake8-pie (misc correctness + style)
+# ``DTZ``      — flake8-datetimez (explicit timezone-aware datetimes)
 # ``LOG``      — flake8-logging (correct exception and logger usage)
 # ``RUF``      — ruff-specific (sorted ``__all__``, dangling asyncio
 #                tasks, unused noqa, ...)
-select = ["E", "F", "I", "UP", "ARG", "BLE", "B", "SIM", "RET", "C4", "PIE", "LOG", "RUF"]
+select = ["E", "F", "I", "UP", "ARG", "BLE", "B", "SIM", "RET", "C4", "PIE", "DTZ", "LOG", "RUF"]
 ignore = [
     # ARG003 (unused class-method args): too noisy on ABC-subclass signatures
     # where the arg is required by the interface contract.

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -9,7 +9,7 @@ import socket
 import tempfile
 import textwrap
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -940,7 +940,10 @@ class TestToolServer(unittest.TestCase):
 
             async def executor(name, args):
                 # A dict carrying values json.dumps rejects by default.
-                return {"when": datetime(2026, 6, 18, 12, 0, 0), "tags": {1, 2, 3}}
+                return {
+                    "when": datetime(2026, 6, 18, 12, 0, 0, tzinfo=timezone.utc),
+                    "tags": {1, 2, 3},
+                }
 
             server._tool_executor = executor
 
@@ -974,7 +977,7 @@ class TestToolServer(unittest.TestCase):
         still yield a valid frame rather than re-raising the very crash the
         guard exists to prevent. The id is stringified in that envelope.
         """
-        bad_id = datetime(2026, 6, 18, 12, 0, 0)
+        bad_id = datetime(2026, 6, 18, 12, 0, 0, tzinfo=timezone.utc)
         out = _safe_dumps({"id": bad_id, "result": {"k": "v"}}, bad_id)  # type: ignore[arg-type]
         payload = json.loads(out)
         self.assertEqual(payload["id"], str(bad_id))
@@ -995,7 +998,10 @@ class TestToolServer(unittest.TestCase):
             await server.start()
 
             async def executor(name, args):
-                return {"when": datetime(2026, 6, 18, 12, 0, 0), "tags": {1, 2, 3}}
+                return {
+                    "when": datetime(2026, 6, 18, 12, 0, 0, tzinfo=timezone.utc),
+                    "tags": {1, 2, 3},
+                }
 
             server._tool_executor = executor
             try:

--- a/tests/runtime/harnesses/test_scaffold.py
+++ b/tests/runtime/harnesses/test_scaffold.py
@@ -497,7 +497,9 @@ async def test_heartbeat_carries_server_time_and_last_event_seq(
     # dataclass repr would fail this.
     import datetime
 
-    parsed = datetime.datetime.strptime(server_time, "%Y-%m-%dT%H:%M:%SZ")
+    parsed = datetime.datetime.strptime(server_time, "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=datetime.timezone.utc
+    )
     assert parsed.year >= 2026
 
     # last_event_seq: the sequence_number of the warmup event


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Enable Ruff's `DTZ` rules to reject ambiguous naive datetimes.
- Make process-log timestamps and REPL session displays timezone-aware while preserving local-time output.
- Mark UTC test fixtures and parsed `Z` timestamps explicitly as UTC-aware.

## Test Plan

- `uv run --no-sync ruff check omnigent tests integrations scripts`
- `uv run --no-sync pytest -q tests/test_process_logging.py tests/repl/test_resume_picker.py tests/inner/test_pi_executor.py::TestToolServer::test_non_json_serializable_result_returns_error_frame tests/inner/test_pi_executor.py::TestToolServer::test_safe_dumps_with_non_serializable_req_id_does_not_raise tests/inner/test_pi_executor.py::TestToolServer::test_generated_bridge_returns_error_for_unserializable_tool_result tests/runtime/harnesses/test_scaffold.py::test_heartbeat_carries_server_time_and_last_event_seq` (53 tests passed)
- `uv run --no-sync pre-commit run --show-diff-on-failure`

## Demo

N/A — datetime correctness and lint enforcement only; displayed local times remain unchanged.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing tests cover process-log filenames, resume-picker rendering, non-JSON datetime fixtures, and UTC heartbeat timestamps.
