### PR TITLE
fix(web): show a new session in the sidebar on the push, not a refetch

### DIFF
--- a/tests/e2e_ui/sessions/test_session_updates_stream.py
+++ b/tests/e2e_ui/sessions/test_session_updates_stream.py
@@ -214,3 +214,52 @@ def test_session_created_elsewhere_appears_via_push(
         expect(page.locator(f'a[href="/c/{new_id}"]')).to_be_visible(timeout=20_000)
     finally:
         httpx.delete(f"{base_url}/v1/sessions/{new_id}", timeout=10.0)
+
+
+def test_new_session_row_renders_without_a_list_refetch(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The pushed row itself puts the session in the sidebar — no list GET.
+
+    The discovery frame carries the same full row ``GET /v1/sessions`` would
+    return, so the client places it directly. Treating the push as a mere
+    signal to refetch costs a round-trip the user waits through, and where the
+    list is served by an asynchronously-updated search index the refetch comes
+    back *without* the new session — leaving it invisible for seconds. So the
+    row appearing while zero list requests have fired is the behaviour to hold
+    onto: a regression that went back to invalidating would show a
+    ``/v1/sessions?...`` hit here.
+
+    :param page: Playwright page (default desktop viewport).
+    :param seeded_session: ``(base_url, existing_session_id)`` from the fixture
+        — gives the tab a session to open so the sidebar + stream are live.
+    """
+    base_url, existing_id = seeded_session
+    hits = _count_session_list_requests(page)
+    page.goto(f"{base_url}/c/{existing_id}")
+    expect(page.locator(f'a[href="/c/{existing_id}"]')).to_be_visible()
+    # Let the initial load's fetch flurry settle so the count below covers only
+    # what the create triggers.
+    page.wait_for_timeout(6_000)
+    baseline = len(hits)
+
+    resp = httpx.post(
+        f"{base_url}/v1/sessions",
+        data={"metadata": "{}"},
+        files={"bundle": ("agent.tar.gz", _build_hello_world_bundle(), "application/gzip")},
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+    new_id = resp.json()["session_id"]
+    try:
+        expect(page.locator(f'a[href="/c/{new_id}"]')).to_be_visible(timeout=20_000)
+        # KEY ASSERTION: the row got there without the client asking the server
+        # for the list again.
+        refetches = hits[baseline:]
+        assert refetches == [], (
+            f"expected the pushed row to render with no list refetch, "
+            f"but saw {len(refetches)}: {refetches}"
+        )
+    finally:
+        httpx.delete(f"{base_url}/v1/sessions/{new_id}", timeout=10.0)

--- a/web/src/hooks/SessionUpdatesProvider.test.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.test.tsx
@@ -306,6 +306,55 @@ describe("SessionUpdatesProvider fingerprint pruning", () => {
 });
 
 describe("SessionUpdatesProvider list invalidation", () => {
+  it("splices a newly-created session into the sidebar instead of refetching the list", () => {
+    // The discovery push carries the same full row the list endpoint returns,
+    // so the sidebar can render it immediately. A refetch would cost a
+    // round-trip — and where the list is served by an async search index, it
+    // comes back without the row and the session stays invisible for seconds.
+    vi.useFakeTimers();
+    try {
+      const client = new QueryClient();
+      seedConversations(client, ["conv_old"]);
+      renderProvider(client, ["/"]);
+      const invalidate = vi.spyOn(client, "invalidateQueries");
+      const handler = frameHandler();
+
+      act(() => handler({ type: "changed", items: [{ ...conv("conv_new"), updated_at: 5_000 }] }));
+      act(() => vi.advanceTimersByTime(300)); // past the debounce
+
+      const list = client.getQueryData<ConversationsInfiniteData>(["conversations", "", false]);
+      expect(list!.pages[0].data.map((c) => c.id)).toEqual(["conv_new", "conv_old"]);
+      expect(invalidate).not.toHaveBeenCalledWith({ queryKey: ["conversations"] });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still reconciles when the new session is filed into a project", () => {
+    // Folders fetch their own ["project-sessions", <name>] list, which the
+    // splice above can't place a row into (it keys off the project's name).
+    vi.useFakeTimers();
+    try {
+      const client = new QueryClient();
+      seedConversations(client, ["conv_old"]);
+      renderProvider(client, ["/"]);
+      const invalidate = vi.spyOn(client, "invalidateQueries");
+      const handler = frameHandler();
+
+      act(() =>
+        handler({
+          type: "changed",
+          items: [{ ...conv("conv_filed"), updated_at: 5_000, project_id: "proj_1" }],
+        }),
+      );
+      act(() => vi.advanceTimersByTime(300));
+
+      expect(invalidate).toHaveBeenCalledWith({ queryKey: ["project-sessions"] });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("invalidates the archived-project-names scan on a remote removal", () => {
     // Another client archiving/relabeling/deleting must refresh the Archived
     // view's project picker — only local mutations invalidate it otherwise.

--- a/web/src/hooks/SessionUpdatesProvider.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.tsx
@@ -24,8 +24,10 @@ import {
   type SessionListWireItem,
   collectConversationIds,
   filtersFromConversationQueryKey,
+  insertItemsIntoPages,
   mergeItemsIntoPages,
   nullsToUndefined,
+  PROJECT_LABEL_KEY,
   removeIdsFromPages,
 } from "@/lib/sessionListCache";
 import { type SessionUpdatesFrame, sessionUpdatesSocket } from "@/lib/sessionUpdatesSocket";
@@ -41,14 +43,25 @@ const DEBOUNCE_MS = 250;
 // drop out the same way they do from the default sidebar list.
 const PROJECT_FOLDER_FILTERS = { searchQuery: "", includeArchived: false } as const;
 
+/** Whether a row belongs to a project, whose folder fetches its own list. */
+function isFiled(item: SessionListWireItem): boolean {
+  return item.project_id != null || item.labels?.[PROJECT_LABEL_KEY] != null;
+}
+
 /**
  * Overlay wire items onto every cached `["conversations", ...]` variant.
  *
+ * Ids the cache has never seen are spliced in rather than merged: the frame
+ * carries the same full row the list endpoint returns, so a session created
+ * anywhere (this tab, another tab, the CLI) enters the sidebar on the push
+ * itself instead of waiting on a list round-trip. Only rows the local sort
+ * can place are inserted; the rest fall back to a server reconcile.
+ *
  * @param queryClient - The app QueryClient.
  * @param items - Wire items from a snapshot/changed frame.
- * @returns Ids not found in any cached page and whether any patched row
- *   needs a server refetch to preserve filtered-query membership or sort
- *   order.
+ * @returns Ids that still need a server list reconcile and whether any
+ *   patched row needs a server refetch to preserve filtered-query membership
+ *   or sort order.
  */
 function applyItemsToCache(
   queryClient: QueryClient,
@@ -93,8 +106,32 @@ function applyItemsToCache(
     if (queryNeedsRefetch) needsRefetch = true;
     if (next !== data) queryClient.setQueryData(key, next);
   }
+  const missing = [...itemsById.values()].filter((item) => !foundAnywhere.has(item.id));
+  const placed = new Set<string>();
+  // Steady-state snapshot ticks restate rows the cache already holds, so the
+  // common case skips the second pass entirely.
+  if (missing.length > 0) {
+    for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
+      queryKey: ["conversations"],
+    })) {
+      const { data: next, inserted } = insertItemsIntoPages(
+        data,
+        missing,
+        filtersFromConversationQueryKey(key),
+      );
+      for (const id of inserted) placed.add(id);
+      if (next !== data) queryClient.setQueryData(key, next);
+    }
+  }
   return {
-    missingIds: [...itemsById.keys()].filter((id) => !foundAnywhere.has(id)),
+    // A placed row already renders where the server's sort would put it, so
+    // only ones we couldn't place still need the list. Sub-agent children are
+    // never sidebar rows (the endpoint lists `kind=default`), so a watched
+    // child missing from every page is expected, not a stale list.
+    missingIds: missing
+      .filter((item) => item.parent_session_id == null)
+      .filter((item) => !placed.has(item.id) || isFiled(item))
+      .map((item) => item.id),
     needsRefetch,
   };
 }
@@ -276,10 +313,11 @@ export function SessionUpdatesProvider({ children }: { children: ReactNode }) {
             frame.items,
             activeIdRef.current,
           );
-          // A watched id absent from every page is a new session whose sort
-          // position we can't place locally. Membership-affecting deltas
-          // (archive/search/connected filters) and updated_at resorting need
-          // the same server-side reconciliation.
+          // What's left is a row the local splice couldn't place (it sorts onto
+          // an unloaded page, or into a search list only the server can decide)
+          // or one filed into a project, whose folder fetches its own list.
+          // Membership-affecting deltas (archive/search/connected filters) and
+          // updated_at resorting need the same server-side reconciliation.
           //
           // Skip the active session: its updated_at bumps on open before the
           // initial list fetch returns, so it lands in missingIds even though

--- a/web/src/lib/sessionListCache.test.ts
+++ b/web/src/lib/sessionListCache.test.ts
@@ -5,6 +5,7 @@ import {
   type SessionListWireItem,
   collectConversationIds,
   filtersFromConversationQueryKey,
+  insertItemsIntoPages,
   mergeItemsIntoPages,
   nullsToUndefined,
   removeIdsFromPages,
@@ -407,6 +408,88 @@ describe("removeIdsFromPages", () => {
     expect(after!.pages[0].data).toEqual([]);
     expect(after!.pages[0].first_id).toBeNull();
     expect(after!.pages[0].last_id).toBeNull();
+  });
+});
+
+describe("insertItemsIntoPages", () => {
+  it("places a newly-visible session at its sorted position and moves the cursor", () => {
+    const before = data([conv("a", { updated_at: 30 }), conv("b", { updated_at: 10 })]);
+
+    const { data: after, inserted } = insertItemsIntoPages(
+      before,
+      [{ id: "fresh", updated_at: 20 }],
+      DEFAULT_FILTERS,
+    );
+
+    // Descending updated_at is the list's own order, so the row lands where
+    // a refetch would have put it — no round-trip, no visible resort later.
+    expect(after!.pages[0].data.map((r) => r.id)).toEqual(["a", "fresh", "b"]);
+    expect(inserted).toEqual(new Set(["fresh"]));
+    // Cursors bound the loaded window; a newest-first row moves first_id.
+    const { data: atTop } = insertItemsIntoPages(
+      before,
+      [{ id: "newest", updated_at: 99 }],
+      DEFAULT_FILTERS,
+    );
+    expect(atTop!.pages[0].first_id).toBe("newest");
+  });
+
+  it("leaves a row that sorts onto an unloaded page to the server", () => {
+    const before: ConversationsInfiniteData = {
+      pages: [
+        { data: [conv("a", { updated_at: 30 })], first_id: "a", last_id: "a", has_more: true },
+      ],
+      pageParams: [undefined],
+    };
+
+    const { data: after, inserted } = insertItemsIntoPages(
+      before,
+      [{ id: "older", updated_at: 5 }],
+      DEFAULT_FILTERS,
+    );
+
+    // Appending it would render it above rows the next page will bring in.
+    expect(after).toBe(before);
+    expect(inserted.size).toBe(0);
+  });
+
+  it("keeps rows the list itself would exclude out of the cache", () => {
+    const before = data([conv("a", { updated_at: 30 })]);
+
+    // Sub-agent children (the endpoint lists kind=default) and archived rows
+    // (in a non-archived list) are absent because they don't belong, not
+    // because the cache is behind.
+    const { inserted: child } = insertItemsIntoPages(
+      before,
+      [{ id: "kid", updated_at: 99, parent_session_id: "a" }],
+      DEFAULT_FILTERS,
+    );
+    const { inserted: archived } = insertItemsIntoPages(
+      before,
+      [{ id: "old", updated_at: 99, archived: true }],
+      DEFAULT_FILTERS,
+    );
+
+    expect(child.size).toBe(0);
+    expect(archived.size).toBe(0);
+  });
+
+  it("never guesses membership for a search list", () => {
+    const before = data([conv("a", { updated_at: 30 })]);
+
+    // The server matches titles AND item content, so whether a row belongs in
+    // a search list isn't decidable here.
+    const { data: after, inserted } = insertItemsIntoPages(
+      before,
+      [{ id: "fresh", updated_at: 99 }],
+      {
+        searchQuery: "deploy",
+        includeArchived: false,
+      },
+    );
+
+    expect(after).toBe(before);
+    expect(inserted.size).toBe(0);
   });
 });
 

--- a/web/src/lib/sessionListCache.ts
+++ b/web/src/lib/sessionListCache.ts
@@ -270,6 +270,70 @@ export function mergeItemsIntoPages(
 }
 
 /**
+ * Splice rows the cache has never seen into one infinite query's first page.
+ *
+ * A pushed row for an id absent from every page is a session that just became
+ * visible to this user (created here or in another tab, forked, shared). The
+ * frame carries the same full row `GET /v1/sessions` would return, so the
+ * client can place it directly instead of round-tripping a list refetch —
+ * which is both slower and, on a deployment whose list is served by an
+ * asynchronously-updated search index, still missing the row.
+ *
+ * Placement mirrors the list's own shape: sessions are sorted by `updated_at`
+ * descending and sub-agent children are excluded (the endpoint lists
+ * `kind=default`). A row older than the first page's last entry belongs on a
+ * page that isn't loaded, so it is left for the caller's refetch rather than
+ * rendered out of order.
+ *
+ * @param data - The cached infinite data, or `undefined` for an unfetched
+ *   query.
+ * @param items - Wire items whose ids are absent from every cached page.
+ * @param filters - Canonical filters for this conversations query.
+ * @returns The (possibly identical) data and the ids actually placed.
+ */
+export function insertItemsIntoPages(
+  data: ConversationsInfiniteData | undefined,
+  items: SessionListWireItem[],
+  filters: ConversationListFilters,
+): { data: ConversationsInfiniteData | undefined; inserted: Set<string> } {
+  const inserted = new Set<string>();
+  // A search list's membership is decided by the server (it matches titles and
+  // item content), so a row that isn't in it may or may not belong.
+  if (!data || items.length === 0 || filters.searchQuery !== "") return { data, inserted };
+  let rows = data.pages[0]?.data;
+  if (rows === undefined) return { data, inserted };
+  for (const item of items) {
+    // Sorting needs `updated_at`; a wire item without one can't be placed.
+    if (item.parent_session_id != null || item.updated_at === undefined) continue;
+    const updatedAt = item.updated_at;
+    const row = { object: "conversation", ...item } as Conversation;
+    if (violatesKnownMembership(row, filters)) continue;
+    let at = rows.findIndex((existing) => existing.updated_at < updatedAt);
+    if (at === -1) {
+      // Older than every loaded row: it belongs after the first page, which is
+      // only the end of the list when nothing follows it.
+      if (data.pages.length > 1 || data.pages[0]!.has_more) continue;
+      at = rows.length;
+    }
+    rows = [...rows.slice(0, at), row, ...rows.slice(at)];
+    inserted.add(row.id);
+  }
+  if (inserted.size === 0) return { data, inserted };
+  // Cursors bound the loaded window, so they follow the rows: `last_id` is the
+  // `after=` anchor the next page is fetched from.
+  const pages = [
+    {
+      ...data.pages[0]!,
+      data: rows,
+      first_id: rows[0]?.id ?? null,
+      last_id: rows[rows.length - 1]?.id ?? null,
+    },
+    ...data.pages.slice(1),
+  ];
+  return { data: { ...data, pages }, inserted };
+}
+
+/**
  * Drop rows with the given ids from one infinite query's cached pages.
  *
  * Page cursors are recomputed from the surviving rows: `last_id` of the


### PR DESCRIPTION
## Related issue

N/A

## Summary

Creating a session outside a project took seconds for its row to show up under
**Sessions** in the sidebar.

The server already publishes the new session on `WS /v1/sessions/updates` the
moment the row is written — and that frame carries the **complete list row**
(`_fetch_watched_items` loads conversations by id). The client threw that row
away: an id it didn't recognise only *scheduled* a debounced
`invalidateQueries(["conversations"])`, so the row couldn't render until
`GET /v1/sessions` came back. Where that list is served by an asynchronously
updated search index, the refetch returns *without* the new session, and it
stays invisible until the index catches up.

Measured on a local server + host, from the create POST:

| event | before |
|---|---|
| WS discovery push (full row) | 166 ms |
| row listable via `GET /v1/sessions` | 191 ms |
| `POST /v1/sessions` returns (blocks on host runner launch) | 0.6 – 5.7 s |

So the data was in the browser at ~170 ms and went unused.

This PR splices the pushed row directly into the cached pages, at the position
the list's own `updated_at`-desc sort would give it, and skips the list
reconcile for rows placed that way. Anything the client can't decide locally
still falls back to the server: search variants (the server matches item
content), project-filed rows (folders fetch their own `["project-sessions"]`
list), and rows that sort onto a page that isn't loaded. Sub-agent children are
never sidebar rows — the endpoint lists `kind=default` — so they no longer
force a refetch either.

```
before   create ──▶ push(row) ──▶ [250 ms debounce] ──▶ GET /v1/sessions ──▶ row
after    create ──▶ push(row) ──▶ row
```

## Test Plan

- `pnpm --filter web exec vitest run` — full web suite green (4961 passed);
  6 new cases added to the existing `sessionListCache` / `SessionUpdatesProvider`
  suites covering sorted placement, cursor movement, the unloaded-page and
  search-variant refusals, sub-agent/archived exclusion, and the
  "splice, don't invalidate" behaviour (plus the project-filed carve-out).
- `pre-commit run --files …` — clean.
- New e2e_ui case `test_new_session_row_renders_without_a_list_refetch`
  (`tests/e2e_ui/sessions/test_session_updates_stream.py`): a session created
  over the API renders in an already-open sidebar with **zero**
  `GET /v1/sessions` list requests. Verified as a real guard — against the
  previous build it fails on the observed refetch.
- End-to-end against a real local server + host + Chromium (Playwright driving
  the landing page through a create): time from the Send click to the new row
  rendering in `[data-testid="sidebar-conversation-list"]`.

## Demo

Measured in the real UI (no visual change to any component, so the numbers are
the demo — the row simply arrives before the chat page does):

| | sidebar row appears | chat page opens |
|---|---|---|
| before | 422 ms | 2744 ms |
| after | **81 – 93 ms** | 643 – 854 ms |

The spliced row was also watched for 10 s after it appeared to confirm no later
refetch drops it back out (no flicker).

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the latency measurement above: a local server with a
connected host, the built SPA, and Playwright timing the sidebar row against the
create POST. That timing depends on a live WS stream and a real runner launch,
which the unit suites deliberately mock, so the placement logic itself is
covered by the new unit tests and the end-to-end timing was verified by hand.

## Changelog

New sessions appear in the sidebar immediately instead of after a delay
