### PR TITLE
fix(web): keep the composer's branch and model painted across a session switch

### DIFF
--- a/tests/e2e_ui/chat/test_claude_model_picker.py
+++ b/tests/e2e_ui/chat/test_claude_model_picker.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 from playwright.sync_api import Page, Route, expect
 
 from omnigent.claude_native import ClaudeNativeUcodeConfig, claude_native_model_options
+from tests.e2e_ui.conftest import seed_committed_turn
 
 _EXPECTED_ROWS = [
     ("opus", "Opus 4.10"),
@@ -425,6 +426,187 @@ def test_claude_native_unpinned_gateway_catalog_offers_only_the_routable_default
     expect(rows.first).to_have_attribute("data-model-id", default_model)
     expect(rows.first).to_have_attribute("data-active", "true")
     _screenshot(page, "unpinned-gateway-picker")
+
+
+_CODEX_MODEL_ID = "gpt-5.5"
+_CODEX_MODEL_LABEL = "Codex Pretty 5.5"
+_CODEX_MODEL_OPTIONS = [
+    {
+        "id": _CODEX_MODEL_ID,
+        "model": "databricks-gpt-5-5",
+        "displayName": _CODEX_MODEL_LABEL,
+        "isDefault": True,
+    }
+]
+_CLAUDE_LLM_MODEL = "system.ai.claude-sonnet-5"
+# Long enough that the stale-label window is unmissable, short enough to keep
+# the test quick. Only the switch back to the Claude session is delayed.
+_SNAPSHOT_DELAY_MS = 2_000
+
+# Records every distinct composer model label the page ever paints, tagged with
+# the session route it was painted under. A transient wrong label is invisible
+# to `expect()` (which retries until it passes), so the assertion runs against
+# this log rather than a point-in-time read.
+_LABEL_RECORDER = """
+(() => {
+  window.__modelLabelLog = [];
+  const record = () => {
+    const el = document.querySelector('[data-testid="composer-model-effort-label"]');
+    const entry = { path: location.pathname, text: el ? el.textContent.trim() : "" };
+    const log = window.__modelLabelLog;
+    const last = log[log.length - 1];
+    if (!last || last.path !== entry.path || last.text !== entry.text) log.push(entry);
+  };
+  new MutationObserver(record).observe(document, {
+    subtree: true,
+    childList: true,
+    characterData: true,
+  });
+})()
+"""
+
+# Holds the incoming session's snapshot GET so the pre-bind window — where the
+# store has dropped the outgoing session's model fields but not yet hydrated the
+# incoming one's — lasts long enough to observe. Armed via `__delaySnapshot`
+# right before the switch so the first visit stays fast.
+_SNAPSHOT_DELAY = """
+(() => {
+  const sessionId = __SESSION_ID__;
+  const delayMs = __DELAY_MS__;
+  const originalFetch = window.fetch.bind(window);
+  window.fetch = async (input, init) => {
+    const url = typeof input === "string" ? input : input.url;
+    if (
+      window.__delaySnapshot &&
+      new URL(url, window.location.origin).pathname === `/v1/sessions/${sessionId}`
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    return originalFetch(input, init);
+  };
+})()
+"""
+
+
+def _patch_native_session_pair(page: Page, codex_session_id: str, claude_session_id: str) -> None:
+    """Patch two session snapshots at once: one codex-native, one claude-native.
+
+    The sibling single-session helpers each own a ``**/v1/sessions/**`` route
+    and ``continue_()`` past the ids they don't serve, so two of them can't be
+    composed (the first matching handler wins and goes straight to the
+    network). This serves both ids from one handler instead.
+
+    :param page: Playwright page before navigation.
+    :param codex_session_id: Session id to shape as codex-native, pinned to
+        ``gpt-5.5`` via ``model_override`` so binding it leaves that model as
+        the cross-session sticky pick.
+    :param claude_session_id: Session id to shape as claude-native, bound to
+        Sonnet 5 with no override of its own.
+    """
+
+    def _handle(route: Route) -> None:
+        request = route.request
+        path = urlparse(request.url).path
+        if request.method != "GET" or path not in (
+            f"/v1/sessions/{codex_session_id}",
+            f"/v1/sessions/{claude_session_id}",
+        ):
+            route.continue_()
+            return
+
+        response = route.fetch()
+        payload = response.json()
+        if path == f"/v1/sessions/{codex_session_id}":
+            wrapper, harness = "codex-native-ui", "codex"
+            payload["llm_model"] = _CODEX_MODEL_ID
+            payload["model_override"] = _CODEX_MODEL_ID
+            payload["model_options"] = _CODEX_MODEL_OPTIONS
+        else:
+            wrapper, harness = "claude-code-native-ui", "claude"
+            payload["llm_model"] = _CLAUDE_LLM_MODEL
+            payload["model_options"] = _MODEL_OPTIONS
+        payload["labels"] = {**payload.get("labels", {}), "omnigent.wrapper": wrapper}
+        payload["harness"] = harness
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    page.route("**/v1/sessions/**", _handle)
+
+
+def test_composer_model_label_never_shows_the_previous_sessions_model(
+    page: Page,
+    seeded_session_pair: tuple[str, str, str],
+) -> None:
+    """Switching Codex → Claude must not paint Codex's model on the way in.
+
+    Failure mode this catches: ``switchTo`` clears the session-scoped model
+    fields (``sessionModelOverride`` / ``llmModel`` / ``codexModelOptions``) but
+    deliberately keeps ``selectedModel``, the cross-session sticky pick. The
+    native picker kind flips to Claude immediately (the session query and the
+    sidebar row are already cached), so for the whole snapshot round trip the
+    composer resolves the sticky and reads ``gpt-5.5`` on a Claude session
+    before correcting itself to Sonnet 5.
+
+    :param page: Playwright page fixture.
+    :param seeded_session_pair: ``(base_url, codex_session, claude_session)``
+        for two real server-backed sessions; both snapshots are patched into
+        native shapes as seen by the browser.
+    """
+    base_url, codex_session, claude_session = seeded_session_pair
+    # Both sessions need a committed transcript: the store caches (and repaints
+    # from) only non-empty ones, and an empty session falls back to the hydrate
+    # placeholder, which hides the composer instead of painting a stale label.
+    for session_id in (codex_session, claude_session):
+        seed_committed_turn(session_id, prompt="ping", reply="pong")
+    _patch_native_session_pair(page, codex_session, claude_session)
+    page.add_init_script(_LABEL_RECORDER)
+    page.add_init_script(
+        _SNAPSHOT_DELAY.replace("__SESSION_ID__", json.dumps(claude_session)).replace(
+            "__DELAY_MS__", str(_SNAPSHOT_DELAY_MS)
+        )
+    )
+
+    label = page.get_by_test_id("composer-model-effort-label")
+
+    # Visit the Claude session first so the return trip is the real-world
+    # switch-back: its snapshot query and transcript are cached, so the
+    # composer stays mounted (no hydrate placeholder) and paints through the
+    # window instead of being replaced by a spinner.
+    page.goto(f"{base_url}/c/{claude_session}")
+    expect(label).to_contain_text("Sonnet 5", timeout=15_000)
+
+    # Open the Codex session — binding it makes gpt-5.5 the sticky pick.
+    page.locator(f'a[href="/c/{codex_session}"]').click()
+    page.wait_for_url(re.compile(rf"/c/{re.escape(codex_session)}"))
+    expect(label).to_contain_text(_CODEX_MODEL_LABEL, timeout=15_000)
+
+    # Switch back to Claude with its snapshot held, and watch every label the
+    # composer paints under the Claude route.
+    page.evaluate("window.__delaySnapshot = true")
+    page.evaluate("window.__modelLabelLog = []")
+    page.locator(f'a[href="/c/{claude_session}"]').click()
+    page.wait_for_url(re.compile(rf"/c/{re.escape(claude_session)}"))
+    expect(label).to_contain_text("Sonnet 5", timeout=15_000)
+
+    log = page.evaluate("window.__modelLabelLog")
+    claude_labels = [e["text"] for e in log if e["path"] == f"/c/{claude_session}"]
+    # Guard against a no-op run: the held snapshot must have produced at least
+    # one pre-bind paint before the settled Sonnet 5 label.
+    assert len(claude_labels) > 1, (
+        f"the delayed-bind window was never observed (labels: {claude_labels}); "
+        "the snapshot delay did not take effect, so this run proves nothing"
+    )
+    leaked = [
+        text for text in claude_labels if _CODEX_MODEL_ID in text or _CODEX_MODEL_LABEL in text
+    ]
+    assert not leaked, (
+        f"the Codex session's model leaked into the Claude session's composer: {leaked} "
+        f"(full label sequence under the Claude route: {claude_labels}). The composer must "
+        "never surface another session's sticky model while the snapshot is in flight."
+    )
 
 
 def test_claude_native_picker_prefers_session_override_over_sticky_model(

--- a/tests/e2e_ui/chat/test_claude_model_picker.py
+++ b/tests/e2e_ui/chat/test_claude_model_picker.py
@@ -439,23 +439,36 @@ _CODEX_MODEL_OPTIONS = [
     }
 ]
 _CLAUDE_LLM_MODEL = "system.ai.claude-sonnet-5"
+_CLAUDE_BRANCH = "feature/claude-worktree"
+_CODEX_BRANCH = "feature/codex-worktree"
 # Long enough that the stale-label window is unmissable, short enough to keep
 # the test quick. Only the switch back to the Claude session is delayed.
 _SNAPSHOT_DELAY_MS = 2_000
 
-# Records every distinct composer model label the page ever paints, tagged with
-# the session route it was painted under. A transient wrong label is invisible
-# to `expect()` (which retries until it passes), so the assertion runs against
-# this log rather than a point-in-time read.
-_LABEL_RECORDER = """
+# Records every distinct composer readout the page paints — model label and
+# worktree branch — tagged with the session route it was painted under. A
+# transient wrong (or blank) value is invisible to `expect()`, which retries
+# until it passes, so assertions run against this log rather than a
+# point-in-time read.
+_COMPOSER_RECORDER = """
 (() => {
-  window.__modelLabelLog = [];
+  window.__composerLog = [];
+  const text = (testId) => {
+    const el = document.querySelector(`[data-testid="${testId}"]`);
+    return el ? el.textContent.trim() : "";
+  };
   const record = () => {
-    const el = document.querySelector('[data-testid="composer-model-effort-label"]');
-    const entry = { path: location.pathname, text: el ? el.textContent.trim() : "" };
-    const log = window.__modelLabelLog;
+    const entry = {
+      path: location.pathname,
+      model: text("composer-model-effort-label"),
+      branch: text("composer-git-branch"),
+    };
+    const log = window.__composerLog;
     const last = log[log.length - 1];
-    if (!last || last.path !== entry.path || last.text !== entry.text) log.push(entry);
+    if (!last || last.path !== entry.path || last.model !== entry.model ||
+        last.branch !== entry.branch) {
+      log.push(entry);
+    }
   };
   new MutationObserver(record).observe(document, {
     subtree: true,
@@ -466,13 +479,15 @@ _LABEL_RECORDER = """
 """
 
 # Holds the incoming session's snapshot GET so the pre-bind window — where the
-# store has dropped the outgoing session's model fields but not yet hydrated the
+# store has dropped the outgoing session's fields but not yet hydrated the
 # incoming one's — lasts long enough to observe. Armed via `__delaySnapshot`
-# right before the switch so the first visit stays fast.
+# right before the switch so the first visit stays fast. `__snapshotHeld`
+# counts the holds actually applied, so a test can prove the window was real.
 _SNAPSHOT_DELAY = """
 (() => {
   const sessionId = __SESSION_ID__;
   const delayMs = __DELAY_MS__;
+  window.__snapshotHeld = 0;
   const originalFetch = window.fetch.bind(window);
   window.fetch = async (input, init) => {
     const url = typeof input === "string" ? input : input.url;
@@ -480,6 +495,7 @@ _SNAPSHOT_DELAY = """
       window.__delaySnapshot &&
       new URL(url, window.location.origin).pathname === `/v1/sessions/${sessionId}`
     ) {
+      window.__snapshotHeld += 1;
       await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
     return originalFetch(input, init);
@@ -502,6 +518,9 @@ def _patch_native_session_pair(page: Page, codex_session_id: str, claude_session
         the cross-session sticky pick.
     :param claude_session_id: Session id to shape as claude-native, bound to
         Sonnet 5 with no override of its own.
+
+    Each session also gets its own worktree branch, so the composer tray's
+    branch readout is attributable to one session or the other.
     """
 
     def _handle(route: Route) -> None:
@@ -521,10 +540,12 @@ def _patch_native_session_pair(page: Page, codex_session_id: str, claude_session
             payload["llm_model"] = _CODEX_MODEL_ID
             payload["model_override"] = _CODEX_MODEL_ID
             payload["model_options"] = _CODEX_MODEL_OPTIONS
+            payload["git_branch"] = _CODEX_BRANCH
         else:
             wrapper, harness = "claude-code-native-ui", "claude"
             payload["llm_model"] = _CLAUDE_LLM_MODEL
             payload["model_options"] = _MODEL_OPTIONS
+            payload["git_branch"] = _CLAUDE_BRANCH
         payload["labels"] = {**payload.get("labels", {}), "omnigent.wrapper": wrapper}
         payload["harness"] = harness
         route.fulfill(
@@ -562,7 +583,7 @@ def test_composer_model_label_never_shows_the_previous_sessions_model(
     for session_id in (codex_session, claude_session):
         seed_committed_turn(session_id, prompt="ping", reply="pong")
     _patch_native_session_pair(page, codex_session, claude_session)
-    page.add_init_script(_LABEL_RECORDER)
+    page.add_init_script(_COMPOSER_RECORDER)
     page.add_init_script(
         _SNAPSHOT_DELAY.replace("__SESSION_ID__", json.dumps(claude_session)).replace(
             "__DELAY_MS__", str(_SNAPSHOT_DELAY_MS)
@@ -586,16 +607,16 @@ def test_composer_model_label_never_shows_the_previous_sessions_model(
     # Switch back to Claude with its snapshot held, and watch every label the
     # composer paints under the Claude route.
     page.evaluate("window.__delaySnapshot = true")
-    page.evaluate("window.__modelLabelLog = []")
+    page.evaluate("window.__composerLog = []")
     page.locator(f'a[href="/c/{claude_session}"]').click()
     page.wait_for_url(re.compile(rf"/c/{re.escape(claude_session)}"))
     expect(label).to_contain_text("Sonnet 5", timeout=15_000)
 
-    log = page.evaluate("window.__modelLabelLog")
-    claude_labels = [e["text"] for e in log if e["path"] == f"/c/{claude_session}"]
-    # Guard against a no-op run: the held snapshot must have produced at least
-    # one pre-bind paint before the settled Sonnet 5 label.
-    assert len(claude_labels) > 1, (
+    log = page.evaluate("window.__composerLog")
+    claude_labels = [e["model"] for e in log if e["path"] == f"/c/{claude_session}"]
+    # Guard against a no-op run: the snapshot must actually have been held, so
+    # the labels below were painted with the incoming bind still in flight.
+    assert page.evaluate("window.__snapshotHeld || 0") >= 1, (
         f"the delayed-bind window was never observed (labels: {claude_labels}); "
         "the snapshot delay did not take effect, so this run proves nothing"
     )
@@ -606,6 +627,78 @@ def test_composer_model_label_never_shows_the_previous_sessions_model(
         f"the Codex session's model leaked into the Claude session's composer: {leaked} "
         f"(full label sequence under the Claude route: {claude_labels}). The composer must "
         "never surface another session's sticky model while the snapshot is in flight."
+    )
+
+
+def test_composer_keeps_branch_and_model_painted_when_switching_back(
+    page: Page,
+    seeded_session_pair: tuple[str, str, str],
+) -> None:
+    """A revisited session paints its own branch and model before the bind lands.
+
+    ``switchTo`` nulls every snapshot-derived field, so the composer tray's
+    worktree branch and the model label both blank out for the whole bind round
+    trip — the composer visibly "jitters" on each switch. The session metadata
+    cache seeds those fields from this session's own last-known values, so the
+    readouts stay populated and are merely refreshed when the snapshot answers.
+
+    :param page: Playwright page fixture.
+    :param seeded_session_pair: ``(base_url, codex_session, claude_session)``
+        for two real server-backed sessions; both snapshots are patched into
+        native shapes, each with its own branch and model.
+    """
+    base_url, codex_session, claude_session = seeded_session_pair
+    # Both sessions need a committed transcript: an empty one falls back to the
+    # hydrate placeholder, which unmounts the composer instead of repainting it.
+    for session_id in (codex_session, claude_session):
+        seed_committed_turn(session_id, prompt="ping", reply="pong")
+    _patch_native_session_pair(page, codex_session, claude_session)
+    page.add_init_script(_COMPOSER_RECORDER)
+    page.add_init_script(
+        _SNAPSHOT_DELAY.replace("__SESSION_ID__", json.dumps(claude_session)).replace(
+            "__DELAY_MS__", str(_SNAPSHOT_DELAY_MS)
+        )
+    )
+
+    label = page.get_by_test_id("composer-model-effort-label")
+    branch = page.get_by_test_id("composer-git-branch")
+
+    # First visit populates the cache for the Claude session.
+    page.goto(f"{base_url}/c/{claude_session}")
+    expect(label).to_contain_text("Sonnet 5", timeout=15_000)
+    expect(branch).to_have_text(_CLAUDE_BRANCH, timeout=15_000)
+
+    page.locator(f'a[href="/c/{codex_session}"]').click()
+    page.wait_for_url(re.compile(rf"/c/{re.escape(codex_session)}"))
+    expect(label).to_contain_text(_CODEX_MODEL_LABEL, timeout=15_000)
+    expect(branch).to_have_text(_CODEX_BRANCH, timeout=15_000)
+
+    # Switch back with the Claude snapshot held, so every paint below happens
+    # while the incoming bind is still in flight.
+    page.evaluate("window.__delaySnapshot = true")
+    page.evaluate("window.__composerLog = []")
+    page.locator(f'a[href="/c/{claude_session}"]').click()
+    page.wait_for_url(re.compile(rf"/c/{re.escape(claude_session)}"))
+    expect(label).to_contain_text("Sonnet 5", timeout=15_000)
+
+    log = page.evaluate("window.__composerLog")
+    painted = [e for e in log if e["path"] == f"/c/{claude_session}"]
+    assert page.evaluate("window.__snapshotHeld || 0") >= 1, (
+        f"the delayed-bind window was never observed (paints: {painted}); "
+        "the snapshot delay did not take effect, so this run proves nothing"
+    )
+    assert painted, "the composer never repainted under the Claude route"
+    # Every paint in the window carries this session's own values: not blank
+    # (the jitter) and not the Codex session's (a cross-session leak).
+    blanked = [e for e in painted if not e["branch"] or not e["model"]]
+    assert not blanked, (
+        f"the composer blanked its branch/model while the snapshot was in flight: {blanked}. "
+        "A revisited session must repaint from its cached metadata."
+    )
+    wrong = [e for e in painted if e["branch"] != _CLAUDE_BRANCH or "Sonnet 5" not in e["model"]]
+    assert not wrong, (
+        f"the composer painted values that are not the Claude session's: {wrong} "
+        f"(full sequence: {painted})."
     )
 
 

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -46,6 +46,7 @@ import {
   updateProjectConfig as apiUpdateProjectConfig,
 } from "@/lib/projectsApi";
 import { evictTranscriptCache, useChatStore } from "@/store/chatStore";
+import { evictSessionMeta } from "@/lib/sessionMetaCache";
 import type { Session } from "@/lib/types";
 import { useSessionUpdatesConnected } from "./useSessionUpdatesConnected";
 import { markConversationSeen } from "./useUnseenConversations";
@@ -383,6 +384,7 @@ export async function deleteConversation(id: string, deleteBranch = false): Prom
   // a dead conversation, they could never flush.
   useChatStore.getState().clearQueuedMessages(id);
   evictTranscriptCache(id);
+  evictSessionMeta(id);
 }
 
 /**

--- a/web/src/lib/sessionMetaCache.test.ts
+++ b/web/src/lib/sessionMetaCache.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  evictSessionMeta,
+  readSessionMeta,
+  writeSessionMeta,
+  type SessionMeta,
+} from "./sessionMetaCache";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+function meta(patch: Partial<SessionMeta> = {}): SessionMeta {
+  return {
+    gitBranch: "feature/x",
+    llmModel: "system.ai.claude-sonnet-5",
+    sessionModelOverride: null,
+    sessionHarness: "claude",
+    nativeVendorOwnsModel: false,
+    codexModelOptions: [{ id: "opus", displayName: "Opus 4.10" }],
+    ...patch,
+  };
+}
+
+describe("sessionMetaCache", () => {
+  it("returns null for a session it has never seen", () => {
+    // A miss must read as "nothing known" so the caller paints blanks rather
+    // than some other session's branch/model.
+    expect(readSessionMeta("conv_unknown")).toBeNull();
+  });
+
+  it("round-trips one session's metadata and keeps sessions independent", () => {
+    writeSessionMeta("conv_a", meta({ gitBranch: "feature/a" }));
+    writeSessionMeta("conv_b", meta({ gitBranch: "feature/b", sessionHarness: "codex" }));
+
+    expect(readSessionMeta("conv_a")?.gitBranch).toBe("feature/a");
+    expect(readSessionMeta("conv_a")?.sessionHarness).toBe("claude");
+    expect(readSessionMeta("conv_b")?.gitBranch).toBe("feature/b");
+    expect(readSessionMeta("conv_a")?.codexModelOptions).toEqual([
+      { id: "opus", displayName: "Opus 4.10" },
+    ]);
+  });
+
+  it("drops an entry that would paint nothing", () => {
+    // An all-empty entry reads the same as a miss, so it must not hold a slot —
+    // and re-writing one must clear a previously useful entry rather than
+    // leaving stale values behind.
+    writeSessionMeta("conv_empty", meta());
+    writeSessionMeta(
+      "conv_empty",
+      meta({
+        gitBranch: null,
+        llmModel: null,
+        sessionHarness: null,
+        codexModelOptions: [],
+      }),
+    );
+    expect(readSessionMeta("conv_empty")).toBeNull();
+  });
+
+  it("evicts a deleted session", () => {
+    writeSessionMeta("conv_gone", meta());
+    evictSessionMeta("conv_gone");
+    expect(readSessionMeta("conv_gone")).toBeNull();
+  });
+
+  it("prunes the oldest-touched sessions past the cap", () => {
+    // 50 is the cap; writing 60 must keep the newest 50 and drop the rest, so
+    // the store can't grow without bound.
+    for (let i = 0; i < 60; i++) writeSessionMeta(`conv_${i}`, meta({ gitBranch: `branch/${i}` }));
+    expect(readSessionMeta("conv_0")).toBeNull();
+    expect(readSessionMeta("conv_9")).toBeNull();
+    expect(readSessionMeta("conv_10")?.gitBranch).toBe("branch/10");
+    expect(readSessionMeta("conv_59")?.gitBranch).toBe("branch/59");
+  });
+
+  it("re-touching a session protects it from pruning", () => {
+    for (let i = 0; i < 50; i++) writeSessionMeta(`conv_${i}`, meta());
+    writeSessionMeta("conv_0", meta({ gitBranch: "branch/touched" }));
+    writeSessionMeta("conv_new", meta());
+    // conv_0 was refreshed, so conv_1 (now the oldest) is evicted instead.
+    expect(readSessionMeta("conv_0")?.gitBranch).toBe("branch/touched");
+    expect(readSessionMeta("conv_1")).toBeNull();
+  });
+
+  it("survives corrupt or hand-edited storage instead of throwing", () => {
+    localStorage.setItem("omnigent:session-meta.v1", "not json");
+    expect(readSessionMeta("conv_a")).toBeNull();
+
+    // Wrong-typed fields degrade to empty rather than reaching the store as
+    // e.g. a number where the composer expects a branch string.
+    localStorage.setItem(
+      "omnigent:session-meta.v1",
+      JSON.stringify([
+        {
+          id: "conv_a",
+          meta: { gitBranch: 42, codexModelOptions: [{ noId: true }, { id: "ok" }] },
+        },
+        { id: 7, meta: {} },
+      ]),
+    );
+    const stored = readSessionMeta("conv_a");
+    expect(stored?.gitBranch).toBeNull();
+    expect(stored?.nativeVendorOwnsModel).toBe(false);
+    expect(stored?.codexModelOptions).toEqual([{ id: "ok" }]);
+  });
+
+  it("never throws when storage is inaccessible", () => {
+    // Private-mode / quota failures surface as throws from the Storage API;
+    // a broken cache must not break session switching.
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("access denied");
+    });
+    expect(() => writeSessionMeta("conv_a", meta())).not.toThrow();
+    expect(readSessionMeta("conv_a")).toBeNull();
+  });
+});

--- a/web/src/lib/sessionMetaCache.ts
+++ b/web/src/lib/sessionMetaCache.ts
@@ -1,0 +1,161 @@
+// Per-session composer metadata — the worktree branch and the model identity —
+// persisted so switching back to a session repaints its tray and model label
+// from last-known values instead of blanking until the snapshot lands. The
+// snapshot overwrites these a moment later; this only fills the gap.
+
+import type { NativeModelOption } from "@/lib/types";
+
+export interface SessionMeta {
+  /** Worktree branch shown in the composer tray. */
+  gitBranch: string | null;
+  /** Model the session launched with. */
+  llmModel: string | null;
+  /** Model pinned on this session, if any. */
+  sessionModelOverride: string | null;
+  /** Harness identity behind the composer's label and gear tooltip. */
+  sessionHarness: string | null;
+  /** Whether the vendor TUI owns the model (no Omnigent-visible pick). */
+  nativeVendorOwnsModel: boolean;
+  /** The session's own model catalog, which the label resolves ids against. */
+  codexModelOptions: NativeModelOption[];
+}
+
+const STORAGE_KEY = "omnigent:session-meta.v1";
+// Cap stored sessions so the store can't grow without bound. The
+// least-recently-touched entries (front of the array) are pruned first.
+const MAX_SESSIONS = 50;
+
+/**
+ * One persisted session entry. The store is an ordered array (not a keyed
+ * object) so recency ordering survives serialization regardless of the id
+ * format — a plain `Record` reorders integer-like keys, breaking both the
+ * "touch = move to end" refresh and the oldest-first pruning. Same shape as
+ * `sessionWorkspaceState`, for the same reason.
+ */
+interface StoredEntry {
+  id: string;
+  meta: SessionMeta;
+}
+
+type Store = StoredEntry[];
+
+function nullableString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+/**
+ * Keep catalog rows that carry the one field every consumer needs (`id`);
+ * the rest are optional to downstream code, so they ride along untouched.
+ */
+function sanitizeModelOptions(value: unknown): NativeModelOption[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (option): option is NativeModelOption =>
+      typeof option === "object" &&
+      option !== null &&
+      typeof (option as { id?: unknown }).id === "string",
+  );
+}
+
+function sanitize(entry: unknown): SessionMeta {
+  if (typeof entry !== "object" || entry === null) return emptyMeta();
+  const record = entry as Record<string, unknown>;
+  return {
+    gitBranch: nullableString(record.gitBranch),
+    llmModel: nullableString(record.llmModel),
+    sessionModelOverride: nullableString(record.sessionModelOverride),
+    sessionHarness: nullableString(record.sessionHarness),
+    nativeVendorOwnsModel: record.nativeVendorOwnsModel === true,
+    codexModelOptions: sanitizeModelOptions(record.codexModelOptions),
+  };
+}
+
+function emptyMeta(): SessionMeta {
+  return {
+    gitBranch: null,
+    llmModel: null,
+    sessionModelOverride: null,
+    sessionHarness: null,
+    nativeVendorOwnsModel: false,
+    codexModelOptions: [],
+  };
+}
+
+/** Whether an entry would paint nothing — not worth a slot in the store. */
+function isEmpty(meta: SessionMeta): boolean {
+  return (
+    meta.gitBranch === null &&
+    meta.llmModel === null &&
+    meta.sessionModelOverride === null &&
+    meta.sessionHarness === null &&
+    meta.codexModelOptions.length === 0
+  );
+}
+
+function readStore(): Store {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    const store: Store = [];
+    for (const item of parsed) {
+      if (typeof item !== "object" || item === null) continue;
+      const record = item as Record<string, unknown>;
+      if (typeof record.id !== "string") continue;
+      store.push({ id: record.id, meta: sanitize(record.meta) });
+    }
+    return store;
+  } catch {
+    return [];
+  }
+}
+
+function writeStore(store: Store): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    // Storage quota/access errors must not break session switching.
+  }
+}
+
+/**
+ * Read one session's cached composer metadata, or `null` when not cached.
+ *
+ * Strictly keyed by session id: a miss returns `null` so the caller paints
+ * nothing, never another session's values.
+ */
+export function readSessionMeta(conversationId: string): SessionMeta | null {
+  return readStore().find((entry) => entry.id === conversationId)?.meta ?? null;
+}
+
+/** Persist one session's composer metadata, replacing any previous entry. */
+export function writeSessionMeta(conversationId: string, meta: SessionMeta): void {
+  const store = readStore();
+  const existingIdx = store.findIndex((entry) => entry.id === conversationId);
+  if (existingIdx >= 0) store.splice(existingIdx, 1);
+  // An all-empty entry reads the same as a miss, so drop it rather than let it
+  // hold a slot (mirrors writeTranscriptCache dropping an empty transcript).
+  if (isEmpty(meta)) {
+    if (existingIdx >= 0) writeStore(store);
+    return;
+  }
+  // Re-append so the most-recently-touched session moves to the end; pruning
+  // then evicts from the front (oldest-touched).
+  store.push({ id: conversationId, meta });
+  if (store.length > MAX_SESSIONS) {
+    store.splice(0, store.length - MAX_SESSIONS);
+  }
+  writeStore(store);
+}
+
+/** Drop a deleted session's cached metadata. */
+export function evictSessionMeta(conversationId: string): void {
+  const store = readStore();
+  const idx = store.findIndex((entry) => entry.id === conversationId);
+  if (idx < 0) return;
+  store.splice(idx, 1);
+  writeStore(store);
+}

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -909,6 +909,35 @@ describe("Composer model/effort label", () => {
     // the leaked model was suppressed.
     expect(label()).toHaveTextContent("High");
   });
+
+  it("does not leak the cross-session sticky model on a native session before its catalog lands", () => {
+    // The Codex→Claude switch repro: `switchTo` clears the session-scoped model
+    // fields but keeps the sticky, so mid-switch a claude-native session has an
+    // empty catalog and the `gpt-5.5` the outgoing Codex session left behind.
+    // The label must wait for a model this session vouches for rather than
+    // paint the previous session's pick for the whole bind round trip.
+    useChatStore.setState({
+      selectedModel: "gpt-5.5", // outgoing Codex session's pick — must not surface
+      sessionModelOverride: null,
+      selectedEffort: "high",
+      llmModel: null,
+      codexModelOptions: [], // cleared by `switchTo`, refilled when the snapshot lands
+    });
+    renderWithTooltips(
+      <Composer
+        {...composerProps({
+          agents: [{ id: "a1", name: "claude" }],
+          selectedAgentId: "a1",
+          modelPickerKind: "claude",
+          showModels: true,
+          codexModelOptions: [],
+        })}
+      />,
+    );
+    expect(label()).not.toHaveTextContent("gpt-5.5");
+    // The real effort still renders — only the leaked model was suppressed.
+    expect(label()).toHaveTextContent("High");
+  });
 });
 
 describe("Composer effort slash-command visibility", () => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -5981,23 +5981,35 @@ function useResolvedComposerModel(
   // the live ``setModel``; a TUI ``/model`` pick posts external_model_change),
   // so like cursor/kiro/opencode the live model is the session override, never
   // the cross-session sticky ``selectedModel``.
+  // The sticky is this session's model only when the session itself advertises
+  // it. `switchTo` clears the session-scoped fields but deliberately keeps
+  // `selectedModel`, so until the incoming snapshot lands the catalog is empty
+  // and the sticky still holds the OUTGOING session's pick — surfacing it paints
+  // e.g. a Codex gpt-5.5 on a Claude session for the whole bind round trip.
+  // Gating on the session's own catalog mirrors the compatibility rule bindStream
+  // applies a moment later, so the label never advertises a model this session
+  // would reject. Post-bind this is a no-op: the store only ever leaves a
+  // catalog-compatible sticky (or the override) in `selectedModel`.
+  const sessionStickyModel =
+    findNativeModelOption(codexModelOptions, selectedModel) !== null ? selectedModel : null;
   const pickerSelectedModel =
     modelPickerKind === "cursor" ||
     modelPickerKind === "kiro" ||
     modelPickerKind === "opencode" ||
     modelPickerKind === "pi"
       ? sessionModelOverride
-      : (sessionModelOverride ?? selectedModel);
+      : (sessionModelOverride ?? sessionStickyModel);
   // SDK/bundle agents (no native picker) never have the cross-session sticky
   // applied to them, so their live model is the session's own — the applied
   // override or the bound default — never `selectedModel` (a pick carried over
   // from an unrelated session, e.g. a gpt-5.5 left from a Codex session showing
-  // on a Claude-SDK agent like Polly). claude-/codex-native keep `selectedModel`:
-  // there the sticky IS the applied model.
+  // on a Claude-SDK agent like Polly). claude-/codex-native keep the sticky —
+  // there it IS the applied model — but only once this session's catalog vouches
+  // for it (see `sessionStickyModel`).
   const nonNativeModel =
     modelPickerKind === null
       ? (sessionModelOverride ?? llmModel)
-      : (sessionModelOverride ?? selectedModel ?? llmModel);
+      : (sessionModelOverride ?? sessionStickyModel ?? llmModel);
   const effectiveModel = nativeVendorOwnsModel
     ? modelPickerKind === "cursor" || modelPickerKind === "kiro"
       ? // cursor mirrors its live TUI model into ``model_override``; kiro sets it

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -493,6 +493,63 @@ describe("chatStore — switchTo", () => {
     expect(settled.loadingMoreHistory).toBe(false);
   });
 
+  it("repaints a revisited session's branch and model before its snapshot lands", async () => {
+    // The composer's tray and model label read these straight off the store, so
+    // nulling them on switch blanks both for the whole bind round trip — the
+    // "jittery composer" report. A revisit paints this session's own last-known
+    // values immediately instead.
+    localStorage.clear();
+    seedSession("conv_meta", [userMessage("meta_1", "hi")]);
+    seedSession("conv_meta_other", [userMessage("meta_other_1", "hi")]);
+    await useChatStore.getState().switchTo("conv_meta");
+    // Stand in for the bound snapshot: what the composer was last showing.
+    useChatStore.setState({
+      gitBranch: "feature/jitter",
+      llmModel: "system.ai.claude-sonnet-5",
+      sessionModelOverride: "opus",
+      sessionHarness: "claude",
+      codexModelOptions: [{ id: "opus", displayName: "Opus 4.10" }],
+    });
+    await useChatStore.getState().switchTo("conv_meta_other");
+
+    const revisit = useChatStore.getState().switchTo("conv_meta");
+    const immediate = useChatStore.getState();
+    expect(immediate.gitBranch).toBe("feature/jitter");
+    expect(immediate.llmModel).toBe("system.ai.claude-sonnet-5");
+    expect(immediate.sessionModelOverride).toBe("opus");
+    expect(immediate.sessionHarness).toBe("claude");
+    // The catalog rides along so the label can resolve "opus" to its
+    // display name rather than printing the raw alias.
+    expect(immediate.codexModelOptions).toEqual([{ id: "opus", displayName: "Opus 4.10" }]);
+    await revisit;
+  });
+
+  it("leaves an uncached session blank rather than inheriting the outgoing session's metadata", async () => {
+    // The cache is strictly per-session: a miss must paint nothing. Falling back
+    // to whatever the outgoing session left in the store is exactly the
+    // cross-session leak the composer model label was fixed for.
+    localStorage.clear();
+    seedSession("conv_meta_from", [userMessage("from_1", "hi")]);
+    seedSession("conv_meta_fresh", []);
+    await useChatStore.getState().switchTo("conv_meta_from");
+    useChatStore.setState({
+      gitBranch: "feature/outgoing",
+      llmModel: "gpt-5.5",
+      sessionModelOverride: "gpt-5.5",
+      sessionHarness: "codex",
+      codexModelOptions: [{ id: "gpt-5.5", displayName: "GPT-5.5" }],
+    });
+
+    const next = useChatStore.getState().switchTo("conv_meta_fresh");
+    const immediate = useChatStore.getState();
+    expect(immediate.gitBranch).toBeNull();
+    expect(immediate.llmModel).toBeNull();
+    expect(immediate.sessionModelOverride).toBeNull();
+    expect(immediate.sessionHarness).toBeNull();
+    expect(immediate.codexModelOptions).toEqual([]);
+    await next;
+  });
+
   it("bridges a multi-page cache gap without resetting the older-history cursor", async () => {
     const before = Array.from({ length: 30 }, (_, i) =>
       userMessage(`cache_before_${i}`, `before ${i}`),

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -78,6 +78,7 @@ import type {
   StreamEvent,
 } from "@/lib/events";
 import { createPresenceIdleTracker } from "@/lib/presenceIdle";
+import { readSessionMeta, writeSessionMeta, type SessionMeta } from "@/lib/sessionMetaCache";
 import { parseEvent, parseSseStream, type SseStreamResult } from "@/lib/sse";
 import { childSessionsQueryKey, type ChildSessionInfo } from "@/hooks/useChildSessions";
 import { sessionItemsQueryKey } from "@/hooks/useSessionItems";
@@ -705,6 +706,18 @@ function writeTranscriptCache(id: string, state: ChatState): void {
 /** Evict a deleted conversation from the transcript cache. */
 export function evictTranscriptCache(id: string): void {
   transcriptCache.delete(id);
+}
+
+/** The composer-facing metadata worth retaining for an instant revisit. */
+function sessionMetaOf(state: ChatState): SessionMeta {
+  return {
+    gitBranch: state.gitBranch,
+    llmModel: state.llmModel,
+    sessionModelOverride: state.sessionModelOverride,
+    sessionHarness: state.sessionHarness,
+    nativeVendorOwnsModel: state.nativeVendorOwnsModel,
+    codexModelOptions: state.codexModelOptions,
+  };
 }
 
 // Catalogs that resolved while their bind snapshot was still hydrating.
@@ -1582,8 +1595,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
     // Write on switch-away; the return bind reconciles any later commits.
     const outgoingId = get().conversationId;
-    if (outgoingId !== null) writeTranscriptCache(outgoingId, get());
+    if (outgoingId !== null) {
+      writeTranscriptCache(outgoingId, get());
+      // Captures live edits the snapshot alone wouldn't have (a TUI `/model`
+      // switch, a branch change) so the revisit repaints what was last shown.
+      writeSessionMeta(outgoingId, sessionMetaOf(get()));
+    }
     const cached = conversationId !== null ? readTranscriptCache(conversationId) : null;
+    const cachedMeta = conversationId !== null ? readSessionMeta(conversationId) : null;
 
     set((s) => {
       // Stash the OUTGOING conversation's still-in-flight optimistic
@@ -1642,7 +1661,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         sessionStatus: "idle",
         backgroundTaskCount: 0,
         isNativeTerminalSession: false,
-        nativeVendorOwnsModel: false,
+        nativeVendorOwnsModel: cachedMeta?.nativeVendorOwnsModel ?? false,
         boundAgentId: null,
         boundAgentName: null,
         // Cached history revalidates without the full-screen hydrate spinner.
@@ -1653,23 +1672,28 @@ export const useChatStore = create<ChatState>((set, get) => ({
         // cache gap bridge. Revalidation clears this without showing UI.
         loadingMoreHistory: cached !== null,
         oldestItemId: cached?.oldestItemId ?? null,
-        llmModel: null,
-        sessionHarness: null,
+        // The composer's model label and branch paint from the snapshot, so
+        // nulling them blanks both until the bind answers. Seed from THIS
+        // session's own last-known values instead; the snapshot overwrites them
+        // a moment later. A cache miss stays null — never the outgoing
+        // session's values, which is the bug this must not reintroduce.
+        llmModel: cachedMeta?.llmModel ?? null,
+        sessionHarness: cachedMeta?.sessionHarness ?? null,
         // ``selectedEffort`` / ``selectedModel`` are sticky user picks —
         // not reset here so a CLI-created new chat inherits them.
         // ``sessionModelOverride`` and the cost switch ARE session-scoped,
         // so they reset with the session and re-hydrate from the snapshot.
-        sessionModelOverride: null,
+        sessionModelOverride: cachedMeta?.sessionModelOverride ?? null,
         costControlModeOverride: null,
         codexPlanMode: false,
         contextWindow: null,
         tokensUsed: null,
         sessionCostUsd: null,
         sessionUsageByModel: null,
-        gitBranch: null,
+        gitBranch: cachedMeta?.gitBranch ?? null,
         todos: [],
         skills: [],
-        codexModelOptions: [],
+        codexModelOptions: cachedMeta?.codexModelOptions ?? [],
         terminalPending: false,
         viewers: [],
         // Drop any queued "Attach to agent" chip that the outgoing session's
@@ -2629,6 +2653,9 @@ async function bindStream(
       };
     });
     racedNativeModelOptions.delete(id);
+    // Persist the freshly bound values so a revisit repaints them even when
+    // this session was never switched away from (e.g. a reload).
+    if (get().conversationId === id) writeSessionMeta(id, sessionMetaOf(get()));
   } catch (err) {
     if (get().conversationId !== id) return;
     set({


### PR DESCRIPTION
> **Stacked on #4093.** This branch is based on that PR's commit, so the diff
> currently shows it as a first commit. It drops out once #4093 merges. Review
> the second commit (`fix(web): keep the composer's branch and model painted…`)
> — that is this PR's change.

## Related issue

N/A

## Summary

Switching sessions blanked the composer's worktree branch and model label for
the whole bind round trip, so the tray visibly flickered on every switch.

`switchTo` nulls every snapshot-derived field, but the composer stays *mounted*
across an in-tab switch (the transcript cache hits, so there is no hydrate
placeholder to hide it). Both readouts therefore empty out until `bindStream`
answers, then pop back.

This adds a bounded per-session metadata cache — `web/src/lib/sessionMetaCache.ts`,
localStorage, 50 entries, LRU, sanitized on read, modelled on the existing
`sessionWorkspaceState.ts` — holding the branch and the model identity
(`llmModel` / `sessionModelOverride` / `sessionHarness` / `nativeVendorOwnsModel`
/ `codexModelOptions`). `switchTo` seeds its reset from it; the snapshot still
overwrites a moment later, so this only fills the gap. Written on switch-away
(catches live TUI `/model` and branch changes) and at the end of `bindStream`
(so it survives a reload), evicted alongside the transcript cache when a session
is deleted.

Two invariants worth calling out:

- **Keyed strictly by session id, and a miss paints nothing.** Falling back to a
  global "last seen" is exactly the cross-session leak #4093 fixed.
- **The model catalog is cached with the model id**, or #4093's compatibility
  gate has nothing to resolve against and the label stays blank anyway.
  `nativeVendorOwnsModel` rides along for the same reason: without it a
  cursor/opencode session falls through to `llmModel`, a meaningless vendor
  default.

### Scope note

The jitter is only *visible* on an in-tab switch back to a session with a
committed transcript. On a cold load / reload / new tab, `loadingConversation`
is true and `ChatPage` returns `<HydratingPlaceholder/>`, which unmounts the
whole surface including the composer — there is no composer to jitter, just a
spinner. So localStorage's cross-reload persistence buys nothing observable
today; it is there because it is the codebase's established pattern for
per-session UI state and is ready if that placeholder gate is ever narrowed. A
module-scope `Map` would fix the visible symptom identically.

The context-usage ring and Plan-mode badge pop in the same window and are
deliberately left alone: the ring needs `tokensUsed`, which changes every turn,
so caching it would flash a stale percentage.

## Test Plan

```
# new e2e test — confirmed to fail without the change
pytest tests/e2e_ui/chat/test_claude_model_picker.py -k keeps_branch_and_model

# full picker + codex suites
pytest tests/e2e_ui/chat/test_claude_model_picker.py tests/e2e_ui/chat/test_codex_model_metadata.py   # 10 passed

# adjacent session-switch suites
pytest tests/e2e_ui/sessions/test_cross_session_routing.py \
       tests/e2e_ui/sessions/test_composer_session_switch_hotkey.py \
       tests/e2e_ui/sessions/test_host_badge.py \
       tests/e2e_ui/sessions/test_sidebar_delete.py                    # 8 passed

pnpm --filter web run test    # 4901 passed
```

Reverting only the `switchTo` seeding and rebuilding makes the new e2e test fail
with `{'model': '', 'branch': ''}` — the exact jitter — while the other 7 tests
in that file still pass.

One existing test needed rework: the #4093 e2e test's no-op guard asserted the
model label *changed* during the bind window, which caching makes false by
design. It now asserts the held snapshot actually applied
(`window.__snapshotHeld`), which is valid in both worlds — verified by running
the whole file against an un-cached build, where only the new test fails.

## Demo

Recorded on a local server with two **real** native sessions (`omnigent claude`
and `omnigent codex`, launched in different worktrees so their branches differ),
with the incoming session's snapshot held so the window is observable. The trace
is every distinct paint under the Claude session's route while switching back
into it.

**Before**

```
1. claude session: model='Opus High'  branch='ux-switch-sessions-composer-jittery'
2. codex session:  model='GPT-5.5 high' branch='fix/host-tunnel-readiness-blocking'
3. back on claude: model='Opus High'  branch='ux-switch-sessions-composer-jittery'

every paint under the Claude route during the switch:
   model='High'         branch=''                                  <-- both blank
   model='Opus High'    branch='ux-switch-sessions-composer-jittery'

RESULT: JITTER — blank paints
```

**After**

```
every paint under the Claude route during the switch:
   model='Opus High'    branch='ux-switch-sessions-composer-jittery'

RESULT: clean — never blanked
```

One paint, already correct — the readouts never empty.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification ran the real flow against a local server with two real
native sessions in different worktrees (distinct branches, distinct pinned
models): open Claude → switch to Codex → switch back, recording every paint.
A/B'd by reverting the one hunk and rebuilding the SPA, which reproduced the
blank window; restoring it cleared it. The Demo section is that run's output.

## Changelog

The composer's worktree branch and model no longer blank out for a moment each time you switch sessions
