### PR TITLE
fix(web): keep the dev proxy's Databricks token fresh

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -30,6 +30,27 @@ The Vite dev server proxies `/v1` and `/api` to `http://localhost:6767`. Set
 OMNIGENT_URL=http://localhost:9000 pnpm run dev
 ```
 
+### Pointing at a deployed Databricks App
+
+A deployed app (`https://<app>.databricksapps.com`) is OAuth-gated by the
+workspace that hosts it, so the proxy has to attach a bearer token. Name the
+`.databrickscfg` profile for that workspace and the proxy mints one, re-minting
+it before it expires:
+
+```bash
+OMNIGENT_URL=https://<app>.aws.databricksapps.com \
+OMNIGENT_AUTH_PROFILE=<profile> \
+pnpm run dev
+```
+
+Log in first if the CLI has no session: `databricks auth login -p <profile>`.
+
+| Variable                | Description                                                          |
+| ----------------------- | -------------------------------------------------------------------- |
+| `OMNIGENT_AUTH_PROFILE` | `.databrickscfg` profile to mint the token from. Preferred.          |
+| `OMNIGENT_AUTH_HOST`    | Workspace host to mint against, when no profile is named.            |
+| `OMNIGENT_AUTH_TOKEN`   | Explicit bearer, used verbatim. Not refreshed — expires in ~an hour. |
+
 Additional `omnigent server` options:
 
 | Flag                  | Default                | Description                          |

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -10,29 +10,90 @@ import { computeBuildVersion } from "./src/lib/buildVersion";
 
 const OMNIGENT_URL = process.env.OMNIGENT_URL ?? "http://localhost:6767";
 
+/**
+ * Workspace to mint the token against, when that isn't the proxy target.
+ *
+ * A Databricks App is served from `*.databricksapps.com` but authenticates
+ * against the workspace that hosts it, and `databricks auth token` only knows
+ * workspace hosts — so point this at the workspace, e.g.
+ * `OMNIGENT_AUTH_HOST=https://my-workspace.cloud.databricks.com`.
+ */
+const OMNIGENT_AUTH_HOST = process.env.OMNIGENT_AUTH_HOST;
+
+/**
+ * `.databrickscfg` profile to mint against, e.g. `OMNIGENT_AUTH_PROFILE=oss`.
+ *
+ * Preferred over a host: several profiles routinely share one workspace host,
+ * and `databricks auth token --host` refuses to guess between them.
+ */
+const OMNIGENT_AUTH_PROFILE = process.env.OMNIGENT_AUTH_PROFILE;
+
+/** How the token is minted, given what the environment specified. */
+function tokenCliArgs(host: string): string[] {
+  if (OMNIGENT_AUTH_PROFILE) return ["auth", "token", "-p", OMNIGENT_AUTH_PROFILE];
+  return ["auth", "token", "--host", OMNIGENT_AUTH_HOST ?? host];
+}
+
+/** Re-mint this long before expiry, so an in-flight request can't age out. */
+const TOKEN_REFRESH_SKEW_MS = 5 * 60_000;
+
+/** Assumed lifetime when a token carries no readable expiry. */
+const TOKEN_ASSUMED_TTL_MS = 30 * 60_000;
+
 let cachedToken: string | null | undefined;
+let cachedTokenExpiresAt = 0;
 
-function resolveToken(host: string): string | null {
-  if (cachedToken !== undefined) return cachedToken;
-
-  if (process.env.OMNIGENT_AUTH_TOKEN) {
-    cachedToken = process.env.OMNIGENT_AUTH_TOKEN;
-    return cachedToken;
+/** Read a JWT's `exp` (ms since epoch), or null when it isn't a readable JWT. */
+function readJwtExpiry(token: string): number | null {
+  const payload = token.split(".")[1];
+  if (!payload) return null;
+  try {
+    const claims = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as {
+      exp?: number;
+    };
+    return typeof claims.exp === "number" ? claims.exp * 1000 : null;
+  } catch {
+    return null;
   }
+}
+
+/**
+ * The bearer for the proxied request, minted on demand and re-minted before it
+ * expires.
+ *
+ * Workspace OAuth tokens last about an hour. Resolving one once per process
+ * left a long-running dev server sending a dead bearer afterwards, and every
+ * request 302'd to the login page while the server itself looked healthy —
+ * so the cache is keyed on the token's own expiry.
+ *
+ * `OMNIGENT_AUTH_TOKEN` is an explicit override and is used verbatim; nothing
+ * here can refresh it, so a long session should prefer the CLI path.
+ */
+function resolveToken(host: string): string | null {
+  if (process.env.OMNIGENT_AUTH_TOKEN) return process.env.OMNIGENT_AUTH_TOKEN;
+
+  if (cachedToken !== undefined && Date.now() < cachedTokenExpiresAt) return cachedToken;
 
   try {
-    const output = execFileSync(
-      "databricks",
-      ["auth", "token", "--host", host, "--output", "json"],
-      {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-      },
-    );
+    const output = execFileSync("databricks", [...tokenCliArgs(host), "--output", "json"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
     const tokenResponse = JSON.parse(output) as { access_token?: string };
     cachedToken = tokenResponse.access_token ?? null;
-  } catch {
+    const expiry = cachedToken === null ? null : readJwtExpiry(cachedToken);
+    cachedTokenExpiresAt = (expiry ?? Date.now() + TOKEN_ASSUMED_TTL_MS) - TOKEN_REFRESH_SKEW_MS;
+  } catch (err) {
     cachedToken = null;
+    // Retry on the next request rather than wedging the proxy on one failure
+    // (an expired CLI login is fixed by `databricks auth login`, not a restart).
+    cachedTokenExpiresAt = 0;
+    // Surface why. Swallowing this left "no auth token" with no cause, when
+    // the CLI had already said exactly what was wrong (ambiguous profile,
+    // expired login, missing binary).
+    const stderr = (err as { stderr?: Buffer | string }).stderr;
+    const detail = (typeof stderr === "string" ? stderr : stderr?.toString())?.trim();
+    console.error(`[dev-proxy] databricks auth token failed: ${detail || String(err)}`);
   }
 
   return cachedToken;
@@ -106,8 +167,13 @@ function createProxyConfig(target: string, useAuth: boolean): Record<string, Pro
 const parsed = new URL(OMNIGENT_URL);
 const useAuth =
   !!process.env.OMNIGENT_AUTH_TOKEN ||
+  !!OMNIGENT_AUTH_HOST ||
+  !!OMNIGENT_AUTH_PROFILE ||
   parsed.hostname.endsWith(".databricks.com") ||
-  parsed.hostname.endsWith(".azuredatabricks.net");
+  parsed.hostname.endsWith(".azuredatabricks.net") ||
+  // A deployed Databricks App — OAuth-gated by its workspace, so it needs a
+  // bearer even though the host isn't a workspace host itself.
+  parsed.hostname.endsWith(".databricksapps.com");
 
 if (useAuth) {
   const token = resolveToken(parsed.origin);
@@ -115,8 +181,10 @@ if (useAuth) {
     console.log(`[dev-proxy] target=${OMNIGENT_URL} (authenticated)`);
   } else {
     console.error(
-      `\n[dev-proxy] ERROR: No auth token for ${parsed.origin}.\n` +
-        `  Set OMNIGENT_AUTH_TOKEN or run:  databricks auth login --host ${parsed.origin}\n`,
+      `\n[dev-proxy] ERROR: No auth token for ${OMNIGENT_AUTH_HOST ?? parsed.origin}.\n` +
+        `  Run:  databricks auth login --host ${OMNIGENT_AUTH_HOST ?? parsed.origin}\n` +
+        `  For a Databricks App, set OMNIGENT_AUTH_PROFILE (or OMNIGENT_AUTH_HOST)\n` +
+        `  to the workspace that hosts it.\n`,
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Related issue

N/A — dev-tooling fix (no behavior change to the shipped app).

## Summary

Pointing the Vite dev server at a deployed Databricks App worked for about an hour and then quietly stopped: every request 302'd to the login page while the dev server itself stayed up, so it looked alive but wouldn't load. Restarting fixed it, for another hour.

Two causes:

- **The token was resolved once per process.** `resolveToken` cached in module scope and returned that value forever, so once the ~1h workspace OAuth token expired the proxy kept attaching a dead bearer.
- **`*.databricksapps.com` didn't turn auth on.** The `useAuth` check only matched `.databricks.com` / `.azuredatabricks.net`. An app host is OAuth-gated by the workspace that hosts it but isn't a workspace host itself, so the only way to reach one was to pass `OMNIGENT_AUTH_TOKEN` explicitly — which nothing can refresh, reproducing the first problem by construction.

Changes:

- Cache the token against its own JWT `exp` and re-mint 5 minutes before it lapses (30-minute assumed TTL if the token isn't a readable JWT).
- Treat a `*.databricksapps.com` target as auth-requiring.
- Mint from a named `.databrickscfg` profile via `OMNIGENT_AUTH_PROFILE`. A workspace host is routinely shared by several profiles and `databricks auth token --host` refuses to guess between them — which is exactly what failed here. `OMNIGENT_AUTH_HOST` stays available for the unambiguous case.
- Report what the CLI actually said on failure. It was being swallowed, leaving a bare "No auth token" when the CLI had already named the cause (ambiguous profile, expired login, missing binary).
- Document the whole flow in `web/README.md`.

`OMNIGENT_AUTH_TOKEN` still works and is used verbatim; it's now documented as the un-refreshable escape hatch.

## Test Plan

Verified live against a real deployed app (`https://omnigents-…aws.databricksapps.com`), driving the dev proxy end to end.

**Auth now engages for an apps host, with no explicit token:**

```
OMNIGENT_URL=https://<app>.aws.databricksapps.com OMNIGENT_AUTH_PROFILE=oss pnpm run dev
→ [dev-proxy] target=https://<app>.aws.databricksapps.com (authenticated)
→ /health                  200
→ /v1/sessions?limit=2     2 sessions
```

**The refresh path actually re-mints** — not just the first mint. Temporarily forced the skew so every request treats the cached token as stale, then issued five requests: each re-minted and all five returned `200`, with zero `auth token failed` lines. Reverted the constant afterwards.

**The profile requirement is not theoretical** — `--host` against this workspace fails, which is what the first attempt hit before the profile knob existed:

```
[dev-proxy] ERROR: No auth token for https://<workspace>.cloud.databricks.com
```

Formatting/lint clean (`prettier --check`, `oxlint`) on both changed files.

No automated test: this is dev-server config that runs outside the app bundle and shells out to the `databricks` CLI, so covering it would mean stubbing the CLI and Vite's proxy plumbing for a file that CI never executes. Verified by live runs above instead.

## Demo

N/A — dev tooling, no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual, against a live deployed Databricks App — see the Test Plan for the three scenarios (auth engages for an apps host; the refresh path re-mints under a forced-stale skew; `--host` genuinely fails where a profile succeeds).

Not covered automatically: `vite.config.ts` is dev-server configuration that CI never runs, and the token path shells out to the `databricks` CLI. A test would have to stub both the CLI and Vite's proxy hooks to assert wiring that production never executes, so the cost/benefit didn't land for me. Happy to add one if you'd rather have it pinned.

## Changelog

The web dev server can now point at a deployed Databricks App and keeps its auth token fresh instead of silently expiring after an hour
