### PR TITLE
feat(ci): apply waiting-on-author when a maintainer engages

### DIFF
--- a/.github/scripts/waiting_on_author.py
+++ b/.github/scripts/waiting_on_author.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import urllib.error
 import urllib.parse
@@ -141,6 +142,25 @@ class GitHubAPI:
 
     def list_commits(self, pull_number: int) -> list[dict[str, Any]]:
         return self.paginated(f"/repos/{self.repo}/pulls/{pull_number}/commits?per_page=100")
+
+    def has_write_access(self, login: str) -> bool:
+        """True when the user can push to the repo, i.e. is a maintainer here.
+
+        Checked via the collaborator permission API rather than the event's
+        `author_association`, which reads CONTRIBUTOR for a maintainer whose org
+        membership is private.
+        """
+        try:
+            data, _ = self.request(
+                "GET", f"/repos/{self.repo}/collaborators/{urllib.parse.quote(login)}/permission"
+            )
+        except urllib.error.HTTPError as error:
+            # 403/404 = not a collaborator, or we cannot see. Fail closed: no
+            # label, so a stranger's comment never moves the PR's state.
+            if error.code in (403, 404):
+                return False
+            raise
+        return (data or {}).get("permission") in {"admin", "write", "maintain"}
 
     def add_label(self, issue_number: int, label: str) -> None:
         self.request(
@@ -290,6 +310,84 @@ def clear_review_label_on_waiting(payload: dict[str, Any], api: GitHubAPI) -> bo
     return removed
 
 
+# A comment whose first non-space token is a slash command (`/review`, `/reopen`,
+# `/merge`, ...). These drive automation rather than ask the author for anything,
+# so they must not flip a PR back to waiting-on-author.
+SLASH_COMMAND = re.compile(r"^[ \t]*/[a-z][\w-]*", re.I)
+
+
+def is_slash_command(body: str | None) -> bool:
+    return bool(SLASH_COMMAND.match(body or ""))
+
+
+def apply_waiting_on_maintainer_activity(
+    event_name: str, payload: dict[str, Any], api: GitHubAPI
+) -> bool:
+    """Put a PR back in the author's court when a maintainer engages with it.
+
+    Any non-approving review, review-thread comment, or PR comment from someone
+    with write access means the author has something to act on -- not just a
+    formal "request changes". Deliberately excluded: approvals (nothing is owed),
+    slash commands (they drive automation), bots, and the author themselves.
+    """
+    if event_name == "issue_comment":
+        if "pull_request" not in payload.get("issue", {}):
+            return False
+        pull_number = payload["issue"]["number"]
+        comment = payload.get("comment") or {}
+        actor = (comment.get("user") or {}).get("login")
+        if is_slash_command(comment.get("body")):
+            print(f"#{pull_number}: slash command, not a request to the author.")
+            return False
+        reason = "a maintainer commented"
+    elif event_name == "pull_request_review_comment":
+        if not payload.get("pull_request"):
+            return False
+        pull_number = payload["pull_request"]["number"]
+        comment = payload.get("comment") or {}
+        actor = (comment.get("user") or {}).get("login")
+        if is_slash_command(comment.get("body")):
+            return False
+        reason = "a maintainer left a review comment"
+    elif event_name == "pull_request_review":
+        if not payload.get("pull_request"):
+            return False
+        pull_number = payload["pull_request"]["number"]
+        review = payload.get("review") or {}
+        actor = (review.get("user") or {}).get("login")
+        # An approval asks nothing of the author; it means the PR is ready.
+        if (review.get("state") or "").lower() == "approved":
+            print(f"#{pull_number}: approving review, leaving the label alone.")
+            return False
+        if is_slash_command(review.get("body")):
+            return False
+        reason = "a maintainer reviewed"
+    else:
+        return False
+
+    if not actor or actor.endswith("[bot]"):
+        return False
+
+    pull = api.get_pull(pull_number)
+    if pull.get("state") != "open":
+        return False
+    author = (pull.get("user") or {}).get("login", "")
+    if actor.lower() == author.lower():
+        return False
+    if LABEL in label_names(pull):
+        return False
+    if not api.has_write_access(actor):
+        print(f"#{pull_number}: @{actor} has no write access; not a maintainer signal.")
+        return False
+
+    api.add_label(pull_number, LABEL)
+    print(f"Added {LABEL} to #{pull_number}: {reason} (@{actor})")
+    if REVIEW_LABEL in label_names(pull):
+        if api.remove_label(pull_number, REVIEW_LABEL):
+            print(f"Removed {REVIEW_LABEL} from #{pull_number}: now {LABEL}")
+    return True
+
+
 def clear_on_author_activity(event_name: str, payload: dict[str, Any], api: GitHubAPI) -> bool:
     pull_number: int | None = None
     actor: str | None = None
@@ -390,7 +488,11 @@ def run(
         close_stale_waiting_prs(api, now=now)
         return
 
-    clear_on_author_activity(event_name, payload, api)
+    # Author activity wins: the same event cannot be both, and clearing the label
+    # is the cheaper check (it exits immediately unless the label is set).
+    if clear_on_author_activity(event_name, payload, api):
+        return
+    apply_waiting_on_maintainer_activity(event_name, payload, api)
 
 
 def load_event_payload() -> dict[str, Any]:

--- a/.github/scripts/waiting_on_author_test.py
+++ b/.github/scripts/waiting_on_author_test.py
@@ -64,7 +64,9 @@ class FakeAPI:
         review_comments: dict[int, list[dict[str, Any]]] | None = None,
         reviews: dict[int, list[dict[str, Any]]] | None = None,
         commits: dict[int, list[dict[str, Any]]] | None = None,
+        writers: list[str] | None = None,
     ):
+        self.writers = writers if writers is not None else ["maintainer1"]
         self.pull = pull or pr()
         self.issues = issues or []
         self.timeline_by_issue = timeline_by_issue or {}
@@ -102,6 +104,9 @@ class FakeAPI:
 
     def list_commits(self, pull_number: int) -> list[dict[str, Any]]:
         return self.commits.get(pull_number, [])
+
+    def has_write_access(self, login: str) -> bool:
+        return login.lower() in {m.lower() for m in self.writers}
 
     def add_label(self, issue_number: int, label: str) -> None:
         self.added.append((issue_number, label))
@@ -367,6 +372,152 @@ class WaitingForReviewTest(unittest.TestCase):
         self.assertEqual(api.closed, [], "an author reply cancels the close")
         self.assertEqual(api.added, [(30, waiting_on_author.REVIEW_LABEL)])
         self.assertEqual(api.review_requests, [(30, ["maintainer1"])])
+
+
+class AutoWaitingOnAuthorTest(unittest.TestCase):
+    """A maintainer engaging with a PR puts it back in the author's court."""
+
+    def dispatch(self, event: str, payload: dict[str, Any], **kw: Any) -> FakeAPI:
+        api = FakeAPI(**kw)
+        waiting_on_author.run(event, payload, api, waiting_on_author.CANONICAL_REPO)
+        return api
+
+    def comment(self, body: str, actor: str = "maintainer1") -> dict[str, Any]:
+        return {
+            "issue": {"number": 12, "pull_request": {}},
+            "comment": {"user": {"login": actor}, "body": body},
+        }
+
+    def test_maintainer_comment_applies_the_label(self) -> None:
+        api = self.dispatch(
+            "issue_comment", self.comment("could you rebase this?"), pull=pr(labels=[])
+        )
+        self.assertEqual(api.added, [(12, waiting_on_author.LABEL)])
+
+    def test_slash_command_does_not_apply_the_label(self) -> None:
+        # /review, /reopen, /merge drive automation; they ask the author nothing.
+        for body in ("/review", "  /review", "/reopen", "/merge\nplease"):
+            api = self.dispatch("issue_comment", self.comment(body), pull=pr(labels=[]))
+            self.assertEqual(api.added, [], f"{body!r} must not label")
+
+    def test_slash_command_mid_comment_still_counts_as_prose(self) -> None:
+        api = self.dispatch(
+            "issue_comment", self.comment("nice work, I'll run /review now"), pull=pr(labels=[])
+        )
+        self.assertEqual(api.added, [(12, waiting_on_author.LABEL)])
+
+    def test_non_maintainer_comment_is_ignored(self) -> None:
+        api = self.dispatch(
+            "issue_comment", self.comment("bump?", actor="stranger"), pull=pr(labels=[])
+        )
+        self.assertEqual(api.added, [])
+
+    def test_bot_comment_is_ignored(self) -> None:
+        api = self.dispatch(
+            "issue_comment",
+            self.comment("CI failed", actor="github-actions[bot]"),
+            pull=pr(labels=[]),
+            writers=["github-actions[bot]"],
+        )
+        self.assertEqual(api.added, [])
+
+    def test_author_comment_does_not_self_label(self) -> None:
+        # The author is also a maintainer on their own PR: still not a request.
+        api = self.dispatch(
+            "issue_comment",
+            self.comment("ready for another look", actor="alice"),
+            pull=pr(author="alice", labels=[]),
+            writers=["alice"],
+        )
+        self.assertEqual(api.added, [])
+
+    def test_approving_review_leaves_the_label_alone(self) -> None:
+        api = self.dispatch(
+            "pull_request_review",
+            {
+                "pull_request": {"number": 12},
+                "review": {"user": {"login": "maintainer1"}, "state": "approved", "body": "lgtm"},
+            },
+            pull=pr(labels=[]),
+        )
+        self.assertEqual(api.added, [])
+
+    def test_commenting_review_applies_the_label(self) -> None:
+        api = self.dispatch(
+            "pull_request_review",
+            {
+                "pull_request": {"number": 12},
+                "review": {
+                    "user": {"login": "maintainer1"},
+                    "state": "commented",
+                    "body": "a few thoughts",
+                },
+            },
+            pull=pr(labels=[]),
+        )
+        self.assertEqual(api.added, [(12, waiting_on_author.LABEL)])
+
+    def test_changes_requested_applies_the_label(self) -> None:
+        api = self.dispatch(
+            "pull_request_review",
+            {
+                "pull_request": {"number": 12},
+                "review": {
+                    "user": {"login": "maintainer1"},
+                    "state": "changes_requested",
+                    "body": "please fix",
+                },
+            },
+            pull=pr(labels=[]),
+        )
+        self.assertEqual(api.added, [(12, waiting_on_author.LABEL)])
+
+    def test_review_thread_comment_applies_the_label(self) -> None:
+        api = self.dispatch(
+            "pull_request_review_comment",
+            {
+                "pull_request": {"number": 12},
+                "comment": {"user": {"login": "maintainer1"}, "body": "this line?"},
+            },
+            pull=pr(labels=[]),
+        )
+        self.assertEqual(api.added, [(12, waiting_on_author.LABEL)])
+
+    def test_applying_clears_waiting_for_review(self) -> None:
+        api = self.dispatch(
+            "issue_comment",
+            self.comment("one more thing"),
+            pull=pr(labels=[waiting_on_author.REVIEW_LABEL]),
+        )
+        self.assertEqual(api.added, [(12, waiting_on_author.LABEL)])
+        self.assertEqual(api.removed, [(12, waiting_on_author.REVIEW_LABEL)])
+
+    def test_already_waiting_is_a_no_op(self) -> None:
+        api = self.dispatch(
+            "issue_comment",
+            self.comment("still waiting"),
+            pull=pr(labels=[waiting_on_author.LABEL]),
+        )
+        self.assertEqual(api.added, [], "no duplicate label")
+
+    def test_closed_pr_is_left_alone(self) -> None:
+        api = self.dispatch(
+            "issue_comment", self.comment("for the record"), pull=pr(labels=[], state="closed")
+        )
+        self.assertEqual(api.added, [])
+
+    def test_author_reply_still_clears_and_hands_off(self) -> None:
+        # The two directions must not fight: author activity wins.
+        api = self.dispatch(
+            "issue_comment",
+            {
+                "issue": {"number": 12, "pull_request": {}},
+                "comment": {"user": {"login": "alice"}, "body": "fixed"},
+            },
+            pull=pr(author="alice", labels=[waiting_on_author.LABEL], assignees=["maintainer1"]),
+        )
+        self.assertEqual(api.removed, [(12, waiting_on_author.LABEL)])
+        self.assertEqual(api.added, [(12, waiting_on_author.REVIEW_LABEL)])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Related issue

Part of OMNI-2315 / OMNI-2214 ("Better review process"). Completes the
`waiting-on-author` state machine: clearing and closing were already automated,
setting it was not.

## Summary

The label had an automated exit and no automated entrance. A maintainer who left
feedback without remembering to apply it got none of the machinery — no handoff
back when the author replied, no 7-day clock.

Any **non-approving engagement from someone with write access** now applies it:

| Signal | Applies label? |
|---|---|
| Review with changes requested | yes |
| Review with a comment (no verdict) | yes |
| Comment on a review thread | yes |
| Plain PR comment | yes |
| **Approving review** | no — nothing is owed by the author |
| **Slash command** (`/review`, `/reopen`, `/merge`) | no — drives automation, asks nothing |
| Bot comment | no |
| The author's own comment, even if they're a maintainer | no |

"Request changes" alone was too narrow: most feedback in this repo arrives as a
plain comment, which is exactly the case that was silently dropping through.

Two details worth calling out:

- **Slash commands are matched only at the start of the body**, so a `/review`
  comment is excluded while prose that happens to mention `/review` still counts
  as feedback. There's a test for both.
- **Write access is read from the collaborator permission API**, not the event's
  `author_association`, which reports `CONTRIBUTOR` for a maintainer whose org
  membership is private. It fails closed on 403/404, so a stranger's comment can
  never move a PR's state.

Author activity still wins when both directions could apply, and applying the
label clears `waiting-for-review`, keeping the two mutually exclusive in both
directions.

No workflow changes: every event needed (`issue_comment`,
`pull_request_review`, `pull_request_review_comment`) was already subscribed, and
the job already grants `issues: write` + `pull-requests: write`.

## Test Plan

- `python3 .github/scripts/waiting_on_author_test.py` — **35 tests, all pass** (21
  existing, 14 new). New cases: maintainer comment / commenting review /
  changes-requested / review-thread comment all label; approval, each slash-command
  form, bot, non-maintainer, and self-comment all do not; applying clears
  `waiting-for-review`; already-labeled is a no-op; closed PRs are untouched; and
  author activity still clears and hands off.
- `ruff check` / `ruff format --check` — clean.
- The rest of this state machine was verified end-to-end against production
  earlier today (handoff both directions, `/reopen`, close notice).

## Demo

N/A — CI label mechanics, no user-visible UI.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Not applicable

## Coverage notes

N/A — covered by unit tests. Worth a live check after merge: leave a plain comment
on an open PR and confirm the label appears, then `/review` and confirm it does not.
