### PR TITLE
feat(ci): accept "Part of #N" as a tracked issue, and document the review process

### DIFF
--- a/.github/workflows/pr-issue-link.js
+++ b/.github/workflows/pr-issue-link.js
@@ -113,11 +113,15 @@ function exemptReason(pr, maintainers = new Set()) {
 }
 
 const message = (author) =>
-  `@${author} This PR doesn't link an issue.
+  `@${author} Thanks for the PR! It doesn't link an issue yet.
 
-Please edit the description to link the issue this PR addresses with a closing keyword, e.g. \`Closes #123\`, or link it from the **Development** section of the sidebar. Linking gives the PR the issue's priority in our review queue, and closes the issue automatically on merge.
+**We require an issue for every PR**, so the work can be prioritized before it's reviewed. Please add one to the description with a closing keyword, e.g. \`Closes #123\`, or link it from the **Development** section of the sidebar. Linking gives your PR the issue's priority in our review queue, and closes the issue when this merges.
 
-If this change genuinely has no associated issue, check **Refactor / chore**, **Docs**, or **Test / CI** under *Type of change* — those types don't need one. Anything else should have an issue so it can be prioritized; open one if it doesn't exist yet.
+No issue exists for this yet? Open one first, then link it. That's how we track what's worth doing, and it's usually quicker than it sounds.
+
+The only exceptions are changes with no user-visible behaviour: pure **Refactor / chore**, **Docs**, or **Test / CI** work. If that's genuinely what this is, check that box under *Type of change*. Anything that fixes a bug, adds a feature, or changes the UI needs an issue, even when it also touches docs or tests.
+
+See [CONTRIBUTING.md](https://github.com/omnigent-ai/omnigent/blob/main/CONTRIBUTING.md#every-pr-needs-an-issue) for the full policy.
 
 _No action is taken beyond this comment._`;
 
@@ -258,7 +262,7 @@ module.exports = async ({ context, github, core }) => {
     // The full verdict list, so a dry run can be reviewed before enforcing.
     if (core.summary) {
       core.summary
-        .addHeading(`Issue-link check ${enforce ? "(enforcing)" : "(dry run — nothing changed)"}`, 3)
+        .addHeading(`Issue-link check ${enforce ? "(enforcing)" : "(dry run, nothing changed)"}`, 3)
         .addRaw(`\n${summary}\n\n`)
         .addTable([
           [

--- a/.github/workflows/pr-issue-link.js
+++ b/.github/workflows/pr-issue-link.js
@@ -53,6 +53,25 @@ const DECLARED_EXEMPT_TYPE = /- \[[xX]\]\s*(?:Refactor \/ chore|Docs|Test \/ CI)
 // otherwise ticking `Test / CI` next to `Bug fix` is a free opt-out.
 const DECLARED_TRACKED_TYPE = /- \[[xX]\]\s*(?:Bug fix|Feature|UI \/ frontend change)\b/;
 
+// Non-closing references to an issue. GitHub only creates a *link* for the
+// closing keywords, so these never reach closingIssuesReferences -- but they do
+// say the work is tracked, which is what the rule is actually asking for. A PR
+// that only partly addresses an issue should not have to claim it closes it.
+// Deliberately excludes a bare `#123`, which is a cross-reference rather than a
+// statement about this PR.
+const TRACKING_REFERENCE =
+  /\b(?:part of|related to|towards?|refs?|references?|see(?:\s+also)?)\b[:\s]*(?:https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/(\d+)|(?:[\w.-]+\/[\w.-]+)?#(\d+))/gi;
+
+// Issue numbers a body claims to be working towards, deduped and in order.
+function trackingReferences(body) {
+  const seen = [];
+  for (const m of (body ?? "").matchAll(TRACKING_REFERENCE)) {
+    const n = Number(m[1] ?? m[2]);
+    if (n && !seen.includes(n)) seen.push(n);
+  }
+  return seen;
+}
+
 const QUERY = `
   query($cursor: String, $searchQuery: String!) {
     rateLimit { remaining resetAt }
@@ -113,11 +132,14 @@ function exemptReason(pr, maintainers = new Set()) {
 }
 
 const message = (author) =>
-  `@${author} Thanks for the PR! It doesn't link an issue yet.
+  `@${author} Thanks for the PR! It doesn't reference an issue yet.
 
-**We require an issue for every PR**, so the work can be prioritized before it's reviewed. Please add one to the description with a closing keyword, e.g. \`Closes #123\`, or link it from the **Development** section of the sidebar. Linking gives your PR the issue's priority in our review queue, and closes the issue when this merges.
+**We require an issue for every PR**, so the work can be prioritized before it's reviewed. Add one to the description:
 
-No issue exists for this yet? Open one first, then link it. That's how we track what's worth doing, and it's usually quicker than it sounds.
+- \`Closes #123\` if this PR finishes the issue. That links it, gives your PR the issue's priority, and closes the issue when this merges. You can also link it from the **Development** section of the sidebar.
+- \`Part of #123\` if this is one step towards it. \`Related to\`, \`Towards\`, and \`Refs\` work the same way, and leave the issue open.
+
+No issue exists for this yet? Open one first, then reference it. That's how we track what's worth doing, and it's usually quicker than it sounds. Note a reference has to point at an issue: naming another PR doesn't count.
 
 The only exceptions are changes with no user-visible behaviour: pure **Refactor / chore**, **Docs**, or **Test / CI** work. If that's genuinely what this is, check that box under *Type of change*. Anything that fixes a bug, adds a feature, or changes the UI needs an issue, even when it also touches docs or tests.
 
@@ -214,6 +236,31 @@ module.exports = async ({ context, github, core }) => {
         continue;
       }
 
+      // No closing link, but the body may still name the issue it works towards.
+      // Each candidate is resolved, because "Refs #4147" often points at another
+      // PR, and a PR is not the tracking record this rule is asking for.
+      let tracked = null;
+      for (const candidate of trackingReferences(pr.body)) {
+        try {
+          const { data } = await github.rest.issues.get({
+            owner,
+            repo,
+            issue_number: candidate,
+          });
+          if (!data.pull_request) {
+            tracked = candidate;
+            break;
+          }
+        } catch (err) {
+          // A number that doesn't resolve proves nothing either way; try the next.
+          core.warning(`Could not resolve #${candidate} from #${pr.number}: ${err.message}`);
+        }
+      }
+      if (tracked) {
+        verdicts.push({ pr: pr.number, verdict: "ok", reason: `references #${tracked}` });
+        continue;
+      }
+
       const author = pr.author?.login ?? "contributor";
 
       // A dry run enumerates every verdict -- that's its whole point, so LIMIT
@@ -285,5 +332,6 @@ module.exports = async ({ context, github, core }) => {
 
 // Exported for the offline unit test.
 module.exports.exemptReason = exemptReason;
+module.exports.trackingReferences = trackingReferences;
 module.exports.MARKER = MARKER;
 module.exports.EFFECTIVE_FROM = EFFECTIVE_FROM;

--- a/.github/workflows/pr-issue-link.test.js
+++ b/.github/workflows/pr-issue-link.test.js
@@ -222,6 +222,11 @@ for (const tracked of ["Bug fix", "Feature", "UI / frontend change"]) {
     assert.match(commented[0].body, /@alice/);
     assert.match(commented[0].body, /Closes #123/);
     assert.ok(commented[0].body.startsWith(script.MARKER), "comment carries the dedupe marker");
+    // House style: no em dashes in anything a contributor reads.
+    assert.ok(!commented[0].body.includes("—"), "no em dashes in the nudge");
+    // The exemption must not read as a free opt-out.
+    assert.match(commented[0].body, /require an issue for every PR/);
+    assert.match(commented[0].body, /even when it also touches docs or tests/);
     assert.deepStrictEqual(labeled, [], "no label is applied");
   }
 

--- a/.github/workflows/pr-issue-link.test.js
+++ b/.github/workflows/pr-issue-link.test.js
@@ -36,7 +36,14 @@ function pr({
 // `env` overrides process.env for the run.
 async function run(
   nodes,
-  { linked = {}, env = {}, linkError = false, maintainers = [], existingComments = {} } = {}
+  {
+    linked = {},
+    env = {},
+    linkError = false,
+    maintainers = [],
+    existingComments = {},
+    issues = {},
+  } = {}
 ) {
   const commented = [];
   const labeled = [];
@@ -77,6 +84,16 @@ async function run(
         listComments: "listComments",
         createComment: async ({ issue_number, body }) => commented.push({ issue_number, body }),
         addLabels: async ({ issue_number, labels: ls }) => labeled.push({ issue_number, labels: ls }),
+        // `issues` maps number -> "issue" | "pr" | undefined (404).
+        get: async ({ issue_number }) => {
+          const kind = issues[issue_number];
+          if (!kind) {
+            const err = new Error("Not Found");
+            err.status = 404;
+            throw err;
+          }
+          return { data: kind === "pr" ? { pull_request: {} } : {} };
+        },
       },
     },
   };
@@ -196,6 +213,27 @@ for (const tracked of ["Bug fix", "Feature", "UI / frontend change"]) {
   );
 }
 
+// ---- tracking-reference parsing (pure) ----
+{
+  const { trackingReferences: refs } = script;
+  assert.deepStrictEqual(refs("Refs #3644"), [3644], "Refs #N");
+  assert.deepStrictEqual(refs("Part of #123"), [123], "Part of #N");
+  assert.deepStrictEqual(refs("blah\nRelated to #5\nblah"), [5], "Related to #N");
+  assert.deepStrictEqual(refs("Towards #9"), [9], "Towards #N");
+  assert.deepStrictEqual(
+    refs("Part of https://github.com/omnigent-ai/omnigent/issues/321"),
+    [321],
+    "full issue URL"
+  );
+  assert.deepStrictEqual(refs("Refs omnigent-ai/omnigent#77"), [77], "cross-repo ref");
+  assert.deepStrictEqual(refs("Part of #7 and refs #7"), [7], "dedupes");
+  // A bare mention is a cross-reference, not a statement about this PR.
+  assert.deepStrictEqual(refs("similar to #77 maybe"), [], "bare #N does not count");
+  assert.deepStrictEqual(refs("this fixes the thing generally"), [], "prose does not count");
+  assert.deepStrictEqual(refs(""), [], "empty body");
+  assert.deepStrictEqual(refs(undefined), [], "missing body");
+}
+
 // ---- end-to-end behaviour ----
 (async () => {
   // Forward-only: the search must never reach past the effective date, so the
@@ -228,6 +266,44 @@ for (const tracked of ["Bug fix", "Feature", "UI / frontend change"]) {
     assert.match(commented[0].body, /require an issue for every PR/);
     assert.match(commented[0].body, /even when it also touches docs or tests/);
     assert.deepStrictEqual(labeled, [], "no label is applied");
+  }
+
+  // A non-closing reference to a real ISSUE satisfies the rule: a PR that only
+  // partly addresses an issue should not have to claim it closes it.
+  for (const kw of ["Part of #77", "Related to #77", "Towards #77", "Refs #77", "See #77"]) {
+    const { commented } = await run([pr({ number: 50, body: `Work here.\n\n${kw}` })], {
+      env: ENFORCE,
+      issues: { 77: "issue" },
+    });
+    assert.strictEqual(commented.length, 0, `${kw} must satisfy the rule`);
+  }
+
+  // ...but only when it resolves to an issue. "Refs #4147" pointing at another PR
+  // is not a tracking record, and three real backlog PRs do exactly this.
+  {
+    const { commented } = await run([pr({ number: 51, body: "Refs #88" })], {
+      env: ENFORCE,
+      issues: { 88: "pr" },
+    });
+    assert.strictEqual(commented.length, 1, "a reference to a PR does not count");
+  }
+
+  // A bare mention is a cross-reference, not a claim about this PR.
+  {
+    const { commented } = await run([pr({ number: 52, body: "similar to #77 maybe" })], {
+      env: ENFORCE,
+      issues: { 77: "issue" },
+    });
+    assert.strictEqual(commented.length, 1, "a bare #N does not count");
+  }
+
+  // An unresolvable number proves nothing; keep checking the rest.
+  {
+    const { commented } = await run([pr({ number: 53, body: "Refs #999\nPart of #77" })], {
+      env: ENFORCE,
+      issues: { 77: "issue" },
+    });
+    assert.strictEqual(commented.length, 0, "falls through to the next candidate");
   }
 
   // A linked PR is left alone even when enforcing.

--- a/.github/workflows/reopen-notice.js
+++ b/.github/workflows/reopen-notice.js
@@ -13,13 +13,13 @@
 const MARKER = "<!-- reopen-notice -->";
 
 const authorClosed = () =>
-  `${MARKER}\nClosed. If you want to pick this back up, comment \`/reopen\` — ` +
+  `${MARKER}\nClosed. If you want to pick this back up, comment \`/reopen\`. ` +
   `GitHub only lets maintainers press the Reopen button, so this command does it for you. ` +
   `It needs the source branch to still exist.`;
 
 const maintainerClosed = (author) =>
   `${MARKER}\n@${author} this PR was closed by a maintainer. If you think that was a mistake, ` +
-  `reply here and ask them to reopen it — \`/reopen\` only undoes automated closes. ` +
+  `reply here and ask them to reopen it. \`/reopen\` only undoes automated closes. ` +
   `See [CONTRIBUTING.md](https://github.com/omnigent-ai/omnigent/blob/main/CONTRIBUTING.md#reopening-a-closed-pr).`;
 
 module.exports = async ({ github, context, core }) => {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,19 +258,67 @@ request enforces this, so unsigned commits will block merging.
 - Branch from `main`, keep changes focused, and include tests or docs when relevant.
 - Sign off your commits with `git commit -s` (see
   [Developer Certificate of Origin](#developer-certificate-of-origin) above).
+- **Link an issue** (see below).
 - Fill in the PR template. For **UI / frontend changes**, check the
   "UI / frontend change" box and attach a **video or images** in the `Demo`
   section showing the new behaviour, so reviewers can see it without checking
   out the branch.
+
+### Every PR needs an issue
+
+We require an issue for every pull request. Issues are how work gets
+prioritized, so a PR without one arrives unsorted and waits longer.
+
+Link it in the description with a closing keyword, for example `Closes #123`, or
+from the **Development** section of the sidebar. Either way GitHub records the
+link, gives your PR the issue's priority, and closes the issue when the PR
+merges.
+
+**No issue for your change yet?** Open one first, then link it. That is also the
+faster path for anything non-trivial: it lets a maintainer confirm the approach
+before you write code.
+
+The only exceptions are changes with no user-visible behaviour: pure
+**Refactor / chore**, **Docs**, or **Test / CI** work. If that is genuinely what
+your PR is, check that box under *Type of change* and no issue is needed.
+Anything that fixes a bug, adds a feature, or changes the UI needs an issue,
+even when it also touches docs or tests.
+
+A bot comments once on PRs that link no issue. It never closes anything.
+
+### Review state labels
+
+Two labels track whose turn it is. Both are managed by automation, so you do not
+need to apply them.
+
+| Label | Meaning |
+| --- | --- |
+| `waiting-on-author` | A maintainer has left feedback. The PR is in your court. |
+| `waiting-for-review` | You have responded. It is back in the reviewer's queue. |
+
+A maintainer reviewing or commenting on your PR sets `waiting-on-author`. When
+you push a commit, comment, or reply to a review, that clears automatically and
+`waiting-for-review` goes on instead, which also re-pings your reviewer. You do
+not need to ask for a re-review.
+
+A PR left in `waiting-on-author` for **7 days** with no reply or new commit is
+closed to keep the review queue readable. That is not a judgement on the change,
+and it is reversible: comment `/reopen` (see below).
+
+**As of 5 August 2026** maintainers follow this process for new pull requests.
+PRs opened before then are being worked through separately, so an older PR may
+not carry these labels yet; that does not mean it has been forgotten. The
+issue-link rule also applies only to PRs opened on or after that date, so you
+will not be asked to retrofit an issue onto an older PR.
 
 ### Reopening a closed PR
 
 If automation closed your PR (as a duplicate, for example) and you think that
 was wrong, comment `/reopen` on it and a bot will reopen it for you. GitHub only
 lets maintainers press the Reopen button, so this command is how you do it
-yourself — you can also use it on a PR you closed by hand.
+yourself. You can also use it on a PR you closed by hand.
 
 Only the PR author can use it, and it won't override a maintainer who closed
 your PR deliberately; ask them in a comment instead. It also needs your source
-branch to still exist — if you deleted it, push it again and open a fresh PR
+branch to still exist. If you deleted it, push it again and open a fresh PR
 linking the old one.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,7 +258,7 @@ request enforces this, so unsigned commits will block merging.
 - Branch from `main`, keep changes focused, and include tests or docs when relevant.
 - Sign off your commits with `git commit -s` (see
   [Developer Certificate of Origin](#developer-certificate-of-origin) above).
-- **Link an issue** (see below).
+- **Reference an issue** (see below).
 - Fill in the PR template. For **UI / frontend changes**, check the
   "UI / frontend change" box and attach a **video or images** in the `Demo`
   section showing the new behaviour, so reviewers can see it without checking
@@ -269,14 +269,28 @@ request enforces this, so unsigned commits will block merging.
 We require an issue for every pull request. Issues are how work gets
 prioritized, so a PR without one arrives unsorted and waits longer.
 
-Link it in the description with a closing keyword, for example `Closes #123`, or
-from the **Development** section of the sidebar. Either way GitHub records the
-link, gives your PR the issue's priority, and closes the issue when the PR
-merges.
+Reference it in the description. Which keyword you use depends on whether the PR
+finishes the issue:
 
-**No issue for your change yet?** Open one first, then link it. That is also the
-faster path for anything non-trivial: it lets a maintainer confirm the approach
-before you write code.
+| Your PR | Write | Effect |
+| --- | --- | --- |
+| Finishes the issue | `Closes #123` (or `Fixes` / `Resolves`) | GitHub links the PR and closes the issue on merge |
+| Is one step towards it | `Part of #123` (or `Related to` / `Towards` / `Refs`) | The issue stays open |
+
+`Closes` is preferred when it applies, because GitHub records a real link and
+closes the issue for you. For a partial change, do not claim `Closes`: use one of
+the second-row keywords instead, so the issue is not closed before the work is
+done. You can also link a closing issue from the **Development** section of the
+sidebar, which counts the same as a `Closes` keyword.
+
+A bare `#123` is not enough on its own. It creates a cross-reference rather than
+saying anything about this PR, so pair it with one of the keywords above. The
+reference also has to point at an **issue**: naming another pull request does not
+count, since a PR is not a tracking record.
+
+**No issue for your change yet?** Open one first, then reference it. That is also
+the faster path for anything non-trivial: it lets a maintainer confirm the
+approach before you write code.
 
 The only exceptions are changes with no user-visible behaviour: pure
 **Refactor / chore**, **Docs**, or **Test / CI** work. If that is genuinely what
@@ -284,7 +298,7 @@ your PR is, check that box under *Type of change* and no issue is needed.
 Anything that fixes a bug, adds a feature, or changes the UI needs an issue,
 even when it also touches docs or tests.
 
-A bot comments once on PRs that link no issue. It never closes anything.
+A bot comments once on PRs that reference no issue. It never closes anything.
 
 ### Review state labels
 


### PR DESCRIPTION
## Related issue

Part of OMNI-2214 ("Better review process"). Follows the machinery merged earlier
today; this PR declares **Docs** below, which is one of the exempt types.

## Summary

Two things, both about the issue requirement that shipped today: it accepted only
closing keywords, and it was written down nowhere a contributor looks.

### `Part of #123` now satisfies the rule

GitHub only creates a *link* for the nine closing keywords. `Part of`,
`Related to`, `Refs`, and a bare `#123` produce a cross-reference, so
`closingIssuesReferences` returns 0 and the check would have nudged them.

That punished the honest case. A PR advancing an issue without finishing it had to
either claim `Closes` (which closes an unfinished issue on merge, corrupting the
tracker) or take the comment. And it was already happening: **#4095 says
`Refs #3644`, a real open issue, and would have been flagged.** It escaped only
because its author is a maintainer.

| Your PR | Write | Effect |
| --- | --- | --- |
| Finishes the issue | `Closes #123` (or `Fixes` / `Resolves`), or a sidebar link | GitHub links it and closes the issue on merge |
| Is one step towards it | `Part of #123` (or `Related to` / `Towards` / `Refs`) | The issue stays open |

Two limits stop it becoming a free pass:

- **A bare `#123` does not count.** It is a cross-reference, not a claim about
  this PR.
- **The reference must resolve to an issue.** `Refs #4147` pointing at another PR
  is not a tracking record, which is the shape three PRs in the current backlog
  have.

This makes the rule declaration-based rather than link-based, consistent with how
the type-of-change exemptions already work. Someone could write `Related to #1`
insincerely, but the same is true of ticking **Docs**, and the alternative forces
people to lie with `Closes` instead.

### CONTRIBUTING documents the process

The issue requirement, the review-state labels, and the 7-day close all shipped
without being written down, so a contributor's first encounter with any of them
was a bot comment. `CONTRIBUTING.md` now covers:

- **Every PR needs an issue**: the table above, that `Closes` is preferred when
  it applies, that a bare `#123` and a PR reference do not count, what to do when
  no issue exists yet, and the only exceptions (pure Refactor / chore, Docs,
  Test / CI).
- **Review state labels**: what `waiting-on-author` and `waiting-for-review`
  mean, that automation manages both so contributors never apply them, that
  replying clears the first and re-pings the reviewer, and that 7 days without a
  reply closes the PR reversibly via `/reopen`.
- **The 5 August 2026 cutover, stated explicitly.** Maintainers follow this
  process for new PRs; PRs opened before then are being worked through separately
  and may not carry these labels yet; and the issue rule does not apply
  retroactively, so nobody is asked to retrofit an issue onto an older PR.

That last point is load-bearing: 478 of 479 currently-open PRs carry neither
label, so a doc describing them as universal would read as "your PR has been
forgotten" to anyone with an older PR.

### The bot comment matches, and is harder to game

- opens by thanking the author instead of leading with what is missing
- states that **an issue is required for every PR**, rather than only noting one
  is absent
- lists both keyword forms with their consequences, so a partial change has a
  correct option
- promotes "open an issue first, then reference it" to its own line, since that is
  the actual ask for anyone whose change has no issue yet
- closes the exemption loophole: a bug fix, feature, or UI change needs an issue
  **even when it also touches docs or tests**. The code already enforced this (a
  tracked type beats an exempt one); the comment now says so, so ticking Docs on a
  bug fix reads as circumvention rather than interpretation.
- links to the CONTRIBUTING section for the full policy

Em dashes are removed from the contributor-facing text in the workflows added
today (`pr-issue-link`, `reopen-notice`) per house style.

## Test Plan

- `node .github/workflows/pr-issue-link.test.js` passes. New coverage: 11
  assertions on the reference parser (`Refs #N`, `Part of #N`, `Related to`,
  `Towards`, full issue URLs, cross-repo `owner/repo#N`, dedup, plus bare-mention
  and no-keyword negatives), 5 end-to-end cases for each accepted keyword, one
  proving a reference to a **PR** still flags, one proving a bare mention still
  flags, one proving an unresolvable number falls through to the next candidate,
  and three pinning the comment wording (no em dashes, the "require an issue for
  every PR" line, the anti-loophole sentence).
- `reopen-pr.test.js`, `reopen-notice.test.js`, and
  `python3 .github/scripts/waiting_on_author_test.py` (35 tests): all pass.
- **Verified against production.** #4095 (`Refs #3644`) now satisfies the rule,
  and all seven currently-flagged PRs still flag, so the change only loosens the
  rule where an author genuinely names an issue.
- Rendered the final comment body by intercepting the real write path, so the
  wording above is verbatim rather than reconstructed.
- Confirmed the CONTRIBUTING anchor the bot links to resolves to the new heading.

## Demo

N/A. Documentation, bot comment wording, and a CI predicate. No user-visible UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added or updated
- [ ] Integration / E2E tests added or updated
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

Unit tests cover the reference parser, each accepted keyword end to end, and the
comment wording. Manual verification was running the shipped script against live
GitHub for #4095 and the seven flagged PRs, rendering the comment through the real
write path, and checking the doc anchor.
