### PR TITLE
fix(web): hold the transcript still while the composer grows

### DIFF
--- a/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
+++ b/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
@@ -1,0 +1,122 @@
+"""E2E: growing the composer must leave the transcript above it untouched.
+
+The composer auto-grows by collapsing its textarea to ``height: auto`` and
+reading the content height back (``hooks/useAutoGrowTextarea.ts``). That
+collapse lasts one layout pass, during which the composer is one row tall and
+the transcript's scroll viewport is correspondingly taller — so the browser
+clamps the transcript's ``scrollTop`` against the taller viewport's smaller
+maximum. The clamp survives the composer springing back, which shunted the
+whole transcript down a line on every re-measure: Shift+Enter, and then every
+keystroke once the composer was multi-line.
+
+A second, subtler source of movement is the composer's height itself: while it
+was a plain flex sibling, every extra row stole height from the transcript's
+scroll viewport. The messages could be held still through that, but the native
+scrollbar (drawn from ``clientHeight``/``scrollHeight``) and the turn rail
+(centered on the same box) still jittered. The composer now floats its extra
+rows over the transcript instead, so that box never changes.
+
+Layout regressions like these are invisible below the browser — jsdom has no
+layout, so ``scrollHeight``/``clientHeight`` are 0 there and neither the clamp
+nor the viewport arithmetic happens at all. The assertions pin what has to hold
+at once: the messages, the scroll geometry, and the rail ticks all stay exactly
+where they were, and the transcript stays stuck to the bottom so a streaming
+reply still follows.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import seed_committed_turn
+
+_TEXT_SECTION = '[data-testid="assistant-text-section"]'
+
+# Geometry of the transcript and the composer, read together so a measurement
+# can't straddle a layout change.
+#
+# ``distanceFromBottom`` is 0-or-1 while the transcript is stuck to the bottom
+# (use-stick-to-bottom parks it one pixel short of the maximum) and grows once
+# a clamp has knocked it loose. ``viewport`` is the scroll geometry the native
+# scrollbar is drawn from — any change there moves the thumb, which reads as
+# jitter next to a composer that's only supposed to be growing. ``railTicks``
+# is the left-edge turn minimap, centered on the same box.
+_PROBE = """() => {
+    const ta = document.querySelector('textarea[aria-label="Message the agent"]');
+    const scroller = ta.closest('form').parentElement.querySelector('[role="log"] > div');
+    const rail = document.querySelector('.turn-rail-fade');
+    return {
+        messageTops: [...document.querySelectorAll('[data-testid="assistant-text-section"]')]
+            .map((section) => Math.round(section.getBoundingClientRect().top)),
+        composerHeight: Math.round(ta.getBoundingClientRect().height),
+        distanceFromBottom: Math.round(
+            scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop),
+        viewport: [scroller.clientHeight, scroller.scrollHeight, Math.round(scroller.scrollTop)],
+        railTicks: rail
+            ? [...rail.querySelectorAll('button')]
+                  .map((tick) => Math.round(tick.getBoundingClientRect().top))
+            : null,
+    };
+}"""
+
+
+def test_composer_growth_does_not_shift_transcript(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Newlines, typing, and deletions all leave the transcript where it was."""
+    base_url, session_id = seeded_session
+    # Enough turns to overflow the viewport: the transcript has to be
+    # scrollable for a scrollTop clamp to have anywhere to land, and each turn
+    # is one tick on the rail.
+    for i in range(6):
+        seed_committed_turn(
+            session_id,
+            prompt=f"Question {i}?",
+            reply=f"Paragraph {i}. " + ("filler sentence for height. " * 12),
+            response_id=f"resp_{i}",
+        )
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    sections = page.locator(_TEXT_SECTION)
+    expect(sections).to_have_count(6, timeout=30_000)
+    composer = page.get_by_label("Message the agent")
+    expect(composer).to_be_visible(timeout=30_000)
+    # Let the initial scroll-to-bottom and the trailing spacer's measurement
+    # settle, so the baseline is the resting layout.
+    page.wait_for_timeout(1500)
+
+    composer.click()
+    baseline = page.evaluate(_PROBE)
+    assert baseline["distanceFromBottom"] <= 1, baseline
+    assert baseline["railTicks"], baseline
+
+    def assert_transcript_idle(state: dict, label: str) -> None:
+        """Everything but the composer itself is byte-identical to baseline."""
+        for key in ("messageTops", "viewport", "railTicks"):
+            assert state[key] == baseline[key], (label, key, baseline[key], state[key])
+        assert state["distanceFromBottom"] <= 1, (label, state)
+
+    # Grow: three Shift+Enter newlines, one line taller each.
+    for _ in range(3):
+        composer.press("Shift+Enter")
+    page.wait_for_timeout(500)
+    grown = page.evaluate(_PROBE)
+    assert grown["composerHeight"] > baseline["composerHeight"], grown
+    assert_transcript_idle(grown, "after newlines")
+
+    # Type into the now-multi-line composer: the height doesn't change, but the
+    # hook re-measures — and used to clamp the transcript on every keystroke.
+    composer.type("hello", delay=30)
+    page.wait_for_timeout(500)
+    assert_transcript_idle(page.evaluate(_PROBE), "after typing")
+
+    # Shrink back: deleting the newlines returns the composer to one row and
+    # still leaves the transcript untouched.
+    for _ in range(len("hello") + 3):
+        composer.press("Backspace")
+    page.wait_for_timeout(500)
+    shrunk = page.evaluate(_PROBE)
+    assert shrunk["composerHeight"] == baseline["composerHeight"], (baseline, shrunk)
+    assert_transcript_idle(shrunk, "after deleting")

--- a/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
+++ b/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
@@ -26,6 +26,8 @@ reply still follows.
 
 from __future__ import annotations
 
+import time
+
 from playwright.sync_api import Page, expect
 
 from tests.e2e_ui.conftest import seed_committed_turn
@@ -60,6 +62,31 @@ _PROBE = """() => {
 }"""
 
 
+def _settled_geometry(page: Page, timeout_s: float = 15.0) -> dict:
+    """Read :data:`_PROBE` once two consecutive reads agree.
+
+    The layout settles through several passes — the composer's measurement, the
+    trailing spacer's ResizeObserver, then stick-to-bottom — and how long that
+    takes varies with CI load. Polling for a stable read beats sleeping a fixed
+    guess: it can't return mid-settle, and it doesn't pay a fixed cost once the
+    layout is already quiet.
+
+    :param page: Playwright page on the chat surface.
+    :param timeout_s: How long to keep polling before giving up.
+    :returns: The probe reading, once stable.
+    :raises AssertionError: If the layout never stops changing.
+    """
+    previous = page.evaluate(_PROBE)
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        page.wait_for_timeout(100)
+        current = page.evaluate(_PROBE)
+        if current == previous:
+            return current
+        previous = current
+    raise AssertionError(f"layout never settled; last reading: {previous}")
+
+
 def test_composer_growth_does_not_shift_transcript(
     page: Page,
     seeded_session: tuple[str, str],
@@ -83,12 +110,10 @@ def test_composer_growth_does_not_shift_transcript(
     expect(sections).to_have_count(6, timeout=30_000)
     composer = page.get_by_label("Message the agent")
     expect(composer).to_be_visible(timeout=30_000)
-    # Let the initial scroll-to-bottom and the trailing spacer's measurement
-    # settle, so the baseline is the resting layout.
-    page.wait_for_timeout(1500)
-
     composer.click()
-    baseline = page.evaluate(_PROBE)
+    # The baseline is the resting layout: the initial scroll-to-bottom and the
+    # trailing spacer's measurement have both landed.
+    baseline = _settled_geometry(page)
     assert baseline["distanceFromBottom"] <= 1, baseline
     assert baseline["railTicks"], baseline
 
@@ -101,22 +126,19 @@ def test_composer_growth_does_not_shift_transcript(
     # Grow: three Shift+Enter newlines, one line taller each.
     for _ in range(3):
         composer.press("Shift+Enter")
-    page.wait_for_timeout(500)
-    grown = page.evaluate(_PROBE)
+    grown = _settled_geometry(page)
     assert grown["composerHeight"] > baseline["composerHeight"], grown
     assert_transcript_idle(grown, "after newlines")
 
     # Type into the now-multi-line composer: the height doesn't change, but the
     # hook re-measures — and used to clamp the transcript on every keystroke.
     composer.type("hello", delay=30)
-    page.wait_for_timeout(500)
-    assert_transcript_idle(page.evaluate(_PROBE), "after typing")
+    assert_transcript_idle(_settled_geometry(page), "after typing")
 
     # Shrink back: deleting the newlines returns the composer to one row and
     # still leaves the transcript untouched.
     for _ in range(len("hello") + 3):
         composer.press("Backspace")
-    page.wait_for_timeout(500)
-    shrunk = page.evaluate(_PROBE)
+    shrunk = _settled_geometry(page)
     assert shrunk["composerHeight"] == baseline["composerHeight"], (baseline, shrunk)
     assert_transcript_idle(shrunk, "after deleting")

--- a/web/src/components/UserMessageNav.tsx
+++ b/web/src/components/UserMessageNav.tsx
@@ -29,7 +29,9 @@ export function UserMessageNav({
     <TooltipProvider>
       <div
         className={cn(
-          "pointer-events-none absolute right-4 bottom-4 flex flex-col gap-1",
+          // bottom clears the composer's growth (0 elsewhere), which overlaps
+          // the bottom of the transcript it's anchored to.
+          "pointer-events-none absolute right-4 bottom-[calc(1rem+var(--composer-growth,0px))] flex flex-col gap-1",
           className,
         )}
       >

--- a/web/src/components/ai-elements/conversation.tsx
+++ b/web/src/components/ai-elements/conversation.tsx
@@ -108,7 +108,10 @@ export const ConversationScrollButton = ({
     !isAtBottom && (
       <Button
         className={cn(
-          "absolute bottom-4 left-[50%] translate-x-[-50%] rounded-full",
+          // Offset by the composer's growth (0 elsewhere): a grown composer
+          // overlaps the bottom of this scroll area, and the button has to
+          // stay above its card.
+          "absolute bottom-[calc(1rem+var(--composer-growth,0px))] left-[50%] translate-x-[-50%] rounded-full",
           // Keep the fill OPAQUE on hover. The outline variant's hover (bg-muted)
           // is a translucent black wash (--muted is #0000000f), so over the chat
           // content behind it the button reads as transparent on hover. Hover

--- a/web/src/hooks/useAutoGrowTextarea.test.tsx
+++ b/web/src/hooks/useAutoGrowTextarea.test.tsx
@@ -27,18 +27,22 @@ function stubScrollHeight(el: HTMLElement, px: number): void {
   });
 }
 
-function Harness({ value }: { value: string }) {
+function Harness({ value, onGrowth }: { value: string; onGrowth?: (px: number) => void }) {
   const ref = useRef<HTMLTextAreaElement>(null);
-  useAutoGrowTextarea(ref, value);
+  useAutoGrowTextarea(ref, value, 10, onGrowth);
   // Inline line-height/padding so getComputedStyle returns real numbers
-  // (jsdom reflects inline styles), letting the maxHeight math run.
+  // (jsdom reflects inline styles), letting the maxHeight math run. The
+  // wrapper mirrors both composers, where the textarea sits in a box of its
+  // own that the hook pins while it collapses to measure.
   return (
-    <textarea
-      ref={ref}
-      data-testid="ta"
-      defaultValue={value}
-      style={{ lineHeight: "20px", paddingTop: "0px", paddingBottom: "0px" }}
-    />
+    <div data-testid="wrapper">
+      <textarea
+        ref={ref}
+        data-testid="ta"
+        defaultValue={value}
+        style={{ lineHeight: "20px", paddingTop: "0px", paddingBottom: "0px" }}
+      />
+    </div>
   );
 }
 
@@ -89,5 +93,61 @@ describe("useAutoGrowTextarea", () => {
     // prompt scrolls instead of growing without bound. A larger value means
     // the maxRows clamp regressed.
     expect(ta.style.height).toBe("200px");
+  });
+
+  it("holds the wrapper's height while the textarea collapses to measure", () => {
+    // The collapse to "auto" is a one-row box. Left free to reach the page it
+    // briefly shortens the composer, and the browser clamps the transcript's
+    // scrollTop against the taller viewport that opens up — a clamp that
+    // sticks, shunting the chat down a line on every keystroke. jsdom can't
+    // reproduce the clamp (no layout), so assert the invariant that prevents
+    // it: the wrapper's box is fixed for as long as the textarea is collapsed.
+    const { getByTestId } = render(<Harness value="two\nlines" />);
+    const ta = getByTestId("ta") as HTMLTextAreaElement;
+    const wrapper = getByTestId("wrapper") as HTMLDivElement;
+    wrapper.getBoundingClientRect = () => ({ height: 100 }) as DOMRect;
+
+    // scrollHeight is read while the textarea is collapsed, so it's the one
+    // moment that sees the layout the rest of the page would have seen.
+    let wrapperHeightWhileCollapsed: string | null = null;
+    Object.defineProperty(ta, "scrollHeight", {
+      configurable: true,
+      get: () => {
+        wrapperHeightWhileCollapsed = wrapper.style.height;
+        return 40;
+      },
+    });
+    roCallback?.([], {} as ResizeObserver);
+
+    expect(wrapperHeightWhileCollapsed).toBe("100px");
+    // Released again once the real height is on, so the wrapper goes back to
+    // tracking its content instead of freezing at the pinned value.
+    expect(wrapper.style.height).toBe("");
+    expect(ta.style.height).toBe("40px");
+  });
+
+  it("reports how far past one row the box has grown", () => {
+    // The in-session composer subtracts this from its own top margin, keeping
+    // the extra rows out of the flex column so the transcript's scroll
+    // viewport — and the scrollbar and turn rail drawn from it — hold still.
+    const growth: number[] = [];
+    const { getByTestId } = render(<Harness value="x" onGrowth={(px) => growth.push(px)} />);
+    const ta = getByTestId("ta") as HTMLTextAreaElement;
+
+    // One 20px row: resting height, nothing to float.
+    stubScrollHeight(ta, 20);
+    roCallback?.([], {} as ResizeObserver);
+    expect(growth.at(-1)).toBe(0);
+
+    // Four rows: three of them past resting.
+    stubScrollHeight(ta, 80);
+    roCallback?.([], {} as ResizeObserver);
+    expect(growth.at(-1)).toBe(60);
+
+    // Past the 10-row cap the box scrolls instead of growing, so the reported
+    // growth caps with it rather than tracking the content.
+    stubScrollHeight(ta, 800);
+    roCallback?.([], {} as ResizeObserver);
+    expect(growth.at(-1)).toBe(180);
   });
 });

--- a/web/src/hooks/useAutoGrowTextarea.test.tsx
+++ b/web/src/hooks/useAutoGrowTextarea.test.tsx
@@ -126,6 +126,15 @@ describe("useAutoGrowTextarea", () => {
     expect(ta.style.height).toBe("40px");
   });
 
+  it("reports no growth while the element has no layout", () => {
+    // Mid route swap scrollHeight reads 0 and the height is left alone. The
+    // growth has to be published anyway: a caller offsetting its layout by the
+    // last value would otherwise hold that offset until the next measure.
+    const growth: number[] = [];
+    render(<Harness value="two rows" onGrowth={(px) => growth.push(px)} />);
+    expect(growth).toEqual([0]);
+  });
+
   it("reports how far past one row the box has grown", () => {
     // The in-session composer subtracts this from its own top margin, keeping
     // the extra rows out of the flex column so the transcript's scroll

--- a/web/src/hooks/useAutoGrowTextarea.ts
+++ b/web/src/hooks/useAutoGrowTextarea.ts
@@ -28,7 +28,12 @@ function measureTextarea(
   if (pinned) wrapper.style.height = `${wrapperHeight}px`;
   try {
     ta.style.height = "auto";
-    if (ta.scrollHeight === 0) return;
+    if (ta.scrollHeight === 0) {
+      // Not laid out, so there's no growth to report either — say so rather
+      // than leave a stale offset applied across a route swap.
+      onGrowth?.(0);
+      return;
+    }
     const cs = getComputedStyle(ta);
     const lineHeight = parseFloat(cs.lineHeight);
     const paddingTop = parseFloat(cs.paddingTop);
@@ -36,8 +41,8 @@ function measureTextarea(
     const maxHeight = lineHeight * maxRows + paddingTop + paddingBottom;
     const height = Math.min(ta.scrollHeight, maxHeight);
     ta.style.height = height + "px";
-    // Resting height is a single row, or the CSS floor where the composer sets
-    // one (the landing composer's `min-h`).
+    // Resting height is a single row — or a CSS floor, for a composer that
+    // sets one, so its empty height doesn't read as growth.
     const resting = Math.max(
       lineHeight + paddingTop + paddingBottom,
       parseFloat(cs.minHeight) || 0,

--- a/web/src/hooks/useAutoGrowTextarea.ts
+++ b/web/src/hooks/useAutoGrowTextarea.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useLayoutEffect } from "react";
+import { type RefObject, useLayoutEffect, useRef } from "react";
 
 /**
  * Measure ``ta`` and set its height to fit its content, capped at
@@ -6,16 +6,48 @@ import { type RefObject, useLayoutEffect } from "react";
  * element isn't laid out yet (e.g. mid client-side route swap), so the
  * natural height is left untouched rather than collapsed to 0px, which
  * would clip the content/placeholder.
+ *
+ * Reading the content height means collapsing to ``auto`` — a one-row box,
+ * since these textareas are ``rows={1}`` — and that collapse must not escape
+ * the composer. For the one layout it lasts the composer is short, so the
+ * transcript's scroll viewport is correspondingly taller, and the browser
+ * clamps its ``scrollTop`` against that larger viewport's smaller maximum.
+ * The clamp sticks once the composer springs back, so every re-measure shunts
+ * the transcript down a line. Pinning the wrapper's height keeps the collapse
+ * inside the composer.
  */
-function measureTextarea(ta: HTMLTextAreaElement, maxRows: number): void {
-  ta.style.height = "auto";
-  if (ta.scrollHeight === 0) return;
-  const cs = getComputedStyle(ta);
-  const lineHeight = parseFloat(cs.lineHeight);
-  const paddingTop = parseFloat(cs.paddingTop);
-  const paddingBottom = parseFloat(cs.paddingBottom);
-  const maxHeight = lineHeight * maxRows + paddingTop + paddingBottom;
-  ta.style.height = Math.min(ta.scrollHeight, maxHeight) + "px";
+function measureTextarea(
+  ta: HTMLTextAreaElement,
+  maxRows: number,
+  onGrowth?: (px: number) => void,
+): void {
+  const wrapper = ta.parentElement;
+  const wrapperHeight = wrapper?.getBoundingClientRect().height ?? 0;
+  const restoreHeight = wrapper?.style.height ?? "";
+  const pinned = wrapper !== null && wrapperHeight > 0;
+  if (pinned) wrapper.style.height = `${wrapperHeight}px`;
+  try {
+    ta.style.height = "auto";
+    if (ta.scrollHeight === 0) return;
+    const cs = getComputedStyle(ta);
+    const lineHeight = parseFloat(cs.lineHeight);
+    const paddingTop = parseFloat(cs.paddingTop);
+    const paddingBottom = parseFloat(cs.paddingBottom);
+    const maxHeight = lineHeight * maxRows + paddingTop + paddingBottom;
+    const height = Math.min(ta.scrollHeight, maxHeight);
+    ta.style.height = height + "px";
+    // Resting height is a single row, or the CSS floor where the composer sets
+    // one (the landing composer's `min-h`).
+    const resting = Math.max(
+      lineHeight + paddingTop + paddingBottom,
+      parseFloat(cs.minHeight) || 0,
+    );
+    onGrowth?.(Math.max(0, height - resting));
+  } finally {
+    // Released before the next layout, so the composer resizes in one step
+    // from its old height to its new one.
+    if (pinned) wrapper.style.height = restoreHeight;
+  }
 }
 
 /**
@@ -30,15 +62,29 @@ function measureTextarea(ta: HTMLTextAreaElement, maxRows: number): void {
  * A ``ResizeObserver`` re-measures when the element's box changes,
  * covering the case where ``scrollHeight`` reads 0 on mount (e.g. mid
  * client-side route swap, before layout settles).
+ *
+ * ``onGrowth`` reports how much taller than its resting height the box now
+ * is, so a caller can keep that growth out of the surrounding layout — see
+ * the in-session composer, which floats the extra rows over the transcript
+ * rather than shrinking it.
  */
 export function useAutoGrowTextarea(
   ref: RefObject<HTMLTextAreaElement | null>,
   value: string,
   maxRows = 10,
+  onGrowth?: (px: number) => void,
 ) {
+  // Read through a ref so an inline callback doesn't re-subscribe the
+  // observer below on every render. Declared first: effects run in order, so
+  // this is current before either measuring effect uses it.
+  const onGrowthRef = useRef(onGrowth);
+  useLayoutEffect(() => {
+    onGrowthRef.current = onGrowth;
+  });
+
   // Re-measure on content / maxRows change.
   useLayoutEffect(() => {
-    if (ref.current) measureTextarea(ref.current, maxRows);
+    if (ref.current) measureTextarea(ref.current, maxRows, onGrowthRef.current);
   }, [ref, value, maxRows]);
 
   // Install one observer per element (not per keystroke — value isn't a
@@ -49,7 +95,7 @@ export function useAutoGrowTextarea(
   useLayoutEffect(() => {
     const ta = ref.current;
     if (!ta || typeof ResizeObserver === "undefined") return;
-    const ro = new ResizeObserver(() => measureTextarea(ta, maxRows));
+    const ro = new ResizeObserver(() => measureTextarea(ta, maxRows, onGrowthRef.current));
     ro.observe(ta);
     return () => ro.disconnect();
   }, [ref, maxRows]);

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1598,6 +1598,15 @@ function MainAgentSurface({
     conversationRef.current = el;
     setContainerEl(el);
   }, []);
+  // How far the composer has grown past its resting height. The composer keeps
+  // that growth out of the flex column, so the wrapper's box never moves —
+  // this only lifts the overlays pinned to its bottom edge (the scroll-to-
+  // bottom button, the Working… tab, the message nav) clear of the taller
+  // card. Written straight to the DOM: a re-render per line of typing would
+  // re-render the whole transcript for a purely visual offset.
+  const publishComposerGrowth = useCallback((px: number) => {
+    conversationRef.current?.style.setProperty("--composer-growth", `${px}px`);
+  }, []);
   const [terminalSurfaceEl, setTerminalSurfaceEl] = useState<HTMLElement | null>(null);
   // True only while the chat/terminal surface is the frontmost thing on screen.
   // Drives both native overlays so neither floats over an opened drawer.
@@ -1918,6 +1927,7 @@ function MainAgentSurface({
         onShowReconnectHelp={onShowReconnectHelp}
         costRoutingEligible={costRoutingEligible}
         subAgentLabel={subAgentLabel}
+        onGrowthChange={publishComposerGrowth}
       />
 
       {/* Chat/Terminal toggle for terminal-first sessions, reconnect-or-
@@ -2019,7 +2029,9 @@ function WorkingStatusPin({ show, suppress = false }: { show: boolean; suppress?
       aria-live="polite"
       data-testid="working-indicator-pin"
       className={cn(
-        "pointer-events-none absolute inset-x-0 bottom-0 z-20 transition-opacity duration-200",
+        // bottom tracks --composer-growth so the tab keeps meeting the card's
+        // top edge while the composer is grown (it overlaps this wrapper).
+        "pointer-events-none absolute inset-x-0 bottom-[var(--composer-growth,0px)] z-20 transition-opacity duration-200",
         visible ? "opacity-100" : "opacity-0",
       )}
     >
@@ -3595,6 +3607,13 @@ interface ComposerProps {
    * tray above the card. See ``subAgentComposerLabel``.
    */
   subAgentLabel?: string | null;
+  /**
+   * Reports how many pixels taller than its resting height the composer has
+   * grown. The composer keeps that growth out of the column's flex layout
+   * (see the negative top margin below); the transcript uses the number to
+   * lift its bottom-anchored overlays clear of the taller card.
+   */
+  onGrowthChange?: (px: number) => void;
 }
 
 /**
@@ -4003,6 +4022,7 @@ export function Composer({
   onShowReconnectHelp,
   costRoutingEligible = false,
   subAgentLabel = null,
+  onGrowthChange,
 }: ComposerProps) {
   const [value, setValue] = useState("");
   const dictation = useDictationInsert(setValue);
@@ -4032,6 +4052,7 @@ export function Composer({
   // dropdown instead of sending (see submit()).
   const [pickerOpenNonce, setPickerOpenNonce] = useState(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const isComposingRef = useRef(false);
   // Highlight overlay mirroring the textarea; scroll-synced so the tinted
@@ -4484,7 +4505,20 @@ export function Composer({
   };
 
   // Auto-grow the textarea from 1 row up to 10 rows, then let it scroll.
-  useAutoGrowTextarea(textareaRef, value);
+  // The extra rows float over the transcript instead of shrinking it: a
+  // negative top margin holds the form's margin box at its resting height, so
+  // the transcript's scroll viewport — and with it the scrollbar's travel and
+  // the turn rail's centering — stays exactly where it was. Only the taller
+  // card overlaps, and it's opaque across the message column.
+  const applyGrowth = useCallback(
+    (px: number) => {
+      const form = formRef.current;
+      if (form) form.style.marginTop = px > 0 ? `${-px}px` : "";
+      onGrowthChange?.(px);
+    },
+    [onGrowthChange],
+  );
+  useAutoGrowTextarea(textareaRef, value, 10, applyGrowth);
 
   // Scope recall to the active conversation so ArrowUp surfaces only this
   // chat's prompts, not the last thing typed in any other chat.
@@ -4774,9 +4808,12 @@ export function Composer({
 
   return (
     <form
+      ref={formRef}
       onSubmit={handleSubmit}
       className={cn(
-        "chat-composer-form px-4 md:px-6",
+        // relative: the grown card overlaps the transcript above it, and a
+        // positioned box paints over that in-flow sibling.
+        "chat-composer-form relative px-4 md:px-6",
         isTerminalFirst ? "terminal-first-composer-form pb-1.5" : "pb-3",
       )}
     >


### PR DESCRIPTION
## Related issue

N/A

## Summary

Pressing Shift+Enter in the session composer shunted the whole transcript down a line, and the scrollbar thumb and left-edge turn rail jittered along with it. Everything above the composer now holds still — only the composer itself moves.

Two independent causes:

- **The transcript jumped.** `useAutoGrowTextarea` reads its content height by collapsing the textarea to `height: auto` — a one-row box, since these textareas are `rows={1}`. For the one layout pass that lasts, the composer is short and the transcript's scroll viewport is correspondingly taller, so the browser clamps its `scrollTop` against the taller viewport's smaller maximum. The clamp survives the composer springing back, so every re-measure shifted the transcript: Shift+Enter, and then *every keystroke* once the composer was multi-line. It also knocked the transcript off its bottom lock, so a streaming reply stopped following. Fixed by pinning the textarea's wrapper height across the measurement, keeping the collapse inside the composer.
- **The scrollbar and rail jittered.** The composer was a plain flex sibling, so every extra row genuinely stole height from the transcript's scroll viewport (`clientHeight` 796 → 724 on a 4-row composer). Messages could be held still through that, but the native scrollbar is drawn from `clientHeight`/`scrollHeight` and the turn rail is centered on the same box, so both moved. The hook now reports how far past its resting height the textarea has grown, and the form offsets that with a negative top margin: its *margin box* stays one row tall, the extra rows float over the transcript, and the three overlays pinned to the transcript's bottom edge (scroll-to-bottom button, Working… tab, message nav) track the growth so they keep meeting the card.

ELI5: the composer used to shove the conversation out of its way to make room. Now it grows over the empty space above it instead, and nothing else notices.

**The tradeoff:** the grown card is opaque and floats over the tail of the transcript, so a tall draft can cover the last line or two of the newest reply — where before they were pushed up and stayed visible. That's the deliberate choice, because the alternative is the bug: keeping the newest line pinned above a growing composer *requires* moving the transcript, which is what made the messages, scrollbar and rail jitter in the first place. In practice the trailing spacer means there's usually empty space under the last reply for the composer to grow into, the covered text is one scroll away, and it reappears the moment the draft is sent or shortened.

```
          before                            after
 ┌──────────────────────┐          ┌──────────────────────┐
 │ message   ▲ shifted  │▒         │ message              │▒  ▒ = scrollbar
 │ message   │ up 47px  │▒         │ message   (unmoved)  │▒     (unmoved)
 │─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ │▒ ← rail  │─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ │      rail ticks
 │       (viewport      │  moved   │      ┌─────────────┐ │▒     unmoved
 │        shrank)       │          │      │  composer   │ │▒  ← floats over
 ├──────────────────────┤          │      │   (grown)   │ │      the transcript
 │      composer        │          ├──────┴─────────────┴─┤
 └──────────────────────┘          └──────────────────────┘
```

## Test Plan

New e2e test `tests/e2e_ui/chat/test_composer_growth_transcript_stability.py` seeds a scrollable transcript and asserts that across newlines, typing, and deletions the message positions, the scroll geometry (`clientHeight`/`scrollHeight`/`scrollTop`), and the rail tick positions are all byte-identical, and that the transcript stays stuck to the bottom.

Both halves were confirmed non-vacuous by ablation on a real build:

- Revert the wrapper pin → `messageTops` fails (47px shift, `distanceFromBottom` 1 → 48).
- Revert the negative margin → `viewport` fails (`[622, 1850, 1227]` → `[550, 1778, 1227]`); the message assertions still pass there, so the geometry assertions are what catch this class.

Measured live on a seeded session, 4× Shift+Enter:

| | before | after |
|---|---|---|
| viewport (client / scroll / top) | 796 / 2294 / 1497 | identical |
| rail ticks | 350, 366, 382, 398, 414, 430 | identical |
| message tops | −1319 … 171 | identical |
| composer top | 796 | 700 ← the only thing that moves |

Also run: full `web` vitest suite (4957 passed), and the e2e composer / slash-menu / attachments / working-indicator / jump-to-top suites (9 passed). `pre-commit run --files` clean on every changed file.

## Demo

Verified in a real browser against a live server. Screen capture of the before/after is not attached because this PR adds no image assets; the geometry table above is the measurement of the same behaviour, and the e2e test reproduces it in one command:

```
pnpm --filter web run build
pytest tests/e2e_ui/chat/test_composer_growth_transcript_stability.py --ui-skip-build
```

To see it by hand: open a session with enough history to fill the viewport, click into the composer, hold Shift+Enter. The messages, the scrollbar thumb and the left-edge rail ticks stay put while the composer grows upward into the gap. Before this change the text stepped down ~24px per press and the thumb resized with it.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: drove a live local server in Chromium, measuring the transcript's scroll geometry, rail tick positions and message rects around Shift+Enter, plain typing, and backspacing — plus the scrolled-up case, where the grown composer overlaps real content and the scroll-to-bottom button correctly lifts with it (bottom 780 → 636). Checked the one artifact this could introduce — the transcript column being wider than the composer card on narrow windows, which would let a right-aligned bubble show beside it — at 1000px wide; the bubble's right edge (541) still lands inside the card (556), and at typical widths both are capped at `max-w-3xl` and coincide exactly.

## Changelog

The chat composer no longer pushes the conversation around when you add newlines with Shift+Enter

---

This pull request and its description were written by Isaac.

