### PR TITLE
fix(server): unpin a session when the caller archives it

### DIFF
--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -1874,6 +1874,17 @@ def register_core_routes(
                 await asyncio.to_thread(conversation_store.delete_label, session_id, _clear_key)
         if labels_to_set:
             await asyncio.to_thread(conversation_store.set_labels, session_id, labels_to_set)
+        # Archiving means "get this out of my way", which contradicts a pin
+        # ("keep it at the top"), so drop the archiver's own pin — otherwise the
+        # session lingers as a pinned row if later unarchived. Runs after the
+        # label upsert so a same-request {archived, pin} can't re-add the pin,
+        # and after _spawn_archive_stop so a raise here can't leave the session
+        # archived-but-not-stopped. Per-user key only; delete_label no-ops when
+        # the session wasn't pinned.
+        if body.archived is True:
+            await asyncio.to_thread(
+                conversation_store.delete_label, session_id, pinned_label_key(user_id)
+            )
         if requested_codex_collaboration_mode is not None:
             _publish_collaboration_mode(
                 session_id,

--- a/tests/server/routes/test_sessions_crud.py
+++ b/tests/server/routes/test_sessions_crud.py
@@ -414,6 +414,67 @@ async def test_patch_session_pins_and_unpins(
     assert user_key not in conv.labels
 
 
+async def test_archiving_clears_the_callers_pin(
+    client: httpx.AsyncClient,
+    session_id: str,
+    db_uri: str,
+) -> None:
+    """Archiving a session drops the caller's own pin: a pinned row shouldn't
+    linger if the session is later unarchived. Only the requester's per-user key
+    is cleared."""
+    from omnigent.stores.conversation_store import pinned_label_key
+
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    user_key = pinned_label_key(None)
+
+    # Pin, then archive.
+    resp = await client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"labels": {"omnigent.pinned": "1721760000000"}},
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 200
+    conv = conv_store.get_conversation(session_id)
+    assert conv is not None
+    assert conv.labels.get(user_key) == "1721760000000"
+
+    resp = await client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"archived": True},
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 200
+    conv = conv_store.get_conversation(session_id)
+    assert conv is not None
+    assert conv.archived is True
+    assert user_key not in conv.labels
+
+
+async def test_archiving_wins_over_a_same_request_pin(
+    client: httpx.AsyncClient,
+    session_id: str,
+    db_uri: str,
+) -> None:
+    """A single PATCH carrying both ``archived: true`` and a pin is
+    contradictory; archive is authoritative. The pin-clear runs after the label
+    upsert, so the session ends up archived and unpinned, not re-pinned."""
+    from omnigent.stores.conversation_store import pinned_label_key
+
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    user_key = pinned_label_key(None)
+
+    resp = await client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"archived": True, "labels": {"omnigent.pinned": "1721760000000"}},
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 200
+    conv = conv_store.get_conversation(session_id)
+    assert conv is not None
+    assert conv.archived is True
+    assert user_key not in conv.labels
+
+
 async def test_patch_rejects_client_supplied_per_user_pin_key(
     client: httpx.AsyncClient,
     session_id: str,


### PR DESCRIPTION
## Related issue

Closes #

<!-- TODO: link the issue this fixes; CI's issue-reference check requires it for a bug fix. -->

## Summary

- Archiving a session now clears the archiver's own pin. Archiving hides a
  session from the default view, but the per-user `omnigent.pinned.<user>`
  label used to persist — so an archived session stayed pinned in storage and
  would resurface as a pinned row if later unarchived.
- Scoped to the requester: only the caller's pin key is deleted (a shared
  session's other viewers keep their own pins, since one user must not mutate
  another's labels). `delete_label` no-ops when the session wasn't pinned.
- Builds on #4200, which kept the sidebar's Pinned section independent of the
  session filter. The Pinned query already excludes archived rows
  (`?pinned=true` with the default `include_archived=false`), so this closes the
  remaining gap: the stored pin no longer silently resurrects on unarchive.

## Test Plan

- Added `test_archiving_clears_the_callers_pin`: pins a session, archives it,
  asserts `archived is True` and the per-user pin key is gone.
- `python -m pytest tests/server/routes/test_sessions_crud.py -k "archiving_clears or pins_and_unpins"` — passes.
- `ruff format --check` and `ruff check` clean on the changed files.

## Demo

N/A — no new UI; server-side state change. Reproduce in-app: pin a session,
archive it, then unarchive it — it returns unpinned rather than jumping back
into the Pinned section.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Covered by the new API-level test exercising the PATCH archive path.

## Changelog

Archiving a session now also unpins it, so it won't reappear pinned when unarchived
