### PR TITLE
fix(sdk): tighten client helper types

### DIFF
--- a/sdks/python-client/omnigent_client/_files.py
+++ b/sdks/python-client/omnigent_client/_files.py
@@ -176,7 +176,7 @@ class SessionFilesNamespace:
         :param order: Sort order, e.g. ``"desc"``.
         :returns: File metadata entries.
         """
-        params: dict[str, object] = {"limit": limit, "order": order}
+        params: dict[str, str | int] = {"limit": limit, "order": order}
         if after is not None:
             params["after"] = after
         resp = await self._http.get(self._path, params=params)

--- a/sdks/python-client/omnigent_client/_sessions.py
+++ b/sdks/python-client/omnigent_client/_sessions.py
@@ -21,6 +21,7 @@ callers obtain it via ``client.sessions.create()``.
 
 from __future__ import annotations
 
+import builtins
 import json
 import logging
 from collections.abc import AsyncIterator
@@ -661,7 +662,7 @@ class SessionsNamespace:
         limit: int = 100,
         after: str | None = None,
         order: str = "asc",
-    ) -> list[dict[str, Any]]:
+    ) -> builtins.list[dict[str, Any]]:
         """
         List items in a session with cursor-based pagination.
 
@@ -688,14 +689,15 @@ class SessionsNamespace:
         )
         raise_for_status(resp.status_code, response_body(resp))
         body = require_json_object(resp, "GET /v1/sessions/{session_id}/items")
-        return body.get("data", [])
+        data = body.get("data", [])
+        return data if isinstance(data, list) else []
 
     async def child_sessions(
         self,
         session_id: str,
         *,
         limit: int = 100,
-    ) -> list[dict[str, Any]]:
+    ) -> builtins.list[dict[str, Any]]:
         """
         List sub-agent (child) sessions under a parent session.
 
@@ -721,7 +723,8 @@ class SessionsNamespace:
         )
         raise_for_status(resp.status_code, response_body(resp))
         body = require_json_object(resp, "GET /v1/sessions/{session_id}/child_sessions")
-        return body.get("data", [])
+        data = body.get("data", [])
+        return data if isinstance(data, list) else []
 
     async def child_sessions_tree(
         self,
@@ -729,7 +732,7 @@ class SessionsNamespace:
         *,
         max_depth: int = _DEFAULT_SUBTREE_DEPTH,
         limit: int = 100,
-    ) -> list[dict[str, Any]]:
+    ) -> builtins.list[dict[str, Any]]:
         """List the whole sub-agent subtree under *session_id*, flattened.
 
         :meth:`child_sessions` is one level deep; this recurses it breadth-first

--- a/sdks/python-client/omnigent_client/_transforms.py
+++ b/sdks/python-client/omnigent_client/_transforms.py
@@ -12,7 +12,7 @@ stream. Compose with ``pipe()``:
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 
 from ._blocks import (
     AnyBlock,
@@ -20,8 +20,10 @@ from ._blocks import (
     TextDone,
 )
 
+StreamTransform = Callable[[AsyncIterator[AnyBlock]], AsyncIterator[AnyBlock]]
 
-def pipe(stream: AsyncIterator[AnyBlock], *transforms: object) -> AsyncIterator[AnyBlock]:
+
+def pipe(stream: AsyncIterator[AnyBlock], *transforms: StreamTransform) -> AsyncIterator[AnyBlock]:
     """Compose transforms left-to-right.
 
     ``pipe(stream, t1, t2)`` is equivalent to ``t2(t1(stream))``.
@@ -31,7 +33,7 @@ def pipe(stream: AsyncIterator[AnyBlock], *transforms: object) -> AsyncIterator[
     return stream
 
 
-def skip_blocks(*types: type) -> object:
+def skip_blocks(*types: type) -> StreamTransform:
     """Drop blocks of the given types.
 
     Usage::
@@ -50,7 +52,7 @@ def skip_blocks(*types: type) -> object:
     return _transform
 
 
-def skip_intermediate_ends() -> object:
+def skip_intermediate_ends() -> StreamTransform:
     """Suppress ``ResponseEndBlock`` events from tool loop iterations.
 
     Only yields the final ``ResponseEndBlock`` — the one not followed
@@ -78,7 +80,7 @@ def skip_intermediate_ends() -> object:
     return _transform
 
 
-def merge_text_across_iterations() -> object:
+def merge_text_across_iterations() -> StreamTransform:
     """Merge ``TextDone`` blocks across tool loop iterations.
 
     When the tool loop runs N iterations, each may produce a
@@ -115,7 +117,7 @@ def merge_text_across_iterations() -> object:
     return _transform
 
 
-def only_agent(agent_name: str | None) -> object:
+def only_agent(agent_name: str | None) -> StreamTransform:
     """Filter to blocks from a specific agent.
 
     Pass ``None`` to include all agents (no filtering).


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Fix the Python SDK's HTTP query parameter, session collection, and stream-transform annotations.
- Replace ambiguous `object` transform types with a reusable callable contract.
- Reduce the SDK Pyrefly baseline from 17 errors to 12 without enabling the gate yet.

## Test Plan

- `uv run --no-sync pyrefly check sdks/python-client/omnigent_client/_files.py sdks/python-client/omnigent_client/_sessions.py sdks/python-client/omnigent_client/_transforms.py sdks/python-client/omnigent_client/_session.py` (0 errors)
- `uv run --no-sync ruff check sdks/python-client/omnigent_client/_files.py sdks/python-client/omnigent_client/_sessions.py sdks/python-client/omnigent_client/_transforms.py`
- `uv run --no-sync pytest -q tests/frontends/sdk/test_transforms.py tests/frontends/sdk/test_sessions_namespace.py tests/frontends/sdk/test_session.py` (43 tests passed)
- `uv run --no-sync pre-commit run --show-diff-on-failure`

## Demo

N/A — SDK typing cleanup only.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Existing SDK tests cover stream transforms, session collection helpers, and query collection behavior.
