### PR TITLE
fix(claude-native): keep the working indicator alive across turns

### DIFF
--- a/omnigent/claude_native_status_file.py
+++ b/omnigent/claude_native_status_file.py
@@ -32,15 +32,18 @@ from dataclasses import dataclass
 from pathlib import Path
 
 # Runner-side status vocabulary the file maps onto. ``busy`` and
-# ``waiting`` both mean "the turn is not finished" from the session's
-# point of view, so both map to ``running`` (Option A — ``waiting`` is
-# not yet surfaced as a distinct "needs input" state).
+# ``waiting`` both mean "the turn is not finished" from the session's point
+# of view, so both map to ``running``; ``waiting`` is distinguished for the
+# UI by the ``waitingFor`` reason rather than by a separate status. (The
+# session vocabulary's own ``waiting`` means something else entirely —
+# "turn ended, background work remains" — and must not be reused here.)
 RUNNING = "running"
 IDLE = "idle"
 
-# Claude interactive-session status literals (writer ``b3f`` in the
-# bundle). ``running``/``completed``/``failed`` belong to background jobs
-# and are not expected here, but map defensively rather than crash.
+# Claude interactive-session status literals. The interactive writer emits
+# exactly ``busy`` / ``shell`` / ``idle`` / ``waiting``: ``busy`` while the
+# turn is loading or a delegate is active, and ``waiting`` while a dialog
+# owns the input.
 _STATUS_TO_RUNNER: dict[str, str] = {
     "busy": RUNNING,
     "waiting": RUNNING,
@@ -78,11 +81,15 @@ class SessionStatus:
         "needs input" surfacing.
     :param status_updated_at: The file's ``statusUpdatedAt`` epoch-ms
         value, or ``None`` when absent.
+    :param waiting_for: The file's ``waitingFor`` reason when the raw status
+        is ``waiting`` — a short human phrase, e.g. ``"permission prompt"``,
+        ``"input needed"``, ``"dialog open"``. ``None`` otherwise.
     """
 
     runner_status: str
     raw_status: str
     status_updated_at: int | None
+    waiting_for: str | None = None
 
 
 def sessions_dir(config_dir: Path | None = None) -> Path:
@@ -229,10 +236,14 @@ def read_session_status(path: Path) -> SessionStatus | None:
         return None
     updated = record.get("statusUpdatedAt")
     status_updated_at = updated if isinstance(updated, int) else None
+    # Only meaningful alongside ``waiting`` — the writer merges updates into
+    # the existing record, so ignore any reason left over from an earlier one.
+    reason = record.get("waitingFor") if raw_status == "waiting" else None
     return SessionStatus(
         runner_status=runner_status,
         raw_status=raw_status,
         status_updated_at=status_updated_at,
+        waiting_for=reason if isinstance(reason, str) and reason else None,
     )
 
 
@@ -257,17 +268,21 @@ class SessionStatusPoller:
 
     - **Resolving:** each :meth:`tick` retries :func:`resolve_status_file`
       until it locks on or :data:`_MAX_RESOLVE_ATTEMPTS` is exhausted.
-      While resolving, :attr:`active` is ``False`` and the caller keeps
-      the PTY watcher authoritative for status.
-    - **Active:** once resolved, :attr:`active` is ``True`` (the caller
-      mutes PTY-derived status) and each tick reads the file and fires the
-      callback on a changed runner status.
+    - **Active:** once resolved, :attr:`active` is ``True`` and each tick
+      reads the file and fires the callback on a changed runner status.
     - **Exhausted:** if resolution never succeeds, :attr:`active` stays
-      ``False`` permanently and the PTY watcher remains the status source.
+      ``False`` permanently and the file contributes nothing.
 
-    :param on_status: Callback invoked with :data:`RUNNING` / :data:`IDLE`
-        on each status transition (and once on first read). Must not block
-        the watcher thread for long.
+    The poller never displaces the PTY watcher: it supplies an *additional*
+    status edge at Claude's real turn boundary, plus the freshness-bounded
+    :meth:`asserts_running` level the watcher consults before declaring a
+    quiet pane idle.
+
+    :param on_status: Callback invoked as ``(runner_status, waiting_for)``
+        on each transition (and once on first read). Fires when either part
+        changes, so ``busy`` → ``waiting`` still delivers its reason even
+        though both map to :data:`RUNNING`. Must not block the watcher
+        thread for long.
     :param pane_pid_getter: Returns the terminal's current pane pid, or
         ``None``. Called during resolution; on the omnigent launch path
         this pid names the status file.
@@ -280,7 +295,7 @@ class SessionStatusPoller:
     def __init__(
         self,
         *,
-        on_status: Callable[[str], None],
+        on_status: Callable[[str, str | None], None],
         pane_pid_getter: Callable[[], int | None],
         session_id_getter: Callable[[], str | None],
         config_dir: Path | None = None,
@@ -293,18 +308,17 @@ class SessionStatusPoller:
         self._attempts = 0
         self._exhausted = False
         self._last_mtime: float | None = None
-        self._last_runner_status: str | None = None
+        self._last_edge: tuple[str, str | None] | None = None
+        self._last_status: SessionStatus | None = None
 
     @property
     def active(self) -> bool:
-        """Whether the file is currently the authoritative status source.
+        """Whether a resolved file is still being read.
 
-        ``True`` only while a resolved file is still being read. The caller
-        reads this to decide whether to suppress the PTY-derived status
-        edges (file is authoritative) or keep them (still resolving, gave
-        up, or the file vanished). Goes back to ``False`` once the file
-        disappears — clean exit unlinks it — so the PTY watcher cleanly
-        reclaims status and exit detection.
+        ``False`` while resolving, once resolution gave up, or after the
+        file disappears (clean exit unlinks it). Status edges from the PTY
+        watcher are published regardless — this only reports whether the
+        file is contributing.
         """
         return self._path is not None and not self._exhausted
 
@@ -336,6 +350,47 @@ class SessionStatusPoller:
         if self._attempts >= _MAX_RESOLVE_ATTEMPTS:
             self._exhausted = True
 
+    def asserts_running(self, *, ttl_s: float, now: float | None = None) -> bool:
+        """Whether the file *recently* reported the session as running.
+
+        The file is written only when its value changes, so its status is a
+        level that can outlive the truth — Claude keeps reporting ``busy``
+        while a delegate or background task is active, long after the turn
+        itself ended. Callers therefore treat it as authoritative only for
+        *ttl_s* after the write, and fall back to the pane watcher once it
+        goes stale rather than pinning the session to ``running`` forever.
+
+        :param ttl_s: How long after ``statusUpdatedAt`` the level is still
+            trusted, in seconds.
+        :param now: Wall-clock override (tests); uses :func:`time.time`
+            when ``None``.
+        :returns: ``True`` when the last read said running and is still fresh.
+        """
+        status = self._last_status
+        if status is None or status.runner_status != RUNNING:
+            return False
+        # ``waiting`` does not decay: a dialog owns Claude's input until it
+        # closes, and closing it changes the value — so a new write is
+        # guaranteed. ``busy`` decays, because a delegate or background task
+        # keeps it set long after the turn it belongs to has ended.
+        if status.raw_status == "waiting":
+            return True
+        if status.status_updated_at is None:
+            return False
+        clock = time.time() if now is None else now
+        return clock - status.status_updated_at / 1000.0 <= ttl_s
+
+    @property
+    def waiting_for(self) -> str | None:
+        """Why Claude is parked, when it is parked on a dialog.
+
+        ``None`` unless the last read was ``waiting`` and carried a reason.
+        """
+        status = self._last_status
+        if status is None or status.raw_status != "waiting":
+            return None
+        return status.waiting_for
+
     def _read_and_publish(self) -> None:
         """Read the resolved file and fire the callback on a status change."""
         assert self._path is not None
@@ -351,8 +406,16 @@ class SessionStatusPoller:
         self._last_mtime = mtime
         status = read_session_status(self._path)
         if status is None:
+            # An unrecognized literal — the file is an undocumented internal
+            # detail whose vocabulary can grow. We are now blind to this
+            # transition, so drop the dedup baseline: the next readable
+            # status must publish rather than be swallowed as a duplicate.
+            self._last_status = None
+            self._last_edge = None
             return
-        if status.runner_status == self._last_runner_status:
+        self._last_status = status
+        edge = (status.runner_status, status.waiting_for)
+        if edge == self._last_edge:
             return
-        self._last_runner_status = status.runner_status
-        self._on_status(status.runner_status)
+        self._last_edge = edge
+        self._on_status(status.runner_status, status.waiting_for)

--- a/omnigent/claude_native_status_file.py
+++ b/omnigent/claude_native_status_file.py
@@ -81,7 +81,7 @@ class SessionStatus:
         "needs input" surfacing.
     :param status_updated_at: The file's ``statusUpdatedAt`` epoch-ms
         value, or ``None`` when absent.
-    :param waiting_for: The file's ``waitingFor`` reason when the raw status
+    :param blocked_on: The file's ``waitingFor`` reason when the raw status
         is ``waiting`` — a short human phrase, e.g. ``"permission prompt"``,
         ``"input needed"``, ``"dialog open"``. ``None`` otherwise.
     """
@@ -89,7 +89,7 @@ class SessionStatus:
     runner_status: str
     raw_status: str
     status_updated_at: int | None
-    waiting_for: str | None = None
+    blocked_on: str | None = None
 
 
 def sessions_dir(config_dir: Path | None = None) -> Path:
@@ -243,7 +243,7 @@ def read_session_status(path: Path) -> SessionStatus | None:
         runner_status=runner_status,
         raw_status=raw_status,
         status_updated_at=status_updated_at,
-        waiting_for=reason if isinstance(reason, str) and reason else None,
+        blocked_on=reason if isinstance(reason, str) and reason else None,
     )
 
 
@@ -278,7 +278,7 @@ class SessionStatusPoller:
     :meth:`asserts_running` level the watcher consults before declaring a
     quiet pane idle.
 
-    :param on_status: Callback invoked as ``(runner_status, waiting_for)``
+    :param on_status: Callback invoked as ``(runner_status, blocked_on)``
         on each transition (and once on first read). Fires when either part
         changes, so ``busy`` → ``waiting`` still delivers its reason even
         though both map to :data:`RUNNING`. Must not block the watcher
@@ -381,7 +381,7 @@ class SessionStatusPoller:
         return clock - status.status_updated_at / 1000.0 <= ttl_s
 
     @property
-    def waiting_for(self) -> str | None:
+    def blocked_on(self) -> str | None:
         """Why Claude is parked, when it is parked on a dialog.
 
         ``None`` unless the last read was ``waiting`` and carried a reason.
@@ -389,7 +389,7 @@ class SessionStatusPoller:
         status = self._last_status
         if status is None or status.raw_status != "waiting":
             return None
-        return status.waiting_for
+        return status.blocked_on
 
     def _read_and_publish(self) -> None:
         """Read the resolved file and fire the callback on a status change."""
@@ -414,8 +414,8 @@ class SessionStatusPoller:
             self._last_edge = None
             return
         self._last_status = status
-        edge = (status.runner_status, status.waiting_for)
+        edge = (status.runner_status, status.blocked_on)
         if edge == self._last_edge:
             return
         self._last_edge = edge
-        self._on_status(status.runner_status, status.waiting_for)
+        self._on_status(status.runner_status, status.blocked_on)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2147,11 +2147,11 @@ def create_runner_app(
     def _publish_session_status(
         session_id: str,
         status: str,
-        waiting_for: str | None = None,
+        blocked_on: str | None = None,
     ) -> None:
         event: dict[str, object] = {"type": "session.status", "status": status}
-        if waiting_for is not None:
-            event["waiting_for"] = waiting_for
+        if blocked_on is not None:
+            event["blocked_on"] = blocked_on
         _publish_event(session_id, event)
 
     resource_registry.set_session_status_publisher(_publish_session_status)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2144,11 +2144,15 @@ def create_runner_app(
 
     resource_registry.set_terminal_activity_publisher(_publish_terminal_activity)
 
-    def _publish_session_status(session_id: str, status: str) -> None:
-        _publish_event(
-            session_id,
-            {"type": "session.status", "status": status},
-        )
+    def _publish_session_status(
+        session_id: str,
+        status: str,
+        waiting_for: str | None = None,
+    ) -> None:
+        event: dict[str, object] = {"type": "session.status", "status": status}
+        if waiting_for is not None:
+            event["waiting_for"] = waiting_for
+        _publish_event(session_id, event)
 
     resource_registry.set_session_status_publisher(_publish_session_status)
 

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -359,9 +359,9 @@ class SessionResourceRegistry:
         directly. Only the claude-native agent terminal's watcher calls
         it — see :meth:`_start_terminal_activity_watcher`.
 
-        :param publisher: Callable ``(session_id, status, waiting_for) ->
+        :param publisher: Callable ``(session_id, status, blocked_on) ->
             None`` where *status* is ``"running"`` or ``"idle"`` and
-            *waiting_for* is a short reason the agent is parked on a dialog
+            *blocked_on* is a short reason the agent is parked on a dialog
             (e.g. ``"permission prompt"``), or ``None``.
         """
         self._session_status_publisher = publisher
@@ -410,22 +410,22 @@ class SessionResourceRegistry:
             self._published_session_status.pop(session_id, None)
             return self._last_session_status.pop(session_id, None)
 
-    def _claim_status_edge(self, session_id: str, status: str, waiting_for: str | None) -> bool:
+    def _claim_status_edge(self, session_id: str, status: str, blocked_on: str | None) -> bool:
         """Record an edge as published, reporting whether it was a change.
 
-        Keyed on the ``(status, waiting_for)`` pair so a session that stays
+        Keyed on the ``(status, blocked_on)`` pair so a session that stays
         ``running`` while it parks on a dialog still delivers the reason.
 
         :param session_id: Session/conversation identifier, e.g. ``"conv_abc"``.
         :param status: Status about to be published, e.g. ``"running"``.
-        :param waiting_for: Reason the agent is parked, or ``None``.
+        :param blocked_on: Reason the agent is parked, or ``None``.
         :returns: ``True`` when this differs from the last published edge
             (so the caller should publish), ``False`` when it is a duplicate.
         """
         with self._lock:
-            if self._published_session_status.get(session_id) == (status, waiting_for):
+            if self._published_session_status.get(session_id) == (status, blocked_on):
                 return False
-            self._published_session_status[session_id] = (status, waiting_for)
+            self._published_session_status[session_id] = (status, blocked_on)
             return True
 
     def _sync_status_edge(self, session_id: str, status: str) -> None:
@@ -1088,7 +1088,7 @@ class SessionResourceRegistry:
         # means "never emitted", so the first changed tick always fires.
         last_activity_emit: dict[str, float | None] = {"value": None}
 
-        def _waiting_reason() -> str | None:
+        def _blocked_reason() -> str | None:
             # The reason rides every edge, not just the poller's own, so a
             # redrawing pane under a dialog doesn't publish a bare ``running``
             # that erases it.
@@ -1096,9 +1096,9 @@ class SessionResourceRegistry:
                 ttl_s=_CLAUDE_NATIVE_STATUS_FILE_LEVEL_TTL_SECONDS
             ):
                 return None
-            return status_poller.waiting_for
+            return status_poller.blocked_on
 
-        def _publish_status(status: str, waiting_for: str | None = None) -> None:
+        def _publish_status(status: str, blocked_on: str | None = None) -> None:
             # Publish one running/idle edge: dedup against the last value,
             # memo for exit classification, and hop to the loop (publishers
             # are loop-only). Shared by the PTY edges and the claude-native
@@ -1108,10 +1108,10 @@ class SessionResourceRegistry:
             # :meth:`note_external_session_status`).
             if status_publisher is None:
                 return
-            if not self._claim_status_edge(session_id, status, waiting_for):
+            if not self._claim_status_edge(session_id, status, blocked_on):
                 return
             self._set_session_status_memo(session_id, status)
-            loop.call_soon_threadsafe(status_publisher, session_id, status, waiting_for)
+            loop.call_soon_threadsafe(status_publisher, session_id, status, blocked_on)
 
         # claude-native additionally reads Claude's own ``sessions/<pid>.json``
         # status (present since Claude Code v2.1.139): it flips on the real
@@ -1156,7 +1156,7 @@ class SessionResourceRegistry:
             # produces no write at all — and the session would sit on its
             # stale ``idle`` for the whole turn with no working indicator.
             if emit_status:
-                _publish_status("running", _waiting_reason())
+                _publish_status("running", _blocked_reason())
 
         def _on_exit() -> None:
             def _schedule() -> None:
@@ -1267,9 +1267,9 @@ class SessionResourceRegistry:
             the bridge directory holding the captured Claude session uuid.
         :param instance: The launched terminal instance (exposes
             ``pane_pid_sync``).
-        :param on_status: Callback fired as ``(status, waiting_for)`` on each
+        :param on_status: Callback fired as ``(status, blocked_on)`` on each
             transition, where *status* is ``running`` / ``idle`` and
-            *waiting_for* names the dialog the agent is parked on, if any.
+            *blocked_on* names the dialog the agent is parked on, if any.
         :returns: A ``SessionStatusPoller`` the watcher drives per tick.
         """
         from omnigent.claude_native_bridge import (

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -95,6 +95,16 @@ _CLAUDE_NATIVE_STATUS_IDLE_THRESHOLD_SECONDS = 1.0
 # don't 5x the capture-pane subprocess load on every terminal.
 _CLAUDE_NATIVE_STATUS_POLL_INTERVAL_SECONDS = 0.2
 
+# How long Claude's ``sessions/<pid>.json`` status stays trusted as a *level*
+# after it was written. The file is rewritten only when its value changes, so
+# a ``busy`` written for a delegate or background task outlives the turn that
+# produced it; honouring it forever would pin the session to "Working…" with
+# no way back. Inside this window a quiet pane is read as "parked on a prompt"
+# (the case the pane diff genuinely cannot see) and the session stays running;
+# past it the pane watcher decides. Comfortably above the 1s idle threshold so
+# a real prompt is not lost to the gap between the write and the pane settling.
+_CLAUDE_NATIVE_STATUS_FILE_LEVEL_TTL_SECONDS = 10.0
+
 # Minimum wall-clock interval (seconds) between consecutive
 # ``session.terminal.activity`` emissions for a single terminal. The
 # claude-native agent terminal polls its pane every 200ms
@@ -295,13 +305,19 @@ class SessionResourceRegistry:
         # working status that replaces the hook-based ``UserPromptSubmit``
         # → running / ``Stop`` → idle bracketing. Set by the runner via
         # :meth:`set_session_status_publisher`.
-        self._session_status_publisher: Callable[[str, str], None] | None = None
+        self._session_status_publisher: Callable[[str, str, str | None], None] | None = None
         # Latest PTY-derived status (running/idle) per session. Lets
         # :meth:`_handle_terminal_exit` tell a clean shutdown (idle) from a
         # mid-turn crash. Written from the watcher thread and the turn-start
         # hook; all access goes through the ``_*_session_status_memo`` helpers
         # under ``self._lock``.
         self._last_session_status: dict[str, str] = {}
+        # Last status *edge published to the server* per session, shared by the
+        # watcher and the native forwarders' hook-derived edges so the two
+        # dedup against one baseline. Kept separate from the exit memo above,
+        # which the turn-start hook also writes — deduping against that one
+        # would swallow the turn's real ``running``.
+        self._published_session_status: dict[str, tuple[str, str | None]] = {}
         # Optional callback invoked on the event loop when a watched terminal
         # disappears unexpectedly. The callback receives the terminal's
         # lifecycle relationship so the runner can decide whether the owning
@@ -331,7 +347,7 @@ class SessionResourceRegistry:
 
     def set_session_status_publisher(
         self,
-        publisher: Callable[[str, str], None],
+        publisher: Callable[[str, str, str | None], None],
     ) -> None:
         """Install the PTY-activity-derived session-status publisher.
 
@@ -343,8 +359,10 @@ class SessionResourceRegistry:
         directly. Only the claude-native agent terminal's watcher calls
         it — see :meth:`_start_terminal_activity_watcher`.
 
-        :param publisher: Callable ``(session_id, status) -> None`` where
-            *status* is ``"running"`` or ``"idle"``.
+        :param publisher: Callable ``(session_id, status, waiting_for) ->
+            None`` where *status* is ``"running"`` or ``"idle"`` and
+            *waiting_for* is a short reason the agent is parked on a dialog
+            (e.g. ``"permission prompt"``), or ``None``.
         """
         self._session_status_publisher = publisher
 
@@ -389,7 +407,31 @@ class SessionResourceRegistry:
     def _take_session_status_memo(self, session_id: str) -> str | None:
         """Pop and return the session's recorded PTY status (or ``None``)."""
         with self._lock:
+            self._published_session_status.pop(session_id, None)
             return self._last_session_status.pop(session_id, None)
+
+    def _claim_status_edge(self, session_id: str, status: str, waiting_for: str | None) -> bool:
+        """Record an edge as published, reporting whether it was a change.
+
+        Keyed on the ``(status, waiting_for)`` pair so a session that stays
+        ``running`` while it parks on a dialog still delivers the reason.
+
+        :param session_id: Session/conversation identifier, e.g. ``"conv_abc"``.
+        :param status: Status about to be published, e.g. ``"running"``.
+        :param waiting_for: Reason the agent is parked, or ``None``.
+        :returns: ``True`` when this differs from the last published edge
+            (so the caller should publish), ``False`` when it is a duplicate.
+        """
+        with self._lock:
+            if self._published_session_status.get(session_id) == (status, waiting_for):
+                return False
+            self._published_session_status[session_id] = (status, waiting_for)
+            return True
+
+    def _sync_status_edge(self, session_id: str, status: str) -> None:
+        """Adopt an externally-published *status* as the dedup baseline."""
+        with self._lock:
+            self._published_session_status[session_id] = (status, None)
 
     def note_session_turn_started(self, session_id: str) -> None:
         """Mark a session as having an in-flight turn.
@@ -412,6 +454,12 @@ class SessionResourceRegistry:
         clean shutdown, while ``running`` / ``waiting`` still classify a later
         exit as mid-turn.
 
+        Also adopts *status* as the watcher's dedup baseline. The forwarder
+        publishes these edges directly to the server, so without this the
+        watcher would still believe its own last edge is live and swallow the
+        next turn's ``running`` as a duplicate — leaving the session stuck on
+        the hook's ``idle`` with no working indicator for the whole turn.
+
         :param session_id: Session/conversation identifier, e.g. ``"conv_abc"``.
         :param status: External native status, e.g. ``"running"`` or ``"idle"``.
         """
@@ -419,6 +467,7 @@ class SessionResourceRegistry:
             self._set_session_status_memo(session_id, "idle")
         elif status in {"running", "waiting"}:
             self._set_session_status_memo(session_id, "running")
+        self._sync_status_edge(session_id, status)
 
     @property
     def terminal_registry(self) -> TerminalRegistry | None:
@@ -1032,12 +1081,6 @@ class SessionResourceRegistry:
         resource_id = terminal_resource_id(terminal_name, session_key)
         loop = asyncio.get_running_loop()
 
-        # Last status edge emitted for this terminal, mutated only on the
-        # watcher daemon thread (single-threaded), so the running/idle
-        # transition is deduped without a lock. Scoped to this watcher's
-        # lifetime, so a fresh terminal gets a fresh baseline — no stale
-        # cross-launch state to clean up.
-        last_status: dict[str, str | None] = {"value": None}
         # Monotonic time of the last activity pulse published for this
         # terminal, mutated only on the watcher daemon thread (so no lock),
         # used to throttle emissions to at most one per
@@ -1045,24 +1088,38 @@ class SessionResourceRegistry:
         # means "never emitted", so the first changed tick always fires.
         last_activity_emit: dict[str, float | None] = {"value": None}
 
-        def _publish_status(status: str) -> None:
+        def _waiting_reason() -> str | None:
+            # The reason rides every edge, not just the poller's own, so a
+            # redrawing pane under a dialog doesn't publish a bare ``running``
+            # that erases it.
+            if status_poller is None or not status_poller.asserts_running(
+                ttl_s=_CLAUDE_NATIVE_STATUS_FILE_LEVEL_TTL_SECONDS
+            ):
+                return None
+            return status_poller.waiting_for
+
+        def _publish_status(status: str, waiting_for: str | None = None) -> None:
             # Publish one running/idle edge: dedup against the last value,
             # memo for exit classification, and hop to the loop (publishers
             # are loop-only). Shared by the PTY edges and the claude-native
-            # status-file poller so both go through the same dedup/memo.
-            if status_publisher is None or last_status["value"] == status:
+            # status-file poller so both go through the same dedup/memo. The
+            # dedup baseline lives on the registry, not this closure, so a
+            # forwarder's hook-derived edge resyncs it (see
+            # :meth:`note_external_session_status`).
+            if status_publisher is None:
                 return
-            last_status["value"] = status
+            if not self._claim_status_edge(session_id, status, waiting_for):
+                return
             self._set_session_status_memo(session_id, status)
-            loop.call_soon_threadsafe(status_publisher, session_id, status)
+            loop.call_soon_threadsafe(status_publisher, session_id, status, waiting_for)
 
-        # claude-native prefers Claude's own ``sessions/<pid>.json`` status
-        # (present since Claude Code v2.1.139) over the PTY frame-diff: it
-        # flips on the real turn edge and distinguishes ``waiting`` (needs
-        # input) from ``busy``. Built only for the claude-native role; other
-        # native roles stay PTY-only. ``None`` (old Claude, missing file)
-        # leaves the PTY watcher authoritative — see ``poller.active`` gating
-        # in the PTY edges below.
+        # claude-native additionally reads Claude's own ``sessions/<pid>.json``
+        # status (present since Claude Code v2.1.139): it flips on the real
+        # turn edge and knows when a dialog owns the input, neither of which
+        # the PTY frame-diff can see. It supplements the PTY watcher rather
+        # than replacing it — the file is written only on a value *change*, so
+        # it cannot be trusted to re-assert a status it already holds. Built
+        # only for the claude-native role; other native roles stay PTY-only.
         status_poller = (
             self._build_claude_native_status_poller(
                 session_id=session_id,
@@ -1093,12 +1150,13 @@ class SessionResourceRegistry:
                     loop.call_soon_threadsafe(activity_publisher, session_id, resource_id)
             # Pane changed → the agent is working. Coalesce to the
             # idle→running edge so a continuously-redrawing pane doesn't
-            # re-emit ``running`` every poll. Skipped while the status-file
-            # poller is authoritative (it owns the edge, and the file
-            # distinguishes ``waiting`` from ``busy`` — which the pane
-            # diff can't); the PTY edge resumes if the poller falls back.
-            if emit_status and (status_poller is None or not status_poller.active):
-                _publish_status("running")
+            # re-emit ``running`` every poll. Always published, never deferred
+            # to the status file: that file is rewritten only when its value
+            # *changes*, so a turn starting while it already reads ``busy``
+            # produces no write at all — and the session would sit on its
+            # stale ``idle`` for the whole turn with no working indicator.
+            if emit_status:
+                _publish_status("running", _waiting_reason())
 
         def _on_exit() -> None:
             def _schedule() -> None:
@@ -1152,12 +1210,16 @@ class SessionResourceRegistry:
             # Pane quiet for the claude-native status threshold → the
             # agent has stopped. Edge-triggered: re-arms only after new
             # output mutates the pane (which flips back to ``running``).
-            # Skipped while the status-file poller is authoritative — the
-            # 1s pane-quiescence heuristic would otherwise race the file's
-            # real turn edge; the PTY idle resumes if the poller falls back.
+            # Held back only while the status file *freshly* reports running:
+            # a dialog owning the input quiets the pane without ending the
+            # turn, which the pane diff alone cannot tell from a finished one.
+            # Past that freshness window the pane decides, so a ``busy`` left
+            # standing by a background task can't pin the session to running.
             # Edge ordering: the watcher thread runs idle/exit serially, so
             # this idle commits before any later on_exit reads the memo.
-            if status_poller is None or not status_poller.active:
+            if status_poller is None or not status_poller.asserts_running(
+                ttl_s=_CLAUDE_NATIVE_STATUS_FILE_LEVEL_TTL_SECONDS
+            ):
                 _publish_status("idle")
             # Clear the activity throttle so the next working episode emits
             # its first pulse immediately, keeping the activity badge
@@ -1189,7 +1251,7 @@ class SessionResourceRegistry:
         *,
         session_id: str,
         instance: TerminalInstance,
-        on_status: Callable[[str], None],
+        on_status: Callable[[str, str | None], None],
     ) -> SessionStatusPoller:
         """Build the claude-native ``sessions/<pid>.json`` status poller.
 
@@ -1205,8 +1267,9 @@ class SessionResourceRegistry:
             the bridge directory holding the captured Claude session uuid.
         :param instance: The launched terminal instance (exposes
             ``pane_pid_sync``).
-        :param on_status: Callback fired with ``running`` / ``idle`` on each
-            status transition.
+        :param on_status: Callback fired as ``(status, waiting_for)`` on each
+            transition, where *status* is ``running`` / ``idle`` and
+            *waiting_for* names the dialog the agent is parked on, if any.
         :returns: A ``SessionStatusPoller`` the watcher drives per tick.
         """
         from omnigent.claude_native_bridge import (

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -3528,7 +3528,7 @@ def _publish_status(
     error: ErrorDetail | None = None,
     response_id: str | None = None,
     background_task_count: int | None = None,
-    waiting_for: str | None = None,
+    blocked_on: str | None = None,
 ) -> None:
     """
     Publish a typed :class:`SessionStatusEvent` to the live stream and
@@ -3628,15 +3628,15 @@ def _publish_status(
         response_id=response_id,
         error=error,
         background_task_count=background_task_count,
-        waiting_for=waiting_for,
+        blocked_on=blocked_on,
     )
     payload = event.model_dump()
     if response_id is None:
         payload.pop("response_id", None)
     if background_task_count is None:
         payload.pop("background_task_count", None)
-    if waiting_for is None:
-        payload.pop("waiting_for", None)
+    if blocked_on is None:
+        payload.pop("blocked_on", None)
     session_stream.publish(session_id, payload)
 
 

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -3528,6 +3528,7 @@ def _publish_status(
     error: ErrorDetail | None = None,
     response_id: str | None = None,
     background_task_count: int | None = None,
+    waiting_for: str | None = None,
 ) -> None:
     """
     Publish a typed :class:`SessionStatusEvent` to the live stream and
@@ -3627,12 +3628,15 @@ def _publish_status(
         response_id=response_id,
         error=error,
         background_task_count=background_task_count,
+        waiting_for=waiting_for,
     )
     payload = event.model_dump()
     if response_id is None:
         payload.pop("response_id", None)
     if background_task_count is None:
         payload.pop("background_task_count", None)
+    if waiting_for is None:
+        payload.pop("waiting_for", None)
     session_stream.publish(session_id, payload)
 
 

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -5263,14 +5263,14 @@ async def _relay_runner_stream(
                             # via external_session_status (the codex-shared path)
                             # — the PTY idle oscillates on mid-turn lulls and
                             # would deliver a premature, lock-out completion.
-                            raw_waiting_for = event.get("waiting_for")
+                            raw_blocked_on = event.get("blocked_on")
                             _publish_status(
                                 session_id,
                                 status,
                                 status_error,
-                                waiting_for=(
-                                    raw_waiting_for
-                                    if isinstance(raw_waiting_for, str) and raw_waiting_for
+                                blocked_on=(
+                                    raw_blocked_on
+                                    if isinstance(raw_blocked_on, str) and raw_blocked_on
                                     else None
                                 ),
                             )

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -5263,7 +5263,17 @@ async def _relay_runner_stream(
                             # via external_session_status (the codex-shared path)
                             # — the PTY idle oscillates on mid-turn lulls and
                             # would deliver a premature, lock-out completion.
-                            _publish_status(session_id, status, status_error)
+                            raw_waiting_for = event.get("waiting_for")
+                            _publish_status(
+                                session_id,
+                                status,
+                                status_error,
+                                waiting_for=(
+                                    raw_waiting_for
+                                    if isinstance(raw_waiting_for, str) and raw_waiting_for
+                                    else None
+                                ),
+                            )
                         if status == "running":
                             text_acc.clear()
                         continue

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -890,6 +890,13 @@ def register_events_routes(
                 and raw_bg_count >= 0
                 else None
             )
+            # Why a still-running session is parked, e.g. a permission prompt
+            # the web UI does not mirror. Absent or blank = not parked, so the
+            # indicator falls back to its ordinary working label.
+            raw_waiting_for = body.data.get("waiting_for")
+            waiting_for = (
+                raw_waiting_for if isinstance(raw_waiting_for, str) and raw_waiting_for else None
+            )
             # A sub-agent's background-task ``waiting`` must deliver as ``idle``
             # so the parent's terminal-delivery branch below fires (otherwise
             # the orchestrator hangs); the tally still drives the child spinner.
@@ -903,6 +910,7 @@ def register_events_routes(
                 status_error,
                 response_id=response_id,
                 background_task_count=bg_count,
+                waiting_for=waiting_for,
             )
             forward_body = body.model_dump()
             forward_body["data"] = await _enrich_idle_status_with_subagent_output(

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -893,9 +893,9 @@ def register_events_routes(
             # Why a still-running session is parked, e.g. a permission prompt
             # the web UI does not mirror. Absent or blank = not parked, so the
             # indicator falls back to its ordinary working label.
-            raw_waiting_for = body.data.get("waiting_for")
-            waiting_for = (
-                raw_waiting_for if isinstance(raw_waiting_for, str) and raw_waiting_for else None
+            raw_blocked_on = body.data.get("blocked_on")
+            blocked_on = (
+                raw_blocked_on if isinstance(raw_blocked_on, str) and raw_blocked_on else None
             )
             # A sub-agent's background-task ``waiting`` must deliver as ``idle``
             # so the parent's terminal-delivery branch below fires (otherwise
@@ -910,7 +910,7 @@ def register_events_routes(
                 status_error,
                 response_id=response_id,
                 background_task_count=bg_count,
-                waiting_for=waiting_for,
+                blocked_on=blocked_on,
             )
             forward_body = body.model_dump()
             forward_body["data"] = await _enrich_idle_status_with_subagent_output(

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2632,12 +2632,14 @@ class SessionStatusEvent(_SSEEventBase):
         is emitted. ``None`` for every non-failed transition.
         Clients render ``error.message`` as the terminal error
         line; without it a setup failure shows as a silent end.
-    :param waiting_for: Short human phrase naming what a still-``running``
+    :param blocked_on: Short human phrase naming what a still-``running``
         session is parked on, e.g. ``"permission prompt"`` or
         ``"dialog open"``. Set by terminal-backed integrations whose agent
         can block on a dialog the web UI does not mirror, so the client can
         say *why* nothing is moving instead of showing a bare spinner.
-        ``None`` whenever the session is not parked.
+        ``None`` whenever the session is not parked. Unrelated to the
+        ``waiting`` status above, which means the turn has ended and only
+        background work remains.
 
     Category: **transient** (SSE-only). Status is rederived on
     reconnect from the cached last-relayed turn lifecycle event
@@ -2650,7 +2652,7 @@ class SessionStatusEvent(_SSEEventBase):
     response_id: str | None = None
     error: ErrorDetail | None = None
     background_task_count: int | None = None
-    waiting_for: str | None = None
+    blocked_on: str | None = None
 
 
 class SessionUsageEvent(_SSEEventBase):

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2632,6 +2632,12 @@ class SessionStatusEvent(_SSEEventBase):
         is emitted. ``None`` for every non-failed transition.
         Clients render ``error.message`` as the terminal error
         line; without it a setup failure shows as a silent end.
+    :param waiting_for: Short human phrase naming what a still-``running``
+        session is parked on, e.g. ``"permission prompt"`` or
+        ``"dialog open"``. Set by terminal-backed integrations whose agent
+        can block on a dialog the web UI does not mirror, so the client can
+        say *why* nothing is moving instead of showing a bare spinner.
+        ``None`` whenever the session is not parked.
 
     Category: **transient** (SSE-only). Status is rederived on
     reconnect from the cached last-relayed turn lifecycle event
@@ -2644,6 +2650,7 @@ class SessionStatusEvent(_SSEEventBase):
     response_id: str | None = None
     error: ErrorDetail | None = None
     background_task_count: int | None = None
+    waiting_for: str | None = None
 
 
 class SessionUsageEvent(_SSEEventBase):

--- a/openapi.json
+++ b/openapi.json
@@ -5543,7 +5543,7 @@
               }
             ],
             "default": null,
-            "description": "Machine-readable failure detail, present only when `status == \"failed\"`. Carries the message the runner attached when a turn died \u2014 most importantly a SETUP-phase failure (spec resolution, spawn-env build) that ends the turn before any `response.failed` event is emitted. `None` for every non-failed transition. Clients render `error.message` as the terminal error line; without it a setup failure shows as a silent end. Category: **transient** (SSE-only). Status is rederived on reconnect from the cached last-relayed turn lifecycle event or by re-querying the runner; not persisted by the runtime."
+            "description": "Machine-readable failure detail, present only when `status == \"failed\"`. Carries the message the runner attached when a turn died \u2014 most importantly a SETUP-phase failure (spec resolution, spawn-env build) that ends the turn before any `response.failed` event is emitted. `None` for every non-failed transition. Clients render `error.message` as the terminal error line; without it a setup failure shows as a silent end."
           },
           "response_id": {
             "anyOf": [
@@ -5587,6 +5587,19 @@
             "description": "Always `\"session.status\"`.",
             "title": "Type",
             "type": "string"
+          },
+          "waiting_for": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Short human phrase naming what a still-`running` session is parked on, e.g. `\"permission prompt\"` or `\"dialog open\"`. Set by terminal-backed integrations whose agent can block on a dialog the web UI does not mirror, so the client can say *why* nothing is moving instead of showing a bare spinner. `None` whenever the session is not parked. Category: **transient** (SSE-only). Status is rederived on reconnect from the cached last-relayed turn lifecycle event or by re-querying the runner; not persisted by the runtime.",
+            "title": "Waiting For"
           }
         },
         "required": [

--- a/openapi.json
+++ b/openapi.json
@@ -5528,6 +5528,19 @@
             "default": null,
             "title": "Background Task Count"
           },
+          "blocked_on": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Short human phrase naming what a still-`running` session is parked on, e.g. `\"permission prompt\"` or `\"dialog open\"`. Set by terminal-backed integrations whose agent can block on a dialog the web UI does not mirror, so the client can say *why* nothing is moving instead of showing a bare spinner. `None` whenever the session is not parked. Unrelated to the `waiting` status above, which means the turn has ended and only background work remains. Category: **transient** (SSE-only). Status is rederived on reconnect from the cached last-relayed turn lifecycle event or by re-querying the runner; not persisted by the runtime.",
+            "title": "Blocked On"
+          },
           "conversation_id": {
             "description": "The conversation/session identifier whose status changed, e.g. `\"conv_abc123\"`.",
             "title": "Conversation Id",
@@ -5587,19 +5600,6 @@
             "description": "Always `\"session.status\"`.",
             "title": "Type",
             "type": "string"
-          },
-          "waiting_for": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Short human phrase naming what a still-`running` session is parked on, e.g. `\"permission prompt\"` or `\"dialog open\"`. Set by terminal-backed integrations whose agent can block on a dialog the web UI does not mirror, so the client can say *why* nothing is moving instead of showing a bare spinner. `None` whenever the session is not parked. Category: **transient** (SSE-only). Status is rederived on reconnect from the cached last-relayed turn lifecycle event or by re-querying the runner; not persisted by the runtime.",
-            "title": "Waiting For"
           }
         },
         "required": [

--- a/tests/e2e_ui/chat/test_working_indicator_blocked_reason.py
+++ b/tests/e2e_ui/chat/test_working_indicator_blocked_reason.py
@@ -4,7 +4,7 @@ A native-terminal agent can block on a prompt that lives only in its TUI —
 a permission request, a sandbox request, an open dialog — which the web
 chat does not mirror. The session is still running, so the indicator stays
 lit, but a bare rotating "Working…" hides the fact that nothing will move
-until someone answers. The status edge carries a ``waiting_for`` reason and
+until someone answers. The status edge carries a ``blocked_on`` reason and
 the indicator names it instead.
 
 Drives the real status edges through the Sessions events route (the same
@@ -41,20 +41,20 @@ def _publish_status(
     session_id: str,
     status: str,
     *,
-    waiting_for: str | None = None,
+    blocked_on: str | None = None,
 ) -> None:
     """Publish a session status through the native-harness events route.
 
     :param base_url: Base URL of the local e2e server.
     :param session_id: Session/conversation id.
     :param status: Session status to publish, e.g. ``"running"``.
-    :param waiting_for: Why the session is parked, e.g. ``"permission
+    :param blocked_on: Why the session is parked, e.g. ``"permission
         prompt"``. ``None`` omits the field — the session is not parked.
     :returns: None.
     """
     data: dict[str, object] = {"status": status}
-    if waiting_for is not None:
-        data["waiting_for"] = waiting_for
+    if blocked_on is not None:
+        data["blocked_on"] = blocked_on
     resp = httpx.post(
         f"{base_url}/v1/sessions/{session_id}/events",
         json={"type": "external_session_status", "data": data},
@@ -85,14 +85,14 @@ def test_working_indicator_names_what_the_agent_is_parked_on(
     # 2. The agent parks on a prompt that lives only in its TUI. The session
     #    is still running, so the indicator stays lit — but it now says what
     #    it is waiting on rather than shimmering with no explanation.
-    _publish_status(base_url, session_id, "running", waiting_for="permission prompt")
-    expect(working).to_contain_text("Waiting: permission prompt", timeout=15_000)
+    _publish_status(base_url, session_id, "running", blocked_on="permission prompt")
+    expect(working).to_contain_text("Blocked on: permission prompt", timeout=15_000)
 
     # 3. The prompt is answered and work resumes: the reason is dropped (it is
     #    not sticky) and the ordinary rotating label comes back.
     _publish_status(base_url, session_id, "running")
     expect(working).to_contain_text(_WORKING_LABEL_RE, timeout=15_000)
-    expect(working).not_to_contain_text("Waiting:", timeout=15_000)
+    expect(working).not_to_contain_text("Blocked on:", timeout=15_000)
 
     # 4. The turn ends: the indicator goes out regardless.
     _publish_status(base_url, session_id, "idle")

--- a/tests/e2e_ui/chat/test_working_indicator_waiting_reason.py
+++ b/tests/e2e_ui/chat/test_working_indicator_waiting_reason.py
@@ -1,0 +1,99 @@
+"""Working indicator behavior when the agent is parked on a dialog.
+
+A native-terminal agent can block on a prompt that lives only in its TUI —
+a permission request, a sandbox request, an open dialog — which the web
+chat does not mirror. The session is still running, so the indicator stays
+lit, but a bare rotating "Working…" hides the fact that nothing will move
+until someone answers. The status edge carries a ``waiting_for`` reason and
+the indicator names it instead.
+
+Drives the real status edges through the Sessions events route (the same
+path a native forwarder posts to), so the test is deterministic — no live
+LLM turn, whose timing would make the assertions flaky.
+"""
+
+from __future__ import annotations
+
+import re
+
+import httpx
+from playwright.sync_api import Page, expect
+
+_WORKING = '[data-testid="working-indicator"]'
+
+# Rotating labels the working indicator cycles through — mirror of
+# WORKING_MESSAGES in web/src/pages/ChatPage.tsx. Which one shows depends on
+# the wall-clock bucket the turn lands on, so the test accepts any of them.
+# Keep this list in sync if that pool changes.
+_WORKING_LABELS = (
+    "Working…",
+    "Cooking…",
+    "Crunching…",
+    "Tinkering…",
+    "Pondering…",
+    "Brewing…",
+)
+_WORKING_LABEL_RE = re.compile("|".join(re.escape(label) for label in _WORKING_LABELS))
+
+
+def _publish_status(
+    base_url: str,
+    session_id: str,
+    status: str,
+    *,
+    waiting_for: str | None = None,
+) -> None:
+    """Publish a session status through the native-harness events route.
+
+    :param base_url: Base URL of the local e2e server.
+    :param session_id: Session/conversation id.
+    :param status: Session status to publish, e.g. ``"running"``.
+    :param waiting_for: Why the session is parked, e.g. ``"permission
+        prompt"``. ``None`` omits the field — the session is not parked.
+    :returns: None.
+    """
+    data: dict[str, object] = {"status": status}
+    if waiting_for is not None:
+        data["waiting_for"] = waiting_for
+    resp = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={"type": "external_session_status", "data": data},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+def test_working_indicator_names_what_the_agent_is_parked_on(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The indicator reports the parked reason, then returns to working.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` from the local server
+        fixture.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    working = page.locator(_WORKING)
+
+    # 1. A turn is in flight: the indicator is lit with an ordinary label.
+    _publish_status(base_url, session_id, "running")
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(working).to_contain_text(_WORKING_LABEL_RE, timeout=15_000)
+
+    # 2. The agent parks on a prompt that lives only in its TUI. The session
+    #    is still running, so the indicator stays lit — but it now says what
+    #    it is waiting on rather than shimmering with no explanation.
+    _publish_status(base_url, session_id, "running", waiting_for="permission prompt")
+    expect(working).to_contain_text("Waiting: permission prompt", timeout=15_000)
+
+    # 3. The prompt is answered and work resumes: the reason is dropped (it is
+    #    not sticky) and the ordinary rotating label comes back.
+    _publish_status(base_url, session_id, "running")
+    expect(working).to_contain_text(_WORKING_LABEL_RE, timeout=15_000)
+    expect(working).not_to_contain_text("Waiting:", timeout=15_000)
+
+    # 4. The turn ends: the indicator goes out regardless.
+    _publish_status(base_url, session_id, "idle")
+    expect(working).to_have_count(0, timeout=15_000)

--- a/tests/runner/test_resource_registry.py
+++ b/tests/runner/test_resource_registry.py
@@ -412,7 +412,7 @@ class _FakeStatusPoller:
         self._on_status = on_status
         self.active = False
         self.running_level = False
-        self.waiting_for: str | None = None
+        self.blocked_on: str | None = None
         self.ticks = 0
 
     def tick(self) -> None:
@@ -422,9 +422,9 @@ class _FakeStatusPoller:
         del ttl_s, now
         return self.running_level
 
-    def emit(self, status: str, waiting_for: str | None = None) -> None:
+    def emit(self, status: str, blocked_on: str | None = None) -> None:
         """Simulate the file reporting a new status."""
-        self._on_status(status, waiting_for)
+        self._on_status(status, blocked_on)
 
 
 async def _observe_native_with_fake_poller(
@@ -1284,7 +1284,7 @@ def test_resolve_environment_runner_workspace_overrides_absolute_spec_cwd(
 
 
 @pytest.mark.asyncio
-async def test_waiting_reason_rides_pane_edges(tmp_path: Path) -> None:
+async def test_blocked_reason_rides_pane_edges(tmp_path: Path) -> None:
     """The parked reason travels with every edge, not just the file's own.
 
     Claude reports ``waitingFor`` once, when the dialog opens. The pane keeps
@@ -1336,7 +1336,7 @@ async def test_waiting_reason_rides_pane_edges(tmp_path: Path) -> None:
     poller = pollers[0]
     poller.active = True
     poller.running_level = True
-    poller.waiting_for = "permission prompt"
+    poller.blocked_on = "permission prompt"
 
     poller.emit("running", "permission prompt")
     callbacks["on_activity"]()  # pane redraw under the dialog
@@ -1344,7 +1344,7 @@ async def test_waiting_reason_rides_pane_edges(tmp_path: Path) -> None:
     assert edges == [("running", "permission prompt")]
 
     # Dialog answered: the file drops the reason and the pane keeps moving.
-    poller.waiting_for = None
+    poller.blocked_on = None
     poller.emit("running", None)
     await asyncio.sleep(0)
     assert edges == [("running", "permission prompt"), ("running", None)]

--- a/tests/runner/test_resource_registry.py
+++ b/tests/runner/test_resource_registry.py
@@ -388,7 +388,7 @@ async def _observe_native_agent_terminal_and_capture(
     instance.start_idle_watcher_thread = _capture_watcher  # type: ignore[attr-defined]
     # A status publisher is required for the native agent terminal's watcher to
     # wire its running/idle edges (and thus record the PTY status).
-    registry.set_session_status_publisher(lambda _sid, _status: None)
+    registry.set_session_status_publisher(lambda _sid, _status, _reason=None: None)
     await registry.observe_required_terminal(
         session_id,
         instance.name,  # type: ignore[attr-defined]
@@ -402,34 +402,42 @@ async def _observe_native_agent_terminal_and_capture(
 class _FakeStatusPoller:
     """Controllable stand-in for the claude-native status-file poller.
 
-    Lets a test flip :attr:`active` (file resolved vs. falling back) and
-    fire status edges through the registry's callback, without touching a
-    real ``sessions/<pid>.json``.
+    Lets a test flip :attr:`active` (file resolved vs. falling back), flip
+    :attr:`running_level` (the file freshly reports running vs. its value
+    having gone stale), and fire status edges through the registry's
+    callback, without touching a real ``sessions/<pid>.json``.
     """
 
     def __init__(self, on_status: object) -> None:
         self._on_status = on_status
         self.active = False
+        self.running_level = False
+        self.waiting_for: str | None = None
         self.ticks = 0
 
     def tick(self) -> None:
         self.ticks += 1
 
-    def emit(self, status: str) -> None:
+    def asserts_running(self, *, ttl_s: float, now: float | None = None) -> bool:
+        del ttl_s, now
+        return self.running_level
+
+    def emit(self, status: str, waiting_for: str | None = None) -> None:
         """Simulate the file reporting a new status."""
-        self._on_status(status)
+        self._on_status(status, waiting_for)
 
 
 async def _observe_native_with_fake_poller(
     tmp_path: Path,
     session_id: str,
-) -> tuple[dict[str, object], list[str], list[_FakeStatusPoller]]:
+) -> tuple[dict[str, object], list[str], list[_FakeStatusPoller], SessionResourceRegistry]:
     """Observe a claude-native terminal with an injected fake poller.
 
-    :returns: ``(callbacks, statuses, pollers)`` — the wired watcher
-        callbacks, the list the status publisher appends to, and the
+    :returns: ``(callbacks, statuses, pollers, registry)`` — the wired watcher
+        callbacks, the list the status publisher appends to, the
         single-element list holding the injected poller (so the test can
-        drive ``active`` / ``emit``).
+        drive ``active`` / ``running_level`` / ``emit``), and the registry
+        itself (so the test can post external status edges).
     """
     terminal_registry = TerminalRegistry()
     registry = SessionResourceRegistry(terminal_registry=terminal_registry)
@@ -437,7 +445,9 @@ async def _observe_native_with_fake_poller(
     terminal_registry._by_conversation.setdefault(session_id, {})[("claude", "main")] = instance
     statuses: list[str] = []
     pollers: list[_FakeStatusPoller] = []
-    registry.set_session_status_publisher(lambda _sid, status: statuses.append(status))
+    registry.set_session_status_publisher(
+        lambda _sid, status, _reason=None: statuses.append(status)
+    )
 
     def _fake_build(*, session_id: str, instance: object, on_status: object) -> _FakeStatusPoller:
         del session_id, instance
@@ -469,14 +479,16 @@ async def _observe_native_with_fake_poller(
     await registry.observe_required_terminal(
         session_id, "claude", "main", instance, resource_role=CLAUDE_NATIVE_TERMINAL_ROLE
     )
-    return callbacks, statuses, pollers
+    return callbacks, statuses, pollers, registry
 
 
 @pytest.mark.asyncio
 async def test_claude_native_wires_status_poller_tick(tmp_path: Path) -> None:
     """The claude-native watcher is wired with an ``on_tick`` that drives
     the status-file poller."""
-    callbacks, _statuses, pollers = await _observe_native_with_fake_poller(tmp_path, "conv_tick")
+    callbacks, _statuses, pollers, _registry = await _observe_native_with_fake_poller(
+        tmp_path, "conv_tick"
+    )
     assert len(pollers) == 1
     on_tick = callbacks["on_tick"]
     assert callable(on_tick)
@@ -486,30 +498,90 @@ async def test_claude_native_wires_status_poller_tick(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_status_file_preempts_pty_edges_when_active(tmp_path: Path) -> None:
-    """While the poller is active, the file's status wins and PTY pane
-    edges do not publish status."""
-    callbacks, statuses, pollers = await _observe_native_with_fake_poller(tmp_path, "conv_pre")
+async def test_pty_activity_publishes_running_even_with_active_status_file(
+    tmp_path: Path,
+) -> None:
+    """Pane activity publishes ``running`` even while the file poller is active.
+
+    Claude rewrites ``sessions/<pid>.json`` only when its value *changes*, so a
+    turn that starts while the file already reads ``busy`` produces no write at
+    all. If the file were allowed to mute the pane watcher, nothing could
+    publish ``running`` and the session would sit on a stale ``idle`` — no
+    working indicator, no stop button — for the whole turn.
+    """
+    callbacks, statuses, pollers, _registry = await _observe_native_with_fake_poller(
+        tmp_path, "conv_pre"
+    )
     poller = pollers[0]
     poller.active = True
 
-    # File says running; PTY activity must NOT double-publish.
-    poller.emit("running")
+    # The file already holds ``busy`` from an earlier turn, so it emits nothing.
     callbacks["on_activity"]()
-    # File says idle; PTY idle heuristic must NOT override it.
-    poller.emit("idle")
-    callbacks["on_idle"]()
 
     # Status edges publish via loop.call_soon_threadsafe; let them drain.
     await asyncio.sleep(0)
+    assert statuses == ["running"]
+
+
+@pytest.mark.asyncio
+async def test_pty_idle_deferred_only_while_file_freshly_running(tmp_path: Path) -> None:
+    """A quiet pane goes idle unless the file *freshly* reports running.
+
+    A dialog owning Claude's input quiets the pane without ending the turn, so
+    a fresh ``running`` level holds the idle edge back. Once that level goes
+    stale — a ``busy`` left standing by a background task outlives its turn —
+    the pane decides again, so the session can never be pinned to ``running``.
+    """
+    callbacks, statuses, pollers, _registry = await _observe_native_with_fake_poller(
+        tmp_path, "conv_idle_gate"
+    )
+    poller = pollers[0]
+    poller.active = True
+    poller.running_level = True
+
+    callbacks["on_activity"]()  # → running
+    callbacks["on_idle"]()  # suppressed: file freshly says running
+    await asyncio.sleep(0)
+    assert statuses == ["running"]
+
+    poller.running_level = False  # the file's level went stale
+    callbacks["on_idle"]()
+    await asyncio.sleep(0)
     assert statuses == ["running", "idle"]
+
+
+@pytest.mark.asyncio
+async def test_hook_status_resyncs_watcher_dedup(tmp_path: Path) -> None:
+    """A forwarder's hook-derived edge rebases the watcher's dedup.
+
+    ``Stop`` → ``idle`` is posted to the server by the claude-native forwarder,
+    bypassing this watcher. Without adopting it as the baseline the watcher
+    still believes ``running`` is live and swallows the next turn's genuine
+    ``running`` as a duplicate, leaving the session stuck on the hook's idle.
+    """
+    callbacks, statuses, pollers, registry = await _observe_native_with_fake_poller(
+        tmp_path, "conv_resync"
+    )
+    pollers[0].active = True
+
+    callbacks["on_activity"]()
+    await asyncio.sleep(0)
+    assert statuses == ["running"]
+
+    # The forwarder posts Stop → idle straight to the server.
+    registry.note_external_session_status("conv_resync", "idle")
+
+    # Next turn: the pane moves again and must re-publish ``running``.
+    callbacks["on_activity"]()
+    await asyncio.sleep(0)
+    assert statuses == ["running", "running"]
 
 
 @pytest.mark.asyncio
 async def test_pty_edges_drive_status_when_poller_inactive(tmp_path: Path) -> None:
     """With no file (poller inactive), the PTY pane edges remain the status
     source — the fallback path for old Claude versions."""
-    callbacks, statuses, pollers = await _observe_native_with_fake_poller(
+    callbacks, statuses, pollers, _registry = await _observe_native_with_fake_poller(
         tmp_path, "conv_fallback"
     )
     # Poller stays inactive (file never resolved).
@@ -1209,3 +1281,70 @@ def test_resolve_environment_runner_workspace_overrides_absolute_spec_cwd(
     # Compare via realpath because tmp_path on macOS goes through
     # /var → /private/var symlinks.
     assert os.path.realpath(env.cwd) == os.path.realpath(workspace)
+
+
+@pytest.mark.asyncio
+async def test_waiting_reason_rides_pane_edges(tmp_path: Path) -> None:
+    """The parked reason travels with every edge, not just the file's own.
+
+    Claude reports ``waitingFor`` once, when the dialog opens. The pane keeps
+    redrawing underneath it, so if a pane-derived ``running`` shipped without
+    the reason it would immediately erase what the file just said and the UI
+    would fall back to a bare spinner.
+    """
+    terminal_registry = TerminalRegistry()
+    registry = SessionResourceRegistry(terminal_registry=terminal_registry)
+    instance = make_test_terminal_instance("claude", "main", tmp_path)
+    terminal_registry._by_conversation.setdefault("conv_reason", {})[("claude", "main")] = instance
+    edges: list[tuple[str, str | None]] = []
+    pollers: list[_FakeStatusPoller] = []
+    registry.set_session_status_publisher(
+        lambda _sid, status, reason=None: edges.append((status, reason))
+    )
+
+    def _fake_build(*, session_id: str, instance: object, on_status: object) -> _FakeStatusPoller:
+        del session_id, instance
+        poller = _FakeStatusPoller(on_status)
+        pollers.append(poller)
+        return poller
+
+    registry._build_claude_native_status_poller = _fake_build  # type: ignore[method-assign]
+
+    callbacks: dict[str, object] = {}
+
+    def _capture_watcher(
+        on_idle: object | None = None,
+        *,
+        on_activity: object | None = None,
+        on_exit: object | None = None,
+        on_tick: object | None = None,
+        idle_threshold_s: float | None = None,
+        poll_interval_s: float | None = None,
+        replace: bool = False,
+    ) -> None:
+        del idle_threshold_s, poll_interval_s, replace
+        callbacks["on_idle"] = on_idle
+        callbacks["on_activity"] = on_activity
+        callbacks["on_exit"] = on_exit
+        callbacks["on_tick"] = on_tick
+
+    instance.start_idle_watcher_thread = _capture_watcher  # type: ignore[attr-defined]
+    await registry.observe_required_terminal(
+        "conv_reason", "claude", "main", instance, resource_role=CLAUDE_NATIVE_TERMINAL_ROLE
+    )
+
+    poller = pollers[0]
+    poller.active = True
+    poller.running_level = True
+    poller.waiting_for = "permission prompt"
+
+    poller.emit("running", "permission prompt")
+    callbacks["on_activity"]()  # pane redraw under the dialog
+    await asyncio.sleep(0)
+    assert edges == [("running", "permission prompt")]
+
+    # Dialog answered: the file drops the reason and the pane keeps moving.
+    poller.waiting_for = None
+    poller.emit("running", None)
+    await asyncio.sleep(0)
+    assert edges == [("running", "permission prompt"), ("running", None)]

--- a/tests/runner/test_session_resources.py
+++ b/tests/runner/test_session_resources.py
@@ -1627,7 +1627,9 @@ async def test_claude_native_terminal_drives_session_status_from_pane_activity(
     status_edges: list[_StatusEdge] = []
     registry.set_terminal_activity_publisher(lambda _sid, _tid: None)
     registry.set_session_status_publisher(
-        lambda sid, status: status_edges.append(_StatusEdge(session_id=sid, status=status))
+        lambda sid, status, _reason=None: status_edges.append(
+            _StatusEdge(session_id=sid, status=status)
+        )
     )
 
     await registry.launch_required_terminal(
@@ -1755,7 +1757,7 @@ async def test_terminal_activity_pulses_throttled_to_one_per_second(
     registry.set_terminal_activity_publisher(lambda _sid, tid: activity_pulses.append(tid))
     # The idle-reset behaviour is only wired for the claude-native role, so
     # the status publisher must be installed to exercise on_idle.
-    registry.set_session_status_publisher(lambda _sid, _status: None)
+    registry.set_session_status_publisher(lambda _sid, _status, _reason=None: None)
 
     await registry.launch_required_terminal(
         session_id="conv_throttle",

--- a/tests/test_claude_native_status_file.py
+++ b/tests/test_claude_native_status_file.py
@@ -29,6 +29,8 @@ def _write_session_file(
     session_id: str,
     status: str,
     kind: str = "interactive",
+    status_updated_at: int = 1785480000000,
+    waiting_for: str | None = None,
 ) -> Path:
     """Write a minimal ``<pid>.json`` matching Claude's schema.
 
@@ -49,8 +51,9 @@ def _write_session_file(
                 "cwd": "/repo",
                 "kind": kind,
                 "status": status,
-                "statusUpdatedAt": 1785480000000,
-                "updatedAt": 1785480000000,
+                "statusUpdatedAt": status_updated_at,
+                "updatedAt": status_updated_at,
+                **({"waitingFor": waiting_for} if waiting_for is not None else {}),
             }
         ),
         encoding="utf-8",
@@ -161,7 +164,7 @@ def test_poller_publishes_edges_only(tmp_path: Path) -> None:
     _write_session_file(sessions, pid=1, session_id="s", status="busy")
     published: list[str] = []
     poller = SessionStatusPoller(
-        on_status=published.append,
+        on_status=lambda status, _reason: published.append(status),
         pane_pid_getter=_StubPidGetter(1),
         session_id_getter=lambda: "s",
         config_dir=tmp_path,
@@ -185,7 +188,7 @@ def test_poller_gives_up_when_file_never_appears(tmp_path: Path) -> None:
     (tmp_path / "sessions").mkdir()
     published: list[str] = []
     poller = SessionStatusPoller(
-        on_status=published.append,
+        on_status=lambda status, _reason: published.append(status),
         pane_pid_getter=_StubPidGetter(404),
         session_id_getter=lambda: None,
         config_dir=tmp_path,
@@ -204,7 +207,7 @@ def test_poller_deactivates_when_file_vanishes(tmp_path: Path) -> None:
     path = _write_session_file(sessions, pid=1, session_id="s", status="busy")
     published: list[str] = []
     poller = SessionStatusPoller(
-        on_status=published.append,
+        on_status=lambda status, _reason: published.append(status),
         pane_pid_getter=_StubPidGetter(1),
         session_id_getter=lambda: "s",
         config_dir=tmp_path,
@@ -215,3 +218,162 @@ def test_poller_deactivates_when_file_vanishes(tmp_path: Path) -> None:
     path.unlink()
     poller.tick()
     assert not poller.active
+
+
+def test_shell_status_maps_to_idle(tmp_path: Path) -> None:
+    """``shell`` is Claude's idle-family value, not a working one.
+
+    The interactive writer substitutes ``shell`` for ``idle`` while a shell is
+    attached. Leaving it unmapped made the read unparseable, so the transition
+    was dropped and the session kept whatever status it already had.
+    """
+    path = _write_session_file(tmp_path / "sessions", pid=7, session_id="s", status="shell")
+    status = read_session_status(path)
+    assert status is not None
+    assert status.runner_status == IDLE
+    assert status.raw_status == "shell"
+
+
+def test_unknown_status_clears_dedup_so_next_read_publishes(tmp_path: Path) -> None:
+    """An unrecognized literal must not swallow the next real edge.
+
+    The file is an undocumented internal detail whose vocabulary can grow. A
+    value we cannot map leaves us blind to that transition, so the dedup
+    baseline has to drop — otherwise the next readable status looks like a
+    duplicate of a stale one and never publishes.
+    """
+    sessions = tmp_path / "sessions"
+    _write_session_file(sessions, pid=1, session_id="s", status="busy")
+    published: list[str] = []
+    poller = SessionStatusPoller(
+        on_status=lambda status, _reason: published.append(status),
+        pane_pid_getter=_StubPidGetter(1),
+        session_id_getter=lambda: "s",
+        config_dir=tmp_path,
+    )
+    poller.tick()
+    assert published == [RUNNING]
+
+    # A literal this version does not know about.
+    _write_session_file(sessions, pid=1, session_id="s", status="teleporting")
+    poller.tick()
+    assert published == [RUNNING]
+
+    # Back to a value we understand — same runner status as before, but our
+    # knowledge lapsed in between, so it must publish rather than dedup.
+    _write_session_file(sessions, pid=1, session_id="s", status="busy")
+    poller.tick()
+    assert published == [RUNNING, RUNNING]
+
+
+def test_asserts_running_only_while_fresh(tmp_path: Path) -> None:
+    """The running level is trusted only briefly after it was written.
+
+    Claude keeps reporting ``busy`` while a delegate or background task is
+    active, long after the turn ended. Treating that as authoritative forever
+    would pin the session to "Working…"; past the window the pane watcher
+    decides again.
+    """
+    sessions = tmp_path / "sessions"
+    now = 1785480100.0
+    _write_session_file(
+        sessions,
+        pid=1,
+        session_id="s",
+        status="busy",
+        status_updated_at=int((now - 2) * 1000),
+    )
+    published: list[str] = []
+    poller = SessionStatusPoller(
+        on_status=lambda status, _reason: published.append(status),
+        pane_pid_getter=_StubPidGetter(1),
+        session_id_getter=lambda: "s",
+        config_dir=tmp_path,
+    )
+    poller.tick()
+    assert poller.asserts_running(ttl_s=10.0, now=now) is True
+    assert poller.asserts_running(ttl_s=1.0, now=now) is False
+
+    # An idle level never asserts running, however fresh.
+    _write_session_file(
+        sessions,
+        pid=1,
+        session_id="s",
+        status="idle",
+        status_updated_at=int(now * 1000),
+    )
+    poller.tick()
+    assert poller.asserts_running(ttl_s=10.0, now=now) is False
+
+
+def test_waiting_carries_its_reason(tmp_path: Path) -> None:
+    """``waiting`` exposes ``waitingFor`` so the UI can say what it is parked on."""
+    sessions = tmp_path / "sessions"
+    parked = _write_session_file(
+        sessions, pid=1, session_id="s", status="waiting", waiting_for="permission prompt"
+    )
+    status = read_session_status(parked)
+    assert status is not None
+    assert status.runner_status == RUNNING
+    assert status.waiting_for == "permission prompt"
+
+    # The writer merges updates into the existing record, so a reason left
+    # behind by an earlier ``waiting`` must not leak onto a later status.
+    busy = _write_session_file(
+        sessions, pid=2, session_id="s", status="busy", waiting_for="permission prompt"
+    )
+    assert read_session_status(busy).waiting_for is None
+
+
+def test_poller_publishes_when_only_the_reason_changes(tmp_path: Path) -> None:
+    """``busy`` → ``waiting`` must publish even though both map to running.
+
+    Deduping on the runner status alone would swallow the transition and the
+    reason would never reach the UI.
+    """
+    sessions = tmp_path / "sessions"
+    _write_session_file(sessions, pid=1, session_id="s", status="busy")
+    published: list[tuple[str, str | None]] = []
+    poller = SessionStatusPoller(
+        on_status=lambda status, reason: published.append((status, reason)),
+        pane_pid_getter=_StubPidGetter(1),
+        session_id_getter=lambda: "s",
+        config_dir=tmp_path,
+    )
+    poller.tick()
+    assert published == [(RUNNING, None)]
+
+    _write_session_file(
+        sessions, pid=1, session_id="s", status="waiting", waiting_for="dialog open"
+    )
+    poller.tick()
+    assert published == [(RUNNING, None), (RUNNING, "dialog open")]
+    assert poller.waiting_for == "dialog open"
+
+
+def test_waiting_level_does_not_decay(tmp_path: Path) -> None:
+    """A dialog holds the session open however long it stays up.
+
+    Unlike ``busy`` — which a background task keeps set past its turn — a
+    ``waiting`` clears only when Claude writes a new status, so it is safe to
+    trust indefinitely and wrong to time out (the pane is quiet the whole time).
+    """
+    sessions = tmp_path / "sessions"
+    now = 1785480100.0
+    _write_session_file(
+        sessions,
+        pid=1,
+        session_id="s",
+        status="waiting",
+        status_updated_at=int((now - 3600) * 1000),
+        waiting_for="input needed",
+    )
+    published: list[tuple[str, str | None]] = []
+    poller = SessionStatusPoller(
+        on_status=lambda status, reason: published.append((status, reason)),
+        pane_pid_getter=_StubPidGetter(1),
+        session_id_getter=lambda: "s",
+        config_dir=tmp_path,
+    )
+    poller.tick()
+    assert poller.asserts_running(ttl_s=10.0, now=now) is True

--- a/tests/test_claude_native_status_file.py
+++ b/tests/test_claude_native_status_file.py
@@ -30,7 +30,7 @@ def _write_session_file(
     status: str,
     kind: str = "interactive",
     status_updated_at: int = 1785480000000,
-    waiting_for: str | None = None,
+    blocked_on: str | None = None,
 ) -> Path:
     """Write a minimal ``<pid>.json`` matching Claude's schema.
 
@@ -53,7 +53,7 @@ def _write_session_file(
                 "status": status,
                 "statusUpdatedAt": status_updated_at,
                 "updatedAt": status_updated_at,
-                **({"waitingFor": waiting_for} if waiting_for is not None else {}),
+                **({"waitingFor": blocked_on} if blocked_on is not None else {}),
             }
         ),
         encoding="utf-8",
@@ -310,19 +310,19 @@ def test_waiting_carries_its_reason(tmp_path: Path) -> None:
     """``waiting`` exposes ``waitingFor`` so the UI can say what it is parked on."""
     sessions = tmp_path / "sessions"
     parked = _write_session_file(
-        sessions, pid=1, session_id="s", status="waiting", waiting_for="permission prompt"
+        sessions, pid=1, session_id="s", status="waiting", blocked_on="permission prompt"
     )
     status = read_session_status(parked)
     assert status is not None
     assert status.runner_status == RUNNING
-    assert status.waiting_for == "permission prompt"
+    assert status.blocked_on == "permission prompt"
 
     # The writer merges updates into the existing record, so a reason left
     # behind by an earlier ``waiting`` must not leak onto a later status.
     busy = _write_session_file(
-        sessions, pid=2, session_id="s", status="busy", waiting_for="permission prompt"
+        sessions, pid=2, session_id="s", status="busy", blocked_on="permission prompt"
     )
-    assert read_session_status(busy).waiting_for is None
+    assert read_session_status(busy).blocked_on is None
 
 
 def test_poller_publishes_when_only_the_reason_changes(tmp_path: Path) -> None:
@@ -344,11 +344,11 @@ def test_poller_publishes_when_only_the_reason_changes(tmp_path: Path) -> None:
     assert published == [(RUNNING, None)]
 
     _write_session_file(
-        sessions, pid=1, session_id="s", status="waiting", waiting_for="dialog open"
+        sessions, pid=1, session_id="s", status="waiting", blocked_on="dialog open"
     )
     poller.tick()
     assert published == [(RUNNING, None), (RUNNING, "dialog open")]
-    assert poller.waiting_for == "dialog open"
+    assert poller.blocked_on == "dialog open"
 
 
 def test_waiting_level_does_not_decay(tmp_path: Path) -> None:
@@ -366,7 +366,7 @@ def test_waiting_level_does_not_decay(tmp_path: Path) -> None:
         session_id="s",
         status="waiting",
         status_updated_at=int((now - 3600) * 1000),
-        waiting_for="input needed",
+        blocked_on="input needed",
     )
     published: list[tuple[str, str | None]] = []
     poller = SessionStatusPoller(

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -461,6 +461,13 @@ export interface SessionStatusEvent {
   status: "idle" | "launching" | "running" | "waiting" | "failed";
   responseId?: string;
   backgroundTaskCount?: number;
+  /**
+   * Short phrase naming what a still-`running` session is parked on, e.g.
+   * "permission prompt". Terminal-backed agents can block on a dialog the
+   * web UI does not mirror; this says why nothing is moving. Absent when
+   * the session is not parked.
+   */
+  waitingFor?: string;
   /** Structured failure detail; only present when `status === "failed"`. */
   error?: { code: string; message: string };
 }

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -467,7 +467,7 @@ export interface SessionStatusEvent {
    * web UI does not mirror; this says why nothing is moving. Absent when
    * the session is not parked.
    */
-  waitingFor?: string;
+  blockedOn?: string;
   /** Structured failure detail; only present when `status === "failed"`. */
   error?: { code: string; message: string };
 }

--- a/web/src/lib/sse.test.ts
+++ b/web/src/lib/sse.test.ts
@@ -85,6 +85,30 @@ describe("parseEvent — session.superseded", () => {
   });
 });
 
+describe("parseEvent — session.status (waiting_for)", () => {
+  function waitingFor(data: Record<string, unknown>): string | undefined {
+    const ev = parseEvent("session.status", {
+      conversation_id: "conv_a",
+      status: "running",
+      ...data,
+    });
+    return (ev as SessionStatusEvent | null)?.waitingFor;
+  }
+
+  it("threads the reason so the indicator can name what the agent is parked on", () => {
+    expect(waitingFor({ waiting_for: "permission prompt" })).toBe("permission prompt");
+  });
+
+  it("leaves it undefined when absent (the session is not parked)", () => {
+    expect(waitingFor({})).toBeUndefined();
+  });
+
+  it("ignores an empty or non-string reason rather than rendering a blank one", () => {
+    expect(waitingFor({ waiting_for: "" })).toBeUndefined();
+    expect(waitingFor({ waiting_for: 7 })).toBeUndefined();
+  });
+});
+
 describe("parseEvent — session.status (background_task_count)", () => {
   function bgCount(data: Record<string, unknown>): number | undefined {
     const ev = parseEvent("session.status", { conversation_id: "conv_a", status: "idle", ...data });

--- a/web/src/lib/sse.test.ts
+++ b/web/src/lib/sse.test.ts
@@ -85,27 +85,27 @@ describe("parseEvent — session.superseded", () => {
   });
 });
 
-describe("parseEvent — session.status (waiting_for)", () => {
-  function waitingFor(data: Record<string, unknown>): string | undefined {
+describe("parseEvent — session.status (blocked_on)", () => {
+  function blockedOn(data: Record<string, unknown>): string | undefined {
     const ev = parseEvent("session.status", {
       conversation_id: "conv_a",
       status: "running",
       ...data,
     });
-    return (ev as SessionStatusEvent | null)?.waitingFor;
+    return (ev as SessionStatusEvent | null)?.blockedOn;
   }
 
   it("threads the reason so the indicator can name what the agent is parked on", () => {
-    expect(waitingFor({ waiting_for: "permission prompt" })).toBe("permission prompt");
+    expect(blockedOn({ blocked_on: "permission prompt" })).toBe("permission prompt");
   });
 
   it("leaves it undefined when absent (the session is not parked)", () => {
-    expect(waitingFor({})).toBeUndefined();
+    expect(blockedOn({})).toBeUndefined();
   });
 
   it("ignores an empty or non-string reason rather than rendering a blank one", () => {
-    expect(waitingFor({ waiting_for: "" })).toBeUndefined();
-    expect(waitingFor({ waiting_for: 7 })).toBeUndefined();
+    expect(blockedOn({ blocked_on: "" })).toBeUndefined();
+    expect(blockedOn({ blocked_on: 7 })).toBeUndefined();
   });
 });
 

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -449,12 +449,18 @@ export function parseEvent(rawType: string, data: Record<string, unknown>): Stre
               message: (rawError as Record<string, unknown>).message as string,
             }
           : undefined;
+      // Absent = not parked. An empty string is treated the same, so a
+      // blank reason never renders as a dangling parenthetical.
+      const rawWaitingFor = data.waiting_for;
+      const waitingFor =
+        typeof rawWaitingFor === "string" && rawWaitingFor ? rawWaitingFor : undefined;
       return {
         type: "session_status",
         conversationId,
         status,
         responseId,
         backgroundTaskCount,
+        ...(waitingFor !== undefined ? { waitingFor } : {}),
         ...(error !== undefined ? { error } : {}),
       } satisfies SessionStatusEvent;
     }

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -451,16 +451,15 @@ export function parseEvent(rawType: string, data: Record<string, unknown>): Stre
           : undefined;
       // Absent = not parked. An empty string is treated the same, so a
       // blank reason never renders as a dangling parenthetical.
-      const rawWaitingFor = data.waiting_for;
-      const waitingFor =
-        typeof rawWaitingFor === "string" && rawWaitingFor ? rawWaitingFor : undefined;
+      const rawBlockedOn = data.blocked_on;
+      const blockedOn = typeof rawBlockedOn === "string" && rawBlockedOn ? rawBlockedOn : undefined;
       return {
         type: "session_status",
         conversationId,
         status,
         responseId,
         backgroundTaskCount,
-        ...(waitingFor !== undefined ? { waitingFor } : {}),
+        ...(blockedOn !== undefined ? { blockedOn } : {}),
         ...(error !== undefined ? { error } : {}),
       } satisfies SessionStatusEvent;
     }

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -793,14 +793,14 @@ describe("shouldShowWorkingIndicator", () => {
 
 describe("workingIndicatorLabel — parked on a dialog", () => {
   it("names what the agent is waiting on", () => {
-    expect(workingIndicatorLabel(0, 0, "permission prompt")).toBe("Waiting: permission prompt");
+    expect(workingIndicatorLabel(0, 0, "permission prompt")).toBe("Blocked on: permission prompt");
   });
 
   it("outranks the background tally and the rotation", () => {
     // Being blocked on the user is the one state that needs an action, and the
     // dialog may exist only in the terminal tab — so it must not be buried
     // under a rotating "Cooking…" or a background-shell count.
-    expect(workingIndicatorLabel(3, 2, "dialog open")).toBe("Waiting: dialog open");
+    expect(workingIndicatorLabel(3, 2, "dialog open")).toBe("Blocked on: dialog open");
   });
 
   it("falls back to the normal label when not parked", () => {

--- a/web/src/pages/ChatPage.test.ts
+++ b/web/src/pages/ChatPage.test.ts
@@ -791,6 +791,24 @@ describe("shouldShowWorkingIndicator", () => {
 
 // ── workingIndicatorLabel ───────────────────────────────────────────────────
 
+describe("workingIndicatorLabel — parked on a dialog", () => {
+  it("names what the agent is waiting on", () => {
+    expect(workingIndicatorLabel(0, 0, "permission prompt")).toBe("Waiting: permission prompt");
+  });
+
+  it("outranks the background tally and the rotation", () => {
+    // Being blocked on the user is the one state that needs an action, and the
+    // dialog may exist only in the terminal tab — so it must not be buried
+    // under a rotating "Cooking…" or a background-shell count.
+    expect(workingIndicatorLabel(3, 2, "dialog open")).toBe("Waiting: dialog open");
+  });
+
+  it("falls back to the normal label when not parked", () => {
+    expect(workingIndicatorLabel(0, 0, null)).toBe("Working…");
+    expect(workingIndicatorLabel(1, 0, null)).toBe("1 background task still running");
+  });
+});
+
 describe("workingIndicatorLabel", () => {
   it("shows the plain Working label when no background tasks remain", () => {
     expect(workingIndicatorLabel(0)).toBe("Working…");

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2108,6 +2108,7 @@ function UserMessageNavConnected(props: React.ComponentProps<typeof UserMessageN
 function WorkingStatusPin({ show, suppress = false }: { show: boolean; suppress?: boolean }) {
   const { isAtBottom } = useStickToBottomContext();
   const bgCount = useChatStore((s) => s.backgroundTaskCount);
+  const waitingFor = useChatStore((s) => s.waitingFor);
   const tick = useWorkingLabelTick();
   const visible = show && !isAtBottom && !suppress;
   return (
@@ -2148,7 +2149,7 @@ function WorkingStatusPin({ show, suppress = false }: { show: boolean; suppress?
           >
             <OttoIcon className="otto-working h-4 w-auto shrink-0" />
             <Shimmer className="text-sm font-mono" duration={1.5}>
-              {workingIndicatorLabel(bgCount, tick)}
+              {workingIndicatorLabel(bgCount, tick, waitingFor)}
             </Shimmer>
           </div>
         )}
@@ -2747,12 +2748,22 @@ export const WORKING_MESSAGES = [
 ] as const;
 
 /**
- * The label shown next to the working spinner. When background shells outlive
- * the turn (`bgCount > 0`) it names how many are still running (the tick is
- * ignored — that count is information, not decoration). Otherwise it rotates
- * through `WORKING_MESSAGES` by wall-clock `tick`.
+ * The label shown next to the working spinner. When the agent is parked on a
+ * dialog (`waitingFor`) it says so — that outranks everything else, because it
+ * is the one case where the session needs the user rather than time, and the
+ * dialog may live only in the terminal tab. Otherwise, when background shells
+ * outlive the turn (`bgCount > 0`) it names how many are still running (the
+ * tick is ignored — that count is information, not decoration). Failing both
+ * it rotates through `WORKING_MESSAGES` by wall-clock `tick`.
  */
-export function workingIndicatorLabel(bgCount: number, tick = 0): string {
+export function workingIndicatorLabel(
+  bgCount: number,
+  tick = 0,
+  waitingFor: string | null = null,
+): string {
+  if (waitingFor) {
+    return `Waiting: ${waitingFor}`;
+  }
   if (bgCount > 0) {
     return bgCount === 1
       ? "1 background task still running"
@@ -2763,8 +2774,9 @@ export function workingIndicatorLabel(bgCount: number, tick = 0): string {
 
 function WorkingIndicator() {
   const bgCount = useChatStore((s) => s.backgroundTaskCount);
+  const waitingFor = useChatStore((s) => s.waitingFor);
   const tick = useWorkingLabelTick();
-  const label = workingIndicatorLabel(bgCount, tick);
+  const label = workingIndicatorLabel(bgCount, tick, waitingFor);
   return (
     <Message from="assistant" data-testid="working-indicator" aria-hidden="true">
       <MessageContent>

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2108,7 +2108,7 @@ function UserMessageNavConnected(props: React.ComponentProps<typeof UserMessageN
 function WorkingStatusPin({ show, suppress = false }: { show: boolean; suppress?: boolean }) {
   const { isAtBottom } = useStickToBottomContext();
   const bgCount = useChatStore((s) => s.backgroundTaskCount);
-  const waitingFor = useChatStore((s) => s.waitingFor);
+  const blockedOn = useChatStore((s) => s.blockedOn);
   const tick = useWorkingLabelTick();
   const visible = show && !isAtBottom && !suppress;
   return (
@@ -2149,7 +2149,7 @@ function WorkingStatusPin({ show, suppress = false }: { show: boolean; suppress?
           >
             <OttoIcon className="otto-working h-4 w-auto shrink-0" />
             <Shimmer className="text-sm font-mono" duration={1.5}>
-              {workingIndicatorLabel(bgCount, tick, waitingFor)}
+              {workingIndicatorLabel(bgCount, tick, blockedOn)}
             </Shimmer>
           </div>
         )}
@@ -2749,7 +2749,7 @@ export const WORKING_MESSAGES = [
 
 /**
  * The label shown next to the working spinner. When the agent is parked on a
- * dialog (`waitingFor`) it says so — that outranks everything else, because it
+ * dialog (`blockedOn`) it says so — that outranks everything else, because it
  * is the one case where the session needs the user rather than time, and the
  * dialog may live only in the terminal tab. Otherwise, when background shells
  * outlive the turn (`bgCount > 0`) it names how many are still running (the
@@ -2759,10 +2759,10 @@ export const WORKING_MESSAGES = [
 export function workingIndicatorLabel(
   bgCount: number,
   tick = 0,
-  waitingFor: string | null = null,
+  blockedOn: string | null = null,
 ): string {
-  if (waitingFor) {
-    return `Waiting: ${waitingFor}`;
+  if (blockedOn) {
+    return `Blocked on: ${blockedOn}`;
   }
   if (bgCount > 0) {
     return bgCount === 1
@@ -2774,9 +2774,9 @@ export function workingIndicatorLabel(
 
 function WorkingIndicator() {
   const bgCount = useChatStore((s) => s.backgroundTaskCount);
-  const waitingFor = useChatStore((s) => s.waitingFor);
+  const blockedOn = useChatStore((s) => s.blockedOn);
   const tick = useWorkingLabelTick();
-  const label = workingIndicatorLabel(bgCount, tick, waitingFor);
+  const label = workingIndicatorLabel(bgCount, tick, blockedOn);
   return (
     <Message from="assistant" data-testid="working-indicator" aria-hidden="true">
       <MessageContent>

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -314,6 +314,13 @@ export interface ChatState {
   sessionStatus: SessionStatus;
   backgroundTaskCount: number;
   /**
+   * Why a still-`running` session is parked, e.g. "permission prompt".
+   * Terminal-backed agents can block on a dialog the web UI does not
+   * mirror, so the working indicator names it instead of shimmering with
+   * no explanation. `null` whenever the session is not parked.
+   */
+  waitingFor: string | null;
+  /**
    * Whether the active session is a native-terminal wrapper
    * (claude-native / codex-native), derived from the `omnigent.wrapper`
    * label on bind. Web messages on these sessions are NOT persisted at
@@ -934,6 +941,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   status: "idle",
   sessionStatus: "idle",
   backgroundTaskCount: 0,
+  waitingFor: null,
   isNativeTerminalSession: false,
   nativeVendorOwnsModel: false,
   boundAgentId: null,
@@ -1227,6 +1235,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // count is sticky (see the `session_status` handler) precisely so a
       // trailing idle can't wipe it, so it has to be cleared explicitly here.
       backgroundTaskCount: 0,
+      waitingFor: null,
     }));
 
     // Pin the destination before joining the send chain: a stalled prior
@@ -1375,7 +1384,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
             // instead of being left on a silent, empty composer.
             set((s) => ({ blocks: [...s.blocks, makeClientErrorBlock(message, code)] }));
           }
-          set({ status: "idle", sessionStatus: "idle", backgroundTaskCount: 0 });
+          set({ status: "idle", sessionStatus: "idle", backgroundTaskCount: 0, waitingFor: null });
         }
       }
     } finally {
@@ -1535,6 +1544,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         status: "idle",
         sessionStatus: "idle",
         backgroundTaskCount: 0,
+        waitingFor: null,
       };
       if (s.activeResponse?.state === "streaming") {
         patch.activeResponse = {
@@ -1626,6 +1636,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         status: "idle",
         sessionStatus: "idle",
         backgroundTaskCount: 0,
+        waitingFor: null,
         isNativeTerminalSession: false,
         nativeVendorOwnsModel: false,
         boundAgentId: null,
@@ -2592,6 +2603,7 @@ async function bindStream(
         // live SSE edge that set this is long gone, so the count rides in on
         // the snapshot (server keeps it sticky past the trailing PTY `idle`).
         backgroundTaskCount: session.backgroundTaskCount ?? 0,
+        waitingFor: null,
         selectedEffort: effectiveEffort,
         selectedModel:
           catalogWonBindRace && preservedModelValid ? state.selectedModel : effectiveModel,
@@ -4402,7 +4414,13 @@ export function handleSessionEvent(event: StreamEvent): void {
         // runner's PTY-activity watcher); the client must not second-guess it.
         // The bubble lifecycle below (`status`/`activeResponse`) still defers
         // to response_end, but that is separate from the session-level status.
-        const patch: Partial<ChatState> = { sessionStatus: event.status };
+        const patch: Partial<ChatState> = {
+          sessionStatus: event.status,
+          // Not sticky, unlike the background tally: every edge carries the
+          // current reason (the runner re-attaches it to its own pane edges),
+          // so an absent one means "no longer parked".
+          waitingFor: event.waitingFor ?? null,
+        };
         // The background-shell tally is STICKY. Only the Stop-hook-derived
         // status carries an authoritative count (the forwarder relabels its
         // `idle` to `waiting` and attaches `background_task_count`); the

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -319,7 +319,7 @@ export interface ChatState {
    * mirror, so the working indicator names it instead of shimmering with
    * no explanation. `null` whenever the session is not parked.
    */
-  waitingFor: string | null;
+  blockedOn: string | null;
   /**
    * Whether the active session is a native-terminal wrapper
    * (claude-native / codex-native), derived from the `omnigent.wrapper`
@@ -941,7 +941,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   status: "idle",
   sessionStatus: "idle",
   backgroundTaskCount: 0,
-  waitingFor: null,
+  blockedOn: null,
   isNativeTerminalSession: false,
   nativeVendorOwnsModel: false,
   boundAgentId: null,
@@ -1235,7 +1235,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // count is sticky (see the `session_status` handler) precisely so a
       // trailing idle can't wipe it, so it has to be cleared explicitly here.
       backgroundTaskCount: 0,
-      waitingFor: null,
+      blockedOn: null,
     }));
 
     // Pin the destination before joining the send chain: a stalled prior
@@ -1384,7 +1384,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
             // instead of being left on a silent, empty composer.
             set((s) => ({ blocks: [...s.blocks, makeClientErrorBlock(message, code)] }));
           }
-          set({ status: "idle", sessionStatus: "idle", backgroundTaskCount: 0, waitingFor: null });
+          set({ status: "idle", sessionStatus: "idle", backgroundTaskCount: 0, blockedOn: null });
         }
       }
     } finally {
@@ -1544,7 +1544,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         status: "idle",
         sessionStatus: "idle",
         backgroundTaskCount: 0,
-        waitingFor: null,
+        blockedOn: null,
       };
       if (s.activeResponse?.state === "streaming") {
         patch.activeResponse = {
@@ -1636,7 +1636,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         status: "idle",
         sessionStatus: "idle",
         backgroundTaskCount: 0,
-        waitingFor: null,
+        blockedOn: null,
         isNativeTerminalSession: false,
         nativeVendorOwnsModel: false,
         boundAgentId: null,
@@ -2603,7 +2603,7 @@ async function bindStream(
         // live SSE edge that set this is long gone, so the count rides in on
         // the snapshot (server keeps it sticky past the trailing PTY `idle`).
         backgroundTaskCount: session.backgroundTaskCount ?? 0,
-        waitingFor: null,
+        blockedOn: null,
         selectedEffort: effectiveEffort,
         selectedModel:
           catalogWonBindRace && preservedModelValid ? state.selectedModel : effectiveModel,
@@ -4419,7 +4419,7 @@ export function handleSessionEvent(event: StreamEvent): void {
           // Not sticky, unlike the background tally: every edge carries the
           // current reason (the runner re-attaches it to its own pane edges),
           // so an absent one means "no longer parked".
-          waitingFor: event.waitingFor ?? null,
+          blockedOn: event.blockedOn ?? null,
         };
         // The background-shell tally is STICKY. Only the Stop-hook-derived
         // status carries an authoritative count (the forwarder relabels its


### PR DESCRIPTION
## Related issue

N/A

## Summary

A claude-native session could lose its working indicator entirely — no spinner, no stop button in the chat view — while the terminal tab showed the TUI clearly working. Not transient: it stayed dark for the rest of the session and survived a reload, because the server's status really was `idle`.

**ELI5.** Claude Code keeps a small file saying what it's doing. We started trusting that file and switched *off* the old method (watching the terminal screen). But the file is only rewritten when the answer *changes* — it has no heartbeat. Claude counts background tasks as "working", so when a turn ends with a background shell alive the file still says `busy` while our `Stop` hook independently marks the session idle. The two now disagree, and on the next turn the file's value is *already* `busy`, so **nothing is written at all** — no change for us to see, and the screen-watcher that would have caught it was switched off.

```
turn 1  file: busy ──────────────────────────► poller publishes running   ✅
        Stop hook ─────────────────────────► server: idle  (bypasses the watcher)
turn 2  file: busy (unchanged ⇒ NO WRITE) ──► poller silent
        pane redraws ──────────────────────► muted ✗   ⇒ session stuck idle, all turn
```

- **The pane watcher is never muted.** Pane activity always publishes `running` — the file can't re-assert a value it already holds. A quiet pane still defers to the file, but only while `asserts_running()` reports it fresh, so a `busy` left standing by a background task can't pin the session to "Working…" either.
- **The publish-dedup moved onto the registry**, so a forwarder's hook-derived edge rebases it. Previously the watcher still believed its own `running` was live and swallowed the next turn's edge — an independent second latch into the same dead state.
- **An unrecognized status literal drops the dedup baseline** instead of silently consuming the transition, and `asserts_running` finally consumes `statusUpdatedAt` (parsed since #3906, never read).
- **Claude's `waitingFor` is surfaced** through a new optional `waiting_for` field on `session.status`. A session parked on a dialog the web UI doesn't mirror now reads **"Waiting: permission prompt"** instead of a bare spinner. `waiting` is deliberately *not* reused as a status — the store reads that as "turn ended, background work remains" and would finalize the in-flight response.

Note `busy` decays after 10s but `waiting` does not: a dialog clears only when Claude writes a new status, whereas `busy` outlives its turn and must decay.

## Test Plan

- `pytest tests/runner/test_resource_registry.py tests/runner/test_session_resources.py tests/server/test_stream_events.py tests/test_claude_native_status_file.py tests/test_claude_native_status.py` — 126 passed.
- `vitest run src/lib/sse.test.ts src/pages/ChatPage.test.ts src/store/chatStore.test.ts` — 473 passed. `tsc --noEmit` clean, `pre-commit` clean.
- **A/B against the real poller + registry**, driving the exact sequence above (file `busy` → `Stop` hook idle → next turn's pane activity):

```
BEFORE   turn-2 edges: []            ⇒ session stays idle, no spinner, no stop button
AFTER    turn-2 edges: ['running']   ⇒ indicator lights up
```

- Manual: with a claude-native session, start a background shell (`ctrl+b`), let the turn finish, then send another message. Before this change that second turn shows no spinner; after it lights up immediately.

## Demo

No recording — reproducing needs a live claude-native session driven across a turn boundary with a background shell alive, which doesn't capture meaningfully as a short clip. The deterministic A/B above is the evidence; the visible change is the existing "Working…" indicator appearing when it previously did not, plus the new `Waiting: <reason>` label.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New tests cover each failure mode independently: pane activity publishing `running` while the file poller is active, the freshness gate in both directions, the hook-derived edge rebasing the dedup, unrecognized literals not swallowing the next edge, reason-only transitions (`busy` → `waiting`, which map to the same runner status), the reason riding pane edges so a redraw under a dialog can't erase it, and the label's precedence over the rotation and background tally.

Manual verification covered the live sequence on a real claude-native session, since the bug needs a real Claude process writing its own status file across a turn boundary.

## Changelog

The chat view no longer loses its working indicator mid-session on Claude Code sessions, and says when the agent is parked on a prompt.
