### PR TITLE
fix(routing): OSS judge fallback, family-confined child spawns, routed-harness inbox delivery

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1878,6 +1878,12 @@ def create_runner_app(
     _live_response_id: dict[str, str] = {}
     _session_start_cache: dict[str, float] = {}  # session_id → registered start time
     _session_spec_cache: dict[str, _SpecEntry | None] = {}  # session_id → session AgentSpec
+    # session_id → the harness the session actually runs, when it differs from
+    # the spec's. Smart Routing pins a routed child's harness on the
+    # conversation and forwards it as ``harness_override``; without this record
+    # every spec-derived read (native-vs-SDK checks above all) still answers
+    # with the harness the spec declared, which a routed session is not on.
+    _session_harness_overrides: dict[str, str] = {}
     _session_snapshot_cache: dict[str, _SessionSnapshot] = {}  # session_id → snapshot
     _session_snapshot_locks: dict[str, asyncio.Lock] = {}  # session_id → snapshot fetch lock
     _session_spec_locks: dict[str, asyncio.Lock] = {}  # session_id → spec resolution lock
@@ -2638,6 +2644,10 @@ def create_runner_app(
         # endpoint at all.
         _routing_class = init_context.routing_class
         remember_session_routing_class(session_id, _routing_class)
+        if init_context.envelope is not None:
+            _note_session_harness_override(
+                session_id, init_context.envelope.snapshot.harness_override
+            )
 
         spec: AgentSpec | None = None
         spec_entry: _SpecEntry | None = None
@@ -3262,6 +3272,7 @@ def create_runner_app(
         forget_session_routing_class(session_id)
 
         _session_spec_cache.pop(session_id, None)
+        _session_harness_overrides.pop(session_id, None)
         _session_skills_cache.pop(session_id, None)
         _session_cursor_model_names.pop(session_id, None)
         _drop_session_claude_launch_config(session_id)
@@ -3742,7 +3753,32 @@ def create_runner_app(
             title=snapshot.sub_agent_name or "",
         )
 
+    def _note_session_harness_override(conv_id: str, harness_override: str | None) -> None:
+        """Record the harness a session was forwarded, so reads match the run.
+
+        A routed child arrives with ``harness_override`` naming a harness its
+        (sub-)agent spec never declared — Smart Routing picks it on the first
+        message. The ``"auto"`` sentinel is not a harness, so it is ignored.
+
+        :param conv_id: Session/conversation id, e.g. ``"conv_child456"``.
+        :param harness_override: The forwarded override, e.g. ``"codex"``.
+        :returns: None.
+        """
+        if not harness_override or harness_override == "auto":
+            return
+        _session_harness_overrides[conv_id] = (
+            canonicalize_harness(harness_override) or harness_override
+        )
+
     def _session_harness_name(conv_id: str) -> str | None:
+        # The override wins: a routed session runs the harness the server
+        # pinned, not the one its spec declares. Reading the spec here left a
+        # sub-agent whose spec says ``claude-native`` looking native while it
+        # actually ran ``claude-sdk``, so its completion was never pushed to
+        # the parent inbox (the native path that owes it never ran).
+        override = _session_harness_overrides.get(conv_id)
+        if override is not None:
+            return override
         spec = _session_spec_cache.get(conv_id)
         if spec is None:
             return None
@@ -5138,6 +5174,7 @@ def create_runner_app(
                 _dispatched_agent_id,
             )
             _session_spec_cache.pop(conv, None)
+            _session_harness_overrides.pop(conv, None)
             _session_skills_cache.pop(conv, None)
             _session_cursor_model_names.pop(conv, None)
             _drop_session_claude_launch_config(conv)
@@ -5206,6 +5243,7 @@ def create_runner_app(
         harness_name: str | None = None
         spawn_env: dict[str, str] | None = None
         instructions: str | None = None
+        _note_session_harness_override(conv, cast(str | None, msg_body.get("harness_override")))
         if cached_spec is not None:
             h = (
                 cast(str | None, msg_body.get("harness_override"))
@@ -5510,6 +5548,7 @@ def create_runner_app(
         spawn_env = (
             dispatch.spawn_env if dispatch else cast(dict[str, str] | None, body.get("spawn_env"))
         )
+        _note_session_harness_override(conv_id, cast(str | None, body.get("harness_override")))
         startup_envelope = _fresh_session_init_envelope(conv_id)
         startup_labels = startup_envelope.snapshot.labels if startup_envelope is not None else None
         if not harness_name:
@@ -8068,6 +8107,7 @@ def create_runner_app(
 
     def _clear_session_agent_caches(session_id: str, agent_id: str | None = None) -> None:
         _session_spec_cache.pop(session_id, None)
+        _session_harness_overrides.pop(session_id, None)
         _session_skills_cache.pop(session_id, None)
         _session_cursor_model_names.pop(session_id, None)
         _drop_session_claude_launch_config(session_id)

--- a/omnigent/runner/subagent_routing.py
+++ b/omnigent/runner/subagent_routing.py
@@ -724,12 +724,15 @@ async def _decide(
     # ``raw_model`` / ``applied`` stay truthful to whatever the router picks.
     task = _routing_task(req)
 
-    from omnigent.server.routing_backend import backends_from_caps, select_router
+    from omnigent.server.routing_backend import (
+        backends_from_caps,
+        route_with_fallback,
+        select_router,
+    )
 
-    router = select_router(backends_from_caps(caps), gateway_backed=gateway_backed)
-    if router is None:
+    backends = backends_from_caps(caps)
+    if select_router(backends, gateway_backed=gateway_backed) is None:
         return _unavailable_decision("no routing client configured")
-    client = router.client
 
     candidates = (
         available_models
@@ -750,26 +753,31 @@ async def _decide(
     # allow with no model, the hook leaves ``tool_input`` untouched, and the
     # spawn runs on exactly the model it named.
     raised: str | None = None
+    client: Any = backends.any()  # type: ignore[explicit-any]
+    source: str | None = None
+    result = None
     try:
-        result = await client.route(task, candidates)
+        call = await route_with_fallback(backends, task, candidates, gateway_backed=gateway_backed)
     except Exception as exc:  # noqa: BLE001 — router outages are a normal path here
         _logger.warning(
             "route-subagent: router call failed for session=%s", session_id, exc_info=True
         )
-        result = None
         # A client that raises past its own error reporting leaves
         # ``last_error`` unset; without this the chip said only "no verdict"
         # and the cause lived in the server log alone.
         from omnigent.server.smart_routing import failure_detail
 
         raised = f"router call failed: {failure_detail(exc)}"
+    else:
+        if call is not None:
+            result, client, source = call.result, call.client, call.source
     if result is None or not getattr(result, "model", None):
         detail = (
             _opt_str(getattr(client, "last_error", None)) or raised or "router returned no verdict"
         )
         return _unavailable_decision(detail)
 
-    return replace(_decision_from_result(req, result, candidates), router_source=router.source)
+    return replace(_decision_from_result(req, result, candidates), router_source=source)
 
 
 def _requested_match(req: SubagentRouteRequest, model: str | None) -> bool:

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -4525,23 +4525,29 @@ async def _forward_event_to_runner(
                     route_session_harness,
                 )
 
-                # A child may only leave its parent's harness family when the
-                # parent is in Smart Routing (auto) harness mode; otherwise the
-                # candidate set is the parent's family, so a codex session's
-                # children stay on codex. Same family rule the native-subagent
-                # hook path applies to in-harness spawns.
-                _child_family = (
-                    None
-                    if auto_harness_session(conv, _parent_conv)
-                    else harness_family(_resolve_harness(_parent_conv))
-                )
-                # Which families the pick may land on decides whose gateway
+                # Confine the pick to the harness this CHILD runs. A child that
+                # reaches here has one: either its sub-agent spec declares it
+                # (a named worker like polly's ``pi``) or the spawn pinned it —
+                # an unpinned child of a Smart Routing parent carries the
+                # "auto" sentinel and was resolved by the auto block above.
+                # Read off the PARENT before, which offered a pi worker the
+                # brain's claude family and a claude worker the codex family;
+                # under an auto parent it dropped the restriction entirely, so
+                # a pi child could be handed a codex verdict it then ran pi on.
+                _child_harness = _resolve_harness(conv)
+                _child_pinned = _child_harness is not None and _child_harness != "auto"
+                _child_family = harness_family(_child_harness) if _child_pinned else None
+                # A single-harness candidate set is the honest offer for a
+                # pinned child: the family filter alone still admits the other
+                # harnesses in that family (a ``codex-native`` child would be
+                # offered SDK ``codex``), and it cannot narrow a harness whose
+                # family is unknown at all.
+                _child_candidates = (_child_harness,) if _child_pinned else None
+                # Which harnesses the pick may land on decides whose gateway
                 # backing must hold: a cross-harness child can go either way, a
-                # family-restricted one only where its parent already runs.
+                # pinned one only where it already runs.
                 _child_gateway_harnesses = (
-                    AUTO_NATIVE_ROUTING_HARNESSES
-                    if _child_family is None
-                    else (_resolve_harness(_parent_conv) or "",)
+                    (_child_harness or "",) if _child_pinned else AUTO_NATIVE_ROUTING_HARNESSES
                 )
                 _child_host = await _session_routing_host(conv, host_store)
                 if _child_host is None and _parent_conv is not None:
@@ -4557,6 +4563,7 @@ async def _forward_event_to_runner(
                     catalog_session_id=conv.parent_conversation_id,
                     runner_client=runner_client,
                     allowed_family=_child_family,
+                    harness_candidates=_child_candidates,
                     gateway_backed=_child_backed,
                     allow_static_fallback=_child_backed,
                 )
@@ -6786,6 +6793,40 @@ def _spec_routes_its_own_harness(
     return _validated_spec_smart_routing_harness(loaded.spec) is not None
 
 
+def _spawn_pins_its_harness(
+    body: SessionCreateRequest,
+    agent: Agent,
+    agent_cache: AgentCache | None,
+) -> bool:
+    """Whether this child create already names the harness the child runs on.
+
+    Two pins count, and both come from outside the router: an explicit
+    ``harness_override`` on the spawn, and a declared sub-agent whose spec
+    carries its own harness (polly's ``pi`` / ``claude_code`` workers). Either
+    way the child's CLI is decided before any message is routed, so handing the
+    router the whole multi-harness catalog can only produce a verdict the pane
+    will not honor.
+
+    :param body: The validated create request.
+    :param agent: The parent agent row whose bundle holds the sub-agent specs.
+    :param agent_cache: Cache for loading the parsed parent bundle. ``None``
+        cannot resolve a sub-agent spec, so only the explicit pin is seen.
+    :returns: ``True`` when the child's harness is already chosen.
+    """
+    if body.harness_override is not None:
+        return True
+    if not body.sub_agent_name:
+        return False
+    from omnigent.model_catalog import spec_harness
+
+    sub_spec = _resolve_subagent_spec(
+        agent=agent,
+        sub_agent_name=body.sub_agent_name,
+        agent_cache=agent_cache,
+    )
+    return sub_spec is not None and spec_harness(sub_spec) is not None
+
+
 async def _resolve_fixed_native_model_routing(
     body: SessionCreateRequest,
     request: Request,
@@ -7154,6 +7195,15 @@ async def _create_session_from_existing_agent(
     # child, so a codex session ends up with claude children. Those children
     # keep the harness they were created with and are routed in-family (see
     # the child-routing call in ``_forward_event_to_runner``).
+    #
+    # Nor is a spawn that NAMED its harness forced: a declared sub-agent
+    # (polly's ``pi``) and an explicit ``harness_override`` both pin the CLI the
+    # child boots on, which the sentinel does not move — it only re-decides the
+    # row. Forcing them handed the router the whole catalog for a pane already
+    # committed to one harness, so a ``pi`` worker could be stamped with an
+    # applied codex verdict while running pi, and a ``claude-native`` worker
+    # lost its terminal labels (skipped for forced-auto children below). Those
+    # children route in their own family instead.
     _force_auto_for_child = False
     _parent_for_routing: Conversation | None = None
     if body.parent_session_id is not None:
@@ -7164,6 +7214,7 @@ async def _create_session_from_existing_agent(
             _parent_for_routing is not None
             and subagent_routing_enabled(_parent_for_routing.subagent_routing_override)
             and auto_harness_session(_parent_for_routing)
+            and not await asyncio.to_thread(_spawn_pins_its_harness, body, agent, agent_cache)
         ):
             try:
                 await asyncio.to_thread(_validated_harness_override_executor_type, agent)

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -6369,6 +6369,42 @@ def _oss_routing_available(caps: Any = None) -> bool:  # type: ignore[explicit-a
     return backends_from_caps(caps).local is not None
 
 
+def _external_router_usable(caps: Any = None) -> bool:  # type: ignore[explicit-any]
+    """Whether the external ``routes:select`` router can still answer here.
+
+    False for a deployment that configures none, and for one whose router has
+    latched a permanent failure (its workspace has no routing API) — the
+    surfaces that need a task_v1 menu then take their judge-only shape.
+
+    :param caps: A ``RuntimeCaps``-shaped object. ``None`` reads the globals.
+    :returns: ``True`` when an external routing client can serve a call.
+    """
+    from omnigent.server.routing_backend import backends_from_caps, usable_external
+
+    if caps is None:
+        try:
+            from omnigent.runtime._globals import _caps
+        except ImportError:
+            return False
+        caps = _caps
+    return usable_external(backends_from_caps(caps)) is not None
+
+
+def _judge_only_harness_note(harness: str, verdict: dict[str, Any]) -> str:
+    """Explain on the chip why only the model was routed.
+
+    :param harness: The pane the create kept, e.g. ``"claude-native"``.
+    :param verdict: The routing verdict whose rationale is being extended.
+    :returns: The rationale to show, with the harness note appended.
+    """
+    rationale = str(verdict.get("rationale") or "").strip()
+    note = (
+        f"Harness routing needs the workspace router, which is unavailable here; "
+        f"kept {harness} and routed the model with the built-in judge."
+    )
+    return f"{rationale} {note}".strip()
+
+
 async def _session_routing_host(
     conv: Conversation,
     host_store: HostStore | None,
@@ -6820,6 +6856,9 @@ async def _resolve_native_smart_routing(
 
     Falls back to the first installed candidate when routing is unavailable, so
     the session still lands on a terminal (with the CLI's own default model).
+    Same candidate when only the built-in judge is configured: choosing between
+    two panes is the workspace router's job, so a judge-only deployment routes
+    the default pane's MODEL and says so on the chip.
 
     :param body: The create request; ``smart_routing_message`` carries the
         routing text and ``host_id`` selects whose CLIs are on offer.
@@ -6838,7 +6877,11 @@ async def _resolve_native_smart_routing(
     :raises HTTPException: 404 if ``host_id`` is unknown, 403 if it belongs
         to another user.
     """
-    from omnigent.server.smart_routing import AUTO_NATIVE_ROUTING_HARNESSES, route_session_harness
+    from omnigent.server.smart_routing import (
+        AUTO_NATIVE_ROUTING_HARNESSES,
+        models_in_family,
+        route_session_harness,
+    )
 
     host = await _routing_host_for_create(body, request, user_id)
     # Both arms must be gateway-backed before the WORKSPACE router may choose
@@ -6854,13 +6897,46 @@ async def _resolve_native_smart_routing(
     if not installed:
         return None, None, None, "No native CLI is installed on this host."
 
+    # Choosing BETWEEN native panes belongs to the workspace router: its menu is
+    # what ranks two CLIs against one task, and the pick is baked into the
+    # terminal launch. With no external router usable, this create keeps the
+    # default pane and routes only its model with the built-in judge — a normal
+    # Smart Routing session, minus the harness half — instead of declining.
+    judge_only = not _external_router_usable()
+    candidates = (installed[0],) if judge_only else installed
     harness, model, verdict, error = await route_session_harness(
         body.smart_routing_message or "",
-        harness_candidates=installed,
-        catalog=await _pre_session_model_catalog(request, host, installed),
+        harness_candidates=candidates,
+        catalog=await _pre_session_model_catalog(request, host, candidates),
         gateway_backed=backed,
         allow_static_fallback=backed,
     )
+    if judge_only:
+        kept = native_coding_agent_for_harness(candidates[0])
+        kept_name = kept.agent_name if kept is not None else None
+        if model is None or verdict is None:
+            return (
+                kept_name,
+                None,
+                None,
+                error or "Routing unavailable; using the default native harness.",
+            )
+        if not models_in_family(candidates[0], [model]):
+            # One pane on offer, so the seam resolves any pick onto it — and an
+            # out-of-family model would reach the launch as a ``--model`` this
+            # CLI cannot run. Keep the pane, pin nothing, say why.
+            return (
+                kept_name,
+                None,
+                None,
+                f"Not applied: this {candidates[0]} session cannot run {model}.",
+            )
+        return (
+            kept_name,
+            model,
+            {**verdict, "rationale": _judge_only_harness_note(candidates[0], verdict)},
+            None,
+        )
     native_agent = native_coding_agent_for_harness(harness) if harness is not None else None
     if native_agent is None:
         # Routing unavailable (or it named something that is not a native

--- a/omnigent/server/routing_backend.py
+++ b/omnigent/server/routing_backend.py
@@ -9,17 +9,24 @@ candidate menu it is handed, so it serves any harness.
 Gateway backing therefore selects the SOURCE rather than hiding the surface: an
 off-gateway pane still routes, just with the built-in judge, and the decision
 records which router answered so the UI can say so.
+
+The same holds when the preferred router FAILS: :func:`route_with_fallback`
+asks the judge behind it rather than declining the call, which is what keeps a
+deployment whose workspace has no routing API on Smart Routing at all.
 """
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from omnigent.server.smart_routing import RoutingClient
+    from omnigent.server.smart_routing import RoutingClient, RoutingResult
+
+_logger = logging.getLogger(__name__)
 
 #: Which router produced a decision. ``"databricks-aigw"`` is the external
 #: ``task_v1`` service; ``"oss-llm"`` is the built-in judge.
@@ -53,6 +60,23 @@ class RoutingBackends:
         return self.external or self.local
 
 
+def usable_external(backends: RoutingBackends) -> RoutingClient | None:
+    """The external client, unless it has latched a permanent failure.
+
+    A workspace whose routing API is not enabled answers every
+    ``routes:select`` the same way, so the client latches that and this reads
+    as "no external router" from then on — the deployment's real posture for
+    the rest of the process.
+
+    :param backends: The deployment's configured clients.
+    :returns: The external client when it can still answer, else ``None``.
+    """
+    client = backends.external
+    if client is None or getattr(client, "permanently_unavailable", False):
+        return None
+    return client
+
+
 @dataclass(frozen=True)
 class RouterChoice:
     """A selected router and the source name to stamp on its decision.
@@ -79,11 +103,83 @@ def select_router(
     :returns: The chosen client plus its source, or ``None`` when neither
         backend can serve (today's "routing unavailable").
     """
-    if gateway_backed and backends.external is not None:
-        return RouterChoice(client=backends.external, source="databricks-aigw")
+    external = usable_external(backends)
+    if gateway_backed and external is not None:
+        return RouterChoice(client=external, source="databricks-aigw")
     if backends.local is not None:
         return RouterChoice(client=backends.local, source="oss-llm")
     return None
+
+
+@dataclass(frozen=True)
+class RoutedCall:
+    """The answer one routing call got, and who gave it.
+
+    :param result: The verdict, or ``None`` when nothing could answer.
+    :param source: Which router answered (or was asked last).
+    :param client: The client asked last, so the caller can read its
+        ``last_error`` for the reason behind a ``None`` *result*.
+    """
+
+    result: RoutingResult | None
+    source: RouterSource
+    client: RoutingClient
+
+
+async def route_with_fallback(
+    backends: RoutingBackends,
+    message: str,
+    available_models: dict[str, list[str]],
+    *,
+    gateway_backed: bool,
+) -> RoutedCall | None:
+    """Call the deployment's router, falling back to the judge when it fails.
+
+    The external service is still preferred wherever it can serve — that is the
+    Databricks posture and this does not change it. What it adds is that its
+    failure is no longer the end of the call: a deployment that also configures
+    the built-in judge routes with the judge instead of declining, and the
+    decision records ``oss-llm`` so the chip says who answered.
+
+    :param backends: The deployment's configured clients.
+    :param message: The task text to route on.
+    :param available_models: Harness id → candidate model ids.
+    :param gateway_backed: Whether every harness family involved resolves
+        AI-Gateway-backed inference (see :func:`select_router`).
+    :returns: The answer, or ``None`` when no backend is configured at all.
+    :raises Exception: Whatever the client that answered last raised — the
+        external one only when there is no judge to fall back to, so each
+        caller's existing fail-open handling still sees it.
+    """
+    choice = select_router(backends, gateway_backed=gateway_backed)
+    if choice is None:
+        return None
+    if choice.source != "databricks-aigw" or backends.local is None:
+        return RoutedCall(
+            result=await choice.client.route(message, available_models),
+            source=choice.source,
+            client=choice.client,
+        )
+    try:
+        result = await choice.client.route(message, available_models)
+    except Exception:  # noqa: BLE001 — the judge is the fallback for any failure
+        _logger.warning(
+            "routing: the external router raised; falling back to the built-in judge",
+            exc_info=True,
+        )
+    else:
+        if result is not None:
+            return RoutedCall(result=result, source="databricks-aigw", client=choice.client)
+        _logger.info(
+            "routing: the external router gave no verdict (%s); "
+            "falling back to the built-in judge",
+            getattr(choice.client, "last_error", None),
+        )
+    return RoutedCall(
+        result=await backends.local.route(message, available_models),
+        source="oss-llm",
+        client=backends.local,
+    )
 
 
 def reported_gateway_inference(
@@ -172,6 +268,11 @@ def _managed_llm_capability(caps: Any) -> bool:  # type: ignore[explicit-any]  #
 def routing_sources(caps: Any) -> dict[str, bool]:  # type: ignore[explicit-any]  # RuntimeCaps
     """Report which routers this deployment can answer a routing call with.
 
+    Reports what can answer NOW, not what was configured: an external client
+    that has latched a permanent failure (its workspace has no routing API)
+    reads as absent, so ``/v1/info`` stops advertising a router that will only
+    decline. Nothing about that is persisted — a restart re-probes.
+
     :param caps: A ``RuntimeCaps`` (or structural equivalent), or ``None``.
     :returns: ``{"external": ..., "oss": ...}`` — ``"external"`` is the
         workspace AI-Gateway ``task_v1`` client, ``"oss"`` the built-in judge
@@ -179,7 +280,7 @@ def routing_sources(caps: Any) -> dict[str, bool]:  # type: ignore[explicit-any]
     """
     backends = backends_from_caps(caps)
     return {
-        "external": backends.external is not None,
+        "external": usable_external(backends) is not None,
         "oss": backends.local is not None or _managed_llm_capability(caps),
     }
 

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -662,6 +662,24 @@ def _router_error_detail(body: str) -> str:
     return text[:300]
 
 
+def router_permanently_disabled(status_code: int, body: str) -> bool:
+    """Whether the router's answer reports a condition no retry can clear.
+
+    A workspace without the routing API answers ``routes:select`` with a 404
+    saying it is not enabled for the account. That is configuration, not an
+    outage: every later call would 404 identically, so the client latches it
+    and the deployment's other backend answers instead.
+
+    :param status_code: The response status.
+    :param body: The raw response text.
+    :returns: ``True`` when the service is disabled for this account.
+    """
+    if status_code != 404:
+        return False
+    text = (body or "").lower()
+    return "routes:select" in text and "not enabled" in text
+
+
 # ── Route-options seam ──────────────────────────────────────────────────────
 #
 # Every assumption about the router's wire contract lives here: the arms it
@@ -1597,6 +1615,12 @@ class ExternalRoutingClient:
         # a 401 or the router's required-model-set error). Set on every failure
         # path, cleared on success.
         self.last_error: str | None = None
+        # Latched once the service reports a condition no retry can clear (the
+        # routing API is not enabled for this account). Every later call short-
+        # circuits to the stored reason, so a deployment whose workspace has no
+        # routing API pays one request, not one per turn.
+        self.permanently_unavailable = False
+        self._permanent_error: str | None = None
 
     def _resolve_credentials(self) -> tuple[Any, Mapping[str, str]]:  # type: ignore[explicit-any]
         """Resolve one request's credentials as ``(httpx auth, extra headers)``.
@@ -1695,6 +1719,11 @@ class ExternalRoutingClient:
 
         from omnigent.api.routing.v1 import routing_pb2 as pb
 
+        if self.permanently_unavailable:
+            # The account has no routing API; skip the call rather than spend a
+            # round trip per turn to be told so again.
+            self.last_error = self._permanent_error
+            return None
         # The seam turns the catalog into router vocabulary and injects
         # whatever arms the router's scenario menu demands.
         harnesses = list(available_models)
@@ -1763,6 +1792,14 @@ class ExternalRoutingClient:
             self.last_error = (
                 f"router returned HTTP {resp.status_code}: {_router_error_detail(resp.text)}"
             )
+            if router_permanently_disabled(resp.status_code, resp.text):
+                _logger.warning(
+                    "ExternalRoutingClient: %s is not enabled for this account; "
+                    "no further routes:select calls will be made in this process",
+                    self._url,
+                )
+                self.permanently_unavailable = True
+                self._permanent_error = self.last_error
             return None
         try:
             out = json_format.ParseDict(resp.json(), pb.SelectRouteResponse())
@@ -1933,10 +1970,14 @@ async def route_session_harness(
     except ImportError:
         return None, None, None, "Smart routing is not available."
 
-    from omnigent.server.routing_backend import backends_from_caps, select_router
+    from omnigent.server.routing_backend import (
+        backends_from_caps,
+        route_with_fallback,
+        select_router,
+    )
 
-    router = select_router(backends_from_caps(_caps), gateway_backed=gateway_backed)
-    if router is None:
+    backends = backends_from_caps(_caps)
+    if select_router(backends, gateway_backed=gateway_backed) is None:
         return None, None, None, "Smart routing is not configured on this server."
 
     # Fetch the live catalog. Its rows are keyed by worker name (sub-agent
@@ -2004,15 +2045,20 @@ async def route_session_harness(
         return None, None, None, "No routable harnesses are available on this runner."
 
     try:
-        result = await router.client.route(user_message, harness_models)
+        call = await route_with_fallback(
+            backends, user_message, harness_models, gateway_backed=gateway_backed
+        )
     except Exception as exc:  # routing failures must not block session creation
         _logger.exception("smart_routing: route_session_harness failed")
         return None, None, None, f"Routing call failed: {failure_detail(exc)}"
+    if call is None:
+        return None, None, None, "Smart routing is not configured on this server."
+    result = call.result
 
     if result is None:
         # Surface the client's specific failure reason (e.g. HTTP 401 with the
         # gateway's message) when it exposes one; otherwise a generic note.
-        detail = routing_last_error(router.client)
+        detail = routing_last_error(call.client)
         reason = (
             f"Routing unavailable: {detail}"
             if detail
@@ -2070,7 +2116,7 @@ async def route_session_harness(
     verdict: dict[str, Any] = {
         "model": chosen_model,
         "rationale": result.rationale,
-        "router_source": router.source,
+        "router_source": call.source,
     }
     if raw_model and _bare_id(raw_model, prefixes) != _bare_id(chosen_model, prefixes):
         verdict["raw_model"] = raw_model
@@ -2120,10 +2166,14 @@ async def route_turn(
     except ImportError:
         return None, None
 
-    from omnigent.server.routing_backend import backends_from_caps, select_router
+    from omnigent.server.routing_backend import (
+        backends_from_caps,
+        route_with_fallback,
+        select_router,
+    )
 
-    router = select_router(backends_from_caps(_caps), gateway_backed=gateway_backed)
-    if router is None:
+    backends = backends_from_caps(_caps)
+    if select_router(backends, gateway_backed=gateway_backed) is None:
         _logger.info(
             "smart_routing: route_turn skipped for session=%s: no routing client configured",
             session_id,
@@ -2186,9 +2236,12 @@ async def route_turn(
             )
             return None, None
 
-    result = await router.client.route(user_message, available)
-    if result is None:
+    call = await route_with_fallback(
+        backends, user_message, available, gateway_backed=gateway_backed
+    )
+    if call is None or call.result is None:
         return None, None
+    result = call.result
 
     # An injected arm can still come back barred (the menu is offered whole), and
     # a turn cannot change harness — so swap the model for one this gateway
@@ -2220,7 +2273,7 @@ async def route_turn(
     verdict: dict[str, Any] = {
         "model": model,
         "rationale": result.rationale,
-        "router_source": router.source,
+        "router_source": call.source,
     }
     if raw_model and _bare_id(raw_model, prefixes) != _bare_id(model, prefixes):
         verdict["raw_model"] = raw_model

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -2081,6 +2081,27 @@ async def route_session_harness(
         if result.harness
         else harness_for_model(chosen_model, harness_models, prefixes=prefixes)
     )
+    if chosen_harness is not None and chosen_harness not in harness_models:
+        # A harness this call never offered is not a verdict — it is a pick the
+        # caller cannot honor. A child confined to one harness would otherwise
+        # have another family's harness written to its row and stamped
+        # "applied" while its pane keeps running the harness it booted on.
+        # A verdict may still spell an offered harness as its WORKER name
+        # (``claude_code``), which is the same harness, not an escape.
+        from omnigent.harness_aliases import canonicalize_harness
+
+        _spelled = _WORKER_NAME_TO_HARNESS.get(chosen_harness) or canonicalize_harness(
+            chosen_harness
+        )
+        if _spelled in harness_models:
+            chosen_harness = _spelled
+        else:
+            _logger.info(
+                "smart_routing: dropping verdict harness=%s; offered=%s",
+                chosen_harness,
+                offered,
+            )
+            chosen_harness = None
     if chosen_harness is None and result.harness in harness_models:
         # Every offered harness bars the pick, and the family the caller allowed
         # is not negotiable — swap the model instead of the harness.

--- a/tests/e2e/routing/_mock_router.py
+++ b/tests/e2e/routing/_mock_router.py
@@ -17,6 +17,10 @@ task_v1 behaviour the CUJ matrix in this directory is scored against:
 * Picks come only from ``route_options``, and the rationale is the same rule
   trace the live router emits (captured verbatim from staging logs), so the
   chips and decision cards under test carry production-shaped text.
+* :attr:`MockRouter.disabled` reproduces a workspace whose account never had
+  the routing API turned on: every ``routes:select`` answers the 404 that
+  deployment gets (:data:`NOT_ENABLED_MESSAGE`), which is a permanent
+  condition rather than an outage.
 
 The rule table is :func:`decide`; it is the whole routing policy and is unit
 tested by ``test_mock_router.py``.
@@ -63,6 +67,10 @@ ROUTES_SELECT_PATH = "/routes:select"
 #: Base path the mock serves under, so the configured ``base_url`` looks like
 #: the gateway's (``.../ai-gateway/routing/v1``) rather than a bare host.
 BASE_PATH = "/ai-gateway/routing/v1"
+
+#: What a workspace without the routing API answers, verbatim. The condition is
+#: account-level, so it never clears on retry.
+NOT_ENABLED_MESSAGE = "routing/v1/routes:select is not enabled for this account."
 
 # Deterministic stand-ins for task_v1's "errors or code refs" regex family:
 # stack traces, file paths, backticked symbols, code fences, CLI flags.
@@ -293,6 +301,8 @@ class MockRouter:
 
     base_url: str
     calls: list[RecordedCall] = field(default_factory=list)
+    #: Serve the account-level "not enabled" 404 instead of routing.
+    disabled: bool = False
     _lock: threading.Lock = field(default_factory=threading.Lock)
 
     def record(self, call: RecordedCall) -> None:
@@ -382,6 +392,19 @@ def _handler_class(router: MockRouter) -> type[BaseHTTPRequestHandler]:
             )
             prompt = str((body.get("task") or {}).get("prompt") or "")
             router_name = (body.get("route_selector") or {}).get("router_name")
+            if router.disabled:
+                router.record(
+                    RecordedCall(
+                        prompt=prompt,
+                        offered=offered,
+                        router_name=router_name,
+                        status=404,
+                        model=None,
+                        rationale=None,
+                    )
+                )
+                self._reply(404, {"error_code": "NOT_FOUND", "message": NOT_ENABLED_MESSAGE})
+                return
             try:
                 payload = select_route(body)
             except MenuRejected as exc:

--- a/tests/runner/test_native_subagent_inbox_delivery.py
+++ b/tests/runner/test_native_subagent_inbox_delivery.py
@@ -29,6 +29,7 @@ from tests.runner.conftest import (
     _FakeProcessManager,
     _runner_client,
     _ScriptedHarnessClient,
+    _sse,
 )
 
 # Reuse the proven runner-turn stubs from the sessions-native suite.
@@ -348,3 +349,78 @@ async def test_top_level_session_idle_is_noop(
 
     assert http == 204
     assert items == []
+
+
+@pytest.mark.asyncio
+async def test_routed_child_off_its_native_spec_still_delivers(
+    _clean_subagent_registry: None,
+) -> None:
+    """A child routed onto an SDK harness delivers, though its spec says native.
+
+    The Smart Routing shape: polly's ``claude_code`` worker declares
+    ``claude-native``, but a routed child is forwarded ``harness_override`` and
+    actually runs ``claude-sdk``. The runner read the harness off the cached
+    SPEC, so the turn looked native and its completion was left to a native
+    path that never runs — the parent waited forever while the pi sibling
+    (whose spec harness is already non-native) was the only one to report.
+    """
+    runner_app._session_inboxes_ref[PARENT_SESSION_ID] = asyncio.Queue()
+    runner_app.register_subagent_work(
+        parent_session_id=PARENT_SESSION_ID,
+        child_session_id=CHILD_SESSION_ID,
+        agent="claude_code",
+        title="joke-claude",
+    )
+    harness_client = _ScriptedHarnessClient(
+        [
+            _sse({"type": "response.created", "response": {"id": "resp_1"}}),
+            _sse({"type": "response.output_text.delta", "delta": "knock knock"}),
+            _sse({"type": "response.completed", "response": {"id": "resp_1"}}),
+        ]
+    )
+    pm = _FakeProcessManager(harness_client)
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return AgentSpec(
+            spec_version=1,
+            name="claude_code",
+            executor=ExecutorSpec(type="omnigent", config={"harness": "claude-native"}),
+        )
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    inbox = runner_app._session_inboxes_ref[PARENT_SESSION_ID]
+    async with _runner_client(app) as client:
+        resp = await client.post(
+            f"/v1/sessions/{CHILD_SESSION_ID}/events",
+            json={
+                "type": "message",
+                "agent_id": "ag_reviewer",
+                "harness_override": "claude-sdk",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "tell me a joke"}],
+                },
+            },
+        )
+        assert resp.status_code in (200, 202), resp.text
+        for _ in range(200):
+            if not inbox.empty():
+                break
+            await asyncio.sleep(0.01)
+
+    items: list[dict[str, Any]] = []
+    while not inbox.empty():
+        items.append(inbox.get_nowait())
+    assert items, (
+        "a routed child finished its turn but nothing reached the parent inbox: "
+        "the runner read the harness off the spec (claude-native) instead of the "
+        "forwarded harness_override (claude-sdk)"
+    )
+    assert items[0]["status"] == "completed"
+    assert items[0]["conversation_id"] == CHILD_SESSION_ID

--- a/tests/server/integration/test_routing_integration.py
+++ b/tests/server/integration/test_routing_integration.py
@@ -915,6 +915,103 @@ async def test_child_of_an_auto_parent_keeps_cross_harness_candidates(
     assert set(routing_client.offered[0]) == {"claude-sdk", "codex", "pi"}
 
 
+@pytest.mark.parametrize(
+    ("case", "picked", "verdict_harness", "applied"),
+    [
+        # The reported verdict: the external router named codex + a gpt arm for
+        # a child spawned onto pi. Nothing offered runs it, so the chip declines.
+        ("cross-family-declines", GPT_MODEL, "codex", False),
+        # An in-family pick is applied normally.
+        ("in-family-applies", ROUTED_MODEL, "pi", True),
+    ],
+)
+async def test_named_worker_child_of_an_auto_parent_stays_on_its_own_harness(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    case: str,
+    picked: str,
+    verdict_harness: str,
+    applied: bool,
+) -> None:
+    """A spawn that named a worker keeps that worker's harness.
+
+    The polly shape: a Smart Routing brain whose ``pi`` sub-agent declares its
+    own harness. The spawn pins the CLI the child boots on, so the router is
+    offered pi alone — it used to be handed every family, and a codex verdict
+    was written to the row and stamped "applied" on a pane running pi.
+    """
+    agent = await create_test_agent(
+        client,
+        name=f"routing-child-named-worker-{case}",
+        executor={
+            "type": "omnigent",
+            "config": {"harness": "claude-sdk", "smart_routing_harness": "auto"},
+        },
+        sub_agents=[{"name": "pi", "executor": {"type": "omnigent", "config": {"harness": "pi"}}}],
+    )
+    parent = await client.post(
+        "/v1/sessions",
+        json={"agent_id": agent["id"], "cost_control_mode_override": "on"},
+    )
+    assert parent.status_code == 201, parent.text
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    parent_conv = conv_store.get_conversation(str(parent.json()["id"]))
+    assert parent_conv is not None
+    assert parent_conv.harness_override == "auto"
+
+    child = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": agent["id"],
+            "parent_session_id": parent.json()["id"],
+            "sub_agent_name": "pi",
+            "title": "pi:joke-pi",
+        },
+    )
+    assert child.status_code == 201, child.text
+    child_conv = conv_store.get_conversation(str(child.json()["id"]))
+    assert child_conv is not None
+    # The named worker is not handed the auto sentinel: its harness is decided.
+    assert child_conv.harness_override != "auto"
+    assert AUTO_HARNESS_LABEL_KEY not in child_conv.labels
+
+    routing_client = FakeRoutingClient(
+        RoutingResult(model=picked, rationale="cheap and fast", harness=verdict_harness)
+    )
+    body = SessionEventInput(
+        type="message",
+        data={"role": "user", "content": [{"type": "input_text", "text": "tell me a joke"}]},
+    )
+    with patch("omnigent.runtime._globals._caps", new=FakeCaps(routing_client=routing_client)):
+        async with echo_runner_client() as runner_client:
+            await orchestration_module._forward_event_to_runner(
+                child_conv.id,
+                child_conv,
+                body,
+                conv_store,
+                runner_client,
+            )
+
+    # Only the child's own harness was on offer.
+    assert set(routing_client.offered[0]) == {"pi"}
+    # And nothing cross-family lands: the row never moves off pi, and the chip
+    # is an in-family pick or an honest decline — never another family stamped
+    # "applied" over a pane that is still running pi.
+    refreshed = conv_store.get_conversation(child_conv.id)
+    assert refreshed is not None
+    assert refreshed.harness_override in (None, "pi")
+    decisions = _routing_decisions(conv_store, child_conv.id)
+    assert len(decisions) == 1
+    assert decisions[0].data.scope == "child_session"
+    assert decisions[0].data.harness in (None, "pi")
+    assert decisions[0].data.applied is applied
+    if applied:
+        assert refreshed.model_override == decisions[0].data.model
+    else:
+        assert decisions[0].data.model == "unavailable"
+        assert refreshed.model_override is None
+
+
 # ── 7b. The subagent-routing switch is the child-spawn gate ────────
 
 

--- a/tests/server/routes/test_native_smart_routing_create.py
+++ b/tests/server/routes/test_native_smart_routing_create.py
@@ -1126,7 +1126,9 @@ async def test_auto_routing_still_runs_when_the_host_reports_no_gateway_map() ->
 
     body = SimpleNamespace(host_id="host_1", smart_routing_message=ROUTING_MESSAGE)
     routing_client = FakeRoutingClient(RoutingResult(model=GPT_MODEL, rationale="narrow change"))
-    with patch("omnigent.runtime._globals._caps", new=FakeCaps(routing_client=routing_client)):
+    # An external router is what puts both panes on the menu; unknown gateway
+    # backing must not take it away.
+    with patch("omnigent.runtime._globals._caps", new=_caps_with(routing_client, oss=False)):
         agent_name, model, _verdict, error = await _resolve_native_smart_routing(
             cast("Any", body),
             cast("Any", _routing_request(_host_reporting(None))),
@@ -1135,6 +1137,55 @@ async def test_auto_routing_still_runs_when_the_host_reports_no_gateway_map() ->
 
     assert error is None
     assert (agent_name, model) == ("codex-native-ui", GPT_MODEL)
+
+
+async def test_a_judge_only_deployment_keeps_the_default_pane_and_routes_its_model() -> None:
+    """Choosing BETWEEN panes needs the workspace router; the model does not.
+
+    A native create bakes its harness into the terminal launch, so with no
+    external router the create keeps the default pane and routes only its
+    model — a normal Smart Routing session minus the harness half — rather
+    than declining into a session with no terminal.
+    """
+    from omnigent.server.routes._sessions.orchestration import _resolve_native_smart_routing
+
+    body = SimpleNamespace(host_id="host_1", smart_routing_message=ROUTING_MESSAGE)
+    judge = FakeRoutingClient(RoutingResult(model=CLAUDE_MODEL, rationale="sized task"))
+    with patch("omnigent.runtime._globals._caps", new=FakeCaps(routing_client=judge)):
+        agent_name, model, verdict, error = await _resolve_native_smart_routing(
+            cast("Any", body),
+            cast("Any", _routing_request(_host_reporting(None))),
+            "alice@example.com",
+        )
+
+    assert error is None
+    assert (agent_name, model) == ("claude-native-ui", CLAUDE_MODEL)
+    assert verdict is not None
+    assert verdict["router_source"] == "oss-llm"
+    # The chip says why the harness did not move.
+    assert "Harness routing" in verdict["rationale"]
+    # Only the kept pane was ever on the menu.
+    assert list(judge.offered[0]) == ["claude-native"]
+
+
+async def test_a_judge_only_create_pins_nothing_when_the_pick_is_out_of_family() -> None:
+    """One pane on offer means any pick resolves onto it — so check the family."""
+    from omnigent.server.routes._sessions.orchestration import _resolve_native_smart_routing
+
+    body = SimpleNamespace(host_id="host_1", smart_routing_message=ROUTING_MESSAGE)
+    judge = FakeRoutingClient(RoutingResult(model=GPT_MODEL, rationale="narrow change"))
+    with patch("omnigent.runtime._globals._caps", new=FakeCaps(routing_client=judge)):
+        agent_name, model, verdict, error = await _resolve_native_smart_routing(
+            cast("Any", body),
+            cast("Any", _routing_request(_host_reporting(None))),
+            "alice@example.com",
+        )
+
+    # The session still opens a terminal; it just keeps the CLI's own model.
+    assert agent_name == "claude-native-ui"
+    assert (model, verdict) == (None, None)
+    assert error is not None
+    assert GPT_MODEL in error
 
 
 async def test_top_level_smart_routing_create_is_rejected_when_no_router_can_serve(
@@ -1234,6 +1285,56 @@ async def test_fixed_harness_routing_create_succeeds_off_the_gateway_with_the_ju
     items = (await client.get(f"/v1/sessions/{created.json()['id']}/items")).json()["data"]
     decisions = [i for i in items if i["type"] == "routing_decision"]
     assert decisions and decisions[0]["router_source"] == "oss-llm"
+
+
+@pytest.mark.parametrize("harness", list(AUTO_NATIVE_ROUTING_HARNESSES))
+async def test_a_pane_create_routes_with_the_judge_when_the_router_is_not_enabled(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    harness: str,
+) -> None:
+    """Picking Smart Routing in the CLI's model menu, on a workspace with no router.
+
+    The gateway backing is fine here — the workspace simply never had the
+    routing API enabled, so ``routes:select`` 404s. The session must still get
+    a normal Smart Routing decision, from the judge.
+    """
+    from omnigent.server.routes._sessions import orchestration
+    from omnigent.server.routing_backend import RoutingBackends
+
+    wrappers = await _native_wrappers(client, db_uri)
+    pick = _OFF_GATEWAY_CATALOG[harness][0]
+    external = FakeRoutingClient(
+        None, last_error="router returned HTTP 404: routes:select is not enabled for this account."
+    )
+    judge = FakeRoutingClient(RoutingResult(model=pick, rationale="sized task"))
+    caps = FakeCaps(
+        routing_client=external,
+        routing_backends=RoutingBackends(external=external, local=judge),
+    )
+    body = {
+        "agent_id": wrappers[harness],
+        "cost_control_mode_override": "on",
+        "smart_routing_message": ROUTING_MESSAGE,
+    }
+    with (
+        patch("omnigent.runtime._globals._caps", new=caps),
+        patch.object(orchestration, "_routing_host_for_create", return_value=_host_reporting({})),
+        patch.object(
+            orchestration,
+            "_pre_session_model_catalog",
+            AsyncMock(return_value={harness: [pick]}),
+        ),
+    ):
+        created = await client.post("/v1/sessions", json=body)
+
+    assert created.status_code == 201, created.text
+    assert created.json()["model_override"] == pick
+    decisions = _routing_decision_items(db_uri, created.json()["id"])
+    assert decisions and decisions[0]["router_source"] == "oss-llm"
+    assert decisions[0]["applied"] is True
+    # The router was asked first — the judge is the fallback, not the default.
+    assert external.calls != []
 
 
 @pytest.mark.parametrize(

--- a/tests/server/test_routing_backend.py
+++ b/tests/server/test_routing_backend.py
@@ -20,9 +20,11 @@ from omnigent.server.routing_backend import (
     RoutingBackends,
     backends_from_caps,
     gateway_backs_all,
+    route_with_fallback,
     routing_available,
     routing_sources,
     select_router,
+    usable_external,
 )
 
 _HOST_ID = "aabbccddeeff00112233445566778899"
@@ -255,3 +257,145 @@ def test_routing_unavailable_when_nothing_is_configured(caps: Any) -> None:
 def test_availability_is_exactly_some_source_can_answer(caps: Any) -> None:
     """The invariant that keeps the flag and the source map from drifting."""
     assert routing_available(caps) is any(routing_sources(caps).values())
+
+
+# ── a latched permanent failure reads as "no external router" ───────────────
+#
+# A workspace whose account never had the routing API enabled answers every
+# ``routes:select`` with the same 404. The client latches that, and this
+# deployment is a judge-only one for as long as the process lives.
+
+
+@dataclass
+class _Tripped:
+    """A client that has latched an account-level permanent failure."""
+
+    name: str = "external"
+    permanently_unavailable: bool = True
+
+
+def test_select_router_skips_a_router_that_latched_a_permanent_failure() -> None:
+    tripped = _Tripped()
+    choice = select_router(RoutingBackends(external=tripped, local=_LOCAL), gateway_backed=True)
+    assert choice is not None
+    assert (choice.client, choice.source) == (_LOCAL, "oss-llm")
+    # Nothing left to answer with once the judge is absent too.
+    assert select_router(RoutingBackends(external=tripped), gateway_backed=True) is None
+
+
+def test_usable_external_hides_a_tripped_client() -> None:
+    assert usable_external(RoutingBackends(external=_EXTERNAL)) is _EXTERNAL
+    assert usable_external(RoutingBackends(external=_Tripped())) is None
+    assert usable_external(RoutingBackends(local=_LOCAL)) is None
+
+
+def test_routing_sources_stops_advertising_a_tripped_router() -> None:
+    caps = _caps(
+        routing_backends=RoutingBackends(external=_Tripped(), local=_LOCAL),
+        routing_client=None,
+        policy_llm_connection_factory=None,
+    )
+    assert routing_sources(caps) == {"external": False, "oss": True}
+    assert routing_available(caps) is True
+
+
+# ── route_with_fallback: the external router first, the judge behind it ─────
+
+
+class _Recording:
+    """Routing-client double recording how many calls it took.
+
+    :param result: What :meth:`route` returns.
+    :param error: Raised from :meth:`route` instead of returning.
+    :param last_error: The protocol's reason field for a ``None`` result.
+    """
+
+    def __init__(
+        self,
+        result: Any = None,  # type: ignore[explicit-any]  # a RoutingResult stand-in
+        *,
+        error: Exception | None = None,
+        last_error: str | None = None,
+    ) -> None:
+        self.result = result
+        self.error = error
+        self.last_error = last_error
+        self.calls = 0
+
+    async def route(
+        self,
+        _message: str,
+        _available: dict[str, list[str]],
+    ) -> Any:  # type: ignore[explicit-any]  # a RoutingResult stand-in
+        """Record the call and answer with the canned verdict (or raise)."""
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+_MENU = {"claude-sdk": ["databricks-claude-opus-4-8"]}
+_VERDICT = "verdict"
+
+
+async def test_route_with_fallback_prefers_the_external_router() -> None:
+    external, local = _Recording(_VERDICT), _Recording(_VERDICT)
+    call = await route_with_fallback(
+        RoutingBackends(external=external, local=local), "hi", _MENU, gateway_backed=True
+    )
+    assert call is not None
+    assert (call.result, call.source, call.client) == (_VERDICT, "databricks-aigw", external)
+    assert local.calls == 0
+
+
+async def test_route_with_fallback_asks_the_judge_when_the_router_declines() -> None:
+    external = _Recording(None, last_error="router returned HTTP 404: not enabled")
+    local = _Recording(_VERDICT)
+    call = await route_with_fallback(
+        RoutingBackends(external=external, local=local), "hi", _MENU, gateway_backed=True
+    )
+    assert call is not None
+    assert (call.result, call.source, call.client) == (_VERDICT, "oss-llm", local)
+
+
+async def test_route_with_fallback_asks_the_judge_when_the_router_raises() -> None:
+    external = _Recording(error=RuntimeError("connection reset"))
+    local = _Recording(_VERDICT)
+    call = await route_with_fallback(
+        RoutingBackends(external=external, local=local), "hi", _MENU, gateway_backed=True
+    )
+    assert call is not None
+    assert (call.result, call.source) == (_VERDICT, "oss-llm")
+
+
+async def test_route_with_fallback_reports_the_last_router_asked() -> None:
+    """Both declined: the caller reads its reason off whoever answered last."""
+    external = _Recording(None, last_error="router returned HTTP 404: not enabled")
+    local = _Recording(None, last_error="the judge had no opinion")
+    call = await route_with_fallback(
+        RoutingBackends(external=external, local=local), "hi", _MENU, gateway_backed=True
+    )
+    assert call is not None
+    assert (call.result, call.source, call.client) == (None, "oss-llm", local)
+
+
+async def test_route_with_fallback_lets_a_lone_router_fail_the_way_it_always_did() -> None:
+    """No judge behind it: the caller's own fail-open handling still sees the raise."""
+    external = _Recording(error=RuntimeError("connection reset"))
+    with pytest.raises(RuntimeError):
+        await route_with_fallback(
+            RoutingBackends(external=external), "hi", _MENU, gateway_backed=True
+        )
+
+
+async def test_route_with_fallback_uses_the_judge_off_the_gateway() -> None:
+    external, local = _Recording(_VERDICT), _Recording(_VERDICT)
+    call = await route_with_fallback(
+        RoutingBackends(external=external, local=local), "hi", _MENU, gateway_backed=False
+    )
+    assert call is not None
+    assert (call.source, external.calls) == ("oss-llm", 0)
+
+
+async def test_route_with_fallback_reports_an_unconfigured_deployment() -> None:
+    assert await route_with_fallback(RoutingBackends(), "hi", _MENU, gateway_backed=True) is None

--- a/tests/server/test_routing_oss_fallback.py
+++ b/tests/server/test_routing_oss_fallback.py
@@ -1,0 +1,260 @@
+"""The built-in judge answers when the external router cannot.
+
+The deployment under test is the fully-OSS one: a ``llm:`` block for the judge,
+a ``kind: databricks`` provider for inference, and no ``routing:`` block — so
+the bootstrap points an external client at a workspace whose account never had
+the routing API enabled. Every ``routes:select`` there is a 404, and before
+this the whole session declined with "Routing unavailable" while the configured
+judge was never asked.
+
+The external router is still preferred wherever it can serve (the Databricks
+posture), so these tests pin both halves: the fallback, and that a healthy
+router keeps the call.
+
+Runs against the deterministic ``routes:select`` mock the e2e routing CUJs use,
+over loopback — a real HTTP 404 with the real body, no gateway dependency.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from omnigent.server.routing_backend import RoutingBackends, routing_sources, select_router
+from omnigent.server.smart_routing import (
+    ExternalRoutingClient,
+    RoutingResult,
+    RoutingSettings,
+    route_session_harness,
+    route_turn,
+)
+from tests.e2e.routing._mock_router import MockRouter, serve_mock_router
+from tests.server.helpers import FakeCaps, FakeRoutingClient
+
+OPUS = "databricks-claude-opus-4-8"
+SONNET = "databricks-claude-sonnet-5"
+#: A claude-sdk pane's own catalog: both task_v1 claude arms are servable, so
+#: the mock's ``cc`` menu is complete and its pick maps back to a catalog id.
+CLAUDE_CATALOG = [OPUS, SONNET]
+#: Short and code-free, so the mock's rule 0 fires and the pick is fixed.
+TRIVIAL = "hi there"
+
+
+@pytest.fixture
+def router() -> Iterator[MockRouter]:
+    """A ``routes:select`` service on loopback, healthy by default."""
+    yield from serve_mock_router()
+
+
+def _external(router: MockRouter) -> ExternalRoutingClient:
+    """Build a client pointed at *router* that sends no credential.
+
+    :param router: The running mock.
+    :returns: The client the deployment's ``routing_backends.external`` holds.
+    """
+    return ExternalRoutingClient(
+        base_url=router.base_url,
+        router_name="task_v1",
+        # The sole authority once set, so nothing probes the developer's own
+        # Databricks environment for a token.
+        auth_provider=dict,
+    )
+
+
+def _judge(model: str = OPUS, harness: str = "claude-sdk") -> FakeRoutingClient:
+    """The built-in judge, returning a fixed verdict.
+
+    :param model: The model the judge picks.
+    :param harness: The harness the judge names alongside it.
+    :returns: The stand-in client.
+    """
+    return FakeRoutingClient(RoutingResult(model=model, rationale="judge pick", harness=harness))
+
+
+@contextmanager
+def _deployment(
+    *,
+    external: Any = None,  # type: ignore[explicit-any]  # a routing client
+    local: Any = None,  # type: ignore[explicit-any]  # a routing client
+) -> Iterator[FakeCaps]:
+    """Install caps carrying *external* / *local* as the routing backends.
+
+    :param external: The external ``routes:select`` client, or ``None``.
+    :param local: The built-in judge, or ``None``.
+    :yields: The installed caps, for reading routing reports off.
+    """
+    caps = FakeCaps(
+        routing_client=external or local,
+        routing_backends=RoutingBackends(external=external, local=local),
+        routing_settings=RoutingSettings(),
+    )
+    with patch("omnigent.runtime._globals._caps", new=caps):
+        yield caps
+
+
+# ── the reported regression ─────────────────────────────────────────────────
+
+
+async def test_a_not_enabled_router_hands_the_turn_to_the_judge(router: MockRouter) -> None:
+    router.disabled = True
+    judge = _judge()
+    with _deployment(external=_external(router), local=judge):
+        model, verdict = await route_turn("claude-sdk", TRIVIAL, catalog=CLAUDE_CATALOG)
+    assert model == OPUS
+    assert verdict is not None
+    assert verdict["router_source"] == "oss-llm"
+    assert router.count() == 1
+    assert judge.calls != []
+
+
+async def test_the_not_enabled_404_is_asked_once_per_process(router: MockRouter) -> None:
+    router.disabled = True
+    judge = _judge()
+    external = _external(router)
+    with _deployment(external=external, local=judge) as caps:
+        first = await route_turn("claude-sdk", TRIVIAL, catalog=CLAUDE_CATALOG)
+        second = await route_turn("claude-sdk", TRIVIAL, catalog=CLAUDE_CATALOG)
+        # The condition is account-level, so the report stops advertising a
+        # router that can only decline — without persisting anything.
+        assert routing_sources(caps) == {"external": False, "oss": True}
+        choice = select_router(
+            RoutingBackends(external=external, local=judge), gateway_backed=True
+        )
+        assert choice is not None
+        assert choice.source == "oss-llm"
+    assert first[0] == second[0] == OPUS
+    assert second[1] is not None
+    assert second[1]["router_source"] == "oss-llm"
+    # One request total: the second turn never went back to the router.
+    assert router.count() == 1
+
+
+async def test_a_healthy_router_still_answers_the_turn(router: MockRouter) -> None:
+    judge = _judge()
+    with _deployment(external=_external(router), local=judge):
+        model, verdict = await route_turn("claude-sdk", TRIVIAL, catalog=CLAUDE_CATALOG)
+    # Rule 0's cheapest arm on the claude-only menu.
+    assert model == SONNET
+    assert verdict is not None
+    assert verdict["router_source"] == "databricks-aigw"
+    assert judge.calls == []
+    assert router.count() == 1
+
+
+async def test_a_judge_only_deployment_routes_the_turn(router: MockRouter) -> None:
+    del router
+    judge = _judge()
+    with _deployment(local=judge):
+        model, verdict = await route_turn("claude-sdk", TRIVIAL, catalog=CLAUDE_CATALOG)
+    assert model == OPUS
+    assert verdict is not None
+    assert verdict["router_source"] == "oss-llm"
+
+
+async def test_a_router_that_raises_hands_the_turn_to_the_judge() -> None:
+    judge = _judge()
+    broken = FakeRoutingClient(error=RuntimeError("connection reset"))
+    with _deployment(external=broken, local=judge):
+        model, verdict = await route_turn("claude-sdk", TRIVIAL, catalog=CLAUDE_CATALOG)
+    assert model == OPUS
+    assert verdict is not None
+    assert verdict["router_source"] == "oss-llm"
+
+
+async def test_no_judge_leaves_the_router_failure_on_the_card(router: MockRouter) -> None:
+    """With nothing to fall back to, the turn still declines — visibly."""
+    router.disabled = True
+    with _deployment(external=_external(router)):
+        model, verdict = await route_turn("claude-sdk", TRIVIAL, catalog=CLAUDE_CATALOG)
+    assert (model, verdict) == (None, None)
+
+
+# ── the session/auto-harness path (polly, debby) ────────────────────────────
+
+
+async def test_polly_smart_routing_gets_a_judge_decision(router: MockRouter) -> None:
+    """The reported bug: a ``smart_routing_harness: auto`` session declined.
+
+    The spec hands its brain harness to the router, so the create routes
+    harness AND model on the first message. The judge is cross-harness by
+    design, so a workspace with no routing API must not cost the session its
+    decision.
+    """
+    router.disabled = True
+    judge = _judge(model=OPUS, harness="claude-sdk")
+    with _deployment(external=_external(router), local=judge):
+        harness, model, verdict, error = await route_session_harness(
+            TRIVIAL,
+            session_id="conv_polly",
+            catalog={"claude-sdk": CLAUDE_CATALOG},
+        )
+    assert error is None
+    assert (harness, model) == ("claude-sdk", OPUS)
+    assert verdict is not None
+    assert verdict["router_source"] == "oss-llm"
+
+
+async def test_the_judge_may_move_a_session_to_another_harness() -> None:
+    """Judge-only is still harness + model: it is offered the whole menu."""
+    judge = _judge(model="databricks-gpt-5-5", harness="codex")
+    with _deployment(local=judge):
+        harness, model, verdict, error = await route_session_harness(
+            TRIVIAL,
+            session_id="conv_polly",
+            catalog={"claude-sdk": CLAUDE_CATALOG, "codex": ["databricks-gpt-5-5"]},
+        )
+    assert error is None
+    assert (harness, model) == ("codex", "databricks-gpt-5-5")
+    assert verdict is not None
+    assert verdict["router_source"] == "oss-llm"
+    # Every candidate harness reached the judge, not just the session's own.
+    assert set(judge.offered[0]) >= {"claude-sdk", "codex"}
+
+
+# ── the deployment the bug was reported on, assembled from config ───────────
+
+
+async def test_the_oss_config_routes_with_its_judge(router: MockRouter) -> None:
+    """``llm:`` + a databricks provider + no ``routing:`` block.
+
+    The bootstrap still auto-builds the workspace router — that is the right
+    default for a workspace that HAS the API — and the judge covers the one
+    that does not.
+    """
+    from omnigent.cli import _build_routing_backends
+
+    router.disabled = True
+    host = router.base_url[: -len("/ai-gateway/routing/v1")]
+    cfg = {"providers": {"ws": {"kind": "databricks", "profile": "ws", "default": True}}}
+    with (
+        patch(
+            "omnigent.runtime.credentials.databricks.resolve_databricks_workspace",
+            return_value=MagicMock(host=host),
+        ),
+        patch(
+            "omnigent.runtime.policies.builder._resolve_server_llm_connection",
+            return_value=None,
+        ),
+        patch(
+            "omnigent.runtime.policies.builder._build_policy_llm_client",
+            return_value=MagicMock(),
+        ),
+        patch.object(ExternalRoutingClient, "_resolve_credentials", return_value=(None, {})),
+    ):
+        from omnigent.spec import parse_server_llm
+
+        backends = _build_routing_backends(
+            cfg, parse_server_llm({"model": OPUS}), RoutingSettings()
+        )
+        assert isinstance(backends.external, ExternalRoutingClient)
+        judge = _judge()
+        with _deployment(external=backends.external, local=judge):
+            model, verdict = await route_turn("claude-sdk", TRIVIAL, catalog=CLAUDE_CATALOG)
+    assert model == OPUS
+    assert verdict is not None
+    assert verdict["router_source"] == "oss-llm"
+    assert router.count() == 1

--- a/tests/server/test_smart_routing.py
+++ b/tests/server/test_smart_routing.py
@@ -1382,6 +1382,55 @@ async def test_external_routing_client_records_last_error_on_http_failure() -> N
     assert "Credential was not sent" in client.last_error
 
 
+@pytest.mark.asyncio
+async def test_a_routing_api_that_is_not_enabled_is_asked_exactly_once() -> None:
+    """The 404 is account-level configuration, so retrying it only adds latency."""
+    import httpx
+
+    from omnigent.server.smart_routing import ExternalRoutingClient
+
+    served = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        nonlocal served
+        served += 1
+        return httpx.Response(
+            404,
+            json={
+                "error_code": "NOT_FOUND",
+                "message": "routing/v1/routes:select is not enabled for this account.",
+            },
+        )
+
+    client = ExternalRoutingClient(base_url="https://host/v1", router_name="task_v1")
+    with _patch_httpx(httpx.MockTransport(handler)):
+        assert await client.route("hi", {"h": ["m"]}) is None
+        assert client.permanently_unavailable is True
+        assert await client.route("hi again", {"h": ["m"]}) is None
+    assert served == 1
+    # The reason survives the short circuit, so the chip still says why.
+    assert client.last_error is not None
+    assert "not enabled" in client.last_error
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_404_is_not_latched() -> None:
+    """Only the account-level message is permanent; a stray 404 is retried."""
+    import httpx
+
+    from omnigent.server.smart_routing import ExternalRoutingClient
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(404, json={"error_code": "NOT_FOUND", "message": "no route"})
+
+    client = ExternalRoutingClient(base_url="https://host/v1", router_name="task_v1")
+    with _patch_httpx(httpx.MockTransport(handler)):
+        assert await client.route("hi", {"h": ["m"]}) is None
+    assert client.permanently_unavailable is False
+
+
 def test_router_error_detail_unwraps_nested_message() -> None:
     from omnigent.server.smart_routing import _router_error_detail
 

--- a/tests/server/test_subagent_routing.py
+++ b/tests/server/test_subagent_routing.py
@@ -1319,6 +1319,45 @@ async def test_a_gateway_backed_spawn_is_routed_by_the_external_router() -> None
     assert local.calls == []
 
 
+async def test_a_spawn_falls_back_to_the_judge_when_the_router_fails() -> None:
+    """A workspace with no routing API must not cost every spawn its decision."""
+    from omnigent.server.routing_backend import RoutingBackends
+
+    external = FakeRoutingClient(
+        None, last_error="router returned HTTP 404: routes:select is not enabled"
+    )
+    local = FakeRoutingClient(RoutingResult(model=CLAUDE_MODEL, rationale="local"))
+    caps = FakeCaps(
+        routing_client=external,
+        routing_backends=RoutingBackends(external=external, local=local),
+    )
+    decision = await resolve_subagent_route(
+        "conv_fallback", _request(), caps=caps, gateway_backed=True
+    )
+    assert decision.router_source == "oss-llm"
+    assert decision.model == CLAUDE_MODEL
+    assert external.calls != []
+
+
+async def test_a_spawn_keeps_the_routers_reason_when_nothing_can_answer() -> None:
+    """Fail-open is unchanged: the spawn runs, the chip carries the reason."""
+    from omnigent.server.routing_backend import RoutingBackends
+
+    external = FakeRoutingClient(None, last_error="router returned HTTP 404: not enabled")
+    local = FakeRoutingClient(None, last_error="the judge had no opinion")
+    caps = FakeCaps(
+        routing_client=external,
+        routing_backends=RoutingBackends(external=external, local=local),
+    )
+    decision = await resolve_subagent_route(
+        "conv_none", _request(), caps=caps, gateway_backed=True
+    )
+    assert decision.action == "allow"
+    assert decision.model is None
+    assert decision.router_source is None
+    assert "the judge had no opinion" in decision.rationale
+
+
 async def test_an_external_only_deployment_cannot_route_an_off_gateway_spawn() -> None:
     from omnigent.server.routing_backend import RoutingBackends
 

--- a/web/src/lib/smartRoutingAvailability.test.ts
+++ b/web/src/lib/smartRoutingAvailability.test.ts
@@ -60,63 +60,84 @@ describe("smartRoutingUnavailableReason", () => {
     ).toEqual({ kind: "not-gateway-backed", harnesses: ["codex-native"] });
   });
 
-  // Off the gateway is only a loss for the external router. With the built-in
-  // judge configured it answers for that arm instead, so routing proceeds.
-  it("is null for an off-gateway arm when the built-in judge can answer", () => {
+  // Picking the harness is the external router's job. A deployment whose only
+  // source is the built-in judge keeps per-harness routing and loses this row,
+  // and it says so rather than blaming the host.
+  it("reports the missing external router, gateway backing notwithstanding", () => {
+    expect(
+      smartRoutingUnavailableReason({
+        routingEnabled: true,
+        wrappersRegistered: true,
+        unreadyHarnesses: [],
+        notGatewayBackedHarnesses: [],
+        externalRoutingAvailable: false,
+      }),
+    ).toEqual({ kind: "external-router-required" });
+  });
+
+  // Omitting the field keeps the pre-source answer (an older server that only
+  // reports `smart_routing_enabled` must lose nothing); only an explicit false
+  // takes the row away.
+  it.each([
+    [undefined, null],
+    [true, null],
+    [false, { kind: "external-router-required" }],
+  ] as const)("externalRoutingAvailable %s yields %j", (externalRoutingAvailable, expected) => {
+    expect(
+      smartRoutingUnavailableReason({
+        routingEnabled: true,
+        wrappersRegistered: true,
+        unreadyHarnesses: [],
+        ...(externalRoutingAvailable === undefined ? {} : { externalRoutingAvailable }),
+      }),
+    ).toEqual(expected);
+  });
+
+  // Routing being off is the more fundamental cause, so it still wins.
+  it("reports routing being off ahead of the missing external router", () => {
+    expect(
+      smartRoutingUnavailableReason({
+        routingEnabled: false,
+        wrappersRegistered: true,
+        unreadyHarnesses: [],
+        externalRoutingAvailable: false,
+      }),
+    ).toEqual({ kind: "routing-disabled" });
+  });
+
+  // ...and the missing router outranks anything about the host: no external
+  // router means no fully-auto row however well the machine is set up.
+  it.each([
+    [
+      "a wrapper agent is missing",
+      { routingEnabled: true, wrappersRegistered: false, unreadyHarnesses: [] },
+    ],
+    [
+      "an arm isn't ready",
+      { routingEnabled: true, wrappersRegistered: true, unreadyHarnesses: ["claude-native"] },
+    ],
+  ] as const)("reports the missing external router ahead of %s", (_case, inputs) => {
+    expect(
+      smartRoutingUnavailableReason({
+        ...inputs,
+        notGatewayBackedHarnesses: ["codex-native"],
+        externalRoutingAvailable: false,
+      }),
+    ).toEqual({ kind: "external-router-required" });
+  });
+
+  // The built-in judge does not cover an off-gateway arm here — it can't pick
+  // the harness — so the gateway cause stands even with the judge configured.
+  it("still reports an off-gateway arm with the external router present", () => {
     expect(
       smartRoutingUnavailableReason({
         routingEnabled: true,
         wrappersRegistered: true,
         unreadyHarnesses: [],
         notGatewayBackedHarnesses: SMART_ROUTING_ARMS,
-        ossRoutingAvailable: true,
+        externalRoutingAvailable: true,
       }),
-    ).toBeNull();
-  });
-
-  // Omitting the field keeps the pre-source behaviour, and an explicit false
-  // reads the same — only the judge being available lifts the cause.
-  it.each([
-    [undefined, { kind: "not-gateway-backed", harnesses: ["codex-native"] }],
-    [false, { kind: "not-gateway-backed", harnesses: ["codex-native"] }],
-    [true, null],
-  ] as const)("ossRoutingAvailable %s yields %j", (ossRoutingAvailable, expected) => {
-    expect(
-      smartRoutingUnavailableReason({
-        routingEnabled: true,
-        wrappersRegistered: true,
-        unreadyHarnesses: [],
-        notGatewayBackedHarnesses: ["codex-native"],
-        ...(ossRoutingAvailable === undefined ? {} : { ossRoutingAvailable }),
-      }),
-    ).toEqual(expected);
-  });
-
-  // The judge lifts only the gateway cause; the more fundamental ones stand.
-  it.each([
-    [
-      "routing is off",
-      { routingEnabled: false, wrappersRegistered: true, unreadyHarnesses: [] },
-      { kind: "routing-disabled" },
-    ],
-    [
-      "a wrapper agent is missing",
-      { routingEnabled: true, wrappersRegistered: false, unreadyHarnesses: [] },
-      { kind: "wrappers-missing" },
-    ],
-    [
-      "an arm isn't ready",
-      { routingEnabled: true, wrappersRegistered: true, unreadyHarnesses: ["claude-native"] },
-      { kind: "harnesses-unready", harnesses: ["claude-native"] },
-    ],
-  ] as const)("still reports %s with the judge available", (_case, inputs, expected) => {
-    expect(
-      smartRoutingUnavailableReason({
-        ...inputs,
-        notGatewayBackedHarnesses: ["codex-native"],
-        ossRoutingAvailable: true,
-      }),
-    ).toEqual(expected);
+    ).toEqual({ kind: "not-gateway-backed", harnesses: ["claude-native", "codex-native"] });
   });
 
   // An arm that isn't installed can't have an inference config to judge, so
@@ -202,6 +223,16 @@ describe("smartRoutingDroppedMessage", () => {
   it("blames the server flag, not the host, when routing is off", () => {
     const message = smartRoutingDroppedMessage({ kind: "routing-disabled" }, context);
     expect(message).toBe("Smart Routing is turned off on this server — switched to Claude Code.");
+    expect(message).not.toContain("machine-2");
+  });
+
+  // Judge-only: blame the server's router set, not the host — the machine is
+  // fine, and "set up your CLI" would send the user down the wrong path.
+  it("blames the server's router set when only the built-in judge is configured", () => {
+    const message = smartRoutingDroppedMessage({ kind: "external-router-required" }, context);
+    expect(message).toBe(
+      "Smart Routing across harnesses needs the workspace AI gateway router on this server — switched to Claude Code.",
+    );
     expect(message).not.toContain("machine-2");
   });
 

--- a/web/src/lib/smartRoutingAvailability.ts
+++ b/web/src/lib/smartRoutingAvailability.ts
@@ -1,11 +1,11 @@
 // Why top-level Smart Routing can (or can't) be offered on the new-chat
 // landing, and how to say so.
 //
-// The landing drops a Smart Routing pick it can't honour. Four different
+// The landing drops a Smart Routing pick it can't honour. Five different
 // conditions cause that, and they need different words: a server with routing
-// switched off is not a host missing a CLI, neither is a deployment whose
-// native wrapper agents aren't registered, and neither is a host whose CLI runs
-// off something other than the workspace AI gateway.
+// switched off is not a deployment whose only router is the built-in judge, is
+// not a deployment whose native wrapper agents aren't registered, and is not a
+// host whose CLI runs off something other than the workspace AI gateway.
 
 import { SMART_ROUTING_LABEL } from "@/lib/agentLabels";
 import { nativeCodingAgentForHarness } from "@/lib/nativeCodingAgents";
@@ -21,6 +21,12 @@ export const SMART_ROUTING_ARMS = ["claude-native", "codex-native"] as const;
 export type SmartRoutingUnavailableCause =
   /** The server has routing switched off (`smart_routing_enabled: false`). */
   | { kind: "routing-disabled" }
+  /**
+   * The server's only router is the built-in judge. The native-pane row needs
+   * the external AI-Gateway router to choose which CLI pane launches, so a
+   * judge-only deployment has nothing to answer it.
+   */
+  | { kind: "external-router-required" }
   /** A native wrapper agent Smart Routing binds isn't registered. */
   | { kind: "wrappers-missing" }
   /** Ready-to-run arms are missing on the selected host. */
@@ -29,7 +35,8 @@ export type SmartRoutingUnavailableCause =
    * Arms whose family the host doesn't back with the workspace AI gateway. The
    * external router's apply layer rewrites the model through the gateway, so a
    * CLI pointed anywhere else can't be routed by it even with the CLI
-   * installed. Only fires when the built-in judge can't answer instead.
+   * installed. The built-in judge does not cover for it here — the native-pane
+   * row runs on the external router alone.
    */
   | { kind: "not-gateway-backed"; harnesses: string[] };
 
@@ -59,16 +66,23 @@ export function smartRoutingSourceFor(inputs: {
 }
 
 /**
- * Classify why Smart Routing can't be offered, most-fundamental cause first —
- * routing being off makes the host's CLIs irrelevant, and a CLI that isn't
- * installed makes its inference config irrelevant.
+ * Classify why the top-level native-pane Smart Routing row — the router picks
+ * which native CLI pane launches AND its model — can't be offered,
+ * most-fundamental cause first: routing being off makes the router sources
+ * irrelevant, a source that can't drive the pane makes the host's CLIs
+ * irrelevant, and a CLI that isn't installed makes its inference config
+ * irrelevant.
  *
- * An off-gateway arm is only a loss when the external router is the only one
- * that can answer: with the built-in judge available it routes that arm
- * instead, so ``not-gateway-backed`` stops firing.
+ * Only the external AI-Gateway router drives that pane, so every gate here
+ * reads it alone; a deployment whose only source is the built-in judge keeps
+ * per-harness Smart Routing and loses this row. Scoped to the native-pane row:
+ * a bundle agent's routed brain runs the judge's harness pick happily and gates
+ * on {@link smartRoutingSourceFor} instead.
  *
  * @param inputs - The independent conditions, read off the server flags,
- *   the agent list, and the selected host.
+ *   the agent list, and the selected host. ``externalRoutingAvailable`` is
+ *   optional so an older caller (and a server that predates
+ *   ``smart_routing_sources``) keeps the pre-source answer.
  * @returns The cause, or ``null`` when Smart Routing is available.
  */
 export function smartRoutingUnavailableReason(inputs: {
@@ -76,15 +90,16 @@ export function smartRoutingUnavailableReason(inputs: {
   wrappersRegistered: boolean;
   unreadyHarnesses: readonly string[];
   notGatewayBackedHarnesses?: readonly string[];
-  ossRoutingAvailable?: boolean;
+  externalRoutingAvailable?: boolean;
 }): SmartRoutingUnavailableCause | null {
   if (!inputs.routingEnabled) return { kind: "routing-disabled" };
+  if (inputs.externalRoutingAvailable === false) return { kind: "external-router-required" };
   if (!inputs.wrappersRegistered) return { kind: "wrappers-missing" };
   if (inputs.unreadyHarnesses.length > 0) {
     return { kind: "harnesses-unready", harnesses: [...inputs.unreadyHarnesses] };
   }
   const notBacked = inputs.notGatewayBackedHarnesses ?? [];
-  if (notBacked.length > 0 && inputs.ossRoutingAvailable !== true) {
+  if (notBacked.length > 0) {
     return { kind: "not-gateway-backed", harnesses: [...notBacked] };
   }
   return null;
@@ -135,6 +150,8 @@ export function smartRoutingDroppedMessage(
   switch (cause.kind) {
     case "routing-disabled":
       return `${SMART_ROUTING_LABEL} is turned off on this server — switched to ${to}.`;
+    case "external-router-required":
+      return `${SMART_ROUTING_LABEL} across harnesses needs the workspace AI gateway router on this server — switched to ${to}.`;
     case "wrappers-missing":
       return `${SMART_ROUTING_LABEL} needs the ${armList(SMART_ROUTING_ARMS)} agents registered on this server — switched to ${to}.`;
     case "harnesses-unready":

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -3713,30 +3713,73 @@ describe("NewChatLandingScreen Smart Routing harness row", () => {
     expect(screen.getByTestId(SMART_ROUTING_ROW)).toBeTruthy();
   });
 
-  // The gateway is the EXTERNAL router's requirement. With the built-in judge
-  // configured it covers the off-gateway arm, so the row the cases above hid
-  // stays — including with no external router at all.
+  // The row launches a native pane whose harness the EXTERNAL router picks, so
+  // the built-in judge cannot stand in for an off-gateway arm the way it does
+  // for a per-harness model pick.
   it.each([
-    ["codex isn't gateway-backed", { "claude-native": true, "codex-native": false }, true],
-    ["claude isn't gateway-backed", { "claude-native": false, "codex-native": true }, true],
-    ["neither is gateway-backed", { "claude-native": false, "codex-native": false }, true],
-    [
-      "neither is gateway-backed and there's no external router",
-      { "claude-native": false, "codex-native": false },
-      false,
-    ],
-  ] as const)(
-    "keeps the row when the built-in judge can answer and %s",
-    (_case, gateway, external) => {
-      mockHosts([{ ...host("online"), gateway_inference: gateway } as Host]);
-      renderLanding({
-        smart_routing_enabled: true,
-        smart_routing_sources: { external, oss: true },
-      });
-      openPicker();
-      expect(screen.getByTestId(SMART_ROUTING_ROW)).toBeTruthy();
-    },
-  );
+    ["codex isn't gateway-backed", { "claude-native": true, "codex-native": false }],
+    ["claude isn't gateway-backed", { "claude-native": false, "codex-native": true }],
+    ["neither is gateway-backed", { "claude-native": false, "codex-native": false }],
+  ] as const)("hides the row when the judge is configured and %s", (_case, gateway) => {
+    mockHosts([{ ...host("online"), gateway_inference: gateway } as Host]);
+    renderLanding({
+      smart_routing_enabled: true,
+      smart_routing_sources: { external: true, oss: true },
+    });
+    openPicker();
+    expect(screen.queryByTestId(SMART_ROUTING_ROW)).toBeNull();
+    expect(screen.getByTestId("new-chat-landing-agent-a1")).toBeTruthy();
+  });
+
+  // The judge-only deployment: no external router, so the pane's harness pick
+  // has nobody to make it. Gateway backing is beside the point.
+  it.each([
+    ["both families gateway-backed", { "claude-native": true, "codex-native": true }],
+    ["the host reports nothing", undefined],
+  ] as const)("hides the row on a judge-only server with %s", (_case, gateway) => {
+    mockHosts([{ ...host("online"), gateway_inference: gateway } as Host]);
+    renderLanding({
+      smart_routing_enabled: true,
+      smart_routing_sources: { external: false, oss: true },
+    });
+    openPicker();
+    expect(screen.queryByTestId(SMART_ROUTING_ROW)).toBeNull();
+    expect(screen.getByTestId("new-chat-landing-agent-a1")).toBeTruthy();
+  });
+
+  // Both sources, both arms on the gateway: the one shape that keeps the row —
+  // and the shape a legacy server (no `smart_routing_sources`, just
+  // `smart_routing_enabled: true`) resolves to, so it loses nothing.
+  it("shows the row when the external router is configured alongside the judge", () => {
+    mockHosts([
+      {
+        ...host("online"),
+        gateway_inference: { "claude-native": true, "codex-native": true },
+      } as Host,
+    ]);
+    renderLanding({
+      smart_routing_enabled: true,
+      smart_routing_sources: { external: true, oss: true },
+    });
+    openPicker();
+    expect(screen.getByTestId(SMART_ROUTING_ROW)).toBeTruthy();
+  });
+
+  // Neither source: the row goes, same as judge-only.
+  it("hides the row when the server reports neither source", () => {
+    mockHosts([
+      {
+        ...host("online"),
+        gateway_inference: { "claude-native": true, "codex-native": true },
+      } as Host,
+    ]);
+    renderLanding({
+      smart_routing_enabled: true,
+      smart_routing_sources: { external: false, oss: false },
+    });
+    openPicker();
+    expect(screen.queryByTestId(SMART_ROUTING_ROW)).toBeNull();
+  });
 
   it("announces the gateway as the cause when a host switch takes the row away", async () => {
     mockHosts([
@@ -4259,6 +4302,24 @@ describe("NewChatLandingScreen bundle-agent Smart Routing", () => {
       expect(screen.getByTestId("new-chat-landing-harness-auto")).toBeTruthy();
     },
   );
+
+  // The judge-only deployment. A bundle agent's routed brain runs the judge's
+  // harness pick, so this surface must NOT follow the native-pane row off a
+  // server with no external router — whatever the gateway map says.
+  it.each([
+    ["both arms gateway-backed", { "claude-native": true, "codex-native": true }],
+    ["neither arm gateway-backed", { "claude-native": false, "codex-native": false }],
+    ["the host reports nothing", undefined],
+  ])("keeps the Smart Routing brain on a judge-only server with %s", (_case, gateway) => {
+    mockHosts([{ ...host("online"), gateway_inference: gateway } as Host]);
+    renderLanding({
+      smart_routing_enabled: true,
+      smart_routing_sources: { external: false, oss: true },
+    });
+    openAgentConfig("ag_debby");
+    openSelect("new-chat-landing-config-harness");
+    expect(screen.getByTestId("new-chat-landing-harness-auto")).toBeTruthy();
+  });
 
   // Sources decide, not the gateway map: with neither router configured the
   // fully-auto brain goes even on a fully gateway-backed host.

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1912,7 +1912,7 @@ export function NewChatLandingScreen() {
   // Unfiltered brain-harness labels: safe for membership checks and for
   // labelling an existing pick, but the OPTIONS offered in the gear modal use
   // the gated `brainHarnessLabels` below, which drops the fully-auto row when
-  // the gateway cannot back both arms.
+  // neither router can back both arms.
   const brainHarnessLabelsAll = useBrainHarnessLabels(smartRoutingEnabled);
   // Provider-named label for the sandbox option (e.g. "Modal Sandbox"),
   // falling back to the generic "New Sandbox" when the server names no
@@ -2686,25 +2686,28 @@ export function NewChatLandingScreen() {
         unreadyHarnesses: SMART_ROUTING_ARMS.filter((harness) =>
           harnessUnconfiguredOnHost(harness, harnessWarningHost),
         ),
-        // The five-arm menu the top-level row drives needs BOTH families on the
-        // gateway for the external router, so either one the host doesn't back
-        // takes the row away — unless the built-in judge can route it instead.
+        // Picking the harness is the external router's job alone, so the row
+        // needs it configured AND both families on the gateway its apply layer
+        // rewrites through. The built-in judge routes a model inside one
+        // harness and can't stand in here.
+        externalRoutingAvailable: externalRoutingConfigured,
         notGatewayBackedHarnesses: SMART_ROUTING_ARMS.filter(
           (harness) => !hostBacksHarnessWithGateway(harnessWarningHost, harness),
         ),
-        ossRoutingAvailable: ossRoutingConfigured,
       }),
-    [smartRoutingEnabled, smartRoutingWrappers, harnessWarningHost, ossRoutingConfigured],
+    [smartRoutingEnabled, smartRoutingWrappers, harnessWarningHost, externalRoutingConfigured],
   );
   const smartRoutingHarnessAvailable = smartRoutingUnavailableCause === null;
   // The fully-auto brain needs SOME router able to answer for both model
   // families — the router may land the session's work on either, and an arm the
   // external router can't reach (off the workspace AI gateway) is only a loss
-  // when the built-in judge can't cover it either. Source availability ONLY:
-  // unlike the top-level row, the bundle brain routes across SDK harnesses, so
-  // the native wrappers/CLIs are deliberately not required here. Gates the
-  // OPTIONS map only — membership checks and the summary label for an existing
-  // pick keep reading `brainHarnessLabelsAll`.
+  // when the built-in judge can't cover it either. The judge picks the bundle
+  // brain's harness as well as its model, so unlike the native-pane row above
+  // this surface stays on a judge-only deployment. Source availability ONLY:
+  // the bundle brain routes across SDK harnesses, so the native wrappers/CLIs
+  // are deliberately not required here. Gates the OPTIONS map only — membership
+  // checks and the summary label for an existing pick keep reading
+  // `brainHarnessLabelsAll`.
   const brainRoutable = SMART_ROUTING_ARMS.every(
     (harness) =>
       smartRoutingSourceFor({


### PR DESCRIPTION
# Summary

Three Smart Routing fixes for the release, all reported from manual testing on
latest main.

**1. Restores the fully-OSS Smart Routing flow (release blocker).** A deployment with a
top-level `llm:` block, a `kind: databricks` provider, and **no** `routing:`
block currently declines every routed session with
`Routing unavailable: router returned HTTP 404: routing/v1/routes:select is not
enabled for this account.` — the auto-defaulted external AI-Gateway client is
preferred everywhere, its failure was terminal, and the configured built-in
judge was never consulted.

- **Fall back to the judge.** `route_with_fallback()` keeps the external
  `routes:select` client preferred wherever it can serve, and consults the
  `llm:` judge when the external client returns no verdict or raises. The
  fallback decision is stamped `router_source: "oss-llm"`. All routing entry
  points go through it: session-scope create routing, first-message turn
  routing, the native `route-turn` hook, and subagent spawn routing.
- **Circuit-break the permanent 404.** A 404 whose body says `routes:select …
  is not enabled` latches the external client off for the rest of the process
  (one warning log, no persistence; a restart re-probes). `/v1/info`
  `smart_routing_sources.external` reports false once tripped, so clients see
  what can actually answer.
- **Judge-only native creates route the model, not the harness.** With no
  usable external router, a native-pane Smart Routing create keeps the default
  installed pane and routes only its model, saying so in the chip rationale.
  Bundle agents (polly/debby) keep judge-driven harness + model selection —
  that is their pre-existing `smart_routing_harness: auto` behavior and the
  judge's verdict schema carries the harness.
- **The web UI's native-pane "Smart Routing" harness row now requires the
  external router** (`smart_routing_sources.external`). Judge-only deployments
  keep per-harness Smart Routing and the bundle agents' auto brain; an
  off-gateway arm hides the row even when the judge exists, because a
  harness-picking row the judge cannot serve would only fail at launch. Legacy
  servers that omit `smart_routing_sources` degrade to today's behavior.

**2. A named-worker spawn stays on its own harness.** A Smart Routing parent
(e.g. polly) force-auto'd **every** child create, including spawns that named a
worker (`sys_session_send(agent="pi")`), and the auto path routed with no
family confinement — so three children pinned to pi / codex / claude code all
received identical `harness: codex, applied` verdicts and were respawned onto
codex mid-flight. A spawn that pins its harness (spec-declared or explicit
override) now keeps it, the child-routing call confines candidates to the
child's own family, and a verdict naming a harness the call never offered is
dropped rather than applied.

**3. Completions from routed children reach the parent inbox.** The runner
decided native-vs-SDK completion delivery from the child's **spec** harness,
ignoring the `harness_override` the session actually ran on. Children whose
spec said `codex-native`/`claude-native` but ran SDK after routing had their
completions skipped — the parent sat "waiting" forever, and only the pi child
(spec non-native) delivered. The forwarded override is now recorded per session
and wins in `_session_harness_name`, so delivery follows the process that
actually ran. This was only reachable via Smart Routing today, which is why it
never reproduced in plain sessions.

Known follow-up (not in this PR): a genuinely unpinned auto child still boots
its spec harness and respawns onto the routed one at its first message; and the
false "did not resolve in the parent spec" warning at child turn time.

# Test Plan

- `tests/server/test_routing_oss_fallback.py` (new) drives the real
  `ExternalRoutingClient` against the e2e mock router over loopback, including
  a genuine not-enabled 404 (`MockRouter.disabled` mode added to the mock).
- Extended `test_routing_backend.py`, `test_smart_routing.py`,
  `test_subagent_routing.py`, `test_native_smart_routing_create.py`: llm-only
  config routes via the judge; not-enabled 404 → judge verdict with
  `router_source: "oss-llm"`; the second call skips the external client;
  a healthy external router is still preferred (judge never called); judge-only
  native create; the reported polly repro.
- Regression is pinned: with the four source files reverted to main, 11 of the
  new tests fail; restored, all green. 451 passed / 16 skipped on the touched
  suites plus 108 on adjacent integration suites.
- Web: `smartRoutingAvailability.test.ts` + `NewChatDialog.test.tsx` gating
  matrix (external+oss / oss-only / neither / legacy payload), plus an
  `it.each` proving the bundle-agent auto brain survives oss-only. 300 web
  tests pass; `tsc -b`, prettier, oxlint clean.
- Child spawns: new integration test pins a named worker of an auto parent to
  its own harness (fails on pre-fix code), and a new runner test drives a real
  SDK turn on a `claude-native` spec with a routed override and asserts the
  parent inbox receives the completion.
- The four commits were developed independently and re-verified as a stack:
  593 tests pass across the combined routing/runner suites.
- Live repro of the reported polly scenario (three pinned children on
  pi/codex/claude) captured pre-fix on this machine; post-fix live round
  running as verification.

# Demo

N/A — behavioral fix; the visible change is a routed `oss-llm` chip replacing
the `Routing unavailable: … 404 …` decline on judge-only deployments, and the
native-pane Smart Routing row hiding there.

# Type of change

- [x] Bug fix
- [ ] New feature
- [x] UI / frontend change
- [ ] Refactor
- [ ] Documentation

# Test coverage

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual verification completed

# Coverage notes

The reported repro (polly smart-routing on an llm-only server config) is
covered as a test; a live judge-only stack round is running on the reporter's
config shape as post-merge verification.

This pull request and its description were written by Isaac.
