### PR TITLE
feat(ci): label fresh PRs waiting-for-review once they clear the bar

### DIFF
--- a/.github/workflows/demo-check.yml
+++ b/.github/workflows/demo-check.yml
@@ -68,3 +68,16 @@ jobs:
           script: |
             const script = require(".github/workflows/pr-issue-link.js");
             await script({ context, github, core });
+      # Applies `waiting-for-review` to PRs that clear the bar, giving maintainers
+      # a queue of reviewable PRs instead of the whole open list. Dry-run by
+      # default; ENFORCE="true" applies the label.
+      - name: Ready-for-review gate
+        if: always()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          ENFORCE: "false"
+        with:
+          retries: 3
+          script: |
+            const script = require(".github/workflows/ready-for-review.js");
+            await script({ context, github, core });

--- a/.github/workflows/ready-for-review-test.yml
+++ b/.github/workflows/ready-for-review-test.yml
@@ -1,0 +1,32 @@
+name: Ready-for-Review Gate Test
+
+# Offline unit test for the ready-for-review gate: runs ready-for-review.test.js
+# (mocked GitHub client, no network). Triggers only when the script, its test, or
+# the issue-link module it reuses change. Runs on `pull_request` (PR head
+# checkout) so it tests the PR's own version. No secrets, no network.
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/ready-for-review.js
+      - .github/workflows/ready-for-review.test.js
+      - .github/workflows/pr-issue-link.js
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ready-for-review-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run ready-for-review gate unit test
+        run: node .github/workflows/ready-for-review.test.js

--- a/.github/workflows/ready-for-review.js
+++ b/.github/workflows/ready-for-review.js
@@ -1,0 +1,194 @@
+// Put a fresh PR into `waiting-for-review` once it clears the minimum bar, so
+// maintainers have a queue of PRs that are actually reviewable rather than the
+// whole open list.
+//
+// Until now `waiting-for-review` had exactly one entrance: the handoff that fires
+// when an author replies to feedback. A PR nobody had touched yet sat in neither
+// state, which is why almost every open PR carries no review-state label.
+//
+// The bar today is deliberately just "references an issue". It is meant to rise:
+// CI green, demo present, Polly clean. Each is a predicate added to `meetsBar`,
+// and the rest of this file stays the same.
+//
+// Never applied when:
+//   - the PR is a draft (the author is telling us it is not ready)
+//   - `waiting-on-author` is set (the ball is in the author's court; applying
+//     both would break the mutual exclusion the two labels rely on)
+//   - the label is already there (idempotent, and it must not fight a maintainer
+//     who removed it on purpose -- see REMOVED_BY_HUMAN below)
+//
+// Forward-only, sharing pr-issue-link.js's effective date: labelling 478 backlog
+// PRs in one sweep would bury the signal it exists to create.
+
+const issueLink = require("./pr-issue-link.js");
+
+const MS_PER_HOUR = 60 * 60 * 1000;
+const HOURS_TO_SCAN = 24;
+const REVIEW_LABEL = "waiting-for-review";
+const WAITING_LABEL = "waiting-on-author";
+
+const QUERY = `
+  query($cursor: String, $searchQuery: String!) {
+    rateLimit { remaining resetAt }
+    search(query: $searchQuery, type: ISSUE, first: 50, after: $cursor) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        ... on PullRequest {
+          number
+          isDraft
+          labels(first: 30) { nodes { name } }
+          body
+          timelineItems(last: 50, itemTypes: [UNLABELED_EVENT]) {
+            nodes {
+              ... on UnlabeledEvent {
+                label { name }
+                actor { login }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const LINK_QUERY = `
+  query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        closingIssuesReferences(first: 1) { totalCount }
+      }
+    }
+  }
+`;
+
+// True when someone removed this label before. A maintainer who takes it off is
+// saying "not ready", and a sweep that reapplies it every hour would be arguing
+// with them.
+function removedBefore(pr) {
+  const events = pr.timelineItems?.nodes ?? [];
+  return events.some((e) => e?.label?.name === REVIEW_LABEL);
+}
+
+// Does this PR reference an issue? Reuses the same resolution as the nudge, so
+// the gate and the nudge can never disagree about what counts.
+async function referencesIssue({ github, core, owner, repo, pr }) {
+  try {
+    const resp = await github.graphql(LINK_QUERY, { owner, repo, number: pr.number });
+    if (resp.repository.pullRequest.closingIssuesReferences.totalCount > 0) return true;
+  } catch (err) {
+    // Unverifiable: say no rather than labelling on a guess.
+    core.warning(`Could not resolve links for #${pr.number}: ${err.message}`);
+    return false;
+  }
+  for (const candidate of issueLink.trackingReferences(pr.body)) {
+    try {
+      const { data } = await github.rest.issues.get({ owner, repo, issue_number: candidate });
+      if (!data.pull_request) return true;
+    } catch {
+      // A number that does not resolve proves nothing; try the next.
+    }
+  }
+  return false;
+}
+
+// Returns null when the PR is ready, or the reason it is not.
+async function belowBar(ctx) {
+  if (!(await referencesIssue(ctx))) return "no issue referenced";
+  return null;
+}
+
+module.exports = async ({ context, github, core }) => {
+  const { owner, repo } = context.repo;
+  const enforce = process.env.ENFORCE === "true";
+
+  try {
+    const windowStart = new Date(Date.now() - HOURS_TO_SCAN * MS_PER_HOUR);
+    const cutoff = new Date(
+      Math.max(windowStart.getTime(), new Date(issueLink.EFFECTIVE_FROM).getTime())
+    );
+    const cutoffString = cutoff.toISOString().replace(/\.\d{3}Z$/, "Z");
+    const searchQuery = `repo:${owner}/${repo} is:pr is:open created:>${cutoffString}`;
+    console.log(`Scanning PRs: ${searchQuery} (enforce=${enforce})`);
+
+    let cursor = null;
+    let hasNextPage = true;
+    const allPRs = [];
+    while (hasNextPage) {
+      const response = await github.graphql(QUERY, { cursor, searchQuery });
+      const { remaining, resetAt } = response.rateLimit;
+      console.log(`Rate limit: ${remaining} remaining, resets at ${resetAt}`);
+      const { nodes, pageInfo } = response.search;
+      hasNextPage = pageInfo.hasNextPage;
+      cursor = pageInfo.endCursor;
+      allPRs.push(...nodes);
+    }
+    console.log(`Found ${allPRs.length} open PRs in the window`);
+
+    const verdicts = [];
+    for (const pr of allPRs) {
+      const labels = pr.labels?.nodes?.map((l) => l.name) ?? [];
+      let skip = null;
+      if (pr.isDraft) skip = "draft";
+      else if (labels.includes(REVIEW_LABEL)) skip = "already labelled";
+      else if (labels.includes(WAITING_LABEL)) skip = "waiting on author";
+      else if (removedBefore(pr)) skip = "label was removed by hand";
+      if (skip) {
+        verdicts.push({ pr: pr.number, verdict: "skip", reason: skip });
+        continue;
+      }
+
+      const reason = await belowBar({ github, core, owner, repo, pr });
+      if (reason) {
+        verdicts.push({ pr: pr.number, verdict: "below bar", reason });
+        continue;
+      }
+
+      verdicts.push({ pr: pr.number, verdict: "READY", reason: "meets the bar" });
+      if (!enforce) continue;
+      await github.rest.issues.addLabels({
+        owner,
+        repo,
+        issue_number: pr.number,
+        labels: [REVIEW_LABEL],
+      });
+      console.log(`Added ${REVIEW_LABEL} to #${pr.number}`);
+    }
+
+    const counts = verdicts.reduce((acc, v) => {
+      acc[v.verdict] = (acc[v.verdict] || 0) + 1;
+      return acc;
+    }, {});
+    const summary = Object.entries(counts)
+      .map(([k, n]) => `${k}=${n}`)
+      .join(" ");
+    console.log(`Done (enforce=${enforce}). ${summary}`);
+
+    if (core.summary) {
+      core.summary
+        .addHeading(
+          `Ready-for-review gate ${enforce ? "(enforcing)" : "(dry run, nothing changed)"}`,
+          3
+        )
+        .addRaw(`\n${summary}\n\n`)
+        .addTable([
+          [
+            { data: "PR", header: true },
+            { data: "Verdict", header: true },
+            { data: "Reason", header: true },
+          ],
+          ...verdicts.map((v) => [`#${v.pr}`, v.verdict, v.reason]),
+        ]);
+      await core.summary.write();
+    }
+  } catch (error) {
+    if (error.status === 429 || error.message?.includes("rate limit")) {
+      console.log("Rate limit hit. Exiting gracefully.");
+      return;
+    }
+    throw error;
+  }
+};
+
+module.exports.removedBefore = removedBefore;
+module.exports.REVIEW_LABEL = REVIEW_LABEL;

--- a/.github/workflows/ready-for-review.js
+++ b/.github/workflows/ready-for-review.js
@@ -62,12 +62,22 @@ const LINK_QUERY = `
   }
 `;
 
-// True when someone removed this label before. A maintainer who takes it off is
+// True when a HUMAN removed this label before. A maintainer who takes it off is
 // saying "not ready", and a sweep that reapplies it every hour would be arguing
 // with them.
-function removedBefore(pr) {
+//
+// The actor check is the whole point: waiting_on_author.py removes this label
+// itself whenever `waiting-on-author` goes on, since the two are mutually
+// exclusive. Counting that bot removal would permanently disqualify any PR that
+// has ever been through a review round trip, which is most of them.
+function removedByHuman(pr) {
   const events = pr.timelineItems?.nodes ?? [];
-  return events.some((e) => e?.label?.name === REVIEW_LABEL);
+  return events.some(
+    (e) =>
+      e?.label?.name === REVIEW_LABEL &&
+      e?.actor?.login &&
+      !e.actor.login.endsWith("[bot]")
+  );
 }
 
 // Does this PR reference an issue? Reuses the same resolution as the nudge, so
@@ -132,7 +142,7 @@ module.exports = async ({ context, github, core }) => {
       if (pr.isDraft) skip = "draft";
       else if (labels.includes(REVIEW_LABEL)) skip = "already labelled";
       else if (labels.includes(WAITING_LABEL)) skip = "waiting on author";
-      else if (removedBefore(pr)) skip = "label was removed by hand";
+      else if (removedByHuman(pr)) skip = "label was removed by hand";
       if (skip) {
         verdicts.push({ pr: pr.number, verdict: "skip", reason: skip });
         continue;
@@ -146,13 +156,20 @@ module.exports = async ({ context, github, core }) => {
 
       verdicts.push({ pr: pr.number, verdict: "READY", reason: "meets the bar" });
       if (!enforce) continue;
-      await github.rest.issues.addLabels({
-        owner,
-        repo,
-        issue_number: pr.number,
-        labels: [REVIEW_LABEL],
-      });
-      console.log(`Added ${REVIEW_LABEL} to #${pr.number}`);
+      // Per-PR, so one failed write does not abandon the rest of the sweep. The
+      // label is idempotent and the sweep is hourly, so a miss self-heals.
+      try {
+        await github.rest.issues.addLabels({
+          owner,
+          repo,
+          issue_number: pr.number,
+          labels: [REVIEW_LABEL],
+        });
+        console.log(`Added ${REVIEW_LABEL} to #${pr.number}`);
+      } catch (err) {
+        if (err.status === 429 || err.message?.includes("rate limit")) throw err;
+        core.warning(`Could not label #${pr.number}: ${err.message}`);
+      }
     }
 
     const counts = verdicts.reduce((acc, v) => {
@@ -190,5 +207,5 @@ module.exports = async ({ context, github, core }) => {
   }
 };
 
-module.exports.removedBefore = removedBefore;
+module.exports.removedByHuman = removedByHuman;
 module.exports.REVIEW_LABEL = REVIEW_LABEL;

--- a/.github/workflows/ready-for-review.test.js
+++ b/.github/workflows/ready-for-review.test.js
@@ -17,15 +17,23 @@ function pr({
     isDraft: draft,
     labels: { nodes: labels.map((name) => ({ name })) },
     body,
+    // Each entry is a label name (removed by a human) or [name, actor].
     timelineItems: {
-      nodes: unlabeled.map((name) => ({ label: { name }, actor: { login: "maintainer1" } })),
+      nodes: unlabeled.map((u) =>
+        Array.isArray(u)
+          ? { label: { name: u[0] }, actor: { login: u[1] } }
+          : { label: { name: u }, actor: { login: "maintainer1" } }
+      ),
     },
   };
 }
 
 // `linked` maps PR number -> closing-issue count; `issues` maps number ->
 // "issue" | "pr" | undefined (404).
-async function run(nodes, { linked = {}, issues = {}, env = {}, linkError = false } = {}) {
+async function run(
+  nodes,
+  { linked = {}, issues = {}, env = {}, linkError = false, failLabelOn = null } = {}
+) {
   const labeled = [];
   const rows = [];
   let searchCalls = 0;
@@ -56,7 +64,14 @@ async function run(nodes, { linked = {}, issues = {}, env = {}, linkError = fals
     },
     rest: {
       issues: {
-        addLabels: async ({ issue_number, labels: ls }) => labeled.push({ issue_number, labels: ls }),
+        addLabels: async ({ issue_number, labels: ls }) => {
+          if (issue_number === failLabelOn) {
+            const err = new Error("boom");
+            err.status = 500;
+            throw err;
+          }
+          labeled.push({ issue_number, labels: ls });
+        },
         get: async ({ issue_number }) => {
           const kind = issues[issue_number];
           if (!kind) {
@@ -165,6 +180,44 @@ const verdictOf = (rows, n) => (rows.find((r) => r[0] === `#${n}`) || [])[1];
       env: ENFORCE,
     });
     assert.strictEqual(labeled.length, 1, "unrelated removals are ignored");
+  }
+  // The bot removes this label itself on every waiting-on-author transition, so
+  // counting that would disqualify any PR that has been through a review round
+  // trip. Observed on a real PR: unlabeled waiting-for-review by
+  // github-actions[bot].
+  {
+    const { labeled } = await run(
+      [pr({ number: 181, unlabeled: [[script.REVIEW_LABEL, "github-actions[bot]"]] })],
+      { linked: { 181: 1 }, env: ENFORCE }
+    );
+    assert.strictEqual(labeled.length, 1, "a bot removal is not a human 'not ready'");
+  }
+  // A human removal still wins even when a bot also removed it earlier.
+  {
+    const { labeled } = await run(
+      [
+        pr({
+          number: 182,
+          unlabeled: [[script.REVIEW_LABEL, "github-actions[bot]"], script.REVIEW_LABEL],
+        }),
+      ],
+      { linked: { 182: 1 }, env: ENFORCE }
+    );
+    assert.strictEqual(labeled.length, 0, "a human removal is still respected");
+  }
+
+  // One failed label write must not abandon the rest of the sweep.
+  {
+    const { labeled, warnings } = await run(
+      [pr({ number: 191 }), pr({ number: 192 })],
+      { linked: { 191: 1, 192: 1 }, env: ENFORCE, failLabelOn: 191 }
+    );
+    assert.deepStrictEqual(
+      labeled.map((l) => l.issue_number),
+      [192],
+      "the sweep continues past a write failure"
+    );
+    assert.ok(warnings.some((w) => /Could not label #191/.test(w)));
   }
 
   // Dry run touches nothing but still reports.

--- a/.github/workflows/ready-for-review.test.js
+++ b/.github/workflows/ready-for-review.test.js
@@ -1,0 +1,194 @@
+// Local unit test for ready-for-review.js -- mocks the GitHub client and runs the
+// real decision logic. No network.
+
+const assert = require("assert");
+const path = require("path");
+const script = require(path.resolve(".github/workflows/ready-for-review.js"));
+
+function pr({
+  number,
+  body = "",
+  draft = false,
+  labels = [],
+  unlabeled = [],
+}) {
+  return {
+    number,
+    isDraft: draft,
+    labels: { nodes: labels.map((name) => ({ name })) },
+    body,
+    timelineItems: {
+      nodes: unlabeled.map((name) => ({ label: { name }, actor: { login: "maintainer1" } })),
+    },
+  };
+}
+
+// `linked` maps PR number -> closing-issue count; `issues` maps number ->
+// "issue" | "pr" | undefined (404).
+async function run(nodes, { linked = {}, issues = {}, env = {}, linkError = false } = {}) {
+  const labeled = [];
+  const rows = [];
+  let searchCalls = 0;
+  const summary = {
+    addHeading: () => summary,
+    addRaw: () => summary,
+    addTable: (t) => {
+      rows.push(...t.slice(1));
+      return summary;
+    },
+    write: async () => {},
+  };
+  const github = {
+    graphql: async (query, vars) => {
+      if (query.includes("pullRequest(number:")) {
+        if (linkError) throw new Error("boom");
+        return {
+          repository: {
+            pullRequest: { closingIssuesReferences: { totalCount: linked[vars.number] ?? 0 } },
+          },
+        };
+      }
+      const done = searchCalls++ > 0;
+      return {
+        rateLimit: { remaining: 4999, resetAt: "n/a" },
+        search: { pageInfo: { hasNextPage: !done, endCursor: "c" }, nodes: done ? [] : nodes },
+      };
+    },
+    rest: {
+      issues: {
+        addLabels: async ({ issue_number, labels: ls }) => labeled.push({ issue_number, labels: ls }),
+        get: async ({ issue_number }) => {
+          const kind = issues[issue_number];
+          if (!kind) {
+            const err = new Error("Not Found");
+            err.status = 404;
+            throw err;
+          }
+          return { data: kind === "pr" ? { pull_request: {} } : {} };
+        },
+      },
+    },
+  };
+  const warnings = [];
+  const saved = { ...process.env };
+  Object.assign(process.env, env);
+  try {
+    await script({
+      context: { repo: { owner: "o", repo: "r" } },
+      github,
+      core: { warning: (m) => warnings.push(m), summary },
+    });
+  } finally {
+    for (const k of Object.keys(env)) delete process.env[k];
+    Object.assign(process.env, saved);
+  }
+  return { labeled, rows, warnings };
+}
+
+const ENFORCE = { ENFORCE: "true" };
+const verdictOf = (rows, n) => (rows.find((r) => r[0] === `#${n}`) || [])[1];
+
+(async () => {
+  // A fresh PR with a closing link clears the bar.
+  {
+    const { labeled } = await run([pr({ number: 10 })], { linked: { 10: 1 }, env: ENFORCE });
+    assert.deepStrictEqual(labeled, [{ issue_number: 10, labels: [script.REVIEW_LABEL] }]);
+  }
+
+  // ...and so does a non-closing reference to a real issue, matching the nudge.
+  {
+    const { labeled } = await run([pr({ number: 11, body: "Part of #77" })], {
+      issues: { 77: "issue" },
+      env: ENFORCE,
+    });
+    assert.strictEqual(labeled.length, 1, "Part of #N clears the bar");
+  }
+
+  // A reference to another PR is not a tracking record.
+  {
+    const { labeled, rows } = await run([pr({ number: 12, body: "Refs #88" })], {
+      issues: { 88: "pr" },
+      env: ENFORCE,
+    });
+    assert.strictEqual(labeled.length, 0);
+    assert.strictEqual(verdictOf(rows, 12), "below bar");
+  }
+
+  // No reference at all: below the bar.
+  {
+    const { labeled, rows } = await run([pr({ number: 13 })], { env: ENFORCE });
+    assert.strictEqual(labeled.length, 0);
+    assert.strictEqual(verdictOf(rows, 13), "below bar");
+  }
+
+  // Draft: the author is saying it is not ready.
+  {
+    const { labeled, rows } = await run([pr({ number: 14, draft: true })], {
+      linked: { 14: 1 },
+      env: ENFORCE,
+    });
+    assert.strictEqual(labeled.length, 0);
+    assert.strictEqual(verdictOf(rows, 14), "skip");
+  }
+
+  // waiting-on-author wins: the two labels must never both be set.
+  {
+    const { labeled } = await run([pr({ number: 15, labels: ["waiting-on-author"] })], {
+      linked: { 15: 1 },
+      env: ENFORCE,
+    });
+    assert.strictEqual(labeled.length, 0, "never applied alongside waiting-on-author");
+  }
+
+  // Idempotent.
+  {
+    const { labeled } = await run([pr({ number: 16, labels: [script.REVIEW_LABEL] })], {
+      linked: { 16: 1 },
+      env: ENFORCE,
+    });
+    assert.strictEqual(labeled.length, 0, "no duplicate label");
+  }
+
+  // A maintainer who removed the label meant it; do not reapply every hour.
+  {
+    const { labeled, rows } = await run(
+      [pr({ number: 17, unlabeled: [script.REVIEW_LABEL] })],
+      { linked: { 17: 1 }, env: ENFORCE }
+    );
+    assert.strictEqual(labeled.length, 0, "respects a manual removal");
+    assert.strictEqual(verdictOf(rows, 17), "skip");
+  }
+  // ...but an unrelated label removal is not a signal about this one.
+  {
+    const { labeled } = await run([pr({ number: 18, unlabeled: ["needs-demo"] })], {
+      linked: { 18: 1 },
+      env: ENFORCE,
+    });
+    assert.strictEqual(labeled.length, 1, "unrelated removals are ignored");
+  }
+
+  // Dry run touches nothing but still reports.
+  {
+    const { labeled, rows } = await run([pr({ number: 19 })], { linked: { 19: 1 } });
+    assert.strictEqual(labeled.length, 0, "dry run must not label");
+    assert.strictEqual(verdictOf(rows, 19), "READY");
+  }
+
+  // An unverifiable link lookup must not label on a guess.
+  {
+    const { labeled, warnings } = await run([pr({ number: 20 })], {
+      linkError: true,
+      env: ENFORCE,
+    });
+    assert.strictEqual(labeled.length, 0, "fails closed");
+    assert.ok(warnings.some((w) => /Could not resolve links for #20/.test(w)));
+  }
+
+  // The scan never reaches back past the shared effective date.
+  {
+    const issueLink = require(path.resolve(".github/workflows/pr-issue-link.js"));
+    assert.ok(issueLink.EFFECTIVE_FROM, "shares the issue-link effective date");
+  }
+
+  console.log("ready-for-review.test.js: all assertions passed");
+})();


### PR DESCRIPTION
## Related issue

Part of OMNI-2214 / OMNI-2315. Closes the last gap in the review-state machine;
this PR declares **Test / CI** below, which is one of the exempt types.

## Summary

`waiting-for-review` had exactly one entrance: `hand_off_to_reviewer`, which fires
when an author replies to feedback on a PR already carrying `waiting-on-author`.

A PR nobody had touched yet therefore sat in **neither** state. That is why 478 of
479 currently-open PRs carry no review-state label, and why the label cannot yet be
used as the review queue it was built to be. A fresh PR that references an issue
should be labelled ready, and today nothing does that.

This adds a sweep step that applies the label to PRs clearing the bar.

**The bar today is just "references an issue."** It reuses `pr-issue-link.js`'s
resolution (closing links, sidebar links, and `Part of` / `Related to` / `Towards`
/ `Refs` pointing at a real issue), so the gate and the nudge can never disagree
about what counts. It is designed to rise: CI green, demo present, Polly clean each
become one more predicate in `belowBar`, and nothing else changes.

**Never applied when:**

- the PR is a **draft** (the author is telling us it is not ready)
- `waiting-on-author` is set (the ball is in the author's court, and applying both
  would break the mutual exclusion the pair relies on)
- the label is already there (idempotent)
- **a human removed it before.** A maintainer who takes the label off is saying
  "not ready"; an hourly sweep that reapplies it would be arguing with them. An
  unrelated label removal is ignored.

**Forward-only**, sharing `EFFECTIVE_FROM` with the issue-link check: labelling 478
backlog PRs in one sweep would bury the signal the label exists to create.

Ships **dry-run** (`ENFORCE: "false"`), consistent with how the nudge shipped.

## Test Plan

- `node .github/workflows/ready-for-review.test.js` passes. 12 cases: a closing
  link clears the bar; `Part of #N` to a real issue clears it; a reference to a
  **PR** does not; no reference does not; drafts skip; `waiting-on-author` wins;
  idempotent; a prior manual removal is respected while an unrelated removal is
  ignored; a dry run reports `READY` without labelling; an unverifiable link
  lookup fails closed; and the effective date is shared with the issue-link module.
- **Verified against production** with the label write rigged to throw, so
  "nothing was touched" is proven rather than assumed:

  ```
  Found 26 open PRs in the window
  Done (enforce=false). READY=4 below bar=20 skip=2
  ```

  The 4 ready are #4178, #4128, #4113, #4095. Note **#4095 is the `Refs #3644` PR**
  from the earlier `Part of` fix, so that change flows through to the gate as
  intended. #4173 comes back `below bar (no issue referenced)`, matching the nudge's
  verdict on the same PR. No write was attempted.
- A new `ready-for-review-test.yml` runs the unit test on any PR touching the
  script, its test, or the issue-link module it reuses.

## Demo

N/A. CI label mechanics, no user-visible UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added or updated
- [ ] Integration / E2E tests added or updated
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

Unit tests cover every predicate and exclusion. Manual verification was running the
shipped script against live GitHub with the label write rigged to throw, confirming
both the verdict set and that nothing was written.

## Follow-up

Once this is enforcing, CONTRIBUTING can state that reviewers work the
`waiting-for-review` queue. It deliberately does not say that today, because the
label was not yet applied to fresh PRs and the doc would have read as "we will
never review your PR."
