### PR TITLE
feat(ci): enforce the issue-reference check

### DIFF
--- a/.github/workflows/demo-check.yml
+++ b/.github/workflows/demo-check.yml
@@ -5,10 +5,10 @@ name: PR Hygiene
 #   1. Demo check -- comment on PRs that check "Bug fix" / "Feature" /
 #      "UI / frontend change" but provide no demo (screenshot / video).
 #      See demo-check.js.
-#   2. Issue-link check -- comment on PRs that link no issue. Forward-only (nothing
-#      opened before its effective date is considered, so the backlog is
-#      untouched) and dry-run by default: it writes the verdict list to the step
-#      summary and changes nothing until ENFORCE is "true". See pr-issue-link.js.
+#   2. Issue-link check -- comment on PRs that reference no issue. Forward-only:
+#      nothing opened before its effective date is considered, so the backlog is
+#      untouched. Enforcing, capped at LIMIT comments per run. See
+#      pr-issue-link.js.
 #
 # Both skip drafts and PRs they've already flagged -- the demo check dedupes on
 # its `needs-demo` label, the issue-link check on a marker in its own comment.
@@ -53,16 +53,17 @@ jobs:
           script: |
             const script = require(".github/workflows/demo-check.js");
             await script({ context, github, core });
-      # Dry run: resolves every verdict into the step summary without
-      # commenting or labeling. Flip ENFORCE to "true" once the verdict list has
-      # been reviewed; LIMIT then caps how many PRs one run may flag (it does not
-      # truncate a dry run, whose job is to show the complete list).
+      # LIMIT bounds how many contributors a single run may comment on. It is
+      # deliberately low while the wording gets its first real-world read, and can
+      # be raised once the first live comments look right. Setting ENFORCE back to
+      # "false" returns to a dry run, which enumerates every verdict into the step
+      # summary and writes nothing.
       - name: Issue-link check
         if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
-          ENFORCE: "false"
-          LIMIT: "25"
+          ENFORCE: "true"
+          LIMIT: "3"
         with:
           retries: 3
           script: |


### PR DESCRIPTION
## Related issue

Part of OMNI-2214 / OMNI-2311. Flips the flag on the check merged earlier today;
this PR declares **Test / CI** below, which is one of the exempt types.

## Summary

The issue-reference check has run dry for a day. Its verdicts were audited against
live GitHub twice, with every write method rigged to throw so "nothing was touched"
was proven rather than assumed:

```
Found 26 open PRs in the window
Done (enforce=false). exempt=17 FLAG=8 ok=1
```

What the audit confirmed:

- **Every flagged PR genuinely references no issue.** The two whose bodies mention
  numbers point at **pull requests**, not issues, so they are correctly flagged.
- **Every exemption is legitimate.** All maintainer exemptions are `MEMBER` *and*
  listed in `.github/MAINTAINER`, with no borderline cases; the rest are drafts, one
  trivial change, and one declared docs PR.
- **No PR carries the dedupe marker**, so nothing is double-nudged on the first
  enforcing run. (A marker search returns hits only because Polly quoted the marker
  string while reviewing the code that defines it.)
- A control run with `ENFORCE=true` against the same client attempted **exactly one**
  `createComment` and no `addLabels`, so the dry run's silence was a real property
  rather than an unexercised path.

## Why LIMIT is 3, not 25

The first enforcing run is the only one where a wording mistake is unrecoverable,
and several PRs in the current window are from **first-time contributors** whose
first interaction with the repo would be this comment. Three lets the wording get
its first real-world read with a bounded blast radius; raise it once the live
comments look right.

Setting `ENFORCE` back to `"false"` returns to a dry run at any point.

## What a contributor will see

> @author Thanks for the PR! It doesn't reference an issue yet.
>
> **We require an issue for every PR**, so the work can be prioritized before it's
> reviewed. Add one to the description:
>
> - `Closes #123` if this PR finishes the issue...
> - `Part of #123` if this is one step towards it. `Related to`, `Towards`, and
>   `Refs` work the same way, and leave the issue open.
>
> No issue exists for this yet? Open one first, then reference it...
>
> The only exceptions are changes with no user-visible behaviour: pure
> **Refactor / chore**, **Docs**, or **Test / CI** work... Anything that fixes a
> bug, adds a feature, or changes the UI needs an issue, even when it also touches
> docs or tests.
>
> *No action is taken beyond this comment.*

Rendered by intercepting the real write path, so that is verbatim. The policy is
documented in
[CONTRIBUTING](https://github.com/omnigent-ai/omnigent/blob/main/CONTRIBUTING.md#every-pr-needs-an-issue),
which the comment links to.

Nothing is closed, and nothing is labelled. The check comments once per PR and
that is all.

## Test Plan

- Unit tests unchanged and passing: `node .github/workflows/pr-issue-link.test.js`.
- Two live dry runs plus the `ENFORCE=true` control described above.
- The sweep this step lives in has run on schedule successfully all day, so the
  step inherits a working cron rather than needing new scheduling.

## Demo

N/A. One environment variable in a CI workflow.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added or updated
- [ ] Integration / E2E tests added or updated
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

Not unit-testable: this changes a workflow environment value, and the enforcing and
dry-run paths are both already covered by the existing tests. Verification was the
live dry runs and the write-blocked control run.
