### PR TITLE
fix(server): don't let Claude's interrupt record steal a steered upload

### DIFF
--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import re
 import secrets
 import time
 import urllib.parse
@@ -3176,6 +3177,52 @@ async def _create_and_publish_codex_child(
 def _is_kiro_native_session(conv: Conversation) -> bool:
     """Return whether a conversation is backed by the native Kiro terminal."""
     return conv.labels.get("omnigent.wrapper") == "kiro-native-ui"
+
+
+# Claude Code writes this record into its own transcript when a turn is
+# interrupted (Escape, or steering while a tool is in flight). Anchored so a
+# user's bracketed question such as "[Request interrupted by user?]" stays a
+# real message. Kept in sync with `INTERRUPT_RE` in web/src/lib/systemMessage.ts,
+# which re-classifies the mirrored record as a muted "Interrupted" marker.
+_CLAUDE_INTERRUPT_RECORD_RE = re.compile(r"^\[Request interrupted by user(?: for tool use)?\]$")
+
+
+def _is_native_interrupt_record(data: MessageData) -> bool:
+    """
+    Whether a mirrored user item is the vendor CLI's own interrupt record.
+
+    The transcript forwarder mirrors every user-role record back, but this
+    one is synthesized by Claude itself — it is not the round-trip of a web
+    message, so no :mod:`omnigent.runtime.pending_inputs` entry exists for
+    it. Draining one anyway shifts the FIFO by a slot: the marker absorbs
+    the queued message's uploads and the real message persists with none.
+
+    Runtime ``[System: ...]`` notices are deliberately NOT matched here.
+    Those are posted through ``POST /v1/sessions/{id}/events`` and record a
+    pending entry of their own (see
+    :func:`_dispatch_session_event_to_runner`), so their mirror-back must
+    keep draining normally.
+
+    Matched on the first line only, exactly as ``parseSystemMessage`` does
+    web-side. The two predicates must agree: a record the web hides as a
+    marker but the server drains for would put the bug straight back.
+
+    :param data: The mirrored user message's data, whose ``content`` is a
+        list of block dicts, e.g. ``[{"type": "input_text", "text":
+        "[Request interrupted by user]"}]``.
+    :returns: ``True`` for an interrupt record, ``False`` for a real
+        user message.
+    """
+    if any(
+        isinstance(block, dict) and block.get("type") in ("input_image", "input_file")
+        for block in data.content
+    ):
+        return False
+    text = _message_text(data.content)
+    if text is None:
+        return False
+    first_line = text.strip().split("\n", 1)[0]
+    return _CLAUDE_INTERRUPT_RECORD_RE.match(first_line) is not None
 
 
 def _merge_pending_file_blocks(

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -207,6 +207,7 @@ from omnigent.server.routes._sessions.helpers import (
     _invalidate_runner_backed_snapshot_state,
     _is_codex_native_subagent,
     _is_kiro_native_session,
+    _is_native_interrupt_record,
     _last_task_error_from_labels,
     _latest_assistant_text_from_store,
     _latest_message_preview,
@@ -1988,6 +1989,9 @@ async def _persist_external_conversation_item(
     # entry's file blocks (image / file) into the item BEFORE persisting.
     # The transcript is text-only, so without this the image is dropped
     # from durable history and disappears on every reload / navigation.
+    # The vendor CLI's own interrupt record is exempt: it is synthesized by
+    # Claude (not a queued web message) and has no pending entry, so
+    # draining for it would hand the queued message's uploads to the marker.
     cleared_pending_id: str | None = None
     skipped_kiro_pending: list[pending_inputs.DrainedInput] = []
     if (
@@ -1995,6 +1999,7 @@ async def _persist_external_conversation_item(
         and isinstance(item.data, MessageData)
         and item.data.role == "user"
         and not item.data.is_meta
+        and not _is_native_interrupt_record(item.data)
     ):
         if _is_kiro_native_session(conv):
             text = _message_text(item.data.content) or ""

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -1625,6 +1625,132 @@ async def test_external_user_message_drain_publishes_cleared_pending_id(
 
 
 @pytest.mark.parametrize(
+    "interrupt_text",
+    ["[Request interrupted by user]", "[Request interrupted by user for tool use]"],
+)
+async def test_external_interrupt_record_leaves_pending_input_for_real_message(
+    client: httpx.AsyncClient,
+    interrupt_text: str,
+) -> None:
+    """
+    Regression: steering with an upload must not feed it to the interrupt marker.
+
+    Interrupting a turn to steer makes Claude write its own ``[Request
+    interrupted by user...]`` record into the transcript BEFORE the steering
+    message. The forwarder mirrors both back as user items. The interrupt
+    record has no pending-input entry of its own, so a FIFO drain for it
+    shifts the queue by a slot: the marker absorbs the queued message's
+    uploads and the real message persists with none. In the web UI that
+    renders as the raw marker text next to the screenshots, followed by a
+    blank bubble (the real message's ``[Attached:]`` markers are stripped and
+    its file blocks are gone). Assert the marker persists bare and the
+    steering message keeps the image.
+    """
+    from omnigent.runtime import pending_inputs
+
+    pending_inputs.reset_for_tests()
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    # The optimistic entry for the steering message: an image-only upload.
+    pid = pending_inputs.record(
+        session["id"],
+        [{"type": "input_image", "file_id": "file_shot1", "filename": "shot.png"}],
+    )
+    try:
+        for text in (
+            interrupt_text,
+            "[Attached: /tmp/uploads/shot.png]",
+        ):
+            resp = await client.post(
+                f"/v1/sessions/{session['id']}/events",
+                json={
+                    "type": "external_conversation_item",
+                    "data": {
+                        "item_type": "message",
+                        "item_data": {
+                            "role": "user",
+                            "content": [{"type": "input_text", "text": text}],
+                        },
+                        "response_id": "native_turn_1",
+                    },
+                },
+            )
+            assert resp.status_code == 202, resp.text
+
+        items = (await client.get(f"/v1/sessions/{session['id']}/items")).json()["data"]
+        messages = [item for item in items if item["type"] == "message"]
+        assert len(messages) == 2, messages
+        marker, steered = messages
+        # The marker stays text-only, so the UI still classifies it as a
+        # system marker instead of rendering it as user text beside an image.
+        assert marker["content"] == [{"type": "input_text", "text": interrupt_text}]
+        # The upload landed on the message that actually queued it.
+        assert steered["content"][0] == {
+            "type": "input_image",
+            "file_id": "file_shot1",
+            "filename": "shot.png",
+        }
+        assert steered["content"][1]["text"] == "[Attached: /tmp/uploads/shot.png]"
+        # The real message drained the entry (the marker must not have).
+        assert pending_inputs.snapshot_for(session["id"]) == []
+        assert pid
+    finally:
+        pending_inputs.reset_for_tests()
+
+
+async def test_external_interrupt_lookalike_still_drains_pending_input(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    The interrupt-record exemption must not swallow real user messages.
+
+    A user can type a message that merely resembles the marker. Over-matching
+    would skip the drain for it, stranding the pending entry and dropping the
+    upload it carries — the same class of bug from the other direction. The
+    regex is anchored, so a bracketed question is a normal message.
+    """
+    from omnigent.runtime import pending_inputs
+
+    pending_inputs.reset_for_tests()
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    pending_inputs.record(
+        session["id"],
+        [{"type": "input_image", "file_id": "file_shot2", "filename": "shot.png"}],
+    )
+    try:
+        resp = await client.post(
+            f"/v1/sessions/{session['id']}/events",
+            json={
+                "type": "external_conversation_item",
+                "data": {
+                    "item_type": "message",
+                    "item_data": {
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": "[Request interrupted by user?]"}
+                        ],
+                    },
+                    "response_id": "native_turn_1",
+                },
+            },
+        )
+        assert resp.status_code == 202, resp.text
+
+        items = (await client.get(f"/v1/sessions/{session['id']}/items")).json()["data"]
+        user_msg = next(item for item in items if item["type"] == "message")
+        assert user_msg["content"][0] == {
+            "type": "input_image",
+            "file_id": "file_shot2",
+            "filename": "shot.png",
+        }
+        assert pending_inputs.snapshot_for(session["id"]) == []
+    finally:
+        pending_inputs.reset_for_tests()
+
+
+@pytest.mark.parametrize(
     ("created_by", "mirrored_text"),
     [
         ("alice@example.com", "[alice@example.com]: hello"),

--- a/web/src/pages/ChatPage.userBubble.test.tsx
+++ b/web/src/pages/ChatPage.userBubble.test.tsx
@@ -127,6 +127,43 @@ describe("UserBubble system messages", () => {
     expect(screen.queryByTestId("system-message")).toBeNull();
     expect(screen.getByText("build finished")).toBeInTheDocument();
   });
+
+  it("renders a steering interrupt as a muted marker and its uploads as their own bubble", () => {
+    // The two items a mid-tool-use steer produces, once the pending-input
+    // drain stops handing the uploads to the marker: Claude's own interrupt
+    // record (text-only) and the user's attachments-only message.
+    renderBubble(userBubble("[Request interrupted by user for tool use]"));
+    const marker = screen.getByTestId("system-message");
+    expect(marker.getAttribute("data-system-kind")).toBe("interrupted");
+    expect(marker).toHaveTextContent("Interrupted");
+    // The raw record must not survive as user-bubble text.
+    expect(screen.queryByText(/\[Request interrupted by user/)).toBeNull();
+    expect(screen.queryByTestId("message-bubble")).toBeNull();
+
+    cleanup();
+
+    renderBubble(
+      userBubble("[Attached: /tmp/uploads/shot1.png]\n\n[Attached: /tmp/uploads/shot2.png]", {
+        content: [
+          { type: "input_image", file_id: "file_1", filename: "shot1.png" },
+          { type: "input_image", file_id: "file_2", filename: "shot2.png" },
+          {
+            type: "input_text",
+            text: "[Attached: /tmp/uploads/shot1.png]\n\n[Attached: /tmp/uploads/shot2.png]",
+          },
+        ],
+      }),
+    );
+    // A real bubble with both screenshots — not the blank pill the stolen
+    // file blocks used to leave behind.
+    expect(screen.getByTestId("message-bubble")).toBeInTheDocument();
+    expect(screen.getByAltText("shot1.png")).toBeInTheDocument();
+    expect(screen.getByAltText("shot2.png")).toBeInTheDocument();
+    // Upload markers are stripped from the text, and an empty text renders
+    // nothing rather than an empty markdown block.
+    expect(screen.queryByText(/\[Attached:/)).toBeNull();
+    expect(screen.queryByTestId("system-message")).toBeNull();
+  });
 });
 
 describe("AssistantBubble lifecycle rendering", () => {

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -2782,6 +2782,72 @@ describe("chatStore — send (file attachments)", () => {
     ]);
   });
 
+  it("does not hand the upload to the interrupt marker that precedes it", async () => {
+    // Steering mid-tool-use makes Claude write its own "[Request interrupted
+    // by user...]" record BEFORE the steering message, and the forwarder
+    // mirrors both back as consumed events. The marker was never queued
+    // here, so the FIFO-head fallback must not pop the optimistic bubble for
+    // it — otherwise the marker renders as raw user text beside the
+    // screenshots and the real message lands as a blank bubble.
+    useChatStore.setState({
+      conversationId: "conv_existing",
+      abortController: new AbortController(),
+    });
+
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/v1/sessions/conv_existing/resources/files")) {
+        return mockResponse({
+          id: "file_real_shot",
+          name: "shot.png",
+          metadata: { filename: "shot.png", bytes: 10, created_at: 0 },
+        });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const file = new File(["bytes"], "shot.png", { type: "image/png" });
+    await useChatStore.getState().send("", "agent_xyz", [file]);
+
+    handleSessionEvent({
+      type: "session_input_consumed",
+      itemId: "msg_interrupt",
+      itemType: "message",
+      data: {
+        role: "user",
+        content: [{ type: "input_text", text: "[Request interrupted by user for tool use]" }],
+      },
+    });
+
+    // Marker committed bare, optimistic bubble untouched.
+    const afterMarker = useChatStore.getState();
+    expect(afterMarker.pendingUserMessages).toHaveLength(1);
+    const marker = afterMarker.blocks[0] as UserMessageBlock;
+    expect(marker.content).toEqual([
+      { type: "input_text", text: "[Request interrupted by user for tool use]" },
+    ]);
+
+    handleSessionEvent({
+      type: "session_input_consumed",
+      itemId: "msg_steer",
+      itemType: "message",
+      data: {
+        role: "user",
+        content: [{ type: "input_text", text: "[Attached: /tmp/uploads/shot.png]" }],
+      },
+    });
+
+    // The upload landed on the message that actually queued it.
+    const state = useChatStore.getState();
+    expect(state.pendingUserMessages).toEqual([]);
+    const steered = state.blocks[1] as UserMessageBlock;
+    expect(steered.ctx.itemId).toBe("msg_steer");
+    expect(steered.content).toEqual([
+      { type: "input_image", file_id: "file_real_shot", filename: "shot.png" },
+      { type: "input_text", text: "[Attached: /tmp/uploads/shot.png]" },
+    ]);
+  });
+
   it("keeps the optimistic bubble's stable key on the native path (no pending_id adoption)", async () => {
     // The native POST returns a pending_id, but the optimistic bubble
     // must KEEP its client temp id as its React key — swapping to the

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -103,6 +103,7 @@ import { isClaudeNativeModel } from "@/lib/claudeNativeModels";
 import { isCodexNativeModel } from "@/lib/codexNativeModels";
 import { codexPlanModeFromSession } from "@/lib/codexPlanMode";
 import { getCurrentAuthorId } from "@/lib/identity";
+import { isSystemUserContent } from "@/lib/systemMessage";
 import { isNativeWrapper } from "@/lib/nativeCodingAgents";
 
 export interface SendOptions {
@@ -4482,12 +4483,14 @@ export function handleSessionEvent(event: StreamEvent): void {
       //   2. FIFO head — for an optimistic bubble whose POST hasn't
       //      returned the id to adopt yet (consumed raced ahead), or a
       //      cross-client send. Per-session SSE ordering makes the head
-      //      the right entry. Unconditional (no text match): the native
-      //      transcript reformats text (reply-quote `>` blockquotes,
-      //      `[Attached:]` markers), so a text guard would wrongly skip
-      //      the drop and strand the bubble as a duplicate.
+      //      the right entry. No text match: the native transcript
+      //      reformats text (reply-quote `>` blockquotes, `[Attached:]`
+      //      markers), so a text guard would wrongly skip the drop and
+      //      strand the bubble as a duplicate. Only system markers, which
+      //      never had a bubble here, are held back.
       //   3. No pending entry — render the event payload as a fresh
-      //      committed bubble (TUI-typed message, or another client).
+      //      committed bubble (TUI-typed message, marker, or another
+      //      client).
       useChatStore.setState((s) => {
         if (hasCommittedItem(s.blocks, event.itemId)) return {};
 
@@ -4520,7 +4523,18 @@ export function handleSessionEvent(event: StreamEvent): void {
         }
 
         // 2. FIFO head fallback (id not adopted yet / cross-client).
-        const head = s.pendingUserMessages[0];
+        //    Skipped for a mirrored system marker (the vendor CLI's own
+        //    interrupt record): it is synthesized by the CLI, never queued
+        //    here, so popping the head would hand the queued message's
+        //    uploads to the marker and leave the real message empty. A
+        //    `[System: …]` notice DOES have a pending entry, but the server
+        //    drains it and names it via `clearedPendingId`, so it lands on
+        //    branch 1 and never reaches this fallback.
+        const eventContent = userContentFromEvent(event);
+        const head =
+          eventContent !== null && isSystemUserContent(eventContent)
+            ? undefined
+            : s.pendingUserMessages[0];
         if (head) {
           const content = committedContentFor(event, head.content);
           if (content === null) return {};
@@ -4540,13 +4554,13 @@ export function handleSessionEvent(event: StreamEvent): void {
           };
         }
 
-        // 3. Nothing pending — render the event payload fresh.
-        const content = userContentFromEvent(event);
-        if (content === null) return {};
+        // 3. Nothing pending (or a marker that owns no bubble) — render the
+        //    event payload fresh.
+        if (eventContent === null) return {};
         return {
           blocks: [
             ...s.blocks,
-            committedUserBlock(event.itemId, content, undefined, event.createdBy),
+            committedUserBlock(event.itemId, eventContent, undefined, event.createdBy),
           ],
         };
       });


### PR DESCRIPTION
## Related issue

N/A

## Summary

Steering a claude-native turn mid-tool-use, with a screenshot attached, produced two broken bubbles: the literal text `[Request interrupted by user for tool use]` sitting next to the screenshots, followed by a completely blank bubble. It persisted that way, so it survived reload.

**ELI5:** Omnigent keeps a little queue of "messages you sent that the CLI hasn't echoed back yet", and pops one off each time a user message comes back from the transcript. Claude writes its *own* "I was interrupted" line into that transcript — which looks like a user message but was never in the queue. So it popped your real message off the queue and took its screenshots with it.

Concretely: Claude Code writes its own `[Request interrupted by user for tool use]` record **before** the steering message, and the forwarder mirrors both back as user items. `_persist_external_conversation_item` treated every mirrored user message as the round-trip of a queued web message — FIFO-draining a `pending_inputs` entry and folding that entry's uploaded `input_image` / `input_file` blocks into the item. The interrupt record has no pending entry of its own, so draining for it shifted the queue by a slot.

```
  transcript order          pending_inputs FIFO        result
  ─────────────────         ───────────────────        ──────
  [Request interrupted…] ──► drains entry #1  ────────► marker + your 2 screenshots  ✗
  [Attached: /abs/a.png] ──► queue empty      ────────► text-only, markers stripped
  [Attached: /abs/b.png]                               → blank bubble               ✗
```

Both rendering symptoms fall out of that one shift:
- The marker item now carries image blocks, so `UserBubble`'s system-marker gate (`images.length === 0 && …`) bails and the raw record renders as user text instead of the muted "System: Interrupted" chip.
- The real message keeps only absolute-path `[Attached: …]` markers. `extractUserText` strips them to `""` and `extractAttachedPaths` deliberately skips absolute paths (they're meant to be represented by the file blocks that were taken) → nothing left to render.

**Fix:** exempt the vendor CLI's own interrupt record from the drain.

Runtime `[System: …]` notices are deliberately **not** exempt — they're posted through `POST /events` and record a pending entry of their own (`_dispatch_session_event_to_runner`), so their mirror-back must keep draining. The predicate matches on the first line only, exactly as `parseSystemMessage` does web-side; a record the web hides as a marker but the server drained for would put the bug straight back.

`chatStore`'s `session.input.consumed` handler had the same flaw on the live path, so its FIFO-head fallback now holds back system markers too. A `[System: …]` notice still lands on the drop-by-id branch via `clearedPendingId`, so it is unaffected.

## Test Plan

Both new server tests were confirmed to **fail without the fix** — the marker item persists as `[{input_image …}, {input_text "[Request interrupted by user]"}]`, i.e. the exact reported bubble. Same A/B for the store test.

- `tests/server/integration/test_sessions_endpoints.py`
  - `test_external_interrupt_record_leaves_pending_input_for_real_message` (both marker spellings) — drives the real `POST /events` ingest with the two items in transcript order, reads back `GET /items`, asserts the marker stays text-only and the upload lands on the steering message.
  - `test_external_interrupt_lookalike_still_drains_pending_input` — guards the other direction: a real message that merely *looks* like the marker (`[Request interrupted by user?]`) must still drain, or the exemption would strand uploads.
- `web/src/store/chatStore.test.ts` — the live SSE path: marker event arrives first, optimistic bubble must survive it, upload lands on the following real message.
- `web/src/pages/ChatPage.userBubble.test.tsx` — pins the rendering: marker → `data-system-kind="interrupted"` chip; attachments-only message → a real bubble with both images and no leftover `[Attached:` text.

Full suites green: `test_sessions_endpoints.py` + `test_pending_inputs.py` + `test_claude_native_forwarder.py` + `test_claude_native_bridge.py` (534 passed), and the whole web suite (275 files / 4956 tests). `pre-commit` clean on all changed files.

## Demo

No image committed (keeping `docs/images/` untouched). Captured from the actual rendered DOM in the new `ChatPage.userBubble.test.tsx` case:

**Before**
```
                        ┌────────────────────────────────────────┐
                        │ [ screenshot 1 ]                       │
                        │ [ screenshot 2 ]                       │
                        │ [Request interrupted by user for tool  │
                        │  use]                                  │   ← raw marker as user text
                        └────────────────────────────────────────┘
                                                          ┌────┐
                                                          │    │   ← blank bubble
                                                          └────┘
```

**After**
```
                     🚫 System: Interrupted                        ← centered, muted, text-xs

                                        ┌──────────────────┐
                                        │  [ screenshot 1 ]│       ← right-aligned user bubble
                                        │  [ screenshot 2 ]│
                                        └──────────────────┘
```

Rendered markup for the marker (was previously a user bubble):
```html
<div class="my-1 flex flex-col items-center gap-1 text-muted-foreground text-xs"
     data-testid="system-message" data-system-kind="interrupted">
  <svg class="lucide-ban size-3.5"/><span><strong>System:</strong> Interrupted</span>
</div>
```

and for the steering message (was previously the blank pill):
```html
<div data-testid="message-bubble" data-role="user" class="… ml-auto justify-end">
  <div class="mb-1.5 flex flex-wrap gap-2">
    <button aria-label="Zoom image: shot1.png"><img alt="shot1.png" class="max-h-64 rounded-md object-contain"></button>
    <button aria-label="Zoom image: shot2.png"><img alt="shot2.png" …></button>
  </div>
</div>
```

Empty text renders nothing rather than an empty markdown block (`{text && <FilePathAwareMessageResponse>}`), and the hover Copy action is hidden for an image-only message — so the bubble shrink-wraps to the screenshots.

To reproduce by hand: start a claude-native session, give it a long-running tool call, then paste a screenshot and send while the tool is in flight.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — covered by the automated tests above, each confirmed failing without the fix.

Note: already-affected sessions won't self-heal. The items are persisted with the uploads on the wrong item, so existing transcripts stay broken on reload; this only prevents recurrence.

## Changelog

Steering a native session mid-tool-use no longer shows a raw "[Request interrupted by user]" line and a blank bubble — the interruption renders as a muted marker and your attachments stay on your message.
