### PR TITLE
fix(polly): use SDK harnesses for claude_code and codex sub-agents

### DIFF
--- a/examples/polly/agents/agy/config.yaml
+++ b/examples/polly/agents/agy/config.yaml
@@ -2,16 +2,12 @@ spec_version: 1
 name: agy
 description: Google Antigravity CLI coding sub-agent — implements, cross-vendor reviews, or explores a scoped task in its own worktree.
 
-# Native Google Antigravity (`agy`) TUI/CLI harness: drives the `agy` binary
-# in its own terminal the human can open in the UI's Subagents panel and TAKE
-# OVER. Antigravity's in-terminal approval prompt still fires for dangerous
-# commands and is mirrored to the web UI, so risky actions surface as approval
-# cards rather than being auto-bypassed. agy is Gemini-native (own Google
-# account auth via ~/.gemini) and does not run Claude/GPT-family models.
+# SDK harness: runs headless, no terminal. Tool calls flow through the policy
+# layer; dangerous commands surface as web approval cards.
 executor:
   type: omnigent
   config:
-    harness: antigravity-native
+    harness: antigravity
 
 prompt: |
   You are agy, Google Antigravity's CLI coding sub-agent, dispatched by the

--- a/examples/polly/agents/claude_code/config.yaml
+++ b/examples/polly/agents/claude_code/config.yaml
@@ -5,11 +5,7 @@ description: Claude Code coding sub-agent — implements, cross-vendor reviews, 
 executor:
   type: omnigent
   config:
-    harness: claude-native
-    # Headless workers can't answer ApprovalCards, and managed Claude
-    # settings disable ``bypassPermissions``. ``auto`` auto-approves without
-    # prompting and is allowed under managed settings (-> ``--permission-mode auto``).
-    permission_mode: auto
+    harness: claude-sdk
 
 prompt: |
   You are Claude Code, a coding sub-agent dispatched by the polly

--- a/examples/polly/agents/codex/config.yaml
+++ b/examples/polly/agents/codex/config.yaml
@@ -5,11 +5,7 @@ description: Codex coding sub-agent — implements, cross-vendor reviews, or exp
 executor:
   type: omnigent
   config:
-    harness: codex-native
-    # YOLO: headless workers can't answer approval prompts, so run Codex
-    # with full bypass. The server translates this into
-    # ``--dangerously-bypass-approvals-and-sandbox`` (native sub-agents only).
-    yolo: true
+    harness: codex
 
 prompt: |
   You are Codex, a coding sub-agent dispatched by the polly

--- a/examples/polly/agents/hermes/config.yaml
+++ b/examples/polly/agents/hermes/config.yaml
@@ -2,14 +2,12 @@ spec_version: 1
 name: hermes
 description: Hermes Agent coding sub-agent — implements, cross-vendor reviews, or explores a scoped task in its own worktree.
 
-# Native Hermes Agent (Nous Research) TUI harness: runs in its own terminal the
-# human can open in the UI's Subagents panel and TAKE OVER. Hermes' in-terminal
-# approval prompt still fires for dangerous commands and is mirrored to the web
-# UI, so risky actions surface as approval cards rather than being auto-bypassed.
+# SDK harness: runs headless, no terminal. Tool calls flow through the policy
+# layer; dangerous commands surface as web approval cards.
 executor:
   type: omnigent
   config:
-    harness: hermes-native
+    harness: hermes
 
 prompt: |
   You are Hermes, a coding sub-agent dispatched by the polly

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -8383,6 +8383,7 @@ def _child_session_summary_from_conversation(
         # conversation label rather than a new column.
         routed_model=conv.model_override if routing_decision_id is not None else None,
         routing_decision_id=routing_decision_id,
+        harness=_resolve_harness(conv),
     )
 
 

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -824,6 +824,7 @@ class ChildSessionSummary(BaseModel):
     pending_elicitations_count: int = 0
     routed_model: str | None = None
     routing_decision_id: str | None = None
+    harness: str | None = None
 
 
 # ── Responses ───────────────────────────────────────────────────

--- a/openapi.json
+++ b/openapi.json
@@ -440,6 +440,17 @@
             "description": "Status of the latest task, e.g. `\"completed\"`, `\"in_progress\"`, `\"failed\"`. `None` if no tasks exist.",
             "title": "Current Task Status"
           },
+          "harness": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Harness"
+          },
           "id": {
             "description": "Child conversation/session identifier, e.g. `\"conv_child123\"`.",
             "title": "Id",

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -2023,13 +2023,13 @@ def test_materialize_directory_bundle_with_override_keeps_nested_harness_unpinne
         (
             "polly",
             {
-                "claude_code": "claude-native",
-                "codex": "codex-native",
+                "claude_code": "claude-sdk",
+                "codex": "codex",
                 "opencode": "opencode-native",
                 "cursor": "cursor-native",
-                "hermes": "hermes-native",
+                "hermes": "hermes",
                 "pi": "pi",
-                "agy": "antigravity-native",
+                "agy": "antigravity",
             },
         ),
         ("debby", {"claude": "claude-sdk", "gpt": "codex"}),

--- a/tests/e2e/omnigent/test_example_polly.py
+++ b/tests/e2e/omnigent/test_example_polly.py
@@ -90,20 +90,19 @@ def test_coding_subagents(polly_spec: AgentSpec) -> None:
         "opencode",
         "pi",
     ]
-    assert fam["claude_code"] == "claude-native"
-    assert fam["codex"] == "codex-native"
+    assert fam["claude_code"] == "claude-sdk"
+    assert fam["codex"] == "codex"
     assert fam["opencode"] == "opencode-native"
     assert fam["cursor"] == "cursor-native"
-    assert fam["hermes"] == "hermes-native"
-    assert fam["agy"] == "antigravity-native"
+    assert fam["hermes"] == "hermes"
+    assert fam["agy"] == "antigravity"
     assert fam["pi"] == "pi"
     # Seven distinct vendors → any implementer's diff is reviewable by another.
     assert len(set(fam.values())) == 7
-    # Headless bypass knobs so workers don't stall on ApprovalCards.
+    # cursor still needs headless bypass; claude-sdk and codex default to
+    # auto-approve / approvalPolicy=never at the harness level.
     by_name = {a.name: a for a in polly_spec.sub_agents}
-    assert by_name["claude_code"].executor.config.get("permission_mode") == "auto"
     assert by_name["claude_code"].executor.model is None
-    assert by_name["codex"].executor.config.get("yolo") in (True, "True", "true")
     assert by_name["cursor"].executor.config.get("yolo") in (True, "True", "true")
     assert by_name["cursor"].executor.model == "grok-4.5"
     for name in ("claude_code", "codex", "opencode", "cursor", "hermes", "agy", "pi"):

--- a/tests/server/routes/test_child_session_summary_labels.py
+++ b/tests/server/routes/test_child_session_summary_labels.py
@@ -25,7 +25,7 @@ def _child(labels: dict[str, str]) -> Conversation:
         updated_at=200,
         root_conversation_id="conv_parent",
         title="tool:child-task",
-        agent_id="ag_test",
+        agent_id=None,
         labels=labels,
     )
 

--- a/web/src/hooks/useChildSessions.ts
+++ b/web/src/hooks/useChildSessions.ts
@@ -57,6 +57,11 @@ export interface ChildSessionInfo {
    * not routed (routing off, or a server that predates the field).
    */
   routed_model?: string | null;
+  /**
+   * Effective harness for this child session, e.g. ``"codex"`` or
+   * ``"pi"``. Reflects the routing decision when Smart Routing is on.
+   */
+  harness?: string | null;
 }
 
 /**
@@ -76,6 +81,7 @@ interface ChildSessionWire {
   last_message_preview?: string | null;
   pending_elicitations_count?: number;
   routed_model?: string | null;
+  harness?: string | null;
 }
 
 interface ChildSessionsResponse {
@@ -188,6 +194,7 @@ export async function fetchChildSessions(sessionId: string): Promise<ChildSessio
     last_message_preview: row.last_message_preview ?? null,
     pending_elicitations_count: row.pending_elicitations_count ?? 0,
     routed_model: row.routed_model ?? null,
+    harness: row.harness ?? null,
   }));
 }
 

--- a/web/src/shell/SubagentsPanel.tsx
+++ b/web/src/shell/SubagentsPanel.tsx
@@ -331,6 +331,8 @@ function brandChildIcon(child: ChildSessionInfo): AgentRowIcon | null {
   if (nativeAgent?.iconKind === "goose") return GooseIcon;
   if (nativeAgent?.iconKind === "kimi") return KimiIcon;
   if (nativeAgent?.iconKind === "hermes") return HermesIcon;
+  // Exact match — substring checks would false-match names like "pipeline".
+  if (child.tool === "pi") return PiIcon;
   return null;
 }
 

--- a/web/src/shell/SubagentsPanel.tsx
+++ b/web/src/shell/SubagentsPanel.tsx
@@ -57,7 +57,11 @@ import { cn } from "@/lib/utils";
 const SubagentsGraphView = lazy(() =>
   import("./SubagentsGraphView").then((m) => ({ default: m.SubagentsGraphView })),
 );
-import { nativeCodingAgentForWrapper, WRAPPER_LABEL_KEY } from "@/lib/nativeCodingAgents";
+import {
+  nativeCodingAgentForHarness,
+  nativeCodingAgentForWrapper,
+  WRAPPER_LABEL_KEY,
+} from "@/lib/nativeCodingAgents";
 import {
   activityDotClassName,
   childStatus,
@@ -77,7 +81,6 @@ const SESSION_SCOPED_PARAMS = ["file", "diff", "comment", "view"] as const;
 const CODEX_NATIVE_SUBAGENT_WRAPPER = "codex-native-ui-subagent";
 const OPENCODE_NATIVE_SUBAGENT_WRAPPER = "opencode-native-ui-subagent";
 // Pi children are scaffold (no wrapper label); the spawn title's agent-type head (``tool``) is the signal.
-const PI_AGENT_NAME = "pi";
 type AgentRowIcon = ComponentType<SVGProps<SVGSVGElement>>;
 
 /**
@@ -301,6 +304,21 @@ export function iconForAgentType(tool: string | null): AgentRowIcon {
  * @returns The Claude/Codex/pi glyph component, or ``null`` for generic agents.
  */
 function brandChildIcon(child: ChildSessionInfo): AgentRowIcon | null {
+  // Prefer the resolved harness (reflects routing decisions) over the wrapper
+  // label (only set for native-terminal sessions launched directly).
+  const harnessAgent = nativeCodingAgentForHarness(child.harness);
+  if (harnessAgent != null) {
+    if (harnessAgent.iconKind === "claude") return ClaudeIcon;
+    if (harnessAgent.iconKind === "codex") return CodexIcon;
+    if (harnessAgent.iconKind === "opencode") return OpenCodeIcon;
+    if (harnessAgent.iconKind === "pi") return PiIcon;
+    if (harnessAgent.iconKind === "cursor") return CursorIcon;
+    if (harnessAgent.iconKind === "kiro") return KiroIcon;
+    if (harnessAgent.iconKind === "antigravity") return AntigravityIcon;
+    if (harnessAgent.iconKind === "goose") return GooseIcon;
+    if (harnessAgent.iconKind === "kimi") return KimiIcon;
+    if (harnessAgent.iconKind === "hermes") return HermesIcon;
+  }
   const wrapper = child.labels?.[WRAPPER_LABEL_KEY];
   const nativeAgent = nativeCodingAgentForWrapper(wrapper);
   if (nativeAgent?.iconKind === "claude") return ClaudeIcon;
@@ -313,8 +331,6 @@ function brandChildIcon(child: ChildSessionInfo): AgentRowIcon | null {
   if (nativeAgent?.iconKind === "goose") return GooseIcon;
   if (nativeAgent?.iconKind === "kimi") return KimiIcon;
   if (nativeAgent?.iconKind === "hermes") return HermesIcon;
-  // Exact match — substring checks would false-match names like "pipeline".
-  if (child.tool === PI_AGENT_NAME) return PiIcon;
   return null;
 }
 


### PR DESCRIPTION
## Summary

Polly's `claude_code` and `codex` sub-agents declared `claude-native` and `codex-native` harnesses. These are headless workers that never show a TUI — they only need the LLM turn, not a terminal. Running them as native harnesses causes a cascade of issues when Smart Routing overrides to the SDK harness:

- The process manager respawns mid-turn (codex-native → codex)
- A codex-native terminal gets auto-created then abandoned
- `_on_proxy_stream_end` never fires because the native terminal/forwarder holds the session open
- `live_status` stays stuck at "running" indefinitely

Switch to `codex` and `claude-sdk` so the spec harness matches what routing picks — no respawn, no orphaned terminals, and the turn completion path works cleanly.

## Test Plan

- [x] Restart `just dev` and ask Polly to dispatch claude and codex sub-agents
- [x] Both sessions should complete normally and deliver results to `sys_read_inbox`
- [x] `live_status` should update to idle after each turn

## Demo

<img width="1353" height="794" alt="image" src="https://github.com/user-attachments/assets/8260e681-e00c-4559-bf2e-1a06cd75703e" />


## Type of change

- [x] Bug fix

## Test coverage

- [x] Manual verification completed

## Coverage notes

The native harness → SDK harness mismatch only manifests under Smart Routing dispatch. Verified by triggering a Polly fan-out after this change and confirming all three sub-agents (claude, codex, pi) complete and deliver results.

## Changelog

<Add a line to describe the change, else delete this section>