### PR TITLE
fix(sdk): narrow session stream events

### DIFF
--- a/sdks/python-client/omnigent_client/_sessions_chat.py
+++ b/sdks/python-client/omnigent_client/_sessions_chat.py
@@ -211,14 +211,14 @@ class _AgentToolsGetter(Protocol):
 # terminal set listed in ``omnigent/server/schemas.py`` (and
 # the ``_TERMINAL_STATUSES`` set in
 # :mod:`omnigent_client._session`).
-_TURN_TERMINAL_EVENT_TYPES: tuple[type[ServerStreamEvent], ...] = (
+_TURN_TERMINAL_EVENT_TYPES = (
     CompletedEvent,
     FailedEvent,
     IncompleteEvent,
     CancelledEvent,
 )
 
-_RESPONSE_START_EVENT_TYPES: tuple[type[ServerStreamEvent], ...] = (
+_RESPONSE_START_EVENT_TYPES = (
     CreatedEvent,
     QueuedEvent,
     InProgressEvent,
@@ -560,7 +560,7 @@ class SessionsChat:
         # turns cannot publish all output before this subscriber exists.
         stream_aiter = self._namespace.stream(self._session.id)
         hook_state = _StreamHookState()
-        first_event_task = asyncio.create_task(stream_aiter.__anext__())
+        first_event_task = asyncio.ensure_future(stream_aiter.__anext__())
         try:
             first_event: ServerStreamEvent | None
             try:
@@ -573,6 +573,7 @@ class SessionsChat:
             except StopAsyncIteration:
                 return
             await self._namespace.post_event(self._session.id, event_payload)
+            event: ServerStreamEvent
             if first_event is None:
                 try:
                     event = await first_event_task


### PR DESCRIPTION
## Related issue

Refs #3644

Depends on #4100.

## Summary

- Accept the sessions stream iterator's declared `Awaitable` when priming its first event.
- Make the guaranteed post-subscription event type explicit and retain concrete lifecycle event-class inference.
- Clear the final four Python SDK Pyrefly errors, bringing the full SDK baseline to zero.

## Test Plan

- `uv run --no-sync pyrefly check sdks/python-client` (0 errors)
- `uv run --no-sync ruff check sdks/python-client/omnigent_client/_sessions_chat.py`
- `uv run --no-sync pytest -q tests/frontends/sdk/test_sessions_chat.py` (33 tests passed)
- `uv run --no-sync pre-commit run --show-diff-on-failure`

## Demo

N/A — SDK stream typing cleanup only.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The full sessions-chat suite covers first-event subscription ordering, lifecycle hooks, terminal events, elicitation, and client-side tool dispatch.
