### PR TITLE
fix(tests): repair stale helper name that crashes the inner-rest pytest shard

### DIFF
--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -291,7 +291,7 @@ class TestPromptExtraction(unittest.TestCase):
         # ``{"type": "image", "source": {"type": "base64", ...}}`` — raw base64
         # with no ``data:`` URI prefix. Redaction must catch this shape too, or a
         # replayed image tool result flattens hundreds of KB into prompt text.
-        from omnigent.inner.claude_sdk_executor import _render_prior_content
+        from omnigent.inner.claude_sdk_executor import _render_prior_content_blocks
 
         image_payload = base64.b64encode(b"synthetic png bytes").decode("ascii")
         content = [
@@ -305,7 +305,7 @@ class TestPromptExtraction(unittest.TestCase):
             }
         ]
 
-        rendered = _render_prior_content(content)
+        rendered = self._text_of(_render_prior_content_blocks(content))
 
         self.assertNotIn(image_payload, rendered)
         self.assertIn(


### PR DESCRIPTION
## Related issue

N/A (CI breakage on `main`)

## Summary

`Pytest (inner-rest)` is red on `main` with an `INTERNALERROR`, not a normal
test failure. Root cause is a stale helper name introduced in #3120:

```
tests/inner/test_claude_sdk_executor.py:294
    from omnigent.inner.claude_sdk_executor import _render_prior_content
ImportError: cannot import name '_render_prior_content'
```

The real function is `_render_prior_content_blocks`. The `ImportError` escapes
inside pytest's unittest plugin (`AttributeError: 'tuple' object has no
attribute 'value'`), which **kills the xdist worker**, so the entire shard
aborts with `INTERNALERROR` and the blamed test is reported as an unrelated
`crashitem`. That is why the failure looks random and lands on whichever test
the dead worker was holding.

Fixes the import name, and joins the result through the file's existing
`_text_of` helper since `_render_prior_content_blocks` returns content blocks
rather than a string.

## Test Plan

Reproduced on clean `origin/main` in a throwaway worktree (no other changes):

```
$ pytest tests/inner/test_claude_sdk_executor.py -q
INTERNALERROR> AttributeError: 'tuple' object has no attribute 'value'
1 failed, 6 passed
```

After the fix:

```
$ pytest tests/inner/test_claude_sdk_executor.py -q
122 passed
```

I also confirmed the test is still load-bearing rather than trivially green:
disabling the base64 `source`-block arm of `_redact_inline_base64` makes it
fail, and restoring it makes it pass. (Note the placeholder is produced by
`_redact_inline_base64` via the `json.dumps` fallback, not by the
`_get_inline_data_uri_info` branch — neutering the latter does not affect this
test.)

`pre-commit run --files tests/inner/test_claude_sdk_executor.py` → passed.

## Demo

N/A (test-only change)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Repairs an existing test rather than adding one; the before/after and the
neutering check above are the verification.
