### PR TITLE
fix(onboarding): prefer date-shaped version token for date-floor harnesses

### DIFF
--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -674,6 +674,11 @@ def harness_setup_hint(harness: str | None) -> str:
 
 _VERSION_RE = re.compile(r"(\d+\.\d+\.\d+(?:[-.][0-9A-Za-z]+)*)")
 
+# Matches calendar-date versions like ``2026.06.05`` or Cursor's
+# ``2026.06.19-20-24-33-653a7fb``: a 4-digit year, month, day, each
+# dot-or-hyphen separated, optionally followed by build metadata.
+_DATE_VERSION_RE = re.compile(r"(20\d{2}[.\-]\d{1,2}[.\-]\d{1,2}(?:[-.][0-9A-Za-z]+)*)")
+
 
 def _normalize_date_version(version: str) -> str:
     """Trim date-shaped versions (``YYYY.MM.DD[-build]``) to their date part.
@@ -698,6 +703,20 @@ def _normalize_date_version(version: str) -> str:
     return version
 
 
+def _any_harness_declares_date_min_version() -> bool:
+    """Return ``True`` if any harness install spec uses a date-shaped floor.
+
+    Hermes prints ``v0.20.0 (2026.8.3)`` — a semver token first, then a date —
+    while its declared ``min_version`` is the date (``2026.06.05``). For such
+    harnesses the parser must prefer the date token so the comparison matches
+    the spec's own shape.
+    """
+    return any(
+        spec.min_version is not None and _DATE_VERSION_RE.match(spec.min_version)
+        for spec in _all_harness_install().values()
+    )
+
+
 def _parse_harness_cli_version(text: str) -> str | None:
     """Extract a semver-ish string from ``<binary> --version`` output.
 
@@ -706,8 +725,20 @@ def _parse_harness_cli_version(text: str) -> str | None:
     kept generic so any harness can declare a version range in its install spec.
     Date-shaped versions (e.g. Cursor's ``2026.06.22`` or
     ``2026.06.19-20-24-33-653a7fb``) are normalized to ``YYYY.MM.DD``.
+
+    When a harness's declared ``min_version`` is itself date-shaped, prefer the
+    first date-shaped token in the output over the first semver token. Hermes
+    emits ``v0.20.0 (2026.8.3)`` — without this preference ``_VERSION_RE.search``
+    matches ``v0.20.0`` and the date-shaped cutoff rejects it, so the host
+    reports ``version-too-low`` even though the trailing date satisfies it.
     """
-    match = _VERSION_RE.search(text or "")
+    if not text:
+        return None
+    if _any_harness_declares_date_min_version():
+        date_match = _DATE_VERSION_RE.search(text)
+        if date_match is not None:
+            return _normalize_date_version(date_match.group(1))
+    match = _VERSION_RE.search(text)
     if match is None:
         return None
     return _normalize_date_version(match.group(1))

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -1196,12 +1196,48 @@ def test_harness_cli_installed_ignores_upper_bound_for_unversioned_specs(
         ("2026.05.24.1.dda726e", "2026.05.24"),
         ("kimi version 1.47.0", "1.47.0"),
         ("1.17.7-rc1", "1.17.7-rc1"),
+        # Hermes prints a semver token first, then a date in parentheses.
+        # The parser must prefer the date because Hermes's min_version
+        # (``2026.06.05``) is itself date-shaped — otherwise ``v0.20.0``
+        # is matched and rejected against the date floor.
+        ("Hermes Agent v0.20.0 (2026.8.3)", "2026.08.03"),
+        ("Hermes Agent v0.20.0 (2026.06.19)", "2026.06.19"),
     ],
 )
 def test_parse_harness_cli_version_normalizes_date_versions(raw: str, expected: str) -> None:
     """Date-shaped Cursor versions are stripped to ``YYYY.MM.DD`` so PEP 440 can
-    compare them; normal semver versions stay unchanged."""
+    compare them; normal semver versions stay unchanged. When the version output
+    contains both a semver and a date token and any harness declares a
+    date-shaped floor, the date token wins so harnesses like Hermes aren't
+    flagged ``version-too-low`` against their own date floor."""
     assert hi._parse_harness_cli_version(raw) == expected
+
+
+def test_hermes_mixed_version_output_satisfies_date_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hermes emits ``v0.20.0 (2026.8.3)`` — semver first, then a date. Its
+    declared ``min_version`` is ``2026.06.05`` (date-shaped). Without preferring
+    the date token the parser grabs ``v0.20.0`` and the date floor rejects it,
+    causing the host to report ``version-too-low`` even though the trailing date
+    satisfies the floor. End-to-end, ``harness_cli_installed`` must read ``True``."""
+    monkeypatch.setattr(hi.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    hermes_output = (
+        "Hermes Agent v0.20.0 (2026.8.3)\n"
+        "Install directory: /home/user/.hermes/hermes-agent\n"
+        "Install method: git\n"
+    )
+
+    def _run(argv: list[str], **k: object) -> subprocess.CompletedProcess[str]:
+        if len(argv) >= 2 and argv[1] == "--version":
+            return subprocess.CompletedProcess(
+                args=argv, returncode=0, stdout=hermes_output, stderr=""
+            )
+        raise AssertionError(f"unexpected subprocess: {argv!r}")
+
+    monkeypatch.setattr(hi.subprocess, "run", _run)
+    assert hi.harness_cli_installed(hi.HERMES_KEY) is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Related issue

A Hermes harness whose `--version` output prints a semver token *first* and a date *second* (e.g. `Hermes Agent v0.20.0 (2026.8.3)`) is always flagged `version-too-low`, even when the trailing date satisfies the spec's date-shaped `min_version`. Consequence: every `omni hermes` runner launch fails with `412 HARNESS_NOT_CONFIGURED`, and the host's `configured_harnesses` map reports `hermes-native` / `hermes` / `native-hermes` as `version-too-low`. No existing issue located; opening this PR to fix.

## Summary

- `_parse_harness_cli_version` used `_VERSION_RE.search()`, which returns the *first* semver-shaped token. For Hermes that is `v0.20.0`, and `Version("0.20.0") < Version("2026.06.05")` evaluates true against the date-shaped `min_version` → `version-too-low`.
- When any harness install spec declares a date-shaped `min_version`, prefer the first **date-shaped** token in the output over the first semver token. Otherwise fall back to the legacy semver-first match, preserving behavior for harnesses whose `min_version` is semver (claude, codex, kimi, opencode, qwen, …).
- Adds a `_DATE_VERSION_RE` pattern and a `_any_harness_declares_date_min_version()` helper. `_normalize_date_version` is reused unchanged so the comparison still goes through `packaging.Version`.

```
hermes --version
  BEFORE: parse "0.20.0"  -> 0.20.0 < 2026.06.05  -> version-too-low  -> 412
  AFTER:  parse "2026.8.3" -> 2026.08.03 >= 2026.06.05 -> ready          -> 200
```

## Test Plan

- [x] `uv run pytest tests/onboarding/test_harness_install.py -v` — 126 passed (incl. 2 new parametrize rows + 1 new end-to-end test).
- [x] `uv run pytest tests/onboarding/ -q` — 991 passed, 0 regressions (one unrelated `test_databricks_sdk_installed_true_in_dev_env` requires the `all` extra; passes with `uv sync --extra all --extra dev`).
- [x] `uv run ruff check` + `ruff format --check` on both changed files — clean.
- [x] `uv run --no-sync pyrefly check omnigent/onboarding/harness_install.py` — 0 errors.
- [x] End-to-end live verification: patched the same change into an installed Omnigent 0.8.2 site-packages, restarted the host daemon, and confirmed via `GET /v1/hosts/<id>` that `hermes-native` / `hermes` / `native-hermes` flip from `"version-too-low"` → `true`; `omni hermes` then launches the runner and a Hermes terminal instead of returning `412 HARNESS_NOT_CONFIGURED`.

New regression cases:
- `test_parse_harness_cli_version_normalizes_date_versions[Hermes Agent v0.20.0 (2026.8.3)-2026.08.03]`
- `test_parse_harness_cli_version_normalizes_date_versions[Hermes Agent v0.20.0 (2026.06.19)-2026.06.19]`
- `test_hermes_mixed_version_output_satisfies_date_floor`

## Demo

```text
BEFORE (hermes --version output → parser → host readiness):
  input:  "Hermes Agent v0.20.0 (2026.8.3)"
  parsed: "0.20.0"  (semver-first match by _VERSION_RE.search)
  check:  0.20.0 < 2026.06.05  →  version-too-low
  runner 412 HARNESS_NOT_CONFIGURED

AFTER (date-shaped token preferred when any spec uses a date floor):
  input:  "Hermes Agent v0.20.0 (2026.8.3)"
  parsed: "2026.8.3"  →  normalized "2026.08.03"
  check:  2026.08.03 >= 2026.06.05  →  ready
  runner 200 ✓  — Hermes terminal launches
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Two parametrize rows added to the existing `test_parse_harness_cli_version_normalizes_date_versions` covering the mixed semver-then-date Hermes `--version` shape. A new `test_hermes_mixed_version_output_satisfies_date_floor` stubs `subprocess.run` with the actual Hermes `--version` output and asserts `harness_cli_installed(HERMES_KEY) is True` end-to-end. Live verification against a real Omnigent host daemon confirms `configured_harnesses` flips from `version-too-low` to `true`.

## Changelog

`omni hermes` no longer fails with `412 HARNESS_NOT_CONFIGURED` when Hermes prints a semver token before its date version (e.g. `v0.20.0 (2026.8.3)`); the date token is preferred for harnesses whose `min_version` is date-shaped.