### PR TITLE
fix(ci): point the stale-PR closer at /reopen

### DIFF
--- a/.github/scripts/waiting_on_author.py
+++ b/.github/scripts/waiting_on_author.py
@@ -56,13 +56,21 @@ def latest_waiting_label_at(timeline: list[dict[str, Any]]) -> str | None:
 
 
 def close_message(label_applied_at: str) -> str:
+    # Point at `/reopen` (reopen-pr.yml), not GitHub's Reopen button: reopening
+    # needs Triage+ on the base repo, which a fork contributor does not have, so
+    # telling them to reopen it themselves is advice they cannot act on.
     return "\n".join(
         [
             f"Closing this PR because it has been labeled `{LABEL}` for "
             f"{WAITING_DAYS} days without an author reply or new commit.",
             "",
-            f"The label was last applied on {label_applied_at}. If you are "
-            "ready to continue, please reopen this PR or open a new one.",
+            f"The label was last applied on {label_applied_at}. This isn't a "
+            "judgement on the merit of the PR -- it's how we keep the review "
+            "queue readable.",
+            "",
+            "If you're ready to continue, comment `/reopen` and this PR comes "
+            "back, as long as its source branch still exists. If the branch is "
+            "gone, push it again and open a fresh PR referencing this one.",
         ]
     )
 

--- a/.github/scripts/waiting_on_author_test.py
+++ b/.github/scripts/waiting_on_author_test.py
@@ -177,6 +177,10 @@ class WaitingOnAuthorTest(unittest.TestCase):
         self.assertEqual(api.closed, [20])
         self.assertEqual(len(api.comments), 1)
         self.assertIn(waiting_on_author.LABEL, api.comments[0][1])
+        # Must point at `/reopen`, not GitHub's Reopen button: a fork author
+        # cannot press that, so telling them to is advice they can't act on.
+        self.assertIn("/reopen", api.comments[0][1])
+        self.assertNotIn("please reopen this PR", api.comments[0][1])
 
     def test_scheduled_sweep_removes_label_after_author_comment(self) -> None:
         api = FakeAPI(


### PR DESCRIPTION
## Related issue

Follow-up to #4084 (`/reopen`). No separate issue; this is the one-line change
that makes the existing closer's advice actionable now that `/reopen` is live.

## Summary

The 7-day `waiting-on-author` closer has been running for a while and its message
ends with "please reopen this PR or open a new one". Reopening a PR needs Triage+
on the base repo, which a fork contributor does not have — so for the people
actually receiving this comment, half the advice is impossible to follow. It
happened last week: an author replied that GitHub wouldn't let them reopen once
their head branch was deleted, and re-raised the same work as a fresh PR.

Now that `/reopen` exists and is verified working, the message points at it, and
says what to do in the one case nothing can fix (source branch already gone).

Also borrows Spark's framing that the close is not a judgement on the PR's merit.
That matters more than it looks: the evidence on stale bots is that they shrink
active contributor counts along with backlogs
([arXiv 2305.18150](https://arxiv.org/abs/2305.18150)), and the projects where
auto-close is socially accepted all pair it with a non-judgmental message and a
trivial way back.

Before:

> The label was last applied on `<date>`. If you are ready to continue, please
> reopen this PR or open a new one.

After:

> The label was last applied on `<date>`. This isn't a judgement on the merit of
> the PR -- it's how we keep the review queue readable.
>
> If you're ready to continue, comment `/reopen` and this PR comes back, as long
> as its source branch still exists. If the branch is gone, push it again and open
> a fresh PR referencing this one.

## Test Plan

- `python3 .github/scripts/waiting_on_author_test.py` — 21 tests, all pass. Added
  assertions that the close comment contains `/reopen` and no longer contains the
  old "please reopen this PR" wording, so this cannot silently regress back to
  advice contributors can't act on.
- `ruff check` / `ruff format --check` — clean.
- Rendered the message locally to confirm the wording and date interpolation.
- `/reopen` itself was verified end-to-end against production earlier today: a
  closed PR went CLOSED → OPEN on the command, and the close notice posted.

## Demo

N/A — CI comment wording.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

Unit tests cover the message content; manual verification was rendering the
message and the earlier end-to-end `/reopen` check against production.
