### PR TITLE
fix: Python isolation flag probe, clickable context ring, compaction …

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -94,6 +94,19 @@ _PERMISSION_HOOK_FILE = "permission_hook.json"
 _CONTEXT_FILE = "context.json"
 _USER_CLAUDE_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
 _MCP_SERVER_NAME = "omnigent"
+
+
+def _python_isolation_flags(python: str) -> list[str]:
+    """Return ``["-I"]`` when isolated mode can import omnigent, else ``[]``."""
+    import subprocess
+
+    ok = subprocess.run(
+        [python, "-I", "-c", "import omnigent"],
+        capture_output=True,
+    ).returncode == 0
+    return ["-I"] if ok else []
+
+
 _MCP_PROTOCOL_VERSION = "2024-11-05"
 # Tools-changed: harness POSTs to the bridge MCP server's localhost
 # control endpoint, which emits ``notifications/tools/list_changed``
@@ -1116,12 +1129,13 @@ def build_mcp_config(bridge_dir: Path, *, python_executable: str | None = None) 
     :returns: JSON-serializable Claude MCP config.
     """
     python = python_executable or sys.executable
+    iso = _python_isolation_flags(python)
     return {
         "mcpServers": {
             _MCP_SERVER_NAME: {
                 "command": python,
                 "args": [
-                    "-I",
+                    *iso,
                     "-m",
                     "omnigent.claude_native_bridge",
                     "serve-mcp",
@@ -1177,14 +1191,10 @@ def build_hook_settings(
     :returns: JSON-serializable Claude settings fragment.
     """
     python = python_executable or sys.executable
-    # -I (isolated mode) prevents Python from adding the session's
-    # working directory to sys.path, which would shadow the installed
-    # omnigent package with a local checkout in the cwd (e.g. a
-    # git worktree that has its own omnigent/ directory on a
-    # different branch).
+    isolation_flags = _python_isolation_flags(python)
     command_parts = [
         python,
-        "-I",
+        *isolation_flags,
         "-m",
         "omnigent.claude_native_hook",
         "--bridge-dir",
@@ -1204,7 +1214,7 @@ def build_hook_settings(
     # that file and publishes ``response.output_text.delta`` events.
     message_display_command_parts = [
         python,
-        "-I",
+        *isolation_flags,
         "-m",
         "omnigent.claude_native_message_display_hook",
         "--bridge-dir",
@@ -1279,7 +1289,7 @@ def build_hook_settings(
         # restarting Claude.
         permission_command_parts = [
             python,
-            "-I",
+            *isolation_flags,
             "-m",
             "omnigent.claude_native_hook",
             "permission-request",
@@ -1303,7 +1313,7 @@ def build_hook_settings(
         # Policy-gate native Claude Code tools, not just relay/MCP tools.
         evaluate_policy_command_parts = [
             python,
-            "-I",
+            *isolation_flags,
             "-m",
             "omnigent.claude_native_hook",
             "evaluate-policy",
@@ -1319,7 +1329,7 @@ def build_hook_settings(
         # form. It's a no-op in other modes to avoid double-surfacing.
         ask_uq_command_parts = [
             python,
-            "-I",
+            *isolation_flags,
             "-m",
             "omnigent.claude_native_hook",
             "ask-user-question",
@@ -1372,7 +1382,7 @@ def build_hook_settings(
     # user had globally so claude-hud / their bar still renders.
     status_parts = [
         python,
-        "-I",
+        *isolation_flags,
         "-m",
         "omnigent.claude_native_status",
         "--bridge-dir",

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -32,6 +32,7 @@ import {
   XIcon,
 } from "lucide-react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { userColor, userColorTint, userInitials } from "@/lib/userBadge";
 import { useNavigate, useParams } from "@/lib/routing";
@@ -3661,50 +3662,83 @@ export function buildSlashCommandWithArgsSet(
 /** Circumference of the progress ring (r=5.5). */
 const RING_CIRCUMFERENCE = 2 * Math.PI * 5.5;
 
-/** Circular progress ring showing how much context window is used, with the used percentage beside it. */
+/** Format a token count compactly: 1234 → "1.2k", 1234567 → "1.2M". */
+function fmtTokens(n: number | null | undefined): string {
+  if (n == null) return "—";
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return n.toLocaleString();
+}
+
+/** Clickable context ring with popover showing token breakdown and compact button. */
 function ContextRing({ contextWindow, tokensUsed }: { contextWindow: number; tokensUsed: number }) {
   const pct = Math.min(tokensUsed / contextWindow, 1);
-  // Arc, %, label, and tooltip all encode context USED: a fresh session
-  // shows an empty ring at 0% and the ring fills as context is consumed.
   const usedArc = pct * RING_CIRCUMFERENCE;
   const usedPct = Math.round(pct * 100);
+  const sessionUsageByModel = useChatStore((s) => s.sessionUsageByModel);
+  const sessionCostUsd = useChatStore((s) => s.sessionCostUsd);
+
+  const totals = useMemo(() => {
+    let input = 0, output = 0, cacheRead = 0, cacheCreate = 0;
+    if (sessionUsageByModel) {
+      for (const u of Object.values(sessionUsageByModel)) {
+        input += u.inputTokens ?? 0;
+        output += u.outputTokens ?? 0;
+        cacheRead += u.cacheReadInputTokens ?? 0;
+        cacheCreate += u.cacheCreationInputTokens ?? 0;
+      }
+    }
+    return { input, output, cacheRead, cacheCreate };
+  }, [sessionUsageByModel]);
 
   const color =
     pct > 0.8 ? "text-destructive" : pct > 0.6 ? "text-warning" : "text-muted-foreground";
 
+  const ringIcon = (
+    <span
+      className={cn("flex items-center gap-1.5 cursor-pointer", color)}
+      aria-label={`${usedPct}% of context used`}
+    >
+      <svg viewBox="0 0 16 16" width="16" height="16" fill="none" aria-hidden="true">
+        <circle cx="8" cy="8" r="5.5" stroke="currentColor" strokeWidth="2" opacity="0.2" />
+        {usedArc > 0 && (
+          <circle
+            cx="8" cy="8" r="5.5" stroke="currentColor" strokeWidth="2"
+            strokeLinecap="round" strokeDasharray={`${usedArc} ${RING_CIRCUMFERENCE}`}
+            transform="rotate(-90 8 8)"
+          />
+        )}
+      </svg>
+      <span className="text-xs tabular-nums" aria-hidden="true">{usedPct}%</span>
+    </span>
+  );
+
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span
-          className={cn("flex items-center gap-1.5", color)}
-          aria-label={`${usedPct}% of context used`}
+    <Popover>
+      <PopoverTrigger asChild>{ringIcon}</PopoverTrigger>
+      <PopoverContent side="top" align="end" className="w-64 p-3 text-xs">
+        <div className="mb-2 flex justify-between">
+          <span className="text-muted-foreground">Context</span>
+          <span>{fmtTokens(tokensUsed)} / {fmtTokens(contextWindow)}</span>
+        </div>
+        <div className="mb-3 h-1.5 rounded-full bg-muted overflow-hidden">
+          <div className={cn("h-full rounded-full", pct > 0.8 ? "bg-destructive" : pct > 0.6 ? "bg-warning" : "bg-primary")} style={{ width: `${usedPct}%` }} />
+        </div>
+        <div className="space-y-1 text-muted-foreground">
+          <div className="flex justify-between"><span>Input</span><span>{fmtTokens(totals.input)}</span></div>
+          <div className="flex justify-between"><span>Output</span><span>{fmtTokens(totals.output)}</span></div>
+          {totals.cacheRead > 0 && <div className="flex justify-between"><span>Cache read</span><span>{fmtTokens(totals.cacheRead)}</span></div>}
+          {totals.cacheCreate > 0 && <div className="flex justify-between"><span>Cache create</span><span>{fmtTokens(totals.cacheCreate)}</span></div>}
+          {sessionCostUsd != null && <div className="flex justify-between font-medium text-foreground"><span>Cost</span><span>${sessionCostUsd.toFixed(4)}</span></div>}
+        </div>
+        <button
+          className="mt-3 w-full rounded bg-muted px-2 py-1 text-xs hover:bg-muted/80"
+          onClick={() => useChatStore.getState().compact()}
         >
-          <svg viewBox="0 0 16 16" width="16" height="16" fill="none" aria-hidden="true">
-            {/* Track */}
-            <circle cx="8" cy="8" r="5.5" stroke="currentColor" strokeWidth="2" opacity="0.2" />
-            {/* Used arc — skipped at 0, where round linecaps would still paint a dot. */}
-            {usedArc > 0 && (
-              <circle
-                cx="8"
-                cy="8"
-                r="5.5"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeDasharray={`${usedArc} ${RING_CIRCUMFERENCE}`}
-                transform="rotate(-90 8 8)"
-              />
-            )}
-          </svg>
-          <span className="text-xs tabular-nums" aria-hidden="true">
-            {usedPct}%
-          </span>
-        </span>
-      </TooltipTrigger>
-      <TooltipContent side="top" className="max-w-44 text-center text-xs">
-        <p className="tabular-nums">{usedPct}% of context used.</p>
-      </TooltipContent>
-    </Tooltip>
+          Compact Context
+        </button>
+      </PopoverContent>
+    </Popover>
   );
 }
 

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -1712,7 +1712,26 @@ export const useChatStore = create<ChatState>((set, get) => ({
   compact: async () => {
     const { conversationId } = get();
     if (!conversationId) return;
-    await postEvent(conversationId, { type: "compact", data: {} });
+    if ((useChatStore as any)._compactingNow) return;
+    (useChatStore as any)._compactingNow = true;
+    const removeAllLoadingBlocks = () => {
+      useChatStore.setState((s) => {
+        const filtered = s.blocks.filter((b) => b.type !== "compaction_loading");
+        return filtered.length === s.blocks.length ? {} : { blocks: filtered };
+      });
+    };
+    const tid = window.setTimeout(() => {
+      removeAllLoadingBlocks();
+      (useChatStore as any)._compactingNow = false;
+    }, 15_000);
+    (useChatStore as any)._compactionTimeout = tid;
+    try {
+      await postEvent(conversationId, { type: "compact", data: {} });
+    } catch {
+      window.clearTimeout(tid);
+      removeAllLoadingBlocks();
+      (useChatStore as any)._compactingNow = false;
+    }
   },
 
   refreshSessionState: async (conversationId) => {
@@ -4245,23 +4264,21 @@ export function handleSessionEvent(event: StreamEvent): void {
       queryClient?.invalidateQueries({ queryKey: terminalsQueryKey(event.conversationId) });
       return;
     case "compaction_completed":
-      // Update the context-ring immediately with the post-compaction token
-      // estimate so the ring reflects the reduced context without waiting
-      // for the next LLM response.completed event.
+      window.clearTimeout((useChatStore as any)._compactionTimeout);
+      (useChatStore as any)._compactingNow = false;
       if (event.totalTokens != null) {
         useChatStore.setState({ tokensUsed: event.totalTokens });
       }
       return;
-    case "compaction_failed":
-      // Compaction failed — history is unchanged. Remove the compaction_loading
-      // block so the "Compacting…" shimmer disappears without leaving a marker.
+    case "compaction_failed": {
+      window.clearTimeout((useChatStore as any)._compactionTimeout);
+      (useChatStore as any)._compactingNow = false;
       useChatStore.setState((s) => {
-        const idx = [...s.blocks].reverse().findIndex((b) => b.type === "compaction_loading");
-        if (idx === -1) return {};
-        const realIdx = s.blocks.length - 1 - idx;
-        return { blocks: [...s.blocks.slice(0, realIdx), ...s.blocks.slice(realIdx + 1)] };
+        const filtered = s.blocks.filter((b) => b.type !== "compaction_loading");
+        return filtered.length === s.blocks.length ? {} : { blocks: filtered };
       });
       return;
+    }
     case "policy_denied":
       // Policy denied the user input — drop the optimistic bubble (the
       // server won't emit session.input.consumed for denied inputs, so


### PR DESCRIPTION
…spinner

- claude_native_bridge: runtime probe for -I isolation flag compatibility so hooks work when omnigent is installed with pip --user
- ChatPage: replace tooltip-only context ring with clickable popover showing token breakdown (input/output/cache) and compact button
- chatStore: fix compaction spinner persisting on failure — add 15s timeout fallback, duplicate click prevention, and error cleanup

<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. Linking also
gives this PR the issue's priority in the review queue. If an older, still-open
community PR already closes the same issue, the newer one may be auto-closed as
a duplicate (maintainer PRs are exempt).

If this is either a `Refactor / chore`, `Docs`, or `Test / CI` *Type of change* 
below, then no issue is required to be associated. 
-->

Closes #

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

## Demo

<!--
Video or images demonstrating the change. Drag-and-drop a screenshot or screen
recording, or paste a link. Expected for UI / frontend changes (check the
"UI / frontend change" box below) — show the new behaviour. Optional otherwise;
use `N/A` for non-visual changes.
-->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

<Add a line to describe the change, else delete this section>
