### PR TITLE
fix(android): make OIDC login flows origin-bound and cancellable

### DIFF
--- a/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
@@ -383,7 +383,10 @@ class MainActivity : AppCompatActivity() {
      * rules, so we both attempt a reorder-to-front (works within the grace
      * period) AND post a "tap to return" notification as the reliable path back.
      */
-    private fun onSessionToken(token: String) {
+    private fun onSessionToken(
+        loginOrigin: String,
+        token: String,
+    ) {
         // The poll can land after the activity is gone (it ran on a background
         // thread up to 5 min) — never touch a destroyed WebView.
         if (isDestroyed || isFinishing || !::webView.isInitialized) return

--- a/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/MainActivity.kt
@@ -383,10 +383,17 @@ class MainActivity : AppCompatActivity() {
      * rules, so we both attempt a reorder-to-front (works within the grace
      * period) AND post a "tap to return" notification as the reliable path back.
      */
-    private fun onSessionToken(
+    internal fun onSessionToken(
         loginOrigin: String,
         token: String,
     ) {
+        // A server switch can land between starting a login and its poll
+        // completing; a token minted for another origin must never be
+        // injected into the current one.
+        if (loginOrigin != pinnedOrigin) {
+            authLog("onSessionToken: origin changed since login started — dropping token")
+            return
+        }
         // The poll can land after the activity is gone (it ran on a background
         // thread up to 5 min) — never touch a destroyed WebView.
         if (isDestroyed || isFinishing || !::webView.isInitialized) return
@@ -522,6 +529,7 @@ class MainActivity : AppCompatActivity() {
         serverUrl: String,
         newOrigin: String,
     ) {
+        loginManager.cancel() // a login for the old origin must not outlive the switch
         removeBridge()
         pinnedOrigin = newOrigin
         pageLoaded = false

--- a/web/android/app/src/main/java/ai/omnigent/android/OidcLoginManager.kt
+++ b/web/android/app/src/main/java/ai/omnigent/android/OidcLoginManager.kt
@@ -5,9 +5,11 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
+import androidx.annotation.VisibleForTesting
 import org.json.JSONObject
 import java.net.HttpURLConnection
 import java.net.URL
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -30,19 +32,36 @@ import java.util.concurrent.atomic.AtomicBoolean
  * injects it into the WebView's CookieManager and reloads — authenticated.
  */
 class OidcLoginManager {
-    private val io = Executors.newSingleThreadExecutor()
     private val main = Handler(Looper.getMainLooper())
-    private val inFlight = AtomicBoolean(false)
 
-    // Held only for the duration of a login; nulled by [shutdown] so a poll that
-    // finishes after the host is destroyed can neither invoke into a dead
-    // Activity nor pin it (and its View tree) for the poll's lifetime.
-    @Volatile private var sessionCallback: ((String) -> Unit)? = null
+    // One executor per login flow, so cancel() can shut a flow down (interrupting
+    // its polling sleep) without a stale poll blocking or outliving the next one.
+    // Only touched on the main thread.
+    private var flow: Flow? = null
+
+    // A cancelled flow never delivers, so a poll that finishes after the host is
+    // destroyed — or after a switch to another server — can't invoke into it.
+    private class Flow(
+        val executor: ExecutorService,
+    ) {
+        val cancelled = AtomicBoolean(false)
+    }
+
+    // The flow's two network steps, substitutable so tests can drive a token
+    // through the completion path without a server.
+    @VisibleForTesting
+    internal var requestTicket: (origin: String) -> Ticket? = { httpRequestTicket(it) }
+
+    @VisibleForTesting
+    internal var pollForToken: (origin: String, ticket: String) -> String? = { origin, ticket ->
+        httpPollForToken(origin, ticket)
+    }
 
     /**
      * Begin a login against [origin] (the pinned server). Opens the browser and
      * polls in the background; [onSession] is invoked on the main thread with the
-     * session JWT once the browser flow completes.
+     * origin the flow was started for and the session JWT once the browser flow
+     * completes.
      *
      * Returns true if this call started a flow, or false if one was already in
      * flight (a second concurrent call is ignored). The caller uses the result so
@@ -51,11 +70,12 @@ class OidcLoginManager {
     fun start(
         activity: Activity,
         origin: String,
-        onSession: (String) -> Unit,
+        onSession: (origin: String, token: String) -> Unit,
     ): Boolean {
-        if (!inFlight.compareAndSet(false, true)) return false
-        sessionCallback = onSession
-        io.execute {
+        if (flow != null) return false
+        val current = Flow(Executors.newSingleThreadExecutor())
+        flow = current
+        current.executor.execute {
             var token: String? = null
             try {
                 val ticket = requestTicket(origin)
@@ -68,32 +88,48 @@ class OidcLoginManager {
                     )
                 }
             } catch (_: InterruptedException) {
-                // shutdown() interrupted the poll — the host is going away; drop.
+                // cancel() interrupted the poll — this flow is abandoned; drop.
             } catch (t: Throwable) {
                 authLog("login flow error: ${t.javaClass.simpleName}")
             } finally {
-                inFlight.set(false)
+                current.executor.shutdown()
             }
             val result = token
-            // sessionCallback is null once shutdown() ran — never invoke into a
-            // destroyed host.
-            if (result != null) main.post { sessionCallback?.invoke(result) }
+            main.post {
+                // Deliver only for a flow that wasn't cancelled — a cancelled flow's
+                // token belongs to a server the host has switched away from.
+                if (result != null && !current.cancelled.get()) {
+                    onSession(origin, result)
+                }
+                // Free the slot for the next login — unless onSession already
+                // started one (a re-login) or cancel() moved on to another flow.
+                if (flow === current) flow = null
+            }
         }
         return true
     }
 
-    /** Cancel an in-flight login and release the host. Call from onDestroy. */
-    fun shutdown() {
-        sessionCallback = null
-        io.shutdownNow() // interrupts the polling sleep so the task exits promptly
+    /**
+     * Abandon any in-flight login: no callback will fire, and a new [start] is
+     * immediately possible. Safe to call with no flow in flight.
+     */
+    fun cancel() {
+        flow?.let {
+            it.cancelled.set(true)
+            it.executor.shutdownNow() // interrupts the polling sleep so the task exits promptly
+        }
+        flow = null
     }
 
-    private data class Ticket(
+    /** Release the host entirely. Call from onDestroy. */
+    fun shutdown() = cancel()
+
+    internal data class Ticket(
         val id: String,
         val loginUrl: String,
     )
 
-    private fun requestTicket(origin: String): Ticket? {
+    private fun httpRequestTicket(origin: String): Ticket? {
         val conn = (URL("$origin/auth/cli-login").openConnection() as HttpURLConnection)
         conn.requestMethod = "POST"
         // Bodyless POST — set Content-Length explicitly; some servers/WAFs reject
@@ -133,7 +169,7 @@ class OidcLoginManager {
         runCatching { activity.startActivity(intent) }
     }
 
-    private fun pollForToken(
+    private fun httpPollForToken(
         origin: String,
         ticket: String,
     ): String? {

--- a/web/android/app/src/test/java/ai/omnigent/android/OidcLoginManagerTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/OidcLoginManagerTest.kt
@@ -1,0 +1,101 @@
+package ai.omnigent.android
+
+import android.app.Activity
+import android.os.Looper
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class OidcLoginManagerTest {
+    // Port 1 is never listening — requestTicket fails fast, and the flow ends
+    // without a token. The start/cancel bookkeeping tests use it so they never
+    // touch a real login; the delivery tests stub the two network steps instead.
+    private val deadOrigin = "http://127.0.0.1:1"
+    private val origin = "https://server.example"
+
+    // Build the host once per test and reuse it: driving an Activity lifecycle
+    // idles the main looper, which would run a finished flow's queued completion
+    // (the post that frees the slot) in the middle of the assertions below.
+    private fun activity(): Activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+
+    // The flow completes on its own thread and posts back; pump the (paused)
+    // main looper until the post lands or the window closes.
+    private fun drainMain(condition: () -> Boolean = { false }) {
+        val deadline = System.currentTimeMillis() + 2_000
+        while (System.currentTimeMillis() < deadline) {
+            shadowOf(Looper.getMainLooper()).idle()
+            if (condition()) return
+            Thread.sleep(5)
+        }
+    }
+
+    @Test
+    fun `second start while a flow is in flight is refused`() {
+        val activity = activity()
+        val manager = OidcLoginManager()
+        assertTrue(manager.start(activity, deadOrigin) { _, _ -> })
+        assertFalse(manager.start(activity, deadOrigin) { _, _ -> })
+        manager.shutdown()
+    }
+
+    @Test
+    fun `cancel frees the manager for an immediate new start`() {
+        val activity = activity()
+        val manager = OidcLoginManager()
+        assertTrue(manager.start(activity, deadOrigin) { _, _ -> })
+        manager.cancel()
+        assertTrue(manager.start(activity, deadOrigin) { _, _ -> })
+        manager.shutdown()
+    }
+
+    @Test
+    fun `a completed flow delivers the origin it was started for with the token`() {
+        val activity = activity()
+        val manager = OidcLoginManager()
+        manager.requestTicket = { OidcLoginManager.Ticket("ticket-1", "/auth/login?t=1") }
+        manager.pollForToken = { _, _ -> "session-jwt" }
+
+        var delivered: Pair<String, String>? = null
+        assertTrue(manager.start(activity, origin) { o, t -> delivered = o to t })
+        drainMain { delivered != null }
+
+        assertEquals(origin to "session-jwt", delivered)
+        manager.shutdown()
+    }
+
+    @Test
+    fun `a cancelled flow does not deliver a token that lands after the switch`() {
+        val activity = activity()
+        val manager = OidcLoginManager()
+        val polling = CountDownLatch(1)
+        val cancelled = CountDownLatch(1)
+        manager.requestTicket = { OidcLoginManager.Ticket("ticket-1", "/auth/login?t=1") }
+        manager.pollForToken = { _, _ ->
+            // Hold the flow mid-poll until the host has switched servers, then
+            // hand back a token anyway — cancel() interrupts this wait.
+            polling.countDown()
+            runCatching { cancelled.await(2, TimeUnit.SECONDS) }
+            "stale-token"
+        }
+
+        var delivered: Pair<String, String>? = null
+        assertTrue(manager.start(activity, origin) { o, t -> delivered = o to t })
+        assertTrue(polling.await(2, TimeUnit.SECONDS))
+        manager.cancel()
+        cancelled.countDown()
+        drainMain { delivered != null }
+
+        assertNull(delivered)
+    }
+}

--- a/web/android/app/src/test/java/ai/omnigent/android/SessionTokenBindingTest.kt
+++ b/web/android/app/src/test/java/ai/omnigent/android/SessionTokenBindingTest.kt
@@ -1,0 +1,40 @@
+package ai.omnigent.android
+
+import android.webkit.CookieManager
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class SessionTokenBindingTest {
+    // JWT-shaped (three base64url segments) so isJwtShaped passes.
+    private val token = "aGVhZGVy.cGF5bG9hZA.c2lnbmF0dXJl"
+    private val pinned = "https://example.com"
+
+    private fun launch(): MainActivity {
+        ServerStore(ApplicationProvider.getApplicationContext()).connect(pinned)
+        return Robolectric.buildActivity(MainActivity::class.java).setup().get()
+    }
+
+    @Test
+    fun `token from a different origin is dropped`() {
+        val activity = launch()
+        activity.onSessionToken("https://other.example", token)
+        val cookie = CookieManager.getInstance().getCookie(pinned)
+        assertFalse(cookie?.contains("ap_session") == true)
+    }
+
+    @Test
+    fun `token from the pinned origin is injected`() {
+        val activity = launch()
+        activity.onSessionToken(pinned, token)
+        val cookie = CookieManager.getInstance().getCookie(pinned)
+        assertTrue(cookie?.contains("ap_session") == true)
+    }
+}


### PR DESCRIPTION
## Related issue

Closes #5454

## Summary

Fixes a pre-existing race in the Android shell's OIDC login: `OidcLoginManager` polls the *old* origin for a session token, but `onSessionToken` injected the result into whatever `pinnedOrigin` was current, and `reloadWithNewServer` neither cancelled nor invalidated an in-flight login — so a server switch mid-login (via the server-switcher menu today, deep links in a follow-up PR) could place one server's session token on another origin.

- `OidcLoginManager` now runs one executor per login flow, carries the originating origin through the callback (`(origin, token)`), and exposes `cancel()` — a cancelled flow can neither deliver a token nor block the next login for up to 5 minutes.
- `MainActivity.onSessionToken` drops any token whose originating origin no longer matches `pinnedOrigin`, before touching the cookie store.
- `reloadWithNewServer` cancels any in-flight login as its first effect, before the origin pin swap.

ELI5: logging in is like ordering a package to your house. If you move houses while the package is in transit, the old flow would happily deliver your old house key to the new house. Now the key is labeled with the address it was made for, and moving cancels the delivery.

```
before: start(origin A) ── poll A ──► token ──► inject into pinnedOrigin (now B!)
after:  start(origin A) ── poll A ──► token ──► origin A != pinnedOrigin B → dropped
        reloadWithNewServer(B) ──► loginManager.cancel() first
```

## Test Plan

- `OidcLoginManagerTest` (new): second `start()` while in flight is refused; `cancel()` frees the manager immediately; a flow cancelled mid-poll does NOT deliver its token (both guard branches executed via a `@VisibleForTesting` ticket/poll seam, mutation-checked); a live flow delivers `(origin, token)`.
- `SessionTokenBindingTest` (new): a token from a different origin is dropped (no cookie); a token from the pinned origin is injected.
- Full unit suite + `:app:lintDebug` green (4 pre-existing unrelated local test failures excluded; verified identical at base commit).

## Demo

N/A (non-visual).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Both new test classes execute the security-relevant branches directly (token-after-cancel suppression, cross-origin token rejection); the login flow's HTTP functions are seam-injected in tests, with production defaults unchanged.

This pull request and its description were written by Isaac.

