### PR TITLE
feat(github): pick a repo from your GitHub account in New Chat

### DIFF
--- a/omnigent/server/github_app_client.py
+++ b/omnigent/server/github_app_client.py
@@ -23,6 +23,18 @@ from omnigent.server.github_app import (
 
 _TOKEN_ENDPOINT = "https://github.com/login/oauth/access_token"
 _USER_ENDPOINT = "https://api.github.com/user"
+# Repos the token can access (App-scoped), most-recently-pushed first.
+_USER_REPOS_ENDPOINT = "https://api.github.com/user/repos"
+_REPOS_PER_PAGE = 100
+# Cap the walk so a user with thousands of repos gets a bounded, fast
+# response for the picker (the newest ~300 by push time).
+_REPOS_MAX_PAGES = 3
+
+_REPO_BRANCHES_ENDPOINT = "https://api.github.com/repos/{full_name}/branches"
+_BRANCHES_PER_PAGE = 100
+# Cap the branch walk the same way — a busy repo can have hundreds of
+# branches, but the picker only needs a bounded, fast list.
+_BRANCHES_MAX_PAGES = 3
 
 _HTTP_TIMEOUT_S = 15.0
 
@@ -88,6 +100,97 @@ class GitHubAppClient:
         if not login or user_id is None:
             raise GitHubAppError("GitHub /user response missing login/id")
         return str(login), int(user_id)
+
+    async def list_repos(self, access_token: str) -> tuple[list[dict[str, object]], bool]:
+        """List repos the authenticated user can access, App-scoped.
+
+        Reads ``/user/repos`` most-recently-pushed first, following up to
+        :data:`_REPOS_MAX_PAGES` pages. Returns a compact projection for the
+        new-chat repo picker (not the full GitHub payload).
+
+        :param access_token: A valid user access token.
+        :returns: ``(repos, truncated)`` — repos as
+            ``{full_name, clone_url, default_branch, private, pushed_at}`` newest
+            first, and ``truncated=True`` when the page cap was hit and more
+            repos almost certainly exist (so the UI can say the list is partial
+            rather than silently dropping them).
+        :raises GitHubAppError: When the API call fails.
+        """
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/vnd.github+json",
+        }
+        repos: list[dict[str, object]] = []
+        truncated = False
+        async with self._http_client() as client:
+            for page in range(1, _REPOS_MAX_PAGES + 1):
+                resp = await client.get(
+                    _USER_REPOS_ENDPOINT,
+                    params={"per_page": _REPOS_PER_PAGE, "page": page, "sort": "pushed"},
+                    headers=headers,
+                )
+                if resp.status_code != 200:
+                    raise GitHubAppError(f"GitHub /user/repos returned {resp.status_code}")
+                batch = resp.json()
+                if not isinstance(batch, list) or not batch:
+                    break
+                for entry in batch:
+                    if not isinstance(entry, dict) or not entry.get("full_name"):
+                        continue
+                    repos.append(
+                        {
+                            "full_name": entry["full_name"],
+                            "clone_url": entry.get("clone_url"),
+                            "default_branch": entry.get("default_branch"),
+                            "private": bool(entry.get("private")),
+                            "pushed_at": entry.get("pushed_at"),
+                        }
+                    )
+                if len(batch) < _REPOS_PER_PAGE:
+                    break
+            else:
+                # Ran the full page cap without an early break → the last page
+                # was full, so there are almost certainly more repos than shown.
+                truncated = True
+        return repos, truncated
+
+    async def list_branches(self, access_token: str, full_name: str) -> list[str]:
+        """List branch names for ``full_name`` (``owner/repo``), App-scoped.
+
+        Reads ``/repos/{full_name}/branches`` following up to
+        :data:`_BRANCHES_MAX_PAGES` pages, for the per-repo branch picker.
+
+        :param access_token: A valid user access token.
+        :param full_name: The repository's ``owner/name``.
+        :returns: Branch names in the order GitHub returns them.
+        :raises GitHubAppError: When the API call fails.
+        """
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/vnd.github+json",
+        }
+        url = _REPO_BRANCHES_ENDPOINT.format(full_name=full_name)
+        branches: list[str] = []
+        async with self._http_client() as client:
+            for page in range(1, _BRANCHES_MAX_PAGES + 1):
+                resp = await client.get(
+                    url,
+                    params={"per_page": _BRANCHES_PER_PAGE, "page": page},
+                    headers=headers,
+                )
+                if resp.status_code != 200:
+                    raise GitHubAppError(
+                        f"GitHub /repos/{full_name}/branches returned {resp.status_code}"
+                    )
+                batch = resp.json()
+                if not isinstance(batch, list) or not batch:
+                    break
+                for entry in batch:
+                    if isinstance(entry, dict) and entry.get("name"):
+                        branches.append(str(entry["name"]))
+                if len(batch) < _BRANCHES_PER_PAGE:
+                    break
+        return branches
 
     async def _token_request(self, fields: dict[str, str]) -> GitHubTokenSet:
         """POST the given form fields to the token endpoint and parse the reply."""

--- a/omnigent/server/routes/connections_github.py
+++ b/omnigent/server/routes/connections_github.py
@@ -1,12 +1,14 @@
-"""GitHub App integration routes: connect / callback / status / disconnect.
+"""GitHub App integration routes: connect / callback / status / disconnect, plus
+the repo/branch listing that backs the New Chat repo picker.
 
 Mounted under ``/v1`` so paths are ``/v1/connections/github/...``. Only mounted
 when a :class:`GitHubAppConfig` is configured. Lets a signed-in user connect
 their GitHub account so their managed sandboxes authenticate ``gh`` / git as
 them. The shared OAuth flow (signed state, CSRF/replay binding, redirect
 sanitising, the four endpoints) lives in
-:mod:`omnigent.server.routes.connections_base`; this module is just the GitHub
-adapter. See ``docs/GITHUB_APP_SETUP.md``.
+:mod:`omnigent.server.routes.connections_base`; this module is the GitHub
+adapter plus the GitHub-only repo/branch endpoints. See
+``docs/GITHUB_APP_SETUP.md``.
 """
 
 from __future__ import annotations
@@ -15,19 +17,22 @@ import asyncio
 import hashlib
 import hmac
 import logging
+import re
 from typing import Any
 
-from fastapi import Request
+from fastapi import APIRouter, HTTPException, Request
 from httpx import HTTPError
 
 from omnigent.connections.github import GithubConnectionStore
-from omnigent.server.auth import AuthProvider
+from omnigent.server.auth import RESERVED_USER_LOCAL, AuthProvider
 from omnigent.server.github_app import (
     GitHubAppConfig,
     GitHubAppError,
     build_authorize_url,
 )
 from omnigent.server.github_app_client import GitHubAppClient
+from omnigent.server.github_identity import resolve_access_token
+from omnigent.server.routes._auth_helpers import require_user
 from omnigent.server.routes.connections_base import (
     ConnectionError,
     ConnectStart,
@@ -39,6 +44,16 @@ _logger = logging.getLogger(__name__)
 # Context string binding the derived key to the state-signing purpose, so the
 # same input secret used elsewhere never produces the same HMAC key.
 _STATE_KEY_INFO = b"omnigent.connections.github.oauth-state.v1"
+
+# GitHub owner / repo name charset, enforced before either reaches the branches
+# URL so a caller can never smuggle a path or query. A dot is allowed but a
+# dot-run (``..``) is not, so ``owner``/``repo`` can never be a traversal segment.
+_GITHUB_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _valid_github_name(name: str) -> bool:
+    """Whether *name* is a safe GitHub owner/repo segment (no ``..``)."""
+    return bool(_GITHUB_NAME_RE.match(name)) and ".." not in name
 
 
 def _derive_state_signing_key(client_secret: str) -> bytes:
@@ -69,7 +84,7 @@ class GithubConnectionHooks:
     ) -> None:
         self.config = config
         self.store = store
-        self._api = client if client is not None else GitHubAppClient(config)
+        self.api = client if client is not None else GitHubAppClient(config)
 
     def signing_key(self) -> bytes:
         return _derive_state_signing_key(self.config.client_secret)
@@ -89,8 +104,8 @@ class GithubConnectionHooks:
     async def complete(self, user_id: str, code: str, claims: dict[str, Any]) -> None:
         del claims  # GitHub carries no extra state claims.
         try:
-            tokens = await self._api.exchange_code(code)
-            login, github_user_id = await self._api.fetch_login(tokens.access_token)
+            tokens = await self.api.exchange_code(code)
+            login, github_user_id = await self.api.fetch_login(tokens.access_token)
         except (GitHubAppError, HTTPError, ValueError) as exc:
             raise ConnectionError(str(exc)) from exc
         await asyncio.to_thread(
@@ -111,8 +126,59 @@ def create_connections_github_router(
     client: GitHubAppClient | None = None,
 ):
     """Build the GitHub App integration router — the GitHub adapter over the
-    shared ``/connections/{provider}/*`` flow."""
-    return create_connection_router(
-        GithubConnectionHooks(config, store, client),
-        auth_provider=auth_provider,
-    )
+    shared ``/connections/{provider}/*`` flow, plus the GitHub-only repo/branch
+    endpoints the New Chat picker reads."""
+    hooks = GithubConnectionHooks(config, store, client)
+    api = hooks.api
+
+    def _current_user(request: Request) -> str:
+        user_id = require_user(request, auth_provider)
+        return user_id if user_id is not None else RESERVED_USER_LOCAL
+
+    def _repo_routes(router: APIRouter) -> None:
+        @router.get("/connections/github/repos")
+        async def repos(request: Request) -> dict[str, object]:
+            """List repos the connected user can access, for the new-chat picker.
+
+            ``connected: false`` (with an empty list) when the caller hasn't
+            linked GitHub, so the UI can fall back to a free-text repo URL.
+            ``truncated: true`` when the page cap was hit and more repos exist
+            than are returned, so the UI can say the list is partial.
+            """
+            user_id = _current_user(request)
+            token = await resolve_access_token(user_id, store=store, client=api)
+            if token is None:
+                return {"connected": False, "repos": [], "truncated": False}
+            try:
+                repo_list, truncated = await api.list_repos(token)
+            except GitHubAppError as exc:
+                _logger.warning("GitHub repo list failed for %s: %s", user_id, exc)
+                raise HTTPException(
+                    status_code=502, detail="Failed to list GitHub repositories"
+                ) from exc
+            return {"connected": True, "repos": repo_list, "truncated": truncated}
+
+        @router.get("/connections/github/repos/{owner}/{repo}/branches")
+        async def repo_branches(request: Request, owner: str, repo: str) -> dict[str, object]:
+            """List branch names for ``owner/repo``, for the per-repo branch picker.
+
+            ``connected: false`` (empty list) when the caller hasn't linked
+            GitHub. Owner/repo are charset-validated before they reach the
+            GitHub URL so a caller cannot smuggle a path.
+            """
+            user_id = _current_user(request)
+            if not _valid_github_name(owner) or not _valid_github_name(repo):
+                raise HTTPException(status_code=400, detail="Invalid repository name")
+            token = await resolve_access_token(user_id, store=store, client=api)
+            if token is None:
+                return {"connected": False, "branches": []}
+            try:
+                branches = await api.list_branches(token, f"{owner}/{repo}")
+            except GitHubAppError as exc:
+                _logger.warning("GitHub branch list failed for %s/%s: %s", owner, repo, exc)
+                raise HTTPException(
+                    status_code=502, detail="Failed to list GitHub branches"
+                ) from exc
+            return {"connected": True, "branches": branches}
+
+    return create_connection_router(hooks, auth_provider=auth_provider, extra_routes=_repo_routes)

--- a/tests/server/routes/test_integrations_github.py
+++ b/tests/server/routes/test_integrations_github.py
@@ -72,6 +72,25 @@ class _FakeClient:
     async def fetch_login(self, access_token: str) -> tuple[str, int]:
         return "octocat", 42
 
+    async def list_repos(self, access_token: str) -> tuple[list[dict[str, object]], bool]:
+        return (
+            [
+                {
+                    "full_name": "caffeinelabs/app",
+                    "clone_url": "https://github.com/caffeinelabs/app.git",
+                    "default_branch": "main",
+                    "private": True,
+                    "pushed_at": "2026-07-28T00:00:00Z",
+                }
+            ],
+            False,
+        )
+
+    async def list_branches(self, access_token: str, full_name: str) -> list[str]:
+        self.branch_calls: list[str] = getattr(self, "branch_calls", [])
+        self.branch_calls.append(full_name)
+        return ["main", "dev"]
+
 
 def _config() -> GitHubAppConfig:
     return GitHubAppConfig(
@@ -247,3 +266,63 @@ def test_disconnect(db_uri: str) -> None:
 )
 def test_sanitize_return_to_blocks_off_origin(raw: str | None, expected: str) -> None:
     assert sanitize_return_to(raw) == expected
+
+
+def test_repos_unconnected_returns_false(db_uri: str) -> None:
+    tc, _store, _config, _client = _app(db_uri)
+    resp = tc.get("/v1/connections/github/repos", headers=_USER)
+    assert resp.status_code == 200
+    assert resp.json() == {"connected": False, "repos": [], "truncated": False}
+
+
+def test_repos_lists_when_connected(db_uri: str) -> None:
+    tc, store, _config, _client = _app(db_uri)
+    store.upsert(
+        "alice@example.com",
+        github_login="octocat",
+        github_user_id=42,
+        tokens=GitHubTokenSet("ghu_a", "ghr_a", None, None, "repo"),
+    )
+    resp = tc.get("/v1/connections/github/repos", headers=_USER)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["connected"] is True
+    assert [r["full_name"] for r in body["repos"]] == ["caffeinelabs/app"]
+    assert body["repos"][0]["default_branch"] == "main"
+
+
+def test_repo_branches_unconnected_returns_false(db_uri: str) -> None:
+    tc, _store, _config, _client = _app(db_uri)
+    resp = tc.get("/v1/connections/github/repos/caffeinelabs/app/branches", headers=_USER)
+    assert resp.status_code == 200
+    assert resp.json() == {"connected": False, "branches": []}
+
+
+def test_repo_branches_lists_when_connected(db_uri: str) -> None:
+    tc, store, _config, client = _app(db_uri)
+    store.upsert(
+        "alice@example.com",
+        github_login="octocat",
+        github_user_id=42,
+        tokens=GitHubTokenSet("ghu_a", "ghr_a", None, None, "repo"),
+    )
+    resp = tc.get("/v1/connections/github/repos/caffeinelabs/app/branches", headers=_USER)
+    assert resp.status_code == 200
+    assert resp.json() == {"connected": True, "branches": ["main", "dev"]}
+    assert client.branch_calls == ["caffeinelabs/app"]
+
+
+def test_repo_branches_rejects_bad_name(db_uri: str) -> None:
+    tc, store, _config, _client = _app(db_uri)
+    store.upsert(
+        "alice@example.com",
+        github_login="octocat",
+        github_user_id=42,
+        tokens=GitHubTokenSet("ghu_a", "ghr_a", None, None, "repo"),
+    )
+    # A path-traversal owner must be rejected before any GitHub call.
+    resp = tc.get("/v1/connections/github/repos/..%2Fx/app/branches", headers=_USER)
+    assert resp.status_code in (400, 404)
+    # A dot-run in a charset-valid segment is also rejected (no traversal).
+    resp = tc.get("/v1/connections/github/repos/o..o/app/branches", headers=_USER)
+    assert resp.status_code == 400

--- a/tests/server/test_github_app.py
+++ b/tests/server/test_github_app.py
@@ -75,3 +75,97 @@ async def test_fetch_login() -> None:
 
     login, uid = await _client(handler).fetch_login("ghu_x")
     assert (login, uid) == ("octocat", 583231)
+
+
+@pytest.mark.asyncio
+async def test_list_repos_projects_fields_and_stops_on_short_page() -> None:
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(str(request.url))
+        assert request.url.path == "/user/repos"
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "full_name": "caffeinelabs/app",
+                    "clone_url": "https://github.com/caffeinelabs/app.git",
+                    "default_branch": "main",
+                    "private": True,
+                    "pushed_at": "2026-07-28T00:00:00Z",
+                    "stargazers_count": 3,
+                },
+                {"description": "no full_name — skipped"},
+            ],
+        )
+
+    repos, truncated = await _client(handler).list_repos("ghu_x")
+    # Short page (< per_page) → only one request, no over-fetch, not truncated.
+    assert len(calls) == 1
+    assert truncated is False
+    # Only the projected keys survive; the entry missing full_name is dropped.
+    assert repos == [
+        {
+            "full_name": "caffeinelabs/app",
+            "clone_url": "https://github.com/caffeinelabs/app.git",
+            "default_branch": "main",
+            "private": True,
+            "pushed_at": "2026-07-28T00:00:00Z",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_repos_flags_truncation_at_page_cap() -> None:
+    # Every page comes back full → the page cap is hit and truncated=True so the
+    # UI can say the list is partial instead of silently dropping repos.
+    def handler(request: httpx.Request) -> httpx.Response:
+        page = [
+            {"full_name": f"o/r{i}", "clone_url": None, "default_branch": "main"}
+            for i in range(100)  # a full per_page page
+        ]
+        return httpx.Response(200, json=page)
+
+    repos, truncated = await _client(handler).list_repos("ghu_x")
+    assert truncated is True
+    assert len(repos) == 300  # 3 full pages (the cap)
+
+
+@pytest.mark.asyncio
+async def test_list_repos_non_200_raises() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"message": "Bad credentials"})
+
+    with pytest.raises(GitHubAppError):
+        await _client(handler).list_repos("ghu_bad")
+
+
+@pytest.mark.asyncio
+async def test_list_branches_returns_names_and_stops_on_short_page() -> None:
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.url.path)
+        assert request.url.path == "/repos/caffeinelabs/app/branches"
+        return httpx.Response(
+            200,
+            json=[
+                {"name": "main", "protected": True},
+                {"name": "dev"},
+                {"no_name": "skipped"},
+            ],
+        )
+
+    branches = await _client(handler).list_branches("ghu_x", "caffeinelabs/app")
+    # Short page (< per_page) → single request, entries without a name dropped.
+    assert calls == ["/repos/caffeinelabs/app/branches"]
+    assert branches == ["main", "dev"]
+
+
+@pytest.mark.asyncio
+async def test_list_branches_non_200_raises() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"message": "Not Found"})
+
+    with pytest.raises(GitHubAppError):
+        await _client(handler).list_branches("ghu_bad", "caffeinelabs/nope")

--- a/web/src/lib/githubIntegration.ts
+++ b/web/src/lib/githubIntegration.ts
@@ -45,6 +45,62 @@ export function beginGithubConnect(returnTo: string): void {
   window.location.href = url;
 }
 
+/** A repo the connected user can access, from ``GET .../github/repos``. */
+export interface GithubRepo {
+  /** ``owner/name``, e.g. ``"caffeinelabs/app"``. */
+  full_name: string;
+  /** HTTPS clone URL, or null. */
+  clone_url: string | null;
+  /** Default branch, or null. */
+  default_branch: string | null;
+  /** Whether the repo is private. */
+  private: boolean;
+  /** ISO-8601 last-push time, or null (list is newest-first). */
+  pushed_at: string | null;
+}
+
+/** Shape of ``GET /v1/connections/github/repos``. */
+export interface GithubRepoList {
+  /** False when the user hasn't connected GitHub (repos is then empty). */
+  connected: boolean;
+  repos: GithubRepo[];
+  /** True when the page cap was hit and more repos exist than are returned. */
+  truncated?: boolean;
+}
+
+/**
+ * Fetch the repos the current user can access (App-scoped, newest first).
+ * Returns ``connected: false`` with an empty list when GitHub isn't linked,
+ * so callers can fall back to a free-text repo URL.
+ */
+export async function fetchGithubRepos(): Promise<GithubRepoList> {
+  const res = await authenticatedFetch("/v1/connections/github/repos");
+  if (!res.ok) {
+    throw new Error(`GitHub repos failed: ${res.status}`);
+  }
+  return (await res.json()) as GithubRepoList;
+}
+
+/** Shape of ``GET .../github/repos/{owner}/{repo}/branches``. */
+export interface GithubBranchList {
+  /** False when the user hasn't connected GitHub (branches is then empty). */
+  connected: boolean;
+  branches: string[];
+}
+
+/**
+ * Fetch the branch names for ``fullName`` (``owner/repo``), for the
+ * per-repo branch picker. Returns ``connected: false`` with an empty list
+ * when GitHub isn't linked.
+ */
+export async function fetchGithubBranches(fullName: string): Promise<GithubBranchList> {
+  const res = await authenticatedFetch(`/v1/connections/github/repos/${fullName}/branches`);
+  if (!res.ok) {
+    throw new Error(`GitHub branches failed: ${res.status}`);
+  }
+  return (await res.json()) as GithubBranchList;
+}
+
 /** Disconnect the current user's GitHub account. */
 export async function disconnectGithub(): Promise<void> {
   const res = await authenticatedFetch("/v1/connections/github/disconnect", {

--- a/web/src/lib/repoPreferences.test.ts
+++ b/web/src/lib/repoPreferences.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readLastSandboxRepo, writeLastSandboxRepo } from "./repoPreferences";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("repoPreferences", () => {
+  it("returns null when nothing is stored", () => {
+    expect(readLastSandboxRepo()).toBeNull();
+  });
+
+  it("round-trips a written repo + branch", () => {
+    writeLastSandboxRepo("https://github.com/org/repo.git", "main");
+    expect(readLastSandboxRepo()).toEqual({
+      url: "https://github.com/org/repo.git",
+      branch: "main",
+    });
+  });
+
+  it("keeps a repo with no branch (default-branch case)", () => {
+    writeLastSandboxRepo("https://github.com/org/repo.git", "");
+    expect(readLastSandboxRepo()).toEqual({
+      url: "https://github.com/org/repo.git",
+      branch: "",
+    });
+  });
+
+  it("trims surrounding whitespace before storing", () => {
+    writeLastSandboxRepo("  https://github.com/org/repo.git  ", "  dev  ");
+    expect(readLastSandboxRepo()).toEqual({
+      url: "https://github.com/org/repo.git",
+      branch: "dev",
+    });
+  });
+
+  it("clears the preference when the url is blank", () => {
+    writeLastSandboxRepo("https://github.com/org/repo.git", "main");
+    writeLastSandboxRepo("   ", "main");
+    expect(readLastSandboxRepo()).toBeNull();
+  });
+
+  it("overwrites the previous value", () => {
+    writeLastSandboxRepo("https://github.com/org/a.git", "main");
+    writeLastSandboxRepo("https://github.com/org/b.git", "dev");
+    expect(readLastSandboxRepo()).toEqual({
+      url: "https://github.com/org/b.git",
+      branch: "dev",
+    });
+  });
+
+  it("returns null for a stored entry with a blank url (defensive)", () => {
+    localStorage.setItem("omnigent:last-sandbox-repo", JSON.stringify({ url: "  ", branch: "x" }));
+    expect(readLastSandboxRepo()).toBeNull();
+  });
+
+  it("returns null for malformed stored json (defensive)", () => {
+    localStorage.setItem("omnigent:last-sandbox-repo", "not json");
+    expect(readLastSandboxRepo()).toBeNull();
+  });
+
+  it("never throws when storage is inaccessible", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("access denied");
+    });
+    expect(() => writeLastSandboxRepo("https://github.com/org/repo.git", "main")).not.toThrow();
+    expect(readLastSandboxRepo()).toBeNull();
+  });
+});

--- a/web/src/lib/repoPreferences.ts
+++ b/web/src/lib/repoPreferences.ts
@@ -1,0 +1,63 @@
+// Persisted, app-global preference for the last GitHub repo (and branch) the
+// user launched a sandbox session with.
+//
+// Mirrors baseBranchPreferences: the landing composer reads this to seed the
+// repo URL + branch fields when there's no in-session draft, so returning users
+// don't re-pick the same repo every time. The stored URL is the source of
+// truth the free-text field shows; the repo combobox derives its selection from
+// it, so a stored repo the account can no longer access simply shows unselected
+// (no stale entry is forced into the picker). Written on session create.
+
+const STORAGE_KEY = "omnigent:last-sandbox-repo";
+
+/** The last repo the user launched with: its clone URL and branch (may be ""). */
+export interface LastSandboxRepo {
+  /** Repo URL, e.g. ``https://github.com/org/repo.git`` (never blank). */
+  url: string;
+  /** Branch name, or ``""`` for the repo's default. */
+  branch: string;
+}
+
+/**
+ * Read the last repo the user launched a sandbox with: the stored
+ * ``{url, branch}``, or ``null`` when nothing is stored, on a server render (no
+ * ``window``), when storage is inaccessible, or when the stored value is
+ * malformed / has a blank URL — never throws. Trims on read so a hand-edited or
+ * stale entry can't seed an un-normalized value.
+ */
+export function readLastSandboxRepo(): LastSandboxRepo | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const url = String((parsed as { url?: unknown }).url ?? "").trim();
+    const branch = String((parsed as { branch?: unknown }).branch ?? "").trim();
+    return url === "" ? null : { url, branch };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist ``url`` (+ optional ``branch``) as the last repo launched with. A
+ * blank (or whitespace-only) URL clears the preference. Swallows quota/access
+ * errors so a failed write can't break session creation.
+ */
+export function writeLastSandboxRepo(url: string, branch: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    const trimmedUrl = url.trim();
+    if (trimmedUrl === "") {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ url: trimmedUrl, branch: branch.trim() }),
+    );
+  } catch {
+    // localStorage quota or access errors shouldn't break session creation.
+  }
+}

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -2567,6 +2567,76 @@ describe("NewChatLandingScreen", () => {
     expect(screen.queryByTestId("new-chat-landing-branch-chip")).toBeNull();
   });
 
+  it("offers a GitHub repo picker that fills the sandbox repo URL + branch", async () => {
+    // enabled_connections has github + a connected /repos response → the picker renders
+    // inside the repo chip and drives the same URL/branch state as the
+    // free-text fields.
+    authenticatedFetchMock.mockImplementation(((input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/connections/github/repos") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            connected: true,
+            repos: [
+              {
+                full_name: "octo/hello",
+                clone_url: "https://github.com/octo/hello.git",
+                default_branch: "main",
+                private: false,
+                pushed_at: "2026-07-28T00:00:00Z",
+              },
+            ],
+          }),
+        } as unknown as Response);
+      }
+      if (url.startsWith("/v1/connections/github/repos/octo/hello/branches")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ connected: true, branches: ["main", "dev"] }),
+        } as unknown as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as unknown as Response);
+    }) as unknown as typeof authenticatedFetch);
+
+    renderLanding({ managed_sandboxes_enabled: true, enabled_connections: ["github"] });
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain("New Sandbox"),
+    );
+
+    fireEvent.click(screen.getByTestId("new-chat-landing-repo-chip"));
+    // Open the searchable repo combobox, filter by typing, then pick the repo.
+    fireEvent.click(await screen.findByTestId("new-chat-landing-repo-select"));
+    fireEvent.change(await screen.findByTestId("new-chat-landing-repo-search"), {
+      target: { value: "hello" },
+    });
+    fireEvent.click(await screen.findByRole("option", { name: /octo\/hello/ }));
+
+    // Picking the repo composes the clone URL into the shared URL field.
+    expect((screen.getByTestId("new-chat-landing-repo-input") as HTMLInputElement).value).toBe(
+      "https://github.com/octo/hello.git",
+    );
+
+    // Its branches load into the searchable branch combobox; open it, wait for
+    // the async list, then choosing one fills the branch.
+    fireEvent.click(await screen.findByTestId("new-chat-landing-repo-branch-select"));
+    fireEvent.click(await screen.findByRole("option", { name: "dev" }));
+    expect(
+      (screen.getByTestId("new-chat-landing-repo-branch-input") as HTMLInputElement).value,
+    ).toBe("dev");
+  });
+
+  it("hides the GitHub repo picker when the GitHub App is disabled", async () => {
+    renderLanding({ managed_sandboxes_enabled: true, enabled_connections: [] });
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain("New Sandbox"),
+    );
+    fireEvent.click(screen.getByTestId("new-chat-landing-repo-chip"));
+    // The free-text URL input is present; the connected-account picker is not.
+    await screen.findByTestId("new-chat-landing-repo-input");
+    expect(screen.queryByTestId("new-chat-landing-repo-select")).toBeNull();
+  });
+
   it("creates a managed session without host_id/workspace and no provisioning subtext", async () => {
     // Controlled promise so the in-flight state is observable
     // deterministically before the create resolves.

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "@/lib/routing";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   MonitorIcon,
   MonitorCloudIcon,
@@ -8,7 +8,9 @@ import {
   ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
+  ChevronsUpDownIcon,
   GitBranchIcon,
+  LockIcon,
   ArrowUpIcon,
   Loader2Icon,
   FileTextIcon,
@@ -40,13 +42,6 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { showToast } from "@/components/ui/toast";
 import {
-  Command,
-  CommandEmpty,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
-import {
   CLAUDE_NATIVE_EFFORTS,
   PI_NATIVE_EFFORTS,
   ConfigRow,
@@ -72,11 +67,20 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { authenticatedFetch } from "@/lib/identity";
+import { fetchGithubBranches, fetchGithubRepos, type GithubRepo } from "@/lib/githubIntegration";
 import { isImeCompositionKeyEvent } from "@/lib/ime";
 import { isComposerSendKey, readSubmitWithModEnter } from "@/lib/composerSendShortcutPreferences";
 import { attachmentKey, validateAttachments } from "@/lib/attachments";
 import { recordOptimisticTitle } from "@/lib/optimisticTitles";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { HarnessSetupDialog } from "@/shell/HarnessSetupDialog";
 import {
@@ -124,6 +128,7 @@ import { readLastHarness, writeLastHarness } from "@/lib/harnessPreferences";
 import { readHideUnconfiguredHarnesses } from "@/lib/harnessVisibilityPreferences";
 import { readDefaultBaseBranch } from "@/lib/baseBranchPreferences";
 import { readAlwaysUseWorktree } from "@/lib/worktreeDefaultPreferences";
+import { readLastSandboxRepo, writeLastSandboxRepo } from "@/lib/repoPreferences";
 import { readHarnessOptions, writeHarnessOption, type HarnessOptions } from "@/lib/modePreferences";
 import {
   AUTO_HARNESS_DESCRIPTION,
@@ -784,6 +789,181 @@ export function deriveRepoName(url: string): string | null {
   const last = t.split(/[/:]/).pop() ?? "";
   const name = last.endsWith(".git") ? last.slice(0, -4) : last;
   return name === "" ? null : name;
+}
+
+/** Shared trigger styling for the repo/branch comboboxes. */
+const COMBOBOX_TRIGGER_CLASS =
+  "flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-xs outline-none transition-colors hover:border-ring/60 focus-visible:border-ring";
+
+/**
+ * Searchable combobox for picking one of the caller's GitHub repos.
+ *
+ * A trigger button opens a `cmdk` search list (repos are filtered as you
+ * type on ``owner/name``), which scales to accounts with many repos far
+ * better than a native ``<select>``. Selecting a repo fills the same
+ * URL/branch state the free-text inputs drive; the empty value shows the
+ * "Choose a repository…" placeholder.
+ *
+ * @param repos The caller's accessible repos (newest-first from the API).
+ * @param value The selected repo's ``owner/name`` ("" = none).
+ * @param onSelect Called with the chosen repo (or ``null`` to clear).
+ */
+function SandboxRepoCombobox({
+  repos,
+  value,
+  onSelect,
+}: {
+  repos: GithubRepo[];
+  value: string;
+  onSelect: (repo: GithubRepo | null) => void;
+}): ReactNode {
+  const [open, setOpen] = useState(false);
+  const selected = repos.find((r) => r.full_name === value) ?? null;
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          role="combobox"
+          aria-expanded={open}
+          aria-label="GitHub repository"
+          className={COMBOBOX_TRIGGER_CLASS}
+          data-testid="new-chat-landing-repo-select"
+        >
+          <span className="truncate">{selected ? selected.full_name : "Choose a repository…"}</span>
+          <ChevronsUpDownIcon className="ml-auto size-3.5 shrink-0 opacity-50" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-(--radix-popover-trigger-width) min-w-72 p-0">
+        <Command>
+          <CommandInput
+            placeholder="Search repositories…"
+            data-testid="new-chat-landing-repo-search"
+          />
+          <CommandList>
+            <CommandEmpty>No repositories found.</CommandEmpty>
+            <CommandGroup>
+              {repos.map((r) => (
+                <CommandItem
+                  key={r.full_name}
+                  value={r.full_name}
+                  data-checked={r.full_name === value}
+                  onSelect={() => {
+                    onSelect(r);
+                    setOpen(false);
+                  }}
+                >
+                  <span className="truncate">{r.full_name}</span>
+                  {r.private && (
+                    <LockIcon
+                      className="size-3 shrink-0 opacity-60"
+                      aria-label="Private repository"
+                    />
+                  )}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+/**
+ * Searchable branch combobox for the connected-GitHub repo picker.
+ *
+ * Lazily fetches the chosen repo's branches and filters them as you type.
+ * The empty value is the "default branch" sentinel: leaving it selected
+ * appends no ``#branch`` fragment, so the server clones the repo's default
+ * branch.
+ *
+ * @param fullName The chosen repo's ``owner/name``.
+ * @param value The currently selected branch ("" = default).
+ * @param defaultBranch The repo's default branch, for the sentinel label.
+ * @param onChange Called with the newly selected branch.
+ */
+function SandboxRepoBranchSelect({
+  fullName,
+  value,
+  defaultBranch,
+  onChange,
+}: {
+  fullName: string;
+  value: string;
+  defaultBranch: string | null;
+  onChange: (branch: string) => void;
+}): ReactNode {
+  const [open, setOpen] = useState(false);
+  const { data, isPending } = useQuery({
+    queryKey: ["github-branches", fullName],
+    queryFn: () => fetchGithubBranches(fullName),
+    staleTime: 5 * 60_000,
+  });
+  const branches = data?.connected ? data.branches : [];
+  const defaultLabel = defaultBranch ? `Default (${defaultBranch})` : "Default branch";
+  // Options: the fetched branches minus the default (represented by the
+  // empty-value sentinel). Include the current value even before the list
+  // loads (e.g. a draft-restored branch) so the trigger label always
+  // resolves to a real option.
+  const options = branches.filter((b) => b !== defaultBranch);
+  if (value !== "" && !options.includes(value)) {
+    options.unshift(value);
+  }
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          role="combobox"
+          aria-expanded={open}
+          aria-label={`Branch for ${fullName}`}
+          className={COMBOBOX_TRIGGER_CLASS}
+          data-testid="new-chat-landing-repo-branch-select"
+        >
+          <GitBranchIcon className="size-3.5 shrink-0 opacity-60" />
+          <span className="truncate">{value === "" ? defaultLabel : value}</span>
+          <ChevronsUpDownIcon className="ml-auto size-3.5 shrink-0 opacity-50" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-(--radix-popover-trigger-width) min-w-72 p-0">
+        <Command>
+          <CommandInput
+            placeholder="Search branches…"
+            data-testid="new-chat-landing-repo-branch-search"
+          />
+          <CommandList>
+            <CommandEmpty>{isPending ? "Loading branches…" : "No branches found."}</CommandEmpty>
+            <CommandGroup>
+              <CommandItem
+                value={defaultLabel}
+                data-checked={value === ""}
+                onSelect={() => {
+                  onChange("");
+                  setOpen(false);
+                }}
+              >
+                {defaultLabel}
+              </CommandItem>
+              {options.map((b) => (
+                <CommandItem
+                  key={b}
+                  value={b}
+                  data-checked={b === value}
+                  onSelect={() => {
+                    onChange(b);
+                    setOpen(false);
+                  }}
+                >
+                  {b}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
 }
 
 /**
@@ -2348,12 +2528,32 @@ export function NewChatLandingScreen() {
   // Sandbox repository inputs — composed into the managed create's
   // `workspace` string (`<url>[#<branch>]`); both blank = empty
   // server-created workspace.
+  // Seed from the in-session draft, else the last repo the user launched with
+  // (remembered across visits) so returning users don't re-pick it. The repo
+  // combobox derives its selection from the URL, so a remembered repo the
+  // account can no longer access just shows unselected.
   const [sandboxRepoUrl, setSandboxRepoUrl] = useState<string>(
-    () => restoredDraft?.sandboxRepoUrl ?? "",
+    () => restoredDraft?.sandboxRepoUrl ?? readLastSandboxRepo()?.url ?? "",
   );
   const [sandboxRepoBranch, setSandboxRepoBranch] = useState<string>(
-    () => restoredDraft?.sandboxRepoBranch ?? "",
+    () => restoredDraft?.sandboxRepoBranch ?? readLastSandboxRepo()?.branch ?? "",
   );
+  // When the server advertises the GitHub App and the caller has connected
+  // their account, offer a picker over their repos instead of only the
+  // free-text URL. The /repos endpoint returns `connected: false` when the
+  // account isn't linked, so gating the query on `enabled_connections` and
+  // reading `connected` off the payload doubles as the connection check.
+  const githubReposEnabled =
+    info !== "loading" && (info.enabled_connections ?? []).includes("github");
+  const { data: sandboxRepoData, isError: sandboxReposErrored } = useQuery({
+    queryKey: ["github-repos"],
+    queryFn: fetchGithubRepos,
+    enabled: githubReposEnabled,
+    staleTime: 5 * 60_000,
+  });
+  const sandboxRepoPickerConnected = sandboxRepoData?.connected ?? false;
+  const sandboxRepos = sandboxRepoPickerConnected ? (sandboxRepoData?.repos ?? []) : [];
+  const sandboxReposTruncated = sandboxRepoData?.truncated ?? false;
   const [workspace, setWorkspace] = useState<string>(() => restoredDraft?.workspace ?? "");
   // Source tracking for the create's field-omission contract: true while the
   // slot's value is the untouched seed the project-prefill effect wrote from
@@ -3795,6 +3995,13 @@ export function NewChatLandingScreen() {
   // Sandbox repository chip label: repo name (server's clone-dir rule)
   // plus the pinned branch, e.g. "repo#main"; placeholder when unset.
   const sandboxRepoName = deriveRepoName(sandboxRepoUrl);
+  // The connected-GitHub repo (if any) whose clone URL matches the current
+  // free-text value, so the picker <select> stays in sync with the URL field
+  // and we can offer the matching branch list.
+  const selectedSandboxRepo = sandboxRepos.find(
+    (r) => (r.clone_url ?? `https://github.com/${r.full_name}.git`) === sandboxRepoUrl.trim(),
+  );
+  const showGithubRepoPicker = githubReposEnabled && sandboxRepoPickerConnected;
   const sandboxRepoLabel = sandboxRepoName
     ? sandboxRepoBranch.trim()
       ? `${sandboxRepoName}#${sandboxRepoBranch.trim()}`
@@ -4038,6 +4245,12 @@ export function NewChatLandingScreen() {
     // form submit) and Enter-key sends alike. After the guard so guarded no-ops
     // don't emit, matching the disabled Start button.
     trackClick("new_chat.start_session", "button");
+    // Remember the repo/branch for next time (seeds the picker on the next
+    // visit). Only when a repo is actually set — a no-repo session leaves the
+    // remembered repo untouched rather than clearing it.
+    if (sandboxRepoUrl.trim()) {
+      writeLastSandboxRepo(sandboxRepoUrl, sandboxRepoBranch);
+    }
     setCreating(true);
     setCreateError(null);
     // The draft is spent from the moment it is submitted: it belongs to the
@@ -5285,11 +5498,70 @@ export function NewChatLandingScreen() {
                           </Tooltip>
                         )}
                       </div>
+                      {/* Connected-GitHub picker: choose one of the caller's
+                        repos + a branch, which fills the same URL/branch state
+                        the free-text inputs below drive. Only shown when the
+                        server advertises the GitHub App and the account is
+                        linked; otherwise the free-text URL is the only path. */}
+                      {showGithubRepoPicker && (
+                        <>
+                          <SandboxRepoCombobox
+                            repos={sandboxRepos}
+                            value={selectedSandboxRepo?.full_name ?? ""}
+                            onSelect={(repo) => {
+                              setSandboxRepoUrl(
+                                repo
+                                  ? (repo.clone_url ?? `https://github.com/${repo.full_name}.git`)
+                                  : "",
+                              );
+                              // A new repo has its own branches — reset so a
+                              // stale branch never rides along.
+                              setSandboxRepoBranch("");
+                            }}
+                          />
+                          {sandboxReposTruncated && (
+                            <p
+                              className="text-xs text-muted-foreground"
+                              data-testid="new-chat-landing-repo-truncated"
+                            >
+                              Showing your most recently pushed repositories. Don't see one? Paste
+                              its URL below.
+                            </p>
+                          )}
+                          {selectedSandboxRepo && (
+                            <SandboxRepoBranchSelect
+                              fullName={selectedSandboxRepo.full_name}
+                              value={sandboxRepoBranch}
+                              defaultBranch={selectedSandboxRepo.default_branch}
+                              onChange={setSandboxRepoBranch}
+                            />
+                          )}
+                          <p className="text-xs text-muted-foreground">
+                            or paste a repository URL:
+                          </p>
+                        </>
+                      )}
+                      {/* Connected but the repo list failed to load: say so
+                        explicitly, so a transient error isn't mistaken for
+                        "GitHub not connected" (the picker just wouldn't render). */}
+                      {githubReposEnabled && sandboxReposErrored && !showGithubRepoPicker && (
+                        <p
+                          className="text-xs text-destructive"
+                          data-testid="new-chat-landing-repo-error"
+                        >
+                          Couldn't load your GitHub repositories. Paste a repository URL below.
+                        </p>
+                      )}
                       <input
                         id="landing-repo-url"
                         type="text"
                         value={sandboxRepoUrl}
-                        onChange={(e) => setSandboxRepoUrl(e.target.value)}
+                        onChange={(e) => {
+                          // Editing the repo invalidates a branch picked for the
+                          // previous repo, so clear it (mirrors the repo select).
+                          setSandboxRepoUrl(e.target.value);
+                          setSandboxRepoBranch("");
+                        }}
                         placeholder="https://github.com/org/repo"
                         className="rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors focus-visible:border-ring"
                         data-testid="new-chat-landing-repo-input"


### PR DESCRIPTION
Part of #5626

> **Stack (review bottom-up):** #4514 credential store → #4235 GitHub App connect → #4236 credential broker → #4237 repo picker → #4238 GitHub MCP → #4239 session PRs → #5203 Databricks connect. All target `main` (GitHub can't base a cross-fork PR on a fork branch), so file diffs are cumulative — **review each PR's single commit**.

## Summary

**Repo picker** for New Chat: searchable repo + branch comboboxes populated from the connected GitHub account (`/v1/connections/github/repos`), plus remember-last-repo (localStorage) that seeds the picker on the next visit.

## Test Plan

- `pytest tests/server/routes/test_integrations_github.py -k repos`
- `web`: `repoPreferences.test.ts` + the picker test.
- Verified the combobox lists real repos + branches on the demo.

## Demo

UI change — repo/branch comboboxes in the New Chat composer (verified in-browser on the github-mvp demo).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Test coverage

- [x] Unit tests added/updated
- [x] Manual verification completed

## Coverage notes

Manual verification: exercised the picker in-browser on the github-mvp demo.
