### PR TITLE
feat: expose latest issue ranking view

### DIFF
--- a/deploy/issue_prioritization/README.md
+++ b/deploy/issue_prioritization/README.md
@@ -36,6 +36,7 @@ The job reads open community issues from `github_issues_bronze`, persists LLM
 classifications in `issue_classifications`, appends the ranking to `issue_scores`,
 and writes ranking plus proposed label mutations to the managed
 `issue_priority_artifacts` volume. Dry-run never changes GitHub issues.
+`issue_scores_latest` always exposes the newest complete run for dashboard queries.
 
 Force a classifier refresh after prompt changes or for a backfill:
 

--- a/deploy/issue_prioritization/databricks.yml
+++ b/deploy/issue_prioritization/databricks.yml
@@ -30,6 +30,8 @@ variables:
     default: issue_classifications
   scores_table:
     default: issue_scores
+  latest_scores_view:
+    default: issue_scores_latest
   bot_state_table:
     default: issue_bot_state
   artifact_volume_name:

--- a/deploy/issue_prioritization/resources/issue_prioritization.job.yml
+++ b/deploy/issue_prioritization/resources/issue_prioritization.job.yml
@@ -28,6 +28,7 @@ resources:
               source-table: ${var.catalog}.${var.schema}.${var.source_table}
               classifications-table: ${var.catalog}.${var.schema}.${var.classifications_table}
               scores-table: ${var.catalog}.${var.schema}.${var.scores_table}
+              latest-scores-view: ${var.catalog}.${var.schema}.${var.latest_scores_view}
               bot-state-table: ${var.catalog}.${var.schema}.${var.bot_state_table}
               artifact-dir: /Volumes/${var.catalog}/${var.schema}/${var.artifact_volume_name}
               model-endpoint: ${var.model_endpoint}

--- a/deploy/issue_prioritization/src/issue_prioritization/databricks_io.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/databricks_io.py
@@ -97,9 +97,10 @@ class SparkClassificationRepository:
 
 
 class SparkScoreSink:
-    def __init__(self, spark: object, table: str) -> None:
+    def __init__(self, spark: object, table: str, latest_view: str) -> None:
         self.spark = spark
         self.table = _table(table)
+        self.latest_view = _table(latest_view)
 
     def write(self, run: PipelineRun) -> None:
         mutations = {plan.target.issue_number: plan for plan in run.mutations}
@@ -147,6 +148,7 @@ class SparkScoreSink:
                 .mode("append")
                 .saveAsTable(self.table)
             )
+            self.spark.sql(latest_scores_view_sql(self.table, self.latest_view))
 
 
 class VolumeArtifactSink:
@@ -253,3 +255,12 @@ def _table(value: str) -> str:
     if not _IDENTIFIER.fullmatch(value):
         raise ValueError(f"expected catalog.schema.table, got {value!r}")
     return value
+
+
+def latest_scores_view_sql(scores_table: str, latest_view: str) -> str:
+    scores_table = _table(scores_table)
+    latest_view = _table(latest_view)
+    return f"""CREATE OR REPLACE VIEW {latest_view} AS
+    SELECT *
+    FROM {scores_table}
+    WHERE run_id = (SELECT max_by(run_id, scored_at) FROM {scores_table})"""

--- a/deploy/issue_prioritization/src/issue_prioritization/job.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/job.py
@@ -49,6 +49,7 @@ def main() -> None:
     parser.add_argument("--source-table", required=True)
     parser.add_argument("--classifications-table", required=True)
     parser.add_argument("--scores-table", required=True)
+    parser.add_argument("--latest-scores-view", required=True)
     parser.add_argument("--bot-state-table", required=True)
     parser.add_argument("--artifact-dir", required=True)
     parser.add_argument("--model-endpoint", default="")
@@ -124,7 +125,7 @@ def main() -> None:
         source=SparkIssueSource(spark, args.source_table),
         classifier=ai_query_classifier(spark, args.model_endpoint, areas),
         classifications=SparkClassificationRepository(spark, args.classifications_table),
-        scores=SparkScoreSink(spark, args.scores_table),
+        scores=SparkScoreSink(spark, args.scores_table, args.latest_scores_view),
         artifacts=VolumeArtifactSink(args.artifact_dir, config),
         engine=ScoreEngine(config, areas),
         maintainers=maintainers,

--- a/deploy/issue_prioritization/tests/test_databricks_io.py
+++ b/deploy/issue_prioritization/tests/test_databricks_io.py
@@ -4,7 +4,7 @@ import json
 from datetime import UTC, datetime
 
 from issue_prioritization.config import ScoringConfig
-from issue_prioritization.databricks_io import VolumeArtifactSink
+from issue_prioritization.databricks_io import VolumeArtifactSink, latest_scores_view_sql
 from issue_prioritization.mutations import BotState, MutationPlan, MutationTarget
 from issue_prioritization.pipeline import PipelineMode, PipelineRun
 
@@ -52,3 +52,13 @@ def test_dry_run_artifact_contains_complete_mutation_plan(tmp_path) -> None:
     assert metadata["mode"] == "dry_run"
     assert metadata["adopt_legacy_bot_priorities"] is False
     assert metadata["legacy_priorities_adopted"] == 0
+
+
+def test_latest_scores_view_selects_one_complete_run() -> None:
+    statement = latest_scores_view_sql(
+        "main.team.issue_scores",
+        "main.team.issue_scores_latest",
+    )
+
+    assert statement.startswith("CREATE OR REPLACE VIEW main.team.issue_scores_latest")
+    assert "max_by(run_id, scored_at) FROM main.team.issue_scores" in statement

--- a/deploy/issue_prioritization/tests/test_spark_io.py
+++ b/deploy/issue_prioritization/tests/test_spark_io.py
@@ -55,12 +55,16 @@ class FakeSpark:
         self.catalog = FakeCatalog()
         self.schemas = []
         self.frames = []
+        self.statements = []
 
     def createDataFrame(self, rows, schema):
         self.schemas.append(schema)
         frame = FakeFrame()
         self.frames.append(frame)
         return frame
+
+    def sql(self, statement):
+        self.statements.append(statement)
 
 
 def test_classification_schema_handles_empty_arrays() -> None:
@@ -83,7 +87,11 @@ def test_classification_schema_handles_empty_arrays() -> None:
 
 def test_score_sink_uses_schema_evolution() -> None:
     spark = FakeSpark()
-    sink = SparkScoreSink(spark, "main.team.scores")
+    sink = SparkScoreSink(
+        spark,
+        "main.team.scores",
+        "main.team.scores_latest",
+    )
     issue = Issue(1, "Title", "url", IssueType.BUG, Severity.S3)
     ranked = RankedIssue(
         rank=1,
@@ -104,6 +112,7 @@ def test_score_sink_uses_schema_evolution() -> None:
 
     assert spark.schemas[0].count("ARRAY<STRING>") == 5
     assert spark.frames[0].write.options == {"mergeSchema": "true"}
+    assert spark.statements[0].startswith("CREATE OR REPLACE VIEW main.team.scores_latest")
 
 
 def test_bot_state_schema_handles_empty_ownership() -> None:


### PR DESCRIPTION
## Related issue

N/A — implementation of the issue-prioritization v2 design in the parent stack.

## Summary

- Adds an `issue_scores_latest` Unity Catalog view that always exposes the newest complete scoring run.
- Keeps dashboard consumers independent from score-history storage and job run IDs.

**ELI5:** The dashboard gets one stable table name while the job keeps every historical ranking behind it.

```text
issue_scores history -> issue_scores_latest -> existing AI/BI dashboard
```

## Test Plan

- `uv run --project deploy/issue_prioritization pytest -q` — 42 tests.
- `uv run --project deploy/issue_prioritization ruff check deploy/issue_prioritization`
- Parse Databricks bundle resources as YAML.

## Demo

N/A — dashboard wiring is a governed SQL view; the existing dashboard draft will be updated after workspace-profile confirmation and a real dry-run creates the table.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The generated latest-run view statement is unit-tested. Workspace SQL execution and dashboard-draft wiring await explicit Databricks profile selection.

## Changelog

Dashboards can query the latest issue-priority ranking through one stable Unity Catalog view.


