### PR TITLE
ci: mirror linked issue priority onto closing PRs

### DIFF
--- a/.github/scripts/sync_pr_priority.py
+++ b/.github/scripts/sync_pr_priority.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Mirror a linked issue's priority label onto the pull request that closes it.
+
+A PR only inherits a priority when it *closes* an issue via a closing keyword
+(``closes``/``fixes``/``resolves`` #n); a plain "related to #n" mention never
+creates a closing link, so it is ignored. When a PR closes several issues with
+different priorities the highest one wins, and stale priority labels left by an
+earlier run are dropped. Pure stdlib so it runs without an install and the
+label logic is unit-tested directly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+CANONICAL_REPO = "omnigent-ai/omnigent"
+
+# Priority labels from most to least urgent; the earliest match wins.
+PRIORITY_ORDER = ("P0-critical", "P1-high", "P2-medium", "P3-low")
+PRIORITY_LABELS = frozenset(PRIORITY_ORDER)
+
+_CLOSING_ISSUES_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      closingIssuesReferences(first: 50) {
+        nodes {
+          number
+          labels(first: 50) { nodes { name } }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def desired_priority(closing_issue_labels: list[list[str]]) -> str | None:
+    """Highest-priority label across the issues a PR closes, or None."""
+    present = {label for labels in closing_issue_labels for label in labels}
+    for priority in PRIORITY_ORDER:
+        if priority in present:
+            return priority
+    return None
+
+
+def label_changes(current: list[str], desired: str | None) -> tuple[str | None, list[str]]:
+    """Return the priority to add (if missing) and stale priorities to remove."""
+    current_priorities = [label for label in current if label in PRIORITY_LABELS]
+    to_remove = [label for label in current_priorities if label != desired]
+    to_add = desired if desired is not None and desired not in current_priorities else None
+    return to_add, to_remove
+
+
+class GitHubAPI:
+    def __init__(self, token: str, repo: str) -> None:
+        self.token = token
+        self.repo = repo
+        self.owner, _, self.name = repo.partition("/")
+
+    def _request(self, url: str, body: dict[str, Any] | None, method: str) -> Any:
+        data = None if body is None else json.dumps(body).encode()
+        request = urllib.request.Request(
+            url,
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        with urllib.request.urlopen(request) as response:
+            raw = response.read()
+            return json.loads(raw.decode()) if raw else None
+
+    def closing_issue_labels(self, pull_number: int) -> list[list[str]]:
+        payload = {
+            "query": _CLOSING_ISSUES_QUERY,
+            "variables": {"owner": self.owner, "name": self.name, "number": pull_number},
+        }
+        result = self._request("https://api.github.com/graphql", payload, "POST")
+        if result and result.get("errors"):
+            raise RuntimeError(f"GraphQL error: {result['errors']}")
+        nodes = (
+            result.get("data", {})
+            .get("repository", {})
+            .get("pullRequest", {})
+            .get("closingIssuesReferences", {})
+            .get("nodes", [])
+        )
+        return [
+            [label["name"] for label in node.get("labels", {}).get("nodes", [])] for node in nodes
+        ]
+
+    def pull_labels(self, pull_number: int) -> list[str]:
+        result = self._request(
+            f"https://api.github.com/repos/{self.repo}/issues/{pull_number}/labels",
+            None,
+            "GET",
+        )
+        return [label["name"] for label in result or []]
+
+    def add_label(self, pull_number: int, label: str) -> None:
+        self._request(
+            f"https://api.github.com/repos/{self.repo}/issues/{pull_number}/labels",
+            {"labels": [label]},
+            "POST",
+        )
+
+    def remove_label(self, pull_number: int, label: str) -> None:
+        quoted = urllib.parse.quote(label, safe="")
+        try:
+            self._request(
+                f"https://api.github.com/repos/{self.repo}/issues/{pull_number}/labels/{quoted}",
+                None,
+                "DELETE",
+            )
+        except urllib.error.HTTPError as error:
+            if error.code != 404:
+                raise
+
+
+def sync_pull(api: GitHubAPI, pull_number: int) -> None:
+    desired = desired_priority(api.closing_issue_labels(pull_number))
+    to_add, to_remove = label_changes(api.pull_labels(pull_number), desired)
+    for label in to_remove:
+        api.remove_label(pull_number, label)
+        print(f"Removed stale priority {label} from #{pull_number}.")
+    if to_add:
+        api.add_label(pull_number, to_add)
+        print(f"Applied {to_add} to #{pull_number} from its closing-linked issue(s).")
+    if not to_add and not to_remove:
+        print(f"#{pull_number} priority already in sync ({desired or 'none'}).")
+
+
+def run(repo: str, pull_number: int, api: GitHubAPI) -> None:
+    if repo != CANONICAL_REPO:
+        print(f"Skipping {repo}; priority sync only runs for {CANONICAL_REPO}.")
+        return
+    sync_pull(api, pull_number)
+
+
+def main() -> int:
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    token = os.environ.get("GITHUB_TOKEN")
+    pull_number = os.environ.get("PR_NUMBER")
+    if not token:
+        print("GITHUB_TOKEN is required", file=sys.stderr)
+        return 1
+    if not pull_number:
+        print("PR_NUMBER is required", file=sys.stderr)
+        return 1
+    run(repo, int(pull_number), GitHubAPI(token, repo))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/sync_pr_priority.py
+++ b/.github/scripts/sync_pr_priority.py
@@ -77,7 +77,7 @@ class GitHubAPI:
                 "X-GitHub-Api-Version": "2022-11-28",
             },
         )
-        with urllib.request.urlopen(request) as response:
+        with urllib.request.urlopen(request, timeout=30) as response:
             raw = response.read()
             return json.loads(raw.decode()) if raw else None
 
@@ -89,15 +89,15 @@ class GitHubAPI:
         result = self._request("https://api.github.com/graphql", payload, "POST")
         if result and result.get("errors"):
             raise RuntimeError(f"GraphQL error: {result['errors']}")
-        nodes = (
-            result.get("data", {})
-            .get("repository", {})
-            .get("pullRequest", {})
-            .get("closingIssuesReferences", {})
-            .get("nodes", [])
-        )
+        # GitHub may return null for data or any intermediate node (e.g. an
+        # unknown PR number), so treat each missing level as empty.
+        data = (result or {}).get("data") or {}
+        repository = data.get("repository") or {}
+        pull_request = repository.get("pullRequest") or {}
+        nodes = (pull_request.get("closingIssuesReferences") or {}).get("nodes") or []
         return [
-            [label["name"] for label in node.get("labels", {}).get("nodes", [])] for node in nodes
+            [label["name"] for label in (node.get("labels") or {}).get("nodes") or []]
+            for node in nodes
         ]
 
     def pull_labels(self, pull_number: int) -> list[str]:
@@ -158,7 +158,12 @@ def main() -> int:
     if not pull_number:
         print("PR_NUMBER is required", file=sys.stderr)
         return 1
-    run(repo, int(pull_number), GitHubAPI(token, repo))
+    try:
+        pull_number_int = int(pull_number)
+    except ValueError:
+        print(f"PR_NUMBER must be an integer, got {pull_number!r}", file=sys.stderr)
+        return 1
+    run(repo, pull_number_int, GitHubAPI(token, repo))
     return 0
 
 

--- a/.github/scripts/sync_pr_priority_test.py
+++ b/.github/scripts/sync_pr_priority_test.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Offline tests for sync_pr_priority.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+
+SCRIPT_PATH = pathlib.Path(__file__).with_name("sync_pr_priority.py")
+SPEC = importlib.util.spec_from_file_location("sync_pr_priority", SCRIPT_PATH)
+sync_pr_priority = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(sync_pr_priority)
+
+
+class FakeAPI:
+    def __init__(self, *, closing: list[list[str]], current: list[str]) -> None:
+        self._closing = closing
+        self._current = current
+        self.added: list[tuple[int, str]] = []
+        self.removed: list[tuple[int, str]] = []
+
+    def closing_issue_labels(self, pull_number: int) -> list[list[str]]:
+        assert pull_number
+        return self._closing
+
+    def pull_labels(self, pull_number: int) -> list[str]:
+        assert pull_number
+        return self._current
+
+    def add_label(self, pull_number: int, label: str) -> None:
+        self.added.append((pull_number, label))
+
+    def remove_label(self, pull_number: int, label: str) -> None:
+        self.removed.append((pull_number, label))
+
+
+class DesiredPriorityTest(unittest.TestCase):
+    def test_no_closing_issue_yields_none(self) -> None:
+        self.assertIsNone(sync_pr_priority.desired_priority([]))
+
+    def test_closing_issue_without_priority_yields_none(self) -> None:
+        self.assertIsNone(sync_pr_priority.desired_priority([["Bug", "comp:server"]]))
+
+    def test_single_priority_is_returned(self) -> None:
+        self.assertEqual(sync_pr_priority.desired_priority([["P2-medium"]]), "P2-medium")
+
+    def test_highest_priority_wins_across_issues(self) -> None:
+        self.assertEqual(
+            sync_pr_priority.desired_priority([["P3-low"], ["P1-high"], ["P2-medium"]]),
+            "P1-high",
+        )
+
+    def test_highest_priority_wins_within_one_issue(self) -> None:
+        self.assertEqual(
+            sync_pr_priority.desired_priority([["P0-critical", "P3-low"]]),
+            "P0-critical",
+        )
+
+
+class LabelChangesTest(unittest.TestCase):
+    def test_adds_missing_priority(self) -> None:
+        self.assertEqual(sync_pr_priority.label_changes(["Bug"], "P1-high"), ("P1-high", []))
+
+    def test_noop_when_already_correct(self) -> None:
+        self.assertEqual(sync_pr_priority.label_changes(["P1-high", "Bug"], "P1-high"), (None, []))
+
+    def test_replaces_stale_priority(self) -> None:
+        self.assertEqual(
+            sync_pr_priority.label_changes(["P3-low"], "P1-high"), ("P1-high", ["P3-low"])
+        )
+
+    def test_removes_priority_when_no_longer_desired(self) -> None:
+        self.assertEqual(
+            sync_pr_priority.label_changes(["P2-medium"], None), (None, ["P2-medium"])
+        )
+
+    def test_leaves_non_priority_labels_untouched(self) -> None:
+        self.assertEqual(sync_pr_priority.label_changes(["Bug", "python"], None), (None, []))
+
+
+class SyncPullTest(unittest.TestCase):
+    def test_applies_priority_from_closing_issue(self) -> None:
+        api = FakeAPI(closing=[["P1-high"]], current=["Bug"])
+        sync_pr_priority.sync_pull(api, 7)
+        self.assertEqual(api.added, [(7, "P1-high")])
+        self.assertEqual(api.removed, [])
+
+    def test_swaps_stale_priority(self) -> None:
+        api = FakeAPI(closing=[["P0-critical"]], current=["P2-medium"])
+        sync_pr_priority.sync_pull(api, 7)
+        self.assertEqual(api.added, [(7, "P0-critical")])
+        self.assertEqual(api.removed, [(7, "P2-medium")])
+
+    def test_related_only_pr_gets_nothing(self) -> None:
+        # No closing references -> no priority, and nothing to strip.
+        api = FakeAPI(closing=[], current=["Bug"])
+        sync_pr_priority.sync_pull(api, 7)
+        self.assertEqual(api.added, [])
+        self.assertEqual(api.removed, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/sync_pr_priority_test.py
+++ b/.github/scripts/sync_pr_priority_test.py
@@ -101,5 +101,44 @@ class SyncPullTest(unittest.TestCase):
         self.assertEqual(api.removed, [])
 
 
+class ClosingIssueLabelsParseTest(unittest.TestCase):
+    """GraphQL response parsing tolerates null nodes and surfaces errors."""
+
+    def _api_returning(self, response: object) -> sync_pr_priority.GitHubAPI:
+        api = sync_pr_priority.GitHubAPI("token", "owner/name")
+
+        def stub_request(*_args: object, **_kwargs: object) -> object:
+            return response
+
+        api._request = stub_request  # type: ignore[method-assign]
+        return api
+
+    def test_parses_labels(self) -> None:
+        response = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "closingIssuesReferences": {
+                            "nodes": [{"labels": {"nodes": [{"name": "P1-high"}]}}]
+                        }
+                    }
+                }
+            }
+        }
+        self.assertEqual(self._api_returning(response).closing_issue_labels(1), [["P1-high"]])
+
+    def test_null_data_yields_empty(self) -> None:
+        self.assertEqual(self._api_returning({"data": None}).closing_issue_labels(1), [])
+
+    def test_null_pull_request_yields_empty(self) -> None:
+        response = {"data": {"repository": {"pullRequest": None}}}
+        self.assertEqual(self._api_returning(response).closing_issue_labels(1), [])
+
+    def test_errors_raise(self) -> None:
+        response = {"data": None, "errors": [{"message": "boom"}]}
+        with self.assertRaises(RuntimeError):
+            self._api_returning(response).closing_issue_labels(1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.github/workflows/sync-pr-priority.yml
+++ b/.github/workflows/sync-pr-priority.yml
@@ -1,0 +1,113 @@
+name: Sync PR Priority
+
+# Mirrors a linked issue's priority label (P0-P3) onto the PR that closes it.
+# Only closing links (closes/fixes/resolves #n) count -- a plain "related to
+# #n" mention is ignored. Runs on PR events and re-syncs when an issue's labels
+# change. Uses only default-branch code and never checks out or executes PR
+# files; it edits labels through the API.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+  issues:
+    types:
+      - labeled
+      - unlabeled
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to sync"
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-pr-priority-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    # On issue label events, only react when the changed label is a priority
+    # (P0-P3) label; other label edits (Bug, triaged, ...) never affect sync.
+    if: >-
+      github.repository == 'omnigent-ai/omnigent' &&
+      (github.event_name != 'issues' ||
+       contains(fromJSON('["P0-critical", "P1-high", "P2-medium", "P3-low"]'), github.event.label.name))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout default-branch script
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: .github/scripts/sync_pr_priority.py
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      # For issue label events, find open PRs that close this issue so we can
+      # re-sync each of them. For PR / dispatch events we already know the PR.
+      - name: Resolve PR numbers to sync
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_FROM_PR: ${{ github.event.pull_request.number }}
+          PR_FROM_DISPATCH: ${{ github.event.inputs.pr_number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${EVENT_NAME}" == "issues" ]]; then
+            # Only relevant when a priority label was (un)set on the issue.
+            prs=$(
+              gh api graphql -f query='
+                query($owner:String!,$name:String!,$number:Int!){
+                  repository(owner:$owner,name:$name){
+                    issue(number:$number){
+                      closedByPullRequestsReferences(first:50, includeClosedPrs:false){
+                        nodes { number }
+                      }
+                    }
+                  }
+                }' \
+                -f owner="${REPO%/*}" -f name="${REPO#*/}" -F number="${ISSUE_NUMBER}" \
+                --jq '.data.repository.issue.closedByPullRequestsReferences.nodes[].number' \
+              || true
+            )
+          elif [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            prs="${PR_FROM_DISPATCH}"
+          else
+            prs="${PR_FROM_PR}"
+          fi
+
+          echo "prs<<EOF" >> "${GITHUB_OUTPUT}"
+          echo "${prs}" >> "${GITHUB_OUTPUT}"
+          echo "EOF" >> "${GITHUB_OUTPUT}"
+
+      - name: Sync priority labels
+        if: steps.resolve.outputs.prs != ''
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          while read -r pr; do
+            [[ -z "${pr}" ]] && continue
+            echo "Syncing PR #${pr}"
+            PR_NUMBER="${pr}" python3 .github/scripts/sync_pr_priority.py
+          done <<< "${{ steps.resolve.outputs.prs }}"

--- a/.github/workflows/sync-pr-priority.yml
+++ b/.github/workflows/sync-pr-priority.yml
@@ -74,7 +74,9 @@ jobs:
 
           if [[ "${EVENT_NAME}" == "issues" ]]; then
             # Only relevant when a priority label was (un)set on the issue.
-            prs=$(
+            # On lookup failure, warn and treat as no PRs rather than failing
+            # the whole workflow.
+            if ! prs=$(
               gh api graphql -f query='
                 query($owner:String!,$name:String!,$number:Int!){
                   repository(owner:$owner,name:$name){
@@ -86,9 +88,11 @@ jobs:
                   }
                 }' \
                 -f owner="${REPO%/*}" -f name="${REPO#*/}" -F number="${ISSUE_NUMBER}" \
-                --jq '.data.repository.issue.closedByPullRequestsReferences.nodes[].number' \
-              || true
-            )
+                --jq '.data.repository.issue.closedByPullRequestsReferences.nodes[].number'
+            ); then
+              echo "::warning::Failed to resolve PRs closing issue #${ISSUE_NUMBER}; skipping sync."
+              prs=""
+            fi
           elif [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             prs="${PR_FROM_DISPATCH}"
           else
@@ -104,10 +108,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          PRS: ${{ steps.resolve.outputs.prs }}
         run: |
           set -euo pipefail
           while read -r pr; do
             [[ -z "${pr}" ]] && continue
             echo "Syncing PR #${pr}"
             PR_NUMBER="${pr}" python3 .github/scripts/sync_pr_priority.py
-          done <<< "${{ steps.resolve.outputs.prs }}"
+          done <<< "${PRS}"


### PR DESCRIPTION
## Related issue

N/A — repo automation improvement, no tracked issue.

## Summary

Adds a workflow that mirrors an issue's priority label onto the PR that closes it.

- Copies `P0-critical`/`P1-high`/`P2-medium`/`P3-low` from a linked issue onto the PR — **only** when the PR closes it via a closing keyword (`closes`/`fixes`/`resolves #n`). A plain "related to #n" mention creates no closing link and is ignored (queried via GraphQL `closingIssuesReferences`, so no fragile text parsing).
- When a PR closes several issues with different priorities, the **highest** wins (P0 > P1 > P2 > P3). Stale priority labels from an earlier run are removed; non-priority labels are never touched.
- Event-driven, not a cron sweep: runs on PR open/edit/synchronize/reopen/ready, and re-syncs open PRs when an issue's priority changes. The `issues` trigger is **gated at the job level to priority labels only** (via `github.event.label.name`), so editing other labels (`Bug`, `triaged`, …) skips the job at ~0 runner cost. `workflow_dispatch` provides an on-demand lever.

## Test Plan

- `python3 .github/scripts/sync_pr_priority_test.py` — 13 offline unit tests (pure label logic, no network) pass.
- `pre-commit run --files ...` — ruff format/check + yaml checks pass.
- Live smoke test against a real PR:
  ```
  GITHUB_TOKEN=$(gh auth token) GITHUB_REPOSITORY=omnigent-ai/omnigent \
    PR_NUMBER=3220 python3 .github/scripts/sync_pr_priority.py
  ```
  PR #3220 (`closes #3219`, which is `P2-medium`) → applied `P2-medium`, left its `size/M` untouched, and ignored the issue's other labels (Bug, help wanted, comp:web-ui, triaged). Re-running reports `already in sync`.

## Demo

N/A — non-visual CI automation.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Label-selection logic (`desired_priority`, `label_changes`, `sync_pull`) is covered by 13 offline unit tests. The GitHub API layer isn't unit-tested (thin stdlib HTTP wrapper); it was exercised manually end-to-end against live PR #3220 as described in the Test Plan.

This pull request and its description were written by Isaac.
