### PR TITLE
fix: correct harness version gates and pi reasoning detection

### DIFF
--- a/dev/lint/hardcoded_model_allowlist.txt
+++ b/dev/lint/hardcoded_model_allowlist.txt
@@ -36,6 +36,7 @@ omnigent/inner/pi_executor.py databricks-gpt-5-4 1
 omnigent/inner/pi_executor.py databricks-gpt-5-4-mini 1
 omnigent/inner/pi_executor.py databricks-gpt-5-5 1
 omnigent/inner/pi_executor.py databricks-gpt-5-5-pro 1
+omnigent/inner/pi_executor.py gpt-5-6 1
 omnigent/model_catalog.py claude-fable-5 1
 omnigent/model_catalog.py claude-haiku-4-5 1
 omnigent/model_catalog.py claude-opus-4-8 1

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -864,15 +864,38 @@ def _build_models_json(
 # parser only consumes that channel when the model entry declares
 # ``reasoning: true``; without it the stream carries no ``content`` and the
 # turn dies with "Stream ended without finish_reason".
+# gpt-5-6 also needs it: pi 0.80.7 hardcodes ``store: false`` and then replays a
+# prior reasoning-item id (``rs_...``) on a later tool-loop turn, which CST
+# cannot resolve because ``store: false`` means items are never persisted.
+# Declaring reasoning here makes pi request portable ``reasoning.encrypted_content``,
+# the stateless fix. The real ids use dashes (``databricks-gpt-5-6-sol``,
+# ``system.ai.gpt-5-6-sol``), so the fragment is dash-form, not the dotted prose.
 # Note: GLM, kimi, and inkling now route via Responses API (system.ai.* ids)
 # so they no longer need this flag.
-_PI_REASONING_MODEL_FRAGMENTS: tuple[str, ...] = ("deepseek",)
+_PI_REASONING_MODEL_FRAGMENTS: tuple[str, ...] = ("deepseek", "gpt-5-6")
 
 
 def _pi_model_is_reasoning(model: str) -> bool:
     """Return whether *model* needs Pi's ``reasoning: true`` model flag."""
     lower = model.lower()
-    return any(fragment in lower for fragment in _PI_REASONING_MODEL_FRAGMENTS)
+    return any(_fragment_matches(fragment, lower) for fragment in _PI_REASONING_MODEL_FRAGMENTS)
+
+
+def _fragment_matches(fragment: str, text: str) -> bool:
+    """True if *fragment* occurs in *text* and is not immediately followed by a digit.
+
+    A plain substring test would let a version-bearing fragment like ``gpt-5-6``
+    also match a longer, unrelated token such as ``gpt-5-60`` and mis-classify it
+    as a reasoning model. Requiring a non-digit after the match keeps ``gpt-5-6``
+    and ``gpt-5-6-sol`` matching while rejecting ``gpt-5-60``.
+    """
+    start = text.find(fragment)
+    while start != -1:
+        end = start + len(fragment)
+        if end == len(text) or not text[end].isdigit():
+            return True
+        start = text.find(fragment, start + 1)
+    return False
 
 
 def _pi_needs_responses_api(model: str) -> bool:

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -103,13 +103,15 @@ KIRO_KEY = "kiro"
 #   to the day after 2026-06-01 so we don't support stale pre-June builds.
 # - kimi: first ``kimi-cli`` release after 2026-06-01 is 1.47.0
 #   (https://github.com/MoonshotAI/kimi-cli/blob/main/CHANGELOG.md).
-# - hermes: parent_session_id schema was introduced in v0.17.0, but Hermes now
-#   ships date-tagged releases; the first one after 2026-06-01 is 2026.06.05.
+# - hermes: parent_session_id schema was introduced in v0.17.0. Although Hermes
+#   also publishes date-tagged releases, `hermes --version` reports the agent
+#   SEMVER (e.g. 0.19.0), which is what _parse_harness_cli_version extracts, so
+#   the floor must be the semver feature floor (0.17.0), not a YYYY.MM.DD date.
 _CODEX_MIN_VERSION = "0.137.0"
 _PI_MIN_VERSION = "0.79.0"
 _QWEN_MIN_VERSION = "0.18.1"
 _GOOSE_MIN_VERSION = "1.38.0"
-_HERMES_MIN_VERSION = "2026.06.05"
+_HERMES_MIN_VERSION = "0.17.0"
 _KIRO_MIN_VERSION = "2.10.0"
 _CLAUDE_MIN_VERSION = "2.1.161"
 _CURSOR_MIN_VERSION = "2026.06.02"
@@ -179,10 +181,11 @@ _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
         # ``pi >= 0.79.0``; older CLIs would prompt mid-session.
         min_version=_PI_MIN_VERSION,
     ),
-    # Pin the install to the supported 1.17.x range: opencode-ai's npm ``latest``
+    # Pin the install to the 1.17.x range: opencode-ai's npm ``latest``
     # is a ``0.0.0-beta-*`` pre-release, so a bare ``opencode-ai`` would install a
     # version the runtime version-check (``check_opencode_version``,
-    # >=1.17.7,<1.18.0) then rejects. ``~1.17.7`` mirrors that exact range.
+    # >=1.17.7,<1.19.0) then rejects. ``~1.17.7`` (>=1.17.7,<1.18.0) stays a
+    # conservative subset of that gate, keeping the install on the 1.17.x line.
     # The same version bounds are enforced in setup via ``min_version`` /
     # ``max_version_exclusive`` so the install/upgrade prompt fires before
     # the runtime gate does.

--- a/omnigent/opencode_native_app_server.py
+++ b/omnigent/opencode_native_app_server.py
@@ -98,7 +98,7 @@ _VERSION_RE = re.compile(r"(\d+\.\d+\.\d+(?:[-.][0-9A-Za-z]+)*)")
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 # Escape hatch: set truthy to bypass the OpenCode CLI version gate (e.g. to
-# try an as-yet-unvalidated 1.18+/v2 release). Mirrors OMNIGENT_NO_UPDATE_CHECK.
+# try an as-yet-unvalidated 1.19+/v2 release). Mirrors OMNIGENT_NO_UPDATE_CHECK.
 _SKIP_VERSION_CHECK_ENV = "OMNIGENT_OPENCODE_SKIP_VERSION_CHECK"
 
 

--- a/omnigent/opencode_native_client.py
+++ b/omnigent/opencode_native_client.py
@@ -28,9 +28,9 @@ import httpx
 _logger = logging.getLogger(__name__)
 
 # Pinned OpenCode CLI/API version range. The source monorepo reports
-# 1.17.7; we accept 1.17.x and refuse 1.18+ until validated.
+# 1.17.7; we accept 1.17.x and 1.18.x and refuse 1.19+ until validated.
 OPENCODE_MIN_VERSION = "1.17.7"
-OPENCODE_MAX_VERSION_EXCLUSIVE = "1.18.0"
+OPENCODE_MAX_VERSION_EXCLUSIVE = "1.19.0"
 
 _DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
 

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -31,6 +31,7 @@ from omnigent.inner.pi_executor import (
     PiExecutor,
     _build_models_json,
     _generate_extension_js,
+    _pi_model_is_reasoning,
     _pi_provider_for_model,
     _PiRpcSession,
     _redact_argv_for_log,
@@ -455,6 +456,27 @@ class TestBuildModelsJson(unittest.TestCase):
         provider = result["providers"][_pi_provider_for_model(model)]
         entry = next(e for e in provider["models"] if e["id"] == model)
         self.assertIs(entry.get("reasoning"), True, model)
+
+    def test_dynamic_gpt_5_6_model_gets_reasoning_flag(self):
+        # pi 0.80.7 hardcodes ``store: false`` and replays a prior reasoning-item
+        # id on later tool-loop turns; CST cannot resolve it without persistence.
+        # Marking gpt-5-6 as reasoning makes pi request portable
+        # ``reasoning.encrypted_content`` (the stateless fix).
+        model = "databricks-gpt-5-6-sol"
+        result = _build_models_json("https://host.example.com", "tok", model=model)
+        provider = result["providers"][_pi_provider_for_model(model)]
+        entry = next(e for e in provider["models"] if e["id"] == model)
+        self.assertIs(entry.get("reasoning"), True, model)
+
+    def test_pi_model_is_reasoning_gpt_5_6_boundary(self):
+        # The gpt-5-6 fragment must classify the real (dash-form) ids as
+        # reasoning, but a plain substring check would also match a malformed
+        # token like ``gpt-5-60``; the digit-boundary guard rejects that.
+        self.assertTrue(_pi_model_is_reasoning("databricks-gpt-5-6-luna"))
+        self.assertTrue(_pi_model_is_reasoning("databricks-gpt-5-6-sol"))
+        self.assertTrue(_pi_model_is_reasoning("system.ai.gpt-5-6-sol"))
+        self.assertTrue(_pi_model_is_reasoning("databricks-deepseek-r1"))
+        self.assertFalse(_pi_model_is_reasoning("databricks-gpt-5-60"))
 
     def test_dynamic_non_reasoning_model_has_no_reasoning_flag(self):
         model = "databricks-mlflow-2-5-pro"

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -1076,7 +1076,7 @@ def test_ui_setup_steps_generic_for_non_installable() -> None:
 @pytest.mark.parametrize(
     "key,min_version,max_version_exclusive",
     [
-        (hi.OPENCODE_KEY, "1.17.7", "1.18.0"),
+        (hi.OPENCODE_KEY, "1.17.7", "1.19.0"),
         (hi.CURSOR_KEY, "2026.06.02", None),
         (hi.KIMI_KEY, "1.47.0", None),
         (ANTHROPIC_FAMILY, "2.1.161", None),
@@ -1084,7 +1084,7 @@ def test_ui_setup_steps_generic_for_non_installable() -> None:
         (hi.PI_KEY, "0.79.0", None),
         (hi.QWEN_KEY, "0.18.1", None),
         (hi.GOOSE_KEY, "1.38.0", None),
-        (hi.HERMES_KEY, "2026.06.05", None),
+        (hi.HERMES_KEY, "0.17.0", None),
         (hi.KIRO_KEY, "2.10.0", None),
     ],
 )
@@ -1102,9 +1102,10 @@ def test_versioned_specs_declare_bounds(
     "version,expected",
     [
         ("1.17.6", False),  # below min
-        ("1.18.0", False),  # at max exclusive
+        ("1.19.0", False),  # at max exclusive
         ("2.0.0", False),  # above max
         ("1.17.8", True),  # inside range
+        ("1.18.3", True),  # inside range (1.18.x now accepted)
     ],
 )
 def test_harness_cli_installed_checks_version_for_versioned_specs(
@@ -1116,7 +1117,7 @@ def test_harness_cli_installed_checks_version_for_versioned_specs(
 
     def _run(argv: list[str], **k: object) -> subprocess.CompletedProcess[str]:
         if len(argv) >= 2 and argv[1] == "--version":
-            # OpenCode's supported range is [1.17.7, 1.18.0).
+            # OpenCode's supported range is [1.17.7, 1.19.0).
             return subprocess.CompletedProcess(
                 args=argv, returncode=0, stdout=f"{version}\n", stderr=""
             )
@@ -1207,7 +1208,6 @@ def test_parse_harness_cli_version_normalizes_date_versions(raw: str, expected: 
     [
         (hi.CURSOR_KEY, "2026.05.24", "2026.06.22"),
         (hi.KIMI_KEY, "1.46.0", "1.48.0"),
-        (hi.HERMES_KEY, "2026.05.29", "2026.06.19"),
     ],
 )
 def test_harness_cli_installed_enforces_default_post_2026_06_01_floors(
@@ -1238,6 +1238,32 @@ def test_harness_cli_installed_enforces_default_post_2026_06_01_floors(
 
     monkeypatch.setattr(hi.subprocess, "run", _run_ok)
     assert hi.harness_cli_installed(key) is True
+
+
+@pytest.mark.parametrize(
+    "reported,installed",
+    [
+        ("0.16.0", False),  # below the 0.17.0 parent_session_id feature floor
+        ("0.17.0", True),  # at the floor
+        ("0.19.0", True),  # above the floor
+    ],
+)
+def test_harness_cli_installed_enforces_hermes_semver_floor(
+    monkeypatch: pytest.MonkeyPatch, reported: str, installed: bool
+) -> None:
+    """Hermes gates on the agent SEMVER that ``hermes --version`` reports (e.g.
+    ``0.19.0``), not a YYYY.MM.DD date, so ``0.17.0`` is the effective floor."""
+    monkeypatch.setattr(hi.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    def _run(argv: list[str], **k: object) -> subprocess.CompletedProcess[str]:
+        if len(argv) >= 2 and argv[1] == "--version":
+            return subprocess.CompletedProcess(
+                args=argv, returncode=0, stdout=f"{reported}\n", stderr=""
+            )
+        raise AssertionError(f"unexpected subprocess: {argv!r}")
+
+    monkeypatch.setattr(hi.subprocess, "run", _run)
+    assert hi.harness_cli_installed(hi.HERMES_KEY) is installed
 
 
 def test_harness_cli_installed_false_when_version_unparseable(

--- a/tests/test_opencode_native_app_server.py
+++ b/tests/test_opencode_native_app_server.py
@@ -31,9 +31,10 @@ def test_parse_opencode_version() -> None:
 def test_check_version_in_range() -> None:
     check_opencode_version("1.17.7")
     check_opencode_version("1.17.99")
+    check_opencode_version("1.18.3")
 
 
-@pytest.mark.parametrize("version", ["1.16.0", "1.18.0", "2.0.0"])
+@pytest.mark.parametrize("version", ["1.16.0", "1.19.0", "2.0.0"])
 def test_check_version_out_of_range_raises(version: str) -> None:
     with pytest.raises(OpenCodeVersionError):
         check_opencode_version(version)
@@ -186,7 +187,7 @@ async def test_start_raises_on_unsupported_version_without_env(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setattr(appsrv.shutil, "which", lambda name: f"/usr/bin/{name}")
-    monkeypatch.setattr(appsrv, "resolve_opencode_version", lambda _path: "1.18.0")
+    monkeypatch.setattr(appsrv, "resolve_opencode_version", lambda _path: "1.19.0")
     monkeypatch.delenv("OMNIGENT_OPENCODE_SKIP_VERSION_CHECK", raising=False)
     server = OpenCodeNativeServer(
         bridge_dir=tmp_path,
@@ -214,7 +215,7 @@ async def test_start_skips_version_gate_when_env_set(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setattr(appsrv.shutil, "which", lambda name: f"/usr/bin/{name}")
-    monkeypatch.setattr(appsrv, "resolve_opencode_version", lambda _path: "1.18.0")
+    monkeypatch.setattr(appsrv, "resolve_opencode_version", lambda _path: "1.19.0")
     monkeypatch.setenv("OMNIGENT_OPENCODE_SKIP_VERSION_CHECK", "1")
     server = OpenCodeNativeServer(
         bridge_dir=tmp_path,
@@ -235,7 +236,7 @@ async def test_start_skips_version_gate_when_env_set(
     monkeypatch.setattr(appsrv.subprocess, "Popen", lambda argv, **kwargs: _FakeProc())
     monkeypatch.setattr(OpenCodeNativeServer, "_wait_until_ready", fake_wait)
     await server.start()
-    assert server.version == "1.18.0"
+    assert server.version == "1.19.0"
     assert server.process is not None
 
 


### PR DESCRIPTION
## Related issue

N/A

## Summary

Three narrowly scoped fixes to harness version gating and pi reasoning-model detection. No refactors beyond these. Reworked from the auto-closed #3444 onto current main, with the Fix 3 correctness gap Polly flagged now resolved.

- OpenCode version ceiling: `OPENCODE_MAX_VERSION_EXCLUSIVE` was `1.18.0`, but all current opencode releases are >=1.18.0 (1.18.3 local, 1.18.8 latest), so every release was rejected at boot with `OpenCodeVersionError`. Raised it to `1.19.0`. The constant feeds both the runtime gate (`opencode_native_app_server.check_opencode_version`) and the setup/readiness spec (`onboarding/harness_install.py` opencode `max_version_exclusive`), so the one edit covers both.
- Hermes version floor: `_HERMES_MIN_VERSION` was `2026.06.05`, a YYYY.MM.DD date, but `_parse_harness_cli_version` extracts the first x.y.z semver token from `hermes --version` (e.g. 0.19.0), not the date. `Version('0.19.0') < Version('2026.06.05')` always failed version-too-low, so every hermes install was rejected. Changed the floor to `0.17.0`, the real feature floor (parent_session_id schema, cited in the code comments), and documented the unit as a semver.
- Pi reasoning detection for gpt-5-6: `_PI_REASONING_MODEL_FRAGMENTS` only matched `deepseek`, so dynamically registered gpt-5-6 models were not marked `reasoning: true` and pi did not request portable `reasoning.encrypted_content`. Added `gpt-5-6`. Root cause: pi 0.80.7 hardcodes `store: false` then replays a prior reasoning-item id (`rs_...`) on a later tool-loop turn; CST cannot resolve it because `store: false` means items are not persisted. Requesting encrypted reasoning content is the stateless fix.

The fragment is spelled in dash form (`gpt-5-6`) to match the ids pi actually sees (`databricks-gpt-5-6-luna`, `system.ai.gpt-5-6-sol`); the prior revision used a dotted `gpt-5.6` that never matched any real id. A digit-boundary guard keeps `gpt-5-6` and `gpt-5-6-sol` matching while rejecting `gpt-5-60`. The new fragment is registered in `dev/lint/hardcoded_model_allowlist.txt` per the repo's no-hardcoded-models policy.

## Test Plan

- `uv run --no-sync python -m pytest tests/inner/test_pi_executor.py tests/test_opencode_native_app_server.py tests/onboarding/test_harness_install.py` -> 289 passed.
- `pre-commit` on all changed files (ruff format, ruff check, no-hardcoded-models, and the other anti-pattern hooks) -> all pass.
- Added/adjusted assertions: opencode 1.18.3 accepted / 1.19.0 rejected; a 0.19.0-style hermes version passes the floor while <0.17.0 fails; real dash-form gpt-5-6 ids (`databricks-gpt-5-6-sol`, `system.ai.gpt-5-6-sol`) are classified as reasoning models while `gpt-5-60` is not.

## Demo

N/A

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A
