### PR TITLE
feat(github): executor-agnostic GitHub credential broker

### DIFF
--- a/omnigent/git_credential_github.py
+++ b/omnigent/git_credential_github.py
@@ -1,0 +1,164 @@
+"""Git credential helper that fetches the session's GitHub token from the server.
+
+Installed in a managed sandbox as git's ``credential.helper`` for
+``github.com``. On each HTTPS auth challenge git runs this with ``get`` and the
+request on stdin; the helper calls the server's host-facing credential endpoint
+(:mod:`omnigent.server.routes.host_github`) over the sandbox's existing
+authenticated channel and prints back ``username`` / ``password``.
+
+Why this shape:
+- The **GitHub token is never persisted** in the sandbox — it's fetched fresh
+  per git operation and lives only in this short-lived process's stdout.
+- It is **executor-agnostic**: every executor already starts the host with a
+  server URL + launch token, so nothing GitHub-specific is injected per
+  executor. The host bakes the endpoint coordinates (server URL, host id, launch
+  token) into the ``credential.helper`` invocation, so the helper works
+  regardless of whether the process running git inherited the runner's env.
+
+The launch token *does* live in the git config (a lesser, host-scoped,
+expiring credential already present in this disposable sandbox); the user's
+GitHub token does not.
+
+Threat model: this removes the GitHub token from disk/env, not the ability of
+in-sandbox code to request one. Any process that can read the launch token (git
+config / argv) can call the endpoint and obtain the owner's full-scope user
+token for its lifetime; teardown stops future fetches but does not revoke an
+already-fetched token. The trust boundary is the sandbox, not this helper.
+
+Run as: ``git credential.helper`` →
+``python -m omnigent.git_credential_github --server <url> --host-id <id>
+--host-token <tok>``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import shlex
+import subprocess
+import sys
+
+import httpx
+
+from omnigent.host.identity import HOST_TOKEN_ENV_VAR as _HOST_TOKEN_ENV_VAR
+from omnigent.host.identity import MANAGED_HOST_TOKEN_HEADER
+
+_TIMEOUT_S = 15.0
+
+
+def _read_git_request() -> dict[str, str]:
+    """Parse git's ``key=value`` credential request from stdin (blank-line terminated)."""
+    fields: dict[str, str] = {}
+    for line in sys.stdin:
+        line = line.rstrip("\n")
+        if not line:
+            break
+        key, _, value = line.partition("=")
+        fields[key] = value
+    return fields
+
+
+def _credential_url(server: str, host_id: str) -> str:
+    return f"{server.rstrip('/')}/v1/hosts/{host_id}/github-credential"
+
+
+def _fetch(server: str, host_id: str, host_token: str) -> dict | None:
+    """Fetch the credential endpoint JSON, or ``None`` on any failure."""
+    try:
+        resp = httpx.get(
+            _credential_url(server, host_id),
+            headers={MANAGED_HOST_TOKEN_HEADER: host_token},
+            timeout=_TIMEOUT_S,
+        )
+    except httpx.HTTPError:
+        return None
+    if resp.status_code != 200:
+        return None
+    try:
+        return resp.json()
+    except ValueError:
+        return None
+
+
+def _fetch_credential(server: str, host_id: str, host_token: str) -> tuple[str, str] | None:
+    """Fetch ``(username, token)`` from the server, or ``None`` if unavailable."""
+    data = _fetch(server, host_id, host_token)
+    if not data or not data.get("connected") or not data.get("token"):
+        return None
+    return str(data.get("username") or "x-access-token"), str(data["token"])
+
+
+def configure_host_git(server_url: str, host_id: str) -> None:
+    """Configure git in a managed sandbox to use the GitHub credential broker.
+
+    Called by ``omnigent host`` at startup — executor-agnostic, since the host
+    runs in every executor and holds ``$OMNIGENT_HOST_TOKEN``. Sets a github.com
+    ``credential.helper`` that fetches the owner's token from the server per git
+    op (the GitHub token is never written to disk), and, when the owner has
+    GitHub connected, sets the commit author to them. Best-effort: never raises
+    (git may be absent, or GitHub not configured on the server).
+    """
+    token = (os.environ.get(_HOST_TOKEN_ENV_VAR) or "").strip()
+    if not token:
+        return
+
+    def _git(*args: str) -> None:
+        with contextlib.suppress(OSError, subprocess.SubprocessError):
+            subprocess.run(
+                ["git", "config", "--global", *args],
+                check=False,
+                capture_output=True,
+                timeout=_TIMEOUT_S,
+            )
+
+    # Bake the (lesser, expiring) launch token into the helper invocation so the
+    # helper works regardless of whether the agent's process inherited the env;
+    # the GitHub token itself is still fetched per-op and never stored.
+    helper = (
+        "!python3 -m omnigent.git_credential_github "
+        f"--server {shlex.quote(server_url)} --host-id {shlex.quote(host_id)} "
+        f"--host-token {shlex.quote(token)}"
+    )
+    _git("credential.https://github.com.helper", helper)
+
+    data = _fetch(server_url, host_id, token) or {}
+    owner = str(data.get("owner") or "")
+    if data.get("connected") and "@" in owner:
+        _git("user.email", owner)
+        login = data.get("login")
+        _git("user.name", str(login) if login else owner.split("@", 1)[0])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--server", required=True)
+    parser.add_argument("--host-id", required=True)
+    parser.add_argument("--host-token", required=True)
+    # git passes the operation (get/store/erase) as the first positional arg.
+    parser.add_argument("operation", nargs="?", default="get")
+    args, _ = parser.parse_known_args(argv)
+
+    # Only ``get`` returns credentials; ``store``/``erase`` are no-ops (nothing
+    # is persisted — the token is re-fetched next time).
+    if args.operation != "get":
+        return 0
+
+    request = _read_git_request()
+    # Fail closed: only vend for github.com over https. A missing/empty host, a
+    # different host, or a non-https protocol declines (return 0, no output) so
+    # git falls through to the next helper — the brokered token can never leak
+    # to another host even if this is ever wired as a global credential helper.
+    if request.get("host") != "github.com" or request.get("protocol") != "https":
+        return 0
+
+    cred = _fetch_credential(args.server, args.host_id, args.host_token)
+    if cred is None:
+        return 0  # decline; git tries the next helper / prompts
+    username, token = cred
+    sys.stdout.write(f"username={username}\npassword={token}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -3999,6 +3999,14 @@ def run_host_process(
     if _cli_log is not None and _cli_log != host_log_path:
         print(f"CLI diagnostics: {display_log_path(_cli_log)}")
 
+    # Executor-agnostic GitHub setup: point git at the server's credential
+    # broker and attribute commits to the owner. Best-effort; the host runs in
+    # every executor and holds the launch token, so no launcher needs to inject
+    # anything GitHub-specific.
+    from omnigent.git_credential_github import configure_host_git
+
+    configure_host_git(server_url, identity.host_id)
+
     if lifecycle_lock is None and daemon_target is not None:
         lifecycle_lock = DaemonLifecycleLock.for_target(daemon_target)
     host = HostProcess(identity, server_url, lifecycle_lock=lifecycle_lock)

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -3061,6 +3061,23 @@ def create_app(
             prefix="/v1",
             tags=["hosts"],
         )
+        # Host-facing GitHub credential vending: a sandbox fetches its owner's
+        # token over the launch-token-authenticated channel instead of having it
+        # injected. Only when GitHub is configured (app.state set by the
+        # connection-provider wiring above).
+        if (
+            getattr(app.state, "github_config", None) is not None
+            and getattr(app.state, "github_store", None) is not None
+        ):
+            from omnigent.server.routes.host_github import create_host_github_router
+
+            app.include_router(
+                create_host_github_router(
+                    host_store, app.state.github_store, app.state.github_client
+                ),
+                prefix="/v1",
+                tags=["hosts"],
+            )
         app.include_router(
             create_hosts_router(
                 host_registry,

--- a/omnigent/server/github_identity.py
+++ b/omnigent/server/github_identity.py
@@ -1,0 +1,63 @@
+"""Resolve a user's GitHub access token for the credential broker.
+
+Bridges the connection store and the GitHub App client: reads the stored
+connection and transparently refreshes an expired access token, so the broker
+always vends a currently-valid token. See ``designs/CREDENTIAL_STORE.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from omnigent.connections.github import GithubConnectionStore
+from omnigent.db.utils import now_epoch
+from omnigent.server.github_app import GitHubAppError
+from omnigent.server.github_app_client import GitHubAppClient
+
+_logger = logging.getLogger(__name__)
+
+# Refresh a token that expires within this margin so it does not lapse
+# mid-launch (or shortly after) inside the sandbox.
+_REFRESH_MARGIN_S = 300
+
+
+async def resolve_access_token(
+    user_id: str,
+    *,
+    store: GithubConnectionStore,
+    client: GitHubAppClient,
+) -> str | None:
+    """Resolve a valid user access token for *user_id*, or ``None``.
+
+    Reads the stored connection and transparently refreshes a token that is
+    at/near expiry (persisting the refresh). Best-effort: any failure (no
+    connection, no refresh token, refresh rejected) returns ``None``.
+
+    :param user_id: The user whose token to resolve.
+    :param store: The connection store (also used to persist a refresh).
+    :param client: The GitHub App client.
+    :returns: A usable access token, or ``None``.
+    """
+    connection = await _run_sync(store.get, user_id, with_tokens=True)
+    if connection is None or not connection.access_token:
+        return None
+    access_token = connection.access_token
+    expires_at = connection.token_expires_at
+    if expires_at is not None and expires_at <= now_epoch() + _REFRESH_MARGIN_S:
+        if not connection.refresh_token:
+            return None
+        try:
+            refreshed = await client.refresh_token(connection.refresh_token)
+        except GitHubAppError as exc:
+            _logger.warning("GitHub token refresh failed for %s: %s", user_id, exc)
+            return None
+        await _run_sync(store.update_tokens, user_id, refreshed)
+        access_token = refreshed.access_token
+    return access_token
+
+
+async def _run_sync(func, /, *args, **kwargs):
+    """Run a synchronous store call off the event loop."""
+    import asyncio
+
+    return await asyncio.to_thread(lambda: func(*args, **kwargs))

--- a/omnigent/server/routes/host_github.py
+++ b/omnigent/server/routes/host_github.py
@@ -1,0 +1,104 @@
+"""Host-facing endpoint that vends a session's GitHub credential.
+
+A managed sandbox authenticates back to the server with its launch token
+(:data:`~omnigent.host.identity.MANAGED_HOST_TOKEN_HEADER`) — the same channel
+the host tunnel uses. This route resolves that token to the session **owner**
+and returns the owner's connected GitHub token, so the sandbox can obtain
+credentials *over the existing authenticated channel* instead of having each
+executor inject them into the environment.
+
+Consumers (all inside the sandbox/runner, never the agent's own process):
+- the git credential helper (``omnigent git-credential-github``), per git op;
+- the GitHub MCP proxy, when it connects to GitHub's hosted MCP.
+
+The token is fetched on demand and never persisted in the sandbox: the server
+re-resolves it (:func:`resolve_access_token`) on each request and stops vending
+the moment the launch token expires or the host row is deleted (session
+teardown). Responses are ``Cache-Control: no-store`` so no intermediary retains
+it.
+
+Threat model — be precise about what teardown does and does not do. What this
+vends is the session owner's **full-scope user token** (whatever scopes they
+granted, typically ``repo`` = all their repos), not a repo-scoped one. Teardown
+stops *future* vends, but a token already handed out stays valid at GitHub for
+its own lifetime (~8h) regardless — this endpoint cannot revoke it. And any
+process in the sandbox that can reach this endpoint (it authenticates with the
+launch token baked into the sandbox's git config) can obtain that token for its
+TTL. So the trust boundary is the sandbox itself, not this endpoint: it removes
+the token from disk/env, not the ability of in-sandbox code to request one. See
+``designs/CREDENTIAL_STORE.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from fastapi import APIRouter, Header, HTTPException, Response
+
+from omnigent.connections.github import GithubConnectionStore
+from omnigent.server.github_app_client import GitHubAppClient
+from omnigent.server.github_identity import resolve_access_token
+from omnigent.stores.host_store import HostStore
+
+_logger = logging.getLogger(__name__)
+
+# The username git uses with a token over HTTPS (``https://<user>:<token>@…``);
+# GitHub ignores the value but requires a non-empty one.
+_GIT_TOKEN_USERNAME = "x-access-token"
+
+
+def create_host_github_router(
+    host_store: HostStore,
+    github_store: GithubConnectionStore,
+    github_client: GitHubAppClient,
+) -> APIRouter:
+    """Build the host-facing GitHub-credential router.
+
+    :param host_store: Resolves a launch token + host id to the session owner.
+    :param github_store: The per-user GitHub connection store.
+    :param github_client: GitHub App client, for refreshing user tokens.
+    :returns: A router exposing ``GET /hosts/{host_id}/github-credential``.
+    """
+    router = APIRouter()
+
+    @router.get("/hosts/{host_id}/github-credential")
+    async def github_credential(
+        host_id: str,
+        response: Response,
+        x_omnigent_host_token: str | None = Header(default=None),
+    ) -> dict[str, object]:
+        """Return the session owner's GitHub credential for *host_id*.
+
+        Authenticated by the launch token (constant-time, expiry-aware, and
+        bound to *host_id*), exactly like the host tunnel. Returns
+        ``{"connected": false}`` when the owner hasn't linked GitHub (or the
+        feature is off), so a caller can fall back cleanly; ``401`` when the
+        token doesn't resolve.
+        """
+        # Never let a proxy/browser cache a vended token.
+        response.headers["Cache-Control"] = "no-store"
+        if not x_omnigent_host_token:
+            raise HTTPException(status_code=401, detail="missing host token")
+        managed = await asyncio.to_thread(
+            host_store.resolve_launch_token, host_id, x_omnigent_host_token
+        )
+        if managed is None:
+            raise HTTPException(status_code=401, detail="unauthenticated")
+        token = await resolve_access_token(
+            managed.user_id, store=github_store, client=github_client
+        )
+        if token is None:
+            return {"connected": False}
+        # ``owner``/``login`` let the host attribute commits to the human
+        # (author identity), decoupled from the push credential.
+        connection = await asyncio.to_thread(github_store.get, managed.user_id)
+        return {
+            "connected": True,
+            "username": _GIT_TOKEN_USERNAME,
+            "token": token,
+            "owner": managed.user_id,
+            "login": connection.github_login if connection is not None else None,
+        }
+
+    return router

--- a/tests/server/routes/test_host_github.py
+++ b/tests/server/routes/test_host_github.py
@@ -1,0 +1,106 @@
+"""Tests for the host-facing GitHub-credential endpoint."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from omnigent.connections.github import GithubConnectionStore
+from omnigent.host.identity import MANAGED_HOST_TOKEN_HEADER
+from omnigent.server.github_app import GitHubTokenSet
+from omnigent.server.routes.host_github import create_host_github_router
+
+
+class SecretBox:  # test double for the KMS SecretCipher: key- and context-bound
+    def __init__(self, key: str) -> None:
+        self._key = key
+
+    def encrypt(self, plaintext: str, *, context) -> str:
+        import base64
+        import json
+
+        return base64.b64encode(
+            json.dumps({"k": self._key, "c": dict(context), "p": plaintext}).encode()
+        ).decode("ascii")
+
+    def decrypt(self, ciphertext: str, *, context):
+        import base64
+        import json
+
+        try:
+            d = json.loads(base64.b64decode(ciphertext.encode("ascii")))
+        except ValueError:
+            return None
+        return d["p"] if d["k"] == self._key and d["c"] == dict(context) else None
+
+
+@dataclass
+class _Managed:
+    user_id: str
+
+
+class _FakeHostStore:
+    """Resolves a single (host_id, token) pair to an owner."""
+
+    def __init__(self, host_id: str, token: str, owner: str) -> None:
+        self._host_id, self._token, self._owner = host_id, token, owner
+
+    def resolve_launch_token(self, host_id: str, token: str) -> _Managed | None:
+        if host_id == self._host_id and token == self._token:
+            return _Managed(self._owner)
+        return None
+
+
+def _app(db_uri: str, host_store: _FakeHostStore) -> tuple[TestClient, GithubConnectionStore]:
+    store = GithubConnectionStore(db_uri, SecretBox("enc-secret"))
+    app = FastAPI()
+    app.include_router(
+        create_host_github_router(host_store, store, None),  # type: ignore[arg-type]
+        prefix="/v1",
+    )
+    return TestClient(app), store
+
+
+_HDR = {MANAGED_HOST_TOKEN_HEADER: "launch-tok"}
+
+
+def test_returns_token_for_valid_host_token(db_uri: str) -> None:
+    hs = _FakeHostStore("host1", "launch-tok", "alice@example.com")
+    tc, store = _app(db_uri, hs)
+    store.upsert(
+        "alice@example.com",
+        github_login="octocat",
+        github_user_id=42,
+        tokens=GitHubTokenSet("ghu_live", "ghr_x", None, None, "repo"),
+    )
+    resp = tc.get("/v1/hosts/host1/github-credential", headers=_HDR)
+    assert resp.status_code == 200
+    assert resp.headers.get("cache-control") == "no-store"
+    assert resp.json() == {
+        "connected": True,
+        "username": "x-access-token",
+        "token": "ghu_live",
+        "owner": "alice@example.com",
+        "login": "octocat",
+    }
+
+
+def test_unauthenticated_without_or_with_bad_token(db_uri: str) -> None:
+    hs = _FakeHostStore("host1", "launch-tok", "alice@example.com")
+    tc, _store = _app(db_uri, hs)
+    assert tc.get("/v1/hosts/host1/github-credential").status_code == 401
+    bad = tc.get("/v1/hosts/host1/github-credential", headers={MANAGED_HOST_TOKEN_HEADER: "nope"})
+    assert bad.status_code == 401
+    # Right token but wrong host id → also fails closed.
+    other = tc.get("/v1/hosts/other/github-credential", headers=_HDR)
+    assert other.status_code == 401
+
+
+def test_connected_false_when_owner_has_no_github(db_uri: str) -> None:
+    hs = _FakeHostStore("host1", "launch-tok", "alice@example.com")
+    tc, _store = _app(db_uri, hs)  # no upsert → owner hasn't linked GitHub
+    resp = tc.get("/v1/hosts/host1/github-credential", headers=_HDR)
+    assert resp.status_code == 200
+    assert resp.json() == {"connected": False}

--- a/tests/test_git_credential_github.py
+++ b/tests/test_git_credential_github.py
@@ -1,0 +1,69 @@
+"""Tests for the sandbox-side GitHub credential helper + host git setup."""
+
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+import omnigent.git_credential_github as h
+from omnigent.host.identity import HOST_TOKEN_ENV_VAR
+
+
+def test_get_prints_credentials_for_github(monkeypatch: pytest.MonkeyPatch) -> None:
+    cred = {"connected": True, "username": "x-access-token", "token": "T"}
+    monkeypatch.setattr(h, "_fetch", lambda *a, **k: cred)
+    monkeypatch.setattr(sys, "stdin", io.StringIO("protocol=https\nhost=github.com\n\n"))
+    out = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", out)
+    rc = h.main(["--server", "http://s", "--host-id", "hid", "--host-token", "tok", "get"])
+    assert rc == 0
+    assert "username=x-access-token" in out.getvalue()
+    assert "password=T" in out.getvalue()
+
+
+def test_get_declines_for_non_github_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO("protocol=https\nhost=gitlab.com\n\n"))
+    out = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", out)
+    rc = h.main(["--server", "http://s", "--host-id", "hid", "--host-token", "tok", "get"])
+    assert rc == 0 and out.getvalue() == ""  # declined → git falls through
+
+
+def test_get_fails_closed_on_missing_host_or_non_https(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Fail closed: an empty/missing host or a non-https protocol must decline
+    # (no output) so the brokered token never leaks to an unintended host.
+    for stdin in ("protocol=https\n\n", "protocol=http\nhost=github.com\n\n", "\n"):
+        monkeypatch.setattr(sys, "stdin", io.StringIO(stdin))
+        out = io.StringIO()
+        monkeypatch.setattr(sys, "stdout", out)
+        rc = h.main(["--server", "http://s", "--host-id", "h", "--host-token", "t", "get"])
+        assert rc == 0 and out.getvalue() == ""
+
+
+def test_store_and_erase_are_noops(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+    for op in ("store", "erase"):
+        assert h.main(["--server", "http://s", "--host-id", "h", "--host-token", "t", op]) == 0
+
+
+def test_configure_host_git_sets_helper_and_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(HOST_TOKEN_ENV_VAR, "launch-tok")
+    calls: list[list[str]] = []
+    monkeypatch.setattr(h.subprocess, "run", lambda args, **k: calls.append(args) or None)
+    cred = {"connected": True, "owner": "alice@example.com", "login": "octo"}
+    monkeypatch.setattr(h, "_fetch", lambda *a, **k: cred)
+    h.configure_host_git("http://srv", "host1")
+    flat = [" ".join(c) for c in calls]
+    assert any("credential.https://github.com.helper" in c and "host1" in c for c in flat)
+    assert any("user.email alice@example.com" in c for c in flat)
+    assert any("user.name octo" in c for c in flat)
+
+
+def test_configure_host_git_noop_without_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(HOST_TOKEN_ENV_VAR, raising=False)
+    calls: list[object] = []
+    monkeypatch.setattr(h.subprocess, "run", lambda *a, **k: calls.append(a))
+    h.configure_host_git("http://srv", "host1")
+    assert calls == []  # no token → nothing configured


### PR DESCRIPTION
Part of #5626

> **Stack (review bottom-up):** #4514 credential store → #4235 GitHub App connect → #4236 credential broker → #4237 repo picker → #4238 GitHub MCP → #4239 session PRs → #5203 Databricks connect. All target `main` (GitHub can't base a cross-fork PR on a fork branch), so file diffs are cumulative — **review each PR's single commit**.

## Summary

Executor-agnostic **credential broker**: sandboxes fetch a short-lived GitHub token from `GET /v1/hosts/{host_id}/github-credential` over the host↔server channel instead of receiving it in env or on disk. A git credential helper (`omnigent.git_credential_github`) resolves it on demand; `configure_host_git()` wires it at host startup. Only the lesser/expiring launch token ever lands in git config.

## Test Plan

- `pytest tests/host/test_connect.py` (broker route + helper).
- Verified on the demo: private-repo clone + push with no token in the agent env or on disk.

## Demo

N/A — no user-facing UI in this PR.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Test coverage

- [x] Unit tests added/updated
- [x] Manual verification completed

## Coverage notes

Manual verification: exercised end-to-end on the github-mvp sandbox instance.
