### PR TITLE
chore(ci): raise the issue-nudge limit to 25

### DIFF
--- a/.github/workflows/demo-check.yml
+++ b/.github/workflows/demo-check.yml
@@ -53,17 +53,16 @@ jobs:
           script: |
             const script = require(".github/workflows/demo-check.js");
             await script({ context, github, core });
-      # LIMIT bounds how many contributors a single run may comment on. It is
-      # deliberately low while the wording gets its first real-world read, and can
-      # be raised once the first live comments look right. Setting ENFORCE back to
-      # "false" returns to a dry run, which enumerates every verdict into the step
-      # summary and writes nothing.
+      # LIMIT bounds how many contributors a single run may comment on, so a
+      # mistake in the wording or the predicate cannot reach the whole queue in one
+      # sweep. Setting ENFORCE back to "false" returns to a dry run, which
+      # enumerates every verdict into the step summary and writes nothing.
       - name: Issue-link check
         if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           ENFORCE: "true"
-          LIMIT: "3"
+          LIMIT: "25"
         with:
           retries: 3
           script: |


### PR DESCRIPTION
## Related issue

Part of OMNI-2214 / OMNI-2311. Raises the cap set in #4180; this PR declares
**Test / CI** below, which is one of the exempt types.

## Summary

`LIMIT` was 3 so the nudge's wording could get its first real-world read on a bounded
number of PRs. It has now posted on **8 PRs, including three first-time
contributors**, and reads correctly. Raise it to 25.

**Keeping a cap rather than removing it.** The cap is not only about the first run: it
bounds how far a mistake in the wording or in the predicate can reach in a single
sweep. 25 is above the current flagged count, so it no longer paces normal operation
while still limiting the damage from a bad change.

**The ready-for-review gate has no `LIMIT` and needs none**, so there is nothing to
raise on that side: applying a label notifies nobody and is trivially reversible,
unlike commenting on a contributor's PR.

## Test Plan

- `node .github/workflows/pr-issue-link.test.js` passes. The `LIMIT` behaviour is
  already covered: the cap applies only when enforcing, a dry run enumerates every
  verdict regardless, `LIMIT=0` flags nothing, and a malformed value flags nothing
  rather than everything.
- Observed live at `LIMIT: 3`: `Done (enforce=true). exempt=16 ok=2 FLAG=3 deferred=5`,
  then subsequent sweeps picked up the deferred five, ending at
  `exempt=16 ok=2 skip=6 FLAG=2` as the marker deduped the already-nudged PRs. The cap
  and the dedupe both behaved as designed.

## Demo

N/A. One environment variable in a CI workflow.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added or updated
- [ ] Integration / E2E tests added or updated
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

Not unit-testable: this changes a workflow environment value, and the `LIMIT`
behaviour it adjusts is already covered by existing tests. Verification was observing
the live sweeps at `LIMIT: 3` described above.
