### PR TITLE
fix(web): reseed composer prefill when a project's defaults change

### DIFF
--- a/web/src/shell/NewChatDialog.projectPrefill.test.tsx
+++ b/web/src/shell/NewChatDialog.projectPrefill.test.tsx
@@ -271,6 +271,30 @@ describe("NewChatLandingScreen project prefill", () => {
     expect(body.agent_id).toBe("ag_other");
   });
 
+  it("reseeds the SAME project after its stored defaults change (edited then re-opened)", async () => {
+    const EDITED_REPO = "/Users/corey/projects/alpha-edited";
+    // First open reads the original config.
+    setProjectConfig({ host_id: "host_1", workspace: REPO });
+    const rerender = renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("alpha"),
+    );
+
+    // User edits the project's defaults; the save seeds the fresh config into
+    // the cache, so a re-open of the SAME project (`?project=Alpha` unchanged)
+    // must pick up the new workspace rather than latch onto the settled seed.
+    setProjectConfig({ host_id: "host_1", workspace: EDITED_REPO });
+    rerender(<NewChatLandingScreen />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain(
+        "alpha-edited",
+      ),
+    );
+    const body = await submitAndReadBody();
+    expect(body.workspace).toBe(EDITED_REPO);
+  });
+
   it("does not seed an offline config host (falls back to the generic default)", async () => {
     vi.mocked(useHosts).mockReturnValue({
       data: [host(), host({ host_id: "host_off", name: "sleepy", status: "offline" })],

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2103,12 +2103,31 @@ export function NewChatLandingScreen() {
   // once per settled workspace (and can't loop once it sets a branch name).
   const worktreeSeededForRef = useRef<string | null>(null);
 
+  // Signature of the stored config the machine last settled from. Lets a later
+  // save be noticed even when the pencil re-opens the SAME project — the config
+  // content changes while `projectParam` does not. `null` = not yet seeded.
+  const seededConfigSigRef = useRef<string | null>(null);
+  const prefillConfigSig = useMemo(
+    () => (prefillConfig === undefined ? null : JSON.stringify(prefillConfig)),
+    [prefillConfig],
+  );
+
   // The landing screen stays mounted while `?project=` changes (clicking
   // another project's pencil), so re-create a fresh visit by hand: clear
   // every seedable slot and restart the machine. Values the user set are
-  // reset too — a pencil click means "set me up for this project".
+  // reset too — a pencil click means "set me up for this project". Also
+  // restart when the SAME project's stored defaults change (the user edited
+  // its settings, then re-opened its composer): `projectParam` stays put, so
+  // without this the already-settled machine would keep the stale seeds.
   useEffect(() => {
-    if (prefill.project === projectParam) return;
+    const projectChanged = prefill.project !== projectParam;
+    const configChanged =
+      !projectChanged &&
+      projectParam !== "" &&
+      prefillConfigSig !== null &&
+      seededConfigSigRef.current !== null &&
+      prefillConfigSig !== seededConfigSigRef.current;
+    if (!projectChanged && !configChanged) return;
     setSandboxSelected(false);
     setSelectedHostId(null);
     setPickedAgentId(projectParam !== "" ? null : readLastAgentId());
@@ -2116,8 +2135,19 @@ export function NewChatLandingScreen() {
     setBranchName("");
     seededHostRef.current = null;
     worktreeSeededForRef.current = null;
+    seededConfigSigRef.current = prefillConfigSig;
     setPrefill(initialPrefillState(projectParam));
-  }, [projectParam, prefill.project]);
+  }, [projectParam, prefill.project, prefillConfigSig]);
+
+  // Record the config the machine settled from, once it's loaded and the
+  // machine is done, so the reseed effect above can spot a later change to it
+  // (the reseed on a project switch runs before the config has loaded, leaving
+  // the signature `null` until this fills it in).
+  useEffect(() => {
+    if (prefill.project !== projectParam) return;
+    if (prefillConfigSig === null || !prefillDone(prefill)) return;
+    seededConfigSigRef.current = prefillConfigSig;
+  }, [prefill, projectParam, prefillConfigSig]);
 
   // Auto-select an option so a session can be started without an explicit
   // pick. Prefer the user's last explicit choice (persisted across visits);


### PR DESCRIPTION
## Related issue

N/A

## Summary

Updating a project's default settings and then clicking the **new session in project** pencil icon didn't refresh the prefilled defaults — the update only appeared after clicking a different project (or Home) and back.

- The composer's landing screen stays mounted; the pencil just navigates to `/?project=<name>`. The project-prefill state machine that reads stored defaults only restarted when the `?project=` param **changed**, so re-clicking the *same* project's pencil kept its already-settled (stale) seeds.
- The saved config was already fresh in the react-query cache — the settled machine simply wasn't re-reading it. Clicking another project flipped the param away and back, which restarted the machine (the workaround users hit).
- Fix: track a signature of the config the machine last settled from and restart the prefill when that content changes for the same project, mirroring the existing project-switch reset.

## Test Plan

- `cd web && npm test` — 4959 passed / 3 expected-fail / 1 skipped.
- `cd web && npm run build` — clean (tsc + vite).
- Added a regression test in `NewChatDialog.projectPrefill.test.tsx` ("reseeds the SAME project after its stored defaults change"); verified it **fails on the unpatched source** and passes with the fix.
- Manual: open a project with defaults, edit a default (e.g. working directory) and save, then click the same project's pencil — the composer now prefills the updated defaults immediately.

## Demo

N/A — behavioural fix; the composer looks unchanged, it just reads fresh defaults. Repro steps in the Test Plan.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added a unit regression test that reproduces the stale-prefill bug (fails without the fix). Manually verified in the running app that editing a project's defaults and re-clicking its "new session" pencil now prefills the updated values without navigating away first.

## Changelog

The "new session in project" composer now picks up a project's edited default settings immediately, without having to click away and back.

This pull request and its description were written by Isaac.