### PR TITLE
fix(claude-native): map Claude's new "shell" status to idle

### DIFF
--- a/omnigent/claude_native_status_file.py
+++ b/omnigent/claude_native_status_file.py
@@ -45,6 +45,13 @@ _STATUS_TO_RUNNER: dict[str, str] = {
     "busy": RUNNING,
     "waiting": RUNNING,
     "idle": IDLE,
+    # The turn ended but a background shell is still alive (Claude Code
+    # >= v2.1.197). The agent loop is idle, so this maps to ``idle`` — the
+    # Stop hook separately relabels its own ``idle`` to ``waiting`` with the
+    # shell tally, which is what keeps the spinner lit. Mapping ``shell`` to
+    # ``running`` would strand the composer on the "(queued)" placeholder,
+    # since the session never reads idle while a background shell runs.
+    "shell": IDLE,
     # Background-job literals, mapped defensively for robustness.
     "running": RUNNING,
     "completed": IDLE,

--- a/tests/test_claude_native_status_file.py
+++ b/tests/test_claude_native_status_file.py
@@ -121,14 +121,18 @@ def test_resolve_missing_pid_no_session_returns_none(tmp_path: Path) -> None:
 
 
 def test_read_status_maps_interactive_vocabulary(tmp_path: Path) -> None:
-    """``busy``/``waiting`` → running, ``idle`` → idle."""
+    """``busy``/``waiting`` → running, ``idle``/``shell`` → idle."""
     sessions = tmp_path / "sessions"
     busy = _write_session_file(sessions, pid=1, session_id="s", status="busy")
     waiting = _write_session_file(sessions, pid=2, session_id="s", status="waiting")
     idle = _write_session_file(sessions, pid=3, session_id="s", status="idle")
+    shell = _write_session_file(sessions, pid=4, session_id="s", status="shell")
     assert read_session_status(busy).runner_status == RUNNING
     assert read_session_status(waiting).runner_status == RUNNING
     assert read_session_status(idle).runner_status == IDLE
+    # Turn ended, background shell still alive → the agent loop is idle. Mapping
+    # this to running would strand the composer queueing messages.
+    assert read_session_status(shell).runner_status == IDLE
     # Raw status is preserved for future "needs input" surfacing.
     assert read_session_status(waiting).raw_status == "waiting"
 


### PR DESCRIPTION
## Related issue

A regression for claude code session: if there's background tasks running and user sends a new message, the new message is always queued instead of sent immediately.

## Summary

- Claude Code >= v2.1.197 writes a new `status: "shell"` value to its per-session status file when a turn ends but a background shell is still alive.
- The status-file poller (`SessionStatusPoller`, added in #3906) didn't know that literal, so `read_session_status` returned `None`, the poller fired no edge and stayed stuck on its last `running` — while also suppressing the PTY watcher's `idle`. The session never reported idle while a background shell ran, so `sessionStatus` stayed `running`, `shouldQueueSend` returned true, and **every new message queued client-side instead of starting a fresh turn**.
- This regressed the "don't queue while only background work runs" behavior fixed in #2974.
- Fix: map `shell` → `idle`. The agent loop is idle; the Stop hook separately relabels its own `idle` → `waiting` with the shell tally, which is what keeps the "N background tasks still running" spinner lit.

## Test Plan

- Reproduced live: created a claude-native session, started a background loop (`while true; do echo joke; sleep 30; done`), tapped the raw `session.status` SSE stream, and confirmed Claude's status file reports `"shell"` at turn-end (`~/.claude/sessions/<pid>.json`, version `2.1.197`). Verified `"shell"` was absent from `_STATUS_TO_RUNNER`, so `read_session_status` returned `None` and the poller stayed stuck on `running`.
- Confirmed the server does NOT mangle `waiting` for top-level sessions (POSTing `external_session_status: waiting`+count passes through to the client SSE unchanged) — so the bug is isolated to the poller's status mapping.
- `pytest tests/test_claude_native_status_file.py` — all 12 pass, including the new `shell` → idle assertion.
- `ruff format`, `ruff check`, and `pyrefly` clean via pre-commit.

## Demo

N/A — backend status-mapping fix, no visual component of its own (restores prior composer behaviour).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Extended `test_read_status_maps_interactive_vocabulary` to assert `shell` → idle. Manually verified the live repro end-to-end: Claude's status file reports `"shell"` while a background shell runs after turn-end, which the old map dropped to `None`; the new mapping resolves the session to idle so the composer sends immediately.

## Changelog

Claude Code sessions with a background task running no longer queue new messages — they start a fresh turn immediately.