### PR TITLE
feat: add guarded GitHub issue updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -49,7 +49,8 @@ body:
     id: harness
     attributes:
       label: Harness
-      description: Select the affected harness, if any.
+      description: Select the affected harnesses, if any.
+      multiple: true
       options:
         - Not applicable
         - Claude
@@ -72,6 +73,7 @@ body:
     id: harness-mode
     attributes:
       label: Harness mode
+      multiple: true
       options:
         - Not applicable
         - SDK
@@ -114,6 +116,7 @@ body:
     id: auth-type
     attributes:
       label: Authentication type
+      multiple: true
       options:
         - Not authentication-related
         - Local

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,3 +44,83 @@ body:
       placeholder: e.g. Ubuntu 24.04, macOS 15.1
     validations:
       required: false
+
+  - type: dropdown
+    id: harness
+    attributes:
+      label: Harness
+      description: Select the affected harness, if any.
+      options:
+        - Not applicable
+        - Claude
+        - Codex
+        - Cursor
+        - Antigravity
+        - Hermes
+        - OpenCode
+        - Pi
+        - Copilot
+        - Goose
+        - Kimi
+        - Kiro
+        - Qwen
+        - Other
+    validations:
+      required: false
+
+  - type: dropdown
+    id: harness-mode
+    attributes:
+      label: Harness mode
+      options:
+        - Not applicable
+        - SDK
+        - Native
+        - Other
+    validations:
+      required: false
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform or device
+      multiple: true
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Desktop app
+        - iOS
+        - Android
+        - Docker
+        - Other
+    validations:
+      required: false
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Observed impact
+      options:
+        - All users or sessions
+        - Most users or sessions
+        - Some users or sessions
+        - One narrow or edge case
+        - Unknown
+    validations:
+      required: false
+
+  - type: dropdown
+    id: auth-type
+    attributes:
+      label: Authentication type
+      options:
+        - Not authentication-related
+        - Local
+        - Multi-user
+        - OIDC
+        - OAuth
+        - Databricks
+        - Other
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -31,7 +31,8 @@ body:
     id: harness
     attributes:
       label: Harness
-      description: Select the affected harness, if any.
+      description: Select the affected harnesses, if any.
+      multiple: true
       options:
         - Not applicable
         - Claude
@@ -72,6 +73,7 @@ body:
     id: harness-mode
     attributes:
       label: Harness mode
+      multiple: true
       options:
         - Not applicable
         - SDK
@@ -97,6 +99,7 @@ body:
     id: auth-type
     attributes:
       label: Authentication type
+      multiple: true
       options:
         - Not authentication-related
         - Local

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -26,3 +26,84 @@ body:
       description: Any workarounds or alternative approaches you've thought about.
     validations:
       required: false
+
+  - type: dropdown
+    id: harness
+    attributes:
+      label: Harness
+      description: Select the affected harness, if any.
+      options:
+        - Not applicable
+        - Claude
+        - Codex
+        - Cursor
+        - Antigravity
+        - Hermes
+        - OpenCode
+        - Pi
+        - Copilot
+        - Goose
+        - Kimi
+        - Kiro
+        - Qwen
+        - Other
+    validations:
+      required: false
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform or device
+      multiple: true
+      options:
+        - Not platform-specific
+        - macOS
+        - Linux
+        - Windows
+        - Desktop app
+        - iOS
+        - Android
+        - Docker
+        - Other
+    validations:
+      required: false
+
+  - type: dropdown
+    id: harness-mode
+    attributes:
+      label: Harness mode
+      options:
+        - Not applicable
+        - SDK
+        - Native
+        - Other
+    validations:
+      required: false
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Expected reach
+      options:
+        - Most users
+        - A substantial user segment
+        - Some users
+        - One narrow or edge case
+        - Unknown
+    validations:
+      required: false
+
+  - type: dropdown
+    id: auth-type
+    attributes:
+      label: Authentication type
+      options:
+        - Not authentication-related
+        - Local
+        - Multi-user
+        - OIDC
+        - OAuth
+        - Databricks
+        - Other
+    validations:
+      required: false

--- a/.github/areas.json
+++ b/.github/areas.json
@@ -17,6 +17,9 @@
     "               comp:policies, comp:harnesses, comp:infra) -- gh cannot add a",
     "               label that does not exist, and there is no label-sync. Several",
     "               areas may share a label (all harness areas share comp:harnesses).",
+    "  priority_label - v2 comp:* label proposed by the ranking job. This may use",
+    "               labels from .github/issue-prioritization-labels.json; the legacy",
+    "               issue-triage workflow ignores it until v2 is enabled.",
     "  weight     - importance multiplier for the composite issue-priority score",
     "               (designs/prioritization). Discrete bands 1.4/1.2/1.1/1.0/0.9. Applies",
     "               to EVERY area, harness or not -- it is the unified component-weight",
@@ -46,6 +49,7 @@
     {
       "key": "repo-automation",
       "label": "comp:infra",
+      "priority_label": "comp:infra",
       "weight": 0.9,
       "weight_source": "editorial",
       "definition": "Repo automation and CI: GitHub Actions workflows, scripts, Dependabot, issue/PR templates.",
@@ -61,6 +65,7 @@
     {
       "key": "web",
       "label": "comp:web-ui",
+      "priority_label": "comp:web-ui",
       "weight": 1.0,
       "weight_source": "editorial",
       "definition": "The web frontend (web/) shared by all clients: React UI, components, embed. NOT the desktop or mobile app shells (those are separate areas below).",
@@ -75,6 +80,7 @@
     {
       "key": "desktop-app",
       "label": "comp:web-ui",
+      "priority_label": "comp:web-ui",
       "weight": 1.0,
       "weight_source": "editorial",
       "definition": "The desktop app shell (Electron wrapper around the web UI): main process, packaging, native desktop chrome.",
@@ -90,6 +96,7 @@
     {
       "key": "mobile-app",
       "label": "comp:web-ui",
+      "priority_label": "comp:ios",
       "weight": 1.0,
       "weight_source": "editorial",
       "definition": "The mobile app shell (iOS wrapper around the web UI): native mobile integration and packaging.",
@@ -103,8 +110,25 @@
       ]
     },
     {
+      "key": "android-app",
+      "label": "comp:web-ui",
+      "priority_label": "comp:android",
+      "weight": 1.0,
+      "weight_source": "editorial",
+      "definition": "The Android app shell: native Android integration and packaging.",
+      "paths": [
+        "web/android/"
+      ],
+      "owners": [
+        "serena-ruan",
+        "fanzeyi",
+        "daniellok-db"
+      ]
+    },
+    {
       "key": "inner",
       "label": "comp:harnesses",
+      "priority_label": "comp:harness-t2",
       "weight": 1.1,
       "weight_source": "editorial",
       "definition": "Core agent runtime and the harness/executor layer shared by all harnesses (loader, executor base, tool bridge, sandboxes). Harness-specific code has its own areas below.",
@@ -125,6 +149,7 @@
     {
       "key": "runner",
       "label": "comp:runner",
+      "priority_label": "comp:runner",
       "weight": 1.2,
       "weight_source": "editorial",
       "definition": "The agent runner: the execution engine that drives a turn.",
@@ -144,6 +169,7 @@
     {
       "key": "runtime",
       "label": "comp:runner",
+      "priority_label": "comp:runner",
       "weight": 1.2,
       "weight_source": "editorial",
       "definition": "The agent runtime and execution scaffolding surrounding the runner.",
@@ -163,6 +189,7 @@
     {
       "key": "server",
       "label": "comp:server",
+      "priority_label": "comp:server",
       "weight": 1.2,
       "weight_source": "editorial",
       "definition": "The Omnigent server: HTTP API, session creation and lifecycle, request routing.",
@@ -181,8 +208,34 @@
       ]
     },
     {
+      "key": "auth",
+      "label": "comp:server",
+      "priority_label": "comp:auth",
+      "weight": 1.2,
+      "weight_source": "editorial",
+      "definition": "Authentication, OIDC/OAuth, account login, and runtime credentials.",
+      "paths": [
+        "omnigent/cli_auth.py",
+        "omnigent/runtime/credentials/",
+        "omnigent/server/auth.py",
+        "omnigent/server/oidc.py",
+        "omnigent/server/oidc_access.py",
+        "omnigent/server/routes/_auth_helpers.py",
+        "omnigent/server/routes/accounts_auth.py",
+        "omnigent/server/routes/auth.py",
+        "omnigent/server/routes/device_auth.py"
+      ],
+      "owners": [
+        "dhruv0811",
+        "TomeHirata",
+        "SabhyaC26",
+        "fanzeyi"
+      ]
+    },
+    {
       "key": "onboarding",
       "label": "comp:tui",
+      "priority_label": "comp:tui",
       "weight": 1.0,
       "weight_source": "editorial",
       "definition": "The setup / onboarding flow: first-run setup, provider auth, credential onboarding driven through the CLI.",
@@ -197,6 +250,7 @@
     {
       "key": "policies",
       "label": "comp:policies",
+      "priority_label": "comp:policies",
       "weight": 1.0,
       "weight_source": "editorial",
       "definition": "Safety policies, guardrails, and policy evaluation/elicitation.",
@@ -213,6 +267,7 @@
     {
       "key": "spec",
       "label": "comp:repr",
+      "priority_label": "comp:repr",
       "weight": 0.9,
       "weight_source": "editorial",
       "definition": "Spec and schema layer: representation of agents/sessions and their serialized form.",
@@ -228,6 +283,7 @@
     {
       "key": "llms",
       "label": "comp:harnesses",
+      "priority_label": "comp:harness-t2",
       "weight": 1.1,
       "weight_source": "editorial",
       "definition": "LLM provider and model-catalog layer: gateways, provider adapters, model selection.",
@@ -242,6 +298,7 @@
     {
       "key": "host",
       "label": "comp:server",
+      "priority_label": "comp:server",
       "weight": 1.2,
       "weight_source": "editorial",
       "definition": "The host / daemon: the long-running local process that hosts sessions and terminals.",
@@ -258,6 +315,7 @@
     {
       "key": "sandbox",
       "label": "comp:runner",
+      "priority_label": "comp:sandbox",
       "weight": 1.2,
       "weight_source": "editorial",
       "definition": "The OS sandbox (bwrap/seatbelt isolation) and egress controls around agent execution.",
@@ -272,6 +330,7 @@
     {
       "key": "db",
       "label": "comp:server",
+      "priority_label": "comp:db",
       "weight": 1.2,
       "weight_source": "editorial",
       "definition": "Database and persistence layer for the server.",
@@ -291,6 +350,7 @@
     {
       "key": "stores",
       "label": "comp:repr",
+      "priority_label": "comp:repr",
       "weight": 0.9,
       "weight_source": "editorial",
       "definition": "Stores: persistence and serialization of sessions, history, and artifacts.",
@@ -313,6 +373,7 @@
     {
       "key": "terminals",
       "label": "comp:tui",
+      "priority_label": "comp:tui",
       "weight": 1.0,
       "weight_source": "editorial",
       "definition": "Terminal management: PTY/terminal launch, read, and lifecycle.",
@@ -332,6 +393,7 @@
     {
       "key": "tools",
       "label": "comp:harnesses",
+      "priority_label": "comp:harness-t2",
       "weight": 1.1,
       "weight_source": "editorial",
       "definition": "Built-in tools and the tool-bridge exposed to harnesses.",
@@ -352,6 +414,7 @@
     {
       "key": "entities",
       "label": "comp:repr",
+      "priority_label": "comp:repr",
       "weight": 0.9,
       "weight_source": "editorial",
       "definition": "Entity models: the core data model for agents, sessions, and related objects.",
@@ -366,6 +429,7 @@
     {
       "key": "repl",
       "label": "comp:tui",
+      "priority_label": "comp:tui",
       "weight": 0.9,
       "weight_source": "editorial",
       "definition": "The interactive REPL and its terminal UI.",
@@ -383,6 +447,7 @@
     {
       "key": "resources",
       "label": "comp:server",
+      "priority_label": "comp:server",
       "weight": 1.0,
       "weight_source": "editorial",
       "definition": "Bundled resources and static assets used by the runtime.",
@@ -398,6 +463,7 @@
     {
       "key": "deploy",
       "label": "comp:infra",
+      "priority_label": "comp:infra",
       "weight": 0.9,
       "weight_source": "editorial",
       "definition": "Deploy targets and deployment configuration (Docker, Railway, Render, etc.).",
@@ -413,6 +479,7 @@
     {
       "key": "sdks",
       "label": "comp:server",
+      "priority_label": "comp:server",
       "weight": 1.0,
       "weight_source": "editorial",
       "definition": "Python and UI client SDKs.",
@@ -433,6 +500,7 @@
     {
       "key": "harness-claude",
       "label": "comp:harnesses",
+      "priority_label": "comp:harness-t1",
       "weight": 1.4,
       "weight_source": "telemetry",
       "definition": "The Claude harness family: the Claude SDK executor/harness (claude-sdk) and the native Claude Code terminal integration.",
@@ -454,6 +522,7 @@
     {
       "key": "harness-codex",
       "label": "comp:harnesses",
+      "priority_label": "comp:harness-t1",
       "weight": 1.4,
       "weight_source": "telemetry",
       "definition": "The Codex / OpenAI harness family: the OpenAI Agents SDK executor/harness, the open-responses SDK, and the native Codex integration.",
@@ -477,6 +546,7 @@
     {
       "key": "harness-cursor",
       "label": "comp:harnesses",
+      "priority_label": "comp:harness-t2",
       "weight": 1.1,
       "weight_source": "telemetry",
       "definition": "The Cursor harness: SDK executor/harness and the native Cursor integration.",
@@ -492,6 +562,7 @@
     {
       "key": "harness-antigravity",
       "label": "comp:harnesses",
+      "priority_label": "comp:harness-t2",
       "weight": 1.1,
       "weight_source": "telemetry",
       "definition": "The Antigravity (Gemini) harness: SDK executor/harness, native integration, and Gemini/Antigravity auth.",
@@ -509,6 +580,7 @@
     {
       "key": "harness-goose",
       "label": "comp:harnesses",
+      "priority_label": "comp:harness-t3",
       "weight": 0.9,
       "weight_source": "telemetry",
       "definition": "The Goose harness: SDK executor/harness, native TUI/ACP integration, and Goose auth.",
@@ -525,6 +597,7 @@
     {
       "key": "harness-hermes",
       "label": "comp:harnesses",
+      "priority_label": "comp:harness-t2",
       "weight": 1.1,
       "weight_source": "telemetry",
       "definition": "The Hermes harness: SDK executor/harness and the native Hermes integration.",
@@ -540,6 +613,7 @@
     {
       "key": "harness-kimi",
       "label": "comp:harnesses",
+      "priority_label": "comp:harness-t3",
       "weight": 0.9,
       "weight_source": "telemetry",
       "definition": "The Kimi harness: SDK executor/harness and the native Kimi integration.",
@@ -558,6 +632,7 @@
     {
       "key": "harness-kiro",
       "label": "comp:harnesses",
+      "priority_label": "comp:harness-t3",
       "weight": 0.9,
       "weight_source": "telemetry",
       "definition": "The Kiro harness: SDK executor/harness and the native Kiro integration.",
@@ -574,6 +649,7 @@
     {
       "key": "harness-opencode",
       "label": "comp:harnesses",
+      "priority_label": "comp:harness-t2",
       "weight": 1.1,
       "weight_source": "telemetry",
       "definition": "The OpenCode harness: SDK executor/harness, native integration, HTTP transport, and OpenCode auth.",
@@ -592,6 +668,7 @@
     {
       "key": "harness-pi",
       "label": "comp:harnesses",
+      "priority_label": "comp:harness-t2",
       "weight": 1.1,
       "weight_source": "telemetry",
       "definition": "The Pi harness: SDK executor/harness and the native Pi integration.",
@@ -607,6 +684,7 @@
     {
       "key": "harness-qwen",
       "label": "comp:harnesses",
+      "priority_label": "comp:harness-t3",
       "weight": 0.9,
       "weight_source": "telemetry",
       "definition": "The Qwen harness: SDK executor/harness and the native Qwen integration.",
@@ -623,6 +701,7 @@
     {
       "key": "harness-copilot",
       "label": "comp:harnesses",
+      "priority_label": "comp:harness-t2",
       "weight": 1.1,
       "weight_source": "telemetry",
       "definition": "The GitHub Copilot harness: SDK executor/harness and Copilot auth.",

--- a/.github/issue-prioritization-labels.json
+++ b/.github/issue-prioritization-labels.json
@@ -1,0 +1,26 @@
+{
+  "labels": [
+    {"name": "Bug", "color": "d73a4a", "description": "Unexpected or broken behavior"},
+    {"name": "Feature", "color": "a2eeef", "description": "New capability or improvement"},
+    {"name": "Docs", "color": "0075ca", "description": "Documentation change"},
+    {"name": "severity:S0", "color": "8b0000", "description": "Critical severity"},
+    {"name": "severity:S1", "color": "d93f0b", "description": "High severity"},
+    {"name": "severity:S2", "color": "fbca04", "description": "Medium severity"},
+    {"name": "severity:S3", "color": "c5def5", "description": "Low or uncertain severity"},
+    {"name": "comp:server", "color": "1d76db", "description": "Server and API"},
+    {"name": "comp:runner", "color": "5319e7", "description": "Agent runner and runtime"},
+    {"name": "comp:repr", "color": "bfdadc", "description": "Representation and storage models"},
+    {"name": "comp:web-ui", "color": "006b75", "description": "Web and desktop UI"},
+    {"name": "comp:tui", "color": "0e8a16", "description": "CLI, REPL, and terminal UI"},
+    {"name": "comp:policies", "color": "b60205", "description": "Policies and guardrails"},
+    {"name": "comp:infra", "color": "cfd3d7", "description": "Infrastructure and CI"},
+    {"name": "comp:harness-t1", "color": "5319e7", "description": "Highest-usage harnesses"},
+    {"name": "comp:harness-t2", "color": "7057ff", "description": "Mainline harnesses"},
+    {"name": "comp:harness-t3", "color": "bfd4f2", "description": "Lower-usage harnesses"},
+    {"name": "comp:sandbox", "color": "b60205", "description": "Sandbox isolation and egress"},
+    {"name": "comp:db", "color": "0e8a16", "description": "Database, persistence, and migrations"},
+    {"name": "comp:ios", "color": "1d76db", "description": "iOS app shell"},
+    {"name": "comp:android", "color": "3ddc84", "description": "Android app shell"},
+    {"name": "comp:auth", "color": "0052cc", "description": "Authentication and credentials"}
+  ]
+}

--- a/.github/workflows/areas.test.js
+++ b/.github/workflows/areas.test.js
@@ -5,6 +5,10 @@ const fs = require("fs");
 const path = require("path");
 
 const areas = JSON.parse(fs.readFileSync(path.resolve(".github/areas.json"), "utf8")).areas;
+const priorityLabels = new Set(
+  JSON.parse(fs.readFileSync(path.resolve(".github/issue-prioritization-labels.json"), "utf8"))
+    .labels.map((label) => label.name),
+);
 const maint = new Set(
   fs.readFileSync(path.resolve(".github/MAINTAINER"), "utf8")
     .split("\n").map((l) => l.replace(/#.*/, "").trim().toLowerCase()).filter(Boolean)
@@ -31,6 +35,14 @@ for (const a of areas)
 // Every label is one of the real comp:* labels.
 for (const a of areas)
   assert(`area ${a.key} label ${a.label} is a real comp:*`, ALLOWED_LABELS.has(a.label));
+
+// V2 labels are declared separately so the active triage workflow can keep
+// using the legacy label until issue prioritization is enabled.
+for (const a of areas)
+  assert(
+    `area ${a.key} priority_label ${a.priority_label} is declared`,
+    priorityLabels.has(a.priority_label),
+  );
 
 // Every area has >= 2 owners (the 2+ codeowner requirement). Paused owners
 // still count -- pausing someone must not force adding a new active owner.
@@ -72,8 +84,10 @@ const cases = [
   ["omnigent/inner/kiro_native_harness.py", "harness-kiro"],
   ["web/src/main.tsx", "web"],
   ["web/ios/App.swift", "mobile-app"],
+  ["web/android/app/src/main/MainActivity.kt", "android-app"],
   ["web/electron/main.ts", "desktop-app"],
   ["omnigent/server/api.py", "server"],
+  ["omnigent/server/auth.py", "auth"],
 ];
 for (const [fn, key] of cases) {
   const m = resolve(fn);

--- a/deploy/issue_prioritization/README.md
+++ b/deploy/issue_prioritization/README.md
@@ -34,8 +34,50 @@ databricks bundle run issue_prioritization --target dev --profile <profile>
 
 The job reads open community issues from `github_issues_bronze`, persists LLM
 classifications in `issue_classifications`, appends the ranking to `issue_scores`,
-and writes the same review artifacts to the managed `issue_priority_artifacts`
-volume. It has no GitHub mutation adapter in this layer.
+and writes ranking plus proposed label mutations to the managed
+`issue_priority_artifacts` volume. Dry-run never changes GitHub issues.
+
+Force a classifier refresh after prompt changes or for a backfill:
+
+```bash
+databricks bundle run issue_prioritization --target dev --profile <profile> \
+  --params regrade=true
+```
+
+For the one-time backfill, preview regrading only priorities whose latest label
+event came from a known legacy bot. This needs read credentials but keeps the
+GitHub write gate off:
+
+```bash
+databricks bundle deploy --target dev --profile <profile> \
+  --var="github_secret_scope=<scope>" \
+  --var="model_endpoint=<endpoint>"
+databricks bundle run issue_prioritization --target dev --profile <profile> \
+  --params regrade=true,adopt_legacy_bot_priorities=true
+```
+
+`run.json` records whether regrade/adoption was enabled and how many historical
+priorities were adopted. Human-authored priority events remain blocked in
+`mutations.json`.
+
+## GitHub apply gate
+
+The schedule is paused. GitHub writes additionally require `mode=apply`, the
+deploy variable `allow_github_writes=true`, and a configured secret scope. The
+job re-reads every issue's live labels before writing and preserves maintainer
+priority and severity overrides. Human-added component labels are never removed.
+
+```bash
+databricks bundle deploy --target dev --profile <profile> \
+  --var="allow_github_writes=true" \
+  --var="github_secret_scope=<scope>"
+databricks bundle run issue_prioritization --target dev --profile <profile> \
+  --params mode=apply,adopt_legacy_bot_priorities=true
+```
+
+Keep the write variable false until a dry-run's `ranking.*` and
+`mutations.json` artifacts have been reviewed. Apply mode also creates any
+missing labels declared in `.github/issue-prioritization-labels.json`.
 
 ## Tests
 

--- a/deploy/issue_prioritization/databricks.yml
+++ b/deploy/issue_prioritization/databricks.yml
@@ -11,6 +11,7 @@ sync:
   include:
     - .github/areas.json
     - .github/MAINTAINER
+    - .github/issue-prioritization-labels.json
 
 artifacts:
   default:
@@ -29,11 +30,26 @@ variables:
     default: issue_classifications
   scores_table:
     default: issue_scores
+  bot_state_table:
+    default: issue_bot_state
   artifact_volume_name:
     default: issue_priority_artifacts
   model_endpoint:
     description: Model Serving endpoint used for S0-S3 classification.
     default: ""
+  github_repo:
+    default: omnigent-ai/omnigent
+  github_secret_scope:
+    description: Secret scope containing the GitHub token used only in apply mode.
+    default: ""
+  github_token_secret_key:
+    default: github-token
+  legacy_priority_bot_logins:
+    description: Comma-separated actors whose historical priority labels may be adopted.
+    default: github-actions[bot],omnigent-ci[bot]
+  allow_github_writes:
+    description: Hard gate for GitHub mutations. Keep false until rollout approval.
+    default: "false"
 
 targets:
   dev:

--- a/deploy/issue_prioritization/resources/issue_prioritization.job.yml
+++ b/deploy/issue_prioritization/resources/issue_prioritization.job.yml
@@ -11,6 +11,10 @@ resources:
       parameters:
         - name: mode
           default: dry_run
+        - name: regrade
+          default: "false"
+        - name: adopt_legacy_bot_priorities
+          default: "false"
       tasks:
         - task_key: score_open_issues
           python_wheel_task:
@@ -18,14 +22,23 @@ resources:
             entry_point: issue-priority-job
             named_parameters:
               mode: "{{job.parameters.mode}}"
+              regrade: "{{job.parameters.regrade}}"
+              adopt-legacy-bot-priorities: "{{job.parameters.adopt_legacy_bot_priorities}}"
               run-id: "{{job.run_id}}"
               source-table: ${var.catalog}.${var.schema}.${var.source_table}
               classifications-table: ${var.catalog}.${var.schema}.${var.classifications_table}
               scores-table: ${var.catalog}.${var.schema}.${var.scores_table}
+              bot-state-table: ${var.catalog}.${var.schema}.${var.bot_state_table}
               artifact-dir: /Volumes/${var.catalog}/${var.schema}/${var.artifact_volume_name}
               model-endpoint: ${var.model_endpoint}
               areas-path: ${workspace.file_path}/.github/areas.json
               maintainers-path: ${workspace.file_path}/.github/MAINTAINER
+              label-manifest-path: ${workspace.file_path}/.github/issue-prioritization-labels.json
+              github-repo: ${var.github_repo}
+              github-secret-scope: ${var.github_secret_scope}
+              github-token-secret-key: ${var.github_token_secret_key}
+              legacy-priority-bot-logins: ${var.legacy_priority_bot_logins}
+              allow-github-writes: ${var.allow_github_writes}
           environment_key: default
           libraries:
             - whl: ../dist/*.whl

--- a/deploy/issue_prioritization/src/issue_prioritization/areas.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/areas.py
@@ -15,6 +15,11 @@ class Area:
     label: str
     weight: Decimal
     definition: str = ""
+    priority_label: str | None = None
+
+    @property
+    def issue_label(self) -> str:
+        return self.priority_label or self.label
 
 
 @dataclass(frozen=True)
@@ -39,12 +44,15 @@ class AreaCatalog:
                     label=str(raw_area["label"]),
                     weight=Decimal(str(raw_area["weight"])),
                     definition=str(raw_area.get("definition", "")),
+                    priority_label=str(raw_area.get("priority_label") or raw_area["label"]),
                 )
             )
 
         by_label: dict[str, list[Area]] = {}
         for area in areas:
             by_label.setdefault(area.label, []).append(area)
+            if area.issue_label != area.label:
+                by_label.setdefault(area.issue_label, []).append(area)
         return cls(
             by_key={area.key: area for area in areas},
             by_label={label: tuple(items) for label, items in by_label.items()},

--- a/deploy/issue_prioritization/src/issue_prioritization/classification.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/classification.py
@@ -7,7 +7,9 @@ from dataclasses import dataclass
 from typing import Protocol
 
 from issue_prioritization.areas import AreaCatalog
-from issue_prioritization.domain import IssueType, Severity
+from issue_prioritization.domain import IssueType, Priority, Severity
+
+_PRIORITY_LABELS = {priority.value for priority in Priority}
 
 
 @dataclass(frozen=True)
@@ -24,7 +26,7 @@ class IssueContent:
             {
                 "title": self.title,
                 "body": self.body,
-                "labels": sorted(self.labels),
+                "labels": sorted(_classification_labels(self.labels)),
             },
             sort_keys=True,
             separators=(",", ":"),
@@ -62,7 +64,9 @@ class PromptClassifier:
         area_keys = tuple(
             key for key in _string_list(value.get("area_keys")) if key in self.areas.by_key
         )
-        component_labels = tuple(dict.fromkeys(self.areas.by_key[key].label for key in area_keys))
+        component_labels = tuple(
+            dict.fromkeys(self.areas.by_key[key].issue_label for key in area_keys)
+        )
         return Classification(
             issue_number=issue.number,
             issue_type=_issue_type(value.get("type")),
@@ -76,7 +80,7 @@ class PromptClassifier:
 
 def build_prompt(issue: IssueContent, areas: AreaCatalog) -> str:
     area_lines = [
-        f"- {area.key}: label={area.label}. {area.definition}"
+        f"- {area.key}: label={area.issue_label}. {area.definition}"
         for area in sorted(areas.by_key.values(), key=lambda item: item.key)
     ]
     return f"""Classify this Omnigent GitHub issue.
@@ -145,3 +149,13 @@ def _string_list(value: object) -> list[str]:
     if not isinstance(value, list):
         return []
     return [str(item) for item in value]
+
+
+def _classification_labels(labels: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(
+        label
+        for label in labels
+        if label not in _PRIORITY_LABELS
+        and not label.startswith("severity:")
+        and not label.startswith("comp:")
+    )

--- a/deploy/issue_prioritization/src/issue_prioritization/databricks_io.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/databricks_io.py
@@ -10,17 +10,22 @@ from issue_prioritization.bronze import BronzeIssue
 from issue_prioritization.classification import Classification, PromptClassifier
 from issue_prioritization.config import ScoringConfig
 from issue_prioritization.domain import IssueType, Severity
+from issue_prioritization.mutations import BotState
 from issue_prioritization.pipeline import PipelineRun
 
 _IDENTIFIER = re.compile(r"^[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+){2}$")
 _CLASSIFICATION_SCHEMA = """issue_number BIGINT, issue_type STRING, severity STRING,
 area_keys ARRAY<STRING>, component_labels ARRAY<STRING>, reasoning STRING,
 content_hash STRING"""
-_SCORE_SCHEMA = """run_id STRING, mode STRING, scored_at TIMESTAMP, rank BIGINT,
-previous_rank BIGINT, rank_delta BIGINT, issue_number BIGINT, title STRING, url STRING,
-issue_type STRING, severity STRING, score DOUBLE, current_priority STRING,
-proposed_priority STRING, area_keys ARRAY<STRING>, component_labels ARRAY<STRING>,
-breakdown_json STRING"""
+_SCORE_SCHEMA = """run_id STRING, mode STRING, regrade BOOLEAN,
+adopt_legacy_bot_priorities BOOLEAN, legacy_priorities_adopted BIGINT,
+scored_at TIMESTAMP, rank BIGINT, previous_rank BIGINT, rank_delta BIGINT,
+issue_number BIGINT, title STRING, url STRING, issue_type STRING, severity STRING,
+score DOUBLE, current_priority STRING, proposed_priority STRING,
+area_keys ARRAY<STRING>, component_labels ARRAY<STRING>, breakdown_json STRING,
+labels_add ARRAY<STRING>, labels_remove ARRAY<STRING>, mutation_blocked ARRAY<STRING>"""
+_BOT_STATE_SCHEMA = """issue_number BIGINT, priority STRING, severity STRING,
+components ARRAY<STRING>"""
 
 
 class SparkIssueSource:
@@ -75,10 +80,11 @@ class SparkClassificationRepository:
             }
             for item in classifications
         ]
-        frame = self.spark.createDataFrame(rows, schema=_CLASSIFICATION_SCHEMA)
         if not self.spark.catalog.tableExists(self.table):
+            frame = self.spark.createDataFrame(rows, schema=_CLASSIFICATION_SCHEMA)
             frame.write.format("delta").mode("overwrite").saveAsTable(self.table)
             return
+        frame = self.spark.createDataFrame(rows, schema=self.spark.table(self.table).schema)
         view = "issue_priority_classification_updates"
         frame.createOrReplaceTempView(view)
         self.spark.sql(
@@ -96,14 +102,19 @@ class SparkScoreSink:
         self.table = _table(table)
 
     def write(self, run: PipelineRun) -> None:
+        mutations = {plan.target.issue_number: plan for plan in run.mutations}
         rows = []
         for item in run.ranked:
             issue = item.issue
             result = item.result
+            mutation = mutations.get(issue.number)
             rows.append(
                 {
                     "run_id": run.run_id,
                     "mode": run.mode.value,
+                    "regrade": run.regrade,
+                    "adopt_legacy_bot_priorities": run.adopt_legacy_bot_priorities,
+                    "legacy_priorities_adopted": run.legacy_priorities_adopted,
                     "scored_at": run.scored_at,
                     "rank": item.rank,
                     "previous_rank": item.previous_rank,
@@ -123,6 +134,9 @@ class SparkScoreSink:
                     "breakdown_json": json.dumps(
                         [asdict(step) for step in result.steps], default=str
                     ),
+                    "labels_add": list(mutation.labels_add) if mutation else [],
+                    "labels_remove": list(mutation.labels_remove) if mutation else [],
+                    "mutation_blocked": list(mutation.blocked) if mutation else [],
                 }
             )
         if rows:
@@ -146,10 +160,79 @@ class VolumeArtifactSink:
         metadata = {
             "run_id": run.run_id,
             "mode": run.mode.value,
+            "regrade": run.regrade,
+            "adopt_legacy_bot_priorities": run.adopt_legacy_bot_priorities,
+            "legacy_priorities_adopted": run.legacy_priorities_adopted,
             "scored_at": run.scored_at.isoformat(),
             "classifications_updated": run.classifications_updated,
         }
         (destination / "run.json").write_text(json.dumps(metadata, indent=2) + "\n")
+        mutations = [
+            {
+                "issue_number": plan.target.issue_number,
+                "target": {
+                    "priority": plan.target.priority,
+                    "severity": plan.target.severity,
+                    "components": list(plan.target.components),
+                },
+                "labels_add": list(plan.labels_add),
+                "labels_remove": list(plan.labels_remove),
+                "blocked": list(plan.blocked),
+                "next_bot_state": {
+                    "priority": plan.next_state.priority,
+                    "severity": plan.next_state.severity,
+                    "components": list(plan.next_state.components),
+                },
+            }
+            for plan in run.mutations
+        ]
+        (destination / "mutations.json").write_text(json.dumps(mutations, indent=2) + "\n")
+
+
+class SparkBotStateRepository:
+    def __init__(self, spark: object, table: str) -> None:
+        self.spark = spark
+        self.table = _table(table)
+
+    def load(self) -> dict[int, BotState]:
+        if not self.spark.catalog.tableExists(self.table):
+            return {}
+        return {
+            int(row.issue_number): BotState(
+                issue_number=int(row.issue_number),
+                priority=str(row.priority) if row.priority else None,
+                severity=str(row.severity) if row.severity else None,
+                components=tuple(row.components or ()),
+            )
+            for row in self.spark.table(self.table).collect()
+        }
+
+    def upsert(self, states: list[BotState]) -> None:
+        rows = [
+            {
+                "issue_number": state.issue_number,
+                "priority": state.priority,
+                "severity": state.severity,
+                "components": list(state.components),
+            }
+            for state in states
+        ]
+        if not rows:
+            return
+        if not self.spark.catalog.tableExists(self.table):
+            frame = self.spark.createDataFrame(rows, schema=_BOT_STATE_SCHEMA)
+            frame.write.format("delta").mode("overwrite").saveAsTable(self.table)
+            return
+        frame = self.spark.createDataFrame(rows, schema=self.spark.table(self.table).schema)
+        view = "issue_priority_bot_state_updates"
+        frame.createOrReplaceTempView(view)
+        self.spark.sql(
+            f"""MERGE INTO {self.table} target
+            USING {view} source
+            ON target.issue_number = source.issue_number
+            WHEN MATCHED THEN UPDATE SET *
+            WHEN NOT MATCHED THEN INSERT *"""
+        )
 
 
 def ai_query_classifier(spark: object, endpoint: str, areas: object) -> PromptClassifier:

--- a/deploy/issue_prioritization/src/issue_prioritization/github.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/github.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Protocol
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+from issue_prioritization.labels import LabelManifest
+from issue_prioritization.mutations import BotStateRepository, MutationPlanner
+from issue_prioritization.pipeline import PipelineRun
+
+
+class GitHubLabels(Protocol):
+    def sync_missing_labels(self, manifest: LabelManifest) -> None: ...
+
+    def issue_labels(self, issue_number: int) -> tuple[str, ...]: ...
+
+    def apply_labels(
+        self,
+        issue_number: int,
+        labels_add: tuple[str, ...],
+        labels_remove: tuple[str, ...],
+    ) -> None: ...
+
+
+class PriorityLabelHistory(Protocol):
+    def priority_label_actor(self, issue_number: int, priority: str) -> str | None: ...
+
+
+class GitHubClient:
+    def __init__(
+        self,
+        token: str,
+        repo: str,
+        transport: Callable[[str, str, object | None], object] | None = None,
+    ) -> None:
+        self.token = token
+        self.repo = repo
+        self.transport = transport or self._request
+
+    def sync_missing_labels(self, manifest: LabelManifest) -> None:
+        existing = self._repo_labels()
+        for label in manifest.labels:
+            if label.name in existing:
+                continue
+            self.transport(
+                "POST",
+                "/labels",
+                {
+                    "name": label.name,
+                    "color": label.color,
+                    "description": label.description,
+                },
+            )
+
+    def issue_labels(self, issue_number: int) -> tuple[str, ...]:
+        value = self.transport("GET", f"/issues/{issue_number}", None)
+        if not isinstance(value, dict):
+            raise ValueError("GitHub issue response must be an object")
+        labels = value.get("labels", [])
+        return tuple(
+            str(label["name"]) for label in labels if isinstance(label, dict) and label.get("name")
+        )
+
+    def apply_labels(
+        self,
+        issue_number: int,
+        labels_add: tuple[str, ...],
+        labels_remove: tuple[str, ...],
+    ) -> None:
+        if labels_add:
+            self.transport("POST", f"/issues/{issue_number}/labels", {"labels": labels_add})
+        for label in labels_remove:
+            self.transport(
+                "DELETE",
+                f"/issues/{issue_number}/labels/{quote(label, safe='')}",
+                None,
+            )
+
+    def priority_label_actor(self, issue_number: int, priority: str) -> str | None:
+        actor = None
+        latest_event_id = -1
+        page = 1
+        while True:
+            value = self.transport(
+                "GET",
+                f"/issues/{issue_number}/events?per_page=100&page={page}",
+                None,
+            )
+            if not isinstance(value, list):
+                raise ValueError("GitHub issue events response must be an array")
+            for event in value:
+                if not isinstance(event, dict):
+                    continue
+                label = event.get("label")
+                if not isinstance(label, dict) or label.get("name") != priority:
+                    continue
+                event_id = int(event.get("id") or 0)
+                if event_id < latest_event_id:
+                    continue
+                latest_event_id = event_id
+                if event.get("event") == "unlabeled":
+                    actor = None
+                elif event.get("event") == "labeled":
+                    event_actor = event.get("actor")
+                    actor = (
+                        str(event_actor["login"])
+                        if isinstance(event_actor, dict) and event_actor.get("login")
+                        else None
+                    )
+            if len(value) < 100:
+                return actor
+            page += 1
+
+    def _repo_labels(self) -> set[str]:
+        labels: set[str] = set()
+        page = 1
+        while True:
+            value = self.transport("GET", f"/labels?per_page=100&page={page}", None)
+            if not isinstance(value, list):
+                raise ValueError("GitHub labels response must be an array")
+            labels.update(
+                str(label["name"])
+                for label in value
+                if isinstance(label, dict) and label.get("name")
+            )
+            if len(value) < 100:
+                return labels
+            page += 1
+
+    def _request(self, method: str, path: str, payload: object | None) -> object:
+        body = json.dumps(payload).encode() if payload is not None else None
+        request = Request(
+            f"https://api.github.com/repos/{self.repo}{path}",
+            data=body,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urlopen(request, timeout=30) as response:
+                content = response.read()
+        except HTTPError as exc:
+            detail = exc.read().decode(errors="replace")
+            raise RuntimeError(f"GitHub API {method} {path} failed: {exc.code} {detail}") from exc
+        return json.loads(content) if content else None
+
+
+class GitHubLegacyPriorityOwnership:
+    def __init__(self, client: PriorityLabelHistory, bot_logins: set[str]) -> None:
+        self.client = client
+        self.bot_logins = {login.lower() for login in bot_logins}
+
+    def is_bot_owned(self, issue_number: int, priority: str) -> bool:
+        actor = self.client.priority_label_actor(issue_number, priority)
+        return actor is not None and actor.lower() in self.bot_logins
+
+
+class GitHubMutationSink:
+    def __init__(
+        self,
+        client: GitHubLabels,
+        manifest: LabelManifest,
+        planner: MutationPlanner,
+        states: BotStateRepository,
+    ) -> None:
+        self.client = client
+        self.manifest = manifest
+        self.planner = planner
+        self.states = states
+
+    def apply(self, run: PipelineRun) -> None:
+        self.client.sync_missing_labels(self.manifest)
+        states = self.states.load()
+        updated = []
+        try:
+            for proposed in run.mutations:
+                issue_number = proposed.target.issue_number
+                current_labels = self.client.issue_labels(issue_number)
+                state = self.planner.resolve_state(
+                    issue_number,
+                    current_labels,
+                    states.get(issue_number),
+                )
+                plan = self.planner.plan_one(
+                    proposed.target,
+                    current_labels,
+                    state,
+                )
+                if plan.labels_add or plan.labels_remove:
+                    self.client.apply_labels(issue_number, plan.labels_add, plan.labels_remove)
+                previous = states.get(issue_number)
+                if plan.next_state != previous and (
+                    previous is not None or plan.next_state.has_ownership
+                ):
+                    updated.append(plan.next_state)
+                states[issue_number] = plan.next_state
+        finally:
+            self.states.upsert(updated)

--- a/deploy/issue_prioritization/src/issue_prioritization/job.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/job.py
@@ -6,27 +6,63 @@ from pathlib import Path
 from issue_prioritization.areas import AreaCatalog
 from issue_prioritization.config import ScoringConfig
 from issue_prioritization.databricks_io import (
+    SparkBotStateRepository,
     SparkClassificationRepository,
     SparkIssueSource,
     SparkScoreSink,
     VolumeArtifactSink,
     ai_query_classifier,
 )
+from issue_prioritization.github import (
+    GitHubClient,
+    GitHubLegacyPriorityOwnership,
+    GitHubMutationSink,
+)
+from issue_prioritization.labels import LabelManifest
+from issue_prioritization.mutations import MutationPlanner
 from issue_prioritization.pipeline import IssuePrioritizationPipeline, PipelineMode
 from issue_prioritization.scoring import ScoreEngine
 
 
+def _enabled(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes"}
+
+
+def validate_github_write_gate(
+    mode: PipelineMode,
+    allow_github_writes: str,
+    github_secret_scope: str,
+    adopt_legacy_bot_priorities: bool = False,
+) -> None:
+    if mode == PipelineMode.APPLY and not _enabled(allow_github_writes):
+        raise RuntimeError("apply mode is disabled: allow_github_writes is false")
+    if (mode == PipelineMode.APPLY or adopt_legacy_bot_priorities) and not github_secret_scope:
+        raise RuntimeError("github_secret_scope is required for GitHub access")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--mode", choices=[PipelineMode.DRY_RUN], default=PipelineMode.DRY_RUN)
+    parser.add_argument("--mode", choices=list(PipelineMode), default=PipelineMode.DRY_RUN)
+    parser.add_argument("--regrade", default="false")
+    parser.add_argument("--adopt-legacy-bot-priorities", default="false")
     parser.add_argument("--run-id", required=True)
     parser.add_argument("--source-table", required=True)
     parser.add_argument("--classifications-table", required=True)
     parser.add_argument("--scores-table", required=True)
+    parser.add_argument("--bot-state-table", required=True)
     parser.add_argument("--artifact-dir", required=True)
     parser.add_argument("--model-endpoint", default="")
     parser.add_argument("--areas-path", required=True, type=Path)
     parser.add_argument("--maintainers-path", required=True, type=Path)
+    parser.add_argument("--label-manifest-path", required=True, type=Path)
+    parser.add_argument("--github-repo", required=True)
+    parser.add_argument("--github-secret-scope", default="")
+    parser.add_argument("--github-token-secret-key", default="github-token")
+    parser.add_argument(
+        "--legacy-priority-bot-logins",
+        default="github-actions[bot],omnigent-ci[bot]",
+    )
+    parser.add_argument("--allow-github-writes", default="false")
     args = parser.parse_args()
 
     from pyspark.sql import SparkSession
@@ -37,6 +73,48 @@ def main() -> None:
 
     config = ScoringConfig.default()
     areas = AreaCatalog.from_json(args.areas_path)
+    manifest = LabelManifest.from_json(args.label_manifest_path)
+    states = SparkBotStateRepository(spark, args.bot_state_table)
+    mode = PipelineMode(args.mode)
+    adopt_legacy = _enabled(args.adopt_legacy_bot_priorities)
+    validate_github_write_gate(
+        mode,
+        args.allow_github_writes,
+        args.github_secret_scope,
+        adopt_legacy,
+    )
+    github_client = None
+    if mode == PipelineMode.APPLY or adopt_legacy:
+        from pyspark.dbutils import DBUtils
+
+        token = DBUtils(spark).secrets.get(
+            scope=args.github_secret_scope,
+            key=args.github_token_secret_key,
+        )
+        github_client = GitHubClient(token, args.github_repo)
+    legacy_priorities = None
+    if adopt_legacy:
+        if github_client is None:
+            raise RuntimeError("legacy priority adoption requires a GitHub client")
+        legacy_priorities = GitHubLegacyPriorityOwnership(
+            github_client,
+            {
+                login.strip()
+                for login in args.legacy_priority_bot_logins.split(",")
+                if login.strip()
+            },
+        )
+    planner = MutationPlanner(manifest, states, legacy_priorities)
+    mutation_sink = None
+    if mode == PipelineMode.APPLY:
+        if github_client is None:
+            raise RuntimeError("apply mode requires a GitHub client")
+        mutation_sink = GitHubMutationSink(
+            github_client,
+            manifest,
+            planner,
+            states,
+        )
     maintainers = {
         line.split("#", 1)[0].strip().lower()
         for line in args.maintainers_path.read_text().splitlines()
@@ -50,8 +128,15 @@ def main() -> None:
         artifacts=VolumeArtifactSink(args.artifact_dir, config),
         engine=ScoreEngine(config, areas),
         maintainers=maintainers,
+        mutation_planner=planner,
+        mutation_sink=mutation_sink,
     )
-    run = pipeline.run(args.run_id, PipelineMode(args.mode))
+    run = pipeline.run(
+        args.run_id,
+        mode,
+        regrade=_enabled(args.regrade),
+        adopt_legacy_bot_priorities=adopt_legacy,
+    )
     print(
         f"Scored {len(run.ranked)} issues; "
         f"refreshed {run.classifications_updated} classifications; "

--- a/deploy/issue_prioritization/src/issue_prioritization/labels.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/labels.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class LabelDefinition:
+    name: str
+    color: str
+    description: str
+
+
+@dataclass(frozen=True)
+class LabelManifest:
+    labels: tuple[LabelDefinition, ...]
+
+    @classmethod
+    def from_json(cls, path: str | Path) -> LabelManifest:
+        value = json.loads(Path(path).read_text())
+        return cls(
+            labels=tuple(
+                LabelDefinition(
+                    name=str(item["name"]),
+                    color=str(item["color"]),
+                    description=str(item["description"]),
+                )
+                for item in value["labels"]
+            )
+        )
+
+    @property
+    def severity_labels(self) -> set[str]:
+        return {label.name for label in self.labels if label.name.startswith("severity:")}
+
+    @property
+    def component_labels(self) -> set[str]:
+        return {label.name for label in self.labels if label.name.startswith("comp:")}

--- a/deploy/issue_prioritization/src/issue_prioritization/mutations.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/mutations.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from issue_prioritization.artifacts import RankedIssue
+from issue_prioritization.domain import Priority, Severity
+from issue_prioritization.labels import LabelManifest
+
+
+@dataclass(frozen=True)
+class BotState:
+    issue_number: int
+    priority: str | None
+    severity: str | None
+    components: tuple[str, ...]
+
+    @property
+    def has_ownership(self) -> bool:
+        return self.priority is not None or self.severity is not None or bool(self.components)
+
+
+class BotStateRepository(Protocol):
+    def load(self) -> dict[int, BotState]: ...
+
+    def upsert(self, states: list[BotState]) -> None: ...
+
+
+class LegacyPriorityOwnership(Protocol):
+    def is_bot_owned(self, issue_number: int, priority: str) -> bool: ...
+
+
+@dataclass(frozen=True)
+class MutationTarget:
+    issue_number: int
+    priority: str
+    severity: str
+    components: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MutationPlan:
+    target: MutationTarget
+    labels_add: tuple[str, ...]
+    labels_remove: tuple[str, ...]
+    blocked: tuple[str, ...]
+    next_state: BotState
+
+
+class MutationPlanner:
+    def __init__(
+        self,
+        manifest: LabelManifest,
+        states: BotStateRepository,
+        legacy_priorities: LegacyPriorityOwnership | None = None,
+    ) -> None:
+        self.manifest = manifest
+        self.states = states
+        self.legacy_priorities = legacy_priorities
+        self.priority_labels = {priority.value for priority in Priority}
+
+    def plan_all(
+        self,
+        ranked: tuple[RankedIssue, ...],
+        current_labels: dict[int, tuple[str, ...]],
+        states: dict[int, BotState] | None = None,
+    ) -> tuple[MutationPlan, ...]:
+        states = states if states is not None else self.load_states()
+        plans = []
+        for item in ranked:
+            labels = current_labels.get(item.issue.number, ())
+            state = self.resolve_state(item.issue.number, labels, states.get(item.issue.number))
+            plans.append(self.plan_one(target_from_ranked(item), labels, state))
+        return tuple(plans)
+
+    def load_states(self) -> dict[int, BotState]:
+        return self.states.load()
+
+    def resolve_state(
+        self,
+        issue_number: int,
+        current_labels: tuple[str, ...],
+        state: BotState | None,
+    ) -> BotState | None:
+        if state is not None or self.legacy_priorities is None:
+            return state
+        priorities = set(current_labels) & self.priority_labels
+        if len(priorities) != 1:
+            return None
+        priority = next(iter(priorities))
+        if not self.legacy_priorities.is_bot_owned(issue_number, priority):
+            return None
+        return BotState(issue_number, priority, None, ())
+
+    def severity_override(
+        self,
+        current_labels: tuple[str, ...],
+        state: BotState | None,
+    ) -> Severity | None:
+        labels = set(current_labels) & self.manifest.severity_labels
+        if len(labels) != 1:
+            return None
+        label = next(iter(labels))
+        if state is not None and label == state.severity:
+            return None
+        return Severity(label.removeprefix("severity:"))
+
+    def plan_one(
+        self,
+        target: MutationTarget,
+        current_labels: tuple[str, ...],
+        state: BotState | None,
+    ) -> MutationPlan:
+        existing = set(current_labels)
+        labels_add: set[str] = set()
+        labels_remove: set[str] = set()
+        blocked: list[str] = []
+
+        current_priorities = existing & self.priority_labels
+        current_priority = next(iter(current_priorities)) if len(current_priorities) == 1 else None
+        priority_written = False
+        priority_owned = not current_priorities or (
+            state is not None and current_priority == state.priority
+        )
+        if len(current_priorities) > 1:
+            blocked.append("priority_label_conflict")
+        elif current_priority != target.priority:
+            if priority_owned:
+                labels_add.add(target.priority)
+                priority_written = True
+                if current_priority:
+                    labels_remove.add(current_priority)
+            else:
+                blocked.append("priority_human_override")
+
+        current_severities = existing & self.manifest.severity_labels
+        current_severity = next(iter(current_severities)) if len(current_severities) == 1 else None
+        severity_written = False
+        severity_owned = not current_severities or (
+            state is not None and current_severity == state.severity
+        )
+        if len(current_severities) > 1:
+            blocked.append("severity_label_conflict")
+        elif current_severity != target.severity:
+            if severity_owned:
+                labels_add.add(target.severity)
+                severity_written = True
+                if current_severity:
+                    labels_remove.add(current_severity)
+            else:
+                blocked.append("severity_human_override")
+
+        existing_components = existing & self.manifest.component_labels
+        target_components = set(target.components)
+        components_added = target_components - existing_components
+        labels_add.update(components_added)
+        if state:
+            labels_remove.update((set(state.components) & existing_components) - target_components)
+        bot_components = components_added
+        if state:
+            bot_components |= set(state.components) & existing_components & target_components
+
+        next_state = BotState(
+            issue_number=target.issue_number,
+            priority=target.priority if priority_written else state_priority(state),
+            severity=target.severity if severity_written else state_severity(state),
+            components=tuple(sorted(bot_components)),
+        )
+        return MutationPlan(
+            target=target,
+            labels_add=tuple(sorted(labels_add)),
+            labels_remove=tuple(sorted(labels_remove)),
+            blocked=tuple(blocked),
+            next_state=next_state,
+        )
+
+
+def target_from_ranked(item: RankedIssue) -> MutationTarget:
+    return MutationTarget(
+        issue_number=item.issue.number,
+        priority=item.result.priority.value,
+        severity=f"severity:{item.issue.severity.value}",
+        components=item.issue.component_labels,
+    )
+
+
+def state_priority(state: BotState | None) -> str | None:
+    return state.priority if state else None
+
+
+def state_severity(state: BotState | None) -> str | None:
+    return state.severity if state else None

--- a/deploy/issue_prioritization/src/issue_prioritization/pipeline.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/pipeline.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Protocol
@@ -8,11 +8,13 @@ from typing import Protocol
 from issue_prioritization.artifacts import RankedIssue, rank_issues
 from issue_prioritization.bronze import BronzeIssue
 from issue_prioritization.classification import Classification, Classifier
+from issue_prioritization.mutations import MutationPlan, MutationPlanner
 from issue_prioritization.scoring import ScoreEngine
 
 
 class PipelineMode(StrEnum):
     DRY_RUN = "dry_run"
+    APPLY = "apply"
 
 
 class IssueSource(Protocol):
@@ -33,6 +35,10 @@ class ArtifactSink(Protocol):
     def write(self, run: PipelineRun) -> None: ...
 
 
+class MutationSink(Protocol):
+    def apply(self, run: PipelineRun) -> None: ...
+
+
 @dataclass(frozen=True)
 class PipelineRun:
     run_id: str
@@ -40,6 +46,10 @@ class PipelineRun:
     scored_at: datetime
     ranked: tuple[RankedIssue, ...]
     classifications_updated: int
+    mutations: tuple[MutationPlan, ...]
+    regrade: bool = False
+    adopt_legacy_bot_priorities: bool = False
+    legacy_priorities_adopted: int = 0
 
 
 class IssuePrioritizationPipeline:
@@ -52,6 +62,8 @@ class IssuePrioritizationPipeline:
         artifacts: ArtifactSink,
         engine: ScoreEngine,
         maintainers: set[str],
+        mutation_planner: MutationPlanner | None = None,
+        mutation_sink: MutationSink | None = None,
     ) -> None:
         self.source = source
         self.classifier = classifier
@@ -60,8 +72,16 @@ class IssuePrioritizationPipeline:
         self.artifacts = artifacts
         self.engine = engine
         self.maintainers = maintainers
+        self.mutation_planner = mutation_planner
+        self.mutation_sink = mutation_sink
 
-    def run(self, run_id: str, mode: PipelineMode = PipelineMode.DRY_RUN) -> PipelineRun:
+    def run(
+        self,
+        run_id: str,
+        mode: PipelineMode = PipelineMode.DRY_RUN,
+        regrade: bool = False,
+        adopt_legacy_bot_priorities: bool = False,
+    ) -> PipelineRun:
         now = datetime.now(UTC)
         issues = [
             issue
@@ -73,7 +93,7 @@ class IssuePrioritizationPipeline:
         updated = []
         for issue in issues:
             cached = existing.get(issue.number)
-            if cached and cached.content_hash == issue.content().content_hash:
+            if not regrade and cached and cached.content_hash == issue.content().content_hash:
                 resolved[issue.number] = cached
                 continue
             classification = self.classifier.classify(issue.content())
@@ -82,14 +102,54 @@ class IssuePrioritizationPipeline:
         if updated:
             self.classifications.upsert(updated)
 
-        normalized = [issue.to_issue(resolved[issue.number], now) for issue in issues]
+        persisted_bot_states = self.mutation_planner.load_states() if self.mutation_planner else {}
+        bot_states = persisted_bot_states
+        if self.mutation_planner:
+            bot_states = {
+                issue.number: state
+                for issue in issues
+                if (
+                    state := self.mutation_planner.resolve_state(
+                        issue.number,
+                        issue.labels,
+                        bot_states.get(issue.number),
+                    )
+                )
+                is not None
+            }
+        normalized = []
+        for issue in issues:
+            normalized_issue = issue.to_issue(resolved[issue.number], now)
+            if self.mutation_planner:
+                severity = self.mutation_planner.severity_override(
+                    issue.labels,
+                    bot_states.get(issue.number),
+                )
+                if severity is not None:
+                    normalized_issue = replace(normalized_issue, severity=severity)
+            normalized.append(normalized_issue)
+        ranked = tuple(rank_issues(normalized, self.engine))
+        current_labels = {issue.number: issue.labels for issue in issues}
+        mutations = (
+            self.mutation_planner.plan_all(ranked, current_labels, bot_states)
+            if self.mutation_planner
+            else ()
+        )
         run = PipelineRun(
             run_id=run_id,
             mode=mode,
             scored_at=now,
-            ranked=tuple(rank_issues(normalized, self.engine)),
+            ranked=ranked,
             classifications_updated=len(updated),
+            mutations=mutations,
+            regrade=regrade,
+            adopt_legacy_bot_priorities=adopt_legacy_bot_priorities,
+            legacy_priorities_adopted=len(set(bot_states) - set(persisted_bot_states)),
         )
         self.scores.write(run)
         self.artifacts.write(run)
+        if mode == PipelineMode.APPLY:
+            if self.mutation_sink is None:
+                raise RuntimeError("apply mode requires a mutation sink")
+            self.mutation_sink.apply(run)
         return run

--- a/deploy/issue_prioritization/tests/test_classification.py
+++ b/deploy/issue_prioritization/tests/test_classification.py
@@ -51,3 +51,18 @@ def test_classifier_validates_area_keys_and_linear_type_label() -> None:
     assert result.severity == Severity.S1
     assert result.area_keys == ("db",)
     assert result.component_labels == ("comp:db",)
+
+
+def test_content_hash_ignores_bot_managed_labels() -> None:
+    base = IssueContent(1, "Broken", "Details", ("Bug",), "community")
+    managed = IssueContent(
+        1,
+        "Broken",
+        "Details",
+        ("Bug", "P1-high", "severity:S1", "comp:db"),
+        "community",
+    )
+    changed = IssueContent(1, "Broken", "Details", ("Bug", "needs-info"), "community")
+
+    assert base.content_hash == managed.content_hash
+    assert base.content_hash != changed.content_hash

--- a/deploy/issue_prioritization/tests/test_databricks_io.py
+++ b/deploy/issue_prioritization/tests/test_databricks_io.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+from issue_prioritization.config import ScoringConfig
+from issue_prioritization.databricks_io import VolumeArtifactSink
+from issue_prioritization.mutations import BotState, MutationPlan, MutationTarget
+from issue_prioritization.pipeline import PipelineMode, PipelineRun
+
+
+def test_dry_run_artifact_contains_complete_mutation_plan(tmp_path) -> None:
+    target = MutationTarget(7, "P1-high", "severity:S1", ("comp:db",))
+    plan = MutationPlan(
+        target=target,
+        labels_add=("P1-high", "severity:S1", "comp:db"),
+        labels_remove=("P2-medium",),
+        blocked=(),
+        next_state=BotState(7, "P1-high", "severity:S1", ("comp:db",)),
+    )
+    run = PipelineRun(
+        "preview",
+        PipelineMode.DRY_RUN,
+        datetime.now(UTC),
+        (),
+        0,
+        (plan,),
+    )
+
+    VolumeArtifactSink(str(tmp_path), ScoringConfig.default()).write(run)
+
+    payload = json.loads((tmp_path / "preview" / "mutations.json").read_text())
+    assert payload == [
+        {
+            "issue_number": 7,
+            "target": {
+                "priority": "P1-high",
+                "severity": "severity:S1",
+                "components": ["comp:db"],
+            },
+            "labels_add": ["P1-high", "severity:S1", "comp:db"],
+            "labels_remove": ["P2-medium"],
+            "blocked": [],
+            "next_bot_state": {
+                "priority": "P1-high",
+                "severity": "severity:S1",
+                "components": ["comp:db"],
+            },
+        }
+    ]
+    metadata = json.loads((tmp_path / "preview" / "run.json").read_text())
+    assert metadata["mode"] == "dry_run"
+    assert metadata["adopt_legacy_bot_priorities"] is False
+    assert metadata["legacy_priorities_adopted"] == 0

--- a/deploy/issue_prioritization/tests/test_github.py
+++ b/deploy/issue_prioritization/tests/test_github.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from issue_prioritization.github import (
+    GitHubClient,
+    GitHubLegacyPriorityOwnership,
+    GitHubMutationSink,
+)
+from issue_prioritization.labels import LabelDefinition, LabelManifest
+from issue_prioritization.mutations import (
+    BotState,
+    MutationPlan,
+    MutationPlanner,
+    MutationTarget,
+)
+from issue_prioritization.pipeline import PipelineMode, PipelineRun
+
+
+class FakeStates:
+    def __init__(self, values):
+        self.values = values
+        self.updated = []
+
+    def load(self):
+        return self.values
+
+    def upsert(self, states):
+        self.updated.extend(states)
+
+
+class FakeClient:
+    def __init__(self):
+        self.synced = False
+        self.labels = ("P2-medium", "severity:S2", "comp:server")
+        self.applied = []
+
+    def sync_missing_labels(self, manifest):
+        self.synced = True
+
+    def issue_labels(self, issue_number):
+        return self.labels
+
+    def apply_labels(self, issue_number, labels_add, labels_remove):
+        self.applied.append((issue_number, labels_add, labels_remove))
+
+
+def _manifest() -> LabelManifest:
+    return LabelManifest(
+        labels=(
+            LabelDefinition("severity:S1", "000000", ""),
+            LabelDefinition("severity:S2", "000000", ""),
+            LabelDefinition("comp:db", "000000", ""),
+            LabelDefinition("comp:server", "000000", ""),
+        )
+    )
+
+
+def test_apply_rechecks_live_labels_before_writing() -> None:
+    state = BotState(1, "P2-medium", "severity:S2", ("comp:server",))
+    states = FakeStates({1: state})
+    manifest = _manifest()
+    planner = MutationPlanner(manifest, states)
+    target = MutationTarget(1, "P1-high", "severity:S1", ("comp:db",))
+    proposed = MutationPlan(target, (), (), (), state)
+    run = PipelineRun("run", PipelineMode.APPLY, datetime.now(UTC), (), 0, (proposed,))
+    client = FakeClient()
+
+    GitHubMutationSink(client, manifest, planner, states).apply(run)
+
+    assert client.synced
+    assert client.applied == [
+        (
+            1,
+            ("P1-high", "comp:db", "severity:S1"),
+            ("P2-medium", "comp:server", "severity:S2"),
+        )
+    ]
+    assert states.updated[0].priority == "P1-high"
+
+
+def test_apply_preserves_human_priority_changed_after_dry_run() -> None:
+    state = BotState(1, "P2-medium", "severity:S2", ("comp:server",))
+    states = FakeStates({1: state})
+    manifest = _manifest()
+    planner = MutationPlanner(manifest, states)
+    target = MutationTarget(1, "P1-high", "severity:S2", ("comp:server",))
+    proposed = MutationPlan(target, (), (), (), state)
+    run = PipelineRun("run", PipelineMode.APPLY, datetime.now(UTC), (), 0, (proposed,))
+    client = FakeClient()
+    client.labels = ("P3-low", "severity:S2", "comp:server")
+
+    GitHubMutationSink(client, manifest, planner, states).apply(run)
+
+    assert client.applied == []
+    assert states.updated == []
+
+
+def test_apply_checkpoints_successful_writes_after_a_later_failure() -> None:
+    first = BotState(1, "P2-medium", "severity:S2", ("comp:server",))
+    second = BotState(2, "P2-medium", "severity:S2", ("comp:server",))
+    states = FakeStates({1: first, 2: second})
+    manifest = _manifest()
+    planner = MutationPlanner(manifest, states)
+    targets = (
+        MutationPlan(
+            MutationTarget(1, "P1-high", "severity:S1", ("comp:db",)),
+            (),
+            (),
+            (),
+            first,
+        ),
+        MutationPlan(
+            MutationTarget(2, "P1-high", "severity:S1", ("comp:db",)),
+            (),
+            (),
+            (),
+            second,
+        ),
+    )
+    run = PipelineRun("run", PipelineMode.APPLY, datetime.now(UTC), (), 0, targets)
+
+    class FailingClient(FakeClient):
+        def apply_labels(self, issue_number, labels_add, labels_remove):
+            if issue_number == 2:
+                raise RuntimeError("GitHub unavailable")
+            super().apply_labels(issue_number, labels_add, labels_remove)
+
+    with pytest.raises(RuntimeError, match="GitHub unavailable"):
+        GitHubMutationSink(FailingClient(), manifest, planner, states).apply(run)
+
+    assert [state.issue_number for state in states.updated] == [1]
+
+
+def test_legacy_priority_uses_the_latest_label_actor() -> None:
+    events = [
+        {
+            "id": 1,
+            "event": "labeled",
+            "label": {"name": "P2-medium"},
+            "actor": {"login": "github-actions[bot]"},
+        },
+        {
+            "id": 3,
+            "event": "labeled",
+            "label": {"name": "P2-medium"},
+            "actor": {"login": "maintainer"},
+        },
+        {
+            "id": 2,
+            "event": "unlabeled",
+            "label": {"name": "P2-medium"},
+            "actor": {"login": "maintainer"},
+        },
+    ]
+    client = GitHubClient("token", "org/repo", lambda method, path, payload: events)
+
+    actor = client.priority_label_actor(1, "P2-medium")
+
+    assert actor == "maintainer"
+    assert not GitHubLegacyPriorityOwnership(
+        client,
+        {"github-actions[bot]"},
+    ).is_bot_owned(1, "P2-medium")

--- a/deploy/issue_prioritization/tests/test_job.py
+++ b/deploy/issue_prioritization/tests/test_job.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from issue_prioritization.job import validate_github_write_gate
+from issue_prioritization.pipeline import PipelineMode
+
+
+def test_dry_run_does_not_require_github_credentials() -> None:
+    validate_github_write_gate(PipelineMode.DRY_RUN, "false", "")
+
+
+def test_apply_requires_both_write_gate_and_secret_scope() -> None:
+    with pytest.raises(RuntimeError, match="allow_github_writes is false"):
+        validate_github_write_gate(PipelineMode.APPLY, "false", "scope")
+
+    with pytest.raises(RuntimeError, match="github_secret_scope is required"):
+        validate_github_write_gate(PipelineMode.APPLY, "true", "")
+
+    validate_github_write_gate(PipelineMode.APPLY, "true", "scope")
+
+
+def test_legacy_adoption_requires_read_credentials_but_not_write_gate() -> None:
+    with pytest.raises(RuntimeError, match="github_secret_scope is required"):
+        validate_github_write_gate(
+            PipelineMode.DRY_RUN,
+            "false",
+            "",
+            adopt_legacy_bot_priorities=True,
+        )
+
+    validate_github_write_gate(
+        PipelineMode.DRY_RUN,
+        "false",
+        "scope",
+        adopt_legacy_bot_priorities=True,
+    )

--- a/deploy/issue_prioritization/tests/test_mutations.py
+++ b/deploy/issue_prioritization/tests/test_mutations.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from issue_prioritization.labels import LabelDefinition, LabelManifest
+from issue_prioritization.mutations import (
+    BotState,
+    MutationPlanner,
+    MutationTarget,
+)
+
+
+class FakeStates:
+    def __init__(self, values=None):
+        self.values = values or {}
+        self.updated = []
+
+    def load(self):
+        return self.values
+
+    def upsert(self, states):
+        self.updated.extend(states)
+
+
+class FakeLegacyPriorities:
+    def __init__(self, owned=True):
+        self.owned = owned
+
+    def is_bot_owned(self, issue_number, priority):
+        return self.owned
+
+
+def _manifest() -> LabelManifest:
+    return LabelManifest(
+        labels=(
+            LabelDefinition("severity:S0", "000000", ""),
+            LabelDefinition("severity:S1", "000000", ""),
+            LabelDefinition("severity:S2", "000000", ""),
+            LabelDefinition("severity:S3", "000000", ""),
+            LabelDefinition("comp:db", "000000", ""),
+            LabelDefinition("comp:server", "000000", ""),
+        )
+    )
+
+
+def _target() -> MutationTarget:
+    return MutationTarget(1, "P1-high", "severity:S1", ("comp:db",))
+
+
+def test_existing_priority_without_bot_state_is_human_owned() -> None:
+    planner = MutationPlanner(_manifest(), FakeStates())
+
+    plan = planner.plan_one(_target(), ("P2-medium",), None)
+
+    assert "priority_human_override" in plan.blocked
+    assert "P1-high" not in plan.labels_add
+    assert "P2-medium" not in plan.labels_remove
+    assert "severity:S1" in plan.labels_add
+    assert plan.next_state.priority is None
+    assert plan.next_state.severity == "severity:S1"
+
+
+def test_matching_human_labels_do_not_become_bot_owned() -> None:
+    planner = MutationPlanner(_manifest(), FakeStates())
+
+    plan = planner.plan_one(
+        _target(),
+        ("P1-high", "severity:S1", "comp:db"),
+        None,
+    )
+
+    assert plan.labels_add == ()
+    assert plan.labels_remove == ()
+    assert plan.next_state == BotState(1, None, None, ())
+
+
+def test_bot_owned_priority_can_be_regraded() -> None:
+    state = BotState(1, "P2-medium", "severity:S2", ("comp:server",))
+    planner = MutationPlanner(_manifest(), FakeStates({1: state}))
+
+    plan = planner.plan_one(
+        _target(),
+        ("P2-medium", "severity:S2", "comp:server"),
+        state,
+    )
+
+    assert plan.blocked == ()
+    assert set(plan.labels_add) == {"P1-high", "severity:S1", "comp:db"}
+    assert set(plan.labels_remove) == {"P2-medium", "severity:S2", "comp:server"}
+    assert plan.next_state.priority == "P1-high"
+
+
+def test_human_priority_change_is_never_overwritten() -> None:
+    state = BotState(1, "P0-critical", "severity:S1", ("comp:db",))
+    planner = MutationPlanner(_manifest(), FakeStates({1: state}))
+
+    plan = planner.plan_one(_target(), ("P3-low", "severity:S1", "comp:db"), state)
+
+    assert plan.blocked == ("priority_human_override",)
+    assert plan.next_state.priority == "P0-critical"
+    assert "P1-high" not in plan.labels_add
+
+
+def test_human_component_labels_are_not_removed() -> None:
+    state = BotState(1, None, None, ("comp:server",))
+    planner = MutationPlanner(_manifest(), FakeStates({1: state}))
+
+    plan = planner.plan_one(
+        _target(),
+        ("comp:server", "comp:db"),
+        state,
+    )
+
+    assert plan.labels_remove == ("comp:server",)
+    assert "comp:db" not in plan.labels_remove
+    assert plan.next_state.components == ()
+
+
+def test_existing_bot_owned_component_stays_owned() -> None:
+    state = BotState(1, None, None, ("comp:db",))
+    planner = MutationPlanner(_manifest(), FakeStates({1: state}))
+
+    plan = planner.plan_one(_target(), ("comp:db",), state)
+
+    assert plan.next_state.components == ("comp:db",)
+
+
+def test_human_severity_is_exposed_as_a_scoring_override() -> None:
+    planner = MutationPlanner(_manifest(), FakeStates())
+
+    assert planner.severity_override(("severity:S2",), None).value == "S2"
+    assert (
+        planner.severity_override(
+            ("severity:S2",),
+            BotState(1, None, "severity:S2", ()),
+        )
+        is None
+    )
+
+
+def test_conflicting_axis_labels_are_never_mutated() -> None:
+    planner = MutationPlanner(_manifest(), FakeStates())
+
+    plan = planner.plan_one(
+        _target(),
+        ("P1-high", "P2-medium", "severity:S1", "severity:S2"),
+        None,
+    )
+
+    assert plan.labels_add == ("comp:db",)
+    assert plan.labels_remove == ()
+    assert set(plan.blocked) == {"priority_label_conflict", "severity_label_conflict"}
+
+
+def test_legacy_bot_priority_can_be_adopted_for_backfill() -> None:
+    planner = MutationPlanner(
+        _manifest(),
+        FakeStates(),
+        FakeLegacyPriorities(),
+    )
+
+    state = planner.resolve_state(1, ("P2-medium",), None)
+
+    assert state == BotState(1, "P2-medium", None, ())
+
+
+def test_legacy_human_priority_is_not_adopted() -> None:
+    planner = MutationPlanner(
+        _manifest(),
+        FakeStates(),
+        FakeLegacyPriorities(owned=False),
+    )
+
+    assert planner.resolve_state(1, ("P2-medium",), None) is None

--- a/deploy/issue_prioritization/tests/test_pipeline.py
+++ b/deploy/issue_prioritization/tests/test_pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import UTC, datetime
 from decimal import Decimal
 
@@ -8,6 +9,8 @@ from issue_prioritization.bronze import BronzeIssue
 from issue_prioritization.classification import Classification
 from issue_prioritization.config import ScoringConfig
 from issue_prioritization.domain import IssueType, Severity
+from issue_prioritization.labels import LabelDefinition, LabelManifest
+from issue_prioritization.mutations import MutationPlanner
 from issue_prioritization.pipeline import IssuePrioritizationPipeline
 from issue_prioritization.scoring import ScoreEngine
 
@@ -48,6 +51,19 @@ class CaptureSink:
 
     def write(self, run):
         self.runs.append(run)
+
+
+class FakeStates:
+    def load(self):
+        return {}
+
+    def upsert(self, states):
+        pass
+
+
+class FakeLegacyPriorities:
+    def is_bot_owned(self, issue_number, priority):
+        return True
 
 
 def _bronze(number, author="community"):
@@ -141,3 +157,112 @@ def test_pipeline_reclassifies_changed_content() -> None:
     assert classifier.calls == 1
     assert classifications.updated == [classification]
     assert run.classifications_updated == 1
+
+
+def test_pipeline_can_force_regrade_cached_content() -> None:
+    issue = _bronze(1)
+    classification = Classification(
+        issue_number=1,
+        issue_type=IssueType.BUG,
+        severity=Severity.S2,
+        area_keys=("db",),
+        component_labels=("comp:db",),
+        reasoning="Refreshed",
+        content_hash=issue.content().content_hash,
+    )
+    classifier = FakeClassifier(classification)
+    classifications = FakeClassifications({1: classification})
+    sink = CaptureSink()
+    area = Area("db", "comp:db", Decimal("1.2"))
+    catalog = AreaCatalog(by_key={"db": area}, by_label={"comp:db": (area,)})
+    pipeline = IssuePrioritizationPipeline(
+        source=FakeSource([issue]),
+        classifier=classifier,
+        classifications=classifications,
+        scores=sink,
+        artifacts=sink,
+        engine=ScoreEngine(ScoringConfig.default(), catalog),
+        maintainers=set(),
+    )
+
+    pipeline.run("run-regrade", regrade=True)
+
+    assert classifier.calls == 1
+    assert classifications.updated == [classification]
+
+
+def test_pipeline_scores_with_human_severity_override() -> None:
+    issue = _bronze(1)
+    issue = replace(issue, labels=(*issue.labels, "severity:S3"))
+    classification = Classification(
+        issue_number=1,
+        issue_type=IssueType.BUG,
+        severity=Severity.S1,
+        area_keys=("db",),
+        component_labels=("comp:db",),
+        reasoning="No workaround",
+        content_hash=issue.content().content_hash,
+    )
+    area = Area("db", "comp:db", Decimal("1.2"))
+    catalog = AreaCatalog(by_key={"db": area}, by_label={"comp:db": (area,)})
+    manifest = LabelManifest(labels=(LabelDefinition("severity:S3", "000000", ""),))
+    pipeline = IssuePrioritizationPipeline(
+        source=FakeSource([issue]),
+        classifier=FakeClassifier(classification),
+        classifications=FakeClassifications({1: classification}),
+        scores=CaptureSink(),
+        artifacts=CaptureSink(),
+        engine=ScoreEngine(ScoringConfig.default(), catalog),
+        maintainers=set(),
+        mutation_planner=MutationPlanner(manifest, FakeStates()),
+    )
+
+    run = pipeline.run("run-human-severity")
+
+    assert run.ranked[0].issue.severity == Severity.S3
+    assert run.ranked[0].result.score == Decimal("12.00")
+
+
+def test_dry_run_previews_safe_legacy_priority_regrade() -> None:
+    issue = _bronze(1)
+    classification = Classification(
+        issue_number=1,
+        issue_type=IssueType.BUG,
+        severity=Severity.S1,
+        area_keys=("db",),
+        component_labels=("comp:db",),
+        reasoning="No workaround",
+        content_hash=issue.content().content_hash,
+    )
+    area = Area("db", "comp:db", Decimal("1.2"))
+    catalog = AreaCatalog(by_key={"db": area}, by_label={"comp:db": (area,)})
+    manifest = LabelManifest(
+        labels=(
+            LabelDefinition("severity:S1", "000000", ""),
+            LabelDefinition("comp:db", "000000", ""),
+        )
+    )
+    planner = MutationPlanner(
+        manifest,
+        FakeStates(),
+        FakeLegacyPriorities(),
+    )
+    pipeline = IssuePrioritizationPipeline(
+        source=FakeSource([issue]),
+        classifier=FakeClassifier(classification),
+        classifications=FakeClassifications({1: classification}),
+        scores=CaptureSink(),
+        artifacts=CaptureSink(),
+        engine=ScoreEngine(ScoringConfig.default(), catalog),
+        maintainers=set(),
+        mutation_planner=planner,
+    )
+
+    run = pipeline.run(
+        "run-legacy-preview",
+        adopt_legacy_bot_priorities=True,
+    )
+
+    assert run.legacy_priorities_adopted == 1
+    assert set(run.mutations[0].labels_add) == {"P1-high", "comp:db", "severity:S1"}
+    assert run.mutations[0].labels_remove == ("P2-medium",)

--- a/deploy/issue_prioritization/tests/test_spark_io.py
+++ b/deploy/issue_prioritization/tests/test_spark_io.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from issue_prioritization.artifacts import RankedIssue
 from issue_prioritization.classification import Classification
 from issue_prioritization.databricks_io import (
+    SparkBotStateRepository,
     SparkClassificationRepository,
     SparkScoreSink,
 )
@@ -16,6 +17,7 @@ from issue_prioritization.domain import (
     ScoreResult,
     Severity,
 )
+from issue_prioritization.mutations import BotState
 from issue_prioritization.pipeline import PipelineMode, PipelineRun
 
 
@@ -95,9 +97,19 @@ def test_score_sink_uses_schema_evolution() -> None:
         datetime.now(UTC),
         (ranked,),
         0,
+        (),
     )
 
     sink.write(run)
 
-    assert spark.schemas[0].count("ARRAY<STRING>") == 2
+    assert spark.schemas[0].count("ARRAY<STRING>") == 5
     assert spark.frames[0].write.options == {"mergeSchema": "true"}
+
+
+def test_bot_state_schema_handles_empty_ownership() -> None:
+    spark = FakeSpark()
+    repository = SparkBotStateRepository(spark, "main.team.bot_state")
+
+    repository.upsert([BotState(1, None, None, ())])
+
+    assert "components ARRAY<STRING>" in spark.schemas[0]


### PR DESCRIPTION
## Related issue

N/A — implementation of the issue-prioritization v2 design in the parent stack.

## Summary

- Adds severity/component labels and richer issue intake fields, including harness, platform, impact, and auth.
- Adds an apply mode behind two gates, live-label rechecks, and persisted bot ownership so human priority/severity judgments and human-added components are preserved.
- Adds an off-by-default backfill switch that adopts a historical priority only when its latest label event came from an allowlisted legacy bot.
- Keeps dry-run non-mutating while emitting the exact proposed label changes for review.

**ELI5:** The bot writes only after two explicit switches, checks the issue again at the last moment, and remembers which labels were actually its own.

```text
dry-run -> ranking + mutations.json
apply   -> hard gate -> live GitHub recheck -> safe label diff -> bot state
```

## Test Plan

- `uv run --project deploy/issue_prioritization pytest -q` — 41 tests.
- `node .github/workflows/areas.test.js`
- `uv build --project deploy/issue_prioritization --wheel`
- Parse Databricks bundle resources as YAML.

## Demo

N/A — non-visual issue automation.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests cover dry-run artifacts, both apply gates, live-label races, human overrides, legacy-bot provenance, ownership transitions, label conflicts, and successful-write checkpointing after a later API failure.

## Changelog

Issue prioritization can safely propose and apply severity, priority, and component labels without overwriting maintainer judgment.


