### PR TITLE
fix(cli): point runner tunnel rejection hint to stop

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1802,20 +1802,21 @@ def main() -> None:
     from omnigent.cli_diagnostics import (
         log_cli_error_hint,
         log_cli_exception,
-        print_setup_hint,
+        print_stale_host_hint,
         setup_cli_logging,
     )
 
     setup_cli_logging(argv)
 
-    # ``omnigent setup`` IS the setup wizard — if it fails, telling the
-    # user to "run omnigent setup" would be circular. ``upgrade`` (and its
-    # ``update`` alias) is excluded too: its failures (unreachable index,
-    # dev checkout, install error) are never about a missing model
-    # credential, so the setup hint would only mislead. ``integration``
-    # likewise: its errors (package not installed, daemon not running) have
-    # nothing to do with model credentials.
-    suggest_setup = argv[0] not in {"setup", "update", "upgrade", "integration"}
+    # Do not recommend the off-switch when it is already running. Commands
+    # unrelated to runner startup are excluded to avoid a misleading hint.
+    suggest_stale_host_recovery = argv[0] not in {
+        "integration",
+        "setup",
+        "stop",
+        "update",
+        "upgrade",
+    }
 
     # Lightweight update notice: only on an interactive terminal and only
     # for user-facing commands. Reads a cached "latest PyPI version" and
@@ -1839,8 +1840,8 @@ def main() -> None:
     except click.ClickException as exc:
         log_cli_exception(exc, prefix="Click CLI error")
         exc.show()
-        if suggest_setup:
-            print_setup_hint()
+        if suggest_stale_host_recovery:
+            print_stale_host_hint()
         raise SystemExit(exc.exit_code) from exc
     except click.Abort as exc:
         # Ctrl+C / user cancel — no hint, the user knows what they did.
@@ -1852,8 +1853,8 @@ def main() -> None:
         # always-on CLI log has more context than this single crash — then
         # hand off to the friendly crash handler for the calm screen,
         # de-emphasized traceback, and the bug-filing prompt. We drop the
-        # `omnigent setup` hint here: genuine crashes are rarely auth issues,
-        # and "run setup" would contradict the crash screen's reassurance.
+        # stale-host hint here: genuine crashes are not runner startup failures,
+        # and recovery advice would contradict the crash screen's reassurance.
         # `handle_crash` renders the UX and we exit with code 1 (SystemExit
         # does NOT re-trigger sys.excepthook, so there's no double render).
         from omnigent.crash_handler import handle_crash

--- a/omnigent/cli_diagnostics.py
+++ b/omnigent/cli_diagnostics.py
@@ -393,17 +393,14 @@ def log_cli_error_hint(exc: BaseException) -> None:
     print(f"Details logged to {path}", file=dest)
 
 
-def print_setup_hint() -> None:
+def print_stale_host_hint() -> None:
     """
-    Print a one-line configuration-recovery hint on stderr.
+    Print a one-line stale-host recovery hint on stderr.
 
     Used by the top-level :func:`omnigent.cli.main` exception
-    handlers so any error the CLI surfaces ends with a pointer to
-    the model-configuration command. The dominant root cause for CLI
-    failures in the wild is a missing or misconfigured model
-    credential — a hint that nudges the user toward
-    ``omnigent setup`` keeps the recovery path obvious without
-    requiring per-call classification of "is this auth?".
+    handlers so errors that wrap runner startup failures include the
+    recovery path for stale host processes. Those processes can retain
+    invalid server authentication and cause runner tunnel rejections.
 
     Like :func:`log_cli_error_hint`, the line is written through
     to the original ``stderr`` so it survives any logging-driven
@@ -414,8 +411,9 @@ def print_setup_hint() -> None:
     """
     dest = getattr(sys.stderr, "_original_stderr", sys.stderr)
     print(
-        "If this looks like an auth or configuration problem, run "
-        "`omnigent setup` to configure a model credential.",
+        "If this is a runner tunnel rejection (HTTP 401), stale host processes "
+        "may be the cause. Run `omnigent stop` to stop existing Omnigent host instances, "
+        "then try again.",
         file=dest,
     )
 

--- a/tests/cli/test_cli_diagnostics.py
+++ b/tests/cli/test_cli_diagnostics.py
@@ -252,6 +252,23 @@ def test_log_cli_error_hint_uses_original_stderr_when_redirected(
     )
 
 
+def test_stale_host_hint_recommends_generic_stop_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tunnel rejection recovery should stop stale Omnigent processes."""
+    terminal_stderr = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", terminal_stderr)
+
+    cli_diagnostics.print_stale_host_hint()
+
+    hint = terminal_stderr.getvalue()
+    assert "runner tunnel rejection (HTTP 401)" in hint
+    assert "stale host processes" in hint
+    assert "`omnigent stop`" in hint
+    assert "existing Omnigent host instances" in hint
+    assert "omnigent setup" not in hint
+
+
 def test_redirect_stderr_to_log_retargets_existing_logging_stderr_handlers(
     isolated_cli_diagnostics: None,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Related issue

N/A — no matching issue was found for this CLI copy fix.

## Summary

- Replace the generic model-setup suffix on CLI errors with recovery guidance for runner tunnel HTTP 401 rejections.
- Explain that stale host processes can retain invalid authentication and direct users to run `omnigent stop` before retrying.

## Test Plan

- `uv sync --extra all --extra dev`
- `.venv/bin/pre-commit run --all-files`
- `.venv/bin/python -m pytest tests/cli/test_cli_diagnostics.py -q` (13 passed)

## Demo

N/A — non-visual CLI messaging change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test verifies that the hint mentions HTTP 401 tunnel rejection, stale host processes, and `omnigent stop`, and no longer recommends `omnigent setup`.

## Changelog

Runner tunnel HTTP 401 errors now suggest stopping stale host instances with `omnigent stop`.
