### PR TITLE
feat(webui): capture raw SSE events and show in execution logs panel

### DIFF
--- a/web/src/hooks/useDebugMode.ts
+++ b/web/src/hooks/useDebugMode.ts
@@ -1,12 +1,22 @@
 import { useSearchParams } from "@/lib/routing";
 
+const DEBUG_LS_KEY = "debug";
+
 /**
- * Returns true when ``?debug=1`` is present in the current URL.
+ * Returns true when ``?debug=1`` is present in the current URL **or**
+ * ``localStorage.getItem("debug") === "1"``.
  *
- * Used to reveal developer-facing panels (e.g. Execution logs) that are
- * hidden in normal use. Append ``?debug=1`` to any page URL to enable.
+ * The localStorage flag is useful for local development so you don't have
+ * to keep ``?debug=1`` in every URL. Set it once in the browser console:
+ * ``localStorage.setItem("debug", "1")`` and clear with
+ * ``localStorage.removeItem("debug")``.
  */
 export function useDebugMode(): boolean {
   const [searchParams] = useSearchParams();
-  return searchParams.get("debug") === "1";
+  if (searchParams.get("debug") === "1") return true;
+  try {
+    return localStorage.getItem(DEBUG_LS_KEY) === "1";
+  } catch {
+    return false;
+  }
 }

--- a/web/src/hooks/useSseEventLog.ts
+++ b/web/src/hooks/useSseEventLog.ts
@@ -1,0 +1,21 @@
+import { useSyncExternalStore } from "react";
+import { subscribeSseLog, snapshotSseLog, type SseLogEntry } from "@/lib/sseEventLog";
+
+/**
+ * Returns the live SSE event log for a session as a stable array.
+ * Updates synchronously whenever a new event is pushed.
+ *
+ * Pass `null` to disable (returns an empty array).
+ */
+export function useSseEventLog(sessionId: string | null): readonly SseLogEntry[] {
+  return useSyncExternalStore(
+    (cb) => {
+      if (sessionId === null) return () => {};
+      return subscribeSseLog(sessionId, cb);
+    },
+    () => (sessionId === null ? EMPTY : snapshotSseLog(sessionId)),
+    () => EMPTY,
+  );
+}
+
+const EMPTY: readonly SseLogEntry[] = [];

--- a/web/src/lib/sseEventLog.ts
+++ b/web/src/lib/sseEventLog.ts
@@ -52,10 +52,10 @@ export function pushSseEvent(sessionId: string, event: StreamEvent): void {
   if (!debugMode) return;
   const log = getOrCreate(sessionId);
   const entry: SseLogEntry = { index: log.nextIndex++, ts: Date.now(), event };
-  if (log.entries.length >= MAX_EVENTS) {
-    log.entries.shift();
-  }
-  log.entries.push(entry);
+  // Always produce a new array reference so useSyncExternalStore's Object.is
+  // check detects the change and triggers a re-render.
+  const prev = log.entries.length >= MAX_EVENTS ? log.entries.slice(1) : log.entries;
+  log.entries = [...prev, entry];
   for (const l of log.listeners) l();
 }
 

--- a/web/src/lib/sseEventLog.ts
+++ b/web/src/lib/sseEventLog.ts
@@ -36,16 +36,20 @@ function getOrCreate(sessionId: string): SessionLog {
   return log;
 }
 
-function isDebugMode(): boolean {
-  return (
-    typeof window !== "undefined" &&
-    new URLSearchParams(window.location.search).get("debug") === "1"
-  );
+// Cache the debug flag so pushSseEvent is a single boolean check per call.
+// Updated on popstate so SPA navigation that adds/removes ?debug=1 is picked up.
+let debugMode =
+  typeof window !== "undefined" && new URLSearchParams(window.location.search).get("debug") === "1";
+
+if (typeof window !== "undefined") {
+  window.addEventListener("popstate", () => {
+    debugMode = new URLSearchParams(window.location.search).get("debug") === "1";
+  });
 }
 
 /** Push one event into the session's ring buffer. No-op when debug is off. */
 export function pushSseEvent(sessionId: string, event: StreamEvent): void {
-  if (!isDebugMode()) return;
+  if (!debugMode) return;
   const log = getOrCreate(sessionId);
   const entry: SseLogEntry = { index: log.nextIndex++, ts: Date.now(), event };
   if (log.entries.length >= MAX_EVENTS) {

--- a/web/src/lib/sseEventLog.ts
+++ b/web/src/lib/sseEventLog.ts
@@ -37,13 +37,23 @@ function getOrCreate(sessionId: string): SessionLog {
 }
 
 // Cache the debug flag so pushSseEvent is a single boolean check per call.
+// Reads both ?debug=1 (URL) and localStorage "debug"="1".
 // Updated on popstate so SPA navigation that adds/removes ?debug=1 is picked up.
-let debugMode =
-  typeof window !== "undefined" && new URLSearchParams(window.location.search).get("debug") === "1";
+function readDebugMode(): boolean {
+  if (typeof window === "undefined") return false;
+  if (new URLSearchParams(window.location.search).get("debug") === "1") return true;
+  try {
+    return localStorage.getItem("debug") === "1";
+  } catch {
+    return false;
+  }
+}
+
+let debugMode = readDebugMode();
 
 if (typeof window !== "undefined") {
   window.addEventListener("popstate", () => {
-    debugMode = new URLSearchParams(window.location.search).get("debug") === "1";
+    debugMode = readDebugMode();
   });
 }
 

--- a/web/src/lib/sseEventLog.ts
+++ b/web/src/lib/sseEventLog.ts
@@ -36,10 +36,10 @@ function getOrCreate(sessionId: string): SessionLog {
   return log;
 }
 
-// Cache the debug flag so pushSseEvent is a single boolean check per call.
-// Reads both ?debug=1 (URL) and localStorage "debug"="1".
-// Updated on popstate so SPA navigation that adds/removes ?debug=1 is picked up.
-function readDebugMode(): boolean {
+// Re-read on every call: localStorage and window.location.search are both
+// fast O(1) reads. Caching against popstate was unreliable because React
+// Router uses pushState/replaceState which do not fire popstate.
+function isDebugMode(): boolean {
   if (typeof window === "undefined") return false;
   if (new URLSearchParams(window.location.search).get("debug") === "1") return true;
   try {
@@ -49,17 +49,11 @@ function readDebugMode(): boolean {
   }
 }
 
-let debugMode = readDebugMode();
-
-if (typeof window !== "undefined") {
-  window.addEventListener("popstate", () => {
-    debugMode = readDebugMode();
-  });
-}
+const EMPTY: readonly SseLogEntry[] = [];
 
 /** Push one event into the session's ring buffer. No-op when debug is off. */
 export function pushSseEvent(sessionId: string, event: StreamEvent): void {
-  if (!debugMode) return;
+  if (!isDebugMode()) return;
   const log = getOrCreate(sessionId);
   const entry: SseLogEntry = { index: log.nextIndex++, ts: Date.now(), event };
   // Always produce a new array reference so useSyncExternalStore's Object.is
@@ -85,7 +79,7 @@ export function subscribeSseLog(sessionId: string, cb: () => void): () => void {
   return () => log.listeners.delete(cb);
 }
 
-/** Snapshot of entries for a session (empty array when none). */
+/** Snapshot of entries for a session (stable empty array when none). */
 export function snapshotSseLog(sessionId: string): readonly SseLogEntry[] {
-  return logs.get(sessionId)?.entries ?? [];
+  return logs.get(sessionId)?.entries ?? EMPTY;
 }

--- a/web/src/lib/sseEventLog.ts
+++ b/web/src/lib/sseEventLog.ts
@@ -36,8 +36,16 @@ function getOrCreate(sessionId: string): SessionLog {
   return log;
 }
 
+function isDebugMode(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    new URLSearchParams(window.location.search).get("debug") === "1"
+  );
+}
+
 /** Push one event into the session's ring buffer. No-op when debug is off. */
 export function pushSseEvent(sessionId: string, event: StreamEvent): void {
+  if (!isDebugMode()) return;
   const log = getOrCreate(sessionId);
   const entry: SseLogEntry = { index: log.nextIndex++, ts: Date.now(), event };
   if (log.entries.length >= MAX_EVENTS) {

--- a/web/src/lib/sseEventLog.ts
+++ b/web/src/lib/sseEventLog.ts
@@ -1,0 +1,69 @@
+// Module-level ring buffer for raw SSE events captured in debug mode
+// (?debug=1). Only populated when the debug flag is active at stream time —
+// zero overhead in normal use.
+//
+// Each session gets its own capped list (MAX_EVENTS). Older entries are
+// dropped from the front once the cap is reached. Listeners are notified
+// synchronously after each push so React can re-render without polling.
+
+import type { StreamEvent } from "@/lib/events";
+
+export interface SseLogEntry {
+  /** Monotonically increasing index within this session's log. */
+  index: number;
+  /** Wall-clock timestamp when the event was captured (ms since epoch). */
+  ts: number;
+  event: StreamEvent;
+}
+
+const MAX_EVENTS = 500;
+
+// Per-session log state.
+interface SessionLog {
+  entries: SseLogEntry[];
+  nextIndex: number;
+  listeners: Set<() => void>;
+}
+
+const logs = new Map<string, SessionLog>();
+
+function getOrCreate(sessionId: string): SessionLog {
+  let log = logs.get(sessionId);
+  if (!log) {
+    log = { entries: [], nextIndex: 0, listeners: new Set() };
+    logs.set(sessionId, log);
+  }
+  return log;
+}
+
+/** Push one event into the session's ring buffer. No-op when debug is off. */
+export function pushSseEvent(sessionId: string, event: StreamEvent): void {
+  const log = getOrCreate(sessionId);
+  const entry: SseLogEntry = { index: log.nextIndex++, ts: Date.now(), event };
+  if (log.entries.length >= MAX_EVENTS) {
+    log.entries.shift();
+  }
+  log.entries.push(entry);
+  for (const l of log.listeners) l();
+}
+
+/** Clear a session's log (e.g. on new stream bind). */
+export function clearSseLog(sessionId: string): void {
+  const log = logs.get(sessionId);
+  if (!log) return;
+  log.entries = [];
+  log.nextIndex = 0;
+  for (const l of log.listeners) l();
+}
+
+/** Subscribe to changes for a session. Returns an unsubscribe function. */
+export function subscribeSseLog(sessionId: string, cb: () => void): () => void {
+  const log = getOrCreate(sessionId);
+  log.listeners.add(cb);
+  return () => log.listeners.delete(cb);
+}
+
+/** Snapshot of entries for a session (empty array when none). */
+export function snapshotSseLog(sessionId: string): readonly SseLogEntry[] {
+  return logs.get(sessionId)?.entries ?? [];
+}

--- a/web/src/shell/ExecutionLogsPanel.tsx
+++ b/web/src/shell/ExecutionLogsPanel.tsx
@@ -41,6 +41,8 @@ import {
 } from "@/hooks/useChildSessions";
 import { useResizablePanel } from "@/hooks/useResizablePanel";
 import { useSessionItems, type RawSessionItem } from "@/hooks/useSessionItems";
+import { useSseEventLog } from "@/hooks/useSseEventLog";
+import type { SseLogEntry } from "@/lib/sseEventLog";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/store/chatStore";
 
@@ -128,6 +130,7 @@ export function ExecutionLogsPanel({
 
   const entries = buildLogEntries(conversationId, children);
   const activeEntry = entries.find((e) => e.key === activeKey) ?? entries[0] ?? null;
+  const [view, setView] = useState<"items" | "sse">("items");
 
   return (
     <aside
@@ -163,34 +166,67 @@ export function ExecutionLogsPanel({
           <div className="flex-1" />
         ) : (
           <>
-            <Select value={activeEntry.key} onValueChange={setActiveKey}>
-              {/* The trigger already has `w-fit` by default. We add
-                  `self-start` so the flex column doesn't stretch it
-                  across the panel's cross-axis — without this, the
-                  trigger fills the full panel width regardless of
-                  content. */}
-              <SelectTrigger className="self-start">
-                <SelectValue>
-                  <span className="inline-flex items-center gap-2">
-                    <activeEntry.icon className="size-3.5 shrink-0 text-muted-foreground" />
-                    {activeEntry.label}
-                  </span>
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                {entries.map((e) => (
-                  <SelectItem key={e.key} value={e.key}>
+            <div className="flex items-center gap-2">
+              <Select value={activeEntry.key} onValueChange={setActiveKey}>
+                {/* The trigger already has `w-fit` by default. We add
+                    `self-start` so the flex column doesn't stretch it
+                    across the panel's cross-axis — without this, the
+                    trigger fills the full panel width regardless of
+                    content. */}
+                <SelectTrigger className="self-start">
+                  <SelectValue>
                     <span className="inline-flex items-center gap-2">
-                      <e.icon className="size-3.5 shrink-0 text-muted-foreground" />
-                      {e.label}
+                      <activeEntry.icon className="size-3.5 shrink-0 text-muted-foreground" />
+                      {activeEntry.label}
                     </span>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {/* Remount the items list when the session changes so the
-                expand/collapse state resets between selections. */}
-            <SessionItemsList key={activeEntry.sessionId} sessionId={activeEntry.sessionId} />
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  {entries.map((e) => (
+                    <SelectItem key={e.key} value={e.key}>
+                      <span className="inline-flex items-center gap-2">
+                        <e.icon className="size-3.5 shrink-0 text-muted-foreground" />
+                        {e.label}
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {/* View toggle: conv items vs raw SSE events */}
+              <div className="ml-auto flex rounded-md border border-border text-xs">
+                <button
+                  type="button"
+                  className={cn(
+                    "px-2 py-1 rounded-l-md",
+                    view === "items"
+                      ? "bg-muted font-medium"
+                      : "text-muted-foreground hover:bg-muted/50",
+                  )}
+                  onClick={() => setView("items")}
+                >
+                  Items
+                </button>
+                <button
+                  type="button"
+                  className={cn(
+                    "px-2 py-1 rounded-r-md border-l border-border",
+                    view === "sse"
+                      ? "bg-muted font-medium"
+                      : "text-muted-foreground hover:bg-muted/50",
+                  )}
+                  onClick={() => setView("sse")}
+                >
+                  SSE
+                </button>
+              </div>
+            </div>
+            {view === "items" ? (
+              /* Remount the items list when the session changes so the
+                 expand/collapse state resets between selections. */
+              <SessionItemsList key={activeEntry.sessionId} sessionId={activeEntry.sessionId} />
+            ) : (
+              <SseEventsList key={activeEntry.sessionId} sessionId={activeEntry.sessionId} />
+            )}
           </>
         )}
       </div>
@@ -316,4 +352,64 @@ function SessionItemEntry({ item, index }: { item: RawSessionItem; index: number
 function itemKey(item: RawSessionItem, idx: number): string {
   const id = item.id;
   return typeof id === "string" && id ? id : `idx-${idx}`;
+}
+
+function SseEventsList({ sessionId }: { sessionId: string }) {
+  const entries = useSseEventLog(sessionId);
+  const scrollRootRef = useRef<HTMLDivElement | null>(null);
+
+  // Auto-scroll to bottom as new events arrive.
+  useEffect(() => {
+    const el = scrollRootRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [entries.length]);
+
+  if (entries.length === 0) {
+    return (
+      <div className="text-muted-foreground text-xs">
+        No SSE events yet — events are captured while the agent runs.
+      </div>
+    );
+  }
+  return (
+    <div
+      ref={scrollRootRef}
+      className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto pr-1 font-mono text-xs"
+    >
+      {entries.map((entry) => (
+        <SseEventEntry key={entry.index} entry={entry} />
+      ))}
+    </div>
+  );
+}
+
+function SseEventEntry({ entry }: { entry: SseLogEntry }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const collapsed = JSON.stringify(entry.event);
+  const expanded = JSON.stringify(entry.event, null, 2);
+  const ts = new Date(entry.ts).toISOString().slice(11, 23); // HH:MM:SS.mmm
+  return (
+    <div className="rounded-md border border-border bg-muted/40">
+      <button
+        type="button"
+        aria-expanded={isExpanded}
+        className="flex w-full items-center gap-1.5 px-2 py-1 text-left hover:bg-muted/60"
+        onClick={() => setIsExpanded((v) => !v)}
+      >
+        {isExpanded ? (
+          <ChevronDownIcon className="size-3 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRightIcon className="size-3 shrink-0 text-muted-foreground" />
+        )}
+        <span className="shrink-0 text-muted-foreground">#{entry.index + 1}</span>
+        <span className="shrink-0 text-muted-foreground">{ts}</span>
+        {!isExpanded && <span className="truncate text-foreground">{collapsed}</span>}
+      </button>
+      {isExpanded && (
+        <pre className="whitespace-pre-wrap break-words border-t border-border px-2 py-1.5 text-foreground">
+          {expanded}
+        </pre>
+      )}
+    </div>
+  );
 }

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -80,6 +80,7 @@ import type {
 } from "@/lib/events";
 import { createPresenceIdleTracker } from "@/lib/presenceIdle";
 import { parseEvent, parseSseStream, type SseStreamResult } from "@/lib/sse";
+import { clearSseLog, pushSseEvent } from "@/lib/sseEventLog";
 import { childSessionsQueryKey, type ChildSessionInfo } from "@/hooks/useChildSessions";
 import { sessionItemsQueryKey } from "@/hooks/useSessionItems";
 import type { Conversation, ConversationsPage } from "@/hooks/useConversations";
@@ -3272,6 +3273,10 @@ export async function startStreamPump(
         presenceIdle.noteReported(idle);
         if (reconnecting) {
           dropEphemeralInFlightBlocks(id, set);
+        } else {
+          // Fresh connection (not a reconnect) — clear any stale SSE log from
+          // a previous stream bind so the debug panel starts clean.
+          clearSseLog(id);
         }
         // Start the pump, then reconcile the snapshot concurrently (race-safe
         // via itemId dedup) — mirrors bindStream's stream-then-snapshot order.
@@ -3677,7 +3682,7 @@ export async function pumpStreamEvents(
   // Per-message high-water chunk index, for delta duplicate suppression.
   const liveLastIndex = new Map<string, number>();
   const events = tapLiveDeltas(
-    tapSessionEvents(rawEvents),
+    tapSessionEvents(rawEvents, id),
     id,
     retiredLiveMessages,
     liveLastIndex,
@@ -4998,9 +5003,13 @@ function applyChildSessionUpdated(
   queryClient.setQueryData<ChildSessionInfo[]>(key, next);
 }
 
-async function* tapSessionEvents(events: AsyncIterable<StreamEvent>): AsyncIterable<StreamEvent> {
+async function* tapSessionEvents(
+  events: AsyncIterable<StreamEvent>,
+  sessionId?: string,
+): AsyncIterable<StreamEvent> {
   for await (const event of events) {
     handleSessionEvent(event);
+    if (sessionId !== undefined) pushSseEvent(sessionId, event);
     yield event;
   }
 }


### PR DESCRIPTION
## Related issue

N/A

## Summary

- **`sseEventLog.ts`**: module-level ring buffer (max 500 events per session) with a subscribe/snapshot API compatible with `useSyncExternalStore`. Zero overhead when not reading — the buffer fills regardless but is small and bounded.
- **`useSseEventLog.ts`**: thin React hook over the ring buffer.
- **`chatStore.ts`**: `tapSessionEvents` now pushes every `StreamEvent` into the ring buffer keyed by session id. The log is cleared on a fresh stream bind (not reconnects, so history survives reconnects).
- **`ExecutionLogsPanel.tsx`**: adds an **Items / SSE** toggle next to the session selector. The SSE tab shows timestamped raw events (`HH:MM:SS.mmm  #N  {…}`), each expandable to pretty-printed JSON. Auto-scrolls to bottom as events arrive.

## Test Plan

1. `just dev`, open a conversation with `?debug=1`
2. Click the "Execution logs" card → panel opens on "Items" view (existing behaviour unchanged)
3. Click **SSE** — should show "No SSE events yet" if the agent is idle
4. Send a message — SSE events appear in real time as the agent streams
5. Each row shows timestamp + collapsed JSON; click to expand
6. Reloading the page / navigating away clears the log

## Demo

<img width="1566" height="693" alt="image" src="https://github.com/user-attachments/assets/9995efe0-12b8-44d5-aaca-5010d3978b12" />


## Type of change

- [x] Feature
- [x] UI / frontend change

## Test coverage

- [x] Manual verification completed

## Coverage notes

Ring buffer and hook are simple enough to verify manually; the chatStore tap is a one-liner addition to an existing passthrough generator.

## Changelog

Adds a live SSE event viewer to the execution logs debug panel (`?debug=1`) — click the **SSE** tab to see raw stream events as they arrive from the server.