### PR TITLE
fix(codex-native): resolve spec-level auth at native launch like the in-process harness

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -28,6 +28,7 @@ from omnigent.json_types import JsonObject as _JsonObject
 
 if TYPE_CHECKING:
     from omnigent.onboarding.provider_config import ProviderEntry
+    from omnigent.spec.types import AgentSpec
 
 from omnigent.codex_native_bridge import write_policy_hook_config
 from omnigent.codex_native_process_registry import (
@@ -2151,13 +2152,26 @@ def _resolve_subscription_launch(
     )
 
 
-def resolve_native_codex_launch(*, model: str | None) -> NativeCodexLaunch:
+def resolve_native_codex_launch(
+    *, model: str | None, spec: AgentSpec | None = None
+) -> NativeCodexLaunch:
     """Resolve the native Codex launch config across all offerings.
 
     Mirrors the in-process codex harness routing precedence
     (:func:`omnigent.runtime.workflow._resolve_provider_for_build`) for the
     ``openai`` surface, so ``omnigent codex`` and a host-spawned native
     Codex session route through ``omnigent setup``:
+
+    0. (with *spec*) a spec-level credential — ``executor.auth`` naming a
+       provider (:class:`~omnigent.spec.types.ProviderAuth`, fails loud when
+       undeclared), a spec :class:`~omnigent.spec.types.DatabricksAuth`, or a
+       legacy ``executor.profile`` / ``executor.config.profile`` — resolved
+       through :func:`~omnigent.runtime.workflow._resolve_provider_for_build`
+       itself, the same resolver the in-process harness uses, so a spec that
+       routes in-process routes natively too (a spec ``ApiKeyAuth`` resolves
+       to ``None`` for every harness — the resolver leaves bare keys to the
+       claude-sdk / openai-agents builders — so codex-native falls through
+       exactly as in-process codex does);
 
     1. an explicit per-family default provider →
        - ``key`` / ``gateway`` / ``local`` → provider ``-c`` overrides
@@ -2172,12 +2186,16 @@ def resolve_native_codex_launch(*, model: str | None) -> NativeCodexLaunch:
     3. else an ambient-detected provider (first run without configure);
     4. else the codex CLI's own login.
 
-    Credentials are controlled exclusively by ``omnigent setup``
-    provider config (or the legacy global ``auth:`` block) — there is
-    no CLI/env profile override.
+    Without a *spec* (or when the spec carries no spec-level credential),
+    credentials are controlled by ``omnigent setup`` provider config (or the
+    legacy global ``auth:`` block) exactly as before — there is no CLI/env
+    profile override, and machine-level flows are unchanged.
 
     :param model: An explicit/session model override that wins over the
         provider's default model, or ``None``.
+    :param spec: The custom agent spec launching this session, when there is
+        one, so its ``executor.auth`` / legacy profile win over machine-level
+        config (issue #2744 — parity with the in-process codex harness).
     :returns: The resolved :class:`NativeCodexLaunch`.
     """
     from omnigent.onboarding.detected import (
@@ -2189,7 +2207,7 @@ def resolve_native_codex_launch(*, model: str | None) -> NativeCodexLaunch:
         default_provider_for_harness,
         load_config,
     )
-    from omnigent.runtime.workflow import _load_global_auth
+    from omnigent.runtime.workflow import _load_global_auth, _resolve_provider_for_build
     from omnigent.spec.types import DatabricksAuth
 
     explicit = load_config()
@@ -2201,6 +2219,65 @@ def resolve_native_codex_launch(*, model: str | None) -> NativeCodexLaunch:
     no_provider_overrides = (
         ['model_provider="openai"'] if codex_config_provider_dismissed(explicit) else []
     )
+    if spec is not None and (
+        spec.executor.auth is not None
+        or spec.executor.profile
+        or spec.executor.config.get("profile")
+    ):
+        # Spec-level credential (issue #2744): resolve it through the same
+        # resolver the in-process codex harness uses, so switching a working
+        # spec from ``harness: codex`` to ``codex-native`` keeps its auth
+        # working. A named provider that is undeclared raises loud here
+        # instead of parking the TUI on the sign-in screen for a 30s timeout.
+        # A spec ``ApiKeyAuth`` resolves to ``None`` for every harness (the
+        # shared resolver leaves bare keys to the claude-sdk / openai-agents
+        # builders; the in-process codex builder has no ApiKeyAuth branch
+        # either), so codex-native falls through to the machine-level chain
+        # below exactly as in-process codex does — as does a spec credential
+        # that cannot route openai.
+        spec_entry = _resolve_provider_for_build(spec, harness_type="codex", for_launch=True)
+        if spec_entry is not None:
+            if spec_entry.kind == SUBSCRIPTION_KIND:
+                # A spec-named subscription defers to Codex's own login,
+                # logged in or not. The machine-default path would substitute
+                # the first OTHER routable provider on a logged-out Codex
+                # (:func:`_resolve_subscription_launch`) — never do that for
+                # an explicit spec declaration: silently running a credential
+                # the spec did not name is worse than the login screen.
+                from omnigent.onboarding.ambient import codex_auth_has_credential
+
+                if codex_auth_has_credential(_codex_home_config_source_from_env() / "auth.json"):
+                    state = "Codex is logged in"
+                else:
+                    state = (
+                        "Codex is not logged in — the TUI likely renders the "
+                        "sign-in screen and never starts a thread"
+                    )
+                return NativeCodexLaunch(
+                    config_overrides=['model_provider="openai"'],
+                    model=model,
+                    profile=None,
+                    summary=f"Codex CLI login (spec provider {spec_entry.name!r}; {state})",
+                )
+            launch = _codex_provider_launch(spec_entry, model)
+            if launch is not None:
+                if launch.profile is not None:
+                    _logger.info(
+                        "native-codex routing: Databricks ucode profile %r (spec auth)",
+                        launch.profile,
+                    )
+                else:
+                    _logger.info(
+                        "native-codex routing: provider %r (spec auth, model=%s)",
+                        spec_entry.name,
+                        launch.model,
+                    )
+                return launch
+            _logger.warning(
+                "native-codex: spec-level provider %r has no usable openai credential — "
+                "falling back to machine-level resolution.",
+                spec_entry.name,
+            )
     entry = default_provider_for_harness(explicit, "codex")
     if entry is None:
         # No explicit provider default: global auth wins over ambient

--- a/omnigent/runner/background_titles/codex_native.py
+++ b/omnigent/runner/background_titles/codex_native.py
@@ -32,7 +32,8 @@ async def generate_background_title(context: BackgroundTitleContext) -> str | No
     from omnigent.runner.native.orchestration import _codex_native_model_from_spec
 
     model = context.model_override or _codex_native_model_from_spec(context.session_spec)
-    launch = resolve_native_codex_launch(model=model)
+    # Thread the spec so a title exec honors spec-level auth too (#2744).
+    launch = resolve_native_codex_launch(model=model, spec=context.session_spec)
     with tempfile.TemporaryDirectory(prefix="omnigent-codex-title-") as temp_dir:
         temp_root = Path(temp_dir)
         codex_home = temp_root / "codex-home"

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3722,7 +3722,10 @@ async def _auto_create_codex_terminal(
     # synthesis can stamp session_meta.model_provider with the provider
     # this launch actually routes through.
     default_model = launch_config.model_override or _codex_native_model_from_spec(agent_spec)
-    _codex_launch = resolve_native_codex_launch(model=default_model)
+    # Thread the spec so its executor.auth / legacy profile win over
+    # machine-level config, parity with the in-process harness (#2744).
+    _launch_spec = agent_spec.spec if isinstance(agent_spec, ResolvedSpec) else agent_spec
+    _codex_launch = resolve_native_codex_launch(model=default_model, spec=_launch_spec)
     _session_meta_provider = codex_session_meta_model_provider(_codex_launch)
     from omnigent.inner.codex_executor import _find_codex_cli
 

--- a/tests/runner/test_background_session_title.py
+++ b/tests/runner/test_background_session_title.py
@@ -605,7 +605,7 @@ async def test_codex_native_title_uses_ephemeral_tool_free_exec(
     )
     monkeypatch.setattr(
         "omnigent.codex_native_app_server.resolve_native_codex_launch",
-        lambda *, model: NativeCodexLaunch(provider_overrides, model, None),
+        lambda *, model, spec=None: NativeCodexLaunch(provider_overrides, model, None),
     )
     monkeypatch.setattr(
         "omnigent.codex_native_app_server._find_codex_cli",
@@ -681,7 +681,7 @@ async def test_codex_native_title_kills_process_when_cancelled(
 
     monkeypatch.setattr(
         "omnigent.codex_native_app_server.resolve_native_codex_launch",
-        lambda *, model: NativeCodexLaunch([], model, None),
+        lambda *, model, spec=None: NativeCodexLaunch([], model, None),
     )
     monkeypatch.setattr(
         "omnigent.codex_native_app_server._find_codex_cli",

--- a/tests/test_native_codex_provider.py
+++ b/tests/test_native_codex_provider.py
@@ -16,7 +16,9 @@ import pytest
 import yaml
 
 from omnigent.codex_native_app_server import resolve_native_codex_launch
+from omnigent.errors import OmnigentError
 from omnigent.inner.codex_executor import _provider_codex_config_overrides
+from omnigent.spec.types import AgentSpec, ExecutorSpec, ProviderAuth
 
 
 @pytest.fixture()
@@ -436,3 +438,184 @@ def test_resolve_native_codex_launch_undismissed_config_provider_routes_via_pin(
 
     assert launch.config_overrides == ['model_provider="Databricks"']
     assert launch.profile is None
+
+
+# ── Spec-level credentials (issue #2744) ────────────────────────────────────
+
+
+def _spec(*, auth: ProviderAuth | None = None, profile: str | None = None) -> AgentSpec:
+    """Build a minimal codex-native agent spec carrying spec-level credentials."""
+    config: dict[str, object] = {"harness": "codex-native"}
+    if profile is not None:
+        config["profile"] = profile
+    return AgentSpec(
+        spec_version=1,
+        name="test-codex-native",
+        instructions="You are a test agent.",
+        executor=ExecutorSpec(type="omnigent", config=config, model=None, auth=auth),
+        llm=None,
+        os_env=None,
+    )
+
+
+def test_spec_provider_auth_routes_when_machine_has_nothing(_isolated: Path) -> None:
+    """A spec naming a provider routes natively with zero machine-level config.
+
+    The #2744 repro: no machine provider, no global auth, codex not logged in.
+    Pre-fix the launch fell through to "Codex CLI login" and the TUI parked on
+    the sign-in screen; the spec's named provider must route instead.
+    """
+    _seed(
+        _isolated,
+        {
+            "vendor-spec": {
+                "kind": "key",
+                "openai": {
+                    "base_url": "https://spec.example.com/v1",
+                    "api_key": "sk-spec",
+                    "models": {"default": "spec-model"},
+                },
+            }
+        },
+    )
+
+    launch = resolve_native_codex_launch(
+        model=None, spec=_spec(auth=ProviderAuth(name="vendor-spec"))
+    )
+
+    joined = "\n".join(launch.config_overrides)
+    assert 'base_url="https://spec.example.com/v1"' in joined
+    assert "printf %s sk-spec" in joined
+    assert launch.model == "spec-model"
+    assert "Codex CLI login" not in launch.summary
+
+
+def test_spec_provider_auth_beats_machine_default(_isolated: Path) -> None:
+    """A spec-named provider wins over the machine-level default provider."""
+    _seed(
+        _isolated,
+        {
+            "machine-default": {
+                "kind": "key",
+                "default": True,
+                "openai": {
+                    "base_url": "https://default.example.com/v1",
+                    "api_key": "sk-default",
+                },
+            },
+            "vendor-spec": {
+                "kind": "key",
+                "openai": {
+                    "base_url": "https://spec.example.com/v1",
+                    "api_key": "sk-spec",
+                },
+            },
+        },
+    )
+
+    launch = resolve_native_codex_launch(
+        model=None, spec=_spec(auth=ProviderAuth(name="vendor-spec"))
+    )
+
+    joined = "\n".join(launch.config_overrides)
+    assert 'base_url="https://spec.example.com/v1"' in joined
+    assert "default.example.com" not in joined
+
+
+def test_spec_legacy_profile_routes_ucode(_isolated: Path) -> None:
+    """A legacy ``executor.config.profile`` resolves to the ucode profile path."""
+    launch = resolve_native_codex_launch(model=None, spec=_spec(profile="spec-prof"))
+
+    assert launch.profile == "spec-prof"
+
+
+def test_spec_without_auth_keeps_machine_resolution(_isolated: Path) -> None:
+    """A spec with no spec-level credential leaves machine flows untouched."""
+    _seed(
+        _isolated,
+        {
+            "openai": {
+                "kind": "key",
+                "default": True,
+                "openai": {
+                    "base_url": "https://api.openai.com/v1",
+                    "api_key": "sk-oai-default",
+                },
+            }
+        },
+    )
+
+    with_spec = resolve_native_codex_launch(model=None, spec=_spec())
+    without_spec = resolve_native_codex_launch(model=None)
+
+    assert with_spec == without_spec
+    assert 'base_url="https://api.openai.com/v1"' in "\n".join(with_spec.config_overrides)
+
+
+def test_spec_provider_auth_undeclared_fails_loud(_isolated: Path) -> None:
+    """A spec naming an undeclared provider raises instead of a silent timeout."""
+    with pytest.raises(OmnigentError, match="does-not-exist"):
+        resolve_native_codex_launch(
+            model=None, spec=_spec(auth=ProviderAuth(name="does-not-exist"))
+        )
+
+
+def _write_codex_home_login(root: Path, *, logged_in: bool) -> Path:
+    """Write an explicit ``CODEX_HOME`` with a logged-in/out ``auth.json``."""
+    codex_home = root / "codex-home"
+    codex_home.mkdir(parents=True, exist_ok=True)
+    content = '{"auth_mode": "apikey", "OPENAI_API_KEY": "sk-codex-login"}' if logged_in else "{}"
+    (codex_home / "auth.json").write_text(content, encoding="utf-8")
+    return codex_home
+
+
+def test_spec_subscription_logged_out_does_not_substitute(
+    _isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A spec-named subscription never silently routes a different provider.
+
+    The machine-DEFAULT subscription path falls through to the first other
+    routable provider when Codex is logged out (a safety net for defaults).
+    For an explicit spec declaration that substitution would run the agent
+    against a credential its author never named, so the launch must surface
+    Codex's own login instead.
+    """
+    monkeypatch.setenv("CODEX_HOME", str(_write_codex_home_login(_isolated, logged_in=False)))
+    _seed(
+        _isolated,
+        {
+            "codex-sub": {"kind": "subscription", "cli": "codex"},
+            "other": {
+                "kind": "key",
+                "openai": {
+                    "base_url": "https://other.example.com/v1",
+                    "api_key": "sk-other",
+                },
+            },
+        },
+    )
+
+    launch = resolve_native_codex_launch(
+        model=None, spec=_spec(auth=ProviderAuth(name="codex-sub"))
+    )
+
+    assert launch.config_overrides == ['model_provider="openai"']
+    assert "codex-sub" in launch.summary
+    assert "other.example.com" not in "\n".join(launch.config_overrides)
+
+
+def test_spec_subscription_logged_in_uses_cli_login(
+    _isolated: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A spec-named subscription with a live Codex login defers to it."""
+    monkeypatch.setenv("CODEX_HOME", str(_write_codex_home_login(_isolated, logged_in=True)))
+    _seed(_isolated, {"codex-sub": {"kind": "subscription", "cli": "codex"}})
+
+    launch = resolve_native_codex_launch(
+        model=None, spec=_spec(auth=ProviderAuth(name="codex-sub"))
+    )
+
+    assert launch.config_overrides == ['model_provider="openai"']
+    assert launch.profile is None
+    assert "codex-sub" in launch.summary
+    assert "Codex is logged in" in launch.summary


### PR DESCRIPTION
## Related issue

Closes #2744

## Summary

A spec carrying `executor.auth` or a legacy profile routed correctly in-process but was invisible to `resolve_native_codex_launch`, so a custom agent on `codex-native` fell through to the Codex sign-in screen and timed out at launch. This threads the spec into that resolver and hands it to `_resolve_provider_for_build`, the same resolver the in-process codex harness already calls, so a spec that routes in-process now routes natively too.

Sibling of #3175, which landed the model half of this parity gap.

## Test Plan

`uv run pytest tests/test_native_codex_provider.py -k spec_` (7 pass). The rest of that file and all 213 tests in `tests/test_codex_native.py` stay green, including the provider-materialization guards added by #4030. Machine-level resolution is untouched when a spec declares no credential of its own.

## Demo

N/A, no UI or frontend change. The symptom is a launch-time stall in an existing native session path rather than a rendered state, and reproducing it needs a live Codex login plus a custom spec declaring its own provider. The added tests cover each routing branch instead.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Changelog

A custom agent that declares its own provider auth now launches on codex-native instead of stalling on the Codex sign-in screen.
