### PR TITLE
fix(web): open the session after unarchiving it

### DIFF
--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -5,7 +5,7 @@
 
 import type { ReactNode } from "react";
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Conversation } from "@/hooks/useConversations";
@@ -93,7 +93,15 @@ vi.mock("@/hooks/useConversations", async () => {
     // Picker options are sourced from this dedicated scan, decoupled from the
     // loaded rows so archived-only projects on later pages still appear.
     useArchivedProjectNames: () => ({ data: mocks.projectNames }),
-    useArchiveConversation: () => ({ mutate: mocks.archiveMutate, isPending: false }),
+    // Mirrors react-query's mutate: per-call `onSuccess` runs once the
+    // mutation settles, which is what drives the post-unarchive navigation.
+    useArchiveConversation: () => ({
+      mutate: (vars: { id: string; archived: boolean }, opts?: { onSuccess?: () => void }) => {
+        mocks.archiveMutate(vars, opts);
+        opts?.onSuccess?.();
+      },
+      isPending: false,
+    }),
     useStopAndDeleteConversation: () => ({ mutate: mocks.deleteMutate, isPending: false }),
   };
 });
@@ -164,11 +172,17 @@ function conv(id: string, partial: Partial<Conversation> = {}): Conversation {
   };
 }
 
+/** Exposes the router location so navigation assertions read the real URL. */
+function LocationProbe() {
+  return <span data-testid="location">{useLocation().pathname}</span>;
+}
+
 function renderPage(path = "/settings") {
   return render(
     <TooltipProvider>
       <MemoryRouter initialEntries={[path]}>
         <SettingsPage />
+        <LocationProbe />
       </MemoryRouter>
     </TooltipProvider>,
   );
@@ -792,7 +806,12 @@ describe("SettingsPage", () => {
     expect(within(rows[0]).getByText("Old chat")).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("unarchive-conversation"));
-    expect(mocks.archiveMutate).toHaveBeenCalledWith({ id: "conv_archived", archived: false });
+    expect(mocks.archiveMutate.mock.calls[0][0]).toEqual({
+      id: "conv_archived",
+      archived: false,
+    });
+    // Unarchiving opens the restored session (the mock mutate runs onSuccess).
+    expect(screen.getByTestId("location").textContent).toBe("/c/conv_archived");
   });
 
   it("deletes an archived session after confirming, with no row-click navigation", () => {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -23,7 +23,8 @@
  *   entering them stays inside settings — the sidebar keeps the section nav
  *   instead of snapping back to the conversation list.
  * - **Archived sessions** — archived sessions, moved out of the sidebar
- *   list. Not clickable; each row reveals Delete / Unarchive on hover.
+ *   list. Not clickable; each row reveals Delete / Unarchive on hover, and
+ *   Unarchive opens the restored session.
  */
 
 import {
@@ -91,6 +92,7 @@ import {
 } from "@/hooks/useConversations";
 import { conversationDisplayLabel } from "@/shell/sidebarNav";
 import { absoluteTime } from "@/lib/relativeTime";
+import { useNavigate } from "@/lib/routing";
 import { useSettingsRoute } from "@/shell/settingsNav";
 import {
   normalizeResolvedTheme,
@@ -2017,8 +2019,10 @@ function ArchivedSection() {
  * One archived-session row. Not clickable (archived sessions aren't a
  * navigation target here); the title + timestamp read as a record, and the
  * Delete / Unarchive controls reveal on hover (always visible on touch).
+ * Unarchive navigates to the restored session once the PATCH lands.
  */
 function ArchivedRow({ conversation }: { conversation: Conversation }) {
+  const navigate = useNavigate();
   const archive = useArchiveConversation();
   const del = useStopAndDeleteConversation();
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -2061,7 +2065,14 @@ function ArchivedRow({ conversation }: { conversation: Conversation }) {
           className="gap-1.5 dark:bg-secondary dark:hover:bg-secondary/80"
           data-testid="unarchive-conversation"
           disabled={busy}
-          onClick={() => archive.mutate({ id: conversation.id, archived: false })}
+          onClick={() =>
+            archive.mutate(
+              { id: conversation.id, archived: false },
+              // Unarchiving is how a user brings a session back into play, so
+              // land them in it — the row leaves this list either way.
+              { onSuccess: () => navigate(`/c/${conversation.id}`) },
+            )
+          }
         >
           <ArchiveRestoreIcon className="size-3.5" />
           Unarchive


### PR DESCRIPTION
## Related issue

N/A — no tracking issue; small UI bug fix.

## Summary

Unarchiving a session from **Settings → Archived sessions** left you sitting on
the settings page. The row just vanished from the archived list, with no sign of
where the session went — restoring one took a second step of hunting it down in
the sidebar.

- The row's Unarchive button now navigates to `/c/{id}` once the unarchive PATCH
  lands, so the restored session opens where you'd expect.
- Navigation happens in the mutation's `onSuccess`, not optimistically: a failed
  PATCH leaves you on the archived list instead of dropping you into a session
  that is still archived.
- `useNavigate` comes from `@/lib/routing` (the routing IoC seam the embed
  overrides), so the embedded host rebases the target under its mount path.

Settings → Archived is the only live unarchive surface — archived rows no longer
render in the sidebar, so its bulk-unarchive path is unreachable and is left
untouched.

## Test Plan

- `pnpm vitest run src/pages/SettingsPage.test.tsx` — 47/47 pass. Extended the
  existing "lists archived sessions and unarchives on click" test to assert the
  resulting router location; the mocked `useArchiveConversation` now runs the
  per-call `onSuccess` the way react-query does, and a `LocationProbe` reads the
  real `MemoryRouter` path rather than mocking `useNavigate`.
- `pre-commit run --files web/src/pages/SettingsPage.tsx web/src/pages/SettingsPage.test.tsx`
  — prettier, oxlint, and the TypeScript type check all pass.
- Manual, against a local server serving this build: archived a session, opened
  `/settings/archived`, clicked Unarchive → landed on `/c/{id}` with the session
  open and back in the sidebar's Sessions list. Repeated headlessly (Playwright)
  asserting the final URL and zero `pageerror`s.

## Demo

Before — the archived row, with the Unarchive control revealed on hover:

![Settings → Archived sessions, hovering an archived row](https://raw.githubusercontent.com/dbczumar/omnigent/assets/unarchive-opens-session-demo/demo_before.png)

After clicking Unarchive — the session opens at `/c/{id}` and is back under
Sessions in the sidebar:

![The unarchived session, now open](https://raw.githubusercontent.com/dbczumar/omnigent/assets/unarchive-opens-session-demo/demo_after.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test covers the behaviour that regressed (unarchive → navigate). Manual
verification was the end-to-end path the unit test can't reach: a real server,
a real archived session, and the chat view actually loading at the new URL after
the PATCH — confirmed both by hand and with a headless Playwright run that
asserts the final URL and no page errors.

## Changelog

Unarchiving a session from Settings now opens it, instead of leaving you on the settings page.
