### PR TITLE
fix(web): keep the caret in the composer after a command-palette jump

### DIFF
--- a/tests/e2e_ui/hotkeys/test_command_palette_focus.py
+++ b/tests/e2e_ui/hotkeys/test_command_palette_focus.py
@@ -42,23 +42,21 @@ def _wait_for_caret(page: Page, expected: str) -> None:
     page.wait_for_function(f"() => ({_ACTIVE_COMPOSER_JS})() === {expected!r}", timeout=10_000)
 
 
-def _wait_for_highlighted(page: Page, label: str) -> None:
-    """Wait until `label` is the row Enter would run.
+def _select_action_with_keyboard(page: Page, label: str) -> None:
+    """Ensure `label` is the row Enter will run.
 
     The palette re-sorts around the debounced session search, so for a beat
     after the results swap there is no highlighted row and Enter is a no-op.
-    Waiting for the highlight — rather than sleeping past the debounce and
-    hoping — is what keeps the keypress landing on the intended row on a
-    loaded machine.
+    Wait for the action to survive the debounced result swap, then move the
+    keyboard selection onto it when cmdk cleared its transient highlight.
     """
-    page.wait_for_function(
-        """(label) => {
-             const el = document.querySelector('[cmdk-item][aria-selected="true"]');
-             return !!el && el.textContent.trim() === label;
-           }""",
-        arg=label,
-        timeout=10_000,
-    )
+    row = page.get_by_role("option", name=label, exact=True)
+    expect(row).to_be_visible(timeout=10_000)
+    for _ in range(8):
+        if row.get_attribute("aria-selected") == "true":
+            break
+        page.keyboard.press("ArrowDown")
+    expect(row).to_have_attribute("aria-selected", "true", timeout=10_000)
 
 
 def test_new_chat_from_palette_focuses_the_landing_composer(
@@ -76,7 +74,7 @@ def test_new_chat_from_palette_focuses_the_landing_composer(
     palette.type("new chat", delay=20)
     # "New chat" has to be the highlighted row before Enter, or the keypress
     # lands in the gap where the debounced session results are swapping out.
-    _wait_for_highlighted(page, "New chat")
+    _select_action_with_keyboard(page, "New chat")
     page.keyboard.press("Enter")
 
     expect(page.get_by_test_id(_LANDING_INPUT)).to_be_visible(timeout=15_000)

--- a/tests/e2e_ui/hotkeys/test_command_palette_focus.py
+++ b/tests/e2e_ui/hotkeys/test_command_palette_focus.py
@@ -1,0 +1,106 @@
+"""UI e2e: the command palette leaves the caret in the destination composer.
+
+This one only reproduces in a real browser. The palette is a modal dialog, so
+Radix traps focus inside it and only releases the trap when the close animation
+ends — several frames after the selection navigated away. A destination that
+focuses its composer as it mounts therefore has that focus yanked back into the
+dying dialog and dropped on ``<body>``. jsdom runs no animations, so a unit test
+sees the trap release immediately and never catches it.
+
+The journey under test is entirely keyboard-driven: ⌘K from a session, type,
+Enter, then start typing the next prompt without touching the mouse.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+# The new-session landing screen's composer.
+_LANDING_INPUT = "new-chat-landing-input"
+# The in-session composer, which carries no test id — match its placeholder,
+# as the other composer e2e tests do.
+_SESSION_COMPOSER = "Ask the agent anything…"
+
+# Identifies whatever holds the caret: the landing composer's test id, or the
+# in-session composer's placeholder.
+_ACTIVE_COMPOSER_JS = """
+() => {
+  const el = document.activeElement;
+  if (!el || el.tagName !== 'TEXTAREA') return null;
+  return el.getAttribute('data-testid') ?? el.getAttribute('placeholder');
+}
+"""
+
+
+def _wait_for_caret(page: Page, expected: str) -> None:
+    """Wait for `expected` to hold the caret.
+
+    Waiting rather than asserting immediately is what catches the bug: the
+    destination focuses itself on mount and the dying palette steals it back a
+    beat later, so an immediate assertion would pass on the broken build.
+    """
+    page.wait_for_function(f"() => ({_ACTIVE_COMPOSER_JS})() === {expected!r}", timeout=10_000)
+
+
+def test_new_chat_from_palette_focuses_the_landing_composer(
+    page: Page, seeded_session: tuple[str, str]
+) -> None:
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.get_by_placeholder(_SESSION_COMPOSER)).to_be_visible(timeout=30_000)
+
+    page.keyboard.press("Control+k")
+    palette = page.get_by_test_id("command-palette-input")
+    expect(palette).to_be_visible(timeout=10_000)
+    # "new chat" names the action outright, so the top result can't be a
+    # session whose title happens to contain "new".
+    palette.type("new chat", delay=20)
+    # The palette debounces its session search by 300ms; let the list settle so
+    # Enter commits the intended result.
+    page.wait_for_timeout(600)
+    page.keyboard.press("Enter")
+
+    expect(page.get_by_test_id(_LANDING_INPUT)).to_be_visible(timeout=15_000)
+    _wait_for_caret(page, _LANDING_INPUT)
+
+    # The whole point: type the next prompt with no click in between.
+    page.keyboard.type("ship the thing")
+    expect(page.get_by_test_id(_LANDING_INPUT)).to_have_value("ship the thing")
+
+
+def test_sidebar_new_session_focuses_the_landing_composer(
+    page: Page, seeded_session: tuple[str, str]
+) -> None:
+    """The sidebar link has no overlay in the way, but the caret must land the
+    same place — this is the other route onto the new-session page."""
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.get_by_placeholder(_SESSION_COMPOSER)).to_be_visible(timeout=30_000)
+
+    page.get_by_test_id("new-chat-button").click()
+
+    expect(page.get_by_test_id(_LANDING_INPUT)).to_be_visible(timeout=15_000)
+    _wait_for_caret(page, _LANDING_INPUT)
+
+
+def test_session_switch_from_palette_focuses_the_session_composer(
+    page: Page, seeded_session: tuple[str, str]
+) -> None:
+    base_url, session_id = seeded_session
+    page.goto(base_url)
+    expect(page.get_by_test_id(_LANDING_INPUT)).to_be_visible(timeout=30_000)
+
+    # Sessions are the palette's first group, and an empty query lists the
+    # recent ones. Click the row rather than pressing Enter: cmdk pins its
+    # highlight to the first item that rendered, which is an action until the
+    # session search resolves. Which input commits the row is beside the
+    # point — the assertion is about focus after the palette closes.
+    page.keyboard.press("Control+k")
+    palette = page.get_by_role("dialog")
+    expect(page.get_by_test_id("command-palette-input")).to_be_visible(timeout=10_000)
+    # The seeded session is untitled, so it lists under the "New session"
+    # fallback label (conversationDisplayLabel).
+    palette.get_by_text("New session", exact=True).click(timeout=15_000)
+
+    page.wait_for_url(f"**/c/{session_id}", timeout=15_000)
+    _wait_for_caret(page, _SESSION_COMPOSER)

--- a/tests/e2e_ui/hotkeys/test_command_palette_focus.py
+++ b/tests/e2e_ui/hotkeys/test_command_palette_focus.py
@@ -42,6 +42,25 @@ def _wait_for_caret(page: Page, expected: str) -> None:
     page.wait_for_function(f"() => ({_ACTIVE_COMPOSER_JS})() === {expected!r}", timeout=10_000)
 
 
+def _wait_for_highlighted(page: Page, label: str) -> None:
+    """Wait until `label` is the row Enter would run.
+
+    The palette re-sorts around the debounced session search, so for a beat
+    after the results swap there is no highlighted row and Enter is a no-op.
+    Waiting for the highlight — rather than sleeping past the debounce and
+    hoping — is what keeps the keypress landing on the intended row on a
+    loaded machine.
+    """
+    page.wait_for_function(
+        """(label) => {
+             const el = document.querySelector('[cmdk-item][aria-selected="true"]');
+             return !!el && el.textContent.trim() === label;
+           }""",
+        arg=label,
+        timeout=10_000,
+    )
+
+
 def test_new_chat_from_palette_focuses_the_landing_composer(
     page: Page, seeded_session: tuple[str, str]
 ) -> None:
@@ -55,9 +74,9 @@ def test_new_chat_from_palette_focuses_the_landing_composer(
     # "new chat" names the action outright, so the top result can't be a
     # session whose title happens to contain "new".
     palette.type("new chat", delay=20)
-    # The palette debounces its session search by 300ms; let the list settle so
-    # Enter commits the intended result.
-    page.wait_for_timeout(600)
+    # "New chat" has to be the highlighted row before Enter, or the keypress
+    # lands in the gap where the debounced session results are swapping out.
+    _wait_for_highlighted(page, "New chat")
     page.keyboard.press("Enter")
 
     expect(page.get_by_test_id(_LANDING_INPUT)).to_be_visible(timeout=15_000)

--- a/web/src/lib/composerFocus.test.ts
+++ b/web/src/lib/composerFocus.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { onComposerFocusRequest, requestComposerFocus } from "./composerFocus";
+
+const unsubscribes: (() => void)[] = [];
+
+function subscribe(listener: () => void): void {
+  unsubscribes.push(onComposerFocusRequest(listener));
+}
+
+afterEach(() => {
+  for (const off of unsubscribes.splice(0)) off();
+  vi.restoreAllMocks();
+});
+
+describe("composerFocus", () => {
+  it("is a no-op with no composer mounted", () => {
+    expect(() => requestComposerFocus()).not.toThrow();
+  });
+
+  it("notifies every subscriber", () => {
+    const landing = vi.fn();
+    const inSession = vi.fn();
+    subscribe(landing);
+    subscribe(inSession);
+
+    requestComposerFocus();
+
+    expect(landing).toHaveBeenCalledTimes(1);
+    expect(inSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops notifying after unsubscribe", () => {
+    const listener = vi.fn();
+    const off = onComposerFocusRequest(listener);
+
+    off();
+    requestComposerFocus();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("isolates a throwing subscriber so the others still focus", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const survivor = vi.fn();
+    subscribe(() => {
+      throw new Error("boom");
+    });
+    subscribe(survivor);
+
+    expect(() => requestComposerFocus()).not.toThrow();
+    expect(survivor).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/lib/composerFocus.ts
+++ b/web/src/lib/composerFocus.ts
@@ -1,0 +1,55 @@
+/**
+ * Focus hand-off from a closing overlay to whichever composer the page lands on.
+ *
+ * A modal overlay traps focus: while it is open (and while its close animation
+ * plays), any element that takes focus outside the overlay is immediately pulled
+ * back in. A destination that focuses its own composer as it mounts — the
+ * new-session landing screen, the in-session composer — therefore loses that
+ * focus when the navigation came from an overlay, and the user ends up on
+ * `<body>` with nowhere to type. The overlay instead requests focus once it is
+ * gone, and the mounted composer takes it.
+ *
+ * Set-based so Strict-Mode double-mounts dedupe. Requesting focus with no
+ * composer mounted is a no-op.
+ */
+import { useEffect } from "react";
+import type { RefObject } from "react";
+
+type ComposerFocusListener = () => void;
+
+const listeners = new Set<ComposerFocusListener>();
+
+/** Ask the mounted composer to take focus. */
+export function requestComposerFocus(): void {
+  for (const listener of listeners) {
+    try {
+      listener();
+    } catch (err) {
+      console.warn("[composer-focus] listener threw:", err);
+    }
+  }
+}
+
+/** Subscribe a composer to focus requests; returns an unsubscribe. */
+export function onComposerFocusRequest(listener: ComposerFocusListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Focus `ref` whenever an overlay hands focus back to the page.
+ *
+ * `enabled` gates the subscription — pass `false` where programmatic focus is
+ * unwanted (mobile, where it summons the software keyboard).
+ */
+export function useComposerFocusRequests(
+  ref: RefObject<HTMLTextAreaElement | null>,
+  enabled = true,
+): void {
+  useEffect(() => {
+    if (!enabled) return;
+    return onComposerFocusRequest(() => ref.current?.focus());
+  }, [ref, enabled]);
+}

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -4,13 +4,14 @@ import type * as UseHostsModule from "@/hooks/useHosts";
 import type * as RunnerHealthProviderModule from "@/hooks/RunnerHealthProvider";
 import type * as AgentLabelsModule from "@/lib/agentLabels";
 
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useChatStore } from "@/store/chatStore";
 import { clearSessionDrafts, hasSessionDraft } from "@/lib/sessionDrafts";
 import { setOmnigentHostConfig } from "@/lib/host";
 import { COMPOSER_SEND_SHORTCUT_STORAGE_KEY } from "@/lib/composerSendShortcutPreferences";
+import { requestComposerFocus } from "@/lib/composerFocus";
 
 // Composer reads workspace files via a TanStack query hook (for "@"-file
 // mentions). These slash-command tests don't exercise that, so stub the hook
@@ -2909,5 +2910,56 @@ describe("shouldQueueSend", () => {
     // The ordering guard outranks always-steer: draining must stay in order, so
     // a direct send can't overtake a still-queued earlier one.
     expect(shouldQueueSend("conv_a", "streaming", "running", [q("conv_a")], true)).toBe(true);
+  });
+});
+
+// Switching sessions from the command palette re-binds the composer, which
+// focuses it — but the palette's focus trap outlives the navigation and undoes
+// that. The palette hands focus back once it is gone, and the composer takes it
+// so the user can keep typing without reaching for the mouse.
+describe("Composer overlay focus hand-off", () => {
+  beforeEach(() => {
+    useChatStore.setState({ conversationId: "conv_test", skills: [] });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("focuses the textarea when a closing overlay hands focus back", () => {
+    render(<Composer {...composerProps()} />);
+    const ta = textarea();
+    ta.blur();
+    expect(document.activeElement).not.toBe(ta);
+
+    act(() => requestComposerFocus());
+
+    expect(document.activeElement).toBe(ta);
+  });
+
+  it("leaves focus alone on mobile, where it would summon the keyboard", () => {
+    // Same gate as the bind-time focus above: programmatic focus on a phone
+    // pops the software keyboard over the transcript.
+    vi.spyOn(window, "matchMedia").mockImplementation(
+      (query: string) =>
+        ({
+          matches: true,
+          media: query,
+          onchange: null,
+          addListener: () => {},
+          removeListener: () => {},
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          dispatchEvent: () => false,
+        }) as unknown as MediaQueryList,
+    );
+    render(<Composer {...composerProps()} />);
+    const ta = textarea();
+    ta.blur();
+
+    act(() => requestComposerFocus());
+
+    expect(document.activeElement).not.toBe(ta);
   });
 });

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -90,6 +90,7 @@ import type { NativeModelOption, Session, SessionStatus } from "@/lib/types";
 import { usePromptHistory } from "@/hooks/usePromptHistory";
 import { useAutoGrowTextarea } from "@/hooks/useAutoGrowTextarea";
 import { useDictationInsert } from "@/hooks/useDictationInsert";
+import { useComposerFocusRequests } from "@/lib/composerFocus";
 import type { MessageContentBlock } from "@/lib/blocks";
 import { ELICITATION_RESPONSE_PREFIX } from "@/lib/blocks";
 import {
@@ -4495,6 +4496,11 @@ export function Composer({
     if (!conversationId || settledConversationId !== conversationId || !dirtyRef.current) return;
     setSessionDraft(conversationId, { text: value, files });
   }, [conversationId, settledConversationId, value, files]);
+
+  // Switching sessions from the command palette lands here the same way, but
+  // the palette's focus trap outlives the navigation and undoes the focus
+  // above — so take it again once the palette hands it back (see composerFocus).
+  useComposerFocusRequests(textareaRef, !isMobile);
 
   // Adding a reply quote (via the floating "Reply" button) should drop the
   // caret straight into the composer so the user can type immediately. Only

--- a/web/src/shell/CommandPalette.test.tsx
+++ b/web/src/shell/CommandPalette.test.tsx
@@ -1,7 +1,9 @@
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useRef, useState } from "react";
 import type { ComponentProps } from "react";
 
+import { onComposerFocusRequest, useComposerFocusRequests } from "@/lib/composerFocus";
 import { CommandPalette } from "./CommandPalette";
 
 const navigate = vi.fn();
@@ -347,5 +349,124 @@ describe("CommandPalette — empty state", () => {
     });
 
     expect(screen.getByText("No results found")).toBeTruthy();
+  });
+});
+
+// The palette's focus trap outlives the navigation a selection triggers: it
+// holds until the close animation ends, so a destination that focuses its
+// composer on mount has that focus pulled back and then dropped on <body>.
+// The palette therefore hands focus over itself, once it is actually gone.
+describe("CommandPalette — focus hand-off", () => {
+  /** Stands in for a destination page: mounts on navigate, focuses its
+      composer the way the real landing screen and in-session composer do. */
+  function Destination() {
+    const ref = useRef<HTMLTextAreaElement>(null);
+    useComposerFocusRequests(ref);
+    return <textarea ref={ref} autoFocus data-testid="destination-composer" />;
+  }
+
+  function Harness() {
+    const [open, setOpen] = useState(false);
+    const [navigated, setNavigated] = useState(false);
+    navigate.mockImplementation(() => setNavigated(true));
+    return (
+      <>
+        {navigated ? (
+          <div key="destination">
+            <Destination />
+          </div>
+        ) : (
+          <section key="origin">
+            <textarea data-testid="origin-composer" />
+          </section>
+        )}
+        {/* Stands in for the ⌘K hotkey: Radix pins its restore target when the
+            palette opens, so the origin composer must already hold focus. */}
+        <button type="button" data-testid="open-palette" onClick={() => setOpen(true)}>
+          open
+        </button>
+        <CommandPalette
+          open={open}
+          onOpenChange={setOpen}
+          onToggleLeftSidebar={vi.fn()}
+          onToggleRightSidebar={vi.fn()}
+        />
+      </>
+    );
+  }
+
+  /** Radix releases the focus trap a macrotask after the palette unmounts. */
+  async function settle(): Promise<void> {
+    await act(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    });
+  }
+
+  /** Render with the caret in a composer, then open the palette over it. */
+  async function openOverComposer(): Promise<HTMLElement> {
+    render(<Harness />);
+    const origin = screen.getByTestId("origin-composer");
+    origin.focus();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("open-palette"));
+    });
+    return origin;
+  }
+
+  async function selectAndSettle(label: string): Promise<void> {
+    await openOverComposer();
+    await act(async () => {
+      fireEvent.click(screen.getByText(label));
+    });
+    await settle();
+  }
+
+  it("leaves the caret in the new-session composer after New chat", async () => {
+    await selectAndSettle("New chat");
+
+    expect(navigate).toHaveBeenCalledWith("/");
+    expect(document.activeElement).toBe(screen.getByTestId("destination-composer"));
+  });
+
+  it("leaves the caret in the composer after switching sessions", async () => {
+    setSessions([conv("c1", "Fix the parser")]);
+    await selectAndSettle("Fix the parser");
+
+    expect(navigate).toHaveBeenCalledWith("/c/c1");
+    expect(document.activeElement).toBe(screen.getByTestId("destination-composer"));
+  });
+
+  it("does not grab focus when dismissed without selecting", async () => {
+    const requested = vi.fn();
+    const off = onComposerFocusRequest(requested);
+    await openOverComposer();
+
+    await act(async () => {
+      fireEvent.keyDown(document, { key: "Escape" });
+    });
+    await settle();
+    off();
+
+    // Cancelling is not navigation: Radix's own restore stands, and no
+    // composer is yanked into focus behind the user's back.
+    expect(navigate).not.toHaveBeenCalled();
+    expect(requested).not.toHaveBeenCalled();
+  });
+
+  it("does not grab focus for the non-navigating sidebar toggles", async () => {
+    const requested = vi.fn();
+    const off = onComposerFocusRequest(requested);
+    await openOverComposer();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Toggle conversations sidebar"));
+    });
+    await settle();
+    off();
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(requested).not.toHaveBeenCalled();
   });
 });

--- a/web/src/shell/CommandPalette.tsx
+++ b/web/src/shell/CommandPalette.tsx
@@ -17,7 +17,7 @@
 // groups react to the same input.
 
 import type React from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   CalendarClockIcon,
   InboxIcon,
@@ -29,6 +29,7 @@ import {
   XIcon,
 } from "lucide-react";
 import { useNavigate } from "@/lib/routing";
+import { requestComposerFocus } from "@/lib/composerFocus";
 import { useConversations } from "@/hooks/useConversations";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import { cn } from "@/lib/utils";
@@ -60,6 +61,9 @@ interface ActionCommand {
   icon: LucideIcon;
   /** Extra terms the client-side filter matches against (beyond the label). */
   keywords: string[];
+  /** True when running this leaves the page. The destination claims focus as
+      it mounts, so the palette must not restore focus when it closes. */
+  navigates?: boolean;
   run: () => void;
 }
 
@@ -131,6 +135,7 @@ export function CommandPalette({
         label: "New chat",
         icon: SquarePenIcon,
         keywords: ["compose", "start", "new session"],
+        navigates: true,
         run: () => navigate("/"),
       },
       {
@@ -138,6 +143,7 @@ export function CommandPalette({
         label: "Go to Inbox",
         icon: InboxIcon,
         keywords: ["notifications", "comments", "needs response"],
+        navigates: true,
         run: () => navigate("/inbox"),
       },
       {
@@ -145,6 +151,7 @@ export function CommandPalette({
         label: "Go to Automations",
         icon: CalendarClockIcon,
         keywords: ["scheduled", "recurring", "cron", "automation", "schedule"],
+        navigates: true,
         run: () => navigate("/tasks"),
       },
       {
@@ -152,6 +159,7 @@ export function CommandPalette({
         label: "Go to Settings",
         icon: SettingsIcon,
         keywords: ["preferences", "configuration", "account"],
+        navigates: true,
         run: () => navigate("/settings"),
       },
       {
@@ -210,12 +218,24 @@ export function CommandPalette({
     return debouncedQuery ? out : out.slice(0, IDLE_SESSION_LIMIT);
   }, [data, debouncedQuery]);
 
+  // A navigating selection hands the page over to a destination that focuses
+  // its own composer as it mounts — but the palette's focus trap is still up
+  // (it holds until the close animation ends) and pulls that focus straight
+  // back, then drops it on `<body>` as the palette unmounts. So the destination
+  // can't win the race: the palette hands focus over once it is actually gone.
+  // Only for selections — a plain dismiss (Escape, overlay click) doesn't
+  // navigate, so it keeps Radix's own restore and never yanks the caret into a
+  // composer the user didn't ask for.
+  const handedOffRef = useRef(false);
+
   const runAction = (action: ActionCommand): void => {
+    handedOffRef.current = action.navigates === true;
     close();
     action.run();
   };
 
   const goToSession = (id: string): void => {
+    handedOffRef.current = true;
     close();
     navigate(`/c/${id}`);
   };
@@ -249,6 +269,14 @@ export function CommandPalette({
             : undefined
         }
         showCloseButton={false}
+        onCloseAutoFocus={(e) => {
+          if (!handedOffRef.current) return;
+          handedOffRef.current = false;
+          // The pre-open element is gone with the old page; focus the
+          // destination's composer instead of Radix's stale restore target.
+          e.preventDefault();
+          requestComposerFocus();
+        }}
       >
         <DialogTitle className="sr-only">Command palette</DialogTitle>
         {/* shouldFilter=false: the server filters sessions and we filter actions

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -6,7 +6,7 @@ import type * as NativeBridgeModule from "@/lib/nativeBridge";
 
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { MemoryRouter } from "react-router-dom";
+import { Link, MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import {
@@ -28,6 +28,7 @@ import {
   resetLandingDraft,
 } from "./NewChatDialog";
 import { CapabilitiesProvider } from "@/lib/CapabilitiesContext";
+import { requestComposerFocus } from "@/lib/composerFocus";
 import type { ServerInfo } from "@/lib/capabilities";
 import { authenticatedFetch } from "@/lib/identity";
 import {
@@ -761,11 +762,8 @@ function setupLandingMocks() {
   ]);
 }
 
-function renderLanding(infoOverrides: Partial<ServerInfo> = {}, route = "/") {
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  const info: ServerInfo = {
+function landingServerInfo(overrides: Partial<ServerInfo> = {}): ServerInfo {
+  return {
     accounts_enabled: false,
     single_user: false,
     login_url: null,
@@ -781,13 +779,20 @@ function renderLanding(infoOverrides: Partial<ServerInfo> = {}, route = "/") {
     // gateway-gating cases below were written against (off-gateway family → no
     // routing). Cases that exercise the built-in judge pass the field
     // explicitly.
-    smart_routing_sources: { external: infoOverrides.smart_routing_enabled === true, oss: false },
-    features: { harness_install: infoOverrides.harness_install_enabled === true },
+    smart_routing_sources: { external: overrides.smart_routing_enabled === true, oss: false },
+    features: { harness_install: overrides.harness_install_enabled === true },
     harness_install_enabled: false,
     installable_harnesses: [],
     dictation_available: false,
-    ...infoOverrides,
+    ...overrides,
   };
+}
+
+function renderLanding(infoOverrides: Partial<ServerInfo> = {}, route = "/") {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const info = landingServerInfo(infoOverrides);
   return render(
     <QueryClientProvider client={client}>
       <CapabilitiesProvider info={info}>
@@ -5264,5 +5269,63 @@ describe("NewChatLandingScreen Smart Routing flavors are scoped separately", () 
     expect(screen.getByTestId("new-chat-landing-config-harness").textContent).toContain(
       "Smart Routing",
     );
+  });
+});
+
+// The landing screen is where a new prompt gets typed, so it must arrive
+// ready for the keyboard however the user got here — sidebar link, command
+// palette, the per-project pencil, or a pasted URL.
+describe("NewChatLandingScreen composer focus", () => {
+  beforeEach(setupLandingMocks);
+  afterEach(() => {
+    cleanup();
+    resetLandingDraft();
+    localStorage.clear();
+  });
+
+  it("focuses the composer on arrival", () => {
+    renderLanding();
+
+    expect(document.activeElement).toBe(screen.getByTestId("new-chat-landing-input"));
+  });
+
+  it("takes focus when a closing overlay hands it back", () => {
+    renderLanding();
+    // A dialog that navigated here holds its focus trap until its close
+    // animation ends, so it steals the mount focus and hands it over after.
+    const box = screen.getByTestId("new-chat-landing-input");
+    (document.activeElement as HTMLElement).blur();
+    expect(document.activeElement).not.toBe(box);
+
+    act(() => requestComposerFocus());
+
+    expect(document.activeElement).toBe(box);
+  });
+
+  it("re-focuses the composer when the project pencil switches it in place", () => {
+    // The `?project=` pencils navigate without unmounting the screen, so the
+    // textarea's mount-only autoFocus never re-fires.
+    render(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
+        <CapabilitiesProvider info={landingServerInfo()}>
+          <TooltipProvider>
+            <MemoryRouter initialEntries={["/?project=alpha"]}>
+              <Link to="/?project=beta" data-testid="beta-pencil">
+                beta
+              </Link>
+              <NewChatLandingScreen />
+            </MemoryRouter>
+          </TooltipProvider>
+        </CapabilitiesProvider>
+      </QueryClientProvider>,
+    );
+    const box = screen.getByTestId("new-chat-landing-input");
+    (document.activeElement as HTMLElement).blur();
+
+    fireEvent.click(screen.getByTestId("beta-pencil"));
+
+    expect(document.activeElement).toBe(box);
   });
 });

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2417,11 +2417,11 @@ export function NewChatLandingScreen() {
   // the page — including a `?project=` switch that leaves it mounted, which the
   // textarea's `autoFocus` (mount-only) can't see.
   useEffect(() => {
-    textareaRef.current?.focus();
-  }, [projectParam]);
+    if (!isMobileViewport) textareaRef.current?.focus();
+  }, [projectParam, isMobileViewport]);
   // …and again when an overlay hands focus back after navigating here (see
   // composerFocus: its focus trap outlives the navigation).
-  useComposerFocusRequests(textareaRef);
+  useComposerFocusRequests(textareaRef, !isMobileViewport);
   // Permission mode for Claude Code (claude --permission-mode). Only
   // meaningful for the claude-native wrapper; ignored otherwise. Lives in
   // the footer tray's Advanced settings menu.

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -200,6 +200,7 @@ import {
 import { useAutoGrowTextarea } from "@/hooks/useAutoGrowTextarea";
 import { useDictationInsert } from "@/hooks/useDictationInsert";
 import { useRecentHarnesses } from "@/hooks/useRecentHarnesses";
+import { useComposerFocusRequests } from "@/lib/composerFocus";
 import { useRecentWorkspaces } from "@/hooks/useRecentWorkspaces";
 import { useDirectorySessions } from "@/hooks/useDirectorySessions";
 import { useRunnerHealthRegistration } from "@/hooks/RunnerHealthProvider";
@@ -2412,6 +2413,15 @@ export function NewChatLandingScreen() {
   useEffect(() => {
     setSelectedProject(projectParam);
   }, [projectParam]);
+  // This screen exists to be typed into, so take the caret whenever it becomes
+  // the page — including a `?project=` switch that leaves it mounted, which the
+  // textarea's `autoFocus` (mount-only) can't see.
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, [projectParam]);
+  // …and again when an overlay hands focus back after navigating here (see
+  // composerFocus: its focus trap outlives the navigation).
+  useComposerFocusRequests(textareaRef);
   // Permission mode for Claude Code (claude --permission-mode). Only
   // meaningful for the claude-native wrapper; ignored otherwise. Lives in
   // the footer tray's Advanced settings menu.


### PR DESCRIPTION
## Related issue

Closes #4230

## Summary

⌘K → type `new` → Return should drop the user straight into the new-session prompt box. Instead focus landed on `<body>`, so the next keystrokes went nowhere and the flow needed a mouse click to finish.

The landing screen *does* focus its textarea on mount — the command palette takes it back. Radix keeps a modal dialog's `focusin` focus trap installed until the content actually unmounts, and the palette's close animation delays that ~150ms past the navigation. So the trap outlives the route change, sees the destination's `focusin`, yanks focus into the already-off-page palette, and drops it on `<body>` when the palette finally goes.

```
selection ──► close() + navigate("/")        route swaps immediately
              │
              ├─ landing screen mounts, autoFocus → textarea focused
              ├─ palette's trap (still installed) sees focusin outside → steals it back
              └─ ~150ms later the palette unmounts → focus lands on <body>   ✗
```

The destination can't win that race, so the palette hands focus over once it is actually gone:

- **`web/src/lib/composerFocus.ts`** (new) — a tiny bus, in the shape of the existing `browserActionBus`. `requestComposerFocus()` fans out; `useComposerFocusRequests(ref, enabled)` subscribes a composer.
- **`CommandPalette`** — on `onCloseAutoFocus` (Radix's "the trap is released now" moment) after a *navigating* selection, `preventDefault()` the stale restore and request composer focus. A plain dismiss (Escape, overlay click) and the sidebar-toggle actions keep Radix's own restore, so cancelling never yanks the caret into a composer the user didn't ask for.
- **`NewChatLandingScreen`** and the in-session **`Composer`** subscribe. The in-session one is gated on desktop, matching its existing bind-time focus (programmatic focus on mobile summons the software keyboard). Subscribing it makes palette *session-switching* deterministic too — that path survives today only because session hydration happens to outpace the animation.
- **`NewChatLandingScreen`** additionally re-focuses when `?project=` changes. The textarea's `autoFocus` is mount-only, and the per-project "New session" pencils navigate without unmounting the screen.

## Test Plan

**The bug only reproduces in a real browser** — jsdom runs no animations, so the trap releases in the same commit and a jsdom test never sees the steal. So the regression guard is a Playwright test against a live server, and it was run against the old build first to prove it fails.

New `tests/e2e_ui/hotkeys/test_command_palette_focus.py`, `uv run pytest tests/e2e_ui/hotkeys/test_command_palette_focus.py`:

| | before | after |
|---|---|---|
| ⌘K → "new chat" → caret in landing composer | **FAILED** (`activeElement` never becomes the textarea) | PASSED |
| sidebar "New session" → caret in landing composer | PASSED (no overlay in the way) | PASSED |
| ⌘K → pick a session → caret in session composer | PASSED (masked by hydration timing) | PASSED |

The first test types `ship the thing` after the jump with no click in between and asserts the textarea holds it — the actual user journey, not just an `activeElement` check.

jsdom coverage (`cd web && npm test`), all green, 4012 passing overall:

- `web/src/lib/composerFocus.test.ts` — fan-out, unsubscribe, a throwing subscriber not taking the others down, no-op with nothing mounted.
- `web/src/shell/CommandPalette.test.tsx` — caret ends in the destination composer for both a navigating action and a session pick; Escape and the sidebar toggles request nothing.
- `web/src/shell/NewChatDialog.test.tsx` — landing composer focused on arrival, on a hand-off, and on an in-place `?project=` switch.
- `web/src/pages/ChatPage.composer.test.tsx` — in-session composer honours a hand-off on desktop, ignores it on mobile.

Also `npm run type-check` and `pre-commit run` clean.

> Note: the jsdom suites need Node ≤ 22 locally. On Node 26 the built-in experimental `localStorage` global shadows jsdom's and ~60 pre-existing tests in `NewChatDialog.test.tsx` fail on `main` too. CI pins Node 20, so this is a local-only footgun.

## Demo

The change is a focus behaviour, so a still screenshot shows nothing — here is the recorded Playwright run of the fixed journey (⌘K → "new chat" → Return → typing lands in the prompt box, no mouse):

https://github.com/user-attachments/assets/96dc0c95-cca1-4a89-ac48-b3da1ec28c1f

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the before/after e2e run in the table above: the new e2e test was run against a build of `main`'s frontend (fails on the ⌘K path) and then against this branch (passes), against a live `omnigent server` with the real Chromium. That before-run is what proves the test actually catches the bug rather than passing vacuously.

## Changelog

Jumping to a new session from the command palette now puts the caret straight in the prompt box, so ⌘K → "new" → Return → type works without touching the mouse

