### PR TITLE
Smart Routing follow-ups: let a healthy route finish before the hook gives up

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -1949,12 +1949,54 @@ def _ucode_config_for_profile(
     # rejects.
     return ClaudeNativeUcodeConfig(
         env=env,
-        api_key_helper=agent_state.auth_command,
+        api_key_helper=_profile_pinned_auth_command(
+            agent_state.auth_command, workspace_url, profile
+        ),
         model=default_model
         or configured_default
         or model_catalog.resolve_catalog_model("databricks", family="claude").model_id,
         routable_models=routable_models,
     )
+
+
+def _profile_pinned_auth_command(
+    auth_command: str,
+    workspace_url: str,
+    profile: str,
+) -> str:
+    """Pin a Databricks-CLI token helper to the profile the config named.
+
+    ucode writes its own token command into ``~/.ucode/state.json``, and it
+    selects the workspace however ucode was configured — often by host. The
+    server's router client instead authenticates as the ``kind: databricks``
+    provider's named profile. When two ``~/.databrickscfg`` profiles point at
+    one host, those are two different identities: re-authing one leaves the
+    other's token expired, and the pane and the router disagree about whether
+    the workspace is reachable. The named profile is the authority, so the
+    helper is regenerated against it.
+
+    Only the recognizable ``databricks auth token`` shape is rewritten — an
+    enterprise deployment can configure a wholly different token command, and
+    this has no business guessing at its selector.
+
+    :param auth_command: The token command ucode recorded for this agent.
+    :param workspace_url: The profile's workspace, e.g.
+        ``"https://example.databricks.com"``.
+    :param profile: The ``~/.databrickscfg`` profile the config named.
+    :returns: The command to install as ``apiKeyHelper``.
+    """
+    if "databricks auth token" not in auth_command:
+        return auth_command
+    from omnigent.inner.claude_sdk_executor import _databricks_claude_auth_command
+
+    pinned = _databricks_claude_auth_command(workspace_url, profile)
+    if pinned != auth_command:
+        _logger.info(
+            "native-claude: pinning the token helper to Databricks profile %r "
+            "(ucode's recorded command selects the workspace its own way)",
+            profile,
+        )
+    return pinned
 
 
 def _provider_config_for_native_claude(entry: ProviderEntry) -> ClaudeNativeUcodeConfig | None:

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -1975,6 +1975,11 @@ def _profile_pinned_auth_command(
     the workspace is reachable. The named profile is the authority, so the
     helper is regenerated against it.
 
+    Preference, not exclusion: the named profile may itself hold no usable
+    credential (the config names ``DEFAULT`` while the user authenticated under
+    another profile), so ucode's recorded command stays in the helper as the
+    last resort. Without it the pane 401s on the first turn.
+
     Only the recognizable ``databricks auth token`` shape is rewritten — an
     enterprise deployment can configure a wholly different token command, and
     this has no business guessing at its selector.
@@ -1987,16 +1992,17 @@ def _profile_pinned_auth_command(
     """
     if "databricks auth token" not in auth_command:
         return auth_command
-    from omnigent.inner.claude_sdk_executor import _databricks_claude_auth_command
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
 
-    pinned = _databricks_claude_auth_command(workspace_url, profile)
-    if pinned != auth_command:
-        _logger.info(
-            "native-claude: pinning the token helper to Databricks profile %r "
-            "(ucode's recorded command selects the workspace its own way)",
-            profile,
-        )
-    return pinned
+    pinned = databricks_bearer_token_command(workspace_url, profile)
+    if pinned == auth_command:
+        return auth_command
+    _logger.info(
+        "native-claude: pinning the token helper to Databricks profile %r "
+        "(ucode's recorded command selects the workspace its own way)",
+        profile,
+    )
+    return databricks_bearer_token_command(workspace_url, profile, fallback_command=auth_command)
 
 
 def _provider_config_for_native_claude(entry: ProviderEntry) -> ClaudeNativeUcodeConfig | None:

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -249,12 +249,14 @@ def _build_default_databricks_routing_client(
 def _build_external_routing_client(
     routing_cfg: Any,  # type: ignore[explicit-any]  # parsed YAML block
     settings: Any = None,  # type: ignore[explicit-any]  # RoutingSettings | None
+    cfg: Any = None,  # type: ignore[explicit-any]  # parsed server config
 ) -> Any | None:  # type: ignore[explicit-any]  # ExternalRoutingClient | None
     """Build an :class:`ExternalRoutingClient` from the ``routing:`` config.
 
     Requires ``base_url`` + ``router_name``. Auth mirrors the ``llm:`` block:
     an explicit, provider-agnostic ``api_key`` (``${ENV}`` expanded) wins,
-    else the Databricks ``profile`` convenience, else unauthenticated.
+    else the Databricks ``profile`` convenience, else the deployment's own
+    ``kind: databricks`` provider profile, else unauthenticated.
     Optional ``model_prefix`` (a single prefix or a list of prefixes) is
     stripped from catalog model ids sent to the router (and restored on its
     answer) — e.g. ``"databricks-"`` when serving-endpoint names carry that
@@ -266,6 +268,8 @@ def _build_external_routing_client(
     :param settings: The parsed routing settings, supplying the extraction
         model, scenario menus, and model prefixes. ``None`` parses them from
         *routing_cfg*.
+    :param cfg: The parsed server ``--config`` mapping, read only for the
+        provider profile fallback. ``None`` skips that fallback.
     :returns: A configured client, or ``None`` when required config is
         missing (a warning is logged; routing stays off rather than raising).
     """
@@ -298,6 +302,13 @@ def _build_external_routing_client(
         auth = _bearer_auth(expand_env_vars({"api_key": api_key})["api_key"])
     elif profile:
         databricks_profile = profile
+    else:
+        # Named nowhere in ``routing:``, but the deployment's own Databricks
+        # provider names one. Take it rather than falling through to the
+        # ambient SDK chain: ambient resolves by host or [DEFAULT], and a
+        # workspace with two profiles on one host then has the router
+        # authenticating as a different identity than the panes it routes.
+        databricks_profile = _databricks_provider_profile(cfg) if cfg is not None else None
 
     from omnigent.server.smart_routing import ExternalRoutingClient
 
@@ -372,7 +383,7 @@ def _build_routing_backends(
         return RoutingBackends()
     external: Any = None  # type: ignore[explicit-any]
     if provider == "external":
-        external = _build_external_routing_client(routing_cfg, settings)
+        external = _build_external_routing_client(routing_cfg, settings, cfg)
     elif not isinstance(routing_cfg, dict):
         external = _build_default_databricks_routing_client(cfg, settings)
     return RoutingBackends(external=external, local=_build_local_llm_routing_client(server_llm))

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -80,7 +80,7 @@ if TYPE_CHECKING:
     from omnigent.install_ledger import InstallLedger
     from omnigent.onboarding.acp_auth import AcpAgentEntry
     from omnigent.server.smart_routing import LLMRoutingClient
-    from omnigent.smart_routing_cli import RoutingDecision
+    from omnigent.smart_routing_cli import ArmedSession
     from omnigent.spec.types import LLMConfig
     from omnigent.update_check import _InstalledWheelInfo
 
@@ -6211,10 +6211,12 @@ _RESUME_HELP = (
 )
 _CONTINUE_HELP = "Continue the most recent conversation for this agent."
 _NO_SESSION_HELP = "Use a fresh temporary local session store for this run."
-_SMART_ROUTING_HELP = (
-    "Let the server pick the model for this launch (and the harness too, "
-    "unless --harness pins one). Requires -p, except with --harness "
-    "claude-native / codex-native, which route on your first typed message."
+#: ``run --smart-routing`` is gone; the flag survives only to say where routing
+#: moved. Remove the option (and the check that raises this) in 0.11.
+_RUN_SMART_ROUTING_REMOVED = (
+    "CLI smart routing is per-harness first-message only; use the web UI for "
+    "router-picked harnesses. Run `omnigent claude --smart-routing` or "
+    "`omnigent codex --smart-routing` to route this harness's first typed message."
 )
 
 _FORK_HELP = "Fork an existing session by id and open the REPL on the fork."
@@ -6689,68 +6691,31 @@ def _dispatch_native_terminal_harness(
     return True
 
 
-# ── Smart Routing (route before launch) ──────────────────────────────────
-# Only a launch with no harness able to route from inside itself needs the text
-# up front: the cross-harness route has to pick a harness before one exists to
-# hook, and a harness without the first-message hook can never route in-session.
-_SMART_ROUTING_NEEDS_PROMPT = (
-    "--smart-routing needs the text to route up front here: this launch has no "
-    'harness that can route from inside itself, so pass -p "<prompt>", start the '
-    "session from the web UI, or pin --harness claude-native / --harness "
-    "codex-native, which route on the first message you type."
-)
-#: Fail-open harness for a tier-3 route that returned nothing usable.
-_SMART_ROUTING_FALLBACK_HARNESS = "claude-native"
+# ── Smart Routing (arm the session, the harness routes the first message) ─
+# The CLI never routes a prompt at create time: ``--smart-routing`` turns Smart
+# Routing on for a new session and the harness's own first-message hook picks
+# the model once the user types. Routing a prompt up front is the web UI's job.
 
 
-def _smart_routing_capable_harness(harness: str | None) -> str | None:
+def _reject_smart_routing_prompt(prompt: str | None) -> None:
     """
-    Canonical native harness for *harness*, when Smart Routing can launch it.
+    Reject ``--smart-routing`` combined with ``-p``.
 
-    A routed launch has to carry the prompt into the TUI, so only native
-    terminal harnesses whose dispatch spec accepts a prompt qualify.
-
-    :param harness: Requested harness (canonical or alias), e.g.
-        ``"claude-native"``. Bare ``"claude"`` canonicalizes to the SDK
-        harness, which is not routable here.
-    :returns: The canonical harness id, or ``None`` when it is not routable.
-    """
-    from omnigent.native_coding_agents import native_coding_agent_for_harness
-
-    native = native_coding_agent_for_harness(harness)
-    if native is None:
-        return None
-    spec = _NATIVE_TERMINAL_DISPATCH_SPECS.get(native.key)
-    if spec is None or spec.prompt_param is None:
-        return None
-    return native.harness
-
-
-def _require_smart_routing_prompt(
-    prompt: str | None, *, in_harness_routing: bool = True
-) -> str | None:
-    """
-    Resolve the text a routed launch starts from, rejecting an unroutable one.
-
-    A harness that hooks its own first typed message can be launched bare — the
-    hook routes whatever the user types — so a missing prompt is fine there.
-    Any other launch has to route before a harness exists to hook, and needs the
-    text up front.
+    The CLI routes the first message typed *inside* the harness, so a prompt
+    handed over up front would launch on an unrouted model with no sign that
+    the request was dropped.
 
     :param prompt: The ``-p`` text, or ``None``.
-    :param in_harness_routing: Whether this launch's harness routes its own
-        first message (see
-        :func:`omnigent.runner.turn_routing.supports_in_harness_turn_routing`).
-        Defaults to ``True`` for the per-harness ``--smart-routing``
-        subcommands, which exist only on harnesses carrying that hook.
-    :returns: The prompt, or ``None`` when the harness routes in-session.
-    :raises click.UsageError: When there is no text and no in-harness route.
+    :returns: None when the combination is fine.
+    :raises click.UsageError: When *prompt* carries text.
     """
-    if prompt is not None and prompt.strip():
-        return prompt
-    if in_harness_routing:
-        return None
-    raise click.UsageError(_SMART_ROUTING_NEEDS_PROMPT)
+    if prompt is None or not prompt.strip():
+        return
+    raise click.UsageError(
+        "--smart-routing routes the first message you type in the harness, so it "
+        "cannot be combined with -p/--prompt. Drop -p and type the prompt in the "
+        "TUI, or start the session from the web UI to route a prompt at create time."
+    )
 
 
 def _reject_smart_routing_resume(*, resuming: bool, flag: str = "--resume") -> None:
@@ -6774,55 +6739,28 @@ def _reject_smart_routing_resume(*, resuming: bool, flag: str = "--resume") -> N
     )
 
 
-def _with_routed_model_arg(args: tuple[str, ...], model: str | None) -> tuple[str, ...]:
+def _smart_routing_decision(*, server: str, harness: str) -> ArmedSession:
     """
-    Append ``--model <routed>`` to a wrapper's pass-through args.
-
-    A ``--model`` the user typed themselves wins: they asked for that model
-    explicitly, and routing is a default-filling service.
-
-    :param args: The wrapper's pass-through args, e.g. ``("--verbose",)``.
-    :param model: Routed model id, or ``None`` to leave *args* alone.
-    :returns: The args, with the routed model appended when appropriate.
-    """
-    if not model:
-        return args
-    if any(arg == "--model" or arg.startswith("--model=") for arg in args):
-        return args
-    return (*args, "--model", model)
-
-
-def _smart_routing_decision(
-    *,
-    server: str,
-    prompt: str | None,
-    harness: str | None,
-) -> RoutingDecision:
-    """
-    Preflight Smart Routing, then create the routed session for *prompt*.
+    Preflight Smart Routing, then create the session it will route in.
 
     Preflight failures raise (a pick that cannot be applied is worse than no
-    pick); a create the server rejects comes back as a decision with no session
+    pick); a create the server rejects comes back as a result with no session
     whose notice is printed here, so the caller only has to launch a plain
     wrapper session.
 
-    A ``None`` *prompt* creates the session with Smart Routing on but nothing
-    routed: the harness's own first-message hook picks the model once the user
-    types, which is what the stderr line reports.
+    Nothing is routed at create: the session carries Smart Routing on, and
+    *harness*'s own first-message hook picks the model once the user types,
+    which is what the stderr line reports.
 
     :param server: Resolved Omnigent server base URL.
-    :param prompt: The text to route (also the TUI's initial input), or ``None``
-        to leave the pick to the harness's in-session hook.
-    :param harness: Canonical harness to pin, or ``None`` to route the harness
-        too.
-    :returns: The routed session and pick to launch on.
+    :param harness: Canonical native harness to bind, e.g. ``"codex-native"``.
+    :returns: The armed session to attach the wrapper to.
     :raises click.ClickException: When Smart Routing is unavailable.
     """
     from omnigent.smart_routing_cli import (
+        arm_smart_routing_session,
         check_smart_routing_available,
-        create_smart_routing_session,
         known_host_id,
-        smart_routing_families,
     )
 
     # The session must be bound to the host it will run on: the server builds
@@ -6841,205 +6779,23 @@ def _smart_routing_decision(
         host_id = None
     check_smart_routing_available(
         base_url=server,
-        harnesses=smart_routing_families(harness),
+        harnesses=(harness,),
         host_id=host_id,
     )
-    decision = create_smart_routing_session(
+    armed = arm_smart_routing_session(
         base_url=server,
-        prompt=prompt,
         harness=harness,
         host_id=host_id,
         # The server requires a workspace with a host_id, and this is the cwd
         # the wrapper will attach in.
         workspace=str(Path.cwd().resolve()) if host_id is not None else None,
     )
-    if decision.notice is not None:
-        click.echo(decision.notice, err=True)
-    elif prompt is None:
-        click.echo(
-            "omnigent: Smart Routing is on for this session; your first message picks the model.",
-            err=True,
-        )
-    elif decision.model is not None:
-        picked = (
-            f"{decision.harness} on {decision.model}"
-            if decision.harness is not None
-            else decision.model
-        )
-        click.echo(f"omnigent: Smart Routing picked {picked}.", err=True)
-    return decision
-
-
-def _dispatch_smart_routing(
-    *,
-    harness: str | None,
-    server: str | None,
-    prompt: str | None,
-    model: str | None,
-    auto_open_conversation: bool,
-) -> None:
-    """
-    Create the routed session, then attach its native TUI wrapper to it.
-
-    Tier 2 (*harness* given) routes the model only and keeps the requested
-    harness. Tier 3 (*harness* ``None``) routes both, and the wrapper is chosen
-    from the harness the server bound — falling back to
-    :data:`_SMART_ROUTING_FALLBACK_HARNESS` (with a notice) when the create
-    resolved nothing, or a harness the CLI cannot hand a prompt to.
-
-    Without a *prompt*, a *harness* that routes its own first typed message is
-    launched bare: the session is created with Smart Routing on, and the TUI
-    starts with no initial input and no routed ``--model`` (there is no
-    create-time pick — the harness's hook applies one in-session). The auto
-    route cannot do this, because a harness has to be chosen before one exists
-    to hook.
-
-    The wrapper always attaches to the created session rather than bundling its
-    own, so the routed model, the decision card, and the wrapper labels the
-    server wrote at create are the ones the launch runs on. When the create
-    failed entirely, the wrapper starts a plain session instead — the launch is
-    never blocked.
-
-    :param harness: Canonical native harness to pin, or ``None`` for the auto
-        route.
-    :param server: ``--server`` value (or its config default), or ``None``.
-    :param prompt: The routed prompt (also the TUI's initial input), or ``None``
-        to let *harness* route its own first message.
-    :param model: ``--model`` fallback used when routing returns no model.
-    :param auto_open_conversation: Whether to open the web conversation.
-    :returns: None once the TUI attach ends.
-    :raises click.ClickException: When Smart Routing is unavailable.
-    :raises click.UsageError: When there is no prompt and no in-harness route.
-    """
-    from omnigent.runner.turn_routing import supports_in_harness_turn_routing
-
-    prompt = _require_smart_routing_prompt(
-        prompt, in_harness_routing=supports_in_harness_turn_routing(harness)
+    click.echo(
+        armed.notice
+        or "omnigent: Smart Routing is on for this session; your first message picks the model.",
+        err=True,
     )
-    server = _ensure_backend(server)
-    decision = _smart_routing_decision(server=server, prompt=prompt, harness=harness)
-    launch_harness = harness or _smart_routing_capable_harness(decision.harness)
-    if launch_harness is None:
-        launch_harness = _SMART_ROUTING_FALLBACK_HARNESS
-        click.echo(
-            f"omnigent: Smart Routing did not resolve a launchable harness; "
-            f"launching {launch_harness}.",
-            err=True,
-        )
-    routed_model = decision.model or model
-    _dispatch_native_terminal_harness(
-        harness=launch_harness,
-        server=server,
-        model=routed_model,
-        # A routed model is an explicit request, so wrappers that only take a
-        # model when the user asked for one still receive it.
-        model_from_cli=routed_model is not None,
-        prompt=prompt,
-        system_prompt=None,
-        tools=None,
-        log=False,
-        debug_events=False,
-        # Attach to the routed session; ``None`` (create failed) lets the
-        # wrapper start its own.
-        resume_conversation_id=decision.session_id,
-        resume_picker=False,
-        resume_latest=False,
-        fork_session_id=None,
-        ephemeral=False,
-        auto_open_conversation=auto_open_conversation,
-    )
-
-
-def _run_smart_routing(
-    *,
-    target: str | None,
-    harness: str | None,
-    prompt: str | None,
-    server: str | None,
-    model: str | None,
-    resume_conversation_id: str | None,
-    resume_picker: bool,
-    resume_latest: bool,
-    auto_open_conversation: bool,
-    system_prompt: str | None = None,
-    tools: str | None = None,
-    log: bool = False,
-    debug_events: bool = False,
-    fork_session_id: str | None = None,
-    ephemeral: bool = False,
-) -> None:
-    """
-    Handle ``omnigent run --smart-routing``: validate, then route and launch.
-
-    ``--harness`` (a native terminal harness) pins the harness and routes the
-    model; ``--harness auto`` or no ``--harness`` at all routes both, and always
-    needs ``-p`` (the harness is picked before one exists to route in). An AGENT
-    is rejected: a routed session is a native TUI, and an agent spec's
-    prompt/tools are never consulted there.
-
-    :param target: The AGENT argument as the user passed it, or ``None``.
-    :param harness: The ``--harness`` value the user passed, or ``None``.
-    :param prompt: The ``-p`` text, or ``None`` — allowed only when
-        ``--harness`` pins a harness that routes its own first message.
-    :param server: ``--server`` value or its config default.
-    :param model: ``--model`` fallback for an unrouted launch.
-    :param resume_conversation_id: ``--resume <id>`` target, rejected when set.
-    :param resume_picker: ``--resume`` with no value, rejected when set.
-    :param resume_latest: ``--continue``, rejected when set.
-    :param auto_open_conversation: Whether to open the web conversation.
-    :param system_prompt: ``--system-prompt`` value, rejected when set.
-    :param tools: ``--tools`` value, rejected when set.
-    :param log: ``--log``, rejected when set.
-    :param debug_events: ``--debug-events``, rejected when set.
-    :param fork_session_id: ``--fork`` value, rejected when set.
-    :param ephemeral: ``--no-session``, rejected when set.
-    :returns: None once the TUI attach ends.
-    :raises click.ClickException: On a rejected combination, or when Smart
-        Routing is unavailable.
-    """
-    # The same REPL-only options the plain native dispatch rejects: a routed
-    # launch is still a TUI attach, so they would be silently dropped.
-    repl_only = [
-        flag
-        for flag, active in (
-            ("--system-prompt", system_prompt is not None),
-            ("--tools", tools is not None),
-            ("--log", log),
-            ("--debug-events", debug_events),
-            ("--fork", fork_session_id is not None),
-            ("--no-session", ephemeral),
-        )
-        if active
-    ]
-    if repl_only:
-        raise click.ClickException(
-            "--smart-routing launches a native harness TUI; the REPL-only option(s) "
-            f"{', '.join(repl_only)} have no effect there — remove them."
-        )
-    _reject_smart_routing_resume(resuming=resume_conversation_id is not None or resume_picker)
-    _reject_smart_routing_resume(resuming=resume_latest, flag="--continue")
-    if target is not None:
-        raise click.ClickException(
-            "--smart-routing launches a native harness TUI, so it takes no AGENT. "
-            "Drop the AGENT to route the harness and model, or pass "
-            "`--harness claude-native` to route the model only."
-        )
-    requested: str | None = None
-    if harness is not None and harness != "auto":
-        requested = _smart_routing_capable_harness(harness)
-        if requested is None:
-            raise click.ClickException(
-                f"--smart-routing does not support --harness {harness!r}. Use a native "
-                "terminal harness that accepts a prompt (claude-native, codex-native, "
-                "kiro-native), or `--harness auto` to route the harness too."
-            )
-    _dispatch_smart_routing(
-        harness=requested,
-        server=server,
-        prompt=prompt,
-        model=model,
-        auto_open_conversation=auto_open_conversation,
-    )
+    return armed
 
 
 def _reject_agent_with_native_terminal_harness(harness: str) -> None:
@@ -7524,7 +7280,8 @@ def attach(
     "smart_routing",
     is_flag=True,
     default=False,
-    help=_SMART_ROUTING_HELP,
+    hidden=True,
+    help="[REMOVED] Use `omnigent claude|codex --smart-routing` or the web UI.",
 )
 @click.option(
     "--from-openclaw",
@@ -7631,8 +7388,6 @@ def run(
     Examples:
       omnigent run --harness claude-sdk
       omnigent run --harness codex -p "review the last commit"
-      omnigent run --smart-routing -p "review the last commit"
-      omnigent run --harness claude-native --smart-routing -p "fix the flaky test"
       omnigent run --from-openclaw "Gemini CLI" -p "review the last commit"
       omnigent run examples/hello_world.yaml
       omnigent run examples/hello_world.yaml --harness codex --model gpt-5.4-mini
@@ -7648,6 +7403,10 @@ def run(
     # ambient DATABRICKS_CONFIG_PROFILE.
     if databricks_profile:
         os.environ["DATABRICKS_CONFIG_PROFILE"] = databricks_profile
+    # Rejected before anything is resolved: `run` never routed in-harness, and
+    # its create-time route is gone.
+    if smart_routing:
+        raise click.ClickException(_RUN_SMART_ROUTING_REMOVED)
     # Apply config defaults for any value the user did not pass explicitly.
     # Explicit CLI args always take precedence; project-local config overrides
     # global config, which provides user-level defaults.
@@ -7657,31 +7416,6 @@ def run(
     model_from_cli = model_source is click.core.ParameterSource.COMMANDLINE
     harness_source = click.get_current_context().get_parameter_source("harness")
     harness_from_cli = harness_source is not None and harness_source.name == "COMMANDLINE"
-    # Smart Routing owns the whole launch: it routes before anything is
-    # created, then execs a native TUI wrapper. Handle it here, before the
-    # default-agent / first-run resolution below can substitute an agent the
-    # routed launch would have to reject.
-    if smart_routing:
-        _smart_routing_cfg = _load_effective_config()
-        _smart_routing_resume = _split_resume_value(resume)
-        _run_smart_routing(
-            target=target,
-            harness=harness if harness_from_cli else None,
-            prompt=prompt,
-            server=server if server_from_cli else _smart_routing_cfg.get("server"),
-            model=model if model_from_cli else None,
-            resume_conversation_id=_smart_routing_resume.conversation_id,
-            resume_picker=_smart_routing_resume.picker,
-            resume_latest=resume_latest,
-            auto_open_conversation=_resolve_auto_open_conversation_from_config(_smart_routing_cfg),
-            system_prompt=system_prompt,
-            tools=tools,
-            log=log,
-            debug_events=debug_events,
-            fork_session_id=fork_session_id,
-            ephemeral=ephemeral,
-        )
-        return
 
     acp_agent: AcpAgentEntry | None = None
     if from_openclaw is not None:

--- a/omnigent/cli_native.py
+++ b/omnigent/cli_native.py
@@ -74,14 +74,9 @@ def register_native_commands(cli: click.Group) -> None:
     )
     _resolve_harness_startup_args = _late_bound(lambda: _cli._resolve_harness_startup_args)
     _split_resume_value = _late_bound(lambda: _cli._split_resume_value)
+    _reject_smart_routing_prompt = _late_bound(lambda: _cli._reject_smart_routing_prompt)
     _reject_smart_routing_resume = _late_bound(lambda: _cli._reject_smart_routing_resume)
-    _require_smart_routing_prompt = _late_bound(lambda: _cli._require_smart_routing_prompt)
     _smart_routing_decision = _late_bound(lambda: _cli._smart_routing_decision)
-    _with_routed_model_arg = _late_bound(lambda: _cli._with_routed_model_arg)
-
-    from omnigent.runner.turn_routing import (
-        supports_in_harness_turn_routing as _supports_in_harness_turn_routing,
-    )
 
     @cli.command(
         context_settings={
@@ -175,8 +170,8 @@ def register_native_commands(cli: click.Group) -> None:
         is_flag=True,
         default=False,
         help=(
-            "Let the server pick the model for this launch. With -p the pick "
-            "happens up front; without it, your first typed message picks it."
+            "Let the server pick the model for this session. The first message "
+            "you type in the TUI is what gets routed, so this takes no -p."
         ),
     )
     @click.argument("claude_args", nargs=-1, type=click.UNPROCESSED)
@@ -200,7 +195,8 @@ def register_native_commands(cli: click.Group) -> None:
         #     existing Claude config.
         # :param profile_startup: When True, print startup timing marks.
         # :param prompt: Optional initial TUI prompt.
-        # :param smart_routing: When True, route the model from ``prompt``.
+        # :param smart_routing: When True, arm Smart Routing for the session so
+        #     the first typed message picks the model.
         # :param claude_args: Pass-through args for ``claude``.
         """Launch Claude Code with Omnigent.
 
@@ -210,17 +206,13 @@ def register_native_commands(cli: click.Group) -> None:
           omnigent claude --resume conv_abc123
           omnigent claude --resume                  # interactive picker
           omnigent claude --server https://<app>.databricksapps.com
-          omnigent claude --smart-routing -p "fix the flaky test"
+          omnigent claude --smart-routing           # first message picks the model
         """
         _reject_native_on_windows("claude")
         if smart_routing:
             # Validate before any side effects (daemon spawn, server discovery)
-            # so an unroutable invocation fails instantly. This harness hooks
-            # its own first prompt, so a bare launch routes on what gets typed.
-            prompt = _require_smart_routing_prompt(
-                prompt,
-                in_harness_routing=_supports_in_harness_turn_routing("claude-native"),
-            )
+            # so an unroutable invocation fails instantly.
+            _reject_smart_routing_prompt(prompt)
         startup_profiler = StartupProfiler.from_env(
             name="omnigent claude",
             env_var=_CLAUDE_STARTUP_PROFILE_ENV_VAR,
@@ -288,14 +280,11 @@ def register_native_commands(cli: click.Group) -> None:
         )
         extra_args = _resolve_harness_startup_args(cfg, "claude-native", claude_args)
         if smart_routing:
-            # Routing creates the session (that is where the model is picked and
-            # the decision card is written), so attach to it instead of letting
-            # the wrapper bundle a fresh one.
-            decision = _smart_routing_decision(
-                server=server, prompt=prompt, harness="claude-native"
-            )
-            extra_args = _with_routed_model_arg(extra_args, decision.model)
-            resolved_session_id = decision.session_id or resolved_session_id
+            # Arming creates the session (that is where Smart Routing is turned
+            # on and the decision card lands), so attach to it instead of
+            # letting the wrapper bundle a fresh one.
+            armed = _smart_routing_decision(server=server, harness="claude-native")
+            resolved_session_id = armed.session_id or resolved_session_id
         run_claude_native(
             server=server,
             session_id=resolved_session_id,
@@ -358,8 +347,8 @@ def register_native_commands(cli: click.Group) -> None:
         is_flag=True,
         default=False,
         help=(
-            "Let the server pick the model for this launch. With -p the pick "
-            "happens up front; without it, your first typed message picks it."
+            "Let the server pick the model for this session. The first message "
+            "you type in the TUI is what gets routed, so this takes no -p."
         ),
     )
     @click.argument("codex_args", nargs=-1, type=click.UNPROCESSED)
@@ -378,7 +367,8 @@ def register_native_commands(cli: click.Group) -> None:
         # :param session_id: Legacy ``--session`` id; mutually exclusive with ``--resume``.
         # :param model: Codex model id.
         # :param prompt: Optional first prompt.
-        # :param smart_routing: When True, route the model from ``prompt``.
+        # :param smart_routing: When True, arm Smart Routing for the session so
+        #     the first typed message picks the model.
         # :param codex_args: Pass-through args for ``codex`` before ``resume``.
         """Launch Codex with Omnigent.
 
@@ -388,19 +378,13 @@ def register_native_commands(cli: click.Group) -> None:
           omnigent codex --resume conv_abc123
           omnigent codex --resume                  # interactive picker
           omnigent codex --server https://<app>.databricksapps.com
-          omnigent codex --smart-routing -p "fix the flaky test"
+          omnigent codex --smart-routing           # first message picks the model
         """
         _reject_native_on_windows("codex")
-        model_source = click.get_current_context().get_parameter_source("model")
-        model_from_cli = model_source is click.core.ParameterSource.COMMANDLINE
         if smart_routing:
             # Validate before any side effects (daemon spawn, server discovery)
-            # so an unroutable invocation fails instantly. This harness hooks
-            # its own first prompt, so a bare launch routes on what gets typed.
-            prompt = _require_smart_routing_prompt(
-                prompt,
-                in_harness_routing=_supports_in_harness_turn_routing("codex-native"),
-            )
+            # so an unroutable invocation fails instantly.
+            _reject_smart_routing_prompt(prompt)
         choice = _split_resume_value(resume)
         if session_id is not None and (choice.picker or choice.conversation_id is not None):
             raise click.UsageError(
@@ -441,16 +425,11 @@ def register_native_commands(cli: click.Group) -> None:
             cfg=cfg,
         )
         if smart_routing:
-            decision = _smart_routing_decision(
-                server=server, prompt=prompt, harness="codex-native"
-            )
-            # Codex takes the model first-class. A routed model beats the
-            # configured default (the user asked to route) but never an
-            # explicit ``--model``.
-            if decision.model is not None and not model_from_cli:
-                model = decision.model
-            # Attach to the routed session — routing created it.
-            resolved_session_id = decision.session_id or resolved_session_id
+            # Attach to the armed session — arming created it. Nothing is picked
+            # yet, so ``model`` keeps whatever the user or config asked for
+            # until the first typed message routes.
+            armed = _smart_routing_decision(server=server, harness="codex-native")
+            resolved_session_id = armed.session_id or resolved_session_id
         run_codex_native(
             server=server,
             session_id=resolved_session_id,

--- a/omnigent/codex_model_vocabulary.py
+++ b/omnigent/codex_model_vocabulary.py
@@ -26,14 +26,17 @@ sending a value the CLI drops.
 
 **Turns** (``thread/setModel`` on a live thread). Here codex is its own
 vocabulary authority: the live ``model/list`` response IS the mapping, so
-:func:`codex_model_slug` hardcodes no model id. The gateway serves either
-spelling, so a thread switched onto a catalog id still RUNS; codex just warns
-"Model metadata for databricks-gpt-5-6-luna not found. Defaulting to fallback
-metadata" and leaves ``/model`` pointing at the launch slug, which reads as
-"routing did nothing". Extended-catalog rows (``system.ai.glm-5-2``) are
-listed under the catalog spelling, so they translate to themselves. An id no
-row matches is returned verbatim — the turn still runs, which beats skipping
-the switch.
+:func:`codex_reachable_model_slug` hardcodes no model id. Extended-catalog
+rows (``system.ai.glm-5-2``) are listed under the catalog spelling, so they
+translate to themselves.
+
+An id no row matches is not reachable from this pane, and the function returns
+``None`` rather than the id: the routing decision comes from a server-side
+gateway map that can name a model this pane's gateway does not actually serve,
+and switching onto one of those is a silent drop at the next turn. Declining
+the switch keeps the pane on a model it can run and puts the reason where
+someone can read it — the same posture the claude side takes when a routed
+model has no spelling its picker accepts.
 
 Stdlib-only so hook subprocesses can import it on the spawn/routing paths.
 """
@@ -151,21 +154,25 @@ def clamp_spawn_effort(effort: str | None, model: str | None) -> str | None:
     return EXTENDED_MODEL_DEFAULT_EFFORT.get(bare, effort)
 
 
-def codex_model_slug(
+def codex_reachable_model_slug(
     model: str,
     options: Iterable[Mapping[str, Any]],  # type: ignore[explicit-any]  # raw model/list rows
-) -> str:
-    """Translate a routed model id into codex's own spelling.
+) -> str | None:
+    """Translate a routed model id into codex's own spelling, if it serves it.
+
+    Doubles as the reachability check for a routed switch: the live catalog is
+    the only authority on what this pane can be moved onto, so "no row names
+    it" is the answer, not a reason to send the id anyway.
 
     :param model: Model id from a routing decision, e.g.
         ``"databricks-gpt-5-6-luna"``.
     :param options: Raw ``model/list`` rows, e.g.
         ``[{"id": "gpt-5.6-luna", "model": "gpt-5.6-luna"}]``.
-    :returns: The matching row's ``id``, or *model* verbatim when no row
-        names the same model (an empty catalog included).
+    :returns: The matching row's ``id``, or ``None`` when no row names the
+        same model (an empty catalog included).
     """
     if not isinstance(model, str) or not model.strip():
-        return model
+        return None
     target = comparable_model_id(model)
     for option in options:
         if not isinstance(option, Mapping):
@@ -179,4 +186,4 @@ def codex_model_slug(
         for spelling in (slug, option.get("model")):
             if isinstance(spelling, str) and comparable_model_id(spelling) == target:
                 return slug.strip()
-    return model
+    return None

--- a/omnigent/codex_native_hook.py
+++ b/omnigent/codex_native_hook.py
@@ -228,15 +228,17 @@ def _main_route_turn(argv: list[str]) -> int:
        advertised loopback ``route-turn`` endpoint. ``model`` comes from
        the hook payload, which tracks the LIVE thread model —
        ``config.toml`` reports the stale launch model.
-    3. On a routed verdict: switch the thread with
-       ``thread/settings/update`` (codex binds the turn's model before
-       this hook runs, so the switch lands from the next turn), write the
-       marker, and BLOCK the prompt. The runner then replays it as a
-       normal user turn, which runs on the routed model.
+    3. On a routed verdict: check the pick against this pane's live
+       ``model/list``, switch the thread with ``thread/settings/update``
+       (codex binds the turn's model before this hook runs, so the switch
+       lands from the next turn), write the marker, and BLOCK the prompt.
+       The runner then replays it as a normal user turn, which runs on the
+       routed model.
 
     Fails open everywhere: an absent advertisement, an unreachable
-    endpoint, an unroutable verdict or a failed switch all exit ``0`` with
-    no output, and the prompt runs untouched on the current model.
+    endpoint, an unroutable verdict, a pick this pane's gateway does not
+    serve, or a failed switch all exit ``0`` with no output, and the prompt
+    runs untouched on the current model.
 
     :param argv: CLI argv after the ``route-turn`` subcommand, e.g.
         ``["--bridge-dir", "/tmp/x", "--harness", "codex-native"]``.
@@ -327,14 +329,15 @@ def _main_route_turn(argv: list[str]) -> int:
             _write_marker(bridge_dir, session_id, decision)
         return 0
 
-    if not _apply_thread_model(bridge_dir, model):
+    declined = _apply_thread_model(bridge_dir, model)
+    if declined is not None:
         # No marker: the prompt is about to run, and the marker is what
         # tells the runner to replay it. Writing one here would replay a
         # prompt that already ran. The server-side pin still keeps the
         # next prompt from re-routing.
-        trace_turn_routing(bridge_dir, "fail-open", f"could not switch to {model}")
+        trace_turn_routing(bridge_dir, "fail-open", declined)
         print(
-            f"omnigent codex route-turn hook: could not switch to {model}; "
+            f"omnigent codex route-turn hook: {declined}; "
             "letting the prompt run on the current model",
             file=sys.stderr,
         )
@@ -428,9 +431,9 @@ def _post_json(
     return decoded if isinstance(decoded, dict) else None
 
 
-def _apply_thread_model(bridge_dir: Path, model: str) -> bool:
+def _apply_thread_model(bridge_dir: Path, model: str) -> str | None:
     """
-    Switch the live Codex thread onto *model*.
+    Switch the live Codex thread onto *model*, if this pane can serve it.
 
     ``thread/settings/update`` is the thread-level switch (the same one the
     web picker drives through the executor); the app-server accepts a
@@ -439,70 +442,83 @@ def _apply_thread_model(bridge_dir: Path, model: str) -> bool:
     mirrored into ``config.toml`` the way the executor does, so the
     cost-budget gate reads the routed model rather than the launch one.
 
-    The routed catalog id is translated into codex's own spelling first (see
-    :mod:`omnigent.codex_model_vocabulary`) — codex serves either, but only
-    recognizes its own, so an untranslated switch runs the right model while
-    the TUI warns about missing metadata and ``/model`` keeps highlighting
-    the launch slug.
+    The routed id is resolved against this pane's live ``model/list`` first
+    (see :mod:`omnigent.codex_model_vocabulary`), which is both the spelling
+    translation and the reachability check. The routing verdict comes from a
+    server-side gateway map that can go stale, and switching a pane onto a
+    model its gateway cannot serve fails silently at the next turn — so a
+    routed id no row names declines the switch instead, and the pane keeps
+    running on its own model.
 
     :param bridge_dir: Native Codex bridge directory.
     :param model: Routed model id, e.g. ``"databricks-gpt-5-6-luna"``.
-    :returns: ``True`` when Codex accepted the switch.
+    :returns: ``None`` when Codex accepted the switch, else a short reason
+        the switch was declined, for the caller's trace and stderr note.
     """
     import asyncio
 
-    from omnigent.codex_model_vocabulary import codex_model_slug
+    from omnigent.codex_model_vocabulary import codex_reachable_model_slug
     from omnigent.codex_native_app_server import client_for_transport
     from omnigent.codex_native_bridge import write_codex_config_model
     from omnigent.runner.turn_routing import SETTINGS_UPDATE_TIMEOUT_S
 
     state = read_bridge_state(bridge_dir)
     if state is None:
-        return False
+        return "no bridge state to switch through"
 
     # The spelling codex accepted, mirrored into config.toml below so the
     # file and the live thread never disagree about the model.
-    applied = model
+    applied: str | None = None
+    declined: str | None = None
 
     async def _switch() -> None:
-        nonlocal applied
+        nonlocal applied, declined
         client = client_for_transport(state.socket_path, client_name="omnigent-route-turn-hook")
         await client.connect()
         try:
-            applied = codex_model_slug(model, await _list_codex_models(client))
+            rows = await _list_codex_models(client)
+            if rows is None:
+                declined = "could not read this pane's model catalog"
+                return
+            slug = codex_reachable_model_slug(model, rows)
+            if slug is None:
+                declined = f"routed model not in this pane's catalog ({model})"
+                return
             await client.request(
                 "thread/settings/update",
-                {"threadId": state.thread_id, "model": applied},
+                {"threadId": state.thread_id, "model": slug},
             )
+            applied = slug
         finally:
             await client.close()
 
     try:
         asyncio.run(asyncio.wait_for(_switch(), timeout=SETTINGS_UPDATE_TIMEOUT_S))
     except Exception as exc:  # noqa: BLE001 - any failure means "leave the model alone"
-        print(
-            f"omnigent codex route-turn hook: thread/settings/update failed: {exc}",
-            file=sys.stderr,
-        )
-        return False
+        return f"thread/settings/update failed: {exc}"
+    if declined is not None:
+        return declined
+    if applied is None:
+        return f"could not switch to {model}"
     if not write_codex_config_model(bridge_dir, applied):
         print(
             f"omnigent codex route-turn hook: could not mirror {applied} into config.toml",
             file=sys.stderr,
         )
-    return True
+    return None
 
 
-async def _list_codex_models(client: CodexAppServerClient) -> list[dict[str, object]]:
+async def _list_codex_models(client: CodexAppServerClient) -> list[dict[str, object]] | None:
     """
     Read this session's codex model catalog over an open app-server client.
 
-    Hidden rows are included: they are still switchable, and translating a
-    routed model beats sending a spelling codex has no metadata for.
+    Hidden rows are included: they are still switchable, and a routed model
+    listed only there is reachable all the same.
 
     :param client: Connected app-server client.
-    :returns: Raw ``model/list`` rows, empty when the call fails (the
-        caller then applies the routed id verbatim).
+    :returns: Raw ``model/list`` rows, or ``None`` when the call failed —
+        which is not the same as an empty catalog, and the caller declines
+        the switch rather than reading "no rows" as "not reachable".
     """
     rows: list[dict[str, object]] = []
     cursor: str | None = None
@@ -519,11 +535,12 @@ async def _list_codex_models(client: CodexAppServerClient) -> list[dict[str, obj
             cursor = result.get("nextCursor")
             if not isinstance(cursor, str) or not cursor:
                 break
-    except Exception as exc:  # noqa: BLE001 - an unreadable catalog means "no translation"
+    except Exception as exc:  # noqa: BLE001 - an unreadable catalog means "do not switch"
         print(
             f"omnigent codex route-turn hook: model/list failed: {exc}",
             file=sys.stderr,
         )
+        return None
     return rows
 
 

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -1047,34 +1047,19 @@ def _resolve_gateway_env(
 
 
 def _databricks_claude_auth_command(host: str, profile: str | None = None) -> str:
-    """Return the legacy Databricks CLI auth helper command for Claude.
+    """Return the Databricks CLI ``apiKeyHelper`` command for Claude.
 
     :param host: Databricks workspace host, e.g.
         ``"https://example.databricks.com"``.
-    :param profile: Optional ``~/.databrickscfg`` profile name, e.g.
-        ``"oss"``. Preferred over ``--host`` when known: two profiles can
-        share one host, which makes ``databricks auth token --host`` fail
-        ("Use --profile to specify which profile") → empty token → 401.
-        ``--profile`` is always unambiguous.
+    :param profile: Optional ``~/.databrickscfg`` profile name, e.g. ``"oss"``.
+        Preferred over ``--host`` when known; see
+        :func:`~omnigent.inner.databricks_executor.databricks_bearer_token_command`,
+        which owns the command's shape for every harness.
     :returns: Shell command that prints a bearer token.
     """
-    # --profile is unambiguous; --host fails when two profiles share a host.
-    selector = f"--profile {json.dumps(profile)}" if profile else f"--host {json.dumps(host)}"
-    # `--force-refresh` proactively refreshes a still-valid cached token
-    # (guards against a mid-session 401 on long gateway connections) but
-    # only exists in Databricks CLI >= v0.296.0. Probe `--help` and pass it
-    # only when supported: older CLIs reject the unknown flag → empty token
-    # → silent 401. Plain `auth token` still auto-refreshes expired tokens.
-    return (
-        'if [ -n "${DATABRICKS_BEARER:-}" ]; then '
-        'printf "%s\\n" "$DATABRICKS_BEARER"; '
-        "else force=''; "
-        "if databricks auth token --help 2>&1 | grep -q force-refresh; "
-        "then force=--force-refresh; fi; "
-        "env -u DATABRICKS_CONFIG_PROFILE "
-        f"databricks auth token {selector} "
-        "$force --output json | jq -r '.access_token'; fi"
-    )
+    from .databricks_executor import databricks_bearer_token_command
+
+    return databricks_bearer_token_command(host, profile)
 
 
 def _parse_optional_int(value: str | None) -> int | None:

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -1606,36 +1606,19 @@ def _databricks_codex_base_url(host: str) -> str:
 
 
 def _databricks_codex_auth_command(host: str, profile: str | None = None) -> str:
-    """Return the legacy Databricks CLI auth helper command for Codex.
+    """Return the Databricks CLI ``auth.command`` for Codex.
 
     :param host: Databricks workspace host, e.g.
         ``"https://example.databricks.com"``.
-    :param profile: Optional ``~/.databrickscfg`` profile name, e.g.
-        ``"oss"``. Preferred over ``--host`` when known: two profiles can
-        share one host, which makes ``databricks auth token --host`` fail
-        ("Use --profile to specify which profile") → empty token → 401.
-        ``--profile`` is always unambiguous.
+    :param profile: Optional ``~/.databrickscfg`` profile name, e.g. ``"oss"``.
+        Preferred over ``--host`` when known; see
+        :func:`~omnigent.inner.databricks_executor.databricks_bearer_token_command`,
+        which owns the command's shape for every harness.
     :returns: Shell command that prints a bearer token.
     """
-    # --profile is unambiguous; --host fails when two profiles share a host.
-    selector = (
-        f"--profile {json.dumps(profile)}" if profile else f"--host {json.dumps(host.rstrip('/'))}"
-    )
-    # `--force-refresh` proactively refreshes a still-valid cached token
-    # (guards against a mid-session 401 on long gateway connections) but
-    # only exists in Databricks CLI >= v0.296.0. Probe `--help` and pass it
-    # only when supported: older CLIs reject the unknown flag → empty token
-    # → silent 401. Plain `auth token` still auto-refreshes expired tokens.
-    return (
-        'if [ -n "${DATABRICKS_BEARER:-}" ]; then '
-        'printf "%s\\n" "$DATABRICKS_BEARER"; '
-        "else force=''; "
-        "if databricks auth token --help 2>&1 | grep -q force-refresh; "
-        "then force=--force-refresh; fi; "
-        "env -u DATABRICKS_CONFIG_PROFILE "
-        f"databricks auth token {selector} "
-        "$force --output json | jq -r '.access_token'; fi"
-    )
+    from .databricks_executor import databricks_bearer_token_command
+
+    return databricks_bearer_token_command(host, profile)
 
 
 def _databricks_codex_config_overrides(

--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -229,6 +229,57 @@ def _read_databrickscfg_file_fallback(profile: str | None = None) -> DatabricksC
     return None
 
 
+def databricks_bearer_token_command(host: str, profile: str | None = None) -> str:
+    """Build the shell command a harness runs to mint a workspace bearer token.
+
+    The one definition of the generated helper, so the claude and codex
+    harnesses cannot drift apart on which profile they authenticate as or how
+    they handle a refresh failure.
+
+    **Profile selection.** ``--profile`` when the caller names one, ``--host``
+    only as the fallback. Two profiles can share a host, and ``databricks auth
+    token --host`` then fails ("Use --profile to specify which profile") →
+    empty token → 401. Host lookup is also how a pane and the server end up
+    authenticating as *different* profiles for the same workspace, one of them
+    re-authed and the other not.
+
+    **Refresh.** ``--force-refresh`` is attempted first: it renews a still-valid
+    cached token, which is what keeps a long gateway session from hitting a
+    mid-session 401. But it *fails* when the refresh token itself has gone
+    stale, and unconditionally forcing turned a perfectly usable cached access
+    token into a hard auth failure. So the forced attempt is speculative — its
+    output is captured and its stderr dropped — and an empty result falls back
+    to plain ``auth token``, which serves the cached token and renews it only
+    when it is near expiry. The fallback keeps its stderr so a genuine auth
+    failure is still visible. ``--force-refresh`` only exists in Databricks CLI
+    >= v0.296.0, so it stays behind the ``--help`` capability probe.
+
+    :param host: Databricks workspace host, e.g.
+        ``"https://example.databricks.com"``.
+    :param profile: ``~/.databrickscfg`` profile name, e.g. ``"oss"``, or
+        ``None`` to select the workspace by host.
+    :returns: Shell command that prints a bearer token on stdout.
+    """
+    selector = (
+        f"--profile {json.dumps(profile)}" if profile else f"--host {json.dumps(host.rstrip('/'))}"
+    )
+    mint = f"env -u DATABRICKS_CONFIG_PROFILE databricks auth token {selector}"
+    return (
+        # An injected bearer wins: the runner already resolved one.
+        'if [ -n "${DATABRICKS_BEARER:-}" ]; then '
+        'printf "%s\\n" "$DATABRICKS_BEARER"; '
+        "else token=''; "
+        "if databricks auth token --help 2>&1 | grep -q force-refresh; then "
+        f"token=$({mint} --force-refresh --output json 2>/dev/null "
+        "| jq -r '.access_token // empty'); "
+        "fi; "
+        'if [ -z "$token" ]; then '
+        f"token=$({mint} --output json | jq -r '.access_token // empty'); "
+        "fi; "
+        'printf "%s\\n" "$token"; fi'
+    )
+
+
 def _read_databrickscfg_host(profile: str | None = None) -> str | None:
     """
     Read only the workspace host from the Databricks config file.

--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -18,6 +18,7 @@ import asyncio
 import json
 import logging
 import os
+import shlex
 from collections.abc import AsyncIterator, Generator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
@@ -229,7 +230,11 @@ def _read_databrickscfg_file_fallback(profile: str | None = None) -> DatabricksC
     return None
 
 
-def databricks_bearer_token_command(host: str, profile: str | None = None) -> str:
+def databricks_bearer_token_command(
+    host: str,
+    profile: str | None = None,
+    fallback_command: str | None = None,
+) -> str:
     """Build the shell command a harness runs to mint a workspace bearer token.
 
     The one definition of the generated helper, so the claude and codex
@@ -254,16 +259,31 @@ def databricks_bearer_token_command(host: str, profile: str | None = None) -> st
     failure is still visible. ``--force-refresh`` only exists in Databricks CLI
     >= v0.296.0, so it stays behind the ``--help`` capability probe.
 
+    **Fallback command.** The named profile is the identity we *want*, but the
+    user may have authenticated under a different profile on the same host — a
+    config naming a credential-less profile would otherwise 401 every turn.
+    When the caller knows a token command that already worked (the one ucode
+    recorded, say), it runs last, once the named profile has yielded nothing.
+
     :param host: Databricks workspace host, e.g.
         ``"https://example.databricks.com"``.
     :param profile: ``~/.databrickscfg`` profile name, e.g. ``"oss"``, or
         ``None`` to select the workspace by host.
+    :param fallback_command: Shell command printing a bearer token on stdout,
+        run only when the profile above yields an empty token.
     :returns: Shell command that prints a bearer token on stdout.
     """
     selector = (
         f"--profile {json.dumps(profile)}" if profile else f"--host {json.dumps(host.rstrip('/'))}"
     )
     mint = f"env -u DATABRICKS_CONFIG_PROFILE databricks auth token {selector}"
+    fallback = (
+        # ``eval`` on a quoted string: the recorded command is opaque shell,
+        # and inlining it bare would let its own quoting reshape this script.
+        f'if [ -z "$token" ]; then token=$(eval {shlex.quote(fallback_command)}); fi; '
+        if fallback_command
+        else ""
+    )
     return (
         # An injected bearer wins: the runner already resolved one.
         'if [ -n "${DATABRICKS_BEARER:-}" ]; then '
@@ -276,6 +296,7 @@ def databricks_bearer_token_command(host: str, profile: str | None = None) -> st
         'if [ -z "$token" ]; then '
         f"token=$({mint} --output json | jq -r '.access_token // empty'); "
         "fi; "
+        f"{fallback}"
         'printf "%s\\n" "$token"; fi'
     )
 

--- a/omnigent/inner/hook_scripts/subagent_router.py
+++ b/omnigent/inner/hook_scripts/subagent_router.py
@@ -99,11 +99,12 @@ _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1"})
 # the runner answers first, smaller than the harness's hook timeout so this
 # script's fail-open branch can run.
 #
-# Single digits on purpose. This gate holds the parent agent's spawn tool open
-# until it answers, so a fail-open that takes half a minute stalls the agent as
-# surely as an error would; the routing call inside it runs on a 5s budget
-# (``omnigent.server.smart_routing.ROUTING_REQUEST_TIMEOUT_S``).
-REQUEST_TIMEOUT_S = 8.0
+# Well under the half-minute a wedged server used to cost, but wide enough to
+# outlast a HEALTHY route: the server prepares the candidate catalog (~3s on a
+# cold session) before the routing call, which itself runs on
+# ``omnigent.server.smart_routing.ROUTING_REQUEST_TIMEOUT_S``. A tighter budget
+# discards verdicts that did arrive.
+REQUEST_TIMEOUT_S = 15.0
 
 # Headroom hop 1 adds over hop 2. Enough for interpreter start-up and the
 # script's fail-open branch, and no more — every second here is a second the

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -315,8 +315,8 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
         api="anthropic-messages",
         model=model or model_catalog.resolve_catalog_model("databricks", family="claude").model_id,
         # Pi resolves a "!command" apiKey at request time, so the gateway
-        # bearer token is refreshed per request (the auth command itself
-        # force-refreshes), matching codex-native's refresh semantics.
+        # bearer token is re-read per request (the auth command attempts a
+        # refresh), matching codex-native's refresh semantics.
         api_key=api_key,
         auth_header=True,
         extra_models=claude_models,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -3271,6 +3271,10 @@ def create_runner_app(
         await asyncio.to_thread(shutdown_session_router, session_id)
         forget_session_routing_class(session_id)
 
+        from omnigent.runner.tool_dispatch import forget_spawn_family
+
+        forget_spawn_family(session_id)
+
         _session_spec_cache.pop(session_id, None)
         _session_harness_overrides.pop(session_id, None)
         _session_skills_cache.pop(session_id, None)

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -421,6 +421,10 @@ class _CodexNativeLaunchConfig:
         turn may need; and the spawn-routing endpoint, whose advertisement
         gates the generated ``spawn_agent`` hook and the routed-spawn tool
         pre-approvals a routed spawn cannot run without.
+    :param turn_routing: ``True`` when the first-message turn-routing endpoint
+        still has work to do. False on a session something already routed —
+        a web create that pinned the model before the pane launched — so the
+        ``UserPromptSubmit`` hook is never registered and no prompt is held.
     """
 
     workspace: Path
@@ -434,6 +438,7 @@ class _CodexNativeLaunchConfig:
     bypass_sandbox: bool
     auto_harness: bool = False
     routing_enabled: bool = False
+    turn_routing: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
@@ -563,23 +568,25 @@ def _start_turn_router_for_native_session(
     bridge_dir: Path,
     harness: str,
     server_client: httpx.AsyncClient | None,
-    routing_enabled: bool,
+    turn_routing: bool,
 ) -> TurnRouter | None:
     """Start the first-message turn-routing endpoint for a native session.
 
-    Installed only for a session that launched with Smart Routing on. The
-    advertisement it writes is also the switch the harness launch reads to
+    Installed only for a session whose first prompt still has to be routed.
+    The advertisement it writes is also the switch the harness launch reads to
     decide whether to register the ``UserPromptSubmit`` routing hook at all,
-    so an unrouted session's prompts never pay the round trip.
+    so a session that will never route pays no round trip — neither one with
+    routing off, nor one a web create already routed before the pane launched.
 
     :param session_id: Session/conversation identifier.
     :param bridge_dir: Session bridge directory the hook discovers.
     :param harness: Harness the endpoint is being installed for.
     :param server_client: Runner→server client the relay forwards on, and
         the replay delivers through.
-    :param routing_enabled: The session's launch-time Smart Routing state.
-    :returns: The router handle, or ``None`` when routing is off for this
-        session or the endpoint could not start.
+    :param turn_routing: Whether this session still needs first-message
+        routing (:class:`~omnigent.runner.subagent_routing.SessionRoutingClass`).
+    :returns: The router handle, or ``None`` when nothing is left to route
+        for this session or the endpoint could not start.
     """
     from omnigent.runner.turn_routing import ensure_session_turn_router
 
@@ -588,7 +595,7 @@ def _start_turn_router_for_native_session(
         bridge_dir=bridge_dir,
         server_client=server_client,
         harness=harness,
-        routing_enabled=routing_enabled,
+        routing_enabled=turn_routing,
     )
 
 
@@ -1013,6 +1020,7 @@ async def _codex_native_launch_config(
         bypass_sandbox=bypass_sandbox,
         auto_harness=routing_class.auto_harness,
         routing_enabled=routing_class.routing_enabled,
+        turn_routing=routing_class.turn_routing,
     )
 
 
@@ -3999,7 +4007,7 @@ async def _auto_create_codex_terminal(
         bridge_dir=bridge_dir,
         harness="codex-native",
         server_client=server_client,
-        routing_enabled=launch_config.routing_enabled,
+        turn_routing=launch_config.turn_routing,
     )
     app_server.listen_url = codex_ws_url
     await app_server.start()
@@ -5759,6 +5767,10 @@ class _ClaudeSessionLaunchMetadata:
     #: sessions get the routed-spawn system-prompt note and tool pre-approval;
     #: a pinned session's argv stays byte-identical.
     auto_harness: bool = False
+    #: The first-message routing hook still has work to do. False once the
+    #: session carries a routing decision — a web create routes the model
+    #: before the pane launches — so no prompt is ever held and replayed.
+    turn_routing: bool = False
 
 
 def _claude_launch_metadata_from_envelope(
@@ -5781,6 +5793,7 @@ def _claude_launch_metadata_from_envelope(
     return _ClaudeSessionLaunchMetadata(
         routing_enabled=routing_class.routing_enabled,
         auto_harness=routing_class.auto_harness,
+        turn_routing=routing_class.turn_routing,
         reasoning_effort=snapshot.reasoning_effort,
         model_override=snapshot.model_override,
         terminal_launch_args=snapshot.terminal_launch_args,
@@ -5835,6 +5848,7 @@ async def _load_legacy_claude_launch_metadata(
     metadata = _ClaudeSessionLaunchMetadata(
         routing_enabled=routing_class.routing_enabled,
         auto_harness=routing_class.auto_harness,
+        turn_routing=routing_class.turn_routing,
         reasoning_effort=effort if isinstance(effort, str) and effort else None,
         model_override=(
             model_override if isinstance(model_override, str) and model_override else None
@@ -6363,7 +6377,7 @@ async def _auto_create_claude_terminal(
         bridge_dir=bridge_dir,
         harness="claude-native",
         server_client=server_client,
-        routing_enabled=launch_metadata.routing_enabled,
+        turn_routing=launch_metadata.turn_routing,
     )
     # Crash recovery for a blocked-but-never-replayed prompt is not wired here:
     # the pending record on disk is the seam if it ever is, and the recovery's

--- a/omnigent/runner/subagent_routing.py
+++ b/omnigent/runner/subagent_routing.py
@@ -81,15 +81,18 @@ SERVER_ROUTE_PATH = "/v1/sessions/{session_id}/hooks/route-subagent"
 
 #: Seconds the runner's loopback relay waits for a verdict. Hop 3 of the
 #: timeout budget in the module docstring.
-RELAY_TIMEOUT_S = 7.0
+RELAY_TIMEOUT_S = 14.0
 
 #: Seconds the runner waits on the server relay route. Hop 4, inside which
-#: the routing call itself runs on ``ROUTING_REQUEST_TIMEOUT_S`` (5s).
-SERVER_HOP_TIMEOUT_S = 6.0
+#: the whole server-side route runs — candidate preparation and then the
+#: routing call (``ROUTING_REQUEST_TIMEOUT_S``), not the call alone.
+SERVER_HOP_TIMEOUT_S = 13.0
 
 #: Hop 2 of the budget, restated for the docstring cross-reference. The hook
-#: script owns the value; it cannot import this module (stdlib-only).
-HOOK_REQUEST_TIMEOUT_S = 8.0
+#: script owns the value; it cannot import this module (stdlib-only). Sized
+#: like the first-message hook: it must outlast a healthy route, preparation
+#: included, or a verdict that arrived is thrown away.
+HOOK_REQUEST_TIMEOUT_S = 15.0
 
 #: Conversation label carrying the routing decision behind a session's
 #: ``model_override``, so the child-sessions API can join the two without

--- a/omnigent/runner/subagent_routing.py
+++ b/omnigent/runner/subagent_routing.py
@@ -99,6 +99,16 @@ HOOK_REQUEST_TIMEOUT_S = 15.0
 #: a new column or a transcript scan.
 ROUTING_DECISION_LABEL_KEY = "omnigent.routing.decision_id"
 
+#: Conversation label fingerprinting the prompt a create-time route scored.
+#: A native Smart Routing create routes the prompt the user typed on the
+#: landing screen, and that same prompt is then submitted inside the harness —
+#: where the first-prompt hook would score it a second time, seconds later, for
+#: the same verdict. The fingerprint lets that hook recognize its own prompt
+#: and reuse the create's decision. A hash, not the text: a label is metadata
+#: that travels into listings and telemetry, and the user's prompt does not
+#: belong there.
+CREATE_ROUTE_PROMPT_LABEL_KEY = "omnigent.routing.create_prompt"
+
 #: Conversation label marking a session created in auto-harness mode. The
 #: ``harness_override`` sentinel is replaced the moment first-message routing
 #: resolves a harness, so this label is the durable record that the router

--- a/omnigent/runner/subagent_routing.py
+++ b/omnigent/runner/subagent_routing.py
@@ -229,10 +229,18 @@ class SessionRoutingClass:
         model.
     :param auto_harness: The session also let Smart Routing pick the
         harness, so the router may move its spawns across families.
+    :param turn_routing: The session still needs the ``UserPromptSubmit``
+        first-message routing hook. False once something has already routed
+        the session — a web create that routed the model before the pane
+        launched, or an earlier turn — because the hook's only remaining
+        answer is "already routed", paid for with a round trip per prompt.
+        Independent of ``routing_enabled``: a routed session keeps the
+        extended catalog and its spawn routing.
     """
 
     routing_enabled: bool = False
     auto_harness: bool = False
+    turn_routing: bool = False
 
 
 #: The class a session with no recorded routing state is treated as. Read by
@@ -255,7 +263,8 @@ def routing_class_from_snapshot(
     :param harness_override: ``harness_override``; the ``"auto"`` sentinel
         marks auto-harness until first-message routing replaces it.
     :param labels: Conversation labels, which carry the durable
-        :data:`AUTO_HARNESS_LABEL_KEY` record.
+        :data:`AUTO_HARNESS_LABEL_KEY` record and the
+        :data:`ROUTING_DECISION_LABEL_KEY` a completed route stamps.
     :returns: The session's class.
     """
     auto = harness_override == "auto" or (
@@ -264,9 +273,16 @@ def routing_class_from_snapshot(
     # An auto-harness session is a Smart Routing session by construction, so
     # the label implies routing is on even for a row whose cost-control field
     # was never stamped.
+    routes = routing_enabled(cost_control_mode) or auto
+    # The same label the turn hook reads as its "route once" gate: when it is
+    # already there the hook can only ever answer "already routed", so the
+    # launch omits it instead of registering a per-prompt round trip. A create
+    # whose routing failed stamps nothing, and keeps the hook as its retry.
+    already_routed = bool(labels is not None and labels.get(ROUTING_DECISION_LABEL_KEY))
     return SessionRoutingClass(
-        routing_enabled=routing_enabled(cost_control_mode) or auto,
+        routing_enabled=routes,
         auto_harness=auto,
+        turn_routing=routes and not already_routed,
     )
 
 

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -4259,6 +4259,90 @@ def _scan_local_agent_configs(configs_dir: Path) -> list[_JsonObject]:
     return entries
 
 
+async def _spawn_family(
+    server_client: httpx.AsyncClient,
+    conversation_id: str | None,
+) -> str | None:
+    """Return the model family a session's spawns are confined to.
+
+    Only a session running Smart Routing on a PINNED harness confines
+    them: its spawns are routed inside its own family, so an agent from
+    another family has no candidate model it could be routed onto and
+    must never be offered as spawnable in the first place. An
+    auto-harness session hands the family choice to the router, and a
+    plain session is not routed at all — both see the whole surface, byte
+    for byte as before.
+
+    Best-effort: an unreadable session reads as "no confinement", because
+    a discovery listing must not fail on the routing lookup. The
+    child-create gate is the enforcement.
+
+    :param server_client: HTTP client pointed at the Omnigent server.
+    :param conversation_id: The calling session's id, or ``None``.
+    :returns: ``"claude"`` / ``"gpt"`` / ``"pi"`` when the caller's spawns
+        are confined to that family, else ``None``.
+    """
+    from types import SimpleNamespace
+
+    from omnigent.runner.subagent_routing import (
+        auto_harness_session,
+        harness_family,
+        subagent_routing_enabled,
+    )
+
+    if conversation_id is None:
+        return None
+    try:
+        resp = await server_client.get(
+            f"/v1/sessions/{conversation_id}",
+            # Only the routing fields are read, so skip the history and
+            # runner-liveness work the full snapshot would do.
+            params={"include_items": "false", "include_liveness": "false"},
+            timeout=30.0,
+        )
+    except Exception:  # noqa: BLE001 — discovery must not fail on this read
+        return None
+    if resp.status_code != 200:
+        return None
+    snapshot = _string_object_dict(resp.json())
+    if snapshot is None:
+        return None
+    if not subagent_routing_enabled(_optional_string(snapshot.get("subagent_routing_override"))):
+        return None
+    harness = _optional_string(snapshot.get("harness"))
+    labels = _string_object_dict(snapshot.get("labels")) or {}
+    # The shared predicate reads the same two fields off a conversation row.
+    row = SimpleNamespace(
+        labels={key: value for key, value in labels.items() if isinstance(value, str)},
+        harness_override=harness,
+    )
+    if auto_harness_session(row):
+        return None
+    return harness_family(harness)
+
+
+def _in_spawn_family(builtins: list[_JsonObject], family: str | None) -> list[_JsonObject]:
+    """Drop built-in agents *family* cannot serve.
+
+    :param builtins: Projected ``builtins`` rows, each carrying ``harness``.
+    :param family: The caller's confined family, or ``None`` to keep all.
+    :returns: The rows a session confined to *family* may spawn. An agent
+        whose harness has no family (unknown, or multi-family like pi) is
+        kept: nothing proves it is out of family.
+    """
+    if family is None:
+        return builtins
+    from omnigent.runner.subagent_routing import harness_family
+
+    kept: list[_JsonObject] = []
+    for row in builtins:
+        harness = row.get("harness")
+        row_family = harness_family(harness) if isinstance(harness, str) else None
+        if row_family is None or row_family == family:
+            kept.append(row)
+    return kept
+
+
 async def _agent_list_via_rest(
     server_client: httpx.AsyncClient,
     *,
@@ -4283,6 +4367,12 @@ async def _agent_list_via_rest(
       (YAMLs authored with ``sys_os_write`` per the agent-authoring
       skill), projected to ``{name, path, description}``.
 
+    On a pinned Smart Routing session the ``builtins`` section is confined
+    to the caller's own model family (:func:`_spawn_family`) — an agent it
+    could never route a spawn onto is not a launchable agent for it. The
+    other two sections carry no harness to filter on; the child-create gate
+    refuses those.
+
     :param server_client: HTTP client pointed at the Omnigent server.
     :param agent_spec: The running agent's spec, for os_env cwd
         resolution of the local-config scan.
@@ -4296,7 +4386,11 @@ async def _agent_list_via_rest(
     assert spec.cwd is not None
     configs_dir = Path(spec.cwd) / _AGENT_CONFIG_SUBDIR
     local_configs = await asyncio.to_thread(_scan_local_agent_configs, configs_dir)
-    return json.dumps(_project_agent_list(builtins_raw, sessions_raw, local_configs))
+    listing = _project_agent_list(builtins_raw, sessions_raw, local_configs)
+    listing["builtins"] = _in_spawn_family(
+        listing["builtins"], await _spawn_family(server_client, conversation_id)
+    )
+    return json.dumps(listing)
 
 
 def _project_agent_list(

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -4259,6 +4259,18 @@ def _scan_local_agent_configs(configs_dir: Path) -> list[_JsonObject]:
     return entries
 
 
+#: Budget for the confinement lookup. Short on purpose: a slow or wedged
+#: server must not hold an agent listing open, and an unanswered lookup
+#: fails open to the unfiltered list.
+_SPAWN_FAMILY_TIMEOUT_S = 5.0
+
+#: Resolved confinement per session. Routing state is stamped at create and
+#: never changes, so one lookup serves every later ``sys_agent_list``. Only
+#: sessions with routing armed locally reach it, and only answered lookups
+#: are stored, so a fail-open miss is retried next call.
+_spawn_family_cache: dict[str, str | None] = {}
+
+
 async def _spawn_family(
     server_client: httpx.AsyncClient,
     conversation_id: str | None,
@@ -4273,9 +4285,15 @@ async def _spawn_family(
     plain session is not routed at all — both see the whole surface, byte
     for byte as before.
 
-    Best-effort: an unreadable session reads as "no confinement", because
-    a discovery listing must not fail on the routing lookup. The
-    child-create gate is the enforcement.
+    The runner-local routing class answers for those two cases without
+    touching the server, so a plain session — the overwhelming majority —
+    pays nothing for a feature it does not use. Only a locally pinned
+    routed session spends the one cached lookup that reads the
+    subagent-routing switch.
+
+    Best-effort: an unreadable or slow session read fails open to "no
+    confinement", because a discovery listing must not block on the
+    routing lookup. The child-create gate is the enforcement.
 
     :param server_client: HTTP client pointed at the Omnigent server.
     :param conversation_id: The calling session's id, or ``None``.
@@ -4287,18 +4305,24 @@ async def _spawn_family(
     from omnigent.runner.subagent_routing import (
         auto_harness_session,
         harness_family,
+        session_routing_class,
         subagent_routing_enabled,
     )
 
     if conversation_id is None:
         return None
+    local = session_routing_class(conversation_id)
+    if not local.routing_enabled or local.auto_harness:
+        return None
+    if conversation_id in _spawn_family_cache:
+        return _spawn_family_cache[conversation_id]
     try:
         resp = await server_client.get(
             f"/v1/sessions/{conversation_id}",
             # Only the routing fields are read, so skip the history and
             # runner-liveness work the full snapshot would do.
             params={"include_items": "false", "include_liveness": "false"},
-            timeout=30.0,
+            timeout=_SPAWN_FAMILY_TIMEOUT_S,
         )
     except Exception:  # noqa: BLE001 — discovery must not fail on this read
         return None
@@ -4307,18 +4331,27 @@ async def _spawn_family(
     snapshot = _string_object_dict(resp.json())
     if snapshot is None:
         return None
-    if not subagent_routing_enabled(_optional_string(snapshot.get("subagent_routing_override"))):
-        return None
-    harness = _optional_string(snapshot.get("harness"))
-    labels = _string_object_dict(snapshot.get("labels")) or {}
-    # The shared predicate reads the same two fields off a conversation row.
-    row = SimpleNamespace(
-        labels={key: value for key, value in labels.items() if isinstance(value, str)},
-        harness_override=harness,
-    )
-    if auto_harness_session(row):
-        return None
-    return harness_family(harness)
+    family: str | None = None
+    if subagent_routing_enabled(_optional_string(snapshot.get("subagent_routing_override"))):
+        harness = _optional_string(snapshot.get("harness"))
+        labels = _string_object_dict(snapshot.get("labels")) or {}
+        # The shared predicate reads the same two fields off a conversation row.
+        row = SimpleNamespace(
+            labels={key: value for key, value in labels.items() if isinstance(value, str)},
+            harness_override=harness,
+        )
+        if not auto_harness_session(row):
+            family = harness_family(harness)
+    _spawn_family_cache[conversation_id] = family
+    return family
+
+
+def forget_spawn_family(conversation_id: str) -> None:
+    """Drop the cached spawn confinement for a finished session.
+
+    :param conversation_id: Session/conversation identifier.
+    """
+    _spawn_family_cache.pop(conversation_id, None)
 
 
 def _in_spawn_family(builtins: list[_JsonObject], family: str | None) -> list[_JsonObject]:

--- a/omnigent/runner/turn_routing.py
+++ b/omnigent/runner/turn_routing.py
@@ -136,14 +136,19 @@ ROUTE_PATH_TEMPLATE = "/v1/sessions/{session_id}/route-turn"
 SERVER_ROUTE_PATH = "/v1/sessions/{session_id}/hooks/route-turn"
 
 #: Hop 1: the timeout registered on the harness's hook entry. Covers the
-#: hook script's whole life (hop 2a + hop 2b) with one second to spare, so
-#: the harness only steps in when the script itself wedged.
-HARNESS_HOOK_TIMEOUT_S = 15
+#: hook script's whole life (hop 2a + hop 2b) plus its cold start, so the
+#: harness only steps in when the script itself wedged. Stays below Claude
+#: Code's own 30s ``UserPromptSubmit`` default — the harness must not be the
+#: layer that gives up first.
+HARNESS_HOOK_TIMEOUT_S = 22
 
-#: Hop 2a: the hook script's HTTP budget for the routing verdict. The
-#: user-visible cost of a wedged router — the prompt sits in the pane until
-#: this expires — so it stays in single digits.
-HOOK_REQUEST_TIMEOUT_S = 8.0
+#: Hop 2a: the hook script's HTTP budget for the routing verdict. This is
+#: the user-visible cost of a wedged router — the prompt sits in the pane
+#: until it expires — but it must also outlast a HEALTHY route, which is
+#: the whole server-side path: candidate/catalog preparation (~3s measured)
+#: before the ``routes:select`` call, then the call itself. A tighter budget
+#: loses the race with a router that answered, wasting the attempt.
+HOOK_REQUEST_TIMEOUT_S = 15.0
 
 #: Hop 2b: the codex hook's ``thread/settings/update`` budget, after the
 #: verdict. Claude's hook applies nothing, so it has no hop 2b. A local
@@ -151,11 +156,12 @@ HOOK_REQUEST_TIMEOUT_S = 8.0
 SETTINGS_UPDATE_TIMEOUT_S = 5.0
 
 #: Hop 3: seconds the runner's loopback relay waits for a verdict.
-RELAY_TIMEOUT_S = 7.0
+RELAY_TIMEOUT_S = 14.0
 
-#: Hop 4: seconds the runner waits on the server relay route. The routing
-#: call itself (``ROUTING_REQUEST_TIMEOUT_S``, 5s) runs inside this.
-SERVER_HOP_TIMEOUT_S = 6.0
+#: Hop 4: seconds the runner waits on the server relay route. The whole
+#: server-side route runs inside this — catalog preparation and then the
+#: routing call (``ROUTING_REQUEST_TIMEOUT_S``), not the call alone.
+SERVER_HOP_TIMEOUT_S = 13.0
 
 #: Seconds the replay waits for the hook to confirm it blocked the prompt
 #: (:data:`MARKER_FILE`). Timing out means the hook fell open, so the

--- a/omnigent/runner/turn_routing.py
+++ b/omnigent/runner/turn_routing.py
@@ -75,6 +75,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
 import json
 import logging
 import secrets
@@ -194,6 +195,11 @@ _SCOPE = "turn"
 
 #: Prompt text handed to the router, capped like the subagent path.
 _PROMPT_CAP = 4000
+
+#: Hex characters kept from a create-route prompt fingerprint. Long enough
+#: that two prompts in one session never collide, short enough to keep the
+#: label small.
+_FINGERPRINT_CHARS = 32
 
 #: Coroutine that returns ``(model, verdict)`` for one turn — the
 #: ``omnigent.server.smart_routing.route_turn`` seam, injected so the
@@ -496,6 +502,43 @@ def out_of_parent_family(
     return parent_family is not None and own_family is not None and parent_family != own_family
 
 
+def create_route_prompt_fingerprint(prompt: str) -> str:
+    """Fingerprint a prompt for the create-route reuse check.
+
+    Whitespace-insensitive at the edges only: the harness submits the prompt
+    the create routed, but a launcher may add or drop a trailing newline.
+    Anything else is a different prompt and must route on its own.
+
+    :param prompt: The prompt text.
+    :returns: A hex digest, empty for a blank prompt.
+    """
+    text = prompt.strip()
+    if not text:
+        return ""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:_FINGERPRINT_CHARS]
+
+
+def create_route_covers_prompt(conv: Any, prompt: str) -> bool:
+    """Report whether a create-time route already scored *prompt*.
+
+    A native Smart Routing create routes the landing screen's prompt and pins
+    what it picked; the harness then submits that same prompt, and this hook
+    would score it again — a second router call, seconds later, for a verdict
+    the session is already running on. The create records a fingerprint of what
+    it routed, so the repeat is recognizable; a prompt the user edited before
+    sending does not match and routes on its own.
+
+    :param conv: Conversation row for the session.
+    :param prompt: The submitted prompt.
+    :returns: ``True`` when this prompt was already routed at create.
+    """
+    from omnigent.runner.subagent_routing import CREATE_ROUTE_PROMPT_LABEL_KEY
+
+    labels = getattr(conv, "labels", None) or {}
+    recorded = labels.get(CREATE_ROUTE_PROMPT_LABEL_KEY)
+    return bool(recorded) and recorded == create_route_prompt_fingerprint(prompt)
+
+
 async def resolve_turn_route(
     session_id: str,
     req: TurnRouteRequest,
@@ -504,6 +547,7 @@ async def resolve_turn_route(
     parent: Any = None,
     parent_harness: str | None = None,
     route_turn: RouteTurnFn,
+    reuse_create_route: Callable[[], Awaitable[bool]] | None = None,
     pin: Callable[[str], Awaitable[bool]] | None = None,
     persist: Callable[[str, dict[str, Any]], Awaitable[None]] | None = None,
 ) -> TurnRouteDecision:
@@ -522,6 +566,11 @@ async def resolve_turn_route(
         guard. ``None`` skips it (nothing to compare against).
     :param route_turn: The routing seam, called as
         ``route_turn(harness, prompt)``.
+    :param reuse_create_route: Coroutine claiming the create-time decision as
+        this session's routing decision, for a prompt the create already
+        routed; returns ``False`` when there is nothing to claim (or the
+        claim failed), and the prompt is then routed normally. ``None``
+        skips the reuse path.
     :param pin: Coroutine persisting ``model_override``; returns ``False``
         when the write failed (routing is then declined, because an
         unpinned route would re-route on every later prompt). ``None``
@@ -561,6 +610,18 @@ async def resolve_turn_route(
             req.harness,
         )
         return _allow("this session's parent routes only its own model family")
+    if create_route_covers_prompt(conv, req.prompt) and (
+        reuse_create_route is None or await reuse_create_route()
+    ):
+        # The create already routed this exact prompt and pinned what it
+        # picked, so the pane is running the verdict. Routing again would cost
+        # a second judge call for the same answer — and block the prompt to
+        # "switch" onto the model it is already on.
+        _logger.info(
+            "route-turn: session=%s reuses the create-time decision for this prompt",
+            session_id,
+        )
+        return _allow("this session was routed at create on this prompt", terminal=True)
 
     try:
         model, verdict = await route_turn(req.harness, req.prompt[:_PROMPT_CAP])

--- a/omnigent/runner/turn_routing.py
+++ b/omnigent/runner/turn_routing.py
@@ -539,6 +539,29 @@ def create_route_covers_prompt(conv: Any, prompt: str) -> bool:
     return bool(recorded) and recorded == create_route_prompt_fingerprint(prompt)
 
 
+async def _record_turn_decline(
+    record_decline: Callable[[str], Awaitable[None]] | None,
+    cause: str,
+    session_id: str,
+) -> None:
+    """Persist the declined chip for a failed routing call, best-effort.
+
+    The chip is a record, not a gate: a persist failure must not change the
+    fail-open verdict, so every error is swallowed into a log line.
+
+    :param record_decline: The caller's persistence coroutine, or ``None``.
+    :param cause: Why nothing was routed, e.g. ``"Routing call failed: 401"``.
+    :param session_id: Session the decline belongs to, for the log line.
+    :returns: None.
+    """
+    if record_decline is None:
+        return
+    try:
+        await record_decline(cause)
+    except Exception:
+        _logger.exception("route-turn: decline record failed for session=%s", session_id)
+
+
 async def resolve_turn_route(
     session_id: str,
     req: TurnRouteRequest,
@@ -550,6 +573,7 @@ async def resolve_turn_route(
     reuse_create_route: Callable[[], Awaitable[bool]] | None = None,
     pin: Callable[[str], Awaitable[bool]] | None = None,
     persist: Callable[[str, dict[str, Any]], Awaitable[None]] | None = None,
+    record_decline: Callable[[str], Awaitable[None]] | None = None,
 ) -> TurnRouteDecision:
     """Decide what happens to one submitted prompt.
 
@@ -577,6 +601,10 @@ async def resolve_turn_route(
         skips the pin (unit tests).
     :param persist: Coroutine recording the decision chip, called as
         ``persist(model, verdict)``. ``None`` skips persistence.
+    :param record_decline: Coroutine persisting a declined chip when a
+        routing CALL failed, called with the cause. Only the failure
+        branches use it — the benign allows (already routed, routing off,
+        family guard) are not failures and stay chipless. ``None`` skips it.
     :returns: The verdict the hook enforces.
     """
     from omnigent.codex_model_vocabulary import comparable_model_id
@@ -625,11 +653,14 @@ async def resolve_turn_route(
 
     try:
         model, verdict = await route_turn(req.harness, req.prompt[:_PROMPT_CAP])
-    except Exception:  # noqa: BLE001 — a router outage must never block a turn
+    except Exception as exc:  # noqa: BLE001 — a router outage must never block a turn
         _logger.warning(
             "route-turn: router call failed for session=%s; allowing unrouted",
             session_id,
             exc_info=True,
+        )
+        await _record_turn_decline(
+            record_decline, f"Routing call failed: {type(exc).__name__}", session_id
         )
         return _allow("routing unavailable (router call failed)")
     if not model or verdict is None:
@@ -637,6 +668,9 @@ async def resolve_turn_route(
             "route-turn: no verdict for session=%s harness=%s; allowing unrouted",
             session_id,
             req.harness,
+        )
+        await _record_turn_decline(
+            record_decline, "Routing unavailable (router returned no verdict)", session_id
         )
         return _allow("routing unavailable (no verdict)")
     # Spelling-insensitive: codex reports its live model as a dotted slug

--- a/omnigent/runner/turn_routing.py
+++ b/omnigent/runner/turn_routing.py
@@ -459,12 +459,50 @@ def already_routed(conv: Any) -> bool:
     return bool(labels.get(ROUTING_DECISION_LABEL_KEY))
 
 
+def out_of_parent_family(
+    conv: Any,
+    parent: Any,
+    parent_harness: str | None,
+    harness: str | None,
+) -> bool:
+    """Report whether this pane runs outside its parent's routed family.
+
+    A pinned Smart Routing parent routes its spawns inside its own family,
+    so a child pane on another family's CLI has no candidate its parent's
+    family could serve — routing it here would pick a model the pane cannot
+    speak. The create gate refuses such a child outright, so this only
+    catches a pane that exists anyway (a row created before that gate).
+
+    :param conv: Conversation row for the pane.
+    :param parent: Conversation row for its parent, or ``None``.
+    :param parent_harness: The parent's resolved harness, e.g. ``"codex"``.
+    :param harness: The pane's own harness, from the hook payload.
+    :returns: ``True`` when the pane must not be routed.
+    """
+    from omnigent.runner.subagent_routing import (
+        auto_harness_session,
+        harness_family,
+        subagent_routing_enabled,
+    )
+
+    if parent is None or conv is None:
+        return False
+    if not subagent_routing_enabled(getattr(parent, "subagent_routing_override", None)):
+        return False
+    if auto_harness_session(conv, parent):
+        return False
+    parent_family = harness_family(parent_harness)
+    own_family = harness_family(harness)
+    return parent_family is not None and own_family is not None and parent_family != own_family
+
+
 async def resolve_turn_route(
     session_id: str,
     req: TurnRouteRequest,
     *,
     conv: Any,
     parent: Any = None,
+    parent_harness: str | None = None,
     route_turn: RouteTurnFn,
     pin: Callable[[str], Awaitable[bool]] | None = None,
     persist: Callable[[str, dict[str, Any]], Awaitable[None]] | None = None,
@@ -480,6 +518,8 @@ async def resolve_turn_route(
     :param req: The prompt awaiting a verdict.
     :param conv: Conversation row for the session, or ``None``.
     :param parent: Conversation row for its parent, when it has one.
+    :param parent_harness: The parent's resolved harness, for the family
+        guard. ``None`` skips it (nothing to compare against).
     :param route_turn: The routing seam, called as
         ``route_turn(harness, prompt)``.
     :param pin: Coroutine persisting ``model_override``; returns ``False``
@@ -509,6 +549,18 @@ async def resolve_turn_route(
         # prompt in the TUI; the composer gate and create-time path are
         # unaffected.
         return _allow("smart routing is off for this session", terminal=True)
+    if out_of_parent_family(conv, parent, parent_harness, req.harness):
+        # Non-terminal: the parent's subagent-routing switch is togglable, and
+        # a pane this fires for is not supposed to exist at all (the create
+        # gate refuses it), so the extra round trip buys a guard that cannot
+        # go stale.
+        _logger.info(
+            "route-turn: session=%s harness=%s runs outside its parent's routed "
+            "family; allowing unrouted",
+            session_id,
+            req.harness,
+        )
+        return _allow("this session's parent routes only its own model family")
 
     try:
         model, verdict = await route_turn(req.harness, req.prompt[:_PROMPT_CAP])

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2180,6 +2180,7 @@ def create_app(
         from omnigent.server.routes.sessions import (
             _ensure_runner_relay,
             _publish_runner_recovered_status,
+            prefetch_session_routing_catalogs,
         )
 
         # Stamp liveness immediately so other replicas see the runner
@@ -2246,6 +2247,10 @@ def create_app(
                 routed.client,
                 conversation_store,
             )
+            # The session's terminal exists as of the handshake above, so its
+            # model catalogs are answerable now. Warming them here is what
+            # keeps the first routed message off the runner round trip.
+            prefetch_session_routing_catalogs(conv.id, conv, routed.client)
             # Reconcile the persisted pending-elicitation count with this
             # pod's live index. A runner that crashed with prompts parked
             # leaves a stale row (no decrement is ever written on a crash),

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2249,7 +2249,9 @@ def create_app(
             )
             # The session's terminal exists as of the handshake above, so its
             # model catalogs are answerable now. Warming them here is what
-            # keeps the first routed message off the runner round trip.
+            # keeps the first routed message off the runner round trip. The
+            # helper self-gates on routing state, so the plain sessions in this
+            # loop (and any archived row) cost nothing.
             prefetch_session_routing_catalogs(conv.id, conv, routed.client)
             # Reconcile the persisted pending-elicitation count with this
             # pod's live index. A runner that crashed with prompts parked

--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -465,6 +465,11 @@ _model_options_stale: set[str] = set()
 _MODEL_OPTIONS_RETRY_DELAYS_S = (0.25, 0.5, 1.0, 2.0, 2.0)
 
 
+# Strong references to fire-and-forget catalog prefetches, so a task cannot be
+# garbage-collected mid-flight. Entries remove themselves when they finish.
+_catalog_prefetch_tasks: set[asyncio.Task[None]] = set()
+
+
 _pushed_model_options_cache: dict[str, list[dict[str, Any]]] = {}
 
 
@@ -841,6 +846,7 @@ __all__ = [
     "_browser_action_claims",
     "_browser_action_owners",
     "_browser_action_registry",
+    "_catalog_prefetch_tasks",
     "_deferred_elicitation_clear_tasks",
     "_intentional_stop_sessions",
     "_interrupt_fenced_sessions",

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -14,8 +14,17 @@ import re
 import secrets
 import time
 import urllib.parse
+import weakref
 from collections import deque
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Mapping, Sequence
+from collections.abc import (
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Coroutine,
+    Iterable,
+    Mapping,
+    Sequence,
+)
 from dataclasses import dataclass
 from typing import Any, Literal, cast
 
@@ -8906,6 +8915,58 @@ async def _load_model_options(
         return
 
 
+#: How many sessions may warm their catalogs at once. A tunnel flap reconnects
+#: every session bound to the runner at once, and each warm-up costs a runner
+#: round trip plus a provider listing on a worker thread; the cap keeps that
+#: burst off the executor the concurrent session re-init needs.
+_CATALOG_PREFETCH_CONCURRENCY = 4
+
+#: One semaphore per event loop: the server runs a single loop, but an asyncio
+#: primitive cannot be shared across the loops the test suite creates.
+_catalog_prefetch_semaphores: weakref.WeakKeyDictionary[
+    asyncio.AbstractEventLoop, asyncio.Semaphore
+] = weakref.WeakKeyDictionary()
+
+
+def _catalog_prefetch_semaphore() -> asyncio.Semaphore:
+    """
+    Return this loop's catalog-prefetch concurrency gate.
+
+    :returns: The semaphore bounding concurrent prefetches.
+    """
+    loop = asyncio.get_running_loop()
+    semaphore = _catalog_prefetch_semaphores.get(loop)
+    if semaphore is None:
+        semaphore = asyncio.Semaphore(_CATALOG_PREFETCH_CONCURRENCY)
+        _catalog_prefetch_semaphores[loop] = semaphore
+    return semaphore
+
+
+async def _run_catalog_prefetch(
+    coro: Coroutine[Any, Any, Any],
+    session_id: str,
+) -> None:
+    """
+    Run one best-effort catalog prefetch under the concurrency cap.
+
+    Retrieves its own exception: a prefetch is fire-and-forget, so anything it
+    raises (a runner round trip torn down mid-flight, say) would otherwise
+    surface as an unretrieved-task warning and drown real errors. A failure
+    here just leaves a cold cache, which every reader already handles.
+
+    :param coro: The prefetch coroutine to run.
+    :param session_id: Session/conversation identifier, for the log line.
+    """
+    try:
+        async with _catalog_prefetch_semaphore():
+            await coro
+    except asyncio.CancelledError:
+        coro.close()
+        raise
+    except Exception:  # noqa: BLE001 - best-effort warm-up; a cold cache is fine.
+        _logger.debug("Catalog prefetch failed for %s", session_id, exc_info=True)
+
+
 def prefetch_session_routing_catalogs(
     session_id: str,
     conv: Conversation,
@@ -8922,28 +8983,54 @@ def prefetch_session_routing_catalogs(
     prompt; a turn arriving before they finish still falls back to its own
     inline fetch, so this only ever removes waiting.
 
+    Only routed, live sessions warm anything. Smart Routing is the sole reader
+    of these caches, and the caller reconnects *every* session bound to a
+    runner — a plain-session host with a flapping tunnel would otherwise spend
+    two runner round trips per pane, on nothing, while the session re-init
+    running alongside it waits for the same executor. Archived sessions are
+    skipped for the same reason: nothing is going to route a turn on them.
+
     Fire-and-forget: a failed prefetch is a cold cache, which every reader
     already handles.
 
     :param session_id: Session/conversation identifier, e.g. ``"conv_abc"``.
-    :param conv: Conversation row, read for the wrapper label.
+    :param conv: Conversation row, read for the routing state and the wrapper
+        label.
     :param runner_client: HTTP client pointed at the newly bound runner.
     """
+    from omnigent.runner.subagent_routing import routing_class_from_snapshot
     from omnigent.server.smart_routing import prefetch_runner_catalog
+
+    if conv.archived:
+        return
+    routing_class = routing_class_from_snapshot(
+        cost_control_mode=conv.cost_control_mode_override,
+        harness_override=conv.harness_override,
+        labels=conv.labels,
+    )
+    if not routing_class.routing_enabled:
+        return
 
     endpoint = _MODEL_OPTIONS_ENDPOINT_BY_WRAPPER.get(
         conv.labels.get(_CLAUDE_NATIVE_WRAPPER_LABEL_KEY) or ""
     )
     if endpoint is not None and session_id not in _model_options_inflight:
         options_task = asyncio.create_task(
-            _load_model_options(runner_client, session_id, f"/v1/sessions/{session_id}/{endpoint}")
+            _run_catalog_prefetch(
+                _load_model_options(
+                    runner_client, session_id, f"/v1/sessions/{session_id}/{endpoint}"
+                ),
+                session_id,
+            )
         )
         _model_options_inflight[session_id] = options_task
         options_task.add_done_callback(
             lambda _task, sid=session_id: _model_options_inflight.pop(sid, None)
         )
     _catalog_prefetch_tasks.add(
-        task := asyncio.create_task(prefetch_runner_catalog(session_id, runner_client))
+        task := asyncio.create_task(
+            _run_catalog_prefetch(prefetch_runner_catalog(session_id, runner_client), session_id)
+        )
     )
     task.add_done_callback(_catalog_prefetch_tasks.discard)
 

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -152,6 +152,7 @@ from omnigent.server.routes._sessions.common import (  # noqa: F401
     _LAST_TASK_ERROR_MESSAGE_LABEL_KEY,
     _MAX_TERMINAL_LAUNCH_ARG_LEN,
     _MAX_TERMINAL_LAUNCH_ARGS,
+    _MODEL_OPTIONS_ENDPOINT_BY_WRAPPER,
     _MODEL_TOKEN_KEYS,
     _NATIVE_POLICY_NOT_ENFORCED_CODE,
     _NATIVE_TERMINAL_ENSURE_FAILED_CODE,
@@ -169,6 +170,7 @@ from omnigent.server.routes._sessions.common import (  # noqa: F401
     _UPLOAD_READ_CHUNK_BYTES,
     COST_CONTROL_OVERRIDE_VALUES,
     SUBAGENT_ROUTING_OVERRIDE_VALUES,
+    _catalog_prefetch_tasks,
     _logger,
     _managed_launch_tasks,
     _model_options_cache,
@@ -3905,7 +3907,13 @@ def _invalidate_runner_backed_snapshot_state(
         the session (agent switch); ``False`` keeps it serving while the
         session has no runner.
     """
+    from omnigent.server.smart_routing import invalidate_runner_catalog
+
     _runner_skills_cache.pop(session_id, None)
+    # Routing's candidate catalog is runner-derived too: a rebind or a relaunch
+    # can change which models the session can be switched onto, so it must not
+    # keep routing off the previous runner's list.
+    invalidate_runner_catalog(session_id)
     if cancel_inflight:
         inflight = _runner_skills_inflight.pop(session_id, None)
         if inflight is not None:
@@ -8898,6 +8906,48 @@ async def _load_model_options(
         return
 
 
+def prefetch_session_routing_catalogs(
+    session_id: str,
+    conv: Conversation,
+    runner_client: httpx.AsyncClient,
+) -> None:
+    """
+    Warm the catalogs routing reads, at session launch instead of at turn time.
+
+    Both are runner-derived, and paying for them while a user's prompt is held
+    is what made a first routed message slow: the native picker vocabulary is
+    awaited by the turn path when its cached entry is stale, and the runner
+    model catalog is a round trip per turn for panes that have no picker
+    vocabulary. Started when the runner binds, both land well before the first
+    prompt; a turn arriving before they finish still falls back to its own
+    inline fetch, so this only ever removes waiting.
+
+    Fire-and-forget: a failed prefetch is a cold cache, which every reader
+    already handles.
+
+    :param session_id: Session/conversation identifier, e.g. ``"conv_abc"``.
+    :param conv: Conversation row, read for the wrapper label.
+    :param runner_client: HTTP client pointed at the newly bound runner.
+    """
+    from omnigent.server.smart_routing import prefetch_runner_catalog
+
+    endpoint = _MODEL_OPTIONS_ENDPOINT_BY_WRAPPER.get(
+        conv.labels.get(_CLAUDE_NATIVE_WRAPPER_LABEL_KEY) or ""
+    )
+    if endpoint is not None and session_id not in _model_options_inflight:
+        options_task = asyncio.create_task(
+            _load_model_options(runner_client, session_id, f"/v1/sessions/{session_id}/{endpoint}")
+        )
+        _model_options_inflight[session_id] = options_task
+        options_task.add_done_callback(
+            lambda _task, sid=session_id: _model_options_inflight.pop(sid, None)
+        )
+    _catalog_prefetch_tasks.add(
+        task := asyncio.create_task(prefetch_runner_catalog(session_id, runner_client))
+    )
+    task.add_done_callback(_catalog_prefetch_tasks.discard)
+
+
 async def _host_model_options_via_registry(host_id: str) -> list[dict[str, Any]] | None:
     """
     Resolve a host's pre-launch claude catalog over its live tunnel.
@@ -9179,4 +9229,5 @@ __all__ = [
     "_wait_for_runner_client",
     "announce_hosts_changed",
     "cancel_managed_launch_tasks",
+    "prefetch_session_routing_catalogs",
 ]

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -3973,17 +3973,27 @@ async def _refresh_stale_native_model_options(
     """
     if runner_client is None or session_id not in _model_options_stale:
         return
+    # This wait was the biggest single term in routing's pre-router latency on
+    # a first message, and nothing named it in the logs. Time it, so the ladder
+    # above can be sized against a measurement rather than a guess.
+    started = time.monotonic()
     inflight = _model_options_inflight.get(session_id)
-    if inflight is not None:
-        await _await_briefly(inflight)
-        return
-    endpoint = _MODEL_OPTIONS_ENDPOINT_BY_WRAPPER[_CLAUDE_NATIVE_WRAPPER_LABEL_VALUE]
-    task = asyncio.create_task(
-        _load_model_options(runner_client, session_id, f"/v1/sessions/{session_id}/{endpoint}")
+    if inflight is None:
+        endpoint = _MODEL_OPTIONS_ENDPOINT_BY_WRAPPER[_CLAUDE_NATIVE_WRAPPER_LABEL_VALUE]
+        inflight = asyncio.create_task(
+            _load_model_options(runner_client, session_id, f"/v1/sessions/{session_id}/{endpoint}")
+        )
+        _model_options_inflight[session_id] = inflight
+        inflight.add_done_callback(
+            lambda _t, sid=session_id: _model_options_inflight.pop(sid, None)
+        )
+    await _await_briefly(inflight)
+    _logger.info(
+        "smart_routing: session=%s stale catalog refresh waited %.3fs (still_stale=%s)",
+        session_id,
+        time.monotonic() - started,
+        session_id in _model_options_stale,
     )
-    _model_options_inflight[session_id] = task
-    task.add_done_callback(lambda _t, sid=session_id: _model_options_inflight.pop(sid, None))
-    await _await_briefly(task)
 
 
 async def _await_briefly(task: asyncio.Task[None]) -> None:

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -4151,6 +4151,59 @@ def _native_pane_harness(conv: Conversation) -> str | None:
     return native.harness if native is not None else harness
 
 
+def _pinned_spawn_family(parent: Conversation | None) -> str | None:
+    """Return the family a parent's spawns are confined to, if any.
+
+    Only a Smart Routing parent on a PINNED harness confines them — its
+    spawns are routed inside its own family. An auto-harness parent hands
+    the family choice to the router, and a parent that routes no spawns at
+    all confines nothing.
+
+    :param parent: The parent session's row, or ``None`` for a top-level
+        create (nothing to stay in family with).
+    :returns: ``"claude"`` / ``"gpt"`` / ``"pi"``, or ``None`` when the
+        parent's spawns may land in any family.
+    """
+    if parent is None or not subagent_routing_enabled(parent.subagent_routing_override):
+        return None
+    if auto_harness_session(parent):
+        return None
+    return harness_family(_resolve_harness(parent))
+
+
+def _reject_out_of_family_child(
+    parent: Conversation | None,
+    child_harness: str | None,
+) -> None:
+    """Refuse a pinned parent's create of a child in another family.
+
+    The primary defense for the family rule: a pinned codex Smart Routing
+    session must not be able to stand up a claude child at all, rather than
+    standing one up and having routing decline it afterwards. The child is
+    refused here, at the create, where the caller still sees the reason.
+
+    :param parent: The parent session's row, or ``None`` for a top-level
+        create.
+    :param child_harness: The harness the child would run, e.g.
+        ``"claude-native"``. ``None`` (unresolvable) is allowed through —
+        nothing proves it is out of family.
+    :raises OmnigentError: 400 ``INVALID_INPUT`` when the child's family
+        differs from the family the parent's spawns are confined to.
+    """
+    family = _pinned_spawn_family(parent)
+    child_family = harness_family(child_harness)
+    if family is None or child_family is None or family == child_family:
+        return
+    parent_harness = _resolve_harness(parent)
+    raise OmnigentError(
+        f"A {parent_harness} session with Smart Routing spawns only agents in its own "
+        f"model family; {child_harness} is not one. Pick an agent that runs on "
+        f"{parent_harness}, or start the session in Smart Routing (auto) harness mode "
+        "to let the router choose the family.",
+        code=ErrorCode.INVALID_INPUT,
+    )
+
+
 def _out_of_family_spawn_notice(
     conv: Conversation,
     parent: Conversation | None,
@@ -4158,11 +4211,14 @@ def _out_of_family_spawn_notice(
 ) -> str | None:
     """Why a pinned parent's cross-family spawn is not routed, if it is not.
 
-    Cross-family picks belong to sessions whose harness the router owns (Smart
-    Routing / auto): a pinned codex session's spawns stay on codex, so a child
-    pane running another family's CLI has no candidate the parent's family can
-    serve. Same predicate the in-harness spawn gate uses, so "auto" means one
-    thing on both spawn paths.
+    The fail-safe behind :func:`_reject_out_of_family_child`, which refuses
+    the out-of-family child at its create: a pane that exists anyway (a
+    legacy row, an unresolvable harness at create time) still must not be
+    routed. Cross-family picks belong to sessions whose harness the router
+    owns (Smart Routing / auto): a pinned codex session's spawns stay on
+    codex, so a child pane running another family's CLI has no candidate the
+    parent's family can serve. Same predicate the in-harness spawn gate uses,
+    so "auto" means one thing on both spawn paths.
 
     :param conv: The child session's row.
     :param parent: The parent session's row, or ``None`` for a top-level
@@ -7223,6 +7279,18 @@ async def _create_session_from_existing_agent(
                 # Non-omnigent agent (e.g. a native wrapper) — can't route
                 # harness; leave the orchestrator's choice untouched.
                 _force_auto_for_child = False
+        # A pinned Smart Routing parent may only spawn inside its own model
+        # family, so the child that could never be routed is refused here
+        # rather than created and declined afterwards. Auto parents are
+        # unaffected (the router owns their family) and so is a parent that
+        # routes no spawns — neither resolves the child's harness at all.
+        if _pinned_spawn_family(_parent_for_routing) is not None:
+            _reject_out_of_family_child(
+                _parent_for_routing,
+                await asyncio.to_thread(
+                    _create_resolved_harness, agent, body.harness_override, agent_cache
+                ),
+            )
 
     # A session that starts on Smart Routing routes the subagents it spawns.
     # Stamped here, once, so the spawn gate reads one explicit switch instead

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -4448,6 +4448,11 @@ async def _forward_event_to_runner(
     # before the routing card, matching the message routing path).
     _auto_card_model: str | None = None
     _auto_card_verdict: dict[str, Any] | None = None
+    # Set when the auto-harness routing call itself failed. The card still
+    # says so, but the route-once label is left unclaimed — the same rule the
+    # turn, native-pane and child-spawn paths follow, so one outage at create
+    # cannot be the reason this session never routes again.
+    _auto_route_failed = False
     # The resolved harness, read back at card-emission time below.
     _auto_harness: str | None = None
     if conv.harness_override == "auto" and body.type == "message":
@@ -4506,8 +4511,8 @@ async def _forward_event_to_runner(
                 _auto_card_verdict = _auto_verdict
             elif _auto_error is not None:
                 # Routing failed — surface why auto-harness fell back to defaults.
-                _auto_card_model = "unavailable"
-                _auto_card_verdict = {"rationale": _auto_error, "applied": False}
+                _auto_card_model, _auto_card_verdict = _unavailable_routing_card(_auto_error)
+                _auto_route_failed = True
     # ── Server-side intelligent routing ──────────────────────────────
     # When the session toggle is ON and no model has been chosen yet,
     # call the judge LLM on the FIRST message to pick the model for
@@ -4748,7 +4753,14 @@ async def _forward_event_to_runner(
                 scope="session",
                 harness=_auto_harness,
             )
-            await _stamp_routing_decision_label(session_id, conversation_store, _auto_decision_id)
+            if not _auto_route_failed:
+                # A failed call is NOT this session's routing decision: the
+                # label is the route-once gate, so claiming it would make one
+                # create-time outage the reason nothing routes this session
+                # again. The card still shows what happened.
+                await _stamp_routing_decision_label(
+                    session_id, conversation_store, _auto_decision_id
+                )
             if conv.parent_conversation_id is not None:
                 await _emit_server_routing_decision(
                     conv.parent_conversation_id,

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -4866,6 +4866,48 @@ async def _stamp_routing_decision_label(
         )
 
 
+async def _record_create_route_prompt(
+    conv: Conversation,
+    conversation_store: ConversationStore,
+    prompt: str | None,
+) -> Conversation:
+    """Record which prompt a create-time route scored, as a fingerprint.
+
+    Read by the in-harness first-prompt hook: the same prompt submitted again
+    reuses the create's decision instead of paying a second router call for it
+    (:func:`omnigent.runner.turn_routing.create_route_covers_prompt`).
+
+    Best-effort — a label that cannot be written costs the session one extra
+    routing call, not its turn.
+
+    :param conv: The created conversation row.
+    :param conversation_store: Store exposing ``set_labels``.
+    :param prompt: The routed prompt, e.g. the create's
+        ``smart_routing_message``. Blank records nothing.
+    :returns: The refreshed row, or *conv* when nothing was recorded.
+    """
+    from omnigent.runner.subagent_routing import CREATE_ROUTE_PROMPT_LABEL_KEY
+    from omnigent.runner.turn_routing import create_route_prompt_fingerprint
+
+    fingerprint = create_route_prompt_fingerprint(prompt or "")
+    if not fingerprint:
+        return conv
+    try:
+        await asyncio.to_thread(
+            conversation_store.set_labels,
+            conv.id,
+            {CREATE_ROUTE_PROMPT_LABEL_KEY: fingerprint},
+        )
+    except (OSError, ValueError):
+        _logger.warning(
+            "smart_routing: failed to record the create-time prompt for session=%s",
+            conv.id,
+            exc_info=True,
+        )
+        return conv
+    return await asyncio.to_thread(conversation_store.get_conversation, conv.id) or conv
+
+
 async def _dispatch_session_event_to_runner(*args: Any, **kwargs: Any) -> Any:
     """Call-time proxy so a facade patch of this symbol is honored here."""
     from omnigent.server.routes import sessions as _facade
@@ -7609,6 +7651,14 @@ async def _create_session_from_existing_agent(
                 _native_routing_verdict,
                 scope="session",
                 harness=_routed_native.harness if _routed_native is not None else None,
+            )
+            # The same prompt is submitted again inside the harness, where the
+            # first-prompt hook would score it a second time for the verdict
+            # this session is already pinned to. Fingerprint what was routed so
+            # that hook reuses this decision — and an edited prompt still
+            # routes on its own.
+            conv = await _record_create_route_prompt(
+                conv, conversation_store, body.smart_routing_message
             )
         elif _native_routing_error is not None:
             await _emit_server_routing_decision(

--- a/omnigent/server/routes/sessions/__init__.py
+++ b/omnigent/server/routes/sessions/__init__.py
@@ -527,6 +527,7 @@ from omnigent.server.routes._sessions.helpers import (
     _wait_for_managed_runner_tunnel as _wait_for_managed_runner_tunnel,
     announce_hosts_changed as announce_hosts_changed,
     cancel_managed_launch_tasks as cancel_managed_launch_tasks,
+    prefetch_session_routing_catalogs as prefetch_session_routing_catalogs,
 )
 
 # Runner-forward / ASK-gate helpers are patched by tests on this facade module

--- a/omnigent/server/routes/sessions/routes_hooks.py
+++ b/omnigent/server/routes/sessions/routes_hooks.py
@@ -1531,6 +1531,7 @@ def register_hooks_routes(
             _native_turn_catalog,
             _publish_routed_model,
             _stamp_routing_decision_label,
+            _unavailable_routing_card,
         )
         from omnigent.server.smart_routing import route_turn as _route_turn_seam
 
@@ -1629,6 +1630,23 @@ def register_hooks_routes(
             )
             await _stamp_routing_decision_label(session_id, conversation_store, decision_id)
 
+        async def _record_decline(cause: str) -> None:
+            """Persist the declined chip for a failed routing call.
+
+            The card, not the label: a failure must stay visible without
+            claiming the route-once gate, or one outage would make this the
+            session's routing decision forever.
+            """
+            model, verdict = _unavailable_routing_card(cause)
+            await _emit_server_routing_decision(
+                session_id,
+                conversation_store,
+                model,
+                verdict,
+                scope=decision_scope(),
+                harness=route_request.harness,
+            )
+
         async def _reuse_create_route() -> bool:
             """Claim the create-time decision as this session's routing decision.
 
@@ -1659,6 +1677,7 @@ def register_hooks_routes(
             reuse_create_route=_reuse_create_route,
             pin=_pin,
             persist=_persist,
+            record_decline=_record_decline,
         )
         _logger.info(
             "route-turn: session=%s harness=%s live_model=%s pinned=%s action=%s model=%s",

--- a/omnigent/server/routes/sessions/routes_hooks.py
+++ b/omnigent/server/routes/sessions/routes_hooks.py
@@ -1494,6 +1494,7 @@ def register_hooks_routes(
             decision_scope,
             resolve_turn_route,
         )
+        from omnigent.server.routes._sessions.helpers import _resolve_harness
         from omnigent.server.routes._sessions.orchestration import (
             _native_turn_catalog,
             _publish_routed_model,
@@ -1601,6 +1602,9 @@ def register_hooks_routes(
             route_request,
             conv=conv,
             parent=parent,
+            # A pinned routed parent confines its spawns to its own family, so
+            # the pane's own family is not the only one that matters.
+            parent_harness=_resolve_harness(parent) if parent is not None else None,
             route_turn=_route,
             pin=_pin,
             persist=_persist,

--- a/omnigent/server/routes/sessions/routes_hooks.py
+++ b/omnigent/server/routes/sessions/routes_hooks.py
@@ -94,6 +94,38 @@ from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.permission_store import PermissionStore
 
 
+def _create_route_decision_id(
+    session_id: str,
+    conversation_store: ConversationStore,
+) -> str | None:
+    """Return the decision id of a session's create-time routing card.
+
+    The create emits the card but leaves the route-once label unclaimed,
+    because the prompt the user finally submits may not be the one it routed.
+    When it IS the same prompt, the first-prompt hook claims this decision
+    rather than making a second one.
+
+    :param session_id: Session/conversation identifier.
+    :param conversation_store: Store exposing ``list_items``.
+    :returns: The applied ``"session"``-scope decision id, or ``None`` when
+        the session has none.
+    """
+    try:
+        page = conversation_store.list_items(session_id, type="routing_decision", order="asc")
+    except (OSError, ValueError):
+        _logger.warning(
+            "route-turn: could not read session=%s routing decisions", session_id, exc_info=True
+        )
+        return None
+    for item in page.data:
+        data = item.data
+        if getattr(data, "scope", None) == "session" and getattr(data, "applied", False):
+            decision_id = getattr(data, "decision_id", None)
+            if isinstance(decision_id, str) and decision_id:
+                return decision_id
+    return None
+
+
 def register_hooks_routes(
     router: APIRouter,
     *,
@@ -1597,6 +1629,24 @@ def register_hooks_routes(
             )
             await _stamp_routing_decision_label(session_id, conversation_store, decision_id)
 
+        async def _reuse_create_route() -> bool:
+            """Claim the create-time decision as this session's routing decision.
+
+            No second chip: the create's own row already says what was picked,
+            and the pane launched on it. Claiming the route-once label is what
+            makes this the session's decision, so a later prompt does not ask
+            again.
+
+            :returns: ``True`` when the create's decision was claimed.
+            """
+            decision_id = await asyncio.to_thread(
+                _create_route_decision_id, session_id, conversation_store
+            )
+            if decision_id is None:
+                return False
+            await _stamp_routing_decision_label(session_id, conversation_store, decision_id)
+            return True
+
         decision = await resolve_turn_route(
             session_id,
             route_request,
@@ -1606,6 +1656,7 @@ def register_hooks_routes(
             # the pane's own family is not the only one that matters.
             parent_harness=_resolve_harness(parent) if parent is not None else None,
             route_turn=_route,
+            reuse_create_route=_reuse_create_route,
             pin=_pin,
             persist=_persist,
         )

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -52,13 +52,18 @@ ROUTES_SELECT_PATH = "routes:select"
 #:
 #: Sized from the observed round trip: healthy ``routes:select`` answers land
 #: in ~1.4–3s, and the slowest sample on record (~6.7s) was a gateway 500, not
-#: a verdict. Five seconds therefore covers the healthy case with headroom
-#: while capping the hazard paths — a first-message hook and a subagent spawn
-#: gate — at a blink instead of the 30–45s a wedged server used to cost.
+#: a verdict. Nine seconds covers the healthy case with wide headroom while
+#: still capping the hazard paths — a first-message hook and a subagent spawn
+#: gate — well under the 30–45s a wedged server used to cost.
+#:
+#: This budget covers the CALL only. The hops above it must also absorb the
+#: candidate/catalog preparation that runs before it (~3s measured on a first
+#: message), which is why each of them sits several seconds higher rather than
+#: one second above this value.
 #:
 #: One attempt, no retry: on an interactive path a second try only doubles the
 #: stall, and falling open onto the harness's own model is the better answer.
-ROUTING_REQUEST_TIMEOUT_S = 5.0
+ROUTING_REQUEST_TIMEOUT_S = 9.0
 
 # ── Model lists per harness family ──────────────────────────────────────────
 #

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -12,8 +12,10 @@ swap in a different implementation via ``RuntimeCaps``.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import time
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Protocol
@@ -290,7 +292,89 @@ def _catalog_wire_apis(raw: object) -> frozenset[ModelWireAPI]:
     return frozenset(wire_apis)
 
 
+#: How long a fetched runner catalog stays servable without a re-fetch.
+#:
+#: The catalog is the installed CLI's model list: it changes on a relaunch or a
+#: provider-config edit, both of which invalidate this cache explicitly
+#: (:func:`invalidate_runner_catalog`). The TTL is only the backstop for a
+#: change nothing announced, so it is sized for "a long session should not go
+#: stale for hours", not for freshness per turn.
+RUNNER_CATALOG_TTL_S = 300.0
+
+#: session id → (monotonic deadline, catalog). Process-local, like every other
+#: runner-derived overlay cache on the server.
+_runner_catalog_cache: dict[str, tuple[float, dict[str, list[_RunnerModel]]]] = {}
+
+#: Single-flight per session, so a burst of turns costs one runner round trip.
+_runner_catalog_inflight: dict[str, asyncio.Task[dict[str, list[_RunnerModel]] | None]] = {}
+
+
+def invalidate_runner_catalog(session_id: str | None = None) -> None:
+    """Drop the cached runner catalog for *session_id* (or every session).
+
+    Called from the seam that already invalidates runner-derived snapshot
+    overlays, so a relaunched runner, a rebind, or a refreshed snapshot all
+    re-read the catalog instead of routing off the previous process's models.
+
+    :param session_id: Session/conversation identifier; ``None`` clears all.
+    """
+    if session_id is None:
+        _runner_catalog_cache.clear()
+        return
+    _runner_catalog_cache.pop(session_id, None)
+
+
+async def prefetch_runner_catalog(
+    session_id: str,
+    runner_client: httpx.AsyncClient,
+) -> None:
+    """Warm the catalog cache for *session_id* off the turn path.
+
+    Routing's candidate preparation is the runner round trip below, and paying
+    it while a user's prompt is held is what made the first message slow. A
+    launch-time call fills the cache so the first turn reads it instead.
+
+    :param session_id: Session/conversation identifier.
+    :param runner_client: Async HTTP client pointed at the runner.
+    """
+    await _fetch_runner_catalog(session_id, runner_client)
+
+
 async def _fetch_runner_catalog(
+    session_id: str,
+    runner_client: httpx.AsyncClient,
+) -> dict[str, list[_RunnerModel]] | None:
+    """Return this session's runner catalog, from cache when one is warm.
+
+    A miss runs :func:`_load_runner_catalog` under a per-session single flight,
+    so concurrent turns share one round trip. Only a parsed, non-empty catalog
+    is cached: an unreachable runner (a booting session) must stay re-fetchable
+    rather than pin "no catalog" for the whole TTL.
+
+    :param session_id: Session/conversation identifier.
+    :param runner_client: Async HTTP client pointed at the runner.
+    :returns: Worker names mapped to ordered model metadata, or ``None``.
+    """
+    cached = _runner_catalog_cache.get(session_id)
+    if cached is not None:
+        deadline, catalog = cached
+        if time.monotonic() < deadline:
+            return catalog
+        _runner_catalog_cache.pop(session_id, None)
+    inflight = _runner_catalog_inflight.get(session_id)
+    if inflight is None:
+        inflight = asyncio.ensure_future(_load_runner_catalog(session_id, runner_client))
+        _runner_catalog_inflight[session_id] = inflight
+        inflight.add_done_callback(
+            lambda _task, sid=session_id: _runner_catalog_inflight.pop(sid, None)
+        )
+    catalog = await asyncio.shield(inflight)
+    if catalog:
+        _runner_catalog_cache[session_id] = (time.monotonic() + RUNNER_CATALOG_TTL_S, catalog)
+    return catalog
+
+
+async def _load_runner_catalog(
     session_id: str,
     runner_client: httpx.AsyncClient,
 ) -> dict[str, list[_RunnerModel]] | None:
@@ -2207,6 +2291,11 @@ async def route_turn(
         return None, None
 
     _logger.info("smart_routing: routing turn session=%s harness=%s", session_id, harness)
+    # Candidate preparation used to be invisible in the logs, so a slow first
+    # message read as a slow router. Time the two phases separately: this is
+    # the number the timeout ladder above the hook has to cover.
+    _prep_started = time.monotonic()
+    _catalog_fetched = False
     # Prefer the live runner catalog, but only its "self" row — the sub-agent
     # workers' models are not this session's. Key the map by harness id, not the
     # "self" label, so the seam infers the right single-harness scenario.
@@ -2216,6 +2305,7 @@ async def route_turn(
         if in_vocabulary:
             available = {harness or "self": in_vocabulary}
     if available is None and session_id and runner_client is not None:
+        _catalog_fetched = True
         runner_catalog = await fetch_runner_models(session_id, runner_client)
         if runner_catalog and "self" in runner_catalog:
             # A native terminal's own catalog can list models from other
@@ -2262,8 +2352,18 @@ async def route_turn(
             )
             return None, None
 
+    _prep_s = time.monotonic() - _prep_started
+    _route_started = time.monotonic()
     call = await route_with_fallback(
         backends, user_message, available, gateway_backed=gateway_backed
+    )
+    _logger.info(
+        "smart_routing: session=%s prep=%.3fs router=%.3fs catalog_fetch=%s candidates=%d",
+        session_id,
+        _prep_s,
+        time.monotonic() - _route_started,
+        _catalog_fetched,
+        sum(len(models) for models in available.values()),
     )
     if call is None or call.result is None:
         return None, None

--- a/omnigent/smart_routing_cli.py
+++ b/omnigent/smart_routing_cli.py
@@ -1,22 +1,17 @@
-"""CLI-side Smart Routing: pick a harness/model *before* the TUI launches.
+"""CLI-side Smart Routing: arm a session so its harness routes what you type.
 
-``omnigent claude --smart-routing -p "..."`` (tier 2) and
-``omnigent run --smart-routing -p "..."`` (tier 3) both need a routing verdict
-in hand before a native wrapper starts, because the harness pick is physical
-(a session *is* a live ``claude``/``codex`` process) and the model is applied
-as a launch flag. The web UI gets the same verdict server-side at session
-create; the CLI takes the same path — it creates the session itself through the
-standard JSON ``POST /v1/sessions`` with the routing contract fields, reads the
-resolved ``harness`` / ``model_override`` back off the response, and attaches
-the matching native wrapper to that session. One session, routed at create: the
-row already carries the agent binding, the wrapper's presentation labels, the
-routed model, and the routing decision card, so the launched session shows the
-same chip and provenance the web UI gets.
+``omnigent claude --smart-routing`` and ``omnigent codex --smart-routing`` are
+the only CLI entry points. Neither routes anything before the TUI starts: the
+CLI creates the session through the standard JSON ``POST /v1/sessions`` with
+``cost_control_mode_override="on"`` and no ``smart_routing_message``, then
+attaches the native wrapper to it. The harness's own first-message hook picks
+the model once the user types. Routing a prompt at create time is the web UI's
+job — it is the surface that can show and change the pick before the session
+runs.
 
-A harness that routes its own first typed message needs no prompt up front:
-the create then only turns Smart Routing on for the session (no
-``smart_routing_message``), and the in-harness hook picks the model when the
-user types.
+Because the session is created here rather than bundled by the wrapper, the row
+already carries the agent binding, the wrapper's presentation labels, and the
+Smart Routing mode the hook's server-side gate reads.
 
 Two rules shape everything here:
 
@@ -24,9 +19,9 @@ Two rules shape everything here:
   serve means the pick could not be applied — say so and stop. A family
   whose inference is not AI-Gateway-backed is not that case: it downgrades to the server's built-in
   router, and only fails when there is no built-in router either.
-* **Routing itself fails open.** Once preflight passes, any router failure
-  (missing verdict, HTTP error, unreachable server) returns a decision with a
-  one-line notice and no pick. The launch always happens.
+* **Arming itself fails open.** Once preflight passes, a create the server
+  rejects (or cannot answer) returns a one-line notice and no session, and the
+  wrapper launches its own. The launch always happens.
 """
 
 from __future__ import annotations
@@ -41,19 +36,13 @@ import httpx
 
 from omnigent.db.utils import builtin_agent_id
 from omnigent.harness_aliases import canonicalize_harness
-from omnigent.harness_plugins import CLAUDE_NATIVE_CODING_AGENT
 from omnigent.native_coding_agents import native_coding_agent_for_harness
-
-CLAUDE_NATIVE_AGENT_NAME = CLAUDE_NATIVE_CODING_AGENT.agent_name
-
-#: Sentinel ``harness_override`` that asks the server to route the harness too.
-AUTO_HARNESS = "auto"
 
 #: Provenance label on a CLI-routed session. The server merges the wrapper's
 #: own presentation labels (``omnigent.ui`` / ``omnigent.wrapper``) over it.
 ROUTING_SESSION_LABELS = {"omnigent.smart_routing": "cli-route"}
 
-#: Budget for the routed ``POST /v1/sessions``. Generous on the read because
+#: Budget for the armed ``POST /v1/sessions``. Generous on the read because
 #: this is a session CREATE, not a routing call: it validates the workspace on
 #: the host, may cut a worktree, and resolves a pre-launch model catalog. A
 #: short budget here would abandon creates that were merely slow and drop the
@@ -69,45 +58,20 @@ _PREFLIGHT_TIMEOUT = httpx.Timeout(5.0)
 
 
 @dataclass(frozen=True)
-class RoutingDecision:
+class ArmedSession:
     """
-    The routed session the CLI attaches to, and what the router picked.
+    The session the CLI armed for Smart Routing, and what to say about it.
 
     :param session_id: The created session, e.g. ``"conv_abc123"``. The wrapper
         attaches to this instead of bundling its own. ``None`` when the create
         failed — the caller then launches a fresh wrapper session.
-    :param harness: Canonical harness bound to the session, e.g.
-        ``"codex-native"`` (for an ``"auto"`` create the server rebinds the
-        agent to the wrapper it picked). ``None`` when it could not be read.
-    :param model: Routed model id, e.g. ``"databricks-claude-sonnet-4-6"``.
-        ``None`` means launch on the harness default.
-    :param notice: One user-facing line explaining a missing pick, e.g.
-        ``"omnigent: Smart Routing was unavailable (...)"``. ``None`` when the
-        router answered.
+    :param notice: One user-facing line explaining why the session was not
+        armed, e.g. ``"omnigent: Smart Routing was unavailable (...)"``.
+        ``None`` when the create succeeded.
     """
 
     session_id: str | None
-    harness: str | None
-    model: str | None
     notice: str | None
-
-
-def smart_routing_families(harness: str | None) -> tuple[str, ...]:
-    """
-    Harness families whose inference must be gateway-backed for *harness*.
-
-    A fixed-harness route only applies to that harness's pane. The auto route
-    picks across the claude + codex arms, so it needs both — mirroring the web's
-    per-surface gating (top-level Smart Routing needs both; a per-harness
-    Model row needs only its own).
-
-    :param harness: Canonical harness id, or ``None`` / :data:`AUTO_HARNESS`
-        for the auto route.
-    :returns: Harness ids to check, e.g. ``("claude-native", "codex-native")``.
-    """
-    if harness is None or harness == AUTO_HARNESS:
-        return ("claude-native", "codex-native")
-    return (harness,)
 
 
 def local_gateway_inference() -> dict[str, bool]:
@@ -224,52 +188,35 @@ def _routing_sources(info: dict[str, Any]) -> dict[str, bool]:
     return {"external": raw.get("external") is True, "oss": raw.get("oss") is True}
 
 
-def create_smart_routing_session(
+def arm_smart_routing_session(
     *,
     base_url: str,
-    prompt: str | None,
-    harness: str | None,
+    harness: str,
     host_id: str | None = None,
     workspace: str | None = None,
-) -> RoutingDecision:
+) -> ArmedSession:
     """
-    Create the routed session, and read the verdict back off the create.
+    Create the session with Smart Routing on, and nothing routed yet.
 
-    Sends the routing contract — ``cost_control_mode_override="on"``, the
-    ``smart_routing_message`` (prompt-ful create only), and (auto route only)
-    ``harness_override="auto"``; a fixed harness comes from the bound wrapper
-    agent, so it needs no override. The response carries the resolved
-    ``harness`` and ``model_override``, with the session snapshot as a fallback.
-    This is the session the wrapper attaches to — nothing is deleted.
+    Sends ``cost_control_mode_override="on"`` — the mode the harness hook's
+    server-side gate reads — bound to *harness*'s own wrapper agent. No
+    ``smart_routing_message``, so the create routes nothing: the model is picked
+    in-session when the user types their first message. This is the session the
+    wrapper attaches to; nothing is deleted.
 
-    Two modes, split by *prompt*:
-
-    * **With a prompt** the message triggers the create-time route, so the
-      response is expected to carry a model and a missing one earns a notice.
-    * **Without one** only the mode override is sent: Smart Routing is on for
-      the session, but nothing is routed yet — the harness's own first-message
-      hook picks the model in-session, so an empty ``model_override`` is the
-      normal answer and carries no notice.
-
-    Never raises: a create the server rejects (including the auto route's
-    "no native CLI on this host") yields a decision with no session and a
-    notice, and the caller launches a fresh wrapper session instead.
+    Never raises: a create the server rejects yields no session and one notice,
+    and the caller launches a fresh wrapper session instead.
 
     :param base_url: Omnigent server base URL.
-    :param prompt: The user's ``-p`` text. Routed, not dispatched — the TUI
-        delivers it as its own first input. ``None`` creates a bare routed
-        session that routes nothing at create time.
-    :param harness: Canonical harness to pin, or ``None`` for the auto route.
+    :param harness: Canonical native harness to bind, e.g. ``"claude-native"``.
     :param host_id: Host this session will run on, e.g. ``"host_abc123"``.
-        Needed for a real verdict: the server builds the candidate model
-        catalog by round-tripping the bound host's model-options frames, so a
-        hostless create gives the router an empty menu. ``None`` (the server
-        does not know this host yet) still routes, over whatever it can resolve
-        without one.
+        Binding it lets the server resolve the pane's model catalog for the
+        in-session route. ``None`` (the server does not know this host yet)
+        still creates the session.
     :param workspace: Absolute workspace path on *host_id* — the launch cwd.
         Required by the server whenever ``host_id`` is set (it is validated
         against the agent's cwd boundary), so it is sent only with *host_id*.
-    :returns: The :class:`RoutingDecision` to launch on.
+    :returns: The :class:`ArmedSession` to launch on.
     """
     body: dict[str, Any] = {
         "agent_id": _routing_agent_id(harness),
@@ -277,22 +224,11 @@ def create_smart_routing_session(
         "labels": dict(ROUTING_SESSION_LABELS),
         "cost_control_mode_override": "on",
     }
-    if prompt is not None:
-        # The message is what routes at create time; a bare create only turns
-        # Smart Routing on and leaves the pick to the in-harness hook.
-        body["smart_routing_message"] = prompt
-    if harness is None:
-        # Auto route: the sentinel tells the server to pick the harness and
-        # rebind the session's agent to that wrapper.
-        body["harness_override"] = AUTO_HARNESS
     if host_id is not None:
         body["host_id"] = host_id
         # host_id without workspace is a 400 — the server stats the path on the
         # host to validate the agent's cwd boundary.
         body["workspace"] = workspace
-    session_id: str | None = None
-    picked_harness: str | None = None
-    picked_model: str | None = None
     try:
         with httpx.Client(
             base_url=base_url, headers=_headers(base_url), timeout=_TIMEOUT
@@ -303,69 +239,43 @@ def create_smart_routing_session(
             payload = _json_object(resp)
             raw_id = payload.get("id") or payload.get("session_id")
             session_id = raw_id if isinstance(raw_id, str) and raw_id else None
-            # ``harness`` (not ``harness_override``) is the resolved harness on
-            # SessionResponse; native rows leave the override null on purpose.
-            picked_harness = _clean_str(payload.get("harness"))
-            picked_model = _clean_str(payload.get("model_override"))
-            if (picked_model is None or picked_harness is None) and session_id is not None:
-                snapshot = _json_object(client.get(f"/v1/sessions/{session_id}"))
-                picked_harness = picked_harness or _clean_str(snapshot.get("harness"))
-                picked_model = picked_model or _clean_str(snapshot.get("model_override"))
     except httpx.HTTPError as exc:
         return _unavailable(f"could not reach {base_url}: {exc}")
     if session_id is None:
         return _unavailable("the create returned no session id")
-    # A bare create routes nothing yet, so an empty model is expected there and
-    # only a prompt-ful create that came back without one is worth reporting.
-    notice = (
-        None
-        if picked_model is not None or prompt is None
-        else (
-            "omnigent: Smart Routing did not pick a model for this session; "
-            "launching on the harness default."
-        )
-    )
-    return RoutingDecision(
-        session_id=session_id,
-        harness=picked_harness,
-        model=picked_model,
-        notice=notice,
-    )
+    return ArmedSession(session_id=session_id, notice=None)
 
 
-def _unavailable(reason: str) -> RoutingDecision:
+def _unavailable(reason: str) -> ArmedSession:
     """
-    Build the fail-open decision for *reason*.
+    Build the fail-open result for *reason*.
 
     :param reason: Short cause, e.g. ``"the create returned no session id"``.
-    :returns: A decision with no session and one user-facing notice line.
+    :returns: A result with no session and one user-facing notice line.
     """
-    return RoutingDecision(
+    return ArmedSession(
         session_id=None,
-        harness=None,
-        model=None,
         notice=(
-            f"omnigent: Smart Routing was unavailable ({reason}); "
-            "launching on the default harness/model."
+            f"omnigent: Smart Routing was unavailable ({reason}); launching on the default model."
         ),
     )
 
 
-def _routing_agent_id(harness: str | None) -> str:
+def _routing_agent_id(harness: str) -> str:
     """
-    Built-in agent to bind the routing session to.
+    Built-in agent to bind the armed session to.
 
-    The bound agent only has to exist — the routing verdict rides on the
-    session row, not the agent. A fixed harness uses its own ``*-native-ui``
-    built-in; the auto route uses the claude-native built-in, which every
-    server seeds.
+    The bound agent only has to exist and carry the right wrapper — Smart
+    Routing rides on the session row, not the agent.
 
-    :param harness: Canonical harness id, or ``None`` for the auto route.
+    :param harness: Canonical harness id, e.g. ``"codex-native"``.
     :returns: A deterministic built-in agent id.
+    :raises ValueError: When *harness* has no native wrapper agent.
     """
-    native = native_coding_agent_for_harness(harness) if harness else None
-    name = native.agent_name if native is not None else CLAUDE_NATIVE_AGENT_NAME
-    return builtin_agent_id(name)
+    native = native_coding_agent_for_harness(harness)
+    if native is None:
+        raise ValueError(f"{harness!r} has no native wrapper agent to bind")
+    return builtin_agent_id(native.agent_name)
 
 
 def known_host_id(*, base_url: str, host_id: str | None) -> str | None:
@@ -482,13 +392,3 @@ def _json_object(resp: httpx.Response) -> dict[str, Any]:
     except (json.JSONDecodeError, ValueError):
         return {}
     return payload if isinstance(payload, dict) else {}
-
-
-def _clean_str(value: Any) -> str | None:
-    """
-    Normalize a wire value to a non-empty string.
-
-    :param value: Raw JSON value, e.g. ``"codex-native"`` or ``None``.
-    :returns: The stripped string, or ``None`` when it is not usable.
-    """
-    return value.strip() if isinstance(value, str) and value.strip() else None

--- a/tests/cli/test_build_routing_client.py
+++ b/tests/cli/test_build_routing_client.py
@@ -86,6 +86,46 @@ def test_external_defers_profile_auth_to_per_call() -> None:
     assert client._databricks_profile == "staging"
 
 
+def test_external_falls_back_to_the_deployments_databricks_provider_profile() -> None:
+    """
+    A ``routing:`` block that names no profile still authenticates as the config's.
+
+    Otherwise the client falls through to the ambient SDK chain, which resolves
+    by host or ``[DEFAULT]``: on a workspace with two profiles on one host, the
+    router then authenticates as a different identity than the panes it routes,
+    and re-authing one leaves the other's token expired.
+    """
+    cfg = {
+        "providers": {
+            "ws": {"kind": "databricks", "profile": "eng-ml-agent-platform", "default": True},
+        },
+        "routing": {
+            "provider": "external",
+            "base_url": "https://host/v1",
+            "router_name": "task_v0",
+        },
+    }
+    client = _build_external_routing_client(cfg["routing"], None, cfg)
+    assert isinstance(client, ExternalRoutingClient)
+    assert client._databricks_profile == "eng-ml-agent-platform"
+
+
+def test_externals_own_profile_still_wins_over_the_provider_block() -> None:
+    """An explicitly routed profile is the deployment saying which identity to use."""
+    cfg = {
+        "providers": {"ws": {"kind": "databricks", "profile": "agent"}},
+        "routing": {
+            "provider": "external",
+            "base_url": "https://host/v1",
+            "router_name": "task_v0",
+            "profile": "staging",
+        },
+    }
+    client = _build_external_routing_client(cfg["routing"], None, cfg)
+    assert isinstance(client, ExternalRoutingClient)
+    assert client._databricks_profile == "staging"
+
+
 def test_external_api_key_expands_env(monkeypatch: Any) -> None:
     """api_key is provider-agnostic and ${ENV}-expanded into a bearer header."""
     import httpx

--- a/tests/cli/test_smart_routing_cli.py
+++ b/tests/cli/test_smart_routing_cli.py
@@ -1,4 +1,4 @@
-"""Tests for CLI-side Smart Routing: preflight, the routed create, and launch."""
+"""Tests for CLI-side Smart Routing: preflight, the armed create, and launch."""
 
 from __future__ import annotations
 
@@ -12,20 +12,12 @@ import respx
 from click import ClickException, UsageError
 from click.testing import CliRunner
 
-from omnigent.cli import (
-    _dispatch_smart_routing,
-    _require_smart_routing_prompt,
-    _run_smart_routing,
-    _smart_routing_capable_harness,
-    _with_routed_model_arg,
-    cli,
-)
+from omnigent.cli import _reject_smart_routing_prompt, _smart_routing_decision, cli
 from omnigent.smart_routing_cli import (
     ROUTING_SESSION_LABELS,
+    arm_smart_routing_session,
     check_smart_routing_available,
-    create_smart_routing_session,
     known_host_id,
-    smart_routing_families,
 )
 
 _BASE = "http://localhost:6767"
@@ -81,11 +73,8 @@ def _mock_hosts(gateway: dict[str, Any] | None) -> None:
 
 
 def _mock_create(**session: Any) -> respx.Route:
-    """Mock the routed create (and its snapshot re-read) with one session body."""
+    """Mock the armed create with one session body."""
     body = {"id": _SESSION_ID, **session}
-    respx.get(f"{_BASE}/v1/sessions/{_SESSION_ID}").mock(
-        return_value=httpx.Response(200, json=body)
-    )
     return respx.post(f"{_BASE}/v1/sessions").mock(return_value=httpx.Response(201, json=body))
 
 
@@ -138,7 +127,7 @@ def test_preflight_reports_the_hosts_own_reason_string() -> None:
 
 @respx.mock
 def test_preflight_ignores_other_families_than_the_requested_one() -> None:
-    """A fixed-harness route only needs its own family to be gateway-backed."""
+    """A per-harness route only needs its own family to be gateway-backed."""
     _mock_info()
     _mock_hosts({"claude-native": True, "codex-native": False})
 
@@ -166,12 +155,6 @@ def test_preflight_reads_the_spelling_it_was_asked_about() -> None:
         check_smart_routing_available(
             base_url=_BASE, harnesses=("native-claude",), host_id=_HOST_ID
         )
-
-
-def test_auto_route_requires_both_native_families() -> None:
-    assert smart_routing_families(None) == ("claude-native", "codex-native")
-    assert smart_routing_families("auto") == ("claude-native", "codex-native")
-    assert smart_routing_families("codex-native") == ("codex-native",)
 
 
 # ── preflight: the machine-local gate ────────────────────────────────────
@@ -234,16 +217,6 @@ def test_preflight_gates_each_harness_on_the_local_gateway_answer(
             continue
         check_smart_routing_available(base_url=_BASE, harnesses=(harness,), host_id=None)
         _assert_downgrade_notice(capsys, expected=() if gatewayed else (harness,))
-    # The auto route picks across both arms, so one arm off the gateway takes
-    # it — unless the built-in judge can answer for that arm instead.
-    auto = smart_routing_families(None)
-    off_gateway = tuple(harness for harness in auto if local[harness] is False)
-    if off_gateway and not oss:
-        with pytest.raises(ClickException, match="not AI-Gateway-backed"):
-            check_smart_routing_available(base_url=_BASE, harnesses=auto, host_id=None)
-    else:
-        check_smart_routing_available(base_url=_BASE, harnesses=auto, host_id=None)
-        _assert_downgrade_notice(capsys, expected=off_gateway)
 
 
 @respx.mock
@@ -343,62 +316,43 @@ def test_local_gateway_inference_never_raises(monkeypatch: pytest.MonkeyPatch) -
     assert smart_routing_cli.local_gateway_inference() == {}
 
 
-# ── the routed create ────────────────────────────────────────────────────
+# ── the armed create ─────────────────────────────────────────────────────
 
 
 @respx.mock
-def test_create_sends_the_routing_contract_for_a_fixed_harness() -> None:
-    """Tier 2 binds the wrapper agent; the harness needs no override."""
-    route = _mock_create(harness="claude-native", model_override="claude-sonnet-5")
+def test_arming_sends_the_mode_but_never_a_message() -> None:
+    """The CLI arms the session; the harness routes the first typed message."""
+    route = _mock_create(harness="claude-native")
 
-    decision = create_smart_routing_session(
+    armed = arm_smart_routing_session(
         base_url=_BASE,
-        prompt="fix the flaky test",
         harness="claude-native",
         host_id=_HOST_ID,
         workspace="/repo",
     )
 
     payload = json.loads(route.calls.last.request.content)
+    # The mode override is what arms Smart Routing (and what the hook's
+    # server-side gate reads); a message would route at create time, which is
+    # the web UI's job, not the CLI's.
     assert payload["cost_control_mode_override"] == "on"
-    assert payload["smart_routing_message"] == "fix the flaky test"
+    assert "smart_routing_message" not in payload
+    assert "harness_override" not in payload
     assert payload["host_type"] == "external"
-    # Bound to the launch host + its workspace: the router's candidate catalog
-    # comes from that host's model options, and the server 400s a host_id with
-    # no workspace.
+    # Bound to the launch host + its workspace: the pane's model catalog comes
+    # from that host, and the server 400s a host_id with no workspace.
     assert payload["host_id"] == _HOST_ID
     assert payload["workspace"] == "/repo"
     assert payload["labels"] == ROUTING_SESSION_LABELS
-    # A fixed harness comes from the bound wrapper agent, so no override is
-    # sent — only the auto route uses the sentinel.
-    assert "harness_override" not in payload
-    assert (decision.session_id, decision.model) == (_SESSION_ID, "claude-sonnet-5")
-    assert decision.notice is None
+    assert armed == type(armed)(session_id=_SESSION_ID, notice=None)
 
 
 @respx.mock
-def test_create_asks_for_a_harness_on_the_auto_route() -> None:
-    """Tier 3 sends the ``auto`` sentinel and reads the bound harness back."""
-    route = _mock_create(harness="codex-native", model_override="gpt-5.4")
-
-    decision = create_smart_routing_session(
-        base_url=_BASE,
-        prompt="port the parser",
-        harness=None,
-        host_id=_HOST_ID,
-        workspace="/repo",
-    )
-
-    assert json.loads(route.calls.last.request.content)["harness_override"] == "auto"
-    assert (decision.harness, decision.model) == ("codex-native", "gpt-5.4")
-
-
-@respx.mock
-def test_create_omits_the_workspace_when_there_is_no_host() -> None:
+def test_arming_omits_the_workspace_when_there_is_no_host() -> None:
     """No host means no workspace either — the server validates them together."""
-    route = _mock_create(harness="claude-native", model_override="claude-sonnet-5")
+    route = _mock_create(harness="claude-native")
 
-    create_smart_routing_session(base_url=_BASE, prompt="hello", harness="claude-native")
+    arm_smart_routing_session(base_url=_BASE, harness="claude-native")
 
     payload = json.loads(route.calls.last.request.content)
     assert "host_id" not in payload
@@ -406,104 +360,58 @@ def test_create_omits_the_workspace_when_there_is_no_host() -> None:
 
 
 @respx.mock
-def test_create_never_deletes_the_routed_session() -> None:
-    """The routed session IS the session — the wrapper attaches to it."""
+def test_arming_binds_the_requested_harnesss_own_wrapper() -> None:
+    """Each harness arms its own built-in wrapper agent, never a placeholder."""
+    from omnigent.db.utils import builtin_agent_id
+
+    route = _mock_create(harness="codex-native")
+
+    arm_smart_routing_session(base_url=_BASE, harness="codex-native")
+
+    payload = json.loads(route.calls.last.request.content)
+    assert payload["agent_id"] == builtin_agent_id("codex-native-ui")
+
+
+@respx.mock
+def test_arming_never_deletes_the_session_it_created() -> None:
+    """The armed session IS the session — the wrapper attaches to it."""
     deleted = respx.delete(f"{_BASE}/v1/sessions/{_SESSION_ID}").mock(
         return_value=httpx.Response(204)
     )
-    _mock_create(harness="claude-native", model_override="claude-sonnet-5")
+    _mock_create(harness="claude-native")
 
-    create_smart_routing_session(base_url=_BASE, prompt="hello", harness="claude-native")
+    arm_smart_routing_session(base_url=_BASE, harness="claude-native")
 
     assert not deleted.called
-
-
-@respx.mock
-def test_create_falls_back_to_the_session_snapshot() -> None:
-    """A create response without the verdict is re-read from the snapshot."""
-    respx.post(f"{_BASE}/v1/sessions").mock(
-        return_value=httpx.Response(201, json={"id": _SESSION_ID})
-    )
-    respx.get(f"{_BASE}/v1/sessions/{_SESSION_ID}").mock(
-        return_value=httpx.Response(
-            200, json={"harness": "codex-native", "model_override": "gpt-5.4-mini"}
-        )
-    )
-
-    decision = create_smart_routing_session(base_url=_BASE, prompt="hello", harness=None)
-
-    assert (decision.harness, decision.model) == ("codex-native", "gpt-5.4-mini")
-
-
-@respx.mock
-def test_create_without_a_prompt_only_turns_smart_routing_on() -> None:
-    # A bare create arms the session; the in-harness hook picks the model.
-    route = _mock_create(harness="claude-native")
-
-    decision = create_smart_routing_session(
-        base_url=_BASE, prompt=None, harness="claude-native", host_id=_HOST_ID, workspace="/repo"
-    )
-
-    payload = json.loads(route.calls.last.request.content)
-    # The mode override is what arms Smart Routing (and what the hook's
-    # server-side gate reads); the message is what would route at create time.
-    assert payload["cost_control_mode_override"] == "on"
-    assert "smart_routing_message" not in payload
-    assert payload["host_id"] == _HOST_ID
-    assert payload["workspace"] == "/repo"
-    assert payload["labels"] == ROUTING_SESSION_LABELS
-    assert decision.session_id == _SESSION_ID
-    # Nothing is routed yet, so an empty pick is the expected answer — not a
-    # "did not pick a model" notice.
-    assert decision.model is None
-    assert decision.notice is None
-
-
-@respx.mock
-def test_create_keeps_the_session_when_no_model_was_picked() -> None:
-    """Fail-open: the session still launches, on the harness default model."""
-    _mock_create(harness="claude-native", model_override=None)
-
-    decision = create_smart_routing_session(
-        base_url=_BASE, prompt="hello", harness="claude-native"
-    )
-
-    assert decision.session_id == _SESSION_ID
-    assert decision.model is None
-    assert decision.notice is not None
-    assert "did not pick a model" in decision.notice
 
 
 # A create that is rejected, unreachable, or missing a session id never blocks
 # the launch: it returns no session and a notice.
 @respx.mock
 @pytest.mark.parametrize(
-    ("mock_kwargs", "harness", "notice_contains"),
+    ("mock_kwargs", "notice_contains"),
     [
-        ({"return_value": httpx.Response(400, text="no native CLI")}, None, "400"),
-        ({"side_effect": httpx.ConnectError("refused")}, "claude-native", "could not reach"),
-        ({"return_value": httpx.Response(201, json={})}, "claude-native", None),
+        ({"return_value": httpx.Response(400, text="runner is offline")}, "400"),
+        ({"side_effect": httpx.ConnectError("refused")}, "could not reach"),
+        ({"return_value": httpx.Response(201, json={})}, "no session id"),
     ],
 )
-def test_create_fails_open(
-    mock_kwargs: dict[str, Any], harness: str | None, notice_contains: str | None
-) -> None:
+def test_arming_fails_open(mock_kwargs: dict[str, Any], notice_contains: str) -> None:
     respx.post(f"{_BASE}/v1/sessions").mock(**mock_kwargs)
 
-    decision = create_smart_routing_session(base_url=_BASE, prompt="hello", harness=harness)
+    armed = arm_smart_routing_session(base_url=_BASE, harness="claude-native")
 
-    assert (decision.session_id, decision.harness, decision.model) == (None, None, None)
-    assert decision.notice is not None
-    if notice_contains is not None:
-        assert notice_contains in decision.notice
+    assert armed.session_id is None
+    assert armed.notice is not None
+    assert notice_contains in armed.notice
 
 
-# ── dispatch ─────────────────────────────────────────────────────────────
+# ── preflight + arm, as the subcommands call it ──────────────────────────
 
 
 @pytest.fixture
 def _routing_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Point the dispatch helpers at a fake backend, daemon, and host identity."""
+    """Point the launch helpers at a fake backend, daemon, and host identity."""
     monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s: _BASE)
     monkeypatch.setattr("omnigent.cli._ensure_host_daemon", lambda _s: False)
     monkeypatch.setattr(
@@ -513,228 +421,30 @@ def _routing_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @respx.mock
-def test_dispatch_tier2_attaches_the_wrapper_to_the_routed_session(
-    monkeypatch: pytest.MonkeyPatch, _routing_env: None
-) -> None:
-    """A fixed harness keeps its wrapper, gains ``--model``, and attaches."""
+def test_the_decision_binds_the_launch_host_and_cwd(_routing_env: None) -> None:
+    """The armed session runs here, so it carries this host and this workspace."""
     _mock_info()
     _mock_hosts({"claude-native": True})
-    route = _mock_create(harness="claude-native", model_override="claude-opus-4-7")
-    captured: dict[str, Any] = {}
-    monkeypatch.setattr(
-        "omnigent.claude_native.run_claude_native", lambda **kw: captured.update(kw)
-    )
+    route = _mock_create(harness="claude-native")
 
-    _dispatch_smart_routing(
-        harness="claude-native",
-        server=None,
-        prompt="fix the flaky test",
-        model=None,
-        auto_open_conversation=False,
-    )
+    armed = _smart_routing_decision(server=_BASE, harness="claude-native")
 
-    # Attach, not bundle: the routed session already carries the model, the
-    # decision card, and the wrapper labels the server wrote at create.
-    assert captured["session_id"] == _SESSION_ID
-    assert captured["extra_args"] == ("--model", "claude-opus-4-7")
-    assert captured["prompt"] == "fix the flaky test"
+    assert armed.session_id == _SESSION_ID
     payload = json.loads(route.calls.last.request.content)
     assert payload["host_id"] == _HOST_ID
     assert payload["workspace"] == str(Path.cwd().resolve())
 
 
 @respx.mock
-def test_dispatch_tier3_launches_the_harness_the_server_bound(
-    monkeypatch: pytest.MonkeyPatch, _routing_env: None
+def test_the_decision_routes_hostlessly_when_the_server_does_not_know_the_host(
+    _routing_env: None,
 ) -> None:
-    """The auto route picks the harness; the CLI execs that wrapper on it."""
-    _mock_info()
-    _mock_hosts(None)
-    _mock_create(harness="codex-native", model_override="gpt-5.4")
-    captured: dict[str, Any] = {}
-    monkeypatch.setattr("omnigent.codex_native.run_codex_native", lambda **kw: captured.update(kw))
-
-    _dispatch_smart_routing(
-        harness=None,
-        server=None,
-        prompt="port the parser",
-        model=None,
-        auto_open_conversation=False,
-    )
-
-    assert captured["session_id"] == _SESSION_ID
-    assert captured["model"] == "gpt-5.4"
-    assert captured["prompt"] == "port the parser"
-
-
-@respx.mock
-def test_dispatch_launches_bare_when_the_harness_routes_its_own_first_message(
-    monkeypatch: pytest.MonkeyPatch, _routing_env: None, capsys: pytest.CaptureFixture[str]
-) -> None:
-    # No -p on a hooked harness: arm the session, then let the TUI route.
-    _mock_info()
-    _mock_hosts({"claude-native": True})
-    route = _mock_create(harness="claude-native")
-    captured: dict[str, Any] = {}
-    monkeypatch.setattr(
-        "omnigent.claude_native.run_claude_native", lambda **kw: captured.update(kw)
-    )
-
-    _dispatch_smart_routing(
-        harness="claude-native",
-        server=None,
-        prompt=None,
-        model=None,
-        auto_open_conversation=False,
-    )
-
-    payload = json.loads(route.calls.last.request.content)
-    assert payload["cost_control_mode_override"] == "on"
-    assert "smart_routing_message" not in payload
-    assert captured["session_id"] == _SESSION_ID
-    # Nothing was picked at create, so the launch carries no routed --model and
-    # no initial prompt — the hook applies the model on the first typed message.
-    assert captured["extra_args"] == ()
-    assert captured["prompt"] is None
-    assert "Smart Routing is on for this session" in capsys.readouterr().err
-
-
-@respx.mock
-def test_dispatch_bare_preflights_the_pinned_harness(
-    monkeypatch: pytest.MonkeyPatch, _routing_env: None
-) -> None:
-    # A bare launch that cannot be routed fails loud, not silently unrouted.
-    _mock_info()
-    _mock_hosts({"claude-native": False})
-
-    def _must_not_launch(**_kwargs: Any) -> None:
-        raise AssertionError("wrapper launched despite unavailable routing")
-
-    monkeypatch.setattr("omnigent.claude_native.run_claude_native", _must_not_launch)
-
-    with pytest.raises(ClickException, match="not AI-Gateway-backed"):
-        _dispatch_smart_routing(
-            harness="claude-native",
-            server=None,
-            prompt=None,
-            model=None,
-            auto_open_conversation=False,
-        )
-
-
-@respx.mock
-def test_run_smart_routing_launches_a_pinned_codex_bare(
-    monkeypatch: pytest.MonkeyPatch, _routing_env: None
-) -> None:
-    # `run --harness codex-native --smart-routing` with no -p is servable.
-    _mock_info()
-    _mock_hosts({"codex-native": True})
-    route = _mock_create(harness="codex-native")
-    captured: dict[str, Any] = {}
-    monkeypatch.setattr("omnigent.codex_native.run_codex_native", lambda **kw: captured.update(kw))
-
-    _run_smart_routing(**_run_kwargs(harness="codex-native", prompt=None))
-
-    assert "smart_routing_message" not in json.loads(route.calls.last.request.content)
-    assert captured["session_id"] == _SESSION_ID
-    assert captured["model"] is None
-    assert captured["prompt"] is None
-
-
-@respx.mock
-def test_dispatch_fails_open_to_a_fresh_wrapper_session(
-    monkeypatch: pytest.MonkeyPatch, _routing_env: None, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """A rejected create still launches — the wrapper bundles its own session."""
-    _mock_info()
-    _mock_hosts(None)
-    respx.post(f"{_BASE}/v1/sessions").mock(return_value=httpx.Response(503, text="down"))
-    captured: dict[str, Any] = {}
-    monkeypatch.setattr(
-        "omnigent.claude_native.run_claude_native", lambda **kw: captured.update(kw)
-    )
-
-    _dispatch_smart_routing(
-        harness=None,
-        server=None,
-        prompt="port the parser",
-        model=None,
-        auto_open_conversation=False,
-    )
-
-    err = capsys.readouterr().err
-    assert "Smart Routing was unavailable" in err
-    assert "launching claude-native" in err
-    assert captured["session_id"] is None
-    assert captured["extra_args"] == ()
-    assert captured["prompt"] == "port the parser"
-
-
-@respx.mock
-def test_dispatch_tier3_falls_back_when_the_pick_cannot_take_a_prompt(
-    monkeypatch: pytest.MonkeyPatch, _routing_env: None, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """A harness the CLI cannot hand a prompt to is not a usable pick."""
-    _mock_info()
-    _mock_hosts(None)
-    _mock_create(harness="cursor-native", model_override="composer-2.5")
-    captured: dict[str, Any] = {}
-    monkeypatch.setattr(
-        "omnigent.claude_native.run_claude_native", lambda **kw: captured.update(kw)
-    )
-
-    _dispatch_smart_routing(
-        harness=None,
-        server=None,
-        prompt="port the parser",
-        model=None,
-        auto_open_conversation=False,
-    )
-
-    assert "did not resolve a launchable harness" in capsys.readouterr().err
-    assert captured["extra_args"] == ("--model", "composer-2.5")
-
-
-@respx.mock
-def test_dispatch_preflight_error_blocks_the_launch(
-    monkeypatch: pytest.MonkeyPatch, _routing_env: None
-) -> None:
-    """An unavailable-routing error must stop before any wrapper runs."""
-    _mock_info(enabled=False)
-    _mock_hosts(None)
-
-    def _must_not_launch(**_kwargs: Any) -> None:
-        raise AssertionError("wrapper launched despite unavailable routing")
-
-    monkeypatch.setattr("omnigent.claude_native.run_claude_native", _must_not_launch)
-
-    with pytest.raises(ClickException, match="Smart Routing is not enabled"):
-        _dispatch_smart_routing(
-            harness="claude-native",
-            server=None,
-            prompt="hello",
-            model=None,
-            auto_open_conversation=False,
-        )
-
-
-@respx.mock
-def test_dispatch_routes_hostlessly_when_the_server_does_not_know_the_host(
-    monkeypatch: pytest.MonkeyPatch, _routing_env: None
-) -> None:
-    """An unregistered host degrades to a hostless route, not a failed create."""
+    """An unregistered host degrades to a hostless create, not a failed one."""
     _mock_info()
     respx.get(f"{_BASE}/v1/hosts").mock(return_value=httpx.Response(200, json={"hosts": []}))
-    route = _mock_create(harness="claude-native", model_override="claude-sonnet-5")
-    monkeypatch.setattr("omnigent.claude_native.run_claude_native", lambda **kw: None)
+    route = _mock_create(harness="claude-native")
 
-    _dispatch_smart_routing(
-        harness="claude-native",
-        server=None,
-        prompt="hello",
-        model=None,
-        auto_open_conversation=False,
-    )
+    _smart_routing_decision(server=_BASE, harness="claude-native")
 
     payload = json.loads(route.calls.last.request.content)
     assert "host_id" not in payload
@@ -749,113 +459,60 @@ def test_known_host_id_requires_the_server_to_have_seen_the_host() -> None:
         assert known_host_id(base_url=_BASE, host_id=None) is None
 
 
-# ── flag parsing / rejects ───────────────────────────────────────────────
+@respx.mock
+def test_the_routing_preflight_reads_are_not_on_the_creates_long_budget() -> None:
+    """
+    A wedged server cannot stall the launch before the session exists.
+
+    The preflight GETs already degrade to "unknown", which does not gate, so a
+    long wait buys nothing; the create's own 60s read budget is for the create,
+    which does real work. Asserted against the constants so the two stay
+    distinguishable.
+    """
+    from omnigent.smart_routing_cli import _PREFLIGHT_TIMEOUT, _TIMEOUT
+
+    assert _PREFLIGHT_TIMEOUT.read is not None
+    assert _PREFLIGHT_TIMEOUT.connect is not None
+    assert _PREFLIGHT_TIMEOUT.read <= 8.0
+    assert _TIMEOUT.read is not None
+    assert _PREFLIGHT_TIMEOUT.read < _TIMEOUT.read
 
 
-def test_require_prompt_rejects_missing_text_without_an_in_harness_route() -> None:
-    for value in (None, "   "):
-        with pytest.raises(UsageError, match="needs the text to route"):
-            _require_smart_routing_prompt(value, in_harness_routing=False)
-    assert _require_smart_routing_prompt("hi", in_harness_routing=False) == "hi"
+# ── rejected combinations ────────────────────────────────────────────────
 
 
-def test_require_prompt_allows_missing_text_when_the_harness_routes_its_own() -> None:
-    # The per-harness subcommands default to the in-harness route, so a bare
-    # launch is served instead of rejected.
-    assert _require_smart_routing_prompt(None) is None
-    assert _require_smart_routing_prompt("   ") is None
-    assert _require_smart_routing_prompt("hi") == "hi"
-
-
-def _run_kwargs(**overrides: Any) -> dict[str, Any]:
-    """``_run_smart_routing`` kwargs with a valid routed launch as the baseline."""
-    base: dict[str, Any] = {
-        "target": None,
-        "harness": None,
-        "prompt": "hello",
-        "server": None,
-        "model": None,
-        "resume_conversation_id": None,
-        "resume_picker": False,
-        "resume_latest": False,
-        "auto_open_conversation": False,
-    }
-    base.update(overrides)
-    return base
-
-
-def test_run_smart_routing_rejects_an_agent() -> None:
-    with pytest.raises(ClickException, match="takes no AGENT"):
-        _run_smart_routing(**_run_kwargs(target="examples/hello_world.yaml"))
-
-
-@pytest.mark.parametrize(
-    ("overrides", "flag"),
-    [
-        ({"tools": "coding"}, "--tools"),
-        ({"system_prompt": "be terse"}, "--system-prompt"),
-        ({"log": True}, "--log"),
-        ({"debug_events": True}, "--debug-events"),
-        ({"fork_session_id": "conv_src"}, "--fork"),
-        ({"ephemeral": True}, "--no-session"),
-    ],
-)
-def test_run_smart_routing_rejects_repl_only_options(overrides: dict[str, Any], flag: str) -> None:
-    """A routed launch is still a TUI attach — REPL-only flags fail loud."""
-    with pytest.raises(ClickException, match=flag):
-        _run_smart_routing(**_run_kwargs(**overrides))
-
-
-@pytest.mark.parametrize(
-    ("overrides", "flag"),
-    [
-        ({"resume_conversation_id": "conv_old"}, "--resume"),
-        ({"resume_picker": True}, "--resume"),
-        ({"resume_latest": True}, "--continue"),
-    ],
-)
-def test_run_smart_routing_rejects_resuming(overrides: dict[str, Any], flag: str) -> None:
-    """Routing happens at create, so a routed launch is always a new session."""
-    with pytest.raises(ClickException, match=f"cannot be combined with {flag}"):
-        _run_smart_routing(**_run_kwargs(**overrides))
-
-
-def test_run_smart_routing_rejects_a_non_routable_harness() -> None:
-    with pytest.raises(ClickException, match="does not support --harness 'claude-sdk'"):
-        _run_smart_routing(**_run_kwargs(harness="claude-sdk"))
+def test_reject_prompt_only_fires_on_real_text() -> None:
+    # Whitespace is not a prompt; a bare launch must stay servable.
+    assert _reject_smart_routing_prompt(None) is None
+    assert _reject_smart_routing_prompt("   ") is None
+    with pytest.raises(UsageError, match="cannot be combined with -p"):
+        _reject_smart_routing_prompt("fix the flaky test")
 
 
 @pytest.mark.parametrize(
     "args",
     [
-        ["run", "--smart-routing"],
-        ["run", "--smart-routing", "--harness", "auto"],
+        ["claude", "--smart-routing", "-p", "fix the flaky test"],
+        ["claude", "--smart-routing", "--prompt", "fix the flaky test"],
+        ["codex", "--smart-routing", "-p", "port the parser"],
     ],
 )
-def test_cross_harness_routing_without_a_prompt_is_a_usage_error(args: list[str]) -> None:
-    # Nothing exists to hook before the harness is picked, so -p is required.
+def test_a_prompt_with_smart_routing_is_rejected(args: list[str]) -> None:
+    # The CLI routes what you type in the TUI, so a create-time prompt has no
+    # path — say where it does have one instead of launching unrouted.
     result = CliRunner().invoke(cli, args)
 
     assert result.exit_code == 2, result.output
-    assert "needs the text to route up front here" in result.output
-    assert "no harness that can route from inside itself" in result.output
-    assert '-p "<prompt>"' in result.output
-    assert "--harness claude-native" in result.output
-
-
-def test_a_harness_without_the_first_message_hook_still_needs_a_prompt() -> None:
-    # kiro-native is routable, but it cannot route from inside itself.
-    with pytest.raises(UsageError, match="needs the text to route up front here"):
-        _run_smart_routing(**_run_kwargs(harness="kiro-native", prompt=None))
+    assert "cannot be combined with -p/--prompt" in result.output
+    assert "web UI" in result.output
 
 
 @pytest.mark.parametrize(
     "args",
     [
-        ["run", "--smart-routing", "-p", "hi", "--continue"],
-        ["claude", "--smart-routing", "-p", "hi", "--resume", "conv_old"],
-        ["codex", "--smart-routing", "-p", "hi", "--resume", "conv_old"],
-        ["claude", "--smart-routing", "-p", "hi", "--session", "conv_old"],
+        ["claude", "--smart-routing", "--resume", "conv_old"],
+        ["codex", "--smart-routing", "--resume", "conv_old"],
+        ["claude", "--smart-routing", "--session", "conv_old"],
     ],
 )
 def test_smart_routing_with_a_resume_is_rejected(args: list[str]) -> None:
@@ -865,96 +522,33 @@ def test_smart_routing_with_a_resume_is_rejected(args: list[str]) -> None:
     assert "routes a new session" in result.output
 
 
-@respx.mock
-def test_run_smart_routing_with_a_pinned_harness_routes_the_model_only(
-    monkeypatch: pytest.MonkeyPatch, _routing_env: None
-) -> None:
-    """``run --harness codex-native --smart-routing`` keeps codex, routes model."""
-    _mock_info()
-    _mock_hosts({"codex-native": True})
-    route = _mock_create(harness="codex-native", model_override="gpt-5.4-mini")
-    captured: dict[str, Any] = {}
-    monkeypatch.setattr("omnigent.codex_native.run_codex_native", lambda **kw: captured.update(kw))
-
-    _run_smart_routing(**_run_kwargs(harness="codex-native", prompt="add a --dry-run flag"))
-
-    assert "harness_override" not in json.loads(route.calls.last.request.content)
-    assert captured["model"] == "gpt-5.4-mini"
-    assert captured["session_id"] == _SESSION_ID
-
-
-def test_routable_harnesses_are_the_prompt_capable_native_ones() -> None:
-    assert _smart_routing_capable_harness("claude-native") == "claude-native"
-    assert _smart_routing_capable_harness("codex-native") == "codex-native"
-    assert _smart_routing_capable_harness("kiro-native") == "kiro-native"
-    # Wrappers with no prompt parameter, and non-native harnesses, are out —
-    # including bare ``claude``, which canonicalizes to the SDK harness.
-    assert _smart_routing_capable_harness("cursor-native") is None
-    assert _smart_routing_capable_harness("claude") is None
-    assert _smart_routing_capable_harness("claude-sdk") is None
-    assert _smart_routing_capable_harness(None) is None
-
-
 @pytest.mark.parametrize(
-    ("args", "model", "expected"),
+    "args",
     [
-        ((), "sonnet", ("--model", "sonnet")),
-        (("--verbose",), "sonnet", ("--verbose", "--model", "sonnet")),
-        # An explicit user model wins over the routed default.
-        (("--model", "opus"), "sonnet", ("--model", "opus")),
-        (("--model=opus",), "sonnet", ("--model=opus",)),
-        (("--verbose",), None, ("--verbose",)),
+        ["run", "--smart-routing"],
+        ["run", "--smart-routing", "-p", "review the last commit"],
+        ["run", "--harness", "claude-native", "--smart-routing", "-p", "hi"],
     ],
 )
-def test_routed_model_arg_merge(
-    args: tuple[str, ...], model: str | None, expected: tuple[str, ...]
-) -> None:
-    assert _with_routed_model_arg(args, model) == expected
+def test_run_smart_routing_is_removed(args: list[str]) -> None:
+    # `run` never routed from inside a harness, and its create-time route is
+    # gone — the rejection has to name both surfaces that still route.
+    result = CliRunner().invoke(cli, args)
+
+    assert result.exit_code == 1, result.output
+    assert "per-harness first-message only" in result.output
+    assert "omnigent claude --smart-routing" in result.output
+    assert "web UI" in result.output
+
+
+def test_run_no_longer_advertises_smart_routing() -> None:
+    result = CliRunner().invoke(cli, ["run", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "--smart-routing" not in result.output
 
 
 # ── the dedicated subcommands ────────────────────────────────────────────
-
-
-@respx.mock
-def test_claude_subcommand_attaches_to_the_routed_session(
-    monkeypatch: pytest.MonkeyPatch, _routing_env: None
-) -> None:
-    """``omnigent claude --smart-routing -p`` routes, then attaches with --model."""
-    _mock_info()
-    _mock_hosts({"claude-native": True})
-    _mock_create(harness="claude-native", model_override="claude-sonnet-5")
-    captured: dict[str, Any] = {}
-    monkeypatch.setattr("omnigent.cli._load_effective_config", dict)
-    monkeypatch.setattr(
-        "omnigent.claude_native.run_claude_native", lambda **kw: captured.update(kw)
-    )
-
-    result = CliRunner().invoke(cli, ["claude", "--smart-routing", "-p", "fix the flaky test"])
-
-    assert result.exit_code == 0, result.output
-    assert captured["session_id"] == _SESSION_ID
-    assert captured["extra_args"] == ("--model", "claude-sonnet-5")
-    assert captured["prompt"] == "fix the flaky test"
-
-
-@respx.mock
-def test_codex_subcommand_attaches_to_the_routed_session(
-    monkeypatch: pytest.MonkeyPatch, _routing_env: None
-) -> None:
-    """Codex takes the routed model first-class, and keeps its own -p delivery."""
-    _mock_info()
-    _mock_hosts({"codex-native": True})
-    _mock_create(harness="codex-native", model_override="gpt-5.4-mini")
-    captured: dict[str, Any] = {}
-    monkeypatch.setattr("omnigent.cli._load_effective_config", dict)
-    monkeypatch.setattr("omnigent.codex_native.run_codex_native", lambda **kw: captured.update(kw))
-
-    result = CliRunner().invoke(cli, ["codex", "--smart-routing", "-p", "port the parser"])
-
-    assert result.exit_code == 0, result.output
-    assert captured["session_id"] == _SESSION_ID
-    assert captured["model"] == "gpt-5.4-mini"
-    assert captured["prompt"] == "port the parser"
 
 
 @respx.mock
@@ -965,10 +559,10 @@ def test_codex_subcommand_attaches_to_the_routed_session(
         ("codex", "omnigent.codex_native.run_codex_native"),
     ],
 )
-def test_subcommand_without_a_prompt_arms_the_session_and_launches_bare(
+def test_a_subcommand_arms_the_session_and_launches_bare(
     command: str, launcher: str, monkeypatch: pytest.MonkeyPatch, _routing_env: None
 ) -> None:
-    # `omnigent claude|codex --smart-routing` needs no -p: the hook routes.
+    # `omnigent claude|codex --smart-routing` takes no -p: the hook routes.
     _mock_info()
     _mock_hosts({f"{command}-native": True})
     route = _mock_create(harness=f"{command}-native")
@@ -982,36 +576,36 @@ def test_subcommand_without_a_prompt_arms_the_session_and_launches_bare(
     payload = json.loads(route.calls.last.request.content)
     assert payload["cost_control_mode_override"] == "on"
     assert "smart_routing_message" not in payload
+    # Attach, not bundle: the armed session carries the mode, the wrapper labels
+    # and the decision card the server wrote at create.
     assert captured["session_id"] == _SESSION_ID
     assert captured["prompt"] is None
-    # No create-time pick, so no routed model reaches the wrapper.
+    # Nothing is picked at create, so no routed model reaches the wrapper.
     assert captured["extra_args"] == ()
     assert captured.get("model") is None
     assert "Smart Routing is on for this session" in result.output
 
 
 @respx.mock
-def test_explicit_model_beats_the_routed_pick(
+def test_an_explicit_model_survives_arming(
     monkeypatch: pytest.MonkeyPatch, _routing_env: None
 ) -> None:
-    """Routing fills in a default; a model the user typed still wins."""
+    """Arming picks nothing, so a model the user typed reaches the launch."""
     _mock_info()
     _mock_hosts(None)
-    _mock_create(harness="codex-native", model_override="gpt-5.4-mini")
+    _mock_create(harness="codex-native")
     captured: dict[str, Any] = {}
     monkeypatch.setattr("omnigent.cli._load_effective_config", dict)
     monkeypatch.setattr("omnigent.codex_native.run_codex_native", lambda **kw: captured.update(kw))
 
-    result = CliRunner().invoke(
-        cli, ["codex", "--smart-routing", "-p", "hello", "--model", "gpt-5.4"]
-    )
+    result = CliRunner().invoke(cli, ["codex", "--smart-routing", "--model", "gpt-5.4"])
 
     assert result.exit_code == 0, result.output
     assert captured["model"] == "gpt-5.4"
 
 
 @respx.mock
-def test_claude_subcommand_falls_back_to_a_fresh_session(
+def test_a_subcommand_falls_back_to_a_fresh_session(
     monkeypatch: pytest.MonkeyPatch, _routing_env: None
 ) -> None:
     """A rejected create leaves the wrapper to bundle its own session."""
@@ -1024,11 +618,10 @@ def test_claude_subcommand_falls_back_to_a_fresh_session(
         "omnigent.claude_native.run_claude_native", lambda **kw: captured.update(kw)
     )
 
-    result = CliRunner().invoke(cli, ["claude", "--smart-routing", "-p", "hello"])
+    result = CliRunner().invoke(cli, ["claude", "--smart-routing"])
 
     assert result.exit_code == 0, result.output
     assert captured["session_id"] is None
-    assert captured["prompt"] == "hello"
     assert "Smart Routing was unavailable" in result.output
 
 
@@ -1056,36 +649,36 @@ def test_a_create_rejected_for_a_non_routing_reason_says_so_and_still_launches(
         "omnigent.claude_native.run_claude_native", lambda **kw: captured.update(kw)
     )
 
-    result = CliRunner().invoke(cli, ["claude", "--smart-routing", "-p", "hello"])
+    result = CliRunner().invoke(cli, ["claude", "--smart-routing"])
 
     # Not fatal.
     assert result.exit_code == 0, result.output
     # One explicit line, naming the status the server answered with.
     assert "Smart Routing was unavailable" in result.output
     assert "400" in result.output
-    # And the session still launches, unrouted and prompt in hand.
+    # And the session still launches, unrouted.
     assert captured["session_id"] is None
-    assert captured["prompt"] == "hello"
     assert captured["extra_args"] == ()
 
 
 @respx.mock
-def test_the_routing_preflight_reads_are_not_on_the_creates_long_budget() -> None:
-    """
-    A wedged server cannot stall the launch before the session exists.
+def test_an_unavailable_preflight_blocks_the_launch(
+    monkeypatch: pytest.MonkeyPatch, _routing_env: None
+) -> None:
+    """An unavailable-routing error must stop before any wrapper runs."""
+    _mock_info(enabled=False)
+    _mock_hosts(None)
 
-    The preflight GETs already degrade to "unknown", which does not gate, so a
-    long wait buys nothing; the create's own 60s read budget is for the create,
-    which does real work. Asserted against the constants so the two stay
-    distinguishable.
-    """
-    from omnigent.smart_routing_cli import _PREFLIGHT_TIMEOUT, _TIMEOUT
+    def _must_not_launch(**_kwargs: Any) -> None:
+        raise AssertionError("wrapper launched despite unavailable routing")
 
-    assert _PREFLIGHT_TIMEOUT.read is not None
-    assert _PREFLIGHT_TIMEOUT.connect is not None
-    assert _PREFLIGHT_TIMEOUT.read <= 8.0
-    assert _TIMEOUT.read is not None
-    assert _PREFLIGHT_TIMEOUT.read < _TIMEOUT.read
+    monkeypatch.setattr("omnigent.cli._load_effective_config", dict)
+    monkeypatch.setattr("omnigent.claude_native.run_claude_native", _must_not_launch)
+
+    result = CliRunner().invoke(cli, ["claude", "--smart-routing"])
+
+    assert result.exit_code == 1, result.output
+    assert "Smart Routing is not enabled" in result.output
 
 
 # ── credential-provider gating, end to end ───────────────────────────────
@@ -1093,24 +686,10 @@ def test_the_routing_preflight_reads_are_not_on_the_creates_long_budget() -> Non
 # The shape a Databricks user actually has: Claude Code pointed at the workspace
 # AI Gateway, Codex signed in to a personal ChatGPT subscription. Routing is
 # applied by rewriting the launch model to a gateway catalog id, so only the
-# Claude pane can honour it — every routed entry point into Codex must fail
-# fast, and the auto route (which may land on either arm) with it.
+# Claude pane can honour it — a routed launch into Codex must fail fast.
 
 _CODEX_ON_SUBSCRIPTION = {"claude-native": True, "codex-native": False}
 _NO_GATEWAY_AT_ALL = {"claude-native": False, "codex-native": False}
-
-
-@respx.mock
-def test_auto_route_is_refused_when_only_one_arm_is_gateway_backed() -> None:
-    _mock_info()
-    _mock_hosts(_CODEX_ON_SUBSCRIPTION)
-
-    with pytest.raises(ClickException, match=r"codex-native.*not AI-Gateway-backed"):
-        check_smart_routing_available(
-            base_url=_BASE,
-            harnesses=smart_routing_families(None),
-            host_id=_HOST_ID,
-        )
 
 
 @respx.mock
@@ -1121,7 +700,7 @@ def test_claude_route_survives_codex_being_on_a_subscription() -> None:
 
     check_smart_routing_available(
         base_url=_BASE,
-        harnesses=smart_routing_families("claude-native"),
+        harnesses=("claude-native",),
         host_id=_HOST_ID,
     )
 
@@ -1130,16 +709,10 @@ def test_claude_route_survives_codex_being_on_a_subscription() -> None:
 @pytest.mark.parametrize(
     ("args", "gateway"),
     [
-        # The auto route may land on Codex, so one ungatewayed arm blocks it.
-        (["run", "--smart-routing", "-p", "hello"], _CODEX_ON_SUBSCRIPTION),
-        (
-            ["run", "--harness", "codex-native", "--smart-routing", "-p", "hello"],
-            _CODEX_ON_SUBSCRIPTION,
-        ),
-        (["codex", "--smart-routing", "-p", "hello"], _CODEX_ON_SUBSCRIPTION),
+        (["codex", "--smart-routing"], _CODEX_ON_SUBSCRIPTION),
         # No AI Gateway anywhere: every entry point errors, Claude included.
-        (["run", "--smart-routing", "-p", "hello"], _NO_GATEWAY_AT_ALL),
-        (["claude", "--smart-routing", "-p", "hello"], _NO_GATEWAY_AT_ALL),
+        (["claude", "--smart-routing"], _NO_GATEWAY_AT_ALL),
+        (["codex", "--smart-routing"], _NO_GATEWAY_AT_ALL),
     ],
 )
 def test_smart_routing_entry_points_error_on_an_ungatewayed_harness(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -273,6 +273,24 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(autouse=True)
+def _reset_runner_catalog_cache() -> Generator[None, None, None]:
+    """
+    Clear smart routing's per-session runner-catalog cache after every test.
+
+    The cache is process-global and keyed by session id, and the suite reuses
+    a handful of fixed ids (``conv_123`` and friends) across unrelated tests —
+    so one test's catalog would answer another test's fetch and its counting
+    stub would never be called.
+
+    :returns: None.
+    """
+    yield
+    from omnigent.server.smart_routing import _runner_catalog_cache
+
+    _runner_catalog_cache.clear()
+
+
+@pytest.fixture(autouse=True)
 def _isolate_claude_native_state(
     tmp_path_factory: pytest.TempPathFactory,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -285,9 +285,12 @@ def _reset_runner_catalog_cache() -> Generator[None, None, None]:
     :returns: None.
     """
     yield
-    from omnigent.server.smart_routing import _runner_catalog_cache
-
-    _runner_catalog_cache.clear()
+    # sys.modules lookup, not an import: the spec lane blocks omnigent imports
+    # inside some tests, and a lane that never touched smart_routing should not
+    # pay for loading it in every teardown.
+    module = sys.modules.get("omnigent.server.smart_routing")
+    if module is not None:
+        module._runner_catalog_cache.clear()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/e2e_ui/chat/test_smart_routing_session.py
+++ b/tests/e2e_ui/chat/test_smart_routing_session.py
@@ -116,6 +116,72 @@ def test_routed_session_renders_one_routing_chip(
     expect(chip).to_have_attribute("data-applied", "true")
 
 
+def test_spawn_chip_says_the_short_harness_name(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A sub-agent spawn chip says "codex", not the "-native" implementation id.
+
+    The session's own session/turn chips keep the full harness id (covered
+    above); the shortening applies only to the sub-agent scopes.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` for a real server-backed
+        session.
+    :returns: None.
+    """
+    from omnigent.entities import NewConversationItem
+    from omnigent.entities.conversation import parse_item_data
+    from omnigent.stores.conversation_store.sqlalchemy_store import (
+        SqlAlchemyConversationStore,
+    )
+    from tests.e2e_ui.conftest import _server_state
+
+    base_url, session_id = seeded_session
+    database_uri = _server_state.get("database_uri")
+    assert database_uri, "needs the spawned server's database (not --ui-base-url)"
+    store = SqlAlchemyConversationStore(str(database_uri))
+    store.append(
+        session_id,
+        [
+            NewConversationItem(
+                type="routing_decision",
+                response_id="routing_e2e_spawn",
+                data=parse_item_data(
+                    "routing_decision",
+                    {
+                        "model": "databricks-gpt-5-6-luna",
+                        "applied": True,
+                        "rationale": "Trivial task; cheapest arm.",
+                        "harness": "codex-native",
+                        "scope": "native_subagent",
+                        "decision_id": "e2e-decision-spawn",
+                        "router_source": "databricks-aigw",
+                        "agent_name": "researcher",
+                    },
+                ),
+            ),
+        ],
+    )
+    seed_committed_turn(session_id, prompt="spawn a researcher", reply="spawned")
+    # The spawn chip renders only while the session's switch is on.
+    patched = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"subagent_routing_override": "on"},
+        timeout=10.0,
+    )
+    patched.raise_for_status()
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    chip = page.get_by_test_id("routing-decision-card")
+    expect(chip).to_have_count(1, timeout=15_000)
+    harness = chip.get_by_test_id("routing-decision-harness")
+    expect(harness).to_contain_text("codex")
+    expect(harness).not_to_contain_text("codex-native")
+    expect(chip.get_by_test_id("routing-decision-scope")).to_contain_text("subagent")
+
+
 def test_routed_session_config_modal_names_the_routed_model(
     page: Page,
     seeded_session: tuple[str, str],

--- a/tests/e2e_ui/chat/test_smart_routing_session.py
+++ b/tests/e2e_ui/chat/test_smart_routing_session.py
@@ -111,7 +111,9 @@ def test_routed_session_renders_one_routing_chip(
     # The pick itself, and who made it.
     expect(chip).to_contain_text("opus")
     expect(chip.get_by_test_id("routing-decision-source-databricks")).to_be_visible()
-    expect(chip.get_by_test_id("routing-decision-harness")).to_contain_text("claude-native")
+    session_harness = chip.get_by_test_id("routing-decision-harness")
+    expect(session_harness).to_contain_text("claude")
+    expect(session_harness).not_to_contain_text("claude-native")
     # The turn chip is the survivor, so the scope reads as the turn's.
     expect(chip).to_have_attribute("data-applied", "true")
 
@@ -122,8 +124,8 @@ def test_spawn_chip_says_the_short_harness_name(
 ) -> None:
     """A sub-agent spawn chip says "codex", not the "-native" implementation id.
 
-    The session's own session/turn chips keep the full harness id (covered
-    above); the shortening applies only to the sub-agent scopes.
+    Every chip shortens the id this way; the session's own chip is covered
+    above.
 
     :param page: Playwright page fixture.
     :param seeded_session: ``(base_url, session_id)`` for a real server-backed

--- a/tests/inner/test_claude_router_hook.py
+++ b/tests/inner/test_claude_router_hook.py
@@ -641,11 +641,13 @@ def test_the_spawn_gate_asks_on_the_ladders_own_request_budget(
     # "No opinion": the spawn runs on exactly the model it asked for.
     assert raw == ""
     assert seen == [subagent_router.REQUEST_TIMEOUT_S]
-    assert subagent_router.REQUEST_TIMEOUT_S < 10.0
+    # The budget must outlast a healthy route (catalog prep + router call) and
+    # stay at or under the owner's 15s ceiling.
+    assert subagent_router.REQUEST_TIMEOUT_S <= 15.0
     # The harness's own kill has to sit above it, or the fail-open branch above
     # never runs and the harness sees a dead hook instead of "no opinion".
     assert subagent_router.HOOK_TIMEOUT_S > subagent_router.REQUEST_TIMEOUT_S
-    assert subagent_router.HOOK_TIMEOUT_S <= 15
+    assert subagent_router.HOOK_TIMEOUT_S < 30
 
 
 def test_an_unreachable_relay_is_no_opinion_not_a_dropped_spawn(

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -552,12 +552,14 @@ class TestConstructor(unittest.TestCase):
         self.assertIn('databricks auth token --profile "oss"', helper)
         self.assertNotIn("--host", helper)
         # `--force-refresh` only exists in Databricks CLI >= v0.296.0, so it
-        # must be applied via a `--help` capability probe ($force), never
-        # passed unconditionally — an older CLI rejects the unknown flag and
-        # yields an empty token → silent 401.
+        # stays behind a `--help` capability probe — an older CLI rejects the
+        # unknown flag and yields an empty token → silent 401.
         self.assertIn("databricks auth token --help", helper)
-        self.assertIn("force=--force-refresh", helper)
-        self.assertNotIn('oss" --force-refresh', helper)
+        # And even where it exists it is only ATTEMPTED: it fails outright on a
+        # stale refresh token, so an empty result must fall back to the cached
+        # token rather than turning a usable credential into an auth failure.
+        self.assertIn("--force-refresh", helper)
+        self.assertIn('if [ -z "$token" ]; then', helper)
 
     def test_databricks_flag_no_creds_raises(self):
         from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -238,15 +238,19 @@ class TestCodexExecutor(unittest.TestCase):
             any("--host" in override for override in executor._codex_config_overrides)
         )
         # `--force-refresh` only exists in Databricks CLI >= v0.296.0, so it
-        # must be applied via a `--help` capability probe ($force), never
-        # passed unconditionally — an older CLI rejects the unknown flag and
-        # yields an empty token → silent 401.
+        # stays behind a `--help` capability probe — an older CLI rejects the
+        # unknown flag and yields an empty token → silent 401.
         auth_override = next(
             o for o in executor._codex_config_overrides if "databricks auth token" in o
         )
         self.assertIn("databricks auth token --help", auth_override)
-        self.assertIn("force=--force-refresh", auth_override)
-        self.assertNotIn('--profile "test-profile" --force-refresh', auth_override)
+        # And even where it exists it is only ATTEMPTED: it fails outright on a
+        # stale refresh token, so an empty result must fall back to the cached
+        # token rather than turning a usable credential into an auth failure.
+        self.assertIn("--force-refresh", auth_override)
+        # (the TOML fragment escapes the shell's quotes, so match on the test)
+        self.assertIn("if [ -z ", auth_override)
+        self.assertIn("$token", auth_override)
 
     def test_constructor_databricks_flag_with_host_override_skips_profile_lookup(self):
         with (

--- a/tests/inner/test_databricks_auth_command.py
+++ b/tests/inner/test_databricks_auth_command.py
@@ -1,0 +1,115 @@
+"""Tests for the generated Databricks bearer-token helper command.
+
+The one command every harness installs to mint a workspace token
+(``apiKeyHelper`` for Claude Code, ``auth.command`` for Codex), so its profile
+selection and its refresh behaviour are asserted in one place.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _run_generated_helper(
+    command: str,
+    tmp_path: Path,
+    *,
+    force_refresh_works: bool,
+    cached_token_works: bool,
+) -> str:
+    """
+    Run *command* against a fake ``databricks`` CLI and return its stdout.
+
+    :param command: The generated helper command.
+    :param tmp_path: Directory the fake CLI is written into and prepended to
+        ``PATH``.
+    :param force_refresh_works: Whether ``--force-refresh`` succeeds. ``False``
+        is the stale-refresh-token case.
+    :param cached_token_works: Whether plain ``auth token`` succeeds.
+    :returns: The helper's stdout, stripped.
+    """
+    import os
+    import subprocess
+
+    fake = tmp_path / "databricks"
+    fake.write_text(
+        "#!/bin/sh\n"
+        'case "$*" in *--help*) echo "  --force-refresh"; exit 0;; esac\n'
+        'case "$*" in *--force-refresh*)\n'
+        '  [ "$FORCE_OK" = 1 ] && { echo \'{"access_token":"fresh"}\'; exit 0; }\n'
+        "  exit 1;;\n"
+        "*)\n"
+        '  [ "$CACHED_OK" = 1 ] && { echo \'{"access_token":"cached"}\'; exit 0; }\n'
+        "  exit 1;;\n"
+        "esac\n"
+    )
+    fake.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}",
+        "FORCE_OK": "1" if force_refresh_works else "0",
+        "CACHED_OK": "1" if cached_token_works else "0",
+    }
+    env.pop("DATABRICKS_BEARER", None)
+    result = subprocess.run(
+        ["sh", "-c", command], env=env, capture_output=True, text=True, check=False
+    )
+    return result.stdout.strip()
+
+
+@pytest.mark.posix_only
+def test_the_generated_helper_serves_the_cached_token_when_a_refresh_fails(
+    tmp_path: Path,
+) -> None:
+    """
+    A stale refresh token must not cost a perfectly valid cached access token.
+
+    ``--force-refresh`` is worth attempting — it renews a still-valid token and
+    keeps a long gateway session off a mid-session 401 — but it fails outright
+    once the refresh token has gone stale. Forcing it unconditionally turned
+    that into a hard auth failure with a usable credential sitting right there.
+    """
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
+
+    command = databricks_bearer_token_command("https://example.databricks.com", "agent")
+
+    # Healthy: the forced refresh answers, so the token is the fresh one.
+    assert (
+        _run_generated_helper(command, tmp_path, force_refresh_works=True, cached_token_works=True)
+        == "fresh"
+    )
+    # The live incident: the refresh token is stale, the cached one is fine.
+    assert (
+        _run_generated_helper(
+            command, tmp_path, force_refresh_works=False, cached_token_works=True
+        )
+        == "cached"
+    )
+    # Genuinely unauthenticated: nothing to print, and no crash.
+    assert (
+        _run_generated_helper(
+            command, tmp_path, force_refresh_works=False, cached_token_works=False
+        )
+        == ""
+    )
+
+
+def test_the_generated_helper_selects_by_profile_when_one_is_named() -> None:
+    """
+    A named profile is unambiguous; host lookup is only the fallback.
+
+    Two profiles can share a workspace host, and selecting by host then either
+    fails outright or resolves to whichever the CLI picks — which is how a pane
+    and the server end up authenticating as different identities.
+    """
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
+
+    named = databricks_bearer_token_command("https://example.databricks.com", "agent")
+    assert '--profile "agent"' in named
+    assert "--host" not in named
+
+    unnamed = databricks_bearer_token_command("https://example.databricks.com/", None)
+    assert '--host "https://example.databricks.com"' in unnamed
+    assert "--profile" not in unnamed

--- a/tests/inner/test_databricks_auth_command.py
+++ b/tests/inner/test_databricks_auth_command.py
@@ -18,6 +18,7 @@ def _run_generated_helper(
     *,
     force_refresh_works: bool,
     cached_token_works: bool,
+    bearer: str | None = None,
 ) -> str:
     """
     Run *command* against a fake ``databricks`` CLI and return its stdout.
@@ -28,6 +29,7 @@ def _run_generated_helper(
     :param force_refresh_works: Whether ``--force-refresh`` succeeds. ``False``
         is the stale-refresh-token case.
     :param cached_token_works: Whether plain ``auth token`` succeeds.
+    :param bearer: Value for ``DATABRICKS_BEARER``, or ``None`` to unset it.
     :returns: The helper's stdout, stripped.
     """
     import os
@@ -53,10 +55,28 @@ def _run_generated_helper(
         "CACHED_OK": "1" if cached_token_works else "0",
     }
     env.pop("DATABRICKS_BEARER", None)
+    if bearer is not None:
+        env["DATABRICKS_BEARER"] = bearer
     result = subprocess.run(
         ["sh", "-c", command], env=env, capture_output=True, text=True, check=False
     )
     return result.stdout.strip()
+
+
+def _recorded_fallback(tmp_path: Path) -> str:
+    """
+    Write a stub standing in for the token command ucode recorded.
+
+    :param tmp_path: Directory on the helper's ``PATH``.
+    :returns: The command to pass as ``fallback_command``; running it prints
+        ``"recorded"`` and touches ``tmp_path / "fallback-ran"``.
+    """
+    stub = tmp_path / "ucode-token"
+    stub.write_text(f"#!/bin/sh\n: > {tmp_path / 'fallback-ran'}\necho recorded\n")
+    stub.chmod(0o755)
+    # Quoting the stub exercises the eval path against a command that carries
+    # its own quotes, the shape ucode actually records.
+    return 'ucode-token --host "https://example.databricks.com"'
 
 
 @pytest.mark.posix_only
@@ -113,3 +133,87 @@ def test_the_generated_helper_selects_by_profile_when_one_is_named() -> None:
     unnamed = databricks_bearer_token_command("https://example.databricks.com/", None)
     assert '--host "https://example.databricks.com"' in unnamed
     assert "--profile" not in unnamed
+
+
+@pytest.mark.posix_only
+def test_the_named_profile_wins_and_the_recorded_command_stays_unused(
+    tmp_path: Path,
+) -> None:
+    """The pinned profile is the identity we want whenever it can mint a token."""
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
+
+    command = databricks_bearer_token_command(
+        "https://example.databricks.com", "agent", fallback_command=_recorded_fallback(tmp_path)
+    )
+
+    assert (
+        _run_generated_helper(command, tmp_path, force_refresh_works=True, cached_token_works=True)
+        == "fresh"
+    )
+    assert not (tmp_path / "fallback-ran").exists()
+
+
+@pytest.mark.posix_only
+def test_the_recorded_command_runs_when_the_named_profile_yields_nothing(
+    tmp_path: Path,
+) -> None:
+    """
+    A config naming a credential-less profile must not 401 a working session.
+
+    The user may have authenticated under a different profile on the same host,
+    and the command ucode recorded is the one known to have worked.
+    """
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
+
+    command = databricks_bearer_token_command(
+        "https://example.databricks.com", "DEFAULT", fallback_command=_recorded_fallback(tmp_path)
+    )
+
+    assert (
+        _run_generated_helper(
+            command, tmp_path, force_refresh_works=False, cached_token_works=False
+        )
+        == "recorded"
+    )
+    assert (tmp_path / "fallback-ran").exists()
+
+
+@pytest.mark.posix_only
+def test_an_injected_bearer_short_circuits_both_the_profile_and_the_fallback(
+    tmp_path: Path,
+) -> None:
+    """The runner already resolved a token; nothing else should be consulted."""
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
+
+    command = databricks_bearer_token_command(
+        "https://example.databricks.com", "agent", fallback_command=_recorded_fallback(tmp_path)
+    )
+
+    assert (
+        _run_generated_helper(
+            command,
+            tmp_path,
+            force_refresh_works=False,
+            cached_token_works=False,
+            bearer="injected",
+        )
+        == "injected"
+    )
+    assert not (tmp_path / "fallback-ran").exists()
+
+
+@pytest.mark.posix_only
+def test_without_a_recorded_command_an_unauthenticated_profile_stays_empty(
+    tmp_path: Path,
+) -> None:
+    """No fallback to reach for: print nothing rather than crash."""
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
+
+    command = databricks_bearer_token_command("https://example.databricks.com", "agent")
+
+    assert (
+        _run_generated_helper(
+            command, tmp_path, force_refresh_works=False, cached_token_works=False
+        )
+        == ""
+    )

--- a/tests/runner/test_agent_list_spawn_family.py
+++ b/tests/runner/test_agent_list_spawn_family.py
@@ -1,0 +1,139 @@
+"""``sys_agent_list`` hides agents a pinned session could never spawn.
+
+A Smart Routing session pinned to one harness routes its spawns inside its
+own model family, so a built-in agent from another family is not launchable
+for it — and advertising it produced exactly the reported defect: a pinned
+codex session spawning a claude child that routing then declined after the
+fact. The listing is filtered at the source instead.
+
+Auto-harness sessions (the router owns their family) and plain sessions (no
+routing at all) see the whole surface, unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from omnigent.runner.subagent_routing import AUTO_HARNESS_LABEL_KEY
+from omnigent.runner.tool_dispatch import execute_tool
+
+_BUILTINS = [
+    {"id": "ag_claude", "name": "claude-code", "harness": "claude-native"},
+    {"id": "ag_codex", "name": "codex", "harness": "codex-native"},
+    {"id": "ag_pi", "name": "pi", "harness": "pi"},
+    {"id": "ag_unknown", "name": "mystery", "harness": None},
+]
+
+
+def _handler(
+    session: dict[str, Any],  # type: ignore[explicit-any]
+    seen: list[str],
+) -> Any:  # type: ignore[explicit-any]
+    """Build a MockTransport handler serving *session* as the caller's row."""
+
+    async def _serve(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        if request.url.path == "/v1/agents":
+            return httpx.Response(200, json={"data": _BUILTINS})
+        if request.url.path == "/v1/sessions":
+            return httpx.Response(200, json={"data": []})
+        if request.url.path == "/v1/sessions/conv_parent":
+            return httpx.Response(200, json=session)
+        return httpx.Response(404, json={"error": str(request.url)})
+
+    return _serve
+
+
+async def _agent_list(session: dict[str, Any], seen: list[str]) -> dict[str, Any]:  # type: ignore[explicit-any]
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_handler(session, seen)),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_agent_list",
+            arguments="{}",
+            server_client=server_client,
+            conversation_id="conv_parent",
+        )
+    return json.loads(output)
+
+
+def _names(listing: dict[str, Any]) -> list[str]:  # type: ignore[explicit-any]
+    return [row["name"] for row in listing["builtins"]]
+
+
+@pytest.mark.asyncio
+async def test_pinned_routed_session_sees_only_its_own_family() -> None:
+    seen: list[str] = []
+    listing = await _agent_list(
+        {
+            "id": "conv_parent",
+            "harness": "codex-native",
+            "subagent_routing_override": "on",
+            "labels": {},
+        },
+        seen,
+    )
+    # Every other family goes — the same rule the routing decline applies,
+    # where pi is its own family. An agent whose harness resolves to no
+    # family stays: nothing proves it is out of family.
+    assert _names(listing) == ["codex", "mystery"]
+
+
+@pytest.mark.asyncio
+async def test_auto_harness_session_sees_every_family() -> None:
+    seen: list[str] = []
+    listing = await _agent_list(
+        {
+            "id": "conv_parent",
+            "harness": "codex-native",
+            "subagent_routing_override": "on",
+            "labels": {AUTO_HARNESS_LABEL_KEY: "1"},
+        },
+        seen,
+    )
+    assert _names(listing) == ["claude-code", "codex", "pi", "mystery"]
+
+
+@pytest.mark.asyncio
+async def test_plain_session_sees_every_family() -> None:
+    seen: list[str] = []
+    listing = await _agent_list(
+        {
+            "id": "conv_parent",
+            "harness": "codex-native",
+            "subagent_routing_override": None,
+            "labels": {},
+        },
+        seen,
+    )
+    assert _names(listing) == ["claude-code", "codex", "pi", "mystery"]
+
+
+@pytest.mark.asyncio
+async def test_unreadable_session_leaves_the_listing_alone() -> None:
+    seen: list[str] = []
+
+    async def _serve(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/agents":
+            return httpx.Response(200, json={"data": _BUILTINS})
+        if request.url.path == "/v1/sessions":
+            return httpx.Response(200, json={"data": []})
+        return httpx.Response(500, json={"error": "boom"})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_serve),
+        base_url="http://server",
+    ) as server_client:
+        output = await execute_tool(
+            tool_name="sys_agent_list",
+            arguments="{}",
+            server_client=server_client,
+            conversation_id="conv_parent",
+        )
+    assert _names(json.loads(output)) == ["claude-code", "codex", "pi", "mystery"]
+    assert seen == []

--- a/tests/runner/test_agent_list_spawn_family.py
+++ b/tests/runner/test_agent_list_spawn_family.py
@@ -7,18 +7,27 @@ codex session spawning a claude child that routing then declined after the
 fact. The listing is filtered at the source instead.
 
 Auto-harness sessions (the router owns their family) and plain sessions (no
-routing at all) see the whole surface, unchanged.
+routing at all) see the whole surface, unchanged. A plain session never even
+reaches the server for the confinement answer: the runner already knows it
+has no routing armed.
 """
 
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from typing import Any
 
 import httpx
 import pytest
 
-from omnigent.runner.subagent_routing import AUTO_HARNESS_LABEL_KEY
+from omnigent.runner import tool_dispatch
+from omnigent.runner.subagent_routing import (
+    AUTO_HARNESS_LABEL_KEY,
+    SessionRoutingClass,
+    forget_session_routing_class,
+    remember_session_routing_class,
+)
 from omnigent.runner.tool_dispatch import execute_tool
 
 _BUILTINS = [
@@ -27,6 +36,16 @@ _BUILTINS = [
     {"id": "ag_pi", "name": "pi", "harness": "pi"},
     {"id": "ag_unknown", "name": "mystery", "harness": None},
 ]
+
+_PINNED = SessionRoutingClass(routing_enabled=True)
+_AUTO = SessionRoutingClass(routing_enabled=True, auto_harness=True)
+
+
+@pytest.fixture(autouse=True)
+def _clean_session_state() -> Iterator[None]:
+    yield
+    forget_session_routing_class("conv_parent")
+    tool_dispatch.forget_spawn_family("conv_parent")
 
 
 def _handler(
@@ -48,9 +67,9 @@ def _handler(
     return _serve
 
 
-async def _agent_list(session: dict[str, Any], seen: list[str]) -> dict[str, Any]:  # type: ignore[explicit-any]
+async def _run(handler: Any, seen: list[str]) -> dict[str, Any]:  # type: ignore[explicit-any]
     async with httpx.AsyncClient(
-        transport=httpx.MockTransport(_handler(session, seen)),
+        transport=httpx.MockTransport(handler),
         base_url="http://server",
     ) as server_client:
         output = await execute_tool(
@@ -62,12 +81,17 @@ async def _agent_list(session: dict[str, Any], seen: list[str]) -> dict[str, Any
     return json.loads(output)
 
 
+async def _agent_list(session: dict[str, Any], seen: list[str]) -> dict[str, Any]:  # type: ignore[explicit-any]
+    return await _run(_handler(session, seen), seen)
+
+
 def _names(listing: dict[str, Any]) -> list[str]:  # type: ignore[explicit-any]
     return [row["name"] for row in listing["builtins"]]
 
 
 @pytest.mark.asyncio
 async def test_pinned_routed_session_sees_only_its_own_family() -> None:
+    remember_session_routing_class("conv_parent", _PINNED)
     seen: list[str] = []
     listing = await _agent_list(
         {
@@ -86,6 +110,7 @@ async def test_pinned_routed_session_sees_only_its_own_family() -> None:
 
 @pytest.mark.asyncio
 async def test_auto_harness_session_sees_every_family() -> None:
+    remember_session_routing_class("conv_parent", _AUTO)
     seen: list[str] = []
     listing = await _agent_list(
         {
@@ -97,10 +122,28 @@ async def test_auto_harness_session_sees_every_family() -> None:
         seen,
     )
     assert _names(listing) == ["claude-code", "codex", "pi", "mystery"]
+    assert "/v1/sessions/conv_parent" not in seen
 
 
 @pytest.mark.asyncio
-async def test_plain_session_sees_every_family() -> None:
+async def test_plain_session_skips_the_routing_lookup_entirely() -> None:
+    seen: list[str] = []
+    listing = await _agent_list(
+        {
+            "id": "conv_parent",
+            "harness": "codex-native",
+            "subagent_routing_override": "on",
+            "labels": {},
+        },
+        seen,
+    )
+    assert _names(listing) == ["claude-code", "codex", "pi", "mystery"]
+    assert "/v1/sessions/conv_parent" not in seen
+
+
+@pytest.mark.asyncio
+async def test_routed_session_with_subagent_routing_off_sees_every_family() -> None:
+    remember_session_routing_class("conv_parent", _PINNED)
     seen: list[str] = []
     listing = await _agent_list(
         {
@@ -116,24 +159,52 @@ async def test_plain_session_sees_every_family() -> None:
 
 @pytest.mark.asyncio
 async def test_unreadable_session_leaves_the_listing_alone() -> None:
+    remember_session_routing_class("conv_parent", _PINNED)
     seen: list[str] = []
 
     async def _serve(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
         if request.url.path == "/v1/agents":
             return httpx.Response(200, json={"data": _BUILTINS})
         if request.url.path == "/v1/sessions":
             return httpx.Response(200, json={"data": []})
         return httpx.Response(500, json={"error": "boom"})
 
-    async with httpx.AsyncClient(
-        transport=httpx.MockTransport(_serve),
-        base_url="http://server",
-    ) as server_client:
-        output = await execute_tool(
-            tool_name="sys_agent_list",
-            arguments="{}",
-            server_client=server_client,
-            conversation_id="conv_parent",
-        )
-    assert _names(json.loads(output)) == ["claude-code", "codex", "pi", "mystery"]
-    assert seen == []
+    assert _names(await _run(_serve, seen)) == ["claude-code", "codex", "pi", "mystery"]
+    assert "/v1/sessions/conv_parent" in seen
+
+
+@pytest.mark.asyncio
+async def test_timed_out_lookup_fails_open_to_the_full_listing() -> None:
+    remember_session_routing_class("conv_parent", _PINNED)
+    seen: list[str] = []
+
+    async def _serve(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        if request.url.path == "/v1/agents":
+            return httpx.Response(200, json={"data": _BUILTINS})
+        if request.url.path == "/v1/sessions":
+            return httpx.Response(200, json={"data": []})
+        raise httpx.ReadTimeout("wedged server", request=request)
+
+    assert _names(await _run(_serve, seen)) == ["claude-code", "codex", "pi", "mystery"]
+    assert "/v1/sessions/conv_parent" in seen
+
+
+def test_confinement_lookup_budget_stays_short() -> None:
+    assert tool_dispatch._SPAWN_FAMILY_TIMEOUT_S <= 5.0
+
+
+@pytest.mark.asyncio
+async def test_repeat_listings_reuse_the_cached_confinement() -> None:
+    remember_session_routing_class("conv_parent", _PINNED)
+    seen: list[str] = []
+    session = {
+        "id": "conv_parent",
+        "harness": "codex-native",
+        "subagent_routing_override": "on",
+        "labels": {},
+    }
+    assert _names(await _agent_list(session, seen)) == ["codex", "mystery"]
+    assert _names(await _agent_list(session, seen)) == ["codex", "mystery"]
+    assert seen.count("/v1/sessions/conv_parent") == 1

--- a/tests/server/integration/test_routing_integration.py
+++ b/tests/server/integration/test_routing_integration.py
@@ -2167,3 +2167,68 @@ async def test_a_routing_outage_still_delivers_a_child_spawns_turn(
     assert decisions[0].data.model == UNAVAILABLE_MODEL
     assert decisions[0].data.applied is False
     assert decisions[0].data.rationale
+
+
+@pytest.mark.parametrize(
+    ("label", "failure"), ROUTING_FAILURES, ids=[f[0] for f in ROUTING_FAILURES]
+)
+async def test_an_auto_harness_outage_leaves_the_route_once_label_unclaimed(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    label: str,
+    failure: Exception,
+) -> None:
+    """One outage at create must not disable this session's routing for good.
+
+    The auto-harness path stamped the decision label on its own "unavailable"
+    card, and the label is the route-once gate — so a router that was merely
+    down when the session started meant the in-harness hook declined every
+    later prompt as "already routed".
+    """
+    agent = await create_test_agent(
+        client,
+        name=f"routing-outage-auto-{label}",
+        executor={"type": "omnigent", "config": {"harness": "codex"}},
+    )
+    created = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": agent["id"],
+            "cost_control_mode_override": "on",
+            "harness_override": "auto",
+        },
+    )
+    assert created.status_code == 201, created.text
+    session_id = str(created.json()["id"])
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    conv = conv_store.get_conversation(session_id)
+    assert conv is not None
+    assert conv.harness_override == "auto"
+
+    await _send_child_message(conv, conv_store, FakeRoutingClient(None, error=failure), "hi")
+
+    after_outage = conv_store.get_conversation(session_id)
+    assert after_outage is not None
+    # The failure is visible…
+    decisions = _routing_decisions(conv_store, session_id)
+    assert len(decisions) == 1
+    assert decisions[0].data.model == UNAVAILABLE_MODEL
+    assert decisions[0].data.applied is False
+    # …but it claimed neither the model nor the route-once label.
+    assert after_outage.model_override is None
+    assert not after_outage.labels.get(ROUTING_DECISION_LABEL_KEY)
+
+    # So the session's first in-harness prompt still routes.
+    healthy = FakeRoutingClient(RoutingResult(model=GPT_MODEL, rationale="sized task"))
+    with patch("omnigent.runtime._globals._caps", new=FakeCaps(routing_client=healthy)):
+        route = await client.post(
+            f"/v1/sessions/{session_id}/hooks/route-turn",
+            json={"harness": "codex-native", "prompt": "refactor auth"},
+        )
+    assert route.status_code == 200, route.text
+    assert route.json()["action"] == "route"
+    assert route.json()["model"] == GPT_MODEL
+    routed = conv_store.get_conversation(session_id)
+    assert routed is not None
+    assert routed.model_override == GPT_MODEL
+    assert routed.labels.get(ROUTING_DECISION_LABEL_KEY)

--- a/tests/server/integration/test_routing_integration.py
+++ b/tests/server/integration/test_routing_integration.py
@@ -1160,6 +1160,129 @@ async def test_child_create_stamp_inherits_the_parents_switch_not_its_cost_contr
     assert child.subagent_routing_override == stamped
 
 
+# ── 7c. A pinned parent cannot create an out-of-family child ───────
+
+
+async def _pinned_parent(
+    client: httpx.AsyncClient,
+    *,
+    agent_name: str,
+    harness: str,
+    routing_on: bool = True,
+) -> str:
+    """Create a parent pinned to *harness*, with Smart Routing on or off.
+
+    :param client: Test HTTP client.
+    :param agent_name: Agent name to register.
+    :param harness: The parent agent's harness, e.g. ``"codex"``.
+    :param routing_on: Whether the parent routes its spawns.
+    :returns: The parent session id.
+    """
+    agent = await create_test_agent(
+        client,
+        name=agent_name,
+        executor={"type": "omnigent", "config": {"harness": harness}},
+    )
+    body: dict[str, Any] = {"agent_id": agent["id"]}
+    if routing_on:
+        body["cost_control_mode_override"] = "on"
+    parent = await client.post("/v1/sessions", json=body)
+    assert parent.status_code == 201, parent.text
+    return str(parent.json()["id"])
+
+
+async def _create_child(
+    client: httpx.AsyncClient,
+    parent_id: str,
+    *,
+    agent_name: str,
+    harness: str,
+) -> httpx.Response:
+    """POST a child create bound to an agent running *harness*.
+
+    :param client: Test HTTP client.
+    :param parent_id: The parent session id.
+    :param agent_name: Agent name to register for the child.
+    :param harness: The child agent's harness, e.g. ``"claude-sdk"``.
+    :returns: The raw create response.
+    """
+    child_agent = await create_test_agent(
+        client,
+        name=agent_name,
+        executor={"type": "omnigent", "config": {"harness": harness}},
+    )
+    return await client.post(
+        "/v1/sessions",
+        json={"agent_id": child_agent["id"], "parent_session_id": parent_id},
+    )
+
+
+async def test_pinned_parent_cannot_create_a_child_in_another_family(
+    client: httpx.AsyncClient,
+) -> None:
+    parent_id = await _pinned_parent(
+        client, agent_name="family-gate-pinned-parent", harness="codex"
+    )
+    child = await _create_child(
+        client, parent_id, agent_name="family-gate-claude-child", harness="claude-sdk"
+    )
+    assert child.status_code == 400, child.text
+    assert "model family" in child.text
+
+
+async def test_pinned_parent_still_creates_children_in_its_own_family(
+    client: httpx.AsyncClient,
+) -> None:
+    parent_id = await _pinned_parent(
+        client, agent_name="family-gate-same-family-parent", harness="codex"
+    )
+    child = await _create_child(
+        client, parent_id, agent_name="family-gate-codex-child", harness="codex"
+    )
+    assert child.status_code == 201, child.text
+
+
+async def test_auto_parent_may_create_a_child_in_another_family(
+    client: httpx.AsyncClient,
+) -> None:
+    agent = await create_test_agent(
+        client,
+        name="family-gate-auto-parent",
+        executor={"type": "omnigent", "config": {"harness": "codex"}},
+    )
+    parent = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": agent["id"],
+            "cost_control_mode_override": "on",
+            "harness_override": "auto",
+        },
+    )
+    assert parent.status_code == 201, parent.text
+    child = await _create_child(
+        client,
+        str(parent.json()["id"]),
+        agent_name="family-gate-auto-claude-child",
+        harness="claude-sdk",
+    )
+    assert child.status_code == 201, child.text
+
+
+async def test_plain_parent_may_create_a_child_in_another_family(
+    client: httpx.AsyncClient,
+) -> None:
+    parent_id = await _pinned_parent(
+        client,
+        agent_name="family-gate-plain-parent",
+        harness="codex",
+        routing_on=False,
+    )
+    child = await _create_child(
+        client, parent_id, agent_name="family-gate-plain-claude-child", harness="claude-sdk"
+    )
+    assert child.status_code == 201, child.text
+
+
 # ── 8. Truthful record on a claude-native turn ─────────────────────
 
 

--- a/tests/server/routes/test_native_smart_routing_create.py
+++ b/tests/server/routes/test_native_smart_routing_create.py
@@ -486,6 +486,124 @@ async def test_smart_routing_session_keeps_cross_harness_subagents(
     assert resp.json()["harness"] == "codex-native"
 
 
+# ── The create's verdict is not re-derived on the first prompt ──────────────
+#
+# The prompt the landing screen routed is submitted again inside the harness,
+# where the first-prompt hook used to score it a second time — one more judge
+# call, tens of seconds later, for the verdict the pane was already running.
+
+
+async def _route_turn(
+    client: httpx.AsyncClient,
+    session_id: str,
+    routing_client: FakeRoutingClient | None,
+    *,
+    harness: str,
+    prompt: str,
+) -> httpx.Response:
+    """POST the in-harness first-prompt hook for *session_id*.
+
+    :param client: Test HTTP client.
+    :param session_id: The session whose prompt was submitted.
+    :param routing_client: Stub router the hook may call.
+    :param harness: The pane's harness, e.g. ``"codex-native"``.
+    :param prompt: The submitted prompt text.
+    :returns: The raw hook response.
+    """
+    with patch("omnigent.runtime._globals._caps", new=_caps_with(routing_client, oss=False)):
+        return await client.post(
+            f"/v1/sessions/{session_id}/hooks/route-turn",
+            json={"harness": harness, "prompt": prompt},
+        )
+
+
+async def test_the_first_prompt_reuses_the_creates_verdict(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    wrappers = await _native_wrappers(client, db_uri)
+    routing_client = FakeRoutingClient(RoutingResult(model=GPT_MODEL, rationale="narrow change"))
+    created = await _create_smart_routing_session(client, wrappers, routing_client)
+    assert created.status_code == 201, created.text
+    session_id = created.json()["id"]
+
+    route = await _route_turn(
+        client,
+        session_id,
+        routing_client,
+        harness="codex-native",
+        prompt=ROUTING_MESSAGE,
+    )
+    assert route.status_code == 200, route.text
+    # Nothing to switch to and nothing to replay: the pane launched on the pick.
+    assert route.json()["action"] == "allow"
+    assert route.json()["terminal"] is True
+    # One router call for the whole session, not two.
+    assert len(routing_client.offered) == 1
+
+    # One chip, and it is the create's — now claimed as the session's decision,
+    # so a later prompt does not ask again either.
+    decisions = _routing_decision_items(db_uri, session_id)
+    assert len(decisions) == 1
+    assert decisions[0]["scope"] == "session"
+    conv = SqlAlchemyConversationStore(db_uri).get_conversation(session_id)
+    assert conv is not None
+    assert conv.labels.get(ROUTING_DECISION_LABEL_KEY) == decisions[0]["decision_id"]
+
+
+async def test_a_prompt_the_create_did_not_route_still_routes(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    wrappers = await _native_wrappers(client, db_uri)
+    routing_client = FakeRoutingClient(RoutingResult(model=GPT_MODEL, rationale="narrow change"))
+    created = await _create_smart_routing_session(client, wrappers, routing_client)
+    assert created.status_code == 201, created.text
+    session_id = created.json()["id"]
+
+    # The user edited the prompt in the pane before sending it, so the create's
+    # verdict was reached on text nobody submitted.
+    route = await _route_turn(
+        client,
+        session_id,
+        routing_client,
+        harness="codex-native",
+        prompt="actually, just fix the failing test",
+    )
+    assert route.status_code == 200, route.text
+    assert route.json()["action"] == "route"
+    assert len(routing_client.offered) == 2
+
+    decisions = _routing_decision_items(db_uri, session_id)
+    assert [d["scope"] for d in decisions] == ["session", "turn"]
+
+
+async def test_an_outage_at_create_leaves_the_first_prompt_free_to_route(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    wrappers = await _native_wrappers(client, db_uri)
+    created = await _create_smart_routing_session(client, wrappers, None)
+    assert created.status_code == 201, created.text
+    session_id = created.json()["id"]
+
+    healthy = FakeRoutingClient(RoutingResult(model=CLAUDE_MODEL, rationale="sized task"))
+    route = await _route_turn(
+        client,
+        session_id,
+        healthy,
+        harness="claude-native",
+        prompt=ROUTING_MESSAGE,
+    )
+    assert route.status_code == 200, route.text
+    # Nothing was routed at create, so there is no verdict to reuse.
+    assert route.json()["action"] == "route"
+    assert route.json()["model"] == CLAUDE_MODEL
+    conv = SqlAlchemyConversationStore(db_uri).get_conversation(session_id)
+    assert conv is not None
+    assert conv.model_override == CLAUDE_MODEL
+
+
 async def test_bundle_agent_auto_path_is_unchanged(
     client: httpx.AsyncClient,
     db_uri: str,

--- a/tests/server/routes/test_native_smart_routing_create.py
+++ b/tests/server/routes/test_native_smart_routing_create.py
@@ -15,6 +15,7 @@ never sees the first message pre-inference and the turn gate would never fire.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Iterator
 from types import SimpleNamespace
@@ -1823,6 +1824,61 @@ async def test_turn_catalog_refetches_a_stale_pre_launch_catalog() -> None:
         ]
         assert len(requested) == 1
     finally:
+        await runner_client.aclose()
+        _model_options_cache.pop(session_id, None)
+        _model_options_stale.discard(session_id)
+
+
+async def test_launch_prefetch_takes_the_stale_refresh_off_the_turn_path() -> None:
+    """
+    Warming the catalog when the runner binds is what makes a first turn fast.
+
+    The stale-catalog refresh is the biggest single term in routing's
+    pre-router latency: the turn awaits a fetch that retries a booting runner.
+    Started at launch instead, it has landed by the time the prompt arrives and
+    the turn reads the cache — no wait, no second fetch.
+    """
+    from omnigent.server.routes._sessions.orchestration import (
+        _model_options_cache,
+        _model_options_inflight,
+        _model_options_stale,
+        _native_turn_catalog,
+    )
+    from omnigent.server.routes.sessions import prefetch_session_routing_catalogs
+
+    session_id = "conv_prefetch_launch"
+    conv = _native_conv(session_id)
+    # What the host resolved before launch — stale, so a turn would refetch it.
+    _model_options_cache[session_id] = [{"id": "opus", "model": "databricks-claude-opus-5"}]
+    _model_options_stale.add(session_id)
+    requested: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requested.append(request.url.path)
+        if request.url.path.endswith("/models"):
+            return httpx.Response(200, json={"workers": {"self": {"models": [{"id": "opus"}]}}})
+        return httpx.Response(
+            200, json={"models": [{"id": "opus", "model": "databricks-claude-opus-4-8"}]}
+        )
+
+    runner_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://runner.invalid"
+    )
+    try:
+        prefetch_session_routing_catalogs(session_id, conv, runner_client)
+        inflight = _model_options_inflight.get(session_id)
+        assert inflight is not None
+        await inflight
+        assert session_id not in _model_options_stale
+        requested.clear()
+
+        assert await _native_turn_catalog(session_id, conv, runner_client) == [
+            "databricks-claude-opus-4-8"
+        ]
+        # The turn neither waited nor re-fetched: the launch prefetch answered.
+        assert requested == []
+    finally:
+        await asyncio.sleep(0)
         await runner_client.aclose()
         _model_options_cache.pop(session_id, None)
         _model_options_stale.discard(session_id)

--- a/tests/server/routes/test_native_smart_routing_create.py
+++ b/tests/server/routes/test_native_smart_routing_create.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from collections.abc import Iterator
 from types import SimpleNamespace
 from typing import Any, cast
@@ -1714,12 +1715,20 @@ async def test_pre_session_catalog_reads_the_hosts_model_options(
     assert conn.pending_model_options == {}
 
 
-def _native_conv(session_id: str) -> Any:  # type: ignore[explicit-any]
+def _native_conv(  # type: ignore[explicit-any]
+    session_id: str,
+    *,
+    routing: bool = False,
+    archived: bool = False,
+) -> Any:
     from omnigent.harness_plugins import CLAUDE_NATIVE_CODING_AGENT
 
     return SimpleNamespace(
         id=session_id,
         labels={"omnigent.wrapper": CLAUDE_NATIVE_CODING_AGENT.wrapper_label},
+        cost_control_mode_override="on" if routing else None,
+        harness_override=None,
+        archived=archived,
     )
 
 
@@ -1847,7 +1856,7 @@ async def test_launch_prefetch_takes_the_stale_refresh_off_the_turn_path() -> No
     from omnigent.server.routes.sessions import prefetch_session_routing_catalogs
 
     session_id = "conv_prefetch_launch"
-    conv = _native_conv(session_id)
+    conv = _native_conv(session_id, routing=True)
     # What the host resolved before launch — stale, so a turn would refetch it.
     _model_options_cache[session_id] = [{"id": "opus", "model": "databricks-claude-opus-5"}]
     _model_options_stale.add(session_id)
@@ -1882,6 +1891,141 @@ async def test_launch_prefetch_takes_the_stale_refresh_off_the_turn_path() -> No
         await runner_client.aclose()
         _model_options_cache.pop(session_id, None)
         _model_options_stale.discard(session_id)
+
+
+def _prefetch_client(requested: list[str], *, fail: bool = False) -> httpx.AsyncClient:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requested.append(request.url.path)
+        if fail:
+            # What a tunnel torn down mid-prefetch raises: not an httpx error,
+            # so the fetch helpers do not catch it themselves.
+            raise RuntimeError("tunnel closed")
+        if request.url.path.endswith("/models"):
+            return httpx.Response(200, json={"workers": {"self": {"models": [{"id": "opus"}]}}})
+        return httpx.Response(
+            200, json={"models": [{"id": "opus", "model": "databricks-claude-opus-4-8"}]}
+        )
+
+    return httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://runner.invalid"
+    )
+
+
+async def test_plain_session_gets_no_catalog_prefetch_on_runner_connect() -> None:
+    """
+    A reconnect must cost a plain pane nothing.
+
+    The reconnect callback walks every session bound to the runner, so an
+    ungated prefetch turned one host's tunnel flap into two runner round trips
+    per plain pane — work only Smart Routing ever reads — starving the session
+    re-init running alongside it.
+    """
+    from omnigent.server.routes._sessions.common import _catalog_prefetch_tasks
+    from omnigent.server.routes._sessions.orchestration import _model_options_inflight
+    from omnigent.server.routes.sessions import prefetch_session_routing_catalogs
+
+    session_id = "conv_prefetch_plain"
+    requested: list[str] = []
+    runner_client = _prefetch_client(requested)
+    try:
+        before = set(_catalog_prefetch_tasks)
+        prefetch_session_routing_catalogs(session_id, _native_conv(session_id), runner_client)
+        await asyncio.sleep(0)
+
+        assert session_id not in _model_options_inflight
+        assert set(_catalog_prefetch_tasks) == before
+        assert requested == []
+    finally:
+        await runner_client.aclose()
+
+
+async def test_archived_routed_session_gets_no_catalog_prefetch() -> None:
+    """An archived session is not going to route a turn, so it warms nothing."""
+    from omnigent.server.routes._sessions.common import _catalog_prefetch_tasks
+    from omnigent.server.routes._sessions.orchestration import _model_options_inflight
+    from omnigent.server.routes.sessions import prefetch_session_routing_catalogs
+
+    session_id = "conv_prefetch_archived"
+    conv = _native_conv(session_id, routing=True, archived=True)
+    requested: list[str] = []
+    runner_client = _prefetch_client(requested)
+    try:
+        before = set(_catalog_prefetch_tasks)
+        prefetch_session_routing_catalogs(session_id, conv, runner_client)
+        await asyncio.sleep(0)
+
+        assert session_id not in _model_options_inflight
+        assert set(_catalog_prefetch_tasks) == before
+        assert requested == []
+    finally:
+        await runner_client.aclose()
+
+
+async def test_routed_live_session_still_warms_both_catalogs() -> None:
+    """The gate keeps the case it was built for: a routed pane warms both."""
+    from omnigent.server.routes._sessions.common import _catalog_prefetch_tasks
+    from omnigent.server.routes._sessions.orchestration import (
+        _model_options_cache,
+        _model_options_inflight,
+    )
+    from omnigent.server.routes.sessions import prefetch_session_routing_catalogs
+
+    session_id = "conv_prefetch_routed"
+    conv = _native_conv(session_id, routing=True)
+    requested: list[str] = []
+    runner_client = _prefetch_client(requested)
+    try:
+        before = set(_catalog_prefetch_tasks)
+        prefetch_session_routing_catalogs(session_id, conv, runner_client)
+        started = set(_catalog_prefetch_tasks) - before
+        options_task = _model_options_inflight.get(session_id)
+        assert options_task is not None
+        assert len(started) == 1
+        await asyncio.gather(options_task, *started)
+
+        assert sorted(requested) == [
+            f"/v1/sessions/{session_id}/claude-model-options",
+            f"/v1/sessions/{session_id}/models",
+        ]
+        assert _model_options_cache[session_id] == [
+            {"id": "opus", "model": "databricks-claude-opus-4-8"}
+        ]
+    finally:
+        await runner_client.aclose()
+        _model_options_cache.pop(session_id, None)
+
+
+async def test_failing_prefetch_retrieves_its_own_exception(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A prefetch that raises must not leave an unretrieved task exception.
+
+    Nothing awaits these tasks, so an escaping error surfaces only as asyncio's
+    unretrieved-exception warning at GC time — noise that hides real failures.
+    """
+    from omnigent.server.routes._sessions.common import _catalog_prefetch_tasks
+    from omnigent.server.routes._sessions.orchestration import _model_options_inflight
+    from omnigent.server.routes.sessions import prefetch_session_routing_catalogs
+
+    session_id = "conv_prefetch_raises"
+    conv = _native_conv(session_id, routing=True)
+    requested: list[str] = []
+    runner_client = _prefetch_client(requested, fail=True)
+    try:
+        with caplog.at_level(logging.DEBUG, logger="omnigent.server.routes.sessions"):
+            before = set(_catalog_prefetch_tasks)
+            prefetch_session_routing_catalogs(session_id, conv, runner_client)
+            started = set(_catalog_prefetch_tasks) - before
+            options_task = _model_options_inflight.get(session_id)
+            assert options_task is not None
+            await asyncio.gather(options_task, *started)
+
+        assert options_task.exception() is None
+        assert [task.exception() for task in started] == [None]
+        assert any("Catalog prefetch failed" in record.message for record in caplog.records)
+    finally:
+        await runner_client.aclose()
 
 
 async def test_turn_catalog_keeps_a_stale_catalog_when_the_refetch_fails() -> None:

--- a/tests/server/routes/test_native_smart_routing_create.py
+++ b/tests/server/routes/test_native_smart_routing_create.py
@@ -7,9 +7,9 @@ the session row, so the harness is decided during the create — not on the firs
 message event the way the bundle-agent auto path does — and the session is
 rebound to the wrapper the router picked.
 
-A create pinned to one native harness (the CLI's ``omni claude --smart-routing``,
-or the web UI picking a harness with routing on) routes on the same seam for the
-same reason, but only the MODEL: its turns originate in the TUI, so the server
+A create pinned to one native harness (the web UI picking a harness with routing
+on) routes on the same seam for the same reason, but only the MODEL: its turns
+originate in the TUI, so the server
 never sees the first message pre-inference and the turn gate would never fire.
 """
 
@@ -179,9 +179,9 @@ async def _create_fixed_harness_session(
 ) -> httpx.Response:
     """POST a Smart Routing create for a session pinned to one harness.
 
-    The CLI's ``omni claude --smart-routing`` shape: a fixed harness (the native
-    wrapper agent, no ``harness_override``) plus routing on and the prompt as
-    ``smart_routing_message``.
+    The web UI's "Claude Code + Smart Routing" shape: a fixed harness (the
+    native wrapper agent, no ``harness_override``) plus routing on and the
+    prompt as ``smart_routing_message``.
 
     :param client: Test HTTP client.
     :param agent_id: Agent to bind.
@@ -2095,7 +2095,7 @@ async def test_a_routing_outage_still_creates_the_fixed_harness_session(
     failure: Exception,
 ) -> None:
     """
-    ``omni claude --smart-routing`` creates and launches unrouted, with a card.
+    A fixed-harness create launches unrouted, with a card.
 
     The harness was the caller's own choice, so only the model was ever at
     stake: nothing is pinned, the session opens on the CLI's default, and the

--- a/tests/server/test_smart_routing.py
+++ b/tests/server/test_smart_routing.py
@@ -3331,3 +3331,124 @@ async def test_route_turn_or_decline_reports_an_ordinary_no_verdict_as_no_error(
     with patch("omnigent.server.smart_routing.route_turn", new=_no_verdict):
         model, verdict, error = await route_turn_or_decline("claude-native", "refactor auth")
     assert (model, verdict, error) == (None, None, None)
+
+
+# ── runner-catalog cache ───────────────────────────────────────────
+
+
+def _counting_catalog_client(models: Sequence[str]) -> MagicMock:
+    """A runner client whose ``get`` counts calls and answers one catalog."""
+    response = MagicMock()
+    response.json.return_value = {
+        "workers": {"self": {"models": [{"id": model} for model in models]}}
+    }
+    response.raise_for_status = MagicMock()
+    client = MagicMock()
+    client.get = AsyncMock(return_value=response)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_a_warm_catalog_cache_costs_no_runner_round_trip() -> None:
+    """The second turn of a session reads the cache instead of the runner."""
+    client = _counting_catalog_client(["databricks-claude-haiku-4-5"])
+
+    first = await fetch_runner_models("conv_warm", client)
+    second = await fetch_runner_models("conv_warm", client)
+
+    assert first == second == {"self": ["databricks-claude-haiku-4-5"]}
+    client.get.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_a_cold_cache_still_fetches_and_routes() -> None:
+    """Nothing cached is the ordinary first turn: it fetches, and it routes."""
+    expected = RoutingResult(
+        model="databricks-claude-opus-4-8",
+        rationale="complex task",
+        harness="self",
+    )
+    client = _counting_catalog_client(
+        ["databricks-claude-haiku-4-5", "databricks-claude-opus-4-8"]
+    )
+    caps = FakeCaps(routing_client=FakeRoutingClient(expected))
+    with patch("omnigent.runtime._globals._caps", new=caps):
+        model, _verdict = await route_turn(
+            "claude-sdk",
+            "complex task",
+            session_id="conv_cold",
+            runner_client=client,
+        )
+
+    assert model == "databricks-claude-opus-4-8"
+    client.get.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_a_warm_cache_routes_a_turn_without_touching_the_runner() -> None:
+    """A prefetched catalog takes the runner fetch off the turn path entirely."""
+    from omnigent.server.smart_routing import prefetch_runner_catalog
+
+    expected = RoutingResult(
+        model="databricks-claude-opus-4-8",
+        rationale="complex task",
+        harness="self",
+    )
+    client = _counting_catalog_client(
+        ["databricks-claude-haiku-4-5", "databricks-claude-opus-4-8"]
+    )
+    await prefetch_runner_catalog("conv_prefetched", client)
+    client.get.reset_mock()
+
+    caps = FakeCaps(routing_client=FakeRoutingClient(expected))
+    with patch("omnigent.runtime._globals._caps", new=caps):
+        model, _verdict = await route_turn(
+            "claude-sdk",
+            "complex task",
+            session_id="conv_prefetched",
+            runner_client=client,
+        )
+
+    assert model == "databricks-claude-opus-4-8"
+    client.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_invalidating_the_catalog_makes_the_next_turn_re_fetch() -> None:
+    """A rebind changes which models a pane can take, so the cache must drop."""
+    from omnigent.server.smart_routing import invalidate_runner_catalog
+
+    client = _counting_catalog_client(["databricks-claude-haiku-4-5"])
+    await fetch_runner_models("conv_rebound", client)
+    invalidate_runner_catalog("conv_rebound")
+    await fetch_runner_models("conv_rebound", client)
+
+    assert client.get.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_an_unreachable_runner_is_not_cached_as_no_catalog() -> None:
+    """A booting runner must stay re-fetchable rather than pin an empty answer."""
+    import httpx
+
+    client = MagicMock()
+    client.get = AsyncMock(side_effect=httpx.HTTPError("connection refused"))
+
+    assert await fetch_runner_models("conv_booting", client) is None
+    assert await fetch_runner_models("conv_booting", client) is None
+    assert client.get.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_a_runner_rebind_invalidates_the_routing_catalog() -> None:
+    """The snapshot-overlay invalidation seam is wired to the routing cache."""
+    from omnigent.server.routes.sessions import _invalidate_runner_backed_snapshot_state
+
+    client = _counting_catalog_client(["databricks-claude-haiku-4-5"])
+    await fetch_runner_models("conv_overlay", client)
+    _invalidate_runner_backed_snapshot_state(
+        "conv_overlay", cancel_inflight=True, drop_model_options=False
+    )
+    await fetch_runner_models("conv_overlay", client)
+
+    assert client.get.call_count == 2

--- a/tests/server/test_subagent_routing.py
+++ b/tests/server/test_subagent_routing.py
@@ -19,6 +19,7 @@ from omnigent.runner.subagent_routing import (
     ADVERTISEMENT_FILE,
     AUTO_HARNESS_LABEL_KEY,
     PLAIN_SESSION,
+    ROUTING_DECISION_LABEL_KEY,
     SessionRoutingClass,
     SubagentRouteDecision,
     SubagentRouteRequest,
@@ -1118,20 +1119,25 @@ def test_subagent_routing_enabled_is_two_state(override: str | None, expected: b
         (None, None, {}, SessionRoutingClass()),
         ("off", "codex-native", {}, SessionRoutingClass()),
         # Pinned: Smart Routing as the model, codex chosen as the harness.
-        ("on", "codex-native", {}, SessionRoutingClass(routing_enabled=True)),
+        (
+            "on",
+            "codex-native",
+            {},
+            SessionRoutingClass(routing_enabled=True, turn_routing=True),
+        ),
         # Auto-harness, before first-message routing replaces the sentinel.
         (
             "on",
             "auto",
             {},
-            SessionRoutingClass(routing_enabled=True, auto_harness=True),
+            SessionRoutingClass(routing_enabled=True, auto_harness=True, turn_routing=True),
         ),
         # …and after: the sentinel is gone, the durable label is not.
         (
             "on",
             "codex-native",
             {AUTO_HARNESS_LABEL_KEY: "1"},
-            SessionRoutingClass(routing_enabled=True, auto_harness=True),
+            SessionRoutingClass(routing_enabled=True, auto_harness=True, turn_routing=True),
         ),
         # An auto-harness session is a Smart Routing session by construction,
         # so the label alone implies routing is on.
@@ -1139,7 +1145,27 @@ def test_subagent_routing_enabled_is_two_state(override: str | None, expected: b
             None,
             None,
             {AUTO_HARNESS_LABEL_KEY: "1"},
-            SessionRoutingClass(routing_enabled=True, auto_harness=True),
+            SessionRoutingClass(routing_enabled=True, auto_harness=True, turn_routing=True),
+        ),
+        # Already routed — a web create pinned the model before the pane
+        # launched. The session keeps every other routing affordance; only the
+        # first-message hook is dropped, since it could only say "already
+        # routed" once per prompt.
+        (
+            "on",
+            "claude-native",
+            {ROUTING_DECISION_LABEL_KEY: "rd_1"},
+            SessionRoutingClass(routing_enabled=True),
+        ),
+        # Routing off plus a stale decision label is still plain.
+        ("off", "claude-native", {ROUTING_DECISION_LABEL_KEY: "rd_1"}, SessionRoutingClass()),
+        # An auto session the create could not route keeps its hook: the first
+        # message is its retry.
+        (
+            "on",
+            "auto",
+            {AUTO_HARNESS_LABEL_KEY: "1"},
+            SessionRoutingClass(routing_enabled=True, auto_harness=True, turn_routing=True),
         ),
     ],
 )

--- a/tests/server/test_turn_routing.py
+++ b/tests/server/test_turn_routing.py
@@ -275,6 +275,11 @@ async def test_a_router_outage_allows_the_turn_unrouted() -> None:
         del harness, prompt
         raise RuntimeError("router down")
 
+    declines: list[str] = []
+
+    async def _decline(cause: str) -> None:
+        declines.append(cause)
+
     rec = _Recorder()
     decision = await resolve_turn_route(
         "conv_1",
@@ -283,11 +288,15 @@ async def test_a_router_outage_allows_the_turn_unrouted() -> None:
         route_turn=_boom,
         pin=rec.pin,
         persist=rec.persist,
+        record_decline=_decline,
     )
     assert decision.action == "allow"
     assert "routing unavailable" in decision.rationale
     assert rec.pinned == []
     assert rec.chips == []
+    # The failure is visible: a declined chip names the cause, without
+    # claiming the route-once label (the persist/pin seams stayed silent).
+    assert declines == ["Routing call failed: RuntimeError"]
 
 
 async def test_no_verdict_allows_the_turn_unrouted() -> None:
@@ -295,12 +304,63 @@ async def test_no_verdict_allows_the_turn_unrouted() -> None:
         del harness, prompt
         return None, None
 
+    declines: list[str] = []
+
+    async def _decline(cause: str) -> None:
+        declines.append(cause)
+
     rec = _Recorder()
     decision = await resolve_turn_route(
-        "conv_1", _request(), conv=_FakeConv(), route_turn=_none, pin=rec.pin, persist=rec.persist
+        "conv_1",
+        _request(),
+        conv=_FakeConv(),
+        route_turn=_none,
+        pin=rec.pin,
+        persist=rec.persist,
+        record_decline=_decline,
     )
     assert decision.action == "allow"
     assert rec.chips == []
+    assert declines == ["Routing unavailable (router returned no verdict)"]
+
+
+async def test_benign_allows_record_no_decline_chip() -> None:
+    """Already-routed / routing-off are not failures — they stay chipless."""
+    declines: list[str] = []
+
+    async def _decline(cause: str) -> None:
+        declines.append(cause)
+
+    rec = _Recorder()
+    decision = await resolve_turn_route(
+        "conv_1",
+        _request(),
+        conv=_FakeConv(labels={"omnigent.routing.decision_id": "dec_1"}),
+        route_turn=rec.route,
+        pin=rec.pin,
+        persist=rec.persist,
+        record_decline=_decline,
+    )
+    assert decision.action == "allow"
+    assert declines == []
+
+
+async def test_a_failing_decline_record_does_not_change_the_verdict() -> None:
+    """The chip is a record, not a gate — its own failure must be swallowed."""
+
+    async def _boom(harness: str | None, prompt: str) -> tuple[str | None, dict[str, Any] | None]:
+        del harness, prompt
+        raise RuntimeError("router down")
+
+    async def _decline(cause: str) -> None:
+        del cause
+        raise OSError("store down")
+
+    decision = await resolve_turn_route(
+        "conv_1", _request(), conv=_FakeConv(), route_turn=_boom, record_decline=_decline
+    )
+    assert decision.action == "allow"
+    assert decision.terminal is False
 
 
 async def test_a_failed_pin_declines_the_route() -> None:

--- a/tests/server/test_turn_routing.py
+++ b/tests/server/test_turn_routing.py
@@ -47,6 +47,7 @@ class _FakeConv:
     cost_control_mode_override: str | None = "on"
     parent_conversation_id: str | None = None
     labels: dict[str, str] = field(default_factory=dict)
+    subagent_routing_override: str | None = None
 
 
 def _routed_labels() -> dict[str, str]:
@@ -180,6 +181,79 @@ async def test_a_routed_parent_routes_its_child() -> None:
         _request(),
         conv=_FakeConv(cost_control_mode_override=None, parent_conversation_id="conv_parent"),
         parent=_FakeConv(),
+        route_turn=rec.route,
+        pin=rec.pin,
+        persist=rec.persist,
+    )
+    assert decision.action == "route"
+
+
+async def test_a_pinned_parents_out_of_family_pane_is_not_routed() -> None:
+    rec = _Recorder()
+    decision = await resolve_turn_route(
+        "conv_child",
+        _request(harness="claude-native"),
+        conv=_FakeConv(parent_conversation_id="conv_parent"),
+        parent=_FakeConv(subagent_routing_override="on"),
+        parent_harness="codex-native",
+        route_turn=rec.route,
+        pin=rec.pin,
+        persist=rec.persist,
+    )
+    assert decision.action == "allow"
+    assert "model family" in decision.rationale
+    # Nothing was routed, pinned or recorded: the pane keeps its own model.
+    assert rec.routed == []
+    assert rec.pinned == []
+    assert rec.chips == []
+    # Not terminal — the parent's switch can be turned off.
+    assert decision.terminal is False
+
+
+async def test_a_pinned_parents_in_family_pane_still_routes() -> None:
+    rec = _Recorder()
+    decision = await resolve_turn_route(
+        "conv_child",
+        _request(harness="codex-native"),
+        conv=_FakeConv(parent_conversation_id="conv_parent"),
+        parent=_FakeConv(subagent_routing_override="on"),
+        parent_harness="codex-native",
+        route_turn=rec.route,
+        pin=rec.pin,
+        persist=rec.persist,
+    )
+    assert decision.action == "route"
+    assert rec.pinned == [ROUTED_MODEL]
+
+
+async def test_an_auto_parents_cross_family_pane_still_routes() -> None:
+    from omnigent.runner.subagent_routing import AUTO_HARNESS_LABEL_KEY
+
+    rec = _Recorder()
+    decision = await resolve_turn_route(
+        "conv_child",
+        _request(harness="claude-native"),
+        conv=_FakeConv(parent_conversation_id="conv_parent"),
+        parent=_FakeConv(
+            subagent_routing_override="on",
+            labels={AUTO_HARNESS_LABEL_KEY: "1"},
+        ),
+        parent_harness="codex-native",
+        route_turn=rec.route,
+        pin=rec.pin,
+        persist=rec.persist,
+    )
+    assert decision.action == "route"
+
+
+async def test_an_unrouted_parents_cross_family_pane_still_routes() -> None:
+    rec = _Recorder()
+    decision = await resolve_turn_route(
+        "conv_child",
+        _request(harness="claude-native"),
+        conv=_FakeConv(parent_conversation_id="conv_parent"),
+        parent=_FakeConv(),
+        parent_harness="codex-native",
         route_turn=rec.route,
         pin=rec.pin,
         persist=rec.persist,

--- a/tests/server/test_turn_routing.py
+++ b/tests/server/test_turn_routing.py
@@ -1137,16 +1137,18 @@ def test_the_router_clients_own_timeout_sits_inside_the_hook_budget() -> None:
     assert 0 < default < HOOK_REQUEST_TIMEOUT_S
 
 
-def test_every_routing_budget_stays_in_single_digits() -> None:
+def test_every_routing_budget_stays_inside_the_owners_ceiling() -> None:
     """
-    The owner's ruling: a fail-open that takes 30s is blocking in practice.
+    Both halves of the owner's ruling, which pull against each other.
 
-    The relation tests above only pin the ORDERING, which a 45s ladder
-    satisfies just as well as a 15s one. This pins the magnitude: the two
-    hazard paths — a first-message hook holding a typed prompt and a spawn gate
-    holding an agent's tool call — must give up within seconds, so every
-    request budget on them is a single digit and the harness-registered kill is
-    well inside a quarter of a minute.
+    A fail-open that takes 30s is blocking in practice, so the hazard paths — a
+    first-message hook holding a typed prompt and a spawn gate holding an
+    agent's tool call — must give up well inside half a minute. But a budget
+    tight enough to lose the race with a HEALTHY route is worse than a slow
+    one: the verdict arrives and is thrown away, wasting the attempt and
+    duplicating the prompt. A healthy first message costs catalog preparation
+    (~3s measured) plus the routing call (~1.6s), so every hook budget must
+    clear that comfortably while staying at or under the 15s ceiling.
     """
     from omnigent.inner.hook_scripts.subagent_router import (
         HOOK_TIMEOUT_S as SPAWN_HOOK_TIMEOUT_S,
@@ -1157,9 +1159,11 @@ def test_every_routing_budget_stays_in_single_digits() -> None:
     from omnigent.runner import subagent_routing, turn_routing
     from omnigent.server.smart_routing import ROUTING_REQUEST_TIMEOUT_S
 
-    # The routing call itself, the innermost wait on every path.
-    assert ROUTING_REQUEST_TIMEOUT_S <= 8.0
-    # Each hook's own HTTP budget — what the user actually waits out.
+    # The routing call itself, the innermost wait on every path. It must leave
+    # room under the hops above it for the preparation that precedes it.
+    assert ROUTING_REQUEST_TIMEOUT_S <= 10.0
+    # Each hook's own HTTP budget — what the user actually waits out. The floor
+    # is what a healthy route costs end to end; the ceiling is the owner's 15s.
     for budget in (
         turn_routing.HOOK_REQUEST_TIMEOUT_S,
         turn_routing.RELAY_TIMEOUT_S,
@@ -1170,11 +1174,24 @@ def test_every_routing_budget_stays_in_single_digits() -> None:
         subagent_routing.SERVER_HOP_TIMEOUT_S,
         SPAWN_REQUEST_TIMEOUT_S,
     ):
-        assert 0 < budget < 10.0, budget
+        assert 0 < budget <= 15.0, budget
+    # The two hook budgets carry a typed prompt and a spawn tool call, so they
+    # are the ones that must outlast preparation-plus-call, not just the call.
+    _HEALTHY_ROUTE_S = 3.2 + 1.6
+    for budget in (
+        turn_routing.HOOK_REQUEST_TIMEOUT_S,
+        subagent_routing.HOOK_REQUEST_TIMEOUT_S,
+        SPAWN_REQUEST_TIMEOUT_S,
+    ):
+        assert budget > _HEALTHY_ROUTE_S * 2, budget
     # The outermost hop is the harness's own kill, which only needs enough
     # headroom for the hook script to reach its fail-open branch.
-    assert turn_routing.HARNESS_HOOK_TIMEOUT_S <= 15
-    assert SPAWN_HOOK_TIMEOUT_S <= 15
+    # Claude Code's own UserPromptSubmit default is 30s; the harness must not
+    # be the layer that gives up first, so both kills stay under it.
+    assert turn_routing.HARNESS_HOOK_TIMEOUT_S < 30
+    assert SPAWN_HOOK_TIMEOUT_S < 30
+    assert turn_routing.HARNESS_HOOK_TIMEOUT_S > turn_routing.HOOK_REQUEST_TIMEOUT_S
+    assert SPAWN_HOOK_TIMEOUT_S > SPAWN_REQUEST_TIMEOUT_S
 
 
 def test_the_subagent_ladder_is_strictly_decreasing_inwards() -> None:
@@ -1232,7 +1249,7 @@ def test_the_builtin_judge_shares_the_external_routers_budget() -> None:
     # covers the fallback chain and any pre-request token refresh.
     assert "timeout=ROUTING_REQUEST_TIMEOUT_S" in source
     assert "asyncio.wait_for" in source
-    assert ROUTING_REQUEST_TIMEOUT_S <= 8.0
+    assert ROUTING_REQUEST_TIMEOUT_S <= 10.0
 
 
 # ── Route-once under load, and the manual-pin gap ───────────────────

--- a/tests/server/test_turn_routing.py
+++ b/tests/server/test_turn_routing.py
@@ -1891,3 +1891,87 @@ def test_the_claude_sdk_spawn_hook_is_registered_outside_its_own_request() -> No
     assert "timeout=subagent_router.HOOK_TIMEOUT_S" in source
     assert "timeout=subagent_router.REQUEST_TIMEOUT_S" not in source
     assert HOOK_TIMEOUT_S > REQUEST_TIMEOUT_S
+
+
+# ── Hook omission for an already-routed session ─────────────────────────
+#
+# A web create routes a pinned native pane's model before the terminal exists,
+# and stamps the routing-decision label. Registering the ``UserPromptSubmit``
+# hook on top of that buys nothing — its only answer is "already routed" — and
+# costs a held prompt plus a round trip. The advertisement is the switch, so
+# not starting the router is what leaves the hook out of the payload.
+
+
+def _hook_settings_after_launch(
+    tmp_path: Path,
+    *,
+    harness: str,
+    labels: dict[str, str],
+    session_id: str,
+) -> dict[str, Any]:
+    """Generate a native launch's hook settings for one session snapshot."""
+    from omnigent.codex_native_app_server import (
+        _codex_policy_hooks_settings,
+        _turn_router_advertised,
+    )
+    from omnigent.runner.native.orchestration import _start_turn_router_for_native_session
+    from omnigent.runner.subagent_routing import routing_class_from_snapshot
+
+    routing_class = routing_class_from_snapshot(
+        cost_control_mode="on", harness_override=harness, labels=labels
+    )
+    router = _start_turn_router_for_native_session(
+        session_id,
+        bridge_dir=tmp_path,
+        harness=harness,
+        server_client=_FakeServerClient(),
+        turn_routing=routing_class.turn_routing,
+    )
+    try:
+        if harness == "codex-native":
+            return _codex_policy_hooks_settings(
+                tmp_path, "/venv/bin/python", turn_routing=_turn_router_advertised(tmp_path)
+            )
+        from omnigent.claude_native_bridge import build_hook_settings
+
+        return build_hook_settings(tmp_path, turn_routing=router is not None)
+    finally:
+        shutdown_session_turn_router(session_id, router)
+
+
+def _prompt_submit_commands(settings: dict[str, Any]) -> list[str]:
+    """Every ``UserPromptSubmit`` command in a generated hook payload."""
+    return [
+        hook.get("command", "")
+        for entry in settings["hooks"].get("UserPromptSubmit", [])
+        for hook in entry.get("hooks", [])
+    ]
+
+
+@pytest.mark.parametrize("harness", ["claude-native", "codex-native"])
+async def test_a_create_routed_session_launches_without_the_turn_hook(
+    tmp_path: Path, harness: str
+) -> None:
+    from omnigent.runner.subagent_routing import ROUTING_DECISION_LABEL_KEY
+
+    settings = _hook_settings_after_launch(
+        tmp_path,
+        harness=harness,
+        labels={ROUTING_DECISION_LABEL_KEY: "decision-1"},
+        session_id=f"conv_routed_{harness}",
+    )
+    assert not any("route-turn" in command for command in _prompt_submit_commands(settings))
+    assert not (tmp_path / ADVERTISEMENT_FILE).exists()
+
+
+@pytest.mark.parametrize("harness", ["claude-native", "codex-native"])
+async def test_a_declined_create_route_keeps_the_turn_hook(tmp_path: Path, harness: str) -> None:
+    # Fail-open: the create emitted a declined chip and pinned nothing, so no
+    # decision label. The first message is this session's second chance.
+    settings = _hook_settings_after_launch(
+        tmp_path,
+        harness=harness,
+        labels={},
+        session_id=f"conv_declined_{harness}",
+    )
+    assert any("route-turn" in command for command in _prompt_submit_commands(settings))

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -326,6 +326,74 @@ def test_ucode_config_for_profile_reads_allowlisted_claude_state(
     )
 
 
+def _ucode_state_with_auth_command(auth_command: str) -> Any:
+    """Build a one-agent ucode workspace state carrying *auth_command*."""
+    from omnigent.onboarding.ucode_state import UcodeAgentState, UcodeWorkspaceState
+
+    return UcodeWorkspaceState(
+        workspace_url="https://example.databricks.com",
+        agents={
+            "claude": UcodeAgentState(
+                model="databricks-claude-opus-test",
+                base_url="https://example.databricks.com/ai-gateway/anthropic",
+                auth_command=auth_command,
+            )
+        },
+    )
+
+
+def test_ucode_config_pins_the_token_helper_to_the_named_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The profile the config names is the identity the pane must authenticate as.
+
+    ucode records its own token command, and it selects the workspace however
+    ucode was configured — often by host. The server's router client instead
+    uses the ``kind: databricks`` provider's profile. Two profiles on one host
+    are two identities, so host selection is how a pane and the router end up
+    disagreeing about whether the workspace is reachable.
+    """
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.get_workspace_url_for_profile",
+        lambda profile: "https://example.databricks.com",
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.ucode_state.read_ucode_state",
+        lambda workspace_url: _ucode_state_with_auth_command(
+            'databricks auth token --host "https://example.databricks.com" '
+            "--output json | jq -r '.access_token'"
+        ),
+    )
+
+    config = claude_native._ucode_config_for_profile("agent", refresh_models=False)
+
+    assert config is not None
+    helper = config.api_key_helper
+    assert helper is not None
+    assert '--profile "agent"' in helper
+    assert "--host" not in helper
+
+
+def test_ucode_config_leaves_a_non_databricks_token_command_alone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An enterprise deployment's own token command has a selector we don't know."""
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.get_workspace_url_for_profile",
+        lambda profile: "https://example.databricks.com",
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.ucode_state.read_ucode_state",
+        lambda workspace_url: _ucode_state_with_auth_command("corp-auth print-token --scope llm"),
+    )
+
+    config = claude_native._ucode_config_for_profile("agent", refresh_models=False)
+
+    assert config is not None
+    assert config.api_key_helper == "corp-auth print-token --scope llm"
+
+
 def test_ucode_config_for_profile_sets_model_tier_env_vars(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -8,6 +8,7 @@ import importlib.metadata
 import io
 import json
 import os
+import shlex
 import ssl
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -353,17 +354,21 @@ def test_ucode_config_pins_the_token_helper_to_the_named_profile(
     uses the ``kind: databricks`` provider's profile. Two profiles on one host
     are two identities, so host selection is how a pane and the router end up
     disagreeing about whether the workspace is reachable.
+
+    The preference is not exclusive: the recorded command survives as the
+    helper's last resort, for the config that names a credential-less profile.
     """
+    recorded = (
+        'databricks auth token --host "https://example.databricks.com" '
+        "--output json | jq -r '.access_token'"
+    )
     monkeypatch.setattr(
         "omnigent.onboarding.databricks_config.get_workspace_url_for_profile",
         lambda profile: "https://example.databricks.com",
     )
     monkeypatch.setattr(
         "omnigent.onboarding.ucode_state.read_ucode_state",
-        lambda workspace_url: _ucode_state_with_auth_command(
-            'databricks auth token --host "https://example.databricks.com" '
-            "--output json | jq -r '.access_token'"
-        ),
+        lambda workspace_url: _ucode_state_with_auth_command(recorded),
     )
 
     config = claude_native._ucode_config_for_profile("agent", refresh_models=False)
@@ -371,8 +376,11 @@ def test_ucode_config_pins_the_token_helper_to_the_named_profile(
     assert config is not None
     helper = config.api_key_helper
     assert helper is not None
+    # The mint selects by profile; the only --host left is the quoted fallback.
     assert '--profile "agent"' in helper
-    assert "--host" not in helper
+    mint, _, fallback = helper.partition("eval ")
+    assert "--host" not in mint
+    assert fallback.startswith(shlex.quote(recorded))
 
 
 def test_ucode_config_leaves_a_non_databricks_token_command_alone(

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -2809,7 +2809,9 @@ def test_route_turn_falls_open_on_the_ladders_own_request_budget(
     assert seen == [HOOK_REQUEST_TIMEOUT_S]
     # Single digits: a fail-open the user waits half a minute for is blocking
     # in practice, whatever the code path says.
-    assert HOOK_REQUEST_TIMEOUT_S < 10.0
+    # Must outlast a healthy route (catalog prep + router call), capped at the
+    # owner's 15s ceiling.
+    assert HOOK_REQUEST_TIMEOUT_S <= 15.0
     # Nothing blocked and nothing marked, so the prompt ran.
     assert capsys.readouterr().out == ""
     assert not (bridge_dir / MARKER_FILE).exists()

--- a/tests/test_codex_model_vocabulary.py
+++ b/tests/test_codex_model_vocabulary.py
@@ -9,7 +9,7 @@ from omnigent.codex_model_vocabulary import (
     EXTENDED_MODEL_DEFAULT_EFFORT,
     EXTENDED_MODEL_EFFORTS,
     clamp_spawn_effort,
-    codex_model_slug,
+    codex_reachable_model_slug,
     codex_spawn_model,
     comparable_model_id,
 )
@@ -105,38 +105,40 @@ def test_comparable_model_id_folds_prefix_dots_and_case() -> None:
 
 
 def test_catalog_id_translates_to_the_codex_slug() -> None:
-    assert codex_model_slug("databricks-gpt-5-6-luna", _CATALOG) == "gpt-5.6-luna"
-    assert codex_model_slug("databricks-gpt-5-6-sol", _CATALOG) == "gpt-5.6-sol"
-    assert codex_model_slug("databricks-gpt-5-5", _CATALOG) == "gpt-5.5"
+    assert codex_reachable_model_slug("databricks-gpt-5-6-luna", _CATALOG) == "gpt-5.6-luna"
+    assert codex_reachable_model_slug("databricks-gpt-5-6-sol", _CATALOG) == "gpt-5.6-sol"
+    assert codex_reachable_model_slug("databricks-gpt-5-5", _CATALOG) == "gpt-5.5"
 
 
 def test_a_codex_slug_translates_to_itself() -> None:
-    assert codex_model_slug("gpt-5.6-luna", _CATALOG) == "gpt-5.6-luna"
+    assert codex_reachable_model_slug("gpt-5.6-luna", _CATALOG) == "gpt-5.6-luna"
 
 
 def test_an_extended_catalog_id_is_already_the_slug() -> None:
     """glm is listed under its catalog spelling, so it must survive intact."""
-    assert codex_model_slug("system.ai.glm-5-2", _CATALOG) == "system.ai.glm-5-2"
-    assert codex_model_slug("glm-5-2", _CATALOG) == "system.ai.glm-5-2"
+    assert codex_reachable_model_slug("system.ai.glm-5-2", _CATALOG) == "system.ai.glm-5-2"
+    assert codex_reachable_model_slug("glm-5-2", _CATALOG) == "system.ai.glm-5-2"
 
 
-def test_an_unknown_id_stays_verbatim() -> None:
-    """Fail-safe: the gateway may still serve it, so send it unchanged."""
-    assert codex_model_slug("databricks-claude-opus-5", _CATALOG) == "databricks-claude-opus-5"
-    assert codex_model_slug("databricks-gpt-5-6-luna", []) == "databricks-gpt-5-6-luna"
+def test_an_id_no_row_names_is_not_reachable() -> None:
+    """A pick outside the live catalog is a decline, not a switch to attempt."""
+    assert codex_reachable_model_slug("databricks-claude-opus-5", _CATALOG) is None
+    # An empty catalog names nothing, so nothing is reachable through it.
+    assert codex_reachable_model_slug("databricks-gpt-5-6-luna", []) is None
+    assert codex_reachable_model_slug("", _CATALOG) is None
 
 
 def test_a_row_naming_a_separate_servable_id_matches_on_either_side() -> None:
     options = [{"id": "gpt-5.5", "model": "databricks-gpt-5-5"}]
 
-    assert codex_model_slug("databricks-gpt-5-5", options) == "gpt-5.5"
-    assert codex_model_slug("gpt-5.5", options) == "gpt-5.5"
+    assert codex_reachable_model_slug("databricks-gpt-5-5", options) == "gpt-5.5"
+    assert codex_reachable_model_slug("gpt-5.5", options) == "gpt-5.5"
 
 
 def test_malformed_rows_are_skipped() -> None:
     options: list[object] = ["nonsense", {"model": "gpt-5.6-luna"}, {"id": "  "}]
 
-    assert codex_model_slug("databricks-gpt-5-6-luna", options) == "databricks-gpt-5-6-luna"  # type: ignore[arg-type]
+    assert codex_reachable_model_slug("databricks-gpt-5-6-luna", options) is None  # type: ignore[arg-type]
 
 
 def test_catalog_prefixes_match_the_claude_vocabulary() -> None:

--- a/tests/test_codex_native_hook.py
+++ b/tests/test_codex_native_hook.py
@@ -888,7 +888,9 @@ def test_route_turn_falls_open_on_the_ladders_own_request_budget(
 
     assert _run_route_turn(bridge_dir, {"prompt": "hello"}, monkeypatch) == 0
     assert seen == [HOOK_REQUEST_TIMEOUT_S]
-    assert HOOK_REQUEST_TIMEOUT_S < 10.0
+    # Must outlast a healthy route (catalog prep + router call), capped at the
+    # owner's 15s ceiling.
+    assert HOOK_REQUEST_TIMEOUT_S <= 15.0
     assert capsys.readouterr().out == ""
     assert not (bridge_dir / MARKER_FILE).exists()
 

--- a/tests/test_codex_native_hook.py
+++ b/tests/test_codex_native_hook.py
@@ -649,11 +649,11 @@ def test_route_turn_blocks_and_switches_on_a_routed_verdict(
             "terminal": True,
         }
 
-    def _switch(bdir: Path, model: str) -> bool:
+    def _switch(bdir: Path, model: str) -> str | None:
         # The marker is only written after the switch is accepted.
         assert not (bdir / MARKER_FILE).exists()
         switched.append(model)
-        return True
+        return None
 
     monkeypatch.setattr(codex_native_hook, "_post_json", _post)
     monkeypatch.setattr(codex_native_hook, "_apply_thread_model", _switch)
@@ -765,7 +765,11 @@ def test_route_turn_allows_the_prompt_when_the_switch_fails(
             "terminal": True,
         },
     )
-    monkeypatch.setattr(codex_native_hook, "_apply_thread_model", lambda *args: False)
+    monkeypatch.setattr(
+        codex_native_hook,
+        "_apply_thread_model",
+        lambda *args: "could not switch to gpt-5.6-luna",
+    )
 
     exit_code = _run_route_turn(bridge_dir, {"prompt": "hello"}, monkeypatch)
 
@@ -774,6 +778,47 @@ def test_route_turn_allows_the_prompt_when_the_switch_fails(
     assert captured.out == ""
     assert "could not switch" in captured.err
     # No marker: it is the replay handshake, and this prompt is running.
+    assert not (bridge_dir / MARKER_FILE).exists()
+
+
+def test_route_turn_declines_visibly_when_the_pane_cannot_serve_the_pick(
+    bridge_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """
+    An unreachable pick is a recorded decline, not a silent drop.
+
+    The reason reaches both the routing trace and stderr, so "the pane never
+    moved" is answerable without reproducing the stale gateway map.
+    """
+    from omnigent.runner.turn_routing import MARKER_FILE, TRACE_FILE
+
+    _advertise_turn_router(bridge_dir)
+    monkeypatch.setattr(
+        codex_native_hook,
+        "_post_json",
+        lambda *args, **kwargs: {
+            "action": "route",
+            "model": "databricks-claude-opus-5",
+            "rationale": "deep refactor",
+            "terminal": True,
+        },
+    )
+    monkeypatch.setattr(
+        codex_native_hook,
+        "_apply_thread_model",
+        lambda *args: "routed model not in this pane's catalog (databricks-claude-opus-5)",
+    )
+
+    exit_code = _run_route_turn(bridge_dir, {"prompt": "hello"}, monkeypatch)
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    # The prompt runs, unblocked, on the pane's own model.
+    assert captured.out == ""
+    assert "not in this pane's catalog" in captured.err
+    assert "not in this pane's catalog" in (bridge_dir / TRACE_FILE).read_text()
     assert not (bridge_dir / MARKER_FILE).exists()
 
 
@@ -919,7 +964,7 @@ def test_route_turn_traces_the_route_it_applied(
             "terminal": True,
         },
     )
-    monkeypatch.setattr(codex_native_hook, "_apply_thread_model", lambda *args: True)
+    monkeypatch.setattr(codex_native_hook, "_apply_thread_model", lambda *args: None)
 
     assert _run_route_turn(bridge_dir, {"prompt": "hello"}, monkeypatch) == 0
     assert json.loads(capsys.readouterr().out)["decision"] == "block"
@@ -1019,9 +1064,6 @@ _LIVE_CATALOG: list[dict[str, object]] = [
         # Extended-catalog rows are listed under the catalog spelling, which
         # IS codex's id for them — translating must not mangle it.
         ("system.ai.glm-5-2", "system.ai.glm-5-2"),
-        # Nothing in the catalog names it: send it anyway (the gateway may
-        # still serve it) rather than skipping the switch.
-        ("databricks-claude-opus-5", "databricks-claude-opus-5"),
     ],
 )
 def test_apply_thread_model_switches_in_codex_spelling(
@@ -1036,7 +1078,7 @@ def test_apply_thread_model_switches_in_codex_spelling(
     codex_home_for_bridge_dir(bridge_dir).mkdir(parents=True, exist_ok=True)
     client = _install_fake_client(monkeypatch, _FakeAppServerClient(_LIVE_CATALOG))
 
-    assert codex_native_hook._apply_thread_model(bridge_dir, routed) is True
+    assert codex_native_hook._apply_thread_model(bridge_dir, routed) is None
 
     assert client.requests == [
         ("model/list", {"includeHidden": True}),
@@ -1046,23 +1088,50 @@ def test_apply_thread_model_switches_in_codex_spelling(
     assert read_codex_config_model(bridge_dir) == applied
 
 
-def test_apply_thread_model_falls_back_to_the_routed_id_without_a_catalog(
+def test_apply_thread_model_declines_a_model_this_pane_cannot_serve(
     bridge_dir: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An unreadable catalog must not cost the switch — send the id verbatim."""
+    """
+    A stale gateway map can route a pane onto a model its gateway will not run.
+
+    Switching anyway is a silent drop at the next turn, so the live catalog is
+    the authority: no row names the pick, no switch, and the reason is said out
+    loud rather than being swallowed.
+    """
+    from omnigent.codex_native_bridge import read_codex_config_model
+
+    codex_home_for_bridge_dir(bridge_dir).mkdir(parents=True, exist_ok=True)
+    client = _install_fake_client(monkeypatch, _FakeAppServerClient(_LIVE_CATALOG))
+
+    declined = codex_native_hook._apply_thread_model(bridge_dir, "databricks-claude-opus-5")
+
+    assert declined is not None
+    assert "not in this pane's catalog" in declined
+    assert "databricks-claude-opus-5" in declined
+    # The catalog was read, and nothing was switched or mirrored.
+    assert client.requests == [("model/list", {"includeHidden": True})]
+    assert client.closed is True
+    assert read_codex_config_model(bridge_dir) is None
+
+
+def test_apply_thread_model_declines_when_the_catalog_cannot_be_read(
+    bridge_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreadable catalog proves nothing, so it is not proof of reachability."""
     from omnigent.codex_native_bridge import read_codex_config_model
 
     codex_home_for_bridge_dir(bridge_dir).mkdir(parents=True, exist_ok=True)
     client = _install_fake_client(monkeypatch, _FakeAppServerClient(None))
 
-    assert codex_native_hook._apply_thread_model(bridge_dir, "databricks-gpt-5-6-luna") is True
+    declined = codex_native_hook._apply_thread_model(bridge_dir, "databricks-gpt-5-6-luna")
 
-    assert client.requests[-1] == (
-        "thread/settings/update",
-        {"threadId": "thread_abc", "model": "databricks-gpt-5-6-luna"},
-    )
-    assert read_codex_config_model(bridge_dir) == "databricks-gpt-5-6-luna"
+    assert declined is not None
+    assert "could not read this pane's model catalog" in declined
+    # Fail open: no switch, no crash, and the pane keeps its own model.
+    assert [method for method, _params in client.requests] == ["model/list"]
+    assert read_codex_config_model(bridge_dir) is None
 
 
 def test_apply_thread_model_pages_the_catalog(
@@ -1090,7 +1159,7 @@ def test_apply_thread_model_pages_the_catalog(
     codex_home_for_bridge_dir(bridge_dir).mkdir(parents=True, exist_ok=True)
     client = _install_fake_client(monkeypatch, _PagedClient(None))
 
-    assert codex_native_hook._apply_thread_model(bridge_dir, "databricks-gpt-5-6-luna") is True
+    assert codex_native_hook._apply_thread_model(bridge_dir, "databricks-gpt-5-6-luna") is None
 
     assert client.requests[-1] == (
         "thread/settings/update",

--- a/web/src/components/blocks/StatusBlocks.test.tsx
+++ b/web/src/components/blocks/StatusBlocks.test.tsx
@@ -71,13 +71,13 @@ describe("routing decision — harness / scope / raw pick", () => {
   // Harness + which sub-agent the decision covers: without the badge a
   // native-subagent decision is indistinguishable from a session one, and a
   // badge on a session/turn decision would invent a sub-agent that has none.
-  // Sub-agent chips also shorten the harness id: "-native" is how the spawn
-  // runs, not something a spawn chip needs to say. Session/turn chips keep it.
+  // Every chip also shortens the harness id: "-native" is how the pane runs,
+  // not something a chip needs to say, whatever scope took the decision.
   it.each([
-    ["native_subagent", "subagent: researcher", "claude"],
-    ["turn", null, "claude-native"],
-    ["session", null, "claude-native"],
-  ] as const)("card: %s scope renders the sub-agent badge as %s", (scope, badge, harnessText) => {
+    ["native_subagent", "subagent: researcher"],
+    ["turn", null],
+    ["session", null],
+  ] as const)("card: %s scope renders the sub-agent badge as %s", (scope, badge) => {
     render(
       <RoutingDecisionCard
         model="databricks-claude-sonnet-5"
@@ -87,7 +87,8 @@ describe("routing decision — harness / scope / raw pick", () => {
         routing={{ harness: "claude-native", scope }}
       />,
     );
-    expect(screen.getByTestId("routing-decision-harness")).toHaveTextContent(harnessText);
+    // Anchored: a bare "claude" would also match the unshortened id.
+    expect(screen.getByTestId("routing-decision-harness")).toHaveTextContent(/^· claude$/);
     if (badge === null) {
       expect(screen.queryByTestId("routing-decision-scope")).toBeNull();
     } else {

--- a/web/src/components/blocks/StatusBlocks.test.tsx
+++ b/web/src/components/blocks/StatusBlocks.test.tsx
@@ -71,11 +71,13 @@ describe("routing decision — harness / scope / raw pick", () => {
   // Harness + which sub-agent the decision covers: without the badge a
   // native-subagent decision is indistinguishable from a session one, and a
   // badge on a session/turn decision would invent a sub-agent that has none.
+  // Sub-agent chips also shorten the harness id: "-native" is how the spawn
+  // runs, not something a spawn chip needs to say. Session/turn chips keep it.
   it.each([
-    ["native_subagent", "subagent: researcher"],
-    ["turn", null],
-    ["session", null],
-  ] as const)("card: %s scope renders the sub-agent badge as %s", (scope, badge) => {
+    ["native_subagent", "subagent: researcher", "claude"],
+    ["turn", null, "claude-native"],
+    ["session", null, "claude-native"],
+  ] as const)("card: %s scope renders the sub-agent badge as %s", (scope, badge, harnessText) => {
     render(
       <RoutingDecisionCard
         model="databricks-claude-sonnet-5"
@@ -85,7 +87,7 @@ describe("routing decision — harness / scope / raw pick", () => {
         routing={{ harness: "claude-native", scope }}
       />,
     );
-    expect(screen.getByTestId("routing-decision-card")).toHaveTextContent("claude-native");
+    expect(screen.getByTestId("routing-decision-harness")).toHaveTextContent(harnessText);
     if (badge === null) {
       expect(screen.queryByTestId("routing-decision-scope")).toBeNull();
     } else {
@@ -132,7 +134,8 @@ describe("routing decision — harness / scope / raw pick", () => {
         }}
       />,
     );
-    expect(screen.getByTestId("routing-decision-harness")).toHaveTextContent("codex-native");
+    // child_session is a sub-agent scope, so the harness id renders shortened.
+    expect(screen.getByTestId("routing-decision-harness")).toHaveTextContent("codex");
     // The badge's exact wording is pinned once, on subagentScopeLabel.
     expect(screen.getByTestId("routing-decision-scope")).toBeTruthy();
     expect(screen.getByTestId("routing-decision-raw-model")).toHaveTextContent("gpt-5-6-sol");

--- a/web/src/components/blocks/StatusBlocks.tsx
+++ b/web/src/components/blocks/StatusBlocks.tsx
@@ -21,7 +21,11 @@ import { DatabricksIcon } from "@/components/icons/DatabricksIcon";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { shortModelName } from "@/components/CostRoutingControl";
-import { type RoutingDecisionExtras, subagentScopeLabel } from "@/lib/routingDecision";
+import {
+  type RoutingDecisionExtras,
+  harnessDisplayLabel,
+  subagentScopeLabel,
+} from "@/lib/routingDecision";
 import { cn } from "@/lib/utils";
 import { TOOL_SURFACE_WIDTH_CLASS } from "./toolSurface";
 
@@ -176,6 +180,7 @@ export function RoutingDecisionCard({
   const rawShort = rawPickName(model, rawModel);
   const attemptedShort = attemptedPickName(model, attemptedOverride);
   const scopeLabel = subagentScopeLabel(scope, agent);
+  const harnessLabel = harnessDisplayLabel(scope, harness);
   const rowLabel = agent && agent.length > 0 ? agent : "Session";
   const prettyOutput = useMemo(
     () =>
@@ -233,9 +238,9 @@ export function RoutingDecisionCard({
           </span>
         ) : null}
         <span className="text-muted-foreground">{applied ? "· applied" : "· advisory"}</span>
-        {harness ? (
+        {harnessLabel ? (
           <span className="text-muted-foreground" data-testid="routing-decision-harness">
-            · {harness}
+            · {harnessLabel}
           </span>
         ) : null}
         {scopeLabel ? (

--- a/web/src/components/blocks/StatusBlocks.tsx
+++ b/web/src/components/blocks/StatusBlocks.tsx
@@ -180,7 +180,7 @@ export function RoutingDecisionCard({
   const rawShort = rawPickName(model, rawModel);
   const attemptedShort = attemptedPickName(model, attemptedOverride);
   const scopeLabel = subagentScopeLabel(scope, agent);
-  const harnessLabel = harnessDisplayLabel(scope, harness);
+  const harnessLabel = harnessDisplayLabel(harness);
   const rowLabel = agent && agent.length > 0 ? agent : "Session";
   const prettyOutput = useMemo(
     () =>

--- a/web/src/lib/renderItems.test.ts
+++ b/web/src/lib/renderItems.test.ts
@@ -2033,15 +2033,145 @@ describe("buildBubbles — routing chip rendered below its user message", () => 
     });
   });
 
-  it("defers only the adjacent chip when two decisions precede a message", () => {
+  it("defers BOTH chips when two session-scoped decisions precede a message", () => {
+    // Nothing of the conversation sits between them, so neither is a preamble:
+    // both are verdicts on the message that follows, in transcript order.
     const blocks: AnyBlock[] = [
       chipBlock("rd_far", "resp_1", "turn"),
       chipBlock("rd_near", "resp_1", "turn"),
       userBlock("u1", "resp_1"),
     ];
     const bubbles = buildBubbles(blocks, null);
-    expect(kinds(bubbles)).toEqual(["routing_decision", "user", "routing_decision"]);
+    expect(kinds(bubbles)).toEqual(["user", "routing_decision", "routing_decision"]);
     expect(chipIds(bubbles)).toEqual(["rd_far", "rd_near"]);
+  });
+
+  it("a sub-agent chip between two decisions blocks the earlier one from moving", () => {
+    // The spawn chip renders standalone where it occurred; deferring the chip
+    // above it past it would reorder the two.
+    const blocks: AnyBlock[] = [
+      chipBlock("rd_session", "resp_1", "turn"),
+      chipBlock("rd_spawn", "resp_1", "native_subagent"),
+      userBlock("u1", "resp_1"),
+    ];
+    const bubbles = buildBubbles(blocks, null);
+    expect(kinds(bubbles)).toEqual(["routing_decision", "routing_decision", "user"]);
+    expect(chipIds(bubbles)).toEqual(["rd_session", "rd_spawn"]);
+  });
+
+  // Rows copied from `GET /v1/sessions/<id>/items` on a session created with
+  // Smart Routing as BOTH the model and the harness. The create records the
+  // pick as a `session` chip before the harness even boots, the first turn
+  // routes again and records a `turn` chip, and the terminal the harness
+  // brought up lands a `resource_event` in between — so the session's first
+  // message has two chips and a non-conversation row above it.
+  describe("auto-harness create (Smart Routing picks the harness too)", () => {
+    const RATIONALE =
+      "Routed to gpt-5-6-luna because trivial task (prompt<300, no errors/refs, " +
+      "llm easy) -> cheapest arm gpt-5-6-luna; never escalate.";
+
+    function resourceEventItem(id: string): ConversationItem {
+      return {
+        id,
+        type: "resource_event",
+        response_id: "ef1ee84af89447898edbbd3acb64a5d2",
+        status: "completed",
+        event_type: "session.resource.created",
+        resource_id: "terminal_codex_main",
+        resource_type: "terminal",
+      } as unknown as ConversationItem;
+    }
+    function promptItem(): ConversationItem {
+      return {
+        id: "msg_user",
+        type: "message",
+        response_id: "codex_019fd3fb",
+        status: "completed",
+        role: "user",
+        content: [{ type: "input_text", text: "what is 2+2?" }],
+      } as unknown as ConversationItem;
+    }
+    function replyItem(): ConversationItem {
+      return {
+        id: "msg_assistant",
+        type: "message",
+        response_id: "codex_019fd3fb",
+        status: "completed",
+        role: "assistant",
+        content: [{ type: "output_text", text: "2 + 2 = 4." }],
+      } as unknown as ConversationItem;
+    }
+    /** The captured transcript, with the turn chip's verdict overridable. */
+    function autoItems(turn: RoutingDecisionWire = {}): ConversationItem[] {
+      return [
+        routingDecisionItem({
+          id: "rd_create",
+          response_id: "routing_d55b96265e01448a8c8cbfdb404b8ac1",
+          model: "databricks-gpt-5-6-luna",
+          rationale: RATIONALE,
+          harness: "codex-native",
+          scope: "session",
+          decision_id: "628a03ea-da4b-49cb-b41a-6f7c28598381",
+        }),
+        resourceEventItem("re_1"),
+        resourceEventItem("re_2"),
+        routingDecisionItem({
+          id: "rd_turn",
+          response_id: "routing_52d9826e05be482785570c6e86ff41ec",
+          model: "databricks-gpt-5-6-luna",
+          rationale: RATIONALE,
+          harness: "codex-native",
+          scope: "turn",
+          decision_id: "633569bb-dbfd-4c72-85db-88788583842b",
+          ...turn,
+        }),
+        promptItem(),
+        replyItem(),
+      ];
+    }
+
+    it("renders the create chip BELOW the prompt when the turn re-routes", () => {
+      // The turn scored the task differently, so the create pick is real news
+      // and survives the collapse — and it is still a verdict on this message,
+      // not a preamble to it.
+      const blocks = itemsToBlocks(autoItems({ model: "databricks-gpt-5-6-sol" }));
+      const bubbles = buildBubbles(blocks, null);
+      expect(kinds(bubbles)).toEqual(["user", "routing_decision", "routing_decision", "assistant"]);
+      expect(chipIds(bubbles)).toEqual(["rd_create", "rd_turn"]);
+    });
+
+    it("still collapses the repeated verdict to one chip below the prompt", () => {
+      const bubbles = buildBubbles(itemsToBlocks(autoItems()), null);
+      expect(kinds(bubbles)).toEqual(["user", "routing_decision", "assistant"]);
+      expect(chipIds(bubbles)).toEqual(["rd_turn"]);
+    });
+
+    it("stays stable frame by frame as the auto-harness transcript streams in", () => {
+      expectFrameByFrameStable(itemsToBlocks(autoItems({ model: "databricks-gpt-5-6-sol" })), [
+        "user",
+        "routing_decision",
+        "routing_decision",
+        "assistant",
+      ]);
+    });
+
+    it("defers the lone create chip past the terminal's resource row", () => {
+      // A create whose first turn never recorded its own chip — captured from
+      // an auto-harness session mid-flight.
+      const items = [
+        routingDecisionItem({
+          id: "rd_create",
+          model: "databricks-gpt-5-6-sol",
+          harness: "codex-native",
+          scope: "session",
+        }),
+        resourceEventItem("re_1"),
+        promptItem(),
+        replyItem(),
+      ];
+      const bubbles = buildBubbles(itemsToBlocks(items), null);
+      expect(kinds(bubbles)).toEqual(["user", "routing_decision", "assistant"]);
+    });
   });
 
   it("static reload: the itemsToBlocks funnel defers the persisted decision too", () => {

--- a/web/src/lib/renderItems.test.ts
+++ b/web/src/lib/renderItems.test.ts
@@ -2174,6 +2174,64 @@ describe("buildBubbles — routing chip rendered below its user message", () => 
     });
   });
 
+  // The rows a web create pinned to claude-native actually persisted: the
+  // session-scope decision is written AT CREATE, so for a while it is the
+  // session's only item and the prompt exists only as an optimistic pending
+  // bubble (spliced above the chip by `mergePendingBubbles`, tested in
+  // ChatPage.test.ts). These pin the walker's half: one chip throughout, and
+  // it lands below the message with no second position once it is persisted.
+  describe("pinned create routed before its pane launches", () => {
+    function createChip(applied = true): ConversationItem {
+      return routingDecisionItem({
+        id: "rd_create",
+        response_id: "routing_0181ee7e17fa4fa8aa8b18c2d41555e1",
+        model: "databricks-claude-sonnet-5",
+        applied,
+        rationale: "Routed to claude-sonnet-5 because trivial task -> cheapest arm.",
+        harness: "claude-native",
+        scope: "session",
+        decision_id: "2fc19175-929e-41e4-ab4a-6b1c07a0cbe7",
+      });
+    }
+    function prompt(): ConversationItem {
+      return {
+        id: "msg_user",
+        type: "message",
+        role: "user",
+        response_id: "resp_1",
+        status: "completed",
+        content: [{ type: "input_text", text: "what is 2+2?" }],
+      } as unknown as ConversationItem;
+    }
+
+    it("renders the lone create chip while no message has been persisted", () => {
+      const bubbles = buildBubbles(itemsToBlocks([createChip()]), null);
+      expect(kinds(bubbles)).toEqual(["routing_decision"]);
+      expect(chipIds(bubbles)).toEqual(["rd_create"]);
+    });
+
+    it("keeps a DECLINED create chip visible with no message", () => {
+      // Routing failed and the session launched unrouted — the user still has
+      // to see that a decision was attempted.
+      const bubbles = buildBubbles(itemsToBlocks([createChip(false)]), null);
+      expect(kinds(bubbles)).toEqual(["routing_decision"]);
+      expect(bubbles[0]).toMatchObject({ kind: "routing_decision", applied: false });
+    });
+
+    it("renders the chip once, below the prompt, when the message is appended", () => {
+      // Same block list plus the persisted message, through the incremental
+      // cache: the held-and-released region must not paint a stale position.
+      const cache = createBubbleCache();
+      const f1 = itemsToBlocks([createChip()]);
+      expect(kinds(buildBubbles(f1, null, cache))).toEqual(["routing_decision"]);
+      const f2 = [...f1, ...itemsToBlocks([prompt()])];
+      const second = buildBubbles(f2, null, cache);
+      expect(kinds(second)).toEqual(["user", "routing_decision"]);
+      expect(chipIds(second)).toEqual(["rd_create"]);
+      expect(second).toEqual(buildBubbles(f2, null));
+    });
+  });
+
   it("static reload: the itemsToBlocks funnel defers the persisted decision too", () => {
     const items: ConversationItem[] = [
       routingDecisionItem({

--- a/web/src/lib/renderItems.ts
+++ b/web/src/lib/renderItems.ts
@@ -583,6 +583,9 @@ function chipPendingBeforeRegion(blocks: AnyBlock[], startBlock: number): boolea
     return false;
   for (let j = k + 1; j < blocks.length; j += 1) {
     const b = blocks[j]!;
+    // A sibling chip waiting on the same message doesn't end the pairing window
+    // (see `pairableMessageAfter`); real assistant output does.
+    if (b.type === "routing_decision") continue;
     if (!isChipPairingSkippable(b) && b.type !== "user_message") return false;
   }
   return true;
@@ -658,14 +661,15 @@ function walkBubbles(
     }
 
     if (b.type === "user_message") {
-      const chipIndex = deferred.byMessage.get(i);
+      const chipIndexes = deferred.byMessage.get(i);
+      const firstChip = chipIndexes?.[0];
       // The pair's region starts at whichever block came first, so an
       // incremental re-walk rebuilds both bubbles together — plus whatever
       // rendered in between, hence the recorded count rather than `i`'s.
-      lastBubbleStart = chipIndex !== undefined ? Math.min(chipIndex, i) : i;
+      lastBubbleStart = firstChip !== undefined ? Math.min(firstChip, i) : i;
       const regionBubbleStart =
-        chipIndex !== undefined
-          ? (bubbleCountAtChip.get(chipIndex) ?? bubbles.length)
+        firstChip !== undefined
+          ? (bubbleCountAtChip.get(firstChip) ?? bubbles.length)
           : bubbles.length;
       bubbles.push({
         kind: "user",
@@ -676,8 +680,10 @@ function walkBubbles(
         // steady across the optimistic→committed swap — no remount/flink.
         stableKey: b.stableKey,
       });
-      if (chipIndex !== undefined) {
-        bubbles.push(routingChipBubble(blocks[chipIndex] as RoutingDecisionBlock, chipIndex));
+      if (chipIndexes !== undefined) {
+        for (const chipIndex of chipIndexes) {
+          bubbles.push(routingChipBubble(blocks[chipIndex] as RoutingDecisionBlock, chipIndex));
+        }
       }
       lastBubbleCount = bubbles.length - regionBubbleStart;
       i += 1;
@@ -882,8 +888,8 @@ function deferredRoutingChips(
   blocks: AnyBlock[],
   startIndex: number,
   superseded: ReadonlySet<number>,
-): { byMessage: Map<number, number>; indexes: Set<number> } {
-  const byMessage = new Map<number, number>();
+): { byMessage: Map<number, number[]>; indexes: Set<number> } {
+  const byMessage = new Map<number, number[]>();
   const indexes = new Set<number>();
   for (let j = startIndex; j < blocks.length; j += 1) {
     const chip = blocks[j]!;
@@ -891,13 +897,47 @@ function deferredRoutingChips(
     if (superseded.has(j)) continue;
     // Already below its message — leave it where it is.
     if (adjacent(blocks, j, -1)?.type === "user_message") continue;
-    const next = adjacent(blocks, j, 1);
-    if (next !== null && next.type === "user_message") {
-      byMessage.set(next.index, j);
+    const next = pairableMessageAfter(blocks, j, superseded);
+    if (next !== null) {
+      const chips = byMessage.get(next) ?? [];
+      chips.push(j);
+      byMessage.set(next, chips);
       indexes.add(j);
     }
   }
   return { byMessage, indexes };
+}
+
+/**
+ * Index of the user message a chip at `from` routes, looking forward.
+ *
+ * Steps over the non-content blocks `adjacent` skips, plus the sibling chips
+ * that are themselves waiting on the same message: a create with Smart Routing
+ * as BOTH model and harness records the pick as a `session` chip, and the first
+ * turn records its own `turn` chip, so two chips sit above the session's first
+ * message. Neither is a content block between them, so both belong below the
+ * message, in transcript order. Superseded chips render nothing, so they are
+ * stepped over too. A sub-agent chip is NOT stepped over — it renders standalone
+ * where it occurs, and moving a session chip past it would reorder the two.
+ */
+function pairableMessageAfter(
+  blocks: AnyBlock[],
+  from: number,
+  superseded: ReadonlySet<number>,
+): number | null {
+  for (let k = from + 1; k < blocks.length; k += 1) {
+    const b = blocks[k]!;
+    if (isChipPairingSkippable(b)) continue;
+    if (b.type === "user_message") return k;
+    if (
+      b.type === "routing_decision" &&
+      (superseded.has(k) || isSessionScopedDecision(b.routing?.scope))
+    ) {
+      continue;
+    }
+    return null;
+  }
+  return null;
 }
 
 /**

--- a/web/src/lib/routingDecision.test.ts
+++ b/web/src/lib/routingDecision.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  harnessDisplayLabel,
   isSessionScopedDecision,
   routingExtras,
   routingExtrasFromWire,
@@ -134,5 +135,29 @@ describe("showsRoutingDecisionChip", () => {
     [undefined, null, true],
   ] as const)("scope %s with override %s shows: %s", (scope, override, expected) => {
     expect(showsRoutingDecisionChip(scope, override)).toBe(expected);
+  });
+});
+
+describe("harnessDisplayLabel", () => {
+  it("shortens native harness ids on subagent-scoped chips", () => {
+    expect(harnessDisplayLabel("native_subagent", "claude-native")).toBe("claude");
+    expect(harnessDisplayLabel("native_subagent", "codex-native")).toBe("codex");
+    expect(harnessDisplayLabel("child_session", "codex-native")).toBe("codex");
+  });
+
+  it("leaves SDK-brain subagents and session chips unchanged", () => {
+    // A bundle agent's (Polly/Debby) SDK children carry no -native suffix.
+    expect(harnessDisplayLabel("child_session", "codex")).toBe("codex");
+    expect(harnessDisplayLabel("child_session", "claude-sdk")).toBe("claude-sdk");
+    expect(harnessDisplayLabel("child_session", "auto")).toBe("auto");
+    // The session's own chips keep the full harness id.
+    expect(harnessDisplayLabel("session", "claude-native")).toBe("claude-native");
+    expect(harnessDisplayLabel("turn", "codex-native")).toBe("codex-native");
+    expect(harnessDisplayLabel(null, "codex-native")).toBe("codex-native");
+  });
+
+  it("returns null when the decision has no harness", () => {
+    expect(harnessDisplayLabel("native_subagent", null)).toBeNull();
+    expect(harnessDisplayLabel("turn", "  ")).toBeNull();
   });
 });

--- a/web/src/lib/routingDecision.test.ts
+++ b/web/src/lib/routingDecision.test.ts
@@ -139,25 +139,25 @@ describe("showsRoutingDecisionChip", () => {
 });
 
 describe("harnessDisplayLabel", () => {
-  it("shortens native harness ids on subagent-scoped chips", () => {
-    expect(harnessDisplayLabel("native_subagent", "claude-native")).toBe("claude");
-    expect(harnessDisplayLabel("native_subagent", "codex-native")).toBe("codex");
-    expect(harnessDisplayLabel("child_session", "codex-native")).toBe("codex");
+  it("shortens native harness ids", () => {
+    expect(harnessDisplayLabel("claude-native")).toBe("claude");
+    expect(harnessDisplayLabel("codex-native")).toBe("codex");
   });
 
-  it("leaves SDK-brain subagents and session chips unchanged", () => {
+  it("leaves SDK ids unchanged", () => {
     // A bundle agent's (Polly/Debby) SDK children carry no -native suffix.
-    expect(harnessDisplayLabel("child_session", "codex")).toBe("codex");
-    expect(harnessDisplayLabel("child_session", "claude-sdk")).toBe("claude-sdk");
-    expect(harnessDisplayLabel("child_session", "auto")).toBe("auto");
-    // The session's own chips keep the full harness id.
-    expect(harnessDisplayLabel("session", "claude-native")).toBe("claude-native");
-    expect(harnessDisplayLabel("turn", "codex-native")).toBe("codex-native");
-    expect(harnessDisplayLabel(null, "codex-native")).toBe("codex-native");
+    expect(harnessDisplayLabel("codex")).toBe("codex");
+    expect(harnessDisplayLabel("claude-sdk")).toBe("claude-sdk");
+    expect(harnessDisplayLabel("auto")).toBe("auto");
+  });
+
+  it("shortens only a trailing suffix", () => {
+    expect(harnessDisplayLabel("native-brain")).toBe("native-brain");
   });
 
   it("returns null when the decision has no harness", () => {
-    expect(harnessDisplayLabel("native_subagent", null)).toBeNull();
-    expect(harnessDisplayLabel("turn", "  ")).toBeNull();
+    expect(harnessDisplayLabel(null)).toBeNull();
+    expect(harnessDisplayLabel(undefined)).toBeNull();
+    expect(harnessDisplayLabel("  ")).toBeNull();
   });
 });

--- a/web/src/lib/routingDecision.ts
+++ b/web/src/lib/routingDecision.ts
@@ -116,24 +116,18 @@ export function showsRoutingDecisionChip(
 /**
  * Display form of a decision's harness.
  *
- * Sub-agent chips say `"claude"` / `"codex"`: the `-native` suffix is an
- * implementation detail of how the spawn runs, and on a spawn chip it reads
- * as noise. SDK-brain sub-agents (a bundle agent's `codex` / `claude-sdk`
- * children) carry no suffix, so they render unchanged, as do session/turn
- * chips — the session's own harness identity keeps its full id.
+ * Every chip says `"claude"` / `"codex"` whatever its scope: the `-native`
+ * suffix is an implementation detail of how the pane runs, and on a chip it
+ * reads as noise. SDK ids (a bundle agent's `codex` / `claude-sdk` children,
+ * or `auto`) carry no suffix and render unchanged.
  *
- * @param scope - Decision scope; only the sub-agent scopes are shortened.
  * @param harness - Harness id carried on the decision, when known.
  * @returns The display label, or `null` when the decision has no harness.
  */
-export function harnessDisplayLabel(
-  scope: RoutingScope | null | undefined,
-  harness: string | null | undefined,
-): string | null {
+export function harnessDisplayLabel(harness: string | null | undefined): string | null {
   const id = harness?.trim();
   if (!id) return null;
-  if (scope != null && SUBAGENT_SCOPES.has(scope)) return id.replace(/-native$/, "");
-  return id;
+  return id.replace(/-native$/, "");
 }
 
 /**

--- a/web/src/lib/routingDecision.ts
+++ b/web/src/lib/routingDecision.ts
@@ -114,6 +114,29 @@ export function showsRoutingDecisionChip(
 }
 
 /**
+ * Display form of a decision's harness.
+ *
+ * Sub-agent chips say `"claude"` / `"codex"`: the `-native` suffix is an
+ * implementation detail of how the spawn runs, and on a spawn chip it reads
+ * as noise. SDK-brain sub-agents (a bundle agent's `codex` / `claude-sdk`
+ * children) carry no suffix, so they render unchanged, as do session/turn
+ * chips — the session's own harness identity keeps its full id.
+ *
+ * @param scope - Decision scope; only the sub-agent scopes are shortened.
+ * @param harness - Harness id carried on the decision, when known.
+ * @returns The display label, or `null` when the decision has no harness.
+ */
+export function harnessDisplayLabel(
+  scope: RoutingScope | null | undefined,
+  harness: string | null | undefined,
+): string | null {
+  const id = harness?.trim();
+  if (!id) return null;
+  if (scope != null && SUBAGENT_SCOPES.has(scope)) return id.replace(/-native$/, "");
+  return id;
+}
+
+/**
  * Badge text for a sub-agent-scoped decision, e.g. `"subagent: researcher"`.
  *
  * @param scope - Decision scope; only the sub-agent scopes get a badge.

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -384,8 +384,16 @@ const elicitationBubble = (id: string, phase: string): Bubble => ({
     },
   ],
 });
+const routingChipBubble = (id: string, scope: RoutingScope): Bubble => ({
+  kind: "routing_decision",
+  itemId: id,
+  model: "databricks-claude-sonnet-5",
+  applied: true,
+  rationale: "trivial task -> cheapest arm",
+  routing: { scope },
+});
 const bubbleIds = (bubbles: Bubble[]): string[] =>
-  bubbles.map((b) => (b.kind === "user" ? b.itemId : b.kind === "assistant" ? b.stableId : ""));
+  bubbles.map((b) => (b.kind === "assistant" ? b.stableId : b.itemId));
 
 describe("mergePendingBubbles", () => {
   it("appends pending bubbles at the end when nothing trails", () => {
@@ -429,6 +437,40 @@ describe("mergePendingBubbles", () => {
       "e1",
       "e2",
     ]);
+  });
+
+  it("splices the pending prompt ABOVE a create-time routing chip", () => {
+    // A pinned Smart Routing create routes before the pane launches, so the
+    // session-scope chip is the whole committed timeline while the landing
+    // composer's prompt is still optimistic. Appending after it would show
+    // the chip above the message — and move it below a beat later, when the
+    // server persists the message and the walker pairs them.
+    const committed = [routingChipBubble("rd_create", "session")];
+    const merged = mergePendingBubbles(committed, [userBubble("pend_1")]);
+    expect(bubbleIds(merged)).toEqual(["pend_1", "rd_create"]);
+  });
+
+  it("splices above a create whose session AND turn chip both landed first", () => {
+    const committed = [
+      routingChipBubble("rd_create", "session"),
+      routingChipBubble("rd_turn", "turn"),
+    ];
+    const merged = mergePendingBubbles(committed, [userBubble("pend_1")]);
+    expect(bubbleIds(merged)).toEqual(["pend_1", "rd_create", "rd_turn"]);
+  });
+
+  it("does NOT lift a new prompt above a chip already paired with its message", () => {
+    const committed = [userBubble("u1"), routingChipBubble("rd_1", "turn")];
+    const merged = mergePendingBubbles(committed, [userBubble("pend_1")]);
+    expect(bubbleIds(merged)).toEqual(["u1", "rd_1", "pend_1"]);
+  });
+
+  it("does NOT lift a new prompt above a trailing sub-agent chip", () => {
+    // Sub-agent chips render standalone where the spawn happened — they are
+    // not a verdict on the message being typed.
+    const committed = [routingChipBubble("rd_spawn", "native_subagent")];
+    const merged = mergePendingBubbles(committed, [userBubble("pend_1")]);
+    expect(bubbleIds(merged)).toEqual(["rd_spawn", "pend_1"]);
   });
 
   it("does NOT reorder for a tool_call-phase elicitation (message already committed)", () => {
@@ -620,7 +662,14 @@ describe("stripGatedSubagentRoutingChips", () => {
     const shown = stripGatedSubagentRoutingChips(bubbles, null);
     expect(chipIds(shown)).toEqual(["rd_session", "rd_turn", "rd_legacy", "rd_child"]);
     // Everything else keeps its place and its reference (BubbleView's memo).
-    expect(bubbleIds(shown)).toEqual(["", "", "", "", "u1", "a1"]);
+    expect(bubbleIds(shown)).toEqual([
+      "rd_session",
+      "rd_turn",
+      "rd_legacy",
+      "rd_child",
+      "u1",
+      "a1",
+    ]);
   });
 
   it("hides spawn chips on an explicit off", () => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -155,7 +155,7 @@ import {
 } from "@/hooks/useWorkspaceChangedFiles";
 import { ComposerMicButton } from "@/components/ComposerMicButton";
 import { isCostRoutingSession, isSubagentRoutingSession } from "@/components/CostRoutingControl";
-import { showsRoutingDecisionChip } from "@/lib/routingDecision";
+import { isSessionScopedDecision, showsRoutingDecisionChip } from "@/lib/routingDecision";
 import {
   Dialog,
   DialogContent,
@@ -456,23 +456,48 @@ export function reorderCommittedRequestElicitations(committed: Bubble[]): Bubble
   return result ?? committed;
 }
 
+// Insertion point above a run of create-time routing chips — session-scope
+// decisions recorded before the session had any conversation, so they open
+// the committed timeline. Only a run that STARTS the timeline qualifies: a
+// chip anywhere else already sits where it belongs (below its message, or
+// standalone for a sub-agent spawn), and lifting a prompt above it would
+// reorder history.
+function liftAboveCreateRoutingChips(committed: Bubble[], end: number): number {
+  let start = end;
+  while (start > 0) {
+    const chip = committed[start - 1]!;
+    if (chip.kind !== "routing_decision" || !isSessionScopedDecision(chip.routing?.scope)) break;
+    start -= 1;
+  }
+  return start === 0 ? start : end;
+}
+
 // Place optimistic pending user bubbles into the committed timeline.
 //
 // Pending sends normally trail everything (the input should be visible
 // immediately, and they migrate into `blocks` once their
-// `session.input.consumed` event lands). The exception is a REQUEST-phase
-// policy ASK: that message never gets a consumed event until approval, so
-// it stays pending while its elicitation card renders as a committed
-// bubble — appending the pending bubble after the card would show the
-// approval prompt ABOVE the message that triggered it. When the timeline
-// ends in a run of such request-elicitation bubbles, splice the pending
-// bubbles in just before that run so the prompt stays on top.
+// `session.input.consumed` event lands). Two exceptions put committed
+// bubbles below the pending prompt:
+//
+//   • a REQUEST-phase policy ASK — that message never gets a consumed event
+//     until approval, so it stays pending while its elicitation card renders
+//     as a committed bubble, and appending after the card would show the
+//     approval prompt ABOVE the message that triggered it;
+//   • a create-time routing chip — a pinned Smart Routing create routes
+//     before the pane launches, so the chip is committed while the prompt it
+//     decides is still pending, and `buildBubbles` cannot see a pending
+//     message. Splicing above the chip renders it below the prompt from the
+//     first paint, where the persisted message will pair it anyway.
+//
+// When the timeline ends in a run of either, splice the pending bubbles in
+// just before that run so the prompt stays on top.
 export function mergePendingBubbles(committed: Bubble[], pending: Bubble[]): Bubble[] {
   if (pending.length === 0) return committed;
   let insertAt = committed.length;
   while (insertAt > 0 && isStandaloneElicitationBubble(committed[insertAt - 1]!)) {
     insertAt -= 1;
   }
+  insertAt = liftAboveCreateRoutingChips(committed, insertAt);
   if (insertAt === committed.length) return [...committed, ...pending];
   return [...committed.slice(0, insertAt), ...pending, ...committed.slice(insertAt)];
 }

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -3316,6 +3316,53 @@ describe("NewChatLandingScreen smart routing", () => {
     expect(body.reasoning_effort).toBeUndefined();
   });
 
+  // The prompt rides along on a PINNED native create too, so the server routes
+  // the model before the pane launches. Routing after the fact means holding
+  // the first prompt inside the harness and replaying it, which the user sees
+  // as their own message vanishing for seconds.
+  it.each([
+    ["Claude Code", "a1"],
+    ["Codex", "a2"],
+  ] as const)("sends the routing message on a pinned %s create", async (_label, agentId) => {
+    authenticatedFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "conv_pinned_routed" }),
+    } as unknown as Response);
+    renderLanding({ smart_routing_enabled: true });
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+    openAgentConfig(agentId);
+    pickSelectOption("new-chat-landing-config-model", "Smart Routing");
+    saveConfig();
+
+    const { body } = await submitAndReadBody("refactor the auth module");
+    expect(body.agent_id).toBe(agentId);
+    expect(body.cost_control_mode_override).toBe("on");
+    // Routes only — the real message is still delivered after navigation.
+    expect(body.smart_routing_message).toBe("refactor the auth module");
+    // The harness is the user's own pick — the bound wrapper agent names it —
+    // so only the model is routed, and nothing pins one.
+    expect(body.harness_override).not.toBe("auto");
+    expect(body.model_override).toBeUndefined();
+    expect(body.reasoning_effort).toBeUndefined();
+  });
+
+  it("sends no routing message on a pinned harness with routing off", async () => {
+    authenticatedFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "conv_pinned_plain" }),
+    } as unknown as Response);
+    renderLanding({ smart_routing_enabled: true });
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+    const { body } = await submitAndReadBody("refactor the auth module");
+    expect(body.agent_id).toBe("a1");
+    expect(body.cost_control_mode_override).toBeUndefined();
+    expect(body.smart_routing_message).toBeUndefined();
+  });
+
   // Sticky Smart Routing: the pick is remembered per harness in the same
   // localStorage store as the mode/model/effort knobs, so a returning user's
   // next session on that harness starts routed.
@@ -4444,6 +4491,9 @@ describe("NewChatLandingScreen bundle-agent Smart Routing", () => {
       expect(body.reasoning_effort).toBeUndefined();
       expect(body.labels).toBeUndefined();
       expect(body.terminal_launch_args).toBeUndefined();
+      // A bundle agent arms at create and routes on the first message event —
+      // its harness isn't decided yet, so there is nothing to route here.
+      expect(body.smart_routing_message).toBeUndefined();
       expect(raw).not.toContain("permission");
     },
   );

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -3317,6 +3317,16 @@ export function NewChatLandingScreen() {
       // sending both would silently disable routing for the whole session. Never
       // pin a model or an effort alongside routing, whatever the UI state says.
       const routingOwnsModel = costControlOverride === "on";
+      // A pinned native pane routes its MODEL at create too: the terminal
+      // launches with the session row and its turns start in the TUI, so
+      // routing after the fact means blocking the first prompt and replaying
+      // it. Sending the prompt here pins `model_override` before the pane
+      // exists. Bundle agents are excluded — they route on the first message
+      // event by design.
+      const pinnedNativeRoutes =
+        routingOwnsModel &&
+        !smartRoutingHarnessSelected &&
+        SMART_ROUTING_ARMS.some((harness) => harness === nativeAgent?.harness);
 
       // Prepend each "@"-tagged path as an attachment marker on its own line —
       // the same wording the native executors emit and that title-seeding
@@ -3481,7 +3491,8 @@ export function NewChatLandingScreen() {
             harness_override: smartRoutingHarnessSelected
               ? AUTO_HARNESS_ID
               : (pickedHarness ?? undefined),
-            smart_routing_message: smartRoutingHarnessSelected ? initialPrompt : undefined,
+            smart_routing_message:
+              smartRoutingHarnessSelected || pinnedNativeRoutes ? initialPrompt : undefined,
           }),
         });
         // The create doesn't answer until the host has spawned a runner — a


### PR DESCRIPTION
# Smart Routing follow-ups

## Summary

Follow-ups to #4074, found by manual testing after it merged. Landing them
separately so each is reviewable on its own.

**In this PR so far:**

- **A healthy route no longer loses the race with its own hook.** #4074 sized
  the first-message timeout ladder from the `routes:select` call alone, but the
  server prepares the candidate catalog *before* it calls the router — about
  three seconds on a first message. A healthy route therefore cost ~4.8s against
  a 7s relay budget that had already started, so the runner abandoned verdicts
  that did arrive: the attempt was wasted, the prompt was replayed a second
  time, and the transcript showed it twice. Each hop now covers preparation plus
  the call — hook budget at 15s, harness kill at 22s (still under Claude Code's
  own 30s `UserPromptSubmit` default), routing call at 9s. A wedged router costs
  15s, versus the 45s it cost before the ladder existed. The magnitude test
  gains a floor as well as a ceiling so a future tightening cannot re-open the
  gap.

**Also in this PR:**

- **Spawn chips say "claude" / "codex"** — the `-native` suffix is display noise
  on a spawn chip. SDK-brain sub-agents (Polly/Debby children) and the
  session's own chips are unchanged.
- **Out-of-family spawns are refused at the source** for a pinned Smart Routing
  session: other-family agents are filtered from `sys_agent_list`, and an
  out-of-family `sys_session_create` gets a 400 naming the rule. The
  routing-layer decline stays as a fail-safe. Auto-harness sessions keep
  cross-family spawns.
- **The same parent-family guard on the `route-turn` hook** (fail-open decline).
- **One router call per prompt-ful create**: the create stamps a fingerprint of
  the routed prompt, and the first in-harness message reuses that verdict
  instead of routing the same text again. An edited first prompt still routes
  fresh. This also removes the duplicated first message for that flow.
- **Catalog preparation is off the turn hot path**: prefetched when the runner
  connects, cached per session (5-minute TTL, single-flight), invalidated on
  relay teardown/rebind. Warm-cache prep is milliseconds; the ladder above can
  be re-tightened in a later change once this bakes.
- **Codex reachability check**: a routed slug missing from the pane's live
  `model/list` → no switch, a visible decline naming the reason, and the prompt
  runs on the pane's own model.
- **A failed auto-harness route no longer claims the route-once label**, so one
  create-time outage cannot leave a session permanently unrouted.
- **Credential fixes** (both pre-existing): the pane's `apiKeyHelper` and the
  server's router client now resolve the profile the provider config *names*
  (host lookup is only the fallback), and the generated helper only attempts
  `--force-refresh` speculatively, falling back to the valid cached token.
- **Create-time CLI Smart Routing is removed**: `omni run --smart-routing` and
  `-p`/`--prompt` combined with `--smart-routing` are rejected with messages
  that name the replacement (`omni claude|codex --smart-routing` routes the
  first message you type; router-picked harnesses are a web-UI create). The
  hidden `run` flag keeps rejecting until 0.11 so scripts get a real error
  instead of "no such option". Dead plumbing and its test surface went with it
  (`-1087` lines).
- **Every routing chip says `claude` / `codex`** — the `-native` suffix is
  gone from session, turn, and spawn chips alike (it was already gone from
  spawn chips); the raw harness id survives only in the chip's collapsible
  JSON drawer, which is the audit view. Harness *pickers* still show full ids —
  they select a harness rather than report a decision.
- **Auto-harness create chips render below their prompt.** An auto create
  routes twice (create picks the harness, the first turn re-checks), and when
  the two verdicts differed the create chip had no adjacent message to pair
  with, so it rendered above the prompt. The chip walker now scans past
  sibling chips waiting on the same message (never past a sub-agent chip), and
  all deferred chips attach below the message in transcript order. A
  pre-existing test had pinned the buggy order and is rewritten; new tests are
  built from captured wire rows of the failing session shape.

**Diagnosed, deliberately not fixed:** the duplicate first message on a bare
TUI launch's routed prompt is written by the harness's own transcript
forwarder before the hook can block, so suppressing it means racy
harness-specific surgery in two forwarders. The prompt-ful create flow no
longer exhibits it (see the one-router-call change).

## Test Plan

- Ladder tests updated: the magnitude test now pins both bounds (every hook
  budget must outlast a healthy route and stay at or under 15s), and the
  strictly-decreasing relation tests still hold.
- CLI: rewritten `tests/cli/test_smart_routing_cli.py` (54 tests) covers the
  rejections and drives the real `claude`/`codex` subcommands via `CliRunner`.
- Chips: vitest for the label helper and the chip walker (new auto-harness
  ordering cases replay captured wire rows frame by frame), `StatusBlocks`
  scope matrix anchored to `/^· claude$/`, and `e2e_ui` asserts session and
  spawn chips contain the short name and not `claude-native`/`codex-native`.
- Manual CUJ pass on a local stack at this tip: plain claude/codex one-shots
  (pre-PR parity), routed claude and codex TUIs (single replay, cheap-arm
  pick, chip below the prompt), in-family spawn from a routed codex session,
  auto-harness web create (one router call, chip says `codex`), and all four
  CLI rejection gates.

## Demo

Chip changes (covered by the e2e_ui assertions above): session and spawn
chips read "Smart routing · applied · claude" / "… · codex"; a benign
same-arm spawn verdict reads "advisory"; an auto-harness create chip sits
below the prompt it routed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] UI / frontend change
- [ ] Refactor
- [ ] Documentation

## Test coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual verification completed

## Coverage notes

The ladder regression was found by manual TUI testing: the routed verdict
arrived about one second after the runner gave up, visible in the server and
runner logs of one session. The fix is pinned by tests against the constants
rather than wall-clock timing.

This pull request and its description were written by Isaac.
