### PR TITLE
fix(server): honor OMNIGENT_LOCAL_SINGLE_USER on non-loopback binds

### DIFF
--- a/deploy/databricks/src/app.py
+++ b/deploy/databricks/src/app.py
@@ -205,6 +205,16 @@ try:
     # OMNIGENT_AUTH_ENABLED in the deploy env (an explicit
     # provider always wins over the enable switch).
     os.environ.setdefault("OMNIGENT_AUTH_PROVIDER", "header")
+
+    # Header mode here relies on the proxy injecting the identity header. A
+    # single-user marker in the deploy env would turn an un-proxied request
+    # into the "local" user instead, so surface that if it is ever set.
+    from omnigent.server.auth import warn_if_single_user_exposed
+
+    _exposure = warn_if_single_user_exposed("0.0.0.0")
+    if _exposure:
+        logger.warning("%s", _exposure)
+
     auth_provider = create_auth_provider()
     app = create_app(
         agent_store=agent_store,

--- a/deploy/databricks/src/app.py
+++ b/deploy/databricks/src/app.py
@@ -129,7 +129,7 @@ try:
     from omnigent.runtime.agent_cache import AgentCache
     from omnigent.runtime.caps import RuntimeCaps
     from omnigent.server.app import create_app
-    from omnigent.server.auth import create_auth_provider
+    from omnigent.server.auth import create_auth_provider, warn_if_single_user_exposed
 
     # OTel: the Databricks Apps platform auto-injects
     # OTEL_EXPORTER_OTLP_ENDPOINT when `telemetry_export_destinations`
@@ -206,11 +206,7 @@ try:
     # provider always wins over the enable switch).
     os.environ.setdefault("OMNIGENT_AUTH_PROVIDER", "header")
 
-    # Header mode here relies on the proxy injecting the identity header. A
-    # single-user marker in the deploy env would turn an un-proxied request
-    # into the "local" user instead, so surface that if it is ever set.
-    from omnigent.server.auth import warn_if_single_user_exposed
-
+    # A single-user marker here would serve un-proxied requests as "local".
     _exposure = warn_if_single_user_exposed("0.0.0.0")
     if _exposure:
         logger.warning("%s", _exposure)

--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -188,7 +188,11 @@ def _resolve_config() -> _ResolvedConfig:
     # kill-switch path gets the marker: an EXPLICIT
     # OMNIGENT_AUTH_PROVIDER=header deploy declared a header-injecting
     # proxy and must stay strict.
-    from omnigent.server.auth import env_var_is_truthy
+    from omnigent.server.auth import (
+        env_var_is_truthy,
+        resolve_auth_source,
+        warn_if_single_user_exposed,
+    )
 
     # Compose passes OMNIGENT_AUTH_PROVIDER as "" when unset
     # ("${VAR:-}"): empty and missing both mean "not explicitly pinned".
@@ -202,8 +206,6 @@ def _resolve_config() -> _ResolvedConfig:
     # compose up` deploy works with zero config. Gate on the *resolved*
     # selection so an explicit header/oidc deploy (or AUTH_ENABLED=0)
     # doesn't mint accounts secrets it never reads.
-    from omnigent.server.auth import resolve_auth_source
-
     if resolve_auth_source() == "accounts":
         from omnigent.server.accounts_secret import load_or_generate_cookie_secret
 
@@ -221,13 +223,7 @@ def _resolve_config() -> _ResolvedConfig:
                 os.environ, host=host, port=port
             )
 
-    # A container binds a reachable interface, so the AUTH_ENABLED=0 posture
-    # above (which sets the single-user marker) serves unauthenticated requests
-    # as "local". Logged rather than printed: container stderr is usually
-    # buried in a platform log viewer, and the operator who set the kill switch
-    # is not watching a terminal.
-    from omnigent.server.auth import warn_if_single_user_exposed
-
+    # Logged, not printed: container stderr is buried in a platform log viewer.
     _exposure = warn_if_single_user_exposed(host)
     if _exposure:
         logger.warning("%s", _exposure)

--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -221,6 +221,17 @@ def _resolve_config() -> _ResolvedConfig:
                 os.environ, host=host, port=port
             )
 
+    # A container binds a reachable interface, so the AUTH_ENABLED=0 posture
+    # above (which sets the single-user marker) serves unauthenticated requests
+    # as "local". Logged rather than printed: container stderr is usually
+    # buried in a platform log viewer, and the operator who set the kill switch
+    # is not watching a terminal.
+    from omnigent.server.auth import warn_if_single_user_exposed
+
+    _exposure = warn_if_single_user_exposed(host)
+    if _exposure:
+        logger.warning("%s", _exposure)
+
     return _ResolvedConfig(
         cfg=cfg,
         database_url=database_url,

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1134,16 +1134,14 @@ def _apply_bind_auth_defaults(host: str) -> None:
       (the server boots and serves; no terminal prompt). Mirrors the
       Docker/Cloudflare/k8s entrypoints.
     - **Non-loopback + a truthy ``OMNIGENT_LOCAL_SINGLE_USER``** → leave
-      header mode alone and warn loudly. The operator declared a
-      single-operator server, so auto-enabling accounts would route
-      identity through :meth:`UnifiedAuthProvider._check_cookie`, where
-      neither the ``"local"`` fallback nor the identity header is
-      reachable — 401 on every request and 403 on the host tunnel, i.e. a
-      total outage rather than a login prompt. The warning names the
-      exposure because this posture serves unauthenticated to anyone who
-      can reach the bind address, and fires only when the resolved source
-      is actually ``header`` — an explicit accounts/oidc provider beside
-      the marker still requires login, so there is nothing to warn about.
+      header mode alone and warn via
+      :func:`~omnigent.server.auth.warn_if_single_user_exposed`. The
+      operator declared a single-operator server, so auto-enabling
+      accounts would route identity through
+      :meth:`UnifiedAuthProvider._check_cookie`, where neither the
+      ``"local"`` fallback nor the identity header is reachable — 401 on
+      every request and 403 on the host tunnel, a total outage rather
+      than a login prompt.
 
     Uses ``setdefault`` throughout so an operator's explicit value wins.
     Must run before ``create_auth_provider()``, which reads these vars.
@@ -1152,12 +1150,14 @@ def _apply_bind_auth_defaults(host: str) -> None:
         ``"0.0.0.0"``.
     :returns: None.
     """
-    from omnigent.server.auth import bind_host_is_loopback as _bind_host_is_loopback
-    from omnigent.server.auth import env_var_is_truthy as _env_var_is_truthy
-    from omnigent.server.auth import resolve_auth_source as _resolve_auth_source
-    from omnigent.server.auth import warn_if_single_user_exposed as _warn_if_single_user_exposed
+    from omnigent.server.auth import (
+        bind_host_is_loopback,
+        env_var_is_truthy,
+        resolve_auth_source,
+        warn_if_single_user_exposed,
+    )
 
-    _is_loopback_bind = _bind_host_is_loopback(host)
+    _is_loopback_bind = bind_host_is_loopback(host)
     # Compose-style deploys pass OMNIGENT_AUTH_PROVIDER as an empty
     # string when unset ("${VAR:-}"), so empty and missing both mean
     # "not explicitly pinned".
@@ -1165,13 +1165,12 @@ def _apply_bind_auth_defaults(host: str) -> None:
     _auth_provider_explicit = bool(_raw_auth_provider and _raw_auth_provider.strip())
 
     # Loopback + header default → single-user marker (no login).
-    if _is_loopback_bind and not _auth_provider_explicit and _resolve_auth_source() == "header":
+    if _is_loopback_bind and not _auth_provider_explicit and resolve_auth_source() == "header":
         os.environ.setdefault("OMNIGENT_LOCAL_SINGLE_USER", "1")
 
-    # A truthy marker is a deliberate "this is a single-operator server".
-    # Only truthy counts: LOCAL_SINGLE_USER=0 is an explicit opt-out and
-    # must not suppress the accounts auto-enable below.
-    _single_user_requested = _env_var_is_truthy("OMNIGENT_LOCAL_SINGLE_USER")
+    # Only truthy counts: LOCAL_SINGLE_USER=0 is an explicit opt-out and must
+    # not suppress the accounts auto-enable below.
+    _single_user_requested = env_var_is_truthy("OMNIGENT_LOCAL_SINGLE_USER")
 
     # Non-loopback + no explicit auth → accounts (login) mode.
     _auth_enabled_explicit = bool(os.environ.get("OMNIGENT_AUTH_ENABLED", "").strip())
@@ -1192,12 +1191,8 @@ def _apply_bind_auth_defaults(host: str) -> None:
             err=True,
         )
     else:
-        # Exposure warning comes from the auth module so the CLI and the
-        # container entrypoints announce the same posture from one rule.
-        # It self-gates on the resolved source being ``header`` — an explicit
-        # accounts/oidc provider requires login, so there is nothing to warn
-        # about — and on the bind being reachable.
-        _exposure = _warn_if_single_user_exposed(host)
+        # Self-gates on a reachable bind and a resolved source of "header".
+        _exposure = warn_if_single_user_exposed(host)
         if _exposure:
             click.echo(f"  ⚠ {_exposure}", err=True)
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1115,8 +1115,9 @@ def _apply_bind_auth_defaults(host: str) -> None:
 
     The bind address is the discriminator for the *implicit* (env-unset)
     auth posture. Explicit operator choices always win — an
-    ``OMNIGENT_AUTH_PROVIDER`` keeps header/oidc, and
-    ``OMNIGENT_AUTH_ENABLED`` (or its deprecated alias) pins auth on/off.
+    ``OMNIGENT_AUTH_PROVIDER`` keeps header/oidc,
+    ``OMNIGENT_AUTH_ENABLED`` pins auth on/off, and a truthy
+    ``OMNIGENT_LOCAL_SINGLE_USER`` declares a single-user server.
 
     Decision matrix for the env-unset default:
 
@@ -1132,6 +1133,15 @@ def _apply_bind_auth_defaults(host: str) -> None:
       login. First-admin setup happens via the web Create-admin form
       (the server boots and serves; no terminal prompt). Mirrors the
       Docker/Cloudflare/k8s entrypoints.
+    - **Non-loopback + a truthy ``OMNIGENT_LOCAL_SINGLE_USER``** → leave
+      header mode alone and warn loudly. The operator declared a
+      single-operator server, so auto-enabling accounts would route
+      identity through :meth:`UnifiedAuthProvider._check_cookie`, where
+      neither the ``"local"`` fallback nor the identity header is
+      reachable — 401 on every request and 403 on the host tunnel, i.e. a
+      total outage rather than a login prompt. The warning names the
+      exposure because this posture serves unauthenticated to anyone who
+      can reach the bind address.
 
     Uses ``setdefault`` throughout so an operator's explicit value wins.
     Must run before ``create_auth_provider()``, which reads these vars.
@@ -1140,6 +1150,7 @@ def _apply_bind_auth_defaults(host: str) -> None:
         ``"0.0.0.0"``.
     :returns: None.
     """
+    from omnigent.server.auth import env_var_is_truthy as _env_var_is_truthy
     from omnigent.server.auth import resolve_auth_source as _resolve_auth_source
 
     _is_loopback_bind = host in ("127.0.0.1", "localhost", "::1")
@@ -1153,9 +1164,19 @@ def _apply_bind_auth_defaults(host: str) -> None:
     if _is_loopback_bind and not _auth_provider_explicit and _resolve_auth_source() == "header":
         os.environ.setdefault("OMNIGENT_LOCAL_SINGLE_USER", "1")
 
+    # A truthy marker is a deliberate "this is a single-operator server".
+    # Only truthy counts: LOCAL_SINGLE_USER=0 is an explicit opt-out and
+    # must not suppress the accounts auto-enable below.
+    _single_user_requested = _env_var_is_truthy("OMNIGENT_LOCAL_SINGLE_USER")
+
     # Non-loopback + no explicit auth → accounts (login) mode.
     _auth_enabled_explicit = bool(os.environ.get("OMNIGENT_AUTH_ENABLED", "").strip())
-    if not _is_loopback_bind and not _auth_provider_explicit and not _auth_enabled_explicit:
+    if (
+        not _is_loopback_bind
+        and not _auth_provider_explicit
+        and not _auth_enabled_explicit
+        and not _single_user_requested
+    ):
         os.environ.setdefault("OMNIGENT_AUTH_ENABLED", "1")
         click.echo(
             f"  ⚠ Binding to non-local interface {host}: enabling accounts "
@@ -1164,6 +1185,16 @@ def _apply_bind_auth_defaults(host: str) -> None:
             "account.\n"
             "    Set OMNIGENT_AUTH_ENABLED=0 first to override and stay in "
             "single-user mode.",
+            err=True,
+        )
+    elif not _is_loopback_bind and _single_user_requested and not _auth_enabled_explicit:
+        click.echo(
+            "  ⚠ SECURITY: OMNIGENT_LOCAL_SINGLE_USER=1 is set and you are "
+            f"binding to non-local interface {host}.\n"
+            "    This server will serve UNAUTHENTICATED requests as the "
+            '"local" user to anyone who can reach this address.\n'
+            "    Only do this on a trusted private network.\n"
+            "    Unset OMNIGENT_LOCAL_SINGLE_USER to require login instead.",
             err=True,
         )
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1152,10 +1152,12 @@ def _apply_bind_auth_defaults(host: str) -> None:
         ``"0.0.0.0"``.
     :returns: None.
     """
+    from omnigent.server.auth import bind_host_is_loopback as _bind_host_is_loopback
     from omnigent.server.auth import env_var_is_truthy as _env_var_is_truthy
     from omnigent.server.auth import resolve_auth_source as _resolve_auth_source
+    from omnigent.server.auth import warn_if_single_user_exposed as _warn_if_single_user_exposed
 
-    _is_loopback_bind = host in ("127.0.0.1", "localhost", "::1")
+    _is_loopback_bind = _bind_host_is_loopback(host)
     # Compose-style deploys pass OMNIGENT_AUTH_PROVIDER as an empty
     # string when unset ("${VAR:-}"), so empty and missing both mean
     # "not explicitly pinned".
@@ -1189,20 +1191,15 @@ def _apply_bind_auth_defaults(host: str) -> None:
             "single-user mode.",
             err=True,
         )
-    elif not _is_loopback_bind and _single_user_requested and _resolve_auth_source() == "header":
-        # Gated on the *resolved* source, not on whether a provider was pinned:
-        # the exposure exists only in header mode, where the "local" fallback is
-        # reachable. An explicit accounts/oidc provider still requires login, so
-        # warning there would be false.
-        click.echo(
-            "  ⚠ SECURITY: OMNIGENT_LOCAL_SINGLE_USER=1 is set and you are "
-            f"binding to non-local interface {host}.\n"
-            "    This server will serve UNAUTHENTICATED requests as the "
-            '"local" user to anyone who can reach this address.\n'
-            "    Only do this on a trusted private network.\n"
-            "    Unset OMNIGENT_LOCAL_SINGLE_USER to require login instead.",
-            err=True,
-        )
+    else:
+        # Exposure warning comes from the auth module so the CLI and the
+        # container entrypoints announce the same posture from one rule.
+        # It self-gates on the resolved source being ``header`` — an explicit
+        # accounts/oidc provider requires login, so there is nothing to warn
+        # about — and on the bind being reachable.
+        _exposure = _warn_if_single_user_exposed(host)
+        if _exposure:
+            click.echo(f"  ⚠ {_exposure}", err=True)
 
 
 def _create_artifact_store(location: str) -> Any:  # type: ignore[explicit-any]  # returns ArtifactStore protocol (optional deps)

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1141,7 +1141,9 @@ def _apply_bind_auth_defaults(host: str) -> None:
       reachable — 401 on every request and 403 on the host tunnel, i.e. a
       total outage rather than a login prompt. The warning names the
       exposure because this posture serves unauthenticated to anyone who
-      can reach the bind address.
+      can reach the bind address, and fires only when the resolved source
+      is actually ``header`` — an explicit accounts/oidc provider beside
+      the marker still requires login, so there is nothing to warn about.
 
     Uses ``setdefault`` throughout so an operator's explicit value wins.
     Must run before ``create_auth_provider()``, which reads these vars.
@@ -1187,7 +1189,11 @@ def _apply_bind_auth_defaults(host: str) -> None:
             "single-user mode.",
             err=True,
         )
-    elif not _is_loopback_bind and _single_user_requested and not _auth_enabled_explicit:
+    elif not _is_loopback_bind and _single_user_requested and _resolve_auth_source() == "header":
+        # Gated on the *resolved* source, not on whether a provider was pinned:
+        # the exposure exists only in header mode, where the "local" fallback is
+        # reachable. An explicit accounts/oidc provider still requires login, so
+        # warning there would be false.
         click.echo(
             "  ⚠ SECURITY: OMNIGENT_LOCAL_SINGLE_USER=1 is set and you are "
             f"binding to non-local interface {host}.\n"

--- a/omnigent/server/auth.py
+++ b/omnigent/server/auth.py
@@ -27,6 +27,7 @@ and closed over by route factories — no per-request import cost.
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 import os
 import time
@@ -220,18 +221,14 @@ _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 def bind_host_is_loopback(host: str) -> bool:
     """Whether *host* only accepts connections from this machine.
 
-    Recognizes the common literals directly and otherwise defers to
-    :mod:`ipaddress`, so any address in ``127.0.0.0/8`` counts. A
-    wildcard (``0.0.0.0`` / ``::``) is NOT loopback — it accepts traffic
-    from every reachable interface. Unparseable values (a hostname we
-    can't resolve here) are treated as non-loopback: for a warning gate,
-    guessing "reachable" is the safe direction.
+    A wildcard (``0.0.0.0`` / ``::``) is not loopback — it accepts traffic
+    from every reachable interface. Unparseable values (an unresolved
+    hostname) count as non-loopback, so a warning gated on this errs
+    toward "reachable".
 
     :param host: Bind host, e.g. ``"127.0.0.1"``, ``"0.0.0.0"``.
     :returns: ``True`` when the bind is loopback-only.
     """
-    import ipaddress
-
     if host in _LOOPBACK_HOSTS:
         return True
     try:
@@ -244,13 +241,12 @@ def warn_if_single_user_exposed(host: str) -> str | None:
     """Return a warning when a single-user server is network-reachable.
 
     Header mode with the single-user marker serves every unauthenticated
-    request as :data:`RESERVED_USER_LOCAL`. That is the intended local
-    posture on loopback, but on a reachable interface it hands the
-    ``"local"`` identity to anyone who can connect. Gated on the
-    *resolved* source being ``header``: an accounts/oidc server routes
-    identity through the cookie path, so there is no such exposure.
+    request as :data:`RESERVED_USER_LOCAL` — the intended posture on
+    loopback, but on a reachable interface it hands that identity to
+    anyone who can connect. Accounts/oidc route identity through the
+    cookie path, so they are not exposed and stay silent.
 
-    Callers own how the text surfaces — Click's stderr for the CLI, a
+    Callers own how the text surfaces: Click's stderr for the CLI, a
     logger for container entrypoints where stderr is buried.
 
     :param host: The resolved bind host, e.g. ``"0.0.0.0"``.

--- a/omnigent/server/auth.py
+++ b/omnigent/server/auth.py
@@ -214,6 +214,62 @@ def local_single_user_enabled() -> bool:
     return env_var_is_truthy(_LOCAL_SINGLE_USER_ENV)
 
 
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+
+def bind_host_is_loopback(host: str) -> bool:
+    """Whether *host* only accepts connections from this machine.
+
+    Recognizes the common literals directly and otherwise defers to
+    :mod:`ipaddress`, so any address in ``127.0.0.0/8`` counts. A
+    wildcard (``0.0.0.0`` / ``::``) is NOT loopback — it accepts traffic
+    from every reachable interface. Unparseable values (a hostname we
+    can't resolve here) are treated as non-loopback: for a warning gate,
+    guessing "reachable" is the safe direction.
+
+    :param host: Bind host, e.g. ``"127.0.0.1"``, ``"0.0.0.0"``.
+    :returns: ``True`` when the bind is loopback-only.
+    """
+    import ipaddress
+
+    if host in _LOOPBACK_HOSTS:
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def warn_if_single_user_exposed(host: str) -> str | None:
+    """Return a warning when a single-user server is network-reachable.
+
+    Header mode with the single-user marker serves every unauthenticated
+    request as :data:`RESERVED_USER_LOCAL`. That is the intended local
+    posture on loopback, but on a reachable interface it hands the
+    ``"local"`` identity to anyone who can connect. Gated on the
+    *resolved* source being ``header``: an accounts/oidc server routes
+    identity through the cookie path, so there is no such exposure.
+
+    Callers own how the text surfaces — Click's stderr for the CLI, a
+    logger for container entrypoints where stderr is buried.
+
+    :param host: The resolved bind host, e.g. ``"0.0.0.0"``.
+    :returns: The multi-line warning, or ``None`` when not exposed.
+    """
+    if bind_host_is_loopback(host):
+        return None
+    if not local_single_user_enabled() or resolve_auth_source() != "header":
+        return None
+    return (
+        f"SECURITY: {_LOCAL_SINGLE_USER_ENV} is set and the server is bound to "
+        f"the non-local interface {host}.\n"
+        f'    This server will serve UNAUTHENTICATED requests as the "'
+        f'{RESERVED_USER_LOCAL}" user to anyone who can reach this address.\n'
+        "    Only do this on a trusted private network.\n"
+        f"    Unset {_LOCAL_SINGLE_USER_ENV} to require login instead."
+    )
+
+
 def resolve_auth_header() -> str:
     """Resolve the trusted identity header name for header-auth mode.
 

--- a/tests/cli/test_bind_auth_defaults.py
+++ b/tests/cli/test_bind_auth_defaults.py
@@ -5,7 +5,9 @@ Covers the four corners of the matrix:
 - loopback + env-unset → single-user marker (no login);
 - non-loopback + env-unset → accounts mode (login required) + warning;
 - explicit ``OMNIGENT_AUTH_PROVIDER`` → no implicit change;
-- explicit ``OMNIGENT_AUTH_ENABLED=0`` → no implicit re-enable.
+- explicit ``OMNIGENT_AUTH_ENABLED=0`` → no implicit re-enable;
+- non-loopback + explicit ``OMNIGENT_LOCAL_SINGLE_USER=1`` → header mode
+  kept (no accounts auto-enable) + security warning.
 """
 
 from __future__ import annotations
@@ -152,6 +154,86 @@ def test_non_loopback_empty_auth_provider_string_is_unset(monkeypatch: pytest.Mo
     _apply_bind_auth_defaults("0.0.0.0")
 
     assert os.environ.get("OMNIGENT_AUTH_ENABLED") == "1"
+
+
+# ── non-loopback + explicit single-user marker ──────────────────────
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "192.168.1.10", "10.0.0.5"])
+@pytest.mark.parametrize("marker", ["1", "true", "yes", "TRUE"])
+def test_non_loopback_respects_explicit_single_user(
+    host: str, marker: str, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A truthy OMNIGENT_LOCAL_SINGLE_USER wins on a non-loopback bind.
+
+    Auto-enabling accounts here would switch identity resolution to the
+    cookie path, where neither the ``"local"`` fallback nor the identity
+    header is reachable — every request 401s and the host tunnel 403s.
+    The operator declared a single-operator server, so header mode stays.
+    """
+    monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", marker)
+    _apply_bind_auth_defaults(host)
+
+    # Accounts mode must NOT be auto-enabled over the explicit marker.
+    assert os.environ.get("OMNIGENT_AUTH_ENABLED") is None
+    assert os.environ.get("OMNIGENT_LOCAL_SINGLE_USER") == marker
+
+    from omnigent.server.auth import resolve_auth_source
+
+    assert resolve_auth_source() == "header"
+
+    # The warning names the exposure, not just the mode: this posture
+    # serves unauthenticated to anyone who can reach the bind address.
+    _msg = _stderr(capsys)
+    assert host in _msg
+    assert "unauthenticated" in _msg.lower()
+    assert "OMNIGENT_LOCAL_SINGLE_USER" in _msg
+
+
+def test_non_loopback_single_user_zero_still_enables_accounts(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """OMNIGENT_LOCAL_SINGLE_USER=0 is an opt-out — accounts still auto-enable.
+
+    Only a *truthy* marker declares a single-user server; an explicit
+    "off" must not suppress the network-exposed login default.
+    """
+    monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", "0")
+    _apply_bind_auth_defaults("0.0.0.0")
+
+    assert os.environ.get("OMNIGENT_AUTH_ENABLED") == "1"
+    assert "accounts" in _stderr(capsys).lower()
+
+
+def test_non_loopback_single_user_with_auth_enabled_one_keeps_accounts(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An explicit AUTH_ENABLED=1 beats the single-user marker.
+
+    Both are explicit; the narrower "auth on" wins, and the
+    unauthenticated-exposure warning must not fire for a server that
+    does require login.
+    """
+    monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", "1")
+    monkeypatch.setenv("OMNIGENT_AUTH_ENABLED", "1")
+    _apply_bind_auth_defaults("0.0.0.0")
+
+    assert os.environ.get("OMNIGENT_AUTH_ENABLED") == "1"
+    assert _stderr(capsys) == ""
+
+
+def test_loopback_single_user_emits_no_warning(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The exposure warning is scoped to non-loopback binds.
+
+    On loopback the single-user marker is the normal, safe default — it
+    must stay silent.
+    """
+    monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", "1")
+    _apply_bind_auth_defaults("127.0.0.1")
+
+    assert _stderr(capsys) == ""
 
 
 # ── OIDC ───────────────────────────────────────────────────────────

--- a/tests/cli/test_bind_auth_defaults.py
+++ b/tests/cli/test_bind_auth_defaults.py
@@ -222,6 +222,61 @@ def test_non_loopback_single_user_with_auth_enabled_one_keeps_accounts(
     assert _stderr(capsys) == ""
 
 
+@pytest.mark.parametrize("provider", ["accounts", "oidc"])
+def test_non_loopback_single_user_with_explicit_login_provider_is_silent(
+    provider: str, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An explicit login provider beside the marker suppresses the warning.
+
+    ``OMNIGENT_AUTH_PROVIDER`` wins outright in ``resolve_auth_source``, so
+    identity goes through the cookie path and login *is* required. Claiming
+    unauthenticated exposure here would be false.
+    """
+    monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", "1")
+    monkeypatch.setenv("OMNIGENT_AUTH_PROVIDER", provider)
+    _apply_bind_auth_defaults("0.0.0.0")
+
+    from omnigent.server.auth import resolve_auth_source
+
+    assert resolve_auth_source() == provider
+    assert _stderr(capsys) == ""
+
+
+def test_non_loopback_single_user_with_explicit_header_provider_warns(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An explicit header provider beside the marker still warns.
+
+    Header mode is exactly where the ``"local"`` fallback is reachable, so
+    pinning it deliberately is real exposure — the warning must not be
+    silenced just because the provider was named explicitly.
+    """
+    monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", "1")
+    monkeypatch.setenv("OMNIGENT_AUTH_PROVIDER", "header")
+    _apply_bind_auth_defaults("0.0.0.0")
+
+    assert "unauthenticated" in _stderr(capsys).lower()
+
+
+def test_non_loopback_single_user_with_auth_enabled_zero_warns(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """AUTH_ENABLED=0 beside the marker warns: it resolves to header mode.
+
+    The kill-switch is "set" but falsy, so ``resolve_auth_source`` returns
+    ``header`` and the unauthenticated ``"local"`` fallback is live. The
+    exposure is real and must be announced.
+    """
+    monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", "1")
+    monkeypatch.setenv("OMNIGENT_AUTH_ENABLED", "0")
+    _apply_bind_auth_defaults("0.0.0.0")
+
+    from omnigent.server.auth import resolve_auth_source
+
+    assert resolve_auth_source() == "header"
+    assert "unauthenticated" in _stderr(capsys).lower()
+
+
 def test_loopback_single_user_emits_no_warning(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/e2e/omnigent/conftest.py
+++ b/tests/e2e/omnigent/conftest.py
@@ -252,6 +252,30 @@ def configure_mock_llm(
     resp.raise_for_status()
 
 
+def set_fallback_mock_llm(
+    mock_llm_server_url: str,
+    key: str,
+    text: str,
+) -> None:
+    """Set a non-resettable fallback response for a queue key.
+
+    Returned once the regular queue for *key* is exhausted, so a test
+    stays deterministic when the harness makes more model calls than it
+    queued responses for — e.g. a background session-title call racing
+    the user turn for the same keyed queue.
+
+    :param mock_llm_server_url: Mock server base URL.
+    :param key: Queue key (typically the model name).
+    :param text: Fallback response text.
+    """
+    resp = httpx.post(
+        f"{mock_llm_server_url}/mock/set_fallback",
+        json={"key": key, "text": text},
+        timeout=5.0,
+    )
+    resp.raise_for_status()
+
+
 def reset_mock_llm(mock_llm_server_url: str) -> None:
     """Clear all keyed queues, captured requests, and gates."""
     resp = httpx.post(f"{mock_llm_server_url}/mock/reset", timeout=5.0)

--- a/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
+++ b/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
@@ -76,11 +76,9 @@ def test_run_harness_without_agent_live_repl_round_trip(
     marker = f"{probe.marker}_RUN_HARNESS_WITHOUT_AGENT"
     prompt = _PROMPT_TEMPLATE.format(marker=marker)
 
-    # Harnesses that register a background session-title generator issue an
-    # extra model call that races the user turn for this same keyed queue, so
-    # the number of calls per run is not fixed. A fallback makes the marker the
-    # answer to EVERY call on this key — whichever call wins, the turn renders
-    # the marker instead of the queue's generic default.
+    # A background session-title generator races the user turn for this same
+    # keyed queue, so the call count per run is not fixed. The fallback answers
+    # every call with the marker, so whichever wins, the turn still renders it.
     configure_mock_llm(
         mock_llm_server_url,
         [{"text": marker}],

--- a/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
+++ b/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
@@ -31,7 +31,7 @@ from tests.e2e.omnigent._pexpect_harness import (
     spawn_omnigent_run,
     strip_ansi,
 )
-from tests.e2e.omnigent.conftest import configure_mock_llm
+from tests.e2e.omnigent.conftest import configure_mock_llm, set_fallback_mock_llm
 
 _PROMPT_TEMPLATE = (
     "Reply with exactly the identifier between <answer> tags, but omit the tags: "
@@ -76,14 +76,17 @@ def test_run_harness_without_agent_live_repl_round_trip(
     marker = f"{probe.marker}_RUN_HARNESS_WITHOUT_AGENT"
     prompt = _PROMPT_TEMPLATE.format(marker=marker)
 
-    # claude-code issues a warmup/title call before the turn that consumes one
-    # queued response, so the turn call needs another; queue a few markers.
-    responses = [{"text": marker}] * (4 if probe.harness == "claude-sdk" else 1)
+    # Harnesses that register a background session-title generator issue an
+    # extra model call that races the user turn for this same keyed queue, so
+    # the number of calls per run is not fixed. A fallback makes the marker the
+    # answer to EVERY call on this key — whichever call wins, the turn renders
+    # the marker instead of the queue's generic default.
     configure_mock_llm(
         mock_llm_server_url,
-        responses,
+        [{"text": marker}],
         key=model,
     )
+    set_fallback_mock_llm(mock_llm_server_url, model, marker)
 
     # claude-sdk speaks the Anthropic wire, not OPENAI_*. Point it at the mock
     # and pass a static gateway token via ANTHROPIC_AUTH_TOKEN (Authorization:

--- a/tests/server/test_single_user_exposure_warning.py
+++ b/tests/server/test_single_user_exposure_warning.py
@@ -1,12 +1,10 @@
 """Unit tests for the single-user exposure warning helpers.
 
-``warn_if_single_user_exposed`` is the one rule every spawn path shares —
-the CLI prints it to stderr, the container entrypoints log it — so the
-gating lives here rather than being re-derived per adapter.
-
-The warning fires only where the exposure is real: a reachable bind, a
-truthy single-user marker, AND a resolved source of ``header`` (the one
-mode where the unauthenticated ``"local"`` fallback is live).
+``warn_if_single_user_exposed`` is the rule every spawn path shares — the
+CLI prints it to stderr, the container entrypoints log it. It fires only
+where the exposure is real: a reachable bind, a truthy single-user
+marker, and a resolved source of ``header`` (the one mode where the
+unauthenticated ``"local"`` fallback is live).
 """
 
 from __future__ import annotations
@@ -49,11 +47,7 @@ def test_non_loopback_hosts_recognized(host: str) -> None:
 
 
 def test_unresolvable_host_treated_as_reachable() -> None:
-    """An unparseable host errs toward "reachable" so the warning still fires.
-
-    For a security warning, over-warning on a name we can't classify is the
-    safe direction.
-    """
+    """An unparseable host errs toward "reachable" so the warning still fires."""
     assert bind_host_is_loopback("some-k8s-service.internal") is False
 
 
@@ -101,8 +95,7 @@ def test_silent_under_explicit_login_provider(
 ) -> None:
     """An explicit login provider routes identity through the cookie path.
 
-    Login really is required there, so claiming unauthenticated exposure
-    would be false.
+    Login is required there, so claiming exposure would be false.
     """
     monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", "1")
     monkeypatch.setenv("OMNIGENT_AUTH_PROVIDER", provider)
@@ -123,8 +116,7 @@ def test_warns_under_explicit_header_provider(monkeypatch: pytest.MonkeyPatch) -
 def test_warns_under_auth_enabled_zero(monkeypatch: pytest.MonkeyPatch) -> None:
     """``AUTH_ENABLED=0`` is set-but-falsy, resolving to header mode.
 
-    This is the Docker kill-switch posture, which also sets the marker —
-    exactly the container case CLI stderr never covered.
+    The Docker kill-switch posture, which also sets the marker.
     """
     monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", "1")
     monkeypatch.setenv("OMNIGENT_AUTH_ENABLED", "0")

--- a/tests/server/test_single_user_exposure_warning.py
+++ b/tests/server/test_single_user_exposure_warning.py
@@ -1,0 +1,140 @@
+"""Unit tests for the single-user exposure warning helpers.
+
+``warn_if_single_user_exposed`` is the one rule every spawn path shares —
+the CLI prints it to stderr, the container entrypoints log it — so the
+gating lives here rather than being re-derived per adapter.
+
+The warning fires only where the exposure is real: a reachable bind, a
+truthy single-user marker, AND a resolved source of ``header`` (the one
+mode where the unauthenticated ``"local"`` fallback is live).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.server.auth import (
+    bind_host_is_loopback,
+    warn_if_single_user_exposed,
+)
+
+_AUTH_ENVS = (
+    "OMNIGENT_AUTH_PROVIDER",
+    "OMNIGENT_AUTH_ENABLED",
+    "OMNIGENT_LOCAL_SINGLE_USER",
+    "OMNIGENT_OIDC_ISSUER",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear auth env vars so each case starts from a known posture."""
+    for _var in _AUTH_ENVS:
+        monkeypatch.delenv(_var, raising=False)
+
+
+# ── bind_host_is_loopback ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1", "127.0.0.5"])
+def test_loopback_hosts_recognized(host: str) -> None:
+    """Literals and the wider 127.0.0.0/8 range count as loopback."""
+    assert bind_host_is_loopback(host) is True
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "::", "192.168.1.10", "10.0.0.5"])
+def test_non_loopback_hosts_recognized(host: str) -> None:
+    """Wildcards are NOT loopback — they accept traffic from every interface."""
+    assert bind_host_is_loopback(host) is False
+
+
+def test_unresolvable_host_treated_as_reachable() -> None:
+    """An unparseable host errs toward "reachable" so the warning still fires.
+
+    For a security warning, over-warning on a name we can't classify is the
+    safe direction.
+    """
+    assert bind_host_is_loopback("some-k8s-service.internal") is False
+
+
+# ── warn_if_single_user_exposed ─────────────────────────────────────
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "192.168.1.10"])
+@pytest.mark.parametrize("marker", ["1", "true", "yes", "TRUE"])
+def test_warns_on_reachable_bind_with_truthy_marker(
+    host: str, marker: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reachable bind + truthy marker + header mode → warning names the exposure."""
+    monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", marker)
+
+    msg = warn_if_single_user_exposed(host)
+
+    assert msg is not None
+    assert host in msg
+    assert "unauthenticated" in msg.lower()
+    assert "OMNIGENT_LOCAL_SINGLE_USER" in msg
+
+
+def test_silent_on_loopback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On loopback the marker is the normal, safe local posture."""
+    monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", "1")
+
+    assert warn_if_single_user_exposed("127.0.0.1") is None
+
+
+def test_silent_without_marker() -> None:
+    """No marker means no ``"local"`` fallback, so nothing is exposed."""
+    assert warn_if_single_user_exposed("0.0.0.0") is None
+
+
+def test_silent_with_falsy_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``=0`` is an explicit opt-out, not a declaration."""
+    monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", "0")
+
+    assert warn_if_single_user_exposed("0.0.0.0") is None
+
+
+@pytest.mark.parametrize("provider", ["accounts", "oidc"])
+def test_silent_under_explicit_login_provider(
+    provider: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An explicit login provider routes identity through the cookie path.
+
+    Login really is required there, so claiming unauthenticated exposure
+    would be false.
+    """
+    monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", "1")
+    monkeypatch.setenv("OMNIGENT_AUTH_PROVIDER", provider)
+    if provider == "oidc":
+        monkeypatch.setenv("OMNIGENT_OIDC_ISSUER", "https://idp.example.com")
+
+    assert warn_if_single_user_exposed("0.0.0.0") is None
+
+
+def test_warns_under_explicit_header_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pinning header mode deliberately is still exposure, so still warn."""
+    monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", "1")
+    monkeypatch.setenv("OMNIGENT_AUTH_PROVIDER", "header")
+
+    assert warn_if_single_user_exposed("0.0.0.0") is not None
+
+
+def test_warns_under_auth_enabled_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``AUTH_ENABLED=0`` is set-but-falsy, resolving to header mode.
+
+    This is the Docker kill-switch posture, which also sets the marker —
+    exactly the container case CLI stderr never covered.
+    """
+    monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", "1")
+    monkeypatch.setenv("OMNIGENT_AUTH_ENABLED", "0")
+
+    assert warn_if_single_user_exposed("0.0.0.0") is not None
+
+
+def test_silent_under_auth_enabled_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A truthy enable switch resolves to accounts — login required."""
+    monkeypatch.setenv("OMNIGENT_LOCAL_SINGLE_USER", "1")
+    monkeypatch.setenv("OMNIGENT_AUTH_ENABLED", "1")
+
+    assert warn_if_single_user_exposed("0.0.0.0") is None


### PR DESCRIPTION
## Related issue

Closes #4193

## Summary

Upgrading a self-hosted single-operator server from 0.6.0 to 0.7.0 turned every
request into a 401 and every host-tunnel connect into a 403 — a total outage, not
a degradation, since no host attaches and no agent can be dispatched.

Root cause is not in `server/auth.py` (which the reporter read correctly — it is
consistent with its own docstring). `_apply_bind_auth_defaults` in `cli.py` runs
*before* `create_auth_provider()` and, on a non-loopback bind with no explicit
auth, sets `OMNIGENT_AUTH_ENABLED=1`. It asks three questions — is the bind
loopback, is `AUTH_PROVIDER` pinned, is `AUTH_ENABLED` pinned — but never asks
whether `OMNIGENT_LOCAL_SINGLE_USER` is set. So an operator's explicit
"I am a single-user server" was silently overridden.

That flips identity resolution to the cookie path, where **both** the reserved
`"local"` fallback and the `X-Forwarded-Email` check are unreachable by
construction — they live only in `_check_header()`:

```
                 get_user_id(request)                     auth.py:446
                          |
                which source is active?
                          |
        +-----------------+------------------+
        |                                    |
  "accounts"/"oidc"                      "header"
        |                                    |
   _check_cookie()                    _check_header()     auth.py:576
        |                                    |
  session cookie?                   X-Forwarded-Email?
   yes -> user                       yes -> user          <-- unreachable
   no  -> None -> 401                no  -> LOCAL_SINGLE_USER?
                                            yes -> "local"  <-- unreachable
                                            no  -> None -> 401
```

This is why two seemingly unrelated paths failed together, and why the marker
appeared to do nothing while `/v1/info` still reported `single_user: true`
alongside `accounts_enabled: true` — a self-contradiction that made the state
look impossible to debug.

Introduced by #3107 (2026-07-23), which landed in v0.7.0. The security intent
there was right — a wide-open server on `0.0.0.0` is a real hole — the bug is
only in overriding an explicit operator declaration without noticing it existed.

**Fix:** a truthy `OMNIGENT_LOCAL_SINGLE_USER` now suppresses the accounts
auto-enable and keeps header mode, with a loud stderr warning naming the
exposure. Only *truthy* counts, so `LOCAL_SINGLE_USER=0` stays an opt-out and
still gets accounts mode; an explicit `AUTH_ENABLED=1` still wins over the
marker. Reproduced on `main` (0.9.0.dev0), so this was still live, not just a
0.7.0 artifact.

Trade-off worth a reviewer's eye: honoring the marker means an operator who
leaves a stale `LOCAL_SINGLE_USER=1` in their environment now serves
unauthenticated on an exposed interface where 0.7.0/0.8.x would have required
login. That is the pre-0.7.0 contract and the marker's documented meaning, and
the new warning states the exposure in as many words — but it is a deliberate
choice of "explicit operator intent wins" over "fail closed", not an oversight.

## Test Plan

`uv run --extra dev python -m pytest tests/cli/test_bind_auth_defaults.py -q`
— 27 pass (was 13). The 12 new cases fail against the unfixed `cli.py`
(verified by stashing the fix), so they pin the actual defect.

`uv run --extra dev python -m pytest tests/cli/test_bind_auth_defaults.py
tests/cli/test_server_lifecycle.py tests/cli/test_cli_auth.py
tests/server/test_accounts.py -q` — 144 pass, no regressions.

Live end-to-end against a real server on an isolated DB, running the exact
repro steps from #4193:

```
OMNIGENT_LOCAL_SINGLE_USER=1 omnigent server --host 0.0.0.0 --port 6794 \
  --no-open --database-uri "sqlite:////tmp/scratch/chat.db"
```

| Probe | Before | After |
|---|---|---|
| `GET /v1/hosts` loopback, no header | 401 | **200** `{"hosts":[]}` |
| `GET /v1/hosts` with `X-Forwarded-Email` | 401 | **200** `{"hosts":[]}` |
| `GET /v1/me` | 401 | **200** `{"user_id":"local","is_admin":true}` |
| `GET /v1/info` | `accounts_enabled:true` + `single_user:true` | `accounts_enabled:false` + `single_user:true` |

Regression check — same bind, **no** marker, confirming #3107's default survives:

```
$ omnigent server --host 0.0.0.0 --port 6795 --no-open
  ⚠ Binding to non-local interface 0.0.0.0: enabling accounts (login) mode ...
$ curl -s http://127.0.0.1:6795/v1/hosts
{"error":{"code":"unauthorized","message":"Authentication required"}}   HTTP 401
```

New startup warning:

```
  ⚠ SECURITY: OMNIGENT_LOCAL_SINGLE_USER=1 is set and you are binding to non-local interface 0.0.0.0.
    This server will serve UNAUTHENTICATED requests as the "local" user to anyone who can reach this address.
    Only do this on a trusted private network.
    Unset OMNIGENT_LOCAL_SINGLE_USER to require login instead.
```

### Drive-by: E2E flake fix (second commit)

The first CI run failed one unrelated E2E test,
`test_run_harness_without_agent_live_repl_round_trip[codex]`, with a pexpect EOF.
A re-run passed, so it was a flake — but the root cause is deterministic and
worth closing rather than papering over with retries.

`codex` registers a background session-title generator
(`harness_plugins.py:799`), so the run issues **two** model calls that race for
the **one** keyed mock queue. Verified by instrumenting `/mock/requests`:

```
[PROBE] total LLM requests captured: 2   # test queued only 1
```

Whichever call lands first consumes the marker; the loser gets
`_ResponseQueue.next()`'s default `"Mock LLM response"`
(`mock_llm_server.py:561-569`), the turn never renders the marker, and pexpect
EOFs. The test's own comment already accounted for this on `claude-sdk`
(queueing 4) but every other harness got 1.

Confirmed the ordering with two distinct queued markers — locally the real turn
wins entry 0, so the CI failure is the opposite ordering under load.

Fix: serve the marker as a non-resettable fallback, so *every* call on that key
answers with it and the assertion no longer depends on call ordering or count.
Adds `set_fallback_mock_llm` to `tests/e2e/omnigent/conftest.py`, mirroring the
helper that already exists in `tests/e2e_ui/conftest.py`.

Verified by simulating the CI ordering (queue drained before the turn):

| Scenario | Without fallback | With fallback |
|---|---|---|
| Queue drained when turn arrives | `pexpect EOF` (the CI signature) | **passes** — marker served |

Full matrix: 4 passed (`codex`, `pi`, `openai-agents`, `qwen`).
`[claude-sdk]` fails on my machine identically **with and without** this change
(local `claude` credential issue — it is not run in the CI shard that failed),
so it is pre-existing and out of scope.

## Demo

N/A — server-side auth resolution, no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The 12 new unit cases cover the corner the old matrix missed entirely
(`LOCAL_SINGLE_USER=1` + non-loopback bind), across truthy spellings
(`1`/`true`/`yes`/`TRUE`) and hosts (`0.0.0.0`/`192.168.1.10`/`10.0.0.5`), plus
the `=0` opt-out, the `AUTH_ENABLED=1` precedence case, and warning silence on
loopback. Manual verification covered the live server paths a unit test can't
reach — the real 401→200 transition, the `/v1/info` contradiction clearing, and
the #3107 regression check — since those need an actual bound socket and DB.

Not covered automatically: the host-tunnel 403. It shares the single
`get_user_id` call (`routes/host_tunnel.py:178`) that the HTTP assertions
already pin, and standing up a real daemon handshake for it would cost far more
than it proves.

## Changelog

`omnigent server --host 0.0.0.0` with `OMNIGENT_LOCAL_SINGLE_USER=1` no longer 401s every request and 403s the host tunnel; the single-user marker is honored on network-exposed binds, with a warning that the server serves unauthenticated requests
