### PR TITLE
ci(pyrefly): check Python client SDK

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         language: system
         entry: .venv/bin/pyrefly check
         pass_filenames: false
-        files: ^(omnigent/.*\.pyi?|pyproject\.toml|pyrefly\.toml|uv\.lock)$
+        files: ^(omnigent/.*\.pyi?|sdks/python-client/.*\.py|pyproject\.toml|pyrefly\.toml|uv\.lock)$
 
       # Project-specific test-quality lint rules (dev/lint/). Run on test
       # files only — the patterns never occur in production code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Pyrefly is the canonical Python type checker for the repository.
 ```bash
 uv run pytest                      # Python tests (e2e/live skipped by default)
 uv run ruff check . && uv run ruff format --check .
-uv run --no-sync pyrefly check     # Python type checking (omnigent/)
+uv run --no-sync pyrefly check     # Python type checking (core and client SDK)
 uv run pre-commit run --all-files
 ```
 

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -1,6 +1,7 @@
 project-includes = [
     "omnigent/**/*.py",
     "omnigent/**/*.pyi",
+    "sdks/python-client/**/*.py",
 ]
 
 project-excludes = []


### PR DESCRIPTION
## Related issue

Related to #3644.

## Summary

- Extend the canonical Pyrefly project from the core package to sdks/python-client.
- Run that expanded check from pre-commit/CI whenever client SDK Python files change.
- Update contributor guidance to describe the full enforced scope.

This is stacked on #4100. Cleanup chain: #4096 -> #4100 (including #4101) -> this gate.

## Test Plan

- uv run --no-sync pyrefly check sdks/python-client — 0 errors.
- uv run --no-sync pre-commit run --all-files — all hooks pass.

## Demo

N/A — non-visual lint configuration change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The expanded Pyrefly hook passes against the complete repository, including the Python client SDK.