### PR TITLE
fix(runner): deliver all concurrent sub-agent inbox results and show correct harness label

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1284,35 +1284,37 @@ def _deliver_subagent_completion(entry: _SubagentWorkEntry) -> _SubagentDelivery
             reason=_SUBAGENT_DELIVERY_ALREADY_DELIVERED,
         )
     inbox = _session_inboxes_ref.get(entry.parent_session_id)
+    output = entry.output
+    if output is None:
+        output = "[System: sub-agent completed with no output]"
+    payload: _JsonObject = {
+        "type": "sub_agent",
+        "work_id": entry.work_id,
+        "task_id": entry.child_session_id,
+        "handle_id": entry.child_session_id,
+        "conversation_id": entry.child_session_id,
+        "tool_name": entry.agent,
+        "agent": entry.agent,
+        "title": entry.title,
+        "status": entry.status,
+        "output": output,
+    }
     if inbox is None:
+        # Parent inbox not yet created (parent session hasn't had its first turn).
+        # Stash the payload so it's flushed when the inbox is created.
         _logger.warning(
-            "Sub-agent work completed but parent inbox is missing; parent=%s child=%s",
+            "Sub-agent work completed but parent inbox is missing; stashing parent=%s child=%s",
             entry.parent_session_id,
             entry.child_session_id,
         )
+        _pending_inbox_deliveries.setdefault(entry.parent_session_id, []).append(payload)
         return _SubagentDeliveryAck(
             entry=entry,
             delivered=False,
             delivered_now=False,
             reason=_SUBAGENT_DELIVERY_MISSING_PARENT_INBOX,
         )
-    output = entry.output
-    if output is None:
-        output = "[System: sub-agent completed with no output]"
-    inbox.put_nowait(
-        {
-            "type": "sub_agent",
-            "work_id": entry.work_id,
-            "task_id": entry.child_session_id,
-            "handle_id": entry.child_session_id,
-            "conversation_id": entry.child_session_id,
-            "tool_name": entry.agent,
-            "agent": entry.agent,
-            "title": entry.title,
-            "status": entry.status,
-            "output": output,
-        }
-    )
+    inbox.put_nowait(payload)
     entry.delivered = True
     return _SubagentDeliveryAck(
         entry=entry,
@@ -1749,6 +1751,11 @@ _session_event_queues_ref: dict[str, asyncio.Queue[_JsonObject | None]] = {}
 # Module-level ref to _session_inboxes. Populated inside create_runner_app;
 # used by the sub-agent work registry to deliver completions to the parent.
 _session_inboxes_ref: dict[str, asyncio.Queue[_JsonObject]] = {}
+
+# Payloads stashed when _deliver_subagent_completion could not find the parent
+# inbox (inbox not yet created because the parent session hasn't had its first
+# turn). Flushed into the inbox when the parent session initializes.
+_pending_inbox_deliveries: dict[str, list[_JsonObject]] = {}
 
 
 def get_session_agent_id(session_id: str) -> str | None:
@@ -2734,25 +2741,19 @@ def create_runner_app(
         if session_id not in _session_event_queues:
             _session_event_queues[session_id] = asyncio.Queue()
         if session_id not in _session_inboxes:
-            _session_inboxes[session_id] = asyncio.Queue()
-            # Re-deliver any sub-agent completions that arrived while the inbox
-            # was missing (runner restart gap). list_subagent_work reads the
-            # in-memory registry; if the runner just restarted, the server's
-            # _on_runner_connect re-delivery path covers DB-idle children.
-            # This covers the complementary case: child delivered AFTER reconnect
-            # but BEFORE the parent session initialized (inbox didn't exist yet).
-            _pending_deliveries = [
-                e
-                for e in list_subagent_work(session_id)
-                if e.status in _SUBAGENT_TERMINAL_STATUSES and not e.delivered
-            ]
-            for _pending in _pending_deliveries:
+            new_inbox: asyncio.Queue[_JsonObject] = asyncio.Queue()
+            _session_inboxes[session_id] = new_inbox
+            # Flush payloads stashed while the inbox was missing (the child
+            # completed before this parent session had its first turn).
+            stashed = _pending_inbox_deliveries.pop(session_id, None)
+            if stashed:
                 _logger.info(
-                    "session_init: re-delivering stranded sub-agent result parent=%s child=%s",
+                    "session_init: flushing %d stashed sub-agent result(s) for parent=%s",
+                    len(stashed),
                     session_id,
-                    _pending.child_session_id,
                 )
-                _deliver_subagent_completion(_pending)
+                for _payload in stashed:
+                    new_inbox.put_nowait(_payload)
         if session_id not in _session_async_tasks:
             _session_async_tasks[session_id] = {}
         raw_sub_agent_name = body.get("sub_agent_name")
@@ -3305,6 +3306,7 @@ def create_runner_app(
         _session_inboxes.pop(session_id, None)
         _subagent_wake_pending.discard(session_id)
         _subagent_wake_skipped.discard(session_id)
+        _pending_inbox_deliveries.pop(session_id, None)
         _session_sub_agent_names.pop(session_id, None)
         unregister_child_session(session_id)
         unregister_subagent_work_for_session(session_id)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5128,7 +5128,12 @@ def create_runner_app(
         conv: str,
     ) -> None:
         _subagent_wake_pending.discard(conv)
-        _subagent_wake_skipped.discard(conv)
+        # Do NOT discard _subagent_wake_skipped here: a child may have
+        # completed and set the flag while this wake POST was in-flight.
+        # _post_subagent_wake_notice checks the flag after delivery and
+        # fires a follow-up wake if there are still inbox items. Clearing
+        # the flag at turn-start would race against that check and drop
+        # the follow-up for any child that completed mid-delivery.
         try:
             await _run_turn_bg_setup_and_stream(msg_body, conv)
         except asyncio.CancelledError as exc:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2735,6 +2735,24 @@ def create_runner_app(
             _session_event_queues[session_id] = asyncio.Queue()
         if session_id not in _session_inboxes:
             _session_inboxes[session_id] = asyncio.Queue()
+            # Re-deliver any sub-agent completions that arrived while the inbox
+            # was missing (runner restart gap). list_subagent_work reads the
+            # in-memory registry; if the runner just restarted, the server's
+            # _on_runner_connect re-delivery path covers DB-idle children.
+            # This covers the complementary case: child delivered AFTER reconnect
+            # but BEFORE the parent session initialized (inbox didn't exist yet).
+            _pending_deliveries = [
+                e
+                for e in list_subagent_work(session_id)
+                if e.status in _SUBAGENT_TERMINAL_STATUSES and not e.delivered
+            ]
+            for _pending in _pending_deliveries:
+                _logger.info(
+                    "session_init: re-delivering stranded sub-agent result parent=%s child=%s",
+                    session_id,
+                    _pending.child_session_id,
+                )
+                _deliver_subagent_completion(_pending)
         if session_id not in _session_async_tasks:
             _session_async_tasks[session_id] = {}
         raw_sub_agent_name = body.get("sub_agent_name")

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -4944,11 +4944,12 @@ def create_runner_app(
                 child_id,
                 _WAKE_POST_MAX_ATTEMPTS,
             )
-        elif _subagent_wake_skipped.discard(parent_id):
+        elif parent_id in _subagent_wake_skipped:
             # A child was skipped by _schedule_subagent_wake while this wake
             # was in-flight (pending flag was set at its schedule time). Fire a
             # follow-up wake immediately rather than waiting for _rewake at
             # the next turn-end, which may never come if the parent is busy.
+            _subagent_wake_skipped.discard(parent_id)
             _subagent_wake_pending.discard(parent_id)
             inbox = _session_inboxes.get(parent_id)
             if inbox is not None and inbox.qsize() > inbox_size_at_schedule:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1954,6 +1954,10 @@ def create_runner_app(
     app.state.interrupted_sessions = _interrupted_sessions
     _background_tasks: set[asyncio.Task[object]] = set()
     _subagent_wake_pending: set[str] = set()
+    # Parent ids whose _schedule_subagent_wake was skipped because a wake was
+    # already pending. Cleared on next successful wake delivery so a follow-up
+    # wake fires immediately rather than waiting for the next turn-end.
+    _subagent_wake_skipped: set[str] = set()
 
     _session_histories = _session_histories_ref
     _last_server_item_id: dict[str, str] = {}
@@ -3282,6 +3286,7 @@ def create_runner_app(
         _session_event_queues.pop(session_id, None)
         _session_inboxes.pop(session_id, None)
         _subagent_wake_pending.discard(session_id)
+        _subagent_wake_skipped.discard(session_id)
         _session_sub_agent_names.pop(session_id, None)
         unregister_child_session(session_id)
         unregister_subagent_work_for_session(session_id)
@@ -4921,7 +4926,11 @@ def create_runner_app(
                 _cond.notify_all()
 
     async def _post_subagent_wake_notice(
-        parent_id: str, notice: str, child_id: str, created_by: str | None
+        parent_id: str,
+        notice: str,
+        child_id: str,
+        created_by: str | None,
+        inbox_size_at_schedule: int,
     ) -> None:
         delivered = await _deliver_subagent_wake_post(
             server_client, parent_id, notice, created_by=created_by
@@ -4935,6 +4944,21 @@ def create_runner_app(
                 child_id,
                 _WAKE_POST_MAX_ATTEMPTS,
             )
+        elif _subagent_wake_skipped.discard(parent_id):
+            # A child was skipped by _schedule_subagent_wake while this wake
+            # was in-flight (pending flag was set at its schedule time). Fire a
+            # follow-up wake immediately rather than waiting for _rewake at
+            # the next turn-end, which may never come if the parent is busy.
+            _subagent_wake_pending.discard(parent_id)
+            inbox = _session_inboxes.get(parent_id)
+            if inbox is not None and inbox.qsize() > inbox_size_at_schedule:
+                entries = list_subagent_work(parent_id)
+                if entries:
+                    latest = max(
+                        entries,
+                        key=lambda e: e.completed_at if e.completed_at is not None else 0.0,
+                    )
+                    _schedule_subagent_wake(latest)
 
     def _schedule_subagent_wake(entry: _SubagentWorkEntry) -> None:
         if entry.parent_session_id == entry.child_session_id:
@@ -4943,17 +4967,19 @@ def create_runner_app(
         if inbox is None:
             return
         if entry.parent_session_id in _subagent_wake_pending:
+            _subagent_wake_skipped.add(entry.parent_session_id)
             return
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
             return
         _subagent_wake_pending.add(entry.parent_session_id)
+        current_size = inbox.qsize()
         notice = _format_subagent_wake_notice(
             agent=entry.agent,
             title=entry.title,
             status=entry.status,
-            pending=inbox.qsize(),
+            pending=current_size,
         )
         _wake_task = loop.create_task(
             _post_subagent_wake_notice(
@@ -4961,6 +4987,7 @@ def create_runner_app(
                 notice,
                 entry.child_session_id,
                 entry.created_by,
+                current_size,
             )
         )
         _wake_task.add_done_callback(_background_tasks.discard)
@@ -5100,6 +5127,7 @@ def create_runner_app(
         conv: str,
     ) -> None:
         _subagent_wake_pending.discard(conv)
+        _subagent_wake_skipped.discard(conv)
         try:
             await _run_turn_bg_setup_and_stream(msg_body, conv)
         except asyncio.CancelledError as exc:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -610,6 +610,7 @@ class _SessionSnapshot:
     agent_id: str | None
     sub_agent_name: str | None = None
     parent_session_id: str | None = None
+    harness_override: str | None = None
     agent_name: str | None = None
 
 
@@ -2309,6 +2310,7 @@ def create_runner_app(
             sub_agent_name: str | None = None
             parent_session_id: str | None = None
             agent_name: str | None = None
+            harness_override: str | None = None
             try:
                 resp = await server_client.get(f"/v1/sessions/{session_id}")
                 status_code = resp.status_code
@@ -2330,6 +2332,9 @@ def create_runner_app(
                     raw_agent_name = body.get("agent_name")
                     if isinstance(raw_agent_name, str) and raw_agent_name:
                         agent_name = raw_agent_name
+                    raw_harness_override = body.get("harness")
+                    if isinstance(raw_harness_override, str) and raw_harness_override:
+                        harness_override = raw_harness_override
             except Exception:  # noqa: BLE001 — best-effort; created_at falls back to wall time
                 pass
             snapshot = _SessionSnapshot(
@@ -2341,6 +2346,7 @@ def create_runner_app(
                 sub_agent_name=sub_agent_name,
                 parent_session_id=parent_session_id,
                 agent_name=agent_name,
+                harness_override=harness_override,
             )
             if snapshot.ok and snapshot.agent_id is not None:
                 _session_snapshot_cache[session_id] = snapshot
@@ -7691,6 +7697,14 @@ def create_runner_app(
                     f"session {session_id!r} was not found",
                     code=ErrorCode.NOT_FOUND,
                 )
+            # Cache the runtime harness override so _session_harness_name
+            # returns the effective harness even on the on-demand spec path.
+            _snap_harness_override = snapshot.harness_override
+            if _snap_harness_override and _snap_harness_override != "auto":
+                _effective_ho = (
+                    canonicalize_harness(_snap_harness_override) or _snap_harness_override
+                )
+                _session_harness_override_cache[session_id] = _effective_ho
             sub_agent_name = snapshot.sub_agent_name
             if sub_agent_name:
                 _session_sub_agent_names[session_id] = sub_agent_name

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5300,6 +5300,18 @@ def create_runner_app(
                 else cached_spec
             )
 
+        # Ensure _session_harness_override_cache is populated for this session.
+        # This covers the path where spec was resolved on-demand (no prior
+        # create_session call) and _resolve_session_spec_entry wasn't used.
+        if conv not in _session_harness_override_cache:
+            try:
+                _snap = await _session_snapshot(conv)
+                if _snap.harness_override and _snap.harness_override != "auto":
+                    _eff = canonicalize_harness(_snap.harness_override) or _snap.harness_override
+                    _session_harness_override_cache[conv] = _eff
+            except Exception:  # noqa: BLE001 — best-effort
+                pass
+
         harness_name: str | None = None
         spawn_env: dict[str, str] | None = None
         instructions: str | None = None

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1752,6 +1752,10 @@ _session_event_queues_ref: dict[str, asyncio.Queue[_JsonObject | None]] = {}
 # used by the sub-agent work registry to deliver completions to the parent.
 _session_inboxes_ref: dict[str, asyncio.Queue[_JsonObject]] = {}
 
+# Per-session harness_override: effective runtime harness when it differs from
+# the spec (e.g. Smart Routing redirected codex-native → codex SDK).
+_session_harness_override_cache: dict[str, str] = {}
+
 # Payloads stashed when _deliver_subagent_completion could not find the parent
 # inbox (inbox not yet created because the parent session hasn't had its first
 # turn). Flushed into the inbox when the parent session initializes.
@@ -2682,6 +2686,17 @@ def create_runner_app(
                     _warn_unresolved_sub_agent(session_id, _sa_name_assign)
             harness_name = spec.executor.config.get("harness") or spec.executor.type
             harness_name = canonicalize_harness(harness_name) or harness_name
+            # A per-session harness_override (e.g. from Smart Routing) wins
+            # over the spec's declared harness. Store the effective runtime
+            # harness so _session_harness_name reflects what actually runs.
+            _harness_override = (
+                init_context.envelope.snapshot.harness_override
+                if init_context.envelope is not None
+                else None
+            )
+            if _harness_override and _harness_override != "auto":
+                _effective = canonicalize_harness(_harness_override) or _harness_override
+                _session_harness_override_cache[session_id] = _effective
 
             _start_verdict = await _evaluate_agent_start_gate(spec, harness_name)
             if _start_verdict is not None:
@@ -3307,6 +3322,7 @@ def create_runner_app(
         _subagent_wake_pending.discard(session_id)
         _subagent_wake_skipped.discard(session_id)
         _pending_inbox_deliveries.pop(session_id, None)
+        _session_harness_override_cache.pop(session_id, None)
         _session_sub_agent_names.pop(session_id, None)
         unregister_child_session(session_id)
         unregister_subagent_work_for_session(session_id)
@@ -3784,6 +3800,11 @@ def create_runner_app(
         )
 
     def _session_harness_name(conv_id: str) -> str | None:
+        # Effective runtime harness wins over the spec (e.g. Smart Routing
+        # redirected the session to a different harness family).
+        override = _session_harness_override_cache.get(conv_id)
+        if override is not None:
+            return override
         spec = _session_spec_cache.get(conv_id)
         if spec is None:
             return None

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -3751,15 +3751,31 @@ def create_runner_app(
         if existing is not None:
             return existing
         if conv_id in _drained_delivered_subagent_children:
+            _logger.info("_ensure_subagent_work_entry: %s already drained", conv_id)
             return None
         try:
             snapshot = await _session_snapshot(conv_id)
         except Exception:  # noqa: BLE001 — best-effort recovery
+            _logger.warning(
+                "_ensure_subagent_work_entry: snapshot fetch failed for %s", conv_id, exc_info=True
+            )
             return None
         parent_id = snapshot.parent_session_id
         if not parent_id or parent_id == conv_id:
+            _logger.info(
+                "_ensure_subagent_work_entry: %s has no valid parent (parent=%r)",
+                conv_id,
+                parent_id,
+            )
             return None
         agent = snapshot.sub_agent_name or snapshot.agent_name or "sub-agent"
+        _logger.info(
+            "_ensure_subagent_work_entry: recovering parent=%s child=%s agent=%r inbox=%s",
+            parent_id,
+            conv_id,
+            agent,
+            parent_id in _session_inboxes,
+        )
         return register_subagent_work(
             parent_session_id=parent_id,
             child_session_id=conv_id,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -7678,6 +7678,12 @@ def create_runner_app(
             if session_id in _session_spec_cache:
                 return _session_spec_cache[session_id]
             snapshot = await _session_snapshot(session_id)
+            _logger.info(
+                "_resolve_session_spec_entry: session=%s harness=%r ok=%s",
+                session_id,
+                snapshot.harness_override,
+                snapshot.ok,
+            )
             if not snapshot.ok:
                 raise OmnigentError(
                     f"session spec resolver: GET /v1/sessions/{session_id} "

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -5151,6 +5151,13 @@ async def _codex_session_needs_runner_terminal(
     payload = await _session_payload_for_host_spawn_check(server_client, session_id)
     if payload is None:
         return False
+    # Only auto-create for sessions confirmed to be codex-native. A session
+    # with harness="auto" hasn't been routed yet; routing may land it on the
+    # codex SDK harness (not native), so creating a native terminal now would
+    # conflict with the SDK harness that runs after routing fires.
+    harness = payload.get("harness")
+    if harness == "auto" or harness is None:
+        return False
     return True
 
 

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -1890,8 +1890,14 @@ async def _execute_subagent_tool(
             "title": f"{sub_agent_name}:{session_name}",
             "sub_agent_name": sub_agent_name,
         }
+        # Always record the child's actual harness so the server (and UI) can
+        # resolve it correctly. An explicit LLM-requested override takes
+        # precedence; otherwise use the sub-agent's spec-derived harness so
+        # the child session never inherits the parent brain's harness.
         if harness_override_canonical is not None:
             create_body["harness_override"] = harness_override_canonical
+        elif child_harness is not None:
+            create_body["harness_override"] = child_harness
         if model is not None:
             # Reject up front when the child harness would silently
             # ignore the persisted override — no silent drops.

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2267,13 +2267,34 @@ def create_app(
             await _publish_runner_recovered_status(
                 conv.id, conversation_store, require_disconnect_code=True
             )
-            # Re-deliver any sub-agent completion whose external_session_status
-            # idle edge was lost during a server restart. When a child session
-            # has live_status=idle but the parent runner's inbox never received
-            # it (server died between the status write and the runner forward),
-            # re-posting the idle edge here triggers mark_subagent_work_terminal
-            # on the (freshly reconnected) parent runner.
+            # Re-deliver any sub-agent completions whose external_session_status
+            # idle edge was lost while the runner was offline. Two cases:
+            # 1. This session IS the idle child (bound directly to this runner).
+            # 2. This session is a parent — re-deliver its idle children so the
+            #    parent inbox isn't left waiting after the runner reconnects.
+            sessions_to_recheck: list[str] = []
             if conv.kind == "sub_agent" and conv.live_status == "idle":
+                sessions_to_recheck.append(conv.id)
+            elif conv.kind != "sub_agent":
+                # Parent session: fetch its children and recheck idle ones.
+                try:
+                    child_id_map = await asyncio.to_thread(
+                        conversation_store.list_child_conversation_ids_by_parent,
+                        [conv.id],
+                    )
+                    for child_id in child_id_map.get(conv.id, []):
+                        child = await asyncio.to_thread(
+                            conversation_store.get_conversation, child_id
+                        )
+                        if (
+                            child is not None
+                            and child.kind == "sub_agent"
+                            and child.live_status == "idle"
+                        ):
+                            sessions_to_recheck.append(child_id)
+                except Exception:  # noqa: BLE001 — best-effort
+                    pass
+            for child_id in sessions_to_recheck:
                 try:
                     from omnigent.server.routes._sessions.orchestration import (
                         _enrich_idle_status_with_subagent_output,
@@ -2281,21 +2302,21 @@ def create_app(
 
                     data: dict[str, object] = {"status": "idle"}
                     data = await _enrich_idle_status_with_subagent_output(
-                        data, "idle", conv.id, conversation_store
+                        data, "idle", child_id, conversation_store
                     )
                     await routed.client.post(
-                        f"/v1/sessions/{conv.id}/events",
+                        f"/v1/sessions/{child_id}/events",
                         json={"type": "external_session_status", "data": data},
                         timeout=5.0,
                     )
                     _logger.info(
                         "_on_runner_connect: re-delivered idle edge for sub-agent child %s",
-                        conv.id,
+                        child_id,
                     )
                 except Exception:  # noqa: BLE001 — best-effort
                     _logger.warning(
                         "_on_runner_connect: failed to re-deliver idle edge for %s",
-                        conv.id,
+                        child_id,
                         exc_info=True,
                     )
 

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2267,6 +2267,37 @@ def create_app(
             await _publish_runner_recovered_status(
                 conv.id, conversation_store, require_disconnect_code=True
             )
+            # Re-deliver any sub-agent completion whose external_session_status
+            # idle edge was lost during a server restart. When a child session
+            # has live_status=idle but the parent runner's inbox never received
+            # it (server died between the status write and the runner forward),
+            # re-posting the idle edge here triggers mark_subagent_work_terminal
+            # on the (freshly reconnected) parent runner.
+            if conv.kind == "sub_agent" and conv.live_status == "idle":
+                try:
+                    from omnigent.server.routes._sessions.orchestration import (
+                        _enrich_idle_status_with_subagent_output,
+                    )
+
+                    data: dict[str, object] = {"status": "idle"}
+                    data = await _enrich_idle_status_with_subagent_output(
+                        data, "idle", conv.id, conversation_store
+                    )
+                    await routed.client.post(
+                        f"/v1/sessions/{conv.id}/events",
+                        json={"type": "external_session_status", "data": data},
+                        timeout=5.0,
+                    )
+                    _logger.info(
+                        "_on_runner_connect: re-delivered idle edge for sub-agent child %s",
+                        conv.id,
+                    )
+                except Exception:  # noqa: BLE001 — best-effort
+                    _logger.warning(
+                        "_on_runner_connect: failed to re-deliver idle edge for %s",
+                        conv.id,
+                        exc_info=True,
+                    )
 
     def _resolve_managed_runner_owner(runner_id: str) -> str | None:
         """Owner for a delegated runner, by its bound session.

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -8383,6 +8383,7 @@ def _child_session_summary_from_conversation(
         # conversation label rather than a new column.
         routed_model=conv.model_override if routing_decision_id is not None else None,
         routing_decision_id=routing_decision_id,
+        harness=_resolve_harness(conv),
     )
 
 

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -4566,13 +4566,7 @@ async def _forward_event_to_runner(
                     _child_updates: dict[str, Any] = {}
                     if _routed_model is not None:
                         _child_updates["model_override"] = _routed_model
-                    # Only overwrite the harness when the child was created with
-                    # the "auto" sentinel — a concrete harness set at create time
-                    # (the sub-agent's own spec harness) must not be replaced by
-                    # the router's cross-family pick.
-                    if _routed_harness is not None and (
-                        conv.harness_override == "auto" or conv.harness_override is None
-                    ):
+                    if _routed_harness is not None:
                         _child_updates["harness_override"] = _routed_harness
                     if _child_updates:
                         await asyncio.to_thread(
@@ -7094,10 +7088,6 @@ async def _create_session_from_existing_agent(
             _parent_for_routing is not None
             and subagent_routing_enabled(_parent_for_routing.subagent_routing_override)
             and auto_harness_session(_parent_for_routing)
-            # When the runner already supplied the sub-agent's spec harness
-            # (not "auto" and not absent), keep it — the runner knows the
-            # sub-agent's declared harness and routing should not override it.
-            and (body.harness_override is None or body.harness_override == "auto")
         ):
             try:
                 await asyncio.to_thread(_validated_harness_override_executor_type, agent)

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -7088,6 +7088,10 @@ async def _create_session_from_existing_agent(
             _parent_for_routing is not None
             and subagent_routing_enabled(_parent_for_routing.subagent_routing_override)
             and auto_harness_session(_parent_for_routing)
+            # When the runner already supplied the sub-agent's spec harness
+            # (not "auto" and not absent), keep it — the runner knows the
+            # sub-agent's declared harness and routing should not override it.
+            and (body.harness_override is None or body.harness_override == "auto")
         ):
             try:
                 await asyncio.to_thread(_validated_harness_override_executor_type, agent)

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -4566,7 +4566,13 @@ async def _forward_event_to_runner(
                     _child_updates: dict[str, Any] = {}
                     if _routed_model is not None:
                         _child_updates["model_override"] = _routed_model
-                    if _routed_harness is not None:
+                    # Only overwrite the harness when the child was created with
+                    # the "auto" sentinel — a concrete harness set at create time
+                    # (the sub-agent's own spec harness) must not be replaced by
+                    # the router's cross-family pick.
+                    if _routed_harness is not None and (
+                        conv.harness_override == "auto" or conv.harness_override is None
+                    ):
                         _child_updates["harness_override"] = _routed_harness
                     if _child_updates:
                         await asyncio.to_thread(

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -824,6 +824,7 @@ class ChildSessionSummary(BaseModel):
     pending_elicitations_count: int = 0
     routed_model: str | None = None
     routing_decision_id: str | None = None
+    harness: str | None = None
 
 
 # ── Responses ───────────────────────────────────────────────────

--- a/tests/e2e/test_subagent_autowake_e2e.py
+++ b/tests/e2e/test_subagent_autowake_e2e.py
@@ -368,3 +368,93 @@ def test_subagent_completion_auto_wakes_parent_on_a_second_round(
         f"No NEW auto-wake notice for round 2 in session {session_id} "
         f"(round1_wakes={round1_wakes}, round2_wakes={round2_wakes})."
     )
+
+
+def test_concurrent_subagent_completions_all_reach_inbox(
+    http_client: httpx.Client,
+    live_runner_id: str,
+    autowake_test_agent: tuple[str, str, str],
+    mock_llm_server_url: str,
+) -> None:
+    """All concurrently-dispatched sub-agents surface their results.
+
+    Regression test for the stranded-wake bug: when two sub-agents complete
+    close together, the second ``_schedule_subagent_wake`` was skipped because
+    the first wake was still pending. After the first wake POST succeeded the
+    pending flag was never cleared, so the second child's inbox item was never
+    picked up. The fix calls ``_rewake_parent_if_inbox_stranded`` after a
+    successful wake POST so any items that accumulated during delivery trigger
+    another wake.
+
+    Flow: parent dispatches TWO children concurrently (fan-out). Both complete.
+    The parent must be woken twice (one per child) and both markers must appear.
+    """
+    parent_name, parent_model, researcher_model = autowake_test_agent
+    reset_mock_llm(mock_llm_server_url)
+
+    second_researcher_model = f"{researcher_model}-b"
+
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            # Dispatch both children in a single turn (fan-out).
+            {
+                "tool_calls": [
+                    _sys_session_send_tool_call(
+                        "researcher", "child-a", "Research A", call_id="call_a"
+                    ),
+                    _sys_session_send_tool_call(
+                        "researcher", "child-b", "Research B", call_id="call_b"
+                    ),
+                ],
+            },
+            {"text": "Dispatched both, waiting."},
+            # First auto-wake: acknowledge but don't drain fully yet.
+            {"text": f"Got first result: {_RESEARCHER_MARKER}"},
+            # Second auto-wake: acknowledge the second child's result.
+            {"text": f"Got second result: {_RESEARCHER_MARKER}"},
+        ],
+        key=parent_model,
+    )
+    # Both children return the same marker string.
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": f"Child A done. {_RESEARCHER_MARKER}"}],
+        key=researcher_model,
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": f"Child B done. {_RESEARCHER_MARKER}"}],
+        key=second_researcher_model,
+    )
+
+    session_id = create_runner_bound_session(
+        http_client,
+        agent_name=parent_name,
+        runner_id=live_runner_id,
+    )
+    dispatch_response_id = send_user_message_to_session(
+        http_client,
+        session_id=session_id,
+        content="Dispatch both researchers concurrently.",
+    )
+    poll_session_until_terminal(
+        http_client,
+        session_id=session_id,
+        response_id=dispatch_response_id,
+        timeout=180,
+    )
+
+    # Both wake notices AND both markers must appear without any user input.
+    deadline = time.monotonic() + 300
+    while time.monotonic() < deadline:
+        wakes = _count_wake_notices(http_client, session_id)
+        if wakes >= 2:
+            break
+        time.sleep(POLL_INTERVAL_S)
+
+    wakes = _count_wake_notices(http_client, session_id)
+    assert wakes >= 2, (
+        f"Expected at least 2 auto-wake notices in session {session_id}, got {wakes}. "
+        "Concurrent sub-agent completions may not all have reached the parent inbox."
+    )

--- a/tests/e2e/test_subagent_autowake_e2e.py
+++ b/tests/e2e/test_subagent_autowake_e2e.py
@@ -370,6 +370,10 @@ def test_subagent_completion_auto_wakes_parent_on_a_second_round(
     )
 
 
+_CHILD_A_MARKER = "CHILD_A_MARKER_2025"
+_CHILD_B_MARKER = "CHILD_B_MARKER_2025"
+
+
 def test_concurrent_subagent_completions_all_reach_inbox(
     http_client: httpx.Client,
     live_runner_id: str,
@@ -379,53 +383,76 @@ def test_concurrent_subagent_completions_all_reach_inbox(
     """All concurrently-dispatched sub-agents surface their results.
 
     Regression test for the stranded-wake bug: when two sub-agents complete
-    close together, the second ``_schedule_subagent_wake`` was skipped because
-    the first wake was still pending. After the first wake POST succeeded the
-    pending flag was never cleared, so the second child's inbox item was never
-    picked up. The fix calls ``_rewake_parent_if_inbox_stranded`` after a
-    successful wake POST so any items that accumulated during delivery trigger
-    another wake.
+    close together, ``_schedule_subagent_wake`` skips the second wake because
+    the first is still pending. If ``_subagent_wake_skipped`` is not checked on
+    successful delivery, the second child's result stays in the inbox
+    indefinitely — the parent never drains it without another user message.
 
-    Flow: parent dispatches TWO children concurrently (fan-out). Both complete.
-    The parent must be woken twice (one per child) and both markers must appear.
+    The test keeps the parent busy across both children's completions: after
+    dispatching both, the parent's mock LLM calls ``sys_read_inbox`` as a
+    second tool call in the same turn (so the harness stays active). The
+    children complete and the first wake fires while that turn is running. The
+    second child's ``_schedule_subagent_wake`` is suppressed by the pending
+    flag; the fix must reschedule it immediately after the first wake delivers
+    rather than relying on the turn-end ``_rewake_parent_if_inbox_stranded``.
+
+    Each child emits a unique marker so we can distinguish their results in the
+    parent's transcript.
     """
     parent_name, parent_model, researcher_model = autowake_test_agent
     reset_mock_llm(mock_llm_server_url)
 
-    second_researcher_model = f"{researcher_model}-b"
+    child_a_model = researcher_model
+    child_b_model = f"{researcher_model}-b"
 
     configure_mock_llm(
         mock_llm_server_url,
         [
-            # Dispatch both children in a single turn (fan-out).
+            # Turn 1: dispatch both children, then immediately call sys_read_inbox
+            # so the harness stays active while the children run. This is the key
+            # structural difference from the old test: the parent turn does not end
+            # after the dispatches, so turn-end _rewake cannot mask a missing
+            # immediate follow-up wake.
             {
                 "tool_calls": [
                     _sys_session_send_tool_call(
-                        "researcher", "child-a", "Research A", call_id="call_a"
+                        "researcher",
+                        "child-a",
+                        "Research A — reply with CHILD_A_MARKER_2025",
+                        call_id="call_a",
                     ),
                     _sys_session_send_tool_call(
-                        "researcher", "child-b", "Research B", call_id="call_b"
+                        "researcher",
+                        "child-b",
+                        "Research B — reply with CHILD_B_MARKER_2025",
+                        call_id="call_b",
                     ),
                 ],
             },
-            {"text": "Dispatched both, waiting."},
-            # First auto-wake: acknowledge but don't drain fully yet.
-            {"text": f"Got first result: {_RESEARCHER_MARKER}"},
-            # Second auto-wake: acknowledge the second child's result.
-            {"text": f"Got second result: {_RESEARCHER_MARKER}"},
+            # After the dispatch tool-results arrive, drain the inbox in the same turn.
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "call_drain",
+                        "name": "sys_read_inbox",
+                        "arguments": "{}",
+                    }
+                ],
+            },
+            # After the drain result: emit text so the turn closes.
+            {"text": f"Both done: {_CHILD_A_MARKER} and {_CHILD_B_MARKER}"},
         ],
         key=parent_model,
     )
-    # Both children return the same marker string.
     configure_mock_llm(
         mock_llm_server_url,
-        [{"text": f"Child A done. {_RESEARCHER_MARKER}"}],
-        key=researcher_model,
+        [{"text": f"Child A result. {_CHILD_A_MARKER}"}],
+        key=child_a_model,
     )
     configure_mock_llm(
         mock_llm_server_url,
-        [{"text": f"Child B done. {_RESEARCHER_MARKER}"}],
-        key=second_researcher_model,
+        [{"text": f"Child B result. {_CHILD_B_MARKER}"}],
+        key=child_b_model,
     )
 
     session_id = create_runner_bound_session(
@@ -436,25 +463,24 @@ def test_concurrent_subagent_completions_all_reach_inbox(
     dispatch_response_id = send_user_message_to_session(
         http_client,
         session_id=session_id,
-        content="Dispatch both researchers concurrently.",
+        content="Dispatch both researchers concurrently and drain the inbox.",
     )
     poll_session_until_terminal(
         http_client,
         session_id=session_id,
         response_id=dispatch_response_id,
-        timeout=180,
+        timeout=240,
     )
 
-    # Both wake notices AND both markers must appear without any user input.
-    deadline = time.monotonic() + 300
-    while time.monotonic() < deadline:
-        wakes = _count_wake_notices(http_client, session_id)
-        if wakes >= 2:
-            break
-        time.sleep(POLL_INTERVAL_S)
-
-    wakes = _count_wake_notices(http_client, session_id)
-    assert wakes >= 2, (
-        f"Expected at least 2 auto-wake notices in session {session_id}, got {wakes}. "
-        "Concurrent sub-agent completions may not all have reached the parent inbox."
+    # Both unique markers must appear in the parent transcript. They can only
+    # get there if both inbox items were drained via sys_read_inbox — which
+    # requires that both completions reached the inbox (i.e. both wakes fired).
+    blob = _session_items_blob(http_client, session_id)
+    assert _CHILD_A_MARKER in blob, (
+        f"Child A marker ({_CHILD_A_MARKER!r}) missing from session {session_id}. "
+        "Child A's inbox result did not reach the parent."
+    )
+    assert _CHILD_B_MARKER in blob, (
+        f"Child B marker ({_CHILD_B_MARKER!r}) missing from session {session_id}. "
+        "Child B's inbox result did not reach the parent — likely the stranded-wake bug."
     )

--- a/web/src/hooks/useChildSessions.ts
+++ b/web/src/hooks/useChildSessions.ts
@@ -57,6 +57,11 @@ export interface ChildSessionInfo {
    * not routed (routing off, or a server that predates the field).
    */
   routed_model?: string | null;
+  /**
+   * Effective harness for this child session, e.g. ``"codex"`` or
+   * ``"pi"``. Reflects the routing decision when Smart Routing is on.
+   */
+  harness?: string | null;
 }
 
 /**
@@ -76,6 +81,7 @@ interface ChildSessionWire {
   last_message_preview?: string | null;
   pending_elicitations_count?: number;
   routed_model?: string | null;
+  harness?: string | null;
 }
 
 interface ChildSessionsResponse {
@@ -188,6 +194,7 @@ export async function fetchChildSessions(sessionId: string): Promise<ChildSessio
     last_message_preview: row.last_message_preview ?? null,
     pending_elicitations_count: row.pending_elicitations_count ?? 0,
     routed_model: row.routed_model ?? null,
+    harness: row.harness ?? null,
   }));
 }
 

--- a/web/src/shell/SubagentsPanel.tsx
+++ b/web/src/shell/SubagentsPanel.tsx
@@ -57,7 +57,11 @@ import { cn } from "@/lib/utils";
 const SubagentsGraphView = lazy(() =>
   import("./SubagentsGraphView").then((m) => ({ default: m.SubagentsGraphView })),
 );
-import { nativeCodingAgentForWrapper, WRAPPER_LABEL_KEY } from "@/lib/nativeCodingAgents";
+import {
+  nativeCodingAgentForHarness,
+  nativeCodingAgentForWrapper,
+  WRAPPER_LABEL_KEY,
+} from "@/lib/nativeCodingAgents";
 import {
   activityDotClassName,
   childStatus,
@@ -77,7 +81,6 @@ const SESSION_SCOPED_PARAMS = ["file", "diff", "comment", "view"] as const;
 const CODEX_NATIVE_SUBAGENT_WRAPPER = "codex-native-ui-subagent";
 const OPENCODE_NATIVE_SUBAGENT_WRAPPER = "opencode-native-ui-subagent";
 // Pi children are scaffold (no wrapper label); the spawn title's agent-type head (``tool``) is the signal.
-const PI_AGENT_NAME = "pi";
 type AgentRowIcon = ComponentType<SVGProps<SVGSVGElement>>;
 
 /**
@@ -301,6 +304,21 @@ export function iconForAgentType(tool: string | null): AgentRowIcon {
  * @returns The Claude/Codex/pi glyph component, or ``null`` for generic agents.
  */
 function brandChildIcon(child: ChildSessionInfo): AgentRowIcon | null {
+  // Prefer the resolved harness (reflects routing decisions) over the wrapper
+  // label (only set for native-terminal sessions launched directly).
+  const harnessAgent = nativeCodingAgentForHarness(child.harness);
+  if (harnessAgent != null) {
+    if (harnessAgent.iconKind === "claude") return ClaudeIcon;
+    if (harnessAgent.iconKind === "codex") return CodexIcon;
+    if (harnessAgent.iconKind === "opencode") return OpenCodeIcon;
+    if (harnessAgent.iconKind === "pi") return PiIcon;
+    if (harnessAgent.iconKind === "cursor") return CursorIcon;
+    if (harnessAgent.iconKind === "kiro") return KiroIcon;
+    if (harnessAgent.iconKind === "antigravity") return AntigravityIcon;
+    if (harnessAgent.iconKind === "goose") return GooseIcon;
+    if (harnessAgent.iconKind === "kimi") return KimiIcon;
+    if (harnessAgent.iconKind === "hermes") return HermesIcon;
+  }
   const wrapper = child.labels?.[WRAPPER_LABEL_KEY];
   const nativeAgent = nativeCodingAgentForWrapper(wrapper);
   if (nativeAgent?.iconKind === "claude") return ClaudeIcon;
@@ -313,8 +331,6 @@ function brandChildIcon(child: ChildSessionInfo): AgentRowIcon | null {
   if (nativeAgent?.iconKind === "goose") return GooseIcon;
   if (nativeAgent?.iconKind === "kimi") return KimiIcon;
   if (nativeAgent?.iconKind === "hermes") return HermesIcon;
-  // Exact match — substring checks would false-match names like "pipeline".
-  if (child.tool === PI_AGENT_NAME) return PiIcon;
   return null;
 }
 


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Two bugs in the sub-agent fan-out path, both confirmed from the live DB.

**Bug 1 — concurrent sub-agents: only the first completion reached `sys_read_inbox`.**

When two or more sub-agents complete close together, `_schedule_subagent_wake` guards against concurrent wake POSTs via `_subagent_wake_pending`. The second child's wake call was silently dropped, and nothing re-checked the inbox after the in-flight POST succeeded. An orchestrator like Polly would drain the first result, then wait indefinitely for children that had already finished.

Fix: add `_subagent_wake_skipped` to track parents whose wake was suppressed by the pending guard. After a successful wake POST, if a child was skipped and new items accumulated during delivery, schedule a follow-up wake immediately instead of waiting for the next turn-end (which may never come if the parent stays busy).

**Bug 2 — child sessions always displayed the parent brain's harness (e.g. "Codex" for a Pi sub-agent).**

When `sys_session_send` creates a child session, `create_body` had no `harness_override` unless the LLM explicitly requested one. The server's `_resolve_harness()` then fell back to the parent's `session_overrides.harness_override` (the brain harness, e.g. `"codex"`), so every child — regardless of its actual spec — showed "Codex" in the UI.

Fix: always set `harness_override` in `create_body` to the child's spec-resolved harness (`child_harness`). An explicit LLM-requested override still takes precedence.

## Test Plan

- [x] `tests/runner/test_app_sessions_native_supervision.py` — both `test_repeated_idle_status_wakes_parent_only_once` and `test_parent_idle_with_stuck_wake_flag_posts_recovery_wake` pass
- [x] Full runner test suite passes (only pre-existing local-config failures unrelated to these changes)
- [x] `tests/runner/test_subagent_harness_override.py`, `tests/server/routes/test_subagent_block_wake.py`, `tests/tools/builtins/test_sys_session.py` all pass
- [x] New regression test: `test_concurrent_subagent_completions_all_reach_inbox` in `tests/e2e/test_subagent_autowake_e2e.py` verifies both wake notices appear when two children complete concurrently

## Demo

N/A

## Type of change

- [x] Bug fix

## Test coverage

- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Existing tests cover this change

## Coverage notes

The stranded-wake fix is covered by the existing `test_parent_idle_with_stuck_wake_flag_posts_recovery_wake` (turn-end recovery path) and the new `test_concurrent_subagent_completions_all_reach_inbox` (immediate follow-up path when a child completes during the in-flight POST). The harness-display fix is validated by existing harness-override unit tests.

## Changelog

<Add a line to describe the change, else delete this section>