### PR TITLE
fix(ci): only count an asserted reference to an open issue

### DIFF
--- a/.github/workflows/pr-issue-link.js
+++ b/.github/workflows/pr-issue-link.js
@@ -62,14 +62,46 @@ const DECLARED_TRACKED_TYPE = /- \[[xX]\]\s*(?:Bug fix|Feature|UI \/ frontend ch
 const TRACKING_REFERENCE =
   /\b(?:part of|related to|towards?|refs?|references?|see(?:\s+also)?)\b[:\s]*(?:https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/(\d+)|(?:[\w.-]+\/[\w.-]+)?#(\d+))/gi;
 
+// Strips text that is being shown rather than asserted: fenced code blocks and
+// blockquoted lines. Without this, a PR that quotes documentation containing
+// "Part of #123" satisfies its own rule, which happened on the first live run.
+function assertedText(body) {
+  return (body ?? "")
+    .replace(/```[\s\S]*?(?:```|$)/g, "")
+    .replace(/~~~[\s\S]*?(?:~~~|$)/g, "")
+    .split("\n")
+    .filter((line) => !/^\s*>/.test(line))
+    .join("\n");
+}
+
 // Issue numbers a body claims to be working towards, deduped and in order.
 function trackingReferences(body) {
   const seen = [];
-  for (const m of (body ?? "").matchAll(TRACKING_REFERENCE)) {
+  for (const m of assertedText(body).matchAll(TRACKING_REFERENCE)) {
     const n = Number(m[1] ?? m[2]);
     if (n && !seen.includes(n)) seen.push(n);
   }
   return seen;
+}
+
+// Resolve one reference: is it an OPEN, non-draft issue in this repo?
+//
+// Shared so the nudge and the ready-for-review gate cannot drift on what counts.
+//   - a pull request is not a tracking record
+//   - a closed issue is not tracked work
+//   - a draft issue is not agreed work yet
+// Returns false when the number cannot be resolved: unverifiable is not evidence.
+async function resolvesToOpenIssue({ github, core, owner, repo, number }) {
+  try {
+    const { data } = await github.rest.issues.get({ owner, repo, issue_number: number });
+    if (data.pull_request) return false;
+    if (data.state !== "open") return false;
+    if (data.draft) return false;
+    return true;
+  } catch (err) {
+    core?.warning?.(`Could not resolve #${number}: ${err.message}`);
+    return false;
+  }
 }
 
 const QUERY = `
@@ -237,23 +269,13 @@ module.exports = async ({ context, github, core }) => {
       }
 
       // No closing link, but the body may still name the issue it works towards.
-      // Each candidate is resolved, because "Refs #4147" often points at another
-      // PR, and a PR is not the tracking record this rule is asking for.
+      // Each candidate is resolved: "Refs #4147" often points at another PR, and a
+      // closed or draft issue is not tracked work.
       let tracked = null;
       for (const candidate of trackingReferences(pr.body)) {
-        try {
-          const { data } = await github.rest.issues.get({
-            owner,
-            repo,
-            issue_number: candidate,
-          });
-          if (!data.pull_request) {
-            tracked = candidate;
-            break;
-          }
-        } catch (err) {
-          // A number that doesn't resolve proves nothing either way; try the next.
-          core.warning(`Could not resolve #${candidate} from #${pr.number}: ${err.message}`);
+        if (await resolvesToOpenIssue({ github, core, owner, repo, number: candidate })) {
+          tracked = candidate;
+          break;
         }
       }
       if (tracked) {
@@ -333,5 +355,7 @@ module.exports = async ({ context, github, core }) => {
 // Exported for the offline unit test.
 module.exports.exemptReason = exemptReason;
 module.exports.trackingReferences = trackingReferences;
+module.exports.assertedText = assertedText;
+module.exports.resolvesToOpenIssue = resolvesToOpenIssue;
 module.exports.MARKER = MARKER;
 module.exports.EFFECTIVE_FROM = EFFECTIVE_FROM;

--- a/.github/workflows/pr-issue-link.test.js
+++ b/.github/workflows/pr-issue-link.test.js
@@ -92,7 +92,11 @@ async function run(
             err.status = 404;
             throw err;
           }
-          return { data: kind === "pr" ? { pull_request: {} } : {} };
+          // "issue" (open), "closed", "draft", or "pr".
+          if (kind === "pr") return { data: { pull_request: {}, state: "open" } };
+          if (kind === "closed") return { data: { state: "closed" } };
+          if (kind === "draft") return { data: { state: "open", draft: true } };
+          return { data: { state: "open" } };
         },
       },
     },
@@ -232,6 +236,14 @@ for (const tracked of ["Bug fix", "Feature", "UI / frontend change"]) {
   assert.deepStrictEqual(refs("this fixes the thing generally"), [], "prose does not count");
   assert.deepStrictEqual(refs(""), [], "empty body");
   assert.deepStrictEqual(refs(undefined), [], "missing body");
+  // Quoted and fenced text is shown, not asserted.
+  assert.deepStrictEqual(refs("> Part of #123"), [], "blockquote excluded");
+  assert.deepStrictEqual(refs("  > - `Part of #123` example"), [], "indented blockquote excluded");
+  assert.deepStrictEqual(refs("```\nPart of #123\n```"), [], "fenced block excluded");
+  assert.deepStrictEqual(refs("~~~\nRefs #123\n~~~"), [], "tilde fence excluded");
+  assert.deepStrictEqual(refs("> quoted #9\n\nPart of #7"), [7], "keeps the asserted one");
+  // An unterminated fence swallows the rest, which is the safe direction.
+  assert.deepStrictEqual(refs("```\nPart of #5"), [], "unterminated fence excluded");
 }
 
 // ---- end-to-end behaviour ----
@@ -278,14 +290,45 @@ for (const tracked of ["Bug fix", "Feature", "UI / frontend change"]) {
     assert.strictEqual(commented.length, 0, `${kw} must satisfy the rule`);
   }
 
-  // ...but only when it resolves to an issue. "Refs #4147" pointing at another PR
-  // is not a tracking record, and three real backlog PRs do exactly this.
-  {
+  // ...but only when it resolves to an OPEN, non-draft issue.
+  for (const [kind, why] of [
+    ["pr", "a reference to a PR does not count"],
+    ["closed", "a closed issue is not tracked work"],
+    ["draft", "a draft issue is not agreed work yet"],
+  ]) {
     const { commented } = await run([pr({ number: 51, body: "Refs #88" })], {
       env: ENFORCE,
-      issues: { 88: "pr" },
+      issues: { 88: kind },
     });
-    assert.strictEqual(commented.length, 1, "a reference to a PR does not count");
+    assert.strictEqual(commented.length, 1, why);
+  }
+
+  // Quoted or fenced text is shown, not asserted. A PR that documents the bot's
+  // own comment must not satisfy its own rule -- this fired on a real PR.
+  {
+    const quoted = "See the wording:\n\n> - `Part of #77` if this is one step towards it.\n";
+    const { commented } = await run([pr({ number: 54, body: quoted })], {
+      env: ENFORCE,
+      issues: { 77: "issue" },
+    });
+    assert.strictEqual(commented.length, 1, "a blockquoted example does not count");
+  }
+  {
+    const fenced = "Example:\n\n```\nPart of #77\n```\n";
+    const { commented } = await run([pr({ number: 55, body: fenced })], {
+      env: ENFORCE,
+      issues: { 77: "issue" },
+    });
+    assert.strictEqual(commented.length, 1, "a fenced example does not count");
+  }
+  // A real reference alongside a quoted one still counts.
+  {
+    const both = "> quoting `Part of #99` here\n\nPart of #77\n";
+    const { commented } = await run([pr({ number: 56, body: both })], {
+      env: ENFORCE,
+      issues: { 77: "issue", 99: "issue" },
+    });
+    assert.strictEqual(commented.length, 0, "an asserted reference still counts");
   }
 
   // A bare mention is a cross-reference, not a claim about this PR.

--- a/.github/workflows/ready-for-review.js
+++ b/.github/workflows/ready-for-review.js
@@ -92,11 +92,8 @@ async function referencesIssue({ github, core, owner, repo, pr }) {
     return false;
   }
   for (const candidate of issueLink.trackingReferences(pr.body)) {
-    try {
-      const { data } = await github.rest.issues.get({ owner, repo, issue_number: candidate });
-      if (!data.pull_request) return true;
-    } catch {
-      // A number that does not resolve proves nothing; try the next.
+    if (await issueLink.resolvesToOpenIssue({ github, core, owner, repo, number: candidate })) {
+      return true;
     }
   }
   return false;

--- a/.github/workflows/ready-for-review.test.js
+++ b/.github/workflows/ready-for-review.test.js
@@ -79,7 +79,11 @@ async function run(
             err.status = 404;
             throw err;
           }
-          return { data: kind === "pr" ? { pull_request: {} } : {} };
+          // "issue" (open), "closed", "draft", or "pr".
+          if (kind === "pr") return { data: { pull_request: {}, state: "open" } };
+          if (kind === "closed") return { data: { state: "closed" } };
+          if (kind === "draft") return { data: { state: "open", draft: true } };
+          return { data: { state: "open" } };
         },
       },
     },
@@ -119,14 +123,28 @@ const verdictOf = (rows, n) => (rows.find((r) => r[0] === `#${n}`) || [])[1];
     assert.strictEqual(labeled.length, 1, "Part of #N clears the bar");
   }
 
-  // A reference to another PR is not a tracking record.
-  {
+  // A reference must resolve to an OPEN, non-draft issue. Shares the resolver
+  // with the nudge, so the two cannot disagree about what counts.
+  for (const [kind, why] of [
+    ["pr", "a PR is not a tracking record"],
+    ["closed", "a closed issue is not tracked work"],
+    ["draft", "a draft issue is not agreed work yet"],
+  ]) {
     const { labeled, rows } = await run([pr({ number: 12, body: "Refs #88" })], {
-      issues: { 88: "pr" },
+      issues: { 88: kind },
       env: ENFORCE,
     });
-    assert.strictEqual(labeled.length, 0);
+    assert.strictEqual(labeled.length, 0, why);
     assert.strictEqual(verdictOf(rows, 12), "below bar");
+  }
+
+  // A quoted example must not clear the bar either.
+  {
+    const { labeled } = await run(
+      [pr({ number: 121, body: "> - `Part of #77` if this is one step towards it." })],
+      { issues: { 77: "issue" }, env: ENFORCE }
+    );
+    assert.strictEqual(labeled.length, 0, "a blockquoted example does not clear the bar");
   }
 
   // No reference at all: below the bar.


### PR DESCRIPTION
## Related issue

Part of OMNI-2214. Fixes two holes in the issue rule found by the first live run of
the ready-for-review gate; this PR declares **Test / CI** below, which is one of
the exempt types.

## Summary

Two ways a PR could satisfy the issue requirement without tracking any work.
Neither is hypothetical: both fired on real PRs.

### Quoted text counted as a reference

#4180 documents the bot's own comment, including this line inside a blockquote:

> - `Part of #123` if this is one step towards it.

`#123` is a real issue in this repo, so the parser resolved it and the PR satisfied
its own rule. Fenced code blocks had the same hole.

Blockquoted lines and fenced blocks are now stripped before scanning, because
quoted text is being *shown*, not asserted. An unterminated fence swallows the rest
of the body, which is the safe direction. A real reference alongside a quoted one
still counts.

### Closed and draft issues counted

The resolver only checked that the target was not a pull request. A closed issue is
not tracked work and a draft issue is not agreed work yet, so both are now rejected.

### One resolver instead of two

`ready-for-review.js` carried its own copy of the resolution that tested only
`.pull_request`, which is exactly how the gate and the nudge would drift on what
counts. Both now call the shared `resolvesToOpenIssue`.

**Worth knowing:** this drops #4095 from the ready set. Its `Refs #3644` points at
an issue that has since closed, so under the stricter rule it no longer qualifies.
The live READY count will fall from 5 to about 3.

## Test Plan

- `node .github/workflows/pr-issue-link.test.js` and
  `node .github/workflows/ready-for-review.test.js` both pass.
- New coverage in both suites: a reference to a **PR**, a **closed** issue, and a
  **draft** issue are each rejected; a blockquoted example and a fenced example are
  rejected; an asserted reference alongside a quoted one still counts.
- Six parser assertions for quote and fence stripping, including the indented
  blockquote and unterminated fence forms.
- **Verified against the live PRs that exposed this:**

  ```
  #4180 (quoted example)   refs after stripping: []
  #4095 (real Refs #3644)  #3644 state=closed -> counts=false
  #123  (closed issue)     counts=false
  ```

## Demo

N/A. CI predicate, no user-visible UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added or updated
- [ ] Integration / E2E tests added or updated
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

Unit tests cover both holes and the shared resolver. Manual verification was
running the fixed resolver against the three live cases above.
