### PR TITLE
fix(sdk): validate response model scalars

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         language: system
         entry: .venv/bin/pyrefly check
         pass_filenames: false
-        files: ^(omnigent/.*\.pyi?|pyproject\.toml|pyrefly\.toml|uv\.lock)$
+        files: ^(omnigent/.*\.pyi?|sdks/python-client/.*\.py|pyproject\.toml|pyrefly\.toml|uv\.lock)$
 
       # Project-specific test-quality lint rules (dev/lint/). Run on test
       # files only — the patterns never occur in production code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Pyrefly is the canonical Python type checker for the repository.
 ```bash
 uv run pytest                      # Python tests (e2e/live skipped by default)
 uv run ruff check . && uv run ruff format --check .
-uv run --no-sync pyrefly check     # Python type checking (omnigent/)
+uv run --no-sync pyrefly check     # Python type checking (core and client SDK)
 uv run pre-commit run --all-files
 ```
 

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -1,6 +1,7 @@
 project-includes = [
     "omnigent/**/*.py",
     "omnigent/**/*.pyi",
+    "sdks/python-client/**/*.py",
 ]
 
 project-excludes = []

--- a/sdks/python-client/omnigent_client/_sessions_chat.py
+++ b/sdks/python-client/omnigent_client/_sessions_chat.py
@@ -211,14 +211,14 @@ class _AgentToolsGetter(Protocol):
 # terminal set listed in ``omnigent/server/schemas.py`` (and
 # the ``_TERMINAL_STATUSES`` set in
 # :mod:`omnigent_client._session`).
-_TURN_TERMINAL_EVENT_TYPES: tuple[type[ServerStreamEvent], ...] = (
+_TURN_TERMINAL_EVENT_TYPES = (
     CompletedEvent,
     FailedEvent,
     IncompleteEvent,
     CancelledEvent,
 )
 
-_RESPONSE_START_EVENT_TYPES: tuple[type[ServerStreamEvent], ...] = (
+_RESPONSE_START_EVENT_TYPES = (
     CreatedEvent,
     QueuedEvent,
     InProgressEvent,
@@ -560,7 +560,7 @@ class SessionsChat:
         # turns cannot publish all output before this subscriber exists.
         stream_aiter = self._namespace.stream(self._session.id)
         hook_state = _StreamHookState()
-        first_event_task = asyncio.create_task(stream_aiter.__anext__())
+        first_event_task = asyncio.ensure_future(stream_aiter.__anext__())
         try:
             first_event: ServerStreamEvent | None
             try:
@@ -573,6 +573,7 @@ class SessionsChat:
             except StopAsyncIteration:
                 return
             await self._namespace.post_event(self._session.id, event_payload)
+            event: ServerStreamEvent
             if first_event is None:
                 try:
                     event = await first_event_task

--- a/sdks/python-client/omnigent_client/_types.py
+++ b/sdks/python-client/omnigent_client/_types.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 
+def _json_int(value: object) -> int:
+    """Parse an integer-compatible JSON scalar."""
+    if isinstance(value, (bool, int, float, str)):
+        return int(value)
+    raise TypeError(f"expected a JSON number or numeric string, got {type(value).__name__}")
+
+
 @dataclass
 class ConversationRef:
     """Reference to a conversation, as returned on response objects."""
@@ -82,11 +89,11 @@ class Response:
         usage_raw = data.get("usage")
         usage = (
             Usage(
-                input_tokens=int(usage_raw.get("input_tokens", 0)),
-                output_tokens=int(usage_raw.get("output_tokens", 0)),
-                total_tokens=int(usage_raw.get("total_tokens", 0)),
+                input_tokens=_json_int(usage_raw.get("input_tokens", 0)),
+                output_tokens=_json_int(usage_raw.get("output_tokens", 0)),
+                total_tokens=_json_int(usage_raw.get("total_tokens", 0)),
                 context_tokens=(
-                    int(usage_raw["context_tokens"])
+                    _json_int(usage_raw["context_tokens"])
                     if usage_raw.get("context_tokens") is not None
                     else None
                 ),
@@ -109,13 +116,14 @@ class Response:
             if isinstance(inc_raw, dict)
             else None
         )
+        output_raw = data.get("output", [])
         return cls(
             id=str(data.get("id", "")),
             status=str(data.get("status", "")),
             model=str(data.get("model", "")),
-            output=data.get("output", []) if isinstance(data.get("output"), list) else [],
-            created_at=int(data.get("created_at", 0)),
-            completed_at=int(data["completed_at"])
+            output=output_raw if isinstance(output_raw, list) else [],
+            created_at=_json_int(data.get("created_at", 0)),
+            completed_at=_json_int(data["completed_at"])
             if data.get("completed_at") is not None
             else None,
             previous_response_id=(
@@ -150,7 +158,7 @@ class Agent:
             id=str(data.get("id", "")),
             name=str(data.get("name", "")),
             description=str(data["description"]) if data.get("description") is not None else None,
-            created_at=int(data.get("created_at", 0)),
+            created_at=_json_int(data.get("created_at", 0)),
         )
 
 
@@ -169,8 +177,8 @@ class File:
         return cls(
             id=str(data.get("id", "")),
             filename=str(data.get("filename", "")),
-            bytes=int(data.get("bytes", 0)),
-            created_at=int(data.get("created_at", 0)),
+            bytes=_json_int(data.get("bytes", 0)),
+            created_at=_json_int(data.get("created_at", 0)),
         )
 
 
@@ -210,7 +218,7 @@ class Conversation:
         return cls(
             id=str(data.get("id", "")),
             title=str(data["title"]) if data.get("title") is not None else None,
-            created_at=int(data.get("created_at", 0)),
+            created_at=_json_int(data.get("created_at", 0)),
             labels=labels,
         )
 
@@ -227,8 +235,9 @@ class PaginatedList:
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> PaginatedList:
         """Parse a paginated list from a JSON dict."""
+        items_raw = data.get("data", [])
         return cls(
-            data=data.get("data", []) if isinstance(data.get("data"), list) else [],
+            data=items_raw if isinstance(items_raw, list) else [],
             first_id=str(data["first_id"]) if data.get("first_id") is not None else None,
             last_id=str(data["last_id"]) if data.get("last_id") is not None else None,
             has_more=bool(data.get("has_more", False)),

--- a/tests/frontends/sdk/test_types.py
+++ b/tests/frontends/sdk/test_types.py
@@ -1,0 +1,57 @@
+"""Tests for Python SDK response dataclasses."""
+
+from __future__ import annotations
+
+import pytest
+from omnigent_client._types import File, PaginatedList, Response
+
+
+def test_response_from_dict_parses_integer_compatible_json_scalars() -> None:
+    response = Response.from_dict(
+        {
+            "id": "resp_1",
+            "status": "completed",
+            "model": "agent",
+            "output": [{"type": "message"}],
+            "created_at": "10",
+            "completed_at": 12.0,
+            "usage": {
+                "input_tokens": "3",
+                "output_tokens": 4.0,
+                "total_tokens": 7,
+            },
+        }
+    )
+
+    assert response.created_at == 10
+    assert response.completed_at == 12
+    assert response.output == [{"type": "message"}]
+    assert response.usage is not None
+    assert response.usage.total_tokens == 7
+
+
+def test_file_from_dict_rejects_non_scalar_integer_fields() -> None:
+    with pytest.raises(TypeError, match="expected a JSON number or numeric string"):
+        File.from_dict(
+            {
+                "id": "file_1",
+                "filename": "report.txt",
+                "bytes": {},
+                "created_at": 10,
+            }
+        )
+
+
+def test_collection_fields_fall_back_when_payload_is_not_a_list() -> None:
+    response = Response.from_dict(
+        {
+            "id": "resp_1",
+            "status": "completed",
+            "model": "agent",
+            "output": {"type": "message"},
+        }
+    )
+    page = PaginatedList.from_dict({"data": {"id": "file_1"}})
+
+    assert response.output == []
+    assert page.data == []


### PR DESCRIPTION
## Related issue

Refs #3644

## Summary

- Add explicit JSON integer parsing for Python SDK response dataclasses.
- Narrow response and pagination collection fields before model construction.
- Reduce the SDK Pyrefly baseline from 12 errors to four, all now isolated to stream handling.

## Test Plan

- `uv run --no-sync pyrefly check sdks/python-client/omnigent_client/_types.py` (0 errors)
- `uv run --no-sync ruff check sdks/python-client/omnigent_client/_types.py tests/frontends/sdk/test_types.py`
- `uv run --no-sync pytest -q tests/frontends/sdk/test_types.py tests/frontends/sdk/test_stream.py tests/frontends/sdk/test_session.py tests/frontends/sdk/test_sessions_chat.py` (57 tests passed)
- `uv run --no-sync pre-commit run --show-diff-on-failure`

## Demo

N/A — SDK response parsing and typing only.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New tests cover numeric JSON conversion, malformed integer fields, and collection fallbacks; existing response and stream suites cover downstream model use.
