### PR TITLE
fix: publish only complete ranking runs

### DIFF
--- a/deploy/issue_prioritization/src/issue_prioritization/databricks_io.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/databricks_io.py
@@ -171,7 +171,6 @@ class VolumeArtifactSink:
             "scored_at": run.scored_at.isoformat(),
             "classifications_updated": run.classifications_updated,
         }
-        (destination / "run.json").write_text(json.dumps(metadata, indent=2) + "\n")
         mutations = [
             {
                 "issue_number": plan.target.issue_number,
@@ -192,6 +191,9 @@ class VolumeArtifactSink:
             for plan in run.mutations
         ]
         (destination / "mutations.json").write_text(json.dumps(mutations, indent=2) + "\n")
+        pending_metadata = destination / ".run.json.tmp"
+        pending_metadata.write_text(json.dumps(metadata, indent=2) + "\n")
+        pending_metadata.replace(destination / "run.json")
 
 
 class SparkBotStateRepository:

--- a/deploy/issue_prioritization/src/issue_prioritization/pipeline.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/pipeline.py
@@ -146,8 +146,8 @@ class IssuePrioritizationPipeline:
             adopt_legacy_bot_priorities=adopt_legacy_bot_priorities,
             legacy_priorities_adopted=len(set(bot_states) - set(persisted_bot_states)),
         )
-        self.scores.write(run)
         self.artifacts.write(run)
+        self.scores.write(run)
         if mode == PipelineMode.APPLY:
             if self.mutation_sink is None:
                 raise RuntimeError("apply mode requires a mutation sink")

--- a/deploy/issue_prioritization/tests/test_databricks_io.py
+++ b/deploy/issue_prioritization/tests/test_databricks_io.py
@@ -52,6 +52,7 @@ def test_dry_run_artifact_contains_complete_mutation_plan(tmp_path) -> None:
     assert metadata["mode"] == "dry_run"
     assert metadata["adopt_legacy_bot_priorities"] is False
     assert metadata["legacy_priorities_adopted"] == 0
+    assert not (tmp_path / "preview" / ".run.json.tmp").exists()
 
 
 def test_latest_scores_view_selects_one_complete_run() -> None:

--- a/deploy/issue_prioritization/tests/test_pipeline.py
+++ b/deploy/issue_prioritization/tests/test_pipeline.py
@@ -4,6 +4,8 @@ from dataclasses import replace
 from datetime import UTC, datetime
 from decimal import Decimal
 
+import pytest
+
 from issue_prioritization.areas import Area, AreaCatalog
 from issue_prioritization.bronze import BronzeIssue
 from issue_prioritization.classification import Classification
@@ -266,3 +268,77 @@ def test_dry_run_previews_safe_legacy_priority_regrade() -> None:
     assert run.legacy_priorities_adopted == 1
     assert set(run.mutations[0].labels_add) == {"P1-high", "comp:db", "severity:S1"}
     assert run.mutations[0].labels_remove == ("P2-medium",)
+
+
+def test_pipeline_publishes_scores_only_after_artifacts_complete() -> None:
+    issue = _bronze(1)
+    classification = Classification(
+        issue_number=1,
+        issue_type=IssueType.BUG,
+        severity=Severity.S1,
+        area_keys=("db",),
+        component_labels=("comp:db",),
+        reasoning="No workaround",
+        content_hash=issue.content().content_hash,
+    )
+    area = Area("db", "comp:db", Decimal("1.2"))
+    catalog = AreaCatalog(by_key={"db": area}, by_label={"comp:db": (area,)})
+    events = []
+
+    class OrderedSink(CaptureSink):
+        def __init__(self, name):
+            super().__init__()
+            self.name = name
+
+        def write(self, run):
+            events.append(self.name)
+            super().write(run)
+
+    pipeline = IssuePrioritizationPipeline(
+        source=FakeSource([issue]),
+        classifier=FakeClassifier(classification),
+        classifications=FakeClassifications({1: classification}),
+        scores=OrderedSink("scores"),
+        artifacts=OrderedSink("artifacts"),
+        engine=ScoreEngine(ScoringConfig.default(), catalog),
+        maintainers=set(),
+    )
+
+    pipeline.run("run-publish-order")
+
+    assert events == ["artifacts", "scores"]
+
+
+def test_pipeline_does_not_publish_scores_when_artifacts_fail() -> None:
+    issue = _bronze(1)
+    classification = Classification(
+        issue_number=1,
+        issue_type=IssueType.BUG,
+        severity=Severity.S1,
+        area_keys=("db",),
+        component_labels=("comp:db",),
+        reasoning="No workaround",
+        content_hash=issue.content().content_hash,
+    )
+    area = Area("db", "comp:db", Decimal("1.2"))
+    catalog = AreaCatalog(by_key={"db": area}, by_label={"comp:db": (area,)})
+    scores = CaptureSink()
+
+    class FailingArtifacts:
+        def write(self, run):
+            raise RuntimeError("volume unavailable")
+
+    pipeline = IssuePrioritizationPipeline(
+        source=FakeSource([issue]),
+        classifier=FakeClassifier(classification),
+        classifications=FakeClassifications({1: classification}),
+        scores=scores,
+        artifacts=FailingArtifacts(),
+        engine=ScoreEngine(ScoringConfig.default(), catalog),
+        maintainers=set(),
+    )
+
+    with pytest.raises(RuntimeError, match="volume unavailable"):
+        pipeline.run("run-artifact-failure")
+
+    assert scores.runs == []


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Finish ranking and mutation artifacts before appending score rows or advancing the latest-run view.
- Write `run.json` last through an atomic rename so it acts as the artifact completion marker.
- Leave failed artifact runs out of the dashboard view.

```text
artifacts -> completion marker -> score table -> latest view
```

## Test Plan

- `uv run --project deploy/issue_prioritization pytest -q deploy/issue_prioritization/tests`
- `pre-commit run --all-files`

## Demo

N/A — non-visual run-publication safety change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests assert artifact-first publication, no score publish on artifact failure, and atomic completion-marker cleanup.