### PR TITLE
fix(gateway): strip bracket suffixes from model IDs; skip model override on cli-config path

### DIFF
--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -129,7 +129,7 @@ _CODEX_PROVIDER_CONFIG_PREFIX = "model_providers."
 _CODEX_ENV_DENY_EXACT: frozenset[str] = frozenset({"OPENAI_API_KEY"})
 
 
-def _extract_codex_last_turn_usage(params: object, model: str) -> dict[str, object] | None:
+def _extract_codex_last_turn_usage(params: object, model: str | None) -> dict[str, object] | None:
     """Map a ``thread/tokenUsage/updated`` payload's ``last`` breakdown
     onto the wire shape that :class:`TurnComplete` consumes.
 
@@ -1623,7 +1623,7 @@ class _CodexAppServerSession:
         messages: list[Message],
         tools: list[ToolSpec],
         system_prompt: str,
-        model: str,
+        model: str | None,
         cwd: str,
         sandbox: str,
         reasoning_effort: str | None = None,
@@ -2204,7 +2204,7 @@ class _CodexAppServerSession:
 @dataclass
 class _CodexSessionState:
     app_session: _CodexAppServerSession | None = None
-    signature: tuple[str, str, str, str] | None = None
+    signature: tuple[str | None, str, str, str] | None = None
 
 
 class _AppSessionFactory(Protocol):
@@ -2350,6 +2350,7 @@ class CodexExecutor(Executor):
         self._cwd = cwd
         self._os_env_spec = os_env
         self._model_override = model
+        self._model_provider_override = model_provider_override
         self._gateway = gateway
         self._databricks_profile = databricks_profile
         self._gateway_host = gateway_host.rstrip("/") if gateway_host else None
@@ -2552,7 +2553,7 @@ class CodexExecutor(Executor):
         self,
         state: _CodexSessionState,
         *,
-        signature: tuple[str, str, str, str],
+        signature: tuple[str | None, str, str, str],
         effective_cwd: str,
     ) -> _CodexAppServerSession:
         if state.signature == signature and state.app_session is not None:
@@ -2585,8 +2586,15 @@ class CodexExecutor(Executor):
         state = self._session_states.setdefault(session_key, _CodexSessionState())
         # cfg.model (per-request /model override) wins over the spec default.
         # An unresolved default comes from the active provider catalog.
+        # On the cli-config path (model_provider_override set) the codex binary
+        # owns its own model list via its config.toml — omnigent does not pass a
+        # model override to thread/create, letting the binary use its configured
+        # default. Passing an unresolvable alias (e.g. gpt-5.6) would cause the
+        # binary to call UC and get a validation error.
         model = cfg.model or self._model_override
-        if model is None:
+        if self._model_provider_override is not None:
+            model = None
+        elif model is None:
             provider_name = "databricks" if self._gateway_uses_databricks_profile else "openai"
             resolution = await run_sync_on_thread(
                 model_catalog.resolve_catalog_model,

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -38,6 +38,7 @@ import json
 import logging
 import os
 import pathlib
+import re
 import secrets
 import shutil
 import subprocess
@@ -1990,6 +1991,10 @@ class PiExecutor(Executor):
             if not isinstance(model_id, str):
                 raise TypeError("Databricks model resolution returned a non-string model id")
             return model_id
+        # Strip bracket suffixes (e.g. "[1m]") — context-window hints accepted
+        # by the direct Anthropic API but not by the Databricks AI Gateway.
+        if model and self._gateway:
+            model = re.sub(r"\[.*?\]$", "", model)
         return model
 
     def _generic_openai_wire_api(self) -> str | None:

--- a/omnigent/onboarding/configure_models.py
+++ b/omnigent/onboarding/configure_models.py
@@ -337,10 +337,9 @@ def credential_label(
     if kind == DATABRICKS_KIND:
         return f"Databricks ({profile})" if profile else "Databricks"
     if kind == CLI_CONFIG_KIND:
-        # The provider's own name field is the friendliest label there is
-        # ("Databricks AI Gateway"); the entry name ("codex-databricks") is
-        # the readable fallback.
-        return display_name or provider_name
+        # Use the entry name (e.g. "isaac-databricks-codex" → "Isaac-Databricks-Codex")
+        # so cli-config providers show consistently alongside other provider kinds.
+        return provider_display_name(provider_name)
     if kind == KEY_KIND:
         return f"{provider_display_name(provider_name)} API Key"
     if kind == BEDROCK_KIND:

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shlex
 import subprocess
 from collections.abc import Callable
@@ -809,6 +810,9 @@ def _inline_family_pi_provider(
         # ``zai-org/GLM-4.7``) and already-bare ids through unchanged. Family
         # defaults are bare, so the no-override path is unaffected.
         resolved_model = normalize_model_for_provider(resolved_model, KEY_KIND)
+        # Strip bracket suffixes (e.g. "[1m]") — accepted by the direct
+        # Anthropic API but rejected by the Databricks AI Gateway.
+        resolved_model = re.sub(r"\[.*?\]$", "", resolved_model)
         return PiProviderConfig(
             provider_id=_PI_PROVIDER_ID,
             base_url=family.base_url,

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -2478,18 +2478,18 @@ def test_add_key_does_not_steal_pi_from_fallback_default(isolated_config) -> Non
 # ── cli-config labels + entry builder ───────────────────────────────────────
 
 
-def test_credential_label_cli_config_uses_display_name() -> None:
-    """A cli-config credential labels as the provider's own display name.
+def test_credential_label_cli_config_uses_provider_name() -> None:
+    """A cli-config credential labels from the provider entry name.
 
-    Failure means configure-harnesses shows the raw entry id instead of
-    the friendly name isaac wrote into the provider table.
+    The display_name is ignored so cli-config providers show consistently
+    alongside other kinds (e.g. isaac-databricks-codex → Isaac-Databricks-Codex).
     """
     from omnigent.onboarding.configure_models import credential_label
 
     label = credential_label(
-        "cli-config", "codex-databricks", display_name="Databricks AI Gateway"
+        "cli-config", "isaac-databricks-codex", display_name="Databricks AI Gateway"
     )
-    assert label == "Databricks AI Gateway"
+    assert label == "Isaac-Databricks-Codex"
 
 
 def test_credential_label_cli_config_falls_back_to_entry_name() -> None:
@@ -2499,7 +2499,7 @@ def test_credential_label_cli_config_falls_back_to_entry_name() -> None:
     """
     from omnigent.onboarding.configure_models import credential_label
 
-    assert credential_label("cli-config", "codex-myproxy") == "codex-myproxy"
+    assert credential_label("cli-config", "codex-myproxy") == "Codex-Myproxy"
 
 
 def test_build_cli_config_provider_entry_shapes() -> None:

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -3418,3 +3418,27 @@ class TestCodexAppServerSessionReadOnlyCwd(unittest.TestCase):
             dir_used = self._run_start_and_capture_mkdtemp_dir(writable_dir)
             expected = str(Path(writable_dir) / ".codex-tmp")
             self.assertEqual(dir_used, expected)
+
+
+def test_run_turn_cli_config_passes_no_model_to_thread_create():
+    """On the cli-config path (model_provider_override set), model=None is passed
+    to thread/create so the codex binary uses its own configured model rather than
+    forwarding an unresolvable alias (e.g. gpt-5.6) to the Databricks UC API."""
+
+    async def _t():
+        fake_session = _FakeAppSession([[TurnComplete(response="done")]])
+        executor = CodexExecutor(
+            codex_path="/bin/echo",
+            model="gpt-5.6",
+            model_provider_override="Databricks",
+            app_session_factory=lambda **kwargs: fake_session,
+        )
+        async for _ in executor.run_turn(
+            [{"role": "user", "content": "hi", "session_id": "s1"}],
+            [],
+            "",
+        ):
+            pass
+        assert fake_session.calls[0]["model"] is None
+
+    _run(_t())


### PR DESCRIPTION
## Related issue

N/A

## Summary

Two gateway routing fixes surfaced while debugging Pi and Codex failures against the Databricks AI Gateway:

- **Pi — bracket suffix stripping**: The Databricks AI Gateway rejects model IDs with trailing bracket suffixes like \`system.ai.claude-opus-5[1m]\` (returns 404), even though the direct Anthropic API accepts them as context-window hints. Both \`PiExecutor._resolve_model\` (subprocess path) and \`_inline_family_pi_provider\` in \`pi_native_credentials.py\` (pi-native path) now strip any \`[…]\` suffix when on a gateway path.

- **Codex — cli-config model passthrough**: On the \`cli-config\` path (\`model_provider_override\` set), the codex binary owns its own model list via \`config.toml\`. Passing an unresolvable alias (e.g. \`gpt-5.6\`) as a model override caused the binary to call the UC API and get a validation error. \`run_turn\` now passes \`model=None\` on this path, letting the binary use its configured default.

- **\`credential_label\` for cli-config**: Drops the \`display_name\` field in favour of \`provider_display_name(provider_name)\` so cli-config providers label consistently with other provider kinds.

## Test Plan

- [x] Confirmed \`system.ai.claude-opus-5[1m]\` returns 404 and \`system.ai.claude-opus-5\` returns 200 against the AI Gateway endpoint directly
- [x] \`pre-commit run --all-files\` passes (pyright clean, no hook failures)
- [x] Unit test added for the cli-config \`model=None\` path in \`test_codex_executor.py\`
- [x] Existing \`test_configure_models.py\` tests updated to match new \`credential_label\` behaviour

## Demo

<img width="873" height="945" alt="image" src="https://github.com/user-attachments/assets/787daa7f-30e3-4292-b020-6cd643edbd9c" />


## Type of change

- [x] Bug fix

## Test coverage

- [x] Unit tests added / updated
- [x] Manual verification completed

## Coverage notes

Bracket-stripping verified by hitting the gateway endpoint directly with and without \`[1m]\`. Codex cli-config path verified by the new unit test asserting \`model=None\` is forwarded to \`thread/create\`.

## Changelog

Pi and Pi-native no longer fail with a 404 when a model ID like \`system.ai.claude-opus-5[1m]\` is configured against the Databricks AI Gateway.