### PR TITLE
fix: preserve explicit label removals

### DIFF
--- a/deploy/issue_prioritization/README.md
+++ b/deploy/issue_prioritization/README.md
@@ -68,7 +68,8 @@ priorities were adopted. Human-authored priority events remain blocked in
 The schedule is paused. GitHub writes additionally require `mode=apply`, the
 deploy variable `allow_github_writes=true`, and a configured secret scope. The
 job re-reads every issue's live labels before writing and preserves maintainer
-priority and severity overrides. Human-added component labels are never removed.
+priority and severity overrides. Removing a bot-owned label is also a durable
+override; human-added component labels are never removed.
 
 ```bash
 databricks bundle deploy --target dev --profile <profile> \

--- a/deploy/issue_prioritization/src/issue_prioritization/mutations.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/mutations.py
@@ -119,7 +119,7 @@ class MutationPlanner:
         current_priorities = existing & self.priority_labels
         current_priority = next(iter(current_priorities)) if len(current_priorities) == 1 else None
         priority_written = False
-        priority_owned = not current_priorities or (
+        priority_owned = (not current_priorities and (state is None or state.priority is None)) or (
             state is not None and current_priority == state.priority
         )
         if len(current_priorities) > 1:
@@ -136,7 +136,7 @@ class MutationPlanner:
         current_severities = existing & self.manifest.severity_labels
         current_severity = next(iter(current_severities)) if len(current_severities) == 1 else None
         severity_written = False
-        severity_owned = not current_severities or (
+        severity_owned = (not current_severities and (state is None or state.severity is None)) or (
             state is not None and current_severity == state.severity
         )
         if len(current_severities) > 1:
@@ -152,13 +152,15 @@ class MutationPlanner:
 
         existing_components = existing & self.manifest.component_labels
         target_components = set(target.components)
-        components_added = target_components - existing_components
+        owned_components = set(state.components) if state else set()
+        suppressed_components = (owned_components - existing_components) & target_components
+        components_added = target_components - existing_components - suppressed_components
         labels_add.update(components_added)
-        if state:
-            labels_remove.update((set(state.components) & existing_components) - target_components)
-        bot_components = components_added
-        if state:
-            bot_components |= set(state.components) & existing_components & target_components
+        labels_remove.update((owned_components & existing_components) - target_components)
+        blocked.extend(
+            f"component_human_override:{component}" for component in sorted(suppressed_components)
+        )
+        bot_components = (owned_components & target_components) | components_added
 
         next_state = BotState(
             issue_number=target.issue_number,

--- a/deploy/issue_prioritization/tests/test_github.py
+++ b/deploy/issue_prioritization/tests/test_github.py
@@ -98,6 +98,23 @@ def test_apply_preserves_human_priority_changed_after_dry_run() -> None:
     assert states.updated == []
 
 
+def test_apply_preserves_human_label_removals_after_dry_run() -> None:
+    state = BotState(1, "P2-medium", "severity:S2", ("comp:server",))
+    states = FakeStates({1: state})
+    manifest = _manifest()
+    planner = MutationPlanner(manifest, states)
+    target = MutationTarget(1, "P2-medium", "severity:S2", ("comp:server",))
+    proposed = MutationPlan(target, (), (), (), state)
+    run = PipelineRun("run", PipelineMode.APPLY, datetime.now(UTC), (), 0, (proposed,))
+    client = FakeClient()
+    client.labels = ()
+
+    GitHubMutationSink(client, manifest, planner, states).apply(run)
+
+    assert client.applied == []
+    assert states.updated == []
+
+
 def test_apply_checkpoints_successful_writes_after_a_later_failure() -> None:
     first = BotState(1, "P2-medium", "severity:S2", ("comp:server",))
     second = BotState(2, "P2-medium", "severity:S2", ("comp:server",))

--- a/deploy/issue_prioritization/tests/test_mutations.py
+++ b/deploy/issue_prioritization/tests/test_mutations.py
@@ -99,6 +99,22 @@ def test_human_priority_change_is_never_overwritten() -> None:
     assert "P1-high" not in plan.labels_add
 
 
+def test_human_priority_and_severity_removal_is_never_undone() -> None:
+    state = BotState(1, "P1-high", "severity:S1", ("comp:db",))
+    planner = MutationPlanner(_manifest(), FakeStates({1: state}))
+
+    plan = planner.plan_one(_target(), ("comp:db",), state)
+
+    assert set(plan.blocked) == {
+        "priority_human_override",
+        "severity_human_override",
+    }
+    assert "P1-high" not in plan.labels_add
+    assert "severity:S1" not in plan.labels_add
+    assert plan.next_state.priority == "P1-high"
+    assert plan.next_state.severity == "severity:S1"
+
+
 def test_human_component_labels_are_not_removed() -> None:
     state = BotState(1, None, None, ("comp:server",))
     planner = MutationPlanner(_manifest(), FakeStates({1: state}))
@@ -120,6 +136,18 @@ def test_existing_bot_owned_component_stays_owned() -> None:
 
     plan = planner.plan_one(_target(), ("comp:db",), state)
 
+    assert plan.next_state.components == ("comp:db",)
+
+
+def test_human_removed_bot_component_is_not_readded() -> None:
+    state = BotState(1, None, None, ("comp:db",))
+    planner = MutationPlanner(_manifest(), FakeStates({1: state}))
+
+    plan = planner.plan_one(_target(), (), state)
+
+    assert plan.labels_add == ("P1-high", "severity:S1")
+    assert plan.labels_remove == ()
+    assert plan.blocked == ("component_human_override:comp:db",)
     assert plan.next_state.components == ("comp:db",)
 
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Treat removal of a bot-owned priority, severity, or component label as a durable human override.
- Keep suppression in bot state so later apply runs do not recreate the removed label.
- Record component suppression in dry-run mutation artifacts.

```text
bot-owned label -> maintainer removes it -> apply rechecks live labels -> no re-add
```

## Test Plan

- `uv run --project deploy/issue_prioritization pytest -q deploy/issue_prioritization/tests`
- `pre-commit run --all-files`

## Demo

N/A — non-visual GitHub mutation safety change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests cover removed priority, severity, and component labels plus the live-label recheck path.