### PR TITLE
fix(ci): skip maintainer, bot, and closed PRs in the ready-for-review gate

### DIFF
--- a/.github/workflows/ready-for-review.js
+++ b/.github/workflows/ready-for-review.js
@@ -11,11 +11,16 @@
 // and the rest of this file stays the same.
 //
 // Never applied when:
+//   - the author is a maintainer or a bot. The label exists to route incoming
+//     contributions; maintainers land their own work and half the in-window PRs
+//     are theirs, so labelling them halves the signal. It matches the nudge, which
+//     exempts maintainers for the same reason.
+//   - the PR is closed or merged. `is:open` in the search lags, so one that closed
+//     in the last few minutes still comes back and must not be labelled.
 //   - the PR is a draft (the author is telling us it is not ready)
 //   - `waiting-on-author` is set (the ball is in the author's court; applying
 //     both would break the mutual exclusion the two labels rely on)
-//   - the label is already there (idempotent, and it must not fight a maintainer
-//     who removed it on purpose -- see REMOVED_BY_HUMAN below)
+//   - the label is already there (idempotent), or a human removed it before
 //
 // Forward-only, sharing pr-issue-link.js's effective date: labelling 478 backlog
 // PRs in one sweep would bury the signal it exists to create.
@@ -26,6 +31,7 @@ const MS_PER_HOUR = 60 * 60 * 1000;
 const HOURS_TO_SCAN = 24;
 const REVIEW_LABEL = "waiting-for-review";
 const WAITING_LABEL = "waiting-on-author";
+const MAINTAINER_ASSOCIATIONS = ["MEMBER", "OWNER", "COLLABORATOR"];
 
 const QUERY = `
   query($cursor: String, $searchQuery: String!) {
@@ -35,7 +41,10 @@ const QUERY = `
       nodes {
         ... on PullRequest {
           number
+          state
           isDraft
+          authorAssociation
+          author { login __typename }
           labels(first: 30) { nodes { name } }
           body
           timelineItems(last: 50, itemTypes: [UNLABELED_EVENT]) {
@@ -105,6 +114,17 @@ async function belowBar(ctx) {
   return null;
 }
 
+// True when the PR is the project's own work rather than an incoming contribution.
+// Checked on both signals, like the nudge: a maintainer whose org membership is
+// private reads as CONTRIBUTOR, and one with write access may be unlisted.
+function isOwnWork(pr, maintainers) {
+  const login = pr.author?.login ?? "";
+  if (pr.author?.__typename === "Bot" || login.endsWith("[bot]")) return "bot";
+  if (MAINTAINER_ASSOCIATIONS.includes(pr.authorAssociation)) return "maintainer";
+  if (maintainers.has(login.toLowerCase())) return "maintainer";
+  return null;
+}
+
 module.exports = async ({ context, github, core }) => {
   const { owner, repo } = context.repo;
   const enforce = process.env.ENFORCE === "true";
@@ -132,11 +152,37 @@ module.exports = async ({ context, github, core }) => {
     }
     console.log(`Found ${allPRs.length} open PRs in the window`);
 
+    // Read from the API, not the checked-out tree, so a PR cannot self-grant by
+    // editing the file (same approach as the nudge).
+    const maintainers = new Set();
+    try {
+      const resp = await github.rest.repos.getContent({
+        owner,
+        repo,
+        path: ".github/MAINTAINER",
+        ref: context.payload.repository?.default_branch ?? "main",
+      });
+      Buffer.from(resp.data.content, "base64")
+        .toString("utf8")
+        .split("\n")
+        .map((l) => l.replace(/#.*$/, "").trim().toLowerCase())
+        .filter(Boolean)
+        .forEach((m) => maintainers.add(m));
+    } catch (err) {
+      core.warning(`Could not load .github/MAINTAINER: ${err.message}`);
+    }
+
     const verdicts = [];
     for (const pr of allPRs) {
       const labels = pr.labels?.nodes?.map((l) => l.name) ?? [];
-      let skip = null;
-      if (pr.isDraft) skip = "draft";
+      let skip = isOwnWork(pr, maintainers);
+      if (skip) {
+        // own work: reported as-is
+      }
+      // `is:open` in the search is index-backed and lags, so a PR closed or merged
+      // in the last few minutes still comes back. Check the state we were handed.
+      else if (pr.state !== "OPEN") skip = pr.state.toLowerCase();
+      else if (pr.isDraft) skip = "draft";
       else if (labels.includes(REVIEW_LABEL)) skip = "already labelled";
       else if (labels.includes(WAITING_LABEL)) skip = "waiting on author";
       else if (removedByHuman(pr)) skip = "label was removed by hand";

--- a/.github/workflows/ready-for-review.test.js
+++ b/.github/workflows/ready-for-review.test.js
@@ -11,10 +11,17 @@ function pr({
   draft = false,
   labels = [],
   unlabeled = [],
+  state = "OPEN",
+  author = "ext",
+  assoc = "CONTRIBUTOR",
+  bot = false,
 }) {
   return {
     number,
+    state,
     isDraft: draft,
+    authorAssociation: assoc,
+    author: { login: author, __typename: bot ? "Bot" : "User" },
     labels: { nodes: labels.map((name) => ({ name })) },
     body,
     // Each entry is a label name (removed by a human) or [name, actor].
@@ -32,7 +39,14 @@ function pr({
 // "issue" | "pr" | undefined (404).
 async function run(
   nodes,
-  { linked = {}, issues = {}, env = {}, linkError = false, failLabelOn = null } = {}
+  {
+    linked = {},
+    issues = {},
+    env = {},
+    linkError = false,
+    failLabelOn = null,
+    maintainers = [],
+  } = {}
 ) {
   const labeled = [];
   const rows = [];
@@ -63,6 +77,11 @@ async function run(
       };
     },
     rest: {
+      repos: {
+        getContent: async () => ({
+          data: { content: Buffer.from(maintainers.join("\n"), "utf8").toString("base64") },
+        }),
+      },
       issues: {
         addLabels: async ({ issue_number, labels: ls }) => {
           if (issue_number === failLabelOn) {
@@ -93,7 +112,10 @@ async function run(
   Object.assign(process.env, env);
   try {
     await script({
-      context: { repo: { owner: "o", repo: "r" } },
+      context: {
+        repo: { owner: "o", repo: "r" },
+        payload: { repository: { default_branch: "main" } },
+      },
       github,
       core: { warning: (m) => warnings.push(m), summary },
     });
@@ -152,6 +174,50 @@ const verdictOf = (rows, n) => (rows.find((r) => r[0] === `#${n}`) || [])[1];
     const { labeled, rows } = await run([pr({ number: 13 })], { env: ENFORCE });
     assert.strictEqual(labeled.length, 0);
     assert.strictEqual(verdictOf(rows, 13), "below bar");
+  }
+
+  // The label routes incoming contributions, so the project's own work is skipped.
+  for (const [who, opts] of [
+    ["MEMBER", { assoc: "MEMBER" }],
+    ["OWNER", { assoc: "OWNER" }],
+    ["COLLABORATOR", { assoc: "COLLABORATOR" }],
+    ["a bot", { bot: true, author: "omnigent-ci[bot]" }],
+  ]) {
+    const { labeled, rows } = await run([pr({ number: 30, ...opts })], {
+      linked: { 30: 1 },
+      env: ENFORCE,
+    });
+    assert.strictEqual(labeled.length, 0, `${who} PRs are not labelled`);
+    assert.strictEqual(verdictOf(rows, 30), "skip");
+  }
+  // A maintainer with private org membership reads as CONTRIBUTOR, so the
+  // MAINTAINER file is the second signal (same as the nudge).
+  {
+    const { labeled } = await run([pr({ number: 31, author: "listed-maintainer" })], {
+      linked: { 31: 1 },
+      env: ENFORCE,
+      maintainers: ["listed-maintainer", "# a comment"],
+    });
+    assert.strictEqual(labeled.length, 0, "the MAINTAINER file also exempts");
+  }
+  // ...but a genuine outside contributor still gets the label.
+  {
+    const { labeled } = await run([pr({ number: 32, author: "outsider" })], {
+      linked: { 32: 1 },
+      env: ENFORCE,
+      maintainers: ["listed-maintainer"],
+    });
+    assert.strictEqual(labeled.length, 1, "contributors are still labelled");
+  }
+
+  // `is:open` in the search lags, so a just-closed or merged PR still comes back.
+  for (const state of ["CLOSED", "MERGED"]) {
+    const { labeled, rows } = await run([pr({ number: 33, state })], {
+      linked: { 33: 1 },
+      env: ENFORCE,
+    });
+    assert.strictEqual(labeled.length, 0, `${state} PRs are not labelled`);
+    assert.strictEqual(verdictOf(rows, 33), "skip");
   }
 
   // Draft: the author is saying it is not ready.


### PR DESCRIPTION
## Related issue

Part of OMNI-2214 / OMNI-2315. Fixes the gate enabled in #4188; this PR declares
**Test / CI** below, which is one of the exempt types.

## Summary

Three exclusions the gate was missing.

### Maintainer and bot PRs

The gate had no author check at all, so it labelled the team's own work. **Two of the
four PRs labelled on the first enforcing run were `MEMBER`-authored** (#4187, #4113).

That halves the signal the label exists to create. `waiting-for-review` is meant to
route *incoming contributions* into a review queue; maintainers land their own changes
and do not need routing. Half the in-window PRs are maintainer PRs (12 of 24
non-draft), so leaving them in makes the queue no more useful than the open-PR list.
The nudge already exempts maintainers for exactly this reason, and the two checks
should agree.

Detection uses both signals, matching the nudge: `authorAssociation` catches most
cases, and `.github/MAINTAINER` catches a maintainer whose org membership is private
and therefore reads as `CONTRIBUTOR`. The file is read from the API rather than the
checked-out tree, so a PR cannot self-grant by editing it. Bots are skipped too.

### Closed and merged PRs

`is:open` in the search query is index-backed and lags, so a PR closed or merged in
the last few minutes still comes back from the search and would be labelled. The gate
now checks the `state` it was handed before writing. Drafts were already skipped.

## Test Plan

- `node .github/workflows/ready-for-review.test.js` passes, with new cases for each
  exclusion: `MEMBER` / `OWNER` / `COLLABORATOR` / bot authors are skipped; a
  maintainer found only via `.github/MAINTAINER` is skipped; a genuine outside
  contributor is still labelled; and `CLOSED` / `MERGED` PRs are skipped.
- **Verified against production** with the label write rigged to throw:

  ```
  skip: maintainer 13
  skip: already labelled 2
  below bar: no issue referenced 10
  skip: draft 2
  ```

  The two already-labelled are the community PRs (#4178, #4128), which correctly keep
  the label. No write attempted.

## Note on the two maintainer PRs already labelled

#4187 and #4113 were labelled before this fix. The gate will not remove a label it
already applied, so those two keep it until someone takes it off by hand. That is
deliberate: the sweep never removes `waiting-for-review`, and teaching it to would
risk fighting a maintainer who applied it on purpose.

## Demo

N/A. CI label mechanics, no user-visible UI.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added or updated
- [ ] Integration / E2E tests added or updated
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

Unit tests cover every new exclusion. Manual verification was running the fixed gate
against live GitHub with the label write rigged to throw.
