### PR TITLE
Unify dropdown styling

### DIFF
--- a/web/src/components/FileMentionMenu.tsx
+++ b/web/src/components/FileMentionMenu.tsx
@@ -46,15 +46,15 @@ export function FileMentionMenu({
 
   return (
     <div className="absolute bottom-full left-0 z-10 mb-2 flex items-end gap-2">
-      <div className="w-80 max-w-[calc(100vw-2rem)] shrink-0 overflow-hidden rounded-xl border border-border bg-popover shadow-menu">
-        <div className="flex items-center justify-between gap-2 px-2 pb-0.5 pt-1.5 text-sm font-medium text-muted-foreground">
+      <div className="w-80 max-w-[calc(100vw-2rem)] shrink-0 overflow-hidden rounded-[12px] border border-border bg-popover p-2 shadow-menu">
+        <div className="flex items-center justify-between gap-2 px-1.5 py-1 text-sm font-medium text-muted-foreground">
           <span className="truncate">{currentDir ? `/${currentDir}` : "Workspace"}</span>
           <span className="shrink-0 text-[10px]">↵ open · ⇥ attach</span>
         </div>
         {entries.length === 0 && loading ? (
-          <div className="px-3 py-2 text-ui text-muted-foreground">Loading…</div>
+          <div className="px-1.5 py-1 text-ui text-muted-foreground">Loading…</div>
         ) : (
-          <div ref={listRef} role="listbox" className="max-h-80 overflow-y-auto p-1">
+          <div ref={listRef} role="listbox" className="max-h-80 overflow-y-auto">
             {entries.map((entry, i) => {
               const isDir = entry.type === "directory";
               return (
@@ -65,8 +65,8 @@ export function FileMentionMenu({
                   data-testid={`file-mention-item-${i}`}
                   data-active={i === activeIndex ? "true" : undefined}
                   className={cn(
-                    "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-ui text-foreground",
-                    i === activeIndex && "bg-accent",
+                    "flex w-full items-center gap-2 rounded-md px-1.5 py-1 text-left text-ui text-foreground",
+                    i === activeIndex && "bg-muted dark:bg-muted/50",
                   )}
                 >
                   <button

--- a/web/src/components/HarnessConfigControls.tsx
+++ b/web/src/components/HarnessConfigControls.tsx
@@ -9,6 +9,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { SMART_ROUTING_LABEL } from "@/lib/agentLabels";
+import { cn } from "@/lib/utils";
 
 // Sentinel Select values for the Model row. Radix requires a non-empty value,
 // so the two "no explicit model" choices ride on reserved tokens rather than
@@ -78,7 +79,11 @@ export function RoutingModelSelect({
       <SelectTrigger className="w-full" data-testid={testId} aria-label={ariaLabel}>
         <SelectValue />
       </SelectTrigger>
-      <SelectContent position="popper" align="start" className={contentClassName}>
+      <SelectContent
+        position="popper"
+        align="start"
+        className={cn("w-(--radix-select-trigger-width)", contentClassName)}
+      >
         {offerSmartRouting && (
           <SelectItem value={MODEL_SELECT_SMART}>{SMART_ROUTING_LABEL}</SelectItem>
         )}

--- a/web/src/components/HarnessConfigControls.tsx
+++ b/web/src/components/HarnessConfigControls.tsx
@@ -82,7 +82,7 @@ export function RoutingModelSelect({
       <SelectContent
         position="popper"
         align="start"
-        className={cn("w-(--radix-select-trigger-width)", contentClassName)}
+        className={cn("w-max min-w-(--radix-select-trigger-width) max-w-[300px]", contentClassName)}
       >
         {offerSmartRouting && (
           <SelectItem value={MODEL_SELECT_SMART}>{SMART_ROUTING_LABEL}</SelectItem>

--- a/web/src/components/ModelValueCombobox.tsx
+++ b/web/src/components/ModelValueCombobox.tsx
@@ -80,14 +80,14 @@ export function ModelValueCombobox({
         className="w-full rounded border border-border bg-background px-2 py-1.5 text-ui placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-ring"
       />
       {showList && (
-        <div className="max-h-40 overflow-y-auto rounded-lg border border-border bg-popover p-1 text-popover-foreground">
+        <div className="max-h-40 overflow-y-auto rounded-[12px] border border-border bg-popover p-2 text-popover-foreground shadow-menu">
           {filtered.map((v) => {
             const isSelected = selectedSet.has(v);
             return (
               <button
                 key={v}
                 type="button"
-                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-ui hover:bg-accent hover:text-accent-foreground"
+                className="flex w-full items-center gap-2 rounded-md px-1.5 py-1 text-left text-ui hover:bg-muted hover:text-foreground dark:hover:bg-muted/50"
                 // mousedown fires before the input's blur, so the value toggles
                 // before the click-outside handler would close the dropdown.
                 onMouseDown={(e) => {

--- a/web/src/components/PermissionsModal.tsx
+++ b/web/src/components/PermissionsModal.tsx
@@ -422,7 +422,7 @@ function AddUserCombobox({ value, onChange }: AddUserFieldProps) {
       />
       {isOpen && (
         // Wider than the (narrow) field so suggested emails aren't truncated.
-        <div className="absolute left-0 top-full z-50 mt-1 w-96 rounded-lg border bg-popover p-1 text-popover-foreground shadow-menu">
+        <div className="absolute left-0 top-full z-50 mt-1 w-96 rounded-[12px] border border-border bg-popover p-2 text-popover-foreground shadow-menu">
           {isLoading ? (
             <div className="py-6 text-center text-ui text-muted-foreground">Searching…</div>
           ) : suggestions.length === 0 ? (
@@ -441,8 +441,8 @@ function AddUserCombobox({ value, onChange }: AddUserFieldProps) {
                     commit(index);
                   }}
                   className={cn(
-                    "flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-ui",
-                    index === activeIndex && "bg-muted",
+                    "flex cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 text-ui",
+                    index === activeIndex && "bg-muted dark:bg-muted/50",
                   )}
                 >
                   {/* Primary label fills the row and truncates. When the host

--- a/web/src/components/SlashCommandMenu.tsx
+++ b/web/src/components/SlashCommandMenu.tsx
@@ -134,8 +134,8 @@ function MenuRowButton({
       data-testid={`slash-menu-item-${row.name.slice(1)}`}
       data-active={active ? "true" : undefined}
       className={cn(
-        "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-ui text-foreground hover:bg-accent",
-        active && "bg-accent",
+        "flex w-full items-center gap-2 rounded-md px-1.5 py-1 text-left text-ui text-foreground hover:bg-muted dark:hover:bg-muted/50",
+        active && "bg-muted dark:bg-muted/50",
       )}
       // preventDefault keeps the textarea focused while the user clicks.
       onMouseDown={(e) => e.preventDefault()}
@@ -196,13 +196,13 @@ export function SlashCommandMenu({
   const active = activeIndex >= 0 ? rows[activeIndex] : undefined;
 
   const sectionHeader = (label: string) => (
-    <div className="px-2 pb-0.5 pt-1.5 text-sm font-medium text-muted-foreground">{label}</div>
+    <div className="px-1.5 py-1 text-sm font-medium text-muted-foreground">{label}</div>
   );
 
   return (
     <div className="absolute bottom-full left-0 z-10 mb-2 flex items-end gap-2">
-      <div className="w-64 shrink-0 overflow-hidden rounded-xl border border-border bg-popover shadow-menu">
-        <div ref={listRef} className="max-h-80 overflow-y-auto p-1">
+      <div className="w-64 shrink-0 overflow-hidden rounded-[12px] border border-border bg-popover p-2 shadow-menu">
+        <div ref={listRef} className="max-h-80 overflow-y-auto">
           {builtinRows.length > 0 && sectionHeader("Commands")}
           {builtinRows.map((row) => (
             <MenuRowButton
@@ -229,7 +229,7 @@ export function SlashCommandMenu({
       {active && (
         <div
           data-testid="slash-menu-detail"
-          className="hidden max-h-80 w-80 shrink-0 overflow-y-auto rounded-xl border border-border bg-popover p-3 shadow-menu md:block"
+          className="hidden max-h-80 w-80 shrink-0 overflow-y-auto rounded-[12px] border border-border bg-popover p-2 shadow-menu md:block"
         >
           <p className="font-mono text-sm font-medium text-foreground">{active.name}</p>
           <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">

--- a/web/src/components/scheduled/ModelEffortFields.tsx
+++ b/web/src/components/scheduled/ModelEffortFields.tsx
@@ -78,7 +78,11 @@ export function ModelEffortFields({
           <SelectTrigger id="task-model" data-testid="task-model-trigger" className="w-full">
             <SelectValue />
           </SelectTrigger>
-          <SelectContent position="popper" align="start">
+          <SelectContent
+            position="popper"
+            align="start"
+            className="w-(--radix-select-trigger-width)"
+          >
             <SelectItem value={MODEL_SELECT_DEFAULT}>Default</SelectItem>
             {modelOptions.map((m) => (
               <SelectItem key={m.id} value={m.id}>
@@ -99,7 +103,11 @@ export function ModelEffortFields({
           <SelectTrigger id="task-effort" data-testid="task-effort-trigger" className="w-full">
             <SelectValue />
           </SelectTrigger>
-          <SelectContent position="popper" align="start">
+          <SelectContent
+            position="popper"
+            align="start"
+            className="w-(--radix-select-trigger-width)"
+          >
             <SelectItem value={EFFORT_SELECT_NONE}>Default</SelectItem>
             {CLAUDE_NATIVE_EFFORTS.map((e) => (
               <SelectItem key={e.value} value={e.value}>

--- a/web/src/components/ui/context-menu.tsx
+++ b/web/src/components/ui/context-menu.tsx
@@ -36,7 +36,7 @@ function ContextMenuContent({
       <ContextMenuPrimitive.Content
         data-slot="context-menu-content"
         className={cn(
-          "z-50 max-h-(--radix-context-menu-content-available-height) min-w-32 origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-menu ring-1 ring-foreground/10 duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "z-50 max-h-(--radix-context-menu-content-available-height) w-max min-w-32 origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto whitespace-nowrap rounded-[12px] border border-border bg-popover p-2 text-popover-foreground shadow-menu duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}
         {...props}
@@ -64,7 +64,7 @@ function ContextMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "group/context-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-ui outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        "group/context-menu-item relative flex cursor-default items-center gap-2 rounded-md px-1.5 py-1 text-ui outline-hidden select-none focus:bg-muted focus:text-foreground dark:focus:bg-muted/50 data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
         className,
       )}
       {...props}
@@ -86,7 +86,7 @@ function ContextMenuCheckboxItem({
       data-slot="context-menu-checkbox-item"
       data-inset={inset}
       className={cn(
-        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-ui outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default items-center gap-2 rounded-md py-1 pr-8 pl-1.5 text-ui outline-hidden select-none focus:bg-muted focus:text-foreground dark:focus:bg-muted/50 data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       checked={checked}
@@ -124,7 +124,7 @@ function ContextMenuRadioItem({
       data-slot="context-menu-radio-item"
       data-inset={inset}
       className={cn(
-        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-ui outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default items-center gap-2 rounded-md py-1 pr-8 pl-1.5 text-ui outline-hidden select-none focus:bg-muted focus:text-foreground dark:focus:bg-muted/50 data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -205,7 +205,7 @@ function ContextMenuSubTrigger({
       data-slot="context-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-ui outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "flex cursor-default items-center gap-2 rounded-md px-1.5 py-1 text-ui outline-hidden select-none focus:bg-muted focus:text-foreground dark:focus:bg-muted/50 data-inset:pl-7 data-open:bg-muted data-open:text-foreground dark:data-open:bg-muted/50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -237,7 +237,7 @@ function ContextMenuSubContent({
         sideOffset={sideOffset}
         collisionPadding={collisionPadding}
         className={cn(
-          "z-50 min-w-[96px] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-menu ring-1 ring-foreground/10 duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "z-50 w-max min-w-[96px] origin-(--radix-context-menu-content-transform-origin) overflow-hidden whitespace-nowrap rounded-[12px] border border-border bg-popover p-2 text-popover-foreground shadow-menu duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}
         {...props}

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -15,7 +15,7 @@ function SelectGroup({ className, ...props }: React.ComponentProps<typeof Select
   return (
     <SelectPrimitive.Group
       data-slot="select-group"
-      className={cn("scroll-my-1 p-1", className)}
+      className={cn("scroll-my-1", className)}
       {...props}
     />
   );
@@ -64,7 +64,7 @@ function SelectContent({
         data-slot="select-content"
         data-align-trigger={position === "item-aligned"}
         className={cn(
-          "relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-menu ring-1 ring-foreground/10 duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[12px] border border-border bg-popover text-popover-foreground shadow-menu duration-150 ease-[cubic-bezier(0.16,1,0.3,1)] data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,
@@ -75,9 +75,10 @@ function SelectContent({
       >
         <SelectScrollUpButton />
         <SelectPrimitive.Viewport
+          data-slot="select-viewport"
           data-position={position}
           className={cn(
-            "data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)",
+            "p-2 data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)",
             position === "popper" && "",
           )}
         >
@@ -93,7 +94,7 @@ function SelectLabel({ className, ...props }: React.ComponentProps<typeof Select
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
-      className={cn("px-1.5 py-1 text-sm text-muted-foreground", className)}
+      className={cn("px-1.5 py-1 text-sm font-medium text-muted-foreground", className)}
       {...props}
     />
   );
@@ -108,7 +109,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-ui outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "relative flex w-full cursor-default items-center gap-2 rounded-md py-1 pr-8 pl-1.5 text-ui outline-hidden select-none focus:bg-muted focus:text-foreground dark:focus:bg-muted/50 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -5950,7 +5950,11 @@ function SessionConfigModal({
                 >
                   <SelectValue placeholder={EFFORT_UNAVAILABLE_PLACEHOLDER} />
                 </SelectTrigger>
-                <SelectContent position="popper" align="start">
+                <SelectContent
+                  position="popper"
+                  align="start"
+                  className="w-(--radix-select-trigger-width)"
+                >
                   <SelectItem value={EFFORT_SELECT_NONE}>Default</SelectItem>
                   {effortLevels.map((level) => (
                     <SelectItem

--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -1107,7 +1107,7 @@ function FileViewerBody({
             {action.options.map((option) => (
               <DropdownMenuItem
                 key={option.key}
-                className={cn("whitespace-nowrap", option.active && "bg-accent")}
+                className={cn("whitespace-nowrap", option.active && "bg-muted dark:bg-muted/50")}
                 onSelect={interactive ? option.onSelect : undefined}
               >
                 {option.icon}
@@ -1284,7 +1284,7 @@ function FileViewerBody({
                               // active choice.
                               className={cn(
                                 "whitespace-nowrap",
-                                action.options && option.active && "bg-accent",
+                                action.options && option.active && "bg-muted dark:bg-muted/50",
                               )}
                               onSelect={(e) => {
                                 if (option.keepOpen) e.preventDefault();

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -998,7 +998,7 @@ export function AgentHarnessPicker({
         data-testid={`new-chat-landing-agent-${agent.id}`}
         data-active={active ? "true" : undefined}
         onSelect={() => onSelectAgent(agent)}
-        className="items-start gap-2 rounded-sm px-2 py-1.5 text-ui data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
+        className="items-start data-[active=true]:bg-muted data-[active=true]:text-foreground dark:data-[active=true]:bg-muted/50"
       >
         {renderRowInner(agent, true)}
         {renderBadge(agent)}
@@ -1055,7 +1055,7 @@ export function AgentHarnessPicker({
     <DropdownMenuItem
       data-testid="new-chat-landing-create-agent"
       onSelect={onCreateCustomAgent}
-      className="gap-2 rounded-sm px-2 py-1.5 text-ui text-muted-foreground"
+      className="text-muted-foreground"
     >
       <PlusIcon className="size-3.5" />
       Create custom agent
@@ -1073,7 +1073,7 @@ export function AgentHarnessPicker({
           data-testid="new-chat-landing-agent-pending"
           data-active={effectiveAgentId === pendingAgentId ? "true" : undefined}
           onSelect={onSelectPending}
-          className="items-start gap-2 rounded-sm px-2 py-1.5 text-ui data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
+          className="items-start data-[active=true]:bg-muted data-[active=true]:text-foreground dark:data-[active=true]:bg-muted/50"
         >
           <div className="flex min-w-0 flex-1 items-baseline gap-2.5">
             <span className="truncate">{pendingAgent.name}</span>
@@ -1153,7 +1153,7 @@ export function AgentHarnessPicker({
         // height cap / pin a width; tailwind-merge lets the passed max-h/width
         // override the defaults.
         className={cn(
-          "max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-64 max-w-[calc(100vw-2rem)] overflow-y-auto p-1",
+          "max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-64 max-w-[calc(100vw-2rem)] overflow-y-auto",
           contentClassName,
         )}
       >
@@ -1166,7 +1166,7 @@ export function AgentHarnessPicker({
                 e.preventDefault();
                 setMobilePage(null);
               }}
-              className="items-center gap-1.5 rounded-sm px-2 py-1.5 text-ui font-medium"
+              className="items-center font-medium"
             >
               <ChevronLeftIcon className="size-4 shrink-0 opacity-70" />
               <span className="truncate">More</span>
@@ -1183,7 +1183,7 @@ export function AgentHarnessPicker({
                 e.preventDefault();
                 setMobilePage(null);
               }}
-              className="items-center gap-1.5 rounded-sm px-2 py-1.5 text-ui font-medium"
+              className="items-center font-medium"
             >
               <ChevronLeftIcon className="size-4 shrink-0 opacity-70" />
               <span className="truncate">Custom agents</span>
@@ -1204,7 +1204,7 @@ export function AgentHarnessPicker({
                     onSelectAutoHarness?.();
                     setOpen(false);
                   }}
-                  className="items-center gap-2 rounded-sm px-2 py-1.5 text-13 data-[active=true]:bg-accent/60 data-[active=true]:text-foreground"
+                  className="items-center text-13 data-[active=true]:bg-muted data-[active=true]:text-foreground dark:data-[active=true]:bg-muted/50"
                 >
                   <span className="flex-1 truncate">{SMART_ROUTING_LABEL}</span>
                 </DropdownMenuItem>
@@ -1227,7 +1227,7 @@ export function AgentHarnessPicker({
                         e.preventDefault();
                         setMobilePage("more");
                       }}
-                      className="items-center gap-2 rounded-sm px-2 py-1.5 text-ui"
+                      className="items-center"
                     >
                       <span className="flex-1">More</span>
                       <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground/70" />
@@ -1237,11 +1237,11 @@ export function AgentHarnessPicker({
                     <DropdownMenuSub>
                       <DropdownMenuSubTrigger
                         data-testid="new-chat-landing-harness-more"
-                        className="items-center gap-2 rounded-sm px-2 py-1.5 text-ui"
+                        className="items-center"
                       >
                         <span className="flex-1">More</span>
                       </DropdownMenuSubTrigger>
-                      <DropdownMenuSubContent className="max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-56 max-w-[calc(100vw-2rem)] overflow-y-auto p-1">
+                      <DropdownMenuSubContent className="max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-56 max-w-[calc(100vw-2rem)] overflow-y-auto">
                         {moreHarnessEntries.map(renderEntry)}
                       </DropdownMenuSubContent>
                     </DropdownMenuSub>
@@ -1266,7 +1266,7 @@ export function AgentHarnessPicker({
                     e.preventDefault();
                     setMobilePage("custom");
                   }}
-                  className="items-center gap-2 rounded-sm px-2 py-1.5 text-ui"
+                  className="items-center"
                 >
                   <span className="flex-1">Custom agents</span>
                   <ChevronRightIcon className="size-4 shrink-0 text-muted-foreground/70" />
@@ -1276,11 +1276,11 @@ export function AgentHarnessPicker({
                 <DropdownMenuSub>
                   <DropdownMenuSubTrigger
                     data-testid="new-chat-landing-custom-agents"
-                    className="items-center gap-2 rounded-sm px-2 py-1.5 text-ui"
+                    className="items-center"
                   >
                     <span className="flex-1">Custom agents</span>
                   </DropdownMenuSubTrigger>
-                  <DropdownMenuSubContent className="max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-56 max-w-[calc(100vw-2rem)] overflow-y-auto p-1">
+                  <DropdownMenuSubContent className="max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-56 max-w-[calc(100vw-2rem)] overflow-y-auto">
                     {customAgentsBody}
                   </DropdownMenuSubContent>
                 </DropdownMenuSub>
@@ -1573,7 +1573,7 @@ function HarnessConfigModal({
                   <SelectContent
                     position="popper"
                     align="start"
-                    className="[&_[data-slot=select-item]]:pl-2.5"
+                    className="w-(--radix-select-trigger-width) [&_[data-slot=select-item]]:pl-2.5"
                   >
                     <SelectItem value={EFFORT_SELECT_NONE}>Default</SelectItem>
                     {CLAUDE_NATIVE_EFFORTS.map((e) => (
@@ -4093,7 +4093,7 @@ export function NewChatLandingScreen() {
                           onSelect={selectSandbox}
                           data-testid="new-chat-landing-sandbox-option"
                           data-active={sandboxSelected ? "true" : undefined}
-                          className="text-sm data-[active=true]:bg-accent/60"
+                          className="text-sm data-[active=true]:bg-muted dark:data-[active=true]:bg-muted/50"
                         >
                           <span className="flex items-center gap-2">
                             <MonitorCloudIcon className="size-4 text-muted-foreground" />
@@ -4145,7 +4145,7 @@ export function NewChatLandingScreen() {
                       onSelect={() => selectHost(host.host_id)}
                       data-testid={`new-chat-landing-host-${host.host_id}`}
                       data-active={host.host_id === selectedHostId ? "true" : undefined}
-                      className="text-sm data-[active=true]:bg-accent/60"
+                      className="text-sm data-[active=true]:bg-muted dark:data-[active=true]:bg-muted/50"
                     >
                       <HostOption
                         host={host}
@@ -4428,10 +4428,10 @@ export function NewChatLandingScreen() {
                             // Floats over the popover as a combobox popup, so it
                             // doesn't stretch the box. Bounded height + internal
                             // scroll keep it from running off the viewport.
-                            className="absolute top-full right-0 left-0 z-20 mt-1 flex max-h-40 flex-col overflow-y-auto rounded-md border border-input bg-popover p-1 shadow-menu"
+                            className="absolute top-full right-0 left-0 z-20 mt-1 flex max-h-40 flex-col overflow-y-auto rounded-[12px] border border-border bg-popover p-2 shadow-menu"
                             data-testid="new-chat-landing-worktree-dropdown"
                           >
-                            <span className="px-2 pt-1 pb-0.5 text-sm font-medium tracking-wide text-muted-foreground uppercase">
+                            <span className="px-1.5 py-1 text-sm font-medium text-muted-foreground">
                               Existing worktrees
                             </span>
                             <ul className="flex flex-col gap-0.5">
@@ -4452,8 +4452,8 @@ export function NewChatLandingScreen() {
                                         setBranchInputFocused(false);
                                         setWorktreePopoverOpen(false);
                                       }}
-                                      className={`flex w-full flex-col items-start gap-0.5 rounded-md px-2 py-1 text-left text-sm transition-colors hover:bg-accent ${
-                                        selected ? "bg-accent" : ""
+                                      className={`flex w-full flex-col items-start gap-0.5 rounded-md px-1.5 py-1 text-left text-sm transition-colors hover:bg-muted dark:hover:bg-muted/50 ${
+                                        selected ? "bg-muted dark:bg-muted/50" : ""
                                       }`}
                                       data-testid="new-chat-landing-worktree-option"
                                     >

--- a/web/src/shell/ProjectSettingsDialog.tsx
+++ b/web/src/shell/ProjectSettingsDialog.tsx
@@ -339,7 +339,7 @@ export function ProjectSettingsDialog({
                       className="fixed inset-0 z-10 cursor-default"
                       onClick={() => setWorkspaceOpen(false)}
                     />
-                    <div className="absolute top-full right-0 left-0 z-20 mt-1 rounded-md border bg-popover shadow-menu">
+                    <div className="absolute top-full right-0 left-0 z-20 mt-1 rounded-[12px] border border-border bg-popover p-2 shadow-menu [&>[data-testid=workspace-picker]]:border-0">
                       <WorkspacePicker
                         hostId={browsableHostId}
                         initialPath={isNavigablePath(workspace) ? workspace : undefined}

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -3328,7 +3328,7 @@ function ConversationRow({
             <ContextMenuTrigger asChild>
               <HoverCardTrigger asChild>{rowLink}</HoverCardTrigger>
             </ContextMenuTrigger>
-            <ContextMenuContent className="min-w-44 [&_[role=menuitem]]:text-sm">
+            <ContextMenuContent className="min-w-44">
               <ConversationMenuItems
                 components={contextBundle}
                 setMenuOpen={() => {}}
@@ -3345,7 +3345,7 @@ function ConversationRow({
       ) : isMobile ? (
         <ContextMenu>
           <ContextMenuTrigger asChild>{rowLink}</ContextMenuTrigger>
-          <ContextMenuContent className="min-w-44 [&_[role=menuitem]]:text-sm">
+          <ContextMenuContent className="min-w-44">
             <ConversationMenuItems
               components={contextBundle}
               setMenuOpen={() => {}}
@@ -3361,7 +3361,7 @@ function ConversationRow({
                 <TooltipTrigger asChild>{rowLink}</TooltipTrigger>
               </div>
             </ContextMenuTrigger>
-            <ContextMenuContent className="min-w-44 [&_[role=menuitem]]:text-sm">
+            <ContextMenuContent className="min-w-44">
               <ConversationMenuItems
                 components={contextBundle}
                 setMenuOpen={() => {}}

--- a/web/src/shell/TableBubbleMenu.tsx
+++ b/web/src/shell/TableBubbleMenu.tsx
@@ -223,14 +223,14 @@ function HandleMenu({
   return createPortal(
     <div
       data-table-handle-menu
-      className="fixed z-[9999] min-w-[180px] overflow-hidden rounded-md border border-border bg-popover py-1 shadow-menu"
+      className="fixed z-[9999] min-w-[180px] overflow-hidden rounded-[12px] border border-border bg-popover p-2 shadow-menu"
       style={{ top: anchorTop, left: anchorLeft }}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
       {items.map((item) =>
         "separator" in item ? (
-          <div key={item.id} className="mx-2 my-1 h-px bg-border" />
+          <div key={item.id} className="-mx-1 my-1 h-px bg-border" />
         ) : (
           <button
             key={item.id}
@@ -241,7 +241,7 @@ function HandleMenu({
               onClose();
             }}
             className={cn(
-              "flex w-full items-center gap-2.5 px-3 py-1.5 text-sm transition-colors",
+              "flex w-full items-center gap-2 rounded-md px-1.5 py-1 text-ui transition-colors",
               item.destructive
                 ? "text-destructive hover:bg-destructive/10"
                 : "text-foreground hover:bg-muted",

--- a/web/src/shell/WorkspacePathField.tsx
+++ b/web/src/shell/WorkspacePathField.tsx
@@ -67,8 +67,10 @@ function PathRow({ path, active, onSelect, testId }: RowProps) {
         e.preventDefault();
         onSelect();
       }}
-      className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition ${
-        active ? "bg-accent text-accent-foreground" : "hover:bg-accent hover:text-accent-foreground"
+      className={`flex w-full items-center gap-2 rounded-md px-1.5 py-1 text-left text-ui transition ${
+        active
+          ? "bg-muted text-foreground dark:bg-muted/50"
+          : "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50"
       }`}
       data-testid={testId}
     >
@@ -292,14 +294,12 @@ export function WorkspacePathField({
           // clipped by the dialog's scrollable body, and a body
           // portal can't be clicked through Radix's modal layer.
           // Inline content just scrolls with the form instead.
-          className="mt-1 max-h-72 overflow-y-auto rounded-md border border-border bg-popover shadow-menu"
+          className="mt-1 max-h-72 overflow-y-auto rounded-[12px] border border-border bg-popover p-2 shadow-menu"
           data-testid="workspace-path-dropdown"
         >
           {filteredRecent.length > 0 && (
             <>
-              <div className="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                Recent
-              </div>
+              <div className="px-1.5 py-1 text-sm font-medium text-muted-foreground">Recent</div>
               {filteredRecent.map((path, i) => (
                 <PathRow
                   key={`recent-${path}`}
@@ -313,9 +313,7 @@ export function WorkspacePathField({
           )}
           {matches.length > 0 && (
             <>
-              <div className="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                Matches
-              </div>
+              <div className="px-1.5 py-1 text-sm font-medium text-muted-foreground">Matches</div>
               {matches.map((path, j) => (
                 <PathRow
                   key={`match-${path}`}
@@ -327,7 +325,7 @@ export function WorkspacePathField({
               ))}
               {hiddenMatchCount > 0 && (
                 <div
-                  className="px-3 py-2 text-sm text-muted-foreground"
+                  className="px-1.5 py-1 text-sm text-muted-foreground"
                   data-testid="workspace-match-overflow"
                 >
                   +{hiddenMatchCount} more — keep typing to narrow
@@ -335,7 +333,7 @@ export function WorkspacePathField({
               )}
             </>
           )}
-          {showLoading && <div className="px-3 py-2 text-sm text-muted-foreground">Loading…</div>}
+          {showLoading && <div className="px-1.5 py-1 text-sm text-muted-foreground">Loading…</div>}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Related issue

N/A — visual consistency pass with no linked issue.

## Summary

Config and sidebar menus were visually inconsistent: Select popovers (Model / Effort / Permissions) used the older ring/`rounded-lg` treatment, while conversation kebabs used the approved DropdownMenu chrome. Context menus also forced a smaller font than the kebab.

This PR aligns Select, ContextMenu, and the hand-rolled suggestion/list menus to that approved look (`rounded-[12px]`, `border-border`, muted focus/hover, shared gutters), pins Model/Effort popovers to trigger width like Permissions, and drops the Sidebar context-menu `text-sm` override so kebab and right-click match.

## Test Plan

- [x] `pnpm test` in `web/` (full suite green during development; targeted suites for new-chat / composer / scheduled-task / Sidebar row actions)
- [x] `pnpm type-check` in `web/`
- [x] oxlint + prettier on touched files
- [ ] Manual: new-chat gear → Model / Effort / Permissions side-by-side (width, gutter, hover)
- [ ] Manual: composer gear Model / Effort
- [ ] Manual: sidebar session kebab vs right-click context menu (font size + chrome)
- [ ] Manual: slash `/`, file `@`, workspace path suggestions, worktree list

## Demo

N/A

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Class-only styling; behavior and testids unchanged. Existing unit tests for config modals, Sidebar row actions, and related pickers still pass. Manual check focuses on visual parity across Select / DropdownMenu / ContextMenu surfaces (especially Model/Effort/Permissions width+gutter and kebab vs context font size).

## Changelog

Dropdowns and menus use one consistent popup style across the app