### PR TITLE
fix: use GitHub upvotes for issue demand

### DIFF
--- a/deploy/issue_prioritization/README.md
+++ b/deploy/issue_prioritization/README.md
@@ -20,7 +20,9 @@ GitHub write path.
 
 All weights and enabled modules live in
 `src/issue_prioritization/default_scoring.json`. Readiness and age are present
-but disabled by default.
+but disabled by default. Duplicate reach is also disabled until the upstream
+triage pipeline exposes confirmed duplicate links as structured data. Community
+demand counts GitHub `+1` reactions only, not all reaction types.
 
 ## Databricks dry-run
 

--- a/deploy/issue_prioritization/src/issue_prioritization/artifacts.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/artifacts.py
@@ -85,7 +85,7 @@ def _row(item: RankedIssue) -> dict[str, object]:
         "area_keys": list(issue.area_keys),
         "component_labels": list(issue.component_labels),
         "duplicate_count": issue.duplicate_count,
-        "reaction_count": issue.reaction_count,
+        "upvote_count": issue.upvote_count,
         "breakdown": [
             {
                 "name": step.name,

--- a/deploy/issue_prioritization/src/issue_prioritization/bronze.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/bronze.py
@@ -18,7 +18,7 @@ class BronzeIssue:
     author: str
     labels: tuple[str, ...]
     created_at: datetime
-    reaction_count: int
+    upvote_count: int
     duplicate_count: int
 
     @classmethod
@@ -31,7 +31,7 @@ class BronzeIssue:
             author=str(_first(value, "author_login", "user_login", "author", default="")),
             labels=_labels(_first(value, "labels", "label_names", default=())),
             created_at=_timestamp(_first(value, "created_at")),
-            reaction_count=_reaction_count(value),
+            upvote_count=_upvote_count(value),
             duplicate_count=max(0, int(_first(value, "duplicate_count", default=0) or 0)),
         )
 
@@ -54,7 +54,7 @@ class BronzeIssue:
             area_keys=classification.area_keys,
             component_labels=classification.component_labels,
             duplicate_count=self.duplicate_count,
-            reaction_count=self.reaction_count,
+            upvote_count=self.upvote_count,
             current_priority=_current_priority(self.labels),
             needs_info="needs-info" in self.labels,
             age_days=max(0, (now - self.created_at).days),
@@ -96,8 +96,13 @@ def _timestamp(value: object) -> datetime:
     return parsed.replace(tzinfo=parsed.tzinfo or UTC)
 
 
-def _reaction_count(value: Mapping[str, object]) -> int:
-    direct = _first(value, "reaction_count", "reactions_total_count")
+def _upvote_count(value: Mapping[str, object]) -> int:
+    direct = _first(
+        value,
+        "upvote_count",
+        "thumbs_up_count",
+        "reactions_plus_one_count",
+    )
     if direct is not None:
         return max(0, int(direct))
     reactions = value.get("reactions")
@@ -107,7 +112,7 @@ def _reaction_count(value: Mapping[str, object]) -> int:
         except json.JSONDecodeError:
             return 0
     if isinstance(reactions, Mapping):
-        return max(0, int(reactions.get("total_count", 0)))
+        return max(0, int(reactions.get("+1", 0)))
     return 0
 
 

--- a/deploy/issue_prioritization/src/issue_prioritization/databricks_io.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/databricks_io.py
@@ -21,7 +21,8 @@ _SCORE_SCHEMA = """run_id STRING, mode STRING, regrade BOOLEAN,
 adopt_legacy_bot_priorities BOOLEAN, legacy_priorities_adopted BIGINT,
 scored_at TIMESTAMP, rank BIGINT, previous_rank BIGINT, rank_delta BIGINT,
 issue_number BIGINT, title STRING, url STRING, issue_type STRING, severity STRING,
-score DOUBLE, current_priority STRING, proposed_priority STRING,
+score DOUBLE, upvote_count BIGINT, duplicate_count BIGINT,
+current_priority STRING, proposed_priority STRING,
 area_keys ARRAY<STRING>, component_labels ARRAY<STRING>, breakdown_json STRING,
 labels_add ARRAY<STRING>, labels_remove ARRAY<STRING>, mutation_blocked ARRAY<STRING>"""
 _BOT_STATE_SCHEMA = """issue_number BIGINT, priority STRING, severity STRING,
@@ -126,6 +127,8 @@ class SparkScoreSink:
                     "issue_type": issue.issue_type.value,
                     "severity": issue.severity.value,
                     "score": float(result.score),
+                    "upvote_count": issue.upvote_count,
+                    "duplicate_count": issue.duplicate_count,
                     "current_priority": issue.current_priority.value
                     if issue.current_priority
                     else None,

--- a/deploy/issue_prioritization/src/issue_prioritization/default_scoring.json
+++ b/deploy/issue_prioritization/src/issue_prioritization/default_scoring.json
@@ -24,13 +24,13 @@
       "default_weight": 1.0
     },
     "duplicates": {
-      "enabled": true,
+      "enabled": false,
       "increment": 0.15,
       "max_bonus": 0.5
     },
     "demand": {
       "enabled": true,
-      "reaction_cap": 12,
+      "upvote_cap": 12,
       "max_points": 15
     },
     "readiness": {

--- a/deploy/issue_prioritization/src/issue_prioritization/domain.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/domain.py
@@ -36,7 +36,7 @@ class Issue:
     area_keys: tuple[str, ...] = ()
     component_labels: tuple[str, ...] = ()
     duplicate_count: int = 0
-    reaction_count: int = 0
+    upvote_count: int = 0
     current_priority: Priority | None = None
     needs_info: bool = False
     is_ready: bool = False
@@ -54,7 +54,7 @@ class Issue:
             area_keys=_string_tuple(value.get("area_keys", ())),
             component_labels=_string_tuple(value.get("component_labels", ())),
             duplicate_count=max(0, int(value.get("duplicate_count", 0))),
-            reaction_count=max(0, int(value.get("reaction_count", 0))),
+            upvote_count=max(0, int(value.get("upvote_count", 0))),
             current_priority=Priority(str(current_priority)) if current_priority else None,
             needs_info=bool(value.get("needs_info", False)),
             is_ready=bool(value.get("is_ready", False)),

--- a/deploy/issue_prioritization/src/issue_prioritization/scoring.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/scoring.py
@@ -47,10 +47,10 @@ class DemandModule:
     name: str = "demand"
 
     def apply(self, issue: Issue, score: Decimal) -> ScoreStep:
-        cap = int(self.config.decimal("reaction_cap"))
-        reactions = min(issue.reaction_count, cap)
+        cap = int(self.config.decimal("upvote_cap"))
+        upvotes = min(issue.upvote_count, cap)
         points = (
-            self.config.decimal("max_points") * Decimal(reactions) / Decimal(cap)
+            self.config.decimal("max_points") * Decimal(upvotes) / Decimal(cap)
             if cap
             else Decimal(0)
         )

--- a/deploy/issue_prioritization/tests/test_artifacts.py
+++ b/deploy/issue_prioritization/tests/test_artifacts.py
@@ -24,6 +24,8 @@ def test_dry_run_artifacts_are_complete_and_deterministic(tmp_path) -> None:
             severity=Severity.S1,
             area_keys=("db",),
             current_priority=Priority.P2,
+            upvote_count=3,
+            duplicate_count=2,
         ),
         Issue(
             number=1,
@@ -49,6 +51,9 @@ def test_dry_run_artifacts_are_complete_and_deterministic(tmp_path) -> None:
     summary = json.loads((first / "summary.json").read_text())
     assert summary["issue_count"] == 2
     assert summary["priority_changes"] == 2
+    ranking = json.loads((first / "ranking.json").read_text())
+    assert ranking[0]["upvote_count"] == 3
+    assert ranking[0]["duplicate_count"] == 2
 
 
 def test_cli_writes_review_artifacts_without_network(tmp_path) -> None:

--- a/deploy/issue_prioritization/tests/test_bronze.py
+++ b/deploy/issue_prioritization/tests/test_bronze.py
@@ -20,7 +20,7 @@ def test_bronze_adapter_accepts_github_structs_and_json() -> None:
             "user_login": "community",
             "labels": '[{"name":"Bug"},{"name":"P1-high"}]',
             "created_at": "2026-08-01T00:00:00Z",
-            "reactions": {"total_count": 3},
+            "reactions": {"total_count": 5, "+1": 3, "-1": 2},
         }
     )
     classification = Classification(
@@ -36,9 +36,22 @@ def test_bronze_adapter_accepts_github_structs_and_json() -> None:
     normalized = issue.to_issue(classification, datetime(2026, 8, 5, tzinfo=UTC))
 
     assert issue.labels == ("Bug", "P1-high")
-    assert issue.reaction_count == 3
+    assert issue.upvote_count == 3
     assert normalized.current_priority == Priority.P1
     assert normalized.age_days == 4
+
+
+def test_bronze_adapter_does_not_count_non_upvote_reactions() -> None:
+    issue = BronzeIssue.from_mapping(
+        {
+            "number": 42,
+            "title": "Android login fails",
+            "created_at": "2026-08-01T00:00:00Z",
+            "reactions": {"total_count": 4, "-1": 2, "confused": 2},
+        }
+    )
+
+    assert issue.upvote_count == 0
 
 
 def test_spark_source_rejects_unquoted_table_expressions() -> None:

--- a/deploy/issue_prioritization/tests/test_pipeline.py
+++ b/deploy/issue_prioritization/tests/test_pipeline.py
@@ -75,7 +75,7 @@ def _bronze(number, author="community"):
         author=author,
         labels=("Bug", "P2-medium"),
         created_at=datetime(2026, 8, 1, tzinfo=UTC),
-        reaction_count=0,
+        upvote_count=0,
         duplicate_count=0,
     )
 

--- a/deploy/issue_prioritization/tests/test_scoring.py
+++ b/deploy/issue_prioritization/tests/test_scoring.py
@@ -53,7 +53,12 @@ def test_low_weight_s1_bug_falls_to_p2() -> None:
 
 
 def test_duplicate_reach_is_capped() -> None:
-    result = ScoreEngine(ScoringConfig.default(), _catalog()).score(
+    default = ScoringConfig.default()
+    modules = dict(default.modules)
+    modules["duplicates"] = ModuleConfig(True, modules["duplicates"].values)
+    enabled = replace(default, modules=modules)
+
+    result = ScoreEngine(enabled, _catalog()).score(
         _issue(severity=Severity.S2, duplicate_count=100)
     )
 
@@ -78,7 +83,6 @@ def test_optional_modules_are_disabled_by_default() -> None:
     assert [step.name for step in result.steps] == [
         "severity",
         "component",
-        "duplicates",
         "demand",
     ]
 
@@ -99,8 +103,8 @@ def test_optional_modules_can_be_enabled_independently() -> None:
 def test_demand_is_linear_and_type_independent() -> None:
     engine = ScoreEngine(ScoringConfig.default(), _catalog())
 
-    bug = engine.score(_issue(reaction_count=6))
-    feature = engine.score(_issue(issue_type=IssueType.ENHANCEMENT, reaction_count=6))
+    bug = engine.score(_issue(upvote_count=6))
+    feature = engine.score(_issue(issue_type=IssueType.ENHANCEMENT, upvote_count=6))
 
     assert bug.score == Decimal("91.50")
     assert feature.score == bug.score
@@ -112,7 +116,7 @@ def test_demand_is_capped() -> None:
             issue_type=IssueType.ENHANCEMENT,
             severity=Severity.S2,
             area_keys=("harness-kimi",),
-            reaction_count=1000,
+            upvote_count=1000,
         )
     )
 

--- a/deploy/issue_prioritization/tests/test_spark_io.py
+++ b/deploy/issue_prioritization/tests/test_spark_io.py
@@ -111,6 +111,8 @@ def test_score_sink_uses_schema_evolution() -> None:
     sink.write(run)
 
     assert spark.schemas[0].count("ARRAY<STRING>") == 5
+    assert "upvote_count BIGINT" in spark.schemas[0]
+    assert "duplicate_count BIGINT" in spark.schemas[0]
     assert spark.frames[0].write.options == {"mergeSchema": "true"}
     assert spark.statements[0].startswith("CREATE OR REPLACE VIEW main.team.scores_latest")
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Count only GitHub `+1` reactions as community demand; other reactions no longer inflate scores.
- Keep duplicate reach disabled until triage persists confirmed links as structured data.
- Persist both raw inputs beside each score so dry-run artifacts and dashboard rows are auditable.

ELI5: a thumbs-up raises demand; a thumbs-down or confused reaction does not. Duplicate scoring stays off rather than guessing from comments.

```text
GitHub +1 ──> upvote_count ──> demand module ──> score
confirmed duplicate data (not yet available) ──> module stays off
```

## Test Plan

- `uv run --project deploy/issue_prioritization pytest -q deploy/issue_prioritization/tests`
- `pre-commit run --all-files`

## Demo

N/A — non-visual scoring and persistence change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests cover mixed reaction types, non-upvote reactions, disabled duplicate scoring, artifact fields, and the persisted score schema.