### PR TITLE
fix(runner): suppress KeyboardInterrupt traceback on zygote Ctrl+C + fix concurrent sub-agent inbox delivery

### DIFF
--- a/omnigent/runner/_zygote.py
+++ b/omnigent/runner/_zygote.py
@@ -599,7 +599,10 @@ def main() -> None:
         )
         raise SystemExit(2)
 
-    _ZygoteServer(control_sock).serve()
+    try:
+        _ZygoteServer(control_sock).serve()
+    except KeyboardInterrupt:
+        pass
 
 
 if __name__ == "__main__":

--- a/omnigent/runner/_zygote.py
+++ b/omnigent/runner/_zygote.py
@@ -602,6 +602,7 @@ def main() -> None:
     try:
         _ZygoteServer(control_sock).serve()
     except KeyboardInterrupt:
+        # Ctrl+C is a normal operator-driven shutdown; exit quietly without a traceback.
         pass
 
 

--- a/omnigent/runner/_zygote.py
+++ b/omnigent/runner/_zygote.py
@@ -599,11 +599,9 @@ def main() -> None:
         )
         raise SystemExit(2)
 
-    try:
+    # Ctrl+C is a normal operator-driven shutdown; exit quietly without a traceback.
+    with contextlib.suppress(KeyboardInterrupt):
         _ZygoteServer(control_sock).serve()
-    except KeyboardInterrupt:
-        # Ctrl+C is a normal operator-driven shutdown; exit quietly without a traceback.
-        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- **Zygote Ctrl+C cleanup**: wrap `_ZygoteServer.serve()` in a `KeyboardInterrupt` catch so pressing Ctrl+C during dev exits silently instead of printing a confusing full traceback.
- **Concurrent sub-agent inbox delivery** (from fix/subagent-inbox-harness-display): deliver all concurrent sub-agent inbox results and show the correct harness label; fix a dead `elif` branch and strengthen the concurrent-wake e2e test.

## Test Plan

1. Start the runner and press Ctrl+C — no traceback should appear.
2. Run the concurrent sub-agent e2e test: verify inbox results are all delivered and harness labels are correct.

## Demo

<img width="913" height="105" alt="image" src="https://github.com/user-attachments/assets/5e17fc99-a2e0-4733-871b-999f829beecf" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] E2E tests added / updated
- [x] Manual verification completed

## Coverage notes

Ctrl+C suppression is simple enough that manual verification suffices. Concurrent sub-agent inbox has e2e coverage added in the fixup commit.