### PR TITLE
feat(web): keep conversation streams open in the background

### DIFF
--- a/tests/e2e_ui/chat/test_claude_model_picker.py
+++ b/tests/e2e_ui/chat/test_claude_model_picker.py
@@ -540,15 +540,22 @@ def test_composer_model_label_never_shows_the_previous_sessions_model(
     page: Page,
     seeded_session_pair: tuple[str, str, str],
 ) -> None:
-    """Switching Codex → Claude must not paint Codex's model on the way in.
+    """Opening a Claude session must not paint the previous session's model.
 
-    Failure mode this catches: ``switchTo`` clears the session-scoped model
-    fields (``sessionModelOverride`` / ``llmModel`` / ``codexModelOptions``) but
-    deliberately keeps ``selectedModel``, the cross-session sticky pick. The
-    native picker kind flips to Claude immediately (the session query and the
-    sidebar row are already cached), so for the whole snapshot round trip the
-    composer resolves the sticky and reads ``gpt-5.5`` on a Claude session
-    before correcting itself to Sonnet 5.
+    Failure mode this catches: a COLD open clears (never had) the
+    session-scoped model fields (``sessionModelOverride`` / ``llmModel`` /
+    ``codexModelOptions``) but deliberately keeps ``selectedModel``, the
+    cross-session sticky pick. If the composer mounts before the snapshot
+    lands, it resolves that sticky and reads ``gpt-5.5`` on a Claude session
+    before correcting itself to Sonnet 5. The store must hold the hydrating
+    placeholder for the whole snapshot round trip so the composer never
+    mounts against empty session-scoped state.
+
+    Cold open, not switch-back, on purpose: a conversation already visited is
+    now held live (its stream stays open in the background), so returning to
+    it repaints its own settled state with no snapshot fetch and therefore no
+    pre-bind window at all. The first open is the only place this window
+    still exists.
 
     :param page: Playwright page fixture.
     :param seeded_session_pair: ``(base_url, codex_session, claude_session)``
@@ -556,9 +563,8 @@ def test_composer_model_label_never_shows_the_previous_sessions_model(
         native shapes as seen by the browser.
     """
     base_url, codex_session, claude_session = seeded_session_pair
-    # Both sessions need a committed transcript: the store caches (and repaints
-    # from) only non-empty ones, and an empty session falls back to the hydrate
-    # placeholder, which hides the composer instead of painting a stale label.
+    # Both sessions need a committed transcript so the composer renders rather
+    # than falling back to the empty-session state.
     for session_id in (codex_session, claude_session):
         seed_committed_turn(session_id, prompt="ping", reply="pong")
     _patch_native_session_pair(page, codex_session, claude_session)
@@ -571,19 +577,12 @@ def test_composer_model_label_never_shows_the_previous_sessions_model(
 
     label = page.get_by_test_id("composer-model-effort-label")
 
-    # Visit the Claude session first so the return trip is the real-world
-    # switch-back: its snapshot query and transcript are cached, so the
-    # composer stays mounted (no hydrate placeholder) and paints through the
-    # window instead of being replaced by a spinner.
-    page.goto(f"{base_url}/c/{claude_session}")
-    expect(label).to_contain_text("Sonnet 5", timeout=15_000)
-
-    # Open the Codex session — binding it makes gpt-5.5 the sticky pick.
-    page.locator(f'a[href="/c/{codex_session}"]').click()
-    page.wait_for_url(re.compile(rf"/c/{re.escape(codex_session)}"))
+    # Open the Codex session FIRST and only — binding it makes gpt-5.5 the
+    # sticky pick, and leaves Claude never-visited so its open is cold.
+    page.goto(f"{base_url}/c/{codex_session}")
     expect(label).to_contain_text(_CODEX_MODEL_LABEL, timeout=15_000)
 
-    # Switch back to Claude with its snapshot held, and watch every label the
+    # Cold-open Claude with its snapshot held, and watch every label the
     # composer paints under the Claude route.
     page.evaluate("window.__delaySnapshot = true")
     page.evaluate("window.__modelLabelLog = []")

--- a/web/src/components/StreamBudgetBanner.test.tsx
+++ b/web/src/components/StreamBudgetBanner.test.tsx
@@ -1,0 +1,32 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { StreamBudgetBanner } from "./StreamBudgetBanner";
+import { useChatStore } from "@/store/chatStore";
+
+afterEach(() => {
+  cleanup();
+  useChatStore.setState({ streamBudgetExceeded: false, streamBudgetBannerDismissed: false });
+});
+
+describe("StreamBudgetBanner", () => {
+  it("stays hidden while the tab is within budget", () => {
+    useChatStore.setState({ streamBudgetExceeded: false, streamBudgetBannerDismissed: false });
+    render(<StreamBudgetBanner />);
+    expect(screen.queryByText(/a lot of conversations open across your tabs/i)).toBeNull();
+  });
+
+  it("warns to close tabs when over budget", () => {
+    useChatStore.setState({ streamBudgetExceeded: true, streamBudgetBannerDismissed: false });
+    render(<StreamBudgetBanner />);
+    expect(screen.getByText(/a lot of conversations open across your tabs/i)).toBeTruthy();
+  });
+
+  it("hides once dismissed and records the dismissal", () => {
+    useChatStore.setState({ streamBudgetExceeded: true, streamBudgetBannerDismissed: false });
+    render(<StreamBudgetBanner />);
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(useChatStore.getState().streamBudgetBannerDismissed).toBe(true);
+    expect(screen.queryByText(/a lot of conversations open across your tabs/i)).toBeNull();
+  });
+});

--- a/web/src/components/StreamBudgetBanner.tsx
+++ b/web/src/components/StreamBudgetBanner.tsx
@@ -1,0 +1,60 @@
+import { AlertTriangleIcon, XIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useChatStore } from "@/store/chatStore";
+
+/**
+ * Warns that this tab is over the origin-wide stream budget: every stream slot
+ * is held by other tabs (see `streamSlots`) and this tab had to open its
+ * conversation over budget, so its live updates may lag until a tab is closed.
+ *
+ * Floats as a rounded card at the top-right, just below the chat header
+ * (positioned like `JumpToTopButton`, so it must render as a sibling inside the
+ * `relative` conversation container). Dismissable per over-budget episode — a
+ * fresh episode re-shows it (see `streamBudgetBannerDismissed`).
+ */
+export function StreamBudgetBanner() {
+  const exceeded = useChatStore((s) => s.streamBudgetExceeded);
+  const dismissed = useChatStore((s) => s.streamBudgetBannerDismissed);
+  const dismiss = useChatStore((s) => s.dismissStreamBudgetBanner);
+
+  if (!exceeded || dismissed) return null;
+
+  return (
+    <div
+      // Below the h-14 (56px) header; z-40 clears the z-30 header, matching
+      // JumpToTopButton. The inset var (0px off the iOS shell) keeps it aligned
+      // when the header shifts down by the safe-area inset. Right-aligned.
+      style={{ top: "calc(56px + var(--omnigent-inset-top, 0px))" }}
+      className="pointer-events-none absolute inset-x-0 z-40 flex justify-end px-3"
+    >
+      <div
+        role="status"
+        aria-live="polite"
+        className={cn(
+          "pointer-events-auto flex max-w-2xl items-center gap-2.5 rounded-xl px-3.5 py-2 text-ui shadow-lg",
+          "border border-amber-300 bg-amber-100 text-amber-900",
+          "dark:border-amber-700/60 dark:bg-amber-950 dark:text-amber-100",
+          "animate-in fade-in-0 slide-in-from-top-1 duration-200",
+        )}
+      >
+        <AlertTriangleIcon className="size-4 shrink-0" aria-hidden="true" />
+        <span className="min-w-0 flex-1">
+          You have a lot of conversations open across your tabs. If you experience any slowness,
+          please close a few tabs.
+        </span>
+        <button
+          type="button"
+          onClick={dismiss}
+          aria-label="Dismiss"
+          className={cn(
+            "-mr-1 shrink-0 rounded p-0.5 text-amber-900/60 hover:bg-amber-200 hover:text-amber-900",
+            "dark:text-amber-100/60 dark:hover:bg-amber-900 dark:hover:text-amber-100",
+          )}
+        >
+          <XIcon className="size-4" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/hooks/useBrowserAgentRelay.test.tsx
+++ b/web/src/hooks/useBrowserAgentRelay.test.tsx
@@ -58,11 +58,11 @@ function installBridge(overrides: Record<string, unknown> = {}) {
  *  single claim fetch to have fired. */
 async function runAction(
   evt: BrowserActionRequestEvent,
-  opts: { expectResult?: boolean } = {},
+  opts: { expectResult?: boolean; source?: string } = {},
 ): Promise<void> {
-  const { expectResult = true } = opts;
+  const { expectResult = true, source = CONV } = opts;
   renderHook(() => useBrowserAgentRelay(CONV));
-  emitBrowserActionRequest(evt);
+  emitBrowserActionRequest(evt, source);
   if (expectResult) {
     await vi.waitFor(() => {
       expect(
@@ -155,6 +155,46 @@ describe("useBrowserAgentRelay — claim-first protocol", () => {
     const body = postedResult();
     expect(body.claim_token).toBe("tok_1");
     expect((body.result as { ok: boolean }).ok).toBe(true);
+  });
+
+  it("routes claim, dispatch, and result to the delivering conversation, not the mounted one", async () => {
+    // A background conversation (A) issues a browser action while a different
+    // conversation (B) is on screen and owns the relay. Every hop must target A:
+    // claiming at B is rejected as an owner mismatch, so nothing executes and
+    // A's browser tool times out. This is what background streams made reachable.
+    const VISIBLE = "conv_visible_B";
+    const BACKGROUND = "conv_background_A";
+    const bridge = installBridge();
+    authenticatedFetch.mockResolvedValueOnce(WON).mockResolvedValueOnce(jsonResponse({}));
+
+    renderHook(() => useBrowserAgentRelay(VISIBLE));
+    emitBrowserActionRequest(actionEvent("navigate", { url: "https://a" }), BACKGROUND);
+
+    await vi.waitFor(() => {
+      expect(
+        authenticatedFetch.mock.calls.some((c) => String(c[0]).includes("/browser/action_result/")),
+      ).toBe(true);
+    });
+
+    const claimUrl = String(
+      authenticatedFetch.mock.calls.find((c) =>
+        String(c[0]).includes("/browser/action_claim/"),
+      )![0],
+    );
+    expect(claimUrl).toContain(`/v1/sessions/${BACKGROUND}/browser/action_claim/`);
+    expect(claimUrl).not.toContain(VISIBLE);
+
+    // Dispatch targeted A's WebContentsView, and the result posted to A.
+    expect(bridge.browserOpenOrNavigate).toHaveBeenCalledWith(BACKGROUND, "https://a", undefined, {
+      force: true,
+      agent: true,
+    });
+    const resultUrl = String(
+      authenticatedFetch.mock.calls.find((c) =>
+        String(c[0]).includes("/browser/action_result/"),
+      )![0],
+    );
+    expect(resultUrl).toContain(`/v1/sessions/${BACKGROUND}/browser/action_result/`);
   });
 });
 
@@ -309,7 +349,7 @@ describe("useBrowserAgentRelay — result POST resilience", () => {
       .mockRejectedValueOnce(new Error("result POST network error"));
 
     renderHook(() => useBrowserAgentRelay(CONV));
-    emitBrowserActionRequest(actionEvent("screenshot"));
+    emitBrowserActionRequest(actionEvent("screenshot"), CONV);
 
     await vi.waitFor(() => {
       // Both the claim and the (failed) result POST were attempted.
@@ -326,7 +366,7 @@ describe("useBrowserAgentRelay — result POST resilience", () => {
     (window as unknown as { omnigentDesktop?: unknown }).omnigentDesktop = undefined;
 
     renderHook(() => useBrowserAgentRelay(CONV));
-    emitBrowserActionRequest(actionEvent("screenshot"));
+    emitBrowserActionRequest(actionEvent("screenshot"), CONV);
     await Promise.resolve();
     await Promise.resolve();
 

--- a/web/src/hooks/useBrowserAgentRelay.ts
+++ b/web/src/hooks/useBrowserAgentRelay.ts
@@ -338,24 +338,31 @@ async function postResult(
 }
 
 /**
- * Register the embedded-browser relay for a conversation. No-op outside Electron.
- * Mount ONE instance per active conversation (typically from `BrowserPane`).
+ * Register the embedded-browser relay. No-op outside Electron. Mounted for the
+ * active conversation (from `AppShell`), but it serves EVERY conversation's
+ * actions: an action is claimed, dispatched, and answered against the session
+ * whose stream delivered it (`sourceConversationId`), not the mounted one — a
+ * background conversation can issue a browser action while another is on screen,
+ * and its WebContentsView is keyed by that session. Claiming at the mounted
+ * (visible) session would be rejected by the server as an owner mismatch.
  *
- * @param conversationId The conversation whose WebContentsView this relay drives.
+ * @param conversationId Gate only — the relay registers while a conversation is
+ *   open. Routing uses the delivering conversation, not this.
  */
 export function useBrowserAgentRelay(conversationId: string | null | undefined): void {
   useEffect(() => {
     if (!conversationId) return;
     if (!supportsBrowser()) return;
 
-    const handler = async (evt: BrowserActionRequestEvent) => {
+    const handler = async (evt: BrowserActionRequestEvent, sourceConversationId: string | null) => {
+      if (!sourceConversationId) return; // no delivering session — nothing to target
       const desktop = getBrowserDesktop();
       if (!desktop) return; // no browser-capable shell — nothing to claim
       // Claim FIRST — only the winner proceeds, so two windows can't double-execute.
-      const claimToken = await claimAction(conversationId, evt.actionId);
+      const claimToken = await claimAction(sourceConversationId, evt.actionId);
       if (!claimToken) return;
-      const result = await dispatch(conversationId, evt.action, evt.args, desktop);
-      await postResult(conversationId, evt.actionId, claimToken, result);
+      const result = await dispatch(sourceConversationId, evt.action, evt.args, desktop);
+      await postResult(sourceConversationId, evt.actionId, claimToken, result);
     };
 
     return onBrowserActionRequest(handler);

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -47,7 +47,7 @@ import {
   renameProject as apiRenameProject,
   updateProjectConfig as apiUpdateProjectConfig,
 } from "@/lib/projectsApi";
-import { useChatStore } from "@/store/chatStore";
+import { releaseConversation, useChatStore } from "@/store/chatStore";
 import type { Session } from "@/lib/types";
 import { useSessionUpdatesConnected } from "./useSessionUpdatesConnected";
 import { markConversationSeen } from "./useUnseenConversations";
@@ -494,6 +494,8 @@ export async function deleteConversation(id: string, deleteBranch = false): Prom
   // Drop any client-side queued messages for the now-deleted session; bound to
   // a dead conversation, they could never flush.
   useChatStore.getState().clearQueuedMessages(id);
+  // A deleted conversation must stop pumping and let go of its stream.
+  releaseConversation(id);
 }
 
 /**

--- a/web/src/lib/browserActionBus.test.ts
+++ b/web/src/lib/browserActionBus.test.ts
@@ -12,14 +12,18 @@ afterEach(() => {
 });
 
 describe("browserActionBus", () => {
-  it("delivers an emitted event to a registered listener", () => {
-    const seen: BrowserActionRequestEvent[] = [];
-    const unsub = onBrowserActionRequest((e) => seen.push(e));
+  it("delivers an emitted event and its source conversation to a listener", () => {
+    const seen: { evt: BrowserActionRequestEvent; conversationId: string | null }[] = [];
+    const unsub = onBrowserActionRequest((e, conversationId) =>
+      seen.push({ evt: e, conversationId }),
+    );
     const evt = event();
 
-    emitBrowserActionRequest(evt);
+    emitBrowserActionRequest(evt, "conv_src");
 
-    expect(seen).toEqual([evt]);
+    // The delivering conversation rides alongside — the relay needs it to
+    // claim/dispatch against the right session.
+    expect(seen).toEqual([{ evt, conversationId: "conv_src" }]);
     unsub();
   });
 
@@ -29,7 +33,7 @@ describe("browserActionBus", () => {
     const unsubA = onBrowserActionRequest(a);
     const unsubB = onBrowserActionRequest(b);
 
-    emitBrowserActionRequest(event());
+    emitBrowserActionRequest(event(), "conv_src");
 
     expect(a).toHaveBeenCalledTimes(1);
     expect(b).toHaveBeenCalledTimes(1);
@@ -42,7 +46,7 @@ describe("browserActionBus", () => {
     const unsub = onBrowserActionRequest(listener);
     unsub();
 
-    emitBrowserActionRequest(event());
+    emitBrowserActionRequest(event(), "conv_src");
 
     expect(listener).not.toHaveBeenCalled();
   });
@@ -52,7 +56,7 @@ describe("browserActionBus", () => {
     const unsub1 = onBrowserActionRequest(listener);
     const unsub2 = onBrowserActionRequest(listener);
 
-    emitBrowserActionRequest(event());
+    emitBrowserActionRequest(event(), "conv_src");
 
     // Same function registered twice collapses to one Set entry.
     expect(listener).toHaveBeenCalledTimes(1);
@@ -70,7 +74,7 @@ describe("browserActionBus", () => {
     const unsubAfter = onBrowserActionRequest(after);
 
     // Must not throw despite the first listener throwing.
-    expect(() => emitBrowserActionRequest(event())).not.toThrow();
+    expect(() => emitBrowserActionRequest(event(), "conv_src")).not.toThrow();
     expect(boom).toHaveBeenCalledTimes(1);
     expect(after).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalled();
@@ -79,6 +83,6 @@ describe("browserActionBus", () => {
   });
 
   it("emitting with no listeners registered is a no-op", () => {
-    expect(() => emitBrowserActionRequest(event())).not.toThrow();
+    expect(() => emitBrowserActionRequest(event(), "conv_src")).not.toThrow();
   });
 });

--- a/web/src/lib/browserActionBus.ts
+++ b/web/src/lib/browserActionBus.ts
@@ -6,7 +6,16 @@
  */
 import type { BrowserActionRequestEvent } from "./events";
 
-export type BrowserActionListener = (event: BrowserActionRequestEvent) => void;
+/**
+ * `conversationId` is the conversation whose STREAM delivered the action — the
+ * session the relay must claim/dispatch/post against. The event payload carries
+ * no conversation id, and with background streams the delivering conversation
+ * may not be the one the relay was mounted for, so it has to ride alongside.
+ */
+export type BrowserActionListener = (
+  event: BrowserActionRequestEvent,
+  conversationId: string | null,
+) => void;
 
 const listeners = new Set<BrowserActionListener>();
 
@@ -20,10 +29,13 @@ export function onBrowserActionRequest(listener: BrowserActionListener): () => v
 
 /** Fan a browser action request out to every listener; a throwing listener is
  *  isolated so it can't stop the others or the event pump. */
-export function emitBrowserActionRequest(event: BrowserActionRequestEvent): void {
+export function emitBrowserActionRequest(
+  event: BrowserActionRequestEvent,
+  conversationId: string | null,
+): void {
   for (const listener of listeners) {
     try {
-      listener(event);
+      listener(event, conversationId);
     } catch (err) {
       console.warn("[browser-relay] action listener threw:", err);
     }

--- a/web/src/lib/presenceIdle.test.ts
+++ b/web/src/lib/presenceIdle.test.ts
@@ -109,3 +109,43 @@ describe("createPresenceIdleTracker", () => {
     expect(t.idleNow()).toBe(true);
   });
 });
+
+// The store keeps one abort controller per LIVE stream and aborts them all on a
+// flip, because the `idle` query param rides on each stream's GET — recycling
+// only one would leave every other open stream reporting a stale flag. That
+// fan-out lives in `chatStore`'s `presenceAttemptControllers`; this pins the
+// contract it relies on, including that aborting mid-iteration (each abort
+// settles an attempt, which removes it from the live set) recycles every stream.
+describe("recycling every live stream on a flip", () => {
+  it("aborts all registered attempts, even as they deregister mid-flip", () => {
+    const live = new Set<AbortController>();
+    const t = createPresenceIdleTracker({
+      onFlip: () => {
+        // Copy first: abort handlers below mutate `live` while we iterate.
+        for (const c of [...live]) c.abort();
+      },
+      idleAfterMs: IDLE_AFTER_MS,
+    });
+
+    // Three concurrent streams, each deregistering itself when aborted — the
+    // shape `startStreamPump`'s `finally` produces.
+    const aborted: number[] = [];
+    for (let i = 0; i < 3; i++) {
+      const c = new AbortController();
+      c.signal.addEventListener("abort", () => {
+        aborted.push(i);
+        live.delete(c);
+      });
+      live.add(c);
+    }
+
+    t.noteReported(false);
+    t.handleVisibilityChange(true);
+    vi.advanceTimersByTime(IDLE_AFTER_MS + 1);
+
+    // All three recycled (a single shared controller would abort only one), and
+    // the set drains as each attempt tears down.
+    expect(aborted).toEqual([0, 1, 2]);
+    expect(live.size).toBe(0);
+  });
+});

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -6108,7 +6108,7 @@ function SessionConfigModal({
   costRoutingEligible: boolean;
   subagentRoutingEligible: boolean;
 }) {
-  const selectedEffort = useChatStore((s) => s.selectedEffort);
+  const selectedEffort = useSessionEffort();
   const costControlModeOverride = useChatStore((s) => s.costControlModeOverride);
   const subagentRoutingOverride = useChatStore((s) => s.subagentRoutingOverride);
   const conversationId = useChatStore((s) => s.conversationId);
@@ -6515,7 +6515,7 @@ function useSessionConfigSummary({
   codexModelOptions: readonly NativeModelOption[];
   costRoutingEligible: boolean;
 }): { label: string; value: string }[] {
-  const selectedEffort = useChatStore((s) => s.selectedEffort);
+  const selectedEffort = useSessionEffort();
   const costControlModeOverride = useChatStore((s) => s.costControlModeOverride);
   const { modelLabel } = useResolvedComposerModel(modelPickerKind, codexModelOptions);
   const routingOn = costRoutingEligible && costControlModeOverride === "on";
@@ -6535,6 +6535,21 @@ function useSessionConfigSummary({
     rows.push({ label: "Effort", value: effortValue ?? "Default" });
   }
   return rows;
+}
+
+/**
+ * The effort this conversation is actually at.
+ *
+ * `sessionReasoningEffort` is conversation-scoped, so two live conversations at
+ * different efforts each read their own; `selectedEffort` is the single
+ * app-global sticky pick, used only as the pre-hydration fallback. Reading the
+ * sticky pick alone would show a warm-switched conversation the last effort
+ * picked anywhere.
+ */
+function useSessionEffort(): string | null {
+  const sessionReasoningEffort = useChatStore((s) => s.sessionReasoningEffort);
+  const stickyEffort = useChatStore((s) => s.selectedEffort);
+  return sessionReasoningEffort ?? stickyEffort;
 }
 
 /**
@@ -6675,7 +6690,7 @@ function ComposerModelEffortLabel({
   costRoutingEligible: boolean;
   harnessLabel: string | null;
 }) {
-  const selectedEffort = useChatStore((s) => s.selectedEffort);
+  const selectedEffort = useSessionEffort();
   const costControlModeOverride = useChatStore((s) => s.costControlModeOverride);
   const { modelLabel } = useResolvedComposerModel(modelPickerKind, codexModelOptions);
   const routingOn = costRoutingEligible && costControlModeOverride === "on";

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -60,6 +60,7 @@ import { CompactionMarker, RoutingDecisionCard } from "@/components/blocks/Statu
 import { SystemMessageView } from "@/components/blocks/SystemMessage";
 import { isSystemUserContent, parseSystemMessage } from "@/lib/systemMessage";
 import { Button } from "@/components/ui/button";
+import { StreamBudgetBanner } from "@/components/StreamBudgetBanner";
 import { OttoIcon } from "@/components/icons/OttoIcon";
 import { cn } from "@/lib/utils";
 import { QueuedMessagesStrip } from "@/pages/QueuedMessagesStrip";
@@ -2139,6 +2140,10 @@ function MainAgentSurface({
               scroller={scroller}
               hasMoreHistory={hasMoreHistory}
             />
+            {/* Too-many-tabs warning: floats as a rounded card just below the
+            header, a sibling of Conversation for the same reason as
+            JumpToTopButton — outside the chat-scroll-fade mask. */}
+            <StreamBudgetBanner />
             {/* Left-edge minimap: one tick per turn, scrolls independently, pages
             in older history on scroll-up. Sibling of Conversation for the same
             reason as JumpToTopButton — it escapes the chat-scroll-fade mask.

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -34,6 +34,7 @@ import { itemsToBlocks } from "@/lib/itemsToBlocks";
 import { buildBubbles } from "@/lib/renderItems";
 import { INITIAL_WINDOW_ITEMS, SESSION_HISTORY_PAGE_SIZE } from "@/lib/sessionsApi";
 import { getCurrentAuthorId } from "@/lib/identity";
+import { PRESENCE_IDLE_AFTER_MS } from "@/lib/presenceIdle";
 import type {
   SessionCreatedEvent,
   SessionInputConsumedEvent,
@@ -57,7 +58,10 @@ import {
   startStreamPump,
   useChatStore,
   type FrameScheduler,
+  bindConversationForTest,
+  releaseConversation,
 } from "./chatStore";
+import { conversationRegistry } from "./conversationRegistry";
 import { useTerminalActivityStore } from "./terminalActivity";
 
 // The real `send` action, captured before any test stubs it via
@@ -111,19 +115,49 @@ function nativeToolItem(responseId: string): ConversationItem {
   };
 }
 
-// A stream that delivers no events and closes with the server's `[DONE]`
-// sentinel — i.e. a deliberate clean server close, which the reconnect
-// loop in `startStreamPump` treats as terminal (no re-subscribe). Without
-// the `[DONE]`, a bare close reads as a transport drop and the loop would
-// reconnect, spinning these single-shot tests.
+// Controllers of every open `emptyStream`, closed in `afterEach`.
+//
+// Aborting the store's `AbortController` does NOT settle a parked
+// `reader.read()`: `mockResponse` hands back a plain object, so there is no
+// fetch plumbing tying the signal to the stream (a real fetch errors the body on
+// abort). Without closing these explicitly, `parseSseStream` stays parked on the
+// read forever and the pump outlives the test — `conversationRegistry.clear()`
+// aborts the controller, which is not enough.
+const openEmptyStreams = new Set<ReadableStreamDefaultController<Uint8Array>>();
+
+// A stream that delivers no events and stays open, like a real idle session
+// stream between turns (the server holds it and emits heartbeats). Never
+// closing keeps it OPEN — `switchTo`/`ensureBoundSession` treat a stream that
+// ended as no longer current and re-bind, so a mock that closed immediately
+// would make every entry look dead and defeat background retention.
+//
+// Deliberately not `data: [DONE]`: in production that sentinel means a
+// clean server-side close, which is terminal by design.
 function emptyStream(): ReadableStream<Uint8Array> {
-  const enc = new TextEncoder();
+  let own: ReadableStreamDefaultController<Uint8Array> | null = null;
   return new ReadableStream({
     start(controller) {
-      controller.enqueue(enc.encode("data: [DONE]\n\n"));
-      controller.close();
+      own = controller;
+      openEmptyStreams.add(controller);
+    },
+    cancel() {
+      // The consumer let go first, so this one needs no closing. Drop only its
+      // own controller — the set holds every other live stream's too.
+      if (own !== null) openEmptyStreams.delete(own);
     },
   });
+}
+
+/** Close every open `emptyStream` so parked readers settle. */
+function closeOpenEmptyStreams(): void {
+  for (const controller of openEmptyStreams) {
+    try {
+      controller.close();
+    } catch {
+      // Already closed or errored — nothing to do.
+    }
+  }
+  openEmptyStreams.clear();
 }
 
 function mockResponse(
@@ -373,10 +407,6 @@ beforeEach(() => {
     blocks: [],
     pendingUserMessages: [],
     queuedMessages: [],
-    // Reset the per-conversation stash too, or a stash entry left by one
-    // navigation test leaks into the next (the entry survives switchTo by
-    // design — that's the whole point — so beforeEach must clear it).
-    pendingByConversation: {},
     activeResponse: null,
     status: "idle",
     sessionStatus: "idle",
@@ -397,6 +427,14 @@ beforeEach(() => {
 
 afterEach(() => {
   useChatStore.getState().abortController?.abort();
+  // Every live entry owns an open stream now (the default mock never closes),
+  // so tear the registry down or its pumps outlive the test and leak into the
+  // next one's fetch mock.
+  conversationRegistry.clear();
+  // Aborting is not enough on its own: the mocked Response has no fetch
+  // plumbing, so nothing errors the body and `parseSseStream` stays parked on
+  // `reader.read()`. Close the streams so those reads actually settle.
+  closeOpenEmptyStreams();
   vi.useRealTimers();
   vi.unstubAllGlobals();
   // Reset the stubbed viewer identity to the default (null) so a value set
@@ -435,6 +473,37 @@ function seedPendingInputs(
   sessionPendingInputs.set(id, inputs);
 }
 
+describe("test harness teardown", () => {
+  it("settles a parked SSE reader, which aborting alone cannot do", async () => {
+    // Guards the `afterEach` contract. The default `/stream` mock stays open (so
+    // background retention is exercised faithfully), but `mockResponse` returns a
+    // plain object with no fetch plumbing — so aborting the store's controller
+    // never errors the body, and `parseSseStream` would stay parked on
+    // `reader.read()` for the whole run. Closing the stream is what settles it.
+    seedSession("conv_teardown", []);
+    await useChatStore.getState().switchTo("conv_teardown");
+    expect(openEmptyStreams.size).toBeGreaterThan(0);
+
+    // What `conversationRegistry.clear()` does, and all it does.
+    useChatStore.getState().abortController?.abort();
+    const stream = emptyStream();
+    const reader = stream.getReader();
+    let settled = false;
+    void reader.read().then(() => {
+      settled = true;
+    });
+    await tick();
+    // Still parked: the abort above has no relationship to this stream.
+    expect(settled).toBe(false);
+
+    closeOpenEmptyStreams();
+    await tick();
+    // Closing settled it, and the registry of open streams is empty.
+    expect(settled).toBe(true);
+    expect(openEmptyStreams.size).toBe(0);
+  });
+});
+
 describe("chatStore — switchTo", () => {
   it("hydrates blocks from the session snapshot when switching to a real conv id", async () => {
     const items: ConversationItem[] = [
@@ -454,6 +523,231 @@ describe("chatStore — switchTo", () => {
     expect(user.content).toEqual([{ type: "input_text", text: "hello" }]);
     expect(state.loadingConversation).toBe(false);
     expect(state.conversationLoadError).toBeNull();
+  });
+
+  it("keeps a backgrounded conversation live, so returning to it needs no refetch", async () => {
+    // The feature: switching away no longer tears the stream down, so switching
+    // back neither re-opens a stream nor re-fetches the snapshot. This is what
+    // the transcript LRU used to approximate (paint stale, then revalidate).
+    seedSession("conv_a", [userMessage("resp_a", "in a")]);
+    seedSession("conv_b", [userMessage("resp_b", "in b")]);
+
+    await useChatStore.getState().switchTo("conv_a");
+    expect(useChatStore.getState().blocks).toHaveLength(1);
+
+    await useChatStore.getState().switchTo("conv_b");
+    const callsAfterB = fetchMock.mock.calls.length;
+
+    await useChatStore.getState().switchTo("conv_a");
+    // Painted from the live entry: conv_a's transcript is right there.
+    expect(useChatStore.getState().conversationId).toBe("conv_a");
+    expect(useChatStore.getState().blocks).toHaveLength(1);
+    // And nothing was fetched to get it.
+    expect(fetchMock.mock.calls.length).toBe(callsAfterB);
+  });
+
+  it("commits a message sent in a backgrounded conversation, in transcript order", async () => {
+    // End-to-end version of the interleaving regression, through the real pump.
+    //
+    // The renderer appends `pendingUserMessages` AFTER committed `blocks`
+    // (ChatPage's `mergePendingBubbles`), so an optimistic bubble is always
+    // visually last. That is correct while it is in flight, and becomes a bug if
+    // it never commits: `session.input.consumed` is the ONLY thing that promotes
+    // it into `blocks`. Drop that event for a background conversation and the
+    // user message stays pinned below assistant output that arrived after it —
+    // which reads as scrambled ordering when the user switches back.
+    const sink = pushableStream();
+    seedSession("conv_bgsend", []);
+    seedSession("conv_other", []);
+    const base = fetchMock.getMockImplementation()!;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_bgsend/stream")
+        return mockResponse(null, { bodyStream: sink.stream });
+      return base(input, init);
+    });
+
+    await useChatStore.getState().switchTo("conv_bgsend");
+    await useChatStore.getState().send("hello from bg", "agent_xyz");
+    // Optimistic bubble is pending: nothing committed yet.
+    expect(useChatStore.getState().pendingUserMessages).toHaveLength(1);
+
+    // The user navigates away; conv_bgsend keeps its stream.
+    await useChatStore.getState().switchTo("conv_other");
+
+    // The runner commits the message, then streams its reply — the order the
+    // user should see on return.
+    sink.push(
+      sse("session.input.consumed", {
+        // Nested envelope, as the server sends it (see `parseEvent`).
+        data: {
+          item_id: "item_bg_user",
+          type: "message",
+          data: { role: "user", content: [{ type: "input_text", text: "hello from bg" }] },
+        },
+      }),
+    );
+    sink.push(sse("response.created", { id: "resp_bg", status: "in_progress", output: [] }));
+    // Past the reducer's flush threshold so the text lands as a block.
+    sink.push(sse("response.output_text.delta", { delta: `${"z".repeat(34)} ` }));
+    await tick();
+    await tick();
+
+    // Back to the backgrounded conversation.
+    await useChatStore.getState().switchTo("conv_bgsend");
+    const state = useChatStore.getState();
+
+    // The bubble was promoted, so nothing trails the transcript...
+    expect(state.pendingUserMessages).toEqual([]);
+    // ...and the user message sits BEFORE the assistant reply that followed it.
+    const kinds = state.blocks.map((b) => b.type);
+    expect(kinds[0]).toBe("user_message");
+    expect(state.blocks[0]!.ctx.itemId).toBe("item_bg_user");
+    expect(kinds.slice(1)).not.toContain("user_message");
+
+    sink.close();
+  });
+
+  it("re-binds a retained conversation whose stream ended, instead of painting it stale", async () => {
+    // Registry membership alone does not mean "current". A clean server close
+    // (`[DONE]`) ends the pump for good and clears `abortController`, but does
+    // not release the entry — so treating "has an entry" as live meant returning
+    // to the conversation repainted whatever it held when the stream died and
+    // never reopened it: permanently stale until the next send.
+    const sink = pushableStream();
+    seedSession("conv_dead", [userMessage("resp_d", "first")]);
+    seedSession("conv_away", []);
+    const base = fetchMock.getMockImplementation()!;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_dead/stream")
+        return mockResponse(null, { bodyStream: sink.stream });
+      return base(input, init);
+    });
+
+    await useChatStore.getState().switchTo("conv_dead");
+    expect(useChatStore.getState().blocks).toHaveLength(1);
+
+    // The server closes the stream deliberately; the pump stops for good.
+    sink.push("data: [DONE]\n\n");
+    sink.close();
+    await tick();
+    await tick();
+    expect(conversationRegistry.peek("conv_dead")!.getState().abortController).toBeNull();
+
+    await useChatStore.getState().switchTo("conv_away");
+    // Meanwhile the conversation gained an item the dead stream never delivered.
+    seedSession("conv_dead", [
+      userMessage("resp_d", "first"),
+      assistantMessage("resp_d", "second"),
+    ]);
+
+    await useChatStore.getState().switchTo("conv_dead");
+    // Re-bound: the fresh snapshot is here, exactly once.
+    expect(useChatStore.getState().blocks).toHaveLength(2);
+    expect(useChatStore.getState().blocks.map((b) => b.type)).toEqual([
+      "user_message",
+      "text_done",
+    ]);
+    expect(useChatStore.getState().abortController).not.toBeNull();
+  });
+
+  it("keeps an unsent bubble when re-binding a conversation whose stream died", async () => {
+    // The re-bind starts from a clean entry so the snapshot can't duplicate a
+    // stale transcript — but a send the server never acknowledged exists nowhere
+    // else, so dropping the entry wholesale would lose the user's message.
+    seedSession("conv_rebind_keep", []);
+    await useChatStore.getState().switchTo("conv_rebind_keep");
+    const entry = conversationRegistry.peek("conv_rebind_keep")!;
+    // A dead stream (cleared controller) holding an unsettled optimistic bubble.
+    entry.setState({
+      abortController: null,
+      pendingUserMessages: [{ tempId: "pend_keep", content: [{ type: "input_text", text: "hi" }] }],
+    });
+    await useChatStore.getState().switchTo(null);
+
+    await useChatStore.getState().switchTo("conv_rebind_keep");
+
+    expect(useChatStore.getState().pendingUserMessages.map((p) => p.tempId)).toEqual(["pend_keep"]);
+  });
+
+  it("reconciles a backgrounded conversation's stale approval card on tab focus", async () => {
+    // `bindStream` registers a visibilitychange reconcile per stream, so every
+    // LIVE conversation gets one — not just the visible one. Gating the apply on
+    // the active conversation made a background reconcile fetch the snapshot and
+    // then discard it, leaving a card that was answered elsewhere stuck pending
+    // until a page refresh.
+    seedSession("conv_vis_elic", []);
+    seedPendingElicitations("conv_vis_elic", [
+      {
+        type: "response.elicitation_request",
+        elicitation_id: "elic_vis",
+        params: {
+          mode: "form",
+          message: "Approve while hidden?",
+          phase: "tool_call_approval",
+          policy_name: "test_policy",
+          content_preview: "",
+        },
+      },
+    ]);
+    seedSession("conv_vis_other", []);
+
+    await useChatStore.getState().switchTo("conv_vis_elic");
+    const cardOf = (id: string) =>
+      conversationRegistry
+        .peek(id)!
+        .getState()
+        .blocks.filter((b): b is ElicitationBlock => b.type === "elicitation");
+    expect(cardOf("conv_vis_elic")[0]!.status).toBe("pending");
+
+    // Background it, then the prompt is answered on another surface.
+    await useChatStore.getState().switchTo("conv_vis_other");
+    seedPendingElicitations("conv_vis_elic", []);
+
+    // Tab regains focus: every live stream's listener reconciles.
+    document.dispatchEvent(new Event("visibilitychange"));
+    await tick();
+    await tick();
+
+    const reconciled = cardOf("conv_vis_elic");
+    expect(reconciled).toHaveLength(1);
+    expect(reconciled[0]!.status).toBe("responded");
+    expect(reconciled[0]!.response).toEqual({ action: "auto_resolved" });
+  });
+
+  it("does not abort a conversation's stream when switching away", async () => {
+    const sink = pushableStream();
+    seedSession("conv_a", []);
+    seedSession("conv_b", []);
+    const base = fetchMock.getMockImplementation()!;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_a/stream")
+        return mockResponse(null, { bodyStream: sink.stream });
+      return base(input, init);
+    });
+
+    await useChatStore.getState().switchTo("conv_a");
+    const aController = useChatStore.getState().abortController;
+    expect(aController).not.toBeNull();
+
+    await useChatStore.getState().switchTo("conv_b");
+    // conv_a keeps pumping in the background — that is the whole point.
+    expect(aController!.signal.aborted).toBe(false);
+
+    sink.close();
+  });
+
+  it("keeps each conversation's transcript separate across switches", async () => {
+    seedSession("conv_a", [userMessage("resp_a", "in a")]);
+    seedSession("conv_b", [userMessage("resp_b", "in b"), assistantMessage("resp_b", "reply b")]);
+
+    await useChatStore.getState().switchTo("conv_a");
+    await useChatStore.getState().switchTo("conv_b");
+    expect(useChatStore.getState().blocks).toHaveLength(2);
+    await useChatStore.getState().switchTo("conv_a");
+    expect(useChatStore.getState().blocks).toHaveLength(1);
   });
 
   it("hydrates pendingUserMessages from the snapshot's pending_inputs (native rebind)", async () => {
@@ -543,434 +837,6 @@ describe("chatStore — switchTo", () => {
         content: [{ type: "input_image", file_id: "file_xyz", filename: "a.png" }],
       },
     ]);
-  });
-
-  it("restores an un-acked optimistic bubble from the per-conversation stash on navigate-back", async () => {
-    // The first-message bug: a native web message's optimistic bubble lives
-    // only in client memory until the server records it — the transcript
-    // round-trip lags (esp. on a cold-starting runner), so for a window
-    // BOTH the items and pending_inputs in the snapshot are empty. If the
-    // user navigates away in that window, switchTo wipes the bubble; the
-    // navigate-back snapshot is still empty, so without the stash the chat
-    // shows nothing until the round-trip's session.input.consumed lands.
-    seedSession("conv_native", []); // pre-record: nothing server-side yet
-    seedSession("conv_other", []);
-
-    // Land on the native session, then model send()'s optimistic push.
-    await useChatStore.getState().switchTo("conv_native");
-    useChatStore.setState({
-      pendingUserMessages: [{ tempId: "pend_1", content: [{ type: "input_text", text: "hello" }] }],
-    });
-
-    // Navigate away (stashes conv_native's bubble) and back.
-    await useChatStore.getState().switchTo("conv_other");
-    await useChatStore.getState().switchTo("conv_native");
-
-    // Restored from the stash despite the empty snapshot. If the stash
-    // logic is reverted, switchTo's reset leaves this [] — the exact
-    // disappeared-first-message bug.
-    expect(useChatStore.getState().pendingUserMessages).toEqual([
-      { tempId: "pend_1", content: [{ type: "input_text", text: "hello" }] },
-    ]);
-  });
-
-  it("drops the stashed bubble on navigate-back when its message persisted while away", async () => {
-    // If the round-trip completes while the user is on another session, the
-    // navigate-back snapshot already carries the committed item. The
-    // restored stash bubble must be deduped against it (by text/endsWith),
-    // or the message double-renders (committed item + trailing bubble).
-    seedSession("conv_other", []);
-
-    await useChatStore.getState().switchTo("conv_native");
-    useChatStore.setState({
-      pendingUserMessages: [{ tempId: "pend_1", content: [{ type: "input_text", text: "hello" }] }],
-    });
-    await useChatStore.getState().switchTo("conv_other");
-
-    // While away, the message round-tripped into durable history.
-    seedSession("conv_native", [userMessage("resp1", "hello")]);
-    await useChatStore.getState().switchTo("conv_native");
-
-    // Stash bubble deduped away; the committed item is the only copy. If
-    // the dedup didn't apply to restored bubbles, pendingUserMessages would
-    // still hold the stale entry (a visible duplicate).
-    expect(useChatStore.getState().pendingUserMessages).toEqual([]);
-    const userBlocks = useChatStore.getState().blocks.filter((b) => b.type === "user_message");
-    expect(userBlocks).toHaveLength(1); // committed "hello" renders exactly once
-  });
-
-  it("keeps the stashed bubble when its text matches an OLDER message already in history", async () => {
-    // Resumed/disconnected-session regression (the offline-host report): the
-    // conversation already has a committed "hello". The user sends another
-    // "hello" whose optimistic bubble isn't recorded server-side yet (the
-    // runner is relaunching, so the POST is still in flight), then navigates
-    // away and back. The navigate-back dedup must NOT treat the PRE-EXISTING
-    // committed "hello" as the persisted copy of the new bubble — only a copy
-    // NEW since the bubble was stashed counts. Without the baseline the bubble
-    // vanishes until its own copy finally commits ("disappears then reappears").
-    seedSession("conv_native", [userMessage("resp_old", "hello")]);
-    seedSession("conv_other", []);
-
-    await useChatStore.getState().switchTo("conv_native");
-    // The snapshot's committed "hello" is in blocks now — it forms the dedup
-    // baseline captured when we navigate away. Add the new optimistic bubble.
-    useChatStore.setState((s) => ({
-      pendingUserMessages: [
-        ...s.pendingUserMessages,
-        { tempId: "pend_1", content: [{ type: "input_text", text: "hello" }] },
-      ],
-    }));
-
-    // Away and back — the snapshot still has ONLY the older committed "hello".
-    await useChatStore.getState().switchTo("conv_other");
-    await useChatStore.getState().switchTo("conv_native");
-
-    // Bubble survives: the older committed copy was already in the baseline,
-    // so it isn't mistaken for the new message persisting. Revert the
-    // baseline logic and this is [] — the disappeared-message bug.
-    expect(useChatStore.getState().pendingUserMessages).toEqual([
-      { tempId: "pend_1", content: [{ type: "input_text", text: "hello" }] },
-    ]);
-    const userBlocks = useChatStore.getState().blocks.filter((b) => b.type === "user_message");
-    expect(userBlocks).toHaveLength(1); // the old committed "hello", bubble separate
-  });
-
-  it("still drops the stashed bubble when a NEW committed copy appears beside an older match", async () => {
-    // The baseline must not over-protect: if history already had a "hello"
-    // AND the user's new "hello" round-trips into history while away, the
-    // snapshot now holds TWO — one more than the baseline — so the stash
-    // bubble IS the persisted one and must be deduped away (no duplicate).
-    seedSession("conv_native", [userMessage("resp_old", "hello")]);
-    seedSession("conv_other", []);
-
-    await useChatStore.getState().switchTo("conv_native");
-    useChatStore.setState((s) => ({
-      pendingUserMessages: [
-        ...s.pendingUserMessages,
-        { tempId: "pend_1", content: [{ type: "input_text", text: "hello" }] },
-      ],
-    }));
-    await useChatStore.getState().switchTo("conv_other");
-
-    // While away, the new "hello" committed — history now has two copies.
-    seedSession("conv_native", [
-      userMessage("resp_old", "hello"),
-      userMessage("resp_new", "hello"),
-    ]);
-    await useChatStore.getState().switchTo("conv_native");
-
-    expect(useChatStore.getState().pendingUserMessages).toEqual([]);
-    const userBlocks = useChatStore.getState().blocks.filter((b) => b.type === "user_message");
-    expect(userBlocks).toHaveLength(2); // both committed copies, no trailing bubble
-  });
-
-  it("replays all pending_inputs on navigate-back, deduping a restored in-flight twin by content", async () => {
-    // Navigate-back re-seeds from the snapshot's pending_inputs — the
-    // server is the source of truth for every queued message it knows
-    // about, the viewer's own and collaborators' alike (no viewer
-    // identity needed). A restored in-flight bubble whose record landed
-    // server-side while its POST response was still in transit is
-    // dropped in favor of its content-identical server twin: the server
-    // entry carries the durable pending_id, so the eventual consumed
-    // event clears it BY ID. The own message is image-only here because
-    // that's the case only content equality can correlate — the
-    // text-based dedupe has nothing to match, and keeping both copies
-    // would double-render and strand one of them (the stuck-pending-
-    // bubble bug).
-    seedSession("conv_other", []);
-
-    await useChatStore.getState().switchTo("conv_native");
-    useChatStore.setState({
-      pendingUserMessages: [
-        {
-          tempId: "pend_1",
-          content: [{ type: "input_image", file_id: "file_xyz", filename: "a.png" }],
-        },
-      ],
-    });
-    await useChatStore.getState().switchTo("conv_other");
-
-    // While away (still pre-persist): the server holds the viewer's own
-    // entry (recorded by the in-flight POST) and a collaborator's.
-    seedSession("conv_native", []);
-    seedPendingInputs("conv_native", [
-      {
-        pending_id: "pending_mine",
-        content: [{ type: "input_image", file_id: "file_xyz", filename: "a.png" }],
-        created_by: "alice@databricks.com",
-      },
-      {
-        pending_id: "pending_bob",
-        content: [{ type: "input_text", text: "from bob" }],
-        created_by: "bob@databricks.com",
-      },
-    ]);
-    await useChatStore.getState().switchTo("conv_native");
-
-    const pending = useChatStore.getState().pendingUserMessages;
-    // Both server entries, nothing else. If the restored twin weren't
-    // deduped, the image bubble would appear twice (length 3); if
-    // pending_inputs replay were dropped, "from bob" would be missing.
-    expect(pending).toEqual([
-      {
-        tempId: "pending_mine",
-        content: [{ type: "input_image", file_id: "file_xyz", filename: "a.png" }],
-        author: "alice@databricks.com",
-      },
-      {
-        tempId: "pending_bob",
-        content: [{ type: "input_text", text: "from bob" }],
-        author: "bob@databricks.com",
-      },
-    ]);
-  });
-
-  it("drops a settled send's bubble on navigate-back once the server has resolved it (stuck-bubble regression)", async () => {
-    // The reported strand, replayed end-to-end through the real client
-    // paths:
-    //   1. send an image-only message from the composer (real upload +
-    //      POST /events; send() promotes the "pending:" placeholder to
-    //      the uploaded file id and stamps `posted` when the POST
-    //      settles);
-    //   2. confirm the live SSE stream is connected and pumping;
-    //   3. navigate away — switchTo aborts the SSE transport, so the
-    //      session.input.consumed event the transcript round-trip
-    //      publishes while away is fired into a dead socket and lost
-    //      (the live stream has no replay). The abort IS the missed
-    //      event: no bytes can arrive on a severed transport, so the
-    //      test deliberately delivers nothing after this point.
-    //   4. while away, the round-trip commits the message server-side
-    //      and drains its pending_inputs entry;
-    //   5. navigate back — the snapshot shows the committed item and
-    //      nothing pending.
-    // The send settled, so the server snapshot is authoritative and the
-    // bubble must NOT come back. Before the fix the stash restored it at
-    // step 5 and nothing could ever clear it — image-only content
-    // defeats the text dedupe, native sessions skip the idle-clear, and
-    // the consumed event was long gone — leaving a permanent pending
-    // bubble that "rotated" on every later send.
-    const sink = pushableStream();
-    let nativeStreamOpens = 0;
-    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : input.toString();
-      // First bind gets the controllable live stream (so the test can
-      // prove it was connected before the drop); the navigate-back
-      // rebind gets a plain empty stream.
-      if (url === "/v1/sessions/conv_native/stream") {
-        nativeStreamOpens += 1;
-        return nativeStreamOpens === 1
-          ? mockResponse(null, { bodyStream: sink.stream })
-          : streamResponse();
-      }
-      // Real upload target for the image attachment.
-      if (url === "/v1/sessions/conv_native/resources/files" && init?.method === "POST") {
-        return mockResponse({
-          id: "file_real",
-          name: "a.png",
-          metadata: { filename: "a.png", bytes: 3, created_at: 0 },
-        });
-      }
-      // Native wrapper: the message round-trips through the TUI, not
-      // persisted at POST time — the precondition for the bug.
-      if (url.split("?")[0] === "/v1/sessions/conv_native" && (init?.method ?? "GET") === "GET") {
-        return mockResponse({
-          id: "conv_native",
-          agent_id: "agent_xyz",
-          status: "idle",
-          created_at: 0,
-          items: sessionSnapshots.get("conv_native") ?? [],
-          pending_inputs: sessionPendingInputs.get("conv_native") ?? [],
-          labels: { "omnigent.wrapper": "claude-code-native-ui" },
-        });
-      }
-      return defaultFetchHandler(input, init);
-    });
-    seedSession("conv_native", []);
-    seedSession("conv_other", []);
-
-    await useChatStore.getState().switchTo("conv_native");
-    expect(useChatStore.getState().isNativeTerminalSession).toBe(true);
-
-    // 1. Real image-only send: upload → POST /events → settle.
-    const image = new File([new Uint8Array([137, 80, 78])], "a.png", { type: "image/png" });
-    await useChatStore.getState().send("", "agent_xyz", [image]);
-
-    // The bubble carries the REAL uploaded file id (send promoted the
-    // "pending:a.png" placeholder) and the settled flag — proving the
-    // full upload + POST path ran, not a hand-injected bubble. If
-    // file_id were still "pending:a.png", the upload promotion broke;
-    // if posted were undefined, the settle stamp broke and navigation
-    // would wrongly stash this bubble.
-    const sent = useChatStore.getState().pendingUserMessages;
-    expect(sent).toHaveLength(1);
-    expect(sent[0]!.content).toEqual([
-      { type: "input_image", file_id: "file_real", filename: "a.png" },
-    ]);
-    expect(sent[0]!.posted).toBe(true);
-
-    // 2. Prove the live stream is connected and pumping BEFORE the
-    // drop, so the missed event below is a real loss on a real
-    // connection, not an artifact of a stream that never attached.
-    sink.push(
-      sse("session.status", {
-        type: "session.status",
-        conversation_id: "conv_native",
-        status: "running",
-      }),
-    );
-    await tick();
-    expect(useChatStore.getState().sessionStatus).toBe("running");
-
-    // 3. Navigate away. The abort severs the transport — the consumed
-    // event published during the gap can never reach this client.
-    await useChatStore.getState().switchTo("conv_other");
-
-    // 4. While away: the transcript round-trip committed the message
-    // (file blocks merged into the durable item) and drained
-    // pending_inputs — the snapshot now shows the committed item and
-    // nothing pending.
-    seedSession("conv_native", [
-      {
-        id: "msg_img_user",
-        response_id: "resp_img",
-        type: "message",
-        role: "user",
-        status: "completed",
-        content: [
-          { type: "input_image", file_id: "file_real", filename: "a.png" },
-          { type: "input_text", text: "[Attached: a.png]" },
-        ],
-      },
-    ]);
-
-    // 5. Navigate back: no pending bubble survives — the committed item
-    // is the only copy. If switchTo still stashed settled sends, this
-    // would hold the stranded image bubble forever.
-    await useChatStore.getState().switchTo("conv_native");
-    expect(useChatStore.getState().pendingUserMessages).toEqual([]);
-    const userBlocks = useChatStore.getState().blocks.filter((b) => b.type === "user_message");
-    expect(userBlocks).toHaveLength(1); // the committed copy renders exactly once
-
-    // Unpark the first bind's pump so it unwinds cleanly.
-    sink.close();
-  });
-
-  it("first-message regression: an in-flight send survives navigation; a settled one defers to the server", async () => {
-    // End-to-end lifecycle of the navigation-survival policy, driving the
-    // REAL send() path (not a setState-injected bubble).
-    //
-    // Phase 1: a brand-new native session's first POST is held
-    // open while the host cold-starts the runner — the server hasn't
-    // reached pending_inputs.record() yet, so for that whole window the
-    // snapshot has neither a committed item NOR a pending_inputs entry
-    // (confirmed in the logz trace: items=0, pending_inputs=0). The mock
-    // /events POST never resolves to model that. Navigating away and back
-    // must restore the bubble from the client stash — the server cannot
-    // replay a message it has never been told about.
-    //
-    // Phase 2 (stuck-bubble fix): once the POST settles, the server owns
-    // the message, so navigation defers to the snapshot. Here the
-    // snapshot shows nothing pending (the entry was resolved while
-    // away), so the bubble must NOT come back — if it did, nothing
-    // could ever clear it (the consumed event is gone and native
-    // sessions skip the idle-clear): the permanent stuck bubble.
-    let releaseEventsPost: (() => void) | null = null;
-    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : input.toString();
-      // Cold-starting runner: the /events POST is held open until the
-      // test releases it. record() only runs server-side after that.
-      if (url.match(/\/v1\/sessions\/[^/]+\/events$/) && init?.method === "POST") {
-        return new Promise<Response>((resolve) => {
-          releaseEventsPost = () => resolve(mockResponse({ queued: true }));
-        }) as unknown as Response;
-      }
-      // Native wrapper: message round-trips through the TUI, not
-      // persisted at POST time (the precondition for both phases).
-      if (url.split("?")[0] === "/v1/sessions/conv_native" && (init?.method ?? "GET") === "GET") {
-        return mockResponse({
-          id: "conv_native",
-          agent_id: "agent_xyz",
-          status: "idle",
-          created_at: 0,
-          items: sessionSnapshots.get("conv_native") ?? [],
-          pending_inputs: sessionPendingInputs.get("conv_native") ?? [],
-          labels: { "omnigent.wrapper": "claude-code-native-ui" },
-        });
-      }
-      return defaultFetchHandler(input, init);
-    });
-    seedSession("conv_native", []);
-    seedSession("conv_other", []);
-
-    // Bind the native session, then send the first message through the
-    // real path. Not awaited — the POST is deliberately in flight.
-    await useChatStore.getState().switchTo("conv_native");
-    const sendDone = useChatStore.getState().send("hello", "agent_xyz");
-    await tick(); // let send() reach the held-open POST
-
-    expect(useChatStore.getState().isNativeTerminalSession).toBe(true);
-    const sent = useChatStore.getState().pendingUserMessages;
-    expect(sent).toHaveLength(1); // optimistic bubble is showing
-    expect(sent[0]!.content).toEqual([{ type: "input_text", text: "hello" }]);
-    const sentTempId = sent[0]!.tempId; // client-only id; the server has no copy yet
-
-    // Phase 1: navigate away (POST still in flight) and back.
-    await useChatStore.getState().switchTo("conv_other");
-    await useChatStore.getState().switchTo("conv_native");
-
-    // The SAME optimistic bubble is restored from the stash — proving it
-    // came from client memory, not a re-fetch (the snapshot is empty). The
-    // stable tempId rules out any other source. Without the stash this is
-    // [] and the assertion fails: the disappeared-first-message bug.
-    const after = useChatStore.getState().pendingUserMessages;
-    expect(after).toHaveLength(1);
-    expect(after[0]!.tempId).toBe(sentTempId);
-    expect(after[0]!.content).toEqual([{ type: "input_text", text: "hello" }]);
-
-    // Phase 2: the POST settles (runner came up, server recorded +
-    // forwarded the message). The live bubble keeps rendering, but it is
-    // now server-owned for navigation purposes.
-    releaseEventsPost!();
-    await sendDone;
-    expect(useChatStore.getState().pendingUserMessages).toHaveLength(1); // still on screen
-
-    // Navigate away and back again. The snapshot has no pending_inputs
-    // entry (resolved while away) and no committed item yet — the
-    // server says nothing is pending, and the server wins. If switchTo
-    // still stashed settled sends, the bubble would come back here as a
-    // permanently-stuck pending message.
-    await useChatStore.getState().switchTo("conv_other");
-    await useChatStore.getState().switchTo("conv_native");
-    expect(useChatStore.getState().pendingUserMessages).toEqual([]);
-  });
-
-  it("drops a settled slash-command echo on navigate-back (nothing can ever reconcile it)", async () => {
-    // The optimistic /skill echo follows the same navigation-survival
-    // policy as a message send: once its POST settles the server has
-    // persisted the visible receipt, so navigation defers to the
-    // snapshot. The echo is the most strand-prone bubble if wrongly
-    // stashed — its receipt is a SlashCommandBlock, not a user message,
-    // so the navigate-back text dedupe can never match it, and no
-    // session.input.consumed ever fires for a slash command.
-    seedSession("conv_native", []);
-    seedSession("conv_other", []);
-
-    await useChatStore.getState().switchTo("conv_native");
-    await useChatStore.getState().sendSlashCommand("compact", "", "agent_xyz");
-
-    // Echo is showing (with the typed command text) while we wait for
-    // the slash_command receipt event.
-    const echo = useChatStore.getState().pendingUserMessages;
-    expect(echo).toHaveLength(1);
-    expect(echo[0]!.content).toEqual([{ type: "input_text", text: "/compact" }]);
-
-    // Navigate away and back: the settled echo is not restored (the
-    // persisted receipt in the snapshot is the durable copy). If
-    // sendSlashCommand skipped the posted stamp, the stash would
-    // resurrect the echo here as a bubble nothing can clear.
-    await useChatStore.getState().switchTo("conv_other");
-    await useChatStore.getState().switchTo("conv_native");
-    expect(useChatStore.getState().pendingUserMessages).toEqual([]);
   });
 
   // The session.status handler keys off isNativeTerminalSession to decide
@@ -1239,7 +1105,12 @@ describe("chatStore — switchTo", () => {
     expect(state.hasMoreHistory).toBe(true);
   });
 
-  it("drops a stale loadMoreHistory page that resolves after navigating away and back", async () => {
+  it("applies a scroll-up page that resolves after navigating away and back", async () => {
+    // This used to be "drops a stale page": navigating away destroyed the window
+    // and re-hydrated it on return, so an in-flight cursor-relative page was
+    // relative to a window that no longer existed. The conversation now keeps its
+    // window across navigation, so the page is still valid when it lands and must
+    // be applied rather than discarded.
     const total = INITIAL_WINDOW_ITEMS + SESSION_HISTORY_PAGE_SIZE;
     const itemsA = Array.from({ length: total }, (_, idx) =>
       userMessage(`a_${idx.toString().padStart(4, "0")}`, `a ${idx}`),
@@ -1251,40 +1122,33 @@ describe("chatStore — switchTo", () => {
     const windowIds = useChatStore.getState().blocks.map((b) => b.ctx.itemId);
     expect(windowIds).toHaveLength(INITIAL_WINDOW_ITEMS);
 
-    // Defer ONLY the first scroll-up page (the `after=` cursor fetch);
-    // binds use cursorless initial-window fetches and stay live.
-    let releaseStalePage: (() => void) | null = null;
+    // Hold the scroll-up page open across the navigation round trip.
+    let releasePage: (() => void) | null = null;
     fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();
-      if (/\/v1\/sessions\/conv_a\/items\?.*after=/.test(url) && releaseStalePage === null) {
+      if (/\/v1\/sessions\/conv_a\/items\?.*after=/.test(url) && releasePage === null) {
         return new Promise<Response>((resolve) => {
-          releaseStalePage = () => resolve(defaultFetchHandler(input, init));
+          releasePage = () => resolve(defaultFetchHandler(input, init));
         });
       }
       return defaultFetchHandler(input, init);
     });
 
-    const stale = useChatStore.getState().loadMoreHistory();
+    const inFlight = useChatStore.getState().loadMoreHistory();
     await useChatStore.getState().switchTo("conv_b");
-    await useChatStore.getState().switchTo("conv_a"); // fresh window for A
-    releaseStalePage!();
-    await stale;
+    await useChatStore.getState().switchTo("conv_a");
+    releasePage!();
+    await inFlight;
 
     const state = useChatStore.getState();
-    // The stale page is cursor-relative to the PRE-navigation window; the
-    // round trip passed the conversation-id guard, so only the generation
-    // check stops it from prepending below the fresh hydration merge.
-    expect(state.blocks.map((b) => b.ctx.itemId)).toEqual(windowIds);
-    expect(state.oldestItemId).toBe(itemsA.at(-INITIAL_WINDOW_ITEMS)!.id);
-    expect(state.hasMoreHistory).toBe(true);
-    expect(state.loadingMoreHistory).toBe(false);
-
-    // The window is healthy: a fresh scroll-up still pages correctly.
-    await useChatStore.getState().loadMoreHistory();
-    expect(useChatStore.getState().blocks.map((b) => b.ctx.itemId)).toEqual([
+    // Prepended onto the window it was fetched against, which is still current.
+    expect(state.blocks.map((b) => b.ctx.itemId)).toEqual([
       ...itemsA.slice(0, SESSION_HISTORY_PAGE_SIZE).map((item) => item.id),
       ...windowIds,
     ]);
+    expect(state.oldestItemId).toBe(itemsA[0]!.id);
+    expect(state.hasMoreHistory).toBe(false);
+    expect(state.loadingMoreHistory).toBe(false);
   });
 
   it("loadMoreHistory dedupes a page overlapping blocks kept across a rebind", async () => {
@@ -1366,6 +1230,94 @@ describe("chatStore — switchTo", () => {
     ]);
   });
 
+  it("keeps each conversation's own effort across a warm A→B→A switch", async () => {
+    // `selectedEffort` is a single app-global sticky pick, so it cannot answer
+    // "what is THIS conversation at" once a warm switch skips hydration: cold
+    // opening B set it to B's value, and returning to still-live A mirrored no
+    // effort field and returned without a bind — so A displayed B's effort.
+    // `sessionReasoningEffort` is conversation-scoped, so each keeps its own.
+    seedSession("conv_eff_a", []);
+    seedSession("conv_eff_b", []);
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const path = url.split("?")[0];
+      if (
+        (path === "/v1/sessions/conv_eff_a" || path === "/v1/sessions/conv_eff_b") &&
+        (init?.method ?? "GET") === "GET"
+      ) {
+        return mockResponse({
+          id: path.split("/").pop(),
+          agent_id: "agent_xyz",
+          status: "idle",
+          created_at: 0,
+          items: [],
+          labels: { "omnigent.wrapper": "claude-code-native-ui" },
+          reasoning_effort: path.endsWith("conv_eff_a") ? "high" : "low",
+        });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    await useChatStore.getState().switchTo("conv_eff_a");
+    expect(useChatStore.getState().sessionReasoningEffort).toBe("high");
+
+    // Cold-open B at a different effort. This moves the app-global sticky pick.
+    await useChatStore.getState().switchTo("conv_eff_b");
+    expect(useChatStore.getState().sessionReasoningEffort).toBe("low");
+
+    // Warm switch back: no bind, so the projection is the only source of truth.
+    await useChatStore.getState().switchTo("conv_eff_a");
+    expect(useChatStore.getState().sessionReasoningEffort).toBe("high");
+    // And B still holds its own.
+    expect(conversationRegistry.peek("conv_eff_b")!.getState().sessionReasoningEffort).toBe("low");
+  });
+
+  it("loadMoreHistory settles on the conversation that scrolled, not the visible one", async () => {
+    // Backgrounding is not staleness. Resolving the target after the await left
+    // `loadingMoreHistory: true` pinned on the scrolling conversation — and since
+    // a live entry is never re-bound on return, that guard then no-oped EVERY
+    // future scroll-up: dead history until a page refresh.
+    // One full window plus one page, so there is genuinely more to scroll to.
+    const items: ConversationItem[] = Array.from(
+      { length: INITIAL_WINDOW_ITEMS + SESSION_HISTORY_PAGE_SIZE },
+      (_, idx) => userMessage(`bh_${idx.toString().padStart(4, "0")}`, `bh ${idx}`),
+    );
+    seedSession("conv_scroll", items);
+    seedSession("conv_visible", []);
+    await useChatStore.getState().switchTo("conv_scroll");
+    const windowIds = useChatStore.getState().blocks.map((b) => b.ctx.itemId);
+
+    let releasePage: (() => void) | null = null;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (/\/v1\/sessions\/conv_scroll\/items\?.*after=/.test(url) && releasePage === null) {
+        return new Promise<Response>((resolve) => {
+          releasePage = () => resolve(defaultFetchHandler(input, init));
+        });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const page = useChatStore.getState().loadMoreHistory();
+    expect(conversationRegistry.peek("conv_scroll")!.getState().loadingMoreHistory).toBe(true);
+
+    // Switch away while the page is still open, then let it land.
+    await useChatStore.getState().switchTo("conv_visible");
+    releasePage!();
+    await page;
+
+    const scrolled = conversationRegistry.peek("conv_scroll")!.getState();
+    // The flag cleared, so scroll-up still works when the user returns...
+    expect(scrolled.loadingMoreHistory).toBe(false);
+    // ...and the page landed on the conversation it belongs to, in order.
+    expect(scrolled.blocks.map((b) => b.ctx.itemId)).toEqual([
+      ...items.slice(0, SESSION_HISTORY_PAGE_SIZE).map((item) => item.id),
+      ...windowIds,
+    ]);
+    // The visible conversation gained nothing.
+    expect(useChatStore.getState().blocks).toEqual([]);
+  });
+
   it("does not run flat session items through the nested snapshot flattener", async () => {
     seedSessionSnapshot("conv_native", []);
     seedSessionItems("conv_native", [nativeToolItem("resp_native")]);
@@ -1421,7 +1373,10 @@ describe("chatStore — switchTo", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("aborts the in-flight stream's controller when switching conversations", async () => {
+  it("aborts a conversation's stream when it is released, not when switched away", async () => {
+    // Switch-away used to abort (see "does not abort a conversation's stream
+    // when switching away"). Release — conversation deleted, or evicted from the
+    // registry — is what tears the stream down now.
     const controller = new AbortController();
     useChatStore.setState({
       conversationId: "conv_abc",
@@ -1430,11 +1385,49 @@ describe("chatStore — switchTo", () => {
     seedSession("conv_def");
 
     await useChatStore.getState().switchTo("conv_def");
-
-    expect(controller.signal.aborted).toBe(true);
-    // The NEW bind creates a fresh controller; that one stays for the
-    // lifetime of the new session's stream.
+    expect(controller.signal.aborted).toBe(false);
     expect(useChatStore.getState().conversationId).toBe("conv_def");
+
+    releaseConversation("conv_abc");
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it("shows the hydrating placeholder while a COLD conversation binds", async () => {
+    // `loadingConversation` unmounts the chat surface during hydration. It has
+    // to be set for a cold entry: the composer would otherwise mount against
+    // empty session-scoped state (`llmModel` / `sessionModelOverride` null) and
+    // resolve its model label from the sticky cross-session pick — painting the
+    // PREVIOUS conversation's model until the snapshot lands.
+    const seen: boolean[] = [];
+    const unsubscribe = useChatStore.subscribe((s) => seen.push(s.loadingConversation));
+    // Hold every request so the hydrating window stays open to observe.
+    fetchMock.mockImplementation(() => new Promise<Response>(() => {}));
+    void useChatStore.getState().switchTo("conv_cold_hydrate");
+    await tick();
+    unsubscribe();
+
+    expect(seen).toContain(true);
+    expect(useChatStore.getState().loadingConversation).toBe(true);
+  });
+
+  it("does NOT show the placeholder when returning to a live conversation", async () => {
+    // The converse, and the whole point of keeping streams open: a revisit
+    // repaints the entry's own settled state, so flashing a spinner over an
+    // already-current transcript would undo the snappiness this buys.
+    seedSession("conv_warm", [userMessage("resp_w", "already here")]);
+    await useChatStore.getState().switchTo("conv_warm");
+    seedSession("conv_elsewhere", []);
+    await useChatStore.getState().switchTo("conv_elsewhere");
+
+    const seen: boolean[] = [];
+    const unsubscribe = useChatStore.subscribe((s) => seen.push(s.loadingConversation));
+    await useChatStore.getState().switchTo("conv_warm");
+    unsubscribe();
+
+    expect(seen).not.toContain(true);
+    expect(useChatStore.getState().loadingConversation).toBe(false);
+    // And it painted from the live entry, not from a refetch.
+    expect(useChatStore.getState().blocks).toHaveLength(1);
   });
 
   it("switching to null clears state without opening a stream", async () => {
@@ -1619,6 +1612,180 @@ describe("chatStore — send (first-send ordering)", () => {
     expect(eventBodies.map(textOf)).toEqual(["1", "2", "3"]);
   });
 
+  it("serializes a second send issued while a NEW chat's session is still being created", async () => {
+    // The narrowest ordering window, and the one a per-conversation chain
+    // opens: the first send from `/` has no conversation id, so it takes a slot
+    // under the new-session key. `ensureBoundSession` then publishes the real id
+    // to the store BEFORE that send's POST — so a second send fired in that
+    // window pins the real id and would key on an EMPTY chain, overtaking the
+    // first. The first send's slot has to reach the real id before the id
+    // becomes visible to anyone else.
+    const eventBodies: string[] = [];
+    const resolvers: (() => void)[] = [];
+    seedSession("conv_new");
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_new/events" && init?.method === "POST") {
+        eventBodies.push(init.body as string);
+        return new Promise<Response>((resolve) => {
+          resolvers.push(() => resolve(mockResponse({ queued: true, item_id: "ci_mock" })));
+        });
+      }
+      return defaultFetchHandler(input, init);
+    });
+    const textOf = (body: string): string =>
+      (JSON.parse(body).data.content[0] as { text: string }).text;
+
+    // Hold the bind's snapshot GET so `ensureBoundSession` parks INSIDE
+    // `bindStream` — after it published the real id to the store, but before
+    // the first send reaches its POST. That is the window, and it lasts as long
+    // as the bind's network work does.
+    let releaseSnapshot: (() => void) | null = null;
+    const baseHandler = fetchMock.getMockImplementation()!;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      // Only the FIRST snapshot GET is held; later ones (the second send's
+      // rebind check) pass through, so the latch isolates the window under test.
+      if (
+        /^\/v1\/sessions\/conv_new(\?|$)/.test(url) &&
+        (init?.method ?? "GET") === "GET" &&
+        releaseSnapshot === null
+      ) {
+        return new Promise<Response>((resolve) => {
+          releaseSnapshot = () => resolve(baseHandler(input, init) as Promise<Response>);
+        });
+      }
+      return baseHandler(input, init);
+    });
+
+    // First send from the landing route (conversationId === null).
+    const p1 = useChatStore.getState().send("first", "agent_xyz");
+    await tick();
+    await tick();
+    await tick();
+    // The id is visible to any other send, but the first send is still parked
+    // in its bind and has not reached `rekey` yet.
+    expect(useChatStore.getState().conversationId).toBe("conv_new");
+    expect(releaseSnapshot).not.toBeNull();
+
+    // Second send now resolves `conv_new` as its own submit-time target.
+    const p2 = useChatStore.getState().send("second", "agent_xyz");
+    await tick();
+    await tick();
+
+    // The first send is still parked in its bind, so ITS post hasn't fired.
+    // The second must not overtake it: pre-fix it keyed an empty chain (the
+    // first send's slot was still under the new-session key) and fired here,
+    // reaching the server before "first".
+    expect(eventBodies.map(textOf)).toEqual([]);
+
+    releaseSnapshot!();
+    await tick();
+    await tick();
+    // The bind finished; the first send's POST goes out first, alone.
+    expect(eventBodies.map(textOf)).toEqual(["first"]);
+
+    // Releasing the first POST hands the chain to the second, which then runs
+    // its own bind check + upload before posting.
+    resolvers[0]!();
+    /* oxlint-disable no-await-in-loop */
+    for (let i = 0; i < 6; i++) await tick();
+    /* oxlint-enable no-await-in-loop */
+    expect(eventBodies.map(textOf)).toEqual(["first", "second"]);
+
+    resolvers[1]!();
+    await Promise.all([p1, p2]);
+    // Delivery order is submission order.
+    expect(eventBodies.map(textOf)).toEqual(["first", "second"]);
+  });
+
+  it("keeps three sends ordered across a new chat's id publication", async () => {
+    // The chain has to migrate as ONE unit, carrying its already-queued
+    // followers. Send 2 queues under the new-session key (before the id exists);
+    // send 3 arrives after the id is published, so it keys the real id directly.
+    // Moving only the creating send's slot left send 3 waiting on send 1 rather
+    // than on send 2 — so both became runnable at once.
+    //
+    // The invariant is strict serialization, asserted by leaving send 2's POST
+    // UNRESOLVED: send 3 must not reach the wire until send 2's has returned.
+    // (Asserting only the final array can't catch this — with both in flight
+    // the mock's microtask order still happens to append them in sequence,
+    // while against a real server the two are racing.)
+    const eventBodies: string[] = [];
+    const resolvers: (() => void)[] = [];
+    seedSession("conv_new");
+    const baseHandler = fetchMock.getMockImplementation()!;
+    let releaseSnapshot: (() => void) | null = null;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_new/events" && init?.method === "POST") {
+        eventBodies.push(init.body as string);
+        return new Promise<Response>((resolve) => {
+          resolvers.push(() => resolve(mockResponse({ queued: true, item_id: "ci_mock" })));
+        });
+      }
+      // Hold the first bind's snapshot so send 1 parks inside `bindStream` with
+      // the id already published — the window both followers land in.
+      if (
+        /^\/v1\/sessions\/conv_new(\?|$)/.test(url) &&
+        (init?.method ?? "GET") === "GET" &&
+        releaseSnapshot === null
+      ) {
+        return new Promise<Response>((resolve) => {
+          releaseSnapshot = () => resolve(baseHandler(input, init) as Promise<Response>);
+        });
+      }
+      return baseHandler(input, init);
+    });
+    const textOf = (body: string): string =>
+      (JSON.parse(body).data.content[0] as { text: string }).text;
+
+    // Sends 1 and 2 are submitted in the SAME tick, from the landing route: no
+    // id exists yet, so both take slots under the new-session key. This has to
+    // be synchronous — `rekey` fires as soon as `createSession` returns, so any
+    // await here would let send 2 key the real id and miss the case under test.
+    const p1 = useChatStore.getState().send("1", "agent_xyz");
+    const p2 = useChatStore.getState().send("2", "agent_xyz");
+    /* oxlint-disable no-await-in-loop */
+    for (let i = 0; i < 3; i++) await tick();
+    /* oxlint-enable no-await-in-loop */
+    // The id is now visible, and send 1 is parked in its bind.
+    expect(useChatStore.getState().conversationId).toBe("conv_new");
+    expect(releaseSnapshot).not.toBeNull();
+    // Send 3 resolves the real id and must queue behind send 2, not send 1.
+    const p3 = useChatStore.getState().send("3", "agent_xyz");
+    await tick();
+    await tick();
+    expect(eventBodies.map(textOf)).toEqual([]);
+
+    releaseSnapshot!();
+    /* oxlint-disable no-await-in-loop */
+    for (let i = 0; i < 4; i++) await tick();
+    /* oxlint-enable no-await-in-loop */
+    // Send 1 posts alone — the followers are still chained behind it.
+    expect(eventBodies.map(textOf)).toEqual(["1"]);
+
+    // Release ONLY send 1. Send 2 may now post; send 3 must stay parked, because
+    // its predecessor's POST has not returned. Pre-fix, send 3 waited on send 1
+    // too, so it posts here alongside send 2 — two writes racing on one session.
+    resolvers[0]!();
+    /* oxlint-disable no-await-in-loop */
+    for (let i = 0; i < 10; i++) await tick();
+    /* oxlint-enable no-await-in-loop */
+    expect(eventBodies.map(textOf)).toEqual(["1", "2"]);
+
+    // Only now that send 2's POST has returned may send 3 go out.
+    resolvers[1]!();
+    /* oxlint-disable no-await-in-loop */
+    for (let i = 0; i < 10; i++) await tick();
+    /* oxlint-enable no-await-in-loop */
+    expect(eventBodies.map(textOf)).toEqual(["1", "2", "3"]);
+
+    resolvers[2]!();
+    await Promise.all([p1, p2, p3]);
+    expect(eventBodies.map(textOf)).toEqual(["1", "2", "3"]);
+  });
+
   it("PATCHes sticky effort onto a brand-new session before binding the runner", async () => {
     seedSession("conv_new");
     fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
@@ -1763,6 +1930,48 @@ describe("chatStore — send (first-send ordering)", () => {
 
     // The optimistic bubble survives — the POST succeeded.
     expect(useChatStore.getState().pendingUserMessages).toHaveLength(1);
+  });
+
+  it("tears the old pump down before rebinding after a failed snapshot", async () => {
+    // A snapshot failure leaves `conversationLoadError` set while the pump it
+    // opened is STILL RUNNING — `bindStream` catches the error without aborting
+    // its controller. Rebinding blind then replaced the stored controller and
+    // left two subscribers on one entry, so any delta with no item id to dedupe
+    // on (live claude-native text) applied twice.
+    seedSession("conv_two_subs", []);
+    let failSnapshot = true;
+    const openedStreams: AbortSignal[] = [];
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_two_subs/stream") {
+        if (init?.signal) openedStreams.push(init.signal);
+        return mockResponse(null, { bodyStream: pushableStream().stream });
+      }
+      // Fail only the FIRST snapshot GET, so the bind errors with its pump live.
+      if (url.split("?")[0] === "/v1/sessions/conv_two_subs" && (init?.method ?? "GET") === "GET") {
+        if (failSnapshot) {
+          failSnapshot = false;
+          return mockResponse({}, { ok: false, status: 500 });
+        }
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    await useChatStore.getState().switchTo("conv_two_subs");
+    const entry = conversationRegistry.peek("conv_two_subs")!;
+    // The failed bind: error recorded, but its pump is still open.
+    expect(entry.getState().conversationLoadError).not.toBeNull();
+    expect(openedStreams).toHaveLength(1);
+    expect(openedStreams[0]!.aborted).toBe(false);
+
+    // Sending rebinds, because the entry is not stream-current.
+    await useChatStore.getState().send("after a failed load", "agent_xyz");
+
+    // The first pump was aborted rather than orphaned — one live subscriber.
+    expect(openedStreams).toHaveLength(2);
+    expect(openedStreams[0]!.aborted).toBe(true);
+    expect(openedStreams[1]!.aborted).toBe(false);
+    expect(entry.getState().conversationLoadError).toBeNull();
   });
 
   it("degrades gracefully when stream rebind fails — message still posts", async () => {
@@ -2142,6 +2351,74 @@ describe("chatStore — sendSlashCommand", () => {
     expect(state.conversationId).toBe("conv_other");
     expect(state.status).toBe("streaming");
     expect(state.sessionStatus).toBe("running");
+  });
+
+  it("rolls back a denied slash command on the conversation that sent it", async () => {
+    // The converse of the test above: settling must be routed, not skipped. The
+    // denial has to land on the sending conversation even once it is
+    // backgrounded, or its echo hangs there forever with nothing to pop it (a
+    // denied command publishes no receipt).
+    seedSession("conv_slash_bg", []);
+    seedSession("conv_slash_other", []);
+    let resolvePost: (() => void) | null = null;
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.endsWith("/v1/sessions/conv_slash_bg/events")) {
+        return new Promise<Response>((resolve) => {
+          resolvePost = () => resolve(mockResponse({ queued: false, denied: true }));
+        });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    await useChatStore.getState().switchTo("conv_slash_bg");
+    const sending = useChatStore.getState().sendSlashCommand("grill-me", "", "agent_xyz");
+    await tick();
+    expect(conversationRegistry.peek("conv_slash_bg")!.getState().pendingUserMessages).toHaveLength(
+      1,
+    );
+
+    await useChatStore.getState().switchTo("conv_slash_other");
+    resolvePost!();
+    await sending;
+
+    // The sender's echo rolled back and its status settled...
+    const sender = conversationRegistry.peek("conv_slash_bg")!.getState();
+    expect(sender.pendingUserMessages).toEqual([]);
+    expect(sender.status).toBe("idle");
+    expect(sender.sessionStatus).toBe("idle");
+    // ...without disturbing the conversation now on screen.
+    expect(useChatStore.getState().conversationId).toBe("conv_slash_other");
+  });
+
+  it("rolls back a failed slash command on the conversation that sent it", async () => {
+    // Same for a thrown POST: the old code skipped the rollback entirely once
+    // the sender was backgrounded, stranding the echo and leaving `status`
+    // pinned at "streaming" for that conversation.
+    seedSession("conv_slash_fail", []);
+    seedSession("conv_slash_elsewhere", []);
+    let rejectPost: (() => void) | null = null;
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.endsWith("/v1/sessions/conv_slash_fail/events")) {
+        return new Promise<Response>((resolve) => {
+          rejectPost = () => resolve(mockResponse({ error: "boom" }, { ok: false, status: 500 }));
+        });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    await useChatStore.getState().switchTo("conv_slash_fail");
+    const sending = useChatStore.getState().sendSlashCommand("deslop", "", "agent_xyz");
+    await tick();
+
+    await useChatStore.getState().switchTo("conv_slash_elsewhere");
+    rejectPost!();
+    await sending;
+
+    const sender = conversationRegistry.peek("conv_slash_fail")!.getState();
+    expect(sender.pendingUserMessages).toEqual([]);
+    expect(sender.status).toBe("idle");
   });
 
   it("creates and binds a brand-new session before posting the slash_command", async () => {
@@ -2817,6 +3094,53 @@ describe("chatStore — send (file attachments)", () => {
     ]);
   });
 
+  it("promotes real file_ids on the sending conversation when the upload outlives a switch", async () => {
+    // The upload can be slow, so the user may background the conversation while
+    // it is in flight. The refresh must target the conversation that SENT the
+    // attachment: resolving it late from the visible conversation left the
+    // sender's bubble on `pending:<filename>` ids, and claude-native's text-only
+    // `session.input.consumed` then falls back to those placeholders — committing
+    // an attachment the server never gave an id.
+    seedSession("conv_upload", []);
+    seedSession("conv_visible", []);
+    let releaseUpload: () => void = () => {};
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/v1/sessions/conv_upload/resources/files")) {
+        return new Promise<Response>((resolve) => {
+          releaseUpload = () =>
+            resolve(
+              mockResponse({
+                id: "file_real_bg",
+                name: "bg.png",
+                metadata: { filename: "bg.png", bytes: 10, created_at: 0 },
+              }),
+            );
+        });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    await useChatStore.getState().switchTo("conv_upload");
+    const file = new File(["bytes"], "bg.png", { type: "image/png" });
+    const sending = useChatStore.getState().send("with a picture", "agent_xyz", [file]);
+    await tick();
+
+    // Navigate away while the upload is still open.
+    await useChatStore.getState().switchTo("conv_visible");
+    releaseUpload();
+    await sending;
+
+    // The sender's bubble carries the real id...
+    const sender = conversationRegistry.peek("conv_upload")!.getState();
+    expect(sender.pendingUserMessages[0]!.content).toEqual([
+      { type: "input_image", file_id: "file_real_bg", filename: "bg.png" },
+      { type: "input_text", text: "with a picture" },
+    ]);
+    // ...and the conversation the user is looking at was never touched.
+    expect(useChatStore.getState().pendingUserMessages).toEqual([]);
+  });
+
   it("does not hand the upload to the interrupt marker that precedes it", async () => {
     // Steering mid-tool-use makes Claude write its own "[Request interrupted
     // by user...]" record BEFORE the steering message, and the forwarder
@@ -3111,6 +3435,15 @@ describe("chatStore — stop", () => {
 });
 
 describe("chatStore — handleSessionEvent (session.* events)", () => {
+  // These cases call `handleSessionEvent` directly, without the stream that
+  // normally names the delivering conversation. Bind `conv_abc` — the id their
+  // events carry — so a write lands on the active conversation exactly as it
+  // would in production. Cases that assert the cross-conversation guard
+  // deliberately bind something else, or name another conversation in the event.
+  beforeEach(() => {
+    useChatStore.setState({ conversationId: "conv_abc" });
+  });
+
   describe("session.presence", () => {
     it("replaces the viewer list wholesale for the bound conversation", () => {
       useChatStore.setState({
@@ -3168,12 +3501,6 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
         pendingUserMessages: [
           { tempId: "pend_clear", content: [{ type: "input_text", text: "/clear" }] },
         ],
-        pendingByConversation: {
-          conv_old: {
-            messages: [{ tempId: "pend_clear", content: [{ type: "input_text", text: "/clear" }] }],
-            committedTexts: [],
-          },
-        },
       });
       handleSessionEvent({
         type: "session_superseded",
@@ -3184,9 +3511,8 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
       const state = useChatStore.getState();
       // The `/clear` never gets a session.input.consumed on conv_old (the
       // runner rotated away), so its bubble must be dropped here rather than
-      // spinning forever — both the live list and the navigate-back stash.
+      // spinning forever.
       expect(state.pendingUserMessages).toEqual([]);
-      expect(state.pendingByConversation.conv_old).toBeUndefined();
     });
 
     it("ignores a superseded frame from a switched-away conversation", () => {
@@ -3355,6 +3681,11 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
       // cost_control.plan verdict) BEFORE the harness runs; this refetch is
       // what lets the routing-verdict tooltip render mid-turn instead of
       // only after the idle/failed turn-end invalidation.
+      //
+      // Bind conv_ts: the once-per-turn latch compares against
+      // `activeResponse.responseId`, which only advances when the status patch
+      // applies — i.e. for the conversation on screen.
+      useChatStore.setState({ conversationId: "conv_ts" });
       const spy = vi.spyOn(client, "invalidateQueries");
       handleSessionEvent({
         type: "session_status",
@@ -3850,10 +4181,9 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
       ]);
     });
 
-    it("ignores an event for a different conversation than the open one", async () => {
-      // The store tracks one active conversation; a skills nudge for
-      // another session must not fetch or touch the open composer.
-      // refetchSkills' conv-id guard short-circuits before any fetch.
+    it("ignores an event for a conversation that is not live", async () => {
+      // Gated on liveness, not on being on screen: a nudge for a conversation
+      // this tab holds no entry for has nowhere to land, so it must not fetch.
       useChatStore.setState({
         conversationId: "conv_open",
         skills: [{ name: "kept", description: "open session's skill" }],
@@ -3861,7 +4191,7 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
 
       handleSessionEvent({
         type: "session_skills",
-        conversationId: "conv_other",
+        conversationId: "conv_not_live",
       });
       await tick();
 
@@ -3872,35 +4202,31 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
       ]);
     });
 
-    it("drops the refetched skills when the user switched conversations mid-flight", async () => {
-      // A late snapshot for a since-abandoned session must not leak its
-      // skills into the now-open one (post-await conv-id re-check).
-      useChatStore.setState({ conversationId: "conv_abc", skills: [] });
-      fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url.split("?")[0] === "/v1/sessions/conv_abc" && (init?.method ?? "GET") === "GET") {
-          // The user navigates away before the snapshot lands.
-          useChatStore.setState({ conversationId: "conv_other" });
-          return mockResponse({
-            id: "conv_abc",
-            agent_id: "agent_xyz",
-            status: "idle",
-            created_at: 0,
-            items: [],
-            skills: [{ name: "stale", description: "wrong session" }],
-          });
-        }
-        return defaultFetchHandler(input, init);
-      });
+    it("applies the refetched skills to a conversation backgrounded mid-flight", async () => {
+      // `session_skills` is a one-shot nudge with no replay, and a live
+      // background conversation is never re-bound on return — so dropping the
+      // result because the user switched away left its slash-command menu empty
+      // for as long as the entry stayed live. It must land on the conversation
+      // it was fetched for, and only there.
+      seedSession("conv_bg_skills", []);
+      seedSession("conv_foreground", []);
+      await useChatStore.getState().switchTo("conv_bg_skills");
+      await useChatStore.getState().switchTo("conv_foreground");
+      seedSnapshotSkills("conv_bg_skills", [
+        { name: "late", description: "resolved in background" },
+      ]);
 
       handleSessionEvent({
         type: "session_skills",
-        conversationId: "conv_abc",
+        conversationId: "conv_bg_skills",
       });
       await tick();
 
-      // conv_other is now open; conv_abc's stale skills were dropped, and
-      // the seed never wrote skills onto conv_other.
+      // The backgrounded conversation has its skills...
+      expect(conversationRegistry.peek("conv_bg_skills")!.getState().skills).toEqual([
+        { name: "late", description: "resolved in background" },
+      ]);
+      // ...and the visible conversation was not touched.
       expect(useChatStore.getState().skills).toEqual([]);
     });
 
@@ -4058,6 +4384,33 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
         conversationId: "conv_other",
         reasoningEffort: "medium",
       });
+      expect(useChatStore.getState().selectedEffort).toBe("high");
+    });
+
+    it("records a backgrounded conversation's effort switch on that conversation", () => {
+      // The session-scoped value always lands, background included: a live entry
+      // is never re-bound on return, so discarding the event left the picker
+      // showing the wrong effort until a refresh. The app-global sticky pick is
+      // still only adopted from the conversation on screen.
+      bindConversationForTest("conv_effort_bg");
+      bindConversationForTest("conv_effort_fg");
+      useChatStore.setState({ selectedEffort: "high" });
+
+      // Delivered by the backgrounded conversation's OWN stream, which is how
+      // this arrives in production.
+      handleSessionEvent(
+        {
+          type: "session_reasoning_effort",
+          conversationId: "conv_effort_bg",
+          reasoningEffort: "low",
+        },
+        "conv_effort_bg",
+      );
+
+      expect(conversationRegistry.peek("conv_effort_bg")!.getState().sessionReasoningEffort).toBe(
+        "low",
+      );
+      // The visible conversation's sticky pick is untouched.
       expect(useChatStore.getState().selectedEffort).toBe("high");
     });
   });
@@ -4684,6 +5037,157 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
       expect(useChatStore.getState()).toBe(before);
     });
   });
+
+  describe("routing by delivering stream", () => {
+    // Events are routed by the stream that delivered them, not by their
+    // payload: `session.input.consumed`, `session.interrupted` and others carry
+    // no conversation id at all, so their contents cannot say where they belong.
+    //
+    // Each case asserts BOTH halves of that contract — the background
+    // conversation receives the event, and the visible one is untouched.
+    // Asserting only the second half is what let a bug through: a gate that
+    // dropped every background write also left the visible conversation
+    // untouched, so those events vanished (a user bubble whose consumed event
+    // was dropped never committed, and stayed pinned below the assistant output
+    // that arrived after it).
+    let bg: ReturnType<typeof bindConversationForTest>;
+
+    beforeEach(() => {
+      // Bind conv_bg first, then conv_visible — so conv_bg is live in the
+      // registry but backgrounded, exactly as after a switch.
+      bg = bindConversationForTest("conv_bg");
+      bindConversationForTest("conv_visible");
+    });
+
+    it("applies a status patch to the background conversation, not the visible one", () => {
+      useChatStore.setState({ sessionStatus: "idle", status: "idle" });
+      handleSessionEvent(
+        { type: "session_status", conversationId: "conv_bg", status: "running" },
+        "conv_bg",
+      );
+      // conv_bg's own turn lifecycle advances...
+      expect(bg.get().sessionStatus).toBe("running");
+      // ...while the visible conversation stays idle: a background agent's turn
+      // must not light up this conversation's "Working…".
+      expect(useChatStore.getState().sessionStatus).toBe("idle");
+      expect(useChatStore.getState().status).toBe("idle");
+    });
+
+    it("applies a todo list to the background conversation, not the visible one", () => {
+      useChatStore.setState({ todos: [] });
+      const todos = [
+        { content: "bg work", status: "in_progress" as const, activeForm: "Doing bg work" },
+      ];
+      handleSessionEvent({ type: "session_todos", conversationId: "conv_bg", todos }, "conv_bg");
+      expect(bg.get().todos).toEqual(todos);
+      expect(useChatStore.getState().todos).toEqual([]);
+    });
+
+    it("commits a background conversation's consumed input onto its own transcript", () => {
+      // The regression this covers: `session.input.consumed` is the ONLY thing
+      // that promotes an optimistic user bubble into committed `blocks`. Drop it
+      // for a background conversation and the bubble never commits — it renders
+      // as a permanent trailing bubble, below assistant output that arrived
+      // after it, which reads as scrambled message ordering on return.
+      bindConversationForTest("conv_bg", {
+        blocks: [],
+        pendingUserMessages: [
+          { tempId: "pend_bg", content: [{ type: "input_text", text: "from background" }] },
+        ],
+      });
+      bindConversationForTest("conv_visible");
+      useChatStore.setState({ blocks: [], pendingUserMessages: [] });
+
+      handleSessionEvent(
+        {
+          type: "session_input_consumed",
+          itemId: "item_bg",
+          itemType: "message",
+          data: { role: "user", content: [{ type: "input_text", text: "from background" }] },
+        },
+        "conv_bg",
+      );
+
+      // Promoted on conv_bg: popped off pending, appended to its blocks.
+      expect(bg.get().pendingUserMessages).toEqual([]);
+      expect(bg.get().blocks.map((b) => b.ctx.itemId)).toEqual(["item_bg"]);
+      // The visible conversation never sees it.
+      expect(useChatStore.getState().blocks).toEqual([]);
+    });
+
+    it("applies a usage update to the background conversation, not the visible one", () => {
+      useChatStore.setState({ tokensUsed: 100, sessionCostUsd: 1 });
+      handleSessionEvent(
+        {
+          type: "session_usage",
+          conversationId: "conv_bg",
+          contextTokens: 99_999,
+          totalCostUsd: 42,
+        },
+        "conv_bg",
+      );
+      expect(bg.get().tokensUsed).toBe(99_999);
+      expect(bg.get().sessionCostUsd).toBe(42);
+      expect(useChatStore.getState().tokensUsed).toBe(100);
+      expect(useChatStore.getState().sessionCostUsd).toBe(1);
+    });
+
+    it("cancels the background conversation's own turn, never the visible one", () => {
+      // `session.interrupted` also carries no conversation id.
+      bindConversationForTest("conv_bg", {
+        activeResponse: { responseId: "resp_bg", state: "streaming", error: null },
+        interruptedResponseIds: [],
+      });
+      bindConversationForTest("conv_visible");
+      useChatStore.setState({
+        activeResponse: { responseId: "resp_visible", state: "streaming", error: null },
+        interruptedResponseIds: [],
+      });
+
+      handleSessionEvent(
+        { type: "session_interrupted", requestedAt: 0, responseId: "resp_bg" },
+        "conv_bg",
+      );
+
+      // `toMatchObject`: main's turn lifecycle also stamps `completedAt`.
+      expect(bg.get().activeResponse).toMatchObject({
+        responseId: "resp_bg",
+        state: "cancelled",
+        error: null,
+      });
+      expect(bg.get().interruptedResponseIds).toEqual(["resp_bg"]);
+      // The visible turn keeps streaming.
+      expect(useChatStore.getState().activeResponse).toEqual({
+        responseId: "resp_visible",
+        state: "streaming",
+        error: null,
+      });
+      expect(useChatStore.getState().interruptedResponseIds).toEqual([]);
+    });
+
+    it("still applies events delivered by the visible conversation's own stream", () => {
+      // Routing must not make the normal path a no-op — a gate that dropped
+      // everything would satisfy the "visible untouched" half of every case
+      // above. This is the positive control for the foreground path.
+      handleSessionEvent(
+        { type: "session_status", conversationId: "conv_visible", status: "running" },
+        "conv_visible",
+      );
+      expect(useChatStore.getState().sessionStatus).toBe("running");
+    });
+
+    it("drops an event whose conversation has been evicted", () => {
+      // A late event for a conversation the registry has released must not
+      // resurrect its state, and must not fall through onto the visible one.
+      releaseConversation("conv_bg");
+      useChatStore.setState({ sessionStatus: "idle" });
+      handleSessionEvent(
+        { type: "session_status", conversationId: "conv_bg", status: "running" },
+        "conv_bg",
+      );
+      expect(useChatStore.getState().sessionStatus).toBe("idle");
+    });
+  });
 });
 
 describe("chatStore — handleSessionEvent (resource events)", () => {
@@ -5243,6 +5747,45 @@ describe("chatStore — submitApproval", () => {
     }
   });
 
+  it("rolls back on the answering conversation when the failure outlives a switch", async () => {
+    // The approve POST can outlive a switch away. Resolving the rollback target
+    // late reopened the card on whatever conversation was then visible while
+    // leaving the answering one wrongly marked responded — so the user's failed
+    // approval silently disappeared and a stranger's card sprouted buttons.
+    seedSession("conv_approve", []);
+    seedSession("conv_after", []);
+    let failResolve: (() => void) | null = null;
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.endsWith("/v1/sessions/conv_approve/elicitations/elic_late/resolve")) {
+        return new Promise<Response>((resolve) => {
+          failResolve = () => resolve(mockResponse({}, { ok: false, status: 500 }));
+        });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    await useChatStore.getState().switchTo("conv_approve");
+    conversationRegistry.peek("conv_approve")!.setState({
+      blocks: [elicitationBlock("elic_late")],
+    });
+    const approving = useChatStore.getState().submitApproval("elic_late", "accept");
+    await tick();
+
+    await useChatStore.getState().switchTo("conv_after");
+    failResolve!();
+    await approving;
+
+    // The card is answerable again on the conversation that owns it.
+    const card = conversationRegistry.peek("conv_approve")!.getState().blocks[0];
+    expect(card?.type).toBe("elicitation");
+    if (card?.type !== "elicitation") throw new Error("expected an elicitation block");
+    expect(card.status).toBe("pending");
+    expect(card.response).toBeNull();
+    // The visible conversation gained nothing.
+    expect(useChatStore.getState().blocks).toEqual([]);
+  });
+
   it("only updates the matching elicitation by id (other pending blocks untouched)", async () => {
     useChatStore.setState({
       conversationId: "conv_abc",
@@ -5400,6 +5943,14 @@ describe("chatStore — tool_result does not resolve elicitations", () => {
 });
 
 describe("chatStore — elicitation_resolved", () => {
+  // These cases call `handleSessionEvent` directly, with no stream to name the
+  // delivering conversation. Bind one so the write has an entry to land on,
+  // exactly as it would in production (`elicitation_resolved` carries no
+  // conversation id, so it is routed by its delivering stream).
+  beforeEach(() => {
+    bindConversationForTest("conv_elic");
+  });
+
   function elicitationResolvedEvent(id: string): StreamEvent {
     return { type: "elicitation_resolved", elicitationId: id };
   }
@@ -5576,6 +6127,119 @@ describe("chatStore — bindStream sticky-pref handoff", () => {
     const state = useChatStore.getState();
     expect(state.selectedModel).toBe("opus");
     expect(state.selectedEffort).toBe("high");
+  });
+
+  it("lets only the newest model pick settle the persisted sticky preference", async () => {
+    // A conversation-id guard can't order two picks. If A's PATCH is slow, the
+    // user switches to B and picks again, then A resolves last: A's canonical
+    // value overwrote the newer localStorage pref even though the UI correctly
+    // showed B's. The wrong model then came back on reload / in a new chat.
+    seedSession("conv_pick_a", []);
+    seedSession("conv_pick_b", []);
+    let releaseA: (() => void) | null = null;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_pick_a" && init?.method === "PATCH") {
+        return new Promise<Response>((resolve) => {
+          releaseA = () =>
+            resolve(
+              mockResponse({
+                id: "conv_pick_a",
+                agent_id: "agent_xyz",
+                status: "idle",
+                created_at: 0,
+                items: [],
+                model_override: "sonnet",
+              }),
+            );
+        });
+      }
+      if (url === "/v1/sessions/conv_pick_b" && init?.method === "PATCH") {
+        return mockResponse({
+          id: "conv_pick_b",
+          agent_id: "agent_xyz",
+          status: "idle",
+          created_at: 0,
+          items: [],
+          model_override: "opus",
+        });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    await useChatStore.getState().switchTo("conv_pick_a");
+    const pickA = useChatStore.getState().setModel("sonnet");
+    await tick();
+
+    // Switch to B and pick a NEWER model, which settles first.
+    await useChatStore.getState().switchTo("conv_pick_b");
+    await useChatStore.getState().setModel("opus");
+    expect(window.localStorage.getItem("omnigent.picker.model")).toBe("opus");
+
+    // A's slower PATCH now resolves last. It must not revive the older pick.
+    releaseA!();
+    await pickA;
+
+    expect(window.localStorage.getItem("omnigent.picker.model")).toBe("opus");
+    expect(useChatStore.getState().selectedModel).toBe("opus");
+    // A's own session override still settled to its canonical value.
+    expect(conversationRegistry.peek("conv_pick_a")!.getState().sessionModelOverride).toBe(
+      "sonnet",
+    );
+  });
+
+  it("does not move the app-global picker when a bind lands after a switch away", async () => {
+    // `selectedModel` / `selectedEffort` are app-global sticky picks, not
+    // conversation state, so a cold bind that finishes in the background must
+    // hydrate its OWN conversation without touching them — otherwise A's late
+    // snapshot repaints the picker for whichever conversation the user is now
+    // looking at (and two concurrent cold binds are last-response-wins).
+    seedSession("conv_slow_bind", []);
+    seedSession("conv_now_visible", []);
+    let releaseSnapshot: (() => void) | null = null;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (
+        url.split("?")[0] === "/v1/sessions/conv_slow_bind" &&
+        (init?.method ?? "GET") === "GET" &&
+        releaseSnapshot === null
+      ) {
+        return new Promise<Response>((resolve) => {
+          releaseSnapshot = () =>
+            resolve(
+              mockResponse({
+                id: "conv_slow_bind",
+                agent_id: "agent_xyz",
+                status: "idle",
+                created_at: 0,
+                items: [],
+                labels: { "omnigent.wrapper": "claude-code-native-ui" },
+                // The snapshot would hand "sonnet" to the picker.
+                model_override: "sonnet",
+                reasoning_effort: "low",
+                model_options: CLAUDE_MODEL_OPTIONS,
+              }),
+            );
+        });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    useChatStore.setState({ selectedEffort: "high", selectedModel: "opus" });
+    const binding = useChatStore.getState().switchTo("conv_slow_bind");
+    await tick();
+    // The user switches away before the snapshot lands.
+    await useChatStore.getState().switchTo("conv_now_visible");
+    releaseSnapshot!();
+    await binding;
+
+    // The visible conversation's picker is untouched...
+    expect(useChatStore.getState().selectedModel).toBe("opus");
+    expect(useChatStore.getState().selectedEffort).toBe("high");
+    // ...while the backgrounded conversation still hydrated its own state.
+    expect(conversationRegistry.peek("conv_slow_bind")!.getState().sessionModelOverride).toBe(
+      "sonnet",
+    );
   });
 
   it("applies a persisted Claude model after delayed model options arrive", async () => {
@@ -6759,19 +7423,17 @@ describe("chatStore — pumpStreamEvents frame batching", () => {
     expect(order).toEqual(["A", "B", "C"]);
   });
 
-  it("drops a pending frame's buffered blocks when the session switches mid-stream", async () => {
-    useChatStore.setState({ conversationId: "conv_old", blocks: [] });
+  it("lands a pending frame on its OWN conversation, never the visible one", async () => {
+    // A buffered frame that fires after the user switches away must not paint
+    // onto the newly-visible conversation. That used to be enforced by flush()
+    // bailing on a conversationId mismatch — and it dropped the blocks. Now the
+    // buffer belongs to conv_old's entry, so the blocks are kept AND the visible
+    // conversation is untouched.
+    const { set: setOld, get: getOld } = bindConversationForTest("conv_old");
     const sink = pushableStream();
     const controller = new AbortController();
     const manual = manualScheduler();
-    void pumpStreamEvents(
-      "conv_old",
-      sink.stream,
-      controller,
-      setState,
-      getState,
-      manual.scheduler,
-    );
+    void pumpStreamEvents("conv_old", sink.stream, controller, setOld, getOld, manual.scheduler);
 
     sink.push(sse("response.created", { id: "resp_old", status: "in_progress", output: [] }));
     sink.push(delta("A")); // first content → sync flush onto conv_old
@@ -6780,16 +7442,15 @@ describe("chatStore — pumpStreamEvents frame batching", () => {
     await tick();
     expect(manual.pending()).toBe(true);
 
-    // switchTo binds another session: conversationId changes + the old
-    // controller aborts. The new session starts empty.
-    controller.abort();
-    useChatStore.setState({ conversationId: "conv_new", blocks: [] });
+    // The user navigates to another conversation. conv_old keeps its stream.
+    bindConversationForTest("conv_new");
 
-    // Firing the stale frame must NOT land conv_old's buffered B/C onto
-    // conv_new — flush() early-returns on the conversationId mismatch.
     manual.fire();
     expect(useChatStore.getState().conversationId).toBe("conv_new");
+    // conv_new is untouched...
     expect(useChatStore.getState().blocks).toEqual([]);
+    // ...and conv_old kept its own buffered output rather than discarding it.
+    expect(getOld().blocks.length).toBeGreaterThan(0);
   });
 });
 
@@ -6874,22 +7535,52 @@ describe("chatStore — pumpStreamEvents end reasons", () => {
     expect(st.activeResponse).toEqual({ responseId: "resp_k", state: "streaming", error: null });
   });
 
-  it("returns 'switched' when the conversation changes mid-stream", async () => {
-    useChatStore.setState({ conversationId: "conv_sw_a", blocks: [] });
+  it("keeps pumping when the user switches to another conversation", async () => {
+    // Switching away used to end the pump ("switched"), because one shared
+    // `blocks` array meant a background pump would corrupt the visible
+    // transcript. Each conversation now owns its state, so backgrounding is not
+    // a reason to stop — it is the entire feature. Only disposal ends the pump.
+    const { set: setA, get: getA } = bindConversationForTest("conv_sw_a");
     const sink = pushableStream();
     const done = pumpStreamEvents(
       "conv_sw_a",
       sink.stream,
       new AbortController(),
-      setState,
-      getState,
+      setA,
+      getA,
       immediate,
     );
     sink.push(sse("response.created", { id: "resp_sw", status: "in_progress", output: [] }));
     await tick();
-    useChatStore.setState({ conversationId: "conv_sw_b" });
-    // A 34-char + trailing-space delta flushes a chunk, so the next
-    // for-await iteration runs the conversation-id guard and bails.
+    bindConversationForTest("conv_sw_b");
+    // A 34-char + trailing-space delta flushes a chunk, so the next for-await
+    // iteration runs the pump's liveness guard — which conv_sw_a still passes.
+    sink.push(sse("response.output_text.delta", { delta: `${"z".repeat(34)} ` }));
+    await tick();
+    // Still running: the delta landed on conv_sw_a, not on the visible one.
+    expect(getA().blocks.length).toBeGreaterThan(0);
+    expect(useChatStore.getState().blocks).toEqual([]);
+    sink.push("data: [DONE]\n\n");
+    sink.close();
+    expect(await done).toBe("server_closed");
+  });
+
+  it("returns 'switched' once its conversation is evicted", async () => {
+    // The end reason survives for the case it now describes: the entry is gone
+    // (evicted or deleted), so there is nowhere to write and nothing to reopen.
+    const { set: setA, get: getA } = bindConversationForTest("conv_sw_gone");
+    const sink = pushableStream();
+    const done = pumpStreamEvents(
+      "conv_sw_gone",
+      sink.stream,
+      new AbortController(),
+      setA,
+      getA,
+      immediate,
+    );
+    sink.push(sse("response.created", { id: "resp_sw", status: "in_progress", output: [] }));
+    await tick();
+    releaseConversation("conv_sw_gone");
     sink.push(sse("response.output_text.delta", { delta: `${"z".repeat(34)} ` }));
     expect(await done).toBe("switched");
   });
@@ -7265,12 +7956,16 @@ describe("chatStore — startStreamPump reconnect loop", () => {
     await loop;
   });
 
-  it("drops a stale reconcile/re-hydrate after a switch-away-and-back mid-backfill", async () => {
+  it("keeps reconciling a conversation the user navigated away from", async () => {
+    // This used to assert the opposite: switch-away destroyed the window, so a
+    // reconcile still in flight was stale and had to be discarded. A background
+    // conversation now keeps its window AND must keep reconciling — the ingress
+    // recycles every stream ~every 5 minutes, and the server keeps no replay
+    // buffer, so skipping the repair would leave it silently missing events.
     const preGap = Array.from({ length: 30 }, (_, i) => gapUser("spre", i));
     const windowItems = preGap.slice(-SESSION_HISTORY_PAGE_SIZE);
     seedSession("conv_stale", preGap);
     seedSession("conv_other", []);
-    // Route /stream opens to sinks AND hold reconcile's first backfill page.
     const sinks: StreamSink[] = [];
     let releaseBackfill: (() => void) | null = null;
     fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
@@ -7288,66 +7983,48 @@ describe("chatStore — startStreamPump reconnect loop", () => {
       return defaultFetchHandler(input, init);
     });
     const controller = new AbortController();
-    useChatStore.setState({
-      conversationId: "conv_stale",
+    const { set: setStale, get: getStale } = bindConversationForTest("conv_stale", {
       abortController: controller,
       blocks: itemsToBlocks(windowItems),
       hasMoreHistory: true,
       oldestItemId: windowItems[0]!.id,
     });
 
-    const loop = startStreamPump("conv_stale", controller, setState, getState);
+    const loop = startStreamPump("conv_stale", controller, setStale, getStale);
     await drainAsync();
     expect(sinks).toHaveLength(1);
 
-    // 100 gap items: if the stale backfill resumed, it would outrun the
-    // page cap and fall through to the window re-hydrate.
+    // A drop mid-turn: the reconnect reconciles, and parks on its first
+    // deferred backfill page.
     const gap = Array.from({ length: 100 }, (_, i) => gapUser("sgap", i));
     seedSessionItems("conv_stale", [...preGap, ...gap]);
     sinks[0]!.error();
     await drainAsync();
-    // Sync gate: reconcile is parked on its first deferred backfill page.
     expect(releaseBackfill).not.toBeNull();
 
-    // The user leaves and comes back: the revisit hydrates a FRESH window
-    // (the newest INITIAL_WINDOW_ITEMS, i.e. every gap item) and then
-    // scrolls one page up.
-    const away = useChatStore.getState().switchTo("conv_other");
+    // The user leaves while that reconcile is still in flight.
+    await useChatStore.getState().switchTo("conv_other");
     await drainAsync(5);
-    await away;
-    const back = useChatStore.getState().switchTo("conv_stale");
-    await drainAsync(5);
-    await back;
-    await useChatStore.getState().loadMoreHistory();
-    const fresh = useChatStore.getState();
-    expect(fresh.blocks.map((b) => b.ctx.itemId)).toEqual(
-      [...preGap.slice(-SESSION_HISTORY_PAGE_SIZE), ...gap].map((item) => item.id),
-    );
 
-    // The stale page resolves: the conversation id matches again, so only
-    // the generation guard separates it from the new window.
+    // It resolves against the backgrounded conversation, which is still live.
     releaseBackfill!();
     await drainAsync();
 
-    const state = useChatStore.getState();
-    // The stale flow must write nothing — pre-fix it ran on to the
-    // re-hydrate fallback, which rewound the scroll-up cursor to the
-    // window top and bumped the generation (voiding future legit pages).
-    expect(state.blocks.map((b) => b.ctx.itemId)).toEqual(
-      [...preGap.slice(-SESSION_HISTORY_PAGE_SIZE), ...gap].map((item) => item.id),
-    );
-    expect(state.oldestItemId).toBe(preGap.at(-SESSION_HISTORY_PAGE_SIZE)!.id);
-    expect(state.historyGeneration).toBe(fresh.historyGeneration);
+    // The visible conversation is untouched...
+    expect(useChatStore.getState().conversationId).toBe("conv_other");
+    expect(useChatStore.getState().blocks).toEqual([]);
+    // ...and conv_stale picked up the items it missed during the gap, so
+    // returning to it shows a current transcript rather than one frozen at the
+    // moment the stream dropped. The 100-item gap exceeds the backfill cap, so
+    // the window is replaced wholesale rather than extended — what matters is
+    // that it now ends at the newest item, not at the pre-gap tail.
+    const staleIds = getStale().blocks.map((b) => b.ctx.itemId);
+    expect(staleIds.at(-1)).toBe(gap.at(-1)!.id);
+    expect(staleIds).not.toContain(windowItems.at(-1)!.id);
 
-    // The new window still pages older from where it left off: pre-fix the
-    // rewound cursor re-fetched the already-rendered page (all dupes) and
-    // the transcript would not have grown.
-    await useChatStore.getState().loadMoreHistory();
-    expect(useChatStore.getState().blocks.map((b) => b.ctx.itemId)).toEqual(
-      [...preGap, ...gap].map((item) => item.id),
-    );
-
-    // Unpark the orphaned pump so the awaited loop can exit.
+    // Release the conversation so the reconnect loop stops: a live entry keeps
+    // reconnecting by design, which is exactly what this test asserts.
+    releaseConversation("conv_stale");
     sinks[1]!.error();
     await drainAsync(2);
     await loop;
@@ -7530,6 +8207,114 @@ describe("chatStore — startStreamPump reconnect loop", () => {
     const last = sinks[1]!;
     last.push("data: [DONE]\n\n");
     last.close();
+    await drainAsync(2);
+    await loop;
+  });
+
+  it("staggers a background conversation's reconnect but never the visible one", async () => {
+    // Every stream is recycled by the ingress at ~5 minutes, so streams opened
+    // together drop together. Without a stagger, a tab holding N conversations
+    // fires N reconnects — each with a snapshot + items fetch — in one burst.
+    seedSession("conv_fg", []);
+    seedSession("conv_bg", []);
+    const opens: string[] = [];
+    const sinks = new Map<string, StreamSink[]>();
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const match = /\/v1\/sessions\/([^/?]+)\/stream/.exec(url);
+      if (match) {
+        const id = match[1]!;
+        opens.push(id);
+        const sink = pushableStream();
+        sinks.set(id, [...(sinks.get(id) ?? []), sink]);
+        return mockResponse(null, { bodyStream: sink.stream });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    // conv_bg is bound first, then conv_fg becomes the visible one.
+    const bg = bindConversationForTest("conv_bg");
+    const bgController = new AbortController();
+    const bgLoop = startStreamPump("conv_bg", bgController, bg.set, bg.get);
+    await vi.advanceTimersByTimeAsync(1);
+    const fg = bindConversationForTest("conv_fg");
+    const fgController = new AbortController();
+    const fgLoop = startStreamPump("conv_fg", fgController, fg.set, fg.get);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(opens).toEqual(["conv_bg", "conv_fg"]);
+
+    // Both drop at the same instant, as the ingress deadline would do.
+    sinks.get("conv_bg")![0]!.error();
+    sinks.get("conv_fg")![0]!.error();
+    await vi.advanceTimersByTimeAsync(1);
+
+    // The visible conversation reconnects immediately; the background one waits.
+    expect(opens.slice(2)).toEqual(["conv_fg"]);
+
+    // Past the jitter ceiling, the background conversation has reconnected too.
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(opens.slice(2).sort()).toEqual(["conv_bg", "conv_fg"]);
+
+    releaseConversation("conv_bg");
+    releaseConversation("conv_fg");
+    bgController.abort();
+    fgController.abort();
+    for (const list of sinks.values()) {
+      for (const sink of list.slice(1)) sink.close();
+    }
+    await drainAsync(2);
+    await Promise.all([bgLoop, fgLoop]);
+  });
+
+  it("recomputes the idle flag on every reconnect, so a backgrounded tab reports idle", async () => {
+    // The `idle` query param on the stream GET is the whole presence uplink, so
+    // the flag has to be recomputed at each (re)connect rather than reused from
+    // the first open — that is what keeps presence eventually-correct even when
+    // a background tab's debounce timer never fires.
+    //
+    // This covers the recompute, NOT the abort that triggers it: the mock body
+    // stream has no signal wiring, so the drop is simulated explicitly below.
+    // `presenceAttemptControllers` (one controller per live stream) is covered
+    // directly in "presence idle tracker" instead.
+    seedSession("conv_pflip", []);
+    const opened: { id: string; idle: boolean }[] = [];
+    const sinks: StreamSink[] = [];
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const match = /\/v1\/sessions\/([^/?]+)\/stream(\?idle=true)?$/.exec(url);
+      if (match) {
+        opened.push({ id: match[1]!, idle: match[2] !== undefined });
+        const sink = pushableStream();
+        sinks.push(sink);
+        return mockResponse(null, { bodyStream: sink.stream });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const controller = new AbortController();
+    useChatStore.setState({ conversationId: "conv_pflip", abortController: controller });
+    const loop = startStreamPump("conv_pflip", controller, setState, getState);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(opened).toEqual([{ id: "conv_pflip", idle: false }]);
+
+    // Tab goes hidden; past the debounce the tracker reports idle by aborting
+    // the live attempt.
+    Object.defineProperty(document, "hidden", { value: true, configurable: true });
+    document.dispatchEvent(new Event("visibilitychange"));
+    await vi.advanceTimersByTimeAsync(PRESENCE_IDLE_AFTER_MS + 1000);
+
+    // A real fetch errors the response body when its signal aborts; the mock
+    // stream has no signal wiring, so surface that here. The pump reads the
+    // failed read as a drop and reopens carrying the recomputed idle flag.
+    sinks[0]!.error(Object.assign(new Error("aborted"), { name: "AbortError" }));
+    await vi.advanceTimersByTimeAsync(6000);
+
+    expect(opened.slice(1)).toEqual([{ id: "conv_pflip", idle: true }]);
+
+    Object.defineProperty(document, "hidden", { value: false, configurable: true });
+    controller.abort();
+    // Only the reopened stream is still open — the first was errored above.
+    sinks[sinks.length - 1]!.close();
     await drainAsync(2);
     await loop;
   });
@@ -8155,6 +8940,41 @@ describe("chatStore — setCostControlMode", () => {
     await expect(useChatStore.getState().setCostControlMode("on")).rejects.toThrow();
     // Back to the pre-toggle value: the pill must not claim a state the
     // server never persisted (it would silently diverge from the snapshot).
+    expect(useChatStore.getState().costControlModeOverride).toBeNull();
+  });
+
+  it("rolls back on the toggling conversation when the failure outlives a switch", async () => {
+    // The rollback used to be skipped entirely once the user switched away, on
+    // the assumption that leaving destroyed the state. It doesn't any more: the
+    // conversation stays live, so returning to it showed the optimistic value
+    // the server had rejected, permanently.
+    seedSession("conv_cc_bg", []);
+    seedSession("conv_cc_fg", []);
+    await useChatStore.getState().switchTo("conv_cc_bg");
+
+    let failPatch: (() => void) | null = null;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_cc_bg" && init?.method === "PATCH") {
+        return new Promise<Response>((resolve) => {
+          failPatch = () =>
+            resolve(mockResponse({ error: { message: "boom" } }, { ok: false, status: 500 }));
+        });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const toggling = useChatStore.getState().setCostControlMode("on");
+    await tick();
+    expect(conversationRegistry.peek("conv_cc_bg")!.getState().costControlModeOverride).toBe("on");
+
+    await useChatStore.getState().switchTo("conv_cc_fg");
+    failPatch!();
+    await expect(toggling).rejects.toThrow();
+
+    // The rejected optimistic flip is gone from the conversation that owns it...
+    expect(conversationRegistry.peek("conv_cc_bg")!.getState().costControlModeOverride).toBeNull();
+    // ...and the visible conversation was never touched.
     expect(useChatStore.getState().costControlModeOverride).toBeNull();
   });
 
@@ -9550,11 +10370,12 @@ describe("chatStore — background cross-session flush", () => {
     });
   });
 
-  it("serializes a background flush behind an in-flight foreground send to the same conversation", async () => {
-    // The navigate-away race: a foreground send() for conv_a is still in flight
-    // (its /events POST held open) when the user switches away, so conv_a's
-    // queue now drains via the background path. Both take a slot on conv_a's
-    // chain, so the background POST cannot overtake the foreground one.
+  it("serializes a background flush behind an in-flight foreground send to the SAME conversation", async () => {
+    // The navigate-away race: a send() for conv_a is still in flight (its
+    // /events POST held open) when the user switches away and conv_a's
+    // remaining queue hands off to the background flush. Both POST paths take a
+    // slot on conv_a's send chain, so the background POST cannot overtake the
+    // foreground one — messages reach the runner in submission order.
     seedConversationsCache([conv("conv_a", "idle"), conv("conv_other", "idle")]);
     useChatStore.setState({
       conversationId: "conv_a",
@@ -9562,16 +10383,18 @@ describe("chatStore — background cross-session flush", () => {
       abortController: new AbortController(),
       status: "idle",
       sessionStatus: "idle",
-      queuedMessages: [],
     });
 
-    // Both POSTs hit the same endpoint, so order is recorded by message text.
+    // Hold conv_a's first POST open and record delivery order.
     const delivered: string[] = [];
     let releaseForeground: () => void = () => {};
     fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();
       if (url === "/v1/sessions/conv_a/events" && init?.method === "POST") {
-        const text = JSON.parse(init.body as string).data.content[0].text;
+        const body = JSON.parse((init as RequestInit).body as string);
+        const text = (body.data?.content ?? []).find(
+          (b: { type: string }) => b.type === "input_text",
+        )?.text;
         delivered.push(text);
         if (text === "fg-msg") {
           return new Promise<Response>((resolve) => {
@@ -9588,7 +10411,8 @@ describe("chatStore — background cross-session flush", () => {
     await tick();
     expect(delivered).toEqual(["fg-msg"]);
 
-    // User navigates away, handing conv_a's queue to the background path.
+    // User navigates away; conv_a's queued follow-up now drains via the
+    // background path. It must NOT overtake the in-flight foreground POST.
     useChatStore.setState({
       conversationId: "conv_other",
       queuedMessages: [{ queueId: "q_1", text: "bg-msg", conversationId: "conv_a" }],
@@ -9598,12 +10422,53 @@ describe("chatStore — background cross-session flush", () => {
     await tick();
     expect(delivered).toEqual(["fg-msg"]);
 
-    // Release the foreground POST → the background POST is now free to deliver.
+    // Release the foreground POST → the background POST is free to deliver.
     releaseForeground();
     await fg;
     await tick();
     await tick();
     expect(delivered).toEqual(["fg-msg", "bg-msg"]);
+  });
+
+  it("does not block a background flush behind a send to a DIFFERENT conversation", async () => {
+    // Ordering is only meaningful within one conversation: the runner appends
+    // per session. A stalled send to the conversation being viewed must not
+    // delay an unrelated conversation's queued message — that was a
+    // head-of-line block from serializing every POST through one global chain.
+    seedConversationsCache([conv("conv_active", "idle"), conv("conv_bg", "idle")]);
+    useChatStore.setState({
+      conversationId: "conv_active",
+      boundAgentId: "agent_xyz",
+      abortController: new AbortController(),
+      status: "idle",
+      sessionStatus: "idle",
+      queuedMessages: [{ queueId: "q_1", text: "bg-msg", conversationId: "conv_bg" }],
+    });
+
+    const delivered: string[] = [];
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_active/events" && init?.method === "POST") {
+        delivered.push("foreground");
+        // Never resolves: conv_active's POST stays in flight for the whole test.
+        return new Promise<Response>(() => {});
+      }
+      if (url === "/v1/sessions/conv_bg/events" && init?.method === "POST") {
+        delivered.push("background");
+        return mockResponse({ queued: true, item_id: "ci_bg" });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    void useChatStore.getState().send("fg-msg", "agent_xyz");
+    await tick();
+    expect(delivered).toEqual(["foreground"]);
+
+    // conv_bg delivers while conv_active's POST is still hanging.
+    useChatStore.getState().flushBackgroundQueues();
+    await tick();
+    await tick();
+    expect(delivered).toEqual(["foreground", "background"]);
   });
 
   it("does not serialize sends across different conversations", async () => {

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -62,6 +62,12 @@ import {
   releaseConversation,
 } from "./chatStore";
 import { conversationRegistry } from "./conversationRegistry";
+import {
+  resetStreamSlotManager,
+  setStreamSlotManagerForTest,
+  type StreamSlot,
+  type StreamSlotManager,
+} from "./streamSlots";
 import { useTerminalActivityStore } from "./terminalActivity";
 
 // The real `send` action, captured before any test stubs it via
@@ -392,6 +398,47 @@ function readConversationRows(): Conversation[] {
   return data?.pages.flatMap((p) => p.data) ?? [];
 }
 
+/**
+ * Deterministic origin-wide slot manager for tests (jsdom has no
+ * `navigator.locks`). `capacity` total slots, of which `externallyHeld` model
+ * other tabs' holds; the rest are grantable to this tab.
+ */
+interface FakeSlotManager extends StreamSlotManager {
+  heldByTab: () => number;
+  setCapacity: (n: number) => void;
+  setExternallyHeld: (n: number) => void;
+}
+function makeFakeSlotManager(
+  opts: { capacity?: number; externallyHeld?: number } = {},
+): FakeSlotManager {
+  let capacity = opts.capacity ?? 100;
+  let externallyHeld = opts.externallyHeld ?? 0;
+  let held = 0;
+  return {
+    tryAcquire: (): Promise<StreamSlot | null> => {
+      if (externallyHeld + held >= capacity) return Promise.resolve(null);
+      held += 1;
+      let released = false;
+      return Promise.resolve({
+        release: () => {
+          if (!released) {
+            released = true;
+            held -= 1;
+          }
+          return Promise.resolve();
+        },
+      });
+    },
+    heldByTab: () => held,
+    setCapacity: (n) => {
+      capacity = n;
+    },
+    setExternallyHeld: (n) => {
+      externallyHeld = n;
+    },
+  };
+}
+
 beforeEach(() => {
   client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   sessionSnapshots = new Map();
@@ -402,6 +449,9 @@ beforeEach(() => {
   sessionSubagentRoutingOverrides = new Map();
   sessionLabels = new Map();
   initChatStore(client);
+  // Generous, deterministic slots for tests that aren't about the cap; the
+  // dedicated stream-slot tests install their own small-capacity manager.
+  setStreamSlotManagerForTest(makeFakeSlotManager());
   useChatStore.setState({
     conversationId: null,
     blocks: [],
@@ -417,6 +467,8 @@ beforeEach(() => {
     subagentRoutingOverride: null,
     codexPlanMode: false,
     abortController: null,
+    streamBudgetExceeded: false,
+    streamBudgetBannerDismissed: false,
     // Restore the real send action; a prior test may have stubbed it.
     send: realSend,
   });
@@ -435,6 +487,7 @@ afterEach(() => {
   // plumbing, so nothing errors the body and `parseSseStream` stays parked on
   // `reader.read()`. Close the streams so those reads actually settle.
   closeOpenEmptyStreams();
+  resetStreamSlotManager();
   vi.useRealTimers();
   vi.unstubAllGlobals();
   // Reset the stubbed viewer identity to the default (null) so a value set
@@ -10632,5 +10685,82 @@ describe("chatStore — attributing pre-turn blocks to the turn", () => {
 
     const rids = useChatStore.getState().blocks.map((b) => b.ctx.responseId);
     expect(rids).toEqual(["", "codex_prev", "codex_now"]);
+  });
+});
+
+describe("chatStore — origin-wide stream slots", () => {
+  it("holds one slot per live stream while within budget", async () => {
+    const slots = makeFakeSlotManager({ capacity: 5 });
+    setStreamSlotManagerForTest(slots);
+    seedSession("conv_a", []);
+    seedSession("conv_b", []);
+
+    await useChatStore.getState().switchTo("conv_a");
+    await useChatStore.getState().switchTo("conv_b");
+
+    // Both stream, neither over budget: one held slot each.
+    expect(slots.heldByTab()).toBe(2);
+    expect(useChatStore.getState().streamBudgetExceeded).toBe(false);
+    expect(conversationRegistry.has("conv_a")).toBe(true);
+    expect(conversationRegistry.has("conv_b")).toBe(true);
+  });
+
+  it("reclaims this tab's own LRU background stream when the origin is saturated", async () => {
+    // Two total slots. Opening a third conversation can't take a free slot, so
+    // the tab evicts its own oldest background stream (conv_a) to make room —
+    // no banner, because it stayed within budget by reclaiming its own.
+    const slots = makeFakeSlotManager({ capacity: 2 });
+    setStreamSlotManagerForTest(slots);
+    for (const id of ["conv_a", "conv_b", "conv_c"]) seedSession(id, []);
+
+    await useChatStore.getState().switchTo("conv_a");
+    await useChatStore.getState().switchTo("conv_b");
+    await useChatStore.getState().switchTo("conv_c");
+
+    expect(conversationRegistry.has("conv_a")).toBe(false); // evicted (LRU)
+    expect(conversationRegistry.has("conv_b")).toBe(true);
+    expect(conversationRegistry.has("conv_c")).toBe(true);
+    expect(slots.heldByTab()).toBe(2); // exactly the budget, no more
+    expect(useChatStore.getState().streamBudgetExceeded).toBe(false);
+  });
+
+  it("opens the active conversation over budget, with the banner, when a fresh tab finds every slot held by others", async () => {
+    // Every slot held by other tabs; this fresh tab has nothing of its own to
+    // reclaim. The conversation must still open (you have to be able to use
+    // what you're looking at), and the too-many-tabs banner is raised.
+    const slots = makeFakeSlotManager({ capacity: 3, externallyHeld: 3 });
+    setStreamSlotManagerForTest(slots);
+    seedSession("conv_new_tab", []);
+
+    await useChatStore.getState().switchTo("conv_new_tab");
+
+    expect(useChatStore.getState().conversationId).toBe("conv_new_tab");
+    expect(useChatStore.getState().abortController).not.toBeNull(); // stream opened
+    expect(slots.heldByTab()).toBe(0); // over budget — no slot held
+    expect(useChatStore.getState().streamBudgetExceeded).toBe(true);
+  });
+
+  it("re-shows the banner on a fresh over-budget episode after the user dismissed it", async () => {
+    const slots = makeFakeSlotManager({ capacity: 2, externallyHeld: 2 });
+    setStreamSlotManagerForTest(slots);
+    for (const id of ["conv_a", "conv_b", "conv_c"]) seedSession(id, []);
+
+    // Fresh tab, every slot held elsewhere → over budget + banner.
+    await useChatStore.getState().switchTo("conv_a");
+    expect(useChatStore.getState().streamBudgetExceeded).toBe(true);
+
+    useChatStore.getState().dismissStreamBudgetBanner();
+    expect(useChatStore.getState().streamBudgetBannerDismissed).toBe(true);
+
+    // A tab closes → a slot frees; the next open takes it and the episode ends.
+    slots.setExternallyHeld(1);
+    await useChatStore.getState().switchTo("conv_b");
+    expect(useChatStore.getState().streamBudgetExceeded).toBe(false);
+
+    // Origin saturates again → a NEW episode re-shows the banner (un-dismissed).
+    slots.setExternallyHeld(2);
+    await useChatStore.getState().switchTo("conv_c");
+    expect(useChatStore.getState().streamBudgetExceeded).toBe(true);
+    expect(useChatStore.getState().streamBudgetBannerDismissed).toBe(false);
   });
 });

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -57,6 +57,7 @@ import {
   setPendingInitialPrompt,
   startStreamPump,
   useChatStore,
+  type ConversationState,
   type FrameScheduler,
   bindConversationForTest,
   releaseConversation,
@@ -10131,6 +10132,44 @@ describe("chatStore — client-side message queue", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("recovers each conversation's own stranded send independently", () => {
+    // `status` and the latch are per-conversation now, so clearing ONE
+    // conversation's stranded latch must not disarm another's. A single shared
+    // timestamp let recovering A strand B — B stayed "streaming" but could no
+    // longer age out, so its composer and queue wedged until reload.
+    seedConversationsCache([conv("conv_a", "idle"), conv("conv_b", "idle")]);
+    // A stale timestamp is stranded without advancing timers (well past the
+    // 180s SEND_CHAIN_MAX_WAIT_MS window).
+    const stale = Date.now() - 10 * 60_000;
+    const wedged: Partial<ConversationState> = {
+      status: "streaming",
+      sessionStatus: "idle",
+      boundAgentId: "agent_xyz",
+      activeResponse: null,
+      sendLatchedAt: stale,
+    };
+    // Two conversations, each holding its own hung-send latch.
+    bindConversationForTest("conv_a", wedged);
+    bindConversationForTest("conv_b", wedged);
+
+    // Recover A (active): its stranded latch clears and its status settles.
+    bindConversationForTest("conv_a");
+    useChatStore.getState().maybeFlushQueuedHead();
+    expect(useChatStore.getState().status).toBe("idle");
+    expect(useChatStore.getState().sendLatchedAt).toBeNull();
+
+    // B is untouched — its own latch survived A's recovery.
+    const b = conversationRegistry.peek("conv_b")!.getState();
+    expect(b.status).toBe("streaming");
+    expect(b.sendLatchedAt).toBe(stale);
+
+    // And B is still independently recoverable. Pre-fix, A's recovery nulled the
+    // shared scalar, so B's latch read as absent and it could never age out.
+    bindConversationForTest("conv_b");
+    useChatStore.getState().maybeFlushQueuedHead();
+    expect(useChatStore.getState().status).toBe("idle");
   });
 });
 

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -80,6 +80,7 @@ import type {
 import { createPresenceIdleTracker } from "@/lib/presenceIdle";
 import { conversationRegistry, type ConversationEntry } from "./conversationRegistry";
 import { createInitialConversationState, isConversationStateKey } from "./conversationState";
+import { getStreamSlotManager, type StreamSlot } from "./streamSlots";
 import { parseEvent, parseSseStream, type SseStreamResult } from "@/lib/sse";
 import { clearSseLog, pushSseEvent } from "@/lib/sseEventLog";
 import { childSessionsQueryKey, type ChildSessionInfo } from "@/hooks/useChildSessions";
@@ -570,6 +571,20 @@ export interface AppChatState {
    * The composer drains this on change and clears it.
    */
   pendingComposerAttachments: ComposerAttachment[];
+  /**
+   * True when this tab could not take an origin-wide stream slot for a
+   * conversation it needed to open: every slot is held by other tabs and this
+   * tab had no background stream of its own to reclaim. The active conversation
+   * still opens (over budget), so the app keeps working; the banner warns the
+   * user to close tabs. Cleared once this tab holds a slot again.
+   */
+  streamBudgetExceeded: boolean;
+  /**
+   * Whether the user dismissed the too-many-tabs banner for the CURRENT
+   * over-budget episode. Reset when `streamBudgetExceeded` goes false→true, so a
+   * fresh episode re-shows it rather than nagging within one episode.
+   */
+  streamBudgetBannerDismissed: boolean;
 }
 
 /** Actions exposed on the root store. */
@@ -722,6 +737,8 @@ export interface ChatActions {
    * snapshot. No-ops for inactive or missing conversations.
    */
   refreshSessionState: (conversationId?: string) => Promise<void>;
+  /** Dismiss the too-many-tabs banner for the current over-budget episode. */
+  dismissStreamBudgetBanner: () => void;
 }
 
 /**
@@ -1074,6 +1091,9 @@ export function initChatStore(client: QueryClient): void {
   // Drop every live conversation: their streams must not outlive the app (or,
   // in tests, leak into the next case).
   conversationRegistry.clear();
+  // Drop this tab's held stream slots; disposed pumps release their own locks,
+  // and a boot/reset starts from an empty set.
+  heldStreamSlots.clear();
   // Reset the POST-ordering chains so a prior run's unresolved send can't block
   // the next one (production calls this once at boot; tests call it per case).
   sendChains.clear();
@@ -1211,6 +1231,8 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
   oldestItemId: null,
   flashItemId: null,
   pendingComposerAttachments: [],
+  streamBudgetExceeded: false,
+  streamBudgetBannerDismissed: false,
   failedSendDraft: null,
   llmModel: null,
   sessionHarness: null,
@@ -1963,6 +1985,8 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
 
   clearPendingComposerAttachments: () => setActive({ pendingComposerAttachments: [] }),
 
+  dismissStreamBudgetBanner: () => rootSetState({ streamBudgetBannerDismissed: true }),
+
   markRunnerLaunched: () => setActive({ runnerLaunchedAt: Date.now() }),
 
   compact: async () => {
@@ -2226,6 +2250,68 @@ type Getter = () => ChatState;
 // replaces it. Writes the root store's own fields with no re-splitting — used by
 // the mirror and by the app-global half of a routed patch.
 const rootSetState = useChatStore.setState;
+
+// ── Origin-wide stream slots ─────────────────────────────
+//
+// One held slot == one live stream this tab is counted for against the shared,
+// cross-tab cap (see `streamSlots`). Keyed by conversation id.
+const heldStreamSlots = new Map<string, StreamSlot>();
+
+/**
+ * Take an origin-wide stream slot for `id` before opening its stream.
+ *
+ * Tries for a free slot; if the origin is saturated, reclaims one of THIS tab's
+ * own background streams (LRU, unpinned) and retries — awaiting the reclaimed
+ * slot's release so the freed lock is observable before the re-check, rather
+ * than racing it and over-evicting. Returns whether a slot is now held.
+ *
+ * Returns false only when a fresh tab finds every slot held by OTHER tabs and
+ * has nothing of its own to reclaim; the active conversation then opens over
+ * budget (the caller proceeds anyway) and the too-many-tabs banner is raised.
+ */
+async function acquireStreamSlot(id: string): Promise<boolean> {
+  if (heldStreamSlots.has(id)) return true; // rebinding a still-slotted stream
+  let slot = await getStreamSlotManager().tryAcquire();
+  // Inherently sequential: each iteration must fully release a reclaimed slot
+  // (so the freed lock is observable) before re-checking, or we'd over-evict.
+  /* eslint-disable no-await-in-loop */
+  while (slot === null) {
+    const evictedId = conversationRegistry.evictLruEvictable(id);
+    if (evictedId === null) break;
+    const evictedSlot = heldStreamSlots.get(evictedId);
+    if (evictedSlot !== undefined) {
+      heldStreamSlots.delete(evictedId);
+      await evictedSlot.release();
+    }
+    slot = await getStreamSlotManager().tryAcquire();
+  }
+  /* eslint-enable no-await-in-loop */
+  if (slot !== null) heldStreamSlots.set(id, slot);
+  setStreamBudgetExceeded(slot === null);
+  return slot !== null;
+}
+
+/** Hand back `id`'s stream slot when its stream ends (pump exits / disposed). */
+function releaseStreamSlot(id: string): void {
+  const slot = heldStreamSlots.get(id);
+  if (slot === undefined) return;
+  heldStreamSlots.delete(id);
+  void slot.release();
+}
+
+/**
+ * Raise or clear the too-many-tabs banner. A fresh over-budget episode
+ * (false→true) un-dismisses it; clearing leaves the dismissed flag alone since
+ * the banner is hidden while within budget regardless.
+ */
+function setStreamBudgetExceeded(exceeded: boolean): void {
+  if (useChatStore.getState().streamBudgetExceeded === exceeded) return;
+  rootSetState(
+    exceeded
+      ? { streamBudgetExceeded: true, streamBudgetBannerDismissed: false }
+      : { streamBudgetExceeded: false },
+  );
+}
 
 // ── Conversation entries ─────────────────────────────────
 //
@@ -2824,6 +2910,16 @@ async function bindStream(
 ): Promise<void> {
   racedNativeModelOptions.delete(id);
   const controller = new AbortController();
+  // Take an origin-wide stream slot before opening the connection, evicting our
+  // own LRU background stream to make room. A fresh tab that finds every slot
+  // held by other tabs opens over budget (no slot) and raises the banner.
+  await acquireStreamSlot(id);
+  if (isConversationDisposed(id)) {
+    // Switched away / evicted while awaiting the slot — don't open a dead
+    // entry's stream, and hand any slot we took back to the origin.
+    releaseStreamSlot(id);
+    return;
+  }
   set({ abortController: controller });
 
   // Opening a conversation URL with no session list loaded yet leaves the
@@ -2835,8 +2931,7 @@ async function bindStream(
   // retry). When sharded (a host fetcher is wired), resolve the session's host_id
   // FIRST (one fast metadata GET that populates the map via sessionFromWire) so
   // the stream keys correctly. Best-effort: a failed resolve falls through to the
-  // unkeyed open (no worse than pre-fix); the conversationId guard bails if the
-  // user navigated away during the resolve. Re-apply after every resync, see
+  // unkeyed open (no worse than pre-fix). Re-apply after every resync, see
   // agentbricks/mas/.claude/skills/sync-omnigents/SKILL.md.
   if (getOmnigentHostConfig().fetcher && getSessionHost(id) === null) {
     try {
@@ -2845,10 +2940,18 @@ async function bindStream(
       // Best-effort: a failed resolve (bad id, transient) falls through to the
       // unkeyed open; the snapshot fetch surfaces the real error.
     }
-    if (get().conversationId !== id) return;
+    // Liveness, not the visible id: a background bind must survive a switch away
+    // (that is the whole feature). Only a dispose (evicted) bails — and then the
+    // slot taken above has to go back to the origin.
+    if (isConversationDisposed(id)) {
+      releaseStreamSlot(id);
+      return;
+    }
   }
 
-  void startStreamPump(id, controller, set, get);
+  // The slot is held for the pump's whole lifetime; released when it exits (a
+  // terminal close, an abort from switchTo/dispose, or eviction).
+  void startStreamPump(id, controller, set, get).finally(() => releaseStreamSlot(id));
 
   // Background tabs can miss the `response.elicitation_resolved` SSE event
   // (browser throttling), so a pending ApprovalCard that was answered on

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -382,6 +382,16 @@ export interface ConversationState {
    */
   failedSendDraft: { conversationId: string; text: string; files: File[] } | null;
   /**
+   * When a send last latched THIS conversation's `status` to "streaming", or
+   * `null`. Conversation-scoped, not a module global, because `status` is now
+   * per-conversation: two conversations can each hold a hung send, and a single
+   * shared timestamp would let recovering one strand the other (its `status`
+   * stays "streaming" but can no longer age out — see `sendLatchIsStranded`).
+   * Lives on the entry so the timestamp and the `status` it guards always
+   * travel together (adoption on new-chat, eviction, mirroring).
+   */
+  sendLatchedAt: number | null;
+  /**
    * LLM model identifier from the bound agent's spec for the active
    * session, e.g. ``"anthropic/claude-sonnet-4-6"``. Populated from
    * the session snapshot on bind; ``null`` before bind or when the
@@ -770,8 +780,9 @@ let queueSeq = 0;
 // When a send last latched local `status` to "streaming". Stamped on the way in
 // and never cleared on the way out: after a normal turn `status` settles to
 // "idle" on its own, so a leftover value is inert — only a `status` still
-// reading "streaming" long afterwards makes it meaningful.
-let sendLatchedAt: number | null = null;
+// reading "streaming" long afterwards makes it meaningful. The timestamp lives
+// on each conversation's entry (`ConversationState.sendLatchedAt`), not here,
+// so two hung sends can't share one scalar — see that field's note.
 
 // A chain link must never be able to deadlock its successors. `postEvent`
 // issues its fetch with no timeout, so a connection that dies mid-flight never
@@ -821,7 +832,8 @@ function cachedConversationStatus(conversationId: string): string | undefined {
  * session's own row disagrees with it. A live streaming response is never stale.
  */
 function sendLatchIsStranded(s: ChatState): boolean {
-  if (sendLatchedAt === null || Date.now() - sendLatchedAt < SEND_CHAIN_MAX_WAIT_MS) return false;
+  if (s.sendLatchedAt === null || Date.now() - s.sendLatchedAt < SEND_CHAIN_MAX_WAIT_MS)
+    return false;
   if (s.activeResponse?.state === "streaming") return false;
   return s.conversationId !== null && cachedConversationStatus(s.conversationId) === "idle";
 }
@@ -1096,8 +1108,8 @@ export function initChatStore(client: QueryClient): void {
   heldStreamSlots.clear();
   // Reset the POST-ordering chains so a prior run's unresolved send can't block
   // the next one (production calls this once at boot; tests call it per case).
+  // The send latch is per-conversation state now, cleared with the registry above.
   sendChains.clear();
-  sendLatchedAt = null;
   queryClient = client;
 }
 
@@ -1234,6 +1246,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
   streamBudgetExceeded: false,
   streamBudgetBannerDismissed: false,
   failedSendDraft: null,
+  sendLatchedAt: null,
   llmModel: null,
   sessionHarness: null,
   subAgentName: null,
@@ -1348,14 +1361,14 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       // ACTIVE conversation can wedge like this; `flushBackgroundQueues`
       // already drives every other queue off the server's own status.
       if (!sendLatchIsStranded(s)) return;
-      sendLatchedAt = null;
       // The stranded send still holds this conversation's chain link, so the
       // drain below would park on it for another SEND_CHAIN_MAX_WAIT_MS. Same
       // evidence, same conclusion: drop the link too. If that send ever does
       // settle, its `release` only clears an entry it still owns, so a fresh
       // chain started here is safe.
       sendChains.delete(s.conversationId);
-      setActive({ status: "idle" });
+      // Clear the latch on THIS conversation's entry only, alongside its status.
+      setActive({ status: "idle", sendLatchedAt: null });
     }
     // Flush the FIRST message OF THE BOUND CONVERSATION (FIFO within it), not
     // the global array head. The queue is one flat array across conversations,
@@ -1487,8 +1500,10 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     // until its own `response.completed` arrives.
     const alreadyStreaming = get().status === "streaming";
     if (!alreadyStreaming) {
-      sendLatchedAt = Date.now();
-      setActive({ status: "streaming", activeResponse: null });
+      // Latch on the SAME entry as `status`, in one patch, so they can't
+      // diverge — a new chat buffers both on root and `adoptPreSessionState`
+      // moves them onto the entry together.
+      setActive({ status: "streaming", activeResponse: null, sendLatchedAt: Date.now() });
     }
 
     // Push to `pendingUserMessages` BEFORE the POST so the bubble
@@ -1690,8 +1705,8 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     // serialization) so a skill invocation behaves like any other turn.
     const alreadyStreaming = get().status === "streaming";
     if (!alreadyStreaming) {
-      sendLatchedAt = Date.now();
-      setActive({ status: "streaming", activeResponse: null });
+      // See `send`: latch and status on one entry, in one patch.
+      setActive({ status: "streaming", activeResponse: null, sendLatchedAt: Date.now() });
     }
     // Optimistic echo of the typed command, mirroring `send`. Without it
     // the chat shows nothing until the server's `slash_command` receipt
@@ -5092,7 +5107,11 @@ export function handleSessionEvent(event: StreamEvent, streamConversationId?: st
     case "browser_action_request":
       // Embedded-browser action: fan out to the relay hook (which claims,
       // executes, posts the result). No store state; no-op without a relay.
-      emitBrowserActionRequest(event);
+      // Carry the delivering conversation so the relay claims/dispatches against
+      // the session that issued the action — a background conversation can emit
+      // one while a different conversation is on screen, and claiming at the
+      // visible session would be rejected as an owner mismatch.
+      emitBrowserActionRequest(event, sourceConversationId);
       return;
     case "session_status": {
       // Captured BEFORE the patch below adopts event.responseId, so a

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -78,6 +78,8 @@ import type {
   StreamEvent,
 } from "@/lib/events";
 import { createPresenceIdleTracker } from "@/lib/presenceIdle";
+import { conversationRegistry, type ConversationEntry } from "./conversationRegistry";
+import { createInitialConversationState, isConversationStateKey } from "./conversationState";
 import { parseEvent, parseSseStream, type SseStreamResult } from "@/lib/sse";
 import { clearSseLog, pushSseEvent } from "@/lib/sseEventLog";
 import { childSessionsQueryKey, type ChildSessionInfo } from "@/hooks/useChildSessions";
@@ -181,34 +183,6 @@ export interface QueuedMessage {
 }
 
 /**
- * A conversation's in-flight optimistic bubbles, stashed so they survive
- * in-app navigation. See {@link ChatState.pendingByConversation}.
- */
-export interface StashedPending {
-  /**
-   * This client's own optimistic bubbles (``pend_`` temp ids) whose POST
-   * has NOT settled yet — the one state the server cannot replay from
-   * ``pending_inputs`` because it hasn't been told about the message.
-   * Settled bubbles are deliberately excluded: the server owns those,
-   * and the navigate-back snapshot re-seeds them (or shows them
-   * committed).
-   */
-  messages: PendingUserMessage[];
-  /**
-   * Normalized committed user-message texts present in `blocks` at the
-   * moment these bubbles were stashed (navigate-away). On navigate-back,
-   * `bindStream` treats a committed message as the now-persisted copy of a
-   * stashed bubble ONLY when it is NEW relative to this baseline — i.e. the
-   * snapshot has MORE committed copies of that text than were here when we
-   * left. Without the baseline, an optimistic bubble whose text coincides
-   * with an OLDER message already in history would be wrongly deduped away
-   * (the "disappears then reappears" bug on a resumed/disconnected session,
-   * which always has prior history).
-   */
-  committedTexts: string[];
-}
-
-/**
  * A workspace path queued for the composer's "@"-mention chips. ``isDir``
  * marks a folder (delivered with a trailing ``/``); ``lineRange`` marks a
  * specific span of a file (delivered as ``path:start-end``), e.g. from the
@@ -232,19 +206,16 @@ export function composerAttachmentKey(a: ComposerAttachment): string {
   return `${a.path}|${a.isDir}|${a.lineRange ? `${a.lineRange.start}-${a.lineRange.end}` : ""}`;
 }
 
-export interface ChatState {
-  // Reactive — subscribed to by UI components.
-  conversationId: string | null;
-  /**
-   * Set when a live `session.superseded` event asks the client to follow
-   * the active conversation to another one (e.g. after a Claude `/clear`).
-   * `ChatPage` observes this, navigates to `/c/<id>` (replacing history so
-   * Back doesn't return to the cleared session), then clears it. Null when
-   * no redirect is pending. The store can't call react-router directly, so
-   * it hands the target to the page via this field. Live-only — a reload of
-   * the old conversation renders the persisted notice instead.
-   */
-  redirectToConversationId: string | null;
+/**
+ * State owned by a SINGLE conversation.
+ *
+ * Every field here describes one conversation: its transcript, turn
+ * lifecycle, binding, usage, and stream. Each lives on its own registry entry
+ * (see `conversationRegistry`), projected onto the root store for whichever
+ * conversation is on screen. A new field belongs here only if it still makes
+ * sense for a conversation the user is NOT looking at.
+ */
+export interface ConversationState {
   /**
    * Flat block list (history + streaming). Renderer walks this.
    *
@@ -259,34 +230,6 @@ export interface ChatState {
   blocks: AnyBlock[];
   /** User messages POSTed but not yet acked via session.input.consumed. */
   pendingUserMessages: PendingUserMessage[];
-  /**
-   * Messages submitted while the agent is busy, held client-side (not yet
-   * POSTed) and shown in the composer's queue strip. The head is flushed
-   * FIFO — one per turn — when the session goes idle. In-memory only.
-   */
-  queuedMessages: QueuedMessage[];
-  /**
-   * In-flight optimistic bubbles stashed per conversation so they survive
-   * in-app navigation (`switchTo`), keyed by conversation id.
-   *
-   * Scope: ONLY sends whose POST hasn't settled (`posted` unset). Until
-   * the POST returns, the message exists nowhere on the server — on a
-   * cold-starting runner the POST is held open for the whole ensure
-   * probe, before `pending_inputs.record()` runs — so navigating away
-   * and back in that window would otherwise drop the user's message
-   * entirely. Once the POST settles the server is the source of
-   * truth: the navigate-back snapshot re-seeds the bubble from
-   * `pending_inputs` while it's still queued, and shows it committed
-   * once the round-trip lands. Stashing a settled bubble is what made
-   * the stuck-forever pending message possible (committed while away +
-   * consumed event missed + image-only content the text dedupe can't
-   * match), so `send` prunes an entry from here the moment its POST
-   * settles. `bindStream` dedupes a restored bubble against committed
-   * messages that are NEW since the bubble was stashed (the round-trip
-   * can outrun the POST response — see
-   * {@link StashedPending.committedTexts}). Pruned to non-empty entries.
-   */
-  pendingByConversation: Record<string, StashedPending>;
   /** Lifecycle of the most recent send. `null` when idle pre-send. */
   activeResponse: ActiveResponse | null;
   /**
@@ -362,17 +305,6 @@ export interface ChatState {
   /** Error from the snapshot fetch in `switchTo`, if any. */
   conversationLoadError: Error | null;
   /**
-   * Sticky picker pick — applies to the current session via PATCH and
-   * survives navigation + reload (localStorage). ``null`` means the
-   * agent-spec default applies.
-   */
-  selectedEffort: string | null;
-  /**
-   * Same shape as ``selectedEffort`` but for the LLM model. ``null``
-   * falls back to the agent's ``llmModel``.
-   */
-  selectedModel: string | null;
-  /**
    * The active session's REAL model override (server ``model_override``):
    * what the next turn actually uses, ``null`` when none and the agent
    * ``llmModel`` default applies. Session-scoped (NOT a sticky pick):
@@ -383,6 +315,18 @@ export interface ChatState {
    * pick as an active "(override)".
    */
   sessionModelOverride: string | null;
+  /**
+   * This session's effective reasoning effort — the server's persisted
+   * ``reasoning_effort`` once hydrated, else the sticky pick applied on bind.
+   * ``null`` when the harness has no effort control or none is set.
+   *
+   * Conversation-scoped for the same reason as ``sessionModelOverride``: two
+   * live conversations can sit at different efforts, and a warm switch back
+   * re-projects this rather than re-binding. ``selectedEffort`` remains the
+   * single app-global sticky pick used for cross-session restore, so it cannot
+   * answer "what is THIS conversation at".
+   */
+  sessionReasoningEffort: string | null;
   /**
    * Per-session cost-control switch for the active session: ``"on"``
    * activates the spec's configured cost-control mode, ``"off"``
@@ -419,15 +363,6 @@ export interface ChatState {
    * fetch. `null` until the first snapshot is hydrated.
    */
   oldestItemId: string | null;
-  /** Bubble that should pulse briefly (highlight on nav jump). */
-  flashItemId: string | null;
-  /**
-   * Workspace files/folders queued to drop into the active composer's
-   * "@"-mention chips from outside the composer — e.g. the file viewer's
-   * "Attach to agent" button, which lives far from the composer in the tree.
-   * The composer drains this on change and clears it.
-   */
-  pendingComposerAttachments: ComposerAttachment[];
   /**
    * The text + attachments of a send that failed before the server took
    * ownership of it, handed back so the composer can restore them for a
@@ -582,8 +517,63 @@ export interface ChatState {
    * cursor into the new one.
    */
   historyGeneration: number;
+}
 
-  // Actions.
+/**
+ * State that belongs to the APP, not to any one conversation.
+ *
+ * Sticky picker prefs span sessions; the rest describe the single active
+ * view (which conversation is on screen, what its composer is holding).
+ * These stay on the root store when per-conversation state moves out.
+ */
+export interface AppChatState {
+  /** The conversation currently on screen. `null` on `/`. */
+  conversationId: string | null;
+  /**
+   * Set when a live `session.superseded` event asks the client to follow
+   * the active conversation to another one (e.g. after a Claude `/clear`).
+   * `ChatPage` observes this, navigates to `/c/<id>` (replacing history so
+   * Back doesn't return to the cleared session), then clears it. Null when
+   * no redirect is pending. The store can't call react-router directly, so
+   * it hands the target to the page via this field. Live-only — a reload of
+   * the old conversation renders the persisted notice instead.
+   */
+  redirectToConversationId: string | null;
+  /**
+   * Messages submitted while the agent is busy, held client-side (not yet
+   * POSTed) and shown in the composer's queue strip. The head is flushed
+   * FIFO — one per turn — when the session goes idle. In-memory only.
+   *
+   * One flat array across ALL conversations (each entry carries its
+   * `conversationId`), so it is app-global rather than per-conversation:
+   * `flushBackgroundQueues` drains conversations the user has navigated
+   * away from.
+   */
+  queuedMessages: QueuedMessage[];
+  /**
+   * Sticky picker pick — applies to the current session via PATCH and
+   * survives navigation + reload (localStorage). ``null`` means the
+   * agent-spec default applies.
+   */
+  selectedEffort: string | null;
+  /**
+   * Same shape as ``selectedEffort`` but for the LLM model. ``null``
+   * falls back to the agent's ``llmModel``.
+   */
+  selectedModel: string | null;
+  /** Bubble that should pulse briefly (highlight on nav jump). */
+  flashItemId: string | null;
+  /**
+   * Workspace files/folders queued to drop into the active composer's
+   * "@"-mention chips from outside the composer — e.g. the file viewer's
+   * "Attach to agent" button, which lives far from the composer in the tree.
+   * The composer drains this on change and clears it.
+   */
+  pendingComposerAttachments: ComposerAttachment[];
+}
+
+/** Actions exposed on the root store. */
+export interface ChatActions {
   send: (text: string, agentId: string, files?: File[], opts?: SendOptions) => Promise<void>;
   /**
    * Queue a message client-side instead of POSTing it now, for a send made
@@ -734,21 +724,37 @@ export interface ChatState {
   refreshSessionState: (conversationId?: string) => Promise<void>;
 }
 
+/**
+ * The root store's shape: the active conversation's state, flattened
+ * alongside app-global state and the actions.
+ *
+ * The `ConversationState` half is a projection of whichever conversation is
+ * active. Reading it is how components stay agnostic about that; writing it
+ * is how the single active conversation is driven today.
+ */
+export interface ChatState extends ConversationState, AppChatState, ChatActions {}
+
 let queryClient: QueryClient | null = null;
+
+/**
+ * Evict a conversation from the live registry.
+ *
+ * Called when a conversation is deleted: its entry must stop pumping and let go
+ * of its stream.
+ */
+export function releaseConversation(id: string): void {
+  conversationRegistry.release(id);
+}
 
 // Catalogs that resolved while their bind snapshot was still hydrating.
 const racedNativeModelOptions = new Map<string, NativeModelOption[]>();
 let pendingSeq = 0;
 let queueSeq = 0;
-// Tail of each conversation's send chain. A send waits on the previous send
-// TO THE SAME CONVERSATION before issuing its own POST, so rapid-fire messages
-// reach the server in submission order. Concurrent `fetch` POSTs have no
-// ordering guarantee, which otherwise lets the server accept messages out of
-// order. Keyed by the conversation pinned at submit time; `null` is the
-// not-yet-created session, of which a tab can only have one in flight. Order
-// only means anything WITHIN a conversation, so keying per conversation stops
-// a stalled POST in one from delaying every other conversation in the tab.
-const sendChains = new Map<string | null, Promise<void>>();
+// When a send last latched local `status` to "streaming". Stamped on the way in
+// and never cleared on the way out: after a normal turn `status` settles to
+// "idle" on its own, so a leftover value is inert — only a `status` still
+// reading "streaming" long afterwards makes it meaningful.
+let sendLatchedAt: number | null = null;
 
 // A chain link must never be able to deadlock its successors. `postEvent`
 // issues its fetch with no timeout, so a connection that dies mid-flight never
@@ -760,12 +766,6 @@ const sendChains = new Map<string | null, Promise<void>>();
 // which take minutes — so this only ever fires on a send that is truly stuck,
 // never reordering a slow one.
 const SEND_CHAIN_MAX_WAIT_MS = 180_000;
-
-// When a send last latched local `status` to "streaming". Stamped on the way in
-// and never cleared on the way out: after a normal turn `status` settles to
-// "idle" on its own, so a leftover value is inert — only a `status` still
-// reading "streaming" long afterwards makes it meaningful.
-let sendLatchedAt: number | null = null;
 
 /**
  * Read one conversation's server-side status from the sidebar cache.
@@ -809,30 +809,71 @@ function sendLatchIsStranded(s: ChatState): boolean {
   return s.conversationId !== null && cachedConversationStatus(s.conversationId) === "idle";
 }
 
+// One send chain per conversation, keyed by conversation id. A `send` waits on
+// the previous send TO THE SAME CONVERSATION before issuing its POST, so
+// rapid-fire messages reach the server in submission order (concurrent `fetch`
+// POSTs have no ordering guarantee). Per conversation, not global: ordering is
+// only meaningful within a session, and a shared chain lets a stalled send to
+// one conversation delay an unrelated one. Chains only ever resolve, never
+// reject.
+//
+// The chain is a mutable box rather than a bare promise so a new chat's chain
+// can be RE-KEYED as one unit. Its `tail` is whatever the most recent entrant
+// is waiting to release, so migrating the box carries every already-queued
+// follower with it; replacing a bare promise under the new key would strand
+// them behind the wrong link. See `enterSendChain`.
+interface SendChain {
+  tail: Promise<void>;
+}
+const sendChains = new Map<string | symbol, SendChain>();
+
+// Sends with no conversation id yet (brand-new chat) serialize together: the
+// session is created inside the chained work, so they can't key by id. A
+// non-string key can never collide with a conversation id.
+const NEW_SESSION_SEND_CHAIN_KEY = Symbol("new-session");
+
 /**
- * Take this send's place in its conversation's POST-ordering chain.
+ * Take a slot in a conversation's send chain.
  *
- * @param conversationId - Conversation pinned at submit time (`null` for a
- *   session the send is about to create).
- * @returns `waitForPrior`, awaited before any network work, and `release`,
- *   which MUST be called from a `finally` to hand off to the next send.
+ * :param conversationId: Conversation to serialize against, or ``null`` for a
+ *     send whose session doesn't exist yet (a brand-new chat). Null callers
+ *     share one chain, which is what orders the create-then-post race.
+ * :returns: ``waitForPrior`` (a bounded wait on the prior send), ``rekey`` to
+ *     call once a new chat's real session id is known, and ``releaseSend`` to
+ *     call after the work settles (in a ``finally``).
  */
-function takeSendChainLink(conversationId: string | null): {
+function enterSendChain(conversationId: string | null): {
   waitForPrior: () => Promise<void>;
-  release: () => void;
+  rekey: (resolvedConversationId: string) => void;
+  releaseSend: () => void;
 } {
-  const prior = sendChains.get(conversationId) ?? Promise.resolve();
-  let resolveLink: () => void = () => {};
-  const link = new Promise<void>((resolve) => {
-    resolveLink = resolve;
+  const key: string | symbol = conversationId ?? NEW_SESSION_SEND_CHAIN_KEY;
+  let chain = sendChains.get(key);
+  if (chain === undefined) {
+    chain = { tail: Promise.resolve() };
+    sendChains.set(key, chain);
+  }
+  const priorSend = chain.tail;
+  let releaseSend: () => void = () => {};
+  const slot = new Promise<void>((resolve) => {
+    releaseSend = resolve;
   });
-  sendChains.set(conversationId, link);
+  // Everything entering after us waits on our slot, so the chain stays a strict
+  // FIFO of submission order.
+  chain.tail = slot;
+  // Captured, not re-read: `rekey` may move this chain to another key, and our
+  // release must still find the box we actually queued on.
+  const ownChain = chain;
   return {
     waitForPrior: async () => {
+      // Bounded so a stalled send can't deadlock its successors: `postEvent`
+      // has no timeout, so a POST whose connection dies never settles and its
+      // link never releases. Past SEND_CHAIN_MAX_WAIT_MS the successor proceeds
+      // anyway — only ordering degrades, versus a composer that queues forever.
       let timer: ReturnType<typeof setTimeout> | undefined;
       try {
         await Promise.race([
-          prior,
+          priorSend,
           new Promise<void>((resolve) => {
             timer = setTimeout(resolve, SEND_CHAIN_MAX_WAIT_MS);
           }),
@@ -841,12 +882,46 @@ function takeSendChainLink(conversationId: string | null): {
         if (timer !== undefined) clearTimeout(timer);
       }
     },
-    release: () => {
-      resolveLink();
-      // Drop the bucket once this link is still the tail, so the map doesn't
-      // accumulate an entry per conversation the user ever sends to. A
-      // successor that already took a link owns the tail, so this no-ops.
-      if (sendChains.get(conversationId) === link) sendChains.delete(conversationId);
+    rekey: (resolvedConversationId) => {
+      // A brand-new chat's id exists only after `createSession`, so this chain
+      // starts under the new-session key. `ensureBoundSession` then publishes
+      // that id to the store and awaits its bind — a send issued in that window
+      // resolves the real id, and would find an empty chain and overtake us.
+      //
+      // So this MUST run while the id is still private to the creating call:
+      // `ensureBoundSession` invokes it via `onSessionResolved`, immediately
+      // after `createSession` and before anything publishes the id.
+      //
+      // The WHOLE chain moves, not just this send's slot: followers that queued
+      // under the new-session key are already waiting on `ownChain.tail`, so
+      // re-pointing the box preserves their order behind us. Installing a bare
+      // slot at the new key instead would let a send arriving after the id is
+      // published wait on US rather than on the true tail, and the two would
+      // then POST concurrently and could arrive out of order.
+      if (sendChains.get(resolvedConversationId) === ownChain) return;
+      // A pre-existing chain under the real id can't happen (the id was just
+      // minted), but if it somehow did, splice ours behind it rather than
+      // dropping its queued sends on the floor.
+      const existing = sendChains.get(resolvedConversationId);
+      if (existing !== undefined && existing !== ownChain) {
+        const priorTail = existing.tail;
+        ownChain.tail = priorTail.then(() => ownChain.tail);
+      }
+      if (sendChains.get(NEW_SESSION_SEND_CHAIN_KEY) === ownChain) {
+        sendChains.delete(NEW_SESSION_SEND_CHAIN_KEY);
+      }
+      sendChains.set(resolvedConversationId, ownChain);
+    },
+    releaseSend: () => {
+      // Drop the chain when nothing is queued behind us — our slot is still its
+      // tail — so the map can't grow without bound across a long session's
+      // conversations. A follower would have replaced `tail`, and must keep it.
+      if (ownChain.tail === slot) {
+        for (const [k, v] of sendChains) {
+          if (v === ownChain) sendChains.delete(k);
+        }
+      }
+      releaseSend();
     },
   };
 }
@@ -947,6 +1022,42 @@ function savePickerPref(key: string, value: string | null): void {
   }
 }
 
+// Bumped by every explicit model pick, so a PATCH that resolves out of order can
+// tell whether its canonicalization is still the newest choice. A conversation-id
+// check is not enough: the user can pick in A, switch to B and pick again, then
+// have A's slower PATCH land last — and two reordered picks WITHIN one
+// conversation share an id. Only the newest pick may settle the sticky pref.
+let modelPickRevision = 0;
+
+/**
+ * Make `id` the live, active conversation and return setters bound to its entry.
+ *
+ * Test-only seam. Production reaches this state through `switchTo` /
+ * `ensureBoundSession`, which also bind a stream and fetch a snapshot; tests
+ * usually want the state without the network. Seeding through the root store
+ * instead would write to the projection, which the next mirror overwrites.
+ *
+ * :param id: conversation to bind, or ``null`` for the landing route.
+ * :param state: optional initial conversation state.
+ * :returns: the entry's `(set, get)` pair, for driving `startStreamPump` and
+ *     friends the way production does.
+ */
+export function bindConversationForTest(
+  id: string | null,
+  state?: Partial<ConversationState>,
+): { set: Setter; get: Getter } {
+  useChatStore.setState({ conversationId: id });
+  conversationRegistry.setActive(id);
+  if (id === null) {
+    useChatStore.setState(createInitialConversationState() as Partial<ChatState>);
+    return { set: setActive, get: () => useChatStore.getState() };
+  }
+  const entry = conversationRegistry.acquire(id);
+  if (state !== undefined) entry.setState(state);
+  mirrorActiveEntry();
+  return { set: entrySetter(entry), get: entryGetter(entry) };
+}
+
 /**
  * Initialize the store with the app's QueryClient. Called once at app
  * boot from `main.tsx`. Without this the store can't fetch items
@@ -960,6 +1071,9 @@ export function initChatStore(client: QueryClient): void {
   workspaceInvalidationTimers.clear();
   backgroundFlushInFlight.clear();
   backgroundFlushCooldownUntil.clear();
+  // Drop every live conversation: their streams must not outlive the app (or,
+  // in tests, leak into the next case).
+  conversationRegistry.clear();
   // Reset the POST-ordering chains so a prior run's unresolved send can't block
   // the next one (production calls this once at boot; tests call it per case).
   sendChains.clear();
@@ -1067,13 +1181,12 @@ export function consumePendingInitialPrompt(conversationId: string): PendingInit
   return prompt;
 }
 
-export const useChatStore = create<ChatState>((set, get) => ({
+export const useChatStore = create<ChatState>((_rootSet, get) => ({
   conversationId: null,
   redirectToConversationId: null,
   blocks: [],
   pendingUserMessages: [],
   queuedMessages: [],
-  pendingByConversation: {},
   activeResponse: null,
   interruptedResponseIds: [],
   status: "idle",
@@ -1089,6 +1202,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   selectedEffort: loadPickerPref(PICKER_PREF_EFFORT_KEY),
   selectedModel: loadPickerPref(PICKER_PREF_MODEL_KEY),
   sessionModelOverride: null,
+  sessionReasoningEffort: null,
   costControlModeOverride: null,
   subagentRoutingOverride: null,
   codexPlanMode: false,
@@ -1122,7 +1236,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     if (conversationId === null) return;
     queueSeq += 1;
     const queueId = `q_${queueSeq}`;
-    set((s) => ({
+    setActive((s) => ({
       queuedMessages: [
         ...s.queuedMessages,
         {
@@ -1141,13 +1255,13 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   dequeueMessage: (queueId) => {
-    set((s) => ({
+    setActive((s) => ({
       queuedMessages: s.queuedMessages.filter((m) => m.queueId !== queueId),
     }));
   },
 
   reorderQueuedMessage: (queueId, beforeQueueId) => {
-    set((s) => {
+    setActive((s) => {
       const moved = s.queuedMessages.find((m) => m.queueId === queueId);
       if (moved === undefined || queueId === beforeQueueId) return {};
       const conversationId = moved.conversationId;
@@ -1181,12 +1295,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const agentId = target?.agentId ?? s.boundAgentId;
     if (target === undefined || agentId === null) return;
     // Remove BEFORE the POST so a concurrent flush can't also send it.
-    set({ queuedMessages: s.queuedMessages.filter((m) => m.queueId !== queueId) });
+    setActive({ queuedMessages: s.queuedMessages.filter((m) => m.queueId !== queueId) });
     void s.send(target.text, agentId, target.files);
   },
 
   clearQueuedMessages: (conversationId) => {
-    set((s) => {
+    setActive((s) => {
       if (!s.queuedMessages.some((m) => m.conversationId === conversationId)) return {};
       return {
         queuedMessages: s.queuedMessages.filter((m) => m.conversationId !== conversationId),
@@ -1219,7 +1333,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // settle, its `release` only clears an entry it still owns, so a fresh
       // chain started here is safe.
       sendChains.delete(s.conversationId);
-      set({ status: "idle" });
+      setActive({ status: "idle" });
     }
     // Flush the FIRST message OF THE BOUND CONVERSATION (FIFO within it), not
     // the global array head. The queue is one flat array across conversations,
@@ -1228,7 +1342,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const head = s.queuedMessages.find((m) => m.conversationId === s.conversationId);
     if (head === undefined) return;
     // Remove it BEFORE the POST so a re-entrant flush can't double-send.
-    set({ queuedMessages: s.queuedMessages.filter((m) => m.queueId !== head.queueId) });
+    setActive({ queuedMessages: s.queuedMessages.filter((m) => m.queueId !== head.queueId) });
     void s.send(head.text, head.agentId ?? s.boundAgentId, head.files);
   },
 
@@ -1277,17 +1391,18 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
       // Remove BEFORE the work starts so a re-entrant trigger can't double-send.
       backgroundFlushInFlight.add(conversationId);
-      set((st) => ({
+      setActive((st) => ({
         queuedMessages: st.queuedMessages.filter((m) => m.queueId !== head.queueId),
       }));
-      // Join the SAME send chain the foreground path uses. A queued message can
-      // hand off from the foreground flush (send() → sendChains) to here the
-      // moment the user navigates away, and the two POST paths would otherwise
-      // race — a background postEvent could overtake a foreground send() still
-      // awaiting its chain slot, delivering out of FIFO order. Both paths take
-      // a slot on THIS conversation's chain (wait before the upload/post,
-      // release in finally), so they share one ordering primitive per session.
-      const { waitForPrior, release: releaseSend } = takeSendChainLink(conversationId);
+      // Join the SAME send chain the foreground path uses for this
+      // conversation. A queued message can hand off from the foreground flush
+      // (send() → its chain) to here the moment the user navigates away, and
+      // the two POST paths would otherwise race — a background postEvent could
+      // overtake a foreground send() still awaiting its chain slot, delivering
+      // out of FIFO order. Taking a slot here (wait before the upload/post,
+      // release in finally) serializes every POST to this conversation across
+      // both paths through one ordering primitive.
+      const { waitForPrior, releaseSend } = enterSendChain(conversationId);
       // Upload any attachments, then post the message referencing their
       // server-assigned file_ids — the same two-phase sequence send() runs
       // (no combined endpoint exists: /resources/files stores the blob and
@@ -1318,7 +1433,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
             conversationId,
             Date.now() + BACKGROUND_FLUSH_COOLDOWN_MS,
           );
-          set((st) => {
+          setActive((st) => {
             const idx = st.queuedMessages.findIndex((m) => m.conversationId === conversationId);
             const at = idx === -1 ? st.queuedMessages.length : idx;
             return {
@@ -1351,7 +1466,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const alreadyStreaming = get().status === "streaming";
     if (!alreadyStreaming) {
       sendLatchedAt = Date.now();
-      set({ status: "streaming", activeResponse: null });
+      setActive({ status: "streaming", activeResponse: null });
     }
 
     // Push to `pendingUserMessages` BEFORE the POST so the bubble
@@ -1373,7 +1488,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       ...(text.trim() ? [{ type: "input_text" as const, text }] : []),
     ];
     const selfAuthor = getCurrentAuthorId();
-    set((s) => ({
+    setActive((s) => ({
       pendingUserMessages: [
         ...s.pendingUserMessages,
         { tempId, content, ...(selfAuthor !== null ? { author: selfAuthor } : {}) },
@@ -1392,11 +1507,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
     // target afterward would leak the message into the now-active session.
     const submitConversationId = get().conversationId;
 
-    // Take our place in this conversation's send chain: wait for its prior
+    // Take our place in THIS conversation's send chain: wait for its prior
     // send's network work, then hand off to the next via `releaseSend` in the
     // finally below. This serializes POSTs in submission order without delaying
-    // the optimistic bubble rendered above.
-    const { waitForPrior, release: releaseSend } = takeSendChainLink(submitConversationId);
+    // the optimistic bubble rendered above. The wait is bounded (see
+    // `enterSendChain`), so a stalled prior send can't queue this one forever.
+    const { waitForPrior, rekey, releaseSend } = enterSendChain(submitConversationId);
 
     // The session this send actually posts to, once resolved. Read in the
     // catch to decide whether a failure may touch the active session's UI.
@@ -1404,7 +1520,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
     try {
       await waitForPrior();
-      const sessionId = await ensureBoundSession(agentId, set, get, opts, submitConversationId);
+      // `rekey` runs INSIDE the call, the moment `createSession` returns and
+      // before the new id is published — a send issued during the bind would
+      // otherwise resolve that id, find an empty chain, and overtake this POST.
+      const sessionId = await ensureBoundSession(agentId, get, opts, submitConversationId, rekey);
       postedSessionId = sessionId;
 
       // Upload any attached files and build the real content blocks with
@@ -1422,8 +1541,13 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // session.input.consumed is text-only (transcript round-trip
       // drops input_image blocks), so the consumed handler falls back
       // to the pending file blocks — they must already carry real ids.
+      //
+      // Targets the session this send posted to, not the visible one: the
+      // upload can outlive a switch away, and leaving the bubble on
+      // `pending:<filename>` ids means the consumed fallback commits those
+      // placeholders as if they were real attachments.
       if (fileBlocks.length > 0) {
-        set((s) => ({
+        setterFor(sessionId)((s) => ({
           pendingUserMessages: s.pendingUserMessages.map((p) =>
             p.tempId === tempId ? { ...p, content: serverContent } : p,
           ),
@@ -1443,19 +1567,13 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // bubble. Settle local state from the POST response instead of
       // depending on the live stream being connected.
       if (postResult.denied) {
-        set((s) => {
-          // The stash copy rolls back even when the user has navigated
-          // away — that's exactly when the entry lives there, and a
-          // denied send has no server-side record to ever reconcile it.
+        // Target the session this send posted to: the user may have navigated
+        // away while the POST was open, and settling the VISIBLE conversation
+        // would clobber an unrelated chat's composer state.
+        setterFor(sessionId)((s) => {
           const patch: Partial<ChatState> = {
-            pendingByConversation: removeFromPendingStash(
-              s.pendingByConversation,
-              sessionId,
-              tempId,
-            ),
+            pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
           };
-          if (s.conversationId !== sessionId) return patch;
-          patch.pendingUserMessages = s.pendingUserMessages.filter((p) => p.tempId !== tempId);
           if (!alreadyStreaming) {
             patch.status = "idle";
             patch.sessionStatus = "idle";
@@ -1465,18 +1583,15 @@ export const useChatStore = create<ChatState>((set, get) => ({
         });
       } else {
         // POST accepted: the server can now account for this message
-        // (native: pending_inputs replay until the round-trip commits
-        // it; non-native: already persisted). Mark the live bubble
-        // settled and drop any stash copy so navigation defers to the
-        // server instead of resurrecting a client copy the server may
-        // have since resolved — the stuck-pending-bubble bug. The live
-        // bubble itself keeps rendering until its consumed event pops
-        // it; only the navigation-survival policy changes here.
-        set((s) => ({
+        // (native: pending_inputs replay until the round-trip commits it;
+        // non-native: already persisted). Mark the bubble settled — that is
+        // what releases this conversation's entry for eviction, since the
+        // server can now replay it. The bubble keeps rendering until its
+        // consumed event pops it.
+        setterFor(sessionId)((s) => ({
           pendingUserMessages: s.pendingUserMessages.map((p) =>
             p.tempId === tempId ? { ...p, posted: true } : p,
           ),
-          pendingByConversation: removeFromPendingStash(s.pendingByConversation, sessionId, tempId),
         }));
       }
       // Note: native-terminal messages return a `pending_id`, but the
@@ -1492,64 +1607,51 @@ export const useChatStore = create<ChatState>((set, get) => ({
       queryClient?.invalidateQueries({ queryKey: ["conversations"] });
     } catch (err) {
       const { message, code } = describeSendFailure(err);
-      // The stash copy rolls back unconditionally: a failed send has no
-      // server-side record, so a bubble stashed by a mid-POST
-      // navigate-away would otherwise strand as forever-pending on
-      // navigate-back (nothing can ever reconcile it).
-      const stashSessionId = postedSessionId ?? submitConversationId;
-      if (stashSessionId !== null) {
-        set((s) => ({
-          pendingByConversation: removeFromPendingStash(
-            s.pendingByConversation,
-            stashSessionId,
-            tempId,
-          ),
-        }));
-        // Hand the message back to the composer so the user can retry it.
-        // Nothing else holds it at this point: the optimistic bubble is about
-        // to roll back, and a first message carried in from the landing screen
-        // has already had its draft cleared and its pending prompt consumed.
-        // Keyed by session so it restores into the one it was meant for even
-        // if the user navigated away while the send was in flight.
-        if (text.trim() !== "" || (files?.length ?? 0) > 0) {
-          set({
-            failedSendDraft: { conversationId: stashSessionId, text, files: files ?? [] },
-          });
-        }
+      // Hand the failed message back to the composer so the user can retry it —
+      // a failed send has no server-side record, so nothing else would restore
+      // it. Keyed by the session it was meant for, so it lands in the right
+      // composer even after a switch away. Written to that conversation's entry
+      // (`failedSendDraft` is conversation-scoped); the composer reads whichever
+      // conversation is active and guards on the id before restoring.
+      const draftSessionId = postedSessionId ?? submitConversationId;
+      if (draftSessionId !== null && (text.trim() !== "" || (files?.length ?? 0) > 0)) {
+        setterFor(draftSessionId)({
+          failedSendDraft: { conversationId: draftSessionId, text, files: files ?? [] },
+        });
       }
-      // A queued send can target a session the user has since switched away
-      // from (submit-time pin). Only roll back the bubble and settle status
-      // when that session is still active — otherwise the failure would
-      // clobber the now-active session's UI. When the throw came from
-      // session setup itself (postedSessionId never resolved), settle
-      // unconditionally: that failure belongs to the active context.
-      if (postedSessionId === null || get().conversationId === postedSessionId) {
-        // Roll back the optimistic bubble — no server idle will fire.
-        set((s) => ({
-          pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
-        }));
-        if (!alreadyStreaming) {
-          if (get().activeResponse !== null) {
-            // A response bubble already exists (the turn started, then failed)
-            // — mark it failed so the error rides on that bubble.
-            finalizeActive(set, "failed", message, null);
-          } else {
-            // No response bubble to carry the failure — the turn never started
-            // (e.g. the runner never came online, so POST /events 503'd). Append
-            // a standalone error block so the user sees WHY nothing happened
-            // instead of being left on a silent, empty composer.
-            set((s) => ({ blocks: [...s.blocks, makeClientErrorBlock(message, code)] }));
-          }
-          set({ status: "idle", sessionStatus: "idle", backgroundTaskCount: 0, blockedOn: null });
+      // Settle the conversation this send targeted, wherever the user is now:
+      // its bubble must roll back and its status must not stay "streaming"
+      // forever. When the throw came from session setup itself
+      // (`postedSessionId` never resolved) there is no target conversation, so
+      // it belongs to the active one — the landing composer's own failure.
+      const failSet = postedSessionId === null ? setActive : setterFor(postedSessionId);
+      const failGet = (): ChatState =>
+        postedSessionId === null ? get() : (setterForState(postedSessionId) ?? get());
+      // Roll back the optimistic bubble — no server idle will fire.
+      failSet((s) => ({
+        pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
+      }));
+      if (!alreadyStreaming) {
+        if (failGet().activeResponse !== null) {
+          // A response bubble already exists (the turn started, then failed)
+          // — mark it failed so the error rides on that bubble.
+          finalizeActive(failSet, "failed", message, null);
         } else {
-          // Sent alongside an already-streaming turn (or a stranded latch). The
-          // bubble is rolled back above, so without a block the message vanishes
-          // with no trace — the failure mode that makes this class of bug so
-          // hard to see. Surface it WITHOUT touching the turn lifecycle:
-          // `finalizeActive` would mark a live response failed, and settling
-          // `status` would end a turn that is still running.
-          set((s) => ({ blocks: [...s.blocks, makeClientErrorBlock(message, code)] }));
+          // No response bubble to carry the failure — the turn never started
+          // (e.g. the runner never came online, so POST /events 503'd). Append
+          // a standalone error block so the user sees WHY nothing happened
+          // instead of being left on a silent, empty composer.
+          failSet((s) => ({ blocks: [...s.blocks, makeClientErrorBlock(message, code)] }));
         }
+        failSet({ status: "idle", sessionStatus: "idle", backgroundTaskCount: 0 });
+      } else {
+        // Sent alongside an already-streaming turn (or a stranded latch): the
+        // bubble is rolled back above, so without a block the message vanishes
+        // with no trace — the failure mode that makes this class of bug so hard
+        // to see. Surface it WITHOUT touching the turn lifecycle: finalizeActive
+        // would fail a live response, and settling status would end a turn that
+        // is still running.
+        failSet((s) => ({ blocks: [...s.blocks, makeClientErrorBlock(message, code)] }));
       }
     } finally {
       // Release the next queued send regardless of success/failure so one
@@ -1567,7 +1669,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const alreadyStreaming = get().status === "streaming";
     if (!alreadyStreaming) {
       sendLatchedAt = Date.now();
-      set({ status: "streaming", activeResponse: null });
+      setActive({ status: "streaming", activeResponse: null });
     }
     // Optimistic echo of the typed command, mirroring `send`. Without it
     // the chat shows nothing until the server's `slash_command` receipt
@@ -1581,7 +1683,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const tempId = `pend_${pendingSeq}`;
     const commandText = args ? `/${name} ${args}` : `/${name}`;
     const selfAuthor = getCurrentAuthorId();
-    set((s) => ({
+    setActive((s) => ({
       pendingUserMessages: [
         ...s.pendingUserMessages,
         {
@@ -1596,14 +1698,15 @@ export const useChatStore = create<ChatState>((set, get) => ({
     // resolve mis-routes to the session the user has since switched to.
     const submitConversationId = get().conversationId;
 
-    const { waitForPrior, release: releaseSend } = takeSendChainLink(submitConversationId);
+    const { waitForPrior, rekey, releaseSend } = enterSendChain(submitConversationId);
 
     // The session this command actually posts to, once resolved.
     let postedSessionId: string | null = null;
 
     try {
       await waitForPrior();
-      const sessionId = await ensureBoundSession(agentId, set, get, opts, submitConversationId);
+      // See `send`: rekey inside the call, before the new id is visible.
+      const sessionId = await ensureBoundSession(agentId, get, opts, submitConversationId, rekey);
       postedSessionId = sessionId;
       // Same wire shape the REPL sends (repl/_repl.py). The server resolves
       // the skill, persists a visible receipt + hidden `<skill>` meta
@@ -1614,19 +1717,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
       });
       if (postResult.denied) {
         // Denied commands publish no receipt, so nothing will pop the
-        // optimistic echo — roll it back here alongside the status
-        // settle. The stash copy rolls back even when the user has
-        // navigated away (that's when the entry lives there).
-        set((s) => {
+        // optimistic echo — roll it back here alongside the status settle.
+        // Targets the session the command posted to: a backgrounded
+        // conversation must still roll its echo back, and settling the VISIBLE
+        // one would clobber an unrelated chat.
+        setterFor(sessionId)((s) => {
           const patch: Partial<ChatState> = {
-            pendingByConversation: removeFromPendingStash(
-              s.pendingByConversation,
-              sessionId,
-              tempId,
-            ),
+            pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
           };
-          if (s.conversationId !== sessionId) return patch;
-          patch.pendingUserMessages = s.pendingUserMessages.filter((p) => p.tempId !== tempId);
           if (!alreadyStreaming) {
             patch.status = "idle";
             patch.sessionStatus = "idle";
@@ -1641,48 +1739,33 @@ export const useChatStore = create<ChatState>((set, get) => ({
         // mid-POST navigate-away strands forever: the receipt is a
         // SlashCommandBlock, not a user message, so the navigate-back
         // text dedupe can never match it, and no consumed event fires.
-        set((s) => ({
+        setterFor(sessionId)((s) => ({
           pendingUserMessages: s.pendingUserMessages.map((p) =>
             p.tempId === tempId ? { ...p, posted: true } : p,
           ),
-          pendingByConversation: removeFromPendingStash(s.pendingByConversation, sessionId, tempId),
         }));
       }
       queryClient?.invalidateQueries({ queryKey: ["conversations"] });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      // The stash copy rolls back unconditionally — a failed command has
-      // no server-side record to ever reconcile a stashed echo.
-      const stashSessionId = postedSessionId ?? submitConversationId;
-      if (stashSessionId !== null) {
-        set((s) => ({
-          pendingByConversation: removeFromPendingStash(
-            s.pendingByConversation,
-            stashSessionId,
-            tempId,
-          ),
-        }));
-      }
-      // Only settle status when the failed command's session is still active
-      // — a queued send can target a session the user switched away from, and
-      // its failure must not reset the now-active session's UI. A throw from
-      // session setup itself (postedSessionId unresolved) settles the active
-      // context as before.
-      const stillActive = postedSessionId === null || get().conversationId === postedSessionId;
-      if (stillActive) {
-        // Roll back the optimistic echo — no receipt will reconcile it.
-        set((s) => ({
-          pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
-        }));
-      }
-      if (stillActive && !alreadyStreaming) {
-        finalizeActive(set, "failed", message, null);
-        set({ status: "idle" });
-      } else if (stillActive) {
-        // Same reasoning as `send`: surface the failure without settling a turn
-        // that may still be live, so a failed command can't vanish silently.
+      // Settle the conversation this command targeted, wherever the user is
+      // now: its echo must roll back and its status must not stay "streaming"
+      // forever. A throw from session setup itself (`postedSessionId` never
+      // resolved) has no target conversation, so it belongs to the active one —
+      // the landing composer's own failure. Mirrors `send`'s catch.
+      const failSet = postedSessionId === null ? setActive : setterFor(postedSessionId);
+      // Roll back the optimistic echo — no receipt will reconcile it.
+      failSet((s) => ({
+        pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
+      }));
+      if (!alreadyStreaming) {
+        finalizeActive(failSet, "failed", message, null);
+        failSet({ status: "idle" });
+      } else {
+        // Same as `send`: surface the failure without settling a turn that may
+        // still be live, so a failed command can't vanish silently.
         const { code } = describeSendFailure(err);
-        set((s) => ({ blocks: [...s.blocks, makeClientErrorBlock(message, code)] }));
+        failSet((s) => ({ blocks: [...s.blocks, makeClientErrorBlock(message, code)] }));
       }
     } finally {
       releaseSend();
@@ -1703,7 +1786,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // user's cancel won't reach the server, but the local UI already
       // reflects the user's stop request below.
     });
-    set((s) => {
+    setActive((s) => {
       if (s.conversationId !== sessionId) return {};
       const patch: Partial<ChatState> = {
         pendingUserMessages: [],
@@ -1740,118 +1823,75 @@ export const useChatStore = create<ChatState>((set, get) => ({
   switchTo: async (conversationId) => {
     if (get().conversationId === conversationId) return;
 
-    // Abort the prior session's stream. The reader loop in
-    // bindStream's pump unwinds via AbortError and stops applying
-    // events to state.blocks.
-    get().abortController?.abort();
+    // Whether this conversation is already live AND current decides everything
+    // below, so read it before anything can create the entry. A retained entry
+    // whose stream died (terminal status, failed bind) is deliberately NOT
+    // treated as live: it must cold-bind again or it stays stale forever.
+    const wasLive = conversationId !== null && isConversationStreamCurrent(conversationId);
 
-    set((s) => {
-      // Stash the OUTGOING conversation's still-in-flight optimistic
-      // bubbles and restore the INCOMING one's. Until a send's POST
-      // settles, the message exists nowhere on the server (a
-      // cold-starting runner holds the POST open before
-      // pending_inputs.record() runs), so wiping pendingUserMessages
-      // here (as a cold load must) would drop the user's message
-      // entirely on navigate-away. The stash bridges exactly
-      // that window and nothing more. Pruned to non-empty so the map
-      // doesn't accrete stale keys; a restored bubble is reconciled
-      // against the server snapshot in bindStream.
-      let pendingByConversation = { ...s.pendingByConversation };
-      if (s.conversationId !== null) {
-        // Stash only THIS client's own UNSETTLED bubbles — client temp
-        // ids (`pend_<n>`, set by send) whose POST hasn't returned.
-        // Everything else is server-owned and re-seeded by the
-        // navigate-back snapshot: snapshot-replayed / foreign bubbles
-        // (server `pending_<hex>` ids) come back via pending_inputs, and
-        // settled own sends (`posted`) come back via pending_inputs while
-        // queued or as committed items once their round-trip lands.
-        // Stashing a settled bubble is what stranded image-only messages
-        // forever (committed while away + consumed event missed → no
-        // pending_inputs entry left, no text for the dedupe to match).
-        const own = s.pendingUserMessages.filter(
-          (p) => p.tempId.startsWith("pend_") && p.posted !== true,
-        );
-        if (own.length > 0) {
-          // Capture the committed user texts present NOW as the dedup
-          // baseline: on navigate-back only committed messages new since this
-          // moment count as the persisted copy of a stashed bubble (see
-          // StashedPending.committedTexts).
-          pendingByConversation[s.conversationId] = {
-            messages: own,
-            committedTexts: committedUserTextsOf(s.blocks),
-          };
-        } else {
-          const { [s.conversationId]: _removedStash, ...remainingStashes } = pendingByConversation;
-          pendingByConversation = remainingStashes;
-        }
-      }
-      return {
-        pendingByConversation,
-        conversationId,
-        // Clear any pending supersession redirect: we've now switched
-        // sessions, so a leftover target (e.g. already consumed by the
-        // navigate that brought us here) must not fire again.
-        redirectToConversationId: null,
-        // Cleared here, so a different session's in-flight preview blocks
-        // (``live:*``) never bleed across.
-        blocks: [],
-        pendingUserMessages:
-          conversationId !== null ? (pendingByConversation[conversationId]?.messages ?? []) : [],
-        activeResponse: null,
-        interruptedResponseIds: [],
-        status: "idle",
-        sessionStatus: "idle",
-        backgroundTaskCount: 0,
-        blockedOn: null,
-        isNativeTerminalSession: false,
-        nativeVendorOwnsModel: false,
-        boundAgentId: null,
-        boundAgentName: null,
-        loadingConversation: conversationId !== null,
-        conversationLoadError: null,
-        hasMoreHistory: false,
-        loadingMoreHistory: false,
-        oldestItemId: null,
-        llmModel: null,
-        sessionHarness: null,
-        // ``selectedEffort`` / ``selectedModel`` are sticky user picks —
-        // not reset here so a CLI-created new chat inherits them.
-        // ``sessionModelOverride`` and the cost switch ARE session-scoped,
-        // so they reset with the session and re-hydrate from the snapshot.
-        sessionModelOverride: null,
-        costControlModeOverride: null,
-        subagentRoutingOverride: null,
-        codexPlanMode: false,
-        contextWindow: null,
-        tokensUsed: null,
-        sessionCostUsd: null,
-        sessionUsageByModel: null,
-        gitBranch: null,
-        todos: [],
-        skills: [],
-        codexModelOptions: [],
-        terminalPending: false,
-        viewers: [],
-        // Drop any queued "Attach to agent" chip that the outgoing session's
-        // composer hadn't drained yet, so it can't bleed into the incoming
-        // session's composer (which drains the store on mount). Same reset
-        // discipline as ``viewers`` above.
-        pendingComposerAttachments: [],
-        runnerLaunchedAt: null,
-        sandboxStatus: null,
-        mcpStartup: null,
-        abortController: null,
-        historyGeneration: s.historyGeneration + 1,
-      };
+    // No abort, no state wipe: the outgoing conversation's entry keeps its
+    // stream open and keeps applying events in the background. That is the
+    // whole feature — returning to it paints instantly and is already current,
+    // instead of paying a reconnect plus a snapshot re-fetch.
+    rootSetState({
+      conversationId,
+      // Clear any pending supersession redirect: we've now switched sessions,
+      // so a leftover target (e.g. already consumed by the navigate that
+      // brought us here) must not fire again.
+      redirectToConversationId: null,
+      // Drop any queued "Attach to agent" chip the outgoing composer hadn't
+      // drained yet, so it can't bleed into the incoming composer (which drains
+      // the store on mount).
+      pendingComposerAttachments: [],
     });
+    conversationRegistry.setActive(conversationId);
 
-    if (conversationId === null) return;
-    // hydratePending: this is a cold load / navigation. When no bubble was
-    // restored from the stash above, replay the snapshot's un-consumed
-    // native messages; when one was, bindStream dedupes it against the
-    // committed snapshot. Reconnect/rebind paths pass false so they never
-    // overwrite the live optimistic bubbles (which would flink).
-    await bindStream(conversationId, set, get, true);
+    if (conversationId === null) {
+      // Landing route: nothing to project, so reset the mirrored fields to a
+      // clean slate rather than leaving the last conversation painted.
+      rootSetState(createInitialConversationState() as Parameters<typeof rootSetState>[0]);
+      return;
+    }
+
+    // Sends the server hasn't acknowledged, carried across the re-bind below.
+    let unsentOnRebind: PendingUserMessage[] = [];
+    if (!wasLive) {
+      // Drop any retained-but-dead entry so `acquire` builds a fresh one. A
+      // re-bind has to start from the initial state: `bindStream` PREPENDS its
+      // snapshot to whatever `blocks` already holds, so re-binding onto a dead
+      // entry's stale transcript would duplicate and mis-order it. Unsent
+      // bubbles are the one thing worth keeping — the server can't replay what
+      // it was never told about.
+      unsentOnRebind =
+        conversationRegistry
+          .peek(conversationId)
+          ?.getState()
+          .pendingUserMessages.filter((p) => p.posted !== true) ?? [];
+      conversationRegistry.release(conversationId);
+    }
+    const entry = conversationRegistry.acquire(conversationId);
+    if (!wasLive) {
+      // Cold entry: nothing is hydrated yet, so the page must show the
+      // hydrating placeholder rather than mount the composer against empty
+      // state. Without this the composer resolves its model label from the
+      // sticky cross-session pick (session-scoped fields are still null) and
+      // paints the PREVIOUS conversation's model until the snapshot lands.
+      // A live entry deliberately skips this — painting it instantly, with no
+      // placeholder, is the whole point of keeping streams open.
+      entry.setState({
+        loadingConversation: true,
+        ...(unsentOnRebind.length > 0 ? { pendingUserMessages: unsentOnRebind } : {}),
+      });
+    }
+    // Paint whatever the entry already holds. For a live entry that is the
+    // current transcript; for a fresh one it is the initial state.
+    mirrorActiveEntry();
+    if (wasLive) return;
+
+    // Cold entry: bind its stream and hydrate history. `hydratePending` replays
+    // the snapshot's un-consumed native messages — correct here because a fresh
+    // entry has no live optimistic bubbles to overwrite.
+    await bindStream(conversationId, entrySetter(entry), entryGetter(entry), true);
   },
 
   submitApproval: async (elicitationId, action, content) => {
@@ -1872,7 +1912,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     // than a generic "Approved" pill.
     const responseValue: ElicitationBlock["response"] =
       content === undefined ? { action } : { action, content };
-    set((s) => ({
+    setActive((s) => ({
       blocks: s.blocks.map((b) =>
         b.type === "elicitation" && b.elicitationId === elicitationId
           ? { ...b, status: "responded", response: responseValue }
@@ -1889,7 +1929,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // Roll back to pending so the user can retry. Surfacing the
       // error is a future affordance — for now, the buttons
       // reappear and the user can try again.
-      set((s) => ({
+      //
+      // Targets the conversation whose card this is: the approval POST can
+      // outlive a switch away, and rolling back the VISIBLE conversation would
+      // reopen an unrelated chat's card while leaving this one wrongly
+      // answered.
+      setterFor(sessionId)((s) => ({
         blocks: s.blocks.map((b) =>
           b.type === "elicitation" && b.elicitationId === elicitationId
             ? { ...b, status: "pending", response: null }
@@ -1901,24 +1946,24 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
   flashUserMessage: (itemId) => {
     if (flashTimer !== null) clearTimeout(flashTimer);
-    set({ flashItemId: itemId });
+    setActive({ flashItemId: itemId });
     flashTimer = setTimeout(() => {
       flashTimer = null;
-      set({ flashItemId: null });
+      setActive({ flashItemId: null });
     }, FLASH_DURATION_MS);
   },
 
   addComposerAttachment: (attachment) => {
-    set((s) => {
+    setActive((s) => {
       const k = composerAttachmentKey(attachment);
       if (s.pendingComposerAttachments.some((a) => composerAttachmentKey(a) === k)) return s;
       return { pendingComposerAttachments: [...s.pendingComposerAttachments, attachment] };
     });
   },
 
-  clearPendingComposerAttachments: () => set({ pendingComposerAttachments: [] }),
+  clearPendingComposerAttachments: () => setActive({ pendingComposerAttachments: [] }),
 
-  markRunnerLaunched: () => set({ runnerLaunchedAt: Date.now() }),
+  markRunnerLaunched: () => setActive({ runnerLaunchedAt: Date.now() }),
 
   compact: async () => {
     const { conversationId } = get();
@@ -1936,7 +1981,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   setEffort: async (effort) => {
-    set({ selectedEffort: effort });
+    // `selectedEffort` is the cross-session sticky pick; `sessionReasoningEffort`
+    // is this conversation's effective value. An explicit pick sets both.
+    setActive({ selectedEffort: effort, sessionReasoningEffort: effort });
     savePickerPref(PICKER_PREF_EFFORT_KEY, effort);
     const { conversationId } = get();
     if (conversationId) {
@@ -1949,7 +1996,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
         staleTime: Infinity,
         retry: false,
       });
-      if (!supportsEffortControl(session)) return;
+      // Harness has no effort control: undo the optimistic session-scoped write
+      // so this conversation doesn't claim an effort the server will never hold.
+      if (!supportsEffortControl(session)) {
+        setterFor(conversationId)({ sessionReasoningEffort: null });
+        return;
+      }
       await updateSession(conversationId, { reasoningEffort: effort });
     }
   },
@@ -1957,7 +2009,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
   setModel: async (model) => {
     // `selectedModel` is the sticky pick; `sessionModelOverride` is this
     // session's applied override. An explicit `/model` sets both.
-    set({ selectedModel: model, sessionModelOverride: model });
+    modelPickRevision += 1;
+    const pickRevision = modelPickRevision;
+    setActive({ selectedModel: model, sessionModelOverride: model });
     savePickerPref(PICKER_PREF_MODEL_KEY, model);
     const { conversationId } = get();
     if (conversationId) {
@@ -1965,8 +2019,18 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // Server-canonical may differ from the optimistic write (e.g.
       // when a clear alias was sent) — refresh local state to match.
       const canonical = session.modelOverride ?? null;
-      set({ selectedModel: canonical, sessionModelOverride: canonical });
-      savePickerPref(PICKER_PREF_MODEL_KEY, canonical);
+      // The override belongs to the session that was PATCHed, so apply it there
+      // even if the user has since switched away.
+      setterFor(conversationId)({ sessionModelOverride: canonical });
+      // The sticky pref (root + localStorage) is app-global and must reflect the
+      // NEWEST pick, so a slower PATCH that resolves last cannot overwrite it —
+      // otherwise the superseded model returns on reload or in a new chat. Both
+      // writes are gated together: persisting without the root write would leave
+      // them disagreeing until the next reload.
+      if (pickRevision === modelPickRevision) {
+        rootSetState({ selectedModel: canonical });
+        savePickerPref(PICKER_PREF_MODEL_KEY, canonical);
+      }
     }
   },
 
@@ -1983,9 +2047,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
     // model-less (e.g. SDK) session doesn't emit a spurious model-cleared change.
     const previousModel = get().sessionModelOverride;
     const clearModel = mode === "on" && previousModel != null;
+    // Pin the target: these are this conversation's switches, and the PATCH can
+    // outlive a switch away. Resolving the target afterwards would leave a
+    // backgrounded conversation showing an optimistic value the server rejected,
+    // with no re-bind on return to correct it.
+    const patchSet = setterFor(conversationId);
     // Optimistic flip so the pill responds instantly; the PATCH
     // response (or the rollback below) is the settled truth.
-    set({
+    patchSet({
       costControlModeOverride: mode,
       ...(clearModel ? { sessionModelOverride: null } : {}),
     });
@@ -1994,19 +2063,18 @@ export const useChatStore = create<ChatState>((set, get) => ({
         costControlModeOverride: mode,
         ...(clearModel ? { modelOverride: null } : {}),
       });
-      if (get().conversationId !== conversationId) return;
-      set({
+      patchSet({
         costControlModeOverride: session.costControlModeOverride ?? null,
         ...(clearModel ? { sessionModelOverride: session.modelOverride ?? null } : {}),
       });
     } catch (err) {
       // Roll back so neither control claims a state the server never persisted.
-      if (get().conversationId === conversationId) {
-        set({
-          costControlModeOverride: previous,
-          ...(clearModel ? { sessionModelOverride: previousModel } : {}),
-        });
-      }
+      // A disposed entry makes this a no-op, which is the only case worth
+      // skipping — there is no state left to correct.
+      patchSet({
+        costControlModeOverride: previous,
+        ...(clearModel ? { sessionModelOverride: previousModel } : {}),
+      });
       throw err;
     }
   },
@@ -2019,15 +2087,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
     // (or the rollback below) is the settled truth. Unlike the session's own
     // routing switch this never touches `model_override` — it governs the
     // sub-agents' models, not this session's.
-    set({ subagentRoutingOverride: mode });
+    // Pinned for the same reason as `setCostControlMode` — see there.
+    const patchSet = setterFor(conversationId);
+    patchSet({ subagentRoutingOverride: mode });
     try {
       const session = await updateSession(conversationId, { subagentRoutingOverride: mode });
-      if (get().conversationId !== conversationId) return;
-      set({ subagentRoutingOverride: session.subagentRoutingOverride ?? null });
+      patchSet({ subagentRoutingOverride: session.subagentRoutingOverride ?? null });
     } catch (err) {
-      if (get().conversationId === conversationId) {
-        set({ subagentRoutingOverride: previous });
-      }
+      patchSet({ subagentRoutingOverride: previous });
       throw err;
     }
   },
@@ -2049,7 +2116,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       return;
     }
     if (get().conversationId !== conversationId) return;
-    set({
+    setActive({
       costControlModeOverride: session.costControlModeOverride ?? null,
       subagentRoutingOverride: session.subagentRoutingOverride ?? null,
     });
@@ -2059,15 +2126,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const { conversationId } = get();
     if (!conversationId) return;
     const previous = get().codexPlanMode;
-    set({ codexPlanMode: enabled });
+    // Pinned for the same reason as `setCostControlMode` — see there.
+    const patchSet = setterFor(conversationId);
+    patchSet({ codexPlanMode: enabled });
     try {
       const session = await updateSession(conversationId, { codexPlanMode: enabled });
-      if (get().conversationId !== conversationId) return;
-      set({ codexPlanMode: codexPlanModeFromSession(session) });
+      patchSet({ codexPlanMode: codexPlanModeFromSession(session) });
     } catch (err) {
-      if (get().conversationId === conversationId) {
-        set({ codexPlanMode: previous });
-      }
+      patchSet({ codexPlanMode: previous });
       throw err;
     }
   },
@@ -2076,20 +2142,30 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const { conversationId, oldestItemId, loadingMoreHistory, hasMoreHistory, historyGeneration } =
       get();
     if (!conversationId || !oldestItemId || loadingMoreHistory || !hasMoreHistory) return;
-    set({ loadingMoreHistory: true });
+    // Pin the originating conversation: this page belongs to it, and it may be
+    // backgrounded before the fetch lands. Resolving the target afterwards would
+    // strand `loadingMoreHistory: true` on it — and since a live entry is never
+    // re-bound on return, that guard would then no-op every future scroll-up.
+    const pageSet = setterFor(conversationId);
+    pageSet({ loadingMoreHistory: true });
     // Drop the result if the window was reset while this page was in flight
     // (navigate away-and-back, rebind hydration, reconnect re-hydrate): the
     // page is cursor-relative to the OLD window, and prepending it into the
     // new one would invert order or rewind the cursor past a silent gap.
+    //
+    // Backgrounding is NOT staleness — only disposal (the entry is gone, so
+    // nothing to fix) or a generation bump (the window moved under us).
     const stale = (): boolean =>
-      get().conversationId !== conversationId || get().historyGeneration !== historyGeneration;
+      isConversationDisposed(conversationId) ||
+      (setterForState(conversationId)?.historyGeneration ?? historyGeneration) !==
+        historyGeneration;
     try {
       const { items, hasMore } = await fetchSessionItemsPage(conversationId, {
         olderThan: oldestItemId,
       });
       if (stale()) return;
       const newBlocks = itemsToBlocks(items);
-      set((state) => {
+      pageSet((state) => {
         // Rebind hydration resets the cursor to the fresh window's top while
         // keeping scrolled-up blocks, so an older page can overlap — dedupe.
         const seen = new Set(
@@ -2108,15 +2184,267 @@ export const useChatStore = create<ChatState>((set, get) => ({
       if (stale()) return;
       // Disable further fetches on error — a persistent server failure
       // would otherwise re-trigger the scroll listener on every scroll event.
-      set({ loadingMoreHistory: false, hasMoreHistory: false });
+      pageSet({ loadingMoreHistory: false, hasMoreHistory: false });
     }
   },
 }));
+
+// ── Store-action setter ──────────────────────────────────
+//
+// The store's own actions (`send`, `stop`, the picker setters, `loadMoreHistory`)
+// write a mix of conversation-scoped and app-global state, and they all mean
+// "the conversation on screen". Route their patches so conversation keys reach
+// that conversation's entry — which is where the state actually lives — and
+// app-global keys stay on the root store.
+//
+// Declared after the store because it closes over `useChatStore`; hoisting makes
+// it available to the actions above, which only ever run after module init.
+// zustand's own `set` (`_rootSet`) is unused: it writes the root store, which is
+// a projection of the active entry, so a write there would be overwritten by the
+// next mirror.
+function setActive(partial: Partial<ChatState> | ((state: ChatState) => Partial<ChatState>)): void {
+  const active = conversationRegistry.getActive();
+  if (active === null) {
+    // Landing route (`/`): no entry exists yet because the session hasn't been
+    // created. Buffer conversation-scoped writes on the root store so the
+    // landing composer's optimistic bubble renders immediately; `switchTo` /
+    // `ensureBoundSession` adopt them into the new entry once it exists (see
+    // `adoptPreSessionState`). Dropping them here would make the first message
+    // of a new chat vanish until the server echoed it back.
+    rootSetState(partial as Parameters<typeof rootSetState>[0]);
+    return;
+  }
+  entrySetter(active)(partial);
+}
 
 // ── Internal helpers ─────────────────────────────────────
 
 type Setter = (partial: Partial<ChatState> | ((state: ChatState) => Partial<ChatState>)) => void;
 type Getter = () => ChatState;
+
+// zustand's unwrapped setter, captured before the routing wrapper below
+// replaces it. Writes the root store's own fields with no re-splitting — used by
+// the mirror and by the app-global half of a routed patch.
+const rootSetState = useChatStore.setState;
+
+// ── Conversation entries ─────────────────────────────────
+//
+// The streaming machinery (`bindStream`, `startStreamPump`, `pumpStreamEvents`,
+// the reconcile helpers) is already threaded on `(set, get)`, so pointing it at
+// a conversation entry instead of the root store is a matter of handing it a
+// different pair. These build that pair.
+//
+// Reads see the entry's own state merged under the root store's app-global
+// fields and actions, so existing code that reads e.g. `get().selectedEffort`
+// or calls `get().send(...)` keeps working. Writes are split by key: conversation
+// state goes to the entry, app-global state to the root store.
+
+/**
+ * Whether a conversation is no longer live — evicted, released, or never bound.
+ *
+ * This is the **liveness** check the streaming machinery runs to decide whether
+ * to keep pumping, reconnecting, and writing. It replaced
+ * `get().conversationId !== id`, which conflated "still loaded?" with "on
+ * screen?" — the same question only while one conversation could be open, and
+ * the reason a background pump used to exit at its first reconnect check.
+ *
+ * Being backgrounded is explicitly NOT a reason to stop: a background stream
+ * must keep applying events and must keep reconciling across the ingress'
+ * ~5-minute stream recycle, or it goes silently stale.
+ */
+function isConversationDisposed(id: string): boolean {
+  const entry = conversationRegistry.peek(id);
+  return entry === undefined || entry.disposed;
+}
+
+/**
+ * Whether a live entry is actually still current — stream open, snapshot loaded.
+ *
+ * Registry membership alone does NOT mean "up to date". `startStreamPump` clears
+ * `abortController` when it stops for good (a terminal 401/403/404, or `[DONE]`),
+ * and a failed `bindStream` leaves `conversationLoadError` set; neither releases
+ * the entry. Treating those as live means returning to the conversation paints
+ * whatever it held when the stream died and never reopens it — stale until the
+ * next send. `switchTo` rebinds when this is false; `ensureBoundSession` makes
+ * the same check before POSTing.
+ */
+function isConversationStreamCurrent(id: string): boolean {
+  const entry = conversationRegistry.peek(id);
+  if (entry === undefined || entry.disposed) return false;
+  const state = entry.getState();
+  return state.abortController !== null && state.conversationLoadError === null;
+}
+
+/**
+ * Tear down an entry's stream, keeping the entry itself alive.
+ *
+ * Needed before re-binding a live entry: a failed snapshot leaves
+ * `conversationLoadError` set while its pump is still running (`bindStream`
+ * catches the error without aborting), so binding again would strand the old
+ * pump — two subscribers on one entry, double-applying any delta that carries no
+ * item id to dedupe on. Aborting ends the reconnect loop and cancels the
+ * in-flight fetch; `bindStream` installs the replacement controller.
+ */
+function abortConversationStream(entry: ConversationEntry): void {
+  const { abortController } = entry.getState();
+  if (abortController === null) return;
+  abortController.abort();
+  entry.setState({ abortController: null });
+}
+
+/** A conversation's state if it is still live, else `null`. */
+function setterForState(conversationId: string): ChatState | null {
+  const entry = conversationRegistry.peek(conversationId);
+  return entry === undefined ? null : entryGetter(entry)();
+}
+
+/**
+ * A setter for a specific conversation, or a no-op when it is no longer live.
+ *
+ * Late-settling send work (a denied POST, a failure) must land on the
+ * conversation it was sent to — not on whatever the user has since switched to.
+ * `setActive` would write the visible conversation, which is how a stale
+ * failure could clobber an unrelated chat's composer state.
+ */
+function setterFor(conversationId: string | null): Setter {
+  if (conversationId === null) return () => {};
+  const entry = conversationRegistry.peek(conversationId);
+  if (entry === undefined) return () => {};
+  return entrySetter(entry);
+}
+
+/**
+ * Move conversation state written before a session existed onto its new entry.
+ *
+ * The landing composer renders an optimistic bubble the moment the user hits
+ * send, which is before `createSession` returns — so those writes land on the
+ * root store (see `setActive`). This hands them to the entry, so the bubble
+ * survives the transition instead of being replaced by the entry's empty
+ * initial state.
+ */
+function adoptPreSessionState(entry: ConversationEntry): void {
+  const root = useChatStore.getState() as unknown as Record<string, unknown>;
+  const buffered: Record<string, unknown> = {};
+  const initial = createInitialConversationState() as unknown as Record<string, unknown>;
+  for (const key of Object.keys(initial)) {
+    const value = root[key];
+    // Only carry values that actually differ from a cold start, so an unrelated
+    // field can't be pinned to whatever the previous conversation left behind.
+    if (value !== undefined && value !== initial[key]) buffered[key] = value;
+  }
+  if (Object.keys(buffered).length > 0) {
+    entry.setState(buffered as Partial<ConversationState>);
+  }
+}
+
+/** Read an entry's conversation state as if it were the whole `ChatState`. */
+function entryGetter(entry: ConversationEntry): Getter {
+  return () =>
+    ({
+      ...useChatStore.getState(),
+      ...entry.getState(),
+      // The root's `conversationId` names what's ON SCREEN. For an entry it
+      // must name the entry itself, so code reading `get().conversationId`
+      // sees the conversation it is working on, not the one being viewed.
+      conversationId: entry.id,
+    }) as ChatState;
+}
+
+/**
+ * Write to an entry, routing app-global keys to the root store.
+ *
+ * The split is by key rather than by caller because the streaming code writes
+ * mixed patches (e.g. `bindStream` sets conversation fields alongside the
+ * sticky-pref handoff). `conversationId` is dropped: an entry's identity is
+ * fixed, and letting a patch move it would silently retarget the stream.
+ */
+function entrySetter(entry: ConversationEntry): Setter {
+  return (partial) => {
+    const patch = typeof partial === "function" ? partial(entryGetter(entry)()) : partial;
+    const conversationPatch: Record<string, unknown> = {};
+    const appPatch: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(patch)) {
+      if (key === "conversationId") continue;
+      if (isConversationStateKey(key)) conversationPatch[key] = value;
+      else appPatch[key] = value;
+    }
+    if (Object.keys(appPatch).length > 0) {
+      // Root store directly: this half is app-global by construction, and going
+      // through the routing wrapper would re-split it.
+      rootSetState(appPatch as unknown as Parameters<typeof rootSetState>[0]);
+    }
+    if (Object.keys(conversationPatch).length > 0) {
+      entry.setState(conversationPatch as Partial<ConversationState>);
+    }
+  };
+}
+
+/**
+ * Project an entry's state onto the root store so components keep reading flat
+ * fields (`useChatStore((s) => s.blocks)`) without knowing about entries.
+ *
+ * One-directional by design — entry → root, never back. A bidirectional mirror
+ * would make "which copy is the truth" ambiguous the moment they disagreed.
+ */
+function mirrorActiveEntry(): void {
+  const activeId = useChatStore.getState().conversationId;
+  if (activeId === null) return;
+  const entry = conversationRegistry.peek(activeId);
+  if (entry === undefined) return;
+  rootSetState(entry.getState() as Parameters<typeof rootSetState>[0]);
+}
+
+// Route `useChatStore.setState` so a conversation-scoped write reaches the
+// active entry rather than the root store's projection of it.
+//
+// Without this, a caller that reaches for the store directly — the load-test
+// harness, the test suite's ~230 state seeds — would write to the projection and
+// have it silently overwritten by the next mirror. Wrapping the store's own
+// setter keeps `useChatStore.setState({ blocks })` meaning what it always meant:
+// "set the visible conversation's blocks".
+useChatStore.setState = ((partial: unknown, replace?: boolean) => {
+  const patch =
+    typeof partial === "function"
+      ? (partial as (s: ChatState) => Partial<ChatState>)(useChatStore.getState())
+      : (partial as Partial<ChatState>);
+  // A patch that names a conversation makes it the active one, binding an entry
+  // if needed. Production reaches this through `switchTo`; this covers the
+  // direct-store callers (the load-test harness, the test suite's state seeds),
+  // for which "set conversationId and some blocks" has always meant "make this
+  // the conversation being viewed".
+  if ("conversationId" in patch) {
+    const nextId = patch.conversationId ?? null;
+    if (nextId !== useChatStore.getState().conversationId) {
+      rootSetState({ conversationId: nextId } as Parameters<typeof rootSetState>[0]);
+      conversationRegistry.setActive(nextId);
+      if (nextId !== null) conversationRegistry.acquire(nextId);
+    }
+  }
+  const active = conversationRegistry.getActive();
+  if (active === null || replace === true) {
+    return rootSetState(partial as Parameters<typeof rootSetState>[0], replace as never);
+  }
+  const conversationPatch: Record<string, unknown> = {};
+  const appPatch: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(patch)) {
+    if (isConversationStateKey(key)) conversationPatch[key] = value;
+    else appPatch[key] = value;
+  }
+  if (Object.keys(appPatch).length > 0) {
+    rootSetState(appPatch as unknown as Parameters<typeof rootSetState>[0]);
+  }
+  if (Object.keys(conversationPatch).length > 0) {
+    // The entry's change notification mirrors this back onto the root store.
+    active.setState(conversationPatch as Partial<ConversationState>);
+  }
+}) as typeof useChatStore.setState;
+
+// Keep the root store's flat fields in step with whichever entry is on screen.
+conversationRegistry.subscribe((id) => {
+  if (useChatStore.getState().conversationId !== id) return;
+  const state = conversationRegistry.peek(id)?.getState();
+  if (state !== undefined) rootSetState(state as Parameters<typeof rootSetState>[0]);
+});
 
 type NativeModelFamily = "claude" | "codex";
 
@@ -2203,16 +2531,20 @@ function deferredNativeStickyModel(session: Session): string | null {
  *     e.g. ``"conv_abc123"``; the send routes here even after a session
  *     switch. ``null`` / ``undefined`` falls back to the live
  *     ``conversationId`` (brand-new-chat path).
+ * :param onSessionResolved: Fires with the new session id the instant
+ *     ``createSession`` returns — BEFORE the id is published to the store, so
+ *     the caller can move its send-chain slot onto the real id before any other
+ *     send can resolve that id and key an empty chain. See `enterSendChain`.
  * :returns: The bound session id.
  * :raises Error: Re-raises a ``conversationLoadError`` if a needed rebind
  *     of an existing session fails to establish the stream.
  */
 async function ensureBoundSession(
   agentId: string,
-  set: Setter,
   get: Getter,
   opts?: SendOptions,
   pinnedConversationId?: string | null,
+  onSessionResolved?: (sessionId: string) => void,
 ): Promise<string> {
   // Use the session pinned at submit time so a queued send still targets
   // where it was composed, not wherever the user switched to meanwhile.
@@ -2228,8 +2560,14 @@ async function ensureBoundSession(
     // missed). Bind the stream FIRST, then post the first message.
     const session = await createSession(agentId, []);
     sessionId = session.id;
+    // Claim the send chain for this id NOW, while it is still private to this
+    // call. Everything below publishes it (the store write, the navigate
+    // callback, the sidebar invalidation) and awaits network work, so a send
+    // issued from here on resolves this id — and would find an empty chain and
+    // overtake us if our slot were still under the new-session key.
+    onSessionResolved?.(sessionId);
     // Native runners read reasoning_effort during bind.
-    const preBindEffort = get().selectedEffort;
+    const preBindEffort = useChatStore.getState().selectedEffort;
     if (preBindEffort != null && supportsEffortControl(session)) {
       await updateSession(sessionId, {
         reasoningEffort: preBindEffort,
@@ -2237,31 +2575,47 @@ async function ensureBoundSession(
       });
     }
     await bindOnlyOnlineRunner(sessionId);
-    set({
-      conversationId: sessionId,
-      // We just created this session — set boundAgentId/Name from the
-      // returned record so the picker doesn't briefly flicker
-      // through `null` before bindStream's getSession resolves.
+    const entry = conversationRegistry.acquire(sessionId);
+    // The landing composer's optimistic bubble (and any status it set) was
+    // buffered on the root store because no entry existed yet — hand it over
+    // before anything else writes, so the bubble survives the transition.
+    adoptPreSessionState(entry);
+    // Set boundAgentId/Name from the returned record so the picker doesn't
+    // briefly flicker through `null` before bindStream's getSession resolves.
+    entry.setState({
       boundAgentId: session.agentId,
       boundAgentName: session.agentName,
       loadingConversation: true,
     });
+    useChatStore.setState({ conversationId: sessionId });
+    conversationRegistry.setActive(sessionId);
+    mirrorActiveEntry();
     opts?.onConversationCreated?.(sessionId);
     queryClient?.invalidateQueries({ queryKey: ["conversations"] });
-    await bindStream(sessionId, set, get);
-  } else if (sessionId === get().conversationId && get().abortController === null) {
-    // The SSE pump is gone — most commonly an HTTP intermediary
-    // closed the connection on idle. POSTing without a live pump
-    // would queue the message, run the turn, and publish events
-    // into an empty subscriber set; the user would never see the
-    // response. Rebind first, and fail loud if the rebind itself
-    // can't establish the stream. Gated on the target still being active —
-    // rebinding a session the user navigated away from would clobber the
-    // now-active session's view.
-    set({ conversationLoadError: null });
-    await bindStream(sessionId, set, get);
-    const loadError = get().conversationLoadError;
-    if (loadError !== null) throw loadError;
+    await bindStream(sessionId, entrySetter(entry), entryGetter(entry));
+  } else {
+    const streamCurrent = isConversationStreamCurrent(sessionId);
+    const entry = conversationRegistry.acquire(sessionId);
+    if (!streamCurrent) {
+      // The SSE pump is gone or the last bind failed — most commonly an HTTP
+      // intermediary closed the connection on idle, or this conversation was
+      // evicted and re-acquired. POSTing without a live pump would queue the
+      // message, run the turn, and publish events into an empty subscriber set;
+      // the user would never see the response. Rebind first, and fail loud if
+      // the rebind itself can't establish the stream.
+      //
+      // Tear the old pump down first. A snapshot failure leaves
+      // `conversationLoadError` set while its pump is STILL OPEN (`bindStream`
+      // catches the snapshot error without aborting the controller), so
+      // rebinding blind would replace the stored controller and leave two
+      // subscribers on one entry — and deltas with no item id, which nothing can
+      // dedupe, would then apply twice.
+      abortConversationStream(entry);
+      entry.setState({ conversationLoadError: null });
+      await bindStream(sessionId, entrySetter(entry), entryGetter(entry));
+      const loadError = entry.getState().conversationLoadError;
+      if (loadError !== null) throw loadError;
+    }
   }
 
   return sessionId;
@@ -2313,13 +2667,17 @@ async function reconcilePendingElicitations(id: string): Promise<void> {
   } catch {
     return;
   }
-  if (useChatStore.getState().conversationId !== id) return;
+  // Liveness, not foreground: every live conversation reconciles, so a
+  // background one that missed `response.elicitation_resolved` doesn't keep
+  // showing a card that was already answered elsewhere. Gating on the visible
+  // conversation made a background reconcile fetch the snapshot and discard it.
+  if (isConversationDisposed(id)) return;
   const stillPending = new Set(
     (session.pendingElicitations ?? [])
       .map((e) => (typeof e.elicitation_id === "string" ? e.elicitation_id : null))
       .filter((x): x is string => x !== null),
   );
-  useChatStore.setState((s) => {
+  setterFor(id)((s) => {
     let changed = false;
     const blocks = s.blocks.map((b) => {
       if (
@@ -2437,8 +2795,11 @@ async function refreshSessionBinding(id: string): Promise<void> {
   } catch {
     return;
   }
-  if (useChatStore.getState().conversationId !== id) return;
-  useChatStore.setState(sessionBindingPatch(session));
+  // Apply to the conversation this refresh was for, not whichever is on screen:
+  // an agent switch in a backgrounded conversation must still re-derive its
+  // binding (most importantly `isNativeTerminalSession`, which gates the
+  // optimistic-bubble lifecycle). `setterFor` no-ops once it is evicted.
+  setterFor(id)(sessionBindingPatch(session));
 }
 
 /**
@@ -2531,7 +2892,7 @@ async function bindStream(
       }),
       fetchSessionItemsPage(id, { limit: INITIAL_WINDOW_ITEMS }),
     ]);
-    if (get().conversationId !== id) return;
+    if (isConversationDisposed(id)) return;
     const items = page.items;
 
     // Sticky-pref handoff for CLI-created sessions with no override.
@@ -2607,6 +2968,10 @@ async function bindStream(
     // before this chat was opened wouldn't render otherwise.
     const pendingElicitationBlocks = pendingElicitationBlocksFromSnapshot(session);
     const oldestItemId = items[0]?.id ?? null;
+    // The sticky pick this bind resolved, applied app-globally after the patch
+    // below — but only while this conversation is still on screen. Resolved
+    // inside the updater because it depends on the catalog bind race.
+    let resolvedStickyModel: string | null = null;
     set((state) => {
       const racedOptions = racedNativeModelOptions.get(id);
       const catalogWonBindRace =
@@ -2652,6 +3017,11 @@ async function bindStream(
       // live blocks the pump already inserted) so the ApprovalCard
       // appears at the bottom of the chat — same position the live
       // stream would have given it.
+      // A cold bind prepends the snapshot to whatever the pump already pushed:
+      // the entry has no window of its own yet. (The cache-window merge
+      // branches that used to live here served the transcript LRU's revisit
+      // path, which no longer exists — a revisit finds a live entry and never
+      // re-binds.)
       const allBlocks = [...unique, ...state.blocks, ...uniquePendingElicitations];
       const hasErrorBlock = allBlocks.some((b) => b.type === "error");
       // Decide the optimistic user bubbles to render after this bind, and
@@ -2706,50 +3076,23 @@ async function bindStream(
       // leaving the POSTed text at the end, so match with endsWith.
       // Image-only entries (no text) are kept.
       //
-      // Baseline-aware so an optimistic bubble whose text coincides with an
-      // OLDER message already in history isn't wrongly dropped: a stashed own
-      // bubble (``pend_`` id) is deduped only against committed copies that
-      // are NEW since it was stashed — i.e. the snapshot now has MORE copies
-      // of that text than the stash's committedTexts baseline. Foreign /
-      // server-replayed entries (server ids) have no baseline (it stays 0),
-      // so they dedupe against all committed copies as before. Without this,
-      // re-sending text that already appears in a resumed/disconnected
-      // session's history makes the new bubble vanish until it commits (the
-      // "disappears then reappears" report).
+      // A cold bind has no live optimistic bubbles of its own — the entry was
+      // just created — so every candidate here comes from the server's
+      // `pending_inputs`, and deduping against all committed copies is correct.
+      // (The old baseline arithmetic existed only because `switchTo` used to
+      // destroy state and restore bubbles from a stash, which could collide
+      // with an older identical message in history.)
       const dedupePending = hydratePending && candidatePending.length > 0;
       const committedUserTexts = dedupePending ? committedUserTextsOf(allBlocks) : [];
-      const stashBaseline = state.pendingByConversation[id]?.committedTexts ?? [];
       const countEndsWith = (texts: string[], suffix: string): number =>
         texts.reduce((n, c) => (c.endsWith(suffix) ? n + 1 : n), 0);
       const snapshotPending: PendingUserMessage[] = dedupePending
         ? candidatePending.filter((p) => {
             const text = messageContentText(p.content);
             if (text === "") return true;
-            const baseline = p.tempId.startsWith("pend_") ? countEndsWith(stashBaseline, text) : 0;
-            return countEndsWith(committedUserTexts, text) <= baseline;
+            return countEndsWith(committedUserTexts, text) === 0;
           })
         : candidatePending;
-      // Keep the stash consistent with what survived dedupe on cold load: a
-      // restored bubble whose message committed while away is now dropped, so
-      // prune it from the stash too (else it lingers until the next
-      // switch-away). Only this client's own bubbles (``pend_`` ids) belong
-      // in the stash — foreign entries are re-served by pending_inputs. Reset
-      // the baseline to the now-current committed texts so a subsequent
-      // navigate-away/back compares against history as it stands after this
-      // bind.
-      const prunedStash = hydratePending
-        ? (() => {
-            const own = snapshotPending.filter((p) => p.tempId.startsWith("pend_"));
-            if (own.length > 0) {
-              return {
-                ...state.pendingByConversation,
-                [id]: { messages: own, committedTexts: committedUserTexts },
-              };
-            }
-            const { [id]: _removedStash, ...remainingStashes } = state.pendingByConversation;
-            return remainingStashes;
-          })()
-        : state.pendingByConversation;
       const syntheticError: ErrorBlock | null =
         session.status === "failed" && session.lastTaskError != null && !hasErrorBlock
           ? {
@@ -2761,11 +3104,12 @@ async function bindStream(
               ...structuredErrorFields(session.lastTaskError),
             }
           : null;
+      resolvedStickyModel =
+        catalogWonBindRace && preservedModelValid ? state.selectedModel : effectiveModel;
       return {
         ...effectiveBindingPatch,
         blocks: syntheticError !== null ? [...allBlocks, syntheticError] : allBlocks,
         pendingUserMessages: snapshotPending,
-        pendingByConversation: prunedStash,
         loadingConversation: false,
         hasMoreHistory: page.hasMore,
         oldestItemId,
@@ -2797,9 +3141,15 @@ async function bindStream(
         // the snapshot (server keeps it sticky past the trailing PTY `idle`).
         backgroundTaskCount: session.backgroundTaskCount ?? 0,
         blockedOn: null,
-        selectedEffort: effectiveEffort,
-        selectedModel:
-          catalogWonBindRace && preservedModelValid ? state.selectedModel : effectiveModel,
+        // `selectedEffort` / `selectedModel` are app-global sticky picks, not
+        // conversation state, so they are applied below — and only while this
+        // conversation is still on screen. A cold bind that finishes after the
+        // user switched away (or a second concurrent bind) would otherwise
+        // overwrite the visible conversation's picker, last-response-wins.
+        //
+        // This conversation's own effective effort, which is what a warm switch
+        // back re-projects (it does not re-bind, so it cannot recompute it).
+        sessionReasoningEffort: effectiveEffort,
         // Session truth for the `/model` readout — overrides the snapshot
         // value spread via `...bindingPatch` so the claude-native sticky
         // handoff (fired above, silent) shows immediately.
@@ -2817,9 +3167,16 @@ async function bindStream(
         }[],
       };
     });
+    // App-global sticky picks: this conversation's snapshot is only allowed to
+    // move them while it is the one on screen. A background bind (a switch away
+    // mid-fetch, or two cold binds racing) must hydrate its own conversation
+    // without touching the visible conversation's picker.
+    if (useChatStore.getState().conversationId === id) {
+      rootSetState({ selectedEffort: effectiveEffort, selectedModel: resolvedStickyModel });
+    }
     racedNativeModelOptions.delete(id);
   } catch (err) {
-    if (get().conversationId !== id) return;
+    if (isConversationDisposed(id)) return;
     set({
       loadingConversation: false,
       conversationLoadError: err instanceof Error ? err : new Error(String(err)),
@@ -3127,7 +3484,7 @@ async function rehydrateWindowOnReconnect(
   } catch {
     return;
   }
-  if (get().conversationId !== id || get().historyGeneration !== generation) return;
+  if (isConversationDisposed(id) || get().historyGeneration !== generation) return;
   const freshBlocks = itemsToBlocks(fresh.items);
   const snapshotPending = pendingElicitationBlocksFromSnapshot(session);
   set((s) => {
@@ -3207,8 +3564,7 @@ async function reconcileOnReconnect(id: string, set: Setter, get: Getter): Promi
   const preGapElicitations = captureElicitationIdsByStatus(get().blocks);
   // A window reset mid-fetch (A→B→A revisit, rebind) defeats the id check alone.
   const generation = get().historyGeneration;
-  const stale = (): boolean =>
-    get().conversationId !== id || get().historyGeneration !== generation;
+  const stale = (): boolean => isConversationDisposed(id) || get().historyGeneration !== generation;
   let session: Session;
   let page: SessionItemsPage;
   try {
@@ -3309,9 +3665,16 @@ async function reconcileOnReconnect(id: string, set: Setter, get: Getter): Promi
 // by recycling the live stream attempt — the same abort-and-reopen the
 // ingress already forces every ~5 minutes. The tracker aborts only the
 // per-attempt controller; the outer controller (teardown) stays live.
-let presenceAttemptController: AbortController | null = null;
+// One entry per live stream: an idle flip must recycle EVERY open stream,
+// since each carries its own `idle` uplink. A single controller would leave
+// all but one stream reporting a stale flag once streams outlive a switch.
+const presenceAttemptControllers = new Set<AbortController>();
 const presenceIdle = createPresenceIdleTracker({
-  onFlip: () => presenceAttemptController?.abort(),
+  onFlip: () => {
+    // Copy first: aborting settles each attempt's `finally`, which mutates
+    // this set while we iterate it.
+    for (const controller of [...presenceAttemptControllers]) controller.abort();
+  },
 });
 if (typeof document !== "undefined") {
   document.addEventListener("visibilitychange", () =>
@@ -3361,13 +3724,21 @@ export async function startStreamPump(
   // so its awaits cannot be parallelized; no-await-in-loop doesn't apply.
   /* eslint-disable no-await-in-loop */
   try {
-    while (!controller.signal.aborted && get().conversationId === id) {
+    while (!controller.signal.aborted && !isConversationDisposed(id)) {
       // Back off only between consecutive failed opens. A drop after a
       // healthy connection (the benign ~5-min ingress recycle) leaves
       // failedOpens at 0, so it reconnects instantly with no delay.
       if (failedOpens > 0) {
         await abortableDelay(nextReconnectDelay(failedOpens), controller.signal);
-        if (controller.signal.aborted || get().conversationId !== id) break;
+        if (controller.signal.aborted || isConversationDisposed(id)) break;
+      } else if (hasConnected && conversationRegistry.getActive()?.id !== id) {
+        // Stagger a BACKGROUND conversation's reconnect. The ingress caps every
+        // stream at ~5 minutes, and streams opened together recycle together, so
+        // without this a tab holding N conversations fires N reconnects — each
+        // with a snapshot + items fetch — in one burst. The conversation on
+        // screen is never delayed.
+        await abortableDelay(backgroundReconnectJitter(), controller.signal);
+        if (controller.signal.aborted || isConversationDisposed(id)) break;
       }
 
       // Per-attempt controller: a presence idle flip recycles just this
@@ -3377,7 +3748,7 @@ export async function startStreamPump(
       const attempt = new AbortController();
       const onOuterAbort = () => attempt.abort();
       controller.signal.addEventListener("abort", onOuterAbort);
-      presenceAttemptController = attempt;
+      presenceAttemptControllers.add(attempt);
       try {
         const idle = presenceIdle.idleNow();
         let streamRes: Response;
@@ -3385,18 +3756,18 @@ export async function startStreamPump(
           streamRes = await openSessionStream(id, attempt.signal, { idle });
         } catch (err) {
           if (err instanceof Error && err.name === "AbortError") {
-            if (controller.signal.aborted || get().conversationId !== id) break;
+            if (controller.signal.aborted || isConversationDisposed(id)) break;
             // Only the attempt was aborted (presence flip mid-open) —
             // reopen immediately with the recomputed idle flag.
             continue;
           }
-          if (get().conversationId !== id) break;
+          if (isConversationDisposed(id)) break;
           console.warn(`Session ${id}: stream connect failed, will retry`, err);
           failedOpens += 1;
           continue;
         }
 
-        if (controller.signal.aborted || get().conversationId !== id) break;
+        if (controller.signal.aborted || isConversationDisposed(id)) break;
         if (!streamRes.ok || !streamRes.body) {
           // Release the unconsumed error-response body so the underlying fetch
           // connection is freed promptly rather than lingering across retries.
@@ -3470,9 +3841,7 @@ export async function startStreamPump(
         if (reason !== "dropped") break;
       } finally {
         controller.signal.removeEventListener("abort", onOuterAbort);
-        if (presenceAttemptController === attempt) {
-          presenceAttemptController = null;
-        }
+        presenceAttemptControllers.delete(attempt);
       }
     }
   } finally {
@@ -3481,6 +3850,16 @@ export async function startStreamPump(
     }
   }
   /* eslint-enable no-await-in-loop */
+}
+
+// Spread background reconnects over a few seconds so N conversations recycling
+// at the same ingress deadline don't fire N snapshot fetches at once. Small
+// enough that a backgrounded conversation is still current well before the user
+// could switch to it.
+const BACKGROUND_RECONNECT_JITTER_MAX_MS = 3_000;
+
+function backgroundReconnectJitter(): number {
+  return Math.random() * BACKGROUND_RECONNECT_JITTER_MAX_MS;
 }
 
 /**
@@ -3674,6 +4053,27 @@ function applyLiveToolOutputDelta(set: Setter, callId: string, delta: string): v
 }
 
 /**
+ * Restore the "mid-turn" signal after a stray `completed` edge.
+ *
+ * A live delta proves the turn is still going even though something flipped
+ * `activeResponse` to `completed` (a stray idle edge, an out-of-order status).
+ * Reopen it to streaming and restore `sessionStatus: "running"` so send-gating
+ * queues instead of firing into the live turn and the Working indicator returns
+ * before the next `running` edge. Local `status` is left alone — it means "this
+ * client's send is in flight", which is false for cross-client / TUI turns.
+ */
+export function reviveStrayCompletedResponse(set: Setter): void {
+  set((s) => {
+    if (s.activeResponse?.state !== "completed") return {};
+    if (isStaleCompletedResponse(s)) return {};
+    return {
+      activeResponse: { ...s.activeResponse, state: "streaming" },
+      sessionStatus: "running",
+    };
+  });
+}
+
+/**
  * Wrap a parsed event stream, diverting terminal-observed live deltas.
  *
  * A `text_delta` carrying a `messageId` is native live streaming:
@@ -3702,7 +4102,7 @@ async function* tapLiveDeltas(
 ): AsyncIterable<StreamEvent> {
   for await (const ev of events) {
     if (ev.type === "text_delta" && ev.messageId !== undefined) {
-      if (get().conversationId === id && !ignored.has(ev.messageId)) {
+      if (!isConversationDisposed(id) && !ignored.has(ev.messageId)) {
         // A scheduled wake streams its first deltas ahead of the batch
         // that names the new turn. They must not preview into the
         // PREVIOUS turn's bubble (anonymous blocks glue to the trailing
@@ -3718,10 +4118,17 @@ async function* tapLiveDeltas(
       continue;
     }
     if (ev.type === "tool_output_delta") {
-      if (get().conversationId === id && !isStaleCompletedResponse(get())) {
+      if (!isConversationDisposed(id) && !isStaleCompletedResponse(get())) {
+        reviveStrayCompletedResponse(set);
         applyLiveToolOutputDelta(set, ev.callId, ev.delta);
       }
       continue;
+    }
+    if (
+      (ev.type === "text_delta" || ev.type === "reasoning_delta") &&
+      !isConversationDisposed(id)
+    ) {
+      reviveStrayCompletedResponse(set);
     }
     yield ev;
   }
@@ -3832,7 +4239,7 @@ export async function pumpStreamEvents(
   // applying any sidecar state in the same commit. No-ops if switched away.
   const flush = (trailing?: AnyBlock, extra?: Partial<ChatState>): void => {
     scheduler.cancel();
-    if (get().conversationId !== id) {
+    if (isConversationDisposed(id)) {
       buffer.length = 0;
       return;
     }
@@ -3876,7 +4283,7 @@ export async function pumpStreamEvents(
   try {
     for await (const block of stream.reduce(events)) {
       if (controller.signal.aborted) return "aborted";
-      if (get().conversationId !== id) return "switched";
+      if (isConversationDisposed(id)) return "switched";
 
       if (block.type === "response_start") {
         // New response: force-flush whatever is buffered, then land the
@@ -4070,7 +4477,7 @@ export async function pumpStreamEvents(
     return sseResult.sawDone ? "server_closed" : "dropped";
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") return "aborted";
-    if (get().conversationId !== id) return "switched";
+    if (isConversationDisposed(id)) return "switched";
     // A reader/parse error (e.g. net::ERR_HTTP2_PROTOCOL_ERROR from the
     // ingress resetting the stream). Commit the tail and report a drop;
     // the reconnect loop re-subscribes rather than marking the turn
@@ -4209,7 +4616,11 @@ async function refetchRunnerBackedSessionState(
   conversationId: string,
   options: RefetchRunnerBackedSessionStateOptions = {},
 ): Promise<void> {
-  if (useChatStore.getState().conversationId !== conversationId) return;
+  // Liveness, not foreground: `session_skills` / `session_model_options` are
+  // one-shot nudges with no replay, and a live background conversation is never
+  // re-bound on return — dropping the nudge here would leave its slash menu and
+  // model catalog empty for as long as the entry stays live.
+  if (isConversationDisposed(conversationId)) return;
   let session: Session;
   try {
     if (queryClient !== null) {
@@ -4233,17 +4644,19 @@ async function refetchRunnerBackedSessionState(
     // the existing state rather than wiping it on a transient error.
     return;
   }
-  // Re-check after the await — the user may have switched conversations
-  // while the request was in flight; applying now would leak another
-  // session's capabilities into the open composer.
-  if (useChatStore.getState().conversationId !== conversationId) return;
+  // The conversation may have been backgrounded (or evicted) while the request
+  // was in flight. Runner-backed state is conversation-scoped, so apply it to
+  // the conversation it was fetched for rather than dropping it — a background
+  // session's resolved skills / model catalog must be there when the user
+  // returns. `setterForState` / `setterFor` no-op once it has been evicted.
+  const currentState = setterForState(conversationId);
+  if (currentState === null) return;
   if (options.modelOptionsResolved === true && (session.codexModelOptions ?? []).length > 0) {
     racedNativeModelOptions.set(conversationId, session.codexModelOptions ?? []);
   }
-  const currentState = useChatStore.getState();
   const stickyModel = deferredNativeStickyModel(session);
   const alreadyApplied = stickyModel != null && currentState.sessionModelOverride === stickyModel;
-  const statePatch: Partial<ChatState> =
+  const statePatch: Partial<ConversationState> =
     options.applyBindingPatch === true
       ? sessionBindingPatch(session)
       : {
@@ -4251,10 +4664,15 @@ async function refetchRunnerBackedSessionState(
           codexModelOptions: session.codexModelOptions ?? [],
         };
   if (stickyModel != null) {
-    statePatch.selectedModel = stickyModel;
     statePatch.sessionModelOverride = stickyModel;
+    // `selectedModel` is the cross-session sticky pick, so recover it only for
+    // the conversation on screen: a backgrounded session's delayed handoff must
+    // not overwrite a model the user has since picked elsewhere.
+    if (useChatStore.getState().conversationId === conversationId) {
+      rootSetState({ selectedModel: stickyModel });
+    }
   }
-  useChatStore.setState(statePatch);
+  setterFor(conversationId)(statePatch);
   if (stickyModel != null && !alreadyApplied) {
     updateSession(conversationId, { modelOverride: stickyModel, silent: true }).catch(
       (err: unknown) => {
@@ -4287,7 +4705,7 @@ function messageContentText(content: MessageContentBlock[]): string {
 /**
  * Normalized texts of the committed user-message blocks in `blocks`,
  * dropping empties (image-only messages). The dedup baseline for the
- * per-conversation pending stash (see {@link StashedPending.committedTexts}).
+ * the snapshot replay in `bindStream`.
  */
 function committedUserTextsOf(blocks: AnyBlock[]): string[] {
   return blocks
@@ -4322,30 +4740,6 @@ function contentKeyOf(content: MessageContentBlock[]): string {
 }
 
 /**
- * Drop one optimistic entry from a conversation's navigation stash.
- *
- * Called when that entry's POST settles — accepted, denied, or failed.
- * From that point the server owns the message's fate (accepted native:
- * replayed via `pending_inputs` until committed; accepted non-native:
- * already persisted; denied/failed: gone), so a lingering stash copy
- * could only resurrect a bubble the server can no longer account for —
- * the stuck-forever pending message. No-op when the entry isn't
- * stashed (the common case: the user never navigated away mid-POST).
- */
-function removeFromPendingStash(
-  stash: Record<string, StashedPending>,
-  conversationId: string,
-  tempId: string,
-): Record<string, StashedPending> {
-  const entry = stash[conversationId];
-  if (!entry || !entry.messages.some((p) => p.tempId === tempId)) return stash;
-  const messages = entry.messages.filter((p) => p.tempId !== tempId);
-  if (messages.length > 0) return { ...stash, [conversationId]: { ...entry, messages } };
-  const { [conversationId]: _removedStash, ...remainingStashes } = stash;
-  return remainingStashes;
-}
-
-/**
  * Apply store side effects for a `session.*` SSE event.
  *
  * Exported for direct unit testing — production code reaches this
@@ -4354,9 +4748,60 @@ function removeFromPendingStash(
  * deliberately ignores these events; session-scoped state lives on
  * the store, not on the reducer's internal state machine.
  *
+ * :param event: the parsed stream event.
+ * :param streamConversationId: the conversation whose stream delivered this
+ *     event — the conversation these writes land on, foreground or background.
+ *     See {@link applyToConversation}. Omit only in tests that mean "as if
+ *     delivered by the active conversation's stream".
+ *
  * No-op for events outside the `session.*` family.
  */
-export function handleSessionEvent(event: StreamEvent): void {
+export function handleSessionEvent(event: StreamEvent, streamConversationId?: string): void {
+  // Routing is by DELIVERING STREAM, not by event payload: several events
+  // (`session.input.consumed`, `session.interrupted`, `session.resource.created`)
+  // carry no conversation id at all, so their contents can't say where they
+  // belong. Default to the active conversation so a caller that omits the id
+  // keeps today's behaviour.
+  const sourceConversationId = streamConversationId ?? useChatStore.getState().conversationId;
+
+  /**
+   * Write conversation-scoped state onto the conversation whose stream
+   * delivered this event — which may be a BACKGROUND one.
+   *
+   * Every branch below that touches `ConversationState` must go through this
+   * rather than `useChatStore.setState` directly. That setter writes the root
+   * store, which is only a projection of the conversation on screen: a
+   * background stream's writes would be dropped there (its events would vanish,
+   * leaving e.g. an optimistic user bubble that never commits), and an
+   * unguarded write would paint its status onto the visible conversation.
+   * Routing to the entry does both jobs at once — the registry mirrors the
+   * active entry back onto the root, so the visible conversation still updates.
+   *
+   * No-op when the conversation is no longer live (evicted / released), so
+   * a late event can't resurrect state for it.
+   */
+  const applyToConversation = (
+    patch: Partial<ConversationState> | ((s: ChatState) => Partial<ConversationState>),
+  ): void => {
+    setterFor(sourceConversationId)(patch);
+  };
+
+  /**
+   * Same as {@link applyToConversation}, for events that name their own target.
+   *
+   * Most `session.*` events carry a `conversationId`. That payload id is
+   * authoritative — a session's stream can carry frames about a DIFFERENT
+   * conversation (a sub-agent's, or a rotated-away session's) — so it has to
+   * agree with the delivering stream before the write applies.
+   */
+  const applyToNamedConversation = (
+    namedConversationId: string,
+    patch: Partial<ConversationState> | ((s: ChatState) => Partial<ConversationState>),
+  ): void => {
+    if (namedConversationId !== sourceConversationId) return;
+    applyToConversation(patch);
+  };
+
   switch (event.type) {
     case "response_completed":
       // Prefer contextTokens (last sub-call total) for the context ring — on
@@ -4367,27 +4812,27 @@ export function handleSessionEvent(event: StreamEvent): void {
       if (event.response.usage != null) {
         const ringTokens = event.response.usage.contextTokens ?? event.response.usage.totalTokens;
         if (ringTokens != null) {
-          useChatStore.setState({ tokensUsed: ringTokens });
+          applyToConversation({ tokensUsed: ringTokens });
         }
       }
       return;
     case "session_todos":
       // Replace the todo list entirely — each event carries the full
       // current list, not a diff.
-      useChatStore.setState({ todos: event.todos });
+      applyToConversation({ todos: event.todos });
       return;
     case "session_terminal_pending":
       // Toggle the Terminal-pill spinner. The runner sets pending=true
       // before auto-creating the terminal and clears it once the
       // terminal lands or auto-create fails.
-      useChatStore.setState({ terminalPending: event.pending });
+      applyToConversation({ terminalPending: event.pending });
       return;
     case "session_sandbox_status":
       // Advance the managed-sandbox provisioning indicator. `ready`
       // clears it — from then on the session looks like any
       // host-bound session; `failed` retains the reason so the page
       // explains why the sandbox never came up.
-      useChatStore.setState({
+      applyToConversation({
         sandboxStatus: event.stage === "ready" ? null : { stage: event.stage, error: event.error },
       });
       return;
@@ -4398,7 +4843,7 @@ export function handleSessionEvent(event: StreamEvent): void {
       // never came up.
       const records = Object.values(event.servers);
       const allReady = records.length === 0 || records.every((r) => r.status === "ready");
-      useChatStore.setState({ mcpStartup: allReady ? null : event.servers });
+      applyToConversation({ mcpStartup: allReady ? null : event.servers });
       return;
     }
     case "session_usage": {
@@ -4425,7 +4870,7 @@ export function handleSessionEvent(event: StreamEvent): void {
         patch.sessionUsageByModel = event.usageByModel;
       }
       if (Object.keys(patch).length > 0) {
-        useChatStore.setState(patch);
+        applyToConversation(patch);
       }
       return;
     }
@@ -4438,38 +4883,41 @@ export function handleSessionEvent(event: StreamEvent): void {
       // terminal switch is a per-session choice, not a new default).
       // Guard by conversation id so a late frame from a switched-away
       // stream cannot overwrite the model for the currently-open session.
-      useChatStore.setState((s) =>
-        s.conversationId === event.conversationId
-          ? { selectedModel: event.model, sessionModelOverride: event.model }
-          : {},
-      );
+      if (event.conversationId === useChatStore.getState().conversationId) {
+        // `selectedModel` is a sticky app-level pref, so it is set directly.
+        useChatStore.setState({ selectedModel: event.model });
+      }
+      applyToNamedConversation(event.conversationId, { sessionModelOverride: event.model });
       return;
     case "session_reasoning_effort":
-      // A thinking-level switch made inside a native terminal. Reflect it
-      // in the picker for the open session; the server persisted
-      // reasoning_effort, so reload restores the same value.
-      // Guard by conversation id so a late event from a previous session
-      // cannot overwrite the effort picker for the currently-open one.
-      useChatStore.setState((s) =>
-        s.conversationId === event.conversationId ? { selectedEffort: event.reasoningEffort } : {},
-      );
+      // A thinking-level switch made inside a native terminal. The session's own
+      // effective effort always lands, background included — a live conversation
+      // is never re-bound on return, so dropping it here would leave the picker
+      // wrong until a refresh.
+      applyToNamedConversation(event.conversationId, {
+        sessionReasoningEffort: event.reasoningEffort,
+      });
+      // `selectedEffort` is the app-global sticky pick, so only adopt a value
+      // reported by the conversation the user is actually looking at.
+      if (
+        event.conversationId === sourceConversationId &&
+        useChatStore.getState().conversationId === event.conversationId
+      ) {
+        useChatStore.setState({ selectedEffort: event.reasoningEffort });
+      }
       return;
     case "session_collaboration_mode":
       // A Codex /plan switch made in either the web UI or native TUI.
       // Guard by conversation id so a late frame from an aborted stream
       // cannot paint Plan mode onto the newly-opened conversation.
-      useChatStore.setState((s) =>
-        s.conversationId === event.conversationId ? { codexPlanMode: event.mode === "plan" } : {},
-      );
+      applyToNamedConversation(event.conversationId, { codexPlanMode: event.mode === "plan" });
       return;
     case "session_presence":
       // Full-state replacement — every presence event carries the
       // complete viewer list, so there is no join/leave ordering to
       // get wrong. Guarded by conversation id so a late frame from a
       // switched-away stream can't paint another session's viewers.
-      useChatStore.setState((s) =>
-        s.conversationId === event.conversationId ? { viewers: event.viewers } : {},
-      );
+      applyToNamedConversation(event.conversationId, { viewers: event.viewers });
       return;
     case "session_agent_changed":
       // The session's bound agent was switched in place (switch-agent
@@ -4479,11 +4927,10 @@ export function handleSessionEvent(event: StreamEvent): void {
       // lifecycle) from a fresh snapshot — the event is the only signal
       // an in-place switch produces; the URL doesn't change, so the
       // switchTo/bindStream path never re-runs.
-      useChatStore.setState((s) =>
-        s.conversationId === event.conversationId
-          ? { boundAgentId: event.agentId, boundAgentName: event.agentName }
-          : {},
-      );
+      applyToNamedConversation(event.conversationId, {
+        boundAgentId: event.agentId,
+        boundAgentName: event.agentName,
+      });
       void refreshSessionBinding(event.conversationId);
       // Refresh the header's agent card and the sidebar row for every
       // connected client (the switching client's dialog already does
@@ -4517,13 +4964,13 @@ export function handleSessionEvent(event: StreamEvent): void {
       // estimate so the ring reflects the reduced context without waiting
       // for the next LLM response.completed event.
       if (event.totalTokens != null) {
-        useChatStore.setState({ tokensUsed: event.totalTokens });
+        applyToConversation({ tokensUsed: event.totalTokens });
       }
       return;
     case "compaction_failed":
       // Compaction failed — history is unchanged. Remove the compaction_loading
       // block so the "Compacting…" shimmer disappears without leaving a marker.
-      useChatStore.setState((s) => {
+      applyToConversation((s) => {
         const idx = [...s.blocks].reverse().findIndex((b) => b.type === "compaction_loading");
         if (idx === -1) return {};
         const realIdx = s.blocks.length - 1 - idx;
@@ -4535,7 +4982,7 @@ export function handleSessionEvent(event: StreamEvent): void {
       // server won't emit session.input.consumed for denied inputs, so
       // it would otherwise linger in the transcript). The "Working…"
       // indicator is driven by session.status, not this.
-      useChatStore.setState({
+      applyToConversation({
         pendingUserMessages: [],
       });
       return;
@@ -4548,7 +4995,10 @@ export function handleSessionEvent(event: StreamEvent): void {
       // Captured BEFORE the patch below adopts event.responseId, so a
       // running/waiting status carrying an unseen id marks a new turn.
       const prevResponseId = useChatStore.getState().activeResponse?.responseId;
-      useChatStore.setState((s) => {
+      // The status patch is conversation-scoped; the cache/query side effects
+      // further down are deliberately NOT (they are keyed by explicit id, so a
+      // sub-agent's status still refreshes its parent's rail).
+      applyToNamedConversation(event.conversationId, (s) => {
         // `sessionStatus` tracks the server's session-level status 1:1 — a
         // server `idle` means the session is idle, full stop, and the
         // "Working…" indicator (which reads only `sessionStatus`) turns off.
@@ -4760,14 +5210,14 @@ export function handleSessionEvent(event: StreamEvent): void {
       //   3. No pending entry — render the event payload as a fresh
       //      committed bubble (TUI-typed message, marker, or another
       //      client).
-      useChatStore.setState((s) => {
+      applyToConversation((s) => {
         if (hasCommittedItem(s.blocks, event.itemId)) {
-          // The committed copy is already in `blocks` — the forwarder-
-          // mirrored item beat this event through the stream, or a
-          // snapshot merge inserted it. Still ack the optimistic
-          // bubble: returning without dropping it strands a duplicate
-          // user bubble at the transcript tail. Same precision order
-          // as below (named entry, then FIFO head), minus the append.
+          // The committed copy is already in `blocks` — the forwarder-mirrored
+          // item beat this event through the stream, or a snapshot merge
+          // inserted it. Still ack the optimistic bubble: returning without
+          // dropping it strands a duplicate user bubble at the transcript tail.
+          // Same precision order as below (named entry, then FIFO head), minus
+          // the append.
           const cleared = event.clearedPendingId;
           const at = cleared ? s.pendingUserMessages.findIndex((p) => p.tempId === cleared) : -1;
           if (at >= 0) {
@@ -4778,12 +5228,11 @@ export function handleSessionEvent(event: StreamEvent): void {
               ],
             };
           }
-          // FIFO-head fallback — same marker guard as the promote path
-          // below. A mirrored system marker (the vendor CLI's own
-          // `[Request interrupted by user]` record) is synthesized by the
-          // CLI, owns no pending entry, and arrives with clearedPendingId
-          // unset; dropping the head would steal a real queued message's
-          // bubble. Hold the head back for a marker.
+          // FIFO-head fallback — same marker guard as the promote path below. A
+          // mirrored system marker (the vendor CLI's own `[Request interrupted
+          // by user]` record) is synthesized by the CLI, owns no pending entry,
+          // and arrives with clearedPendingId unset; dropping the head would
+          // steal a real queued message's bubble. Hold the head back for a marker.
           const eventContent = userContentFromEvent(event);
           if (eventContent !== null && isSystemUserContent(eventContent)) return {};
           if (s.pendingUserMessages.length === 0) return {};
@@ -4872,7 +5321,7 @@ export function handleSessionEvent(event: StreamEvent): void {
       // until refresh. Pop the FIFO head here to ack the local
       // send; non-empty guard so observing clients (with no pending
       // bubble) just render the block.
-      useChatStore.setState((s) => {
+      applyToConversation((s) => {
         if (s.pendingUserMessages.length === 0) return {};
         const [, ...rest] = s.pendingUserMessages;
         return { pendingUserMessages: rest };
@@ -4886,14 +5335,14 @@ export function handleSessionEvent(event: StreamEvent): void {
       // becomes a no-op when it sees the existing terminal state.
       if (event.responseId !== undefined) {
         const interruptedResponseId = event.responseId;
-        useChatStore.setState((s) => {
+        applyToConversation((s) => {
           if (s.interruptedResponseIds.includes(interruptedResponseId)) return {};
           return {
             interruptedResponseIds: [...s.interruptedResponseIds, interruptedResponseId],
           };
         });
       }
-      finalizeCurrentActive("cancelled", event.responseId);
+      finalizeCurrentActive("cancelled", event.responseId, sourceConversationId);
       return;
     case "session_created":
       // Sub-agent spawn signal. Invalidate the parent's child-sessions
@@ -4912,23 +5361,21 @@ export function handleSessionEvent(event: StreamEvent): void {
       // switched away from can't yank the user, and ignore a self-target
       // no-op. `ChatPage` observes `redirectToConversationId` and performs
       // the actual react-router navigation.
+      // Writes app-global state (`redirectToConversationId`) alongside
+      // conversation state, so it keeps its own guard rather than going through
+      // `applyToConversation`: the redirect only makes sense for the
+      // conversation on screen, and a background conversation that gets
+      // superseded should redirect when the user switches to it, not before.
       useChatStore.setState((s) => {
         if (s.conversationId !== event.conversationId) return {};
         if (event.targetConversationId === s.conversationId) return {};
-        // The rotation happened mid-input: the `/clear` (or whatever the
-        // user just sent) never gets a `session.input.consumed` on THIS
-        // conversation — the runner moved to the new one — so its optimistic
-        // user bubble would otherwise spin forever. Drop the superseded
-        // conversation's pending bubbles (live view + the navigate-back
-        // stash) since the turn is over; resuming starts a fresh one.
-        const { [event.conversationId]: _removedStash, ...pendingByConversation } =
-          s.pendingByConversation;
-        return {
-          redirectToConversationId: event.targetConversationId,
-          pendingUserMessages: [],
-          pendingByConversation,
-        };
+        return { redirectToConversationId: event.targetConversationId };
       });
+      // The rotation happened mid-input: the `/clear` (or whatever the user just
+      // sent) never gets a `session.input.consumed` on THIS conversation — the
+      // runner moved to the new one — so its optimistic bubble would otherwise
+      // spin forever. Drop it; resuming starts a fresh turn.
+      applyToNamedConversation(event.conversationId, { pendingUserMessages: [] });
       return;
     case "session_resource_created":
       if (event.resource.type === "terminal") {
@@ -4997,7 +5444,7 @@ export function handleSessionEvent(event: StreamEvent): void {
       // Match by id, not first-pending — the `pending` guard keeps
       // a user-delivered verdict from being overwritten by a later
       // duplicate-resolve.
-      useChatStore.setState((s) => {
+      applyToConversation((s) => {
         const matchIdx = s.blocks.findIndex(
           (b) =>
             b.type === "elicitation" &&
@@ -5188,24 +5635,42 @@ function applyChildSessionUpdated(
   queryClient.setQueryData<ChildSessionInfo[]>(key, next);
 }
 
+/**
+ * Apply `session.*` side effects for each event, then pass it through.
+ *
+ * `conversationId` is the stream's own conversation — the only reliable routing
+ * key, since several events carry no id in their payload. It also keys the raw
+ * SSE debug log the execution-logs panel reads.
+ */
 async function* tapSessionEvents(
   events: AsyncIterable<StreamEvent>,
-  sessionId?: string,
+  conversationId: string,
 ): AsyncIterable<StreamEvent> {
   for await (const event of events) {
-    handleSessionEvent(event);
-    if (sessionId !== undefined) pushSseEvent(sessionId, event);
+    handleSessionEvent(event, conversationId);
+    pushSseEvent(conversationId, event);
     yield event;
   }
 }
 
 /**
- * Force the store's `activeResponse` into a terminal state without
- * needing a closure-scoped setter. Mirrors `finalizeActive` but
- * works from the module-scope `handleSessionEvent` boundary.
+ * Force a conversation's `activeResponse` into a terminal state without
+ * needing a closure-scoped setter. Mirrors `finalizeActive` but works from the
+ * module-scope `handleSessionEvent` boundary.
+ *
+ * :param conversationId: the conversation whose stream reported this, or
+ *     ``null`` to target whichever is active. `activeResponse` is
+ *     conversation-scoped, so this lands on that conversation's entry —
+ *     a background interrupt settles its OWN turn and leaves the visible
+ *     one alone.
  */
-function finalizeCurrentActive(state: ActiveResponse["state"], responseIdOverride?: string): void {
-  useChatStore.setState((s) => {
+function finalizeCurrentActive(
+  state: ActiveResponse["state"],
+  responseIdOverride?: string,
+  conversationId?: string | null,
+): void {
+  const target = conversationId ?? useChatStore.getState().conversationId;
+  setterFor(target)((s) => {
     if (s.activeResponse === null && responseIdOverride === undefined) return {};
     const responseId = s.activeResponse?.responseId ?? responseIdOverride ?? "";
     return {

--- a/web/src/store/conversationRegistry.test.ts
+++ b/web/src/store/conversationRegistry.test.ts
@@ -1,0 +1,337 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ConversationRegistry,
+  getConnectionProtocol,
+  maxLiveConversations,
+} from "./conversationRegistry";
+import type { PendingUserMessage } from "./chatStore";
+
+/** An unsettled optimistic bubble — the shape that pins an entry. */
+function unsentBubble(tempId = "pend_1"): PendingUserMessage {
+  return { tempId, content: [{ type: "input_text", text: "hi" }] };
+}
+
+/** A bubble whose POST has returned; the server owns it now. */
+function postedBubble(tempId = "pend_1"): PendingUserMessage {
+  return { ...unsentBubble(tempId), posted: true };
+}
+
+describe("maxLiveConversations", () => {
+  it("allows 30 when multiplexed and only 3 when serial", () => {
+    // Not a product number: HTTP/2 multiplexes over one connection, while
+    // HTTP/1.1 caps ~6 per origin and an SSE stream holds one for its whole
+    // life — 30 there deadlocks every other fetch.
+    expect(maxLiveConversations("multiplexed")).toBe(30);
+    expect(maxLiveConversations("serial")).toBe(3);
+  });
+});
+
+describe("getConnectionProtocol", () => {
+  /** Pin the navigation entry's negotiated ALPN id. */
+  function withNextHop<T>(nextHopProtocol: string | undefined, body: () => T): T {
+    const spy = vi
+      .spyOn(performance, "getEntriesByType")
+      .mockReturnValue(
+        nextHopProtocol === undefined ? [] : [{ nextHopProtocol } as unknown as PerformanceEntry],
+      );
+    try {
+      return body();
+    } finally {
+      spy.mockRestore();
+    }
+  }
+
+  it("reads the negotiated protocol rather than the URL scheme", () => {
+    // The scheme does not imply the protocol: an HTTPS origin that negotiated
+    // HTTP/1.1 has the same ~6-connection ceiling as the dev server, so
+    // treating it as multiplexed would deadlock the pool.
+    expect(withNextHop("h2", getConnectionProtocol)).toBe("multiplexed");
+    expect(withNextHop("h3", getConnectionProtocol)).toBe("multiplexed");
+    expect(withNextHop("http/1.1", getConnectionProtocol)).toBe("serial");
+  });
+
+  it("falls back to the scheme when no navigation entry is available", () => {
+    // Old browsers, non-navigation contexts: `https:` is the better guess.
+    expect(withNextHop(undefined, getConnectionProtocol)).toBe(
+      location.protocol === "https:" ? "multiplexed" : "serial",
+    );
+  });
+
+  it("treats an empty nextHopProtocol as unknown", () => {
+    // Cross-origin and cached navigations report "" — not a serial transport.
+    expect(withNextHop("", getConnectionProtocol)).toBe(
+      location.protocol === "https:" ? "multiplexed" : "serial",
+    );
+  });
+});
+
+describe("ConversationRegistry", () => {
+  let registry: ConversationRegistry;
+  /** Small enough that eviction is reachable without opening 30 entries. */
+  const CAPACITY = 3;
+
+  beforeEach(() => {
+    registry = new ConversationRegistry(() => CAPACITY);
+  });
+
+  it("creates an entry on first acquire and returns the same one after", () => {
+    const first = registry.acquire("conv_a");
+    expect(first.id).toBe("conv_a");
+    expect(registry.acquire("conv_a")).toBe(first);
+    expect(registry.ids()).toEqual(["conv_a"]);
+  });
+
+  it("starts an entry from the initial conversation state", () => {
+    const entry = registry.acquire("conv_a");
+    expect(entry.getState().blocks).toEqual([]);
+    expect(entry.getState().sessionStatus).toBe("idle");
+    expect(entry.disposed).toBe(false);
+  });
+
+  it("keeps each entry's state independent", () => {
+    const a = registry.acquire("conv_a");
+    const b = registry.acquire("conv_b");
+    a.setState({ sessionStatus: "running" });
+    // The whole point: a background conversation's status cannot bleed.
+    expect(a.getState().sessionStatus).toBe("running");
+    expect(b.getState().sessionStatus).toBe("idle");
+  });
+
+  it("notifies subscribers with the id of the entry that changed", () => {
+    const seen: string[] = [];
+    registry.subscribe((id) => seen.push(id));
+    const a = registry.acquire("conv_a");
+    const b = registry.acquire("conv_b");
+    a.setState({ sessionStatus: "running" });
+    b.setState({ status: "streaming" });
+    expect(seen).toEqual(["conv_a", "conv_b"]);
+  });
+
+  it("does not notify when a patch changes nothing", () => {
+    const entry = registry.acquire("conv_a");
+    const listener = vi.fn();
+    registry.subscribe(listener);
+    entry.setState({ sessionStatus: "idle" }); // already idle
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("ignores app-global keys written through an entry", () => {
+    const entry = registry.acquire("conv_a");
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      // `selectedModel` is a sticky app-level pref, not conversation state.
+      entry.setState({ selectedModel: "opus" } as never);
+      expect(
+        (entry.getState() as unknown as Record<string, unknown>).selectedModel,
+      ).toBeUndefined();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("evicts the least-recently-viewed entry once over budget", () => {
+    // Cap is 3 on HTTP/1.1. conv_a is oldest, so it goes.
+    const a = registry.acquire("conv_a");
+    registry.acquire("conv_b");
+    registry.acquire("conv_c");
+    registry.acquire("conv_d");
+    expect(registry.ids()).toEqual(["conv_b", "conv_c", "conv_d"]);
+    expect(a.disposed).toBe(true);
+    expect(registry.has("conv_a")).toBe(false);
+  });
+
+  it("treats acquire as a recency touch, so a revisited entry is not the victim", () => {
+    registry.acquire("conv_a");
+    registry.acquire("conv_b");
+    registry.acquire("conv_c");
+    registry.acquire("conv_a"); // revisit → conv_b is now oldest
+    registry.acquire("conv_d");
+    expect(registry.ids()).toEqual(["conv_c", "conv_a", "conv_d"]);
+  });
+
+  it("never evicts the conversation on screen, even when it is oldest", () => {
+    registry.acquire("conv_a");
+    registry.setActive("conv_a");
+    registry.acquire("conv_b");
+    registry.acquire("conv_c");
+    registry.acquire("conv_d");
+    expect(registry.has("conv_a")).toBe(true);
+  });
+
+  it("never evicts an entry holding a send the server has not acknowledged", () => {
+    // The one case where eviction is NOT equivalent to a cold load: until the
+    // POST returns, the message exists nowhere but this tab.
+    const a = registry.acquire("conv_a");
+    a.setState({ pendingUserMessages: [unsentBubble()] });
+    registry.acquire("conv_b");
+    registry.acquire("conv_c");
+    registry.acquire("conv_d");
+    expect(registry.has("conv_a")).toBe(true);
+    expect(a.disposed).toBe(false);
+    // conv_b was the next-oldest unprotected entry.
+    expect(registry.has("conv_b")).toBe(false);
+  });
+
+  it("does evict an entry whose sends have all settled", () => {
+    // Once the POST returns, the server can account for the message — the
+    // navigate-back snapshot re-seeds it, so dropping the entry is safe.
+    const a = registry.acquire("conv_a");
+    a.setState({ pendingUserMessages: [postedBubble()] });
+    registry.acquire("conv_b");
+    registry.acquire("conv_c");
+    registry.acquire("conv_d");
+    expect(registry.has("conv_a")).toBe(false);
+  });
+
+  it("exceeds the cap rather than destroying unsent work", () => {
+    // Pathological: every entry is pinned. Going over budget costs a
+    // connection slot; evicting would lose the user's messages.
+    for (const id of ["conv_a", "conv_b", "conv_c"]) {
+      registry.acquire(id).setState({ pendingUserMessages: [unsentBubble(`pend_${id}`)] });
+    }
+    registry.acquire("conv_d");
+    expect(registry.ids()).toHaveLength(4);
+  });
+
+  it("shrinks back to the cap as soon as a pin clears", () => {
+    // Eviction used to run only from `acquire`, so an over-cap registry stayed
+    // over-cap — every excess SSE connection held open until the user happened
+    // to open another conversation. Enough send-and-switch cycles could then
+    // exhaust the HTTP/1.1 pool despite the advertised cap.
+    for (const id of ["conv_a", "conv_b", "conv_c"]) {
+      registry.acquire(id).setState({ pendingUserMessages: [unsentBubble(`pend_${id}`)] });
+    }
+    const d = registry.acquire("conv_d");
+    registry.setActive("conv_d");
+    expect(registry.ids()).toHaveLength(4);
+
+    // conv_a's POST returns: the server owns the message now, so the pin that
+    // was holding the registry over budget is gone.
+    registry.peek("conv_a")!.setState({ pendingUserMessages: [postedBubble("pend_conv_a")] });
+
+    expect(registry.ids()).toEqual(["conv_b", "conv_c", "conv_d"]);
+    expect(registry.has("conv_a")).toBe(false);
+    expect(d.disposed).toBe(false);
+  });
+
+  it("does not evict the entry whose own pin just cleared when it is still needed", () => {
+    // The settling entry is the one being written to; trimming must pick a
+    // different victim (here: the next-oldest unpinned entry) rather than
+    // disposing the entry mid-write.
+    const a = registry.acquire("conv_a");
+    a.setState({ pendingUserMessages: [unsentBubble("pend_a")] });
+    registry.acquire("conv_b").setState({ pendingUserMessages: [unsentBubble("pend_b")] });
+    registry.acquire("conv_c").setState({ pendingUserMessages: [unsentBubble("pend_c")] });
+    registry.acquire("conv_d");
+    registry.setActive("conv_d");
+    // conv_b settles — it is now the oldest unpinned entry, so it is the victim.
+    registry.peek("conv_b")!.setState({ pendingUserMessages: [postedBubble("pend_b")] });
+    expect(registry.has("conv_b")).toBe(false);
+    expect(registry.has("conv_a")).toBe(true);
+    expect(a.disposed).toBe(false);
+  });
+
+  it("trims the outgoing conversation when switching back to an existing one", () => {
+    // Moving the on-screen exemption can itself make an entry evictable. A/B/C
+    // pinned, then cold-opening D leaves four entries — correct, D is protected
+    // as both active and just-acquired. Switching back to A makes the now-unpinned
+    // D a valid victim, but `setActive` used not to trim and `acquire(A)` returns
+    // early for an existing entry, so D's excess SSE connection stayed open until
+    // something unrelated happened.
+    for (const id of ["conv_a", "conv_b", "conv_c"]) {
+      registry.acquire(id).setState({ pendingUserMessages: [unsentBubble(`pend_${id}`)] });
+    }
+    const d = registry.acquire("conv_d");
+    registry.setActive("conv_d");
+    expect(registry.ids()).toHaveLength(4);
+
+    // Back to A, which is still live. D is no longer active or pinned.
+    registry.setActive("conv_a");
+
+    expect(registry.has("conv_d")).toBe(false);
+    expect(d.disposed).toBe(true);
+    expect(registry.ids()).toHaveLength(3);
+    expect(registry.has("conv_a")).toBe(true);
+  });
+
+  it("never evicts the conversation being switched TO", () => {
+    // The incoming conversation is about to be painted, so the new `setActive`
+    // trim must never take it. Here every entry is pinned, so the sweep finds no
+    // legal victim and the registry correctly stays over budget rather than
+    // disposing the entry the user is switching to.
+    const a = registry.acquire("conv_a");
+    a.setState({ pendingUserMessages: [unsentBubble("pend_a")] });
+    registry.acquire("conv_b").setState({ pendingUserMessages: [unsentBubble("pend_b")] });
+    registry.acquire("conv_c").setState({ pendingUserMessages: [unsentBubble("pend_c")] });
+    registry.acquire("conv_d").setState({ pendingUserMessages: [unsentBubble("pend_d")] });
+    registry.setActive("conv_d");
+    expect(registry.ids()).toHaveLength(4);
+
+    registry.setActive("conv_a");
+
+    expect(registry.has("conv_a")).toBe(true);
+    expect(a.disposed).toBe(false);
+    expect(registry.ids()).toHaveLength(4);
+  });
+
+  it("never hands back an entry it just evicted", () => {
+    // Eviction runs after insertion, so the entry being acquired is itself a
+    // candidate. With every older entry pinned, the sweep would otherwise reach
+    // the new one and dispose it — returning a dead entry whose writes are
+    // silently dropped, which is worse than exceeding the cap.
+    for (const id of ["conv_a", "conv_b", "conv_c"]) {
+      registry.acquire(id).setState({ pendingUserMessages: [unsentBubble(`pend_${id}`)] });
+    }
+    const fresh = registry.acquire("conv_d");
+    expect(fresh.disposed).toBe(false);
+    expect(registry.has("conv_d")).toBe(true);
+  });
+
+  it("aborts the stream when an entry is disposed", () => {
+    const entry = registry.acquire("conv_a");
+    const controller = new AbortController();
+    entry.setState({ abortController: controller });
+    registry.release("conv_a");
+    expect(controller.signal.aborted).toBe(true);
+    expect(entry.disposed).toBe(true);
+  });
+
+  it("drops writes to a disposed entry but still serves reads", () => {
+    // In-flight async work must be able to unwind without resurrecting state
+    // for an evicted conversation.
+    const entry = registry.acquire("conv_a");
+    entry.setState({ sessionStatus: "running" });
+    registry.release("conv_a");
+    entry.setState({ sessionStatus: "failed" });
+    expect(entry.getState().sessionStatus).toBe("running");
+  });
+
+  it("is idempotent on repeated release and dispose", () => {
+    const entry = registry.acquire("conv_a");
+    registry.release("conv_a");
+    expect(() => {
+      registry.release("conv_a");
+      entry.dispose();
+    }).not.toThrow();
+  });
+
+  it("clears every entry", () => {
+    const a = registry.acquire("conv_a");
+    const b = registry.acquire("conv_b");
+    registry.setActive("conv_a");
+    registry.clear();
+    expect(registry.ids()).toEqual([]);
+    expect(a.disposed).toBe(true);
+    expect(b.disposed).toBe(true);
+    expect(registry.getActive()).toBeNull();
+  });
+
+  it("reports the active entry, and null once it is gone", () => {
+    registry.acquire("conv_a");
+    registry.setActive("conv_a");
+    expect(registry.getActive()?.id).toBe("conv_a");
+    registry.release("conv_a");
+    expect(registry.getActive()).toBeNull();
+  });
+});

--- a/web/src/store/conversationRegistry.test.ts
+++ b/web/src/store/conversationRegistry.test.ts
@@ -182,6 +182,33 @@ describe("ConversationRegistry", () => {
     expect(a.disposed).toBe(false);
   });
 
+  it("never evicts an entry holding a failed-send draft", () => {
+    // A send that failed rolls its optimistic bubble back but stashes the text
+    // + files as `failedSendDraft` — the only surviving copy, since the server
+    // never received it. If that failure settles after the conversation was
+    // backgrounded, the rolled-back bubble leaves nothing else pinning the
+    // entry, so eviction would drop the retry draft. Pin on the draft too.
+    const a = registry.acquire("conv_a");
+    a.setState({
+      pendingUserMessages: [], // bubble already rolled back
+      failedSendDraft: { conversationId: "conv_a", text: "retry me", files: [] },
+    });
+    registry.acquire("conv_b");
+    expect(registry.evictLruEvictable()).toBe("conv_b");
+    expect(registry.has("conv_a")).toBe(true);
+    expect(a.disposed).toBe(false);
+  });
+
+  it("evicts once a failed-send draft is cleared (composer restored it)", () => {
+    // The pin releases as soon as the draft is consumed on return, so the entry
+    // stops holding a slot the moment its retry copy is safe in the composer.
+    const a = registry.acquire("conv_a");
+    a.setState({ failedSendDraft: { conversationId: "conv_a", text: "x", files: [] } });
+    a.setState({ failedSendDraft: null });
+    expect(registry.evictLruEvictable()).toBe("conv_a");
+    expect(a.disposed).toBe(true);
+  });
+
   it("does evict an entry whose sends have all settled", () => {
     // Once the POST returns, the server can account for the message — the
     // navigate-back snapshot re-seeds it, so reclaiming its slot is safe.

--- a/web/src/store/conversationRegistry.test.ts
+++ b/web/src/store/conversationRegistry.test.ts
@@ -68,11 +68,9 @@ describe("getConnectionProtocol", () => {
 
 describe("ConversationRegistry", () => {
   let registry: ConversationRegistry;
-  /** Small enough that eviction is reachable without opening 30 entries. */
-  const CAPACITY = 3;
 
   beforeEach(() => {
-    registry = new ConversationRegistry(() => CAPACITY);
+    registry = new ConversationRegistry();
   });
 
   it("creates an entry on first acquire and returns the same one after", () => {
@@ -130,15 +128,19 @@ describe("ConversationRegistry", () => {
     }
   });
 
-  it("evicts the least-recently-viewed entry once over budget", () => {
-    // Cap is 3 on HTTP/1.1. conv_a is oldest, so it goes.
+  it("evictLruEvictable disposes the least-recently-viewed entry and returns its id", () => {
+    // The slot layer calls this to reclaim one of this tab's own background
+    // streams when the origin is saturated. conv_a is oldest → it goes.
     const a = registry.acquire("conv_a");
     registry.acquire("conv_b");
     registry.acquire("conv_c");
-    registry.acquire("conv_d");
-    expect(registry.ids()).toEqual(["conv_b", "conv_c", "conv_d"]);
+    expect(registry.evictLruEvictable()).toBe("conv_a");
     expect(a.disposed).toBe(true);
-    expect(registry.has("conv_a")).toBe(false);
+    expect(registry.ids()).toEqual(["conv_b", "conv_c"]);
+  });
+
+  it("returns null when there is nothing to evict", () => {
+    expect(registry.evictLruEvictable()).toBeNull();
   });
 
   it("treats acquire as a recency touch, so a revisited entry is not the victim", () => {
@@ -146,146 +148,59 @@ describe("ConversationRegistry", () => {
     registry.acquire("conv_b");
     registry.acquire("conv_c");
     registry.acquire("conv_a"); // revisit → conv_b is now oldest
-    registry.acquire("conv_d");
-    expect(registry.ids()).toEqual(["conv_c", "conv_a", "conv_d"]);
+    expect(registry.evictLruEvictable()).toBe("conv_b");
+    expect(registry.ids()).toEqual(["conv_c", "conv_a"]);
   });
 
   it("never evicts the conversation on screen, even when it is oldest", () => {
-    registry.acquire("conv_a");
+    const a = registry.acquire("conv_a");
     registry.setActive("conv_a");
     registry.acquire("conv_b");
-    registry.acquire("conv_c");
-    registry.acquire("conv_d");
+    // conv_a is oldest but on screen → skipped; conv_b is reclaimed instead.
+    expect(registry.evictLruEvictable()).toBe("conv_b");
     expect(registry.has("conv_a")).toBe(true);
+    expect(a.disposed).toBe(false);
+  });
+
+  it("never evicts the conversation being bound (exemptId)", () => {
+    // The entry whose stream the slot layer is opening must survive — evicting
+    // it would hand back a dead entry.
+    registry.acquire("conv_a");
+    registry.acquire("conv_d");
+    expect(registry.evictLruEvictable("conv_d")).toBe("conv_a");
+    expect(registry.has("conv_d")).toBe(true);
   });
 
   it("never evicts an entry holding a send the server has not acknowledged", () => {
     // The one case where eviction is NOT equivalent to a cold load: until the
-    // POST returns, the message exists nowhere but this tab.
+    // POST returns, the message exists nowhere but this tab. Skip it, take next.
     const a = registry.acquire("conv_a");
     a.setState({ pendingUserMessages: [unsentBubble()] });
     registry.acquire("conv_b");
-    registry.acquire("conv_c");
-    registry.acquire("conv_d");
+    expect(registry.evictLruEvictable()).toBe("conv_b");
     expect(registry.has("conv_a")).toBe(true);
     expect(a.disposed).toBe(false);
-    // conv_b was the next-oldest unprotected entry.
-    expect(registry.has("conv_b")).toBe(false);
   });
 
   it("does evict an entry whose sends have all settled", () => {
     // Once the POST returns, the server can account for the message — the
-    // navigate-back snapshot re-seeds it, so dropping the entry is safe.
+    // navigate-back snapshot re-seeds it, so reclaiming its slot is safe.
     const a = registry.acquire("conv_a");
     a.setState({ pendingUserMessages: [postedBubble()] });
-    registry.acquire("conv_b");
-    registry.acquire("conv_c");
-    registry.acquire("conv_d");
-    expect(registry.has("conv_a")).toBe(false);
+    expect(registry.evictLruEvictable()).toBe("conv_a");
+    expect(a.disposed).toBe(true);
   });
 
-  it("exceeds the cap rather than destroying unsent work", () => {
-    // Pathological: every entry is pinned. Going over budget costs a
-    // connection slot; evicting would lose the user's messages.
-    for (const id of ["conv_a", "conv_b", "conv_c"]) {
-      registry.acquire(id).setState({ pendingUserMessages: [unsentBubble(`pend_${id}`)] });
-    }
-    registry.acquire("conv_d");
-    expect(registry.ids()).toHaveLength(4);
-  });
-
-  it("shrinks back to the cap as soon as a pin clears", () => {
-    // Eviction used to run only from `acquire`, so an over-cap registry stayed
-    // over-cap — every excess SSE connection held open until the user happened
-    // to open another conversation. Enough send-and-switch cycles could then
-    // exhaust the HTTP/1.1 pool despite the advertised cap.
-    for (const id of ["conv_a", "conv_b", "conv_c"]) {
-      registry.acquire(id).setState({ pendingUserMessages: [unsentBubble(`pend_${id}`)] });
-    }
-    const d = registry.acquire("conv_d");
-    registry.setActive("conv_d");
-    expect(registry.ids()).toHaveLength(4);
-
-    // conv_a's POST returns: the server owns the message now, so the pin that
-    // was holding the registry over budget is gone.
-    registry.peek("conv_a")!.setState({ pendingUserMessages: [postedBubble("pend_conv_a")] });
-
-    expect(registry.ids()).toEqual(["conv_b", "conv_c", "conv_d"]);
-    expect(registry.has("conv_a")).toBe(false);
-    expect(d.disposed).toBe(false);
-  });
-
-  it("does not evict the entry whose own pin just cleared when it is still needed", () => {
-    // The settling entry is the one being written to; trimming must pick a
-    // different victim (here: the next-oldest unpinned entry) rather than
-    // disposing the entry mid-write.
+  it("returns null when every entry is protected rather than destroying unsent work", () => {
+    // The slot layer reads this null as "origin saturated, nothing of mine to
+    // reclaim" and opens the active conversation over budget with the
+    // too-many-tabs banner.
     const a = registry.acquire("conv_a");
     a.setState({ pendingUserMessages: [unsentBubble("pend_a")] });
     registry.acquire("conv_b").setState({ pendingUserMessages: [unsentBubble("pend_b")] });
-    registry.acquire("conv_c").setState({ pendingUserMessages: [unsentBubble("pend_c")] });
-    registry.acquire("conv_d");
-    registry.setActive("conv_d");
-    // conv_b settles — it is now the oldest unpinned entry, so it is the victim.
-    registry.peek("conv_b")!.setState({ pendingUserMessages: [postedBubble("pend_b")] });
-    expect(registry.has("conv_b")).toBe(false);
-    expect(registry.has("conv_a")).toBe(true);
-    expect(a.disposed).toBe(false);
-  });
-
-  it("trims the outgoing conversation when switching back to an existing one", () => {
-    // Moving the on-screen exemption can itself make an entry evictable. A/B/C
-    // pinned, then cold-opening D leaves four entries — correct, D is protected
-    // as both active and just-acquired. Switching back to A makes the now-unpinned
-    // D a valid victim, but `setActive` used not to trim and `acquire(A)` returns
-    // early for an existing entry, so D's excess SSE connection stayed open until
-    // something unrelated happened.
-    for (const id of ["conv_a", "conv_b", "conv_c"]) {
-      registry.acquire(id).setState({ pendingUserMessages: [unsentBubble(`pend_${id}`)] });
-    }
-    const d = registry.acquire("conv_d");
-    registry.setActive("conv_d");
-    expect(registry.ids()).toHaveLength(4);
-
-    // Back to A, which is still live. D is no longer active or pinned.
-    registry.setActive("conv_a");
-
-    expect(registry.has("conv_d")).toBe(false);
-    expect(d.disposed).toBe(true);
-    expect(registry.ids()).toHaveLength(3);
-    expect(registry.has("conv_a")).toBe(true);
-  });
-
-  it("never evicts the conversation being switched TO", () => {
-    // The incoming conversation is about to be painted, so the new `setActive`
-    // trim must never take it. Here every entry is pinned, so the sweep finds no
-    // legal victim and the registry correctly stays over budget rather than
-    // disposing the entry the user is switching to.
-    const a = registry.acquire("conv_a");
-    a.setState({ pendingUserMessages: [unsentBubble("pend_a")] });
-    registry.acquire("conv_b").setState({ pendingUserMessages: [unsentBubble("pend_b")] });
-    registry.acquire("conv_c").setState({ pendingUserMessages: [unsentBubble("pend_c")] });
-    registry.acquire("conv_d").setState({ pendingUserMessages: [unsentBubble("pend_d")] });
-    registry.setActive("conv_d");
-    expect(registry.ids()).toHaveLength(4);
-
-    registry.setActive("conv_a");
-
-    expect(registry.has("conv_a")).toBe(true);
-    expect(a.disposed).toBe(false);
-    expect(registry.ids()).toHaveLength(4);
-  });
-
-  it("never hands back an entry it just evicted", () => {
-    // Eviction runs after insertion, so the entry being acquired is itself a
-    // candidate. With every older entry pinned, the sweep would otherwise reach
-    // the new one and dispose it — returning a dead entry whose writes are
-    // silently dropped, which is worse than exceeding the cap.
-    for (const id of ["conv_a", "conv_b", "conv_c"]) {
-      registry.acquire(id).setState({ pendingUserMessages: [unsentBubble(`pend_${id}`)] });
-    }
-    const fresh = registry.acquire("conv_d");
-    expect(fresh.disposed).toBe(false);
-    expect(registry.has("conv_d")).toBe(true);
+    registry.setActive("conv_b"); // conv_b on screen, conv_a pinned
+    expect(registry.evictLruEvictable()).toBeNull();
+    expect(registry.ids()).toEqual(["conv_a", "conv_b"]);
   });
 
   it("aborts the stream when an entry is disposed", () => {

--- a/web/src/store/conversationRegistry.ts
+++ b/web/src/store/conversationRegistry.ts
@@ -1,0 +1,322 @@
+// Per-conversation state + stream ownership, and the LRU registry that holds
+// them.
+//
+// Each entry owns ONE conversation: its `ConversationState` and its SSE stream
+// (including the reconnect loop). An entry is either **live** — state plus an
+// open stream — or **absent**. There is deliberately no third "retained but
+// detached" state: a detached entry holding stale state that must be reconciled
+// on revisit is a transcript cache in a different shape, which is what keeping
+// streams open replaces. Live-or-gone is the simplification.
+
+import type { ConversationState } from "./chatStore";
+import { createInitialConversationState, isConversationStateKey } from "./conversationState";
+
+/**
+ * Whether the origin's transport multiplexes requests over one connection.
+ *
+ * `multiplexed` — HTTP/2 or HTTP/3: many concurrent streams on one connection.
+ * `serial` — HTTP/1.1: the browser caps connections per origin, and an SSE
+ * stream holds one for its entire life.
+ */
+export type ConnectionProtocol = "multiplexed" | "serial";
+
+/** ALPN ids that multiplex. `h2c` is HTTP/2 over cleartext. */
+const MULTIPLEXED_ALPN_IDS = new Set(["h2", "h2c", "h3"]);
+
+/**
+ * How the browser is actually talking to this origin.
+ *
+ * Prefers the navigation entry's `nextHopProtocol` — the negotiated ALPN id, so
+ * the real answer — because the URL scheme does not imply a protocol: plenty of
+ * HTTPS deployments still negotiate HTTP/1.1, and treating those as multiplexed
+ * would deadlock the connection pool exactly like the dev server does.
+ *
+ * Falls back to the scheme only when the timing entry is unavailable (no
+ * `performance` in the environment, an old browser, or a navigation the entry
+ * doesn't cover), where `https:` is the better guess than `http:`.
+ */
+export function getConnectionProtocol(): ConnectionProtocol {
+  const nextHop = readNextHopProtocol();
+  if (nextHop !== null && nextHop !== "") {
+    return MULTIPLEXED_ALPN_IDS.has(nextHop) ? "multiplexed" : "serial";
+  }
+  const scheme = typeof location === "undefined" ? undefined : location.protocol;
+  return scheme === "https:" ? "multiplexed" : "serial";
+}
+
+/** The document navigation's negotiated ALPN id, or `null` when unavailable. */
+function readNextHopProtocol(): string | null {
+  if (typeof performance === "undefined" || typeof performance.getEntriesByType !== "function") {
+    return null;
+  }
+  try {
+    const [nav] = performance.getEntriesByType("navigation");
+    const value = (nav as PerformanceNavigationTiming | undefined)?.nextHopProtocol;
+    return typeof value === "string" ? value : null;
+  } catch {
+    // `getEntriesByType` is well-supported, but this runs on every eviction
+    // check — a throw here must not take the registry down with it.
+    return null;
+  }
+}
+
+/**
+ * How many conversations stay live at once.
+ *
+ * Derived from the transport, not from product taste. HTTP/2 multiplexes every
+ * request to an origin over one TCP connection, so the ceiling is the server's
+ * `SETTINGS_MAX_CONCURRENT_STREAMS` (~100). Plain HTTP/1.1 — the dev server,
+ * which configures `server.proxy` with no `https` — is capped by the browser at
+ * ~6 connections per origin, and an SSE stream holds one for its entire life.
+ * Thirty streams there is not "slower", it is a deadlock: every ordinary fetch
+ * blocks behind them forever.
+ */
+export function maxLiveConversations(
+  protocol: ConnectionProtocol = getConnectionProtocol(),
+): number {
+  return protocol === "multiplexed" ? 30 : 3;
+}
+
+/** Writes a patch into a conversation's state. Mirrors zustand's `setState`. */
+export type ConversationSetter = (
+  partial: Partial<ConversationState> | ((state: ConversationState) => Partial<ConversationState>),
+) => void;
+
+/** Reads a conversation's current state. */
+export type ConversationGetter = () => ConversationState;
+
+/** Notified whenever an entry's state changes, so the root store can mirror it. */
+type ChangeListener = (id: string) => void;
+
+/**
+ * One conversation's live state and stream.
+ *
+ * `disposed` is the **liveness** flag. The streaming machinery's loop and write
+ * guards ask this — "am I still loaded?" — rather than "am I the conversation on
+ * screen?", which is what let a background pump exit on its first reconnect
+ * check. Nothing here knows or cares whether it is the active conversation.
+ */
+export interface ConversationEntry {
+  readonly id: string;
+  /** True once evicted or released. A disposed entry must stop pumping. */
+  disposed: boolean;
+  getState: ConversationGetter;
+  setState: ConversationSetter;
+  /** Tear down the stream and mark the entry dead. Idempotent. */
+  dispose: () => void;
+}
+
+/**
+ * Owns the set of live conversations.
+ *
+ * Insertion order is recency: `acquire` re-inserts, so the first key is the
+ * least-recently-viewed and therefore the eviction candidate.
+ */
+export class ConversationRegistry {
+  private readonly entries = new Map<string, ConversationEntry>();
+  private readonly listeners = new Set<ChangeListener>();
+  /** Conversation currently on screen; exempt from eviction. */
+  private activeId: string | null = null;
+  /** How many entries may be live. Injectable so tests can pin a small cap. */
+  private readonly capacity: () => number;
+
+  /**
+   * :param capacity: live-entry budget, read on each eviction check. Defaults
+   *     to the transport-derived {@link maxLiveConversations}.
+   */
+  constructor(capacity: () => number = maxLiveConversations) {
+    this.capacity = capacity;
+  }
+
+  /**
+   * Subscribe to state changes across all entries.
+   *
+   * The root store uses this to mirror the active entry. Returns an
+   * unsubscribe function.
+   */
+  subscribe(listener: ChangeListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /** The entry for `id`, or `undefined` when not live. */
+  peek(id: string): ConversationEntry | undefined {
+    return this.entries.get(id);
+  }
+
+  /** Whether `id` is currently live. */
+  has(id: string): boolean {
+    return this.entries.has(id);
+  }
+
+  /** Live entry ids, least-recently-viewed first. */
+  ids(): string[] {
+    return [...this.entries.keys()];
+  }
+
+  /** Every live entry. */
+  all(): ConversationEntry[] {
+    return [...this.entries.values()];
+  }
+
+  /**
+   * Mark which conversation is on screen.
+   *
+   * Only used to exempt it from eviction — no behaviour is gated on being
+   * active. Pass `null` on the landing route.
+   *
+   * Re-trims, because moving the exemption can make the OUTGOING conversation
+   * evictable: an over-cap registry that only stayed over-cap to protect it
+   * must shrink now, not wait for an unrelated acquire.
+   */
+  setActive(id: string | null): void {
+    this.activeId = id;
+    if (id !== null) this.touch(id);
+    this.evictIfOverBudget(id ?? undefined);
+  }
+
+  /** The conversation on screen, or `null`. */
+  getActive(): ConversationEntry | null {
+    if (this.activeId === null) return null;
+    return this.entries.get(this.activeId) ?? null;
+  }
+
+  /**
+   * Get or create the entry for `id`, marking it most-recently-viewed.
+   *
+   * A fresh entry starts from `createInitialConversationState()`; the caller
+   * binds its stream. Creating one may evict the least-recently-viewed entry.
+   */
+  acquire(id: string): ConversationEntry {
+    const existing = this.entries.get(id);
+    if (existing !== undefined) {
+      this.touch(id);
+      return existing;
+    }
+    const entry = this.createEntry(id);
+    this.entries.set(id, entry);
+    this.evictIfOverBudget(id);
+    return entry;
+  }
+
+  /**
+   * Drop `id` — on conversation delete, or when its stream is permanently
+   * unavailable. Replaces the old `evictTranscriptCache`.
+   */
+  release(id: string): void {
+    const entry = this.entries.get(id);
+    if (entry === undefined) return;
+    this.entries.delete(id);
+    entry.dispose();
+  }
+
+  /** Drop every entry (app teardown / test reset). */
+  clear(): void {
+    for (const entry of [...this.entries.values()]) entry.dispose();
+    this.entries.clear();
+    this.activeId = null;
+  }
+
+  /** Move `id` to the most-recently-viewed end of the LRU order. */
+  private touch(id: string): void {
+    const entry = this.entries.get(id);
+    if (entry === undefined) return;
+    this.entries.delete(id);
+    this.entries.set(id, entry);
+  }
+
+  /**
+   * Evict least-recently-viewed entries until within budget.
+   *
+   * Protected from eviction: the conversation on screen, the entry just
+   * acquired (evicting it would hand the caller a disposed entry), and any
+   * entry holding work the server does not know about yet — see
+   * `hasUnsentWork`. When every candidate is protected the map is allowed to
+   * exceed the cap: going over budget costs memory and a connection slot, while
+   * evicting would destroy a user's message.
+   *
+   * Runs from every path that can make an entry evictable — `acquire`, a
+   * clearing pin, and `setActive` (which moves the on-screen exemption) —
+   * because an over-cap registry has to shrink at that moment rather than
+   * waiting for an unrelated acquire. Otherwise repeated send-and-switch leaves
+   * the excess streams open indefinitely and can exhaust an HTTP/1.1 pool.
+   *
+   * :param justAcquiredId: entry the caller is about to be handed, if any.
+   */
+  private evictIfOverBudget(justAcquiredId?: string): void {
+    const budget = this.capacity();
+    for (const id of [...this.entries.keys()]) {
+      if (this.entries.size <= budget) return;
+      if (id === this.activeId || id === justAcquiredId) continue;
+      const entry = this.entries.get(id);
+      if (entry === undefined || hasUnsentWork(entry.getState())) continue;
+      this.entries.delete(id);
+      entry.dispose();
+    }
+  }
+
+  private createEntry(id: string): ConversationEntry {
+    let state = createInitialConversationState();
+    const entry: ConversationEntry = {
+      id,
+      disposed: false,
+      getState: () => state,
+      setState: (partial) => {
+        // A disposed entry still accepts reads, so in-flight async work can
+        // unwind cleanly, but writes are dropped: nothing should be able to
+        // resurrect state for a conversation that has been evicted.
+        if (entry.disposed) return;
+        const wasPinned = hasUnsentWork(state);
+        const patch = typeof partial === "function" ? partial(state) : partial;
+        let changed = false;
+        const next = { ...state };
+        for (const [key, value] of Object.entries(patch)) {
+          if (!isConversationStateKey(key)) {
+            // A key outside `ConversationState` means a caller is trying to
+            // write app-global state through a conversation. Loud in dev
+            // because the alternative is state that silently goes nowhere.
+            if (import.meta.env?.DEV) {
+              console.error(
+                `conversation ${id}: ignoring non-conversation state key "${key}" — ` +
+                  `app-global state belongs on the root store`,
+              );
+            }
+            continue;
+          }
+          if (next[key as keyof ConversationState] !== value) changed = true;
+          (next as Record<string, unknown>)[key] = value;
+        }
+        if (!changed) return;
+        state = next;
+        // A pin that just cleared may have been the only thing holding the map
+        // over budget — see `evictIfOverBudget`. Trim before notifying, so a
+        // listener never observes an over-cap registry that is about to shrink.
+        if (wasPinned && !hasUnsentWork(state)) this.evictIfOverBudget();
+        for (const listener of this.listeners) listener(id);
+      },
+      dispose: () => {
+        if (entry.disposed) return;
+        entry.disposed = true;
+        // Ends the reconnect loop and cancels the in-flight fetch.
+        state.abortController?.abort();
+      },
+    };
+    return entry;
+  }
+}
+
+/**
+ * Whether an entry holds work the server has no record of.
+ *
+ * An unsettled optimistic bubble (`send`'s POST hasn't returned) exists nowhere
+ * but this tab, so evicting the entry would lose the user's message outright —
+ * the one case where dropping an entry is NOT equivalent to a cold load. This
+ * is the hazard `pendingByConversation` was built to survive; pinning replaces
+ * that stash.
+ */
+function hasUnsentWork(state: ConversationState): boolean {
+  return state.pendingUserMessages.some((m) => m.posted !== true);
+}
+
+/** The app's registry. Module-scope, like the store it backs. */
+export const conversationRegistry = new ConversationRegistry();

--- a/web/src/store/conversationRegistry.ts
+++ b/web/src/store/conversationRegistry.ts
@@ -286,14 +286,18 @@ export class ConversationRegistry {
 /**
  * Whether an entry holds work the server has no record of.
  *
- * An unsettled optimistic bubble (`send`'s POST hasn't returned) exists nowhere
- * but this tab, so evicting the entry would lose the user's message outright —
- * the one case where dropping an entry is NOT equivalent to a cold load. This
- * is the hazard `pendingByConversation` was built to survive; pinning replaces
- * that stash.
+ * Two shapes of client-only work, each existing nowhere but this tab, so
+ * evicting the entry would lose it outright — the cases where dropping an entry
+ * is NOT equivalent to a cold load (the hazard `pendingByConversation` was built
+ * to survive; pinning replaces that stash):
+ *
+ *   - an unsettled optimistic bubble (`send`'s POST hasn't returned); and
+ *   - a `failedSendDraft` — a send that failed AND rolled its bubble back, so
+ *     the draft is the sole surviving copy of the user's text and files. It is
+ *     held until the composer restores it on return; evicting first drops it.
  */
 function hasUnsentWork(state: ConversationState): boolean {
-  return state.pendingUserMessages.some((m) => m.posted !== true);
+  return state.pendingUserMessages.some((m) => m.posted !== true) || state.failedSendDraft !== null;
 }
 
 /** The app's registry. Module-scope, like the store it backs. */

--- a/web/src/store/conversationRegistry.ts
+++ b/web/src/store/conversationRegistry.ts
@@ -117,16 +117,6 @@ export class ConversationRegistry {
   private readonly listeners = new Set<ChangeListener>();
   /** Conversation currently on screen; exempt from eviction. */
   private activeId: string | null = null;
-  /** How many entries may be live. Injectable so tests can pin a small cap. */
-  private readonly capacity: () => number;
-
-  /**
-   * :param capacity: live-entry budget, read on each eviction check. Defaults
-   *     to the transport-derived {@link maxLiveConversations}.
-   */
-  constructor(capacity: () => number = maxLiveConversations) {
-    this.capacity = capacity;
-  }
 
   /**
    * Subscribe to state changes across all entries.
@@ -163,16 +153,13 @@ export class ConversationRegistry {
    * Mark which conversation is on screen.
    *
    * Only used to exempt it from eviction — no behaviour is gated on being
-   * active. Pass `null` on the landing route.
-   *
-   * Re-trims, because moving the exemption can make the OUTGOING conversation
-   * evictable: an over-cap registry that only stayed over-cap to protect it
-   * must shrink now, not wait for an unrelated acquire.
+   * active. Pass `null` on the landing route. Eviction is slot-driven now (see
+   * `evictLruEvictable`), so switching between already-live conversations opens
+   * no stream and frees nothing; there is nothing to trim here.
    */
   setActive(id: string | null): void {
     this.activeId = id;
     if (id !== null) this.touch(id);
-    this.evictIfOverBudget(id ?? undefined);
   }
 
   /** The conversation on screen, or `null`. */
@@ -185,7 +172,8 @@ export class ConversationRegistry {
    * Get or create the entry for `id`, marking it most-recently-viewed.
    *
    * A fresh entry starts from `createInitialConversationState()`; the caller
-   * binds its stream. Creating one may evict the least-recently-viewed entry.
+   * binds its stream, which is where the origin-wide stream slot is taken (see
+   * `evictLruEvictable`). Creating an entry does not itself evict anything.
    */
   acquire(id: string): ConversationEntry {
     const existing = this.entries.get(id);
@@ -195,7 +183,6 @@ export class ConversationRegistry {
     }
     const entry = this.createEntry(id);
     this.entries.set(id, entry);
-    this.evictIfOverBudget(id);
     return entry;
   }
 
@@ -226,33 +213,29 @@ export class ConversationRegistry {
   }
 
   /**
-   * Evict least-recently-viewed entries until within budget.
+   * Dispose the least-recently-viewed *evictable* entry to free its stream slot,
+   * returning the id disposed (so the caller can release that entry's slot) or
+   * `null` when nothing was evictable.
    *
-   * Protected from eviction: the conversation on screen, the entry just
-   * acquired (evicting it would hand the caller a disposed entry), and any
-   * entry holding work the server does not know about yet — see
-   * `hasUnsentWork`. When every candidate is protected the map is allowed to
-   * exceed the cap: going over budget costs memory and a connection slot, while
-   * evicting would destroy a user's message.
+   * The slot layer calls this when it can't take a free origin-wide slot, so a
+   * tab reclaims one of ITS OWN background streams before it either gives up
+   * (leaving the new conversation cold) or opens over budget.
    *
-   * Runs from every path that can make an entry evictable — `acquire`, a
-   * clearing pin, and `setActive` (which moves the on-screen exemption) —
-   * because an over-cap registry has to shrink at that moment rather than
-   * waiting for an unrelated acquire. Otherwise repeated send-and-switch leaves
-   * the excess streams open indefinitely and can exhaust an HTTP/1.1 pool.
-   *
-   * :param justAcquiredId: entry the caller is about to be handed, if any.
+   * Never evicts: the conversation on screen, `exemptId` (the one being bound —
+   * disposing it would hand back a dead entry), or an entry holding work the
+   * server has no record of yet (`hasUnsentWork` — evicting that loses the
+   * user's message). When nothing is evictable, returns `null` and the caller
+   * decides what to do with a saturated origin.
    */
-  private evictIfOverBudget(justAcquiredId?: string): void {
-    const budget = this.capacity();
-    for (const id of [...this.entries.keys()]) {
-      if (this.entries.size <= budget) return;
-      if (id === this.activeId || id === justAcquiredId) continue;
-      const entry = this.entries.get(id);
-      if (entry === undefined || hasUnsentWork(entry.getState())) continue;
+  evictLruEvictable(exemptId?: string): string | null {
+    for (const [id, entry] of this.entries) {
+      if (id === this.activeId || id === exemptId) continue;
+      if (hasUnsentWork(entry.getState())) continue;
       this.entries.delete(id);
       entry.dispose();
+      return id;
     }
+    return null;
   }
 
   private createEntry(id: string): ConversationEntry {
@@ -266,7 +249,6 @@ export class ConversationRegistry {
         // unwind cleanly, but writes are dropped: nothing should be able to
         // resurrect state for a conversation that has been evicted.
         if (entry.disposed) return;
-        const wasPinned = hasUnsentWork(state);
         const patch = typeof partial === "function" ? partial(state) : partial;
         let changed = false;
         const next = { ...state };
@@ -288,10 +270,6 @@ export class ConversationRegistry {
         }
         if (!changed) return;
         state = next;
-        // A pin that just cleared may have been the only thing holding the map
-        // over budget — see `evictIfOverBudget`. Trim before notifying, so a
-        // listener never observes an over-cap registry that is about to shrink.
-        if (wasPinned && !hasUnsentWork(state)) this.evictIfOverBudget();
         for (const listener of this.listeners) listener(id);
       },
       dispose: () => {

--- a/web/src/store/conversationState.ts
+++ b/web/src/store/conversationState.ts
@@ -1,0 +1,114 @@
+// Runtime companion to the `ConversationState` type: its key set and its
+// initial values.
+//
+// Both are derived from the type via exhaustive records, so adding a field to
+// `ConversationState` fails the build here rather than silently skipping the
+// split or the reset. The key set is what `createConversationStore`'s setter
+// uses to route a patch — a key missing from it would write conversation state
+// onto the app-global store instead, where it would look correct until a second
+// conversation existed.
+
+import type { ConversationState } from "./chatStore";
+
+// Exhaustive by construction: `Record<keyof ConversationState, true>` rejects a
+// missing key and a stale one.
+const CONVERSATION_STATE_KEY_MAP: Record<keyof ConversationState, true> = {
+  blocks: true,
+  pendingUserMessages: true,
+  activeResponse: true,
+  interruptedResponseIds: true,
+  status: true,
+  sessionStatus: true,
+  backgroundTaskCount: true,
+  blockedOn: true,
+  isNativeTerminalSession: true,
+  nativeVendorOwnsModel: true,
+  boundAgentId: true,
+  boundAgentName: true,
+  loadingConversation: true,
+  conversationLoadError: true,
+  sessionModelOverride: true,
+  sessionReasoningEffort: true,
+  costControlModeOverride: true,
+  subagentRoutingOverride: true,
+  codexPlanMode: true,
+  hasMoreHistory: true,
+  loadingMoreHistory: true,
+  oldestItemId: true,
+  llmModel: true,
+  sessionHarness: true,
+  subAgentName: true,
+  contextWindow: true,
+  tokensUsed: true,
+  sessionCostUsd: true,
+  sessionUsageByModel: true,
+  gitBranch: true,
+  todos: true,
+  skills: true,
+  codexModelOptions: true,
+  terminalPending: true,
+  viewers: true,
+  sandboxStatus: true,
+  mcpStartup: true,
+  abortController: true,
+  runnerLaunchedAt: true,
+  failedSendDraft: true,
+  historyGeneration: true,
+};
+
+const CONVERSATION_STATE_KEYS = new Set<string>(Object.keys(CONVERSATION_STATE_KEY_MAP));
+
+/** Whether `key` names conversation-scoped state (vs. app-global or an action). */
+export function isConversationStateKey(key: string | symbol): key is keyof ConversationState {
+  return typeof key === "string" && CONVERSATION_STATE_KEYS.has(key);
+}
+
+/**
+ * A conversation's state before anything is bound — what a cold load starts
+ * from, and what `switchTo` used to reset the single active slot to.
+ */
+export function createInitialConversationState(): ConversationState {
+  return {
+    blocks: [],
+    pendingUserMessages: [],
+    activeResponse: null,
+    interruptedResponseIds: [],
+    status: "idle",
+    sessionStatus: "idle",
+    backgroundTaskCount: 0,
+    blockedOn: null,
+    isNativeTerminalSession: false,
+    nativeVendorOwnsModel: false,
+    boundAgentId: null,
+    boundAgentName: null,
+    loadingConversation: false,
+    conversationLoadError: null,
+    sessionModelOverride: null,
+    sessionReasoningEffort: null,
+    costControlModeOverride: null,
+    subagentRoutingOverride: null,
+    codexPlanMode: false,
+    hasMoreHistory: false,
+    loadingMoreHistory: false,
+    oldestItemId: null,
+    llmModel: null,
+    sessionHarness: null,
+    subAgentName: null,
+    contextWindow: null,
+    tokensUsed: null,
+    sessionCostUsd: null,
+    sessionUsageByModel: null,
+    gitBranch: null,
+    todos: [],
+    skills: [],
+    codexModelOptions: [],
+    terminalPending: false,
+    viewers: [],
+    sandboxStatus: null,
+    mcpStartup: null,
+    abortController: null,
+    runnerLaunchedAt: null,
+    failedSendDraft: null,
+    historyGeneration: 0,
+  };
+}

--- a/web/src/store/conversationState.ts
+++ b/web/src/store/conversationState.ts
@@ -53,6 +53,7 @@ const CONVERSATION_STATE_KEY_MAP: Record<keyof ConversationState, true> = {
   abortController: true,
   runnerLaunchedAt: true,
   failedSendDraft: true,
+  sendLatchedAt: true,
   historyGeneration: true,
 };
 
@@ -109,6 +110,7 @@ export function createInitialConversationState(): ConversationState {
     abortController: null,
     runnerLaunchedAt: null,
     failedSendDraft: null,
+    sendLatchedAt: null,
     historyGeneration: 0,
   };
 }

--- a/web/src/store/streamSlots.ts
+++ b/web/src/store/streamSlots.ts
@@ -1,0 +1,148 @@
+// Origin-wide budget for how many conversation streams stay open at once.
+//
+// The cap this enforces is shared across every same-origin tab, because the
+// resource it protects — the browser's connection pool (~6 per origin on
+// HTTP/1.1, one multiplexed connection on HTTP/2) — is shared across tabs. A
+// per-tab cap can't see the other tabs, so two tabs at cap 3 each open 6 SSE
+// streams and deadlock every other fetch. `navigator.locks` is the coordination
+// primitive: a lock's holders are visible across all same-origin agents, and a
+// lock auto-releases when its tab closes or crashes, so a dead tab never strands
+// a slot.
+//
+// Modelled as N named slot-locks (`omnigent:stream-slot:0..N-1`) acquired with
+// `{ ifAvailable: true }`. That grants a free slot atomically or hands back
+// `null` — unlike querying the held count and then acquiring, which races (two
+// tabs both read "one free" and both take it). N is the same transport-derived
+// number as before (see `maxLiveConversations`), only now shared.
+
+import { maxLiveConversations } from "./conversationRegistry";
+
+/**
+ * A held origin-wide slot.
+ *
+ * `release` is idempotent and, crucially, resolves only once the underlying lock
+ * is actually released — so a caller that evicts a stream to reclaim its slot
+ * can `await` this before re-checking availability, instead of racing a release
+ * that the browser hasn't processed yet.
+ */
+export interface StreamSlot {
+  release: () => Promise<void>;
+}
+
+export interface StreamSlotManager {
+  /**
+   * Take one free slot without waiting: resolves to a `StreamSlot` when a slot
+   * was granted, or `null` when every slot is held (origin-wide, across tabs).
+   */
+  tryAcquire: () => Promise<StreamSlot | null>;
+}
+
+const SLOT_LOCK_PREFIX = "omnigent:stream-slot:";
+
+/**
+ * Hold `name` until the returned slot's `release` runs, or resolve `null` when
+ * it is already held. `ifAvailable` is what makes this race-free: the callback
+ * either gets the lock or gets `null`, atomically.
+ */
+function holdLockIfFree(name: string): Promise<StreamSlot | null> {
+  return new Promise((settle) => {
+    let releaseHeld: () => void = () => {};
+    let released = false;
+    // `requestDone` resolves when the callback's returned promise settles —
+    // i.e. after `releaseHeld()` runs AND the browser has released the lock.
+    // `release` awaits it so the freed slot is observable to the next acquire.
+    const requestDone = navigator.locks
+      .request(name, { ifAvailable: true }, (lock) => {
+        if (lock === null) {
+          settle(null);
+          return;
+        }
+        return new Promise<void>((r) => {
+          releaseHeld = r;
+          settle({
+            release: async () => {
+              if (!released) {
+                released = true;
+                releaseHeld();
+              }
+              await requestDone;
+            },
+          });
+        });
+      })
+      .catch(() => settle(null));
+  });
+}
+
+/** Web Locks manager: coordinated across every same-origin tab. */
+function webLocksSlotManager(count: () => number): StreamSlotManager {
+  return {
+    async tryAcquire() {
+      const n = Math.max(0, count());
+      // Sequential, not parallel: `ifAvailable` in parallel could grant two
+      // slots to one caller. Take the first free one.
+      for (let i = 0; i < n; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        const slot = await holdLockIfFree(`${SLOT_LOCK_PREFIX}${i}`);
+        if (slot !== null) return slot;
+      }
+      return null;
+    },
+  };
+}
+
+/**
+ * Per-tab counting semaphore, for environments without Web Locks (jsdom, an
+ * insecure context, an old browser). No cross-tab coordination — this simply
+ * degrades to the pre-existing per-tab cap rather than failing to open streams.
+ */
+function inMemorySlotManager(count: () => number): StreamSlotManager {
+  let held = 0;
+  return {
+    tryAcquire() {
+      if (held >= Math.max(0, count())) return Promise.resolve(null);
+      held += 1;
+      let released = false;
+      return Promise.resolve({
+        release: () => {
+          if (!released) {
+            released = true;
+            held -= 1;
+          }
+          return Promise.resolve();
+        },
+      });
+    },
+  };
+}
+
+function webLocksAvailable(): boolean {
+  return (
+    typeof navigator !== "undefined" &&
+    typeof navigator.locks !== "undefined" &&
+    typeof navigator.locks.request === "function"
+  );
+}
+
+function createDefaultStreamSlotManager(): StreamSlotManager {
+  return webLocksAvailable()
+    ? webLocksSlotManager(maxLiveConversations)
+    : inMemorySlotManager(maxLiveConversations);
+}
+
+let activeManager: StreamSlotManager = createDefaultStreamSlotManager();
+
+/** The process-wide slot manager (Web Locks in a real browser). */
+export function getStreamSlotManager(): StreamSlotManager {
+  return activeManager;
+}
+
+/** Swap in a fake manager (tests drive slot availability through this). */
+export function setStreamSlotManagerForTest(manager: StreamSlotManager): void {
+  activeManager = manager;
+}
+
+/** Restore the real manager (test teardown). */
+export function resetStreamSlotManager(): void {
+  activeManager = createDefaultStreamSlotManager();
+}


### PR DESCRIPTION
## Related issue

Closes #2849


https://github.com/user-attachments/assets/4bfc3761-3837-426a-9d42-3768f0f3b225

When exceeding the cap (3 for HTTP/1.1, 30 for HTTP/2)

https://github.com/user-attachments/assets/4a97ab49-6069-41ba-8e95-2fd362235d3b



## Summary

Switching conversations tore down the session SSE stream, so returning to one
paid a stream reconnect plus a snapshot refetch — and anything the agent
produced while you were away only arrived through that rebind.

Each conversation now gets a registry entry owning its own state and stream.
`switchTo` becomes acquire-and-mirror instead of abort-and-wipe: returning to a
conversation paints instantly from an entry that is **already current**, with no
reopen and no refetch. This supersedes fix direction 1 in #2849 — rather than
caching the transcript, the conversation simply stays live. (It also removes the
need for the transcript cache reverted in #4124, which could only make the
switch *paint* faster, and moved the window under the reader while it
revalidated.)

**Net −1300 lines in the store.** Everything deleted existed only to survive the
state wipe:

- `pendingByConversation`, `StashedPending`, `removeFromPendingStash`, and the
  `committedTexts` dedupe baseline — in-flight bubbles stay on their entry, which
  removes the "stuck-forever pending bubble" bug class outright
- the cache-gap-bridge arithmetic in `bindStream`

It also fixes latent cross-conversation corruption. `handleSessionEvent` wrote
conversation state through the store singleton, and only 6 of its 19
state-touching branches checked which conversation the event was for — invisible
while one stream exists, but a background turn's status, todos, usage, committed
messages or interrupt would otherwise paint onto whatever you were looking at.
Events are now routed by the **delivering stream**, which is the only key that
works: `session.input.consumed`, `session.interrupted` and
`session.resource.created` carry no conversation id at all.

### ELI5

Before, only the conversation on screen had a live connection. Walking away hung
up the phone; walking back redialled and asked the server to repeat everything.
Now each conversation keeps its own line open, so coming back you are already
caught up. Only the 30 most recent stay connected — older ones hang up, and
reopening them redials exactly as before.

```
Before                              After
──────                              ─────
switchTo(B)                         switchTo(B)
  abort A's stream                    A keeps streaming in the background
  wipe 36 state fields                B's entry already holds its state
  open B's stream                     mirror B onto the root store  ← instant
  fetch B's snapshot
  paint  ← seconds later            switchTo(A) → already current, 0 requests
```

### Bounds

`MAX_LIVE = 30` on HTTP/2, **3 on HTTP/1.1**. Not a product number: an SSE stream
holds a connection for its whole life, and browsers cap ~6 per origin on
HTTP/1.1 — 30 there is a hard deadlock, not merely slower. The dev server is
HTTP/1.1 (`server.proxy`, no `https`), production is HTTP/2 behind the Databricks
ingress. Eviction is LRU; an evicted conversation cold-loads on return, exactly
as today.

Three protections on eviction: the active conversation, the entry just acquired,
and any entry holding a send the server has no record of (`posted !== true`).
That last one is the hazard `pendingByConversation` existed to survive — the
server doesn't know about the message yet, so eviction would lose the user's
text. The map exceeds the cap rather than destroy data.

Memory is unbounded by choice. Measured against a real corpus (166 local Claude
Code sessions): p50 48 KB, p90 0.4 MB, mean 0.30 MB — thirty typical
conversations is single-digit MB, and a trim mechanism would need
`historyGeneration` / cursor bookkeeping that is itself a bug source.

### Deliberately unchanged

**Presence.** Holding a live stream shows you as an active viewer on that
conversation. Defensible — it genuinely is open and live-updating — and the
server already aggregates per user and holds a leave-grace window, so the
~5-minute stream recycles don't flicker avatars.

**Every reconnect reconciles, background included.** The ~5-minute drop is the
ingress capping every stream on a *healthy* connection, ~12x/hour per stream, and
the server keeps no replay buffer ("events emitted while no subscriber is
connected are dropped silently", `session_stream.py:81`). Skipping the repair for
background entries would leave them silently stale — the exact failure this
removes. Background reconnects are staggered (herd control only; the visible
conversation is never delayed).

## Test Plan

- `cd web && node_modules/.bin/tsc -b` — clean.
- `cd web && npx vitest run` — **5343 passed**, 282 files.
- Every behavioural test was checked against the pre-change code to confirm it
  actually fails. Three turned out vacuous or wrong-way-round on first write and
  were rewritten (see below) — worth knowing that a passing new test here proves
  little until you break the code and watch it fail.
- `pre-commit run` green on every commit.

Four bugs surfaced during development, each now covered by a test:

1. **Background events were dropped, so messages interleaved wrongly.** Found by
   manual testing: after switching back, user bubbles piled up at the end of the
   transcript, below assistant output that arrived after them.
   `session.input.consumed` is the only thing that promotes an optimistic bubble
   into committed `blocks`, and the renderer appends `pendingUserMessages` after
   `blocks` — so an uncommitted bubble is always visually last. It never
   committed because `handleSessionEvent`'s gate compared against the **root
   store's** `conversationId`, which names the conversation on *screen*: for a
   background stream it never matched, so every write was dropped. The gate added
   to make background streams safe was the thing preventing them from working.
   Now routed to the entry, which does both jobs at once. This restored 19
   branches for background conversations, and fixed two sibling cases —
   `refreshSessionBinding` and `refetchRunnerBackedSessionState` bailed the same
   way after their `await`.
2. `send` on `/` pushes its optimistic bubble *before* the session exists — with
   no entry those writes vanished, so the first message of a new chat
   disappeared until the server echoed it. Buffered on the root store and
   adopted by the new entry.
3. Late-settling send work (denied POST, failure) landed on whichever
   conversation was visible rather than the one it targeted.
4. Registry eviction ran after insertion, so with every older entry pinned it
   evicted the entry it was about to return — handing back a dead entry whose
   writes are silently dropped.

On the tests that were initially wrong: the five cross-conversation routing cases
asserted only that the *visible* conversation was untouched — which bug #1 also
satisfied, so they passed for the wrong reason and hid it. Each now asserts both
halves (the background conversation receives the event, the visible one does
not), plus an end-to-end case that sends in a conversation, backgrounds it,
streams a consumed event and a reply, and asserts the user message commits
*before* the reply. Verified all six fail against the old gate while the
foreground positive control still passes.

Manual verification: open two conversations, send in A, switch to B, wait for A's
agent to reply, switch back — A's reply is already present, in order, with no
loading state. Also checked a brand-new chat from `/` (bubble appears instantly)
and >3 conversations in dev to exercise LRU eviction.

> **Note for reviewers:** `npx tsc --noEmit -p tsconfig.json` checks *nothing* in
> `web/` — `tsconfig.json` has `"files": []` and only project references. Use
> `tsc -b` (what pre-commit runs). I lost some verification time to this.

## Demo

N/A — no visual change. The change is that a switched-to conversation is already
current instead of briefly loading; a recording would show the absence of a
loading state.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The 314-test `chatStore.test.ts` suite is the regression net; obsolete
cache/stash cases were replaced by ones asserting the new contract — a
backgrounded conversation stays live, keeps its own transcript, keeps pumping
into its own state without touching the visible one, commits its own messages in
transcript order, and keeps reconciling across a reconnect while backgrounded.
`conversationRegistry.test.ts` adds 19 cases over eviction order, all three
protections, and disposed-entry semantics.

E2E: retargeted `test_composer_model_label_never_shows_the_previous_sessions_model`
onto the cold-open path — it armed a snapshot delay on the switch-*back*, which no
longer has a pre-bind window at all (the conversation is held live), and its own
no-op guard correctly reported that. Noted in the commit that this e2e test does
not discriminate the accompanying fix on its own, so that invariant is pinned at
the store level instead.

Manual verification covered the multi-conversation switch feel and message
ordering, which no automated test asserts end-to-end in a browser, and LRU
eviction at the dev cap of 3.

Not covered automatically: behaviour at 30 concurrent streams over real HTTP/2.
The dev server is HTTP/1.1, so that path can only be exercised against a deployed
build — worth a look before rollout.

## Changelog

Switching between conversations is instant — background conversations stay
connected, so returning to one shows messages that arrived while you were away
