### PR TITLE
fix(web): open a new session on the stream's announcement, not the create

### DIFF
--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -721,6 +721,148 @@ async def _drive_send_busy_spinner(base_url: str, session_id: str) -> None:
             await browser.close()
 
 
+def test_start_session_opens_before_the_create_responds(seeded_session: tuple[str, str]) -> None:
+    """Send opens the session on the stream's announcement, not the response.
+
+    ``POST /v1/sessions`` doesn't answer until the host has finished spawning a
+    runner — a process boot, seconds of it — and the landing screen used to sit
+    on that whole wait before routing anywhere. But the server writes the
+    session row and announces it on ``WS /v1/sessions/updates`` almost
+    immediately, so the id is available long before the response is. This holds
+    the create POST open for the entire test and announces the session over the
+    stream: the chat page must open anyway.
+
+    A regression that goes back to awaiting the response would never leave the
+    landing screen here, since the create never answers.
+
+    The announcement is injected through a mocked updates socket rather than a
+    real create, because this suite has no host daemon for a host-bound create
+    to actually succeed against. The row carries the stubbed agent/host the
+    composer just asked for — that pairing is what the screen matches on to
+    tell its own new session apart from every other session the stream
+    announces to this user.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_open_before_create_responds(base_url, session_id))
+
+
+async def _drive_open_before_create_responds(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_seen = asyncio.Event()
+            # Released only at teardown, so the create is pending for every
+            # assertion below.
+            release_create = asyncio.Event()
+            sockets: list[Any] = []
+
+            def handle_updates(ws: Any) -> None:
+                # Mocked (never connected to the server), so this test owns
+                # exactly what the page receives on the stream.
+                sockets.append(ws)
+
+            await page.route_web_socket(re.compile(r"/v1/sessions/updates"), handle_updates)
+
+            async def handle_hosts(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_hosts_body()
+                )
+
+            async def handle_agents(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_agents_body()
+                )
+
+            async def handle_events(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"queued": True, "item_id": "ci_e2e"}),
+                )
+
+            async def handle_sessions(route: Route) -> None:
+                if route.request.method == "POST":
+                    create_seen.set()
+                    await release_create.wait()
+                    await route.fulfill(
+                        status=200,
+                        content_type="application/json",
+                        body=json.dumps({"id": session_id}),
+                    )
+                else:
+                    await route.continue_()
+
+            await page.route("**/v1/hosts", handle_hosts)
+            await page.route("**/v1/agents", handle_agents)
+            await page.route("**/v1/sessions/*/events", handle_events)
+            await page.route(_SESSIONS_RE, handle_sessions)
+
+            async def handle_agent_scan(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"data": []}),
+                )
+
+            await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+            await _wait_until(lambda: len(sockets) == 1)
+
+            await page.get_by_test_id("new-chat-landing-input").fill("set up the project")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+            # The create is in flight and will stay that way.
+            await _wait_until(create_seen.is_set)
+
+            # A brand-new session the page has never seen, on the agent and
+            # host the composer just asked for: the server's announcement of
+            # the row it wrote before starting the runner.
+            announced_id = "conv_announced_e2e"
+            sockets[0].send(
+                json.dumps(
+                    {
+                        "type": "changed",
+                        "items": [
+                            {
+                                "id": announced_id,
+                                "object": "conversation",
+                                "agent_id": "ag_claude_e2e",
+                                "host_id": _HOST_ID,
+                                "parent_session_id": None,
+                                "title": None,
+                                "created_at": 1_800_000_000,
+                                "updated_at": 1_800_000_000,
+                                "labels": {},
+                                "archived": False,
+                            }
+                        ],
+                    }
+                )
+            )
+
+            # KEY ASSERTION: routed to the announced session while the create
+            # is still pending — the landing composer is gone and the URL is
+            # the announced id, not the one the (unanswered) create would
+            # eventually return.
+            await expect(page).to_have_url(f"{base_url}/c/{announced_id}", timeout=20_000)
+            await expect(page.get_by_test_id("new-chat-landing-input")).to_have_count(0)
+            assert not release_create.is_set(), "the create must still be unanswered here"
+        finally:
+            release_create.set()
+            await browser.close()
+
+
 def test_start_session_remembers_last_picked_host(seeded_session: tuple[str, str]) -> None:
     """The host chip restores the last explicitly-picked host after a reload.
 

--- a/web/src/lib/sessionUpdatesSocket.test.ts
+++ b/web/src/lib/sessionUpdatesSocket.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { HEARTBEAT_WATCHDOG_MS, sessionUpdatesSocket } from "./sessionUpdatesSocket";
+import {
+  HEARTBEAT_WATCHDOG_MS,
+  nextPushedSession,
+  sessionUpdatesSocket,
+} from "./sessionUpdatesSocket";
 
 // Minimal stand-in for the browser WebSocket: records sends/closes and lets
 // the test drive the lifecycle (open, message) by hand. A real socket can't be
@@ -121,3 +125,47 @@ describe("sessionUpdatesSocket heartbeat watchdog", () => {
 // Reconnect backoff is capped at 5 s + jitter; advancing past 5 s guarantees
 // the scheduled reconnect timer has fired regardless of the random jitter.
 const RECONNECT_CEILING_MS = 5_001;
+
+describe("nextPushedSession", () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
+  });
+
+  afterEach(() => {
+    sessionUpdatesSocket.stop();
+    vi.unstubAllGlobals();
+  });
+
+  it("waits for the row the caller is expecting, not merely the next new one", async () => {
+    sessionUpdatesSocket.start();
+    const ws = latestWs();
+    ws.open();
+    const abort = new AbortController();
+    const mine = nextPushedSession((item) => item.id === "conv_mine", abort.signal);
+
+    // A session the caller didn't create lands first — another tab, a
+    // scheduled task, one just shared with them. The stream announces those
+    // identically, so settling on "something new arrived" would hand back the
+    // wrong conversation (and the caller's first message with it).
+    ws.emit({ type: "changed", items: [{ id: "conv_theirs" }] });
+    ws.emit({ type: "changed", items: [{ id: "conv_mine", agent_id: "ag_1" }] });
+
+    await expect(mine).resolves.toMatchObject({ id: "conv_mine", agent_id: "ag_1" });
+  });
+
+  it("resolves null once aborted so the caller falls back to its own result", async () => {
+    sessionUpdatesSocket.start();
+    latestWs().open();
+    const abort = new AbortController();
+    const mine = nextPushedSession(() => true, abort.signal);
+
+    abort.abort();
+    await expect(mine).resolves.toBeNull();
+
+    // Settled for good: a late frame must not revive it, or a caller that
+    // already committed to the authoritative id would be handed a second one.
+    latestWs().emit({ type: "changed", items: [{ id: "conv_late" }] });
+    await expect(mine).resolves.toBeNull();
+  });
+});

--- a/web/src/lib/sessionUpdatesSocket.ts
+++ b/web/src/lib/sessionUpdatesSocket.ts
@@ -264,3 +264,46 @@ class SessionUpdatesSocket {
 
 /** Shared transport instance for the current tab. */
 export const sessionUpdatesSocket = new SessionUpdatesSocket();
+
+/**
+ * Resolve with the first pushed session row matching `match`.
+ *
+ * The server announces a session on this stream as soon as its row is
+ * written — well before a `POST /v1/sessions` that waits on a host runner
+ * launch answers with the same id. A caller that knows what it just asked
+ * for can use this to learn its own session's id early and open the chat
+ * without waiting for the create.
+ *
+ * The stream carries EVERY session that becomes visible to this user —
+ * created in another tab, started by a scheduled task, or just shared with
+ * them — and restates rows already on screen on each snapshot. So `match`
+ * must identify one specific expected session; "anything new" would hand
+ * back somebody else's.
+ *
+ * @param match - Predicate over each row of a snapshot/changed frame.
+ * @param signal - Stops listening when aborted, resolving `null` so the
+ *   caller can fall back to its own result.
+ * @returns The first matching row, or `null` if aborted before one arrived.
+ */
+export function nextPushedSession(
+  match: (item: SessionListWireItem) => boolean,
+  signal: AbortSignal,
+): Promise<SessionListWireItem | null> {
+  if (signal.aborted) return Promise.resolve(null);
+  return new Promise((resolve) => {
+    let unsubscribe = () => {};
+    const onAbort = () => {
+      unsubscribe();
+      resolve(null);
+    };
+    unsubscribe = sessionUpdatesSocket.subscribe((frame) => {
+      if (frame.type !== "snapshot" && frame.type !== "changed") return;
+      const found = frame.items.find(match);
+      if (found === undefined) return;
+      unsubscribe();
+      signal.removeEventListener("abort", onAbort);
+      resolve(found);
+    });
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -1,5 +1,6 @@
 import type * as UseConversationsModule from "@/hooks/useConversations";
 import type * as AgentLabelsModule from "@/lib/agentLabels";
+import type { SessionListWireItem } from "@/lib/sessionListCache";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -49,6 +50,27 @@ vi.mock("@/lib/routing", () => ({
 // (keyed by conversation id), not router state — assert on that call.
 vi.mock("@/store/chatStore", () => ({
   setPendingInitialPrompt: (...args: unknown[]) => setPendingInitialPromptMock(...args),
+}));
+
+// The create races the POST against the updates stream's announcement of the
+// new session row. Stub the stream so a test decides when (and with what row)
+// that announcement lands, and can inspect the matcher the screen built to
+// tell its own session apart from everything else the stream pushes.
+const pushMatchers: ((item: SessionListWireItem) => boolean)[] = [];
+let announcePushedSession: ((row: SessionListWireItem | null) => void) | null = null;
+vi.mock("@/lib/sessionUpdatesSocket", () => ({
+  nextPushedSession: (match: (item: SessionListWireItem) => boolean, signal: AbortSignal) => {
+    pushMatchers.push(match);
+    return new Promise<SessionListWireItem | null>((resolve) => {
+      announcePushedSession = resolve;
+      signal.addEventListener("abort", () => resolve(null), { once: true });
+    });
+  },
+  // Inert transport for anything else in the tree that observes connectivity.
+  sessionUpdatesSocket: {
+    subscribeStatus: () => () => {},
+    isConnected: () => true,
+  },
 }));
 
 vi.mock("@/lib/identity", () => ({ authenticatedFetch: vi.fn() }));
@@ -144,10 +166,26 @@ function setAgents(agents: AvailableAgent[]): void {
   >);
 }
 
-function renderLanding(): void {
+function renderLanding(cachedSessionIds: string[] = []): void {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
+  if (cachedSessionIds.length > 0) {
+    // Sessions already on screen when the create starts. "Never seen by this
+    // tab" is part of how the screen recognizes its own announced row, so the
+    // case that covers that seeds the cache the check reads.
+    client.setQueryData(["conversations", "", false], {
+      pages: [
+        {
+          data: cachedSessionIds.map((id) => ({ id })),
+          first_id: cachedSessionIds[0],
+          last_id: cachedSessionIds.at(-1),
+          has_more: false,
+        },
+      ],
+      pageParams: [undefined],
+    });
+  }
   function Wrapper({ children }: { children: ReactNode }) {
     return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
   }
@@ -220,6 +258,8 @@ function saveConfig(): void {
 beforeEach(() => {
   navigateMock.mockReset();
   setPendingInitialPromptMock.mockReset();
+  pushMatchers.length = 0;
+  announcePushedSession = null;
   vi.mocked(authenticatedFetch).mockReset();
   // Clear the module-level landing draft so a base branch (or other field)
   // left behind by an unmounting test doesn't seed the next one.
@@ -268,6 +308,64 @@ describe("NewChatLandingScreen create flow", () => {
 
     // On success the screen routes to the freshly created session.
     await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_new"));
+  });
+
+  it("opens the session on the stream's announcement instead of waiting for the create", async () => {
+    // POST /v1/sessions doesn't answer until the host has spawned a runner — a
+    // process boot, seconds of it — but the session row exists, and is
+    // announced on the updates stream, almost immediately. Hold the POST open
+    // for the whole test: if the screen still routes, it routed on the
+    // announcement, which is the entire point.
+    vi.mocked(authenticatedFetch).mockReturnValueOnce(
+      new Promise<Response>(() => {}) as ReturnType<typeof authenticatedFetch>,
+    );
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    typeMessage("inspect the repo");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    await waitFor(() => expect(announcePushedSession).not.toBeNull());
+    act(() => announcePushedSession?.({ id: "conv_pushed" }));
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_pushed"));
+    // The first message is handed off under the same id. That coupling is why
+    // the id has to be RIGHT and not merely early — a wrong one would post the
+    // user's message into somebody else's conversation.
+    expect(setPendingInitialPromptMock).toHaveBeenCalledWith(
+      "conv_pushed",
+      expect.objectContaining({ text: "inspect the repo" }),
+    );
+  });
+
+  it("recognizes only the session it just asked for among the stream's pushes", async () => {
+    vi.mocked(authenticatedFetch).mockReturnValueOnce(
+      new Promise<Response>(() => {}) as ReturnType<typeof authenticatedFetch>,
+    );
+
+    renderLanding(["conv_existing"]);
+    await waitForWorkspaceSeed();
+    typeMessage("inspect the repo");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    await waitFor(() => expect(pushMatchers).toHaveLength(1));
+    const isOurs = pushMatchers[0]!;
+    const ours: SessionListWireItem = {
+      id: "conv_mine",
+      agent_id: "ag_hello",
+      host_id: "host_1",
+    };
+    expect(isOurs(ours)).toBe(true);
+
+    // The stream announces every session that becomes visible to this user and
+    // restates the ones already on screen, so each of these would otherwise be
+    // mistaken for the create's own row: a session started elsewhere on another
+    // agent or host, a sub-agent child (never what a create returns), and a row
+    // this tab was already showing.
+    expect(isOurs({ ...ours, agent_id: "ag_other" })).toBe(false);
+    expect(isOurs({ ...ours, host_id: "host_2" })).toBe(false);
+    expect(isOurs({ ...ours, parent_session_id: "conv_parent" })).toBe(false);
+    expect(isOurs({ ...ours, id: "conv_existing" })).toBe(false);
   });
 
   it("shows a busy spinner on the submit button while the create is in flight", async () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -154,6 +154,12 @@ import {
   moveConversationToProject,
   PROJECT_LABEL_KEY,
 } from "@/hooks/useConversations";
+import {
+  collectConversationIds,
+  type ConversationsInfiniteData,
+  type SessionListWireItem,
+} from "@/lib/sessionListCache";
+import { nextPushedSession } from "@/lib/sessionUpdatesSocket";
 import { FileMentionMenu } from "@/components/FileMentionMenu";
 import { useMentionBrowser } from "@/hooks/useMentionBrowser";
 import {
@@ -3003,7 +3009,33 @@ export function NewChatLandingScreen() {
         setPendingAgent(null);
       } else {
         // Normal path: bind to an existing registered agent.
-        const res = await authenticatedFetch("/v1/sessions", {
+        // Which pushed row is ours: the one this tab has never seen, bound
+        // to the agent and host we're about to ask for. Sub-agent children
+        // are never a create's result. Snapshotting the known ids BEFORE
+        // the POST is what makes "never seen" mean "created by this call".
+        const knownSessionIds = new Set(
+          collectConversationIds(
+            [
+              ...queryClient.getQueriesData<ConversationsInfiniteData>({
+                queryKey: ["conversations"],
+              }),
+              ...queryClient.getQueriesData<ConversationsInfiniteData>({
+                queryKey: ["project-sessions"],
+              }),
+            ].map(([, cached]) => cached),
+          ),
+        );
+        // A sandbox create has no host to match on until the sandbox
+        // registers one, so it waits for the response like before.
+        const matchOwnCreate =
+          sandboxSelected || !selectedHostId
+            ? null
+            : (item: SessionListWireItem) =>
+                !knownSessionIds.has(item.id) &&
+                item.parent_session_id == null &&
+                item.agent_id === effectiveAgentId &&
+                item.host_id === selectedHostId;
+        const createRequest = authenticatedFetch("/v1/sessions", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -3064,11 +3096,40 @@ export function NewChatLandingScreen() {
             harness_override: pickedHarness ?? undefined,
           }),
         });
-        if (!res.ok) {
-          setCreateError(await describeCreateError(res));
+        // The create doesn't answer until the host has spawned a runner — a
+        // process boot, seconds of it — but the session row exists (and is
+        // announced on the updates stream) almost immediately. Open the chat
+        // on whichever id lands first: the pushed row typically wins by
+        // seconds, and the chat page renders from the id alone, showing its
+        // own starting spinner while the runner comes up.
+        const abortPush = new AbortController();
+        const pushedRow =
+          matchOwnCreate === null
+            ? Promise.resolve(null)
+            : nextPushedSession(matchOwnCreate, abortPush.signal);
+        const confirmed = (async (): Promise<{ id: string } | { error: string }> => {
+          const response = await createRequest;
+          if (!response.ok) return { error: await describeCreateError(response) };
+          return { id: ((await response.json()) as { id: string }).id };
+        })();
+        // Once the create answers, its id is authoritative — stop listening.
+        void confirmed.finally(() => abortPush.abort()).catch(() => {});
+        const created = await new Promise<{ id: string } | { error: string }>((resolve, reject) => {
+          // Only a match settles this; an abort resolves null and leaves the
+          // response to decide.
+          void pushedRow.then((row) => {
+            if (row !== null) resolve({ id: row.id });
+          });
+          confirmed.then(resolve, reject);
+        });
+        // A row is only written (and announced) after the create has validated
+        // the workspace and agent, so winning on the push can't skip past an
+        // error the user needed to see on this screen.
+        if ("error" in created) {
+          setCreateError(created.error);
           return;
         }
-        data = (await res.json()) as { id: string };
+        data = { id: created.id };
       }
       // Promote the born-filed session to first-class project membership. The
       // create above already stamped the `omni_project` label (so the row


### PR DESCRIPTION
## Related issue

N/A

## Summary

Hitting **Send** on the landing screen left the user staring at it for seconds
before the session page opened.

`POST /v1/sessions` doesn't answer until the host has finished **spawning a
runner** — a Python process boot, not a round-trip — and the screen navigated on
that response. But the server writes the session row and announces it on
`WS /v1/sessions/updates` almost immediately, so the id the UI is blocked on is
available long before the response carries it.

This takes the id from whichever arrives first. The chat page renders from the id
alone, so it opens right away and shows its own starting spinner while the runner
comes up.

```
before   Send ──▶ POST ──────────[host spawns runner]──────────▶ id ──▶ open
after    Send ──▶ POST ──▶ announced ──▶ open
                     └────[host spawns runner]────▶ (response ignored)
```

**The announcement can't be taken at face value.** The stream carries *every*
session that becomes visible to this user — created in another tab, started by a
scheduled task, just shared with them — and nothing ties a row back to this
create. The id isn't only the URL either: it keys the first-message handoff
(`setPendingInitialPrompt`), so a wrong one would post the user's typed message
into somebody else's conversation. So the screen matches the announced row
against what it just asked for — **never seen by this tab, no
`parent_session_id`, same `agent_id`, same `host_id`** — and falls back to the
response when it can't decide. The managed-sandbox path has no host to match on
until the sandbox registers one, so it waits exactly as before.

**Winning on the announcement can't skip an error the user needed to see.** The
workspace and agent are validated *before* `create_conversation`, so a row
existing (and being announced) means the create already passed the checks that
produce a landing-screen error.

UI-only — no server change.

## Test Plan

- `pnpm --filter web exec vitest run` — full web suite green (**5016 passed**).
- Two new unit cases in the existing suites, both verified to **fail without the
  fix**: the landing screen routes (and hands off the first message) on the
  announcement while the POST is held open forever, and the matcher it builds
  accepts only its own row — rejecting a different agent, a different host, a
  sub-agent child, and a row already on screen.
- Two new cases in `sessionUpdatesSocket.test.ts` covering the transport helper:
  it waits for the expected row rather than the next new one, and stays settled
  after abort.
- New e2e_ui case `test_start_session_opens_before_the_create_responds`: holds
  the create POST open for the whole test and announces the session over a
  mocked updates socket — the chat page must open anyway.
- `pre-commit run --files …` — clean.
- End-to-end against a real local server + host + Chromium, on **stock server
  code**, timing the Send click to the session page opening.

## Demo

Click → session page open, same machine, same build, measured with a fresh
working directory per run:

| | page opens | create POST resolves |
|---|---|---|
| before | 1862 / 2008 / 7664 ms | 1849 / 1986 / 7656 ms |
| after | **92 / 95 / 124 / 160 / 202 ms** | still in flight |

Before, page-open tracks the POST to within ~20 ms — that's the gate. After, the
page is open while the create is still running.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the latency measurement above: a local server with a
connected host, the built SPA, and Playwright timing the session page opening
against the create POST. That depends on a live push stream and a real runner
launch, which the unit suites deliberately mock, so the placement and matching
logic is covered by the new unit tests and the timing was confirmed by hand.

The new e2e_ui case could not be executed locally — this machine is saturated
(~290 stray processes from unrelated sessions) and the e2e_ui fixtures fail to
boot their server / mock LLM regardless of this change. CI runs it on clean
infrastructure.

## Changelog

[UI] New sessions open right away instead of waiting for the runner to start
