### PR TITLE
fix(web): persist open shell tabs per session

### DIFF
--- a/tests/e2e_ui/shells/test_shell_tab_persists_across_sessions.py
+++ b/tests/e2e_ui/shells/test_shell_tab_persists_across_sessions.py
@@ -1,0 +1,90 @@
+"""E2E: an open shell tab survives navigating away to another session and back.
+
+Regression for the reported bug: open a shell in the workspace rail, switch to
+a different session, then return — the shell tab used to be gone. Shell tabs
+lived only in transient component state and the conversation-switch effect
+cleared them on every navigation, even though the PTYs themselves live on the
+server and are re-fetched per session. They now persist per session (like the
+open file tabs) in ``sessionWorkspaceState``, so a client-side session switch
+restores the tab strip.
+
+The switch is driven via the in-app sidebar link (client-side navigation), NOT
+``page.goto`` — a full reload would re-seed everything from storage on cold
+load and wouldn't exercise the conversation-switch effect that regressed.
+
+Uses the real ``terminal_session`` fixture (a runner-bound session whose agent
+declares a ``zsh`` terminal) so an actual PTY backs the tab, and creates a
+second bare session on the same runner to switch to.
+"""
+
+from __future__ import annotations
+
+import re
+
+import httpx
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import (
+    _create_runner_bound_session,
+    _server_state,
+    open_right_rail,
+)
+
+
+def _open_new_shell(page: Page) -> None:
+    """Create a shell via the tab strip's "+" → Shell menu (see test_new_shell)."""
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("button", name="Open new").click()
+    page.get_by_role("menuitem", name=re.compile("Shell")).click()
+
+
+def test_shell_tab_persists_across_session_navigation(
+    page: Page, terminal_session: tuple[str, str]
+) -> None:
+    """Open a shell in A, switch to B via the sidebar, return to A — tab stays.
+
+    Before the fix the tab strip was cleared on the conversation-switch effect,
+    so returning to A showed no shell tab. Now the strip is restored from the
+    per-session store and the tab (and its xterm) come back.
+    """
+    base_url, session_a = terminal_session
+    # A second, bare session on the same runner to switch to. Cleaned up below.
+    runner_id = str(_server_state["runner_id"])
+    session_b = _create_runner_bound_session(base_url, runner_id)
+
+    try:
+        page.goto(f"{base_url}/c/{session_a}")
+        _open_new_shell(page)
+
+        rail = page.get_by_role("complementary", name="Workspace")
+        close_tab = rail.get_by_role("button", name=re.compile(r"^Close zsh · u-"))
+        expect(close_tab).to_be_visible(timeout=60_000)
+        terminal_view = rail.get_by_test_id("terminal-view").last
+        expect(terminal_view).to_have_attribute("data-state", "connected", timeout=20_000)
+
+        # Switch to session B via the sidebar link — client-side navigation, so
+        # the conversation-switch effect runs (a full reload wouldn't exercise
+        # the path that regressed). B is a fresh session, so it has no shell tab.
+        page.locator(f'a[href="/c/{session_b}"]').click()
+        page.wait_for_url(re.compile(rf"/c/{re.escape(session_b)}"))
+        expect(
+            page.get_by_role("complementary", name="Workspace").get_by_role(
+                "button", name=re.compile(r"^Close zsh · u-")
+            )
+        ).to_have_count(0)
+
+        # Navigate back to A — the shell tab is restored from the per-session
+        # store, and its xterm reconnects to the still-live PTY.
+        page.locator(f'a[href="/c/{session_a}"]').click()
+        page.wait_for_url(re.compile(rf"/c/{re.escape(session_a)}"))
+
+        rail_back = page.get_by_role("complementary", name="Workspace")
+        expect(rail_back.get_by_role("button", name=re.compile(r"^Close zsh · u-"))).to_be_visible(
+            timeout=30_000
+        )
+        expect(rail_back.get_by_test_id("terminal-view").last).to_have_attribute(
+            "data-state", "connected", timeout=20_000
+        )
+    finally:
+        httpx.delete(f"{base_url}/v1/sessions/{session_b}", timeout=10.0)

--- a/web/src/lib/sessionWorkspaceState.test.ts
+++ b/web/src/lib/sessionWorkspaceState.test.ts
@@ -52,6 +52,29 @@ describe("sessionWorkspaceState", () => {
     expect(stored).toEqual(Array.from({ length: 20 }, (_, i) => `f${i + 5}`));
   });
 
+  it("persists shell tabs (openTerminals + selectedTerminalKey) per session", () => {
+    writeSessionWorkspaceState("conv_shell", {
+      openTerminals: ["terminal:a", "terminal:b"],
+      selectedTerminalKey: "terminal:b",
+    });
+
+    // Shell tabs round-trip like file tabs so a session switch / reload can
+    // restore the strip. A failure means the fields aren't persisted or the
+    // sanitizer drops them.
+    expect(readSessionWorkspaceState("conv_shell")).toEqual({
+      openTerminals: ["terminal:a", "terminal:b"],
+      selectedTerminalKey: "terminal:b",
+    });
+  });
+
+  it("caps the persisted shell tabs at 20, keeping the most recent", () => {
+    const terminals = Array.from({ length: 25 }, (_, i) => `terminal:t${i}`);
+    writeSessionWorkspaceState("conv_terms", { openTerminals: terminals });
+
+    const stored = readSessionWorkspaceState("conv_terms").openTerminals;
+    expect(stored).toEqual(Array.from({ length: 20 }, (_, i) => `terminal:t${i + 5}`));
+  });
+
   it("prunes the least-recently-touched session past the cap (numeric ids)", () => {
     // Seed exactly MAX_SESSIONS sessions with purely numeric ids ("1".."100").
     // Numeric-string keys are the case a plain object store gets wrong: V8

--- a/web/src/lib/sessionWorkspaceState.ts
+++ b/web/src/lib/sessionWorkspaceState.ts
@@ -1,8 +1,10 @@
 // Per-session UI state for the right "Workspace" rail, keyed by conversationId
 // so each session restores its own layout: whether the rail is open, its width,
-// the selected rail tab, and the set of open file tabs (plus which one is
-// active). A brand-new session (no stored `open`) follows the Appearance
-// Workspace panel default; width and file tabs start empty.
+// the selected rail tab, the set of open file tabs, and the set of open shell
+// tabs (plus which one is active). A brand-new session (no stored `open`)
+// follows the Appearance Workspace panel default; width and tabs start empty.
+// Shell tabs restore to whichever terminals still exist — the AppShell prune
+// effect drops keys whose PTY has gone away once the terminal list loads.
 
 import type { RightRailTab } from "@/shell/railTabs";
 
@@ -19,6 +21,10 @@ export interface SessionWorkspaceState {
   openFiles?: string[];
   /** The active file tab (null = a scope view is active). */
   selectedFilePath?: string | null;
+  /** Ordered list of open shell tabs (``terminalTabKey`` values). */
+  openTerminals?: string[];
+  /** The active shell tab (null = a file/scope view is active). */
+  selectedTerminalKey?: string | null;
 }
 
 const STORAGE_KEY = "omnigent:session-workspace-state";
@@ -65,6 +71,15 @@ function sanitize(entry: unknown): SessionWorkspaceState {
   }
   if (record.selectedFilePath === null || typeof record.selectedFilePath === "string") {
     state.selectedFilePath = record.selectedFilePath;
+  }
+  if (
+    Array.isArray(record.openTerminals) &&
+    record.openTerminals.every((k) => typeof k === "string")
+  ) {
+    state.openTerminals = record.openTerminals as string[];
+  }
+  if (record.selectedTerminalKey === null || typeof record.selectedTerminalKey === "string") {
+    state.selectedTerminalKey = record.selectedTerminalKey;
   }
   return state;
 }
@@ -116,6 +131,10 @@ export function writeSessionWorkspaceState(
   // Keep only the most-recent open-file tabs (tabs are appended in open order).
   if (next.openFiles && next.openFiles.length > MAX_OPEN_FILES) {
     next.openFiles = next.openFiles.slice(-MAX_OPEN_FILES);
+  }
+  // Same bound for shell tabs (also appended in open order).
+  if (next.openTerminals && next.openTerminals.length > MAX_OPEN_FILES) {
+    next.openTerminals = next.openTerminals.slice(-MAX_OPEN_FILES);
   }
   // Drop any existing entry and re-append so the most-recently-touched session
   // moves to the end; pruning then evicts from the front (oldest-touched).

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -1959,6 +1959,91 @@ describe("Right workspace card visibility", () => {
     expect(screen.getByTitle("b.ts")).toBeInTheDocument();
     expect(screen.getByTestId("file-viewer-inline")).toHaveAttribute("data-path", "b.ts");
   });
+
+  it("restores the open shell tabs per session (switch away and back keeps them)", () => {
+    // Regression: shell tabs used to live only in transient component state and
+    // were cleared on every conversation switch, so navigating away and back
+    // lost them. They now persist per session like file tabs. Seed a session
+    // with one open + selected shell tab whose terminal is live, and assert the
+    // tab strip restores it and mounts its xterm.
+    writeSessionWorkspaceState("conv_shellmem", {
+      open: true,
+      openTerminals: ["terminal:terminal_bash_s1"],
+      selectedTerminalKey: "terminal:terminal_bash_s1",
+    });
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null, home: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    useTerminalsMock.mockReturnValue({
+      terminals: [{ id: "terminal_bash_s1", name: "bash", session: "s1", running: true }],
+      isLoading: false,
+      error: null,
+    });
+    mockConversations([{ id: "conv_shellmem", permission_level: null }]);
+
+    renderShell("/c/conv_shellmem");
+
+    // The remembered tab renders in the strip (title = "name · session"), and
+    // the persisted active key drives the rail's xterm (stub echoes the id).
+    expect(screen.getByTitle("bash · s1")).toBeInTheDocument();
+    expect(screen.getByTestId("terminal-view-stub")).toHaveTextContent("terminal_bash_s1");
+  });
+
+  it("keeps restored shell tabs while the terminal list is still loading, then prunes dead ones", () => {
+    // The prune effect drops tabs whose terminal is gone — but the incoming
+    // session's list is momentarily empty *while loading*, indistinguishable
+    // from "all closed". Pruning then would wipe the just-restored tabs. The
+    // effect is gated on isLoading: it must skip the load window, then prune
+    // once the real (still-empty) list confirms the terminal is truly gone.
+    writeSessionWorkspaceState("conv_shellload", {
+      open: true,
+      openTerminals: ["terminal:terminal_bash_s1"],
+      selectedTerminalKey: "terminal:terminal_bash_s1",
+    });
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null, home: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    // Loading: list empty but not yet resolved.
+    useTerminalsMock.mockReturnValue({ terminals: [], isLoading: true, error: null });
+    mockConversations([{ id: "conv_shellload", permission_level: null }]);
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const makeTree = () => (
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/c/conv_shellload"]}>
+            <Routes>
+              <Route element={<AppShell />}>
+                <Route
+                  path="c/:conversationId"
+                  element={
+                    <>
+                      <TerminalFirstViewProbe />
+                      <LocationDisplay />
+                    </>
+                  }
+                />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    );
+    const { rerender } = render(makeTree());
+
+    // While loading the restored tab survives the transient empty list.
+    expect(screen.getByTitle("terminal_bash_s1")).toBeInTheDocument();
+
+    // The list resolves to genuinely empty (the terminal is really gone) —
+    // now the prune runs and drops the dead tab.
+    useTerminalsMock.mockReturnValue({ terminals: [], isLoading: false, error: null });
+    rerender(makeTree());
+
+    expect(screen.queryByTitle("terminal_bash_s1")).toBeNull();
+    expect(screen.queryByTestId("terminal-view-stub")).toBeNull();
+  });
 });
 
 describe("Embedded REPL terminal rail inventory", () => {

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -2044,6 +2044,35 @@ describe("Right workspace card visibility", () => {
     expect(screen.queryByTitle("terminal_bash_s1")).toBeNull();
     expect(screen.queryByTestId("terminal-view-stub")).toBeNull();
   });
+
+  it("keeps restored shell tabs when the terminals fetch errors (non-authoritative empty list)", () => {
+    // An errored terminals fetch also yields terminals: [], but that empty list
+    // is not authoritative — we couldn't reach the PTYs, not "they're gone".
+    // Pruning against it would wipe the restored tab, so the prune effect is
+    // gated on error too. The tab must survive an errored read.
+    writeSessionWorkspaceState("conv_shellerr", {
+      open: true,
+      openTerminals: ["terminal:terminal_bash_s1"],
+      selectedTerminalKey: "terminal:terminal_bash_s1",
+    });
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null, home: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    useTerminalsMock.mockReturnValue({
+      terminals: [],
+      isLoading: false,
+      error: new Error("terminals fetch failed: 503"),
+    });
+    mockConversations([{ id: "conv_shellerr", permission_level: null }]);
+
+    renderShell("/c/conv_shellerr");
+
+    // The restored tab survives the errored (non-authoritative) empty list —
+    // the strip keeps the tab (title falls back to the raw id until the
+    // terminal loads) instead of pruning it as if the PTY were gone.
+    expect(screen.getByTitle("terminal_bash_s1")).toBeInTheDocument();
+  });
 });
 
 describe("Embedded REPL terminal rail inventory", () => {

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -291,7 +291,11 @@ export function AppShell() {
   // terminal. The hook is react-query-backed and dedup'd with the rail.
   // reconcileWhilePending: self-heals if the live resource.created SSE was
   // missed (see UseTerminalsOptions for the why).
-  const { terminals, isLoading: terminalsLoading } = useTerminals(conversationId ?? null, {
+  const {
+    terminals,
+    isLoading: terminalsLoading,
+    error: terminalsError,
+  } = useTerminals(conversationId ?? null, {
     reconcileWhilePending: terminalPending,
   });
 
@@ -1145,17 +1149,19 @@ export function AppShell() {
   // Prune shell tabs whose terminal has gone away (closed by the agent, or the
   // runner went offline and emptied the list). Keeps the strip from pointing at
   // dead PTYs; the active selection falls back to the Shells list when its tab
-  // is dropped. Skip while the list is still loading so restored (persisted)
-  // tabs aren't wiped by the transient empty list before the PTYs are fetched.
+  // is dropped. Skip while the list is still loading OR the fetch errored so
+  // restored (persisted) tabs aren't wiped by a non-authoritative empty list —
+  // an errored read is `[]` too, and pruning against it would discard tabs
+  // whose PTYs we simply couldn't reach.
   useEffect(() => {
-    if (terminalsLoading) return;
+    if (terminalsLoading || terminalsError !== null) return;
     const valid = new Set(terminals.map((t) => terminalTabKey(t)));
     setOpenTerminals((prev) => {
       const next = prev.filter((k) => valid.has(k));
       return next.length === prev.length ? prev : next;
     });
     setSelectedTerminalKey((active) => (active !== null && !valid.has(active) ? null : active));
-  }, [terminals, terminalsLoading]);
+  }, [terminals, terminalsLoading, terminalsError]);
 
   function openExecutionLogsPanel(key: string) {
     setSelectedFilePath(null); // close file viewer

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -198,11 +198,16 @@ export function AppShell() {
   // Ordered list of open shell tabs (``terminalTabKey`` values) shown in the
   // right rail's tab strip beside the file tabs. ``selectedTerminalKey`` is the
   // active one (mutually exclusive with ``selectedFilePath`` — the rail's
-  // content slot shows one thing). Not persisted: terminal keys are
-  // session-scoped and the PTYs don't survive a reload, so a fresh visit starts
-  // with no shell tabs; a prune effect drops keys whose terminal has gone away.
-  const [openTerminals, setOpenTerminals] = useState<string[]>([]);
-  const [selectedTerminalKey, setSelectedTerminalKey] = useState<string | null>(null);
+  // content slot shows one thing). Persisted per-session (like file tabs) so a
+  // session switch or reload restores the tab strip; the PTYs live on the
+  // server and are re-fetched by ``useTerminals``, and a prune effect drops any
+  // keys whose terminal has actually gone away once the list loads.
+  const [openTerminals, setOpenTerminals] = useState<string[]>(() =>
+    conversationId ? (readSessionWorkspaceState(conversationId).openTerminals ?? []) : [],
+  );
+  const [selectedTerminalKey, setSelectedTerminalKey] = useState<string | null>(() =>
+    conversationId ? (readSessionWorkspaceState(conversationId).selectedTerminalKey ?? null) : null,
+  );
   // Whether the workspace rail is maximized (covers the full content region,
   // hiding the chat column). Session-transient — a fresh visit starts docked.
   const [rightPanelMaximized, setRightPanelMaximized] = useState(false);
@@ -286,7 +291,7 @@ export function AppShell() {
   // terminal. The hook is react-query-backed and dedup'd with the rail.
   // reconcileWhilePending: self-heals if the live resource.created SSE was
   // missed (see UseTerminalsOptions for the why).
-  const { terminals } = useTerminals(conversationId ?? null, {
+  const { terminals, isLoading: terminalsLoading } = useTerminals(conversationId ?? null, {
     reconcileWhilePending: terminalPending,
   });
 
@@ -709,6 +714,8 @@ export function AppShell() {
       setRightRailTab("files");
       setSelectedFilePath(null);
       setOpenFiles([]);
+      setOpenTerminals([]);
+      setSelectedTerminalKey(null);
       setPanelInitialKeyState(null);
       stateConvRef.current = null;
       return;
@@ -753,11 +760,12 @@ export function AppShell() {
     const nextSelected = urlFile ?? persisted.selectedFilePath ?? null;
     setOpenFiles(nextOpenFiles);
     setSelectedFilePath(nextSelected);
-    // Shell tabs are session-scoped and not persisted — a switch starts the
-    // incoming session with no open shell tabs (the prune effect would drop
-    // stale keys anyway once its terminals load).
-    setOpenTerminals([]);
-    setSelectedTerminalKey(null);
+    // Restore the open shell tabs from the per-session store. The prune effect
+    // drops any key whose terminal no longer exists once this session's
+    // terminal list loads, so a dead PTY can't leave a phantom tab. A restored
+    // shell selection must not coexist with a file selection (one content slot).
+    setOpenTerminals(persisted.openTerminals ?? []);
+    setSelectedTerminalKey(nextSelected ? null : (persisted.selectedTerminalKey ?? null));
     // A maximized rail is transient too — the incoming session starts docked.
     // If we were maximized, restore the sidebar we collapsed on entry (the
     // toggle handler won't run on a session switch).
@@ -802,8 +810,14 @@ export function AppShell() {
     }
     const id = stateConvRef.current;
     if (!id) return;
-    writeSessionWorkspaceState(id, { rightRailTab, openFiles, selectedFilePath });
-  }, [rightRailTab, openFiles, selectedFilePath]);
+    writeSessionWorkspaceState(id, {
+      rightRailTab,
+      openFiles,
+      selectedFilePath,
+      openTerminals,
+      selectedTerminalKey,
+    });
+  }, [rightRailTab, openFiles, selectedFilePath, openTerminals, selectedTerminalKey]);
 
   // Sync the Files-panel scope into the URL. The tree is the default, so we
   // only write the param for "Changed only" — and only while the rail is open,
@@ -1131,15 +1145,17 @@ export function AppShell() {
   // Prune shell tabs whose terminal has gone away (closed by the agent, or the
   // runner went offline and emptied the list). Keeps the strip from pointing at
   // dead PTYs; the active selection falls back to the Shells list when its tab
-  // is dropped.
+  // is dropped. Skip while the list is still loading so restored (persisted)
+  // tabs aren't wiped by the transient empty list before the PTYs are fetched.
   useEffect(() => {
+    if (terminalsLoading) return;
     const valid = new Set(terminals.map((t) => terminalTabKey(t)));
     setOpenTerminals((prev) => {
       const next = prev.filter((k) => valid.has(k));
       return next.length === prev.length ? prev : next;
     });
     setSelectedTerminalKey((active) => (active !== null && !valid.has(active) ? null : active));
-  }, [terminals]);
+  }, [terminals, terminalsLoading]);
 
   function openExecutionLogsPanel(key: string) {
     setSelectedFilePath(null); // close file viewer


### PR DESCRIPTION
## Related issue

N/A

## Summary

- **Bug:** open a shell tab in the workspace rail, navigate to another session, then back — the shell tab is gone.
- **Root cause:** shell tabs (`openTerminals` / `selectedTerminalKey`) lived only in transient React state, and the conversation-switch effect explicitly cleared them on every navigation. The underlying PTYs live on the server and are re-fetched by `useTerminals` — only the tab *strip* was being discarded (unlike file tabs, which already persist per session).
- **Fix:** persist the shell tabs per session in `sessionWorkspaceState` (mirroring the open-file-tabs pattern), seed and restore them on mount/switch, and gate the dead-tab prune effect on the terminals list's loading state so a restored tab isn't wiped by the transient empty list before the session's terminals finish loading.

ELI5: the terminals themselves never went away — the app was just throwing away the little tabs pointing at them whenever you left the page. Now it remembers them like it already does for file tabs.

## Test Plan

- `cd web && npm test` — full suite green (4972 passed, 3 expected-fail, 1 skipped).
- `cd web && npm run build` — `tsc -b` + `vite build` clean.
- Added unit tests:
  - `sessionWorkspaceState`: shell tabs round-trip; 20-tab cap keeps the most recent.
  - `AppShell`: restoring open shell tabs per session renders the tab + mounts its xterm; a restored tab survives the loading window and is pruned only once the list resolves to genuinely empty.
- Manual: open a shell tab, switch to another session, switch back → the tab is still there and selected; reload → restored; agent-closed terminal → its tab is still pruned.

## Demo

Before

https://github.com/user-attachments/assets/be772fcd-f26a-4113-918a-85c2b932517f

After

https://github.com/user-attachments/assets/6b364f5c-feef-4e9e-acff-3f8f0769e88e

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: opened a shell tab, navigated to another session and back (tab persists), reloaded (tab restored from the per-session store), and confirmed an agent-closed terminal's tab still gets pruned once the terminal list loads without it.

## Changelog

Shell tabs now persist per session — opening a shell, switching sessions, and coming back keeps the tab open

This pull request and its description were written by Isaac.