### PR TITLE
chore: throwaway review-flow probe (do not merge)

### DIFF
--- a/dev/scratch/review-flow-probe.md
+++ b/dev/scratch/review-flow-probe.md
@@ -1,0 +1,5 @@
+# Review-flow probe
+
+Throwaway PR used to exercise the merged review-process workflows end to end
+(issue-link nudge dry run, waiting-on-author -> waiting-for-review handoff,
+/reopen). Delete this branch and PR once the probe is done.


### PR DESCRIPTION
## Related issue

(intentionally blank — this probe tests the issue-link check)

## Summary

Throwaway PR to exercise the newly-merged review-process workflows end to end:
the issue-link nudge (dry run), the `waiting-on-author` → `waiting-for-review`
handoff, and `/reopen`. **Do not merge** — it will be closed and its branch
deleted once the probe is done.

## Test Plan

This PR *is* the test.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Not applicable

## Coverage notes

Throwaway probe, deleted after use.
