### PR TITLE
fix(runner): fall back to SDK/OIDC when managed mint fails due to expired proxy bearer

### DIFF
--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -425,10 +425,10 @@ class _InitialAuthTokenFactory:
                     _allow_delegated_mint=False,
                 )
             if self._fallback_factory is None:
+                host = self._server_url or "(server URL unknown)"
                 _logger.error(
                     "host bootstrap bearer expired and no SDK/OIDC credential is available "
-                    "to renew it; run `databricks auth login --host %s` to re-authenticate",
-                    self._server_url or "(server URL unknown)",
+                    f"to renew it; run `databricks auth login --host {host}` to re-authenticate"
                 )
                 return None
             return self._fallback_factory()

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -416,12 +416,13 @@ class _InitialAuthTokenFactory:
                 )
                 self._fallback_resolved = True
             # Managed mint failed because the proxy bearer is expired — the
-            # initial bearer was injected once and cannot self-renew. Re-resolve
-            # without a proxy bearer so we fall through to SDK/OIDC auth.
+            # initial bearer was injected once and cannot self-renew. Skip
+            # managed mint entirely and go straight to SDK/OIDC.
             if getattr(self._fallback_factory, "proxy_auth_failed", False):
                 self._fallback_factory = _make_auth_token_factory(
                     self._server_url,
                     _allow_initial_token=False,
+                    _allow_delegated_mint=False,
                 )
             if self._fallback_factory is None:
                 return None

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -318,6 +318,10 @@ class _RunnerDatabricksAuth(httpx.Auth):
         if self._factory is not None:
             token = self._factory()
             if not token:
+                if getattr(self._factory, "proxy_auth_failed", False):
+                    # Managed mint failed because the proxy bearer is expired.
+                    # Raise so _invalidate + retry can pick up SDK/OIDC auth.
+                    raise httpx.RequestError("Databricks token refresh returned no token")
                 if getattr(self._factory, "declined", False):
                     # The server definitively refuses to mint for this runner
                     # (managed mint factory hit HTTP 400/404 after install —
@@ -680,7 +684,7 @@ def _make_managed_mint_factory(
         mint_url, server_url, binding_token, proxy_bearer=proxy_bearer
     )
     factory()
-    if factory.declined:
+    if factory.declined or factory.proxy_auth_failed:
         return None
     return factory
 
@@ -724,6 +728,10 @@ class _ManagedMintTokenFactory:
         self._cached_token: str | None = None
         self._cached_expires_at = 0.0
         self.declined = False
+        # Set when mint fails with 401/403 on the proxy bearer (not a server
+        # refusal). Unlike ``declined``, this means the caller should try
+        # another credential path (SDK/OIDC) rather than sending bare requests.
+        self.proxy_auth_failed = False
 
     def __call__(self) -> str | None:
         """Return a fresh owner JWT, or ``None``.
@@ -760,6 +768,14 @@ class _ManagedMintTokenFactory:
                     self.declined = True
                     return None
                 return self._still_valid_cached_token(now)
+            if response.status_code in (401, 403):
+                # The proxy bearer is expired or invalid. If we have never
+                # successfully minted, there is no self-sustaining refresh
+                # loop to fall back to — signal proxy_auth_failed so the
+                # caller can try SDK/OIDC instead of looping on a dead bearer.
+                if self._cached_token is None:
+                    self.proxy_auth_failed = True
+                    return None
             return self._still_valid_cached_token(now)
         except (httpx.HTTPError, ValueError, KeyError, OSError):
             # Transient mint failure: keep serving the cached token while

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -318,10 +318,6 @@ class _RunnerDatabricksAuth(httpx.Auth):
         if self._factory is not None:
             token = self._factory()
             if not token:
-                if getattr(self._factory, "proxy_auth_failed", False):
-                    # Managed mint failed because the proxy bearer is expired.
-                    # Raise so _invalidate + retry can pick up SDK/OIDC auth.
-                    raise httpx.RequestError("Databricks token refresh returned no token")
                 if getattr(self._factory, "declined", False):
                     # The server definitively refuses to mint for this runner
                     # (managed mint factory hit HTTP 400/404 after install —
@@ -419,6 +415,14 @@ class _InitialAuthTokenFactory:
                     _proxy_bearer=self._last_initial_token,
                 )
                 self._fallback_resolved = True
+            # Managed mint failed because the proxy bearer is expired — the
+            # initial bearer was injected once and cannot self-renew. Re-resolve
+            # without a proxy bearer so we fall through to SDK/OIDC auth.
+            if getattr(self._fallback_factory, "proxy_auth_failed", False):
+                self._fallback_factory = _make_auth_token_factory(
+                    self._server_url,
+                    _allow_initial_token=False,
+                )
             if self._fallback_factory is None:
                 return None
             return self._fallback_factory()
@@ -427,7 +431,8 @@ class _InitialAuthTokenFactory:
     def declined(self) -> bool:
         """True when the inner fallback factory has definitively declined."""
         with self._lock:
-            return getattr(self._fallback_factory, "declined", False)
+            f = self._fallback_factory
+            return getattr(f, "declined", False) and not getattr(f, "proxy_auth_failed", False)
 
     def invalidate(self) -> bool:
         """Discard the host bearer so the next call resolves local auth."""

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -425,6 +425,11 @@ class _InitialAuthTokenFactory:
                     _allow_delegated_mint=False,
                 )
             if self._fallback_factory is None:
+                _logger.error(
+                    "host bootstrap bearer expired and no SDK/OIDC credential is available "
+                    "to renew it; run `databricks auth login --host %s` to re-authenticate",
+                    self._server_url or "(server URL unknown)",
+                )
                 return None
             return self._fallback_factory()
 

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -425,10 +425,9 @@ class _InitialAuthTokenFactory:
                     _allow_delegated_mint=False,
                 )
             if self._fallback_factory is None:
-                host = self._server_url or "(server URL unknown)"
                 _logger.error(
                     "host bootstrap bearer expired and no SDK/OIDC credential is available "
-                    f"to renew it; run `databricks auth login --host {host}` to re-authenticate"
+                    "to renew it; run `databricks auth login` to re-authenticate"
                 )
                 return None
             return self._fallback_factory()

--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -421,11 +421,16 @@ async def serve_tunnel(
                 if http_status is not None and http_status in _REFRESHABLE_HTTP_STATUSES:
                     http_auth_rejection_streak += 1
                     if http_auth_rejection_streak >= _HTTP_AUTH_REJECTION_FATAL_ATTEMPTS:
+                        login_hint = (
+                            f"run `databricks auth login --host {server_url}` to re-authenticate"
+                            if server_url
+                            else "check remote server authentication"
+                        )
                         raise RuntimeError(
                             f"{RUNNER_TUNNEL_REJECTION_PREFIX}"
                             f"(HTTP {http_status} persisted across "
                             f"{http_auth_rejection_streak} attempts); "
-                            "check remote server authentication"
+                            f"{login_hint}"
                         ) from exc
                     # Invalidate the cached token so the loop-top _refresh_auth_token
                     # fetches a fresh one on the next attempt. The loop-top call is

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -641,6 +641,47 @@ def test_managed_mint_factory_declines_at_request_time_and_auth_sends_bare(
     assert len(calls) == 2  # probe blip + the single definitive 400
 
 
+def test_managed_mint_factory_proxy_auth_failure_falls_through_to_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 403 on the proxy bearer sets proxy_auth_failed → factory not installed."""
+    calls: list[int] = []
+
+    def _proxy_rejects(*args: Any, **kwargs: Any) -> tuple[str, float]:
+        calls.append(1)
+        request = httpx.Request("POST", "https://s.example.com/v1/runners/r/token")
+        raise httpx.HTTPStatusError(
+            "403",
+            request=request,
+            response=httpx.Response(403, request=request),
+        )
+
+    monkeypatch.setenv("RUNNER_SERVER_URL", "https://s.example.com")
+    monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "bind-tok")
+    monkeypatch.setenv("OMNIGENT_RUNNER_DELEGATED_AUTH", "1")
+    monkeypatch.setattr("omnigent.runner._entry._mint_managed_owner_token", _proxy_rejects)
+
+    factory = _ManagedMintTokenFactory(
+        "https://s.example.com/v1/runners/r/token",
+        "https://s.example.com",
+        "bind-tok",
+        proxy_bearer="expired-bearer",
+    )
+    result = factory()
+
+    assert result is None
+    assert factory.proxy_auth_failed is True
+    assert factory.declined is False
+
+    # _make_managed_mint_factory must not install the factory when the
+    # construction probe gets a proxy auth failure.
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    installed = _make_managed_mint_factory(
+        "https://s.example.com", "bind-tok", proxy_bearer="expired-bearer"
+    )
+    assert installed is None
+
+
 def test_mint_managed_owner_token_posts_binding_token_and_parses_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -682,6 +682,44 @@ def test_managed_mint_factory_proxy_auth_failure_falls_through_to_sdk(
     assert installed is None
 
 
+def test_initial_host_token_re_resolves_to_sdk_when_proxy_auth_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When managed mint proxy_auth_fails, _InitialAuthTokenFactory falls back to SDK/OIDC."""
+
+    class _SdkAuth:
+        def current_token(self) -> str:
+            return "sdk-token"
+
+    def _resolve(*args: Any, **kwargs: Any) -> tuple[_SdkAuth, str]:
+        return _SdkAuth(), "https://workspace.cloud.databricks.com"
+
+    def _proxy_rejects(*args: Any, **kwargs: Any) -> tuple[str, float]:
+        request = httpx.Request("POST", "https://app.databricksapps.com/v1/runners/r/token")
+        raise httpx.HTTPStatusError(
+            "403", request=request, response=httpx.Response(403, request=request)
+        )
+
+    monkeypatch.setenv("RUNNER_SERVER_URL", "https://app.databricksapps.com")
+    monkeypatch.setenv("OMNIGENT_RUNNER_INITIAL_AUTH_TOKEN", "expired-host-bearer")
+    monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "bind-tok")
+    monkeypatch.setenv("OMNIGENT_RUNNER_DELEGATED_AUTH", "1")
+    monkeypatch.setattr("omnigent.cli_auth.load_token", lambda _url: None)
+    monkeypatch.setattr("omnigent.inner.databricks_executor._resolve_databricks_auth", _resolve)
+    monkeypatch.setattr("omnigent.runner._entry._mint_managed_owner_token", _proxy_rejects)
+
+    factory = _make_auth_token_factory()
+
+    assert isinstance(factory, _InitialAuthTokenFactory)
+    # Simulate the initial bearer expiring and being invalidated.
+    factory.invalidate()
+
+    # The fallback tries managed mint first (proxy bearer = expired-host-bearer).
+    # That 403s → proxy_auth_failed → re-resolves to SDK/OIDC.
+    token = factory()
+    assert token == "sdk-token"
+
+
 def test_mint_managed_owner_token_posts_binding_token_and_parses_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

n/a

## Summary

Host-launched runners start with a host-injected bearer (`RUNNER_INITIAL_AUTH_TOKEN`, TTL ~1h). When it expires, `_InitialAuthTokenFactory`'s fallback resolves `_ManagedMintTokenFactory` using `_last_initial_token` as the proxy bearer for the Apps edge. But `_last_initial_token` is the same expired bearer — so the edge returns 403 on every mint attempt.

Previously 403 was not in the decline set, so the factory stayed installed, returning `None` forever → `RequestError("no token")` on every callback → session bricks after ~1h.

**Fix:** introduce `proxy_auth_failed` on `_ManagedMintTokenFactory`, set when a mint gets 401/403 with no prior successful mint (meaning the bootstrap loop can never self-sustain). `_make_managed_mint_factory` treats this the same as `declined` (returns `None`), so `_make_auth_token_factory` falls through to SDK/OIDC auth — the host user's Databricks credential, which is what host-launched runners should use for long-running sessions.

**Root cause analysis** (from Slack thread + PR #3902 review):
- Layer 3 (`_ManagedMintTokenFactory`) is designed to self-sustain by promoting the minted JWT to `_proxy_bearer` after the first successful mint. But it never gets that first mint because the proxy bearer is already expired when the fallback first fires (~1h after startup).
- 403 was deliberately excluded from the decline set to handle mid-session IP ACL flips, but that left no escape hatch for the "proxy bearer permanently dead" case.

## Test Plan

```
python -m pytest tests/runner/test_runner_entry.py -x -q
```

91 tests pass including new `test_managed_mint_factory_proxy_auth_failure_falls_through_to_sdk`.

## Demo

Confirmed `omni codex` can continue to work for longer than 1 hour

## Type of change

- [x] Bug fix

## Test coverage

- [x] Unit tests added / updated

## Coverage notes

N/A