### PR TITLE
fix: sync bundle support files

### DIFF
--- a/deploy/issue_prioritization/databricks.yml
+++ b/deploy/issue_prioritization/databricks.yml
@@ -7,11 +7,9 @@ include:
 sync:
   paths:
     - .
-    - ../../.github
-  include:
-    - .github/areas.json
-    - .github/MAINTAINER
-    - .github/issue-prioritization-labels.json
+    - ../../.github/areas.json
+    - ../../.github/MAINTAINER
+    - ../../.github/issue-prioritization-labels.json
 
 artifacts:
   default:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Sync only the three repository support files required by the issue-prioritization bundle.
- Avoid syncing the entire `.github` tree while keeping strict bundle validation valid.

## Test Plan

- `uv run databricks bundle validate -t dev --profile logfood`
- `uv run databricks bundle sync -t dev --dry-run --profile logfood`

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Strict bundle validation passes, and the sync dry-run includes the bundle plus only `.github/areas.json`, `.github/MAINTAINER`, and `.github/issue-prioritization-labels.json`.