### PR TITLE
fix(server): don't hold the session create on the host runner launch

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1128,9 +1128,9 @@ def create_app(
             # slow provision doesn't outlive the ASGI shutdown (the
             # sandbox itself, if already provisioned, is reaped by the
             # provider lifetime cap — see the hook's docstring).
-            from omnigent.server.routes.sessions import cancel_managed_launch_tasks
+            from omnigent.server.routes.sessions import cancel_background_launch_tasks
 
-            await cancel_managed_launch_tasks()
+            await cancel_background_launch_tasks()
             await background_title_coordinator.shutdown()
             _uninstall_subagent_block_notifier()
             set_resource_registry(None)

--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -579,6 +579,12 @@ _SUBAGENT_FORWARD_RECONNECT_WAIT_S = 5.0
 _managed_launch_tasks: set[asyncio.Task[None]] = set()
 
 
+# Background tasks awaiting a direct-host runner launch started by
+# ``POST /v1/sessions``. Held here so the loop can't garbage-collect a task
+# that nothing else references.
+_host_launch_tasks: set[asyncio.Task[None]] = set()
+
+
 _RUNNER_SESSION_INIT_TIMEOUT_S = 10.0
 
 
@@ -835,6 +841,7 @@ __all__ = [
     "_browser_action_owners",
     "_browser_action_registry",
     "_deferred_elicitation_clear_tasks",
+    "_host_launch_tasks",
     "_intentional_stop_sessions",
     "_interrupt_fenced_sessions",
     "_logger",

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -166,6 +166,7 @@ from omnigent.server.routes._sessions.common import (  # noqa: F401
     _UI_ADDED_AGENT_TITLE_PREFIX,
     _UPLOAD_READ_CHUNK_BYTES,
     COST_CONTROL_OVERRIDE_VALUES,
+    _host_launch_tasks,
     _logger,
     _managed_launch_tasks,
     _model_options_cache,
@@ -4249,9 +4250,10 @@ async def _launch_runner_on_host_impl(
     return _HostLaunchAttempt(runner_id=new_runner_id)
 
 
-async def cancel_managed_launch_tasks() -> None:
+async def cancel_background_launch_tasks() -> None:
     """
-    Cancel and await every in-flight background managed launch.
+    Cancel and await every in-flight background launch — managed sandbox
+    provisions and direct-host runner launches alike.
 
     Lifespan-teardown hook: without it, a slow provision outlives the
     ASGI shutdown and dies wherever the loop teardown happens to kill
@@ -4264,7 +4266,7 @@ async def cancel_managed_launch_tasks() -> None:
     :returns: None once every task has settled (cancellations and any
         in-flight failures are absorbed via ``return_exceptions``).
     """
-    tasks = list(_managed_launch_tasks)
+    tasks = list(_managed_launch_tasks) + list(_host_launch_tasks)
     if not tasks:
         return
     for task in tasks:
@@ -8910,5 +8912,5 @@ __all__ = [
     "_wait_for_managed_runner_tunnel",
     "_wait_for_runner_client",
     "announce_hosts_changed",
-    "cancel_managed_launch_tasks",
+    "cancel_background_launch_tasks",
 ]

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -2501,7 +2501,7 @@ async def _run_managed_launch(
     step and the fresh sandbox is torn down.
 
     Server shutdown cancels this task (the lifespan teardown calls
-    :func:`cancel_managed_launch_tasks`); an already-provisioned
+    :func:`cancel_background_launch_tasks`); an already-provisioned
     sandbox then leaks until the provider's lifetime cap reaps it
     (the armed launch token expires with the same cap).
 

--- a/omnigent/server/routes/sessions/__init__.py
+++ b/omnigent/server/routes/sessions/__init__.py
@@ -523,7 +523,7 @@ from omnigent.server.routes._sessions.helpers import (
     _validated_harness_override_executor_type as _validated_harness_override_executor_type,
     _wait_for_managed_runner_tunnel as _wait_for_managed_runner_tunnel,
     announce_hosts_changed as announce_hosts_changed,
-    cancel_managed_launch_tasks as cancel_managed_launch_tasks,
+    cancel_background_launch_tasks as cancel_background_launch_tasks,
 )
 
 # Runner-forward / ASK-gate helpers are patched by tests on this facade module

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -103,6 +103,7 @@ from omnigent.server.routes._sessions.common import (
     _CODEX_NATIVE_COLLABORATION_MODE_LABEL_KEY,
     _CODEX_NATIVE_COLLABORATION_MODES,
     _CODEX_NATIVE_WRAPPER_LABEL_VALUE,
+    _host_launch_tasks,
     _logger,
     _managed_launch_tasks,
     get_server_runner_router,
@@ -493,12 +494,16 @@ def register_core_routes(
                     )
                 )
                 host_registry.send_text(conn, launch_frame)
-                try:
-                    launch_result = await asyncio.wait_for(future, timeout=30.0)
-                except asyncio.TimeoutError:
-                    conn.pending_launches.pop(request_id, None)
-                    launch_result = {"status": "failed", "error": "host launch timed out"}
-                if launch_result.get("status") == "failed":
+
+                async def _settle_host_launch(session_id: str = resp.id) -> None:
+                    """Absorb the host's launch verdict off the create."""
+                    try:
+                        launch_result = await asyncio.wait_for(future, timeout=30.0)
+                    except asyncio.TimeoutError:
+                        conn.pending_launches.pop(request_id, None)
+                        launch_result = {"status": "failed", "error": "host launch timed out"}
+                    if launch_result.get("status") != "failed":
+                        return
                     # Lenient on every create-time launch failure, including
                     # an unconfigured harness: the picker's readiness data
                     # can be stale (the user may have run `omnigent setup`
@@ -511,7 +516,7 @@ def register_core_routes(
                     _logger.warning(
                         "Host %s failed to launch runner for session %s: %s",
                         launch_host_id,
-                        resp.id,
+                        session_id,
                         launch_result.get("error"),
                     )
                     # The runner never booted, so its pending=False clear
@@ -519,7 +524,21 @@ def register_core_routes(
                     # failed launch doesn't strand the Terminal-pill
                     # spinner. No-op when we never set it.
                     if _terminal_first_create:
-                        _publish_terminal_pending(resp.id, False)
+                        _publish_terminal_pending(session_id, False)
+
+                # Spawning a runner on the host takes seconds — a Python
+                # process boot, not a round-trip — and the session is already
+                # created and bound by here. Waiting for the verdict would
+                # hold the response (and so the Web UI's navigation into the
+                # session) for that whole time, for a result no caller acts
+                # on: the failure path is lenient either way. So settle it in
+                # the background, the same shape the managed-sandbox launch
+                # above uses. A first message racing the boot is expected and
+                # handled — it parks on post_event's host-bound connect grace
+                # until the runner registers.
+                launch_task = asyncio.create_task(_settle_host_launch())
+                _host_launch_tasks.add(launch_task)
+                launch_task.add_done_callback(_host_launch_tasks.discard)
                 resp.runner_id = runner_id
                 resp.host_id = launch_host_id
 

--- a/tests/server/integration/test_host_session_binding.py
+++ b/tests/server/integration/test_host_session_binding.py
@@ -1331,14 +1331,14 @@ async def test_managed_launch_fails_when_runner_never_connects(
     assert stages[-1] == ("failed", "managed runner did not connect after launch")
 
 
-async def test_cancel_managed_launch_tasks_returns_while_provision_parked(
+async def test_cancel_background_launch_tasks_returns_while_provision_parked(
     managed_session_env: ManagedSessionEnv,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
     Shutdown teardown does not hang on an in-flight managed provision.
 
-    The lifespan teardown calls ``cancel_managed_launch_tasks`` to
+    The lifespan teardown calls ``cancel_background_launch_tasks`` to
     stop background launches; with a provision parked on the fake's
     gate (a slow provider call), the cancel must settle the task and
     return promptly rather than waiting the provision out — a rolling
@@ -1347,7 +1347,7 @@ async def test_cancel_managed_launch_tasks_returns_while_provision_parked(
     """
     import threading
 
-    from omnigent.server.routes.sessions import cancel_managed_launch_tasks
+    from omnigent.server.routes.sessions import cancel_background_launch_tasks
 
     env = managed_session_env
     gate = threading.Event()
@@ -1364,7 +1364,7 @@ async def test_cancel_managed_launch_tasks_returns_while_provision_parked(
     # The launch is gate-held mid-provision. The teardown hook must
     # return well inside the provision's duration (the gate would hold
     # it 30s) — 5s is the generosity bound, not an expectation.
-    await asyncio.wait_for(cancel_managed_launch_tasks(), timeout=5.0)
+    await asyncio.wait_for(cancel_background_launch_tasks(), timeout=5.0)
 
     # Release the gate so the provision worker thread exits cleanly.
     gate.set()

--- a/tests/server/integration/test_session_host_launch.py
+++ b/tests/server/integration/test_session_host_launch.py
@@ -256,6 +256,60 @@ async def _serve_one_launch(
     raise AssertionError("host never received a launch frame from the inline path")
 
 
+async def _serve_stat_then_hold_launch(
+    comm: ApplicationCommunicator,
+    release: asyncio.Event,
+) -> HostLaunchRunnerFrame:
+    """Answer the workspace stat, then sit on the launch until released.
+
+    Stands in for the real cost of a launch: the host has to spawn a runner
+    process, which takes seconds. Holding the reply lets a test observe what
+    the create does while the host is still silent.
+
+    :param comm: The connected host communicator.
+    :param release: Set by the test once it has asserted on the create; the
+        launch is answered ``launched`` after that, so the server's
+        background settle task finishes instead of being left pending.
+    :returns: The ``host.launch_runner`` frame the server sent.
+    """
+    for _ in range(40):
+        output = await comm.receive_output(timeout=3.0)
+        if output["type"] != "websocket.send":
+            continue
+        frame = decode_host_frame(output["text"])
+        if isinstance(frame, HostStatFrame):
+            await comm.send_input(
+                {
+                    "type": "websocket.receive",
+                    "text": encode_host_frame(
+                        HostStatResultFrame(
+                            request_id=frame.request_id,
+                            status="ok",
+                            exists=True,
+                            type="directory",
+                            canonical_path=frame.path,
+                        )
+                    ),
+                }
+            )
+        elif isinstance(frame, HostLaunchRunnerFrame):
+            await release.wait()
+            await comm.send_input(
+                {
+                    "type": "websocket.receive",
+                    "text": encode_host_frame(
+                        HostLaunchRunnerResultFrame(
+                            request_id=frame.request_id,
+                            status="launched",
+                            runner_id="runner_from_host",
+                        )
+                    ),
+                }
+            )
+            return frame
+    raise AssertionError("host never received a launch frame from the inline path")
+
+
 async def _serve_one_stop(comm: ApplicationCommunicator) -> str:
     """Answer the host's ``host.stop_runner`` round-trip for one Stop.
 
@@ -442,6 +496,56 @@ async def test_inline_launch_binds_runner_and_returns_host(
     assert conv.runner_id == body["runner_id"]
     assert conv.host_id == _HOST_ID
     assert conv.workspace == _WORKSPACE
+
+
+async def test_inline_launch_does_not_hold_the_create(
+    client: httpx.AsyncClient,
+    app: FastAPI,
+    db_uri: str,
+) -> None:
+    """The create returns while the host is still launching the runner.
+
+    Spawning a runner is a process boot on the host — seconds — and the
+    session exists and is bound before the launch frame goes out. Holding
+    the response for the verdict makes the user wait through that boot
+    before the Web UI can navigate into the session, for a result no caller
+    acts on (the failure path is lenient either way). Here the host never
+    answers the launch until the assertions are done, so a create that
+    waited would sit until the 30 s launch timeout and blow the wait_for.
+
+    :param client: ASGI test client.
+    :param app: The FastAPI app the fake host connects to.
+    :param db_uri: Conversation store URI for asserting the persisted row.
+    """
+    comm = await _connect_host(app)
+    agent = await create_test_agent(client)
+
+    release = asyncio.Event()
+    responder = asyncio.create_task(_serve_stat_then_hold_launch(comm, release))
+    resp = await asyncio.wait_for(
+        client.post(
+            "/v1/sessions",
+            json={"agent_id": agent["id"], "host_id": _HOST_ID, "workspace": _WORKSPACE},
+        ),
+        timeout=10.0,
+    )
+
+    # The binding is written before the frame is sent, so the response
+    # carries it even though the host hasn't reported back yet — that's what
+    # lets the UI route to the runner immediately.
+    assert resp.status_code == 201, f"expected 201, got {resp.status_code}: {resp.text}"
+    body = resp.json()
+    assert body["host_id"] == _HOST_ID
+    assert body["runner_id"].startswith("runner_token_"), (
+        f"runner should be bound before the launch settles, got {body['runner_id']!r}"
+    )
+    conv = SqlAlchemyConversationStore(db_uri).get_conversation(body["id"])
+    assert conv is not None
+    assert conv.runner_id == body["runner_id"]
+
+    # Let the launch finish so the background settle task isn't left pending.
+    release.set()
+    await responder
 
 
 async def test_inline_launch_failure_still_returns_bound_session(


### PR DESCRIPTION
## Related issue

N/A

## Summary

Starting a session on a host left the user watching a spinner for seconds before
the session page opened.

`POST /v1/sessions` waited for the host to finish **spawning a runner** — a
Python process boot, not a round-trip — before responding, and the Web UI
navigates into the session on that response. Measured on a local server + host,
that wait was 0.8 s warm and up to 5.7 s cold, while the session row itself
existed within ~50 ms (and the sidebar had already streamed it in).

Nothing acts on the verdict. A failed launch at create is deliberately lenient:
the session opens with its binding intact and the first message drives the real
runner start (`post_event`'s relaunch branch). So the wait bought nothing.

This settles the launch in a background task instead — the same shape the
managed-sandbox launch a few lines above already uses. Unchanged and still
synchronous: the workspace `host.stat` validation, the atomic `set_runner_id`
binding, and sending the launch frame. So the response still carries
`runner_id` / `host_id` exactly as before, and a first message racing the boot
is already handled — it parks on `post_event`'s host-bound connect grace
(`_HOST_BOUND_RUNNER_CONNECT_GRACE_S`, 10 s, cut short by a host-side
`runner_status` query) until the runner registers.

```
before   POST ──[stat]──[bind]──[launch frame]──▶ wait for host to spawn runner ──▶ 201 ──▶ navigate
after    POST ──[stat]──[bind]──[launch frame]──▶ 201 ──▶ navigate
                                             └──▶ (background) absorb the verdict
```

The lifespan teardown hook now drains both launch-task sets, so it is renamed
for what it does: `cancel_managed_launch_tasks` → `cancel_background_launch_tasks`.

## Test Plan

- New `test_inline_launch_does_not_hold_the_create`: the fake host answers the
  workspace stat but sits on the launch frame; the create must still return 201
  with the runner bound. Verified as a real guard — against the previous code it
  fails on the `wait_for` (the create sat until the 30 s launch timeout).
- `pytest tests/server/integration/test_session_host_launch.py
  tests/server/integration/test_host_session_binding.py
  tests/server/integration/test_host_runner_launch_worktree.py
  tests/server/integration/test_sessions_endpoints.py` — all green (the existing
  inline-launch cases already pin the response shape, the lenient failure
  contract, and the "no transcript item at create" rule).
- End-to-end against a real local server + host + Chromium, timing the create
  from the Send click, plus an API-level check that the runner still comes up:
  `POST` returns in 33 ms and `runner_online` flips true at 872 ms — the launch
  still happens, it just isn't in the response path.

## Demo

Same flow, same machine, before vs after (click → observed in the UI):

| | before | after |
|---|---|---|
| **session page opens** | 4989 ms | **83 ms** |
| chat page usable | 5272 ms | 370 ms |
| first user message committed | 12651 ms | **8888 ms** |
| assistant replied | 15243 ms | 11586 ms |

The message lands *sooner* now, not just the page: it goes out while the runner
is still booting and parks on the connect grace, instead of queueing behind the
boot.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

Manual verification covered what the integration tests can't: that the runner
actually still launches (polled `runner_online` after the create) and that the
first message, now sent while the runner is booting, still reaches the agent and
gets a reply. Both confirmed against a real host with a real runner process.

## Changelog

Sessions started on a host open right away instead of waiting for the runner to boot
