### PR TITLE
feat(web): copy a session's `omnigent resume` command from the header

### DIFF
--- a/web/src/lib/resumeCommand.ts
+++ b/web/src/lib/resumeCommand.ts
@@ -1,0 +1,23 @@
+/**
+ * Build the `omnigent resume` command that reattaches a terminal to a
+ * session opened in the browser.
+ *
+ * `omnigent resume <id>` looks the conversation up, reads its
+ * `omnigent.wrapper` label, and hands off to the matching native
+ * wrapper. `--server` is carried explicitly — the browser already knows
+ * which server it is talking to, and naming it resumes against that
+ * same server whether it is local or deployed.
+ *
+ * Emitted as ONE line: unlike the reconnect dialog's backslash-wrapped
+ * form, this string is only ever copied (never rendered in a narrow
+ * box), so it should paste into a shell as a single command.
+ */
+export function buildResumeCommand({
+  conversationId,
+  serverUrl,
+}: {
+  conversationId: string;
+  serverUrl: string;
+}): string {
+  return `omnigent resume ${conversationId} --server ${serverUrl}`;
+}

--- a/web/src/lib/resumeCommand.ts
+++ b/web/src/lib/resumeCommand.ts
@@ -1,17 +1,5 @@
-/**
- * Build the `omnigent resume` command that reattaches a terminal to a
- * session opened in the browser.
- *
- * `omnigent resume <id>` looks the conversation up, reads its
- * `omnigent.wrapper` label, and hands off to the matching native
- * wrapper. `--server` is carried explicitly — the browser already knows
- * which server it is talking to, and naming it resumes against that
- * same server whether it is local or deployed.
- *
- * Emitted as ONE line: unlike the reconnect dialog's backslash-wrapped
- * form, this string is only ever copied (never rendered in a narrow
- * box), so it should paste into a shell as a single command.
- */
+// One line so it pastes straight into a shell; `--server` is explicit so the
+// command resumes against whichever server the browser is talking to.
 export function buildResumeCommand({
   conversationId,
   serverUrl,

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -417,8 +417,7 @@ export function AppShell() {
     !!conversationId && isKnownTopLevel && (permissionLevel === null || permissionLevel >= 1);
   // Agent tools/policies exist to show.
   const hasAgentInfo = !!conversationId && agentHasInfo(boundAgent, conversationId);
-  // Whether the mobile three-dot menu has any entry to offer. Copy-resume
-  // needs only a session, so any open session keeps the menu populated.
+  // Any open session keeps the mobile menu populated (copy-resume needs only a session id).
   const hasHeaderMenu = canShare || hasAgentInfo || !!conversationId;
   // Claude-native sub-agents have no terminal of their own — the parent
   // owns the tmux pane.

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -417,8 +417,9 @@ export function AppShell() {
     !!conversationId && isKnownTopLevel && (permissionLevel === null || permissionLevel >= 1);
   // Agent tools/policies exist to show.
   const hasAgentInfo = !!conversationId && agentHasInfo(boundAgent, conversationId);
-  // Whether the mobile three-dot menu has any entry to offer.
-  const hasHeaderMenu = canShare || hasAgentInfo;
+  // Whether the mobile three-dot menu has any entry to offer. Copy-resume
+  // needs only a session, so any open session keeps the menu populated.
+  const hasHeaderMenu = canShare || hasAgentInfo || !!conversationId;
   // Claude-native sub-agents have no terminal of their own — the parent
   // owns the tmux pane.
   const isClaudeNativeSubagent =

--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -271,14 +271,10 @@ function renderHeaderWithSession(ctx: TerminalFirstContextValue | null) {
 describe("ChatHeader — copy-resume-command placement", () => {
   it("offers the resume action for an open session", () => {
     renderHeaderWithSession(makeTerminalFirstCtx());
-    // The affordance needs only a session id, so it rides along with any
-    // open conversation regardless of share/agent-info gating.
     expect(screen.getByTestId("copy-resume-command")).toBeInTheDocument();
   });
 
   it("omits the resume action on the landing composer", () => {
-    // No conversationId: there is no session to resume, so the button
-    // must not render (it would copy a command naming nothing).
     renderHeader({ sidebarOpen: true });
     expect(screen.queryByTestId("copy-resume-command")).toBeNull();
   });

--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -268,6 +268,22 @@ function renderHeaderWithSession(ctx: TerminalFirstContextValue | null) {
   );
 }
 
+describe("ChatHeader — copy-resume-command placement", () => {
+  it("offers the resume action for an open session", () => {
+    renderHeaderWithSession(makeTerminalFirstCtx());
+    // The affordance needs only a session id, so it rides along with any
+    // open conversation regardless of share/agent-info gating.
+    expect(screen.getByTestId("copy-resume-command")).toBeInTheDocument();
+  });
+
+  it("omits the resume action on the landing composer", () => {
+    // No conversationId: there is no session to resume, so the button
+    // must not render (it would copy a command naming nothing).
+    renderHeader({ sidebarOpen: true });
+    expect(screen.queryByTestId("copy-resume-command")).toBeNull();
+  });
+});
+
 describe("ChatHeader — Chat/Terminal switcher wiring", () => {
   it("mounts the ViewModeToggle for a terminal-first session", () => {
     renderHeaderWithSession(makeTerminalFirstCtx());

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { AgentInfoButton } from "@/components/AgentInfo";
 import { PresenceAvatars } from "@/components/PresenceAvatars";
+import { ResumeSessionButton, ResumeSessionMenuItem } from "./ResumeSessionButton";
 import type { Agent } from "@/hooks/useAgents";
 import { cn } from "@/lib/utils";
 import { TAB_BADGE_BASE } from "./railTabs";
@@ -146,11 +147,11 @@ interface ChatHeaderProps {
  * mask, index.css; chat reserves clearance via ``pt-20``,
  * terminal-first via ``pt-14``). Left slot: open-sidebar +
  * back-to-parent. Right slot: desktop action buttons (Agent info ·
- * Share · right-panel toggle), a mobile three-dot menu mirroring the
- * same actions, and a mobile FAB that opens the rail tabs as
- * full-screen drawers. Stop session lives in the sidebar row's kebab
- * menu; Clone lives on each assistant message's "Fork from here"
- * action (ChatPage), not here.
+ * copy-resume-command · Share · right-panel toggle), a mobile
+ * three-dot menu mirroring the same actions, and a mobile FAB that
+ * opens the rail tabs as full-screen drawers. Stop session lives in
+ * the sidebar row's kebab menu; Clone lives on each assistant
+ * message's "Fork from here" action (ChatPage), not here.
  *
  * All state lives in AppShell — this is a pure presentational component.
  */
@@ -273,11 +274,19 @@ export function ChatHeader({
         {/* Agent info: tools & policies for the bound agent. Desktop-only
             popover; self-hides when the agent has neither configured. */}
         {conversationId && <AgentInfoButton agent={boundAgent} sessionId={conversationId} />}
+        {/* Copy `omnigent resume <id>` so this session can be picked back
+            up in a terminal. Desktop-only — on a phone there's no terminal
+            to paste into, so it folds into the three-dot menu below. */}
+        {conversationId && (
+          <span className="hidden md:inline-flex">
+            <ResumeSessionButton conversationId={conversationId} />
+          </span>
+        )}
         {/* Chat/Terminal switcher for terminal-first sessions — self-gates to
             null otherwise (and in the iOS shell, where it's the native bar). */}
         {conversationId && <ViewModeToggle />}
         {/* Mobile-only three-dot menu folding the action buttons above
-            (Share · Agent info) so the header stays
+            (Share · Agent info · Copy resume command) so the header stays
             uncluttered on a phone. The right-panel/rail control is
             deliberately left out — it has its own affordance below. */}
         {hasHeaderMenu && (
@@ -317,6 +326,7 @@ export function ChatHeader({
                   Agent info
                 </DropdownMenuItem>
               )}
+              {conversationId && <ResumeSessionMenuItem conversationId={conversationId} />}
             </DropdownMenuContent>
           </DropdownMenu>
         )}

--- a/web/src/shell/ResumeSessionButton.test.tsx
+++ b/web/src/shell/ResumeSessionButton.test.tsx
@@ -1,0 +1,90 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { Toaster } from "@/components/ui/toast";
+import { buildResumeCommand } from "@/lib/resumeCommand";
+import { ResumeSessionButton } from "./ResumeSessionButton";
+
+function renderButton(conversationId = "conv-abc123") {
+  return render(
+    <TooltipProvider>
+      <ResumeSessionButton conversationId={conversationId} />
+      <Toaster />
+    </TooltipProvider>,
+  );
+}
+
+describe("buildResumeCommand", () => {
+  it("emits a single-line `omnigent resume` naming the id and server", () => {
+    const command = buildResumeCommand({
+      conversationId: "conv-abc123",
+      serverUrl: "https://example.databricksapps.com",
+    });
+    // One line: the string is copied straight into a shell, never rendered
+    // in a narrow box, so it must not carry backslash continuations.
+    expect(command).toBe(
+      "omnigent resume conv-abc123 --server https://example.databricksapps.com",
+    );
+    expect(command).not.toContain("\n");
+    expect(command).not.toContain("\\");
+  });
+});
+
+describe("ResumeSessionButton", () => {
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    cleanup();
+  });
+
+  it("copies the resume command for the open session", async () => {
+    renderButton("conv-abc123");
+
+    screen.getByTestId("copy-resume-command").click();
+
+    await waitFor(() => {
+      // The window origin is the CLI server URL in tests (no suffix
+      // configured), so the command resumes against the same server the
+      // browser is talking to.
+      expect(writeText).toHaveBeenCalledWith(
+        `omnigent resume conv-abc123 --server ${window.location.origin}`,
+      );
+    });
+  });
+
+  it("confirms the copy in the label and a toast naming the command", async () => {
+    renderButton("conv-abc123");
+
+    const button = screen.getByRole("button", { name: "Copy resume command" });
+    button.click();
+
+    // The icon swap alone doesn't say *which* command landed on the
+    // clipboard — the accessible name and the toast both must.
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Resume command copied" })).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("toast")).toHaveTextContent("Resume command copied");
+    expect(screen.getByTestId("toast")).toHaveTextContent("omnigent resume conv-abc123");
+  });
+
+  it("reports a failed copy instead of claiming success", async () => {
+    writeText.mockRejectedValue(new Error("denied"));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    renderButton();
+
+    screen.getByTestId("copy-resume-command").click();
+
+    // A rejected clipboard write must not flip the button to its
+    // confirmed state — that would tell the user a lie.
+    await waitFor(() => {
+      expect(screen.getByTestId("toast")).toHaveTextContent("Couldn't copy the resume command");
+    });
+    expect(screen.queryByRole("button", { name: "Resume command copied" })).toBeNull();
+  });
+});

--- a/web/src/shell/ResumeSessionButton.test.tsx
+++ b/web/src/shell/ResumeSessionButton.test.tsx
@@ -20,11 +20,7 @@ describe("buildResumeCommand", () => {
       conversationId: "conv-abc123",
       serverUrl: "https://example.databricksapps.com",
     });
-    // One line: the string is copied straight into a shell, never rendered
-    // in a narrow box, so it must not carry backslash continuations.
-    expect(command).toBe(
-      "omnigent resume conv-abc123 --server https://example.databricksapps.com",
-    );
+    expect(command).toBe("omnigent resume conv-abc123 --server https://example.databricksapps.com");
     expect(command).not.toContain("\n");
     expect(command).not.toContain("\\");
   });
@@ -49,9 +45,6 @@ describe("ResumeSessionButton", () => {
     screen.getByTestId("copy-resume-command").click();
 
     await waitFor(() => {
-      // The window origin is the CLI server URL in tests (no suffix
-      // configured), so the command resumes against the same server the
-      // browser is talking to.
       expect(writeText).toHaveBeenCalledWith(
         `omnigent resume conv-abc123 --server ${window.location.origin}`,
       );
@@ -64,8 +57,6 @@ describe("ResumeSessionButton", () => {
     const button = screen.getByRole("button", { name: "Copy resume command" });
     button.click();
 
-    // The icon swap alone doesn't say *which* command landed on the
-    // clipboard — the accessible name and the toast both must.
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Resume command copied" })).toBeInTheDocument();
     });
@@ -80,8 +71,6 @@ describe("ResumeSessionButton", () => {
 
     screen.getByTestId("copy-resume-command").click();
 
-    // A rejected clipboard write must not flip the button to its
-    // confirmed state — that would tell the user a lie.
     await waitFor(() => {
       expect(screen.getByTestId("toast")).toHaveTextContent("Couldn't copy the resume command");
     });

--- a/web/src/shell/ResumeSessionButton.tsx
+++ b/web/src/shell/ResumeSessionButton.tsx
@@ -11,14 +11,8 @@ import { showToast } from "@/components/ui/toast";
 /** How long the affordance holds its confirmed (check icon) state. */
 const COPIED_RESET_MS = 2000;
 
-/**
- * Copy this session's `omnigent resume` command to the clipboard.
- *
- * Shared by the desktop header button and the mobile session menu so the
- * two entry points can't drift apart. Returns `copied` for the
- * confirmed-state icon swap; the toast names the command that landed on
- * the clipboard, which the icon alone can't convey.
- */
+// Shared by the desktop header button and the mobile menu so the two entry
+// points can't drift apart.
 export function useCopyResumeCommand(conversationId: string): {
   copied: boolean;
   copyResumeCommand: () => Promise<void>;
@@ -59,13 +53,8 @@ export function useCopyResumeCommand(conversationId: string): {
   return { copied, copyResumeCommand };
 }
 
-/**
- * Header action that copies this session's `omnigent resume` command, so
- * a session opened in the browser can be picked back up in a terminal.
- *
- * Copy-only: the browser can't launch a local terminal, so handing the
- * user the exact command is the whole affordance.
- */
+// Copy-only: the browser can't launch a local terminal, so handing the
+// user the exact command is the whole affordance.
 export function ResumeSessionButton({ conversationId }: { conversationId: string }) {
   const { copied, copyResumeCommand } = useCopyResumeCommand(conversationId);
   const label = copied ? "Resume command copied" : "Copy resume command";
@@ -84,8 +73,6 @@ export function ResumeSessionButton({ conversationId }: { conversationId: string
           {copied ? <CheckIcon className="size-4" /> : <TerminalIcon className="size-4" />}
         </Button>
       </TooltipTrigger>
-      {/* Bottom placement matches the header's other tooltips, keeping
-          clear of the Electron shell's title-bar strip. */}
       <TooltipContent side="bottom">
         {copied ? label : "Copy `omnigent resume` command"}
       </TooltipContent>
@@ -93,13 +80,9 @@ export function ResumeSessionButton({ conversationId }: { conversationId: string
   );
 }
 
-/**
- * Mobile three-dot menu counterpart of {@link ResumeSessionButton}.
- *
- * A phone rarely has the terminal that would consume the command, but it
- * may well be the device the user is reading the session on — copying
- * here lets them paste it into a note or a remote shell app.
- */
+// Mobile three-dot menu counterpart of ResumeSessionButton; a phone may not
+// have a terminal handy but can still paste the command into a note or
+// remote shell.
 export function ResumeSessionMenuItem({ conversationId }: { conversationId: string }) {
   const { copyResumeCommand } = useCopyResumeCommand(conversationId);
   return (

--- a/web/src/shell/ResumeSessionButton.tsx
+++ b/web/src/shell/ResumeSessionButton.tsx
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { CheckIcon, TerminalIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { copyText } from "@/lib/clipboard";
+import { getCliServerUrl } from "@/lib/host";
+import { buildResumeCommand } from "@/lib/resumeCommand";
+import { showToast } from "@/components/ui/toast";
+
+/** How long the affordance holds its confirmed (check icon) state. */
+const COPIED_RESET_MS = 2000;
+
+/**
+ * Copy this session's `omnigent resume` command to the clipboard.
+ *
+ * Shared by the desktop header button and the mobile session menu so the
+ * two entry points can't drift apart. Returns `copied` for the
+ * confirmed-state icon swap; the toast names the command that landed on
+ * the clipboard, which the icon alone can't convey.
+ */
+export function useCopyResumeCommand(conversationId: string): {
+  copied: boolean;
+  copyResumeCommand: () => Promise<void>;
+} {
+  const [copied, setCopied] = useState(false);
+  const resetTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimeoutRef.current !== null) window.clearTimeout(resetTimeoutRef.current);
+    };
+  }, []);
+
+  const copyResumeCommand = useCallback(async () => {
+    const command = buildResumeCommand({
+      conversationId,
+      serverUrl: getCliServerUrl(),
+    });
+    try {
+      await copyText(command);
+    } catch (err) {
+      console.warn("Failed to copy resume command", err);
+      showToast("Couldn't copy the resume command");
+      return;
+    }
+    setCopied(true);
+    if (resetTimeoutRef.current !== null) window.clearTimeout(resetTimeoutRef.current);
+    resetTimeoutRef.current = window.setTimeout(() => setCopied(false), COPIED_RESET_MS);
+    showToast(
+      <span className="flex min-w-0 flex-col gap-0.5">
+        <span>Resume command copied</span>
+        <code className="truncate font-mono text-xs text-muted-foreground">{command}</code>
+      </span>,
+      { duration: 4000 },
+    );
+  }, [conversationId]);
+
+  return { copied, copyResumeCommand };
+}
+
+/**
+ * Header action that copies this session's `omnigent resume` command, so
+ * a session opened in the browser can be picked back up in a terminal.
+ *
+ * Copy-only: the browser can't launch a local terminal, so handing the
+ * user the exact command is the whole affordance.
+ */
+export function ResumeSessionButton({ conversationId }: { conversationId: string }) {
+  const { copied, copyResumeCommand } = useCopyResumeCommand(conversationId);
+  const label = copied ? "Resume command copied" : "Copy resume command";
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={label}
+          data-testid="copy-resume-command"
+          onClick={copyResumeCommand}
+          className="text-muted-foreground hover:text-foreground"
+        >
+          {copied ? <CheckIcon className="size-4" /> : <TerminalIcon className="size-4" />}
+        </Button>
+      </TooltipTrigger>
+      {/* Bottom placement matches the header's other tooltips, keeping
+          clear of the Electron shell's title-bar strip. */}
+      <TooltipContent side="bottom">
+        {copied ? label : "Copy `omnigent resume` command"}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+/**
+ * Mobile three-dot menu counterpart of {@link ResumeSessionButton}.
+ *
+ * A phone rarely has the terminal that would consume the command, but it
+ * may well be the device the user is reading the session on — copying
+ * here lets them paste it into a note or a remote shell app.
+ */
+export function ResumeSessionMenuItem({ conversationId }: { conversationId: string }) {
+  const { copyResumeCommand } = useCopyResumeCommand(conversationId);
+  return (
+    <DropdownMenuItem
+      onSelect={copyResumeCommand}
+      data-testid="mobile-copy-resume-command"
+      className="gap-2.5 px-2.5 py-2 text-base"
+    >
+      <TerminalIcon className="size-4" />
+      Copy resume command
+    </DropdownMenuItem>
+  );
+}


### PR DESCRIPTION
## Summary

Add a terminal-icon button to the session header's right slot that copies `omnigent resume <id> --server <url>` — the shape the CLI already documents in `omnigent resume --help`. The server URL comes from `getCliServerUrl()`, so the command resumes against whichever server the browser is talking to, local or deployed.

Copy-only, since the browser can't launch a local terminal. A toast names the copied command because the check-icon swap alone doesn't say *which* command landed on the clipboard, and a failed clipboard write reports the failure rather than showing the confirmed state.

`useCopyResumeCommand` backs both the desktop button and the mobile three-dot menu entry so the two can't drift apart.
<img width="902" height="322" alt="Screenshot 2026-08-05 at 12 42 41 AM" src="https://github.com/user-attachments/assets/e7b964fa-47df-4a01-b84d-50d5ce79d1f2" />

<img width="1123" height="959" alt="Screenshot 2026-08-05 at 12 38 40 AM" src="https://github.com/user-attachments/assets/ff3fadfa-1dea-4a46-95b3-2be647d0d75a" />


<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

## Test Plan

- Ran `omnidev` and tested clicking on the button

## Demo

<!--
Video or images demonstrating the change. Drag-and-drop a screenshot or screen
recording, or paste a link. Expected for UI / frontend changes (check the
"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
use `N/A` for non-visual changes.
-->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

<Add a line to describe the change, else delete this section>
