### PR TITLE
fix(python-client): fail loud when a stream opens on a redirect

### DIFF
--- a/sdks/python-client/omnigent_client/_responses.py
+++ b/sdks/python-client/omnigent_client/_responses.py
@@ -18,7 +18,13 @@ from typing import Any
 
 import httpx
 
-from ._errors import ToolCallDenied, raise_for_status, require_json_object, response_body
+from ._errors import (
+    OmnigentError,
+    ToolCallDenied,
+    raise_for_status,
+    require_json_object,
+    response_body,
+)
 from ._events import (
     ClientTaskCancel,
     CompactionCompleted,
@@ -242,6 +248,19 @@ class ResponsesNamespace:
                 if resp.status_code >= 400:
                     await resp.aread()
                     raise_for_status(resp.status_code, response_body(resp))
+                elif 300 <= resp.status_code < 400:
+                    # Redirects are disabled on this client (httpx defaults
+                    # follow_redirects=False), so a 3xx here is a proxy or
+                    # gateway hop we never followed. raise_for_status is a
+                    # no-op below 400, and parse_sse_stream over the
+                    # redirect's non-SSE body would complete with no events —
+                    # a silent, error-free, empty stream. Fail loud instead.
+                    await resp.aread()
+                    raise OmnigentError(
+                        f"stream open was redirected (status {resp.status_code}); "
+                        "this client does not follow redirects on a stream",
+                        resp.status_code,
+                    )
 
                 async for event in parse_sse_stream(resp.aiter_bytes()):
                     # ── Fire hooks and collect state ──────────

--- a/sdks/python-client/omnigent_client/_sessions.py
+++ b/sdks/python-client/omnigent_client/_sessions.py
@@ -34,7 +34,7 @@ from pydantic import TypeAdapter
 from omnigent.server.schemas import ServerStreamEvent
 
 from ._child_status import child_summary_busy
-from ._errors import raise_for_status, require_json_object, response_body
+from ._errors import OmnigentError, raise_for_status, require_json_object, response_body
 from ._timeouts import _SSE_TIMEOUT
 
 # Default recursion cap for the sub-agent tree helpers. Mirrors web's
@@ -1242,6 +1242,19 @@ async def _stream_session_events(
         if resp.status_code >= 400:
             await resp.aread()
             raise_for_status(resp.status_code, response_body(resp))
+        elif 300 <= resp.status_code < 400:
+            # Redirects are disabled on this client (httpx defaults
+            # follow_redirects=False), so a 3xx here is a proxy or gateway
+            # hop we never followed. raise_for_status is a no-op below 400,
+            # and _parse_sse_lines over the redirect's non-SSE body would
+            # complete with no events — handing the caller a silent,
+            # error-free, empty stream. Fail loud instead.
+            await resp.aread()
+            raise OmnigentError(
+                f"stream open was redirected (status {resp.status_code}); "
+                "this client does not follow redirects on a stream",
+                resp.status_code,
+            )
 
         async for event in _parse_sse_lines(resp.aiter_lines()):
             yield event

--- a/tests/frontends/sdk/test_stream_redirect_guard.py
+++ b/tests/frontends/sdk/test_stream_redirect_guard.py
@@ -1,0 +1,53 @@
+"""Regression: opening a stream on a redirect must fail loud, not empty.
+
+The SDK's ``httpx.AsyncClient`` is built with httpx's default
+``follow_redirects=False`` (see :class:`omnigent_client._client.OmnigentClient`),
+and the stream-open guard only rejected ``status >= 400``. A proxy or gateway
+answering a 3xx (e.g. a ``302``) on the stream request therefore fell through to
+the SSE parser, which found no ``data:`` frames in the redirect body and yielded
+nothing — handing the caller a silent, error-free, zero-event stream instead of
+surfacing the connection that never reached the server.
+
+``_stream_session_events`` already documents ``:raises OmnigentError: If the
+server returns a non-2xx status``; this pins the redirect half of that contract
+so the empty-stream failure mode cannot come back.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from omnigent_client._errors import OmnigentError
+from omnigent_client._sessions import _stream_session_events
+
+
+@pytest.mark.asyncio
+async def test_stream_open_on_redirect_raises_instead_of_yielding_nothing() -> None:
+    """A 302 on the stream GET raises ``OmnigentError``; it never completes empty.
+
+    Fails without the fix: the old ``status >= 400`` guard lets the 302 through,
+    ``_parse_sse_lines`` sees a body with no ``data:`` frames, and the async
+    generator finishes with zero events and no error — the exact silent failure
+    a caller cannot distinguish from "the session produced nothing".
+    """
+    seen = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # A gateway bouncing the stream elsewhere. No body — a real redirect
+        # carries none, which is precisely why the SSE parser stays silent.
+        return httpx.Response(
+            302,
+            headers={"location": "https://elsewhere.invalid/v1/sessions/conv_1/stream"},
+        )
+
+    # follow_redirects defaults to False here exactly as in OmnigentClient, so
+    # the 302 is returned to the caller rather than transparently chased.
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        with pytest.raises(OmnigentError) as excinfo:
+            async for _event in _stream_session_events(http, "https://api.invalid", "conv_1"):
+                seen += 1
+
+    # The redirect status is carried on the raised error (not swallowed), and
+    # not a single event leaked out before it was raised.
+    assert excinfo.value.status_code == 302
+    assert seen == 0


### PR DESCRIPTION
Closes #4226

## What

When opening a stream, the client silently swallows a redirect. Its `httpx.AsyncClient` is built with httpx's default `follow_redirects=False`, and the stream-open guard only rejected `status >= 400`:

```python
if resp.status_code >= 400:
    await resp.aread()
    raise_for_status(resp.status_code, response_body(resp))
```

So a proxy or gateway answering a **3xx** (e.g. `302`) on the stream request is neither followed nor rejected — it falls through to the SSE parser, which finds no `data:` frames in the redirect body and yields nothing. The caller gets a **silent, error-free, zero-event stream** and cannot tell it apart from "the session produced nothing".

`_stream_session_events` already documents `:raises OmnigentError: If the server returns a non-2xx status`, so this is the redirect half of a contract the rest of the sessions namespace already keeps.

## Fix

Reject a 3xx on the stream open at both sites — `SessionsNamespace.stream` (via `_stream_session_events`) and the deprecated `/v1/responses` stream — raising `OmnigentError` instead of decoding an empty stream. `raise_for_status` is a no-op below 400, so the redirect case needs its own arm. Redirects stay disabled rather than followed, keeping the client's credential-safety posture intact.

## Test

`tests/frontends/sdk/test_stream_redirect_guard.py` drives `_stream_session_events` with an `httpx.MockTransport` that returns a `302`, and asserts the open raises `OmnigentError` (status `302`) and yields **zero** events. It fails against the old `>= 400` guard (which completes empty, no error) and passes with the fix.

## Not in this PR

While here, `_CODE_MAP` in `_errors.py` is built inside `raise_for_status` but never read (classification is by status code) — it looks like dead code. Left out to keep this change focused; happy to send a separate cleanup.

## Credit

Spotted by @bdchatham while comparing this client against the Go client during review of #4010.
