### PR TITLE
feat: prepare issue ranking dashboard draft

### DIFF
--- a/deploy/issue_prioritization/README.md
+++ b/deploy/issue_prioritization/README.md
@@ -63,6 +63,22 @@ databricks bundle run issue_prioritization --target dev --profile <profile> \
 priorities were adopted. Human-authored priority events remain blocked in
 `mutations.json`.
 
+## Dashboard draft
+
+Prepare an idempotent local dashboard draft after a complete scoring run:
+
+```bash
+databricks api get /api/2.0/lakeview/dashboards/<dashboard-id> \
+  --profile <profile> > /tmp/issue-dashboard.json
+uv run --project deploy/issue_prioritization issue-priority-dashboard-draft \
+  --input /tmp/issue-dashboard.json \
+  --output /tmp/issue-dashboard-draft.json
+```
+
+The draft adds a top-200 ranking table backed by `issue_scores_latest`. The
+command only writes the local output file; it never updates or publishes a
+dashboard.
+
 ## GitHub apply gate
 
 The schedule is paused. GitHub writes additionally require `mode=apply`, the

--- a/deploy/issue_prioritization/README.md
+++ b/deploy/issue_prioritization/README.md
@@ -75,7 +75,7 @@ uv run --project deploy/issue_prioritization issue-priority-dashboard-draft \
   --output /tmp/issue-dashboard-draft.json
 ```
 
-The draft adds a top-200 ranking table backed by `issue_scores_latest`. The
+The draft adds a complete ranking table backed by `issue_scores_latest`. The
 command only writes the local output file; it never updates or publishes a
 dashboard.
 

--- a/deploy/issue_prioritization/pyproject.toml
+++ b/deploy/issue_prioritization/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.12"
 
 [project.scripts]
 issue-priority = "issue_prioritization.cli:main"
+issue-priority-dashboard-draft = "issue_prioritization.dashboard:main"
 issue-priority-job = "issue_prioritization.job:main"
 
 [dependency-groups]

--- a/deploy/issue_prioritization/src/issue_prioritization/dashboard.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/dashboard.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from collections.abc import Mapping
+from pathlib import Path
+
+DATASET_NAME = "issue_priority_ranking"
+PAGE_NAME = "issue_analysis"
+WIDGET_NAME = "ia-priority-ranking"
+
+
+def patch_dashboard(value: Mapping[str, object]) -> dict[str, object]:
+    dashboard = _serialized_dashboard(value)
+    datasets = dashboard.get("datasets")
+    pages = dashboard.get("pages")
+    if not isinstance(datasets, list) or not isinstance(pages, list):
+        raise ValueError("dashboard must contain datasets and pages")
+
+    replacement = _ranking_dataset()
+    dashboard["datasets"] = [
+        *[dataset for dataset in datasets if _name(dataset) != DATASET_NAME],
+        replacement,
+    ]
+
+    page = next((item for item in pages if _name(item) == PAGE_NAME), None)
+    if not isinstance(page, dict):
+        raise ValueError(f"dashboard page {PAGE_NAME!r} not found")
+    layout = page.get("layout")
+    if not isinstance(layout, list):
+        raise ValueError(f"dashboard page {PAGE_NAME!r} has no layout")
+
+    retained = [item for item in layout if _widget_name(item) != WIDGET_NAME]
+    page["layout"] = [*retained, _ranking_widget(_next_row(retained))]
+    return dashboard
+
+
+def _serialized_dashboard(value: Mapping[str, object]) -> dict[str, object]:
+    serialized = value.get("serialized_dashboard")
+    if isinstance(serialized, str):
+        parsed = json.loads(serialized)
+        if not isinstance(parsed, dict):
+            raise ValueError("serialized_dashboard must contain a JSON object")
+        return parsed
+    return copy.deepcopy(dict(value))
+
+
+def _name(value: object) -> object:
+    return value.get("name") if isinstance(value, Mapping) else None
+
+
+def _widget_name(value: object) -> object:
+    if not isinstance(value, Mapping):
+        return None
+    return _name(value.get("widget"))
+
+
+def _next_row(layout: list[object]) -> int:
+    bottoms = []
+    for item in layout:
+        if not isinstance(item, Mapping):
+            continue
+        position = item.get("position")
+        if not isinstance(position, Mapping):
+            continue
+        bottoms.append(int(position.get("y", 0)) + int(position.get("height", 0)))
+    return max(bottoms, default=0)
+
+
+def _ranking_dataset() -> dict[str, object]:
+    return {
+        "name": DATASET_NAME,
+        "displayName": "Issue Priority Ranking",
+        "queryLines": [
+            "SELECT\n",
+            "  rank,\n",
+            "  score,\n",
+            "  proposed_priority,\n",
+            "  COALESCE(current_priority, 'Unprioritized') AS current_priority,\n",
+            "  severity,\n",
+            "  issue_number,\n",
+            "  title,\n",
+            "  CONCAT_WS(', ', component_labels) AS components,\n",
+            "  upvote_count,\n",
+            "  CONCAT_WS(', ', mutation_blocked) AS mutation_blocked,\n",
+            "  url\n",
+            "FROM main.team_eng_omnigent.issue_scores_latest\n",
+            "ORDER BY rank\n",
+            "LIMIT 200 ",
+        ],
+    }
+
+
+def _ranking_widget(y: int) -> dict[str, object]:
+    fields = [
+        "rank",
+        "score",
+        "proposed_priority",
+        "current_priority",
+        "severity",
+        "issue_number",
+        "title",
+        "components",
+        "upvote_count",
+        "mutation_blocked",
+        "url",
+    ]
+    columns: list[dict[str, object]] = [
+        {"fieldName": "rank", "displayName": "Rank"},
+        {
+            "fieldName": "score",
+            "displayName": "Score",
+            "format": {
+                "type": "number",
+                "decimalPlaces": {"type": "max", "places": 2},
+            },
+        },
+        {"fieldName": "proposed_priority", "displayName": "Proposed"},
+        {"fieldName": "current_priority", "displayName": "Current"},
+        {"fieldName": "severity", "displayName": "Severity"},
+        {
+            "fieldName": "issue_number",
+            "displayName": "Issue",
+            "link": {"templatedURL": "{{url}}"},
+        },
+        {"fieldName": "title", "displayName": "Title"},
+        {"fieldName": "components", "displayName": "Components"},
+        {"fieldName": "upvote_count", "displayName": "Upvotes"},
+        {"fieldName": "mutation_blocked", "displayName": "Protected Overrides"},
+    ]
+    return {
+        "widget": {
+            "name": WIDGET_NAME,
+            "queries": [
+                {
+                    "name": "main_query",
+                    "query": {
+                        "datasetName": DATASET_NAME,
+                        "fields": [{"name": field, "expression": f"`{field}`"} for field in fields],
+                        "disaggregated": True,
+                    },
+                }
+            ],
+            "spec": {
+                "version": 2,
+                "widgetType": "table",
+                "frame": {
+                    "showTitle": True,
+                    "title": "Issue Priority Ranking",
+                    "showDescription": True,
+                    "description": (
+                        "Top 200 issues from the latest complete scoring run. Proposed labels "
+                        "remain a dry-run until GitHub writes are explicitly enabled."
+                    ),
+                },
+                "encodings": {"columns": columns},
+                "data": {"queryName": "main_query"},
+            },
+        },
+        "position": {"x": 0, "y": y, "width": 12, "height": 8},
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Prepare a local issue-ranking patch for an Omnigent dashboard export."
+    )
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    source = json.loads(args.input.read_text())
+    if not isinstance(source, dict):
+        raise ValueError("dashboard input must be a JSON object")
+    args.output.write_text(json.dumps(patch_dashboard(source), indent=2) + "\n")

--- a/deploy/issue_prioritization/src/issue_prioritization/dashboard.py
+++ b/deploy/issue_prioritization/src/issue_prioritization/dashboard.py
@@ -86,8 +86,7 @@ def _ranking_dataset() -> dict[str, object]:
             "  CONCAT_WS(', ', mutation_blocked) AS mutation_blocked,\n",
             "  url\n",
             "FROM main.team_eng_omnigent.issue_scores_latest\n",
-            "ORDER BY rank\n",
-            "LIMIT 200 ",
+            "ORDER BY rank ",
         ],
     }
 
@@ -150,7 +149,7 @@ def _ranking_widget(y: int) -> dict[str, object]:
                     "title": "Issue Priority Ranking",
                     "showDescription": True,
                     "description": (
-                        "Top 200 issues from the latest complete scoring run. Proposed labels "
+                        "All issues from the latest complete scoring run. Proposed labels "
                         "remain a dry-run until GitHub writes are explicitly enabled."
                     ),
                 },

--- a/deploy/issue_prioritization/tests/test_dashboard.py
+++ b/deploy/issue_prioritization/tests/test_dashboard.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from issue_prioritization.dashboard import DATASET_NAME, WIDGET_NAME, patch_dashboard
+
+
+def _dashboard() -> dict[str, object]:
+    return {
+        "datasets": [{"name": "existing", "queryLines": ["SELECT 1 "]}],
+        "pages": [
+            {
+                "name": "issue_analysis",
+                "pageType": "PAGE_TYPE_CANVAS",
+                "layoutVersion": "GRID_V1",
+                "layout": [
+                    {
+                        "widget": {"name": "existing-widget"},
+                        "position": {"x": 0, "y": 5, "width": 12, "height": 7},
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_dashboard_patch_adds_ranking_after_existing_layout() -> None:
+    patched = patch_dashboard(_dashboard())
+
+    dataset = next(item for item in patched["datasets"] if item["name"] == DATASET_NAME)
+    assert "issue_scores_latest" in "".join(dataset["queryLines"])
+    assert dataset["queryLines"][-1].endswith(" ")
+
+    widget = patched["pages"][0]["layout"][-1]
+    assert widget["widget"]["name"] == WIDGET_NAME
+    assert widget["position"] == {"x": 0, "y": 12, "width": 12, "height": 8}
+    assert widget["widget"]["spec"]["version"] == 2
+    assert widget["widget"]["spec"]["widgetType"] == "table"
+    fields = {item["name"] for item in widget["widget"]["queries"][0]["query"]["fields"]}
+    columns = {item["fieldName"] for item in widget["widget"]["spec"]["encodings"]["columns"]}
+    assert columns <= fields
+
+
+def test_dashboard_patch_accepts_rest_response_and_is_idempotent() -> None:
+    response = {"serialized_dashboard": json.dumps(_dashboard())}
+
+    once = patch_dashboard(response)
+    twice = patch_dashboard(once)
+
+    assert twice == once
+    assert sum(item["name"] == DATASET_NAME for item in twice["datasets"]) == 1
+    assert sum(item["widget"]["name"] == WIDGET_NAME for item in twice["pages"][0]["layout"]) == 1
+
+
+def test_dashboard_patch_requires_issue_analysis_page() -> None:
+    with pytest.raises(ValueError, match="issue_analysis"):
+        patch_dashboard({"datasets": [], "pages": []})

--- a/deploy/issue_prioritization/tests/test_dashboard.py
+++ b/deploy/issue_prioritization/tests/test_dashboard.py
@@ -31,6 +31,7 @@ def test_dashboard_patch_adds_ranking_after_existing_layout() -> None:
 
     dataset = next(item for item in patched["datasets"] if item["name"] == DATASET_NAME)
     assert "issue_scores_latest" in "".join(dataset["queryLines"])
+    assert "LIMIT" not in "".join(dataset["queryLines"])
     assert dataset["queryLines"][-1].endswith(" ")
 
     widget = patched["pages"][0]["layout"][-1]


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Add an idempotent, local-only CLI that inserts a top-200 priority ranking table into the existing Issue Analysis dashboard export.
- Show score, proposed/current priority, severity, components, upvotes, and protected human overrides from `issue_scores_latest`.
- ELI5: this prepares the dashboard draft file for review but never calls the dashboard update or publish APIs.

```text
dashboard export + issue_scores_latest contract -> local draft JSON
                                              X no live mutation
```

## Test Plan

- `uv run --project deploy/issue_prioritization pytest deploy/issue_prioritization/tests` (53 passed)
- `pre-commit run --all-files`
- Applied the CLI twice to today's dashboard export and verified identical output.
- Validated the ranking query shape read-only on warehouse `9fb2ea023126d1f4`.
- `databricks bundle validate --strict --target dev --profile logfood`
- `databricks bundle sync --dry-run --target dev --profile logfood`

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests cover REST-export parsing, placement after the existing layout, required table bindings, missing-page errors, and idempotency. Manual verification used the current Omnigent dashboard export without updating or publishing it.