### PR TITLE
feat(ci): ask duplicate reporters to self-close instead of waiting

### DIFF
--- a/.github/scripts/issue_duplicates.py
+++ b/.github/scripts/issue_duplicates.py
@@ -363,19 +363,28 @@ def build_duplicate_comment(
                 "If it isn't the same, say so here and a maintainer will reopen it."
             )
         else:
+            # The reporter can settle this faster than a maintainer can: they know
+            # whether the other issue covers their case. Ask them to close it
+            # themselves, and say what to do when it doesn't.
             message = (
                 f"Thanks for reporting this. This looks like the same problem as "
-                f"#{issue_number} — worth a look to see if it covers your case.\n\n"
-                "Leaving it open for a maintainer to confirm."
+                f"#{issue_number} — could you take a look?\n\n"
+                "If it covers your case, please close this one and add anything "
+                f"new over on #{issue_number} so the discussion stays in one place. "
+                "If it doesn't, say what's different and we'll pick it up here."
             )
     elif decision["duplicate_decision"] == "similar":
         references = ", ".join(f"#{number}" for number in decision["similar_issues"])
-        plural = "these" if len(decision["similar_issues"]) > 1 else "it"
+        covers = (
+            "they already cover" if len(decision["similar_issues"]) > 1 else "it already covers"
+        )
+        # Softer than the duplicate case — a loose match is a weaker basis for
+        # asking someone to close their own report — but still theirs to settle.
         message = (
-            f"Thanks for reporting this. {references} may be related — worth a look "
-            f"in case {plural} already covers this.\n\n"
-            "If it's the same problem, feel free to add your details there; "
-            "otherwise a maintainer will pick this up."
+            f"Thanks for reporting this. {references} may be related — could you "
+            f"take a look in case {covers} this?\n\n"
+            "If it turns out to be the same problem, please close this one and add "
+            "your details there. Otherwise leave a note and we'll pick it up here."
         )
     else:
         return ""

--- a/.github/scripts/issue_duplicates_test.py
+++ b/.github/scripts/issue_duplicates_test.py
@@ -183,11 +183,33 @@ class IssueDuplicatesTest(unittest.TestCase):
         self.assertIn("<!-- omnigent-duplicate-check -->", comment)
         self.assertIn("#12", comment)
         self.assertIn("may be related", comment)
+        # Like the duplicate case, this asks the reporter to close it rather than
+        # parking it in a maintainer queue.
+        self.assertIn("please close this one", comment)
+        self.assertNotIn("maintainer", comment)
         # The similar case never surfaces model prose, so injected content in
         # the reasoning cannot reach the comment at all.
         self.assertNotIn("@admin", comment)
         self.assertNotIn("https://example.com", comment)
         self.assertNotIn("#999", comment)
+
+    def test_similar_comment_agrees_in_number_with_its_references(self):
+        """One reference reads "it already covers", several read "they already cover"."""
+
+        def comment_for(numbers):
+            return build_duplicate_comment(
+                {
+                    "duplicate_decision": "similar",
+                    "duplicate_of": None,
+                    "similar_issues": numbers,
+                    "duplicate_confidence": 0.8,
+                    "duplicate_reasoning": "unused",
+                },
+                close_issue=False,
+            )
+
+        self.assertIn("it already covers", comment_for([12]))
+        self.assertIn("they already cover", comment_for([12, 34]))
 
     def test_duplicate_comment_reflects_closure_flag(self):
         decision = {
@@ -202,7 +224,11 @@ class IssueDuplicatesTest(unittest.TestCase):
         close_comment = build_duplicate_comment(decision, close_issue=True)
 
         self.assertIn("#12", observe_comment)
-        self.assertIn("Leaving it open", observe_comment)
+        # The open case asks the reporter to close it themselves rather than
+        # parking the issue in a maintainer queue.
+        self.assertIn("please close this one", observe_comment)
+        self.assertIn("If it doesn't", observe_comment)
+        self.assertNotIn("maintainer", observe_comment)
         self.assertIn("I’m closing it", close_comment)
 
     def test_no_comment_is_built_for_a_none_verdict(self):


### PR DESCRIPTION
## Related issue

Relates to #4198 (Stage 2 of the duplicate-detector rollout — comments are live
now, so this is the copy those comments use).

## Summary

The non-closing duplicate comment ended with *"Leaving it open for a maintainer
to confirm"* — which parks the issue in a queue nobody is watching. The reporter
is the one person who can settle it immediately: they know whether the linked
issue actually covers their case.

- `duplicate` verdict with closure disabled: asks the reporter to look, close
  their own issue if it matches, and say what's different if it doesn't.
- `similar` verdict: same ask, softer framing — a loose match is a weaker basis
  for asking someone to close their own report.
- Fixes a pre-existing grammar bug found by rendering the new copy: the plural
  branch produced *"these already covers this"*. Now agrees in number, with a
  regression test.

Before / after, `duplicate` (closure off):

> ~~Thanks for reporting this. This looks like the same problem as #4164 — worth a look to see if it covers your case. Leaving it open for a maintainer to confirm.~~

> Thanks for reporting this. This looks like the same problem as #4164 — could you take a look?
>
> If it covers your case, please close this one and add anything new over on #4164 so the discussion stays in one place. If it doesn't, say what's different and we'll pick it up here.

`similar`:

> Thanks for reporting this. #4164, #1157 may be related — could you take a look in case they already cover this?
>
> If it turns out to be the same problem, please close this one and add your details there. Otherwise leave a note and we'll pick it up here.

The auto-closing `duplicate` copy is unchanged — the bot already closed the
issue there, so there is nothing to ask for.

## Test Plan

```bash
python3 -m unittest discover -s .github/scripts -p 'issue_duplicates_test.py'
# Ran 27 tests — OK
pre-commit run --files .github/scripts/issue_duplicates.py .github/scripts/issue_duplicates_test.py
```

Also rendered the real output for 1, 2, and 3 references via `build_duplicate_comment`
to check number agreement and that the marker comment is still emitted.

## Demo

N/A — the change is bot comment copy; the rendered text is quoted in the Summary
above.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was rendering `build_duplicate_comment` output directly for
1, 2, and 3 similar-issue references — that is how the pre-existing plural bug
surfaced, and it is now pinned by
`test_similar_comment_agrees_in_number_with_its_references`. The two existing
comment tests were updated to assert the new ask and that the word "maintainer"
no longer appears in the non-closing copy.

## Changelog

Duplicate-detection comments now ask the reporter to close their own issue when
it's already covered, instead of leaving it for a maintainer.

---

This pull request and its description were written by Isaac.