### PR TITLE
fix(cli): point host stop's session-list failure at --force

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -8860,7 +8860,10 @@ def _stop_daemon_sessions(
         if force:
             click.echo(f"{record.target}: skipping session stop: {result.error}", err=True)
             return 0
-        raise click.ClickException(f"{record.target}: {result.error}")
+        raise click.ClickException(
+            f"{record.target}: {result.error} — retry with --force to stop the "
+            f"daemon anyway, or --daemon-only to skip the session stop entirely."
+        )
     if result.base_url is None:
         return 0
     stopped = 0

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -1185,6 +1185,85 @@ def test_host_stop_daemon_only_skips_session_stop(
     assert terminated == ["https://server.example.com"]
 
 
+def test_host_stop_session_list_timeout_points_at_force(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A session-list timeout names the flags that stop the daemon anyway.
+
+    ``GET /v1/sessions`` is one of the slowest managed APIs, so the
+    pre-check times out on healthy hosts. The failure has to name the
+    escape hatch or the daemon looks unstoppable.
+    """
+    monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
+    _write_daemon_registry_record(
+        tmp_path,
+        pid=4242,
+        target="https://server.example.com",
+        mode="server",
+        server_url="https://server.example.com",
+    )
+    monkeypatch.setattr(
+        cli,
+        "_host_http_json",
+        lambda **kwargs: cli._HostHttpResult(
+            status_code=0,
+            body="ReadTimeout: The read operation timed out",
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_terminate_daemon",
+        lambda record, *, force: pytest.fail("daemon terminated despite the failure"),
+    )
+
+    result = CliRunner().invoke(
+        cli_group,
+        ["host", "stop", "--server", "https://server.example.com"],
+    )
+
+    assert result.exit_code != 0
+    assert "ReadTimeout" in result.output
+    assert "--force" in result.output
+    assert "--daemon-only" in result.output
+
+
+def test_host_stop_force_terminates_after_session_list_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``--force`` stops the daemon when the session pre-check times out."""
+    monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
+    _write_daemon_registry_record(
+        tmp_path,
+        pid=4242,
+        target="https://server.example.com",
+        mode="server",
+        server_url="https://server.example.com",
+    )
+    monkeypatch.setattr(
+        cli,
+        "_host_http_json",
+        lambda **kwargs: cli._HostHttpResult(
+            status_code=0,
+            body="ReadTimeout: The read operation timed out",
+        ),
+    )
+    terminated: list[str] = []
+    monkeypatch.setattr(
+        cli,
+        "_terminate_daemon",
+        lambda record, *, force: terminated.append(record.target),
+    )
+
+    result = CliRunner().invoke(
+        cli_group,
+        ["host", "stop", "--server", "https://server.example.com", "--force"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert terminated == ["https://server.example.com"]
+    assert "sessions_stopped=0" in result.output
+
+
 def test_host_stop_session_stops_only_named_sessions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

n/a

## Summary

- `omni host stop` pre-checks the server's session list before terminating a
  daemon, so it never kills a host out from under live sessions
  ([cli.py#L8198-L8211](https://github.com/omnigent-ai/omnigent/blob/main/omnigent/cli.py#L8198-L8211)).
  That pre-check calls `GET /v1/sessions` — one of the slowest APIs on managed —
  so it times out on otherwise-healthy hosts and the command fails with a bare
  `session list failed: ReadTimeout`.
- `--force` **already** skips the pre-check and stops the daemon anyway, and
  `--daemon-only` skips it outright. The failure named neither, so the daemon
  looked unstoppable. This names both in the error.
- Adds a regression test pinning `--force`'s behaviour on a timing-out
  pre-check, so the escape hatch the message now advertises can't silently
  regress.

### Why not just drop the pre-check, or narrow it?

Two adjacent things came up while tracing this and are deliberately **not**
changed here:

1. **`include_archived=true` looks wasteful but isn't safe to drop.** Archiving
   stops sessions as a detached best-effort task (`_spawn_archive_stop` — "the
   archive proceeds regardless of the stop's outcome"), so an archived session
   can still be running. Excluding them could leave a live session unstopped —
   trading correctness for a speed guess.
2. **The real fix is server-side.** `GET /v1/sessions` has no `host_id` filter,
   so the pre-check pages every session in the workspace (`limit=1000`) and
   discards all but this host's. A `host_id` filter would remove the timeout
   rather than work around it. Worth a follow-up.

Also noticed: the pre-check passes `connected=true` in one path, but
`list_sessions` declares no such query param, so it's silently ignored. Left
alone — separate bug.

## Test Plan

```bash
pytest tests/cli/test_backend.py -k host_stop -q   # 5 passed
ruff format --check omnigent/cli.py tests/cli/test_backend.py
ruff check omnigent/cli.py tests/cli/test_backend.py
```

Confirmed the new hint test fails without the change (`git stash` the `cli.py`
edit → `test_host_stop_session_list_timeout_points_at_force` fails on the
missing `--force` hint, and passes with it).

pre-commit's Python hooks (`ruff format`, `ruff check`, `pyrefly`) report no
findings in either changed file. The remaining hook failures in this worktree
are environmental (no local `.venv`, web deps not installed) and unrelated.

## Demo

N/A — error-message text change, covered by the test assertions above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Two unit tests: one asserts the failure names `--force` and `--daemon-only`
(fails without the fix), one pins that `--force` still terminates the daemon
when the pre-check times out.

## Changelog

`omni host stop` now tells you to retry with `--force` when the session-list pre-check times out