### PR TITLE
fix(release): keep the supply-chain cooldown when generating the formula

### DIFF
--- a/.github/scripts/homebrew/generate_formula.py
+++ b/.github/scripts/homebrew/generate_formula.py
@@ -30,6 +30,7 @@ Run by `.github/workflows/homebrew-tap-pr.yml` on `release: published`.
 from __future__ import annotations
 
 import argparse
+import datetime
 import json
 import re
 import subprocess
@@ -55,6 +56,13 @@ DEFAULT_EXTRAS = ["cursor"]
 DEFAULT_PYTHON_VERSION = "3.14"
 DEFAULT_INDEX_URL = "https://pypi.org/simple"
 PYPI_JSON_API = "https://pypi.org/pypi"
+
+# The three packages that release together at one version. At release time they
+# are minutes old, so they are the only ones that legitimately need to be exempt
+# from the supply-chain cooldown re-applied below.
+LOCKSTEP_PACKAGES = ("omnigent", "omnigent-client", "omnigent-ui-sdk")
+# Fallback when `exclude-newer` can't be read out of uv.toml.
+DEFAULT_COOLDOWN_DAYS = 7
 
 # Packages provided by the brewed Python environment (system site-packages),
 # not built as virtualenv resources. `cffi`/`pycparser` are listed because cffi
@@ -142,6 +150,30 @@ _PLACEHOLDERS = (
 def normalize_name(name: str) -> str:
     """PEP 503 normalized project name (lowercase, runs of [-_.] -> -)."""
     return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def cooldown_days(repo_root: Path | None = None) -> int:
+    """The repo's `exclude-newer` span in days, read from uv.toml.
+
+    Read rather than hardcoded so the formula's cooldown cannot silently drift
+    from the one the lockfile uses. Falls back to `DEFAULT_COOLDOWN_DAYS` (with a
+    warning) if uv.toml is missing or expresses the span in a form this doesn't
+    understand -- never silently to "no cooldown".
+    """
+    root = repo_root or Path(__file__).resolve().parents[3]
+    uv_toml = root / "uv.toml"
+    try:
+        m = re.search(r'^exclude-newer\s*=\s*"P(\d+)D"', uv_toml.read_text(), re.MULTILINE)
+    except OSError:
+        m = None
+    if m:
+        return int(m.group(1))
+    print(
+        f"::warning::could not read `exclude-newer` from {uv_toml}; "
+        f"falling back to {DEFAULT_COOLDOWN_DAYS}d cooldown.",
+        file=sys.stderr,
+    )
+    return DEFAULT_COOLDOWN_DAYS
 
 
 def _http_get_json(url: str, retries: int = 5, timeout: int = 30) -> dict:
@@ -301,16 +333,38 @@ def resolve_closure(
     python_version: str,
     index_url: str,
     uv: str,
+    cooldown: int,
 ) -> dict[str, str]:
     """Union of `uv pip compile` resolutions per platform -> {name: version}.
 
-    Runs `uv pip compile` with `--no-config` (ignore the repo's uv.toml cooldown,
-    which would block the just-released version) against the public index. If a
-    package resolves to different versions across platforms, the highest PEP 440
-    version wins and a warning is printed (rare for sdists).
+    Runs `uv pip compile` with `--no-config` against the public index, so neither
+    the repo's uv.toml nor any user-level config decides the index or the uv
+    version floor. But `--no-config` also discards `exclude-newer`, the
+    supply-chain cooldown, so it is re-applied explicitly here: without that, every
+    resource pinned into the formula -- i.e. the code Homebrew users install -- may
+    be a distribution published minutes ago, even though the same dependency graph
+    in uv.lock has to wait out the window.
+
+    The cooldown cannot simply be left on: at release time `omnigent` and its two
+    lockstep SDKs are minutes old, and uv would filter out the very version being
+    packaged ("no version of omnigent==X.Y.Z"). So the window applies to everything
+    except those three, via `--exclude-newer-package`.
+
+    If a package resolves to different versions across platforms, the highest
+    PEP 440 version wins and a warning is printed (rare for sdists).
     """
     extras_spec = f"[{','.join(extras)}]" if extras else ""
     requirement = f"omnigent{extras_spec}=={version}"
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cutoff = (now - datetime.timedelta(days=cooldown)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    # The lockstep packages are exempted up to "now" rather than skipped, so a
+    # typo'd name still gets a cooldown rather than silently getting none.
+    exempt_until = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(
+        f"Cooldown: ignoring distributions uploaded after {cutoff} "
+        f"({cooldown}d), except {', '.join(LOCKSTEP_PACKAGES)}.",
+        file=sys.stderr,
+    )
     closure: dict[str, str] = {}
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
@@ -322,6 +376,14 @@ def resolve_closure(
                 "pip",
                 "compile",
                 "--no-config",
+                # Re-apply the cooldown that --no-config just discarded.
+                "--exclude-newer",
+                cutoff,
+                *[
+                    arg
+                    for pkg in LOCKSTEP_PACKAGES
+                    for arg in ("--exclude-newer-package", f"{pkg}={exempt_until}")
+                ],
                 "--no-header",
                 "--no-annotate",
                 "--python-version",
@@ -402,6 +464,7 @@ def generate(
     index_url: str,
     uv: str,
     exclude: set[str],
+    cooldown: int,
     allow_no_sdist: set[str] | None = None,
     api_base: str = PYPI_JSON_API,
     url_rewrites: list[tuple[str, str]] | None = None,
@@ -418,7 +481,7 @@ def generate(
         f"(python {python_version})…",
         file=sys.stderr,
     )
-    closure = resolve_closure(version, platforms, extras, python_version, index_url, uv)
+    closure = resolve_closure(version, platforms, extras, python_version, index_url, uv, cooldown)
     print(f"Resolved {len(closure)} packages.", file=sys.stderr)
 
     rewrites = url_rewrites or []
@@ -614,6 +677,14 @@ def main(argv: list[str]) -> int:
         help="Package allowed to have no PyPI sdist (repeatable). Without this, a "
         "wheel-only dependency fails the run instead of vanishing from the formula.",
     )
+    ap.add_argument(
+        "--cooldown-days",
+        type=int,
+        default=None,
+        help="Supply-chain cooldown in days: ignore distributions uploaded more "
+        "recently than this, except the lockstep omnigent packages. Defaults to "
+        "the repo uv.toml `exclude-newer` span. 0 disables it (not recommended).",
+    )
     ap.add_argument("--uv", default="uv", help="uv binary path.")
     args = ap.parse_args(argv)
 
@@ -637,6 +708,7 @@ def main(argv: list[str]) -> int:
         index_url=index_url,
         uv=args.uv,
         exclude={normalize_name(n) for n in (args.exclude or [])},
+        cooldown=args.cooldown_days if args.cooldown_days is not None else cooldown_days(),
         allow_no_sdist={normalize_name(n) for n in (args.allow_no_sdist or [])},
         api_base=api_base,
         url_rewrites=url_rewrites,


### PR DESCRIPTION
## Related issue

N/A

## Summary

`generate_formula.py` runs `uv pip compile --no-config`, which discards the repo's
`exclude-newer = "P7D"` along with the index and uv-version config. The cooldown
therefore never applied to the Homebrew formula: every one of the ~100 resource
pins in the artifact `brew install` users receive could be a distribution
published minutes earlier, even though the same dependency graph in `uv.lock` has
to wait the window out. A supply-chain control we apply to our own resolution was
absent from the one thing we ship to end users.

- Re-apply the window explicitly with `--exclude-newer`, keeping `--no-config` so
  the index and `required-version` stay out of the picture.
- The cooldown cannot simply be left enabled: at release time `omnigent` and its
  two lockstep SDKs are minutes old, and uv filters out the very version being
  packaged (`no version of omnigent==X.Y.Z`). Those three are exempted with
  `--exclude-newer-package`, which is what uv's own error message recommends.
- The span is read from `uv.toml` rather than hardcoded, so the formula's cooldown
  cannot silently drift from the lockfile's. If it cannot be read, it falls back
  to 7 days with a warning — never silently to "no cooldown".
- `--cooldown-days` overrides it for local experiments.

Pre-existing since #2654; every formula generated since has had it, including the
0.8.1 one that just shipped.

## Test Plan

Three runs against `omnigent==0.8.1`, all through a PyPI mirror:

- **No-op check** — cooldown 7 vs 0 at the same moment: **0 of 100 pins differ**,
  so this does not churn today's output. (An earlier comparison suggested 3 pins
  moved; that was mirror lag between two days, not the cooldown — the controlled
  run is the valid one.)
- **Enforcement** — cooldown 7 vs 60: **45 pins held back**, e.g. `fastapi`
  0.141.1 -> 0.136.3, `mcp` 1.29.0 -> 1.27.2, `grpcio` 1.83.0 -> 1.81.0. So the
  flag demonstrably filters.
- **Exemption** — at a 60-day cooldown, `omnigent==0.8.1` (published 2 days ago)
  still resolves and is still pinned as the stable url, which is only possible if
  `--exclude-newer-package` is working. Without the exemption, resolution fails
  outright; verified separately by running `uv pip compile` from the repo root
  with the cooldown active:
  `No solution found ... omnigent was filtered by exclude-newer`.

Also `ruff check`, `ruff format`, and the module imports with
`cooldown_days()` returning 7 from the repo's `uv.toml`.

## Demo

N/A — release tooling, no user-visible UI.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The generator has no test suite here, and the property that matters — "resource
pins respect the cooldown" — depends on live PyPI upload times, so it cannot be
asserted hermetically. Verified by the three controlled runs above: a no-op
against today's output, 45 pins moving under an exaggerated window to prove
enforcement, and the lockstep exemption proven by 0.8.1 resolving despite being
2 days old.

Signed-off-by: Zeyi (Rice) Fan <zeyi.f@databricks.com>

