### PR TITLE
chore(triage): rename issue type labels to Feature and Docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest a new feature or improvement
 title: "[Feature] "
-labels: ["enhancement", "needs-triage"]
+labels: ["Feature", "needs-triage"]
 body:
   - type: textarea
     id: problem

--- a/.github/triage/config.yaml
+++ b/.github/triage/config.yaml
@@ -31,7 +31,7 @@ prompt: |
 
   ```
   {
-    "type": "bug" | "enhancement" | "documentation" | null,
+    "type": "bug" | "Feature" | "Docs" | null,
     "components": ["comp:server" | "comp:runner" | "comp:repr" | "comp:web-ui" | "comp:tui" | "comp:policies" | "comp:harnesses" | "comp:infra"],
     "priority": "P0-critical" | "P1-high" | "P2-medium" | "P3-low" | null,
     "needs_info": true | false,
@@ -49,9 +49,9 @@ prompt: |
   repro steps for a bug). When `true`, leave type/component/priority as
   `null`.
 
-  **type** — the issue templates add `bug` or `enhancement` labels
+  **type** — the issue templates add `bug` or `Feature` labels
   automatically; if the existing labels already include one, set the
-  matching type. Otherwise determine from content. Use `documentation`
+  matching type. Otherwise determine from content. Use `Docs`
   for docs-only issues.
 
   **components** — list of affected subsystems (one or more):

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -375,7 +375,7 @@ jobs:
               sys.exit(1)
 
           # Validate fields against allowed values to prevent label injection.
-          ALLOWED_TYPES = {"bug", "enhancement", "documentation"}
+          ALLOWED_TYPES = {"bug", "Feature", "Docs"}
           # Component labels come from .github/areas.json (single source of truth),
           # so the validator can never drift from the area definitions.
           ALLOWED_COMPONENTS = set(json.loads(pathlib.Path("/tmp/components.json").read_text()))

--- a/designs/issue-triage-proposal.md
+++ b/designs/issue-triage-proposal.md
@@ -29,7 +29,7 @@ Two templates:
 | Template | Auto-labels | Required | Optional hints |
 |---|---|---|---|
 | Bug Report | `bug`, `needs-triage` | Description only | Component, repro steps, version, OS |
-| Feature Request | `enhancement`, `needs-triage` | Problem/use case only | Proposed solution, alternatives |
+| Feature Request | `Feature`, `needs-triage` | Problem/use case only | Proposed solution, alternatives |
 
 Questions redirect to GitHub Discussions (via `config.yml` contact link) - they aren't actionable work and would clog the issue tracker. Blank issues enabled for anything that doesn't fit a template.
 
@@ -74,7 +74,7 @@ A maintainer only sees issues that the bot could not fully resolve. The escalati
 - **`P0-critical` / `P1-high`** - always escalated; exempt from stale bot
 - **`needs-triage` still present** - bot wasn't confident enough to classify
 - **Duplicate contested** - reporter reacted 👎 on the duplicate comment
-- **Complex feature requests** - labeled `enhancement` + `P2-medium` or higher
+- **Complex feature requests** - labeled `Feature` + `P2-medium` or higher
 
 Maintainers work from a filtered view: `is:issue is:open label:P0-critical,P1-high,needs-triage -label:stale`. Everything else is either being handled by the bot/lifecycle or picked up by contributors.
 
@@ -137,7 +137,7 @@ Duplicates get a 3-day grace period. Reporter can react 👎 to prevent closure.
 
 | Category | Labels | Purpose |
 |---|---|---|
-| **Type** | `bug`, `enhancement`, `documentation` | What kind of issue |
+| **Type** | `bug`, `Feature`, `Docs` | What kind of issue |
 | **Triage** | `needs-triage`, `triaged`, `needs-info`, `duplicate`, `wontfix` | Triage state |
 | **Priority** | `P0-critical`, `P1-high`, `P2-medium`, `P3-low` | Severity |
 | **Component** | `comp:server`, `comp:runner`, `comp:repr`, `comp:web-ui`, `comp:policies`, `comp:harnesses`, ... | Which subsystem (mirrors CODEOWNERS) |


### PR DESCRIPTION
## Summary

Renames the issue-type triage labels: `enhancement` → `Feature` and
`documentation` → `Docs`. The triage agent's `type` field value is applied
verbatim as a GitHub label, so this updates every place the type flows through
to keep the system coherent:

- `.github/workflows/issue-triage.yml` — `ALLOWED_TYPES` validator allow-list.
- `.github/triage/config.yaml` — agent JSON schema + type classification rule.
- `.github/ISSUE_TEMPLATE/feature_request.yml` — auto-added label on new
  feature requests.
- `designs/issue-triage-proposal.md` — design-doc references.

The repo labels themselves have already been renamed, so no label migration is
needed.

## Test Plan

- `grep -rn "\benhancement\b\|\bdocumentation\b"` over the triage files returns
  no matches (remaining hits are unrelated doc-sync prose).
- Verified the `type` value is applied directly as a label
  (`labels_add.append(t)` gated by `ALLOWED_TYPES`), so the validator and agent
  schema stay in sync with the renamed labels.

## Demo

N/A — no UI / frontend changes.

## Type of change

- [x] Chore / maintenance
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Test coverage

- [ ] Added / updated automated tests
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

Config/workflow-only change with no runnable code path in this repo; verified
by grep and by tracing how the `type` value maps onto an applied label.
