### PR TITLE
feat: add scoring ownership handoff switch

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -19,8 +19,8 @@ name: Issue Triage
 #
 # What the bot does:
 #   1. Removes `needs-triage`, adds `triaged`
-#   2. Classifies component — one `comp:*` label
-#   3. Assigns priority — P0-critical / P1-high / P2-medium / P3-low
+#   2. Classifies component — one `comp:*` label until Databricks owns scoring
+#   3. Assigns priority until Databricks owns scoring
 #   4. Routes to contributors — `good-first-issue` or `help-wanted`
 #   5. Flags incomplete issues — `needs-info` (replaces priority label)
 #   6. Detects duplicates — `duplicate` label + ONE comment
@@ -395,6 +395,7 @@ jobs:
           REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           EVENT_ACTION: ${{ github.event.action }}
+          ISSUE_PRIORITIZATION_V2_ENABLED: ${{ vars.ISSUE_PRIORITIZATION_V2_ENABLED }}
         run: |
           set -euo pipefail
 
@@ -438,6 +439,9 @@ jobs:
           # (gh issue edit --remove-label errors on missing labels).
           issue_data = json.loads(pathlib.Path("/tmp/issue.json").read_text())
           existing_labels = {l["name"] for l in issue_data.get("labels", [])}
+          v2_owns_scoring = (
+              os.environ.get("ISSUE_PRIORITIZATION_V2_ENABLED", "").lower() == "true"
+          )
 
           labels_add = []
           labels_remove = []
@@ -463,14 +467,14 @@ jobs:
 
               # Components (array)
               components = result.get("components", [])
-              if isinstance(components, list):
+              if not v2_owns_scoring and isinstance(components, list):
                   for c in components:
                       if c in ALLOWED_COMPONENTS:
                           labels_add.append(c)
 
               # Priority
               p = result.get("priority")
-              if p and p in ALLOWED_PRIORITIES:
+              if not v2_owns_scoring and p and p in ALLOWED_PRIORITIES:
                   labels_add.append(p)
 
               # Contributor routing
@@ -521,7 +525,11 @@ jobs:
               "components": valid_components,
               "ranked_owners": ranked_owners,
               "duplicate_of": dup if isinstance(dup, int) else None,
-              "priority": result.get("priority") if result.get("priority") in ALLOWED_PRIORITIES else None,
+              "priority": (
+                  result.get("priority")
+                  if not v2_owns_scoring and result.get("priority") in ALLOWED_PRIORITIES
+                  else None
+              ),
               "needs_info": bool(result.get("needs_info")),
               "reasoning": result.get("reasoning", ""),
           }
@@ -559,6 +567,8 @@ jobs:
           # Print summary for the workflow log.
           print(f"Labels to add: {labels_add}")
           print(f"Labels to remove: {labels_remove}")
+          if v2_owns_scoring:
+              print("Databricks v2 owns priority and component labels")
           if output["duplicate_of"]:
               print(f"Duplicate of: #{output['duplicate_of']}")
           print(f"Reasoning: {output['reasoning']}")

--- a/deploy/issue_prioritization/README.md
+++ b/deploy/issue_prioritization/README.md
@@ -83,6 +83,10 @@ Keep the write variable false until a dry-run's `ranking.*` and
 `mutations.json` artifacts have been reviewed. Apply mode also creates any
 missing labels declared in `.github/issue-prioritization-labels.json`.
 
+At rollout, set the repository variable `ISSUE_PRIORITIZATION_V2_ENABLED=true`
+at the same time as enabling this job. That stops the legacy issue-triage action
+from writing priority or component labels, so Databricks is the only owner.
+
 ## Tests
 
 ```bash

--- a/deploy/issue_prioritization/databricks.yml
+++ b/deploy/issue_prioritization/databricks.yml
@@ -42,7 +42,7 @@ variables:
   github_repo:
     default: omnigent-ai/omnigent
   github_secret_scope:
-    description: Secret scope containing the GitHub token used only in apply mode.
+    description: Secret scope for legacy ownership reads and apply-mode writes.
     default: ""
   github_token_secret_key:
     default: github-token

--- a/deploy/issue_prioritization/resources/issue_prioritization.job.yml
+++ b/deploy/issue_prioritization/resources/issue_prioritization.job.yml
@@ -1,7 +1,7 @@
 resources:
   jobs:
     issue_prioritization:
-      name: "[${bundle.target}] Omnigent issue prioritization"
+      name: "[${bundle.target}] Issue prioritization v2"
       max_concurrent_runs: 1
       trigger:
         pause_status: PAUSED


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add the default-off `ISSUE_PRIORITIZATION_V2_ENABLED` repository-variable switch.
- When enabled, legacy issue triage keeps type/routing/duplicate behavior but stops writing priority and component labels.
- Document the coordinated rollout so Databricks becomes the only scoring-label owner.

```text
switch unset/false -> legacy triage owns priority + components
switch true        -> Databricks job owns priority + components
```

## Test Plan

- Executed the workflow's embedded label-planning Python with the switch set to both `false` and `true`.
- `pre-commit run --all-files`

## Demo

N/A — non-visual workflow handoff change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The exact embedded workflow code preserved current labels when false and suppressed only priority/component labels when true; YAML and repository hooks pass.
