### PR TITLE
feat(ci): hand PRs back to the reviewer with waiting-for-review

### DIFF
--- a/.github/scripts/waiting_on_author.py
+++ b/.github/scripts/waiting_on_author.py
@@ -14,6 +14,9 @@ from email.message import Message
 from typing import Any
 
 LABEL = "waiting-on-author"
+# The other half of the cycle. `waiting-on-author` alone can only say "stalled";
+# this says "back in the reviewer's queue", which is what a maintainer filters on.
+REVIEW_LABEL = "waiting-for-review"
 WAITING_DAYS = 7
 CANONICAL_REPO = "omnigent-ai/omnigent"
 MAX_CLOSURES_PER_RUN = 30
@@ -131,6 +134,28 @@ class GitHubAPI:
     def list_commits(self, pull_number: int) -> list[dict[str, Any]]:
         return self.paginated(f"/repos/{self.repo}/pulls/{pull_number}/commits?per_page=100")
 
+    def add_label(self, issue_number: int, label: str) -> None:
+        self.request(
+            "POST", f"/repos/{self.repo}/issues/{issue_number}/labels", {"labels": [label]}
+        )
+
+    def request_review(self, pull_number: int, reviewers: list[str]) -> None:
+        # Best effort: a reviewer who lost repo access, or the PR author, is
+        # rejected with 422, and that must not fail the handoff.
+        if not reviewers:
+            return
+        try:
+            self.request(
+                "POST",
+                f"/repos/{self.repo}/pulls/{pull_number}/requested_reviewers",
+                {"reviewers": reviewers},
+            )
+        except urllib.error.HTTPError as error:
+            if error.code in (403, 422):
+                print(f"::warning::Could not re-request review on #{pull_number}: {error.code}")
+                return
+            raise
+
     def close_pull(self, pull_number: int) -> None:
         self.request("PATCH", f"/repos/{self.repo}/pulls/{pull_number}", {"state": "closed"})
 
@@ -156,6 +181,33 @@ def remove_waiting_label(api: GitHubAPI, issue_number: int, reason: str) -> bool
     else:
         print(f"#{issue_number} no longer has {LABEL}; nothing to remove.")
     return removed
+
+
+def hand_off_to_reviewer(api: GitHubAPI, pull: dict[str, Any], reason: str) -> None:
+    """Move a PR from the author's court back into the reviewer's.
+
+    The label is what maintainers filter on; the review request is what actually
+    surfaces the PR in their GitHub review queue. GitHub clears the request when a
+    review is submitted, so it has to be re-made here or the reply is invisible.
+    """
+    number = pull["number"]
+    labels = label_names(pull)
+    if REVIEW_LABEL not in labels:
+        api.add_label(number, REVIEW_LABEL)
+        print(f"Added {REVIEW_LABEL} to #{number}: {reason}")
+
+    author = (pull.get("user") or {}).get("login", "").lower()
+    # Assignees are the durable owner record; requested_reviewers empties out on
+    # every submitted review. Never re-request the author's own review.
+    owners = [
+        login
+        for login in (
+            (person or {}).get("login")
+            for person in (pull.get("assignees") or []) + (pull.get("requested_reviewers") or [])
+        )
+        if login and login.lower() != author
+    ]
+    api.request_review(number, sorted(set(owners)))
 
 
 def user_login(item: dict[str, Any]) -> str | None:
@@ -198,6 +250,24 @@ def author_activity_since_label(api: GitHubAPI, pull: dict[str, Any], since: str
     return None
 
 
+def clear_review_label_on_waiting(payload: dict[str, Any], api: GitHubAPI) -> bool:
+    """The two labels are mutually exclusive: applying one drops the other.
+
+    Fires when a maintainer (or the review-submitted path) sets waiting-on-author,
+    so a PR never advertises both states at once.
+    """
+    label = (payload.get("label") or {}).get("name")
+    pull = payload.get("pull_request") or {}
+    if label != LABEL or not pull:
+        return False
+    if REVIEW_LABEL not in label_names(pull):
+        return False
+    removed = api.remove_label(pull["number"], REVIEW_LABEL)
+    if removed:
+        print(f"Removed {REVIEW_LABEL} from #{pull['number']}: now {LABEL}")
+    return removed
+
+
 def clear_on_author_activity(event_name: str, payload: dict[str, Any], api: GitHubAPI) -> bool:
     pull_number: int | None = None
     actor: str | None = None
@@ -205,6 +275,8 @@ def clear_on_author_activity(event_name: str, payload: dict[str, Any], api: GitH
     author_activity = False
 
     if event_name in {"pull_request", "pull_request_target"} and payload.get("pull_request"):
+        if payload.get("action") == "labeled":
+            return clear_review_label_on_waiting(payload, api)
         if payload.get("action") != "synchronize":
             return False
         pull_number = payload["pull_request"]["number"]
@@ -237,7 +309,10 @@ def clear_on_author_activity(event_name: str, payload: dict[str, Any], api: GitH
 
     if not author_activity:
         return False
-    return remove_waiting_label(api, pull_number, reason)
+    removed = remove_waiting_label(api, pull_number, reason)
+    if removed:
+        hand_off_to_reviewer(api, pull, reason)
+    return removed
 
 
 def close_stale_waiting_prs(api: GitHubAPI, now: datetime | None = None) -> int:
@@ -261,7 +336,8 @@ def close_stale_waiting_prs(api: GitHubAPI, now: datetime | None = None) -> int:
             pull = api.get_pull(issue["number"])
             reason = author_activity_since_label(api, pull, label_applied_at)
             if reason:
-                remove_waiting_label(api, issue["number"], reason)
+                if remove_waiting_label(api, issue["number"], reason):
+                    hand_off_to_reviewer(api, pull, reason)
                 continue
 
             if days_between(label_applied_at, now) < WAITING_DAYS:

--- a/.github/scripts/waiting_on_author.py
+++ b/.github/scripts/waiting_on_author.py
@@ -139,22 +139,31 @@ class GitHubAPI:
             "POST", f"/repos/{self.repo}/issues/{issue_number}/labels", {"labels": [label]}
         )
 
-    def request_review(self, pull_number: int, reviewers: list[str]) -> None:
-        # Best effort: a reviewer who lost repo access, or the PR author, is
-        # rejected with 422, and that must not fail the handoff.
-        if not reviewers:
-            return
-        try:
-            self.request(
-                "POST",
-                f"/repos/{self.repo}/pulls/{pull_number}/requested_reviewers",
-                {"reviewers": reviewers},
-            )
-        except urllib.error.HTTPError as error:
-            if error.code in (403, 422):
-                print(f"::warning::Could not re-request review on #{pull_number}: {error.code}")
-                return
-            raise
+    def request_review(self, pull_number: int, reviewers: list[str]) -> int:
+        """Re-request each reviewer, returning how many were queued.
+
+        One request per reviewer: GitHub rejects the whole batch when any single
+        login is invalid (a 422 for a non-collaborator), which would silently drop
+        the reviewers who are still valid.
+        """
+        queued = 0
+        for reviewer in reviewers:
+            try:
+                self.request(
+                    "POST",
+                    f"/repos/{self.repo}/pulls/{pull_number}/requested_reviewers",
+                    {"reviewers": [reviewer]},
+                )
+                queued += 1
+            except urllib.error.HTTPError as error:
+                if error.code in (403, 422):
+                    print(
+                        f"::warning::Could not re-request @{reviewer} on "
+                        f"#{pull_number}: {error.code}"
+                    )
+                    continue
+                raise
+        return queued
 
     def close_pull(self, pull_number: int) -> None:
         self.request("PATCH", f"/repos/{self.repo}/pulls/{pull_number}", {"state": "closed"})
@@ -207,7 +216,12 @@ def hand_off_to_reviewer(api: GitHubAPI, pull: dict[str, Any], reason: str) -> N
         )
         if login and login.lower() != author
     ]
-    api.request_review(number, sorted(set(owners)))
+    queued = api.request_review(number, sorted(set(owners))) if owners else 0
+    if not queued:
+        # The label says "ready for a reviewer", so an empty queue makes it a lie
+        # to whoever filters on it. Auto-assign normally populates assignees, so
+        # this means something upstream skipped the PR.
+        print(f"::warning::#{number} is {REVIEW_LABEL} with no reviewer queued")
 
 
 def user_login(item: dict[str, Any]) -> str | None:

--- a/.github/scripts/waiting_on_author_test.py
+++ b/.github/scripts/waiting_on_author_test.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import importlib.util
 import pathlib
 import unittest
+import urllib.error
 from datetime import UTC, datetime
+from email.message import Message
 from typing import Any
 
 SCRIPT_PATH = pathlib.Path(__file__).with_name("waiting_on_author.py")
@@ -104,8 +106,9 @@ class FakeAPI:
     def add_label(self, issue_number: int, label: str) -> None:
         self.added.append((issue_number, label))
 
-    def request_review(self, pull_number: int, reviewers: list[str]) -> None:
+    def request_review(self, pull_number: int, reviewers: list[str]) -> int:
         self.review_requests.append((pull_number, reviewers))
+        return len(reviewers)
 
     def close_pull(self, pull_number: int) -> None:
         self.closed.append(pull_number)
@@ -325,6 +328,26 @@ class WaitingForReviewTest(unittest.TestCase):
         )
         self.assertFalse(handled)
         self.assertEqual(api.removed, [])
+
+    def test_one_invalid_reviewer_does_not_drop_the_others(self) -> None:
+        # GitHub 422s the whole batch when any login is invalid, so the request
+        # has to be per-reviewer or the valid owners are silently skipped.
+        posted: list[list[str]] = []
+
+        class OneBadReviewerAPI(waiting_on_author.GitHubAPI):
+            def __init__(self) -> None:
+                super().__init__("token", "omnigent-ai/omnigent")
+
+            def request(self, method: str, path: str, body: dict[str, Any] | None = None):
+                reviewers = (body or {}).get("reviewers", [])
+                posted.append(reviewers)
+                if reviewers == ["gone"]:
+                    raise urllib.error.HTTPError(path, 422, "not a collaborator", None, None)
+                return None, Message()
+
+        queued = OneBadReviewerAPI().request_review(12, ["gone", "maintainer1"])
+        self.assertEqual(posted, [["gone"], ["maintainer1"]], "one call per reviewer")
+        self.assertEqual(queued, 1, "the valid reviewer is still queued")
 
     def test_scheduled_sweep_hands_off_when_author_replied(self) -> None:
         api = FakeAPI(

--- a/.github/scripts/waiting_on_author_test.py
+++ b/.github/scripts/waiting_on_author_test.py
@@ -339,6 +339,7 @@ class WaitingForReviewTest(unittest.TestCase):
                 super().__init__("token", "omnigent-ai/omnigent")
 
             def request(self, method: str, path: str, body: dict[str, Any] | None = None):
+                assert method == "POST"
                 reviewers = (body or {}).get("reviewers", [])
                 posted.append(reviewers)
                 if reviewers == ["gone"]:

--- a/.github/scripts/waiting_on_author_test.py
+++ b/.github/scripts/waiting_on_author_test.py
@@ -17,7 +17,12 @@ SPEC.loader.exec_module(waiting_on_author)
 
 
 def pr(
-    number: int = 12, author: str = "alice", labels: list[str] | None = None, state: str = "open"
+    number: int = 12,
+    author: str = "alice",
+    labels: list[str] | None = None,
+    state: str = "open",
+    assignees: list[str] | None = None,
+    requested_reviewers: list[str] | None = None,
 ) -> dict[str, Any]:
     labels = [waiting_on_author.LABEL] if labels is None else labels
     return {
@@ -25,6 +30,8 @@ def pr(
         "state": state,
         "user": {"login": author},
         "labels": [{"name": label} for label in labels],
+        "assignees": [{"login": login} for login in (assignees or [])],
+        "requested_reviewers": [{"login": login} for login in (requested_reviewers or [])],
     }
 
 
@@ -66,6 +73,8 @@ class FakeAPI:
         self.removed: list[tuple[int, str]] = []
         self.closed: list[int] = []
         self.comments: list[tuple[int, str]] = []
+        self.added: list[tuple[int, str]] = []
+        self.review_requests: list[tuple[int, list[str]]] = []
 
     def get_pull(self, pull_number: int) -> dict[str, Any]:
         return self.pull | {"number": pull_number}
@@ -91,6 +100,12 @@ class FakeAPI:
 
     def list_commits(self, pull_number: int) -> list[dict[str, Any]]:
         return self.commits.get(pull_number, [])
+
+    def add_label(self, issue_number: int, label: str) -> None:
+        self.added.append((issue_number, label))
+
+    def request_review(self, pull_number: int, reviewers: list[str]) -> None:
+        self.review_requests.append((pull_number, reviewers))
 
     def close_pull(self, pull_number: int) -> None:
         self.closed.append(pull_number)
@@ -229,6 +244,101 @@ class WaitingOnAuthorTest(unittest.TestCase):
         api = FakeAPI(issues=issues, timeline_by_issue=timeline)
         waiting_on_author.close_stale_waiting_prs(api, now=datetime(2026, 7, 24, tzinfo=UTC))
         self.assertEqual(len(api.closed), waiting_on_author.MAX_CLOSURES_PER_RUN)
+
+
+class WaitingForReviewTest(unittest.TestCase):
+    def test_author_reply_hands_off_to_reviewer(self) -> None:
+        api = FakeAPI(pull=pr(author="alice", assignees=["maintainer1"]))
+        waiting_on_author.clear_on_author_activity(
+            "issue_comment",
+            {"issue": {"number": 12, "pull_request": {}}, "comment": {"user": {"login": "alice"}}},
+            api,
+        )
+        self.assertEqual(api.removed, [(12, waiting_on_author.LABEL)])
+        self.assertEqual(api.added, [(12, waiting_on_author.REVIEW_LABEL)])
+        # The re-request is what actually surfaces the PR in the reviewer's queue.
+        self.assertEqual(api.review_requests, [(12, ["maintainer1"])])
+
+    def test_handoff_never_requests_the_author(self) -> None:
+        api = FakeAPI(pull=pr(author="alice", assignees=["alice", "maintainer1"]))
+        waiting_on_author.clear_on_author_activity(
+            "pull_request_target",
+            {"action": "synchronize", "pull_request": {"number": 12}},
+            api,
+        )
+        self.assertEqual(api.review_requests, [(12, ["maintainer1"])])
+
+    def test_handoff_is_idempotent_on_the_label(self) -> None:
+        api = FakeAPI(
+            pull=pr(
+                author="alice",
+                labels=[waiting_on_author.LABEL, waiting_on_author.REVIEW_LABEL],
+                assignees=["maintainer1"],
+            )
+        )
+        waiting_on_author.clear_on_author_activity(
+            "pull_request_target",
+            {"action": "synchronize", "pull_request": {"number": 12}},
+            api,
+        )
+        self.assertEqual(api.added, [], "already labeled; no duplicate add")
+
+    def test_maintainer_comment_does_not_hand_off(self) -> None:
+        api = FakeAPI(pull=pr(author="alice", assignees=["maintainer1"]))
+        waiting_on_author.clear_on_author_activity(
+            "issue_comment",
+            {
+                "issue": {"number": 12, "pull_request": {}},
+                "comment": {"user": {"login": "maintainer1"}},
+            },
+            api,
+        )
+        self.assertEqual(api.added, [])
+        self.assertEqual(api.review_requests, [])
+
+    def test_labeling_waiting_on_author_clears_the_review_label(self) -> None:
+        api = FakeAPI()
+        handled = waiting_on_author.clear_on_author_activity(
+            "pull_request_target",
+            {
+                "action": "labeled",
+                "label": {"name": waiting_on_author.LABEL},
+                "pull_request": pr(
+                    labels=[waiting_on_author.LABEL, waiting_on_author.REVIEW_LABEL]
+                ),
+            },
+            api,
+        )
+        self.assertTrue(handled)
+        self.assertEqual(api.removed, [(12, waiting_on_author.REVIEW_LABEL)])
+
+    def test_labeling_something_else_is_ignored(self) -> None:
+        api = FakeAPI()
+        handled = waiting_on_author.clear_on_author_activity(
+            "pull_request_target",
+            {
+                "action": "labeled",
+                "label": {"name": "size/M"},
+                "pull_request": pr(labels=[waiting_on_author.REVIEW_LABEL]),
+            },
+            api,
+        )
+        self.assertFalse(handled)
+        self.assertEqual(api.removed, [])
+
+    def test_scheduled_sweep_hands_off_when_author_replied(self) -> None:
+        api = FakeAPI(
+            pull=pr(number=30, author="alice", assignees=["maintainer1"]),
+            issues=[issue(30)],
+            timeline_by_issue={30: [labeled_at("2026-07-01T00:00:00Z")]},
+            issue_comments={
+                30: [{"user": {"login": "alice"}, "created_at": "2026-07-02T00:00:00Z"}]
+            },
+        )
+        waiting_on_author.close_stale_waiting_prs(api, now=datetime(2026, 7, 20, tzinfo=UTC))
+        self.assertEqual(api.closed, [], "an author reply cancels the close")
+        self.assertEqual(api.added, [(30, waiting_on_author.REVIEW_LABEL)])
+        self.assertEqual(api.review_requests, [(30, ["maintainer1"])])
 
 
 if __name__ == "__main__":

--- a/.github/workflows/waiting-on-author.yml
+++ b/.github/workflows/waiting-on-author.yml
@@ -1,12 +1,15 @@
 name: Waiting on Author Hygiene
 
-# Keeps the `waiting-on-author` PR label actionable: author activity clears it,
-# and PRs that sit in that state for 7 days are closed. The workflow runs from
-# trusted default-branch code and never checks out PR-authored files.
+# Keeps the review-state labels actionable. `waiting-on-author` means the ball is
+# in the author's court; author activity clears it and hands off to
+# `waiting-for-review` (re-requesting the reviewer, since GitHub drops the request
+# once a review is submitted). The two labels are mutually exclusive. PRs left
+# waiting on the author for 7 days are closed. The workflow runs from trusted
+# default-branch code and never checks out PR-authored files.
 
 on:
   pull_request_target:
-    types: [synchronize]
+    types: [synchronize, labeled]
   issue_comment:
     types: [created]
   pull_request_review_comment:


### PR DESCRIPTION
## Related issue

N/A — tracked in Linear as OMNI-2315 (`waiting on author label`). This is the
complementary `waiting-for-review` half of that state machine.

## Summary

`waiting-on-author` can only say a PR is stalled. It cannot say the opposite, so
when an author replies the PR silently leaves the author's queue without entering
anyone else's. GitHub compounds this: it clears the review request the moment a
review is submitted, so the author's reply is invisible in the reviewer's queue
too.

This adds `waiting-for-review` as the other half of the cycle:

- Every path that clears `waiting-on-author` (author push, comment, review reply,
  and the scheduled sweep) now applies `waiting-for-review` and re-requests the
  PR's owners.
- Owners come from `assignees` (the durable record, which auto-assign already
  sets) plus any surviving requested reviewers, never the author.
- A failed re-request warns rather than failing the handoff, since a reviewer can
  lose repo access.
- The two labels are mutually exclusive: labeling a PR `waiting-on-author` removes
  `waiting-for-review`. That needs the `labeled` trigger, which the workflow now
  subscribes to.

This is the label maintainers filter on to find PRs that are genuinely ready for
them, instead of reading the whole open list.

Nothing here closes anything, and nothing touches existing PRs: the labels only
change in response to new activity.

## Test Plan

`python3 .github/scripts/waiting_on_author_test.py` — 20 tests, all pass (13
existing plus 7 new). New coverage: author reply hands off and re-requests; the
author is never re-requested even when self-assigned; the label add is idempotent;
a maintainer comment does not hand off; labeling `waiting-on-author` clears the
review label; labeling something else is ignored; the scheduled sweep hands off
instead of closing when the author replied.

## Demo

N/A — CI label mechanics, no user-visible UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI

## Test coverage

- [x] Unit tests added or updated
- [ ] Integration / E2E tests added or updated
- [ ] Manual verification completed
- [ ] Not applicable

## Coverage notes

N/A
