### PR TITLE
feat(cli): route host-scoped requests to the replica holding the host's tunnel

### DIFF
--- a/omnigent/antigravity_native.py
+++ b/omnigent/antigravity_native.py
@@ -75,7 +75,6 @@ from tempfile import TemporaryDirectory
 import click
 import httpx
 import yaml
-from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_resume_hint
 from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
@@ -131,6 +130,7 @@ from omnigent.entities.session_resources import terminal_resource_id
 from omnigent.host.daemon_launch import (
     error_text,
     launch_or_reuse_daemon_runner,
+    open_daemon_client,
     wait_for_host_online,
     wait_for_runner_online,
 )
@@ -479,7 +479,11 @@ def _run_with_remote_server(
     from omnigent.cli import _ensure_host_daemon
     from omnigent.host.identity import load_or_create_host_identity
 
-    headers = _remote_headers(server_url=base_url)
+    # This machine's host id keys the WebSocket attach handshake (and its
+    # reconnects) to the replica holding the runner's tunnel; the CLI can set WS
+    # headers, so it rides the header (emitted only on a host-sharded deployment).
+    host_id = load_or_create_host_identity().host_id
+    headers = _remote_headers(server_url=base_url, host_id=host_id)
     try:
         resolved_session_id = _resolve_session_id_for_resume(
             base_url=base_url,
@@ -499,7 +503,6 @@ def _run_with_remote_server(
             with runner_startup_progress(initial_message="Preparing Antigravity...") as progress:
                 progress.update("Connecting to local daemon...")
                 _ensure_host_daemon(base_url)
-                host_id = load_or_create_host_identity().host_id
                 bundle = None if resolved_session_id is not None else _bundle_agent(spec_path)
                 prepared = await _prepare_antigravity_terminal_via_daemon(
                     base_url=base_url,
@@ -529,7 +532,7 @@ def _run_with_remote_server(
 
                 :returns: None.
                 """
-                new_headers = _remote_headers(server_url=base_url)
+                new_headers = _remote_headers(server_url=base_url, host_id=host_id)
                 headers.clear()
                 headers.update(new_headers)
 
@@ -590,12 +593,9 @@ async def _prepare_antigravity_terminal(
     :raises click.ClickException: If any server operation fails.
     """
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(
-        base_url=base_url,
-        headers=headers,
-        timeout=timeout,
-        trust_env=not is_loopback_url(base_url),
-    ) as client:
+    from omnigent.cli_auth import open_server_client
+
+    async with open_server_client(base_url, headers=headers, timeout=timeout) as client:
         bridge_id: str
         conversation_id: str
         resume = False
@@ -787,12 +787,7 @@ async def _prepare_antigravity_terminal_via_daemon(
     :raises click.ClickException: If setup fails.
     """
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(
-        base_url=base_url,
-        headers=headers,
-        timeout=timeout,
-        trust_env=not is_loopback_url(base_url),
-    ) as client:
+    async with open_daemon_client(base_url, headers, host_id, timeout=timeout) as client:
         bridge_id: str
         conversation_id: str
         resume = False
@@ -1622,10 +1617,11 @@ async def _close_antigravity_terminal(
     :param terminal_id: Terminal resource id.
     :returns: None.
     """
+    from omnigent.cli_auth import open_server_client
+
     try:
-        async with httpx.AsyncClient(
-            base_url=base_url,
-            trust_env=not is_loopback_url(base_url),
+        async with open_server_client(
+            base_url,
             headers=headers,
             timeout=httpx.Timeout(10.0),
         ) as client:

--- a/omnigent/antigravity_native_reader.py
+++ b/omnigent/antigravity_native_reader.py
@@ -3269,8 +3269,10 @@ async def run_reader_with_bridge(
     # would keep targeting the rotated-away session).
     current = {"session_id": session_id}
 
-    async with httpx.AsyncClient(
-        base_url=base_url,
+    from omnigent.cli_auth import open_server_client
+
+    async with open_server_client(
+        base_url,
         headers=headers,
         auth=auth,
         timeout=httpx.Timeout(_READER_CLIENT_TIMEOUT_SECONDS),

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -603,9 +603,51 @@ def _is_url(target: str) -> bool:
 # Server URL client helpers
 # ---------------------------------------------------------------------------
 
+# Client-side ``session_id → host_id`` tracking, for routing a session's
+# tunnel-bound traffic to the right server replica when the server runs
+# multiple.
+#
+# A host's control tunnel and its runners' tunnels register on a single
+# replica, so the turn / resource / stream calls for a session running on that
+# host must name the host or they can reach a different replica than the runner
+# tunnel they need. The host_id is the routing key; it's populated when the CLI
+# learns a session's host (session GETs, daemon launch) and read once when a
+# client for that session is built — callers pass the session_id they already
+# have to ``_server_auth`` rather than the auth re-deriving it per request. This
+# is the Python peer of the web UI's ``sessionHost.ts``. (The host_id is
+# translated into the routing header inside ``cli_auth.databricks_request_headers``;
+# OSS only ever threads a host_id.)
+_session_hosts: dict[str, str] = {}
+
+
+def set_session_host(session_id: str, host_id: str | None) -> None:
+    """Record (or clear) the host a session is bound to.
+
+    A ``None``/empty host clears any stale mapping so a session that loses its
+    host binding stops routing to the old replica.
+
+    :param session_id: Session id, e.g. ``"conv_abc123"``.
+    :param host_id: The bound host id, e.g. ``"host_abc123"``, or ``None``.
+    """
+    if host_id:
+        _session_hosts[session_id] = host_id
+    else:
+        _session_hosts.pop(session_id, None)
+
+
+def get_session_host(session_id: str) -> str | None:
+    """Return a session's bound host id, or ``None`` when unknown.
+
+    :param session_id: Session id, e.g. ``"conv_abc123"``.
+    :returns: The host id, or ``None`` (session not seen yet, or hostless).
+    """
+    return _session_hosts.get(session_id)
+
 
 def _remote_headers(
     server_url: str | None = None,
+    *,
+    host_id: str | None,
 ) -> dict[str, str]:
     """
     Build headers for remote AP-server requests.
@@ -626,6 +668,11 @@ def _remote_headers(
 
     :param server_url: Optional remote server URL for looking up
         stored OIDC tokens, e.g. ``"http://localhost:6767"``.
+    :param host_id: The host a request is scoped to, or ``None`` when the
+        caller has no host to name (a host-less read, or a runner-internal
+        request that keys off the runner-env host_id). Required-keyword with
+        no default so every call site consciously decides — pass the request
+        path's host when it has one rather than silently defaulting to unkeyed.
     :returns: Headers to pass to httpx / OmnigentClient.
     """
     # Resolve the bearer in the documented precedence order (one credential
@@ -654,11 +701,14 @@ def _remote_headers(
             headers["Authorization"] = f"Bearer {creds.token}"
     # Workspace routing: when a ?o= selector was recorded at login, name the
     # workspace or the request routes to the account. Merged onto the result
-    # because these ad-hoc requests carry no httpx Auth.
+    # because these ad-hoc requests carry no httpx Auth. ``host_id`` pins a
+    # host-scoped request to the server replica holding that host's tunnel
+    # (translated to the routing header inside the builder); callers derive it
+    # from the request path.
     if server_url:
         from omnigent.cli_auth import databricks_request_headers
 
-        headers.update(databricks_request_headers(server_url))
+        headers.update(databricks_request_headers(server_url, host_id=host_id))
     return headers
 
 
@@ -725,12 +775,18 @@ class _DatabricksTokenAuth(httpx.Auth):
     def __init__(
         self,
         server_url: str | None = None,
+        *,
+        session_id: str | None = None,
     ) -> None:
         """
         :param server_url: Remote server URL for looking up stored
             OIDC tokens, e.g. ``"http://localhost:6767"``.
+        :param session_id: The single session this client drives; its
+            requests are pinned to that session's host replica. ``None``
+            for a hostless / local client.
         """
         self._server_url = server_url
+        self._session_id = session_id
         raw = os.environ.get(_REMOTE_AUTH_TOKEN_ENV)
         self._static_token = raw.strip() if raw else None
         # Lazily-resolved, then reused, SDK auth (one Config → one token
@@ -739,6 +795,19 @@ class _DatabricksTokenAuth(httpx.Auth):
         # long-lived transcript-forwarder client that posts reply items.
         self._sdk_auth: _DatabricksBearerAuth | None = None
         self._sdk_auth_resolved = False
+
+    def pin_session(self, session_id: str | None) -> None:
+        """Repoint this auth at a different session's host.
+
+        ``auth_flow`` reads ``get_session_host(self._session_id)`` per request,
+        so changing the pinned session id changes which host replica the slice
+        key routes to — without rebuilding the client. Used when a client
+        outlives the session it was built for (e.g. a ``--fork`` in the REPL
+        resumes under a new conversation id on a new host).
+
+        :param session_id: The session id to pin to, or ``None`` to unpin.
+        """
+        self._session_id = session_id
 
     def _sdk_token(self) -> str | None:
         """
@@ -794,27 +863,34 @@ class _DatabricksTokenAuth(httpx.Auth):
         :yields: The request with auth header set.
         """
         # Workspace routing (empty when none recorded); independent of the
-        # credential branch below.
+        # credential branch below. On a host-sharded deployment, also pin the
+        # turn/resource/stream traffic for this client's session to the replica
+        # holding its runner tunnel — the slice key is the session's host_id,
+        # from the session→host map. An unsharded server has no sharding layer,
+        # so no key.
         if self._server_url:
             from omnigent.cli_auth import databricks_request_headers
 
-            request.headers.update(databricks_request_headers(self._server_url))
+            session_host = get_session_host(self._session_id) if self._session_id else None
+            request.headers.update(
+                databricks_request_headers(self._server_url, host_id=session_host)
+            )
         if self._static_token:
             request.headers["Authorization"] = f"Bearer {self._static_token}"
-            yield request
-            return
-        # Check stored OIDC token from `omnigent login`.
-        if self._server_url:
-            from omnigent.cli_auth import load_token
+        else:
+            # Check stored OIDC token from `omnigent login`, then fall back to
+            # the reused Databricks SDK auth.
+            oidc_token = None
+            if self._server_url:
+                from omnigent.cli_auth import load_token
 
-            oidc_token = load_token(self._server_url)
+                oidc_token = load_token(self._server_url)
             if oidc_token:
                 request.headers["Authorization"] = f"Bearer {oidc_token}"
-                yield request
-                return
-        token = self._sdk_token()
-        if token:
-            request.headers["Authorization"] = f"Bearer {token}"
+            else:
+                token = self._sdk_token()
+                if token:
+                    request.headers["Authorization"] = f"Bearer {token}"
         yield request
 
 
@@ -842,6 +918,8 @@ def _server_headers(
 
 def _server_auth(
     server_url: str | None = None,
+    *,
+    session_id: str | None,
 ) -> httpx.Auth | None:
     """
     Build an httpx Auth for a remote Omnigent server client.
@@ -854,21 +932,29 @@ def _server_auth(
 
     :param server_url: Optional remote server URL for looking up
         stored OIDC tokens.
+    :param session_id: The single session this client drives, e.g.
+        ``"conv_abc123"``. When set, the auth pins every request to the
+        replica holding that session's runner tunnel (its host, looked up
+        in the session→host map). Required-keyword with no default so every
+        caller consciously decides: pass the session when known so its
+        traffic co-locates, or ``None`` before a session exists / for a
+        host-less client (the slice key then falls back to the runner-env
+        or CLI-own-host id inside ``databricks_request_headers``).
     :returns: Auth instance, or ``None``.
     """
     raw = os.environ.get(_REMOTE_AUTH_TOKEN_ENV)
     if raw and raw.strip():
-        return _DatabricksTokenAuth(server_url=server_url)
+        return _DatabricksTokenAuth(server_url=server_url, session_id=session_id)
     # Check stored `omnigent login` records: a session JWT or a
     # Databricks Apps pointer record.
     if server_url:
         from omnigent.cli_auth import load_databricks_workspace_host, load_token
 
         if load_token(server_url) or load_databricks_workspace_host(server_url):
-            return _DatabricksTokenAuth(server_url=server_url)
+            return _DatabricksTokenAuth(server_url=server_url, session_id=session_id)
     creds = _read_databrickscfg(None)
     if creds is not None and creds.token:
-        return _DatabricksTokenAuth(server_url=server_url)
+        return _DatabricksTokenAuth(server_url=server_url, session_id=session_id)
     return None
 
 
@@ -1146,7 +1232,7 @@ def _wrapper_label_for_conversation(
     try:
         resp = httpx.get(
             f"{base_url}/v1/sessions/{conversation_id}",
-            headers=_remote_headers(server_url=base_url),
+            headers=_remote_headers(server_url=base_url, host_id=None),
             timeout=10.0,
         )
     except httpx.HTTPError as exc:
@@ -1235,7 +1321,7 @@ def _attach_session_info(
     try:
         resp = httpx.get(
             f"{base_url}/v1/sessions/{conversation_id}",
-            headers=_remote_headers(server_url=base_url),
+            headers=_remote_headers(server_url=base_url, host_id=None),
             timeout=10.0,
         )
     except httpx.HTTPError as exc:
@@ -1249,6 +1335,15 @@ def _attach_session_info(
         return empty
     if not isinstance(body, dict):
         return empty
+    # Record the session's host so host-scoped requests (turn dispatch,
+    # resource, stream) can reach the replica holding that host's runner tunnel.
+    # Always write — clearing a stale mapping when the server now reports no
+    # host (e.g. the session's runner was torn down) is as important as setting
+    # one, so later requests for a hostless session don't keep a dead slice key.
+    session_host = body.get("host_id")
+    set_session_host(
+        conversation_id, session_host if isinstance(session_host, str) and session_host else None
+    )
     runner_id = body.get("runner_id")
     snapshot_online = body.get("runner_online")
     if not isinstance(runner_id, str) or not runner_id:
@@ -1286,7 +1381,7 @@ def _pick_agent(base_url: str, *, quiet: bool = False) -> str:
     """
     resp = httpx.get(
         f"{base_url}/v1/sessions",
-        headers=_remote_headers(server_url=base_url),
+        headers=_remote_headers(server_url=base_url, host_id=None),
         params={"limit": 100},
         timeout=10.0,
     )
@@ -1494,6 +1589,7 @@ async def _prepare_chat_session_via_daemon(
     )
     from omnigent.host.daemon_launch import (
         launch_or_reuse_daemon_runner,
+        open_daemon_client,
         wait_for_host_online,
         wait_for_runner_online,
     )
@@ -1526,14 +1622,10 @@ async def _prepare_chat_session_via_daemon(
                 ) from exc
 
         # A separate raw httpx client for the host-runner protocol (the daemon
-        # launch helpers operate on httpx, not the SDK).
+        # launch helpers operate on httpx, not the SDK), pinned to the host's replica.
         timeout = httpx.Timeout(30.0, read=120.0)
-        async with httpx.AsyncClient(
-            base_url=base_url,
-            headers=headers,
-            auth=auth,
-            timeout=timeout,
-            trust_env=not is_loopback_url(base_url),
+        async with open_daemon_client(
+            base_url, headers, host_id, auth=auth, timeout=timeout
         ) as client:
             if progress is not None:
                 progress.update(STARTUP_PHASE_CONNECTING)
@@ -1542,6 +1634,9 @@ async def _prepare_chat_session_via_daemon(
             )
             if progress is not None:
                 progress.update(STARTUP_PHASE_LAUNCHING_AGENT)
+            # Record the session's host so its turn/resource/stream traffic reaches
+            # the replica holding the host's runner tunnel.
+            set_session_host(session_id, host_id)
             runner_id = await launch_or_reuse_daemon_runner(
                 client,
                 host_id=host_id,
@@ -1651,8 +1746,8 @@ def _chat_via_daemon(
             # the spinner before printing its interactive prompt.
             _await_accounts_first_run_setup(base_url, progress=progress)
 
-            headers = _remote_headers(server_url=base_url)
-            auth = _server_auth(server_url=base_url)
+            headers = _remote_headers(server_url=base_url, host_id=None)
+            auth = _server_auth(server_url=base_url, session_id=None)
             host_id = load_or_create_host_identity().host_id
             workspace = str(Path.cwd().resolve())
 
@@ -2101,7 +2196,7 @@ def _run_headless_prompt(
         async with OmnigentClient(
             base_url=base_url,
             headers=_server_headers(runner_id=runner_id),
-            auth=_server_auth(server_url=base_url),
+            auth=_server_auth(server_url=base_url, session_id=None),
         ) as client:
             # Both a local bundle and a remote registered agent go through
             # the sessions API; _query_sessions_once picks the create route
@@ -3862,10 +3957,13 @@ def _run_repl(
         if attach_harness is not None:
             launch_harness = attach_harness
 
+        # Named so a --fork below can repoint it: the auth pins the slice key
+        # to whichever session it names, and a fork lands under a new id.
+        server_auth = _server_auth(server_url=base_url, session_id=resume_conversation_id)
         async with OmnigentClient(
             base_url=base_url,
             headers=_server_headers(runner_id=runner_id),
-            auth=_server_auth(server_url=base_url),
+            auth=server_auth,
         ) as client:
             # When --fork is set, call the fork endpoint before
             # entering the REPL so the user lands in the fork.
@@ -3876,6 +3974,17 @@ def _run_repl(
                 except Exception as exc:
                     raise click.ClickException(f"Fork failed: {exc}") from exc
                 effective_resume_id = fork_result["id"]
+                # The fork is a fresh session on (possibly) a different host.
+                # Record its host and repoint the auth from the source session
+                # to the fork, so this client's requests route to the fork's
+                # replica instead of the source's for the rest of the REPL.
+                fork_host = fork_result.get("host_id")
+                set_session_host(
+                    effective_resume_id,
+                    fork_host if isinstance(fork_host, str) and fork_host else None,
+                )
+                if isinstance(server_auth, _DatabricksTokenAuth):
+                    server_auth.pin_session(effective_resume_id)
                 click.echo(
                     f"Conversation forked. To return to the previous "
                     f"conversation, run --resume {fork_session_id}",
@@ -3956,7 +4065,7 @@ def _run_one_shot(
         async with OmnigentClient(
             base_url=base_url,
             headers=_server_headers(runner_id=runner_id),
-            auth=_server_auth(server_url=base_url),
+            auth=_server_auth(server_url=base_url, session_id=resume_conversation_id),
         ) as client:
             # Both a local bundle and a remote registered agent go through
             # the sessions API; _query_sessions_once picks the create route

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -108,6 +108,7 @@ from omnigent.host.daemon_launch import (
     DAEMON_POLL_INTERVAL_S,
     error_text,
     launch_or_reuse_daemon_runner,
+    open_daemon_client,
     wait_for_host_online,
     wait_for_runner_online,
 )
@@ -3161,10 +3162,11 @@ async def _is_terminal_resource_gone(
         f"/v1/sessions/{url_component(session_id)}"
         f"/resources/terminals/{url_component(terminal_id)}"
     )
+    from omnigent.cli_auth import open_server_client
+
     try:
-        async with httpx.AsyncClient(
-            base_url=base_url,
-            trust_env=not is_loopback_url(base_url),
+        async with open_server_client(
+            base_url,
             headers=headers,
             timeout=httpx.Timeout(timeout_s),
         ) as client:
@@ -3264,12 +3266,11 @@ async def _close_claude_terminal(
         f"/v1/sessions/{url_component(session_id)}"
         f"/resources/terminals/{url_component(terminal_id)}"
     )
+    from omnigent.cli_auth import open_server_client
+
     with contextlib.suppress(Exception):
-        async with httpx.AsyncClient(
-            base_url=base_url,
-            headers=headers,
-            timeout=httpx.Timeout(10.0),
-            trust_env=not is_loopback_url(base_url),
+        async with open_server_client(
+            base_url, headers=headers, timeout=httpx.Timeout(10.0)
         ) as client:
             await client.delete(path)
 
@@ -3407,12 +3408,7 @@ async def _prepare_claude_terminal_via_daemon(
     startup_profiler = startup_profiler or StartupProfiler(name="omnigent claude", enabled=False)
     persist_args = list(_strip_resume_from_claude_args(claude_args))
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(
-        base_url=base_url,
-        headers=headers,
-        timeout=timeout,
-        trust_env=not is_loopback_url(base_url),
-    ) as client:
+    async with open_daemon_client(base_url, headers, host_id, timeout=timeout) as client:
         startup_profiler.mark("daemon prepare http client ready")
         # Resuming an existing session must not re-close its terminal on
         # exit; a fresh launch owns teardown.
@@ -3639,8 +3635,13 @@ def _run_with_remote_server(
     from omnigent.host.identity import load_or_create_host_identity
 
     startup_profiler = startup_profiler or StartupProfiler(name="omnigent claude", enabled=False)
+    # This machine's host id keys the WebSocket attach handshake (and its
+    # reconnects) to the replica holding the runner's tunnel. A browser WS can't
+    # set request headers, but the CLI can, so this rides the header — the
+    # builder emits it only on a host-sharded deployment.
+    host_id = load_or_create_host_identity().host_id
     startup_profiler.mark("remote headers resolving")
-    headers = _remote_headers(server_url=base_url)
+    headers = _remote_headers(server_url=base_url, host_id=host_id)
     startup_profiler.mark("remote headers resolved")
     # ``headers`` carries the bearer for the WebSocket attach handshake
     # (refreshed in place by ``_recover``). For HTTP requests we additionally
@@ -3648,7 +3649,7 @@ def _run_with_remote_server(
     # long-lived transcript-forwarder client survives the ~1h Databricks
     # OAuth token TTL.
     startup_profiler.mark("remote auth resolving")
-    forwarder_auth = _server_auth(server_url=base_url)
+    forwarder_auth = _server_auth(server_url=base_url, session_id=None)
     startup_profiler.mark("remote auth resolved")
     prepared: PreparedClaudeTerminal | None = None
     # Bound before the attach call so the ``finally`` can read it even
@@ -3764,7 +3765,7 @@ def _run_with_remote_server(
             daemon-spawned runner died, the server relaunches it on the
             next message (host-bound auto-relaunch).
             """
-            new_headers = _remote_headers(server_url=base_url)
+            new_headers = _remote_headers(server_url=base_url, host_id=host_id)
             headers.clear()
             headers.update(new_headers)
 
@@ -3846,12 +3847,9 @@ async def _prepare_claude_terminal(
     """
     startup_profiler = startup_profiler or StartupProfiler(name="omnigent claude", enabled=False)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(
-        base_url=base_url,
-        headers=headers,
-        timeout=timeout,
-        trust_env=not is_loopback_url(base_url),
-    ) as client:
+    from omnigent.cli_auth import open_server_client
+
+    async with open_server_client(base_url, headers=headers, timeout=timeout) as client:
         startup_profiler.mark("prepare http client ready")
         cold_resume_args: tuple[str, ...] = ()
         # Cold resume = session existed but no live terminal. Even when

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -794,9 +794,9 @@ async def forward_claude_transcript_to_session(
     task_statuses: dict[str, str] = {}
     task_order: list[str] = []
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
-    async with httpx.AsyncClient(
-        base_url=base_url, headers=headers, auth=auth, timeout=timeout
-    ) as client:
+    from omnigent.cli_auth import open_server_client
+
+    async with open_server_client(base_url, headers=headers, auth=auth, timeout=timeout) as client:
         while True:
             try:
                 async with asyncio.timeout(_FORWARD_LOOP_STALL_DEADLINE_S):

--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -365,6 +365,16 @@ def _rotate_session_on_clear(bridge_dir: Path) -> str | None:
         if isinstance(raw_headers, dict)
         else {}
     )
+    # Route the whole rotation sequence (GET old, POST /v1/sessions or /fork,
+    # PATCH new, DELETE old) to the replica holding this host's tunnel: a managed
+    # create/fork notifies the host inline over its pod-local tunnel, so an
+    # off-replica request can't reach it. This hook client carries no
+    # _RunnerDatabricksAuth, so key the reused headers dict from the runner-env
+    # host_id (databricks_request_headers reads OMNIGENT_RUNNER_SLICE_KEY when no
+    # explicit host_id; emitted only on the workspace mount).
+    from omnigent.cli_auth import databricks_request_headers
+
+    headers.update(databricks_request_headers(ap_server_url))
     try:
         with httpx.Client(
             headers=headers, timeout=httpx.Timeout(_SESSION_ROTATION_TIMEOUT_S)
@@ -411,6 +421,16 @@ def _rotate_session_on_fork(bridge_dir: Path) -> str | None:
         if isinstance(raw_headers, dict)
         else {}
     )
+    # Route the whole rotation sequence (GET old, POST /v1/sessions or /fork,
+    # PATCH new, DELETE old) to the replica holding this host's tunnel: a managed
+    # create/fork notifies the host inline over its pod-local tunnel, so an
+    # off-replica request can't reach it. This hook client carries no
+    # _RunnerDatabricksAuth, so key the reused headers dict from the runner-env
+    # host_id (databricks_request_headers reads OMNIGENT_RUNNER_SLICE_KEY when no
+    # explicit host_id; emitted only on the workspace mount).
+    from omnigent.cli_auth import databricks_request_headers
+
+    headers.update(databricks_request_headers(ap_server_url))
     try:
         with httpx.Client(
             headers=headers, timeout=httpx.Timeout(_SESSION_ROTATION_TIMEOUT_S)
@@ -826,6 +846,13 @@ def _main_permission_request(argv: list[str]) -> int:
         raw_headers = config.get("ap_auth_headers")
         if isinstance(raw_headers, dict):
             headers = {str(key): str(value) for key, value in raw_headers.items()}
+    # A permission request raises a web elicitation that parks in the pod-local
+    # registry on the replica holding this session's runner tunnel; an unkeyed
+    # POST lands elsewhere and the approval is silently lost. Key from the
+    # runner-env host_id (reads OMNIGENT_RUNNER_SLICE_KEY; workspace mount only).
+    from omnigent.cli_auth import databricks_request_headers
+
+    headers.update(databricks_request_headers(ap_server_url))
     url = (
         f"{ap_server_url.rstrip('/')}/v1/sessions/"
         f"{url_component(session_id)}/hooks/permission-request"
@@ -898,6 +925,12 @@ def _main_ask_user_question(argv: list[str]) -> int:
         raw_headers = config.get("ap_auth_headers")
         if isinstance(raw_headers, dict):
             headers = {str(key): str(value) for key, value in raw_headers.items()}
+    # Same as the permission-request hook: the elicitation parks in the pod-local
+    # registry on the session's tunnel replica, so key the POST from the
+    # runner-env host_id or an off-replica landing silently drops the prompt.
+    from omnigent.cli_auth import databricks_request_headers
+
+    headers.update(databricks_request_headers(ap_server_url))
     url = (
         f"{ap_server_url.rstrip('/')}/v1/sessions/"
         f"{url_component(session_id)}/hooks/permission-request"
@@ -1048,6 +1081,12 @@ def _main_evaluate_policy(argv: list[str]) -> int:
         raw_headers = config.get("ap_auth_headers")
         if isinstance(raw_headers, dict):
             headers = {str(k): str(v) for k, v in raw_headers.items()}
+        # This posts to the session's policy registry on the replica holding its
+        # tunnel; key from the runner-env host_id so it isn't misrouted. (The
+        # relay branch above targets a relay token URL, so it needs no key.)
+        from omnigent.cli_auth import databricks_request_headers
+
+        headers.update(databricks_request_headers(ap_server_url))
         session_component = url_component(session_id)
         url = f"{ap_server_url.rstrip('/')}/v1/sessions/{session_component}/policies/evaluate"
         reauth = policy_hook_reauth(ap_server_url, headers)

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2394,6 +2394,7 @@ def _daemon_host_online(record: _HostDaemonRecord, *, timeout_s: float = 2.0) ->
         method="GET",
         path=f"/v1/hosts/{url_component(host_id)}",
         timeout_s=timeout_s,
+        host_id=host_id,
     )
     if result.status_code != 200 or not isinstance(result.body, dict):
         return False
@@ -3140,7 +3141,7 @@ def _ensure_databricks_server_auth(server: str, *, non_interactive: bool = False
     try:
         probe = _httpx.get(
             f"{server}/v1/me",
-            headers=_remote_headers(server_url=server),
+            headers=_remote_headers(server_url=server, host_id=None),
             timeout=10.0,
         )
     except _httpx.HTTPError:
@@ -5754,7 +5755,7 @@ def import_session_command(
             response = httpx.post(
                 f"{base_url}/v1/imports",
                 json=payload,
-                headers=_remote_headers(server_url=base_url),
+                headers=_remote_headers(server_url=base_url, host_id=None),
                 timeout=120.0,
             )
         except httpx.RequestError as exc:
@@ -5952,7 +5953,7 @@ def usage(limit: int, server: str | None, as_json: bool) -> None:
 
     with httpx.Client(
         base_url=base_url,
-        headers=_remote_headers(server_url=base_url),
+        headers=_remote_headers(server_url=base_url, host_id=None),
         timeout=60.0,
         trust_env=_trust_env_for(base_url),
     ) as client:
@@ -6036,7 +6037,7 @@ def session_export(session_id: str, output: str | None, server: str | None) -> N
 
     with httpx.Client(
         base_url=base_url,
-        headers=_remote_headers(server_url=base_url),
+        headers=_remote_headers(server_url=base_url, host_id=None),
         timeout=30.0,
         trust_env=_trust_env_for(base_url),
     ) as client:
@@ -6278,7 +6279,7 @@ def session_import(input_path: str, title: str | None, server: str | None) -> No
 
     with httpx.Client(
         base_url=base_url,
-        headers=_remote_headers(server_url=base_url),
+        headers=_remote_headers(server_url=base_url, host_id=None),
         timeout=120.0,
         trust_env=_trust_env_for(base_url),
     ) as client:
@@ -6808,7 +6809,7 @@ def _dispatch_native_terminal_harness(
         session_id = _resolve_latest_conversation_id(
             base_url=server,
             agent_name=native_agent.agent_name,
-            headers=_remote_headers(server_url=server),
+            headers=_remote_headers(server_url=server, host_id=None),
         )
         # The user explicitly asked to continue; if there's nothing to continue,
         # fail loud rather than silently starting fresh (matches the REPL's
@@ -8162,7 +8163,7 @@ def _selected_daemon_records(
 # Databricks CLI). Within a single CLI invocation the token is valid, so
 # resolving once and reusing it is safe. The lock serialises concurrent
 # resolution for the same URL (two threads must not both pay the cost).
-_host_http_headers_cache: dict[str, dict[str, str]] = {}
+_host_http_headers_cache: dict[tuple[str, str | None], dict[str, str]] = {}
 _host_http_headers_lock = threading.Lock()
 
 
@@ -8189,6 +8190,7 @@ def _host_http_json(
     params: dict[str, str | int] | None = None,
     json_body: _HostJsonObject | None = None,
     timeout_s: float = 10.0,
+    host_id: str | None = None,
 ) -> _HostHttpResult:
     """
     Send one management request to an Omnigent server.
@@ -8203,6 +8205,10 @@ def _host_http_json(
         ``{"type": "stop_session", "data": {}}``.
     :param timeout_s: Request timeout in seconds, e.g. ``2.0`` for a
         quick liveness probe. Defaults to ``10.0`` for management calls.
+    :param host_id: The host this request is scoped to (host-control, or a
+        host-backed session event like stop_session), so it reaches the replica
+        holding that host's tunnel. ``None`` for non-host-scoped calls; the
+        builder emits the routing header only on the workspace-hosted server.
     :returns: Decoded HTTP result.
     """
     import httpx
@@ -8210,11 +8216,17 @@ def _host_http_json(
     from omnigent.chat import _remote_headers
 
     try:
-        if base_url not in _host_http_headers_cache:
+        # Cache the resolved headers per (base_url, host_id): the auth resolution
+        # is the expensive part (token mint / CLI shell-out), and the slice-key
+        # varies by the host a call is scoped to, so both belong in the key.
+        cache_key = (base_url, host_id)
+        if cache_key not in _host_http_headers_cache:
             with _host_http_headers_lock:
-                if base_url not in _host_http_headers_cache:
-                    _host_http_headers_cache[base_url] = _remote_headers(server_url=base_url)
-        headers = _host_http_headers_cache[base_url]
+                if cache_key not in _host_http_headers_cache:
+                    _host_http_headers_cache[cache_key] = _remote_headers(
+                        server_url=base_url, host_id=host_id
+                    )
+        headers = _host_http_headers_cache[cache_key]
         with httpx.Client(
             base_url=base_url,
             headers=headers,
@@ -8429,12 +8441,22 @@ def _runner_online_map(
             if isinstance((runner_id := session.get("runner_id")), str) and runner_id
         }
     )
+    # A runner is spawned on exactly one host; its status endpoint reads the
+    # in-memory tunnel registry, so the check must reach that host's replica or
+    # it reports the runner offline. The session rows carry each runner's host.
+    runner_host: dict[str, str] = {}
+    for session in sessions:
+        rid = session.get("runner_id")
+        host = session.get("host_id")
+        if isinstance(rid, str) and rid and isinstance(host, str) and host:
+            runner_host.setdefault(rid, host)
     statuses: dict[str, bool | None] = {}
     for runner_id in runner_ids:
         result = _host_http_json(
             base_url=base_url,
             method="GET",
             path=f"/v1/runners/{url_component(runner_id)}/status",
+            host_id=runner_host.get(runner_id),
         )
         if result.status_code == 200 and isinstance(result.body, dict):
             online = result.body.get("online")
@@ -8515,6 +8537,7 @@ def _add_daemon_host_status(
         base_url=base_url,
         method="GET",
         path=f"/v1/hosts/{url_component(host_id)}",
+        host_id=host_id,
     )
     if host_result.status_code == 200 and isinstance(host_result.body, dict):
         status = host_result.body.get("status")
@@ -8995,11 +9018,27 @@ def _stop_session_on_server(
     """
     from omnigent.claude_native_bridge import url_component
 
+    # This is a standalone CLI process with an empty session→host map, so read
+    # the session's host from its record first: the stop_session event is a
+    # server→runner forward and must reach the replica holding the runner's
+    # tunnel. The metadata GET itself is host-agnostic (served from any replica).
+    host_id: str | None = None
+    info = _host_http_json(
+        base_url=base_url,
+        method="GET",
+        path=f"/v1/sessions/{url_component(session_id)}",
+    )
+    if info.status_code == 200 and isinstance(info.body, dict):
+        host_value = info.body.get("host_id")
+        if isinstance(host_value, str) and host_value:
+            host_id = host_value
+
     result = _host_http_json(
         base_url=base_url,
         method="POST",
         path=f"/v1/sessions/{url_component(session_id)}/events",
         json_body={"type": "stop_session", "data": {}},
+        host_id=host_id,
     )
     if result.status_code == 0:
         raise click.ClickException(

--- a/omnigent/cli_auth.py
+++ b/omnigent/cli_auth.py
@@ -25,7 +25,12 @@ import os
 import stat
 import tempfile
 import time
+import urllib.parse
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import httpx
 
 _logger = logging.getLogger(__name__)
 _TOKEN_FILE_NAME = "auth_tokens.json"
@@ -277,6 +282,34 @@ def load_databricks_org_id(server_url: str) -> str | None:
 # workspace request by this header (equivalently to the ``?o=`` query param).
 DATABRICKS_ORG_ID_HEADER = "X-Databricks-Org-Id"
 
+# Replica-routing header for a host-sharded deployment. The sharding layer
+# routes requests by this value — else the default fallback — so a host's
+# control tunnel, its runners' tunnels, and their session traffic all land on
+# one replica when they carry the same key (the host_id). Omitted for an
+# unsharded / single-replica deployment, which needs no sticky routing.
+OMNIGENT_SLICE_KEY_HEADER = "X-Databricks-Omnigent-Slice-Key"
+
+# A host-sharded deployment mounts the API at this path; an unsharded /
+# single-replica server mounts elsewhere (usually the root). This is the
+# routing-relevant shape of a server URL, so it lives here next to the
+# request-header builder that keys off it (rather than in the browser-link
+# helpers, which only borrow it).
+WORKSPACE_API_PATH = "/api/2.0/omnigent"
+
+
+def is_workspace_hosted_url(base_url: str) -> bool:
+    """Whether *base_url* is a host-sharded deployment mount.
+
+    True for the host-sharded mount (``https://<host>/api/2.0/omnigent``), which
+    is the only deployment fronted by the sharding layer. Used to gate behavior
+    that only applies there (see :func:`databricks_request_headers`).
+
+    :param base_url: Omnigent server base URL, e.g.
+        ``"https://example.databricks.com/api/2.0/omnigent"``.
+    :returns: ``True`` when the URL path is the workspace API mount.
+    """
+    return urllib.parse.urlsplit(base_url.rstrip("/")).path == WORKSPACE_API_PATH
+
 
 # Opaque extra request headers for dev/test: a JSON object of header name→value
 # in :data:`DATABRICKS_EXTRA_HEADERS_ENV_VAR`. Databricks deployments use it to
@@ -310,7 +343,10 @@ def _databricks_extra_headers() -> dict[str, str]:
 
 
 def databricks_request_headers(
-    server_url: str, *, bearer_token: str | None = None
+    server_url: str,
+    *,
+    bearer_token: str | None = None,
+    host_id: str | None = None,
 ) -> dict[str, str]:
     """Build the headers for a request to a Databricks-fronted server.
 
@@ -335,8 +371,17 @@ def databricks_request_headers(
         ``"https://example.databricks.com/api/2.0/omnigent"``.
     :param bearer_token: The workspace bearer token, or ``None`` when the
         credential is supplied by a separate mechanism (or there is none).
+    :param host_id: The host a request is scoped to (its control tunnel, its
+        runners, and their session traffic all name it so they co-locate on one
+        replica). Pass it unconditionally: it is emitted (as the
+        :data:`OMNIGENT_SLICE_KEY_HEADER` routing header) only when *server_url*
+        is a host-sharded mount, since that is the only deployment with the
+        sharding layer that reads it. ``None`` defaults to the runner's own
+        host_id inside a runner process (via ``OMNIGENT_RUNNER_SLICE_KEY``) and
+        otherwise leaves routing to the default.
     :returns: A header dict carrying ``Authorization``, ``X-Databricks-Org-Id``,
-        and/or the configured extra headers as available, possibly empty.
+        ``X-Databricks-Omnigent-Slice-Key``, and/or the configured extra headers
+        as available, possibly empty.
     """
     headers: dict[str, str] = {}
     if bearer_token:
@@ -344,10 +389,129 @@ def databricks_request_headers(
     org_id = load_databricks_org_id(server_url)
     if org_id:
         headers[DATABRICKS_ORG_ID_HEADER] = org_id
+    # Resolve the slice-key host_id when the caller names none, so every
+    # request still carries a key (routed by the sharding layer rather than
+    # depending on its default). Two ordered fallbacks, both host_ids:
+    #   1. In a runner process, the runner's own host_id (exported at launch as
+    #      OMNIGENT_RUNNER_SLICE_KEY) — keys the runner's server traffic
+    #      (transcript posts, uploads, policy checks) onto its host's replica,
+    #      co-located with its tunnel.
+    #   2. Otherwise, on the CLI, this machine's OWN host_id if it already has a
+    #      host identity — a host-less CLI request (session list, /me-adjacent
+    #      reads, export) then keys to the replica holding this CLI's own hosts'
+    #      tunnels. Read-only (never mints an identity), so a non-host machine
+    #      stays unkeyed (→ default). Gated on the host-sharded mount below so
+    #      the file read only happens for requests that could use it.
+    # Only a host-sharded deployment runs the sharding layer that reads the
+    # header; an unsharded server is single-replica and would just log a header
+    # it ignores — so gate emission (and the CLI identity lookup) on the mount.
+    # Callers never reason about the deployment; a new RPC routed through this
+    # builder is keyed automatically.
+    on_workspace_mount = is_workspace_hosted_url(server_url)
+    if host_id is None:
+        from omnigent.runner.identity import RUNNER_SLICE_KEY_ENV_VAR
+
+        host_id = os.environ.get(RUNNER_SLICE_KEY_ENV_VAR)
+    if host_id is None and on_workspace_mount:
+        from omnigent.host.identity import load_host_identity_if_present
+
+        identity = load_host_identity_if_present()
+        if identity is not None:
+            host_id = identity.host_id
+    # Kill switch: slice-key emission is ON by default; export
+    # ``OMNIGENT_HOST_SLICE_KEY_ENABLED=0`` to turn it off and fall back to the
+    # server's default (workspace-id) routing with no redeploy — a per-process
+    # escape hatch for a bad rollout, since this emits from sidecar-less
+    # processes (laptop CLI, managed sandbox host, spawned runner) that can't
+    # evaluate a server-side flag. Only the exact value "0" disables it; unset,
+    # "1", or anything else leaves emission on.
+    slice_key_enabled = os.environ.get("OMNIGENT_HOST_SLICE_KEY_ENABLED", "1") != "0"
+    if host_id and on_workspace_mount and slice_key_enabled:
+        headers[OMNIGENT_SLICE_KEY_HEADER] = host_id
     # Opaque dev/test extra headers (request-routing selectors); no-op in prod
     # (env unset).
     headers.update(_databricks_extra_headers())
     return headers
+
+
+# Sentinel for the ``timeout`` argument of :func:`open_server_client`. ``None``
+# is a meaningful httpx value ("disable timeout"), so it can't stand in for
+# "unset". When the caller passes nothing we omit ``timeout`` entirely and let
+# httpx apply its own default, rather than silently changing it.
+_TIMEOUT_UNSET: Any = object()
+
+
+def open_server_client(
+    server_url: str,
+    *,
+    auth: httpx.Auth | None = None,
+    bearer_token: str | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: Any = _TIMEOUT_UNSET,
+    follow_redirects: bool = False,
+    transport: httpx.AsyncBaseTransport | None = None,
+    host_id: str | None = None,
+) -> httpx.AsyncClient:
+    """Open an :class:`httpx.AsyncClient` to an Omnigent server, keyed for routing.
+
+    The one way to open a client to the server. It folds
+    :func:`databricks_request_headers` in for you, so a request to a host-sharded
+    mount automatically carries the org-id and slice-key routing headers (and any
+    dev/test selectors) — and a request to an unsharded server carries none.
+    Callers never reason about the deployment; a new server RPC opened through
+    this factory is routed correctly by construction, which is why it exists
+    rather than each site building headers by hand.
+
+    :param server_url: The server base URL, e.g.
+        ``"https://example.databricks.com/api/2.0/omnigent"``. Both the client's
+        ``base_url`` and the input to the routing-header builder.
+    :param auth: An httpx ``Auth`` when the credential is minted per request
+        (e.g. :class:`_RunnerDatabricksAuth`, which re-injects a fresh bearer and
+        the routing headers on the OAuth-redirect retry). Mutually exclusive with
+        *bearer_token* in practice: pass one or the other, not both.
+    :param bearer_token: A static workspace bearer, folded in as
+        ``Authorization``. Leave ``None`` when *auth* supplies the credential or
+        there is none.
+    :param headers: Extra request headers (e.g. the runner ``Origin`` sentinel).
+        Merged *under* the routing headers, so routing always wins over a
+        caller-supplied collision.
+    :param timeout: An httpx timeout (``httpx.Timeout``, ``float``, or ``None``
+        to disable). Omitted by default so httpx applies its own default rather
+        than this factory silently overriding it.
+    :param follow_redirects: Passed through to httpx. Defaults to ``False``
+        (httpx's own default); callers relying on seeing a 3xx — e.g. an auth
+        flow that re-mints on the Databricks Apps OAuth login redirect — keep it
+        ``False``.
+    :param transport: An httpx ``AsyncBaseTransport`` to substitute for the
+        default network transport. Its one production-adjacent use is injecting a
+        test transport (e.g. ``httpx.MockTransport``); ``None`` uses the default.
+    :param host_id: The host a request is scoped to, forwarded to
+        :func:`databricks_request_headers` (which emits it as the slice-key only
+        on a host-sharded mount and otherwise falls back to the runner's own
+        host_id). Pass it unconditionally when known.
+    :returns: A configured :class:`httpx.AsyncClient`.
+    """
+    import httpx
+    from omnigent_client._http import is_loopback_url
+
+    pinned = {
+        **(headers or {}),
+        **databricks_request_headers(server_url, bearer_token=bearer_token, host_id=host_id),
+    }
+    kwargs: dict[str, Any] = {}
+    if timeout is not _TIMEOUT_UNSET:
+        kwargs["timeout"] = timeout
+    if transport is not None:
+        kwargs["transport"] = transport
+    return httpx.AsyncClient(
+        base_url=server_url,
+        headers=pinned,
+        auth=auth,
+        follow_redirects=follow_redirects,
+        # A proxy cannot reach a loopback server, so local targets bypass it.
+        trust_env=not is_loopback_url(server_url),
+        **kwargs,
+    )
 
 
 def clear_token(server_url: str) -> None:

--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -22,7 +22,6 @@ from tempfile import TemporaryDirectory
 import click
 import httpx
 import yaml
-from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_resume_hint
 from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
@@ -72,6 +71,7 @@ from omnigent.harness_availability import (
 from omnigent.host.daemon_launch import (
     error_text,
     launch_or_reuse_daemon_runner,
+    open_daemon_client,
     wait_for_host_online,
     wait_for_runner_online,
 )
@@ -713,8 +713,12 @@ def _run_with_remote_server(
     from omnigent.cli import _ensure_host_daemon
     from omnigent.host.identity import load_or_create_host_identity
 
-    headers = _remote_headers(server_url=base_url)
-    attach_auth = _server_auth(server_url=base_url)
+    # This machine's host id keys the WebSocket attach handshake (and its
+    # reconnects) to the replica holding the runner's tunnel; the CLI can set WS
+    # headers, so it rides the header (emitted only on a host-sharded deployment).
+    host_id = load_or_create_host_identity().host_id
+    headers = _remote_headers(server_url=base_url, host_id=host_id)
+    attach_auth = _server_auth(server_url=base_url, session_id=None)
     try:
         resolved_session_id = _resolve_session_id_for_resume(
             base_url=base_url,
@@ -736,7 +740,6 @@ def _run_with_remote_server(
             with runner_startup_progress(initial_message="Preparing Codex...") as progress:
                 _update_startup_progress(progress, "Connecting to local daemon...")
                 _ensure_host_daemon(base_url)
-                host_id = load_or_create_host_identity().host_id
                 bundle = None if resolved_session_id is not None else _bundle_agent(spec_path)
                 prepared = await _prepare_codex_terminal_via_daemon(
                     base_url=base_url,
@@ -765,7 +768,7 @@ def _run_with_remote_server(
 
                 :returns: None.
                 """
-                new_headers = _remote_headers(server_url=base_url)
+                new_headers = _remote_headers(server_url=base_url, host_id=host_id)
                 headers.clear()
                 headers.update(new_headers)
 
@@ -843,12 +846,7 @@ async def _prepare_codex_terminal_via_daemon(
     """
     persist_args = list(codex_args)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(
-        base_url=base_url,
-        headers=headers,
-        timeout=timeout,
-        trust_env=not is_loopback_url(base_url),
-    ) as client:
+    async with open_daemon_client(base_url, headers, host_id, timeout=timeout) as client:
         reattached = session_id is not None
         fresh_session = session_id is None
         if session_id is None:
@@ -1021,9 +1019,10 @@ async def _post_initial_prompt(
     :returns: None.
     :raises click.ClickException: If Omnigent rejects the prompt.
     """
-    async with httpx.AsyncClient(
-        base_url=base_url,
-        trust_env=not is_loopback_url(base_url),
+    from omnigent.cli_auth import open_server_client
+
+    async with open_server_client(
+        base_url,
         headers=headers,
         auth=auth,
         timeout=httpx.Timeout(30.0),
@@ -1072,12 +1071,9 @@ async def _prepare_codex_terminal(
     :returns: Prepared terminal details.
     """
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(
-        base_url=base_url,
-        headers=headers,
-        timeout=timeout,
-        trust_env=not is_loopback_url(base_url),
-    ) as client:
+    from omnigent.cli_auth import open_server_client
+
+    async with open_server_client(base_url, headers=headers, timeout=timeout) as client:
         bridge_id: str
         thread_id: str | None = None
         if session_id is None:
@@ -1406,9 +1402,10 @@ async def _initialize_fresh_terminal_thread(
         raise click.ClickException("Codex event listener was not initialized.")
     app_server_url = _require_codex_app_server_url(prepared)
     thread_id = await _wait_for_thread_started(prepared.event_client)
-    async with httpx.AsyncClient(
-        base_url=base_url,
-        trust_env=not is_loopback_url(base_url),
+    from omnigent.cli_auth import open_server_client
+
+    async with open_server_client(
+        base_url,
         headers=headers,
         timeout=httpx.Timeout(30.0),
     ) as client:
@@ -2714,10 +2711,11 @@ async def _close_codex_terminal(
     :param terminal_id: Terminal resource id.
     :returns: None.
     """
+    from omnigent.cli_auth import open_server_client
+
     with contextlib.suppress(Exception):
-        async with httpx.AsyncClient(
-            base_url=base_url,
-            trust_env=not is_loopback_url(base_url),
+        async with open_server_client(
+            base_url,
             headers=headers,
             timeout=httpx.Timeout(10.0),
         ) as client:

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -1804,8 +1804,10 @@ async def supervise_forwarder(
     if client is None:
         client = client_for_transport(app_server_url, client_name="omnigent-codex-forwarder")
         await client.connect()
-    async with httpx.AsyncClient(
-        base_url=base_url,
+    from omnigent.cli_auth import open_server_client
+
+    async with open_server_client(
+        base_url,
         headers=headers,
         auth=auth,
         timeout=httpx.Timeout(30.0),

--- a/omnigent/conversation_browser.py
+++ b/omnigent/conversation_browser.py
@@ -9,11 +9,12 @@ import urllib.parse
 import webbrowser
 from collections.abc import Callable
 
-# Databricks workspace-hosted omnigent: the API proxy and the web UI are
-# mounted on different workspace paths. ``conversation_url`` maps the
-# server (API) base onto the UI mount so browser links land on the SPA
-# instead of the JSON API.
-WORKSPACE_API_PATH = "/api/2.0/omnigent"
+# The workspace-hosted API mount (routing-relevant shape) lives in cli_auth
+# next to the header builder that keys off it; the browser-link helpers below
+# only need it to map the API base onto the UI mount. The UI mount is a
+# browser-link concern, so it stays here.
+from omnigent.cli_auth import WORKSPACE_API_PATH
+
 WORKSPACE_UI_PATH = "/omnigent"
 
 # Client-side SPA route for one conversation (see web/src/App.tsx's
@@ -47,22 +48,6 @@ def strip_conversation_path(url: str) -> str:
     return urllib.parse.urlunsplit(
         (parsed.scheme, parsed.netloc, trimmed, parsed.query, parsed.fragment)
     )
-
-
-def is_workspace_hosted_url(base_url: str) -> bool:
-    """
-    Whether *base_url* is a Databricks workspace-hosted Omnigent mount.
-
-    True for the API proxy mount (``https://<ws>/api/2.0/omnigent``) the
-    CLI connects to on a workspace. Used to suppress UI a workspace
-    deployment shouldn't surface (e.g. the startup banner's server-version
-    row, since a workspace build reports no meaningful version string).
-
-    :param base_url: Omnigent server base URL, e.g.
-        ``"https://example.databricks.com/api/2.0/omnigent"``.
-    :returns: ``True`` when the URL path is the workspace API mount.
-    """
-    return urllib.parse.urlsplit(base_url.rstrip("/")).path == WORKSPACE_API_PATH
 
 
 def display_server_url(base_url: str) -> str:

--- a/omnigent/cursor_native.py
+++ b/omnigent/cursor_native.py
@@ -30,7 +30,6 @@ from typing import TypedDict, cast
 import click
 import httpx
 import yaml
-from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
 from omnigent._platform import resolve_cli_binary
@@ -42,6 +41,7 @@ from omnigent.entities.session_resources import terminal_resource_id
 from omnigent.host.daemon_launch import (
     error_text,
     launch_or_reuse_daemon_runner,
+    open_daemon_client,
     wait_for_host_online,
     wait_for_runner_online,
 )
@@ -415,7 +415,7 @@ def _run_with_remote_server(
     from omnigent.cli import _ensure_host_daemon
     from omnigent.host.identity import load_or_create_host_identity
 
-    headers = _remote_headers(server_url=base_url)
+    headers = _remote_headers(server_url=base_url, host_id=None)
     try:
         resolved_session_id = _resolve_session_id_for_resume(
             base_url=base_url,
@@ -498,12 +498,7 @@ async def _prepare_cursor_terminal_via_daemon(
     """
     persist_args = list(cursor_args)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(
-        base_url=base_url,
-        headers=headers,
-        timeout=timeout,
-        trust_env=not is_loopback_url(base_url),
-    ) as client:
+    async with open_daemon_client(base_url, headers, host_id, timeout=timeout) as client:
         # Resuming an existing session can either reattach to a live
         # terminal (prior chat intact) or, if that terminal has exited,
         # cold-start a fresh TUI. We only know which after probing for a

--- a/omnigent/cursor_native_permissions.py
+++ b/omnigent/cursor_native_permissions.py
@@ -862,9 +862,9 @@ async def supervise_cursor_transcript_elicitations(
     store_path: Path | None = None
     loop = asyncio.get_running_loop()
     timeout = httpx.Timeout(_POST_TIMEOUT_S, connect=10.0)
-    async with httpx.AsyncClient(
-        base_url=base_url, headers=headers, auth=auth, timeout=timeout
-    ) as client:
+    from omnigent.cli_auth import open_server_client
+
+    async with open_server_client(base_url, headers=headers, auth=auth, timeout=timeout) as client:
         while True:
             try:
                 if store_path is None or not store_path.exists():

--- a/omnigent/cursor_native_usage.py
+++ b/omnigent/cursor_native_usage.py
@@ -311,9 +311,9 @@ async def forward_cursor_usage_to_session(
     # — the safe direction. Seeding from persisted usage would permanently skip a
     # wake whose idle POST crashed after the usage flush persisted.
     idle_posted_turns = 0
-    async with httpx.AsyncClient(
-        base_url=base_url, headers=headers, auth=auth, timeout=timeout
-    ) as client:
+    from omnigent.cli_auth import open_server_client
+
+    async with open_server_client(base_url, headers=headers, auth=auth, timeout=timeout) as client:
         while True:
             try:
                 lines = await asyncio.to_thread(_read_usage_lines, bridge_dir)

--- a/omnigent/diagnostics.py
+++ b/omnigent/diagnostics.py
@@ -92,7 +92,7 @@ def _fetch_server_info(server_url: str, *, timeout: float) -> dict[str, Any] | N
         base = server_url.rstrip("/")
         resp = httpx.get(
             f"{base}/v1/info",
-            headers=_remote_headers(server_url=base),
+            headers=_remote_headers(server_url=base, host_id=None),
             timeout=timeout,
             trust_env=False,
         )

--- a/omnigent/goose_native.py
+++ b/omnigent/goose_native.py
@@ -29,7 +29,6 @@ from tempfile import TemporaryDirectory
 import click
 import httpx
 import yaml
-from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
 from omnigent._platform import resolve_cli_binary
@@ -41,6 +40,7 @@ from omnigent.entities.session_resources import terminal_resource_id
 from omnigent.host.daemon_launch import (
     error_text,
     launch_or_reuse_daemon_runner,
+    open_daemon_client,
     wait_for_host_online,
     wait_for_runner_online,
 )
@@ -247,7 +247,7 @@ def _run_with_remote_server(
     from omnigent.cli import _ensure_host_daemon
     from omnigent.host.identity import load_or_create_host_identity
 
-    headers = _remote_headers(server_url=base_url)
+    headers = _remote_headers(server_url=base_url, host_id=None)
     try:
         resolved_session_id = _resolve_session_id_for_resume(
             base_url=base_url,
@@ -318,12 +318,7 @@ async def _prepare_goose_terminal_via_daemon(
     """
     persist_args = list(goose_args)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(
-        base_url=base_url,
-        headers=headers,
-        timeout=timeout,
-        trust_env=not is_loopback_url(base_url),
-    ) as client:
+    async with open_daemon_client(base_url, headers, host_id, timeout=timeout) as client:
         reattached = False
         cold_resumed = False
         fresh_session = session_id is None

--- a/omnigent/goose_native_forwarder.py
+++ b/omnigent/goose_native_forwarder.py
@@ -648,9 +648,9 @@ async def forward_goose_store_to_session(
     # supervisor) if the replay's idle post hits a transient server error.
     needs_replay = goose_session_id is not None and last_id > 0
 
-    async with httpx.AsyncClient(
-        base_url=base_url, headers=headers, auth=auth, timeout=timeout
-    ) as client:
+    from omnigent.cli_auth import open_server_client
+
+    async with open_server_client(base_url, headers=headers, auth=auth, timeout=timeout) as client:
         while True:
             try:
                 if needs_replay and goose_session_id is not None:

--- a/omnigent/goose_native_permissions.py
+++ b/omnigent/goose_native_permissions.py
@@ -170,9 +170,9 @@ async def supervise_goose_approval_mirror(
     active: _PendingApproval | None = None
     episode = 0
     timeout = httpx.Timeout(_POST_TIMEOUT_S, connect=10.0)
-    async with httpx.AsyncClient(
-        base_url=base_url, headers=headers, auth=auth, timeout=timeout
-    ) as client:
+    from omnigent.cli_auth import open_server_client
+
+    async with open_server_client(base_url, headers=headers, auth=auth, timeout=timeout) as client:
         while True:
             try:
                 pane = await asyncio.to_thread(capture_goose_pane, bridge_dir)

--- a/omnigent/hermes_native.py
+++ b/omnigent/hermes_native.py
@@ -28,7 +28,6 @@ from tempfile import TemporaryDirectory
 import click
 import httpx
 import yaml
-from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
 from omnigent._platform import resolve_cli_binary
@@ -40,6 +39,7 @@ from omnigent.entities.session_resources import terminal_resource_id
 from omnigent.host.daemon_launch import (
     error_text,
     launch_or_reuse_daemon_runner,
+    open_daemon_client,
     wait_for_host_online,
     wait_for_runner_online,
 )
@@ -245,7 +245,7 @@ def _run_with_remote_server(
     from omnigent.cli import _ensure_host_daemon
     from omnigent.host.identity import load_or_create_host_identity
 
-    headers = _remote_headers(server_url=base_url)
+    headers = _remote_headers(server_url=base_url, host_id=None)
     try:
         resolved_session_id = _resolve_session_id_for_resume(
             base_url=base_url,
@@ -316,12 +316,7 @@ async def _prepare_hermes_terminal_via_daemon(
     """
     persist_args = list(hermes_args)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(
-        base_url=base_url,
-        headers=headers,
-        timeout=timeout,
-        trust_env=not is_loopback_url(base_url),
-    ) as client:
+    async with open_daemon_client(base_url, headers, host_id, timeout=timeout) as client:
         reattached = False
         cold_resumed = False
         fresh_session = session_id is None

--- a/omnigent/hermes_native_forwarder.py
+++ b/omnigent/hermes_native_forwarder.py
@@ -1120,9 +1120,9 @@ async def forward_hermes_store_to_session(
     # Omnigent server so we do it at most once per forwarder lifetime.
     _external_id_synced = False
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
-    async with httpx.AsyncClient(
-        base_url=base_url, headers=headers, auth=auth, timeout=timeout
-    ) as client:
+    from omnigent.cli_auth import open_server_client
+
+    async with open_server_client(base_url, headers=headers, auth=auth, timeout=timeout) as client:
         usage_tracker = _HermesUsageTracker(client, session_id, bridge_dir)
         compaction_persisted = False
         while True:

--- a/omnigent/hermes_native_permissions.py
+++ b/omnigent/hermes_native_permissions.py
@@ -179,9 +179,9 @@ async def supervise_hermes_approval_mirror(
     active: _PendingApproval | None = None
     episode = 0
     timeout = httpx.Timeout(_POST_TIMEOUT_S, connect=10.0)
-    async with httpx.AsyncClient(
-        base_url=base_url, headers=headers, auth=auth, timeout=timeout
-    ) as client:
+    from omnigent.cli_auth import open_server_client
+
+    async with open_server_client(base_url, headers=headers, auth=auth, timeout=timeout) as client:
         while True:
             try:
                 pane = await asyncio.to_thread(capture_hermes_pane, bridge_dir)

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -111,6 +111,7 @@ from omnigent.runner.identity import (
     RUNNER_ID_ENV_VAR,
     RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR,
     RUNNER_PARENT_PID_ENV_VAR,
+    RUNNER_SLICE_KEY_ENV_VAR,
     RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR,
     RUNNER_WORKSPACE_ENV_VAR,
     token_bound_runner_id,
@@ -612,6 +613,7 @@ def _build_runner_env(
     workspace: str,
     parent_pid: int,
     initial_auth_token: str | None = None,
+    host_id: str | None = None,
 ) -> dict[str, str]:
     """
     Build the environment for a spawned runner subprocess.
@@ -683,6 +685,12 @@ def _build_runner_env(
     # MALLOC_ARENA_MAX. setdefault so an operator override still wins.
     for key, value in _proc.malloc_tuning_env().items():
         env.setdefault(key, value)
+    if host_id:
+        # Tell the runner its host so its tunnel co-locates with the host's on
+        # one replica (turn dispatch / terminal-attach for its sessions reach it
+        # there). The runner forwards this to databricks_request_headers, which
+        # emits the routing header only on a host-sharded deployment.
+        env[RUNNER_SLICE_KEY_ENV_VAR] = host_id
     return env
 
 
@@ -1300,6 +1308,7 @@ class HostProcess:
             workspace=str(workspace),
             parent_pid=os.getpid(),
             initial_auth_token=initial_auth_token,
+            host_id=self._identity.host_id,
         )
 
         # Embed the session id so operators can find all logs for a session
@@ -2741,7 +2750,11 @@ class HostProcess:
         # hosts (no recorded selector), so neither is affected.
         from omnigent.cli_auth import databricks_request_headers
 
-        headers.update(databricks_request_headers(self._server_url))
+        # Pin this host's tunnel to its replica via the host_id; the builder
+        # emits the routing header only on a host-sharded deployment.
+        headers.update(
+            databricks_request_headers(self._server_url, host_id=self._identity.host_id)
+        )
 
         managed_token = os.environ.get(HOST_TOKEN_ENV_VAR)
         if managed_token:

--- a/omnigent/host/daemon_launch.py
+++ b/omnigent/host/daemon_launch.py
@@ -52,6 +52,49 @@ def _json_body(resp: httpx.Response) -> dict[str, object]:
     return body if isinstance(body, dict) else {}
 
 
+def open_daemon_client(
+    base_url: str,
+    headers: dict[str, str],
+    host_id: str | None,
+    *,
+    auth: httpx.Auth | None = None,
+    timeout: httpx.Timeout | float | None = None,
+) -> httpx.AsyncClient:
+    """Open an httpx client for the host-runner protocol, pinned to *host_id*.
+
+    Every request a caller makes on this client — the launch, runner-status
+    polls, and the session / terminal calls (including a resume-time reattach
+    check) — is scoped to one host, whose control and runner tunnels register
+    on a single server replica. Baking the host_id routing header into the
+    client's headers at construction pins all of them to that replica, ahead
+    of the first request regardless of the caller's call order. The builder
+    (:func:`~omnigent.cli_auth.databricks_request_headers`) emits the header
+    only on a host-sharded mount, so an unsharded server is unaffected.
+
+    :param base_url: Omnigent server base URL, e.g. the workspace API mount.
+    :param headers: Base HTTP headers (auth bearer, workspace routing); not
+        mutated — a fresh dict carries the merged routing headers.
+    :param host_id: The host to pin to, e.g. ``"host_abc123"``; ``None`` (a
+        hostless / local session) leaves routing to the default fallback.
+    :param auth: Optional per-request ``httpx.Auth`` (e.g. token refresh).
+    :param timeout: Optional httpx timeout for the client.
+    :returns: An ``httpx.AsyncClient`` whose requests all name *host_id*.
+    """
+    from omnigent_client._http import is_loopback_url
+
+    from omnigent.cli_auth import databricks_request_headers
+
+    pinned = {**headers, **databricks_request_headers(base_url, host_id=host_id)}
+    # A proxy cannot reach a loopback server, so local targets bypass it.
+    return httpx.AsyncClient(
+        base_url=base_url,
+        headers=pinned,
+        auth=auth,
+        timeout=timeout,
+        trust_env=not is_loopback_url(base_url),
+    )
+
+
 async def wait_for_host_online(
     client: httpx.AsyncClient,
     host_id: str,

--- a/omnigent/host/identity.py
+++ b/omnigent/host/identity.py
@@ -140,3 +140,43 @@ def load_or_create_host_identity(
         yaml.safe_dump(cfg, f, default_flow_style=False, sort_keys=True)
 
     return identity
+
+
+def load_host_identity_if_present(
+    path: Path = CONFIG_PATH,
+) -> HostIdentity | None:
+    """Return the host identity if one already exists, else ``None`` — no create.
+
+    The read-only sibling of :func:`load_or_create_host_identity`: same
+    env-override and config-file lookup, but it NEVER generates or persists an
+    identity. Use this from code paths that only want to *read* whether this
+    machine is a host (e.g. keying a request by the CLI's own host_id as a
+    slice-key fallback), so a bare read can't mint a host identity on a machine
+    that is not one, and has no filesystem side effect.
+
+    :param path: Path to the config YAML file. Defaults to :data:`CONFIG_PATH`.
+    :returns: The existing :class:`HostIdentity`, or ``None`` when neither the
+        env override nor a persisted ``host:`` section is present.
+    :raises ValueError: If exactly one of the identity env vars is set.
+    """
+    env_host_id = os.environ.get(HOST_ID_ENV_VAR)
+    env_name = os.environ.get(HOST_NAME_ENV_VAR)
+    if (env_host_id is None) != (env_name is None):
+        raise ValueError(
+            f"{HOST_ID_ENV_VAR} and {HOST_NAME_ENV_VAR} must be set together "
+            "(managed-host launch sets both)"
+        )
+    if env_host_id is not None and env_name is not None:
+        return HostIdentity(host_id=_normalize_host_id(env_host_id), name=env_name)
+
+    if not path.exists():
+        return None
+    with open(path) as f:
+        cfg = yaml.safe_load(f) or {}
+    host_section = cfg.get("host")
+    if isinstance(host_section, dict) and "host_id" in host_section and "name" in host_section:
+        return HostIdentity(
+            host_id=_normalize_host_id(host_section["host_id"]),
+            name=host_section["name"],
+        )
+    return None

--- a/omnigent/kimi_native.py
+++ b/omnigent/kimi_native.py
@@ -26,7 +26,6 @@ from tempfile import TemporaryDirectory
 import click
 import httpx
 import yaml
-from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
 from omnigent._platform import resolve_cli_binary
@@ -38,6 +37,7 @@ from omnigent.entities.session_resources import terminal_resource_id
 from omnigent.host.daemon_launch import (
     error_text,
     launch_or_reuse_daemon_runner,
+    open_daemon_client,
     wait_for_host_online,
     wait_for_runner_online,
 )
@@ -250,7 +250,7 @@ def _run_with_remote_server(
     from omnigent.cli import _ensure_host_daemon
     from omnigent.host.identity import load_or_create_host_identity
 
-    headers = _remote_headers(server_url=base_url)
+    headers = _remote_headers(server_url=base_url, host_id=None)
     try:
         resolved_session_id = _resolve_session_id_for_resume(
             base_url=base_url,
@@ -321,12 +321,7 @@ async def _prepare_kimi_terminal_via_daemon(
     """
     persist_args = list(kimi_args)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(
-        base_url=base_url,
-        headers=headers,
-        timeout=timeout,
-        trust_env=not is_loopback_url(base_url),
-    ) as client:
+    async with open_daemon_client(base_url, headers, host_id, timeout=timeout) as client:
         # Resuming an existing session can either reattach to a live
         # terminal (prior chat intact) or, if that terminal has exited,
         # cold-start a fresh TUI. We only know which after probing for a

--- a/omnigent/kimi_native_forwarder.py
+++ b/omnigent/kimi_native_forwarder.py
@@ -391,6 +391,19 @@ async def forward_kimi_wire_to_session(
     first turn), then tails it, POSTing each new user/assistant turn and
     persisting the line offset after every post.
     """
+    # Route the transcript mirror to the replica holding this session's runner
+    # tunnel: the POST /events is published to that pod's in-process session
+    # stream, so an off-replica POST persists the item (shows on reload) but the
+    # live SSE tail never sees it ("no stream until refresh"). Unlike the other
+    # native forwarders, this client carries no _RunnerDatabricksAuth (whose
+    # auth_flow would stamp the key), so key the shared headers dict directly
+    # from the runner-env host_id (databricks_request_headers with no explicit
+    # host_id reads OMNIGENT_RUNNER_SLICE_KEY; emitted only on the workspace
+    # mount). One point covers the client default + every helper POST below,
+    # which all forward this same dict.
+    from omnigent.cli_auth import databricks_request_headers
+
+    headers = {**headers, **databricks_request_headers(base_url)}
     state = _read_state(bridge_dir)
     wire_path = Path(state.wire_path) if state is not None else None
     last_line = state.last_line if state is not None else 0

--- a/omnigent/kiro_native.py
+++ b/omnigent/kiro_native.py
@@ -15,7 +15,6 @@ from tempfile import TemporaryDirectory
 import click
 import httpx
 import yaml
-from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
 from omnigent._platform import resolve_cli_binary
@@ -27,6 +26,7 @@ from omnigent.entities.session_resources import terminal_resource_id
 from omnigent.host.daemon_launch import (
     error_text,
     launch_or_reuse_daemon_runner,
+    open_daemon_client,
     wait_for_host_online,
     wait_for_runner_online,
 )
@@ -281,7 +281,7 @@ def _run_with_remote_server(
     from omnigent.cli import _ensure_host_daemon
     from omnigent.host.identity import load_or_create_host_identity
 
-    headers = _remote_headers(server_url=base_url)
+    headers = _remote_headers(server_url=base_url, host_id=None)
     try:
         resolved_session_id = _resolve_session_id_for_resume(
             base_url=base_url,
@@ -356,12 +356,7 @@ async def _prepare_kiro_terminal_via_daemon(
     if prompt:
         persist_args.append(prompt)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(
-        base_url=base_url,
-        headers=headers,
-        timeout=timeout,
-        trust_env=not is_loopback_url(base_url),
-    ) as client:
+    async with open_daemon_client(base_url, headers, host_id, timeout=timeout) as client:
         reattached = False
         cold_resumed = False
         fresh_session = session_id is None

--- a/omnigent/kiro_native_permissions.py
+++ b/omnigent/kiro_native_permissions.py
@@ -203,9 +203,9 @@ async def supervise_kiro_permission_mirror(
         offset = 0
     pending: dict[str, _PendingPermission] = {}
     timeout = httpx.Timeout(_POST_TIMEOUT_S, connect=10.0)
-    async with httpx.AsyncClient(
-        base_url=base_url, headers=headers, auth=auth, timeout=timeout
-    ) as client:
+    from omnigent.cli_auth import open_server_client
+
+    async with open_server_client(base_url, headers=headers, auth=auth, timeout=timeout) as client:
         while True:
             try:
                 events, offset = await asyncio.to_thread(

--- a/omnigent/kiro_native_session_forwarder.py
+++ b/omnigent/kiro_native_session_forwarder.py
@@ -516,9 +516,9 @@ async def forward_kiro_session_to_omnigent(
     mirrored_external_session_id: str | None = None
     last_posted_cost: float | None = None
     last_posted_model: str | None = None
-    async with httpx.AsyncClient(
-        base_url=base_url, headers=headers, auth=auth, timeout=timeout
-    ) as client:
+    from omnigent.cli_auth import open_server_client
+
+    async with open_server_client(base_url, headers=headers, auth=auth, timeout=timeout) as client:
         while True:
             try:
                 if state.session_id is None or jsonl_path is None or not jsonl_path.exists():

--- a/omnigent/opencode_native.py
+++ b/omnigent/opencode_native.py
@@ -30,7 +30,6 @@ from tempfile import TemporaryDirectory
 import click
 import httpx
 import yaml
-from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_resume_hint
 from omnigent._runner_startup import RunnerStartupProgress, runner_startup_progress
@@ -41,6 +40,7 @@ from omnigent.entities.session_resources import terminal_resource_id
 from omnigent.host.daemon_launch import (
     error_text,
     launch_or_reuse_daemon_runner,
+    open_daemon_client,
     wait_for_host_online,
     wait_for_runner_online,
 )
@@ -217,7 +217,7 @@ def _run_with_remote_server(  # pragma: no cover
     from omnigent.cli import _ensure_host_daemon
     from omnigent.host.identity import load_or_create_host_identity
 
-    headers = _remote_headers(server_url=base_url)
+    headers = _remote_headers(server_url=base_url, host_id=None)
     try:
         resolved_session_id = _resolve_session_id_for_resume(
             base_url=base_url,
@@ -286,12 +286,7 @@ async def _prepare_opencode_terminal_via_daemon(  # pragma: no cover
     """Create or resume an opencode-native session through a daemon runner."""
     persist_args = list(opencode_args)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(
-        base_url=base_url,
-        headers=headers,
-        timeout=timeout,
-        trust_env=not is_loopback_url(base_url),
-    ) as client:
+    async with open_daemon_client(base_url, headers, host_id, timeout=timeout) as client:
         reattached = session_id is not None
         fresh_session = session_id is None
         if session_id is None:

--- a/omnigent/pi_native.py
+++ b/omnigent/pi_native.py
@@ -15,7 +15,6 @@ from tempfile import TemporaryDirectory
 import click
 import httpx
 import yaml
-from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_resume_hint
 from omnigent._platform import resolve_cli_binary
@@ -27,6 +26,7 @@ from omnigent.entities.session_resources import terminal_resource_id
 from omnigent.host.daemon_launch import (
     error_text,
     launch_or_reuse_daemon_runner,
+    open_daemon_client,
     wait_for_host_online,
     wait_for_runner_online,
 )
@@ -293,7 +293,7 @@ def _run_with_remote_server(
     from omnigent.cli import _ensure_host_daemon
     from omnigent.host.identity import load_or_create_host_identity
 
-    headers = _remote_headers(server_url=base_url)
+    headers = _remote_headers(server_url=base_url, host_id=None)
     try:
         resolved_session_id = _resolve_session_id_for_resume(
             base_url=base_url,
@@ -370,12 +370,7 @@ async def _prepare_pi_terminal_via_daemon(
     """
     persist_args = list(pi_args)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(
-        base_url=base_url,
-        headers=headers,
-        timeout=timeout,
-        trust_env=not is_loopback_url(base_url),
-    ) as client:
+    async with open_daemon_client(base_url, headers, host_id, timeout=timeout) as client:
         reattached = session_id is not None
         fresh_session = session_id is None
         if session_id is None:

--- a/omnigent/qwen_native.py
+++ b/omnigent/qwen_native.py
@@ -29,7 +29,6 @@ from tempfile import TemporaryDirectory
 import click
 import httpx
 import yaml
-from omnigent_client._http import is_loopback_url
 
 from omnigent._native_resume_hint import echo_native_cold_resume_hint, echo_native_resume_hint
 from omnigent._platform import resolve_cli_binary
@@ -41,6 +40,7 @@ from omnigent.entities.session_resources import terminal_resource_id
 from omnigent.host.daemon_launch import (
     error_text,
     launch_or_reuse_daemon_runner,
+    open_daemon_client,
     wait_for_host_online,
     wait_for_runner_online,
 )
@@ -245,7 +245,7 @@ def _run_with_remote_server(
     from omnigent.cli import _ensure_host_daemon
     from omnigent.host.identity import load_or_create_host_identity
 
-    headers = _remote_headers(server_url=base_url)
+    headers = _remote_headers(server_url=base_url, host_id=None)
     try:
         resolved_session_id = _resolve_session_id_for_resume(
             base_url=base_url,
@@ -316,12 +316,7 @@ async def _prepare_qwen_terminal_via_daemon(
     """
     persist_args = list(qwen_args)
     timeout = httpx.Timeout(30.0, read=120.0)
-    async with httpx.AsyncClient(
-        base_url=base_url,
-        headers=headers,
-        timeout=timeout,
-        trust_env=not is_loopback_url(base_url),
-    ) as client:
+    async with open_daemon_client(base_url, headers, host_id, timeout=timeout) as client:
         reattached = False
         cold_resumed = False
         fresh_session = session_id is None

--- a/omnigent/qwen_native_forwarder.py
+++ b/omnigent/qwen_native_forwarder.py
@@ -318,9 +318,9 @@ async def forward_qwen_events_to_session(
     offset = persisted.offset
     seen = _new_seen(persisted.seen_uuids)
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
-    async with httpx.AsyncClient(
-        base_url=base_url, headers=headers, auth=auth, timeout=timeout
-    ) as client:
+    from omnigent.cli_auth import open_server_client
+
+    async with open_server_client(base_url, headers=headers, auth=auth, timeout=timeout) as client:
         while True:
             try:
                 items, new_offset = await asyncio.to_thread(
@@ -516,9 +516,9 @@ async def supervise_qwen_compaction_mirror(
     except OSError:
         offset = 0  # not created yet; first poll reads from the start
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
-    async with httpx.AsyncClient(
-        base_url=base_url, headers=headers, auth=auth, timeout=timeout
-    ) as client:
+    from omnigent.cli_auth import open_server_client
+
+    async with open_server_client(base_url, headers=headers, auth=auth, timeout=timeout) as client:
         while True:
             try:
                 statuses, offset = await asyncio.to_thread(

--- a/omnigent/qwen_native_permissions.py
+++ b/omnigent/qwen_native_permissions.py
@@ -260,9 +260,9 @@ async def supervise_qwen_approval_mirror(
     # request_id -> {"elicitation_id": str, "task": asyncio.Task}
     pending: dict[str, _PendingApproval] = {}
     timeout = httpx.Timeout(_POST_TIMEOUT_S, connect=10.0)
-    async with httpx.AsyncClient(
-        base_url=base_url, headers=headers, auth=auth, timeout=timeout
-    ) as client:
+    from omnigent.cli_auth import open_server_client
+
+    async with open_server_client(base_url, headers=headers, auth=auth, timeout=timeout) as client:
         while True:
             try:
                 events, offset = await asyncio.to_thread(

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -493,7 +493,8 @@ def _render_startup_banner_ansi(
         ``None`` for the minimal banner.
     :returns: ANSI-styled string ready to be written to stdout.
     """
-    from omnigent.conversation_browser import display_server_url, is_workspace_hosted_url
+    from omnigent.cli_auth import is_workspace_hosted_url
+    from omnigent.conversation_browser import display_server_url
     from omnigent.inner.banner import BannerLine, startup_banner_strings
 
     remote = _is_remote_server_url(server_url)
@@ -4512,7 +4513,7 @@ async def run_repl(
         #   - the server is a Databricks workspace mount — a workspace build
         #     reports no meaningful version string (its /api/version returns a
         #     placeholder like "source"), so showing it is noise.
-        from omnigent.conversation_browser import is_workspace_hosted_url
+        from omnigent.cli_auth import is_workspace_hosted_url
 
         _show_version = _header is not None and not (
             server_url is not None and is_workspace_hosted_url(server_url)

--- a/omnigent/resume_dispatch.py
+++ b/omnigent/resume_dispatch.py
@@ -113,7 +113,7 @@ def _pick_conversation_for_resume(
     from omnigent.repl._resume_picker import pick_conversation_cross_agent_from_sdk
 
     base_url = server.rstrip("/")
-    headers = _remote_headers(server_url=base_url)
+    headers = _remote_headers(server_url=base_url, host_id=None)
     # Resume is owner-only, so the picker lists only the caller's own
     # sessions — never ones merely shared with them. Resolve who the
     # caller is here so the picker can drop shared rows; best-effort, so
@@ -339,7 +339,7 @@ def _read_wrapper_label_remote(
     from omnigent.chat import _remote_headers
 
     base_url = server.rstrip("/")
-    headers = _remote_headers(server_url=base_url)
+    headers = _remote_headers(server_url=base_url, host_id=None)
     try:
         resp = httpx.get(
             f"{base_url}/v1/sessions/{conv_id}",

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -1158,7 +1158,7 @@ def create_app(
         the app builds its own.
     :returns: A runner FastAPI app exposing the harness-contract subset.
     """
-    from omnigent.cli_auth import databricks_request_headers
+    from omnigent.cli_auth import open_server_client
     from omnigent.runner.app import create_runner_app
     from omnigent.runner.identity import (
         OMNIGENT_INTERNAL_WS_ORIGIN,
@@ -1198,7 +1198,6 @@ def create_app(
     # tunnel the runner opened to the Omnigent server at startup).
     # stdio_cwd=runner_workspace ensures relative command paths like
     # ".venv/bin/python" resolve against the user's project root.
-    from omnigent_client._http import is_loopback_url
 
     from omnigent.runner.mcp_manager import RunnerMcpManager
 
@@ -1207,24 +1206,20 @@ def create_app(
     if auth_token_factory is None:
         auth_token_factory = _make_auth_token_factory()
     binding_token = _runner_tunnel_binding_token_from_env()
-    server_client = httpx.AsyncClient(
-        base_url=server_url,
-        # A proxy cannot reach a loopback server, so local targets bypass it.
-        trust_env=not is_loopback_url(server_url),
+    server_client = open_server_client(
+        server_url,
         auth=_RunnerDatabricksAuth(auth_token_factory),
         # Announce the runner as a first-party non-browser client via the
         # sentinel Origin. The server's require_trusted_origin CSRF guard on
         # the multipart routes (POST /v1/sessions bundle create, file upload
         # — both reached from tool_dispatch over this client) requires a
         # trusted Origin; the runner sends none otherwise, so the sentinel is
-        # what lets sys_session_create / sys_upload_file through.
-        #
-        # The workspace-routing header (empty unless a ?o= selector was
-        # recorded for this server) routes these callbacks to the workspace.
+        # what lets sys_session_create / sys_upload_file through. The factory
+        # folds the routing/slice-key headers in on top; we pass only the
+        # runner's tunnel-binding token (when present) alongside the Origin.
         headers={
             "Origin": OMNIGENT_INTERNAL_WS_ORIGIN,
             **({RUNNER_TUNNEL_TOKEN_HEADER: binding_token} if binding_token is not None else {}),
-            **databricks_request_headers(server_url),
         },
         timeout=httpx.Timeout(5.0, read=None),
         # NOTE: ``follow_redirects`` deliberately stays False.
@@ -1235,6 +1230,7 @@ def create_app(
         # httpx walks the redirect chain inside the auth loop and
         # hands the auth flow only the terminal HTML login page,
         # defeating the retry. See ``_is_login_redirect_or_unauthorized``.
+        follow_redirects=False,
     )
 
     mcp_manager = RunnerMcpManager(

--- a/omnigent/runner/identity.py
+++ b/omnigent/runner/identity.py
@@ -25,6 +25,11 @@ RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR = "OMNIGENT_RUNNER_INITIAL_AUTH_TOKEN"
 # Host-launched runners use their binding token to obtain a short-lived,
 # owner-scoped server bearer instead of resolving the host user's credentials.
 RUNNER_DELEGATED_AUTH_ENV_VAR = "OMNIGENT_RUNNER_DELEGATED_AUTH"
+# Replica-routing key the runner stamps on its tunnel handshake so it
+# co-locates with the host that launched it (value = that host's host_id). The
+# host injects it when spawning the runner; absent for CLI-local runners, which
+# then leave routing to the default.
+RUNNER_SLICE_KEY_ENV_VAR = "OMNIGENT_RUNNER_SLICE_KEY"
 RUNNER_TUNNEL_TOKEN_HEADER = "X-Omnigent-Runner-Tunnel-Token"
 # Sentinel ``Origin`` header that the project's own non-browser WebSocket
 # clients (runner -> server tunnel, host/daemon -> server tunnel,

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -4333,9 +4333,11 @@ async def _codex_discover_thread_and_forward(
         # would resume fresh. Best-effort: a transient Omnigent failure here still
         # leaves chat streaming working — only fork-history carry-over
         # degrades.
+        from omnigent.cli_auth import open_server_client
+
         try:
-            async with httpx.AsyncClient(
-                base_url=server_url,
+            async with open_server_client(
+                server_url,
                 headers=headers,
                 auth=_RunnerDatabricksAuth(auth_factory),
                 timeout=httpx.Timeout(10.0),

--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -17,6 +17,7 @@ import base64
 import binascii
 import contextlib
 import logging
+import os
 import random
 from collections.abc import Awaitable, Callable
 from typing import TypeAlias
@@ -27,6 +28,7 @@ from websockets.exceptions import ConnectionClosedOK, InvalidURI, WebSocketExcep
 
 from omnigent.runner.identity import (
     OMNIGENT_INTERNAL_WS_ORIGIN,
+    RUNNER_SLICE_KEY_ENV_VAR,
     RUNNER_TUNNEL_TOKEN_HEADER,
 )
 from omnigent.runner.transports.ws_tunnel.frames import (
@@ -671,7 +673,13 @@ async def _serve_tunnel_once(
     from omnigent.cli_auth import databricks_request_headers
 
     headers: dict[str, str] = {"Origin": OMNIGENT_INTERNAL_WS_ORIGIN}
-    headers.update(databricks_request_headers(server_url, bearer_token=auth_token))
+    # Co-locate this runner's tunnel with its host's on one server replica: the
+    # host injects its id at launch. Absent for CLI-local runners (no host), and
+    # the builder only emits the routing header on a host-sharded deployment.
+    host_id = os.environ.get(RUNNER_SLICE_KEY_ENV_VAR)
+    headers.update(
+        databricks_request_headers(server_url, bearer_token=auth_token, host_id=host_id)
+    )
     if tunnel_token:
         headers[RUNNER_TUNNEL_TOKEN_HEADER] = tunnel_token
     # Verifying SSL context from a real CA bundle for wss:// — a bare default

--- a/omnigent/smart_routing_cli.py
+++ b/omnigent/smart_routing_cli.py
@@ -231,7 +231,7 @@ def arm_smart_routing_session(
         body["workspace"] = workspace
     try:
         with httpx.Client(
-            base_url=base_url, headers=_headers(base_url), timeout=_TIMEOUT
+            base_url=base_url, headers=_headers(base_url, host_id=host_id), timeout=_TIMEOUT
         ) as client:
             resp = client.post("/v1/sessions", json=body)
             if resp.status_code >= 400:
@@ -292,7 +292,7 @@ def known_host_id(*, base_url: str, host_id: str | None) -> str | None:
     """
     if host_id is None:
         return None
-    payload = _get_json(base_url=base_url, path="/v1/hosts")
+    payload = _get_json(base_url=base_url, path="/v1/hosts", host_id=host_id)
     hosts = payload.get("hosts") if isinstance(payload, dict) else None
     if not isinstance(hosts, list):
         return None
@@ -311,7 +311,7 @@ def _gateway_inference_for_host(*, base_url: str, host_id: str) -> dict[str, Any
     :returns: The map, or ``None`` when the host, the field, or the request is
         unavailable (all of which mean "unknown", which does not gate).
     """
-    payload = _get_json(base_url=base_url, path="/v1/hosts")
+    payload = _get_json(base_url=base_url, path="/v1/hosts", host_id=host_id)
     hosts = payload.get("hosts") if isinstance(payload, dict) else None
     if not isinstance(hosts, list):
         return None
@@ -343,19 +343,23 @@ def _gateway_state(gateway: dict[str, Any], harness: str) -> Any:
     return None
 
 
-def _headers(base_url: str) -> dict[str, str]:
+def _headers(base_url: str, *, host_id: str | None) -> dict[str, str]:
     """
     Auth headers for *base_url*, matching every other CLI server call.
 
     :param base_url: Omnigent server base URL.
+    :param host_id: This machine's host id for the slice-key header, or
+        ``None``. Required kwarg because ``_remote_headers`` makes it required
+        (host_id sharding, commit 615383a) — a preflight read that omitted it
+        used to crash before the routing decision ran.
     :returns: Header mapping, possibly empty for a local server.
     """
     from omnigent.chat import _remote_headers
 
-    return _remote_headers(server_url=base_url)
+    return _remote_headers(server_url=base_url, host_id=host_id)
 
 
-def _get_json(*, base_url: str, path: str) -> dict[str, Any]:
+def _get_json(*, base_url: str, path: str, host_id: str | None = None) -> dict[str, Any]:
     """
     GET *path* and return its JSON object, or ``{}`` on any failure.
 
@@ -366,11 +370,15 @@ def _get_json(*, base_url: str, path: str) -> dict[str, Any]:
 
     :param base_url: Omnigent server base URL.
     :param path: Request path, e.g. ``"/v1/info"``.
+    :param host_id: This machine's host id for the slice-key header, or
+        ``None`` (the ``/v1/info`` availability probe needs no host routing).
     :returns: The decoded object, or ``{}``.
     """
     try:
         with httpx.Client(
-            base_url=base_url, headers=_headers(base_url), timeout=_PREFLIGHT_TIMEOUT
+            base_url=base_url,
+            headers=_headers(base_url, host_id=host_id),
+            timeout=_PREFLIGHT_TIMEOUT,
         ) as client:
             resp = client.get(path)
             if resp.status_code >= 400:

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,29 @@
+"""Shared fixtures for CLI unit tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate the machine's own host identity and runner slice-key env var.
+
+    ``databricks_request_headers`` (reached via ``_remote_headers``,
+    ``open_daemon_client``, and the auth flow) resolves the slice key from,
+    in order: an explicit ``host_id``, the ``OMNIGENT_RUNNER_SLICE_KEY`` env
+    var (set inside a runner process), then the CLI's own host identity. On a
+    developer machine that IS a host — a persisted ``~/.omnigent/config.yaml``
+    ``host:`` section — that last fallback would leak the machine's host_id
+    into requests, so any "no slice key on this call" assertion would flake
+    depending on where the suite runs. Force the read-only lookup to ``None``
+    and clear the runner env so CLI tests exercise only the host they name.
+
+    ``autouse=True`` keeps the isolation on by default; tests that need a real
+    host identity re-patch ``load_host_identity_if_present`` themselves.
+    """
+    monkeypatch.setattr(
+        "omnigent.host.identity.load_host_identity_if_present",
+        lambda *a, **k: None,
+    )
+    monkeypatch.delenv("OMNIGENT_RUNNER_SLICE_KEY", raising=False)

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -1347,6 +1347,10 @@ def test_host_stop_stops_sessions_before_daemon(
                     ]
                 },
             )
+        # Stop resolves the session's host (any-replica metadata read) before
+        # keying the stop event by it.
+        if method == "GET" and path == "/v1/sessions/conv_owned":
+            return cli._HostHttpResult(status_code=200, body={"host_id": "host_abc"})
         if method == "POST" and path == "/v1/sessions/conv_owned/events":
             return cli._HostHttpResult(status_code=200, body={"queued": False})
         raise AssertionError(f"unexpected request: {method} {path}")
@@ -1368,6 +1372,7 @@ def test_host_stop_stops_sessions_before_daemon(
     assert result.exit_code == 0, result.output
     assert events == [
         ("GET", "/v1/sessions"),
+        ("GET", "/v1/sessions/conv_owned"),
         ("POST", "/v1/sessions/conv_owned/events"),
         ("TERM", "https://server.example.com"),
     ]
@@ -1514,6 +1519,37 @@ def test_host_stop_session_stops_only_named_sessions(
 
     assert result.exit_code == 0, result.output
     assert stopped == ["conv_a", "conv_b"]
+
+
+def test_stop_session_keys_event_by_resolved_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``stop-session`` resolves the session's host and keys the stop event by it.
+
+    A standalone ``omni host stop-session`` process has an empty session→host
+    map, so it reads the host from the session record first; the stop_session
+    event is a server→runner forward that must reach the replica holding the
+    runner's tunnel. A metadata GET (any replica) precedes it, and the POST
+    carries ``host_id`` from that record.
+    """
+    calls: list[dict[str, object]] = []
+
+    def _fake_http_json(**kwargs: object) -> cli._HostHttpResult:
+        calls.append(kwargs)
+        if kwargs["method"] == "GET":
+            return cli._HostHttpResult(status_code=200, body={"host_id": "host_bea4"})
+        return cli._HostHttpResult(status_code=202, body={})
+
+    monkeypatch.setattr(cli, "_host_http_json", _fake_http_json)
+
+    cli._stop_session_on_server(base_url="https://ws/api/2.0/omnigent", session_id="conv_1")
+
+    get_call = next(c for c in calls if c["method"] == "GET")
+    post_call = next(c for c in calls if c["method"] == "POST")
+    # Host resolved from the session record, then the stop event is keyed by it.
+    assert get_call["path"] == "/v1/sessions/conv_1"
+    assert post_call["path"] == "/v1/sessions/conv_1/events"
+    assert post_call["host_id"] == "host_bea4"
 
 
 def test_ensure_backend_remote_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1727,7 +1763,7 @@ def _patch_auth_preflight(
 
     monkeypatch.setattr(
         "omnigent.chat._remote_headers",
-        lambda server_url=None: {},
+        lambda server_url=None, *, host_id=None: {},
     )
     monkeypatch.setattr(httpx, "get", lambda url, **kw: _databricks_probe_response(probe_status))
     monkeypatch.setattr(cli, "_workspace_api_server_url", lambda server: server.rstrip("/"))

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -2425,7 +2425,7 @@ def test_remote_headers_prefers_explicit_remote_token_env(monkeypatch: pytest.Mo
         lambda _profile: DatabricksCredentials(host="https://x", token="ambient-token"),
     )
 
-    assert _remote_headers(server_url="https://srv.example.com") == {
+    assert _remote_headers(server_url="https://srv.example.com", host_id=None) == {
         "Authorization": "Bearer env-token"
     }
 
@@ -2453,7 +2453,7 @@ def test_remote_headers_falls_back_to_ambient_databricks_creds(
 
     monkeypatch.setattr(chat_module, "_read_databrickscfg", _fake_read)
 
-    headers = _remote_headers(server_url="https://srv.example.com")
+    headers = _remote_headers(server_url="https://srv.example.com", host_id=None)
 
     # The ambient token reached the Authorization header.
     assert headers == {"Authorization": "Bearer ambient-token"}
@@ -2477,7 +2477,9 @@ def test_remote_headers_adds_org_id_header(monkeypatch: pytest.MonkeyPatch) -> N
         "omnigent.cli_auth.load_databricks_org_id", lambda _url: "2850744067564480"
     )
 
-    headers = _remote_headers(server_url="https://acme.databricks.com/api/2.0/omnigent")
+    headers = _remote_headers(
+        server_url="https://acme.databricks.com/api/2.0/omnigent", host_id=None
+    )
 
     assert headers == {
         "Authorization": "Bearer rec-tok",
@@ -2498,10 +2500,41 @@ def test_remote_headers_omits_org_when_no_record(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(chat_module, "_stored_databricks_record_token", lambda _url: "rec-tok")
     monkeypatch.setattr("omnigent.cli_auth.load_databricks_org_id", lambda _url: None)
 
-    headers = _remote_headers(server_url="https://single.databricks.com/api/2.0/omnigent")
+    headers = _remote_headers(
+        server_url="https://single.databricks.com/api/2.0/omnigent", host_id=None
+    )
 
     assert headers == {"Authorization": "Bearer rec-tok"}
     assert "X-Databricks-Org-Id" not in headers
+
+
+def test_remote_headers_keys_by_host_id_on_workspace_mount(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A host_id rides as the slice-key header on a host-sharded mount.
+
+    The native attach WebSocket handshake (claude / codex / antigravity) and
+    its reconnects build their headers here, so the host_id must surface as the
+    routing header to reach the replica holding the runner's tunnel. It is
+    emitted only on a host-sharded mount; no host_id, or an unsharded server,
+    sends none.
+    """
+    monkeypatch.delenv("OMNIGENT_REMOTE_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr(chat_module, "_stored_databricks_record_token", lambda _url: "rec-tok")
+    monkeypatch.setattr("omnigent.cli_auth.load_databricks_org_id", lambda _url: None)
+
+    mount = "https://acme.databricks.com/api/2.0/omnigent"
+    assert (
+        _remote_headers(server_url=mount, host_id="host_abc")["X-Databricks-Omnigent-Slice-Key"]
+        == "host_abc"
+    )
+    # No host_id → no slice-key header on the same mount.
+    assert "X-Databricks-Omnigent-Slice-Key" not in _remote_headers(server_url=mount, host_id=None)
+    # Unsharded server → no slice-key header even with a host_id.
+    assert "X-Databricks-Omnigent-Slice-Key" not in _remote_headers(
+        server_url="http://127.0.0.1:6767", host_id="host_abc"
+    )
 
 
 def test_server_headers_do_not_encode_runner_affinity() -> None:
@@ -2804,7 +2837,9 @@ def _stub_run_repl_deps(
     monkeypatch.setattr(_repl_pkg, "run_repl", _fake_run_repl)
     monkeypatch.setattr("omnigent.repl._repl.run_repl", _fake_run_repl)
     monkeypatch.setattr("omnigent.chat.OmnigentClient", _FakeClientCtx)
-    monkeypatch.setattr("omnigent.chat._server_auth", lambda server_url=None: None)
+    monkeypatch.setattr(
+        "omnigent.chat._server_auth", lambda server_url=None, *, session_id=None: None
+    )
     monkeypatch.setattr(
         "omnigent.repl._tmux_pane.register_pane",
         lambda **_kw: None,
@@ -3037,7 +3072,7 @@ def test_databricks_token_auth_sets_org_header(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
     monkeypatch.setattr(
         "omnigent.cli_auth.databricks_request_headers",
-        lambda _url: {"X-Databricks-Org-Id": "2850744067564480"},
+        lambda _url, *, host_id=None: {"X-Databricks-Org-Id": "2850744067564480"},
     )
     # Isolate from real Databricks SDK resolution: the bearer is irrelevant
     # here — only the routing header is under test.

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -6596,3 +6596,36 @@ def test_manage_kimi_harness_login_runs_kimi_login(
     _manage_kimi_harness()
 
     login.assert_called_once_with(hi.KIMI_KEY)
+
+
+def test_runner_online_map_keys_status_by_runner_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each runner-status check names the runner's host.
+
+    The status endpoint reads the in-memory tunnel registry, so the check must
+    reach the replica holding that runner's tunnel or it reports the runner
+    offline. A runner is spawned on exactly one host, taken here from the
+    session rows that reference it; a runner with no host row is left unkeyed.
+    """
+    import omnigent.cli as cli
+
+    seen: dict[str, str | None] = {}
+
+    def _fake(*, base_url: str, method: str, path: str, host_id: str | None = None, **_kw):
+        seen[path.rsplit("/", 2)[1]] = host_id  # /v1/runners/{rid}/status
+        return cli._HostHttpResult(status_code=200, body={"online": True})
+
+    monkeypatch.setattr(cli, "_host_http_json", _fake)
+
+    sessions = [
+        {"id": "conv_1", "runner_id": "runner_a", "host_id": "host_1"},
+        {"id": "conv_2", "runner_id": "runner_b", "host_id": "host_2"},
+        {"id": "conv_3", "runner_id": "runner_c"},  # hostless → unkeyed
+    ]
+    result = cli._runner_online_map(
+        base_url="https://ws.example.com/api/2.0/omnigent", sessions=sessions
+    )
+
+    assert result == {"runner_a": True, "runner_b": True, "runner_c": True}
+    assert seen == {"runner_a": "host_1", "runner_b": "host_2", "runner_c": None}

--- a/tests/cli/test_cli_auth.py
+++ b/tests/cli/test_cli_auth.py
@@ -16,7 +16,9 @@ def token_dir(tmp_path, monkeypatch):
     """Redirect the token file to a temp directory.
 
     Patches ``state_dir`` to return ``tmp_path`` so tests don't
-    touch ``~/.omnigent``.
+    touch ``~/.omnigent``. (The machine's own host identity and the runner
+    slice-key env var are isolated globally by the ``_no_ambient_host``
+    autouse fixture in ``conftest.py``.)
 
     :param tmp_path: Pytest temp directory.
     :param monkeypatch: Pytest monkeypatch fixture.
@@ -280,6 +282,117 @@ def test_databricks_request_headers_pairs_bearer_and_org(token_dir) -> None:
     assert databricks_request_headers("https://other.example.com", bearer_token="tok") == {
         "Authorization": "Bearer tok"
     }
+
+
+def test_databricks_request_headers_slice_key(token_dir) -> None:
+    """The slice key is emitted only on a host-sharded deployment.
+
+    Callers pass ``host_id=<host_id>`` unconditionally; the builder
+    itself gates on the server being a host-sharded mount, so a new caller
+    never has to reason about the deployment. On an unsharded server the key
+    is dropped. When emitted, it travels alongside the bearer and ?o= header.
+    """
+    from omnigent.cli_auth import databricks_request_headers, store_databricks_auth
+
+    # Unsharded server: the slice key is DROPPED even though it was passed.
+    assert databricks_request_headers("https://other.example.com", host_id="host_abc123") == {}
+    assert databricks_request_headers("http://127.0.0.1:6767", host_id="host_abc123") == {}
+
+    # Workspace API mount: the key rides, alongside the bearer and ?o= selector.
+    store_databricks_auth(
+        server_url="https://acme.databricks.com/api/2.0/omnigent",
+        workspace_host="https://acme.databricks.com",
+        org_id="2850744067564480",
+    )
+    recorded = "https://acme.databricks.com/api/2.0/omnigent"
+    assert databricks_request_headers(recorded, bearer_token="tok", host_id="host_abc123") == {
+        "Authorization": "Bearer tok",
+        "X-Databricks-Org-Id": "2850744067564480",
+        "X-Databricks-Omnigent-Slice-Key": "host_abc123",
+    }
+
+    # Omitted (default) → no slice-key header even on the workspace mount.
+    assert "X-Databricks-Omnigent-Slice-Key" not in databricks_request_headers(recorded)
+
+
+def test_databricks_request_headers_runner_env_default(
+    token_dir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Inside a runner, an unspecified host_id defaults to the runner's own.
+
+    A runner process exports its host_id at launch (``OMNIGENT_RUNNER_SLICE_KEY``);
+    the builder picks it up when a caller names no host, so the runner's server
+    traffic (transcript posts, uploads, policy checks) keys by host_id and
+    spreads across replicas instead of piling onto the single workspace-key pod.
+    An explicit host_id still wins, the env is honoured only on the workspace
+    mount, and CLI / daemon callers (no such env) are unaffected.
+    """
+    from omnigent.cli_auth import databricks_request_headers, store_databricks_auth
+    from omnigent.runner.identity import RUNNER_SLICE_KEY_ENV_VAR
+
+    store_databricks_auth(
+        server_url="https://acme.databricks.com/api/2.0/omnigent",
+        workspace_host="https://acme.databricks.com",
+    )
+    mount = "https://acme.databricks.com/api/2.0/omnigent"
+
+    # No env, no explicit host_id → no key (CLI / daemon unaffected).
+    monkeypatch.delenv(RUNNER_SLICE_KEY_ENV_VAR, raising=False)
+    assert "X-Databricks-Omnigent-Slice-Key" not in databricks_request_headers(mount)
+
+    # Runner env set → the key defaults to it.
+    monkeypatch.setenv(RUNNER_SLICE_KEY_ENV_VAR, "host_runner")
+    assert databricks_request_headers(mount)["X-Databricks-Omnigent-Slice-Key"] == "host_runner"
+
+    # An explicit host_id still overrides the env.
+    assert (
+        databricks_request_headers(mount, host_id="host_explicit")[
+            "X-Databricks-Omnigent-Slice-Key"
+        ]
+        == "host_explicit"
+    )
+
+    # Gated: even with the env set, an unsharded server emits nothing.
+    assert databricks_request_headers("http://127.0.0.1:6767") == {}
+
+
+def test_databricks_request_headers_slice_key_kill_switch(
+    token_dir, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``OMNIGENT_HOST_SLICE_KEY_ENABLED=0`` disables slice-key emission.
+
+    A per-process kill switch: slice-key emission runs in sidecar-less
+    processes that can't evaluate a server-side flag, so this env var lets a bad
+    rollout fall back to the server's default (workspace-id) routing without a
+    redeploy. Emission is ON by default; only the exact value "0" turns it off.
+    """
+    from omnigent.cli_auth import databricks_request_headers, store_databricks_auth
+
+    store_databricks_auth(
+        server_url="https://acme.databricks.com/api/2.0/omnigent",
+        workspace_host="https://acme.databricks.com",
+    )
+    mount = "https://acme.databricks.com/api/2.0/omnigent"
+
+    # Default (env unset): the key is emitted on the workspace mount.
+    monkeypatch.delenv("OMNIGENT_HOST_SLICE_KEY_ENABLED", raising=False)
+    assert (
+        databricks_request_headers(mount, host_id="host_1")["X-Databricks-Omnigent-Slice-Key"]
+        == "host_1"
+    )
+
+    # Kill switch flipped to "0": no key, same mount and host_id.
+    monkeypatch.setenv("OMNIGENT_HOST_SLICE_KEY_ENABLED", "0")
+    assert "X-Databricks-Omnigent-Slice-Key" not in databricks_request_headers(
+        mount, host_id="host_1"
+    )
+
+    # Only the exact "0" disables it — any other value leaves emission on.
+    monkeypatch.setenv("OMNIGENT_HOST_SLICE_KEY_ENABLED", "1")
+    assert (
+        databricks_request_headers(mount, host_id="host_1")["X-Databricks-Omnigent-Slice-Key"]
+        == "host_1"
+    )
 
 
 def test_databricks_request_headers_folds_extra_headers(token_dir, monkeypatch) -> None:

--- a/tests/cli/test_session_host.py
+++ b/tests/cli/test_session_host.py
@@ -1,0 +1,73 @@
+"""Unit tests for client-side session→host routing helpers in ``chat``."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from omnigent.chat import (
+    _DatabricksTokenAuth,
+    get_session_host,
+    set_session_host,
+)
+from omnigent.cli_auth import OMNIGENT_SLICE_KEY_HEADER
+
+
+@pytest.fixture(autouse=True)
+def _clear_map() -> None:
+    """Reset the module-global session→host map between tests."""
+    from omnigent import chat
+
+    chat._session_hosts.clear()
+    yield
+    chat._session_hosts.clear()
+
+
+def test_set_session_host_clears_on_empty() -> None:
+    """A ``None``/empty host clears any stale mapping."""
+    set_session_host("conv_1", "host_abc")
+    assert get_session_host("conv_1") == "host_abc"
+    set_session_host("conv_1", None)
+    assert get_session_host("conv_1") is None
+    set_session_host("conv_1", "host_abc")
+    set_session_host("conv_1", "")
+    assert get_session_host("conv_1") is None
+
+
+def _slice_key(auth: _DatabricksTokenAuth, url: str) -> str | None:
+    """Run *auth*'s flow on a GET to *url* and return the slice-key header."""
+    flow = auth.auth_flow(httpx.Request("GET", url))
+    request = next(flow)
+    flow.close()
+    return request.headers.get(OMNIGENT_SLICE_KEY_HEADER)
+
+
+def test_auth_keys_by_session_host_on_workspace_mount() -> None:
+    """The auth pins its session's requests to that session's host replica.
+
+    The client is built for one session; it names the session (not a parsed
+    URL), and the auth resolves the host from the session→host map. On the
+    workspace mount the routing header rides; an unmapped session sends none.
+    """
+    mount = "https://acme.databricks.com/api/2.0/omnigent"
+    set_session_host("conv_1", "host_abc")
+
+    keyed = _DatabricksTokenAuth(server_url=mount, session_id="conv_1")
+    assert _slice_key(keyed, f"{mount}/v1/sessions/conv_1/events") == "host_abc"
+    # Any request on this client rides the same key (it is single-session).
+    assert _slice_key(keyed, f"{mount}/v1/sessions/conv_1/stream") == "host_abc"
+
+    # Unmapped session → no key (workspace fallback).
+    unmapped = _DatabricksTokenAuth(server_url=mount, session_id="conv_unknown")
+    assert _slice_key(unmapped, f"{mount}/v1/sessions/conv_unknown/events") is None
+
+    # Hostless (local / no session) client → no key.
+    hostless = _DatabricksTokenAuth(server_url=mount, session_id=None)
+    assert _slice_key(hostless, f"{mount}/v1/sessions/conv_1/events") is None
+
+
+def test_auth_no_key_off_workspace() -> None:
+    """An unsharded server has no sharding layer, so no key is sent."""
+    set_session_host("conv_1", "host_abc")
+    auth = _DatabricksTokenAuth(server_url="http://127.0.0.1:6767", session_id="conv_1")
+    assert _slice_key(auth, "http://127.0.0.1:6767/v1/sessions/conv_1/events") is None

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -3352,6 +3352,67 @@ def test_build_connect_headers_retains_auth_factory(
     assert token_calls == [1, 1, 1]
 
 
+def test_build_connect_headers_slice_key_only_on_workspace_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The slice key rides the handshake only on a host-sharded mount.
+
+    A host-sharded server (``/api/2.0/omnigent``) routes through the
+    sharding layer, so the host pins its tunnel with the slice key (its host_id).
+    An unsharded / local server has no sharding layer, so the key is omitted to
+    keep that server's logs clean.
+
+    :param monkeypatch: The pytest monkeypatch fixture.
+    :returns: None.
+    """
+    import omnigent.runner._entry as entry_mod
+
+    # Isolate the slice-key branch from the bearer/managed-token paths.
+    monkeypatch.delenv("OMNIGENT_HOST_TOKEN", raising=False)
+    monkeypatch.setattr(entry_mod, "_make_auth_token_factory", lambda *, server_url=None: None)
+
+    workspace = _host("https://acme.databricks.com/api/2.0/omnigent")._build_connect_headers()
+    assert workspace["X-Databricks-Omnigent-Slice-Key"] == "host_test_connect"
+
+    self_hosted = _host("http://127.0.0.1:6767")._build_connect_headers()
+    assert "X-Databricks-Omnigent-Slice-Key" not in self_hosted
+
+
+def test_build_runner_env_carries_host_id() -> None:
+    """The runner is told its host id so its tunnel co-locates with the host's.
+
+    The env var carries the host_id whenever one is present, regardless of the
+    server — the runner forwards it to ``databricks_request_headers``, which
+    emits the routing header only on a host-sharded deployment (see
+    ``test_cli_auth.test_databricks_request_headers_slice_key``). With no
+    host_id (a CLI-local runner), the env var is omitted.
+    """
+    from omnigent.runner.identity import RUNNER_SLICE_KEY_ENV_VAR
+
+    def _env(*, server_url: str, host_id: str | None) -> dict[str, str]:
+        return _build_runner_env(
+            {},
+            server_url=server_url,
+            runner_id="runner_abc",
+            binding_token="tok",
+            workspace="/ws",
+            parent_pid=123,
+            host_id=host_id,
+        )
+
+    # Set from host_id on any server (gating lives in the header builder).
+    for server_url in (
+        "https://acme.databricks.com/api/2.0/omnigent",
+        "http://127.0.0.1:6767",
+    ):
+        assert _env(server_url=server_url, host_id="host_x")[RUNNER_SLICE_KEY_ENV_VAR] == "host_x"
+
+    # No host (CLI-local runner) → omitted.
+    assert RUNNER_SLICE_KEY_ENV_VAR not in _env(
+        server_url="https://acme.databricks.com/api/2.0/omnigent", host_id=None
+    )
+
+
 async def test_run_retries_on_login_redirect(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,

--- a/tests/host/test_daemon_launch.py
+++ b/tests/host/test_daemon_launch.py
@@ -15,12 +15,30 @@ import click
 import httpx
 import pytest
 
+from omnigent.cli_auth import OMNIGENT_SLICE_KEY_HEADER
 from omnigent.host import daemon_launch
 from omnigent.host.daemon_launch import (
+    open_daemon_client,
     runner_is_online,
     wait_for_host_online,
     wait_for_runner_online,
 )
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate the machine's own host identity and runner slice-key env.
+
+    ``databricks_request_headers`` (reached via ``open_daemon_client`` with no
+    explicit host) falls back to the CLI's own host_id, so on a machine that IS
+    a host (a persisted ``~/.omnigent/config.yaml`` ``host:`` section) the
+    "no slice key" assertions would pick up that ambient identity.
+    """
+    monkeypatch.setattr(
+        "omnigent.host.identity.load_host_identity_if_present",
+        lambda *a, **k: None,
+    )
+    monkeypatch.delenv("OMNIGENT_RUNNER_SLICE_KEY", raising=False)
 
 
 class _FlakyThenOnline:
@@ -344,3 +362,33 @@ async def test_wait_for_host_online_tolerates_html_fallback_then_online(
         await wait_for_host_online(client, "host_abc123", timeout_s=5.0)
     # 3 = 2 HTML-fallback polls + the one that observed JSON "online".
     assert handler.requests_seen == 3
+
+
+async def test_open_daemon_client_pins_slice_key_on_workspace_mount() -> None:
+    """On the workspace mount the client is pinned to the host's replica.
+
+    The host_id routing header is baked into the client's default headers, so
+    every request it makes — the launch, runner-status polls, and the
+    session/terminal ops (including a resume reattach check that runs before
+    the launch) — reaches the replica holding the host's tunnels. Base headers
+    are preserved.
+    """
+    async with open_daemon_client(
+        "https://ws.example.com/api/2.0/omnigent",
+        {"Authorization": "Bearer t"},
+        "host_abc123",
+    ) as client:
+        assert client.headers.get(OMNIGENT_SLICE_KEY_HEADER) == "host_abc123"
+        assert client.headers.get("Authorization") == "Bearer t"
+
+
+async def test_open_daemon_client_no_slice_key_off_workspace() -> None:
+    """An unsharded server has no sharding layer, so no key is baked."""
+    async with open_daemon_client("http://test", {}, "host_abc123") as client:
+        assert OMNIGENT_SLICE_KEY_HEADER not in client.headers
+
+
+async def test_open_daemon_client_no_slice_key_without_host() -> None:
+    """A hostless (local) session leaves routing to the default fallback."""
+    async with open_daemon_client("https://ws.example.com/api/2.0/omnigent", {}, None) as client:
+        assert OMNIGENT_SLICE_KEY_HEADER not in client.headers

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -1590,9 +1590,9 @@ def test_remote_daemon_run_attaches_without_cli_forwarder(
     monkeypatch.setattr("omnigent.chat._bundle_agent", lambda path: b"bundle")
     monkeypatch.setattr(
         "omnigent.chat._remote_headers",
-        lambda server_url=None: {"Authorization": "Bearer tok"},
+        lambda server_url=None, **_kw: {"Authorization": "Bearer tok"},
     )
-    monkeypatch.setattr("omnigent.chat._server_auth", lambda server_url=None: None)
+    monkeypatch.setattr("omnigent.chat._server_auth", lambda server_url=None, **_kw: None)
     monkeypatch.setattr("omnigent.cli._ensure_host_daemon", lambda base_url: None)
     monkeypatch.setattr(
         "omnigent.host.identity.load_or_create_host_identity",
@@ -5501,7 +5501,7 @@ def test_is_claude_native_conversation_returns_true_on_matching_label(
         )
 
     monkeypatch.setattr(chat.httpx, "get", _fake_get)
-    monkeypatch.setattr(chat, "_remote_headers", lambda server_url=None: {})
+    monkeypatch.setattr(chat, "_remote_headers", lambda server_url=None, **_kw: {})
 
     assert (
         chat._is_claude_native_conversation(
@@ -5538,7 +5538,7 @@ def test_is_claude_native_conversation_returns_false_on_non_matching_label(
         return httpx.Response(200, json={"labels": labels})
 
     monkeypatch.setattr(chat.httpx, "get", _fake_get)
-    monkeypatch.setattr(chat, "_remote_headers", lambda server_url=None: {})
+    monkeypatch.setattr(chat, "_remote_headers", lambda server_url=None, **_kw: {})
 
     assert (
         chat._is_claude_native_conversation(
@@ -5573,7 +5573,7 @@ def test_is_claude_native_conversation_logs_warning_on_non_200(
 
     captured_warnings: list[str] = []
     monkeypatch.setattr(chat.httpx, "get", _fake_get)
-    monkeypatch.setattr(chat, "_remote_headers", lambda server_url=None: {})
+    monkeypatch.setattr(chat, "_remote_headers", lambda server_url=None, **_kw: {})
     monkeypatch.setattr(
         chat.logger,
         "warning",
@@ -5613,7 +5613,7 @@ def test_is_claude_native_conversation_returns_false_on_transport_error(
 
     captured_warnings: list[str] = []
     monkeypatch.setattr(chat.httpx, "get", _raises)
-    monkeypatch.setattr(chat, "_remote_headers", lambda server_url=None: {})
+    monkeypatch.setattr(chat, "_remote_headers", lambda server_url=None, **_kw: {})
     monkeypatch.setattr(
         chat.logger,
         "warning",

--- a/tests/test_conversation_browser.py
+++ b/tests/test_conversation_browser.py
@@ -62,11 +62,14 @@ def test_is_workspace_hosted_url(url: str, expected: bool) -> None:
 
     What this proves: the predicate the banner uses to suppress the
     server-version row fires for ``/api/2.0/omnigent`` and nothing else, so
-    non-Databricks targets keep showing their version.
+    non-Databricks targets keep showing their version. (Now defined in
+    ``cli_auth`` next to the header builder that gates on it.)
 
     :returns: None.
     """
-    assert browser.is_workspace_hosted_url(url) is expected
+    from omnigent.cli_auth import is_workspace_hosted_url
+
+    assert is_workspace_hosted_url(url) is expected
 
 
 def test_conversation_url_quotes_session_id() -> None:

--- a/tests/test_hermes_native_forwarder.py
+++ b/tests/test_hermes_native_forwarder.py
@@ -502,27 +502,15 @@ async def test_forward_loop_patches_external_session_id_once(tmp_path, monkeypat
     import contextlib
 
     @contextlib.asynccontextmanager
-    async def _make_client(**_kw):
+    async def _make_client(*_a, **_kw):
         yield _Client()
 
-    # Patch the module attribute that ``forward_hermes_store_to_session`` reads
-    # at call time (``httpx.AsyncClient``).  Using ``monkeypatch.setattr`` on
-    # the *module* object the forwarder imports (``f.httpx``) guarantees the
-    # right target and automatic undo.
-    monkeypatch.setattr(
-        f,
-        "httpx",
-        type(
-            "_httpx",
-            (),
-            {
-                "AsyncClient": _make_client,
-                "Timeout": lambda *a, **kw: None,
-                "Auth": None,
-                "HTTPError": Exception,
-            },
-        ),
-    )
+    # The forward loop opens its server client through the cli_auth factory
+    # (``open_server_client``, which folds the host_id slice-key + routing
+    # headers), so intercept that — the loop no longer constructs
+    # ``httpx.AsyncClient`` directly, so patching ``f.httpx`` would leave the
+    # real factory client (and a real network call) in place.
+    monkeypatch.setattr("omnigent.cli_auth.open_server_client", _make_client)
 
     async def _sleep(_s):
         iteration["n"] += 1

--- a/tests/test_resume_dispatch.py
+++ b/tests/test_resume_dispatch.py
@@ -614,7 +614,7 @@ def test_read_wrapper_label_remote_returns_label_when_present(
     monkeypatch.setattr(httpx, "get", _fake_get)
     monkeypatch.setattr(
         "omnigent.chat._remote_headers",
-        lambda *, server_url: {},
+        lambda *, server_url, host_id=None: {},
     )
 
     result = resume_dispatch._read_wrapper_label_remote(
@@ -651,7 +651,7 @@ def test_read_wrapper_label_remote_returns_none_when_label_missing(
     monkeypatch.setattr(httpx, "get", _fake_get)
     monkeypatch.setattr(
         "omnigent.chat._remote_headers",
-        lambda *, server_url: {},
+        lambda *, server_url, host_id=None: {},
     )
 
     result = resume_dispatch._read_wrapper_label_remote(
@@ -680,7 +680,7 @@ def test_read_wrapper_label_remote_raises_on_404(
     monkeypatch.setattr(httpx, "get", _fake_get)
     monkeypatch.setattr(
         "omnigent.chat._remote_headers",
-        lambda *, server_url: {},
+        lambda *, server_url, host_id=None: {},
     )
 
     with pytest.raises(click.ClickException) as excinfo:


### PR DESCRIPTION
## Related issue

<!-- No tracked issue; this is client-side infrastructure for horizontally scaling a multi-tenant server deployment. -->

## Summary

Adds a per-host routing key — the `X-Databricks-Omnigent-Slice-Key` header — so that on a horizontally-scaled, multi-tenant deployment every request scoped to a host or session lands on the replica that holds that host's runner tunnel. A host's control tunnel, its runners' tunnels, and a session's turn/resource/stream traffic all converge on one replica when they carry the same key (the `host_id`). On an unsharded / single-replica deployment the key is never emitted, so this is a no-op there.

- **Client-side only**, and additive. The key is built centrally in `cli_auth.databricks_request_headers` (gated on the workspace-hosted mount via `is_workspace_hosted_url`) and threaded through the single server-client factory `open_server_client` plus `_remote_headers` / `open_daemon_client`. Explicit callers pass a `host_id`; runner-side callers (transcript forwarders, permission checks) inherit it automatically from the `OMNIGENT_RUNNER_SLICE_KEY` env var the host stamps at runner launch, so they need no per-callsite change. The WebSocket attach handshake and its reconnects carry the same key.
- `chat._remote_headers` takes a **required** `host_id` keyword (no default), so every call site consciously decides whether a request is host-scoped rather than silently defaulting to unkeyed; host-less reads (probes, health checks) pass `host_id=None` explicitly. (`databricks_request_headers` keeps its `None` default, so runner-side callers stay unchanged.) `_DatabricksTokenAuth` resolves the session's host per request from the session→host map and exposes `pin_session` for when a client outlives its session (a `--fork` in the REPL lands under a new conversation id on a new host). Session-host state is always written on attach — clearing a stale mapping when the server reports no host matters as much as setting one.

### Backwards / forwards compatibility

Old clients that don't send the key keep working: the server treats an absent key as "any replica," which is the existing behavior. The header is only meaningful once a deployment actually runs a sharding layer that reads it, so a client that sends it against a server that ignores it is harmless. This lets the client change ship independently of any server-side routing.

## Test Plan

`ruff check` / `ruff format` clean on all changed files. Unit tests pass under `pytest`:

- `tests/cli/test_cli_auth.py` — the key rides only on the workspace-hosted mount; the runner-env var supplies the default `host_id`; an unsharded server emits nothing.
- `tests/cli/test_session_host.py` — the auth pins requests to the session's host via the session→host map, and clears a stale mapping.
- `tests/host/test_connect.py`, `tests/host/test_daemon_launch.py` — the host control-tunnel handshake and the daemon client carry the key when a host is named, and omit it otherwise.

A new `tests/cli/conftest.py` autouse fixture isolates the runner machine's own host identity so "no key on this call" assertions are hermetic regardless of whether the box running the suite is itself a host.

## Demo

N/A — no user-visible UI change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: exercised the CLI attach / resume / `--fork` paths against a sharded deployment and confirmed the slice key routes host-scoped traffic to the replica holding the runner tunnel, and that an unsharded server sees no header.

## Changelog

Route a host's tunnel, its runners, and its session traffic to one replica so multi-replica deployments keep host-scoped requests sticky.

