### PR TITLE
fix(web): fork fresh from project default base branch instead of reusing last worktree

### DIFF
--- a/tests/e2e_ui/start_session/test_project_config_prefill.py
+++ b/tests/e2e_ui/start_session/test_project_config_prefill.py
@@ -445,3 +445,163 @@ async def _drive_born_filed(base_url: str, session_id: str) -> None:
             assert labels.get("omni_project") == _PROJECT_NAME, body
         finally:
             await browser.close()
+
+
+# The worktree-list endpoint the composer probes for the seeded workspace.
+_WORKTREES_RE = re.compile(r"/v1/hosts/[^/]+/worktrees")
+# The user's most-recent workspace on the host — a LINKED worktree of the repo
+# whose main tree lives at _MAIN_REPO. Seeded into localStorage so the auto-seed
+# would land here (the pre-fix behavior) unless the fork-fresh redirect fires.
+_MAIN_REPO = "/work/gamma"
+_LINKED_WORKTREE = "/work/gamma-worktrees/feature-x"
+
+
+def _base_branch_config_body() -> str:
+    """``GET /v1/projects/{id}`` whose stored config sets a default base branch."""
+    return json.dumps(
+        {
+            "id": _PROJECT_ID,
+            "name": _PROJECT_NAME,
+            "config": {"host_id": _HOST_ID, "base_branch": "develop"},
+        }
+    )
+
+
+def _worktrees_body() -> str:
+    """``GET /v1/hosts/{id}/worktrees`` — the repo's main tree plus one linked
+    worktree (the recent workspace). The composer's fork-fresh probe reads this
+    to decide the recent path is a worktree and redirect to the main tree."""
+    return json.dumps(
+        {
+            "object": "list",
+            "data": [
+                {"path": _MAIN_REPO, "branch": "main", "is_main": True, "detached": False},
+                {
+                    "path": _LINKED_WORKTREE,
+                    "branch": "feature/x",
+                    "is_main": False,
+                    "detached": False,
+                },
+            ],
+        }
+    )
+
+
+def test_composer_forks_fresh_from_project_default_over_last_worktree(
+    seeded_session: tuple[str, str],
+) -> None:
+    """A project default base branch forks fresh instead of reusing the last worktree.
+
+    Regression: the composer auto-seeds the working directory from the user's
+    most-recent workspace. When that path is an existing (linked) worktree, the
+    branch prefilled from it and the project's stored default base branch was
+    silently dropped — a fresh new-chat continued in the old worktree instead of
+    forking off the default. With a default configured, the composer now probes
+    the recent path, redirects the seed to the repo's MAIN work tree, and
+    auto-names a fresh worktree branch so the create forks off the default:
+    ``git: {branch_name: worktree-<hex>, base_branch: "develop"}`` at the main
+    repo — NOT an ``existing_worktree`` bind in the linked worktree.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_fork_fresh(base_url, session_id))
+
+
+async def _drive_fork_fresh(base_url: str, session_id: str) -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+
+            async def handle_hosts(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_hosts_body()
+                )
+
+            async def handle_agents(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_agents_body()
+                )
+
+            async def handle_projects_list(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_projects_list_body()
+                )
+
+            async def handle_project_config(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_base_branch_config_body()
+                )
+
+            async def handle_worktrees(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_worktrees_body()
+                )
+
+            async def handle_events(route: Route) -> None:
+                await route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    body=json.dumps({"queued": True, "item_id": "ci_e2e"}),
+                )
+
+            async def handle_sessions(route: Route) -> None:
+                if route.request.method == "POST":
+                    create_bodies.append(route.request.post_data_json)
+                    await route.fulfill(
+                        status=200,
+                        content_type="application/json",
+                        body=json.dumps({"id": session_id}),
+                    )
+                else:
+                    await route.continue_()
+
+            async def handle_agent_scan(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=json.dumps({"data": []})
+                )
+
+            await page.route("**/v1/hosts", handle_hosts)
+            await page.route("**/v1/agents", handle_agents)
+            await page.route("**/v1/sessions/projects", handle_projects_list)
+            await page.route(_PROJECT_CFG_RE, handle_project_config)
+            await page.route(_WORKTREES_RE, handle_worktrees)
+            await page.route("**/v1/sessions/*/events", handle_events)
+            await page.route(_SESSIONS_RE, handle_sessions)
+            await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+
+            # The most-recent workspace is a LINKED worktree — the pre-fix
+            # auto-seed would land here and reuse it.
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{ {_HOST_ID}: ["{_LINKED_WORKTREE}"] }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/?project={_PROJECT_NAME}")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            # The workspace chip shows the MAIN repo (gamma), not the linked
+            # worktree — proof the fork-fresh redirect fired.
+            await expect(page.get_by_test_id("new-chat-landing-workspace-chip")).to_contain_text(
+                "gamma", timeout=15_000
+            )
+
+            await page.get_by_test_id("new-chat-landing-input").fill("start fresh")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            await _wait_until(lambda: len(create_bodies) == 1)
+            body = create_bodies[0]
+            assert body["host_id"] == _HOST_ID, body
+            # Seeded at the MAIN repo, not the linked worktree.
+            assert body["workspace"] == _MAIN_REPO, body
+            git = body.get("git") or {}
+            # A fresh worktree forked off the project default — not a bind.
+            assert re.fullmatch(r"worktree-[0-9a-f]{8}", git.get("branch_name", "")), body
+            assert git.get("base_branch") == "develop", body
+            assert "existing_worktree" not in git, body
+        finally:
+            await browser.close()

--- a/web/src/shell/NewChatDialog.projectPrefill.test.tsx
+++ b/web/src/shell/NewChatDialog.projectPrefill.test.tsx
@@ -393,4 +393,29 @@ describe("NewChatLandingScreen project prefill", () => {
     // Plain launch — no worktree fork was manufactured from the config workspace.
     expect(body.git).toBeUndefined();
   });
+
+  it("still seeds the recent workspace when the worktree probe errors", async () => {
+    // A non-400 failure from /worktrees leaves the hook's data undefined for
+    // good. The seed must fall back to the candidate as-is (treat the probe
+    // error as "no redirect") rather than blocking on data that never arrives
+    // and leaving the working directory blank forever.
+    localStorage.setItem(RECENT_KEY, JSON.stringify({ host_1: [LINKED_WORKTREE] }));
+    vi.mocked(useHostWorktrees).mockReturnValue({
+      data: undefined,
+      isPlaceholderData: false,
+      isError: true,
+    } as ReturnType<typeof useHostWorktrees>);
+    setProjectConfig({ host_id: "host_1", base_branch: "develop" });
+    renderLanding();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain(
+        "feature-x",
+      ),
+    );
+    const body = await submitAndReadBody();
+    // Seeded the recent path as-is; no redirect, no fabricated fork.
+    expect(body.workspace).toBe(LINKED_WORKTREE);
+    expect(body.git).toBeUndefined();
+  });
 });

--- a/web/src/shell/NewChatDialog.projectPrefill.test.tsx
+++ b/web/src/shell/NewChatDialog.projectPrefill.test.tsx
@@ -373,4 +373,24 @@ describe("NewChatLandingScreen project prefill", () => {
     expect(git.branch_name).toBe("feature/x");
     expect(git.base_branch).toBeUndefined();
   });
+
+  it("does not fork-fresh when the project config supplies its own workspace", async () => {
+    // The config seeds its own workspace (MAIN_REPO) even though a default base
+    // branch is set and the recent path is a linked worktree. The fork-fresh
+    // redirect must NOT hijack that into a worktree launch: the auto-seed is a
+    // no-op on a non-empty field, so no branch is generated and the session
+    // starts plainly in the configured directory.
+    localStorage.setItem(RECENT_KEY, JSON.stringify({ host_1: [LINKED_WORKTREE] }));
+    setWorktreeRepo();
+    setProjectConfig({ host_id: "host_1", workspace: MAIN_REPO, base_branch: "develop" });
+    renderLanding();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("gamma"),
+    );
+    const body = await submitAndReadBody();
+    expect(body.workspace).toBe(MAIN_REPO);
+    // Plain launch — no worktree fork was manufactured from the config workspace.
+    expect(body.git).toBeUndefined();
+  });
 });

--- a/web/src/shell/NewChatDialog.projectPrefill.test.tsx
+++ b/web/src/shell/NewChatDialog.projectPrefill.test.tsx
@@ -306,4 +306,71 @@ describe("NewChatLandingScreen project prefill", () => {
     expect(body.host_id).toBe("host_1");
     expect(body.workspace).toBe(RECENT_WORKSPACE);
   });
+
+  // A repo with a main work tree plus one linked worktree. `git worktree list`
+  // returns both for any path inside the repo, so the probe (keyed on the
+  // recent-workspace path) and the post-redirect main query both resolve here.
+  const MAIN_REPO = "/Users/corey/projects/gamma";
+  const LINKED_WORKTREE = "/Users/corey/projects/gamma-worktrees/feature-x";
+  const WORKTREE_LIST: HostWorktree[] = [
+    { path: MAIN_REPO, branch: "main", is_main: true, detached: false },
+    { path: LINKED_WORKTREE, branch: "feature/x", is_main: false, detached: false },
+  ];
+
+  function setWorktreeRepo(): void {
+    vi.mocked(useHostWorktrees).mockImplementation((hostId, path) => {
+      const inRepo = hostId === "host_1" && (path === MAIN_REPO || path === LINKED_WORKTREE);
+      return {
+        data: inRepo ? WORKTREE_LIST : ([] as HostWorktree[]),
+        isPlaceholderData: false,
+        isError: false,
+      } as ReturnType<typeof useHostWorktrees>;
+    });
+  }
+
+  it("forks fresh from the project default when the last-used workspace is a worktree", async () => {
+    // The most-recent workspace is a linked worktree. Without the fork-fresh
+    // redirect the composer would land in it (bind mode) and never apply the
+    // project's default base branch. With a default set it must instead seed
+    // the MAIN repo, auto-name a branch, and fork off that default.
+    localStorage.setItem(RECENT_KEY, JSON.stringify({ host_1: [LINKED_WORKTREE] }));
+    setWorktreeRepo();
+    setProjectConfig({ host_id: "host_1", base_branch: "develop" });
+    renderLanding();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("gamma"),
+    );
+    const body = await submitAndReadBody();
+    // Redirected to the main repo, not the linked worktree.
+    expect(body.workspace).toBe(MAIN_REPO);
+    const git = body.git as { branch_name: string; base_branch?: string; existing_worktree?: true };
+    // A brand-new worktree (create, not a bind) forked off the project default.
+    expect(git.branch_name).toMatch(/^worktree-[0-9a-f]{8}$/);
+    expect(git.base_branch).toBe("develop");
+    expect(git.existing_worktree).toBeUndefined();
+  });
+
+  it("keeps landing in the last-used worktree when the project has no default base branch", async () => {
+    // No default base branch → the fork-fresh redirect stays off, preserving the
+    // prior behavior: land directly in the recent worktree (git bind mode).
+    localStorage.setItem(RECENT_KEY, JSON.stringify({ host_1: [LINKED_WORKTREE] }));
+    setWorktreeRepo();
+    setProjectConfig({ host_id: "host_1" });
+    renderLanding();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain(
+        "feature-x",
+      ),
+    );
+    const body = await submitAndReadBody();
+    // Bound straight to the worktree dir; the worktree's branch rides along and
+    // no base branch is set (it's a bind, not a fork).
+    expect(body.workspace).toBe(LINKED_WORKTREE);
+    const git = body.git as { branch_name: string; base_branch?: string; existing_worktree?: true };
+    expect(git.existing_worktree).toBe(true);
+    expect(git.branch_name).toBe("feature/x");
+    expect(git.base_branch).toBeUndefined();
+  });
 });

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2379,7 +2379,11 @@ export function NewChatLandingScreen() {
     projectBaseBranch !== null &&
     seededHostRef.current !== selectedHostId &&
     autoSeedCandidate !== null;
-  const { data: seedWorktrees, isPlaceholderData: seedWorktreesArePlaceholder } = useHostWorktrees(
+  const {
+    data: seedWorktrees,
+    isPlaceholderData: seedWorktreesArePlaceholder,
+    isError: seedWorktreesErrored,
+  } = useHostWorktrees(
     forkFreshArmed ? selectedHostId : null,
     forkFreshArmed ? autoSeedCandidate : null,
   );
@@ -2391,6 +2395,11 @@ export function NewChatLandingScreen() {
   // the project default instead of reusing).
   const forkFreshMainPath = useMemo<string | null | undefined>(() => {
     if (!forkFreshArmed) return null;
+    // A probe error (non-400; the hook already maps 400 → []) leaves data
+    // undefined for good. Treat it as "no redirect" so the seed still lands on
+    // the candidate as-is, rather than waiting on data that never arrives and
+    // leaving the workspace blank forever.
+    if (seedWorktreesErrored) return null;
     if (seedWorktreesArePlaceholder || seedWorktrees === undefined) return undefined;
     const norm = normalizeWorkspacePath(autoSeedCandidate);
     const candIsLinkedWorktree = seedWorktrees.some(
@@ -2398,7 +2407,13 @@ export function NewChatLandingScreen() {
     );
     const mainPath = seedWorktrees.find((w) => w.is_main)?.path ?? null;
     return candIsLinkedWorktree && mainPath !== null ? mainPath : null;
-  }, [forkFreshArmed, seedWorktrees, seedWorktreesArePlaceholder, autoSeedCandidate]);
+  }, [
+    forkFreshArmed,
+    seedWorktrees,
+    seedWorktreesArePlaceholder,
+    seedWorktreesErrored,
+    autoSeedCandidate,
+  ]);
 
   // Seed the working directory once per host, into an empty field only, so an
   // explicit pick isn't clobbered. Prefer the most-recent path; else the

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2347,6 +2347,59 @@ export function NewChatLandingScreen() {
     [homeListing, homeListingIsPlaceholder],
   );
 
+  // Fill the branch field with a unique auto-generated name so the user can
+  // spin up a throwaway worktree without inventing one. crypto.randomUUID is
+  // available in every browser the app targets; the short prefix keeps the
+  // dir/branch readable (worktree-1a2b3c4d).
+  const generateBranchName = useCallback(() => {
+    const suffix = crypto.randomUUID().replace(/-/g, "").slice(0, 8);
+    setBranchName(`worktree-${suffix}`);
+  }, []);
+  // The project's stored default base branch (Project settings), trimmed. Wins
+  // over the user-global default (Settings › Git); an unset project default
+  // falls through to the global one, then to blank (fork from current branch).
+  const projectBaseBranch = storedProjectConfig?.base_branch?.trim() || null;
+
+  // The path the once-per-host auto-seed WOULD land on: the most-recent path,
+  // else the derived home. Exposed as a memo so we can probe its repo for
+  // worktrees before committing to it (see the fork-fresh redirect below).
+  const autoSeedCandidate = useMemo(() => recent[0] ?? derivedHome ?? null, [recent, derivedHome]);
+  // "Fork fresh from default": when the project defines a default base branch,
+  // a fresh new-chat must NOT silently continue in the last-used worktree — it
+  // should fork a new branch off that default. The auto-seed can land on a
+  // linked worktree (a recent path that happens to be one), which prefills its
+  // branch and suppresses the base-branch fill. So when a default is set, probe
+  // the seed candidate's repo and redirect the seed to the MAIN work tree. Only
+  // armed until the host is seeded (the once-per-host guard), and skipped for
+  // sandboxes (no host worktrees).
+  const forkFreshArmed =
+    prefillSettled &&
+    selectedHostId !== null &&
+    !sandboxSelected &&
+    projectBaseBranch !== null &&
+    seededHostRef.current !== selectedHostId &&
+    autoSeedCandidate !== null;
+  const { data: seedWorktrees, isPlaceholderData: seedWorktreesArePlaceholder } = useHostWorktrees(
+    forkFreshArmed ? selectedHostId : null,
+    forkFreshArmed ? autoSeedCandidate : null,
+  );
+  // Resolve the fork-fresh redirect to a STABLE value so the seed effect can
+  // depend on the decision, not the worktree array (whose identity churns every
+  // render). `undefined` = probe still loading (wait); `null` = not armed or no
+  // redirect (seed the candidate as-is); a string = the MAIN repo path to
+  // redirect the seed to (the candidate is a linked worktree we should fork off
+  // the project default instead of reusing).
+  const forkFreshMainPath = useMemo<string | null | undefined>(() => {
+    if (!forkFreshArmed) return null;
+    if (seedWorktreesArePlaceholder || seedWorktrees === undefined) return undefined;
+    const norm = normalizeWorkspacePath(autoSeedCandidate);
+    const candIsLinkedWorktree = seedWorktrees.some(
+      (w) => !w.is_main && normalizeWorkspacePath(w.path) === norm,
+    );
+    const mainPath = seedWorktrees.find((w) => w.is_main)?.path ?? null;
+    return candIsLinkedWorktree && mainPath !== null ? mainPath : null;
+  }, [forkFreshArmed, seedWorktrees, seedWorktreesArePlaceholder, autoSeedCandidate]);
+
   // Seed the working directory once per host, into an empty field only, so an
   // explicit pick isn't clobbered. Prefer the most-recent path; else the
   // derived home (which can arrive a render later, hence the dep). Holds
@@ -2355,11 +2408,22 @@ export function NewChatLandingScreen() {
     if (!prefillSettled) return;
     if (selectedHostId === null) return;
     if (seededHostRef.current === selectedHostId) return;
-    const candidate = recent[0] ?? derivedHome;
-    if (!candidate) return;
+    if (autoSeedCandidate === null) return;
+    // Fork-fresh redirect pending: wait for the probe rather than seeding the
+    // wrong path (and locking the once-per-host guard).
+    if (forkFreshMainPath === undefined) return;
+
+    const didForkFresh = forkFreshMainPath !== null;
+    const candidate = didForkFresh ? forkFreshMainPath : autoSeedCandidate;
     seededHostRef.current = selectedHostId;
     setWorkspace((cur) => (cur === "" ? candidate : cur));
-  }, [selectedHostId, recent, derivedHome, prefillSettled]);
+    if (didForkFresh) {
+      // Preempt the opt-in-worktree effect so it can't also seed a branch, then
+      // name one here to fork fresh off the project default.
+      worktreeSeededForRef.current = normalizeWorkspacePath(candidate);
+      generateBranchName();
+    }
+  }, [selectedHostId, autoSeedCandidate, prefillSettled, forkFreshMainPath, generateBranchName]);
 
   // A pick only wins while it exists in the list — a persisted id whose
   // agent has since been unregistered (or hidden) falls back to the default.
@@ -2856,7 +2920,6 @@ export function NewChatLandingScreen() {
   // current default. The project's stored default (Project settings) wins over
   // the user-global one (Settings › Git); an unset project default falls
   // through to the global one, then to blank (fork from current branch).
-  const projectBaseBranch = storedProjectConfig?.base_branch?.trim() || null;
   useEffect(() => {
     if (!shouldCreateWorktree) {
       // No base field shown: reset so the next named branch re-seeds cleanly.
@@ -2880,14 +2943,6 @@ export function NewChatLandingScreen() {
       (w) => (w.branch ?? "").toLowerCase().includes(q) || w.path.toLowerCase().includes(q),
     );
   }, [linkedWorktrees, branchName]);
-  // Fill the branch field with a unique auto-generated name so the user can
-  // spin up a throwaway worktree without inventing one. crypto.randomUUID is
-  // available in every browser the app targets; the short prefix keeps the
-  // dir/branch readable (worktree-1a2b3c4d).
-  const generateBranchName = useCallback(() => {
-    const suffix = crypto.randomUUID().replace(/-/g, "").slice(0, 8);
-    setBranchName(`worktree-${suffix}`);
-  }, []);
   // Project prefill: seed host / workspace / agent from the project's stored
   // config, then settle so the generic defaults fill any slot the config left
   // unset. An opt-in worktree is generated by the dedicated effect below once

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2416,14 +2416,31 @@ export function NewChatLandingScreen() {
     const didForkFresh = forkFreshMainPath !== null;
     const candidate = didForkFresh ? forkFreshMainPath : autoSeedCandidate;
     seededHostRef.current = selectedHostId;
-    setWorkspace((cur) => (cur === "" ? candidate : cur));
-    if (didForkFresh) {
+    // Seed into an empty field only, so a config-supplied (or explicitly
+    // picked) workspace isn't clobbered.
+    const seededWorkspace = workspace === "";
+    if (seededWorkspace) setWorkspace(candidate);
+    // Fork fresh only when we actually seeded the redirect AND no branch is set
+    // — a project that supplies its own workspace keeps a plain launch, and a
+    // branch typed/picked while the probe was loading isn't overwritten (the
+    // same guards the opt-in-worktree effect below enforces).
+    if (didForkFresh && seededWorkspace && branchName === "" && prefilledBranch === "") {
       // Preempt the opt-in-worktree effect so it can't also seed a branch, then
-      // name one here to fork fresh off the project default.
-      worktreeSeededForRef.current = normalizeWorkspacePath(candidate);
+      // name one here to fork fresh off the project default. Store the ref in
+      // the raw representation that effect compares against (workspaceTrimmed).
+      worktreeSeededForRef.current = candidate;
       generateBranchName();
     }
-  }, [selectedHostId, autoSeedCandidate, prefillSettled, forkFreshMainPath, generateBranchName]);
+  }, [
+    selectedHostId,
+    autoSeedCandidate,
+    prefillSettled,
+    forkFreshMainPath,
+    workspace,
+    branchName,
+    prefilledBranch,
+    generateBranchName,
+  ]);
 
   // A pick only wins while it exists in the list — a persisted id whose
   // agent has since been unregistered (or hidden) falls back to the default.


### PR DESCRIPTION
## Related issue

Closes #

## Summary

When a project has a **default base branch** configured (Project settings), a fresh new-chat now forks a new branch off that default instead of silently continuing in the user's last-used worktree.

- The composer auto-seeds the working directory from the most-recent workspace. When that path was an existing linked worktree, the branch prefilled from it, `shouldCreateWorktree` flipped to `false`, and the base-branch seeding effect early-returned — so the project's default base branch was **never applied**. This was a gap in the recently-added default-base-branch feature, not a regression of prior behavior (the last-used-worktree landing predates it).
- Now the once-per-host auto-seed probes the recent path's repo; if it's a linked worktree and a project default is set, it redirects the seed to the repo's **main** work tree and auto-generates a `worktree-<uuid>` branch, engaging the new-worktree + base-branch fill. Deliberate picks, sandboxes, non-git paths, and projects with no default are untouched.
- The fork-fresh decision is resolved to a **stable memoized value** so the seed effect depends on the decision, not the churning worktree-list array identity — avoiding an intermediate re-fire that would let the auto-seed win the race against the project-config workspace prefill.

## Test Plan

- `cd web && npm test` — full vitest suite green (5326 passed, incl. 2 new unit cases: the redirect and the no-default passthrough).
- `cd web && npm run build` — `tsc -b && vite build` clean (exit 0).
- `rtk proxy python -m pytest tests/e2e_ui/start_session/test_project_config_prefill.py -o addopts="" -q` — 4/4 pass, incl. the new `test_composer_forks_fresh_from_project_default_over_last_worktree` asserting the create forks off the default (`git.branch_name = worktree-<hex>`, `git.base_branch = "develop"`, workspace = main repo, no `existing_worktree`).

Manual repro: configure a project with a default base branch, ensure the host's most-recent workspace is an existing linked worktree, open a fresh new chat scoped to that project → it lands in the main repo with an auto-generated branch and the base-branch field pre-filled to the default.

## Demo

_UI change — screen recording to be added by the author._ <!-- TODO: attach before/after recording -->

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — automated unit + e2e coverage added for both the redirect and the preserved no-default behavior.

## Changelog

New chats in a project with a default base branch now fork a fresh branch off that default instead of reopening your last-used worktree

This pull request and its description were written by Isaac.