### PR TITLE
fix: read the live bronze issue contract

### DIFF
--- a/deploy/issue_prioritization/src/issue_prioritization/bronze.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/bronze.py
@@ -20,19 +20,22 @@ class BronzeIssue:
     created_at: datetime
     upvote_count: int
     duplicate_count: int
+    is_pull_request: bool = False
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, object]) -> BronzeIssue:
+        source = _with_raw_json(value)
         return cls(
-            number=int(_first(value, "number", "issue_number")),
-            title=str(_first(value, "title", default="")),
-            body=str(_first(value, "body", default="") or ""),
-            url=str(_first(value, "html_url", "url", default="")),
-            author=str(_first(value, "author_login", "user_login", "author", default="")),
-            labels=_labels(_first(value, "labels", "label_names", default=())),
-            created_at=_timestamp(_first(value, "created_at")),
-            upvote_count=_upvote_count(value),
-            duplicate_count=max(0, int(_first(value, "duplicate_count", default=0) or 0)),
+            number=int(_first(source, "number", "issue_number")),
+            title=str(_first(source, "title", default="")),
+            body=str(_first(source, "body", default="") or ""),
+            url=str(_first(source, "html_url", "url", default="")),
+            author=_author(source),
+            labels=_labels(_first(source, "labels", "label_names", default=())),
+            created_at=_timestamp(_first(source, "created_at")),
+            upvote_count=_upvote_count(source),
+            duplicate_count=max(0, int(_first(source, "duplicate_count", default=0) or 0)),
+            is_pull_request=bool(source.get("pull_request")),
         )
 
     def content(self) -> IssueContent:
@@ -66,6 +69,28 @@ def _first(value: Mapping[str, object], *names: str, default: object = None) -> 
         if name in value:
             return value[name]
     return default
+
+
+def _with_raw_json(value: Mapping[str, object]) -> dict[str, object]:
+    raw = value.get("raw_json")
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except json.JSONDecodeError:
+            raw = None
+    source = dict(raw) if isinstance(raw, Mapping) else {}
+    source.update({key: item for key, item in value.items() if item is not None})
+    return source
+
+
+def _author(value: Mapping[str, object]) -> str:
+    direct = _first(value, "author_login", "user_login", "author")
+    if direct is not None:
+        return str(direct)
+    user = value.get("user")
+    if isinstance(user, Mapping) and user.get("login"):
+        return str(user["login"])
+    return ""
 
 
 def _labels(value: object) -> tuple[str, ...]:

--- a/deploy/issue_prioritization/src/issue_prioritization/databricks_io.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/databricks_io.py
@@ -30,9 +30,10 @@ components ARRAY<STRING>"""
 
 
 class SparkIssueSource:
-    def __init__(self, spark: object, table: str) -> None:
+    def __init__(self, spark: object, table: str, repo: str) -> None:
         self.spark = spark
         self.table = _table(table)
+        self.repo = repo
 
     def load_open_issues(self) -> list[BronzeIssue]:
         frame = self.spark.table(self.table)
@@ -40,9 +41,11 @@ class SparkIssueSource:
         issues = []
         for row in rows:
             value = row.asDict(recursive=True)
-            if value.get("pull_request"):
+            if value.get("repo") != self.repo:
                 continue
-            issues.append(BronzeIssue.from_mapping(value))
+            issue = BronzeIssue.from_mapping(value)
+            if not issue.is_pull_request:
+                issues.append(issue)
         return issues
 
 

--- a/deploy/issue_prioritization/src/issue_prioritization/job.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/job.py
@@ -122,7 +122,7 @@ def main() -> None:
         if line.split("#", 1)[0].strip()
     }
     pipeline = IssuePrioritizationPipeline(
-        source=SparkIssueSource(spark, args.source_table),
+        source=SparkIssueSource(spark, args.source_table, args.github_repo),
         classifier=ai_query_classifier(spark, args.model_endpoint, areas),
         classifications=SparkClassificationRepository(spark, args.classifications_table),
         scores=SparkScoreSink(spark, args.scores_table, args.latest_scores_view),

--- a/deploy/issue_prioritization/tests/test_bronze.py
+++ b/deploy/issue_prioritization/tests/test_bronze.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 
 import pytest
@@ -16,11 +17,15 @@ def test_bronze_adapter_accepts_github_structs_and_json() -> None:
             "issue_number": 42,
             "title": "Android login fails",
             "body": "OIDC redirect does not return",
-            "html_url": "https://github.com/omnigent-ai/omnigent/issues/42",
             "user_login": "community",
             "labels": '[{"name":"Bug"},{"name":"P1-high"}]',
             "created_at": "2026-08-01T00:00:00Z",
-            "reactions": {"total_count": 5, "+1": 3, "-1": 2},
+            "raw_json": json.dumps(
+                {
+                    "html_url": "https://github.com/omnigent-ai/omnigent/issues/42",
+                    "reactions": {"total_count": 5, "+1": 3, "-1": 2},
+                }
+            ),
         }
     )
     classification = Classification(
@@ -36,6 +41,7 @@ def test_bronze_adapter_accepts_github_structs_and_json() -> None:
     normalized = issue.to_issue(classification, datetime(2026, 8, 5, tzinfo=UTC))
 
     assert issue.labels == ("Bug", "P1-high")
+    assert issue.url == "https://github.com/omnigent-ai/omnigent/issues/42"
     assert issue.upvote_count == 3
     assert normalized.current_priority == Priority.P1
     assert normalized.age_days == 4
@@ -56,4 +62,55 @@ def test_bronze_adapter_does_not_count_non_upvote_reactions() -> None:
 
 def test_spark_source_rejects_unquoted_table_expressions() -> None:
     with pytest.raises(ValueError, match="catalog.schema.table"):
-        SparkIssueSource(object(), "main.schema.issues WHERE true")
+        SparkIssueSource(object(), "main.schema.issues WHERE true", "org/repo")
+
+
+def test_spark_source_filters_repository_and_pull_requests() -> None:
+    base = {
+        "issue_number": 42,
+        "title": "Android login fails",
+        "created_at": "2026-08-01T00:00:00Z",
+        "state": "open",
+        "repo": "omnigent-ai/omnigent",
+        "raw_json": json.dumps({"html_url": "https://github.com/issues/42"}),
+    }
+
+    class Row:
+        def __init__(self, value):
+            self.value = value
+
+        def asDict(self, recursive=True):
+            return self.value
+
+    class Frame:
+        def where(self, expression):
+            assert expression == "state = 'open'"
+            return self
+
+        def collect(self):
+            return [
+                Row(base),
+                Row({**base, "issue_number": 43, "repo": "other/repo"}),
+                Row(
+                    {
+                        **base,
+                        "issue_number": 44,
+                        "raw_json": json.dumps(
+                            {
+                                "html_url": "https://github.com/pull/44",
+                                "pull_request": {"url": "https://api.github.com/pulls/44"},
+                            }
+                        ),
+                    }
+                ),
+            ]
+
+    class Spark:
+        def table(self, table):
+            assert table == "main.team.issues"
+            return Frame()
+
+    source = SparkIssueSource(Spark(), "main.team.issues", "omnigent-ai/omnigent")
+    issues = source.load_open_issues()
+
+    assert [issue.number for issue in issues] == [42]


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Read URL, GitHub `+1` reactions, author, and pull-request metadata from the live bronze table's `raw_json`.
- Scope ingestion to the configured repository and defensively exclude pull requests.
- ELI5: the adapter now reads the envelope actually stored in Databricks instead of expecting flattened GitHub fields.

```text
bronze row + raw_json -> normalized issue -> repo/PR filter -> scoring
```

## Test Plan

- `uv run pytest deploy/issue_prioritization/tests/test_bronze.py`
- `uv run pytest deploy/issue_prioritization/tests`
- `uv run pre-commit run --all-files`

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The suite covers nested `raw_json`, GitHub `+1` extraction, repository filtering, and pull-request exclusion. The full local issue-prioritization suite passes with 50 tests.