### PR TITLE
feat(ci): enforce the ready-for-review gate

### DIFF
--- a/.github/workflows/demo-check.yml
+++ b/.github/workflows/demo-check.yml
@@ -70,13 +70,14 @@ jobs:
             const script = require(".github/workflows/pr-issue-link.js");
             await script({ context, github, core });
       # Applies `waiting-for-review` to PRs that clear the bar, giving maintainers
-      # a queue of reviewable PRs instead of the whole open list. Dry-run by
-      # default; ENFORCE="true" applies the label.
+      # a queue of reviewable PRs instead of the whole open list. No LIMIT: a label
+      # notifies nobody and is trivially reversible, unlike the nudge above.
+      # ENFORCE="false" returns to a dry run that reports verdicts and writes nothing.
       - name: Ready-for-review gate
         if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
-          ENFORCE: "false"
+          ENFORCE: "true"
         with:
           retries: 3
           script: |


### PR DESCRIPTION
## Related issue

Part of OMNI-2214 / OMNI-2315. Flips the flag on the gate merged in #4179; this PR
declares **Test / CI** below, which is one of the exempt types.

## Summary

The ready-for-review gate has run dry since it merged, and its verdicts hold up: the
PRs it marks ready all reference an open issue, are not drafts, and are not waiting
on their author. Verified twice against live GitHub with the label write rigged to
throw, so "nothing was touched" was proven rather than assumed.

Until this flips, **no open PR carries `waiting-for-review`** — the only entrance was
the author-reply handoff, so a fresh PR that references an issue got nothing, and the
label cannot yet be used as the review queue it exists to be.

**No `LIMIT`, unlike the issue nudge.** Applying a label notifies nobody and is
trivially reversible, so there is no first-run blast radius to bound. The nudge
needed a cap because it comments on a contributor's PR; this does not.

A maintainer who removes the label is respected: the sweep will not reapply a label a
human took off (`removedByHuman`), and it ignores the bot's own mutual-exclusion
removals.

Four PRs qualify at the time of writing: #4187, #4178, #4128, #4113.

## Test Plan

- `node .github/workflows/ready-for-review.test.js` passes (all predicates and
  exclusions: PR / closed / draft references rejected, quoted examples rejected,
  drafts skipped, `waiting-on-author` wins, idempotent, human-removal respected,
  bot-removal ignored, write failure does not abort the sweep).
- Two live dry runs against production, most recently
  `Done (enforce=false). below bar=22 READY=3 skip=2`, with the label write rigged to
  throw and no write attempted.
- The handoff half of this label pair has been live since #4157 and was verified end
  to end on a real PR, including mutual exclusion in both directions.

## Demo

N/A. One environment variable in a CI workflow.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added or updated
- [ ] Integration / E2E tests added or updated
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

Not unit-testable: this changes a workflow environment value, and both the enforcing
and dry-run paths are already covered by the existing tests. Verification was the
live dry runs described above.
