### PR TITLE
fix(native): surface the upstream failure in the policy-eval relay 502

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -31,6 +31,7 @@ import asyncio
 import contextlib
 import hashlib
 import json
+import logging
 import os
 import queue
 import re
@@ -67,6 +68,8 @@ from omnigent.inner.os_env import OSEnvironment, create_os_environment
 from omnigent.reasoning_effort import CLAUDE_EFFORTS
 from omnigent.tools.base import Tool, ToolContext
 from omnigent.tools.builtins.os_env import build_os_env_tools
+
+_logger = logging.getLogger(__name__)
 
 BRIDGE_DIR_ENV_VAR = "HARNESS_CLAUDE_NATIVE_BRIDGE_DIR"
 REQUEST_SESSION_ID_ENV_VAR = "HARNESS_CLAUDE_NATIVE_REQUEST_SESSION_ID"
@@ -3598,6 +3601,12 @@ def _handler_factory(
     return _ControlHandler
 
 
+# Cap for the upstream-failure detail echoed in the policy-eval proxy's 502
+# body. Applied to the detail before the fixed prefix so the leading cause is
+# never cut mid-reason by the truncation.
+_POLICY_PROXY_ERROR_DETAIL_MAX = 400
+
+
 def _tool_relay_handler_factory(
     token: str,
     tool_executor: ToolExecutor,
@@ -3701,8 +3710,16 @@ def _tool_relay_handler_factory(
             """
             reason = str(exc).strip()
             detail = f"{type(exc).__name__}: {reason}" if reason else type(exc).__name__
+            # Truncate the detail (not the composed message) so the leading
+            # cause always survives intact instead of being cut mid-reason once
+            # the fixed prefix is prepended.
+            if len(detail) > _POLICY_PROXY_ERROR_DETAIL_MAX:
+                detail = detail[: _POLICY_PROXY_ERROR_DETAIL_MAX - 3] + "..."
             message = f"omnigent policy-eval proxy could not reach the Omnigent server: {detail}"
-            body = message[:500].encode("utf-8", "replace")
+            # Keep the full exception (with traceback) in the runner log; the
+            # user-facing body is capped and can drop a diagnostically useful tail.
+            _logger.warning("policy-eval proxy forward failed: %s", detail, exc_info=exc)
+            body = message.encode("utf-8", "replace")
             self.send_response(HTTPStatus.BAD_GATEWAY)
             self.send_header("Content-Type", "text/plain; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -3672,8 +3672,8 @@ def _tool_relay_handler_factory(
             future = asyncio.run_coroutine_threadsafe(policy_client.post(url, json=payload), loop)
             try:
                 resp = future.result(timeout=86400.0)
-            except Exception:  # noqa: BLE001
-                self.send_error(HTTPStatus.BAD_GATEWAY)
+            except Exception as exc:  # noqa: BLE001
+                self._send_policy_proxy_error(exc)
                 return
             raw = resp.content
             self.send_response(resp.status_code)
@@ -3685,6 +3685,29 @@ def _tool_relay_handler_factory(
                 self.send_header("Content-Length", str(len(raw)))
             self.end_headers()
             self.wfile.write(raw)
+
+        def _send_policy_proxy_error(self, exc: Exception) -> None:
+            """Return a 502 whose body names why the upstream forward failed.
+
+            The default ``send_error`` writes a generic ``http.server`` HTML
+            page; the policy hook truncates that body into its fail-closed
+            ``Detail:``, so a bare page reads as an opaque gateway blip. Most
+            failures here are a Databricks token-refresh lapse the
+            refresh-capable client surfaces as ``httpx.RequestError`` — lead the
+            body with that cause so the blocked-turn message is actionable.
+
+            :param exc: The exception raised by the upstream policy POST.
+            :returns: None.
+            """
+            reason = str(exc).strip()
+            detail = f"{type(exc).__name__}: {reason}" if reason else type(exc).__name__
+            message = f"omnigent policy-eval proxy could not reach the Omnigent server: {detail}"
+            body = message[:500].encode("utf-8", "replace")
+            self.send_response(HTTPStatus.BAD_GATEWAY)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
 
         def _read_json_body(self) -> _JsonObject | None:
             """

--- a/tests/runner/test_comment_relay.py
+++ b/tests/runner/test_comment_relay.py
@@ -722,3 +722,62 @@ async def test_relay_policy_evaluate_rejects_wrong_token(
         assert resp.status_code == 401
     finally:
         relay.close()
+
+
+@pytest.mark.asyncio
+async def test_relay_policy_evaluate_surfaces_upstream_error_in_502_body(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Relay /policies/evaluate returns a 502 whose body names the upstream failure.
+
+    When the refresh-capable server_client raises (e.g. the Databricks token
+    could not be refreshed), the relay must surface that reason instead of the
+    generic http.server 502 page, so the hook's fail-closed ``Detail:`` is
+    actionable rather than an opaque gateway error.
+    """
+    import asyncio
+
+    from omnigent.claude_native_bridge import prepare_bridge_dir as _prep
+    from omnigent.claude_native_bridge import start_tool_relay
+
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
+
+    bridge_dir = _prep("relay-policy-error-test", workspace=tmp_path)
+
+    class _RaisingServerClient:
+        """Fake server_client whose policy POST fails like a lapsed token."""
+
+        async def post(self, *a: object, **kw: object) -> object:
+            raise httpx.RequestError("Databricks token refresh returned no token")
+
+    loop = asyncio.get_running_loop()
+    relay = start_tool_relay(
+        bridge_dir=bridge_dir,
+        tools=[],
+        tool_executor=lambda name, args: {},  # type: ignore[arg-type]
+        loop=loop,
+        policy_client=_RaisingServerClient(),
+        session_id="conv_err_test",
+    )
+    try:
+        relay_info = json.loads((bridge_dir / _TOOL_RELAY_FILE).read_text())
+        relay_url = relay_info["url"]
+        relay_token = relay_info["token"]
+
+        async with httpx.AsyncClient() as c:
+            resp = await c.post(
+                f"{relay_url}/policies/evaluate",
+                json={"event": {"type": "PHASE_REQUEST", "target": "", "data": {"text": "hi"}}},
+                headers={"Authorization": f"Bearer {relay_token}"},
+                timeout=5.0,
+            )
+
+        assert resp.status_code == 502
+        # The body must name the upstream cause, not the generic HTML page, so
+        # the hook's fail-closed reason is actionable.
+        assert "Databricks token refresh returned no token" in resp.text
+        assert "<html" not in resp.text.lower()
+    finally:
+        relay.close()

--- a/tests/runner/test_comment_relay.py
+++ b/tests/runner/test_comment_relay.py
@@ -781,3 +781,65 @@ async def test_relay_policy_evaluate_surfaces_upstream_error_in_502_body(
         assert "<html" not in resp.text.lower()
     finally:
         relay.close()
+
+
+@pytest.mark.asyncio
+async def test_relay_policy_evaluate_truncates_long_upstream_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A very long upstream error is truncated with its leading cause intact.
+
+    The detail is capped before the fixed prefix is prepended, so the 502 body
+    always starts with the actionable prefix + cause and ends with an ellipsis
+    rather than being cut mid-reason by a cap applied to the whole message.
+    """
+    import asyncio
+
+    from omnigent.claude_native_bridge import prepare_bridge_dir as _prep
+    from omnigent.claude_native_bridge import start_tool_relay
+
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
+
+    bridge_dir = _prep("relay-policy-trunc-test", workspace=tmp_path)
+
+    class _LongRaisingServerClient:
+        """Fake server_client whose policy POST fails with a very long reason."""
+
+        async def post(self, *a: object, **kw: object) -> object:
+            raise httpx.RequestError("x" * 5000)
+
+    loop = asyncio.get_running_loop()
+    relay = start_tool_relay(
+        bridge_dir=bridge_dir,
+        tools=[],
+        tool_executor=lambda name, args: {},  # type: ignore[arg-type]
+        loop=loop,
+        policy_client=_LongRaisingServerClient(),
+        session_id="conv_trunc_test",
+    )
+    try:
+        relay_info = json.loads((bridge_dir / _TOOL_RELAY_FILE).read_text())
+        relay_url = relay_info["url"]
+        relay_token = relay_info["token"]
+
+        async with httpx.AsyncClient() as c:
+            resp = await c.post(
+                f"{relay_url}/policies/evaluate",
+                json={"event": {}},
+                headers={"Authorization": f"Bearer {relay_token}"},
+                timeout=5.0,
+            )
+
+        assert resp.status_code == 502
+        body = resp.text
+        # The actionable prefix + leading cause survive; the tail is elided.
+        assert body.startswith(
+            "omnigent policy-eval proxy could not reach the Omnigent server: RequestError: "
+        )
+        assert body.endswith("...")
+        # Bounded well under the raw 5000-char reason.
+        assert len(body) < 500
+    finally:
+        relay.close()


### PR DESCRIPTION
## Related issue

N/A — surfaced from a QA report of `omnigent host` against the Databricks-hosted
server (policy evaluation failing closed roughly every hour with a `502`).

## Summary

When a claude/codex/kimi native session runs against a Databricks-hosted
Omnigent server, the `UserPromptSubmit` / tool policy hook does not call the
server directly — it POSTs to the runner's **local** policy-eval relay
(`_ToolRelayHandler` in `claude_native_bridge.py`), which forwards to the server
with the runner's refresh-capable client.

- If that upstream forward *raises* (e.g. the Databricks token could not be
  refreshed, so the client raises `RequestError("Databricks token refresh
  returned no token")`), the relay replied with a bare
  `BaseHTTPRequestHandler.send_error(502)`. That writes Python's stock
  `http.server` HTML page (`<!DOCTYPE HTML> … <p>Error code: 502</p>`), which
  names **no** cause.
- The policy hook truncates that page into its fail-closed `Detail:`, so the
  blocked-turn message users saw was `… server returned 502: <!DOCTYPE HTML>…` —
  which reads like a gateway/server outage rather than the auth-refresh lapse it
  actually was.

This PR replaces the opaque page with a `502` whose plain-text body leads with
the upstream exception, e.g.:

```
omnigent policy-eval proxy could not reach the Omnigent server: RequestError: Databricks token refresh returned no token
```

so the fail-closed reason surfaced to the user is actionable.

**Scope:** diagnosability only. This does **not** change token-refresh behavior;
the underlying refresh failure (server returning `403` on the runner-token mint
endpoint after ~1h) is a separate, server-side investigation.

## Test Plan

- New unit test `test_relay_policy_evaluate_surfaces_upstream_error_in_502_body`
  drives the real relay over HTTP with a `policy_client` that raises like a
  lapsed token, and asserts the `502` body contains the upstream reason and is
  **not** the generic HTML page.
- `pytest tests/runner/test_comment_relay.py -k policy_evaluate` → 3 passed
  (the new test plus the two existing forwarding / wrong-token tests, confirming
  the success and 401 paths are unchanged).
- `pre-commit` green on both files (ruff format, ruff check, pyrefly, scanners).

## Demo

N/A — non-visual (server-side error-message content).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new unit test exercises the exact failure path (upstream `.post()` raising)
end-to-end through a real relay HTTP round-trip; the two existing tests pin the
unchanged success (verdict forwarded) and auth-reject (`401`) paths.

## Changelog

Policy-evaluation failures now report the underlying cause instead of an opaque `502` page.
