### PR TITLE
feat(web): add default base branch to project settings

### DIFF
--- a/tests/e2e_ui/sessions/test_project_settings_dialog.py
+++ b/tests/e2e_ui/sessions/test_project_settings_dialog.py
@@ -1,7 +1,7 @@
 """Browser e2e for the Project settings dialog (project ``config`` defaults).
 
 A project carries owner-private session defaults in its ``config`` JSON
-(``{ host_id?, workspace?, agent_id?, use_worktree? }``). The "Project settings"
+(``{ host_id?, workspace?, agent_id?, use_worktree?, base_branch? }``). The "Project settings"
 dialog (``web/src/shell/ProjectSettingsDialog.tsx``, reached from the
 project-folder kebab) reads and writes that config via ``GET /v1/projects/{id}``
 and ``PATCH /v1/projects/{id}``.
@@ -122,3 +122,78 @@ def test_project_settings_clears_worktree_toggle(
     expect(page.get_by_test_id("project-settings-worktree")).to_have_attribute(
         "data-state", "unchecked"
     )
+
+
+def test_project_settings_base_branch_persists(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The base-branch field shows only with the worktree default on, and persists.
+
+    The base branch only forks a worktree, so its field is hidden until the
+    "Random worktree" toggle is ON. Flipping the toggle reveals it; typing a
+    branch + Save stores ``base_branch`` alongside ``use_worktree:true``.
+    Reopening fetches the stored config and seeds both back.
+    """
+    base_url, session_id = seeded_session
+    project = f"Project {uuid.uuid4().hex[:6]}"
+    _create_project(base_url, project)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # Worktree toggle defaults OFF, so the base-branch field is hidden.
+    _open_project_settings(page, project)
+    toggle = page.get_by_test_id("project-settings-worktree")
+    expect(toggle).to_have_attribute("data-state", "unchecked")
+    expect(page.get_by_test_id("project-settings-base-branch")).to_have_count(0)
+
+    # Turning the worktree default ON reveals the base-branch field; fill + save.
+    toggle.click()
+    base_input = page.get_by_test_id("project-settings-base-branch")
+    expect(base_input).to_be_visible()
+    base_input.fill("develop")
+    page.get_by_test_id("project-settings-save").click()
+    expect(page.get_by_test_id("project-settings-save")).to_have_count(0)
+
+    # Reopen — the stored config seeds the toggle ON and the branch back.
+    _open_project_settings(page, project)
+    expect(page.get_by_test_id("project-settings-worktree")).to_have_attribute(
+        "data-state", "checked"
+    )
+    expect(page.get_by_test_id("project-settings-base-branch")).to_have_value("develop")
+
+
+def test_project_settings_drops_base_branch_when_worktree_off(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Turning the worktree default OFF drops a previously stored base branch.
+
+    Starts from a project whose ``config`` has ``use_worktree:true`` and a
+    ``base_branch``. The base-branch field is only meaningful with worktrees on,
+    so flipping the toggle OFF clears the whole config to ``{}`` — reopening
+    seeds the toggle OFF and (once toggled back on) shows a blank base branch.
+    """
+    base_url, session_id = seeded_session
+    project = f"Project {uuid.uuid4().hex[:6]}"
+    project_id = _create_project(base_url, project)
+    _set_project_config(base_url, project_id, {"use_worktree": True, "base_branch": "develop"})
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # Seeded ON → the base-branch field shows its stored value.
+    _open_project_settings(page, project)
+    expect(page.get_by_test_id("project-settings-base-branch")).to_have_value("develop")
+
+    # Flip the worktree default OFF and save → config clears to {}.
+    page.get_by_test_id("project-settings-worktree").click()
+    page.get_by_test_id("project-settings-save").click()
+    expect(page.get_by_test_id("project-settings-save")).to_have_count(0)
+
+    # Reopen — toggle seeds OFF; toggling back on shows a blank base branch.
+    _open_project_settings(page, project)
+    expect(page.get_by_test_id("project-settings-worktree")).to_have_attribute(
+        "data-state", "unchecked"
+    )
+    page.get_by_test_id("project-settings-worktree").click()
+    expect(page.get_by_test_id("project-settings-base-branch")).to_have_value("")

--- a/web/src/lib/projectsApi.ts
+++ b/web/src/lib/projectsApi.ts
@@ -29,11 +29,16 @@ export interface ProjectConfig {
    * Opt-in worktree default: only `true` is meaningful. When `true`, a new
    * session in a git workspace starts in a fresh randomly-named worktree; unset
    * (the only other value the dialog stores) starts directly in the workspace.
-   * `false` is never written and is treated the same as unset. The base branch a
-   * worktree forks from stays a global preference (Settings › Git), not a
-   * project default.
+   * `false` is never written and is treated the same as unset.
    */
   use_worktree?: boolean;
+  /**
+   * Default base branch a new worktree forks from, pre-filled into the
+   * composer's base-branch field. Takes precedence over the user-global default
+   * (Settings › Git); an unset key falls through to that global default. Blank
+   * is never stored (treated the same as unset).
+   */
+  base_branch?: string;
 }
 
 /** A first-class project. Mirrors the `ProjectObject` response shape. */

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2849,11 +2849,14 @@ export function NewChatLandingScreen() {
   // A new, isolated worktree is created only when a branch is named and the
   // workspace isn't already sitting on that existing worktree.
   const shouldCreateWorktree = branchName.trim() !== "" && !startInExistingWorktree;
-  // Auto-fill the base branch from the configured default (Settings › Git) when
-  // a new-worktree branch is named, but only until the user touches the base
-  // field — then their choice (including a cleared field) stands. Clearing the
-  // branch name (so the base field goes away) re-arms the auto-fill, so naming
-  // a branch again starts fresh from the current default.
+  // Auto-fill the base branch when a new-worktree branch is named, but only
+  // until the user touches the base field — then their choice (including a
+  // cleared field) stands. Clearing the branch name (so the base field goes
+  // away) re-arms the auto-fill, so naming a branch again starts fresh from the
+  // current default. The project's stored default (Project settings) wins over
+  // the user-global one (Settings › Git); an unset project default falls
+  // through to the global one, then to blank (fork from current branch).
+  const projectBaseBranch = storedProjectConfig?.base_branch?.trim() || null;
   useEffect(() => {
     if (!shouldCreateWorktree) {
       // No base field shown: reset so the next named branch re-seeds cleanly.
@@ -2862,9 +2865,9 @@ export function NewChatLandingScreen() {
       return;
     }
     if (!baseBranchEdited) {
-      _setBaseBranch(readDefaultBaseBranch() ?? "");
+      _setBaseBranch(projectBaseBranch ?? readDefaultBaseBranch() ?? "");
     }
-  }, [shouldCreateWorktree, baseBranchEdited]);
+  }, [shouldCreateWorktree, baseBranchEdited, projectBaseBranch]);
   // The branch input doubles as a combobox: focusing it reveals existing
   // worktrees, and what the user types filters them (match on branch or path
   // substring, case-insensitive). Typing a name that matches none = a new

--- a/web/src/shell/ProjectSettingsDialog.test.tsx
+++ b/web/src/shell/ProjectSettingsDialog.test.tsx
@@ -124,6 +124,48 @@ describe("ProjectSettingsDialog", () => {
     await waitFor(() => expect(updateMock).toHaveBeenCalledWith("p_1", {}));
   });
 
+  it("shows the base-branch field only when the worktree default is on, and saves it", async () => {
+    getProjectMock.mockResolvedValue({ id: "p_1", name: "Work", config: {} });
+    renderDialog();
+    await waitFor(() =>
+      expect((screen.getByTestId("project-settings-save") as HTMLButtonElement).disabled).toBe(
+        false,
+      ),
+    );
+    // Base branch is hidden while the worktree default is OFF (nothing to fork).
+    expect(screen.queryByTestId("project-settings-base-branch")).not.toBeInTheDocument();
+
+    // Turning the worktree default ON reveals the base-branch field.
+    fireEvent.click(screen.getByTestId("project-settings-worktree"));
+    const input = screen.getByTestId("project-settings-base-branch");
+    fireEvent.change(input, { target: { value: "  main  " } });
+    fireEvent.click(screen.getByTestId("project-settings-save"));
+
+    // Trimmed and stored alongside the worktree default.
+    await waitFor(() =>
+      expect(updateMock).toHaveBeenCalledWith("p_1", { use_worktree: true, base_branch: "main" }),
+    );
+  });
+
+  it("drops the base branch when the worktree default is off", async () => {
+    // A base branch stored from an earlier ON state must not linger as an
+    // invisible default once the worktree toggle is turned back off.
+    getProjectMock.mockResolvedValue({
+      id: "p_1",
+      name: "Work",
+      config: { use_worktree: true, base_branch: "develop" },
+    });
+    renderDialog();
+    // Seeded ON → the base-branch field shows its stored value.
+    await waitFor(() =>
+      expect(screen.getByTestId("project-settings-base-branch")).toHaveValue("develop"),
+    );
+    // Turn the worktree default OFF → base branch drops, config clears to {}.
+    fireEvent.click(screen.getByTestId("project-settings-worktree"));
+    fireEvent.click(screen.getByTestId("project-settings-save"));
+    await waitFor(() => expect(updateMock).toHaveBeenCalledWith("p_1", {}));
+  });
+
   it("hides the sandbox option when managed sandboxes are disabled", async () => {
     getProjectMock.mockResolvedValue({ id: "p_1", name: "Work", config: {} });
     renderDialog();

--- a/web/src/shell/ProjectSettingsDialog.tsx
+++ b/web/src/shell/ProjectSettingsDialog.tsx
@@ -3,12 +3,13 @@
 // the new-chat composer pre-fill host / working directory / agent and the
 // isolated-worktree default when starting a session in the project.
 //
-// Scope mirrors what the composer prefills today: host, workspace, agent, and
-// whether new sessions start in a fresh git worktree. Model / reasoning-effort
-// / harness are per-agent run config, and the worktree BASE branch is a global
-// preference (Settings › Git) — both deliberately out of scope here. The host
-// and agent pickers reuse the composer's components; the working directory
-// reuses its filesystem browser (inline, so it scrolls inside the modal).
+// Scope mirrors what the composer prefills today: host, workspace, agent,
+// whether new sessions start in a fresh git worktree, and the base branch a
+// worktree forks from (which overrides the user-global default in Settings ›
+// Git). Model / reasoning-effort / harness are per-agent run config,
+// deliberately out of scope here. The host and agent pickers reuse the
+// composer's components; the working directory reuses its filesystem browser
+// (inline, so it scrolls inside the modal).
 // Fields are optional: an unset one stores no default (an absent key), and an
 // all-default dialog stores an empty config.
 
@@ -117,6 +118,10 @@ export function ProjectSettingsDialog({
   // stored (as use_worktree:true), which the composer honors by creating a
   // fresh worktree for new sessions in the project.
   const [useWorktree, setUseWorktree] = useState(false);
+  // Base branch a new worktree forks from; blank stores no default (falls
+  // through to the user-global default in Settings › Git). Only meaningful
+  // alongside the worktree default, but kept independent so it survives toggling.
+  const [baseBranch, setBaseBranch] = useState("");
   const [agentId, setAgentId] = useState<string | null>(null);
   const [workspaceOpen, setWorkspaceOpen] = useState(false);
 
@@ -161,6 +166,7 @@ export function ProjectSettingsDialog({
     setHostId(c.host_id ?? NONE);
     setWorkspace(c.workspace ?? "");
     setUseWorktree(c.use_worktree ?? false);
+    setBaseBranch(c.base_branch ?? "");
     setAgentId(c.agent_id ?? null);
     setWorkspaceOpen(false);
   }, [open, stored, loadFailed]);
@@ -185,6 +191,11 @@ export function ProjectSettingsDialog({
     // Worktrees are opt-in: only an explicit ON is stored (as use_worktree:true);
     // leaving it OFF stores nothing, so an all-default dialog still clears to {}.
     if (useWorktree) config.use_worktree = true;
+    // A base branch only forks a worktree, so it's only meaningful when the
+    // worktree default is on — drop it otherwise so it can't linger as a stale,
+    // invisible default after the toggle is turned off.
+    const base = useWorktree ? trimOrUndef(baseBranch) : undefined;
+    if (base) config.base_branch = base;
 
     updateConfig.mutate(
       { id: projectId, name: projectName, config },
@@ -366,6 +377,24 @@ export function ProjectSettingsDialog({
               />
             </div>
           </Field>
+
+          {useWorktree && (
+            <Field
+              label="Base branch"
+              hint="Branch new worktrees fork from; blank uses the current branch"
+              htmlFor="project-settings-base-branch"
+            >
+              <input
+                id="project-settings-base-branch"
+                data-testid="project-settings-base-branch"
+                className="w-full rounded-md border bg-transparent px-3 py-2 text-ui outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                placeholder="e.g. main"
+                value={baseBranch}
+                onChange={(e) => setBaseBranch(e.target.value)}
+                disabled={isLoading}
+              />
+            </Field>
+          )}
 
           <Field label="Agent" hint="Default agent / harness for new sessions">
             <div className="flex flex-col items-end gap-1" data-testid="project-settings-agent">


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Adds a **default base branch** to a project's stored settings. When you name a new worktree branch in the new-chat composer for that project, the base-branch field pre-fills from this default.
- Precedence: **project default → user-global default (Settings › Git) → blank** (fork from the current branch).
- The field appears in Project settings only when the **Random worktree** default is on (a base branch only forks a worktree), and is dropped from the stored config when the toggle is off, so it can't linger as a stale invisible default.
- No backend change: `projects.config` is a client-owned JSON blob and `base_branch` already flows through to worktree creation via `SessionGitOptions`.

## Test Plan

- `cd web && npm test` — full vitest suite green (5313 passed). New `ProjectSettingsDialog` cases cover reveal-on-toggle, trim + save shape, and drop-when-off.
- `cd web && npm run build` — `tsc -b && vite build` clean.
- `pytest tests/e2e_ui/sessions/test_project_settings_dialog.py` — 4 passed (2 pre-existing + 2 new), driving the real `POST`/`PATCH /v1/projects` round-trip through Chromium.

## Demo

https://github.com/user-attachments/assets/868485a3-10df-457e-8e05-b7eae903b643


## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified in the running app: setting a project base branch pre-fills the composer's base-branch field over the global Settings › Git default, and clears back to the global/blank fallback when unset. Automated coverage: vitest for the dialog write path + precedence logic, and browser e2e for the persistence round-trip.

## Changelog

Projects can set a default base branch that pre-fills when starting a new worktree session