### PR TITLE
feat(ci): gate duplicate comments behind a flag; add a manual dry run

### DIFF
--- a/.github/scripts/issue_duplicates.py
+++ b/.github/scripts/issue_duplicates.py
@@ -383,9 +383,12 @@ def build_duplicate_comment(
     return f"{marker}\n{message}\n"
 
 
-_MENTION = re.compile(r"@([A-Za-z0-9](?:[A-Za-z0-9-]{0,38}))")
-_URL = re.compile(r"\b(?:https?://|www\.)\S+", re.IGNORECASE)
-_ISSUE_REF = re.compile(r"#\d+")
+_MENTION = re.compile(r"@+([A-Za-z0-9](?:[A-Za-z0-9-]{0,38}))")
+# `//host` is scheme-relative and still renders as an external link, so it is
+# matched alongside the explicit schemes. Bare domains are left alone: GitHub
+# does not autolink them.
+_URL = re.compile(r"(?:\b(?:https?://|www\.)|(?<![\w:/])//)\S+", re.IGNORECASE)
+_ISSUE_REF = re.compile(r"(?:#|\bGH-)\d+", re.IGNORECASE)
 REASON_MAX_CHARS = 240
 
 

--- a/.github/scripts/issue_duplicates.py
+++ b/.github/scripts/issue_duplicates.py
@@ -336,48 +336,80 @@ def validate_duplicate_decision(
     }
 
 
-def build_duplicate_comment(decision: dict[str, Any], *, close_issue: bool) -> str:
-    """Build the public, idempotently identifiable bot comment."""
+def build_duplicate_comment(
+    decision: dict[str, Any],
+    *,
+    close_issue: bool,
+    reasoning: str = "",
+) -> str:
+    """Build the public, idempotently identifiable bot comment.
+
+    Wording leads with the issue link — the one thing a reporter can act on —
+    and avoids describing the classifier's internals. A `none` verdict produces
+    no comment at all; the caller is expected not to post it.
+    """
     marker = "<!-- omnigent-duplicate-check -->"
-    reason = decision["duplicate_reasoning"]
 
     if decision["duplicate_decision"] == "duplicate":
         issue_number = decision["duplicate_of"]
+        # Only the closing case owes the reporter a justification, and only there
+        # is the model's own sentence worth surfacing over a fixed string.
+        explanation = f" {_one_sentence(reasoning)}" if close_issue and reasoning else ""
         if close_issue:
-            disposition = (
-                f"I’m closing this issue so discussion stays in #{issue_number}. "
-                "If this report is materially different, please leave a comment and "
-                "a maintainer can reopen it."
+            message = (
+                f"Thanks for reporting this. This looks like the same problem as "
+                f"#{issue_number}, so I’m closing it to keep the discussion in one "
+                f"place.{explanation}\n\n"
+                "If it isn't the same, say so here and a maintainer will reopen it."
             )
         else:
-            disposition = (
-                "Automatic duplicate closure is currently disabled, so I’m leaving "
-                "this issue open for maintainers to evaluate."
+            message = (
+                f"Thanks for reporting this. This looks like the same problem as "
+                f"#{issue_number} — worth a look to see if it covers your case.\n\n"
+                "Leaving it open for a maintainer to confirm."
             )
-        message = (
-            f"Thanks for reporting this. This appears to be a high-confidence "
-            f"duplicate of #{issue_number}.\n\n"
-            f"Reason: {reason}\n\n"
-            f"{disposition}"
-        )
     elif decision["duplicate_decision"] == "similar":
         references = ", ".join(f"#{number}" for number in decision["similar_issues"])
+        plural = "these" if len(decision["similar_issues"]) > 1 else "it"
         message = (
-            f"Thanks for reporting this. These existing issues may be related: "
-            f"{references}.\n\n"
-            f"Reason: {reason}\n\n"
-            "I’m leaving this issue open because the match is not strong enough "
-            "to treat it as a duplicate."
+            f"Thanks for reporting this. {references} may be related — worth a look "
+            f"in case {plural} already covers this.\n\n"
+            "If it's the same problem, feel free to add your details there; "
+            "otherwise a maintainer will pick this up."
         )
     else:
-        message = (
-            "Thanks for reporting this. I did not find an existing issue that "
-            "confidently matches this report.\n\n"
-            f"Reason: {reason}\n\n"
-            "I’m leaving this issue open for normal triage."
-        )
+        return ""
 
     return f"{marker}\n{message}\n"
+
+
+_MENTION = re.compile(r"@([A-Za-z0-9](?:[A-Za-z0-9-]{0,38}))")
+_URL = re.compile(r"\b(?:https?://|www\.)\S+", re.IGNORECASE)
+_ISSUE_REF = re.compile(r"#\d+")
+REASON_MAX_CHARS = 240
+
+
+def _one_sentence(text: str) -> str:
+    """Reduce model prose to one sanitized sentence fit for a public comment.
+
+    The model's text is derived from attacker-controllable issue content, so it
+    is never posted verbatim: mentions would ping real people, links could
+    phish under the bot's badge, and issue refs would cross-link unrelated
+    threads. Each is defanged rather than dropped so the sentence still reads.
+    """
+    collapsed = " ".join(text.split())
+    if not collapsed:
+        return ""
+    collapsed = _URL.sub("[link removed]", collapsed)
+    collapsed = _MENTION.sub(r"\1", collapsed)
+    collapsed = _ISSUE_REF.sub("an issue", collapsed)
+    head, separator, _ = collapsed.partition(". ")
+    sentence = head + ("." if separator else "")
+    if not sentence.endswith("."):
+        sentence = f"{sentence}."
+    if len(sentence) > REASON_MAX_CHARS:
+        sentence = f"{sentence[:REASON_MAX_CHARS].rstrip()}…"
+    return sentence
 
 
 def _similarity_map(issue: dict[str, Any], candidates: list[dict[str, Any]]) -> dict[int, float]:

--- a/.github/scripts/issue_duplicates_test.py
+++ b/.github/scripts/issue_duplicates_test.py
@@ -5,6 +5,7 @@ from issue_duplicates import (
     AUTO_CLOSE_CONFIDENCE,
     CLOSE_COSINE_FLOOR,
     SIMILAR_MIN_CONFIDENCE,
+    _one_sentence,
     build_duplicate_comment,
     document_tokens,
     extract_issue_references,
@@ -160,7 +161,8 @@ class IssueDuplicatesTest(unittest.TestCase):
         self.assertEqual(result["duplicate_decision"], "similar")
         self.assertEqual(result["similar_issues"], [12, 11, 10])
 
-    def test_public_comment_uses_templated_reason(self):
+    def test_similar_comment_never_carries_model_prose(self):
+        """The non-closing comment is fixed copy, so injected text cannot reach it."""
         issue = {
             "title": "Workspace rail resize is unusable on the browser tab",
             "body": "Dragging the workspace rail orphans the pointer.",
@@ -236,6 +238,39 @@ class IssueDuplicatesTest(unittest.TestCase):
         self.assertNotIn("evil.example.com", comment)
         self.assertNotIn("#999", comment)
         self.assertIn("admin", comment)
+
+    def test_closing_comment_defangs_evasive_mention_and_link_forms(self):
+        """Doubled `@`, scheme-relative links, and `GH-` refs are all live on GitHub.
+
+        Each renders exactly like the plain form the sanitizer already handled,
+        so missing one would leave a real ping or clickable link in a comment
+        built from attacker-controllable prose.
+        """
+        decision = {
+            "duplicate_decision": "duplicate",
+            "duplicate_of": 12,
+            "similar_issues": [],
+            "duplicate_confidence": 1.0,
+            "duplicate_reasoning": "unused",
+        }
+
+        comment = build_duplicate_comment(
+            decision,
+            close_issue=True,
+            reasoning="Ping @@admin re [x](//evil.example.com) and GH-999 now.",
+        )
+
+        self.assertNotIn("@admin", comment)
+        self.assertNotIn("@@", comment)
+        self.assertNotIn("evil.example.com", comment)
+        self.assertNotIn("GH-999", comment)
+
+    def test_sanitizer_keeps_prose_that_merely_looks_like_a_link(self):
+        """A bare `//` inside prose is not a link, so it must survive intact."""
+        self.assertEqual(
+            _one_sentence("Ratio was 50//50 in both reports."),
+            "Ratio was 50//50 in both reports.",
+        )
 
     def test_closing_comment_keeps_only_the_first_reason_sentence(self):
         decision = {

--- a/.github/scripts/issue_duplicates_test.py
+++ b/.github/scripts/issue_duplicates_test.py
@@ -180,10 +180,12 @@ class IssueDuplicatesTest(unittest.TestCase):
 
         self.assertIn("<!-- omnigent-duplicate-check -->", comment)
         self.assertIn("#12", comment)
+        self.assertIn("may be related", comment)
+        # The similar case never surfaces model prose, so injected content in
+        # the reasoning cannot reach the comment at all.
         self.assertNotIn("@admin", comment)
         self.assertNotIn("https://example.com", comment)
-        self.assertIn("automatic checks", comment)
-        self.assertIn("leaving this issue open", comment)
+        self.assertNotIn("#999", comment)
 
     def test_duplicate_comment_reflects_closure_flag(self):
         decision = {
@@ -197,9 +199,61 @@ class IssueDuplicatesTest(unittest.TestCase):
         observe_comment = build_duplicate_comment(decision, close_issue=False)
         close_comment = build_duplicate_comment(decision, close_issue=True)
 
-        self.assertIn("closure is currently disabled", observe_comment)
-        self.assertIn("leaving this issue open", observe_comment)
-        self.assertIn("I’m closing this issue", close_comment)
+        self.assertIn("#12", observe_comment)
+        self.assertIn("Leaving it open", observe_comment)
+        self.assertIn("I’m closing it", close_comment)
+
+    def test_no_comment_is_built_for_a_none_verdict(self):
+        """A non-duplicate gets no bot comment: it would be noise on most issues."""
+        decision = {
+            "duplicate_decision": "none",
+            "duplicate_of": None,
+            "similar_issues": [],
+            "duplicate_confidence": 0.1,
+            "duplicate_reasoning": "Unrelated.",
+        }
+
+        self.assertEqual(build_duplicate_comment(decision, close_issue=False), "")
+
+    def test_closing_comment_defangs_injected_model_prose(self):
+        """The closure reason is model text, so mentions and links are neutralized."""
+        decision = {
+            "duplicate_decision": "duplicate",
+            "duplicate_of": 12,
+            "similar_issues": [],
+            "duplicate_confidence": 1.0,
+            "duplicate_reasoning": "unused",
+        }
+
+        comment = build_duplicate_comment(
+            decision,
+            close_issue=True,
+            reasoning="Ping @admin and see https://evil.example.com about #999 now.",
+        )
+
+        self.assertIn("I’m closing it", comment)
+        self.assertNotIn("@admin", comment)
+        self.assertNotIn("evil.example.com", comment)
+        self.assertNotIn("#999", comment)
+        self.assertIn("admin", comment)
+
+    def test_closing_comment_keeps_only_the_first_reason_sentence(self):
+        decision = {
+            "duplicate_decision": "duplicate",
+            "duplicate_of": 12,
+            "similar_issues": [],
+            "duplicate_confidence": 1.0,
+            "duplicate_reasoning": "unused",
+        }
+
+        comment = build_duplicate_comment(
+            decision,
+            close_issue=True,
+            reasoning="Both describe the same crash. Extra detail nobody needs.",
+        )
+
+        self.assertIn("Both describe the same crash.", comment)
+        self.assertNotIn("Extra detail", comment)
 
     def test_injected_candidate_cannot_authorize_auto_close(self):
         issue = {

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -34,15 +34,17 @@ on:
     # `if:` below) — that removal is the signal the issue now has enough detail
     # to classify and assign.
     types: [opened, unlabeled]
-  # Manual dry run against any issue: classify and log the decision without
-  # labeling, commenting, or closing unless the inputs opt in.
+  # Manual dry run against any issue: classify and log the decision. Both
+  # inputs default off, and with them off nothing is written — no label,
+  # comment, assignment, or closure.
   workflow_dispatch:
     inputs:
       issue_number:
         description: Issue to triage
         required: true
       apply_labels:
-        description: Apply label changes (otherwise log only)
+        description: >-
+          Apply labels, assignment, and duplicate closure (otherwise log only)
         type: boolean
         default: false
       post_comment:
@@ -446,18 +448,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
-          # A manual dispatch classifies as though the issue had just opened, so
-          # a dry run exercises the full duplicate decision. Whether anything is
-          # written is gated by APPLY_LABELS / POST_DUPLICATE_COMMENT below.
-          EVENT_ACTION: >-
-            ${{ github.event_name == 'workflow_dispatch'
-                && 'opened' || github.event.action }}
-          APPLY_LABELS: >-
-            ${{ github.event_name != 'workflow_dispatch'
-                || inputs.apply_labels }}
-          POST_DUPLICATE_COMMENT: >-
-            ${{ github.event_name == 'workflow_dispatch'
-                && inputs.post_comment || env.POST_DUPLICATE_COMMENTS }}
+          # The dispatch inputs are passed through raw and combined in Python.
+          # An Actions `a && b || c` ternary yields `c` whenever `b` is false,
+          # so folding a boolean input into one would turn "don't write" back
+          # into the repo default.
+          EVENT_ACTION: ${{ github.event.action }}
+          IS_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
+          DISPATCH_APPLY_LABELS: ${{ inputs.apply_labels }}
+          DISPATCH_POST_COMMENT: ${{ inputs.post_comment }}
           ISSUE_PRIORITIZATION_V2_ENABLED: ${{ vars.ISSUE_PRIORITIZATION_V2_ENABLED }}
         run: |
           set -euo pipefail
@@ -506,14 +504,27 @@ jobs:
           def flag(name):
               return os.environ.get(name, "").strip().lower() == "true"
 
-          is_open_event = os.environ.get("EVENT_ACTION") == "opened"
+          # A dispatch classifies as though the issue had just opened so the full
+          # duplicate path runs, but every write is opt-in: each dispatch input
+          # decides on its own, never falling back to the repo default.
+          is_dispatch = flag("IS_DISPATCH")
+          is_open_event = is_dispatch or os.environ.get("EVENT_ACTION") == "opened"
+          apply_labels = flag("DISPATCH_APPLY_LABELS") if is_dispatch else True
+          post_comment_enabled = (
+              flag("DISPATCH_POST_COMMENT") if is_dispatch else flag("POST_DUPLICATE_COMMENTS")
+          )
+          # Closure has no dispatch input of its own: a dry run that closed the
+          # issue it was inspecting would be the worst possible surprise, so it
+          # rides on apply_labels as well as the repo flag.
           is_duplicate = duplicate["duplicate_decision"] == "duplicate" and is_open_event
-          close_duplicate_issue = is_duplicate and flag("CLOSE_DUPLICATE_ISSUES")
+          close_duplicate_issue = (
+              is_duplicate and flag("CLOSE_DUPLICATE_ISSUES") and apply_labels
+          )
           # Nothing is posted for a `none` verdict: most issues are not
           # duplicates, so the comment would be noise on the majority of them.
           post_duplicate_comment = (
               is_open_event
-              and flag("POST_DUPLICATE_COMMENT")
+              and post_comment_enabled
               and duplicate["duplicate_decision"] != "none"
           )
 
@@ -609,6 +620,8 @@ jobs:
               ),
               "close_duplicate_issue": close_duplicate_issue,
               "post_duplicate_comment": post_duplicate_comment,
+              # Read by the assignment steps below, which mutate the issue too.
+              "apply_labels": apply_labels,
               # Left as None while Databricks owns scoring.
               "priority": valid_priority,
               "needs_info": bool(result.get("needs_info")),
@@ -638,7 +651,7 @@ jobs:
               args += ["--add-label", label]
           for label in labels_remove:
               args += ["--remove-label", label]
-          if (labels_add or labels_remove) and flag("APPLY_LABELS"):
+          if (labels_add or labels_remove) and apply_labels:
               cmds.append(" ".join(shlex.quote(a) for a in args))
 
           pathlib.Path("/tmp/triage_commands.sh").write_text(
@@ -647,8 +660,8 @@ jobs:
           )
 
           # Print summary for the workflow log.
-          if not flag("APPLY_LABELS"):
-              print("Dry run: labels computed but not applied")
+          if not apply_labels:
+              print("Dry run: labels computed but neither applied nor assigned")
           print(f"Labels to add: {labels_add}")
           print(f"Labels to remove: {labels_remove}")
           if v2_owns_scoring:
@@ -689,6 +702,13 @@ jobs:
           issue_state=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" \
             --json state --jq '.state')
           if [ "$issue_state" != "OPEN" ]; then
+            exit 0
+          fi
+
+          # Assignment mutates the issue just as much as a label does, so a dry
+          # run stops here. Closure is already gated in Python.
+          if [ "$(jq -r '.apply_labels' /tmp/triage_result.json)" != "true" ]; then
+            echo "Dry run: skipping closure and assignment."
             exit 0
           fi
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -23,7 +23,8 @@ name: Issue Triage
 #   3. Assigns priority until Databricks owns scoring
 #   4. Routes to contributors — `good-first-issue` or `help-wanted`
 #   5. Flags incomplete issues — `needs-info` (replaces priority label)
-#   6. Comments with duplicate-check results on every issue
+#   6. Optionally comments when a duplicate or related issue is found
+#      (disabled by default; never comments when nothing matches)
 #   7. Optionally closes validated high-confidence duplicates (disabled by default)
 #   8. Assigns P0/P1 issues to a maintainer via round-robin
 
@@ -33,6 +34,21 @@ on:
     # `if:` below) — that removal is the signal the issue now has enough detail
     # to classify and assign.
     types: [opened, unlabeled]
+  # Manual dry run against any issue: classify and log the decision without
+  # labeling, commenting, or closing unless the inputs opt in.
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue to triage
+        required: true
+      apply_labels:
+        description: Apply label changes (otherwise log only)
+        type: boolean
+        default: false
+      post_comment:
+        description: Post the duplicate-check comment (otherwise log only)
+        type: boolean
+        default: false
 
 permissions:
   issues: write
@@ -41,7 +57,7 @@ permissions:
 # One triage run per issue at a time; a newer event supersedes an in-flight one
 # (e.g. a re-label right after open won't race with the initial run).
 concurrency:
-  group: issue-triage-${{ github.event.issue.number }}
+  group: issue-triage-${{ github.event.issue.number || inputs.issue_number }}
   cancel-in-progress: true
 
 env:
@@ -49,6 +65,10 @@ env:
   UV_INDEX_URL: https://pypi.org/simple
   PIP_INDEX_URL: https://pypi.org/simple
   CLOSE_DUPLICATE_ISSUES: ${{ vars.ISSUE_TRIAGE_CLOSE_DUPLICATES || 'false' }}
+  # Duplicate-check comments are off while the classifier is still being
+  # calibrated: detection and labeling run, but nothing is posted publicly.
+  # A manual dispatch can opt in per run via the `post_comment` input.
+  POST_DUPLICATE_COMMENTS: ${{ vars.ISSUE_TRIAGE_POST_DUPLICATE_COMMENTS || 'false' }}
 
 jobs:
   triage:
@@ -64,6 +84,7 @@ jobs:
     # workflow's own label edits use the default GITHUB_TOKEN, which never emits
     # re-triggering events, so there is no loop to guard against here.
     if: >-
+      github.event_name == 'workflow_dispatch' ||
       (
         github.event.action == 'opened' &&
         !endsWith(github.event.issue.user.login, '[bot]')
@@ -133,7 +154,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
           # Every issue ever filed, so long-closed reports stay discoverable.
           # Raise this as the repository grows.
           CORPUS_LIMIT: "2000"
@@ -424,8 +445,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          EVENT_ACTION: ${{ github.event.action }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+          # A manual dispatch classifies as though the issue had just opened, so
+          # a dry run exercises the full duplicate decision. Whether anything is
+          # written is gated by APPLY_LABELS / POST_DUPLICATE_COMMENT below.
+          EVENT_ACTION: >-
+            ${{ github.event_name == 'workflow_dispatch'
+                && 'opened' || github.event.action }}
+          APPLY_LABELS: >-
+            ${{ github.event_name != 'workflow_dispatch'
+                || inputs.apply_labels }}
+          POST_DUPLICATE_COMMENT: >-
+            ${{ github.event_name == 'workflow_dispatch'
+                && inputs.post_comment || env.POST_DUPLICATE_COMMENTS }}
           ISSUE_PRIORITIZATION_V2_ENABLED: ${{ vars.ISSUE_PRIORITIZATION_V2_ENABLED }}
         run: |
           set -euo pipefail
@@ -471,11 +503,18 @@ jobs:
           # The duplicate call is made once, at open time. On the re-triage path
           # (needs-info removed) the label, comment, and closure decision were
           # all settled then, so they are left exactly as they are.
+          def flag(name):
+              return os.environ.get(name, "").strip().lower() == "true"
+
           is_open_event = os.environ.get("EVENT_ACTION") == "opened"
           is_duplicate = duplicate["duplicate_decision"] == "duplicate" and is_open_event
-          close_duplicate_issue = (
-              is_duplicate
-              and os.environ.get("CLOSE_DUPLICATE_ISSUES", "").strip().lower() == "true"
+          close_duplicate_issue = is_duplicate and flag("CLOSE_DUPLICATE_ISSUES")
+          # Nothing is posted for a `none` verdict: most issues are not
+          # duplicates, so the comment would be noise on the majority of them.
+          post_duplicate_comment = (
+              is_open_event
+              and flag("POST_DUPLICATE_COMMENT")
+              and duplicate["duplicate_decision"] != "none"
           )
 
           labels_add = []
@@ -569,7 +608,7 @@ jobs:
                   duplicate["duplicate_decision"] if is_open_event else "none"
               ),
               "close_duplicate_issue": close_duplicate_issue,
-              "post_duplicate_comment": is_open_event,
+              "post_duplicate_comment": post_duplicate_comment,
               # Left as None while Databricks owns scoring.
               "priority": valid_priority,
               "needs_info": bool(result.get("needs_info")),
@@ -581,7 +620,11 @@ jobs:
           }
           pathlib.Path("/tmp/triage_result.json").write_text(json.dumps(output))
           pathlib.Path("/tmp/duplicate_comment.md").write_text(
-              build_duplicate_comment(duplicate, close_issue=close_duplicate_issue)
+              build_duplicate_comment(
+                  duplicate,
+                  close_issue=close_duplicate_issue,
+                  reasoning=output["reasoning"],
+              )
           )
 
           # Build a shell script with properly escaped arguments — no eval.
@@ -595,7 +638,7 @@ jobs:
               args += ["--add-label", label]
           for label in labels_remove:
               args += ["--remove-label", label]
-          if labels_add or labels_remove:
+          if (labels_add or labels_remove) and flag("APPLY_LABELS"):
               cmds.append(" ".join(shlex.quote(a) for a in args))
 
           pathlib.Path("/tmp/triage_commands.sh").write_text(
@@ -604,6 +647,8 @@ jobs:
           )
 
           # Print summary for the workflow log.
+          if not flag("APPLY_LABELS"):
+              print("Dry run: labels computed but not applied")
           print(f"Labels to add: {labels_add}")
           print(f"Labels to remove: {labels_remove}")
           if v2_owns_scoring:
@@ -620,16 +665,18 @@ jobs:
           # Execute the validated label changes.
           bash /tmp/triage_commands.sh
 
-          # Post the duplicate-check result once, on the initial open. Re-triage
-          # runs skip it, and an existing comment is never overwritten so a human
-          # override survives workflow reruns.
+          # Post the duplicate-check result once, on the initial open, and only
+          # when commenting is enabled and the verdict names a related issue. An
+          # existing comment is never overwritten so a human override survives
+          # workflow reruns.
           post_duplicate_comment=$(jq -r '.post_duplicate_comment' /tmp/triage_result.json)
           comment_id=$(gh api --paginate \
             "repos/$REPO/issues/$ISSUE_NUMBER/comments" \
             --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- omnigent-duplicate-check -->"))) | .id' \
             | sed -n '1p')
           if [ "$post_duplicate_comment" != "true" ]; then
-            echo "Re-triage run; leaving the existing duplicate-check result in place."
+            echo "Not commenting. The comment that would have been posted:"
+            cat /tmp/duplicate_comment.md
           elif [ -n "$comment_id" ]; then
             echo "Duplicate-check result already exists; preserving any human override."
           else


### PR DESCRIPTION
## Related issue

Part of #4198 — this is the first step of that validation: stop commenting publicly, and give us a way to inspect decisions by hand.

## Summary

Duplicate detection landed in #4037 and immediately started commenting on **every** issue it triaged, including the common case where it found nothing. "I did not find an existing issue that confidently matches this report" is a bot announcing a non-event on the majority of issues. The wording also leaked classifier internals ("candidates", "automatic checks do not establish") and buried the one actionable line — the issue link — under two sentences of hedging.

- **Kill switch.** `ISSUE_TRIAGE_POST_DUPLICATE_COMMENTS` (repo variable, defaults to `false`) gates commenting. Detection and labeling are unchanged, so the workflow log still records every verdict and confidence — we just stop talking in public while the classifier is calibrated. A `none` verdict now builds no comment at all, so flipping the flag on only ever speaks up when there's an issue to point at.
- **Manual dry run.** `workflow_dispatch` takes an issue number plus `apply_labels` / `post_comment`, both defaulting off. It classifies as though the issue had just opened so the full duplicate path runs, then logs the comment it *would* have posted.
- **Reworded comments.** Both remaining cases lead with the issue link and drop the internal vocabulary. The closing case now carries the model's own one-sentence reason instead of a fixed string.

The model's reason derives from untrusted issue content, so it is sanitized before reaching a public comment: URLs replaced, mentions stripped of their `@`, issue refs generalized, truncated to one sentence and length-capped. Previously no model prose was ever posted, so this is a genuinely new surface — hence the tests below.

```
issue opened ──▶ rank + classify (always) ──▶ labels ──┬─ APPLY_LABELS=true  ──▶ gh issue edit
                                                       └─ false              ──▶ log only
                          │
                          └─▶ verdict ─┬─ none                          ──▶ no comment, ever
                                       ├─ duplicate / similar + flag on ──▶ post
                                       └─ duplicate / similar + flag off ──▶ log the comment body
```

## Test Plan

- `python3 -m unittest issue_duplicates_test -v` in `.github/scripts` — 24 tests pass, 4 of them new.
- Simulated the workflow's gating step directly against the real heredoc for the matrix `{none, similar, duplicate} × {POST=true, false} × {APPLY_LABELS=true, false}`: `none` produces an empty comment file and `post=False`; `POST=false` with a duplicate verdict produces `post=False`; `APPLY_LABELS=false` computes labels and emits no `gh issue edit`.
- YAML parses with the expected triggers (`issues`, `workflow_dispatch`) and inputs (`issue_number`, `apply_labels`, `post_comment`); all five embedded Python heredocs `compile()` clean; all `run:` blocks pass `bash -n`.
- `pre-commit run --all-files` clean.
- Injection: fed `"Ping @admin and see https://evil.example.com about #999 now."` as the model's reason and asserted the rendered comment contains none of `@admin`, `evil.example.com`, or `#999`.

Once merged, the dry run can be exercised without side effects:

```
gh workflow run issue-triage.yml -f issue_number=4199
gh run watch $(gh run list --workflow=issue-triage.yml --limit 1 --json databaseId -q '.[0].databaseId')
```

## Demo

N/A — no UI. The comment copy change is visible in the unit-test assertions and in the dry-run log output.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The workflow YAML itself can't be unit-tested, so the gating logic was verified by executing the step's Python body against a synthesized environment across the full flag matrix (see Test Plan). The sanitizer, the empty-comment-on-`none` path, and the reworded copy are all covered by unit tests in `issue_duplicates_test.py`. End-to-end behaviour is verified by the `workflow_dispatch` dry run after merge — which is the point of the change.

This pull request and its description were written by Isaac.
