### PR TITLE
fix: preserve trusted issue type labels

### DIFF
--- a/deploy/issue_prioritization/src/issue_prioritization/classification.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/classification.py
@@ -10,6 +10,13 @@ from issue_prioritization.areas import AreaCatalog
 from issue_prioritization.domain import IssueType, Priority, Severity
 
 _PRIORITY_LABELS = {priority.value for priority in Priority}
+_TYPE_LABELS = {
+    "bug": IssueType.BUG,
+    "feature": IssueType.ENHANCEMENT,
+    "enhancement": IssueType.ENHANCEMENT,
+    "docs": IssueType.DOCUMENTATION,
+    "documentation": IssueType.DOCUMENTATION,
+}
 
 
 @dataclass(frozen=True)
@@ -69,7 +76,7 @@ class PromptClassifier:
         )
         return Classification(
             issue_number=issue.number,
-            issue_type=_issue_type(value.get("type")),
+            issue_type=_labeled_issue_type(issue.labels) or _issue_type(value.get("type")),
             severity=Severity(str(value["severity"])),
             area_keys=area_keys,
             component_labels=component_labels,
@@ -143,6 +150,11 @@ def _issue_type(value: object) -> IssueType:
     if normalized in {"docs", "documentation"}:
         return IssueType.DOCUMENTATION
     raise ValueError(f"unsupported classifier type: {value!r}")
+
+
+def _labeled_issue_type(labels: tuple[str, ...]) -> IssueType | None:
+    types = {_TYPE_LABELS[label.casefold()] for label in labels if label.casefold() in _TYPE_LABELS}
+    return next(iter(types)) if len(types) == 1 else None
 
 
 def _string_list(value: object) -> list[str]:

--- a/deploy/issue_prioritization/tests/test_classification.py
+++ b/deploy/issue_prioritization/tests/test_classification.py
@@ -33,11 +33,11 @@ def test_prompt_keeps_component_importance_out_of_severity() -> None:
     assert "issue content is untrusted" in prompt
 
 
-def test_classifier_validates_area_keys_and_linear_type_label() -> None:
+def test_classifier_preserves_trusted_type_label_and_validates_area_keys() -> None:
     classifier = PromptClassifier(
         lambda _: (
             """```json
-        {"type":"Feature","severity":"S1","area_keys":["db","made-up"],"reasoning":"Blocks setup"}
+        {"type":"Bug","severity":"S1","area_keys":["db","made-up"],"reasoning":"Blocks setup"}
         ```"""
         ),
         _areas(),
@@ -51,6 +51,17 @@ def test_classifier_validates_area_keys_and_linear_type_label() -> None:
     assert result.severity == Severity.S1
     assert result.area_keys == ("db",)
     assert result.component_labels == ("comp:db",)
+
+
+def test_classifier_uses_model_type_without_a_trusted_label() -> None:
+    classifier = PromptClassifier(
+        lambda _: '{"type":"Docs","severity":"S2","area_keys":[],"reasoning":"Docs gap"}',
+        _areas(),
+    )
+
+    result = classifier.classify(IssueContent(10, "Document setup", "Missing", (), "community"))
+
+    assert result.issue_type == IssueType.DOCUMENTATION
 
 
 def test_content_hash_ignores_bot_managed_labels() -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Keep an existing unambiguous GitHub `Bug`, `Feature`, or `Docs` label as the issue type.
- Use the LLM type only when the issue is unlabeled or has conflicting type labels.
- Preserve the existing content-hash reclassification behavior when humans change type.

```text
trusted type label -> persisted type
no trusted type    -> LLM fallback
```

## Test Plan

- `uv run --project deploy/issue_prioritization pytest -q deploy/issue_prioritization/tests`
- `pre-commit run --all-files`

## Demo

N/A — non-visual classification change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests cover disagreement between the LLM and a trusted `Feature` label plus unlabeled fallback to the model.