### PR TITLE
feat(web): add shared UI shadow tokens

### DIFF
--- a/web/src/components/FileMentionMenu.tsx
+++ b/web/src/components/FileMentionMenu.tsx
@@ -46,7 +46,7 @@ export function FileMentionMenu({
 
   return (
     <div className="absolute bottom-full left-0 z-10 mb-2 flex items-end gap-2">
-      <div className="w-80 max-w-[calc(100vw-2rem)] shrink-0 overflow-hidden rounded-xl border border-border bg-popover shadow-lg">
+      <div className="w-80 max-w-[calc(100vw-2rem)] shrink-0 overflow-hidden rounded-xl border border-border bg-popover shadow-menu">
         <div className="flex items-center justify-between gap-2 px-2 pb-0.5 pt-1.5 text-sm font-medium text-muted-foreground">
           <span className="truncate">{currentDir ? `/${currentDir}` : "Workspace"}</span>
           <span className="shrink-0 text-[10px]">↵ open · ⇥ attach</span>

--- a/web/src/components/PermissionsModal.tsx
+++ b/web/src/components/PermissionsModal.tsx
@@ -422,7 +422,7 @@ function AddUserCombobox({ value, onChange }: AddUserFieldProps) {
       />
       {isOpen && (
         // Wider than the (narrow) field so suggested emails aren't truncated.
-        <div className="absolute left-0 top-full z-50 mt-1 w-96 rounded-lg border bg-popover p-1 text-popover-foreground shadow-md">
+        <div className="absolute left-0 top-full z-50 mt-1 w-96 rounded-lg border bg-popover p-1 text-popover-foreground shadow-menu">
           {isLoading ? (
             <div className="py-6 text-center text-ui text-muted-foreground">Searching…</div>
           ) : suggestions.length === 0 ? (

--- a/web/src/components/SlashCommandMenu.tsx
+++ b/web/src/components/SlashCommandMenu.tsx
@@ -201,7 +201,7 @@ export function SlashCommandMenu({
 
   return (
     <div className="absolute bottom-full left-0 z-10 mb-2 flex items-end gap-2">
-      <div className="w-64 shrink-0 overflow-hidden rounded-xl border border-border bg-popover shadow-lg">
+      <div className="w-64 shrink-0 overflow-hidden rounded-xl border border-border bg-popover shadow-menu">
         <div ref={listRef} className="max-h-80 overflow-y-auto p-1">
           {builtinRows.length > 0 && sectionHeader("Commands")}
           {builtinRows.map((row) => (
@@ -229,7 +229,7 @@ export function SlashCommandMenu({
       {active && (
         <div
           data-testid="slash-menu-detail"
-          className="hidden max-h-80 w-80 shrink-0 overflow-y-auto rounded-xl border border-border bg-popover p-3 shadow-lg md:block"
+          className="hidden max-h-80 w-80 shrink-0 overflow-y-auto rounded-xl border border-border bg-popover p-3 shadow-menu md:block"
         >
           <p className="font-mono text-sm font-medium text-foreground">{active.name}</p>
           <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">

--- a/web/src/components/theme/ThemeColorPicker.tsx
+++ b/web/src/components/theme/ThemeColorPicker.tsx
@@ -136,7 +136,7 @@ export function ThemeColorPicker({
         <PopoverContent
           align="end"
           sideOffset={8}
-          className="w-72 gap-0 overflow-hidden rounded-2xl border border-border/70 bg-popover p-0 shadow-2xl ring-1 ring-black/5"
+          className="w-72 gap-0 overflow-hidden rounded-2xl border border-border/70 bg-popover p-0 shadow-xl ring-1 ring-black/5"
         >
           <div className="flex items-center justify-between px-3.5 py-2.5">
             <span className="text-sm font-medium">{label}</span>

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-ui text-card-foreground ring-1 ring-foreground/10 shadow-sm has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-ui text-card-foreground ring-1 ring-foreground/10 shadow-card has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
         className,
       )}
       {...props}

--- a/web/src/components/ui/context-menu.tsx
+++ b/web/src/components/ui/context-menu.tsx
@@ -36,7 +36,7 @@ function ContextMenuContent({
       <ContextMenuPrimitive.Content
         data-slot="context-menu-content"
         className={cn(
-          "z-50 max-h-(--radix-context-menu-content-available-height) min-w-32 origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "z-50 max-h-(--radix-context-menu-content-available-height) min-w-32 origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-menu ring-1 ring-foreground/10 duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}
         {...props}
@@ -237,7 +237,7 @@ function ContextMenuSubContent({
         sideOffset={sideOffset}
         collisionPadding={collisionPadding}
         className={cn(
-          "z-50 min-w-[96px] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "z-50 min-w-[96px] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-menu ring-1 ring-foreground/10 duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}
         {...props}

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -40,7 +40,7 @@ function DropdownMenuContent({
         sideOffset={sideOffset}
         align={align}
         className={cn(
-          "z-50 max-h-(--radix-dropdown-menu-content-available-height) w-max min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto whitespace-nowrap rounded-[12px] border border-border bg-popover p-2 text-popover-foreground shadow-[0px_8px_28px_0px_rgba(60,40,10,0.12)] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] dark:shadow-[0px_2px_16px_0px_rgba(0,0,0,0.35)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "z-50 max-h-(--radix-dropdown-menu-content-available-height) w-max min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto whitespace-nowrap rounded-[12px] border border-border bg-popover p-2 text-popover-foreground shadow-menu duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}
         {...props}
@@ -241,7 +241,7 @@ function DropdownMenuSubContent({
         sideOffset={sideOffset}
         collisionPadding={collisionPadding}
         className={cn(
-          "z-50 w-max min-w-[96px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden whitespace-nowrap rounded-[12px] border border-border bg-popover p-2 text-popover-foreground shadow-[0px_8px_28px_0px_rgba(60,40,10,0.12)] duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] dark:shadow-[0px_2px_16px_0px_rgba(0,0,0,0.35)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "z-50 w-max min-w-[96px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden whitespace-nowrap rounded-[12px] border border-border bg-popover p-2 text-popover-foreground shadow-menu duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}
         {...props}

--- a/web/src/components/ui/hover-card.tsx
+++ b/web/src/components/ui/hover-card.tsx
@@ -28,7 +28,7 @@ function HoverCardContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-lg bg-popover p-2.5 text-ui text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-lg bg-popover p-2.5 text-ui text-popover-foreground shadow-menu ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}
         {...props}

--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -27,7 +27,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 flex w-72 origin-(--radix-popover-content-transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-ui text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "z-50 flex w-72 origin-(--radix-popover-content-transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-ui text-popover-foreground shadow-menu ring-1 ring-foreground/10 outline-hidden duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}
         {...props}

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -64,7 +64,7 @@ function SelectContent({
         data-slot="select-content"
         data-align-trigger={position === "item-aligned"}
         className={cn(
-          "relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-menu ring-1 ring-foreground/10 duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,

--- a/web/src/components/ui/tooltip.tsx
+++ b/web/src/components/ui/tooltip.tsx
@@ -41,7 +41,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-neutral-900 px-2 py-1.5 text-sm text-white shadow-lg dark:bg-popover dark:text-popover-foreground has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-neutral-900 px-2 py-1.5 text-sm text-white shadow-tooltip dark:bg-popover dark:text-popover-foreground has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}
         {...props}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -106,6 +106,18 @@
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
+  --shadow-composer: 0 0 12px -6px rgb(var(--ui-shadow-neutral-rgb) / 0.12);
+  --shadow-composer-focus: 0 0 20px -4px rgb(var(--ui-shadow-neutral-rgb) / 0.12);
+  --shadow-xs: 0 2px 8px rgb(var(--ui-shadow-neutral-rgb) / 0.04);
+  --shadow-sm: 0 4px 10px -6px rgb(var(--ui-shadow-neutral-rgb) / 0.09);
+  --shadow-md: 0 6px 12px -6px rgb(var(--ui-shadow-neutral-rgb) / 0.12);
+  --shadow-lg: 0 6px 20px -4px rgb(var(--ui-shadow-neutral-rgb) / 0.12);
+  --shadow-menu: 0 8px 28px rgb(var(--ui-shadow-warm-rgb) / 0.12);
+  --shadow-xl: 0 12px 44px rgb(var(--ui-shadow-warm-rgb) / 0.16);
+  --shadow-card:
+    0 4px 16px -2px rgb(var(--ui-shadow-warm-rgb) / 0.1),
+    0 1px 0 rgb(var(--ui-shadow-neutral-rgb) / 0.02);
+  --shadow-tooltip: 0 3px 6px rgb(var(--ui-shadow-neutral-rgb) / 0.05);
 }
 
 /* The two body text steps. Keep these non-inline: `@theme inline` bakes the
@@ -140,6 +152,8 @@
   --desktop-ui-font-size: 13px;
   --icon-size-default: 14px;
   --icon-container-default: 16px;
+  --ui-shadow-neutral-rgb: 0 0 0;
+  --ui-shadow-warm-rgb: 60 40 10;
 
   /* User-controlled UI font family (see Appearance settings /
    * lib/uiFontPreferences.ts). Deliberately left unset here so the `html` rule's
@@ -297,6 +311,8 @@
 
 .dark {
   /* Dark mode tokens — semi-transparent for glassmorphism backdrop-filter */
+  --ui-shadow-neutral-rgb: 0 0 0;
+  --ui-shadow-warm-rgb: 0 0 0;
   --background: #0e1013;
   --foreground: oklch(0.965 0.003 240);
   --card: rgba(31, 39, 45, 0.6);

--- a/web/src/index.css.test.ts
+++ b/web/src/index.css.test.ts
@@ -330,6 +330,34 @@ describe("index.css body text tokens", () => {
   });
 });
 
+describe("index.css shadow tokens", () => {
+  const themeBlock = cssSource.match(/@theme inline \{[^}]*\}/)?.[0].replace(/\s+/g, " ");
+
+  it.each([
+    "--shadow-composer: 0 0 12px -6px rgb(var(--ui-shadow-neutral-rgb) / 0.12)",
+    "--shadow-composer-focus: 0 0 20px -4px rgb(var(--ui-shadow-neutral-rgb) / 0.12)",
+    "--shadow-xs: 0 2px 8px rgb(var(--ui-shadow-neutral-rgb) / 0.04)",
+    "--shadow-sm: 0 4px 10px -6px rgb(var(--ui-shadow-neutral-rgb) / 0.09)",
+    "--shadow-md: 0 6px 12px -6px rgb(var(--ui-shadow-neutral-rgb) / 0.12)",
+    "--shadow-lg: 0 6px 20px -4px rgb(var(--ui-shadow-neutral-rgb) / 0.12)",
+    "--shadow-menu: 0 8px 28px rgb(var(--ui-shadow-warm-rgb) / 0.12)",
+    "--shadow-xl: 0 12px 44px rgb(var(--ui-shadow-warm-rgb) / 0.16)",
+    "--shadow-card: 0 4px 16px -2px rgb(var(--ui-shadow-warm-rgb) / 0.1), 0 1px 0 rgb(var(--ui-shadow-neutral-rgb) / 0.02)",
+    "--shadow-tooltip: 0 3px 6px rgb(var(--ui-shadow-neutral-rgb) / 0.05)",
+  ])("defines %s", (token) => {
+    expect(themeBlock).toContain(token);
+  });
+
+  it("uses the specified light colors and black dark-mode counterparts", () => {
+    expect(cssSource).toMatch(
+      /:root \{[^}]*--ui-shadow-neutral-rgb: 0 0 0;[^}]*--ui-shadow-warm-rgb: 60 40 10;/s,
+    );
+    expect(cssSource).toMatch(
+      /\.dark \{[^}]*--ui-shadow-neutral-rgb: 0 0 0;[^}]*--ui-shadow-warm-rgb: 0 0 0;/s,
+    );
+  });
+});
+
 /* Regression test for the "mobile sidebar is see-through" bug.
  *
  * Below md the sidebar is a full-screen overlay on top of the chat. The

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -4989,7 +4989,7 @@ export function Composer({
         // through, so clearance stops at this edge, not the row's bottom.
         data-composer-card
         className={cn(
-          "relative mx-auto flex w-full flex-col rounded-2xl border border-border bg-card dark:bg-card-solid shadow-sm transition",
+          "relative mx-auto flex w-full flex-col rounded-2xl border border-border bg-card dark:bg-card-solid shadow-composer transition-[border-color,box-shadow] has-[textarea:focus]:shadow-composer-focus",
           CHAT_COLUMN_WIDTH,
           isDragActive && "ring-2 ring-ring ring-inset",
         )}

--- a/web/src/pages/TurnRail.tsx
+++ b/web/src/pages/TurnRail.tsx
@@ -384,7 +384,7 @@ export function TurnRail({
           // inside the narrow w-6 rail column, so without a set width it
           // shrink-wraps to a few words per line. w-80 lets it fill out and
           // preview more content; max-w caps it on small viewports.
-          "pointer-events-none absolute left-7 w-80 max-w-[calc(100vw-4rem)] -translate-y-1/2 rounded-xl border border-border/60 bg-background px-3 py-2 shadow-md transition-[opacity,top] duration-150",
+          "pointer-events-none absolute left-7 w-80 max-w-[calc(100vw-4rem)] -translate-y-1/2 rounded-xl border border-border/60 bg-background px-3 py-2 shadow-tooltip transition-[opacity,top] duration-150",
           hovered ? "opacity-100" : "opacity-0",
         )}
       >

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -3657,7 +3657,7 @@ export function NewChatLandingScreen() {
             // translucent card. Mirrors the chat composer card. Drag-over
             // lifts an inset ring (overlay below).
             className={cn(
-              "relative z-10 flex w-full flex-col rounded-2xl border border-border bg-card dark:bg-card-solid shadow-[0_12px_20px_-20px_rgba(0,0,0,0.14),0_20px_28px_-28px_rgba(0,0,0,0.1)] transition-[border-color,box-shadow] duration-150 has-[textarea:focus]:border-foreground",
+              "relative z-10 flex w-full flex-col rounded-2xl border border-border bg-card dark:bg-card-solid shadow-composer transition-[border-color,box-shadow] duration-150 has-[textarea:focus]:border-foreground has-[textarea:focus]:shadow-composer-focus",
               isDragActive && "ring-2 ring-ring ring-inset",
             )}
             data-testid="new-chat-landing-composer"
@@ -4438,7 +4438,7 @@ export function NewChatLandingScreen() {
                             // Floats over the popover as a combobox popup, so it
                             // doesn't stretch the box. Bounded height + internal
                             // scroll keep it from running off the viewport.
-                            className="absolute top-full right-0 left-0 z-20 mt-1 flex max-h-40 flex-col overflow-y-auto rounded-md border border-input bg-popover p-1 shadow-md"
+                            className="absolute top-full right-0 left-0 z-20 mt-1 flex max-h-40 flex-col overflow-y-auto rounded-md border border-input bg-popover p-1 shadow-menu"
                             data-testid="new-chat-landing-worktree-dropdown"
                           >
                             <span className="px-2 pt-1 pb-0.5 text-sm font-medium tracking-wide text-muted-foreground uppercase">

--- a/web/src/shell/ProjectSettingsDialog.tsx
+++ b/web/src/shell/ProjectSettingsDialog.tsx
@@ -339,7 +339,7 @@ export function ProjectSettingsDialog({
                       className="fixed inset-0 z-10 cursor-default"
                       onClick={() => setWorkspaceOpen(false)}
                     />
-                    <div className="absolute top-full right-0 left-0 z-20 mt-1 rounded-md border bg-popover shadow-md">
+                    <div className="absolute top-full right-0 left-0 z-20 mt-1 rounded-md border bg-popover shadow-menu">
                       <WorkspacePicker
                         hostId={browsableHostId}
                         initialPath={isNavigablePath(workspace) ? workspace : undefined}

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -1939,7 +1939,7 @@ function ConversationList({
           a compact card showing the session's title. */}
         <DragOverlay dropAnimation={null}>
           {activeDrag ? (
-            <div className="pointer-events-none max-w-[16rem] truncate rounded-md border bg-card-solid px-3 py-2 text-ui shadow-lg">
+            <div className="pointer-events-none max-w-[16rem] truncate rounded-md border bg-card-solid px-3 py-2 text-ui shadow-tooltip">
               {activeDrag.label}
             </div>
           ) : null}
@@ -2837,7 +2837,7 @@ function SessionTooltipContent({
       data-testid="session-tooltip-content"
       // Mirror PinnedProjectFlyoutContent's compact HoverCard look: title,
       // then muted, small-icon metadata lines.
-      className="w-64 max-w-[calc(100vw-2rem)] flex-col items-stretch rounded-lg bg-popover p-2.5 text-popover-foreground whitespace-normal shadow-md ring-1 ring-foreground/10"
+      className="w-64 max-w-[calc(100vw-2rem)] flex-col items-stretch rounded-lg bg-popover p-2.5 text-popover-foreground whitespace-normal shadow-menu ring-1 ring-foreground/10"
     >
       <p className="sidebar-compact-text line-clamp-3 font-medium">
         {conversation.title ?? conversation.id}

--- a/web/src/shell/TableBubbleMenu.tsx
+++ b/web/src/shell/TableBubbleMenu.tsx
@@ -223,7 +223,7 @@ function HandleMenu({
   return createPortal(
     <div
       data-table-handle-menu
-      className="fixed z-[9999] min-w-[180px] overflow-hidden rounded-md border border-border bg-popover py-1 shadow-md"
+      className="fixed z-[9999] min-w-[180px] overflow-hidden rounded-md border border-border bg-popover py-1 shadow-menu"
       style={{ top: anchorTop, left: anchorLeft }}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}

--- a/web/src/shell/WorkspacePathField.tsx
+++ b/web/src/shell/WorkspacePathField.tsx
@@ -292,7 +292,7 @@ export function WorkspacePathField({
           // clipped by the dialog's scrollable body, and a body
           // portal can't be clicked through Radix's modal layer.
           // Inline content just scrolls with the form instead.
-          className="mt-1 max-h-72 overflow-y-auto rounded-md border border-border bg-popover shadow-md"
+          className="mt-1 max-h-72 overflow-y-auto rounded-md border border-border bg-popover shadow-menu"
           data-testid="workspace-path-dropdown"
         >
           {filteredRecent.length > 0 && (

--- a/web/src/shell/useCursorTooltip.tsx
+++ b/web/src/shell/useCursorTooltip.tsx
@@ -23,7 +23,7 @@ export function useCursorTooltip(text: string): {
   const tooltip = cursorPos ? (
     <div
       style={{ position: "fixed", left: cursorPos.x, top: cursorPos.y + 14, pointerEvents: "none" }}
-      className="z-50 inline-flex w-fit items-center rounded-md border border-border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-sm"
+      className="z-50 inline-flex w-fit items-center rounded-md border border-border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-tooltip"
     >
       {text}
     </div>


### PR DESCRIPTION
## Related issue

OMNI-2337

## Summary

Elevation shadows were scattered across Tailwind defaults and one-off arbitrary classes, so the UI never shared a single scale. This adds the shared shadow tokens from the design and migrates the main elevated surfaces onto them.

- Define light/dark RGB bases (`0 0 0` / `60 40 10` in light; both `0 0 0` in dark) and the full token set (`composer`, `composer-focus`, `xs`–`xl`, `menu`, `card`, `tooltip`) in `@theme inline`
- Point composers, menus/popovers, cards, and tooltips at the semantic tokens; leave inset/ring/special-purpose shadows alone
- Add CSS regression coverage for the token values and dark-mode bases

## Test Plan

- [x] `cd web && npm test -- src/index.css.test.ts` (pass)
- [x] `cd web && npm test` (5335 passed)
- [x] `cd web && npx oxlint --deny-warnings --report-unused-disable-directives .` (pass)
- [x] `cd web && npm run type-check` (pass)
- [x] `cd web && npm run build` (pass)
- [x] Visual smoke in light and dark: composer rest/focus, menus, cards, tooltips

## Demo

UI / frontend change — please attach a light+dark screenshot or short recording of composer focus, a menu, a card, and a tooltip after local smoke. Automated token coverage is in place; visual confirmation still needed for review.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Token definitions and dark-mode RGB bases are asserted in `web/src/index.css.test.ts`. Full web suite, lint, type-check, and production build were run. Browser visual smoke for elevation surfaces remains for the reviewer/Demo attachment.

## Changelog

Shared elevation shadows for composers, menus, cards, and tooltips