### PR TITLE
fix(claude-native): give scheduled /loop wakes their own marked turns

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -1911,6 +1911,7 @@ def read_transcript_items_since_with_position(
     *,
     agent_name: str,
     current_response_id: str | None = None,
+    settled_response_id: str | None = None,
 ) -> TranscriptReadResult:
     """
     Read transcript items from a line cursor and return byte position.
@@ -1928,6 +1929,9 @@ def read_transcript_items_since_with_position(
         tool-call items, e.g. ``"claude-native-ui"``.
     :param current_response_id: Response id for an in-progress
         Claude assistant turn from a previous poll.
+    :param settled_response_id: Response id whose turn already ended
+        (its ``Stop`` edge posted) — assistant output inheriting it is
+        a scheduled/automatic wake and opens a new marked turn.
     :returns: Parsed items plus line and byte cursors.
     """
     read_result = _read_complete_jsonl_records(
@@ -1955,6 +1959,7 @@ def read_transcript_items_since_with_position(
             record_offset=None,
             agent_name=agent_name,
             current_response_id=active_response_id,
+            settled_response_id=settled_response_id,
         )
         items.extend(parsed)
         usage = _usage_from_transcript_entry(entry)
@@ -1980,6 +1985,7 @@ def read_transcript_items_from_offset(
     start_line: int,
     agent_name: str,
     current_response_id: str | None = None,
+    settled_response_id: str | None = None,
     include_sidechains: bool = False,
 ) -> TranscriptReadResult:
     """
@@ -2000,6 +2006,9 @@ def read_transcript_items_from_offset(
         tool-call items, e.g. ``"claude-native-ui"``.
     :param current_response_id: Response id for an in-progress
         Claude assistant turn from a previous poll.
+    :param settled_response_id: Response id whose turn already ended
+        (its ``Stop`` edge posted) — assistant output inheriting it is
+        a scheduled/automatic wake and opens a new marked turn.
     :param include_sidechains: Pass ``True`` when reading a
         sub-agent's own ``agent-<id>.jsonl`` — every record there is
         a sidechain by Claude's definition, and dropping them would
@@ -2032,6 +2041,7 @@ def read_transcript_items_from_offset(
             record_offset=record.byte_offset,
             agent_name=agent_name,
             current_response_id=active_response_id,
+            settled_response_id=settled_response_id,
             include_sidechains=include_sidechains,
         )
         items.extend(parsed)
@@ -4404,6 +4414,7 @@ def _transcript_items_from_entry(
     record_offset: int | None = None,
     agent_name: str,
     current_response_id: str | None,
+    settled_response_id: str | None = None,
     include_sidechains: bool = False,
 ) -> tuple[str | None, list[ClaudeTranscriptItem]]:
     """
@@ -4464,6 +4475,7 @@ def _transcript_items_from_entry(
             record_offset=record_offset,
             agent_name=agent_name,
             current_response_id=current_response_id,
+            settled_response_id=settled_response_id,
         )
     return current_response_id, []
 
@@ -5061,6 +5073,7 @@ def _assistant_transcript_items_from_entry(
     record_offset: int | None,
     agent_name: str,
     current_response_id: str | None,
+    settled_response_id: str | None = None,
 ) -> tuple[str | None, list[ClaudeTranscriptItem]]:
     """
     Parse a Claude ``role=assistant`` transcript entry.
@@ -5072,13 +5085,25 @@ def _assistant_transcript_items_from_entry(
     :param agent_name: Agent/model name for assistant/tool items.
     :param current_response_id: Response id for the active Claude
         assistant turn.
+    :param settled_response_id: Response id of a turn whose terminal
+        ``Stop`` edge has already been forwarded. Assistant output that
+        would inherit it proves a scheduled/automatic prompt (cron
+        firing, wakeup) started a NEW turn — those re-invocations write
+        no user transcript entry, so without this the resumed output
+        extends the finished turn forever. Such output gets a fresh
+        response id plus a leading wake marker item.
     :returns: Updated active response id and parsed assistant/tool
         items.
     """
     message = entry["message"]
     content = message.get("content") if isinstance(message, dict) else None
     source_key = _transcript_source_key(entry, line_number, record_offset)
-    response_id = current_response_id or _response_id_from_source(source_key)
+    waking = current_response_id is not None and current_response_id == settled_response_id
+    response_id = (
+        _response_id_from_source(source_key)
+        if waking
+        else current_response_id or _response_id_from_source(source_key)
+    )
     items: list[ClaudeTranscriptItem] = []
 
     if isinstance(content, str):
@@ -5092,6 +5117,12 @@ def _assistant_transcript_items_from_entry(
                     text=content,
                 )
             )
+        if waking:
+            # Consume the wake only when the entry produced output — an
+            # empty entry must not burn the fresh id on nothing.
+            if not items:
+                return current_response_id, items
+            items.insert(0, _scheduled_wake_marker_item(source_key, response_id))
         return response_id, items
 
     if not isinstance(content, list):
@@ -5137,7 +5168,35 @@ def _assistant_transcript_items_from_entry(
                     response_id=response_id,
                 )
             )
+    if waking and items:
+        items.insert(0, _scheduled_wake_marker_item(source_key, response_id))
     return response_id if items else current_response_id, items
+
+
+_SCHEDULED_WAKE_MARKER_TEXT = "[System: scheduled prompt fired]"
+
+
+def _scheduled_wake_marker_item(source_key: str, response_id: str) -> ClaudeTranscriptItem:
+    """
+    Build the turn-boundary marker for a scheduled/automatic wake.
+
+    A plain (non-meta) user item on purpose: the web classifies
+    ``[System: ...]`` text as a muted system row and splits assistant
+    bubbles on it, giving each wake its own turn and "Worked for" fold.
+
+    :param source_key: Source key of the waking assistant entry.
+    :param response_id: Fresh response id minted for the new turn.
+    :returns: The marker conversation item.
+    """
+    return ClaudeTranscriptItem(
+        source_id=_source_id(source_key, 0, "scheduled_wake"),
+        item_type="message",
+        data={
+            "role": "user",
+            "content": [{"type": "input_text", "text": _SCHEDULED_WAKE_MARKER_TEXT}],
+        },
+        response_id=response_id,
+    )
 
 
 _CONTEXT_OVERFLOW_RE = re.compile(

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -1942,6 +1942,7 @@ def read_transcript_items_since_with_position(
     )
     items: list[ClaudeTranscriptItem] = []
     active_response_id = current_response_id
+    active_settled_id = settled_response_id
     latest_usage: dict[str, int] | None = None
     latest_model: str | None = None
     for record in read_result.records:
@@ -1959,9 +1960,14 @@ def read_transcript_items_since_with_position(
             record_offset=None,
             agent_name=agent_name,
             current_response_id=active_response_id,
-            settled_response_id=settled_response_id,
+            settled_response_id=active_settled_id,
         )
         items.extend(parsed)
+        # Post-compaction output continues the SAME turn: a batch holding
+        # the compact summary AND the resumed output must not parse the
+        # resume against a still-armed settle (spurious wake marker).
+        if any(item.is_compact_summary for item in parsed):
+            active_settled_id = None
         usage = _usage_from_transcript_entry(entry)
         if usage is not None:
             latest_usage = usage
@@ -2024,6 +2030,7 @@ def read_transcript_items_from_offset(
     )
     items: list[ClaudeTranscriptItem] = []
     active_response_id = current_response_id
+    active_settled_id = settled_response_id
     latest_usage: dict[str, int] | None = None
     latest_model: str | None = None
     for record in read_result.records:
@@ -2041,10 +2048,15 @@ def read_transcript_items_from_offset(
             record_offset=record.byte_offset,
             agent_name=agent_name,
             current_response_id=active_response_id,
-            settled_response_id=settled_response_id,
+            settled_response_id=active_settled_id,
             include_sidechains=include_sidechains,
         )
         items.extend(parsed)
+        # Post-compaction output continues the SAME turn: a batch holding
+        # the compact summary AND the resumed output must not parse the
+        # resume against a still-armed settle (spurious wake marker).
+        if any(item.is_compact_summary for item in parsed):
+            active_settled_id = None
         usage = _usage_from_transcript_entry(entry)
         if usage is not None:
             latest_usage = usage

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -566,6 +566,11 @@ class TranscriptForwardState:
     :param cursor_fingerprint: Hash of bytes immediately before
         ``byte_offset``. Used to detect truncation/replacement before
         seeking into a stale offset.
+    :param settled_response_id: Response id of a turn whose terminal
+        ``Stop`` edge was posted. Assistant output still inheriting it
+        is a scheduled/automatic wake (cron / wakeup firings write no
+        user transcript entry) and opens a new marked turn. Persisted
+        so a forwarder restart inside the wake gap keeps the boundary.
     """
 
     transcript_path: Path
@@ -574,6 +579,7 @@ class TranscriptForwardState:
     current_response_id: str | None = None
     seen_source_ids: tuple[str, ...] = ()
     cursor_fingerprint: str | None = None
+    settled_response_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -651,6 +657,16 @@ class _ForwardDedupeState:
     # ``state.current_response_id`` unadvanced). ``None`` until the first
     # turn-start edge. Reset on /clear and /fork like the other baselines.
     posted_running_response_id: str | None = None
+    # Turn-settle latch driving the scheduled-wake boundary. The Stop edge
+    # records the ended turn's id as PENDING; it activates (moves to
+    # ``settled_response_id``) only once a fully-consumed transcript batch
+    # carries no assistant output for it — the turn's final message can be
+    # delta-held across polls and forward AFTER its Stop edge, and latching
+    # immediately would mis-read that tail as a scheduled wake. Assistant
+    # output inheriting the ACTIVE settled id gets a fresh turn id plus a
+    # ``[System: scheduled prompt fired]`` marker (see the bridge parser).
+    pending_settled_response_id: str | None = None
+    settled_response_id: str | None = None
     # Failed cost posts are retried by this long-running poll loop. Without a
     # retry gate, an edge 429 turns the poll interval into a request storm and
     # prevents the limiter from recovering.
@@ -1063,6 +1079,7 @@ async def forward_claude_transcript_to_session(
                         bridge_dir=bridge_dir,
                         state=hook_state,
                         retry_tracker=status_retries,
+                        dedupe=dedupe,
                         task_subjects=task_subjects,
                         task_statuses=task_statuses,
                         task_order=task_order,
@@ -2685,6 +2702,7 @@ async def _forward_available_status_events(
     bridge_dir: Path,
     state: HookForwardState,
     retry_tracker: _PostRetryTracker,
+    dedupe: _ForwardDedupeState,
     task_subjects: dict[str, str],
     task_statuses: dict[str, str],
     task_order: list[str],
@@ -2713,6 +2731,9 @@ async def _forward_available_status_events(
     :param state: Current hook cursor state.
     :param retry_tracker: In-memory retry/backoff tracker for hook
         status posts.
+    :param dedupe: Mutable per-session baseline; turn-end edges record
+        the ended turn's id on it as a pending settle (scheduled-wake
+        detection — see :func:`_promote_pending_settle`).
     :param task_subjects: Mutable map of task_id → subject text for the
         native task system, e.g. ``{"1": "Create folder 'abc'"}``.
         Updated in-place from ``TaskCreated`` hook events.
@@ -3048,6 +3069,11 @@ async def _forward_available_status_events(
             )
             return durable
         retry_tracker.clear(retry_key)
+        if response_id is not None:
+            # The turn ended — record its id as a pending settle so a later
+            # assistant entry still inheriting it is marked as a scheduled
+            # wake (see _promote_pending_settle and the bridge parser).
+            dedupe.pending_settled_response_id = response_id
         durable = next_durable
         await _write_hook_state_async(bridge_dir, durable)
     durable = HookForwardState(
@@ -3134,6 +3160,52 @@ def _turn_has_assistant_output(items: list[ClaudeTranscriptItem], response_id: s
         if item.item_type == "message" and item.data.get("role") == "assistant":
             return True
     return False
+
+
+def _promote_pending_settle(
+    dedupe: _ForwardDedupeState, items: list[ClaudeTranscriptItem]
+) -> bool:
+    """
+    Activate a pending turn settle once the transcript is quiescent.
+
+    The turn's final assistant message can be delta-held across polls and
+    forward AFTER its ``Stop`` edge posted; latching immediately would
+    mis-read that tail as a scheduled wake. Promote only when a batch
+    carries no assistant output for the pending turn.
+
+    :param dedupe: Mutable per-session dedupe/latch state.
+    :param items: Transcript items read this poll (may be empty).
+    :returns: ``True`` when the pending settle was activated.
+    """
+    pending = dedupe.pending_settled_response_id
+    if pending is None:
+        return False
+    if _turn_has_assistant_output(items, pending):
+        return False
+    dedupe.settled_response_id = pending
+    dedupe.pending_settled_response_id = None
+    return True
+
+
+def _with_settled_response_id(
+    state: TranscriptForwardState, settled_response_id: str | None
+) -> TranscriptForwardState:
+    """
+    Copy ``state`` with a different ``settled_response_id``.
+
+    :param state: Transcript cursor state to copy.
+    :param settled_response_id: Value for the copy.
+    :returns: The updated state.
+    """
+    return TranscriptForwardState(
+        transcript_path=state.transcript_path,
+        line_cursor=state.line_cursor,
+        byte_offset=state.byte_offset,
+        current_response_id=state.current_response_id,
+        seen_source_ids=state.seen_source_ids,
+        cursor_fingerprint=state.cursor_fingerprint,
+        settled_response_id=settled_response_id,
+    )
 
 
 def _compact_summary_text(item: ClaudeTranscriptItem) -> str | None:
@@ -3318,12 +3390,23 @@ async def _forward_available_items(
         is the last durable cursor so retries don't re-post successful
         items.
     """
-    result = await asyncio.to_thread(_read_transcript_items_for_state, state, agent_name)
+    if dedupe.settled_response_id is None and state.settled_response_id is not None:
+        # Restart recovery: adopt the persisted settle so a forwarder
+        # restart inside a scheduled-wake gap still marks the wake.
+        dedupe.settled_response_id = state.settled_response_id
+    result = await asyncio.to_thread(
+        _read_transcript_items_for_state, state, agent_name, dedupe.settled_response_id
+    )
     items = result.items
     if not items:
         if result.line_cursor == state.line_cursor and result.byte_offset == (
             state.byte_offset or 0
         ):
+            # Quiet poll — the transcript is fully consumed, so a pending
+            # turn settle is safe to activate (and persist) here.
+            if _promote_pending_settle(dedupe, items):
+                state = _with_settled_response_id(state, dedupe.settled_response_id)
+                await _write_forward_state_async(bridge_dir, state)
             return state
     current_response_id = result.current_response_id
     seen_source_ids = list(state.seen_source_ids)
@@ -3404,6 +3487,11 @@ async def _forward_available_items(
                 # Hard persist failure or active backoff — stop the batch
                 # here with the cursor before this item so it is retried.
                 return updated
+            # Post-compaction output continues the SAME turn (the
+            # compaction card is the boundary) — drop any settle so the
+            # resume is not mis-marked as a scheduled wake.
+            dedupe.pending_settled_response_id = None
+            dedupe.settled_response_id = None
             seen.add(item.source_id)
             seen_source_ids.append(item.source_id)
             updated = TranscriptForwardState(
@@ -3413,6 +3501,7 @@ async def _forward_available_items(
                 current_response_id=current_response_id,
                 seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
                 cursor_fingerprint=state.cursor_fingerprint,
+                settled_response_id=dedupe.settled_response_id,
             )
             await _write_forward_state_async(bridge_dir, updated)
             continue
@@ -3481,6 +3570,7 @@ async def _forward_available_items(
                     current_response_id=current_response_id,
                     seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
                     cursor_fingerprint=state.cursor_fingerprint,
+                    settled_response_id=dedupe.settled_response_id,
                 )
                 await _write_forward_state_async(bridge_dir, updated)
                 continue
@@ -3510,6 +3600,7 @@ async def _forward_available_items(
                     current_response_id=current_response_id,
                     seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
                     cursor_fingerprint=state.cursor_fingerprint,
+                    settled_response_id=dedupe.settled_response_id,
                 )
                 await _write_forward_state_async(bridge_dir, updated)
                 continue
@@ -3539,8 +3630,12 @@ async def _forward_available_items(
             current_response_id=current_response_id,
             seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
             cursor_fingerprint=state.cursor_fingerprint,
+            settled_response_id=dedupe.settled_response_id,
         )
         await _write_forward_state_async(bridge_dir, updated)
+    # Fully-consumed batch: a pending settle may activate now, provided
+    # this batch carried no assistant output for the settling turn.
+    _promote_pending_settle(dedupe, items)
     updated = TranscriptForwardState(
         transcript_path=state.transcript_path,
         line_cursor=result.line_cursor,
@@ -3548,6 +3643,7 @@ async def _forward_available_items(
         current_response_id=current_response_id,
         seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
         cursor_fingerprint=_jsonl_cursor_fingerprint(state.transcript_path, result.byte_offset),
+        settled_response_id=dedupe.settled_response_id,
     )
     await _write_forward_state_async(bridge_dir, updated)
     # POST usage AFTER items so the ring never leads the transcript.
@@ -3749,12 +3845,15 @@ def _validated_hook_state(
 def _read_transcript_items_for_state(
     state: TranscriptForwardState,
     agent_name: str,
+    settled_response_id: str | None = None,
 ) -> TranscriptReadResult:
     """
     Read transcript items using the best cursor available in ``state``.
 
     :param state: Current transcript forwarder state.
     :param agent_name: Agent/model name to stamp on mirrored output.
+    :param settled_response_id: Active turn-settle latch — assistant
+        output inheriting this id parses as a scheduled wake.
     :returns: Transcript items and updated cursors. States without a
         byte offset are migrated by one line-cursor compatibility scan.
     """
@@ -3764,6 +3863,7 @@ def _read_transcript_items_for_state(
             state.line_cursor,
             agent_name=agent_name,
             current_response_id=state.current_response_id,
+            settled_response_id=settled_response_id,
         )
     return read_transcript_items_from_offset(
         state.transcript_path,
@@ -3771,6 +3871,7 @@ def _read_transcript_items_for_state(
         start_line=state.line_cursor,
         agent_name=agent_name,
         current_response_id=state.current_response_id,
+        settled_response_id=settled_response_id,
     )
 
 
@@ -3821,6 +3922,7 @@ def _validated_transcript_state(
                 current_response_id=state.current_response_id,
                 seen_source_ids=state.seen_source_ids,
                 cursor_fingerprint=current_fingerprint,
+                settled_response_id=state.settled_response_id,
             )
         _logger.warning(
             "Claude transcript cursor missing fingerprint; skipping to end of transcript; "
@@ -5169,6 +5271,7 @@ def _read_forward_state(bridge_dir: Path) -> TranscriptForwardState | None:
     line_cursor = raw.get("line_cursor")
     byte_offset = raw.get("byte_offset")
     current_response_id = raw.get("current_response_id")
+    settled_response_id = raw.get("settled_response_id")
     cursor_fingerprint = raw.get("cursor_fingerprint")
     seen_source_ids = raw.get("seen_source_ids", [])
     if not isinstance(transcript_path, str) or not isinstance(line_cursor, int):
@@ -5179,6 +5282,8 @@ def _read_forward_state(bridge_dir: Path) -> TranscriptForwardState | None:
         return None
     if current_response_id is not None and not isinstance(current_response_id, str):
         return None
+    if settled_response_id is not None and not isinstance(settled_response_id, str):
+        settled_response_id = None
     if cursor_fingerprint is not None and not isinstance(cursor_fingerprint, str):
         return None
     if not isinstance(seen_source_ids, list) or not all(
@@ -5192,6 +5297,7 @@ def _read_forward_state(bridge_dir: Path) -> TranscriptForwardState | None:
         current_response_id=current_response_id,
         seen_source_ids=tuple(seen_source_ids),
         cursor_fingerprint=cursor_fingerprint,
+        settled_response_id=settled_response_id,
     )
 
 
@@ -5208,6 +5314,7 @@ def _write_forward_state(bridge_dir: Path, state: TranscriptForwardState) -> Non
         "transcript_path": str(state.transcript_path),
         "line_cursor": state.line_cursor,
         "current_response_id": state.current_response_id,
+        "settled_response_id": state.settled_response_id,
         "seen_source_ids": list(state.seen_source_ids),
         "updated_at": time.time(),
     }

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -571,6 +571,11 @@ class TranscriptForwardState:
         is a scheduled/automatic wake (cron / wakeup firings write no
         user transcript entry) and opens a new marked turn. Persisted
         so a forwarder restart inside the wake gap keeps the boundary.
+    :param pending_settled_response_id: Settle recorded by the ``Stop``
+        edge but not yet promoted to ``settled_response_id`` (promotion
+        waits for transcript quiescence). Persisted so a restart inside
+        that window doesn't lose the settle — the hook cursor has
+        already advanced past the Stop edge and won't re-read it.
     """
 
     transcript_path: Path
@@ -580,6 +585,7 @@ class TranscriptForwardState:
     seen_source_ids: tuple[str, ...] = ()
     cursor_fingerprint: str | None = None
     settled_response_id: str | None = None
+    pending_settled_response_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -3169,9 +3175,11 @@ def _promote_pending_settle(
     Activate a pending turn settle once the transcript is quiescent.
 
     The turn's final assistant message can be delta-held across polls and
-    forward AFTER its ``Stop`` edge posted; latching immediately would
-    mis-read that tail as a scheduled wake. Promote only when a batch
-    carries no assistant output for the pending turn.
+    forward AFTER its ``Stop`` edge posted — and a late tool result can
+    surface in a batch EARLIER than that held tail. Promote only when a
+    batch carries no item at all for the pending turn: any activity
+    means its tail may still be in flight, and promoting then would
+    mis-mark the tail as a scheduled wake.
 
     :param dedupe: Mutable per-session dedupe/latch state.
     :param items: Transcript items read this poll (may be empty).
@@ -3180,21 +3188,21 @@ def _promote_pending_settle(
     pending = dedupe.pending_settled_response_id
     if pending is None:
         return False
-    if _turn_has_assistant_output(items, pending):
+    if any(item.response_id == pending for item in items):
         return False
     dedupe.settled_response_id = pending
     dedupe.pending_settled_response_id = None
     return True
 
 
-def _with_settled_response_id(
-    state: TranscriptForwardState, settled_response_id: str | None
+def _with_settle_latch(
+    state: TranscriptForwardState, dedupe: _ForwardDedupeState
 ) -> TranscriptForwardState:
     """
-    Copy ``state`` with a different ``settled_response_id``.
+    Copy ``state`` with the dedupe's current settle-latch fields.
 
     :param state: Transcript cursor state to copy.
-    :param settled_response_id: Value for the copy.
+    :param dedupe: Latch source for both settle fields.
     :returns: The updated state.
     """
     return TranscriptForwardState(
@@ -3204,7 +3212,8 @@ def _with_settled_response_id(
         current_response_id=state.current_response_id,
         seen_source_ids=state.seen_source_ids,
         cursor_fingerprint=state.cursor_fingerprint,
-        settled_response_id=settled_response_id,
+        settled_response_id=dedupe.settled_response_id,
+        pending_settled_response_id=dedupe.pending_settled_response_id,
     )
 
 
@@ -3394,6 +3403,11 @@ async def _forward_available_items(
         # Restart recovery: adopt the persisted settle so a forwarder
         # restart inside a scheduled-wake gap still marks the wake.
         dedupe.settled_response_id = state.settled_response_id
+    if (
+        dedupe.pending_settled_response_id is None
+        and state.pending_settled_response_id is not None
+    ):
+        dedupe.pending_settled_response_id = state.pending_settled_response_id
     result = await asyncio.to_thread(
         _read_transcript_items_for_state, state, agent_name, dedupe.settled_response_id
     )
@@ -3404,8 +3418,9 @@ async def _forward_available_items(
         ):
             # Quiet poll — the transcript is fully consumed, so a pending
             # turn settle is safe to activate (and persist) here.
-            if _promote_pending_settle(dedupe, items):
-                state = _with_settled_response_id(state, dedupe.settled_response_id)
+            promoted = _promote_pending_settle(dedupe, items)
+            if promoted or dedupe.pending_settled_response_id != state.pending_settled_response_id:
+                state = _with_settle_latch(state, dedupe)
                 await _write_forward_state_async(bridge_dir, state)
             return state
     current_response_id = result.current_response_id
@@ -3502,6 +3517,7 @@ async def _forward_available_items(
                 seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
                 cursor_fingerprint=state.cursor_fingerprint,
                 settled_response_id=dedupe.settled_response_id,
+                pending_settled_response_id=dedupe.pending_settled_response_id,
             )
             await _write_forward_state_async(bridge_dir, updated)
             continue
@@ -3571,6 +3587,7 @@ async def _forward_available_items(
                     seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
                     cursor_fingerprint=state.cursor_fingerprint,
                     settled_response_id=dedupe.settled_response_id,
+                    pending_settled_response_id=dedupe.pending_settled_response_id,
                 )
                 await _write_forward_state_async(bridge_dir, updated)
                 continue
@@ -3601,6 +3618,7 @@ async def _forward_available_items(
                     seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
                     cursor_fingerprint=state.cursor_fingerprint,
                     settled_response_id=dedupe.settled_response_id,
+                    pending_settled_response_id=dedupe.pending_settled_response_id,
                 )
                 await _write_forward_state_async(bridge_dir, updated)
                 continue
@@ -3631,6 +3649,7 @@ async def _forward_available_items(
             seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
             cursor_fingerprint=state.cursor_fingerprint,
             settled_response_id=dedupe.settled_response_id,
+            pending_settled_response_id=dedupe.pending_settled_response_id,
         )
         await _write_forward_state_async(bridge_dir, updated)
     # Fully-consumed batch: a pending settle may activate now, provided
@@ -3644,6 +3663,7 @@ async def _forward_available_items(
         seen_source_ids=_bounded_seen_source_ids(seen_source_ids),
         cursor_fingerprint=_jsonl_cursor_fingerprint(state.transcript_path, result.byte_offset),
         settled_response_id=dedupe.settled_response_id,
+        pending_settled_response_id=dedupe.pending_settled_response_id,
     )
     await _write_forward_state_async(bridge_dir, updated)
     # POST usage AFTER items so the ring never leads the transcript.
@@ -3923,6 +3943,7 @@ def _validated_transcript_state(
                 seen_source_ids=state.seen_source_ids,
                 cursor_fingerprint=current_fingerprint,
                 settled_response_id=state.settled_response_id,
+                pending_settled_response_id=state.pending_settled_response_id,
             )
         _logger.warning(
             "Claude transcript cursor missing fingerprint; skipping to end of transcript; "
@@ -5272,6 +5293,7 @@ def _read_forward_state(bridge_dir: Path) -> TranscriptForwardState | None:
     byte_offset = raw.get("byte_offset")
     current_response_id = raw.get("current_response_id")
     settled_response_id = raw.get("settled_response_id")
+    pending_settled_response_id = raw.get("pending_settled_response_id")
     cursor_fingerprint = raw.get("cursor_fingerprint")
     seen_source_ids = raw.get("seen_source_ids", [])
     if not isinstance(transcript_path, str) or not isinstance(line_cursor, int):
@@ -5284,6 +5306,10 @@ def _read_forward_state(bridge_dir: Path) -> TranscriptForwardState | None:
         return None
     if settled_response_id is not None and not isinstance(settled_response_id, str):
         settled_response_id = None
+    if pending_settled_response_id is not None and not isinstance(
+        pending_settled_response_id, str
+    ):
+        pending_settled_response_id = None
     if cursor_fingerprint is not None and not isinstance(cursor_fingerprint, str):
         return None
     if not isinstance(seen_source_ids, list) or not all(
@@ -5298,6 +5324,7 @@ def _read_forward_state(bridge_dir: Path) -> TranscriptForwardState | None:
         seen_source_ids=tuple(seen_source_ids),
         cursor_fingerprint=cursor_fingerprint,
         settled_response_id=settled_response_id,
+        pending_settled_response_id=pending_settled_response_id,
     )
 
 
@@ -5315,6 +5342,7 @@ def _write_forward_state(bridge_dir: Path, state: TranscriptForwardState) -> Non
         "line_cursor": state.line_cursor,
         "current_response_id": state.current_response_id,
         "settled_response_id": state.settled_response_id,
+        "pending_settled_response_id": state.pending_settled_response_id,
         "seen_source_ids": list(state.seen_source_ids),
         "updated_at": time.time(),
     }

--- a/tests/e2e_ui/chat/test_working_indicator_reload.py
+++ b/tests/e2e_ui/chat/test_working_indicator_reload.py
@@ -655,3 +655,84 @@ def test_prior_fold_holds_through_followup_send(
 
     expect(fold.nth(1)).to_be_visible(timeout=15_000)
     assert fold.count() == 2
+
+
+def test_settled_fold_holds_through_scheduled_wake(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """
+    A /loop iteration's fold survives the next scheduled wake.
+
+    Claude-native /loop sessions resume on cron/wakeup firings with no
+    real user input; the forwarder mirrors the resume as a
+    ``[System: scheduled prompt fired]`` marker plus a fresh turn's
+    running edge. The settled iteration is still the last assistant
+    bubble through that item-less gap, and a system marker does not end
+    its possibly-live status — the shown-fold latch is what keeps the
+    trace from popping open at every iteration. Both iterations then
+    settle into their own folds.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` from the local server.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.get_by_role("textbox", name="Message the agent")).to_be_visible(timeout=20_000)
+
+    _seed_user_message(base_url, session_id, text="Watch the PR.", response_id="loop_t1")
+    _publish_status(base_url, session_id, "running", response_id="loop_t1")
+    _seed_completed_tool_call(
+        base_url,
+        session_id,
+        response_id="loop_t1",
+        call_id="call_loop_1",
+        arguments='{"command": "gh pr checks"}',
+        output="all green\n",
+    )
+    _seed_assistant_message(
+        base_url, session_id, text="Iteration 1: all green.", response_id="loop_t1"
+    )
+    _publish_status(base_url, session_id, "idle", response_id="loop_t1")
+
+    fold = page.locator(_FOLD)
+    expect(fold.first).to_be_visible(timeout=15_000)
+    # A live-streamed iteration spans one clock, so the fold carries a
+    # duration — the bare "Worked" label was the merged-bubble symptom.
+    expect(fold.first).to_contain_text("Worked for")
+    page.wait_for_timeout(1_000)
+
+    # The wake: marker mirrors, the fresh turn's running edge fires, and
+    # no items land for a while (the model is thinking).
+    _seed_user_message(
+        base_url,
+        session_id,
+        text="[System: scheduled prompt fired]",
+        response_id="loop_t2",
+    )
+    page.wait_for_timeout(300)
+    _publish_status(base_url, session_id, "running", response_id="loop_t2")
+
+    # Fold hide is undebounced, so any dip is visible within one sample.
+    for _ in range(17):
+        assert fold.count() >= 1
+        page.wait_for_timeout(150)
+
+    _seed_completed_tool_call(
+        base_url,
+        session_id,
+        response_id="loop_t2",
+        call_id="call_loop_2",
+        arguments='{"command": "gh pr checks"}',
+        output="still green\n",
+    )
+    _seed_assistant_message(
+        base_url, session_id, text="Iteration 2: still green.", response_id="loop_t2"
+    )
+    _publish_status(base_url, session_id, "idle", response_id="loop_t2")
+
+    expect(fold.nth(1)).to_be_visible(timeout=15_000)
+    assert fold.count() == 2
+    assert page.locator(_ASSISTANT_BUBBLE).count() == 2

--- a/tests/e2e_ui/chat/test_working_indicator_reload.py
+++ b/tests/e2e_ui/chat/test_working_indicator_reload.py
@@ -702,10 +702,30 @@ def test_settled_fold_holds_through_scheduled_wake(
     # A live-streamed iteration spans one clock, so the fold carries a
     # duration — the bare "Worked" label was the merged-bubble symptom.
     expect(fold.first).to_contain_text("Worked for")
-    page.wait_for_timeout(1_000)
+    # Sit past the stray-idle revive window: a real wake fires 60s+
+    # after the finalize, and only a delta INSIDE the window may revive
+    # the finished turn.
+    page.wait_for_timeout(16_000)
 
-    # The wake: marker mirrors, the fresh turn's running edge fires, and
-    # no items land for a while (the model is thinking).
+    # The wake, in live wire order: the new turn's first TEXT DELTAS
+    # stream ahead of the transcript batch (deltas-before-done), then
+    # the marker mirrors and the fresh turn's running edge fires. The
+    # early delta must not revive the FINISHED turn (the revive is for
+    # stray mid-turn idles, which are contradicted within seconds) or
+    # its fold pops open at every iteration.
+    httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={
+            "type": "external_output_text_delta",
+            "data": {"delta": "Iteration 2 starting", "message_id": "m_wake_1", "index": 0},
+        },
+        timeout=10.0,
+    ).raise_for_status()
+    page.wait_for_timeout(400)
+    # The swallowed delta must not preview into the settled bubble
+    # either — that glued the new turn's text to the old fold, breaking
+    # its eligibility and inflating its worked-for span.
+    expect(page.get_by_text("Iteration 2 starting")).to_have_count(0)
     _seed_user_message(
         base_url,
         session_id,

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -1034,6 +1034,52 @@ def test_scheduled_wake_requires_settled_turn(tmp_path: Path) -> None:
     assert result.current_response_id == "resp_live_turn"
 
 
+def test_scheduled_wake_not_marked_for_post_compaction_output(tmp_path: Path) -> None:
+    """
+    Post-compaction output in the SAME batch as the summary is no wake.
+
+    The compaction card is the boundary; the resumed output continues
+    the settled turn. A batch holding the ``isCompactSummary`` record
+    AND the resumed assistant entry must parse the resume with the
+    settle disarmed — no marker, same turn id.
+    """
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text(
+        _transcript_line(
+            {
+                "type": "user",
+                "uuid": "compact-1",
+                "isCompactSummary": True,
+                "message": {"role": "user", "content": "Summary of the prior context."},
+            }
+        )
+        + _transcript_line(_assistant_text_entry("post-compact", "continuing the task")),
+        encoding="utf-8",
+    )
+
+    result = read_transcript_items_from_offset(
+        transcript_path,
+        0,
+        start_line=0,
+        agent_name="claude-native-ui",
+        current_response_id="resp_prev_turn",
+        settled_response_id="resp_prev_turn",
+    )
+
+    texts = [
+        block.get("text")
+        for item in result.items
+        if item.item_type == "message"
+        for block in item.data["content"]
+        if isinstance(block, dict)
+    ]
+    assert claude_native_bridge._SCHEDULED_WAKE_MARKER_TEXT not in texts
+    resumed = result.items[-1]
+    assert resumed.data["role"] == "assistant"
+    assert resumed.response_id == "resp_prev_turn"
+    assert result.current_response_id == "resp_prev_turn"
+
+
 def test_scheduled_wake_skips_tool_results_and_real_prompts(tmp_path: Path) -> None:
     """
     Only assistant output triggers the wake; other entries behave as before.

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -929,6 +929,177 @@ def test_read_transcript_items_from_offset_preserves_partial_trailing_line(
     ]
 
 
+def _transcript_line(entry: dict[str, Any]) -> str:
+    """
+    Serialize one transcript entry as a JSONL line.
+
+    :param entry: Decoded transcript record.
+    :returns: The record as a newline-terminated JSON string.
+    """
+    return json.dumps(entry) + "\n"
+
+
+def _assistant_text_entry(uuid: str, text: str) -> dict[str, Any]:
+    """
+    Build a minimal assistant transcript entry.
+
+    :param uuid: Record uuid (drives deterministic ids).
+    :param text: Assistant output text.
+    :returns: The decoded transcript record.
+    """
+    return {
+        "type": "assistant",
+        "uuid": uuid,
+        "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+    }
+
+
+def test_scheduled_wake_opens_marked_turn(tmp_path: Path) -> None:
+    """
+    Assistant output inheriting a settled turn id opens a marked new turn.
+
+    Cron and wakeup firings re-invoke Claude with no user transcript
+    entry, so the resumed output would inherit the finished turn's id
+    forever. With ``settled_response_id`` set to that id, the parser
+    must mint a fresh id and prepend the scheduled-wake marker.
+    """
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text(
+        _transcript_line(_assistant_text_entry("wake-1", "iteration two output"))
+        + _transcript_line(_assistant_text_entry("wake-2", "more of iteration two")),
+        encoding="utf-8",
+    )
+
+    result = read_transcript_items_from_offset(
+        transcript_path,
+        0,
+        start_line=0,
+        agent_name="claude-native-ui",
+        current_response_id="resp_prev_turn",
+        settled_response_id="resp_prev_turn",
+    )
+
+    kinds = [item.item_type for item in result.items]
+    assert kinds == ["message", "message", "message"]
+    marker = result.items[0]
+    assert marker.data["role"] == "user"
+    assert marker.data["content"] == [
+        {"type": "input_text", "text": claude_native_bridge._SCHEDULED_WAKE_MARKER_TEXT}
+    ]
+    new_turn_id = marker.response_id
+    assert new_turn_id != "resp_prev_turn"
+    # The waking entry's output and the rest of the batch share the new id.
+    assert [item.response_id for item in result.items] == [new_turn_id] * 3
+    assert result.current_response_id == new_turn_id
+
+    # Re-reads are idempotent: same window, same ids (retries dedupe on them).
+    replay = read_transcript_items_from_offset(
+        transcript_path,
+        0,
+        start_line=0,
+        agent_name="claude-native-ui",
+        current_response_id="resp_prev_turn",
+        settled_response_id="resp_prev_turn",
+    )
+    assert [item.source_id for item in replay.items] == [item.source_id for item in result.items]
+    assert [item.response_id for item in replay.items] == [
+        item.response_id for item in result.items
+    ]
+
+
+def test_scheduled_wake_requires_settled_turn(tmp_path: Path) -> None:
+    """
+    Without a settle, post-turn assistant output inherits the active id.
+
+    Mid-turn output (including a delta-held tail flushed late) must keep
+    extending its own turn — no marker, no fresh id.
+    """
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text(
+        _transcript_line(_assistant_text_entry("tail-1", "same turn tail")),
+        encoding="utf-8",
+    )
+
+    result = read_transcript_items_from_offset(
+        transcript_path,
+        0,
+        start_line=0,
+        agent_name="claude-native-ui",
+        current_response_id="resp_live_turn",
+    )
+
+    assert [item.item_type for item in result.items] == ["message"]
+    assert result.items[0].data["role"] == "assistant"
+    assert result.items[0].response_id == "resp_live_turn"
+    assert result.current_response_id == "resp_live_turn"
+
+
+def test_scheduled_wake_skips_tool_results_and_real_prompts(tmp_path: Path) -> None:
+    """
+    Only assistant output triggers the wake; other entries behave as before.
+
+    A late tool result for the settled turn keeps that turn's id (its
+    call card pairs by id), and a REAL user prompt opens the next turn
+    the ordinary way — no wake marker anywhere.
+    """
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text(
+        _transcript_line(
+            {
+                "type": "user",
+                "uuid": "late-result",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "call_bg_1",
+                            "content": "background shell done",
+                        }
+                    ],
+                },
+            }
+        )
+        + _transcript_line(
+            {
+                "type": "user",
+                "uuid": "real-prompt",
+                "message": {"role": "user", "content": "next question"},
+            }
+        )
+        + _transcript_line(_assistant_text_entry("next-turn", "answering the question")),
+        encoding="utf-8",
+    )
+
+    result = read_transcript_items_from_offset(
+        transcript_path,
+        0,
+        start_line=0,
+        agent_name="claude-native-ui",
+        current_response_id="resp_prev_turn",
+        settled_response_id="resp_prev_turn",
+    )
+
+    texts = [
+        block.get("text")
+        for item in result.items
+        if item.item_type == "message"
+        for block in item.data["content"]
+        if isinstance(block, dict)
+    ]
+    assert claude_native_bridge._SCHEDULED_WAKE_MARKER_TEXT not in texts
+    assert [item.item_type for item in result.items] == [
+        "function_call_output",
+        "message",
+        "message",
+    ]
+    # The late result stays on the settled turn; the real prompt resets the
+    # id, so the answer opens a fresh turn without any wake involvement.
+    assert result.items[0].response_id == "resp_prev_turn"
+    assert result.items[2].data["role"] == "assistant"
+    assert result.items[2].response_id not in {"resp_prev_turn", None}
+
+
 def test_read_transcript_line_cursor_migration_preserves_legacy_source_ids(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5303,11 +5303,13 @@ def test_transcript_forward_state_persists_settled_response_id(tmp_path: Path) -
         byte_offset=64,
         current_response_id="resp_a",
         settled_response_id="resp_a",
+        pending_settled_response_id="resp_b",
     )
     forwarder._write_forward_state(bridge_dir, state)
     loaded = forwarder._read_forward_state(bridge_dir)
     assert loaded is not None
     assert loaded.settled_response_id == "resp_a"
+    assert loaded.pending_settled_response_id == "resp_b"
 
     raw = json.loads((bridge_dir / forwarder._FORWARDER_STATE_FILE).read_text("utf-8"))
     del raw["settled_response_id"]
@@ -5338,14 +5340,25 @@ def test_promote_pending_settle_waits_for_turn_quiescence() -> None:
     assert dedupe.settled_response_id is None
     assert dedupe.pending_settled_response_id == "resp_a"
 
-    # A late tool result is not assistant output — it must not defer.
+    # A late tool result also defers: it can surface EARLIER than the
+    # held assistant tail, and promoting on it would mis-mark that tail.
     late_result = ClaudeTranscriptItem(
         source_id="s2:0:function_call_output",
         item_type="function_call_output",
         data={"call_id": "c1", "output": "done"},
         response_id="resp_a",
     )
-    assert forwarder._promote_pending_settle(dedupe, [late_result]) is True
+    assert forwarder._promote_pending_settle(dedupe, [late_result]) is False
+    assert dedupe.pending_settled_response_id == "resp_a"
+
+    # Items for OTHER turns don't defer; a truly quiet batch promotes.
+    other = ClaudeTranscriptItem(
+        source_id="s3:0:message",
+        item_type="message",
+        data={"role": "assistant", "content": [{"type": "output_text", "text": "hi"}]},
+        response_id="resp_b",
+    )
+    assert forwarder._promote_pending_settle(dedupe, [other]) is True
     assert dedupe.settled_response_id == "resp_a"
     assert dedupe.pending_settled_response_id is None
 

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5288,6 +5288,188 @@ def test_delta_forward_state_round_trips(tmp_path: Path) -> None:
     assert forwarder._read_delta_forward_state(bridge_dir).byte_offset == 512
 
 
+def test_transcript_forward_state_persists_settled_response_id(tmp_path: Path) -> None:
+    """
+    The turn-settle latch survives a forwarder restart via the cursor file.
+
+    A restart inside a scheduled-wake gap must still mark the wake; a
+    pre-latch state file (no ``settled_response_id`` key) loads as None.
+    """
+    bridge_dir = prepare_bridge_dir("conv_x", bridge_id="b2", workspace=tmp_path)
+    transcript = tmp_path / "session.jsonl"
+    state = forwarder.TranscriptForwardState(
+        transcript_path=transcript,
+        line_cursor=3,
+        byte_offset=64,
+        current_response_id="resp_a",
+        settled_response_id="resp_a",
+    )
+    forwarder._write_forward_state(bridge_dir, state)
+    loaded = forwarder._read_forward_state(bridge_dir)
+    assert loaded is not None
+    assert loaded.settled_response_id == "resp_a"
+
+    raw = json.loads((bridge_dir / forwarder._FORWARDER_STATE_FILE).read_text("utf-8"))
+    del raw["settled_response_id"]
+    (bridge_dir / forwarder._FORWARDER_STATE_FILE).write_text(json.dumps(raw), "utf-8")
+    legacy = forwarder._read_forward_state(bridge_dir)
+    assert legacy is not None
+    assert legacy.settled_response_id is None
+
+
+def test_promote_pending_settle_waits_for_turn_quiescence() -> None:
+    """
+    A pending settle activates only once its turn has no output in flight.
+
+    The turn's final message can be delta-held across polls and forward
+    AFTER its Stop edge posted — promoting while that batch still
+    carries the turn's output would mis-read the tail as a scheduled
+    wake and split the answer into a phantom new turn.
+    """
+    dedupe = forwarder._ForwardDedupeState()
+    dedupe.pending_settled_response_id = "resp_a"
+    tail = ClaudeTranscriptItem(
+        source_id="s1:0:message",
+        item_type="message",
+        data={"role": "assistant", "content": [{"type": "output_text", "text": "tail"}]},
+        response_id="resp_a",
+    )
+    assert forwarder._promote_pending_settle(dedupe, [tail]) is False
+    assert dedupe.settled_response_id is None
+    assert dedupe.pending_settled_response_id == "resp_a"
+
+    # A late tool result is not assistant output — it must not defer.
+    late_result = ClaudeTranscriptItem(
+        source_id="s2:0:function_call_output",
+        item_type="function_call_output",
+        data={"call_id": "c1", "output": "done"},
+        response_id="resp_a",
+    )
+    assert forwarder._promote_pending_settle(dedupe, [late_result]) is True
+    assert dedupe.settled_response_id == "resp_a"
+    assert dedupe.pending_settled_response_id is None
+
+    # Idempotent once promoted.
+    assert forwarder._promote_pending_settle(dedupe, []) is False
+
+
+@pytest.mark.asyncio
+async def test_scheduled_wake_forwards_marker_and_new_running_edge(tmp_path: Path) -> None:
+    """
+    The full wake pipeline: settle → quiet-poll promote → marked new turn.
+
+    Poll 1 forwards a turn; its Stop edge records the pending settle
+    (covered by the status-events test — recorded directly here). Poll 2
+    is quiet and promotes the settle, persisting it. Poll 3 sees new
+    assistant entries — a cron firing writes no user entry — and must
+    POST a fresh turn-start ``running`` edge plus the scheduled-wake
+    marker ahead of the resumed output, all under a new response id.
+    """
+    bridge_dir = tmp_path / "bridge"
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "uuid": "iter-one",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "Iteration 1: all green."}],
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    state = forwarder.TranscriptForwardState(
+        transcript_path=transcript_path,
+        line_cursor=0,
+        byte_offset=0,
+        cursor_fingerprint=forwarder._jsonl_cursor_fingerprint(transcript_path, 0),
+    )
+    requests: list[dict[str, Any]] = []
+
+    def _handle_request(request: httpx.Request) -> httpx.Response:
+        """
+        Accept every forwarder POST, recording its payload.
+
+        :param request: Outbound HTTP request from the forwarder.
+        :returns: HTTP 202 for the mock Omnigent endpoint.
+        """
+        payload = json.loads(request.content.decode("utf-8"))
+        assert isinstance(payload, dict)
+        requests.append(payload)
+        return httpx.Response(202, json={})
+
+    transport = httpx.MockTransport(_handle_request)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        dedupe = forwarder._ForwardDedupeState()
+        after_turn = await forwarder._forward_available_items(
+            client=client,
+            session_id="conv_abc",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            state=state,
+            retry_tracker=forwarder._PostRetryTracker(),
+            dedupe=dedupe,
+        )
+        turn_one_id = after_turn.current_response_id
+        assert turn_one_id is not None
+
+        # The turn ends: the Stop edge records the pending settle.
+        dedupe.pending_settled_response_id = turn_one_id
+        quiet = await forwarder._forward_available_items(
+            client=client,
+            session_id="conv_abc",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            state=after_turn,
+            retry_tracker=forwarder._PostRetryTracker(),
+            dedupe=dedupe,
+        )
+        assert dedupe.settled_response_id == turn_one_id
+        assert quiet.settled_response_id == turn_one_id
+
+        # A cron firing appends assistant output with NO user entry.
+        with transcript_path.open("a", encoding="utf-8") as handle:
+            handle.write(
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "uuid": "iter-two",
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": "Iteration 2: still green."}],
+                        },
+                    }
+                )
+                + "\n"
+            )
+        requests.clear()
+        await forwarder._forward_available_items(
+            client=client,
+            session_id="conv_abc",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            state=quiet,
+            retry_tracker=forwarder._PostRetryTracker(),
+            dedupe=dedupe,
+        )
+
+    kinds = [request["type"] for request in requests]
+    assert kinds[0] == "external_session_status"
+    running = requests[0]["data"]
+    wake_turn_id = running["response_id"]
+    assert running["status"] == "running"
+    assert wake_turn_id != turn_one_id
+    items = [r["data"] for r in requests if r["type"] == "external_conversation_item"]
+    assert [item["item_data"]["role"] for item in items] == ["user", "assistant"]
+    assert items[0]["item_data"]["content"] == [
+        {"type": "input_text", "text": "[System: scheduled prompt fired]"}
+    ]
+    assert {item["response_id"] for item in items} == {wake_turn_id}
+
+
 async def test_post_external_output_text_delta_sends_expected_payload(tmp_path: Path) -> None:
     """
     The single-delta POST helper sends the canonical event body.
@@ -7164,6 +7346,7 @@ async def test_standalone_hook_persist_failure_holds_cursor_for_retry(
                 bridge_dir=bridge_dir,
                 state=state,
                 retry_tracker=_PostRetryTracker(),
+                dedupe=forwarder._ForwardDedupeState(),
                 task_subjects={},
                 task_statuses={},
                 task_order=[],
@@ -7522,6 +7705,7 @@ async def test_forward_status_events_stamps_response_id_on_idle(tmp_path: Path) 
         return httpx.Response(200, json={})
 
     transport = httpx.MockTransport(handler)
+    dedupe = forwarder._ForwardDedupeState()
     async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
         hook_state = await forwarder._ensure_hook_state(
             bridge_dir, start_at_end=False, session_id="conv_abc"
@@ -7532,11 +7716,17 @@ async def test_forward_status_events_stamps_response_id_on_idle(tmp_path: Path) 
             bridge_dir=bridge_dir,
             state=hook_state,
             retry_tracker=forwarder._PostRetryTracker(),
+            dedupe=dedupe,
             task_subjects={},
             task_statuses={},
             task_order=[],
             response_id="resp_turn_1",
         )
+
+    # The posted turn-end edge records the turn as a PENDING settle for
+    # scheduled-wake detection (it activates once the transcript is quiet).
+    assert dedupe.pending_settled_response_id == "resp_turn_1"
+    assert dedupe.settled_response_id is None
 
     assert bodies == [
         {

--- a/web/src/components/blocks/BlockRenderer.test.tsx
+++ b/web/src/components/blocks/BlockRenderer.test.tsx
@@ -696,6 +696,75 @@ describe("BlockRenderer dispatch", () => {
       await waitFor(() => expect(screen.queryByText("Checking the CLI.")).toBeNull());
     });
 
+    it("keeps a shown fold through a scheduled wake's running edge", async () => {
+      // A /loop iteration ends, folds, and minutes later a cron/wakeup
+      // firing flips the session to running while this settled bubble is
+      // still the last one (the new turn has no items yet). The shown
+      // fold must hold through that item-less gap instead of popping
+      // open every iteration.
+      const items: RenderItem[] = [
+        { kind: "text", itemId: "m0", text: "Polling CI.", final: true },
+        tool(1, "Bash"),
+        { kind: "text", itemId: "m1", text: "All green this round.", final: true },
+      ];
+      const view = (status: "running" | "idle") => (
+        <FileViewerContext.Provider value={FILE_VIEWER_NOOP}>
+          <BlockRenderer
+            items={items}
+            sessionStatus={status}
+            turnLifecycle="completed"
+            isLastAssistant
+            showsWorking={status === "running"}
+          />
+        </FileViewerContext.Provider>
+      );
+      const { rerender } = render(view("idle"));
+      await waitFor(() => expect(screen.getByTestId("turn-worked-fold")).toBeDefined());
+
+      rerender(view("running"));
+      expect(screen.getByTestId("turn-worked-fold")).toBeDefined();
+      // Structural, not timing: the fold stays across further renders.
+      rerender(view("running"));
+      expect(screen.getByTestId("turn-worked-fold")).toBeDefined();
+      expect(screen.queryByText("Polling CI.")).toBeNull();
+    });
+
+    it("a revive clears the latch and restores live-turn suppression", async () => {
+      // If this bubble's OWN turn goes live again (a stray idle's
+      // revive), the trace re-expands, and a later mid-turn settled
+      // misread goes back to being suppressed — the latch must not
+      // carry across a revive and resurrect the codex flicker.
+      const items: RenderItem[] = [
+        { kind: "text", itemId: "m0", text: "Working through it.", final: true },
+        tool(1, "Bash"),
+        { kind: "text", itemId: "m1", text: "Done for now.", final: true },
+      ];
+      const view = (lifecycle: "completed" | "streaming", status: "running" | "idle") => (
+        <FileViewerContext.Provider value={FILE_VIEWER_NOOP}>
+          <BlockRenderer
+            items={items}
+            sessionStatus={status}
+            turnLifecycle={lifecycle}
+            isLastAssistant
+          />
+        </FileViewerContext.Provider>
+      );
+      const { rerender } = render(view("completed", "idle"));
+      await waitFor(() => expect(screen.getByTestId("turn-worked-fold")).toBeDefined());
+
+      // The turn revives — trace expands immediately.
+      rerender(view("streaming", "running"));
+      expect(screen.queryByTestId("turn-worked-fold")).toBeNull();
+      expect(screen.getByText("Working through it.")).toBeDefined();
+
+      // A settled misread while the session still runs stays suppressed.
+      rerender(view("completed", "running"));
+      await new Promise((resolve) => {
+        setTimeout(resolve, 700);
+      });
+      expect(screen.queryByTestId("turn-worked-fold")).toBeNull();
+    });
+
     it("holds the mount fold over a just-active trace so a live edge can cancel it", () => {
       // A reload can land inside a step-wise turn's between-step gap,
       // where the snapshot reads settled although the turn continues.

--- a/web/src/components/blocks/BlockRenderer.tsx
+++ b/web/src/components/blocks/BlockRenderer.tsx
@@ -399,9 +399,16 @@ export function BlockRenderer({
   showsWorking = false,
 }: BlockRendererProps) {
   const isAgentActive = sessionStatus === "running" || sessionStatus === "waiting";
-  const isTurnLive =
-    (turnLifecycle !== undefined ? turnLifecycle === "streaming" : isAgentActive) ||
-    (isLastAssistant && showsWorking);
+  // The bubble's OWN turn is live (streaming into it). Distinct from
+  // POSSIBLY live below: only this clears the shown-fold latch.
+  const isOwnTurnLive = turnLifecycle !== undefined ? turnLifecycle === "streaming" : isAgentActive;
+  // The last assistant bubble while the session works or parks on an
+  // elicitation MAY be the live turn even when its lifecycle reads
+  // settled (a mid-turn (re)connect can miss the edge that names the
+  // turn) — treat it as live for render affordances and fold gating.
+  const possiblyLive =
+    isLastAssistant && (showsWorking || sessionStatus === "running" || hasPendingElicitation);
+  const isTurnLive = isOwnTurnLive || possiblyLive;
 
   // Fold a turn that did work AND either answered here or continues in a
   // later bubble: the trace collapses behind the "Worked for" row, exempt
@@ -415,14 +422,19 @@ export function BlockRenderer({
   // to await sub-agents), and it keeps a stray narration- or
   // reasoning-only fragment of a split turn from folding into a lone
   // "Worked" row with nothing behind it.
+  // Once the fold has SHOWN on a settled bubble, possibly-live no
+  // longer reopens it. A scheduled wake (a /loop cron or wakeup
+  // firing) flips the session to running — Working shimmer included —
+  // while the settled bubble is still the last one and the new turn
+  // has no items yet; without the latch that item-less gap popped the
+  // fold open every iteration. Only this bubble's OWN turn going live
+  // again (a revive) clears the latch and re-expands the trace.
+  const foldLatchedRef = useRef(false);
   const foldEligible =
-    !isTurnLive &&
-    // The last assistant bubble of a RUNNING session — or one parked on
-    // a pending elicitation — is (or may be) the live turn even when its
-    // lifecycle reads settled: a mid-turn (re)connect can miss the edge
-    // that names the turn. Never fold it until the session settles AND
-    // the card is answered; the terminal status edge folds it.
-    !(isLastAssistant && (sessionStatus === "running" || hasPendingElicitation)) &&
+    !isOwnTurnLive &&
+    // Never fold a possibly-live bubble whose fold hasn't shown yet:
+    // the terminal status edge is what folds it (see possiblyLive).
+    (!possiblyLive || foldLatchedRef.current) &&
     !isProvisionalTrace(items) &&
     process.length > 0 &&
     (final.length > 0 || (continued && process.some(isToolItem)));
@@ -470,6 +482,8 @@ export function BlockRenderer({
   useEffect(() => {
     mountedRef.current = true;
     foldShownRef.current = showFold;
+    if (isOwnTurnLive) foldLatchedRef.current = false;
+    else if (showFold) foldLatchedRef.current = true;
   });
 
   if (showFold) {

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -50,6 +50,7 @@ import { type ChildSessionInfo, childSessionsQueryKey } from "@/hooks/useChildSe
 import {
   consumePendingInitialPrompt,
   handleSessionEvent,
+  isStaleCompletedResponse,
   reviveStrayCompletedResponse,
   initChatStore,
   pumpStreamEvents,
@@ -2309,6 +2310,7 @@ describe("chatStore — send while streaming (queueing)", () => {
       responseId: "resp_in_flight",
       state: "completed",
       error: null,
+      completedAt: expect.any(Number),
     });
 
     // The turn was actually still live — its next delta revives it, and
@@ -2321,6 +2323,7 @@ describe("chatStore — send while streaming (queueing)", () => {
       responseId: "resp_in_flight",
       state: "streaming",
       error: null,
+      completedAt: expect.any(Number),
     });
     expect(useChatStore.getState().sessionStatus).toBe("running");
     expect(useChatStore.getState().status).toBe("idle");
@@ -2347,6 +2350,7 @@ describe("chatStore — send while streaming (queueing)", () => {
       responseId: "resp_a",
       state: "completed",
       error: null,
+      completedAt: expect.any(Number),
     });
   });
 
@@ -2398,6 +2402,62 @@ describe("chatStore — send while streaming (queueing)", () => {
     reviveStrayCompletedResponse(useChatStore.setState);
     expect(useChatStore.getState().activeResponse).toBeNull();
     expect(useChatStore.getState().sessionStatus).toBe("idle");
+  });
+
+  it("gates the revive to a window after the finalize", () => {
+    // A scheduled wake's first deltas stream ahead of the batch that
+    // names the new turn; reviving the minutes-old finished turn
+    // popped its "Worked for" fold open at every /loop iteration. A
+    // finalize moments ago is a plausible stray idle and still revives.
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      sessionStatus: "idle",
+      activeResponse: {
+        responseId: "resp_prev_iter",
+        state: "completed",
+        error: null,
+        completedAt: Date.now() - 60_000,
+      },
+    });
+    reviveStrayCompletedResponse(useChatStore.setState);
+    expect(useChatStore.getState().activeResponse?.state).toBe("completed");
+    expect(useChatStore.getState().sessionStatus).toBe("idle");
+
+    useChatStore.setState({
+      activeResponse: {
+        responseId: "resp_live",
+        state: "completed",
+        error: null,
+        completedAt: Date.now() - 1_000,
+      },
+    });
+    reviveStrayCompletedResponse(useChatStore.setState);
+    expect(useChatStore.getState().activeResponse?.state).toBe("streaming");
+    expect(useChatStore.getState().sessionStatus).toBe("running");
+  });
+
+  it("isStaleCompletedResponse: only an old finalize is stale", () => {
+    const base = { responseId: "r", error: null } as const;
+    expect(
+      isStaleCompletedResponse({
+        activeResponse: { ...base, state: "completed", completedAt: Date.now() - 60_000 },
+      }),
+    ).toBe(true);
+    expect(
+      isStaleCompletedResponse({
+        activeResponse: { ...base, state: "completed", completedAt: Date.now() - 1_000 },
+      }),
+    ).toBe(false);
+    // No stamp (legacy snapshot) and non-completed states are never stale.
+    expect(isStaleCompletedResponse({ activeResponse: { ...base, state: "completed" } })).toBe(
+      false,
+    );
+    expect(
+      isStaleCompletedResponse({
+        activeResponse: { ...base, state: "streaming", completedAt: Date.now() - 60_000 },
+      }),
+    ).toBe(false);
+    expect(isStaleCompletedResponse({ activeResponse: null })).toBe(false);
   });
 });
 
@@ -3182,6 +3242,7 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
         responseId: "resp_live",
         state: "completed",
         error: null,
+        completedAt: expect.any(Number),
       });
     });
 

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -4451,6 +4451,7 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
         responseId: "resp_1",
         state: "cancelled",
         error: null,
+        completedAt: expect.any(Number),
       });
     });
 
@@ -7656,6 +7657,7 @@ describe("chatStore — live delta streaming (claude-native)", () => {
       responseId: "codex_turn_123",
       state: "cancelled",
       error: null,
+      completedAt: expect.any(Number),
     });
     expect(state.interruptedResponseIds).toEqual(["codex_turn_123"]);
     useChatStore.setState({ activeResponse: null });

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -2681,13 +2681,19 @@ function reconnectStatusPatch(session: Session, s: ChatState): Partial<ChatState
       ...s.activeResponse,
       state: session.status === "failed" ? "failed" : "completed",
       error: null,
+      completedAt: Date.now(),
     };
     patch.status = "idle";
   } else if (session.status === "waiting") {
     // Turn ended, background work remains. Finalize a still-streaming response
     // and free the local send lifecycle so the composer dispatches a new turn.
     if (s.activeResponse?.state === "streaming") {
-      patch.activeResponse = { ...s.activeResponse, state: "completed", error: null };
+      patch.activeResponse = {
+        ...s.activeResponse,
+        state: "completed",
+        error: null,
+        completedAt: Date.now(),
+      };
     }
     patch.status = "idle";
   } else if (
@@ -3433,13 +3439,23 @@ async function* tapLiveDeltas(
   for await (const ev of events) {
     if (ev.type === "text_delta" && ev.messageId !== undefined) {
       if (get().conversationId === id && !retired.has(ev.messageId)) {
+        // A scheduled wake streams its first deltas ahead of the batch
+        // that names the new turn. They must not preview into the
+        // PREVIOUS turn's bubble (anonymous blocks glue to the trailing
+        // group — killing its fold and inflating its worked-for span):
+        // retire the message so its text renders only via the
+        // authoritative item, which lands in the new turn's bubble.
+        if (isStaleCompletedResponse(get())) {
+          retired.add(ev.messageId);
+          continue;
+        }
         reviveStrayCompletedResponse(set);
         applyLiveDelta(set, ev.messageId, ev.index ?? 0, ev.delta, lastIndex);
       }
       continue;
     }
     if (ev.type === "tool_output_delta") {
-      if (get().conversationId === id) {
+      if (get().conversationId === id && !isStaleCompletedResponse(get())) {
         reviveStrayCompletedResponse(set);
         applyLiveToolOutputDelta(set, ev.callId, ev.delta);
       }
@@ -3495,9 +3511,30 @@ export function adoptTrailingUnattributedBlocks(
   return next;
 }
 
+// How long after a terminal edge a delta still revives the turn. A
+// STRAY mid-turn idle is contradicted by the still-flowing stream
+// within seconds; a scheduled wake (cron / wakeup fires at 60s
+// minimum) streams its FIRST deltas ahead of the transcript batch that
+// names the new turn — reviving the finished turn then popped its
+// "Worked for" fold open at the start of every /loop iteration.
+const REVIVE_WINDOW_MS = 15_000;
+
+/**
+ * Whether the finished turn is too old for a delta to plausibly belong
+ * to it — such deltas open the NEXT turn (a scheduled wake).
+ */
+export function isStaleCompletedResponse(s: { activeResponse: ActiveResponse | null }): boolean {
+  return (
+    s.activeResponse?.state === "completed" &&
+    s.activeResponse.completedAt !== undefined &&
+    Date.now() - s.activeResponse.completedAt > REVIVE_WINDOW_MS
+  );
+}
+
 export function reviveStrayCompletedResponse(set: Setter): void {
   set((s) => {
     if (s.activeResponse?.state !== "completed") return {};
+    if (isStaleCompletedResponse(s)) return {};
     // The delta also proves the SESSION is mid-turn: restore the busy
     // signal the stray idle edge cleared, so send gating
     // (shouldQueueSend) queues instead of firing into the live turn and
@@ -4339,6 +4376,7 @@ export function handleSessionEvent(event: StreamEvent): void {
                 responseId: event.responseId,
                 state: event.status === "failed" ? "failed" : "completed",
                 error: null,
+                completedAt: Date.now(),
               };
             }
           } else {
@@ -4360,6 +4398,7 @@ export function handleSessionEvent(event: StreamEvent): void {
                 ...s.activeResponse,
                 state: event.status === "failed" ? "failed" : "completed",
                 error: null,
+                completedAt: Date.now(),
               };
             }
           }

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -4941,7 +4941,7 @@ function finalizeCurrentActive(state: ActiveResponse["state"], responseIdOverrid
     if (s.activeResponse === null && responseIdOverride === undefined) return {};
     const responseId = s.activeResponse?.responseId ?? responseIdOverride ?? "";
     return {
-      activeResponse: { responseId, state, error: null },
+      activeResponse: { responseId, state, error: null, completedAt: Date.now() },
     };
   });
 }
@@ -4966,7 +4966,7 @@ function finalizeActive(
     if (s.activeResponse === null && !responseIdOverride) return {};
     const responseId = s.activeResponse?.responseId ?? responseIdOverride ?? "";
     return {
-      activeResponse: { responseId, state, error },
+      activeResponse: { responseId, state, error, completedAt: Date.now() },
     };
   });
 }

--- a/web/src/store/types.ts
+++ b/web/src/store/types.ts
@@ -21,4 +21,9 @@ export interface ActiveResponse {
   /** Free-form error message (HTTP error, parse error, abort). Empty
    *  for non-failure states. */
   error: string | null;
+  /** Epoch ms when a terminal edge finalized the turn. Bounds the
+   *  stray-idle revive: deltas shortly after a finalize contradict it
+   *  (revive); a scheduled wake's deltas arrive minutes later and
+   *  belong to the NEXT turn (no revive). */
+  completedAt?: number;
 }


### PR DESCRIPTION
<!-- AI-written description following the repo template. -->

## Related issue

N/A

## Summary

Claude-native `/loop`-style sessions (a cron or `ScheduleWakeup` re-invoking the agent every N minutes) rendered every iteration into one ever-growing chat bubble: cron/wakeup firings write **no user entry** to Claude Code's transcript, so each iteration's output inherited the finished turn's response id. The visible symptoms were the ones this PR fixes:

- The turn fold read a bare **"Worked"** with no duration (the merged bubble's first/last blocks sit on different clocks, so no span can be computed).
- The whole accumulated trace **popped open at every iteration** and re-collapsed when it settled — the fold never stayed closed while the loop ran.

Three coordinated changes give each iteration its own turn and keep settled folds closed:

- **Forwarder settle latch** (`claude_native_forwarder.py`): a turn's `Stop` edge records its response id as a *pending* settle; it activates only once a fully-consumed transcript batch carries no more output for that turn (the final message can be delta-held across polls and flush *after* Stop — latching instantly would misread the turn's own tail as a wake). Persisted in the transcript cursor for restart recovery; cleared on compaction, whose resume continues the same turn.
- **Bridge wake marker** (`claude_native_bridge.py`): assistant output that still inherits a settled id is a scheduled wake — it gets a fresh response id and a leading `[System: scheduled prompt fired]` user item. The marker renders as a muted system row, splits bubbles (so each iteration folds as its own "Worked for Xs"), and stays off the turn rail. Real user prompts, late tool results for the settled turn, task notifications, and compaction resumes are all explicitly unaffected.
- **Web fold latch + delta gate** (`BlockRenderer.tsx`, `chatStore.ts`): a fold that has shown is latched — the possibly-live suppression (session running, Working shimmer, parked elicitation) can no longer reopen it during the item-less wake gap; only the bubble's own turn resuming clears it. Terminal edges now stamp `completedAt` on the active response, and a delta arriving past the revive window (stray mid-turn idles are contradicted within seconds; wakes fire at 60s minimum) neither revives the finished turn nor previews into its bubble — the message is retired and its text lands via the authoritative item in the new turn's bubble.

ELI5: when a loop ticks, Claude just starts talking again without anyone pressing enter. The chat used to glue that onto the previous answer and yank its "Worked for" drawer open every minute. Now each tick gets a little "scheduled prompt fired" divider, its own drawer with a real duration, and old drawers stay shut.

```
Before (one merged bubble):          After (per-iteration turns):
  ┌─ assistant ────────────┐          ┌─ assistant ─────────────┐
  │ iter 1 work + answer   │          │ Worked for 8s ▸         │
  │ iter 2 work + answer   │          │ Iteration 1: all green. │
  │ iter 3 work + answer   │          └─────────────────────────┘
  │ Worked ▸  (no duration,│           [System: scheduled prompt fired]
  │  pops open every tick) │          ┌─ assistant ─────────────┐
  └────────────────────────┘          │ Worked for 5s ▸         │
                                      │ Iteration 2: all green. │
                                      └─────────────────────────┘
```

## Test Plan

- **Bridge units** (`test_claude_native_bridge.py`): wake mints a fresh id + marker with deterministic/idempotent source ids; no settle ⇒ no wake (delta-held tails keep extending their turn); tool results keep the settled turn's id and real user prompts open turns the ordinary way with no marker.
- **Forwarder units** (`test_claude_native_forwarder.py`): the Stop edge records a pending settle; promotion waits for turn quiescence; the settle round-trips through the persisted cursor (legacy state files load as None); full pipeline test — settle → quiet-poll promote → wake batch POSTs a fresh running edge + marker + items under the new id.
- **Web units**: BlockRenderer latch (shown fold survives a wake's running edge incl. `showsWorking`; a revive re-expands and restores suppression; never-shown folds stay suppressed); chatStore revive gate (`completedAt` truth table, stale finalize doesn't revive, fresh one does).
- **E2E** (`test_settled_fold_holds_through_scheduled_wake`, events API, no LLM): settled fold with a duration label → early wake delta (swallowed, no preview into the settled bubble, no revive after the window) → marker + running edge → fold sampled through the item-less gap with no dip → second iteration folds. Whole file (10 tests) passes.
- **Live end-to-end**: real Claude Code TUI via `omnigent claude` with a real every-minute cron. Watched the actual page across iterations sampling every 300ms: markers appear each tick, each iteration folds as its own "Worked for Xs" (5s/8s/4s/3s/5s — no bare "Worked"), and fold count never dipped (previously it dipped at the start of every iteration).

## Demo

Live-verified timeline from a real claude-native cron loop (screenshots intentionally not committed — repo images directory excluded by maintainer request):

```
baseline: folds=3  markers=4
 33.6s   marker #5 appears (wake) — all prior folds stay closed
 37.0s   iteration folds: 4 folds, label "Worked for 3s"
104.3s   marker #6 appears — no dip
110.7s   iteration folds: 5 folds, label "Worked for 5s"
dips (settled fold popped open): NONE
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: launched a real `omnigent claude` TUI session against a dev server built from this branch, armed a genuine every-minute cron in it, and drove a headless browser sampling the live page every 300ms across multiple iterations — asserting fold monotonicity (no settled fold ever popped open), per-iteration markers/bubbles, and duration-bearing fold labels. Existing sessions keep their already-merged history; only iterations mirrored after this forwarder runs gain boundaries.

## Changelog

Scheduled /loop iterations in claude-native sessions now render as separate turns with their own "Worked for" folds that stay closed between ticks

This pull request and its description were written by Isaac.
