### PR TITLE
feat(opencode): generic env-configured gateway (route opencode through an external LLM gateway)

### DIFF
--- a/omnigent/opencode_native_provider.py
+++ b/omnigent/opencode_native_provider.py
@@ -42,6 +42,20 @@ DATABRICKS_GATEWAY_PROVIDER_NAME = "Databricks AI Gateway"
 # Endpoint that exposes the workspace's OpenAI-compatible chat completions.
 _SERVING_ENDPOINTS_PATH = "serving-endpoints"
 
+# Generic OpenAI-compatible gateway for opencode-native, configured purely by
+# env — mirrors the HARNESS_*_GATEWAY_* convention the other harnesses use, but
+# opencode consumes it via the synthesized config file (see module docstring).
+# Lets a deployment route opencode through any gateway (e.g. Bifrost) without
+# the Databricks SDK. BASE_URL is the switch; API_KEY defaults to a dummy for
+# keyless gateways; MODEL is the default model id sent to the gateway.
+ENV_GATEWAY_BASE_URL = "HARNESS_OPENCODE_GATEWAY_BASE_URL"
+ENV_GATEWAY_API_KEY = "HARNESS_OPENCODE_GATEWAY_API_KEY"
+ENV_GATEWAY_MODEL = "HARNESS_OPENCODE_GATEWAY_MODEL"
+ENV_GATEWAY_PROVIDER_ID = "HARNESS_OPENCODE_GATEWAY_PROVIDER_ID"
+ENV_GATEWAY_PROVIDER_NAME = "HARNESS_OPENCODE_GATEWAY_PROVIDER_NAME"
+_DEFAULT_ENV_GATEWAY_PROVIDER_ID = "gateway"
+_DEFAULT_ENV_GATEWAY_PROVIDER_NAME = "LLM Gateway"
+
 
 @dataclass(frozen=True)
 class OpenCodeGatewayResolution:
@@ -306,6 +320,42 @@ def resolve_databricks_gateway(
         base_url=f"{host}/{_SERVING_ENDPOINTS_PATH}",
         api_key=token,
         model_id=resolved_model,
+    )
+
+
+def resolve_env_gateway(*, model_id: str | None = None) -> OpenCodeGatewayResolution | None:
+    """
+    Resolve a generic OpenAI-compatible gateway for opencode from env.
+
+    Reads ``HARNESS_OPENCODE_GATEWAY_*`` (see the constants above): ``BASE_URL``
+    is the switch, ``API_KEY`` defaults to a dummy for keyless gateways, and the
+    model is *model_id* (the session's pinned model) else ``..._MODEL``. Lets a
+    deployment route opencode through any gateway (e.g. an in-cluster Bifrost)
+    with no Databricks SDK. Returns ``None`` when no base URL is set.
+
+    :param model_id: The session's pinned model, e.g. ``"bedrock/claude-sonnet-4-6"``
+        or a ``<provider_id>/<model>`` already qualified with our provider id.
+    :returns: A resolution, or ``None`` when no gateway is configured.
+    """
+    base_url = os.environ.get(ENV_GATEWAY_BASE_URL, "").strip()
+    if not base_url:
+        return None
+    provider_id = os.environ.get(ENV_GATEWAY_PROVIDER_ID, "").strip() or _DEFAULT_ENV_GATEWAY_PROVIDER_ID
+    model = (model_id or "").strip() or os.environ.get(ENV_GATEWAY_MODEL, "").strip()
+    # model_id may already be qualified as "<provider_id>/<model>" (the runner
+    # sets model_override to gateway.qualified_model on relaunch) — strip it so
+    # the provider config declares the bare gateway model id.
+    if provider_id and model.startswith(f"{provider_id}/"):
+        model = model[len(provider_id) + 1 :]
+    if not model:
+        return None
+    return OpenCodeGatewayResolution(
+        base_url=base_url,
+        api_key=os.environ.get(ENV_GATEWAY_API_KEY, "").strip() or "gateway-no-auth",
+        model_id=model,
+        provider_id=provider_id,
+        provider_name=os.environ.get(ENV_GATEWAY_PROVIDER_NAME, "").strip()
+        or _DEFAULT_ENV_GATEWAY_PROVIDER_NAME,
     )
 
 

--- a/omnigent/opencode_native_provider.py
+++ b/omnigent/opencode_native_provider.py
@@ -53,6 +53,13 @@ ENV_GATEWAY_API_KEY = "HARNESS_OPENCODE_GATEWAY_API_KEY"
 ENV_GATEWAY_MODEL = "HARNESS_OPENCODE_GATEWAY_MODEL"
 ENV_GATEWAY_PROVIDER_ID = "HARNESS_OPENCODE_GATEWAY_PROVIDER_ID"
 ENV_GATEWAY_PROVIDER_NAME = "HARNESS_OPENCODE_GATEWAY_PROVIDER_NAME"
+# Additional models to register on the SAME gateway provider, beyond the
+# default in ENV_GATEWAY_MODEL, so opencode's own model switcher can list them
+# — a multi-model gateway (e.g. an OpenRouter-backed Bifrost) otherwise has no
+# way to surface anything past the one pinned default. Comma-separated, e.g.
+# "moonshotai/kimi-k3,deepseek/deepseek-v4". Each may optionally carry the same
+# "<provider_id>/" prefix ENV_GATEWAY_MODEL accepts; it's stripped the same way.
+ENV_GATEWAY_EXTRA_MODELS = "HARNESS_OPENCODE_GATEWAY_EXTRA_MODELS"
 _DEFAULT_ENV_GATEWAY_PROVIDER_ID = "gateway"
 _DEFAULT_ENV_GATEWAY_PROVIDER_NAME = "LLM Gateway"
 
@@ -67,6 +74,9 @@ class OpenCodeGatewayResolution:
     :param model_id: The endpoint/model id, e.g. ``"databricks-claude-sonnet-4-6"``.
     :param provider_id: opencode provider id, e.g. ``"databricks-gateway"``.
     :param provider_name: Human label for the opencode provider block.
+    :param extra_model_ids: Additional model ids to register on the same
+        provider (selectable in opencode's own model switcher), beyond
+        *model_id* which is always the session's default/pinned model.
     """
 
     base_url: str
@@ -74,6 +84,7 @@ class OpenCodeGatewayResolution:
     model_id: str
     provider_id: str = DATABRICKS_GATEWAY_PROVIDER_ID
     provider_name: str = DATABRICKS_GATEWAY_PROVIDER_NAME
+    extra_model_ids: tuple[str, ...] = ()
 
     @property
     def qualified_model(self) -> str:
@@ -103,9 +114,16 @@ def build_opencode_provider_config(resolution: OpenCodeGatewayResolution) -> dic
     """
     Build the ``opencode.json`` declaring a custom OpenAI-compatible provider.
 
-    :param resolution: The resolved gateway (base URL + key + model).
+    Registers *model_id* plus any *extra_model_ids* under the same provider,
+    so a multi-model gateway (e.g. an OpenRouter-backed Bifrost) surfaces more
+    than just the one pinned default in opencode's own model switcher.
+
+    :param resolution: The resolved gateway (base URL + key + model(s)).
     :returns: A config dict ready to serialize to ``opencode.json``.
     """
+    models = {resolution.model_id: {"name": resolution.model_id}}
+    for extra_id in resolution.extra_model_ids:
+        models.setdefault(extra_id, {"name": extra_id})
     return {
         "$schema": "https://opencode.ai/config.json",
         "provider": {
@@ -116,7 +134,7 @@ def build_opencode_provider_config(resolution: OpenCodeGatewayResolution) -> dic
                     "baseURL": resolution.base_url,
                     "apiKey": resolution.api_key,
                 },
-                "models": {resolution.model_id: {"name": resolution.model_id}},
+                "models": models,
             }
         },
     }
@@ -329,9 +347,13 @@ def resolve_env_gateway(*, model_id: str | None = None) -> OpenCodeGatewayResolu
 
     Reads ``HARNESS_OPENCODE_GATEWAY_*`` (see the constants above): ``BASE_URL``
     is the switch, ``API_KEY`` defaults to a dummy for keyless gateways, and the
-    model is *model_id* (the session's pinned model) else ``..._MODEL``. Lets a
-    deployment route opencode through any gateway (e.g. an in-cluster Bifrost)
-    with no Databricks SDK. Returns ``None`` when no base URL is set.
+    model is *model_id* (the session's pinned model) else ``..._MODEL``.
+    ``..._EXTRA_MODELS`` registers additional models on the same provider so
+    opencode's own model switcher can list them too — useful when the gateway
+    fronts several models (e.g. an OpenRouter-backed Bifrost) rather than one
+    fixed endpoint. Lets a deployment route opencode through any gateway (e.g.
+    an in-cluster Bifrost) with no Databricks SDK. Returns ``None`` when no
+    base URL is set.
 
     :param model_id: The session's pinned model, e.g. ``"bedrock/claude-sonnet-4-6"``
         or a ``<provider_id>/<model>`` already qualified with our provider id.
@@ -357,14 +379,25 @@ def resolve_env_gateway(*, model_id: str | None = None) -> OpenCodeGatewayResolu
             _DEFAULT_ENV_GATEWAY_PROVIDER_ID,
         )
         provider_id = _DEFAULT_ENV_GATEWAY_PROVIDER_ID
-    model = (model_id or "").strip() or os.environ.get(ENV_GATEWAY_MODEL, "").strip()
-    # model_id may already be qualified as "<provider_id>/<model>" (the runner
-    # sets model_override to gateway.qualified_model on relaunch) — strip it so
-    # the provider config declares the bare gateway model id.
-    if provider_id and model.startswith(f"{provider_id}/"):
-        model = model[len(provider_id) + 1 :]
+
+    def _strip_own_prefix(candidate: str) -> str:
+        # A model id may already be qualified as "<provider_id>/<model>" (the
+        # runner sets model_override to gateway.qualified_model on relaunch) —
+        # strip it so the provider config declares the bare gateway model id.
+        if provider_id and candidate.startswith(f"{provider_id}/"):
+            return candidate[len(provider_id) + 1 :]
+        return candidate
+
+    model = _strip_own_prefix(
+        (model_id or "").strip() or os.environ.get(ENV_GATEWAY_MODEL, "").strip()
+    )
     if not model:
         return None
+    extra_models = tuple(
+        stripped
+        for raw in os.environ.get(ENV_GATEWAY_EXTRA_MODELS, "").split(",")
+        if (stripped := _strip_own_prefix(raw.strip())) and stripped != model
+    )
     return OpenCodeGatewayResolution(
         base_url=base_url,
         api_key=os.environ.get(ENV_GATEWAY_API_KEY, "").strip() or "gateway-no-auth",
@@ -372,6 +405,7 @@ def resolve_env_gateway(*, model_id: str | None = None) -> OpenCodeGatewayResolu
         provider_id=provider_id,
         provider_name=os.environ.get(ENV_GATEWAY_PROVIDER_NAME, "").strip()
         or _DEFAULT_ENV_GATEWAY_PROVIDER_NAME,
+        extra_model_ids=extra_models,
     )
 
 

--- a/omnigent/opencode_native_provider.py
+++ b/omnigent/opencode_native_provider.py
@@ -340,7 +340,23 @@ def resolve_env_gateway(*, model_id: str | None = None) -> OpenCodeGatewayResolu
     base_url = os.environ.get(ENV_GATEWAY_BASE_URL, "").strip()
     if not base_url:
         return None
-    provider_id = os.environ.get(ENV_GATEWAY_PROVIDER_ID, "").strip() or _DEFAULT_ENV_GATEWAY_PROVIDER_ID
+    provider_id = (
+        os.environ.get(ENV_GATEWAY_PROVIDER_ID, "").strip() or _DEFAULT_ENV_GATEWAY_PROVIDER_ID
+    )
+    if "/" in provider_id or any(ch.isspace() for ch in provider_id):
+        # A "/" or whitespace makes the synthesized "<provider_id>/<model>" id
+        # ambiguous to parse back apart (the prefix-strip below, and the
+        # runner's relaunch path, both split on the first "/"), which can
+        # corrupt resume/summarize. Fall back to the always-valid default
+        # rather than write a provider config we can't reliably read back.
+        _logger.warning(
+            "%s=%r is not a valid opencode provider id (contains '/' or "
+            "whitespace); falling back to %r",
+            ENV_GATEWAY_PROVIDER_ID,
+            provider_id,
+            _DEFAULT_ENV_GATEWAY_PROVIDER_ID,
+        )
+        provider_id = _DEFAULT_ENV_GATEWAY_PROVIDER_ID
     model = (model_id or "").strip() or os.environ.get(ENV_GATEWAY_MODEL, "").strip()
     # model_id may already be qualified as "<provider_id>/<model>" (the runner
     # sets model_override to gateway.qualified_model on relaunch) — strip it so

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -1004,15 +1004,17 @@ async def _auto_create_opencode_terminal(
         build_opencode_provider_config,
         maybe_merge_user_provider_config,
         resolve_databricks_gateway,
+        resolve_env_gateway,
         write_opencode_provider_config,
     )
 
     # Accumulate the synthesized opencode.json: provider/model (Databricks
-    # gateway or a pinned default) + the agent's MCP servers + force-ask.
+    # gateway, a generic env gateway like Bifrost, or a pinned default) + the
+    # agent's MCP servers + force-ask.
     config: dict[str, object] = {}
     gateway = resolve_databricks_gateway(
         _opencode_native_profile_from_spec(agent_spec), model_id=model_override
-    )
+    ) or resolve_env_gateway(model_id=model_override)
     if gateway is not None:
         # Pin the per-prompt model to the synthesized provider/endpoint id, and
         # write it as opencode's default model too so the TUI launches on it.

--- a/tests/test_opencode_native_provider.py
+++ b/tests/test_opencode_native_provider.py
@@ -11,6 +11,11 @@ from pathlib import Path
 import pytest
 
 from omnigent.opencode_native_provider import (
+    ENV_GATEWAY_API_KEY,
+    ENV_GATEWAY_BASE_URL,
+    ENV_GATEWAY_MODEL,
+    ENV_GATEWAY_PROVIDER_ID,
+    ENV_GATEWAY_PROVIDER_NAME,
     OpenCodeGatewayResolution,
     _gateway_endpoint_for_model,
     _strip_jsonc_comments,
@@ -20,6 +25,7 @@ from omnigent.opencode_native_provider import (
     build_opencode_provider_config,
     maybe_merge_user_provider_config,
     resolve_databricks_gateway,
+    resolve_env_gateway,
     write_opencode_provider_config,
 )
 
@@ -189,6 +195,105 @@ def test_resolve_gateway_defaults_non_gateway_model(monkeypatch: pytest.MonkeyPa
 def test_resolve_gateway_none_when_no_token(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_sdk(monkeypatch, host="https://ws.databricks.com", token=None)
     assert resolve_databricks_gateway("oss") is None
+
+
+def _clear_env_gateway_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        ENV_GATEWAY_BASE_URL,
+        ENV_GATEWAY_API_KEY,
+        ENV_GATEWAY_MODEL,
+        ENV_GATEWAY_PROVIDER_ID,
+        ENV_GATEWAY_PROVIDER_NAME,
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_resolve_env_gateway_none_without_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env_gateway_vars(monkeypatch)
+    monkeypatch.setenv(ENV_GATEWAY_MODEL, "openrouter/z-ai/glm-5.2")
+    assert resolve_env_gateway() is None
+
+
+def test_resolve_env_gateway_none_without_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env_gateway_vars(monkeypatch)
+    monkeypatch.setenv(ENV_GATEWAY_BASE_URL, "http://bifrost.internal:4000/v1")
+    assert resolve_env_gateway() is None
+
+
+def test_resolve_env_gateway_model_id_takes_priority_over_env_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_env_gateway_vars(monkeypatch)
+    monkeypatch.setenv(ENV_GATEWAY_BASE_URL, "http://bifrost.internal:4000/v1")
+    monkeypatch.setenv(ENV_GATEWAY_MODEL, "openrouter/z-ai/glm-5.2")
+    res = resolve_env_gateway(model_id="bedrock/claude-sonnet-4-6")
+    assert res is not None
+    assert res.model_id == "bedrock/claude-sonnet-4-6"
+
+
+def test_resolve_env_gateway_falls_back_to_env_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env_gateway_vars(monkeypatch)
+    monkeypatch.setenv(ENV_GATEWAY_BASE_URL, "http://bifrost.internal:4000/v1")
+    monkeypatch.setenv(ENV_GATEWAY_MODEL, "openrouter/z-ai/glm-5.2")
+    res = resolve_env_gateway()
+    assert res is not None
+    assert res.model_id == "openrouter/z-ai/glm-5.2"
+
+
+def test_resolve_env_gateway_strips_own_provider_prefix_from_model_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The runner relaunches a session with model_override set to the previous
+    # qualified_model ("<provider_id>/<model>"); resolving again must not
+    # double-qualify it.
+    _clear_env_gateway_vars(monkeypatch)
+    monkeypatch.setenv(ENV_GATEWAY_BASE_URL, "http://bifrost.internal:4000/v1")
+    monkeypatch.setenv(ENV_GATEWAY_PROVIDER_ID, "bifrost")
+    res = resolve_env_gateway(model_id="bifrost/openrouter/z-ai/glm-5.2")
+    assert res is not None
+    assert res.model_id == "openrouter/z-ai/glm-5.2"
+    assert res.qualified_model == "bifrost/openrouter/z-ai/glm-5.2"
+
+
+def test_resolve_env_gateway_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env_gateway_vars(monkeypatch)
+    monkeypatch.setenv(ENV_GATEWAY_BASE_URL, "http://bifrost.internal:4000/v1")
+    monkeypatch.setenv(ENV_GATEWAY_MODEL, "openrouter/z-ai/glm-5.2")
+    res = resolve_env_gateway()
+    assert res is not None
+    assert res.base_url == "http://bifrost.internal:4000/v1"
+    assert res.api_key == "gateway-no-auth"
+    assert res.provider_id == "gateway"
+    assert res.provider_name == "LLM Gateway"
+
+
+def test_resolve_env_gateway_custom_api_key_provider_id_and_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_env_gateway_vars(monkeypatch)
+    monkeypatch.setenv(ENV_GATEWAY_BASE_URL, "http://bifrost.internal:4000/v1")
+    monkeypatch.setenv(ENV_GATEWAY_MODEL, "openrouter/z-ai/glm-5.2")
+    monkeypatch.setenv(ENV_GATEWAY_API_KEY, "sk-real-key")
+    monkeypatch.setenv(ENV_GATEWAY_PROVIDER_ID, "bifrost")
+    monkeypatch.setenv(ENV_GATEWAY_PROVIDER_NAME, "Bifrost")
+    res = resolve_env_gateway()
+    assert res is not None
+    assert res.api_key == "sk-real-key"
+    assert res.provider_id == "bifrost"
+    assert res.provider_name == "Bifrost"
+
+
+@pytest.mark.parametrize("bad_provider_id", ["has/slash", "has space"])
+def test_resolve_env_gateway_rejects_invalid_provider_id(
+    monkeypatch: pytest.MonkeyPatch, bad_provider_id: str
+) -> None:
+    _clear_env_gateway_vars(monkeypatch)
+    monkeypatch.setenv(ENV_GATEWAY_BASE_URL, "http://bifrost.internal:4000/v1")
+    monkeypatch.setenv(ENV_GATEWAY_MODEL, "openrouter/z-ai/glm-5.2")
+    monkeypatch.setenv(ENV_GATEWAY_PROVIDER_ID, bad_provider_id)
+    res = resolve_env_gateway()
+    assert res is not None
+    assert res.provider_id == "gateway"
 
 
 def test_build_mcp_block_stdio_and_http() -> None:

--- a/tests/test_opencode_native_provider.py
+++ b/tests/test_opencode_native_provider.py
@@ -13,6 +13,7 @@ import pytest
 from omnigent.opencode_native_provider import (
     ENV_GATEWAY_API_KEY,
     ENV_GATEWAY_BASE_URL,
+    ENV_GATEWAY_EXTRA_MODELS,
     ENV_GATEWAY_MODEL,
     ENV_GATEWAY_PROVIDER_ID,
     ENV_GATEWAY_PROVIDER_NAME,
@@ -204,6 +205,7 @@ def _clear_env_gateway_vars(monkeypatch: pytest.MonkeyPatch) -> None:
         ENV_GATEWAY_MODEL,
         ENV_GATEWAY_PROVIDER_ID,
         ENV_GATEWAY_PROVIDER_NAME,
+        ENV_GATEWAY_EXTRA_MODELS,
     ):
         monkeypatch.delenv(var, raising=False)
 
@@ -294,6 +296,65 @@ def test_resolve_env_gateway_rejects_invalid_provider_id(
     res = resolve_env_gateway()
     assert res is not None
     assert res.provider_id == "gateway"
+
+
+def test_resolve_env_gateway_parses_extra_models(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env_gateway_vars(monkeypatch)
+    monkeypatch.setenv(ENV_GATEWAY_BASE_URL, "http://bifrost.internal:4000/v1")
+    monkeypatch.setenv(ENV_GATEWAY_MODEL, "openrouter/z-ai/glm-5.2")
+    monkeypatch.setenv(
+        ENV_GATEWAY_EXTRA_MODELS,
+        "moonshotai/kimi-k3, deepseek/deepseek-v4",
+    )
+    res = resolve_env_gateway()
+    assert res is not None
+    assert res.model_id == "openrouter/z-ai/glm-5.2"
+    assert res.extra_model_ids == ("moonshotai/kimi-k3", "deepseek/deepseek-v4")
+
+
+def test_resolve_env_gateway_extra_models_strip_own_prefix_and_dedupe_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_env_gateway_vars(monkeypatch)
+    monkeypatch.setenv(ENV_GATEWAY_BASE_URL, "http://bifrost.internal:4000/v1")
+    monkeypatch.setenv(ENV_GATEWAY_PROVIDER_ID, "bifrost")
+    monkeypatch.setenv(ENV_GATEWAY_MODEL, "openrouter/z-ai/glm-5.2")
+    # One entry re-qualified with our own provider id (as a relaunch would),
+    # and one entry that duplicates the default model — neither should appear
+    # twice / qualified in the result.
+    monkeypatch.setenv(
+        ENV_GATEWAY_EXTRA_MODELS,
+        "bifrost/moonshotai/kimi-k3,openrouter/z-ai/glm-5.2",
+    )
+    res = resolve_env_gateway()
+    assert res is not None
+    assert res.extra_model_ids == ("moonshotai/kimi-k3",)
+
+
+def test_resolve_env_gateway_no_extra_models_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_env_gateway_vars(monkeypatch)
+    monkeypatch.setenv(ENV_GATEWAY_BASE_URL, "http://bifrost.internal:4000/v1")
+    monkeypatch.setenv(ENV_GATEWAY_MODEL, "openrouter/z-ai/glm-5.2")
+    res = resolve_env_gateway()
+    assert res is not None
+    assert res.extra_model_ids == ()
+
+
+def test_build_provider_config_lists_extra_models() -> None:
+    res = OpenCodeGatewayResolution(
+        base_url="http://bifrost.internal:4000/v1",
+        api_key="gateway-no-auth",
+        model_id="openrouter/z-ai/glm-5.2",
+        provider_id="bifrost",
+        extra_model_ids=("moonshotai/kimi-k3", "deepseek/deepseek-v4"),
+    )
+    cfg = build_opencode_provider_config(res)
+    models = cfg["provider"]["bifrost"]["models"]
+    assert set(models) == {
+        "openrouter/z-ai/glm-5.2",
+        "moonshotai/kimi-k3",
+        "deepseek/deepseek-v4",
+    }
 
 
 def test_build_mcp_block_stdio_and_http() -> None:


### PR DESCRIPTION
## Summary
- `opencode-native`'s only gateway support today is Databricks-only (`resolve_databricks_gateway`).
- Adds `resolve_env_gateway()` to `omnigent/opencode_native_provider.py`, which builds an `OpenCodeGatewayResolution` from generic `HARNESS_OPENCODE_GATEWAY_*` env vars — `BASE_URL` is the switch, `API_KEY` defaults to a dummy for keyless gateways, `MODEL` is the default model id. This mirrors the `HARNESS_*_GATEWAY_*` convention already used by the other native harnesses (claude/codex/pi), just extended to opencode via its synthesized-config-file mechanism.
- `EXTRA_MODELS` (comma-separated) registers additional models on the same provider, so a multi-model gateway (e.g. an OpenRouter-backed Bifrost fronting several models) surfaces more than just the one pinned default in opencode's own model switcher — otherwise a "generic gateway" would still cap you at one hardcoded model, which defeats a lot of the point.
- Wired into `omnigent/runner/native/orchestration.py`'s `_auto_create_opencode_terminal` as a fallback after the Databricks resolver: `resolve_databricks_gateway(...) or resolve_env_gateway(...)`.
- Also rejects a `PROVIDER_ID` containing `/` or whitespace (falls back to the default with a warning) instead of writing a provider config whose `<provider_id>/<model>` id can't be reliably split back apart on resume/relaunch.
- Lets a deployment route the `opencode-native` harness through any OpenAI-compatible gateway (e.g. an in-cluster LLM gateway such as Bifrost) with no provider key inside the sandbox — previously this required a real `omni setup` credential on every managed host.

## Context
- Originally landed on our `staging` branch as `3428eab9`, at a point where this wiring lived in `runner/app.py`. Since then upstream moved the native-harness orchestration code into `runner/native/orchestration.py`, so this PR re-applies the same change at its new home. `opencode_native_provider.py` itself required no changes to the port.
- `EXTRA_MODELS` and the `PROVIDER_ID` validation were added after review — see the resolved discussion threads.

## Test plan
- [x] Unit tests in `tests/test_opencode_native_provider.py` covering `resolve_env_gateway()`: missing base URL/model, `model_id` vs env `MODEL` precedence, provider-prefix stripping, defaults, custom overrides, invalid-provider-id fallback, and `EXTRA_MODELS` parsing/dedup/prefix-stripping.