### PR TITLE
feat(ci): check PR hygiene the moment a PR changes

### DIFF
--- a/.github/workflows/pr-hygiene-live.yml
+++ b/.github/workflows/pr-hygiene-live.yml
@@ -1,0 +1,70 @@
+name: PR Hygiene (live)
+
+# Runs the issue-reference nudge and the ready-for-review gate against a single PR
+# the moment something changes on it, so a contributor is not waiting on the hourly
+# sweep. GitHub's cron is best-effort and in practice fires every 1.5 to 2.5 hours.
+#
+# The sweep in demo-check.yml stays as the safety net: it catches PRs this misses
+# (a run that failed, a link added from the sidebar, which fires no webhook) and it
+# is the only path that reaches PRs opened before this workflow existed. Both routes
+# call the same scripts with the same decision logic; only the fetch differs, so
+# they cannot disagree.
+#
+# `pull_request_target` because the scripts need write access to comment and label on
+# fork PRs. Safe here: it checks out only the trusted default branch's .github and
+# runs no PR-authored code, matching the sweep.
+
+on:
+  pull_request_target:
+    # `edited` matters: adding "Closes #123" to the description is how a nudged
+    # contributor satisfies the rule, and it should clear immediately.
+    types: [opened, reopened, ready_for_review, edited, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  # Per PR, cancelling superseded runs: rapid edits should not queue up duplicates.
+  group: pr-hygiene-live-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  hygiene:
+    if: github.repository == 'omnigent-ai/omnigent' && !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      # Job-level permissions REPLACE the workflow-level block, so restate read.
+      contents: read
+      issues: write # the nudge comment
+      pull-requests: write # commenting on a PR needs this too, not just issues
+    steps:
+      # Trusted default branch, .github only. Never the PR head, so no PR-authored
+      # code runs with the elevated token.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          sparse-checkout: .github
+      - name: Issue-link check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          ENFORCE: "true"
+          # One PR per run, so the sweep's LIMIT (which bounds a batch) does not apply.
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          retries: 3
+          script: |
+            const script = require(".github/workflows/pr-issue-link.js");
+            await script({ context, github, core });
+      - name: Ready-for-review gate
+        if: always()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          ENFORCE: "true"
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          retries: 3
+          script: |
+            const script = require(".github/workflows/ready-for-review.js");
+            await script({ context, github, core });

--- a/.github/workflows/pr-issue-link.js
+++ b/.github/workflows/pr-issue-link.js
@@ -126,6 +126,29 @@ const QUERY = `
   }
 `;
 
+// The same node shape as QUERY, for one named PR. `state` and `createdAt` are
+// extra: an event can name a PR that has since closed, or one predating the
+// effective date, and neither should be touched.
+const ONE_PR_QUERY = `
+  query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        number
+        title
+        state
+        createdAt
+        isDraft
+        additions
+        deletions
+        authorAssociation
+        author { login __typename }
+        labels(first: 30) { nodes { name } }
+        body
+      }
+    }
+  }
+`;
+
 // Resolved per PR rather than in the batch search above: the search connection
 // under-reports closingIssuesReferences, and a false "unlinked" verdict is the
 // one mistake that reaches a contributor.
@@ -217,28 +240,49 @@ module.exports = async ({ context, github, core }) => {
       core.warning(`Could not load .github/MAINTAINER: ${err.message}`);
     }
 
-    const windowStart = new Date(Date.now() - HOURS_TO_SCAN * MS_PER_HOUR);
-    // Never look further back than the effective date, whichever is later.
-    const cutoff = new Date(
-      Math.max(windowStart.getTime(), new Date(EFFECTIVE_FROM).getTime())
-    );
-    const cutoffString = cutoff.toISOString().replace(/\.\d{3}Z$/, "Z");
-    const searchQuery = `repo:${owner}/${repo} is:pr is:open created:>${cutoffString}`;
-    console.log(`Scanning PRs: ${searchQuery} (enforce=${enforce})`);
-
-    let cursor = null;
-    let hasNextPage = true;
+    // One PR when an event names it, the whole window on the cron sweep. Only the
+    // fetch differs: every decision below runs identically either way, so the
+    // instant path and the sweep can never reach different verdicts.
     const allPRs = [];
-    while (hasNextPage) {
-      const response = await github.graphql(QUERY, { cursor, searchQuery });
-      const { remaining, resetAt } = response.rateLimit;
-      console.log(`Rate limit: ${remaining} remaining, resets at ${resetAt}`);
-      const { nodes, pageInfo } = response.search;
-      hasNextPage = pageInfo.hasNextPage;
-      cursor = pageInfo.endCursor;
-      allPRs.push(...nodes);
+    const single = Number(process.env.PR_NUMBER) || null;
+    if (single) {
+      const resp = await github.graphql(ONE_PR_QUERY, { owner, repo, number: single });
+      const pr = resp.repository.pullRequest;
+      // The effective date still applies: an event on an older PR is not a licence
+      // to reach into the backlog.
+      if (!pr) {
+        console.log(`#${single} not found; nothing to do.`);
+      } else if (new Date(pr.createdAt) < new Date(EFFECTIVE_FROM)) {
+        console.log(`#${single} predates ${EFFECTIVE_FROM}; skipping.`);
+      } else if (pr.state !== "OPEN") {
+        console.log(`#${single} is ${pr.state}; skipping.`);
+      } else {
+        allPRs.push(pr);
+      }
+      console.log(`Checking #${single} (enforce=${enforce})`);
+    } else {
+      const windowStart = new Date(Date.now() - HOURS_TO_SCAN * MS_PER_HOUR);
+      // Never look further back than the effective date, whichever is later.
+      const cutoff = new Date(
+        Math.max(windowStart.getTime(), new Date(EFFECTIVE_FROM).getTime())
+      );
+      const cutoffString = cutoff.toISOString().replace(/\.\d{3}Z$/, "Z");
+      const searchQuery = `repo:${owner}/${repo} is:pr is:open created:>${cutoffString}`;
+      console.log(`Scanning PRs: ${searchQuery} (enforce=${enforce})`);
+
+      let cursor = null;
+      let hasNextPage = true;
+      while (hasNextPage) {
+        const response = await github.graphql(QUERY, { cursor, searchQuery });
+        const { remaining, resetAt } = response.rateLimit;
+        console.log(`Rate limit: ${remaining} remaining, resets at ${resetAt}`);
+        const { nodes, pageInfo } = response.search;
+        hasNextPage = pageInfo.hasNextPage;
+        cursor = pageInfo.endCursor;
+        allPRs.push(...nodes);
+      }
+      console.log(`Found ${allPRs.length} open PRs from the last ${HOURS_TO_SCAN} hours`);
     }
-    console.log(`Found ${allPRs.length} open PRs from the last ${HOURS_TO_SCAN} hours`);
 
     const verdicts = [];
     let flagged = 0;

--- a/.github/workflows/pr-issue-link.test.js
+++ b/.github/workflows/pr-issue-link.test.js
@@ -53,13 +53,26 @@ async function run(
     repos: {},
     graphql: async (query, vars) => {
       if (vars.searchQuery) queries.push(vars.searchQuery);
-      if (query.includes("pullRequest(number:")) {
+      // ONE_PR_QUERY also contains "pullRequest(number:", so match on the field
+      // that is unique to the link lookup.
+      if (query.includes("closingIssuesReferences")) {
         if (linkError) throw new Error("boom");
         return {
           repository: {
             pullRequest: {
               closingIssuesReferences: { totalCount: linked[vars.number] ?? 0 },
             },
+          },
+        };
+      }
+      // Single-PR fetch (the instant path).
+      if (query.includes("createdAt")) {
+        const pr = nodes.find((n) => n.number === vars.number) ?? null;
+        return {
+          repository: {
+            pullRequest: pr
+              ? { state: "OPEN", createdAt: "2026-08-06T00:00:00Z", ...pr }
+              : null,
           },
         };
       }
@@ -347,6 +360,47 @@ for (const tracked of ["Bug fix", "Feature", "UI / frontend change"]) {
       issues: { 77: "issue" },
     });
     assert.strictEqual(commented.length, 0, "falls through to the next candidate");
+  }
+
+  // ---- the instant path: PR_NUMBER names one PR ----
+  // Same verdict as the sweep would reach, so the two routes cannot disagree.
+  {
+    const nodes = [pr({ number: 60, author: "alice" }), pr({ number: 61 })];
+    const { commented } = await run(nodes, { env: { ...ENFORCE, PR_NUMBER: "60" } });
+    assert.deepStrictEqual(
+      commented.map((c) => c.issue_number),
+      [60],
+      "only the named PR is touched"
+    );
+  }
+  // An exempt PR named by an event is still exempt.
+  {
+    const { commented } = await run([pr({ number: 62, assoc: "MEMBER" })], {
+      env: { ...ENFORCE, PR_NUMBER: "62" },
+    });
+    assert.strictEqual(commented.length, 0, "the instant path honours exemptions");
+  }
+  // The effective-date floor still applies: an event is not a licence to reach
+  // into the backlog.
+  {
+    const old = pr({ number: 63 });
+    old.createdAt = "2026-07-01T00:00:00Z";
+    const { commented } = await run([old], { env: { ...ENFORCE, PR_NUMBER: "63" } });
+    assert.strictEqual(commented.length, 0, "a pre-cutoff PR is skipped");
+  }
+  // A PR that closed between the event and the run is left alone.
+  {
+    const closed = pr({ number: 64 });
+    closed.state = "CLOSED";
+    const { commented } = await run([closed], { env: { ...ENFORCE, PR_NUMBER: "64" } });
+    assert.strictEqual(commented.length, 0, "a closed PR is skipped");
+  }
+  // An unknown number is a no-op rather than a crash.
+  {
+    const { commented } = await run([pr({ number: 65 })], {
+      env: { ...ENFORCE, PR_NUMBER: "999" },
+    });
+    assert.strictEqual(commented.length, 0, "an unresolvable PR number is a no-op");
   }
 
   // A linked PR is left alone even when enforcing.

--- a/.github/workflows/ready-for-review.js
+++ b/.github/workflows/ready-for-review.js
@@ -61,6 +61,33 @@ const QUERY = `
   }
 `;
 
+// The same node shape as QUERY, for one named PR, plus createdAt for the
+// effective-date floor.
+const ONE_PR_QUERY = `
+  query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        number
+        state
+        createdAt
+        isDraft
+        authorAssociation
+        author { login __typename }
+        labels(first: 30) { nodes { name } }
+        body
+        timelineItems(last: 50, itemTypes: [UNLABELED_EVENT]) {
+          nodes {
+            ... on UnlabeledEvent {
+              label { name }
+              actor { login }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
 const LINK_QUERY = `
   query($owner: String!, $repo: String!, $number: Int!) {
     repository(owner: $owner, name: $repo) {
@@ -130,27 +157,43 @@ module.exports = async ({ context, github, core }) => {
   const enforce = process.env.ENFORCE === "true";
 
   try {
-    const windowStart = new Date(Date.now() - HOURS_TO_SCAN * MS_PER_HOUR);
-    const cutoff = new Date(
-      Math.max(windowStart.getTime(), new Date(issueLink.EFFECTIVE_FROM).getTime())
-    );
-    const cutoffString = cutoff.toISOString().replace(/\.\d{3}Z$/, "Z");
-    const searchQuery = `repo:${owner}/${repo} is:pr is:open created:>${cutoffString}`;
-    console.log(`Scanning PRs: ${searchQuery} (enforce=${enforce})`);
-
-    let cursor = null;
-    let hasNextPage = true;
+    // One PR when an event names it, the whole window on the cron sweep. Only the
+    // fetch differs, so both routes reach identical verdicts.
     const allPRs = [];
-    while (hasNextPage) {
-      const response = await github.graphql(QUERY, { cursor, searchQuery });
-      const { remaining, resetAt } = response.rateLimit;
-      console.log(`Rate limit: ${remaining} remaining, resets at ${resetAt}`);
-      const { nodes, pageInfo } = response.search;
-      hasNextPage = pageInfo.hasNextPage;
-      cursor = pageInfo.endCursor;
-      allPRs.push(...nodes);
+    const single = Number(process.env.PR_NUMBER) || null;
+    if (single) {
+      const resp = await github.graphql(ONE_PR_QUERY, { owner, repo, number: single });
+      const pr = resp.repository.pullRequest;
+      if (!pr) {
+        console.log(`#${single} not found; nothing to do.`);
+      } else if (new Date(pr.createdAt) < new Date(issueLink.EFFECTIVE_FROM)) {
+        console.log(`#${single} predates ${issueLink.EFFECTIVE_FROM}; skipping.`);
+      } else {
+        allPRs.push(pr);
+      }
+      console.log(`Checking #${single} (enforce=${enforce})`);
+    } else {
+      const windowStart = new Date(Date.now() - HOURS_TO_SCAN * MS_PER_HOUR);
+      const cutoff = new Date(
+        Math.max(windowStart.getTime(), new Date(issueLink.EFFECTIVE_FROM).getTime())
+      );
+      const cutoffString = cutoff.toISOString().replace(/\.\d{3}Z$/, "Z");
+      const searchQuery = `repo:${owner}/${repo} is:pr is:open created:>${cutoffString}`;
+      console.log(`Scanning PRs: ${searchQuery} (enforce=${enforce})`);
+
+      let cursor = null;
+      let hasNextPage = true;
+      while (hasNextPage) {
+        const response = await github.graphql(QUERY, { cursor, searchQuery });
+        const { remaining, resetAt } = response.rateLimit;
+        console.log(`Rate limit: ${remaining} remaining, resets at ${resetAt}`);
+        const { nodes, pageInfo } = response.search;
+        hasNextPage = pageInfo.hasNextPage;
+        cursor = pageInfo.endCursor;
+        allPRs.push(...nodes);
+      }
+      console.log(`Found ${allPRs.length} open PRs in the window`);
     }
-    console.log(`Found ${allPRs.length} open PRs in the window`);
 
     // Read from the API, not the checked-out tree, so a PR cannot self-grant by
     // editing the file (same approach as the nudge).

--- a/.github/workflows/ready-for-review.test.js
+++ b/.github/workflows/ready-for-review.test.js
@@ -62,11 +62,20 @@ async function run(
   };
   const github = {
     graphql: async (query, vars) => {
-      if (query.includes("pullRequest(number:")) {
+      if (query.includes("closingIssuesReferences")) {
         if (linkError) throw new Error("boom");
         return {
           repository: {
             pullRequest: { closingIssuesReferences: { totalCount: linked[vars.number] ?? 0 } },
+          },
+        };
+      }
+      // Single-PR fetch (the instant path).
+      if (query.includes("createdAt")) {
+        const found = nodes.find((n) => n.number === vars.number) ?? null;
+        return {
+          repository: {
+            pullRequest: found ? { createdAt: "2026-08-06T00:00:00Z", ...found } : null,
           },
         };
       }
@@ -302,6 +311,38 @@ const verdictOf = (rows, n) => (rows.find((r) => r[0] === `#${n}`) || [])[1];
       "the sweep continues past a write failure"
     );
     assert.ok(warnings.some((w) => /Could not label #191/.test(w)));
+  }
+
+  // ---- the instant path: PR_NUMBER names one PR ----
+  {
+    const nodes = [pr({ number: 70 }), pr({ number: 71 })];
+    const { labeled } = await run(nodes, {
+      linked: { 70: 1, 71: 1 },
+      env: { ...ENFORCE, PR_NUMBER: "70" },
+    });
+    assert.deepStrictEqual(
+      labeled.map((l) => l.issue_number),
+      [70],
+      "only the named PR is labelled"
+    );
+  }
+  // Exclusions still hold on the instant path.
+  {
+    const { labeled } = await run([pr({ number: 72, assoc: "MEMBER" })], {
+      linked: { 72: 1 },
+      env: { ...ENFORCE, PR_NUMBER: "72" },
+    });
+    assert.strictEqual(labeled.length, 0, "maintainer PRs stay skipped");
+  }
+  // The effective-date floor applies to events too.
+  {
+    const old = pr({ number: 73 });
+    old.createdAt = "2026-07-01T00:00:00Z";
+    const { labeled } = await run([old], {
+      linked: { 73: 1 },
+      env: { ...ENFORCE, PR_NUMBER: "73" },
+    });
+    assert.strictEqual(labeled.length, 0, "a pre-cutoff PR is skipped");
   }
 
   // Dry run touches nothing but still reports.


### PR DESCRIPTION
## Related issue

Part of OMNI-2214. Makes the checks merged today act immediately instead of on the
hourly sweep; this PR declares **Test / CI** below, which is one of the exempt types.

## Summary

GitHub's cron is best-effort. The "hourly" sweep actually fired at **09:34, 11:56,
14:10, 16:38, 18:17, 20:23, 22:09, 23:56** today, so **1.5 to 2.5 hours apart**.

That cuts both ways, and the second direction is worse: a contributor waited up to two
hours for the nudge, and then waited up to two hours *again* for it to stop mattering
after they added the issue.

Both scripts now accept a `PR_NUMBER` and fetch that one PR instead of the window.
**Only the fetch differs** — every exemption, resolution, and dedupe path below it is
the same code, so the instant route and the sweep cannot reach different verdicts.

A new `pr-hygiene-live` workflow runs both checks on `pull_request_target` for
`opened`, `reopened`, `ready_for_review`, `edited`, and `synchronize`.

**`edited` is the one that matters most**: editing the description to add
`Closes #123` is how a nudged contributor complies, and that should be recognised at
once.

### The sweep stays

It is the safety net, not redundant:

- it catches PRs a live run missed (a failed run, a cancelled one)
- **it is the only route that sees a sidebar issue link**, which fires no webhook at all
- it is the only route that reaches PRs opened before this workflow existed

### Two guards on the single-PR path

An event can name a PR the sweep would never have selected, so:

- **the `EFFECTIVE_FROM` floor still applies.** An event on an old PR is not a licence
  to reach into the backlog.
- **a PR that closed between the event and the run is skipped.**

## Test Plan

- Both suites pass. New coverage in each: only the named PR is touched; exemptions
  still hold on the instant path; the effective-date floor still applies; a closed PR
  is skipped; an unknown PR number is a no-op rather than a crash.
- One subtlety worth noting: the test mocks matched GraphQL on
  `pullRequest(number:`, which the new single-PR query also contains, so they were
  misrouting it to the link-count branch. Both now match on `closingIssuesReferences`,
  which is unique to that lookup.
- **Verified against production** with writes blocked, on PRs whose sweep verdict is
  already known:

  | PR | Instant path | Matches sweep |
  | --- | --- | --- |
  | #4173 | `skip` (already nudged) | yes |
  | #4187 | exempt (maintainer) | yes |
  | #4178 | `ok` (has a link) | yes |
  | #4104 | `skip` (already nudged) | yes |

## Demo

N/A. CI timing, no user-visible UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added or updated
- [ ] Integration / E2E tests added or updated
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

Unit tests cover the single-PR fetch and both of its guards. Manual verification was
driving the instant path against live GitHub with writes blocked and comparing each
verdict to the sweep's.
