### PR TITLE
fix(ci): give the reopen notice pull-requests: write

### DIFF
--- a/.github/workflows/reopen-notice.yml
+++ b/.github/workflows/reopen-notice.yml
@@ -29,7 +29,11 @@ jobs:
     permissions:
       # Job-level permissions REPLACE the workflow-level block, so restate read.
       contents: read
-      issues: write # post the notice
+      # Commenting on a PR needs BOTH: the endpoint is /issues/{n}/comments, but
+      # GitHub gates it on `pull-requests` when the target is a pull request.
+      # `issues: write` alone returns "Resource not accessible by integration".
+      issues: write
+      pull-requests: write
     steps:
       # Trusted default branch, .github only (the script). Never PR head.
       - name: Check out .github


### PR DESCRIPTION
## Related issue

Follow-up to #4084. No separate issue; this is a one-line permissions fix found
by testing that PR's behaviour after merge.

## Summary

The reopen notice failed on every close with `Resource not accessible by
integration`, so no notice was ever posted.

Posting a comment on a pull request goes through `POST /issues/{n}/comments`, but
GitHub gates that on the `pull-requests` scope when the target is a PR — so
`issues: write` alone is not sufficient. Every other comment-posting workflow in
this repo (`review-sla`, `demo-check`, `waiting-on-author`) already declares both;
`reopen-notice` declared only `issues: write`.

`reopen-pr.yml` already declares both, so the `/reopen` command itself was never
affected — only the notice that advertises it.

## Test Plan

Reproduced against production: opened a throwaway PR, closed it, and the
`Reopen notice on PR close` run failed with the error above and posted nothing
(run 31043337550). After this change the same close should post the notice; I'll
re-run the probe once this merges to confirm.

## Demo

N/A — CI permissions change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

Not unit-testable: the failure is a token-scope behaviour, not logic, so the
existing mocked tests pass either way. Verified by observing the real failing run
and re-running the probe after the fix.
