### PR TITLE
fix(web): keep Pinned and Projects sections independent of the session filter

### DIFF
--- a/tests/e2e_ui/sessions/test_sidebar_pinned_projects_filter_independence.py
+++ b/tests/e2e_ui/sessions/test_sidebar_pinned_projects_filter_independence.py
@@ -1,0 +1,249 @@
+"""Browser e2e: the session filter re-scopes only the flat Sessions list.
+
+The sidebar's session filter (the funnel: All / My sessions / Shared / Archived)
+picks a slice of conversations, but the **Pinned** and **Projects** sections are
+built from the full non-archived set — NOT the filtered slice — so switching the
+filter must never empty them:
+
+- **Pinned** shows EVERY pinned session on every filter. A pinned *shared*
+  session (owned by someone else) stays under Pinned on "My sessions", and a
+  pinned *owned* session stays under Pinned on "Shared sessions"; both survive
+  the "Archived sessions" filter too. Pins are per-user, so the viewer's own pin
+  set drives this regardless of who owns the session.
+- **Projects** renders the same folders and contents on every filter. Filing is
+  owner-only, so a folder shows the viewer's owned sessions — but the group and
+  its folders must not vanish when the filter switches to Shared or Archived.
+
+These drive the real chain the mocked ``Sidebar`` unit tests exercise, but
+end-to-end: seed owned + shared sessions (and a filed project) over the REST
+API, pin/file through the live UI, toggle the filter, and assert the Pinned /
+Projects sections hold their rows. Runs against a dedicated multi-user server
+(the shared ``live_server`` is single-user, which hides the Shared filter), the
+same harness as ``test_sidebar_ownership_gating.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Browser, Locator, Page, expect
+
+from tests.e2e_ui.collaboration._multi_user_server import (
+    ADMIN_EMAIL,
+    MultiUserServer,
+    spawn_multi_user_server,
+)
+from tests.e2e_ui.conftest import _build_hello_world_bundle
+
+# Edit access (2): enough to share a session with a non-owner. Mirrors
+# LEVEL_EDIT in omnigent/server/auth.py.
+_LEVEL_EDIT = 2
+
+# Reserved label key storing project membership (see ``list_projects`` /
+# ``web/src/lib/sessionListCache.ts``). Filing via the label exercises the
+# dual-read the sidebar's Projects group relies on.
+_PROJECT_LABEL_KEY = "omni_project"
+
+_FILTER = '[data-testid="session-filter"]'
+
+
+@pytest.fixture(scope="module")
+def multi_user_server(
+    built_spa: None,
+    mock_llm_server_url: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[MultiUserServer]:
+    """A NON-single-user server so the Shared filter renders."""
+    server_tmp = tmp_path_factory.mktemp("e2e_ui_sidebar_filter_independence")
+    yield from spawn_multi_user_server(mock_llm_server_url, server_tmp)
+
+
+def _create_session(server: MultiUserServer, *, owner_email: str, title: str) -> str:
+    """Create a session owned by *owner_email* and give it a unique *title*.
+
+    A multi-user header-auth server 401s headerless writes, so both the create
+    and the title PATCH carry the owner's ``X-Forwarded-Email``. The title makes
+    the row easy to spot among other tests' sessions on the shared server.
+    """
+    headers = {"X-Forwarded-Email": owner_email}
+    create = httpx.post(
+        f"{server.base_url}/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={"bundle": ("agent.tar.gz", _build_hello_world_bundle(), "application/gzip")},
+        headers=headers,
+        timeout=30.0,
+    )
+    create.raise_for_status()
+    session_id = create.json()["session_id"]
+    _patch(server, session_id, owner_email, {"title": title})
+    return session_id
+
+
+def _patch(server: MultiUserServer, session_id: str, actor_email: str, body: dict) -> None:
+    """PATCH a session as *actor_email* (title / labels / archived)."""
+    resp = httpx.patch(
+        f"{server.base_url}/v1/sessions/{session_id}",
+        json=body,
+        headers={"X-Forwarded-Email": actor_email},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+def _grant(server: MultiUserServer, session_id: str, user_id: str, level: int) -> None:
+    """Grant *user_id* *level* on *session_id* (the admin owner acts)."""
+    resp = httpx.put(
+        f"{server.base_url}/v1/sessions/{session_id}/permissions",
+        json={"user_id": user_id, "level": level},
+        headers={"X-Forwarded-Email": ADMIN_EMAIL},
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+
+
+def _section(page: Page, title: str) -> Locator:
+    """The sidebar ``<section>`` whose collapse-header button reads *title*."""
+    return page.locator("section").filter(has=page.get_by_role("button", name=title, exact=True))
+
+
+def _row(page: Page, session_id: str) -> Locator:
+    """The sidebar row (``<li>``) for *session_id*, located by its href."""
+    return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+
+
+def _set_filter(page: Page, value: str) -> None:
+    """Open the filter funnel and pick *value* (all/mine/shared/archived)."""
+    page.locator(_FILTER).click()
+    page.locator(f'[data-testid="session-filter-{value}"]').click()
+
+
+def _pin_row(page: Page, session_id: str) -> None:
+    """Pin *session_id* via its hover-revealed quick-pin quick action."""
+    row = _row(page, session_id)
+    expect(row).to_be_visible(timeout=30_000)
+    row.hover()
+    pin_button = row.get_by_test_id("quick-pin-conversation")
+    expect(pin_button).to_have_attribute("aria-label", "Pin conversation")
+    pin_button.click()
+    # The toggle flips to unpin once the pin lands — proves it went through the
+    # sidebar's pin state, not a local no-op.
+    expect(_row(page, session_id).get_by_test_id("quick-pin-conversation")).to_have_attribute(
+        "aria-label", "Unpin conversation", timeout=15_000
+    )
+
+
+def _pinned_has(page: Page, session_id: str) -> None:
+    """Assert *session_id* is present under the Pinned section header."""
+    expect(_section(page, "Pinned").locator(f'a[href="/c/{session_id}"]')).to_be_visible(
+        timeout=30_000
+    )
+
+
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
+def test_pinned_section_ignores_the_session_filter(
+    browser: Browser,
+    multi_user_server: MultiUserServer,
+) -> None:
+    """Every pin stays under Pinned on My / Shared / Archived filters.
+
+    Pins the viewer's OWN session and a session SHARED with them, then walks the
+    filter through My sessions, Shared sessions, and Archived sessions — both
+    pins must stay under Pinned on all three. Before the fix the Pinned section
+    was built from the filtered slice, so the shared pin vanished on "My
+    sessions" and the owned pin vanished on "Shared sessions".
+    """
+    server = multi_user_server
+    uniq = uuid.uuid4().hex[:6]
+    viewer_email = f"viewer-pin-{uniq}@ui.test"
+
+    # A session the viewer OWNS, and a session the admin owns SHARED with the
+    # viewer (so "All sessions" shows both up front, ready to pin).
+    owned = _create_session(server, owner_email=viewer_email, title=f"e2e-pin-owned-{uniq}")
+    shared = _create_session(server, owner_email=ADMIN_EMAIL, title=f"e2e-pin-shared-{uniq}")
+    _grant(server, shared, viewer_email, _LEVEL_EDIT)
+
+    ctx = browser.new_context(extra_http_headers={"X-Forwarded-Email": viewer_email})
+    try:
+        page = ctx.new_page()
+        page.goto(f"{server.public_url}/c/{owned}")
+        expect(page.locator(_FILTER)).to_be_visible(timeout=30_000)
+
+        # Pin both from the default "All sessions" view, where both rows show.
+        _pin_row(page, owned)
+        _pin_row(page, shared)
+        _pinned_has(page, owned)
+        _pinned_has(page, shared)
+
+        # My sessions: the owned pin is expected, and the SHARED pin must not
+        # drop out even though it isn't owned by the viewer.
+        _set_filter(page, "mine")
+        _pinned_has(page, owned)
+        _pinned_has(page, shared)
+
+        # Shared sessions: the shared pin is expected, and the OWNED pin must
+        # not drop out even though the viewer owns it.
+        _set_filter(page, "shared")
+        _pinned_has(page, owned)
+        _pinned_has(page, shared)
+
+        # Archived sessions: neither pin is archived, but switching here must
+        # not empty the Pinned section either.
+        _set_filter(page, "archived")
+        _pinned_has(page, owned)
+        _pinned_has(page, shared)
+    finally:
+        ctx.close()
+
+
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
+def test_projects_section_ignores_the_session_filter(
+    browser: Browser,
+    multi_user_server: MultiUserServer,
+) -> None:
+    """The Projects group + its folders survive the Shared / Archived filters.
+
+    Files a viewer-owned session into a project, then walks the filter to Shared
+    and Archived — the Projects group and the folder stay put. Before the fix
+    the Projects section was suppressed entirely on the Shared/Archived tabs, so
+    the folder vanished when the filter switched.
+    """
+    server = multi_user_server
+    uniq = uuid.uuid4().hex[:6]
+    viewer_email = f"viewer-proj-{uniq}@ui.test"
+    project = f"E2E Proj {uniq}"
+
+    # A viewer-owned session filed into a project (filing is owner-only, so the
+    # folder surfaces for the owner). Pin nothing here — pin-precedence would
+    # float it out of the folder.
+    filed = _create_session(server, owner_email=viewer_email, title=f"e2e-proj-filed-{uniq}")
+    _patch(server, filed, viewer_email, {"labels": {_PROJECT_LABEL_KEY: project}})
+
+    ctx = browser.new_context(extra_http_headers={"X-Forwarded-Email": viewer_email})
+    try:
+        page = ctx.new_page()
+        page.goto(f"{server.public_url}/c/{filed}")
+        expect(page.locator(_FILTER)).to_be_visible(timeout=30_000)
+
+        # My sessions: the Projects group and the project folder render.
+        _set_filter(page, "mine")
+        expect(page.get_by_role("button", name="Projects", exact=True)).to_be_visible(
+            timeout=30_000
+        )
+        expect(page.get_by_role("button", name=project, exact=True)).to_be_visible()
+
+        # Shared sessions: the Projects group and the folder must NOT disappear
+        # (this whole section used to be hidden on the Shared tab).
+        _set_filter(page, "shared")
+        expect(page.get_by_role("button", name="Projects", exact=True)).to_be_visible()
+        expect(page.get_by_role("button", name=project, exact=True)).to_be_visible()
+
+        # Archived sessions: same — the Projects group and folder stay put.
+        _set_filter(page, "archived")
+        expect(page.get_by_role("button", name="Projects", exact=True)).to_be_visible()
+        expect(page.get_by_role("button", name=project, exact=True)).to_be_visible()
+    finally:
+        ctx.close()

--- a/tests/e2e_ui/sessions/test_sidebar_pinned_projects_filter_independence.py
+++ b/tests/e2e_ui/sessions/test_sidebar_pinned_projects_filter_independence.py
@@ -247,3 +247,45 @@ def test_projects_section_ignores_the_session_filter(
         expect(page.get_by_role("button", name=project, exact=True)).to_be_visible()
     finally:
         ctx.close()
+
+
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
+def test_shared_session_stays_in_flat_list_on_project_name_collision(
+    browser: Browser,
+    multi_user_server: MultiUserServer,
+) -> None:
+    """A shared session with a colliding project label isn't pulled into a folder.
+
+    Filing is owner-only (unlike pins), so project-folder membership is
+    ownership-gated. The viewer owns a session filed under a project, and a
+    DIFFERENT owner's session — shared with the viewer — carries the same
+    project-name label. That collision must not pull the foreign session into
+    the viewer's folder (which would also drop it from the flat Sessions list).
+    """
+    server = multi_user_server
+    uniq = uuid.uuid4().hex[:6]
+    viewer_email = f"viewer-collide-{uniq}@ui.test"
+    project = f"E2E Collide {uniq}"
+
+    # The viewer's own session filed under the project (surfaces the folder).
+    owned = _create_session(server, owner_email=viewer_email, title=f"e2e-collide-owned-{uniq}")
+    _patch(server, owned, viewer_email, {"labels": {_PROJECT_LABEL_KEY: project}})
+    # An admin-owned session SHARED with the viewer, carrying the SAME project
+    # label — the name collision the ownership guard must reject.
+    shared = _create_session(server, owner_email=ADMIN_EMAIL, title=f"e2e-collide-shared-{uniq}")
+    _patch(server, shared, ADMIN_EMAIL, {"labels": {_PROJECT_LABEL_KEY: project}})
+    _grant(server, shared, viewer_email, _LEVEL_EDIT)
+
+    ctx = browser.new_context(extra_http_headers={"X-Forwarded-Email": viewer_email})
+    try:
+        page = ctx.new_page()
+        page.goto(f"{server.public_url}/c/{owned}")
+        expect(page.locator(_FILTER)).to_be_visible(timeout=30_000)
+
+        # The folder exists (the owned session filed it), but the shared session
+        # is NOT filed away: it stays in the flat Sessions list, not the folder.
+        expect(page.get_by_role("button", name=project, exact=True)).to_be_visible(timeout=30_000)
+        expect(_section(page, "Sessions").locator(f'a[href="/c/{shared}"]')).to_be_visible()
+        expect(_row(page, shared)).to_be_visible()
+    finally:
+        ctx.close()

--- a/web/src/shell/Sidebar.shiftSelect.test.tsx
+++ b/web/src/shell/Sidebar.shiftSelect.test.tsx
@@ -328,21 +328,17 @@ describe("Sidebar shift-click selection", () => {
   });
 
   it("labels Delete with the owned count when the selection is mixed-ownership", async () => {
-    // A project folder can hold sessions owned by other users (the folder query
-    // isn't ownership-filtered). Delete acts only on owned rows, so its label
-    // must reflect the owned count — not the raw "N selected" — when they differ.
-    projectsMock.push("Alpha");
-    const mine = conv("mine", { owner: "viewer", labels: { omni_project: "Alpha" } });
-    const theirs = conv("theirs", { owner: "someone_else", labels: { omni_project: "Alpha" } });
+    // The flat "All sessions" list mixes the viewer's own sessions with ones
+    // shared to them by other owners. Delete acts only on owned rows, so its
+    // label must reflect the owned count — not the raw "N selected" — when they
+    // differ. (Project folders are owner-only, so mixed ownership only arises in
+    // the flat list, not a folder.)
+    const mine = conv("mine", { owner: "viewer" });
+    const theirs = conv("theirs", { owner: "someone_else" });
     mockConversations([mine, theirs]);
-    localStorage.setItem("omnigent:expanded-project-sections", JSON.stringify(["Alpha"]));
     renderSidebar();
 
-    fireEvent.pointerDown(screen.getByRole("button", { name: "Project list actions" }), {
-      button: 0,
-      ctrlKey: false,
-    });
-    fireEvent.click(await screen.findByTestId("projects-select-sessions"));
+    fireEvent.click(screen.getByRole("button", { name: /select/i }));
 
     // Select both rows — "2 selected", but only the owned one is deletable.
     fireEvent.click(await screen.findByRole("link", { name: "mine" }));

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -928,35 +928,44 @@ describe("Sidebar tabs", () => {
     expect(screen.queryByText("conv_mine")).toBeNull();
   });
 
-  it("gives a pinned shared session a Pinned section under Shared, not My sessions", () => {
-    // Pins are ownership-agnostic (localStorage), so every filter reuses the
-    // same Pinned section — scoped to that filter's conversations. A pinned
-    // shared session floats to Pinned under Shared and never leaks onto My
-    // sessions (which shows only owned sessions).
+  it("shows every pinned session in Pinned regardless of the My/Shared filter", () => {
+    // Pins are ownership-agnostic, so the Pinned section always includes all
+    // pinned sessions — an owned pin stays visible on the Shared tab and a
+    // shared pin stays visible on My sessions. Only the unpinned rows re-scope
+    // with the filter.
     mockConversations([
       conv("conv_mine", "Claude Code"),
       conv("conv_shared", "Claude Code", { owner: "other@example.com" }),
     ]);
-    seedPins(["conv_shared"]);
+    seedPins(["conv_mine", "conv_shared"]);
     renderSidebar();
 
-    // "My sessions": owned session is unpinned (no Pinned section), and the
-    // pinned shared row doesn't appear here at all.
+    // "My sessions": both pins show under Pinned even though conv_shared is not
+    // owned by the viewer.
     selectSessionFilter("mine");
-    expect(screen.queryByText("Pinned")).toBeNull();
-    expect(screen.getByText("conv_mine")).toBeInTheDocument();
-    expect(screen.queryByText("conv_shared")).toBeNull();
+    const minePinned = screen.getByText("Pinned").closest("section")!;
+    expect(within(minePinned).getByText("conv_mine")).toBeInTheDocument();
+    expect(within(minePinned).getByText("conv_shared")).toBeInTheDocument();
 
-    // "Shared sessions": the shared session shows under its own Pinned section.
+    // "Shared sessions": both pins still show under Pinned even though
+    // conv_mine is owned by the viewer.
     showSharedTab();
-    const pinnedSection = screen.getByText("Pinned").closest("section")!;
-    expect(within(pinnedSection).getByText("conv_shared")).toBeInTheDocument();
+    const sharedPinned = screen.getByText("Pinned").closest("section")!;
+    expect(within(sharedPinned).getByText("conv_mine")).toBeInTheDocument();
+    expect(within(sharedPinned).getByText("conv_shared")).toBeInTheDocument();
+
+    // "Archived sessions": the (non-archived) pins still show under Pinned —
+    // switching to Archived doesn't empty the section.
+    selectSessionFilter("archived");
+    const archivedPinned = screen.getByText("Pinned").closest("section")!;
+    expect(within(archivedPinned).getByText("conv_mine")).toBeInTheDocument();
+    expect(within(archivedPinned).getByText("conv_shared")).toBeInTheDocument();
   });
 
-  it("does not render project folders on the Shared tab (projects are owner-only)", () => {
-    // Filing into a project is owner-only, so the Shared tab shows no Projects
-    // group; a shared session that carries a project label just lands in the
-    // flat Sessions list there.
+  it("keeps the Projects section and its folders on the Shared tab", () => {
+    // Projects are ownership-agnostic like pins: the Projects group and its
+    // folders always render, unaffected by the filter, so a filed session
+    // stays in its folder on the Shared tab rather than the folder vanishing.
     projectsMock.push("Alpha");
     mockConversations([
       conv("conv_mine", "Claude Code", { labels: { omni_project: "Alpha" } }),
@@ -967,9 +976,11 @@ describe("Sidebar tabs", () => {
     // My sessions tab carries the Projects group.
     expect(screen.getByText("Projects")).toBeInTheDocument();
 
-    // Shared tab: no Projects group; the shared session shows in Sessions.
+    // Shared tab: the Projects group still renders with its Alpha folder, and
+    // the shared session shows in Sessions.
     showSharedTab();
-    expect(screen.queryByText("Projects")).toBeNull();
+    expect(screen.getByText("Projects")).toBeInTheDocument();
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
     expect(screen.getByText("conv_shared")).toBeInTheDocument();
   });
 

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -984,6 +984,33 @@ describe("Sidebar tabs", () => {
     expect(screen.getByText("conv_shared")).toBeInTheDocument();
   });
 
+  it("keeps a shared session in the flat list on a project-name collision", () => {
+    // Filing is owner-only (UNLIKE pins), so `projectGroups` membership is
+    // ownership-gated. A session shared with the viewer that carries its own
+    // owner's `omni_project` label colliding with one of the viewer's folder
+    // names must NOT be treated as filed — otherwise `filedIds` would swallow
+    // it and it would vanish from the flat Sessions list. (The folder's own
+    // expanded contents come from the owner-scoped `?project=` server fetch,
+    // so this asserts the parent-level flat-list scoping the fix changed.)
+    projectsMock.push("Alpha");
+    mockConversations([
+      conv("conv_owned", "Claude Code", { labels: { omni_project: "Alpha" } }),
+      // Shared (owner set) with the SAME project-name label — the collision.
+      conv("conv_shared_alpha", "Claude Code", {
+        owner: "other@example.com",
+        labels: { omni_project: "Alpha" },
+      }),
+    ]);
+    renderSidebar();
+
+    // The owned session is filed (peeled out of the flat list into its
+    // collapsed folder), but the shared collision stays in the flat Sessions
+    // list rather than being pulled into the viewer's folder.
+    const sessionsSection = screen.getByText("Sessions").closest("section")!;
+    expect(within(sessionsSection).queryByText("conv_owned")).toBeNull();
+    expect(within(sessionsSection).getByText("conv_shared_alpha")).toBeInTheDocument();
+  });
+
   it("keeps paginating when the shared tab is empty on the loaded page but more exist", () => {
     // The list is one paginated stream (owned + shared mixed, updated_at desc),
     // so page 1 can be all-owned while shared sessions live on a later page.

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -1302,33 +1302,37 @@ function ConversationList({
     // by when they were pinned (the `omnigent.pinned` label's epoch-ms value;
     // oldest pin at the top, newest at the bottom), NOT by `updated_at`, so a
     // pinned session holds its slot when a new message bumps its `updated_at`.
-    // Pins are ownership-agnostic, so a pinned shared session floats to Pinned
-    // on the Shared tab just like an owned one on My sessions.
-    const pinned = orderByPinnedTimestamp(tabScoped.filter((c) => pinnedSet.has(c.id)));
+    // Pins are ownership-agnostic, so the Pinned section always shows EVERY
+    // pinned session regardless of the My/Shared/All/Archived filter — it's
+    // scoped to notArchived (not tabScoped), so an owned pin stays visible on
+    // the Shared tab, a shared pin stays visible on My sessions, and the pins
+    // don't vanish on the Archived tab either.
+    const pinned = orderByPinnedTimestamp(notArchived.filter((c) => pinnedSet.has(c.id)));
     const pinnedIdSet = new Set(pinned.map((c) => c.id));
 
-    // Filing is owner-only, so Shared renders no folders; Archived is flat too
-    // (archived outranks project membership). Elsewhere each folder holds its
-    // non-pinned sessions — pinning a project's last one leaves it empty.
+    // Projects are ownership-agnostic like pins: the Projects section always
+    // renders with the same folders and contents regardless of the My/Shared/
+    // Archived filter. Scope to notArchived (not tabScoped) so folders don't
+    // empty out when the filter switches to Shared or Archived. Each folder
+    // holds its non-pinned sessions — pinning a project's last one leaves it
+    // empty.
     const filedIds = new Set<string>();
     const projectGroups: { id: string | null; name: string; conversations: Conversation[] }[] =
-      activeTab === "shared" || activeTab === "archived"
-        ? []
-        : projects.map(({ id, name }) => {
-            // Dual-read membership: a session belongs to this folder if it has
-            // the first-class id OR the legacy omni_project label of this name.
-            const inProject = tabScoped.filter(
-              (c) =>
-                ((id !== null && c.project_id === id) || c.labels?.[PROJECT_LABEL_KEY] === name) &&
-                !pinnedIdSet.has(c.id),
-            );
-            inProject.forEach((c) => filedIds.add(c.id));
-            return {
-              id,
-              name,
-              conversations: sortByUpdatedAtDesc(inProject, activeOverride, frozenKeys),
-            };
-          });
+      projects.map(({ id, name }) => {
+        // Dual-read membership: a session belongs to this folder if it has
+        // the first-class id OR the legacy omni_project label of this name.
+        const inProject = notArchived.filter(
+          (c) =>
+            ((id !== null && c.project_id === id) || c.labels?.[PROJECT_LABEL_KEY] === name) &&
+            !pinnedIdSet.has(c.id),
+        );
+        inProject.forEach((c) => filedIds.add(c.id));
+        return {
+          id,
+          name,
+          conversations: sortByUpdatedAtDesc(inProject, activeOverride, frozenKeys),
+        };
+      });
     // NOTE: empty projects are intentionally NOT filtered out. A project comes
     // from the server project list (useProjects), so it can have zero *loaded*
     // conversations — either genuinely empty or because its chats live on an
@@ -1771,70 +1775,69 @@ function ConversationList({
               a collapsible folder row nested beneath it. Folders default
               collapsed; an empty folder shows "No sessions". The folder icon marks
               a project row; the group/section headers carry no icon or count.
-              Shown on the "mine" tab even with zero projects, so "New project"
-              (create-empty) is discoverable — projects are a My-sessions tool. */}
-                {activeTab !== "shared" && (
-                  <SectionGroup
-                    title="Projects"
-                    collapsed={effectiveCollapsedSections.includes("Projects")}
-                    onToggleCollapsed={() => effectiveToggleSectionCollapsed("Projects")}
-                    afterHeader={
-                      projectsSelecting ? (
-                        <BulkActionBar
-                          selectedIds={selectedIds}
-                          allConversations={projectSessionPool}
-                          onDeselectAll={onDeselectAll}
-                          onExit={onExitSelectionMode}
-                        />
-                      ) : undefined
-                    }
-                    headerAction={
-                      !selectionMode ? (
-                        <ProjectHeaderActions
-                          projectNames={sections.projectGroups.map((group) => group.name)}
-                          collapsed={effectiveCollapsedSections.includes("Projects")}
-                          expandedProjects={expandedProjects}
-                          hasProjectSessions={sections.projectGroups.some(
-                            (group) => group.conversations.length > 0,
-                          )}
-                          onExpandAll={expandAllProjects}
-                          onCollapseAll={collapseAllProjects}
-                          onProjectCreated={expandProject}
-                          onEnterSelectionMode={() => onEnterSelectionMode("projects")}
-                        />
-                      ) : undefined
-                    }
-                  >
-                    {sections.projectGroups.map((group) => (
-                      <ProjectFolder
-                        key={group.name}
-                        name={group.name}
-                        projectId={group.id}
-                        windowConversations={group.conversations}
-                        expanded={expandedProjects.includes(group.name)}
-                        // Best-effort marker from the globally-loaded window: a
-                        // collapsed folder hasn't fetched its own sessions yet.
-                        marker={projectMarkerState(group.conversations)}
-                        onToggleCollapsed={() => toggleProjectExpanded(group.name)}
-                        pinnedConversationIds={pinnedConversationIds}
-                        activeOverride={activeOverride}
-                        frozenSortKeys={frozenKeys}
-                        scrollRoot={scrollContainerRef}
-                        onRowClick={onRowClick}
-                        onTogglePinned={onTogglePinned}
-                        selectionMode={projectsSelecting}
+              Always shown (even with zero projects), unaffected by the filter, so
+              "New project" (create-empty) stays discoverable and folders don't
+              vanish when switching to Shared or Archived. */}
+                <SectionGroup
+                  title="Projects"
+                  collapsed={effectiveCollapsedSections.includes("Projects")}
+                  onToggleCollapsed={() => effectiveToggleSectionCollapsed("Projects")}
+                  afterHeader={
+                    projectsSelecting ? (
+                      <BulkActionBar
                         selectedIds={selectedIds}
-                        onToggleSelected={onToggleSelected}
-                        onProjectAssigned={expandProject}
-                        onConversationsLoaded={handleFolderConversationsLoaded}
+                        allConversations={projectSessionPool}
+                        onDeselectAll={onDeselectAll}
+                        onExit={onExitSelectionMode}
                       />
-                    ))}
-                    {sections.projectGroups.length === 0 &&
-                      !effectiveCollapsedSections.includes("Projects") && (
-                        <p className="px-2 py-1 text-ui text-muted-foreground">No projects</p>
-                      )}
-                  </SectionGroup>
-                )}
+                    ) : undefined
+                  }
+                  headerAction={
+                    !selectionMode ? (
+                      <ProjectHeaderActions
+                        projectNames={sections.projectGroups.map((group) => group.name)}
+                        collapsed={effectiveCollapsedSections.includes("Projects")}
+                        expandedProjects={expandedProjects}
+                        hasProjectSessions={sections.projectGroups.some(
+                          (group) => group.conversations.length > 0,
+                        )}
+                        onExpandAll={expandAllProjects}
+                        onCollapseAll={collapseAllProjects}
+                        onProjectCreated={expandProject}
+                        onEnterSelectionMode={() => onEnterSelectionMode("projects")}
+                      />
+                    ) : undefined
+                  }
+                >
+                  {sections.projectGroups.map((group) => (
+                    <ProjectFolder
+                      key={group.name}
+                      name={group.name}
+                      projectId={group.id}
+                      windowConversations={group.conversations}
+                      expanded={expandedProjects.includes(group.name)}
+                      // Best-effort marker from the globally-loaded window: a
+                      // collapsed folder hasn't fetched its own sessions yet.
+                      marker={projectMarkerState(group.conversations)}
+                      onToggleCollapsed={() => toggleProjectExpanded(group.name)}
+                      pinnedConversationIds={pinnedConversationIds}
+                      activeOverride={activeOverride}
+                      frozenSortKeys={frozenKeys}
+                      scrollRoot={scrollContainerRef}
+                      onRowClick={onRowClick}
+                      onTogglePinned={onTogglePinned}
+                      selectionMode={projectsSelecting}
+                      selectedIds={selectedIds}
+                      onToggleSelected={onToggleSelected}
+                      onProjectAssigned={expandProject}
+                      onConversationsLoaded={handleFolderConversationsLoaded}
+                    />
+                  ))}
+                  {sections.projectGroups.length === 0 &&
+                    !effectiveCollapsedSections.includes("Projects") && (
+                      <p className="px-2 py-1 text-ui text-muted-foreground">No projects</p>
+                    )}
+                </SectionGroup>
                 {/* Always rendered, even with no rows: the header carries the
                     filter menu, so hiding it on an empty slice would strand the
                     viewer with no way to pick another filter. */}

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -1302,27 +1302,32 @@ function ConversationList({
     // by when they were pinned (the `omnigent.pinned` label's epoch-ms value;
     // oldest pin at the top, newest at the bottom), NOT by `updated_at`, so a
     // pinned session holds its slot when a new message bumps its `updated_at`.
-    // Pins are ownership-agnostic, so the Pinned section always shows EVERY
-    // pinned session regardless of the My/Shared/All/Archived filter — it's
+    // Pins are ownership-agnostic, so the Pinned section always shows every
+    // non-archived pin regardless of the My/Shared/All/Archived filter — it's
     // scoped to notArchived (not tabScoped), so an owned pin stays visible on
     // the Shared tab, a shared pin stays visible on My sessions, and the pins
-    // don't vanish on the Archived tab either.
+    // don't vanish on the Archived tab either. (An archived session is never
+    // pinned into the live sections — hence notArchived, not allWithPinned.)
     const pinned = orderByPinnedTimestamp(notArchived.filter((c) => pinnedSet.has(c.id)));
     const pinnedIdSet = new Set(pinned.map((c) => c.id));
 
-    // Projects are ownership-agnostic like pins: the Projects section always
-    // renders with the same folders and contents regardless of the My/Shared/
-    // Archived filter. Scope to notArchived (not tabScoped) so folders don't
-    // empty out when the filter switches to Shared or Archived. Each folder
-    // holds its non-pinned sessions — pinning a project's last one leaves it
-    // empty.
+    // The Projects section renders the same folders on every filter (scope to
+    // notArchived, not tabScoped, so folders don't empty out on Shared or
+    // Archived). Filing is owner-only, though — UNLIKE pins — so membership is
+    // gated on ownership: a folder only ever holds the viewer's OWNED sessions.
+    // Without the guard the legacy label arm would match a shared session by
+    // project name alone, pulling a foreign session into the viewer's folder
+    // (and out of the flat Shared list via filedIds). Each folder holds its
+    // non-pinned sessions — pinning a project's last one leaves it empty.
     const filedIds = new Set<string>();
     const projectGroups: { id: string | null; name: string; conversations: Conversation[] }[] =
       projects.map(({ id, name }) => {
         // Dual-read membership: a session belongs to this folder if it has
-        // the first-class id OR the legacy omni_project label of this name.
+        // the first-class id OR the legacy omni_project label of this name,
+        // and (filing being owner-only) the viewer owns it.
         const inProject = notArchived.filter(
           (c) =>
+            isOwnedByViewer(c, viewerId) &&
             ((id !== null && c.project_id === id) || c.labels?.[PROJECT_LABEL_KEY] === name) &&
             !pinnedIdSet.has(c.id),
         );


### PR DESCRIPTION
## Related issue

N/A

## Summary

The sidebar's session filter (**All / My sessions / Shared / Archived**) is meant
to re-scope only the flat **Sessions** list, but the **Pinned** and **Projects**
sections were derived from the already-filtered slice, so switching filters
emptied them:

- A pinned **shared** session vanished from Pinned on *My sessions*, and a pinned
  **owned** session vanished on *Shared sessions*.
- The **Projects** group and its folders disappeared entirely on the *Shared* and
  *Archived* tabs.

Now both sections are built from the full non-archived set (`notArchived`), so
they always show **every** pin and **every** project folder regardless of the
active filter. Only the flat Sessions list still re-scopes with the filter.
(Archived sessions still never appear *inside* Pinned/Projects — those hold live
sessions — so an archived session shows only under the Archived tab's flat list.)

## Test Plan

- `cd web && npm test` → 5311 passed (includes updated `Sidebar.test.tsx`).
- `cd web && npm run build` → clean.
- New e2e UI tests (`tests/e2e_ui/sessions/test_sidebar_pinned_projects_filter_independence.py`),
  run locally against a multi-user server: **2 passed**.
- **Regression-proof:** temporarily reverting the source fix (keeping the tests)
  made both e2e tests fail exactly on the bug (shared pin gone on *My sessions*;
  `Projects` header absent on *Shared*); restoring the fix turned them green.

## Demo

N/A — logic-only change to sidebar section grouping. Behavior is covered by the
e2e tests: toggle the funnel across All/My/Shared/Archived and the Pinned +
Projects sections hold their rows.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: drove the live sidebar (multi-user server) through each
filter and confirmed pins and project folders stay put. Automated coverage in
the new e2e file plus the mocked `Sidebar.test.tsx` cases; the e2e tests were
confirmed to fail against the pre-fix code.

## Changelog

The sidebar's Pinned and Projects sections now stay put when you switch the
session filter (My / Shared / Archived) instead of emptying out.

This pull request and its description were written by Isaac.
