### PR TITLE
feat(web): split the harness picker by support level and remember used harnesses

### DIFF
--- a/tests/e2e_ui/chat/test_harness_support_level_split.py
+++ b/tests/e2e_ui/chat/test_harness_support_level_split.py
@@ -1,0 +1,333 @@
+"""E2E: the New Chat picker leads with fully supported harnesses.
+
+The landing composer (``NewChatLandingScreen`` in
+``web/src/shell/NewChatDialog.tsx``) splits its **Harnesses** group by *support
+level*, not host readiness: only harnesses flagged ``fullySupported`` in
+``web/src/lib/nativeCodingAgents.ts`` (Claude Code and Codex) list inline, and
+every other harness folds into the "More" submenu.
+
+Why the stub marks **every** harness configured: readiness could otherwise
+populate "More" on its own, and the test would pass without proving anything
+about the support-level split. With all four harnesses ready on the host, the
+only thing that can push Cursor and Pi behind "More" is the flag — so this
+covers the actual behavior rather than a confound.
+
+The two rules that interact with the split get their own assertions: the
+currently-selected harness is pinned inline even when it isn't fully supported
+(so the active pick is never buried), and the ordering inside "More" follows the
+same ``sortRank`` as the primary list.
+
+Why the ``page.route`` stubbing and the async-in-a-fresh-thread shape: both are
+inherited from ``chat/test_hide_unconfigured_harnesses.py`` — the e2e harness's
+runner tunnels into the server and registers no *host*, so faking ``/v1/hosts``
+(with ``configured_harnesses``) and ``/v1/agents`` is the established way to
+drive the landing picker, and once a pytest-playwright *sync* test has run in
+the session, pytest-asyncio can't start a loop on the main thread, so each
+async body runs in its own thread via :func:`asyncio.run`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import threading
+from collections.abc import Coroutine
+from typing import Any
+
+from playwright.async_api import Route, async_playwright, expect
+
+# Stubbed host the composer auto-selects (the tunneled runner registers no
+# host). Keyed identically in the recent-workspaces localStorage seed.
+_HOST_ID = "host_e2e"
+_HOST_NAME = "e2e-host"
+
+# Two fully supported harnesses (lead inline) and two that are not (fold into
+# "More"). Cursor (sortRank 30) precedes Pi (40), which the "More" ordering
+# assertion relies on.
+_CLAUDE_AGENT_ID = "ag_claude_e2e"
+_CODEX_AGENT_ID = "ag_codex_e2e"
+_CURSOR_AGENT_ID = "ag_cursor_e2e"
+_PI_AGENT_ID = "ag_pi_e2e"
+
+
+def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:
+    """Run *coro* to completion in a dedicated thread with its own event loop.
+
+    The e2e_ui suite runs many pytest-playwright **sync** tests in the same
+    session; once one has run, pytest-asyncio can't start a loop on the main
+    thread. Running the coroutine from a fresh thread via :func:`asyncio.run`
+    sidesteps that. Any exception (including assertion failures) is captured and
+    re-raised on the calling thread so the test fails normally.
+
+    :param coro: The coroutine to run to completion.
+    :raises Exception: Whatever the coroutine raised, re-raised here.
+    """
+    captured: dict[str, Exception] = {}
+
+    def _worker() -> None:
+        try:
+            asyncio.run(coro)
+        except Exception as exc:
+            captured["error"] = exc
+
+    thread = threading.Thread(target=_worker)
+    thread.start()
+    thread.join()
+    if "error" in captured:
+        raise captured["error"]
+
+
+def _hosts_body() -> str:
+    """Stub body for ``GET /v1/hosts``: one online host, every harness ready.
+
+    Marking all four harnesses configured is the point of the fixture — it
+    removes readiness as a possible cause for the "More" grouping, leaving the
+    ``fullySupported`` flag as the only explanation.
+    """
+    return json.dumps(
+        {
+            "hosts": [
+                {
+                    "host_id": _HOST_ID,
+                    "name": _HOST_NAME,
+                    "owner": "e2e",
+                    "status": "online",
+                    "configured_harnesses": {
+                        "claude-native": True,
+                        "codex-native": True,
+                        "cursor-native": True,
+                        "pi-native": True,
+                    },
+                }
+            ]
+        }
+    )
+
+
+def _agents_body() -> str:
+    """Stub body for ``GET /v1/agents``: two supported + two unsupported natives."""
+    return json.dumps(
+        {
+            "data": [
+                {
+                    "id": _CLAUDE_AGENT_ID,
+                    "name": "claude-native-ui",
+                    "display_name": "Claude Code",
+                    "description": "Anthropic's coding agent",
+                    "harness": "claude-native",
+                    "skills": [],
+                },
+                {
+                    "id": _CODEX_AGENT_ID,
+                    "name": "codex-native-ui",
+                    "display_name": "Codex",
+                    "description": "OpenAI's coding agent",
+                    "harness": "codex-native",
+                    "skills": [],
+                },
+                {
+                    "id": _CURSOR_AGENT_ID,
+                    "name": "cursor-native-ui",
+                    "display_name": "Cursor",
+                    "description": "Cursor's coding agent",
+                    "harness": "cursor-native",
+                    "skills": [],
+                },
+                {
+                    "id": _PI_AGENT_ID,
+                    "name": "pi-native-ui",
+                    "display_name": "Pi",
+                    "description": "Pi coding agent",
+                    "harness": "pi-native",
+                    "skills": [],
+                },
+            ]
+        }
+    )
+
+
+async def _register_routes(page) -> None:
+    """Register the host/agent stubs and neutralize agent discovery.
+
+    :param page: The Playwright page to install routes on.
+    """
+
+    async def handle_hosts(route: Route) -> None:
+        await route.fulfill(status=200, content_type="application/json", body=_hosts_body())
+
+    async def handle_agents(route: Route) -> None:
+        await route.fulfill(status=200, content_type="application/json", body=_agents_body())
+
+    async def handle_agent_scan(route: Route) -> None:
+        # Neutralize agent discovery so only the stubbed agents feed the picker;
+        # sessions other tests left behind would otherwise leak in and swap the
+        # selection out from under the assertions.
+        await route.fulfill(
+            status=200, content_type="application/json", body=json.dumps({"data": []})
+        )
+
+    await page.route("**/v1/hosts", handle_hosts)
+    await page.route("**/v1/agents", handle_agents)
+    await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+
+
+async def _open_picker(page) -> None:
+    """Open the landing agent/harness picker dropdown."""
+    await page.get_by_test_id("new-chat-landing-agent-select").click()
+
+
+def test_previously_launched_harness_is_promoted_inline(
+    seeded_session: tuple[str, str],
+) -> None:
+    """A harness in ``omnigent:recent-harnesses`` leads instead of hiding in "More".
+
+    Same fixture as the split test — every harness configured — so the promotion
+    can only come from the stored recents list. Seeding localStorage rather than
+    driving a real launch keeps this a picker test: the create path's write is
+    covered by the ``NewChatDialog.flow`` unit test.
+    """
+    base_url, session_id = seeded_session
+    del session_id  # this flow never creates a session — only reads the picker
+    _run_in_fresh_loop(_drive_recent(base_url))
+
+
+async def _drive_recent(base_url: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            await _register_routes(page)
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );
+                window.localStorage.setItem(
+                    "omnigent:recent-harnesses",
+                    JSON.stringify(["pi-native"])
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            await _open_picker(page)
+
+            # Pi was launched before → inline alongside the supported harnesses.
+            await expect(
+                page.get_by_test_id(f"new-chat-landing-agent-{_PI_AGENT_ID}")
+            ).to_be_visible(timeout=30_000)
+            # Cursor was not → still behind "More", so the promotion is specific
+            # to the stored entry rather than a blanket un-grouping.
+            await expect(
+                page.get_by_test_id(f"new-chat-landing-agent-{_CURSOR_AGENT_ID}")
+            ).to_have_count(0)
+        finally:
+            await browser.close()
+
+
+def test_picker_leads_with_fully_supported_harnesses(
+    seeded_session: tuple[str, str],
+) -> None:
+    """Claude Code and Codex lead; other harnesses fold into "More".
+
+    1. **primary list** — Claude Code and Codex render inline, in rank order.
+    2. **"More"** — Cursor and Pi are absent inline and appear (in rank order)
+       only after opening the submenu, even though the host reports both ready.
+    3. **selected pick pinned** — choosing Pi promotes it inline, so the active
+       harness is never buried behind a hover.
+    """
+    base_url, session_id = seeded_session
+    del session_id  # this flow never creates a session — only reads the picker
+    _run_in_fresh_loop(_drive(base_url))
+
+
+async def _drive(base_url: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            await _register_routes(page)
+            # Seed a recent working directory so the composer auto-fills (it
+            # never has to touch the host-less file browser).
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            # 1. The fully supported harnesses lead the list inline.
+            await _open_picker(page)
+            claude = page.get_by_test_id(f"new-chat-landing-agent-{_CLAUDE_AGENT_ID}")
+            codex = page.get_by_test_id(f"new-chat-landing-agent-{_CODEX_AGENT_ID}")
+            await expect(claude).to_be_visible(timeout=30_000)
+            await expect(codex).to_be_visible(timeout=30_000)
+
+            # 2. Cursor and Pi are configured on this host yet still not inline:
+            #    support level, not readiness, put them behind "More".
+            await expect(
+                page.get_by_test_id(f"new-chat-landing-agent-{_CURSOR_AGENT_ID}")
+            ).to_have_count(0)
+            await expect(
+                page.get_by_test_id(f"new-chat-landing-agent-{_PI_AGENT_ID}")
+            ).to_have_count(0)
+
+            await page.get_by_test_id("new-chat-landing-harness-more").click()
+            cursor_row = page.get_by_test_id(f"new-chat-landing-agent-{_CURSOR_AGENT_ID}")
+            pi_row = page.get_by_test_id(f"new-chat-landing-agent-{_PI_AGENT_ID}")
+            await expect(cursor_row).to_be_visible(timeout=30_000)
+            await expect(pi_row).to_be_visible()
+            # "More" keeps the primary list's rank ordering: Cursor (30) → Pi (40).
+            assert await _renders_before(page, _CURSOR_AGENT_ID, _PI_AGENT_ID), (
+                "expected Cursor to render before Pi inside the More submenu"
+            )
+
+            # 3. Committing Pi pins it inline — the active pick is never buried.
+            await pi_row.click()
+            await expect(page.get_by_test_id("new-chat-landing-agent-select")).to_contain_text(
+                "Pi"
+            )
+            # Committing closes the menu; wait for it to unmount before
+            # reopening, else the click lands mid-close and never reopens.
+            await page.get_by_test_id("new-chat-landing-harness-more").wait_for(
+                state="detached", timeout=10_000
+            )
+            await _open_picker(page)
+            await expect(
+                page.get_by_test_id(f"new-chat-landing-agent-{_PI_AGENT_ID}")
+            ).to_be_visible(timeout=30_000)
+        finally:
+            await browser.close()
+
+
+async def _renders_before(page, first_agent_id: str, second_agent_id: str) -> bool:
+    """Whether *first_agent_id*'s row precedes *second_agent_id*'s in the DOM.
+
+    Document order is what the user reads top-to-bottom, so comparing positions
+    checks the rendered ordering rather than merely that both rows exist.
+
+    :param page: The Playwright page (both rows are mounted).
+    :param first_agent_id: Stubbed agent id expected to render first.
+    :param second_agent_id: Stubbed agent id expected to render second.
+    :returns: True when the first row precedes the second in document order.
+    """
+    return await page.evaluate(
+        """([firstId, secondId]) => {
+            const sel = (id) => document.querySelector(
+                `[data-testid="new-chat-landing-agent-${id}"]`
+            );
+            const a = sel(firstId);
+            const b = sel(secondId);
+            if (!a || !b) return false;
+            return (a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0;
+        }""",
+        [first_agent_id, second_agent_id],
+    )

--- a/tests/e2e_ui/start_session/test_harness_install.py
+++ b/tests/e2e_ui/start_session/test_harness_install.py
@@ -240,9 +240,10 @@ async def _drive_install(base_url: str) -> None:
             # picker: open it, wait for the Codex row to render (it mounts only
             # after the /v1/agents fetch resolves — can lag under CI load), then
             # click it. Only then does the composer show the "Set up Codex"
-            # notice for its unconfigured harness.
+            # notice for its unconfigured harness. Codex is a fully supported
+            # harness, so it lists inline even while it needs setup — no "More"
+            # drill-in.
             await page.get_by_test_id("new-chat-landing-agent-select").click()
-            await page.get_by_test_id("new-chat-landing-harness-more").click()
             codex_option = page.get_by_test_id("new-chat-landing-agent-ag_codex_e2e")
             await expect(codex_option).to_be_visible(timeout=60_000)
             await codex_option.click()

--- a/web/src/hooks/useRecentHarnesses.test.ts
+++ b/web/src/hooks/useRecentHarnesses.test.ts
@@ -1,0 +1,86 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useRecentHarnesses } from "./useRecentHarnesses";
+
+const KEY = "omnigent:recent-harnesses";
+
+function stored(): unknown {
+  const raw = localStorage.getItem(KEY);
+  return raw === null ? null : JSON.parse(raw);
+}
+
+describe("useRecentHarnesses", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("starts empty and records a launched harness", () => {
+    const { result } = renderHook(() => useRecentHarnesses());
+    expect(result.current.recentHarnesses).toEqual([]);
+
+    act(() => result.current.addRecentHarness("pi-native"));
+    expect(result.current.recentHarnesses).toEqual(["pi-native"]);
+    expect(stored()).toEqual(["pi-native"]);
+  });
+
+  it("moves a repeat launch to the front instead of duplicating it", () => {
+    const { result } = renderHook(() => useRecentHarnesses());
+    act(() => result.current.addRecentHarness("pi-native"));
+    act(() => result.current.addRecentHarness("cursor-native"));
+    act(() => result.current.addRecentHarness("pi-native"));
+    expect(result.current.recentHarnesses).toEqual(["pi-native", "cursor-native"]);
+  });
+
+  it("caps the list at four entries, dropping the oldest", () => {
+    const { result } = renderHook(() => useRecentHarnesses());
+    for (const h of ["a", "b", "c", "d", "e"]) {
+      act(() => result.current.addRecentHarness(h));
+    }
+    expect(result.current.recentHarnesses).toEqual(["e", "d", "c", "b"]);
+  });
+
+  it("skips the write when the harness is already newest", () => {
+    const { result } = renderHook(() => useRecentHarnesses());
+    act(() => result.current.addRecentHarness("pi-native"));
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
+    act(() => result.current.addRecentHarness("pi-native"));
+    // Relaunching the same harness is the common case; re-storing an identical
+    // list would only cost a wasted render.
+    expect(setItem).not.toHaveBeenCalled();
+    expect(result.current.recentHarnesses).toEqual(["pi-native"]);
+  });
+
+  it("ignores blank ids", () => {
+    const { result } = renderHook(() => useRecentHarnesses());
+    act(() => result.current.addRecentHarness("   "));
+    expect(result.current.recentHarnesses).toEqual([]);
+    expect(stored()).toBeNull();
+  });
+
+  it("reads through malformed stored values without throwing", () => {
+    localStorage.setItem(KEY, "{not json");
+    expect(renderHook(() => useRecentHarnesses()).result.current.recentHarnesses).toEqual([]);
+
+    // Wrong shape (object, not array) and non-string members are both dropped.
+    localStorage.setItem(KEY, JSON.stringify({ "pi-native": true }));
+    expect(renderHook(() => useRecentHarnesses()).result.current.recentHarnesses).toEqual([]);
+
+    localStorage.setItem(KEY, JSON.stringify(["pi-native", 7, null]));
+    expect(renderHook(() => useRecentHarnesses()).result.current.recentHarnesses).toEqual([
+      "pi-native",
+    ]);
+  });
+
+  it("survives a storage write failure (quota / disabled)", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    const { result } = renderHook(() => useRecentHarnesses());
+    // Non-fatal: the in-memory list still updates so the current session sees
+    // the promotion; only persistence is lost.
+    act(() => result.current.addRecentHarness("pi-native"));
+    expect(result.current.recentHarnesses).toEqual([]);
+  });
+});

--- a/web/src/hooks/useRecentHarnesses.ts
+++ b/web/src/hooks/useRecentHarnesses.ts
@@ -1,0 +1,77 @@
+// localStorage-backed set of harnesses the user has actually launched. Lets the
+// picker promote a harness someone uses regularly (Pi, Cursor) into the primary
+// list alongside the fully supported ones, instead of leaving it behind "More"
+// forever.
+
+import { useCallback, useMemo, useState } from "react";
+
+const STORAGE_KEY = "omnigent:recent-harnesses";
+const MAX_ENTRIES = 4;
+
+/** Most-recent-first canonical harness ids, e.g. ``["pi-native", …]``. */
+function readAll(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    // Drop anything malformed so a corrupted entry can't crash the picker.
+    return parsed.filter((x): x is string => typeof x === "string");
+  } catch {
+    return [];
+  }
+}
+
+function writeAll(list: string[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+  } catch {
+    // Quota exceeded or storage disabled — non-fatal; recents just stop
+    // persisting until the next successful write.
+  }
+}
+
+export interface RecentHarnesses {
+  /** Most-recent-first harness ids the user has launched. */
+  recentHarnesses: string[];
+  /**
+   * Record ``harness`` as the newest launched harness. De-duplicates (moves an
+   * existing entry to the front) and caps the list. No-op for a blank id.
+   */
+  addRecentHarness: (harness: string) => void;
+}
+
+/**
+ * Track which harnesses this user actually launches.
+ *
+ * Not host-scoped, unlike recent workspaces: a preference for Pi follows the
+ * person across machines, whereas a workspace path is meaningful on one host.
+ *
+ * @returns The recent harness ids plus an ``addRecentHarness`` recorder.
+ */
+export function useRecentHarnesses(): RecentHarnesses {
+  // Bumped by addRecentHarness to recompute after a write; the list is read
+  // synchronously below rather than hydrated via an effect, so the picker never
+  // renders one frame behind the stored value.
+  const [revision, setRevision] = useState(0);
+
+  const recentHarnesses = useMemo(() => {
+    void revision;
+    return readAll();
+  }, [revision]);
+
+  const addRecentHarness = useCallback((harness: string) => {
+    const trimmed = harness.trim();
+    if (!trimmed) return;
+    const existing = readAll();
+    // Already the newest entry → nothing to reorder, so skip the write and the
+    // re-render it would trigger (the common case: relaunching the same harness).
+    if (existing[0] === trimmed) return;
+    writeAll([trimmed, ...existing.filter((h) => h !== trimmed)].slice(0, MAX_ENTRIES));
+    setRevision((r) => r + 1);
+  }, []);
+
+  return { recentHarnesses, addRecentHarness };
+}

--- a/web/src/lib/nativeCodingAgents.test.ts
+++ b/web/src/lib/nativeCodingAgents.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from "vitest";
+import type { NativeCodingAgentSpec } from "./nativeCodingAgents";
 import {
+  NATIVE_CODING_AGENTS,
   UI_MODE_LABEL_KEY,
   UI_MODE_TERMINAL_VALUE,
   WRAPPER_LABEL_KEY,
+  isFullySupportedNativeCodingAgent,
   isNativeTerminalSession,
   nativeCodingAgentForHarness,
   nativeWrapperLabelsForAgent,
@@ -123,5 +126,40 @@ describe("isNativeTerminalSession", () => {
     expect(isNativeTerminalSession(null)).toBe(false);
     expect(isNativeTerminalSession(undefined)).toBe(false);
     expect(isNativeTerminalSession({})).toBe(false);
+  });
+});
+
+describe("isFullySupportedNativeCodingAgent", () => {
+  it("is true for exactly Claude Code and Codex", () => {
+    const supported = (NATIVE_CODING_AGENTS as readonly NativeCodingAgentSpec[])
+      .filter((a) => a.fullySupported === true)
+      .map((a) => a.key);
+    expect(supported).toEqual(["claude", "codex"]);
+  });
+
+  it("resolves the flag by harness and by agent name", () => {
+    expect(
+      isFullySupportedNativeCodingAgent({ name: "claude-native-ui", harness: "claude-native" }),
+    ).toBe(true);
+    expect(
+      isFullySupportedNativeCodingAgent({ name: "codex-native-ui", harness: "codex-native" }),
+    ).toBe(true);
+  });
+
+  it("is false for every other harness (they fold into 'More')", () => {
+    expect(isFullySupportedNativeCodingAgent({ name: "pi-native-ui", harness: "pi-native" })).toBe(
+      false,
+    );
+    expect(
+      isFullySupportedNativeCodingAgent({ name: "cursor-native-ui", harness: "cursor-native" }),
+    ).toBe(false);
+    expect(
+      isFullySupportedNativeCodingAgent({ name: "opencode-native-ui", harness: "opencode-native" }),
+    ).toBe(false);
+  });
+
+  it("is false for non-native agents and null", () => {
+    expect(isFullySupportedNativeCodingAgent({ name: "polly", harness: "claude-sdk" })).toBe(false);
+    expect(isFullySupportedNativeCodingAgent(null)).toBe(false);
   });
 });

--- a/web/src/lib/nativeCodingAgents.test.ts
+++ b/web/src/lib/nativeCodingAgents.test.ts
@@ -7,6 +7,7 @@ import {
   WRAPPER_LABEL_KEY,
   isFullySupportedNativeCodingAgent,
   isNativeTerminalSession,
+  isRecentHarness,
   nativeCodingAgentForHarness,
   nativeWrapperLabelsForAgent,
 } from "./nativeCodingAgents";
@@ -161,5 +162,28 @@ describe("isFullySupportedNativeCodingAgent", () => {
   it("is false for non-native agents and null", () => {
     expect(isFullySupportedNativeCodingAgent({ name: "polly", harness: "claude-sdk" })).toBe(false);
     expect(isFullySupportedNativeCodingAgent(null)).toBe(false);
+  });
+});
+
+describe("isRecentHarness", () => {
+  const pi = { name: "pi-native-ui", harness: "pi-native" };
+
+  it("matches a stored canonical harness id", () => {
+    expect(isRecentHarness(pi, ["pi-native"])).toBe(true);
+  });
+
+  it("folds a stored reversed alias to the canonical spec", () => {
+    expect(isRecentHarness(pi, ["native-pi"])).toBe(true);
+  });
+
+  it("is false for a harness that isn't in the list", () => {
+    expect(isRecentHarness(pi, ["cursor-native"])).toBe(false);
+    expect(isRecentHarness(pi, [])).toBe(false);
+  });
+
+  it("is false for non-native agents, null, and unknown stored ids", () => {
+    expect(isRecentHarness({ name: "polly", harness: "claude-sdk" }, ["claude-sdk"])).toBe(false);
+    expect(isRecentHarness(null, ["pi-native"])).toBe(false);
+    expect(isRecentHarness(pi, ["not-a-harness"])).toBe(false);
   });
 });

--- a/web/src/lib/nativeCodingAgents.ts
+++ b/web/src/lib/nativeCodingAgents.ts
@@ -234,6 +234,20 @@ export function isFullySupportedNativeCodingAgent(
   return nativeCodingAgentForAvailableAgent(agent)?.fullySupported === true;
 }
 
+/**
+ * Whether ``agent``'s harness is one of ``recentHarnesses``. Compares resolved
+ * specs rather than raw strings so a stored reversed alias (``native-pi``) still
+ * matches the canonical spelling (``pi-native``).
+ */
+export function isRecentHarness(
+  agent: Pick<AvailableAgent, "name" | "harness"> | null | undefined,
+  recentHarnesses: readonly string[],
+): boolean {
+  const spec = nativeCodingAgentForAvailableAgent(agent);
+  if (spec === undefined) return false;
+  return recentHarnesses.some((h) => nativeCodingAgentForHarness(h)?.key === spec.key);
+}
+
 export function isNativeWrapper(wrapper: string | null | undefined): boolean {
   return nativeCodingAgentForWrapper(wrapper) !== undefined;
 }

--- a/web/src/lib/nativeCodingAgents.ts
+++ b/web/src/lib/nativeCodingAgents.ts
@@ -27,6 +27,12 @@ export interface NativeCodingAgentSpec {
   iconKind: NativeCodingAgentIconKind;
   sortRank: number;
   capabilities?: readonly NativeCodingAgentCapability[];
+  /**
+   * A fully supported harness — the integration we maintain and test end to
+   * end. Only these lead the picker's primary list; every other harness folds
+   * into the "More" group regardless of whether it is configured on the host.
+   */
+  fullySupported?: boolean;
 }
 
 export const NATIVE_CODING_AGENTS = [
@@ -39,6 +45,7 @@ export const NATIVE_CODING_AGENTS = [
     iconKind: "claude",
     sortRank: 10,
     capabilities: ["permissionMode"],
+    fullySupported: true,
   },
   {
     key: "codex",
@@ -49,6 +56,7 @@ export const NATIVE_CODING_AGENTS = [
     iconKind: "codex",
     sortRank: 20,
     capabilities: ["approvalMode"],
+    fullySupported: true,
   },
   {
     key: "opencode",
@@ -213,6 +221,17 @@ export function isNativeCodingAgent(
   agent: Pick<AvailableAgent, "name" | "harness"> | null | undefined,
 ): boolean {
   return nativeCodingAgentForAvailableAgent(agent) !== undefined;
+}
+
+/**
+ * Whether a harness is fully supported — the maintained, end-to-end tested
+ * integrations that lead the picker. Everything else (including non-native
+ * agents) belongs in the "More" group regardless of host readiness.
+ */
+export function isFullySupportedNativeCodingAgent(
+  agent: Pick<AvailableAgent, "name" | "harness"> | null | undefined,
+): boolean {
+  return nativeCodingAgentForAvailableAgent(agent)?.fullySupported === true;
 }
 
 export function isNativeWrapper(wrapper: string | null | undefined): boolean {

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -177,9 +177,16 @@ function openWorktree(): void {
   fireEvent.click(screen.getByTestId("new-chat-landing-branch-chip"));
 }
 
-/** Open the picker and commit (select + close) an agent by clicking its row. */
+/**
+ * Open the picker and commit (select + close) an agent by clicking its row.
+ * Only the fully supported harnesses lead inline; the rest sit under "More", so
+ * drill in when the row isn't already listed.
+ */
 function selectAgent(agentId: string): void {
   fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+  if (screen.queryByTestId(`new-chat-landing-agent-${agentId}`) == null) {
+    fireEvent.click(screen.getByTestId("new-chat-landing-harness-more"));
+  }
   fireEvent.click(screen.getByTestId(`new-chat-landing-agent-${agentId}`));
 }
 
@@ -756,6 +763,54 @@ describe("NewChatLandingScreen create flow", () => {
     const body = JSON.parse(init.body as string);
     expect(body.labels?.["omnigent.wrapper"]).toBe("opencode-native-ui");
     expect(body.terminal_launch_args).toBeUndefined();
+  });
+
+  it("records the launched harness so the picker can promote it later", async () => {
+    // The picker promotes previously-launched harnesses out of "More"; this is
+    // the write half of that contract. OpenCode isn't fully supported, so
+    // without this record it would stay behind "More" forever.
+    setAgents([
+      agent({ id: "ag_native", name: "claude-native-ui", display_name: "Claude Code" }),
+      agent({ id: "ag_opencode", name: "opencode-native-ui", display_name: "OpenCode" }),
+    ]);
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_opencode" }),
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    expect(localStorage.getItem("omnigent:recent-harnesses")).toBeNull();
+
+    selectAgent("ag_opencode");
+    typeMessage("go");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
+    // Stored under the canonical harness id, not the agent name or wrapper.
+    await waitFor(() =>
+      expect(JSON.parse(localStorage.getItem("omnigent:recent-harnesses") ?? "[]")).toEqual([
+        "opencode-native",
+      ]),
+    );
+  });
+
+  it("does not record a harness when the create fails", async () => {
+    // Only a successful launch earns a primary slot — a failed create must not
+    // promote the harness the user merely attempted.
+    setAgents([agent({ id: "ag_opencode", name: "opencode-native-ui", display_name: "OpenCode" })]);
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: "boom" }),
+      text: async () => "boom",
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    typeMessage("go");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
+    expect(localStorage.getItem("omnigent:recent-harnesses")).toBeNull();
   });
 
   it("omits terminal_launch_args when permission mode is left at default for claude-native", async () => {

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -730,13 +730,16 @@ function selectAgent(agentId: string): void {
 }
 
 /**
- * Select an agent whose harness is unconfigured on the host. Such agents fold
- * into the picker's "More" submenu (they aren't listed inline), so we open the
- * picker, drill into "More", then commit the row.
+ * Select a harness that may live under the picker's "More" submenu. Fully
+ * supported harnesses list inline even when they need setup; everything else
+ * folds into "More". Drills in only when the row isn't already inline, so
+ * callers don't have to track which side of the split their fixture lands on.
  */
 function selectUnconfiguredAgent(agentId: string): void {
   fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
-  fireEvent.click(screen.getByTestId("new-chat-landing-harness-more"));
+  if (screen.queryByTestId(`new-chat-landing-agent-${agentId}`) == null) {
+    fireEvent.click(screen.getByTestId("new-chat-landing-harness-more"));
+  }
   fireEvent.click(screen.getByTestId(`new-chat-landing-agent-${agentId}`));
 }
 
@@ -900,50 +903,130 @@ describe("NewChatLandingScreen", () => {
     ]);
     renderLanding();
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
-    const cursor = screen.getByTestId("new-chat-landing-agent-a_cursor");
-    const pi = screen.getByTestId("new-chat-landing-agent-a_pi");
-    const kiro = screen.getByTestId("new-chat-landing-agent-a_kiro");
+    // Only the fully supported harnesses lead, in rank order, ahead of the
+    // Agents group.
+    const claude = screen.getByTestId("new-chat-landing-agent-a_claude");
+    const codex = screen.getByTestId("new-chat-landing-agent-a_codex");
     const polly = screen.getByTestId("new-chat-landing-agent-a_polly");
-    expect(cursor.compareDocumentPosition(pi) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(pi.compareDocumentPosition(kiro) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(kiro.compareDocumentPosition(polly) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(claude.compareDocumentPosition(codex) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(codex.compareDocumentPosition(polly) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // Every other harness folds into "More", even though all are configured
+    // here — support level, not host readiness, decides the split.
+    for (const id of ["a_cursor", "a_pi", "a_kiro"]) {
+      expect(screen.queryByTestId(`new-chat-landing-agent-${id}`)).toBeNull();
+    }
+    fireEvent.click(screen.getByTestId("new-chat-landing-harness-more"));
+    const morePi = screen.getByTestId("new-chat-landing-agent-a_pi");
+    const moreCursor = screen.getByTestId("new-chat-landing-agent-a_cursor");
+    const moreKiro = screen.getByTestId("new-chat-landing-agent-a_kiro");
+    // "More" keeps the same rank ordering: Cursor (30) → Pi (40) → Kiro (50).
+    expect(
+      moreCursor.compareDocumentPosition(morePi) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      morePi.compareDocumentPosition(moreKiro) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
-  // The default agents are claude-native (a1) and codex-native (a2); the host
-  // below reports codex-native as unconfigured on this machine.
+  it("pins a not-fully-supported harness inline once it is the selected pick", () => {
+    // Pi isn't fully supported, so a fresh picker never leads with it — but
+    // selecting it must pin it inline so the active pick is never buried.
+    mockAgents([
+      {
+        id: "a_claude",
+        name: "claude-native-ui",
+        display_name: "Claude Code",
+        description: null,
+        harness: "claude-native",
+        skills: [],
+      },
+      {
+        id: "a_pi",
+        name: "pi-native-ui",
+        display_name: "Pi",
+        description: null,
+        harness: "pi-native",
+        skills: [],
+      },
+    ]);
+    renderLanding();
+    selectUnconfiguredAgent("a_pi");
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    // Now selected → inline, no drill-down needed.
+    expect(screen.getByTestId("new-chat-landing-agent-a_pi")).toBeTruthy();
+  });
+
+  // claude-native (a1, fully supported) plus cursor-native (a_cursor, not) so
+  // the preference has a "More" row to act on: the host below reports
+  // cursor-native as unconfigured on this machine.
   function mockHostWithHarnessReadiness() {
+    mockAgents([
+      {
+        id: "a1",
+        name: "claude-native-ui",
+        display_name: "Claude Code",
+        description: null,
+        harness: "claude-native",
+        skills: [],
+      },
+      {
+        id: "a_cursor",
+        name: "cursor-native-ui",
+        display_name: "Cursor",
+        description: null,
+        harness: "cursor-native",
+        skills: [],
+      },
+    ]);
+    mockHosts([
+      {
+        ...host("online"),
+        configured_harnesses: { "claude-native": true, "cursor-native": false },
+      } as Host,
+    ]);
+  }
+
+  it("keeps unconfigured harnesses in the 'More' submenu by default (opt-in preference off)", () => {
+    // With the preference untouched the picker keeps offering harnesses that
+    // aren't set up on the host: they stay in "More" (badged, not hidden), so
+    // users can still discover and configure them.
+    mockHostWithHarnessReadiness();
+    renderLanding();
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    expect(screen.getByTestId("new-chat-landing-agent-a1")).toBeTruthy();
+    expect(screen.queryByTestId("new-chat-landing-agent-a_cursor")).toBeNull();
+    fireEvent.click(screen.getByTestId("new-chat-landing-harness-more"));
+    expect(screen.getByTestId("new-chat-landing-agent-a_cursor")).toBeTruthy();
+  });
+
+  it("hides harnesses unconfigured on the selected host when the preference is on", () => {
+    // Preference on → cursor-native (unconfigured on host_1) drops out of the
+    // picker entirely, taking the now-empty "More" trigger with it, while
+    // claude-native (configured, fully supported) stays inline.
+    writeHideUnconfiguredHarnesses(true);
+    mockHostWithHarnessReadiness();
+    renderLanding();
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    expect(screen.getByTestId("new-chat-landing-agent-a1")).toBeTruthy();
+    expect(screen.queryByTestId("new-chat-landing-agent-a_cursor")).toBeNull();
+    expect(screen.queryByTestId("new-chat-landing-harness-more")).toBeNull();
+  });
+
+  it("leads with fully supported harnesses even when they need setup on the host", () => {
+    // Support level outranks readiness for the primary list: an unconfigured
+    // Codex still leads (badged), rather than being demoted to "More".
     mockHosts([
       {
         ...host("online"),
         configured_harnesses: { "claude-native": true, "codex-native": false },
       } as Host,
     ]);
-  }
-
-  it("folds unconfigured harnesses into the 'More' submenu by default (opt-in preference off)", () => {
-    // With the preference untouched the picker keeps offering harnesses that
-    // aren't set up on the host — configured ones (a1) list inline, and the
-    // "needs setup" ones (a2) fold into the "More" submenu (badged, not
-    // hidden), so users can still discover and configure them.
-    mockHostWithHarnessReadiness();
     renderLanding();
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
     expect(screen.getByTestId("new-chat-landing-agent-a1")).toBeTruthy();
-    // a2 is unconfigured → not inline; it lives behind "More".
-    expect(screen.queryByTestId("new-chat-landing-agent-a2")).toBeNull();
-    fireEvent.click(screen.getByTestId("new-chat-landing-harness-more"));
     expect(screen.getByTestId("new-chat-landing-agent-a2")).toBeTruthy();
-  });
-
-  it("hides harnesses unconfigured on the selected host when the preference is on", () => {
-    // Preference on → codex-native (reported unconfigured on host_1) drops out
-    // of the picker while claude-native (configured) stays.
-    writeHideUnconfiguredHarnesses(true);
-    mockHostWithHarnessReadiness();
-    renderLanding();
-    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
-    expect(screen.getByTestId("new-chat-landing-agent-a1")).toBeTruthy();
-    expect(screen.queryByTestId("new-chat-landing-agent-a2")).toBeNull();
+    // Nothing left to group → no "More" trigger at all.
+    expect(screen.queryByTestId("new-chat-landing-harness-more")).toBeNull();
   });
 
   // Polly is a bundle agent whose brain harness (claude-sdk) is overridable, so
@@ -2859,20 +2942,32 @@ describe("NewChatLandingScreen agent picker (mobile drill-in)", () => {
     expect(screen.queryByTestId("new-chat-landing-agent-ag_custom")).toBeNull();
   });
 
-  it("drills into the More page for needs-setup harnesses", () => {
-    // codex-native reported unconfigured on host_1 → folded into "More".
-    mockHosts([
+  it("drills into the More page for harnesses outside the supported set", () => {
+    // cursor-native isn't fully supported → folded into "More" (Claude Code and
+    // Codex lead inline), so touch gets a drill-in page with a Back row.
+    mockAgents([
       {
-        ...host("online"),
-        configured_harnesses: { "claude-native": true, "codex-native": false },
-      } as Host,
+        id: "a1",
+        name: "claude-native-ui",
+        display_name: "Claude Code",
+        description: null,
+        harness: "claude-native",
+        skills: [],
+      },
+      {
+        id: "a_cursor",
+        name: "cursor-native-ui",
+        display_name: "Cursor",
+        description: null,
+        harness: "cursor-native",
+        skills: [],
+      },
     ]);
     renderLanding();
     openPicker();
-    // a2 (Codex, unconfigured) isn't inline; drill into "More" to reach it.
-    expect(screen.queryByTestId("new-chat-landing-agent-a2")).toBeNull();
+    expect(screen.queryByTestId("new-chat-landing-agent-a_cursor")).toBeNull();
     fireEvent.click(screen.getByTestId("new-chat-landing-harness-more"));
-    expect(screen.getByTestId("new-chat-landing-agent-a2")).toBeTruthy();
+    expect(screen.getByTestId("new-chat-landing-agent-a_cursor")).toBeTruthy();
     fireEvent.click(screen.getByTestId("new-chat-landing-page-back"));
     expect(screen.getByTestId("new-chat-landing-agent-a1")).toBeTruthy();
   });

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1085,6 +1085,90 @@ describe("NewChatLandingScreen", () => {
     expect(screen.queryByTestId("new-chat-landing-harness-copilot")).toBeNull();
   });
 
+  // Harnesses the user has actually launched are promoted out of "More" into
+  // the primary list, so a regular Pi / Cursor user gets theirs one click away.
+  function mockClaudeAndPi() {
+    mockAgents([
+      {
+        id: "a_claude",
+        name: "claude-native-ui",
+        display_name: "Claude Code",
+        description: null,
+        harness: "claude-native",
+        skills: [],
+      },
+      {
+        id: "a_pi",
+        name: "pi-native-ui",
+        display_name: "Pi",
+        description: null,
+        harness: "pi-native",
+        skills: [],
+      },
+    ]);
+  }
+
+  it("promotes a previously-launched harness into the primary list", () => {
+    localStorage.setItem("omnigent:recent-harnesses", JSON.stringify(["pi-native"]));
+    mockClaudeAndPi();
+    renderLanding();
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    // Pi isn't fully supported, but the user has launched it → inline, and with
+    // nothing left to group the "More" trigger disappears entirely.
+    expect(screen.getByTestId("new-chat-landing-agent-a_pi")).toBeTruthy();
+    expect(screen.queryByTestId("new-chat-landing-harness-more")).toBeNull();
+  });
+
+  it("leaves an unused harness under 'More'", () => {
+    // Control for the test above: same fixture, empty recents → Pi stays behind
+    // "More", proving the promotion comes from the stored list.
+    mockClaudeAndPi();
+    renderLanding();
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    expect(screen.queryByTestId("new-chat-landing-agent-a_pi")).toBeNull();
+    fireEvent.click(screen.getByTestId("new-chat-landing-harness-more"));
+    expect(screen.getByTestId("new-chat-landing-agent-a_pi")).toBeTruthy();
+  });
+
+  it("matches a stored reversed harness alias against its canonical spec", () => {
+    // Older entries (and the server's reversed spelling) store "native-pi";
+    // it must still promote the canonical pi-native row.
+    localStorage.setItem("omnigent:recent-harnesses", JSON.stringify(["native-pi"]));
+    mockClaudeAndPi();
+    renderLanding();
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    expect(screen.getByTestId("new-chat-landing-agent-a_pi")).toBeTruthy();
+  });
+
+  it("ignores a malformed recent-harnesses entry", () => {
+    // A corrupted value must not crash the picker — it falls back to the
+    // support-level split.
+    localStorage.setItem("omnigent:recent-harnesses", "{not json");
+    mockClaudeAndPi();
+    renderLanding();
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    expect(screen.getByTestId("new-chat-landing-agent-a_claude")).toBeTruthy();
+    expect(screen.queryByTestId("new-chat-landing-agent-a_pi")).toBeNull();
+  });
+
+  it("keeps the hide-unconfigured preference ahead of a recent harness", () => {
+    // Recency promotes within what can launch here; it must not resurrect a
+    // harness the host can't run, which is the whole point of the preference.
+    localStorage.setItem("omnigent:recent-harnesses", JSON.stringify(["pi-native"]));
+    writeHideUnconfiguredHarnesses(true);
+    mockClaudeAndPi();
+    mockHosts([
+      {
+        ...host("online"),
+        configured_harnesses: { "claude-native": true, "pi-native": false },
+      } as Host,
+    ]);
+    renderLanding();
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
+    expect(screen.getByTestId("new-chat-landing-agent-a_claude")).toBeTruthy();
+    expect(screen.queryByTestId("new-chat-landing-agent-a_pi")).toBeNull();
+  });
+
   it("seeds the working directory from the host's most-recent path", async () => {
     renderLanding();
     // host_1's recent ("/Users/corey/repo") seeds the field; the chip shows

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -116,6 +116,7 @@ import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
 import { partitionAgentsByKind, sortAgentsForDisplay } from "@/lib/agentGrouping";
 import { cn } from "@/lib/utils";
 import {
+  isFullySupportedNativeCodingAgent,
   isNativeCodingAgent,
   nativeAgentHasCapability,
   nativeCodingAgentForAvailableAgent,
@@ -960,18 +961,19 @@ export function AgentHarnessPicker({
   // harnessUnconfiguredOnHost returns false with no host / no readiness map, so
   // nothing is hidden in those cases, and unrecognized harnesses stay visible.
   const hideUnconfigured = useMemo(() => readHideUnconfiguredHarnesses(), []);
-  // Split harnesses so the ready-to-use ones lead and the "needs setup" ones
-  // fold into a "More" submenu (kept discoverable, out of the primary list).
-  // The currently-selected harness always stays inline even when unconfigured,
-  // so the active pick is never buried. With the hide-unconfigured preference
-  // on, unconfigured harnesses are dropped entirely (no "More").
+  // Split harnesses by support level: only the fully supported ones lead the
+  // primary list, and every other harness folds into "More" whether or not it
+  // is configured here. The selected harness always stays inline.
   const { readyHarnessEntries, moreHarnessEntries } = useMemo(() => {
     const ready: AvailableAgent[] = [];
     const more: AvailableAgent[] = [];
     for (const a of harnessEntries) {
-      const unconfigured = harnessUnconfiguredOnHost(a.harness, host);
-      if (!unconfigured || a.id === effectiveAgentId) ready.push(a);
-      else if (!hideUnconfigured) more.push(a);
+      const selected = a.id === effectiveAgentId;
+      // The preference hides harnesses that can't launch here — it outranks
+      // support level, but never buries the active pick.
+      if (!selected && hideUnconfigured && harnessUnconfiguredOnHost(a.harness, host)) continue;
+      if (selected || isFullySupportedNativeCodingAgent(a)) ready.push(a);
+      else more.push(a);
     }
     return { readyHarnessEntries: ready, moreHarnessEntries: more };
   }, [harnessEntries, host, hideUnconfigured, effectiveAgentId]);

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -118,6 +118,7 @@ import { cn } from "@/lib/utils";
 import {
   isFullySupportedNativeCodingAgent,
   isNativeCodingAgent,
+  isRecentHarness,
   nativeAgentHasCapability,
   nativeCodingAgentForAvailableAgent,
   nativeWrapperLabelsForAgent,
@@ -137,6 +138,7 @@ import {
 } from "@/hooks/useAvailableAgents";
 import { useAutoGrowTextarea } from "@/hooks/useAutoGrowTextarea";
 import { useDictationInsert } from "@/hooks/useDictationInsert";
+import { useRecentHarnesses } from "@/hooks/useRecentHarnesses";
 import { useRecentWorkspaces } from "@/hooks/useRecentWorkspaces";
 import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
@@ -961,22 +963,26 @@ export function AgentHarnessPicker({
   // harnessUnconfiguredOnHost returns false with no host / no readiness map, so
   // nothing is hidden in those cases, and unrecognized harnesses stay visible.
   const hideUnconfigured = useMemo(() => readHideUnconfiguredHarnesses(), []);
-  // Split harnesses by support level: only the fully supported ones lead the
-  // primary list, and every other harness folds into "More" whether or not it
-  // is configured here. The selected harness always stays inline.
+  const { recentHarnesses } = useRecentHarnesses();
+  // Split harnesses by support level: the fully supported ones lead the primary
+  // list, and every other harness folds into "More" whether or not it is
+  // configured here. Also promoted out of "More": the selected harness (never
+  // bury the active pick) and any the user has launched before, so a regular
+  // Pi / Cursor user gets theirs one click away instead of one hover.
   const { readyHarnessEntries, moreHarnessEntries } = useMemo(() => {
     const ready: AvailableAgent[] = [];
     const more: AvailableAgent[] = [];
     for (const a of harnessEntries) {
       const selected = a.id === effectiveAgentId;
       // The preference hides harnesses that can't launch here — it outranks
-      // support level, but never buries the active pick.
+      // both support level and recency, but never buries the active pick.
       if (!selected && hideUnconfigured && harnessUnconfiguredOnHost(a.harness, host)) continue;
-      if (selected || isFullySupportedNativeCodingAgent(a)) ready.push(a);
-      else more.push(a);
+      if (selected || isFullySupportedNativeCodingAgent(a) || isRecentHarness(a, recentHarnesses)) {
+        ready.push(a);
+      } else more.push(a);
     }
     return { readyHarnessEntries: ready, moreHarnessEntries: more };
-  }, [harnessEntries, host, hideUnconfigured, effectiveAgentId]);
+  }, [harnessEntries, host, hideUnconfigured, effectiveAgentId, recentHarnesses]);
 
   // Split the agents group: built-in bundle agents (Polly / Debby) stay inline
   // in the main list; user-registered custom agents fold into a "Custom agents"
@@ -2016,6 +2022,7 @@ export function NewChatLandingScreen() {
   }, []);
 
   const { recent, addRecent } = useRecentWorkspaces(selectedHostId);
+  const { addRecentHarness } = useRecentHarnesses();
 
   const allHosts = hosts ?? [];
   const onlineHosts = allHosts.filter((h) => h.status === "online");
@@ -3061,6 +3068,10 @@ export function NewChatLandingScreen() {
       }
       // Sandbox creates have no user-picked workspace to remember.
       if (!sandboxSelected) addRecent(workspaceTrimmed);
+      // Remember the launched harness so the picker promotes it out of "More"
+      // next time. Recorded only on a successful create, so a harness the user
+      // merely browsed past never earns a primary slot.
+      if (selectedNativeHarness !== null) addRecentHarness(selectedNativeHarness);
       // Fire-and-forget: don't block navigation on the sidebar list refresh.
       // The background refetch (or the WS session_added push) backfills the
       // new session's row within ~1s of landing in the chat; the chat itself


### PR DESCRIPTION
## Related issue

N/A

## Summary

Two changes to the landing composer's harness picker, plus the CI fallout from the first.

**1. Split by support level, not host readiness.** The picker's primary/"More" split keyed off readiness, so any configured harness led — Claude Code, Codex, Cursor, and Pi all competed for the few primary slots, while "More" held only harnesses that happened to need setup. Support level, which is what actually distinguishes these integrations, wasn't represented. A new `fullySupported` flag on `NativeCodingAgentSpec` marks **Claude Code** and **Codex**; only those lead. The flag is opt-in, so the supported set is two lines in one file rather than a marker on each of the nine others, and a test asserts the set is exactly `[claude, codex]` so it can't drift silently.

**2. Promote harnesses the user actually launches.** The split above is right for a first-time user but left Pi and Cursor regulars a hover away on every new session. A localStorage-backed `useRecentHarnesses` (modeled on `useRecentWorkspaces`, but *not* host-scoped — a preference for Pi follows the person across machines) records the canonical harness id on a successful create, and the picker promotes any recorded harness into the primary list. Regulars get one click; a fresh install still leads with Claude Code and Codex only. No badge on the promoted row — it just appears.

Rules preserved / decided:
- **Recording requires a successful create**, so a harness the user merely browsed past never earns a slot.
- **The hide-unconfigured preference outranks both** support level and recency — promotion applies within what can launch on the host, never resurrecting a harness that can't run there.
- **A fully supported harness leads even when it needs setup** (an unconfigured Codex stays primary, badged, rather than being demoted).
- **Selecting any harness pins it inline** via the existing `effectiveAgentId` rule.
- Stored ids fold through the reversed-alias map, so `native-pi` matches the canonical `pi-native` spec.

## Test Plan

- **CI fixes.** The support-level split broke two tests, both now green: `NewChatDialog.flow`'s `selectAgent` helper drills into "More" only when the row isn't already inline, and `tests/e2e_ui/start_session/test_harness_install.py` no longer drills for Codex (fully supported → leads inline even while needing setup).
- **New e2e_ui spec** (`tests/e2e_ui/chat/test_harness_support_level_split.py`), two tests: the split (supported lead, Cursor/Pi absent inline then present under "More" in rank order, selected Pi pinned inline) and the recency promotion (a stored `pi-native` leads while a non-recent Cursor stays grouped). **Every harness is stubbed configured**, so the split is provably driven by support level rather than readiness.
- **Unit tests**: `useRecentHarnesses` (dedupe/reorder, 4-entry cap, blank ids, malformed JSON, quota-failure write, skipped no-op write); `isRecentHarness` and `isFullySupportedNativeCodingAgent`; five picker tests covering promotion, the unused-harness control, alias matching, corrupt storage, and the readiness-outranks-recency rule; two create-path tests asserting the harness id is written on success and *not* written on a failed create.
- **Mutation-checked the guards** rather than trusting green: removing the `isRecentHarness` promotion fails the two promotion tests; removing the `addRecentHarness` call fails the create-path test; flagging Pi `fullySupported` fails the supported-set guard. All three bite.
- **Full web suite** run and failing files diffed against `main`: no file fails here that doesn't already fail there.
- **Real-browser verification** of all six e2e assertions against a local `omnigent server` (see Coverage notes).

## Demo

Every harness below is reported **configured** on the host, so the grouping is driven purely by support level and recency.

**Before** — all four configured harnesses compete for primary slots; no "More" group:

<img width="1000" alt="picker before: Claude Code, Codex, Cursor, Pi all inline" src="https://raw.githubusercontent.com/omnigent-ai/omnigent/demo-assets-pi/.demo/sup_before.png">

**After** — only the fully supported Claude Code and Codex lead:

<img width="1000" alt="picker after: Claude Code, Codex, then a More row" src="https://raw.githubusercontent.com/omnigent-ai/omnigent/demo-assets-pi/.demo/sup_after.png">

**"More" expanded** — Cursor and Pi, one hover away:

<img width="1000" alt="More submenu expanded showing Cursor and Pi" src="https://raw.githubusercontent.com/omnigent-ai/omnigent/demo-assets-pi/.demo/sup_more.png">

**After launching Pi once** — Pi is promoted inline (Cursor, never launched, stays under "More"):

<img width="1000" alt="picker with Claude Code, Codex, Pi inline and a More row" src="https://raw.githubusercontent.com/omnigent-ai/omnigent/demo-assets-pi/.demo/sup_recent.png">

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was a real-browser check, because the reordering is a rendered-DOM concern jsdom can only partly prove: I built the SPA, booted a local `omnigent server` against that bundle, and drove the picker with Playwright, stubbing `configured_harnesses` so every harness reads as configured. All six assertions from the new e2e spec pass that way — including the step-3 reopen, where I found and fixed a real race (committing closes the menu, so the reopen click lands mid-close unless it waits for the unmount; the committed spec waits).

Two notes for anyone repeating it locally:
- `omnigent server` resolves its bundle from the **main** checkout, not a worktree, so without pinning `OMNIGENT_WEB_UI_DIST` at the freshly built directory you'll silently screenshot a stale bundle.
- The pytest `e2e_ui` fixture can't boot its runner in my local env — a **pre-existing** spec (`test_hide_unconfigured_harnesses.py`) fails there identically — so the new spec's assertions were validated via the equivalent standalone Playwright script rather than through pytest. CI is the real gate for it.

## Changelog

The harness picker now leads with the fully supported harnesses, Claude Code and Codex, and promotes any harness you've launched before out of the "More" group.
