### PR TITLE
fix: preserve global OpenCode plugins in native sessions

### DIFF
--- a/omnigent/opencode_native_provider.py
+++ b/omnigent/opencode_native_provider.py
@@ -451,7 +451,8 @@ def maybe_merge_user_provider_config(config: dict[str, object]) -> dict[str, obj
     server sees both the user's providers (with their custom base URLs) and
     any Omnigent-synthesized providers (e.g. Databricks gateway).
 
-    ``provider`` entries are merged, and the user config's top-level ``model``
+    ``provider`` entries are merged and top-level ``plugin`` entries are
+    preserved (with synthesized plugins taking precedence). The user config's ``model``
     default is adopted **only when the synthesized config pins none** — the
     synthesized config still takes precedence for all keys it sets (model, mcp,
     plugin, permission, etc.). The ``model`` carry-over matters because when
@@ -503,12 +504,26 @@ def maybe_merge_user_provider_config(config: dict[str, object]) -> dict[str, obj
         if isinstance(user_model, str) and user_model:
             target.setdefault("model", user_model)
 
+    def _merge_plugins(target: dict[str, object]) -> None:
+        """Preserve user plugins while retaining synthesized policy hooks."""
+        user_plugins = user_config.get("plugin")
+        if not isinstance(user_plugins, list):
+            return
+        existing = target.get("plugin")
+        merged: list[object] = list(existing) if isinstance(existing, list) else []
+        for plugin in user_plugins:
+            if plugin not in merged:
+                merged.append(plugin)
+        if merged:
+            target["plugin"] = merged
+
     user_providers = user_config.get("provider")
     if not isinstance(user_providers, dict) or not user_providers:
         # No custom providers to merge, but the user's default model still
         # applies when the synthesized config didn't pin one.
         result = dict(config)
         _carry_model(result)
+        _merge_plugins(result)
         return result
 
     result = dict(config)
@@ -526,6 +541,7 @@ def maybe_merge_user_provider_config(config: dict[str, object]) -> dict[str, obj
         result["provider"] = dict(user_providers)
 
     _carry_model(result)
+    _merge_plugins(result)
     result.setdefault("$schema", "https://opencode.ai/config.json")
 
     return result

--- a/tests/test_opencode_native_provider.py
+++ b/tests/test_opencode_native_provider.py
@@ -421,6 +421,31 @@ def test_merge_user_provider_config_carries_model_without_user_providers(
     assert result["model"] == "databricks/databricks-claude-opus-4-8"
 
 
+def test_merge_user_provider_config_preserves_plugins_and_deduplicates(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Global plugins survive per-session config synthesis."""
+    cfg_dir = tmp_path / "cfg" / "opencode"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "opencode.jsonc").write_text(
+        '{"plugin": ["/opt/pulse-agents-harnesses/marshal-opencode", '
+        '"/opt/pulse-agents-harnesses/other"]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+
+    config: dict[str, object] = {
+        "plugin": ["/tmp/omnigent-policy.js", "/opt/pulse-agents-harnesses/other"]
+    }
+    result = maybe_merge_user_provider_config(config)
+
+    assert result["plugin"] == [
+        "/tmp/omnigent-policy.js",
+        "/opt/pulse-agents-harnesses/other",
+        "/opt/pulse-agents-harnesses/marshal-opencode",
+    ]
+
+
 def test_merge_user_provider_config_merges_alongside_synthesized_providers(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
Closes #5345.

Per-session native OpenCode config synthesis merges the user's global providers and default model but drops their top-level `plugin` entries. Any plugin the user's setup relies on for provider auth (e.g. a plugin-based Google/antigravity auth flow) therefore never loads in a native session, and OpenCode falls back to a bare API-key check that fails with "... API key is missing".

This carries the user's `plugin` list into the synthesized session config in `maybe_merge_user_provider_config`, appending the user's plugins after the synthesized policy plugins and deduplicating, so integrations like Marshal stay available. Both merge paths (with and without user-supplied providers) are covered.

Adds regression coverage. Tests: 40 passed.

Verified fail→pass against the live #5345 reproduction by the resolve agent.
