### PR TITLE
fix(web): stop transcript images loading slowly and shoving the page

### DIFF
--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -622,6 +622,38 @@ def _attachment_disposition(filename: str) -> str:
     return f"attachment; filename=\"{ascii_name}\"; filename*=UTF-8''{encoded}"
 
 
+# A file id maps to one set of bytes for the file's whole life — content is
+# never rewritten in place, only deleted — so the id is a strong validator and
+# the bytes can be cached indefinitely. ``private`` keeps the response out of
+# shared caches, since the bytes are readable only by session members.
+FILE_CONTENT_CACHE_CONTROL = "private, max-age=31536000, immutable"
+
+
+def _file_content_etag(file_id: str) -> str:
+    """Build the strong ``ETag`` for a stored file's content.
+
+    :param file_id: The stored file identifier.
+    :returns: A quoted entity tag value.
+    """
+    return f'"{file_id}"'
+
+
+def _if_none_match_matches(header: str | None, etag: str) -> bool:
+    """Check an ``If-None-Match`` request header against an entity tag.
+
+    :param header: Raw ``If-None-Match`` value, or ``None`` when absent.
+    :param etag: The current entity tag, quoted.
+    :returns: ``True`` when the client's cached copy is still current.
+    """
+    if not header:
+        return False
+    candidates = [candidate.strip() for candidate in header.split(",")]
+    if "*" in candidates:
+        return True
+    # Comparison is weak per RFC 9110: strip the ``W/`` prefix before matching.
+    return any(candidate.removeprefix("W/") == etag for candidate in candidates)
+
+
 def _stored_file_to_resource(
     session_id: str,
     stored: StoredFile,
@@ -8930,6 +8962,7 @@ async def _load_model_options_from_host(session_id: str, host_id: str) -> None:
 
 
 __all__ = [
+    "FILE_CONTENT_CACHE_CONTROL",
     "SessionLiveness",
     "_HostLaunchAttempt",
     "_NativeTerminalEnsureOutcome",
@@ -8984,6 +9017,7 @@ __all__ = [
     "_extract_persistent_item_from_sse",
     "_extract_user_text_for_routing",
     "_extract_user_text_from_event",
+    "_file_content_etag",
     "_find_claude_native_subagent_child",
     "_find_codex_native_subagent_child",
     "_find_subagent_child_by_title",
@@ -8997,6 +9031,7 @@ __all__ = [
     "_handle_external_session_todos",
     "_handle_mcp_tools_list",
     "_host_model_options_via_registry",
+    "_if_none_match_matches",
     "_invalidate_runner_backed_snapshot_state",
     "_is_codex_native_subagent",
     "_is_kiro_native_session",

--- a/omnigent/server/routes/sessions/__init__.py
+++ b/omnigent/server/routes/sessions/__init__.py
@@ -334,6 +334,7 @@ from omnigent.server.routes._sessions.common import (
 # Lower-layer helpers (SSE builders, publishers, persistence, runner-forward
 # primitives) live in _sessions.helpers.
 from omnigent.server.routes._sessions.helpers import (
+    FILE_CONTENT_CACHE_CONTROL as FILE_CONTENT_CACHE_CONTROL,
     SessionLiveness as SessionLiveness,
     _HostLaunchAttempt as _HostLaunchAttempt,
     _NativeTerminalEnsureOutcome as _NativeTerminalEnsureOutcome,
@@ -384,6 +385,7 @@ from omnigent.server.routes._sessions.helpers import (
     _extract_persistent_item_from_sse as _extract_persistent_item_from_sse,
     _extract_user_text_for_routing as _extract_user_text_for_routing,
     _extract_user_text_from_event as _extract_user_text_from_event,
+    _file_content_etag as _file_content_etag,
     _find_claude_native_subagent_child as _find_claude_native_subagent_child,
     _find_codex_native_subagent_child as _find_codex_native_subagent_child,
     _find_subagent_child_by_title as _find_subagent_child_by_title,
@@ -394,6 +396,7 @@ from omnigent.server.routes._sessions.helpers import (
     _handle_external_session_todos as _handle_external_session_todos,
     _handle_mcp_tools_list as _handle_mcp_tools_list,
     _host_model_options_via_registry as _host_model_options_via_registry,
+    _if_none_match_matches as _if_none_match_matches,
     _invalidate_runner_backed_snapshot_state as _invalidate_runner_backed_snapshot_state,
     _is_codex_native_subagent as _is_codex_native_subagent,
     _is_kiro_native_session as _is_kiro_native_session,

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -61,9 +61,12 @@ from omnigent.server.routes._sessions.common import (
     set_server_runner_router,
 )
 from omnigent.server.routes._sessions.helpers import (
+    FILE_CONTENT_CACHE_CONTROL,
     _ancestor_session_ids,
     _attachment_disposition,
+    _file_content_etag,
     _get_runner_client_for_resource_access,
+    _if_none_match_matches,
     _load_agent_spec_for_session,
     _proxy_get_session_resources_to_runner,
     _publish_and_persist_resource_event,
@@ -1079,13 +1082,25 @@ def register_resources_routes(
                 status_code=501,
                 detail="file store not configured",
             )
-        stored = file_store.get(file_id, session_id=session_id)
+        stored = await asyncio.to_thread(file_store.get, file_id, session_id=session_id)
         if stored is None:
             raise OmnigentError(
                 "File not found",
                 code=ErrorCode.NOT_FOUND,
             )
-        content = artifact_store.get(stored.id)
+        # Content is immutable per file id, so a still-valid cached copy can be
+        # answered before ever touching the artifact store. Transcripts re-render
+        # the same attachments on every load, and the originals run to megabytes.
+        etag = _file_content_etag(stored.id)
+        if _if_none_match_matches(request.headers.get("if-none-match"), etag):
+            return Response(
+                status_code=304,
+                headers={
+                    "ETag": etag,
+                    "Cache-Control": FILE_CONTENT_CACHE_CONTROL,
+                },
+            )
+        content = await asyncio.to_thread(artifact_store.get, stored.id)
         media_type = mimetypes.guess_type(stored.filename)[0] or "application/octet-stream"
         # The filename and bytes are fully user-controlled. Serving the
         # content inline lets a browser navigating directly to this URL
@@ -1101,6 +1116,8 @@ def register_resources_routes(
             headers={
                 "Content-Disposition": _attachment_disposition(stored.filename),
                 "X-Content-Type-Options": "nosniff",
+                "ETag": etag,
+                "Cache-Control": FILE_CONTENT_CACHE_CONTROL,
             },
         )
 

--- a/tests/e2e_ui/chat/test_transcript_image_layout.py
+++ b/tests/e2e_ui/chat/test_transcript_image_layout.py
@@ -1,0 +1,166 @@
+"""E2E: an inline image preview must hold its space before the bytes arrive.
+
+An attached image used to render into a box with no reserved height: the
+``<img>`` carried ``max-h-64`` but no intrinsic size, so it laid out at ~0 tall
+and jumped to as much as 256px once the bytes decoded. Everything below it was
+displaced at that moment, and nothing in the chat surface absorbs that — the
+transcript scroller runs with ``[overflow-anchor:none]`` because
+``HistoryAutoLoader`` owns prepend anchoring, and
+``PreserveScrollDistanceOnResize`` early-returns off iOS.
+
+This is invisible below the browser: jsdom has no layout, so a component test
+can assert the box's classes but never that the image actually occupies the
+space they promise, nor that the text below it stays put.
+
+Rather than race the network, the test compares the two states directly — the
+same transcript rendered with the image bytes blocked, and with them served. A
+reserved box is the same height either way, so the reply beneath it lands on
+exactly the same pixel. Before the fix the blocked render collapsed and that
+reply sat hundreds of pixels higher.
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+
+import httpx
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import _server_state
+
+_IMAGE_NAME = "shot.png"
+_REPLY = "Reviewing the screenshot."
+
+# A real 240x180 PNG, inline so the fixture needs no image library. Its natural
+# size is irrelevant to the assertions — what matters is that it decodes, so the
+# "served" render is a genuinely loaded image rather than a second broken one.
+_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAPAAAAC0CAIAAAAl/ja/AAABaUlEQVR42u3SQREAMAjAsDFdyEEdKvHAk0sk"
+    "9BpZ/eCKLwGGBkODocHQGBoMDYYGQ4OhMTQYGgwNhgZDY2gwNBgaDA2GxtBgaDA0GBoMjaHB0GBoMDQYGkOD"
+    "ocHQYGgwNIYGQ4OhwdAYGgwNhgZDg6ExNBgaDA2GBkNjaDA0GBoMDYbG0GBoMDQYGgyNocHQYGgwNBgaQ4Oh"
+    "wdBgaDA0hgZDg6HB0GBoDA2GBkODoTE0GBoMDYYGQ2NoMDQYGgwNhsbQYGgwNBgaDI2hwdBgaDA0GBpDg6HB"
+    "0GBoMDSGBkODocHQYGgMDYYGQ4OhMTQYGgwNhgZDY2gwNBgaDA2GxtBgaDA0GBoMjaHB0GBoMDQYGkODocHQ"
+    "YGgwNIYGQ4OhwdBgaAwNhgZDg6HB0BgaDA2GBkNjaDA0GBoMDYbG0GBoMDQYGgyNocHQYGgwNBgaQ4OhwdBg"
+    "aDA0hgZDg6HB0GBoDA2GBkPD3gAlVgKygGocMwAAAABJRU5ErkJggg=="
+)
+
+# The preview box and the reply below it, read together so a measurement can't
+# straddle a layout pass. ``closest('div')`` is the box itself — the lightbox
+# wraps the image in a button, so the image's own parent is that button.
+_PROBE = """() => {
+    const img = document.querySelector('img[alt="shot.png"]');
+    const section = document.querySelector('[data-testid="assistant-text-section"]');
+    return {
+        boxHeight: img ? Math.round(img.closest('div').getBoundingClientRect().height) : null,
+        replyTop: section ? Math.round(section.getBoundingClientRect().top) : null,
+    };
+}"""
+
+
+def _seed_image_turn(base_url: str, session_id: str) -> None:
+    """Attach an image to *session_id* and commit a turn that renders it.
+
+    Uploads through the real file endpoint so the transcript's
+    ``input_image`` block resolves to genuine stored bytes, then writes the
+    turn straight to the store — the same shortcut
+    :func:`tests.e2e_ui.conftest.seed_committed_turn` takes, so no agent turn
+    or model call is involved.
+
+    :param base_url: Spawned server's base URL.
+    :param session_id: Session to attach the image to.
+    """
+    from omnigent.entities import MessageData, NewConversationItem
+    from omnigent.stores.conversation_store.sqlalchemy_store import (
+        SqlAlchemyConversationStore,
+    )
+
+    upload = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/resources/files",
+        files={"file": (_IMAGE_NAME, base64.b64decode(_PNG_B64), "image/png")},
+        timeout=30.0,
+    )
+    upload.raise_for_status()
+    file_id = upload.json()["id"]
+
+    SqlAlchemyConversationStore(str(_server_state["database_uri"])).append(
+        session_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="resp_image",
+                data=MessageData(
+                    role="user",
+                    content=[
+                        {"type": "input_text", "text": "Here is the screenshot."},
+                        {
+                            "type": "input_image",
+                            "file_id": file_id,
+                            "filename": _IMAGE_NAME,
+                        },
+                    ],
+                ),
+            ),
+            NewConversationItem(
+                type="message",
+                response_id="resp_image",
+                data=MessageData(
+                    role="assistant",
+                    content=[{"type": "output_text", "text": _REPLY}],
+                    agent="hello_world",
+                ),
+            ),
+        ],
+    )
+
+
+def _render(page: Page, base_url: str, session_id: str, *, serve_image: bool) -> dict:
+    """Load the transcript and measure it, optionally blocking the image bytes.
+
+    :param page: Playwright page.
+    :param base_url: Spawned server's base URL.
+    :param session_id: Session to open.
+    :param serve_image: When ``False``, the file-content request is aborted so
+        the image never decodes.
+    :returns: The :data:`_PROBE` reading.
+    """
+    # Routes outlive a navigation, so a block left over from an earlier render
+    # would silently starve this one.
+    page.unroute_all()
+    if not serve_image:
+        page.route(re.compile(r"/resources/files/"), lambda route: route.abort())
+
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.get_by_text(_REPLY)).to_be_visible(timeout=30_000)
+    if serve_image:
+        # Only a served image can reach complete=true; a blocked one settles as
+        # soon as the request is aborted.
+        page.wait_for_function(
+            """() => {
+                const img = document.querySelector('img[alt="shot.png"]');
+                return img && img.complete && img.naturalWidth > 0;
+            }""",
+            timeout=30_000,
+        )
+    page.wait_for_timeout(500)
+    return page.evaluate(_PROBE)
+
+
+def test_image_preview_reserves_its_space(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The reply under an image sits on the same pixel loaded or not."""
+    base_url, session_id = seeded_session
+    _seed_image_turn(base_url, session_id)
+
+    blocked = _render(page, base_url, session_id, serve_image=False)
+    served = _render(page, base_url, session_id, serve_image=True)
+
+    # The box is reserved, not derived from the bytes: an image that never
+    # arrives still occupies the space one that does would have taken.
+    assert blocked["boxHeight"] == served["boxHeight"], (blocked, served)
+    # Guards the reservation itself — a collapsed box would agree at ~0.
+    assert served["boxHeight"] > 200, served
+    # The payoff: nothing below the image moves when the bytes land.
+    assert blocked["replyTop"] == served["replyTop"], (blocked, served)

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -1765,6 +1765,41 @@ async def test_download_session_file_content(
 
 
 @pytest.mark.asyncio
+async def test_download_session_file_content_is_revalidatable(
+    file_client: httpx.AsyncClient,
+) -> None:
+    """Content is immutable per file id, so it must be cacheable and revalidate to 304.
+
+    Transcripts re-render the same attachments on every session load and
+    the originals run to megabytes; without these headers the browser
+    re-downloads all of them each time.
+    """
+    upload = await file_client.post(
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files",
+        files={"file": ("shot.png", b"pretend-png-bytes", "image/png")},
+    )
+    file_id = upload.json()["id"]
+    url = f"/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/files/{file_id}/content"
+
+    resp = await file_client.get(url)
+    assert resp.status_code == 200
+    etag = resp.headers["etag"]
+    assert etag == f'"{file_id}"'
+    assert resp.headers["cache-control"] == "private, max-age=31536000, immutable"
+
+    # A conditional re-request must skip the bytes entirely.
+    cached = await file_client.get(url, headers={"If-None-Match": etag})
+    assert cached.status_code == 304
+    assert cached.content == b""
+    assert cached.headers["etag"] == etag
+
+    # A stale validator still gets the full body back.
+    stale = await file_client.get(url, headers={"If-None-Match": '"file_gone"'})
+    assert stale.status_code == 200
+    assert stale.content == b"pretend-png-bytes"
+
+
+@pytest.mark.asyncio
 async def test_download_session_file_html_is_attachment_not_inline(
     file_client: httpx.AsyncClient,
 ) -> None:

--- a/web/src/components/SessionImage.test.tsx
+++ b/web/src/components/SessionImage.test.tsx
@@ -26,12 +26,21 @@ vi.mock("@/components/ui/spinner", () => ({
   Spinner: () => <span data-testid="spinner" />,
 }));
 
-import { SessionImage } from "./SessionImage";
+import type { SessionImage as SessionImageComponent } from "./SessionImage";
+
+// The component caches object URLs in module scope so they survive remounts,
+// so each test needs a fresh module instance — otherwise one test's cached
+// image satisfies the next test's render and its hostFetch mock never runs.
+let SessionImage: typeof SessionImageComponent;
 
 let createObjectURL: ReturnType<typeof vi.fn>;
 let revokeObjectURL: ReturnType<typeof vi.fn>;
 
-beforeEach(() => {
+beforeEach(async () => {
+  // Import before stubbing: the stub replaces the whole URL global, and the
+  // module graph needs the real constructor while it loads.
+  vi.resetModules();
+  ({ SessionImage } = await import("./SessionImage"));
   createObjectURL = vi.fn(() => "blob:fake-url");
   revokeObjectURL = vi.fn();
   vi.stubGlobal("URL", { createObjectURL, revokeObjectURL });
@@ -56,6 +65,15 @@ describe("SessionImage (standalone, no host fetcher)", () => {
     expect(img).toHaveAttribute("src", "/v1/sessions/a/files/x/content");
     expect(img).toHaveClass("c");
     expect(hostFetch).not.toHaveBeenCalled();
+  });
+
+  it("reserves the preview box height before the image loads", () => {
+    // WHY: the chat scroller runs with overflow-anchor:none, so an image that
+    // sized itself only on decode would push the transcript down under the
+    // reader. The enclosing box must carry a fixed height from first paint.
+    render(<SessionImage path="/v1/sessions/a/files/x/content" alt="diagram" />);
+    const box = screen.getByRole("img", { name: "diagram" }).closest("div");
+    expect(box).toHaveClass("h-64");
   });
 });
 
@@ -118,14 +136,63 @@ describe("SessionImage (embedded, host fetcher present)", () => {
     expect(hostFetch).not.toHaveBeenCalled();
   });
 
-  it("revokes the object URL on unmount to avoid leaking blobs", async () => {
-    // WHY: the cleanup must release the created object URL; failing to do so
-    // leaks blob memory across image swaps.
+  it("reuses the cached object URL across remounts instead of refetching", async () => {
+    // WHY: a file id addresses immutable bytes, so re-opening a session must
+    // repaint from the cached blob — refetching megabytes per remount is what
+    // made transcripts slow. The URL therefore has to survive unmount.
     const blob = new Blob(["x"]);
     hostFetch.mockResolvedValue({ ok: true, blob: () => Promise.resolve(blob) });
-    const { unmount } = render(<SessionImage path="/p" alt="pic" />);
+    const first = render(<SessionImage path="/cached" alt="pic" />);
     await screen.findByRole("img", { name: "pic" });
-    unmount();
-    expect(revokeObjectURL).toHaveBeenCalledWith("blob:fake-url");
+    first.unmount();
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+
+    render(<SessionImage path="/cached" alt="pic" />);
+    // Paints straight from cache — no placeholder frame, no second download.
+    expect(screen.getByRole("img", { name: "pic" })).toHaveAttribute("src", "blob:fake-url");
+    expect(hostFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares one download between concurrent mounts of the same path", async () => {
+    // WHY: the same attachment can mount twice in a frame (a switch back while
+    // the first fetch is still open); both must join the in-flight request.
+    const blob = new Blob(["x"]);
+    hostFetch.mockResolvedValue({ ok: true, blob: () => Promise.resolve(blob) });
+    render(
+      <>
+        <SessionImage path="/shared" alt="one" />
+        <SessionImage path="/shared" alt="two" />
+      </>,
+    );
+    await screen.findByRole("img", { name: "one" });
+    await screen.findByRole("img", { name: "two" });
+    expect(hostFetch).toHaveBeenCalledTimes(1);
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+  });
+
+  it("evicts and revokes the oldest image once the cache bound is passed", async () => {
+    // WHY: cached URLs deliberately outlive their components, so without a
+    // bound a long session would leak every image it ever rendered.
+    const blob = new Blob(["x"]);
+    hostFetch.mockResolvedValue({ ok: true, blob: () => Promise.resolve(blob) });
+    const created: string[] = [];
+    createObjectURL.mockImplementation(() => {
+      const url = `blob:evict-${created.length}`;
+      created.push(url);
+      return url;
+    });
+    // One past the 32-entry bound, so the first of these must fall out. They
+    // cache in mount order, since each fetch resolves in the order it started.
+    const paths = Array.from({ length: 33 }, (_, i) => `/evict-${i}`);
+    render(
+      <>
+        {paths.map((path, i) => (
+          <SessionImage key={path} path={path} alt={`pic-${i}`} />
+        ))}
+      </>,
+    );
+    await waitFor(() => expect(screen.getAllByRole("img")).toHaveLength(33));
+    expect(revokeObjectURL).toHaveBeenCalledWith(created[0]);
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/components/SessionImage.tsx
+++ b/web/src/components/SessionImage.tsx
@@ -16,6 +16,26 @@ export interface SessionImageProps {
 }
 
 /**
+ * Fixed-height box every inline preview renders into, reserved before the bytes
+ * arrive and unchanged once they land. The chat scroller runs with
+ * `overflow-anchor: none` (history prepends own the anchoring) and its
+ * resize-compensating observer is iOS-only, so an image that grew on decode
+ * would shove the transcript down under the reader with nothing to absorb it.
+ */
+const PREVIEW_BOX = "flex h-64 max-w-full shrink-0 items-center justify-center";
+
+/**
+ * Cap on the image itself, in the same absolute unit as the box's height so the
+ * two can't drift apart. It has to be absolute rather than `max-h-full`: the
+ * lightbox wraps the image in an auto-height button, and a percentage height
+ * resolves against that wrapper, leaving a tall image free to overflow the box.
+ */
+const PREVIEW_IMAGE = "max-h-64 max-w-full";
+
+/** Placeholder width, so the box holds a slot on the row before its image lands. */
+const PREVIEW_PLACEHOLDER_BOX = "flex h-64 w-40 shrink-0 items-center justify-center";
+
+/**
  * Inline preview for an uploaded image stored as a session file resource.
  *
  * Standalone the file path is same-origin, so a plain `<img src>` works and we
@@ -29,32 +49,104 @@ export function SessionImage({ path, alt, className }: SessionImageProps) {
   // Host config is installed once at embed startup and never changes, so it's
   // safe to branch on it before any hooks. Hooks live in the embedded child.
   if (!getOmnigentHostConfig().fetcher) {
-    return <ZoomableImage src={path} alt={alt} className={className} />;
+    return (
+      <div className={PREVIEW_BOX}>
+        <ZoomableImage
+          src={path}
+          alt={alt}
+          className={cn(PREVIEW_IMAGE, className)}
+          // Offscreen history images cost nothing until scrolled to, and
+          // decoding off the main thread keeps the swap from blocking paint.
+          loading="lazy"
+          decoding="async"
+        />
+      </div>
+    );
   }
   return <EmbeddedSessionImage path={path} alt={alt} className={className} />;
 }
 
 type LoadState = "loading" | "loaded" | "error";
 
+/**
+ * Object URLs for image bytes already pulled through the host fetcher, keyed by
+ * content path. A file id addresses one immutable set of bytes, so a hit is
+ * always current — re-opening a session re-renders the same attachments, and
+ * without this every remount re-downloaded and re-decoded megabytes.
+ *
+ * Bounded and evicted least-recently-used: entries outlive the components that
+ * created them, so nothing else would ever release them.
+ */
+const MAX_CACHED_IMAGES = 32;
+const blobUrlCache = new Map<string, string>();
+
+/** In-flight fetches, so concurrent mounts of one path share a single download. */
+const inFlight = new Map<string, Promise<string>>();
+
+function cacheBlobUrl(path: string, url: string): void {
+  blobUrlCache.set(path, url);
+  while (blobUrlCache.size > MAX_CACHED_IMAGES) {
+    const oldest = blobUrlCache.keys().next();
+    if (oldest.done) break;
+    const evicted = blobUrlCache.get(oldest.value);
+    blobUrlCache.delete(oldest.value);
+    if (evicted) URL.revokeObjectURL(evicted);
+  }
+}
+
+function loadBlobUrl(path: string): Promise<string> {
+  const cached = blobUrlCache.get(path);
+  if (cached) {
+    // Re-insert to mark it most-recently-used.
+    blobUrlCache.delete(path);
+    blobUrlCache.set(path, cached);
+    return Promise.resolve(cached);
+  }
+  const pending = inFlight.get(path);
+  if (pending) return pending;
+
+  const request = hostFetch(path)
+    .then((res) => (res.ok ? res.blob() : Promise.reject(new Error(`HTTP ${res.status}`))))
+    .then((blob) => {
+      const url = URL.createObjectURL(blob);
+      cacheBlobUrl(path, url);
+      return url;
+    })
+    .finally(() => {
+      inFlight.delete(path);
+    });
+  inFlight.set(path, request);
+  return request;
+}
+
 function EmbeddedSessionImage({ path, alt, className }: SessionImageProps) {
-  const [blobUrl, setBlobUrl] = useState<string | null>(null);
-  const [state, setState] = useState<LoadState>("loading");
+  // Seed from cache so a revisited image paints on the first frame instead of
+  // flashing the placeholder.
+  const [blobUrl, setBlobUrl] = useState<string | null>(() =>
+    path ? (blobUrlCache.get(path) ?? null) : null,
+  );
+  const [state, setState] = useState<LoadState>(() =>
+    path && blobUrlCache.has(path) ? "loaded" : "loading",
+  );
 
   useEffect(() => {
     if (!path) {
       setState("error");
       return;
     }
+    const cached = blobUrlCache.get(path);
+    if (cached) {
+      setBlobUrl(cached);
+      setState("loaded");
+      return;
+    }
     setState("loading");
     setBlobUrl(null);
     let cancelled = false;
-    let objectUrl: string | null = null;
-    hostFetch(path)
-      .then((res) => (res.ok ? res.blob() : Promise.reject(new Error(`HTTP ${res.status}`))))
-      .then((blob) => {
+    loadBlobUrl(path)
+      .then((url) => {
         if (cancelled) return;
-        objectUrl = URL.createObjectURL(blob);
-        setBlobUrl(objectUrl);
+        setBlobUrl(url);
         setState("loaded");
       })
       .catch(() => {
@@ -62,7 +154,6 @@ function EmbeddedSessionImage({ path, alt, className }: SessionImageProps) {
       });
     return () => {
       cancelled = true;
-      if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
   }, [path]);
 
@@ -87,10 +178,9 @@ function EmbeddedSessionImage({ path, alt, className }: SessionImageProps) {
       <div
         role="status"
         aria-label="Loading image"
-        // Square placeholder keeps the bubble from collapsing before the
-        // (unknown-dimension) image resolves.
         className={cn(
-          "flex size-24 items-center justify-center rounded-md border border-border bg-muted text-muted-foreground",
+          PREVIEW_PLACEHOLDER_BOX,
+          "rounded-md border border-border bg-muted text-muted-foreground",
           className,
         )}
       >
@@ -99,5 +189,14 @@ function EmbeddedSessionImage({ path, alt, className }: SessionImageProps) {
     );
   }
 
-  return <ZoomableImage src={blobUrl} alt={alt} className={className} />;
+  return (
+    <div className={PREVIEW_BOX}>
+      <ZoomableImage
+        src={blobUrl}
+        alt={alt}
+        className={cn(PREVIEW_IMAGE, className)}
+        decoding="async"
+      />
+    </div>
+  );
 }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3399,9 +3399,12 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
           // a glance without any email text.
           style={showAuthorBadge && author ? { backgroundColor: userColorTint(author) } : undefined}
         >
-          {/* Inline image previews */}
+          {/* Inline image previews — one non-wrapping strip. Wrapping would
+              re-flow the row as each image's width resolves on load, changing
+              the bubble's height and shoving the transcript; scrolling keeps
+              the row exactly one preview tall no matter what lands. */}
           {images.length > 0 && (
-            <div className="mb-1.5 flex flex-wrap gap-2">
+            <div className="mb-1.5 flex gap-2 overflow-x-auto">
               {images.map((img) =>
                 img.file_id.startsWith("pending:") ? (
                   // Upload in-flight — show a chip placeholder
@@ -3424,7 +3427,9 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
                         : undefined
                     }
                     alt={img.filename ?? img.file_id}
-                    className="max-h-64 max-w-full rounded-md object-contain"
+                    // Sizing lives in SessionImage, which reserves a matching
+                    // box so the bubble's height is settled before bytes land.
+                    className="rounded-md object-contain"
                   />
                 ),
               )}


### PR DESCRIPTION
## Related issue

Closes #4186

## Summary

Opening a conversation with image attachments was slow to paint, and the images
shoved the transcript down as they landed. Three independent causes — caching
alone fixes only two of them, and not the jitter.

- **The content route blocked the event loop.** `get_session_file_content` was
  `async def` but called `file_store.get()` and `artifact_store.get()`
  synchronously, while every neighbouring route in the same file already offloads
  with `asyncio.to_thread`. Each image read stalled the whole server, so images
  serialized *and* the SSE stream and the rest of the transcript load stalled with
  them. Both calls now go through `asyncio.to_thread`.
- **No cache headers, though content is immutable.** A `file_id` addresses one
  fixed set of bytes for its whole life (no update endpoint, delete-only), yet
  every load re-downloaded full-resolution originals. Adds a strong `ETag` plus
  `Cache-Control: private, max-age=31536000, immutable`, and answers
  `If-None-Match` with a 304 before touching the artifact store.
- **Images reserved no layout space.** The `<img>` had `max-h-64` but no intrinsic
  size, so it laid out at ~0 height and jumped on decode. Nothing absorbs that:
  the scroller runs `[overflow-anchor:none]` because `HistoryAutoLoader` owns
  prepend anchoring, and `PreserveScrollDistanceOnResize` early-returns off iOS.
  Adds a fixed-height preview box and an LRU object-URL cache for the embedded
  path (which refetched megabytes on every remount).

### ELI5

The server read each image on the one thread that answers *everything*, so the
page froze while images loaded. It also never told the browser the images were
safe to keep, so they were downloaded again every visit. And the page left no
room for them, so text jumped out of the way when they arrived.

```
BEFORE                                    AFTER
 loop ──[img1]──[img2]──[img3]──►          loop ──┬─────────────► (stays free)
        server frozen the whole time              ├─[img1]  (thread)
                                                  ├─[img2]  (thread)
                                                  └─[img3]  (thread)

 [ ~0px ] ──decode──► [ 256px ]            [ 256px ] ──decode──► [ 256px ]
        everything below is PUSHED                    nothing moves
```

## Test Plan

- `pytest tests/server/routes/test_session_resources.py` — **115 passed**,
  including a new test asserting the `ETag` / `Cache-Control` pair, a 304 on a
  matching `If-None-Match`, and full bytes on a stale validator.
- `vitest run src/components/SessionImage.test.tsx src/pages` — **659 passed**
  across 26 files; `SessionImage` grows tests for box reservation, cross-remount
  cache reuse, in-flight sharing, and LRU eviction.
- `pytest tests/e2e_ui/chat/test_transcript_image_layout.py` — **1 passed**. New
  Playwright test: renders the same seeded transcript with the image bytes
  aborted and with them served, and requires the preview box and the reply
  beneath it to land identically. Confirmed it fails without the fix — the
  blocked render collapses the box 180px → 16px and lifts the reply 164px.
- `pre-commit run --files <changed>` — clean. (`pyrefly` fails identically on an
  untouched file in this worktree — 72 pre-existing errors, all in
  `client/omnigent_client/` — so it is environmental, not from this change.)
- Measured end-to-end against a live server + real browser; numbers below.

## Demo

No screen recording attached — the change is about *timing*, which a static
screenshot cannot show, so here are the measurements instead. Each was captured
against a running server with a real Chromium session.

| | before | after |
|---|---|---|
| 8 images, S3-latency artifact store | 749 ms, **0 concurrent requests completed** | 111 ms, 0.5 ms median ping |
| Revisiting a conversation | 1.1 MB re-downloaded | **0 bytes** |
| Text below the images | pushed **469 px** | **0 px** |
| Cumulative layout shift | 0.0889 | 0.0111 |

To see it yourself: open a conversation with a few screenshots, throttle the
network so the bytes land after first paint, scroll to the image turn, and watch
the text below them. Then reload with DevTools open and confirm the images are
served from cache.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The three numbers that matter are not unit-testable, so they were measured
directly and are reproducible:

- **Loop blocking** was A/B'd by mounting the shipped route and a replica of the
  pre-fix route on one app over the same store, with an 80 ms blocking read
  simulating S3 / Volumes. A local disk store hides this entirely (~10 ms reads),
  which is why it went unnoticed.
- **Caching** was confirmed by reading Chromium's own cache flags over CDP across
  two visits in one browser context: 1.1 MB downloaded, then 0.
- **Layout push** was measured in Chromium by holding the image responses until a
  below-the-images anchor was armed, then releasing them and tracking that
  element's viewport travel per frame.

One reviewer-visible tradeoff: a message with **several** images now scrolls
horizontally instead of wrapping onto multiple lines. Fixed-height boxes alone
still moved the page 264 px because the row re-flowed as widths resolved; making
the row a single non-wrapping strip is what takes it to 0. Single-image messages
— the common case — are unchanged. The alternative is uniform fixed-width tiles,
which keeps every image visible but letterboxes wide screenshots.

## Changelog

Conversation images load in parallel, stay cached between visits, and no longer
shove the transcript as they appear
