### PR TITLE
chore(repo): update auth area owners in areas.json

### DIFF
--- a/.github/areas.json
+++ b/.github/areas.json
@@ -228,7 +228,6 @@
       "owners": [
         "dhruv0811",
         "TomeHirata",
-        "SabhyaC26",
         "fanzeyi"
       ]
     },


### PR DESCRIPTION
## Summary

Update the owners list for the `auth` area in `.github/areas.json`. This is the central area / codeowner map used for issue triage and PR reviewer assignment. The `auth` area retains 3 owners, keeping it above the 2+ minimum that `areas.test.js` enforces.

## Test Plan

- `pre-commit run --files .github/areas.json` — passes.
- The `areas.test.js` validator covers this file (every owner in MAINTAINER, real `comp:*` label, 2+ owners, path resolution).

## Demo

N/A — non-visual config change.

## Type of change

- [x] Chore / maintenance

## Test coverage

- [x] Existing automated coverage (`areas.test.js`)
- [x] Manual verification completed

## Coverage notes

Verified locally that pre-commit passes on the changed file; the JSON change is covered by the existing `areas.test.js` validator.

This pull request and its description were written by Isaac.