### PR TITLE
feat: add modular issue scoring core

### DIFF
--- a/deploy/issue_prioritization/README.md
+++ b/deploy/issue_prioritization/README.md
@@ -1,0 +1,29 @@
+# Issue prioritization pipeline
+
+This bundle owns the issue-prioritization v2 implementation. The scoring core is
+pure and reusable; Databricks and GitHub adapters are layered on top.
+
+## Local dry-run
+
+Prepare normalized issue JSON, then run:
+
+```bash
+uv run --project deploy/issue_prioritization issue-priority \
+  --input issues.json \
+  --areas .github/areas.json \
+  --output-dir /tmp/issue-priority-preview
+```
+
+The output directory contains `ranking.json`, `ranking.csv`, `ranking.md`,
+`summary.json`, and the exact `config.json` used. This command has no network or
+GitHub write path.
+
+All weights and enabled modules live in
+`src/issue_prioritization/default_scoring.json`. Readiness and age are present
+but disabled by default.
+
+## Tests
+
+```bash
+uv run --project deploy/issue_prioritization pytest deploy/issue_prioritization/tests
+```

--- a/deploy/issue_prioritization/pyproject.toml
+++ b/deploy/issue_prioritization/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "omnigent-issue-prioritization"
+version = "0.1.0"
+description = "Deterministic issue-prioritization pipeline for Omnigent"
+requires-python = ">=3.12"
+
+[project.scripts]
+issue-priority = "issue_prioritization.cli:main"
+
+[dependency-groups]
+dev = ["pytest>=8", "ruff>=0.12"]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+issue_prioritization = ["default_scoring.json"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]

--- a/deploy/issue_prioritization/src/issue_prioritization/__init__.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/__init__.py
@@ -1,0 +1,15 @@
+from issue_prioritization.areas import AreaCatalog
+from issue_prioritization.config import ScoringConfig
+from issue_prioritization.domain import Issue, IssueType, Priority, ScoreResult, Severity
+from issue_prioritization.scoring import ScoreEngine
+
+__all__ = [
+    "AreaCatalog",
+    "Issue",
+    "IssueType",
+    "Priority",
+    "ScoreEngine",
+    "ScoreResult",
+    "ScoringConfig",
+    "Severity",
+]

--- a/deploy/issue_prioritization/src/issue_prioritization/areas.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/areas.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+
+from issue_prioritization.domain import Issue
+
+
+@dataclass(frozen=True)
+class Area:
+    key: str
+    label: str
+    weight: Decimal
+
+
+@dataclass(frozen=True)
+class AreaCatalog:
+    by_key: Mapping[str, Area]
+    by_label: Mapping[str, tuple[Area, ...]]
+
+    @classmethod
+    def from_json(cls, path: str | Path) -> AreaCatalog:
+        value = json.loads(Path(path).read_text())
+        raw_areas = value.get("areas")
+        if not isinstance(raw_areas, list):
+            raise ValueError("areas.json must contain an areas array")
+
+        areas = []
+        for raw_area in raw_areas:
+            if not isinstance(raw_area, Mapping):
+                raise ValueError("each area must be an object")
+            areas.append(
+                Area(
+                    key=str(raw_area["key"]),
+                    label=str(raw_area["label"]),
+                    weight=Decimal(str(raw_area["weight"])),
+                )
+            )
+
+        by_label: dict[str, list[Area]] = {}
+        for area in areas:
+            by_label.setdefault(area.label, []).append(area)
+        return cls(
+            by_key={area.key: area for area in areas},
+            by_label={label: tuple(items) for label, items in by_label.items()},
+        )
+
+    def weight_for(self, issue: Issue, default: Decimal) -> Decimal:
+        exact = [self.by_key[key].weight for key in issue.area_keys if key in self.by_key]
+        if exact:
+            return max(exact)
+
+        fallback = [
+            area.weight for label in issue.component_labels for area in self.by_label.get(label, ())
+        ]
+        return max(fallback, default=default)

--- a/deploy/issue_prioritization/src/issue_prioritization/artifacts.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/artifacts.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+from issue_prioritization.config import ScoringConfig
+from issue_prioritization.domain import Issue, Priority, ScoreResult
+from issue_prioritization.scoring import ScoreEngine
+
+
+@dataclass(frozen=True)
+class RankedIssue:
+    rank: int
+    previous_rank: int
+    issue: Issue
+    result: ScoreResult
+
+    @property
+    def rank_delta(self) -> int:
+        return self.previous_rank - self.rank
+
+
+def rank_issues(issues: list[Issue], engine: ScoreEngine) -> list[RankedIssue]:
+    current = sorted(issues, key=_current_rank_key)
+    previous_rank = {issue.number: rank for rank, issue in enumerate(current, start=1)}
+    scored = [(issue, engine.score(issue)) for issue in issues]
+    scored.sort(key=lambda item: (item[1].score, item[0].number), reverse=True)
+    return [
+        RankedIssue(rank, previous_rank[issue.number], issue, result)
+        for rank, (issue, result) in enumerate(scored, start=1)
+    ]
+
+
+def write_artifacts(
+    output_dir: str | Path,
+    ranked: list[RankedIssue],
+    config: ScoringConfig,
+) -> None:
+    destination = Path(output_dir)
+    destination.mkdir(parents=True, exist_ok=True)
+    rows = [_row(item) for item in ranked]
+    config_payload = config.as_dict()
+    config_json = json.dumps(config_payload, sort_keys=True, separators=(",", ":"))
+    summary = {
+        "issue_count": len(rows),
+        "config_sha256": hashlib.sha256(config_json.encode()).hexdigest(),
+        "priority_counts": dict(Counter(row["proposed_priority"] for row in rows)),
+        "priority_changes": sum(
+            row["current_priority"] != row["proposed_priority"]
+            for row in rows
+            if row["current_priority"]
+        ),
+    }
+    (destination / "ranking.json").write_text(json.dumps(rows, indent=2) + "\n")
+    (destination / "summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+    (destination / "config.json").write_text(json.dumps(config_payload, indent=2) + "\n")
+    _write_csv(destination / "ranking.csv", rows)
+    _write_markdown(destination / "ranking.md", rows)
+
+
+def _current_rank_key(issue: Issue) -> tuple[int, int]:
+    order = {Priority.P0: 0, Priority.P1: 1, Priority.P2: 2, Priority.P3: 3, None: 4}
+    return order[issue.current_priority], -issue.number
+
+
+def _row(item: RankedIssue) -> dict[str, object]:
+    issue = item.issue
+    result = item.result
+    return {
+        "rank": item.rank,
+        "previous_rank": item.previous_rank,
+        "rank_delta": item.rank_delta,
+        "issue_number": issue.number,
+        "title": issue.title,
+        "url": issue.url,
+        "type": issue.issue_type.value,
+        "severity": issue.severity.value,
+        "score": float(result.score),
+        "current_priority": issue.current_priority.value if issue.current_priority else None,
+        "proposed_priority": result.priority.value,
+        "area_keys": list(issue.area_keys),
+        "component_labels": list(issue.component_labels),
+        "duplicate_count": issue.duplicate_count,
+        "reaction_count": issue.reaction_count,
+        "breakdown": [
+            {
+                "name": step.name,
+                "operation": step.operation,
+                "value": float(step.value),
+                "score_before": float(step.score_before),
+                "score_after": float(step.score_after),
+            }
+            for step in result.steps
+        ],
+    }
+
+
+def _write_csv(path: Path, rows: list[dict[str, object]]) -> None:
+    fields = [
+        "rank",
+        "previous_rank",
+        "rank_delta",
+        "issue_number",
+        "title",
+        "url",
+        "type",
+        "severity",
+        "score",
+        "current_priority",
+        "proposed_priority",
+    ]
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_markdown(path: Path, rows: list[dict[str, object]]) -> None:
+    lines = [
+        "| Rank | Score | Severity | Current | Proposed | Δrank | Issue |",
+        "|---:|---:|---|---|---|---:|---|",
+    ]
+    for row in rows:
+        title = str(row["title"]).replace("|", "\\|")
+        issue = f"[#{row['issue_number']}]({row['url']}) {title}"
+        lines.append(
+            f"| {row['rank']} | {row['score']:.2f} | {row['severity']} | "
+            f"{row['current_priority'] or 'none'} | {row['proposed_priority']} | "
+            f"{row['rank_delta']:+d} | {issue} |"
+        )
+    path.write_text("\n".join(lines) + "\n")

--- a/deploy/issue_prioritization/src/issue_prioritization/cli.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/cli.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from issue_prioritization.areas import AreaCatalog
+from issue_prioritization.artifacts import rank_issues, write_artifacts
+from issue_prioritization.config import ScoringConfig
+from issue_prioritization.domain import Issue
+from issue_prioritization.scoring import ScoreEngine
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate issue-prioritization dry-run artifacts")
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--areas", required=True, type=Path)
+    parser.add_argument("--config", type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    args = parser.parse_args()
+
+    raw = json.loads(args.input.read_text())
+    raw_issues = raw["issues"] if isinstance(raw, dict) else raw
+    if not isinstance(raw_issues, list):
+        raise ValueError("input must be an array or an object with an issues array")
+
+    issues = [Issue.from_mapping(value) for value in raw_issues]
+    config = ScoringConfig.from_json(args.config) if args.config else ScoringConfig.default()
+    engine = ScoreEngine(config, AreaCatalog.from_json(args.areas))
+    ranked = rank_issues(issues, engine)
+    write_artifacts(args.output_dir, ranked, config)
+    print(f"Wrote {len(ranked)} ranked issues to {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/issue_prioritization/src/issue_prioritization/config.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/config.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from decimal import Decimal
+from importlib.resources import files
+from pathlib import Path
+
+from issue_prioritization.domain import Priority, Severity
+
+
+@dataclass(frozen=True)
+class ModuleConfig:
+    enabled: bool
+    values: Mapping[str, Decimal]
+
+    def decimal(self, name: str) -> Decimal:
+        return self.values[name]
+
+
+@dataclass(frozen=True)
+class ScoringConfig:
+    severity_weights: Mapping[Severity, Decimal]
+    priority_thresholds: Mapping[Priority, Decimal]
+    module_order: tuple[str, ...]
+    modules: Mapping[str, ModuleConfig]
+
+    @classmethod
+    def default(cls) -> ScoringConfig:
+        resource = files("issue_prioritization").joinpath("default_scoring.json")
+        return cls.from_mapping(json.loads(resource.read_text()))
+
+    @classmethod
+    def from_json(cls, path: str | Path) -> ScoringConfig:
+        return cls.from_mapping(json.loads(Path(path).read_text()))
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> ScoringConfig:
+        severity_values = _mapping(value, "severity_weights")
+        threshold_values = _mapping(value, "priority_thresholds")
+        module_values = _mapping(value, "modules")
+        modules: dict[str, ModuleConfig] = {}
+        for name, raw_module in module_values.items():
+            if not isinstance(raw_module, Mapping):
+                raise ValueError(f"module {name!r} must be an object")
+            enabled = bool(raw_module.get("enabled", False))
+            values = {
+                str(key): _decimal(raw_value)
+                for key, raw_value in raw_module.items()
+                if key != "enabled"
+            }
+            modules[str(name)] = ModuleConfig(enabled=enabled, values=values)
+
+        raw_order = value.get("module_order", ())
+        if not isinstance(raw_order, list):
+            raise ValueError("module_order must be an array")
+
+        config = cls(
+            severity_weights={
+                Severity(str(name)): _decimal(weight) for name, weight in severity_values.items()
+            },
+            priority_thresholds={
+                Priority(str(name)): _decimal(threshold)
+                for name, threshold in threshold_values.items()
+            },
+            module_order=tuple(str(name) for name in raw_order),
+            modules=modules,
+        )
+        config.validate()
+        return config
+
+    def validate(self) -> None:
+        if set(self.severity_weights) != set(Severity):
+            raise ValueError("severity_weights must define S0-S3")
+        if set(self.priority_thresholds) != set(Priority):
+            raise ValueError("priority_thresholds must define P0-P3")
+        missing = set(self.module_order) - set(self.modules)
+        if missing:
+            raise ValueError(f"module_order references missing modules: {sorted(missing)}")
+
+    def priority_for(self, score: Decimal) -> Priority:
+        for priority in (Priority.P0, Priority.P1, Priority.P2, Priority.P3):
+            if score >= self.priority_thresholds[priority]:
+                return priority
+        return Priority.P3
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "severity_weights": {
+                severity.value: _json_number(weight)
+                for severity, weight in self.severity_weights.items()
+            },
+            "priority_thresholds": {
+                priority.value: _json_number(threshold)
+                for priority, threshold in self.priority_thresholds.items()
+            },
+            "module_order": list(self.module_order),
+            "modules": {
+                name: {
+                    "enabled": module.enabled,
+                    **{key: _json_number(value) for key, value in module.values.items()},
+                }
+                for name, module in self.modules.items()
+            },
+        }
+
+
+def _mapping(value: Mapping[str, object], name: str) -> Mapping[str, object]:
+    result = value.get(name)
+    if not isinstance(result, Mapping):
+        raise ValueError(f"{name} must be an object")
+    return result
+
+
+def _decimal(value: object) -> Decimal:
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        raise ValueError(f"expected number, got {value!r}")
+    return Decimal(str(value))
+
+
+def _json_number(value: Decimal) -> int | float:
+    if value == value.to_integral_value():
+        return int(value)
+    return float(value)

--- a/deploy/issue_prioritization/src/issue_prioritization/default_scoring.json
+++ b/deploy/issue_prioritization/src/issue_prioritization/default_scoring.json
@@ -1,0 +1,50 @@
+{
+  "severity_weights": {
+    "S0": 100,
+    "S1": 60,
+    "S2": 30,
+    "S3": 10
+  },
+  "priority_thresholds": {
+    "P0-critical": 100,
+    "P1-high": 60,
+    "P2-medium": 25,
+    "P3-low": 0
+  },
+  "module_order": [
+    "component",
+    "duplicates",
+    "demand",
+    "readiness",
+    "age"
+  ],
+  "modules": {
+    "component": {
+      "enabled": true,
+      "default_weight": 1.0
+    },
+    "duplicates": {
+      "enabled": true,
+      "increment": 0.15,
+      "max_bonus": 0.5
+    },
+    "demand": {
+      "enabled": true,
+      "reaction_cap": 12,
+      "max_points": 15
+    },
+    "readiness": {
+      "enabled": false,
+      "ready_multiplier": 1.1,
+      "needs_info_multiplier": 0.85
+    },
+    "age": {
+      "enabled": false,
+      "fresh_days": 5,
+      "visibility_days": 21,
+      "fresh_multiplier": 1.0,
+      "visibility_multiplier": 1.2,
+      "stale_multiplier": 0.8
+    }
+  }
+}

--- a/deploy/issue_prioritization/src/issue_prioritization/domain.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/domain.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from decimal import Decimal
+from enum import StrEnum
+
+
+class IssueType(StrEnum):
+    BUG = "bug"
+    ENHANCEMENT = "enhancement"
+    DOCUMENTATION = "documentation"
+
+
+class Severity(StrEnum):
+    S0 = "S0"
+    S1 = "S1"
+    S2 = "S2"
+    S3 = "S3"
+
+
+class Priority(StrEnum):
+    P0 = "P0-critical"
+    P1 = "P1-high"
+    P2 = "P2-medium"
+    P3 = "P3-low"
+
+
+@dataclass(frozen=True)
+class Issue:
+    number: int
+    title: str
+    url: str
+    issue_type: IssueType
+    severity: Severity
+    area_keys: tuple[str, ...] = ()
+    component_labels: tuple[str, ...] = ()
+    duplicate_count: int = 0
+    reaction_count: int = 0
+    current_priority: Priority | None = None
+    needs_info: bool = False
+    is_ready: bool = False
+    age_days: int = 0
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> Issue:
+        current_priority = value.get("current_priority")
+        return cls(
+            number=int(value["number"]),
+            title=str(value.get("title", "")),
+            url=str(value.get("url", "")),
+            issue_type=_issue_type(value["type"]),
+            severity=Severity(str(value["severity"])),
+            area_keys=_string_tuple(value.get("area_keys", ())),
+            component_labels=_string_tuple(value.get("component_labels", ())),
+            duplicate_count=max(0, int(value.get("duplicate_count", 0))),
+            reaction_count=max(0, int(value.get("reaction_count", 0))),
+            current_priority=Priority(str(current_priority)) if current_priority else None,
+            needs_info=bool(value.get("needs_info", False)),
+            is_ready=bool(value.get("is_ready", False)),
+            age_days=max(0, int(value.get("age_days", 0))),
+        )
+
+
+@dataclass(frozen=True)
+class ScoreStep:
+    name: str
+    operation: str
+    value: Decimal
+    score_before: Decimal
+    score_after: Decimal
+
+
+@dataclass(frozen=True)
+class ScoreResult:
+    score: Decimal
+    priority: Priority
+    steps: tuple[ScoreStep, ...]
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(str(item) for item in value)
+
+
+def _issue_type(value: object) -> IssueType:
+    normalized = str(value).strip().lower()
+    aliases = {
+        "bug": IssueType.BUG,
+        "feature": IssueType.ENHANCEMENT,
+        "enhancement": IssueType.ENHANCEMENT,
+        "docs": IssueType.DOCUMENTATION,
+        "documentation": IssueType.DOCUMENTATION,
+    }
+    try:
+        return aliases[normalized]
+    except KeyError as exc:
+        raise ValueError(f"unsupported issue type: {value!r}") from exc

--- a/deploy/issue_prioritization/src/issue_prioritization/scoring.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/scoring.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Protocol
+
+from issue_prioritization.areas import AreaCatalog
+from issue_prioritization.config import ModuleConfig, ScoringConfig
+from issue_prioritization.domain import Issue, ScoreResult, ScoreStep
+
+_CENT = Decimal("0.01")
+
+
+class ScoreModule(Protocol):
+    name: str
+
+    def apply(self, issue: Issue, score: Decimal) -> ScoreStep: ...
+
+
+@dataclass(frozen=True)
+class ComponentModule:
+    catalog: AreaCatalog
+    config: ModuleConfig
+    name: str = "component"
+
+    def apply(self, issue: Issue, score: Decimal) -> ScoreStep:
+        weight = self.catalog.weight_for(issue, self.config.decimal("default_weight"))
+        return _multiply_step(self.name, score, weight)
+
+
+@dataclass(frozen=True)
+class DuplicateModule:
+    config: ModuleConfig
+    name: str = "duplicates"
+
+    def apply(self, issue: Issue, score: Decimal) -> ScoreStep:
+        bonus = min(
+            self.config.decimal("max_bonus"),
+            self.config.decimal("increment") * issue.duplicate_count,
+        )
+        return _multiply_step(self.name, score, Decimal(1) + bonus)
+
+
+@dataclass(frozen=True)
+class DemandModule:
+    config: ModuleConfig
+    name: str = "demand"
+
+    def apply(self, issue: Issue, score: Decimal) -> ScoreStep:
+        cap = int(self.config.decimal("reaction_cap"))
+        reactions = min(issue.reaction_count, cap)
+        points = (
+            self.config.decimal("max_points") * Decimal(reactions) / Decimal(cap)
+            if cap
+            else Decimal(0)
+        )
+        return _add_step(self.name, score, points)
+
+
+@dataclass(frozen=True)
+class ReadinessModule:
+    config: ModuleConfig
+    name: str = "readiness"
+
+    def apply(self, issue: Issue, score: Decimal) -> ScoreStep:
+        if issue.needs_info:
+            multiplier = self.config.decimal("needs_info_multiplier")
+        elif issue.is_ready:
+            multiplier = self.config.decimal("ready_multiplier")
+        else:
+            multiplier = Decimal(1)
+        return _multiply_step(self.name, score, multiplier)
+
+
+@dataclass(frozen=True)
+class AgeModule:
+    config: ModuleConfig
+    name: str = "age"
+
+    def apply(self, issue: Issue, score: Decimal) -> ScoreStep:
+        if issue.age_days <= self.config.decimal("fresh_days"):
+            multiplier = self.config.decimal("fresh_multiplier")
+        elif issue.age_days <= self.config.decimal("visibility_days"):
+            multiplier = self.config.decimal("visibility_multiplier")
+        else:
+            multiplier = self.config.decimal("stale_multiplier")
+        return _multiply_step(self.name, score, multiplier)
+
+
+class ScoreEngine:
+    def __init__(self, config: ScoringConfig, catalog: AreaCatalog) -> None:
+        self.config = config
+        modules: list[ScoreModule] = []
+        for name in config.module_order:
+            module_config = config.modules[name]
+            if not module_config.enabled:
+                continue
+            if name == "component":
+                modules.append(ComponentModule(catalog, module_config))
+            elif name == "duplicates":
+                modules.append(DuplicateModule(module_config))
+            elif name == "demand":
+                modules.append(DemandModule(module_config))
+            elif name == "readiness":
+                modules.append(ReadinessModule(module_config))
+            elif name == "age":
+                modules.append(AgeModule(module_config))
+            else:
+                raise ValueError(f"unsupported scoring module: {name}")
+        self.modules = tuple(modules)
+
+    def score(self, issue: Issue) -> ScoreResult:
+        score = self.config.severity_weights[issue.severity]
+        steps = [ScoreStep("severity", "set", score, Decimal(0), score)]
+        if issue.needs_info:
+            score = Decimal(0)
+            steps.append(ScoreStep("needs_info", "set", score, steps[-1].score_after, score))
+        else:
+            for module in self.modules:
+                step = module.apply(issue, score)
+                steps.append(step)
+                score = step.score_after
+        score = _round(score)
+        return ScoreResult(
+            score=score,
+            priority=self.config.priority_for(score),
+            steps=tuple(steps),
+        )
+
+
+def _multiply_step(name: str, score: Decimal, multiplier: Decimal) -> ScoreStep:
+    return ScoreStep(name, "multiply", multiplier, score, _round(score * multiplier))
+
+
+def _add_step(name: str, score: Decimal, points: Decimal) -> ScoreStep:
+    return ScoreStep(name, "add", _round(points), score, _round(score + points))
+
+
+def _round(value: Decimal) -> Decimal:
+    return value.quantize(_CENT, rounding=ROUND_HALF_UP)

--- a/deploy/issue_prioritization/tests/test_artifacts.py
+++ b/deploy/issue_prioritization/tests/test_artifacts.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from decimal import Decimal
+
+from issue_prioritization.areas import Area, AreaCatalog
+from issue_prioritization.artifacts import rank_issues, write_artifacts
+from issue_prioritization.config import ScoringConfig
+from issue_prioritization.domain import Issue, IssueType, Priority, Severity
+from issue_prioritization.scoring import ScoreEngine
+
+
+def test_dry_run_artifacts_are_complete_and_deterministic(tmp_path) -> None:
+    area = Area("db", "comp:server", Decimal("1.2"))
+    catalog = AreaCatalog(by_key={"db": area}, by_label={"comp:server": (area,)})
+    issues = [
+        Issue(
+            number=2,
+            title="Database crash",
+            url="https://github.com/omnigent-ai/omnigent/issues/2",
+            issue_type=IssueType.BUG,
+            severity=Severity.S1,
+            area_keys=("db",),
+            current_priority=Priority.P2,
+        ),
+        Issue(
+            number=1,
+            title="Small request",
+            url="https://github.com/omnigent-ai/omnigent/issues/1",
+            issue_type=IssueType.ENHANCEMENT,
+            severity=Severity.S3,
+            area_keys=("db",),
+            current_priority=Priority.P1,
+        ),
+    ]
+    config = ScoringConfig.default()
+    ranked = rank_issues(issues, ScoreEngine(config, catalog))
+
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    write_artifacts(first, ranked, config)
+    write_artifacts(second, ranked, config)
+
+    expected = {"ranking.json", "ranking.csv", "ranking.md", "summary.json", "config.json"}
+    assert {path.name for path in first.iterdir()} == expected
+    assert (first / "ranking.json").read_bytes() == (second / "ranking.json").read_bytes()
+    summary = json.loads((first / "summary.json").read_text())
+    assert summary["issue_count"] == 2
+    assert summary["priority_changes"] == 2
+
+
+def test_cli_writes_review_artifacts_without_network(tmp_path) -> None:
+    issues_path = tmp_path / "issues.json"
+    areas_path = tmp_path / "areas.json"
+    output_path = tmp_path / "output"
+    issues_path.write_text(
+        json.dumps(
+            [
+                {
+                    "number": 7,
+                    "title": "iOS login fails",
+                    "url": "https://github.com/omnigent-ai/omnigent/issues/7",
+                    "type": "Bug",
+                    "severity": "S1",
+                    "area_keys": ["ios"],
+                    "current_priority": "P2-medium",
+                }
+            ]
+        )
+    )
+    areas_path.write_text(
+        json.dumps(
+            {
+                "areas": [
+                    {
+                        "key": "ios",
+                        "label": "comp:ios",
+                        "weight": 1.0,
+                    }
+                ]
+            }
+        )
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "issue_prioritization.cli",
+            "--input",
+            str(issues_path),
+            "--areas",
+            str(areas_path),
+            "--output-dir",
+            str(output_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Wrote 1 ranked issues" in result.stdout
+    assert (
+        json.loads((output_path / "ranking.json").read_text())[0]["proposed_priority"] == "P1-high"
+    )

--- a/deploy/issue_prioritization/tests/test_scoring.py
+++ b/deploy/issue_prioritization/tests/test_scoring.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from decimal import Decimal
+
+from issue_prioritization.areas import Area, AreaCatalog
+from issue_prioritization.config import ModuleConfig, ScoringConfig
+from issue_prioritization.domain import Issue, IssueType, Priority, Severity
+from issue_prioritization.scoring import ScoreEngine
+
+
+def _catalog() -> AreaCatalog:
+    areas = {
+        "harness-claude": Area("harness-claude", "comp:harnesses", Decimal("1.4")),
+        "harness-kimi": Area("harness-kimi", "comp:harnesses", Decimal("0.9")),
+        "db": Area("db", "comp:server", Decimal("1.2")),
+    }
+    return AreaCatalog(
+        by_key=areas,
+        by_label={
+            "comp:harnesses": (areas["harness-claude"], areas["harness-kimi"]),
+            "comp:server": (areas["db"],),
+        },
+    )
+
+
+def _issue(**changes: object) -> Issue:
+    issue = Issue(
+        number=1,
+        title="Harness fails",
+        url="https://github.com/omnigent-ai/omnigent/issues/1",
+        issue_type=IssueType.BUG,
+        severity=Severity.S1,
+        area_keys=("harness-claude",),
+    )
+    return replace(issue, **changes)
+
+
+def test_tier_one_s1_bug_stays_p1() -> None:
+    result = ScoreEngine(ScoringConfig.default(), _catalog()).score(_issue())
+
+    assert result.score == Decimal("84.00")
+    assert result.priority == Priority.P1
+
+
+def test_low_weight_s1_bug_falls_to_p2() -> None:
+    result = ScoreEngine(ScoringConfig.default(), _catalog()).score(
+        _issue(area_keys=("harness-kimi",))
+    )
+
+    assert result.score == Decimal("54.00")
+    assert result.priority == Priority.P2
+
+
+def test_duplicate_reach_is_capped() -> None:
+    result = ScoreEngine(ScoringConfig.default(), _catalog()).score(
+        _issue(severity=Severity.S2, duplicate_count=100)
+    )
+
+    assert result.score == Decimal("63.00")
+    assert result.priority == Priority.P1
+
+
+def test_needs_info_has_no_score() -> None:
+    result = ScoreEngine(ScoringConfig.default(), _catalog()).score(_issue(needs_info=True))
+
+    assert result.score == Decimal("0.00")
+    assert result.priority == Priority.P3
+
+
+def test_optional_modules_are_disabled_by_default() -> None:
+    issue = _issue(is_ready=True, age_days=10)
+    default = ScoringConfig.default()
+
+    result = ScoreEngine(default, _catalog()).score(issue)
+
+    assert result.score == Decimal("84.00")
+    assert [step.name for step in result.steps] == [
+        "severity",
+        "component",
+        "duplicates",
+        "demand",
+    ]
+
+
+def test_optional_modules_can_be_enabled_independently() -> None:
+    default = ScoringConfig.default()
+    modules = dict(default.modules)
+    modules["readiness"] = ModuleConfig(True, modules["readiness"].values)
+    enabled = replace(default, modules=modules)
+
+    result = ScoreEngine(enabled, _catalog()).score(_issue(is_ready=True, age_days=10))
+
+    assert result.score == Decimal("92.40")
+    assert "readiness" in [step.name for step in result.steps]
+    assert "age" not in [step.name for step in result.steps]
+
+
+def test_demand_is_linear_and_type_independent() -> None:
+    engine = ScoreEngine(ScoringConfig.default(), _catalog())
+
+    bug = engine.score(_issue(reaction_count=6))
+    feature = engine.score(_issue(issue_type=IssueType.ENHANCEMENT, reaction_count=6))
+
+    assert bug.score == Decimal("91.50")
+    assert feature.score == bug.score
+
+
+def test_demand_is_capped() -> None:
+    result = ScoreEngine(ScoringConfig.default(), _catalog()).score(
+        _issue(
+            issue_type=IssueType.ENHANCEMENT,
+            severity=Severity.S2,
+            area_keys=("harness-kimi",),
+            reaction_count=1000,
+        )
+    )
+
+    assert result.score == Decimal("42.00")
+    assert result.priority == Priority.P2
+
+
+def test_linear_aligned_type_labels_are_normalized() -> None:
+    feature = Issue.from_mapping(
+        {
+            "number": 1,
+            "type": "Feature",
+            "severity": "S2",
+        }
+    )
+    docs = Issue.from_mapping(
+        {
+            "number": 2,
+            "type": "Docs",
+            "severity": "S3",
+        }
+    )
+
+    assert feature.issue_type == IssueType.ENHANCEMENT
+    assert docs.issue_type == IssueType.DOCUMENTATION

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -354,6 +354,10 @@ dev = [
 omnigent = "omnigent.cli:main"
 omni = "omnigent.cli:main"
 
+# Share the repository lockfile with standalone deploy packages.
+[tool.uv.workspace]
+members = ["deploy/issue_prioritization"]
+
 # uv path-deps for the sibling SDK packages (renamed in Stage 3).
 [tool.uv.sources]
 omnigent-client = { path = "sdks/python-client", editable = true }

--- a/uv.lock
+++ b/uv.lock
@@ -19,6 +19,12 @@ cryptography = "2026-06-26T00:00:00Z"
 nimble-python = "2026-07-29T00:00:00Z"
 pydantic-settings = "2026-06-26T00:00:00Z"
 
+[manifest]
+members = [
+    "omnigent",
+    "omnigent-issue-prioritization",
+]
+
 [[package]]
 name = "absl-py"
 version = "2.4.0"
@@ -3458,6 +3464,25 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "omnigent", editable = "." },
     { name = "pydantic", specifier = ">=2.0,<3" },
+]
+
+[[package]]
+name = "omnigent-issue-prioritization"
+version = "0.1.0"
+source = { editable = "deploy/issue_prioritization" }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8" },
+    { name = "ruff", specifier = ">=0.12" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Related issue

N/A — implementation of the issue-prioritization v2 design in the parent branch.

## Summary

- Adds a pure, config-driven Python scoring core for severity, component importance, duplicates, and demand.
- Produces deterministic JSON, CSV, and Markdown rankings; readiness and age remain modular and disabled.

**ELI5:** Give the same issue facts to the scorer and it produces the same score, priority band, and explanation every time.

```text
normalized issues + areas.json + scoring config
                     |
                     v
              deterministic scorer
                     |
                     v
           ranking + score breakdowns
```

## Test Plan

- `uv run --project deploy/issue_prioritization pytest -q`
- `uv run --project deploy/issue_prioritization ruff check deploy/issue_prioritization`
- `uv run --project deploy/issue_prioritization ruff format --check deploy/issue_prioritization`

## Demo

N/A — non-visual scoring library.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Pure scoring, configuration validation, type aliases, determinism, and artifact generation are unit-tested.

## Changelog

Issue rankings now use a deterministic, explainable severity and component scoring model.
